### PR TITLE
feat: allow configurable Cohere API URL in CohereReranker

### DIFF
--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -142,7 +142,9 @@ export class CohereReranker extends BaseReranker {
       };
 
       const response = await axios.post<t.CohereRerankerResponse | undefined>(
-        'https://api.cohere.com/v2/rerank',
+        process.env.COHERE_URL == null || process.env.COHERE_URL === ''
+          ? 'https://api.cohere.com/v2/rerank'
+          : process.env.COHERE_URL,
         requestData,
         {
           headers: {


### PR DESCRIPTION
This pull request makes a small but important change to the `CohereReranker` class to improve configurability of the Cohere API endpoint.

- The URL used for the Cohere rerank API in `CohereReranker` can now be overridden by setting the `COHERE_URL` environment variable; if not set, it defaults to the original Cohere endpoint.

This allows to specify a different base URL for Cohere, such as the ones provided by the Azure AI Foundry.