### PR TITLE
feat: configurable Cohere reranker API URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.78-dev.0",
+  "version": "3.1.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.78-dev.0",
+      "version": "3.1.79",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.78",
+  "version": "3.1.79",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/tools/search/cohere-reranker.test.ts
+++ b/src/tools/search/cohere-reranker.test.ts
@@ -1,0 +1,78 @@
+import { CohereReranker } from './rerankers';
+import { createDefaultLogger } from './utils';
+
+describe('CohereReranker', () => {
+  const mockLogger = createDefaultLogger();
+
+  describe('constructor', () => {
+    it('should use default API URL when no apiUrl is provided', () => {
+      const originalEnv = process.env.COHERE_API_URL;
+      delete process.env.COHERE_API_URL;
+
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        logger: mockLogger,
+      });
+
+      // Access private property for testing
+      const apiUrl = (reranker as unknown as { apiUrl: string }).apiUrl;
+      expect(apiUrl).toBe('https://api.cohere.com/v2/rerank');
+
+      if (originalEnv) {
+        process.env.COHERE_API_URL = originalEnv;
+      }
+    });
+
+    it('should use custom API URL when provided', () => {
+      const customUrl = 'https://my-azure.endpoint.com/v1/rerank';
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        apiUrl: customUrl,
+        logger: mockLogger,
+      });
+
+      const apiUrl = (reranker as unknown as { apiUrl: string }).apiUrl;
+      expect(apiUrl).toBe(customUrl);
+    });
+
+    it('should use environment variable COHERE_API_URL when available', () => {
+      const originalEnv = process.env.COHERE_API_URL;
+      process.env.COHERE_API_URL = 'https://env-cohere.example.com/v2/rerank';
+
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        logger: mockLogger,
+      });
+
+      const apiUrl = (reranker as unknown as { apiUrl: string }).apiUrl;
+      expect(apiUrl).toBe('https://env-cohere.example.com/v2/rerank');
+
+      if (originalEnv) {
+        process.env.COHERE_API_URL = originalEnv;
+      } else {
+        delete process.env.COHERE_API_URL;
+      }
+    });
+
+    it('should prioritize explicit apiUrl over environment variable', () => {
+      const originalEnv = process.env.COHERE_API_URL;
+      process.env.COHERE_API_URL = 'https://env-cohere.example.com/v2/rerank';
+
+      const customUrl = 'https://explicit-cohere.example.com/v2/rerank';
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        apiUrl: customUrl,
+        logger: mockLogger,
+      });
+
+      const apiUrl = (reranker as unknown as { apiUrl: string }).apiUrl;
+      expect(apiUrl).toBe(customUrl);
+
+      if (originalEnv) {
+        process.env.COHERE_API_URL = originalEnv;
+      } else {
+        delete process.env.COHERE_API_URL;
+      }
+    });
+  });
+});

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -49,7 +49,9 @@ export class JinaReranker extends BaseReranker {
     documents: string[],
     topK: number = 5
   ): Promise<t.Highlight[]> {
-    this.logger.debug(`Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`);
+    this.logger.debug(
+      `Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`
+    );
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
@@ -115,15 +117,20 @@ export class JinaReranker extends BaseReranker {
 }
 
 export class CohereReranker extends BaseReranker {
+  private apiUrl: string;
+
   constructor({
     apiKey = process.env.COHERE_API_KEY,
+    apiUrl = process.env.COHERE_API_URL || 'https://api.cohere.com/v2/rerank',
     logger,
   }: {
     apiKey?: string;
+    apiUrl?: string;
     logger?: t.Logger;
   }) {
     super(logger);
     this.apiKey = apiKey;
+    this.apiUrl = apiUrl;
   }
 
   async rerank(
@@ -131,7 +138,9 @@ export class CohereReranker extends BaseReranker {
     documents: string[],
     topK: number = 5
   ): Promise<t.Highlight[]> {
-    this.logger.debug(`Reranking ${documents.length} chunks with Cohere`);
+    this.logger.debug(
+      `Reranking ${documents.length} chunks with Cohere using API URL: ${this.apiUrl}`
+    );
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
@@ -147,7 +156,7 @@ export class CohereReranker extends BaseReranker {
       };
 
       const response = await axios.post<t.CohereRerankerResponse | undefined>(
-        'https://api.cohere.com/v2/rerank',
+        this.apiUrl,
         requestData,
         {
           headers: {
@@ -208,19 +217,32 @@ export const createReranker = (config: {
   jinaApiKey?: string;
   jinaApiUrl?: string;
   cohereApiKey?: string;
+  cohereApiUrl?: string;
   logger?: t.Logger;
 }): BaseReranker | undefined => {
-  const { rerankerType, jinaApiKey, jinaApiUrl, cohereApiKey, logger } = config;
+  const {
+    rerankerType,
+    jinaApiKey,
+    jinaApiUrl,
+    cohereApiKey,
+    cohereApiUrl,
+    logger,
+  } = config;
 
   // Create a default logger if none is provided
   const defaultLogger = logger || createDefaultLogger();
 
   switch (rerankerType.toLowerCase()) {
   case 'jina':
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   case 'cohere':
     return new CohereReranker({
       apiKey: cohereApiKey,
+      apiUrl: cohereApiUrl,
       logger: defaultLogger,
     });
   case 'infinity':
@@ -232,7 +254,11 @@ export const createReranker = (config: {
     defaultLogger.warn(
       `Unknown reranker type: ${rerankerType}. Defaulting to InfinityReranker.`
     );
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   }
 };
 

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -354,6 +354,7 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    cohereApiUrl,
     onSearchResults: _onSearchResults,
     onGetHighlights,
   } = config;
@@ -433,6 +434,7 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    cohereApiUrl,
     logger,
   });
 

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -219,6 +219,7 @@ export interface SearchToolConfig
   jinaApiKey?: string;
   jinaApiUrl?: string;
   cohereApiKey?: string;
+  cohereApiUrl?: string;
   rerankerType?: RerankerType;
   scraperProvider?: ScraperProvider;
   scraperTimeout?: number;


### PR DESCRIPTION
## Summary

Fix for https://github.com/danny-avila/LibreChat/issues/12328

This PR adds support for configurable API URLs in the Cohere reranker, enabling users to specify custom endpoints (e.g., for Azure deployments) while maintaining backward compatibility with the default Cohere API endpoint.

## Key Changes
- **CohereReranker class**: Added `apiUrl` as a private property with support for:
  - Explicit `apiUrl` parameter (highest priority)
  - `COHERE_API_URL` environment variable (medium priority)
  - Default fallback to `https://api.cohere.com/v2/rerank` (lowest priority)
- **createReranker factory function**: Updated to accept and pass through `cohereApiUrl` configuration
- **SearchToolConfig interface**: Added `cohereApiUrl` optional property
- **createSearchTool function**: Updated to accept and forward `cohereApiUrl` parameter
- **Logging improvements**: Enhanced debug logging to include the API URL being used for Cohere reranking
- **Code formatting**: Improved line wrapping for consistency with Jina reranker implementation
- **Test coverage**: Added comprehensive unit tests for CohereReranker constructor covering all URL resolution scenarios

## Implementation Details
The API URL resolution follows a priority order: explicit parameter > environment variable > default URL. This pattern matches the existing implementation for JinaReranker and provides flexibility for different deployment scenarios while maintaining sensible defaults.