### PR TITLE
feat: support Bedrock prompt cache TTL

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1216,7 +1216,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           | t.BedrockAnthropicClientOptions
           | undefined;
         if (bedrockOptions?.promptCache === true) {
-          finalMessages = addBedrockCacheControl<BaseMessage>(finalMessages);
+          finalMessages = addBedrockCacheControl<BaseMessage>(finalMessages, {
+            ttl: bedrockOptions.promptCacheTtl,
+          });
         }
       } else if (agentContext.provider === Providers.OPENROUTER) {
         const openRouterOptions = agentContext.clientOptions as

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -711,6 +711,39 @@ describe('convertToConverseMessages', () => {
     expect(converseMessages[0].content).toEqual([{ text: 'Hello!' }]);
   });
 
+  test('should preserve Bedrock cachePoint TTL on message content', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: 'text', text: 'Cache this prompt.' },
+          { cachePoint: { type: 'default', ttl: '1h' } },
+        ] as any,
+      }),
+    ]);
+
+    expect(converseMessages[0].content).toEqual([
+      { text: 'Cache this prompt.' },
+      { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+  });
+
+  test('should preserve Bedrock cachePoint TTL on system content', () => {
+    const { converseSystem } = convertToConverseMessages([
+      new SystemMessage({
+        content: [
+          { type: 'text', text: 'Long-lived system prompt.' },
+          { cachePoint: { type: 'default', ttl: '1h' } },
+        ] as any,
+      }),
+      new HumanMessage('Hello!'),
+    ]);
+
+    expect(converseSystem).toEqual([
+      { text: 'Long-lived system prompt.' },
+      { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+  });
+
   test('should handle standard v1 format with tool_call blocks (e.g., from Anthropic provider)', () => {
     const { converseMessages, converseSystem } = convertToConverseMessages([
       new SystemMessage("You're an advanced AI assistant."),

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -28,6 +28,9 @@ import type {
   MessageContentReasoningBlock,
 } from '../types';
 
+type BedrockPromptCacheTtl = '5m' | '1h';
+type BedrockCachePointBlock = { type: 'default'; ttl?: BedrockPromptCacheTtl };
+
 /**
  * Convert a LangChain reasoning block to a Bedrock reasoning block.
  */
@@ -392,23 +395,32 @@ const standardContentBlockConverter: StandardContentBlockConverter<{
 };
 
 /**
- * Check if a block has a cache point.
+ * Check if a block has a cache point and return its normalized form (or undefined).
  */
-function isDefaultCachePoint(block: unknown): boolean {
+function getDefaultCachePoint(
+  block: unknown
+): BedrockCachePointBlock | undefined {
   if (typeof block !== 'object' || block === null) {
-    return false;
+    return undefined;
   }
   if (!('cachePoint' in block)) {
-    return false;
+    return undefined;
   }
   const cachePoint = (block as { cachePoint?: unknown }).cachePoint;
   if (typeof cachePoint !== 'object' || cachePoint === null) {
-    return false;
+    return undefined;
   }
   if (!('type' in cachePoint)) {
-    return false;
+    return undefined;
   }
-  return (cachePoint as { type?: string }).type === 'default';
+  if ((cachePoint as { type?: string }).type !== 'default') {
+    return undefined;
+  }
+
+  const ttl = (cachePoint as { ttl?: unknown }).ttl;
+  return ttl === '5m' || ttl === '1h'
+    ? { type: 'default', ttl }
+    : { type: 'default' };
 }
 
 /**
@@ -534,11 +546,10 @@ function convertLangChainContentBlockToConverseContentBlock({
     } as BedrockContentBlock;
   }
 
-  if (isDefaultCachePoint(block)) {
+  const cachePoint = getDefaultCachePoint(block);
+  if (cachePoint != null) {
     return {
-      cachePoint: {
-        type: 'default',
-      },
+      cachePoint,
     } as BedrockContentBlock;
   }
 
@@ -568,14 +579,14 @@ function convertSystemMessageToConverseMessage(
         contentBlocks.push({
           text: (block as { text: string }).text,
         });
-      } else if (isDefaultCachePoint(block)) {
-        contentBlocks.push({
-          cachePoint: {
-            type: 'default',
-          },
-        } as BedrockSystemContentBlock);
       } else {
-        break;
+        const cachePoint = getDefaultCachePoint(block);
+        if (cachePoint == null) {
+          break;
+        }
+        contentBlocks.push({
+          cachePoint,
+        } as BedrockSystemContentBlock);
       }
     }
     if (msg.content.length === contentBlocks.length) {
@@ -638,19 +649,19 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
             block as MessageContentReasoningBlock
           ),
         } as BedrockContentBlock);
-      } else if (isDefaultCachePoint(block)) {
-        contentBlocks.push({
-          cachePoint: {
-            type: 'default',
-          },
-        } as BedrockContentBlock);
       } else {
-        const blockValues = Object.fromEntries(
-          Object.entries(block).filter(([key]) => key !== 'type')
-        );
-        throw new Error(
-          `Unsupported content block type: ${block.type} with content of ${JSON.stringify(blockValues, null, 2)}`
-        );
+        const cachePoint = getDefaultCachePoint(block);
+        if (cachePoint == null) {
+          const blockValues = Object.fromEntries(
+            Object.entries(block).filter(([key]) => key !== 'type')
+          );
+          throw new Error(
+            `Unsupported content block type: ${block.type} with content of ${JSON.stringify(blockValues, null, 2)}`
+          );
+        }
+        contentBlocks.push({
+          cachePoint,
+        } as BedrockContentBlock);
       }
     });
 

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -306,6 +306,26 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(last[1]).toEqual({ cachePoint: { type: 'default' } });
   });
 
+  it('adds a 1-hour cachePoint TTL when configured', () => {
+    const messages: TestMsg[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ];
+    const result = addBedrockCacheControl(messages, { ttl: '1h' });
+    const last = result[1].content as MessageContentComplex[];
+    expect(last[1]).toEqual({ cachePoint: { type: 'default', ttl: '1h' } });
+  });
+
+  it('keeps explicit 5-minute cachePoint TTL when configured', () => {
+    const messages: TestMsg[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ];
+    const result = addBedrockCacheControl(messages, { ttl: '5m' });
+    const last = result[1].content as MessageContentComplex[];
+    expect(last[1]).toEqual({ cachePoint: { type: 'default', ttl: '5m' } });
+  });
+
   it('inserts cachePoint after the last text when multiple text blocks exist', () => {
     const messages: TestMsg[] = [
       {
@@ -1561,14 +1581,14 @@ describe('OpenRouter prompt caching (reuses addCacheControl)', () => {
     const lastUser = converted[2];
 
     expect(Array.isArray(firstUser.content)).toBe(true);
-    expect(
-      (firstUser.content as CacheControlBlock[])[0]
-    ).toHaveProperty('cache_control');
+    expect((firstUser.content as CacheControlBlock[])[0]).toHaveProperty(
+      'cache_control'
+    );
 
     expect(Array.isArray(lastUser.content)).toBe(true);
-    expect(
-      (lastUser.content as CacheControlBlock[])[0]
-    ).toHaveProperty('cache_control');
+    expect((lastUser.content as CacheControlBlock[])[0]).toHaveProperty(
+      'cache_control'
+    );
   });
 
   it('strips Bedrock cache before applying OpenRouter/Anthropic cache', () => {

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -19,6 +19,12 @@ type MessageContentWithCacheControl = MessageContentComplex & {
   cache_control?: unknown;
 };
 
+type BedrockPromptCacheTtl = '5m' | '1h';
+
+type BedrockCacheControlOptions = {
+  ttl?: BedrockPromptCacheTtl;
+};
+
 /**
  * Deep clones a message's content to prevent mutation of the original.
  */
@@ -383,6 +389,18 @@ export function addCacheControlToStablePrefixMessages<
   );
 }
 
+function createBedrockCachePoint(
+  ttl?: BedrockPromptCacheTtl
+): MessageContentComplex {
+  const cachePoint: { type: 'default'; ttl?: BedrockPromptCacheTtl } = {
+    type: 'default',
+  };
+  if (ttl != null) {
+    cachePoint.ttl = ttl;
+  }
+  return { cachePoint } as MessageContentComplex;
+}
+
 /**
  * Checks if a message's content has Anthropic cache_control fields.
  */
@@ -482,7 +500,7 @@ export function stripBedrockCacheControl<T extends MessageWithContent>(
  */
 export function addBedrockCacheControl<
   T extends MessageWithContent & { getType?: () => string; role?: string },
->(messages: T[]): T[] {
+>(messages: T[], options: BedrockCacheControlOptions = {}): T[] {
   if (!Array.isArray(messages) || messages.length < 2) {
     return messages;
   }
@@ -560,15 +578,17 @@ export function addBedrockCacheControl<
       // Insert cache point after the last non-empty text block.
       // Skip if no cacheable text content exists (whitespace-only messages).
       if (needsCacheAdd && lastNonEmptyTextIndex >= 0) {
-        workingContent.splice(lastNonEmptyTextIndex + 1, 0, {
-          cachePoint: { type: 'default' },
-        } as MessageContentComplex);
+        workingContent.splice(
+          lastNonEmptyTextIndex + 1,
+          0,
+          createBedrockCachePoint(options.ttl)
+        );
         messagesModified++;
       }
     } else if (typeof content === 'string' && needsCacheAdd) {
       workingContent = [
         { type: ContentTypes.TEXT, text: content },
-        { cachePoint: { type: 'default' } } as MessageContentComplex,
+        createBedrockCachePoint(options.ttl),
       ];
       messagesModified++;
     } else {

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -86,8 +86,9 @@ export type BedrockAnthropicInput = ChatBedrockConverseInput & {
   additionalModelRequestFields?: ChatBedrockConverseInput['additionalModelRequestFields'] &
     AnthropicReasoning;
   promptCache?: boolean;
+  promptCacheTtl?: '5m' | '1h';
 };
-export type BedrockConverseClientOptions = ChatBedrockConverseInput;
+export type BedrockConverseClientOptions = BedrockAnthropicInput;
 export type BedrockAnthropicClientOptions = BedrockAnthropicInput;
 export type GoogleClientOptions = GoogleGenerativeAIChatInput & {
   customHeaders?: RequestOptions['customHeaders'];


### PR DESCRIPTION
## Summary

Adds Bedrock prompt cache TTL support to the agents Bedrock runtime path. Bedrock cache checkpoints now allow an optional `ttl` value (`5m` or `1h`), and callers can pass `promptCacheTtl` so the generated `cachePoint` blocks include that TTL.

When `promptCacheTtl` is omitted, no TTL is sent and Bedrock keeps its default 5-minute prompt cache behavior.

## Changes

- Add `promptCacheTtl?: "5m" | "1h"` to Bedrock Anthropic input/client options
- Pass the TTL into `addBedrockCacheControl()` from the graph Bedrock options
- Preserve `cachePoint.ttl` through Bedrock message conversion for user, assistant, and system blocks
- Add tests for default behavior, `5m`, `1h`, and message conversion

## References

- AWS CachePointBlock API reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
- AWS Bedrock prompt caching guide: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
- AWS announcement for 1-hour prompt caching: https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-bedrock-one-hour-duration-prompt-caching/
- LibreChat config PR: https://github.com/danny-avila/LibreChat/pull/12875

## Testing

- `npm test -- --runInBand src/messages/cache.test.ts src/llm/bedrock/llm.spec.ts`
- `npm run build`