### PR TITLE
🧷 fix: Dedupe Agent Tool Bindings

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -35,6 +35,15 @@ type AgentSystemContentBlock =
   | { cachePoint: { type: 'default' } };
 
 type PromptCacheProvider = Providers.ANTHROPIC | Providers.OPENROUTER;
+type GraphToolEntry = t.GraphTools[number];
+
+function getBindingToolName(tool: GraphToolEntry): string | undefined {
+  if (tool == null || typeof tool !== 'object' || !('name' in tool)) {
+    return undefined;
+  }
+
+  return typeof tool.name === 'string' ? tool.name : undefined;
+}
 
 /**
  * Encapsulates agent-specific state that can vary between agents in a multi-agent system
@@ -227,6 +236,8 @@ export class AgentContext {
   toolDefinitions?: t.LCTool[];
   /** Set of tool names discovered via tool search (to be loaded) */
   discoveredToolNames: Set<string> = new Set();
+  /** Duplicate tool binding warnings already emitted for this agent. */
+  private loggedDuplicateToolBindings: Set<string> = new Set();
   /** Original AgentInputs used to create this context — used for self-spawn subagent resolution. */
   _sourceInputs?: t.AgentInputs;
   /** Subagent configurations for hierarchical delegation. */
@@ -1334,10 +1345,13 @@ export class AgentContext {
     const filtered = this.getEffectiveInstanceTools();
 
     if (this.graphTools && this.graphTools.length > 0) {
-      return [...(filtered ?? []), ...this.graphTools];
+      return this.dedupeToolsForBinding([
+        ...(filtered ?? []),
+        ...this.graphTools,
+      ] as t.GraphTools);
     }
 
-    return filtered;
+    return filtered ? this.dedupeToolsForBinding(filtered) : filtered;
   }
 
   /** Creates schema-only tools from toolDefinitions for event-driven mode, merged with native tools */
@@ -1361,7 +1375,48 @@ export class AgentContext {
       allTools.push(...instanceTools);
     }
 
-    return allTools;
+    return this.dedupeToolsForBinding(allTools as t.GraphTools);
+  }
+
+  private dedupeToolsForBinding(tools: t.GraphTools): t.GraphTools {
+    const seenNames = new Set<string>();
+    const duplicateNames = new Set<string>();
+    const dedupedTools: GraphToolEntry[] = [];
+
+    for (const tool of tools) {
+      const name = getBindingToolName(tool);
+      if (!name) {
+        dedupedTools.push(tool);
+        continue;
+      }
+
+      if (seenNames.has(name)) {
+        duplicateNames.add(name);
+        continue;
+      }
+
+      seenNames.add(name);
+      dedupedTools.push(tool);
+    }
+
+    if (duplicateNames.size === 0) {
+      return tools;
+    }
+
+    const namesToLog = [...duplicateNames].filter(
+      (name) => !this.loggedDuplicateToolBindings.has(name)
+    );
+    if (namesToLog.length > 0) {
+      for (const name of namesToLog) {
+        this.loggedDuplicateToolBindings.add(name);
+      }
+      const duplicateList = namesToLog.join(', ');
+      console.warn(
+        `[AgentContext] Removed duplicate tool binding(s) for agent "${this.agentId}": ${duplicateList}`
+      );
+    }
+
+    return dedupedTools as t.GraphTools;
   }
 
   /** Filters tool instances for binding based on registry config */

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -966,6 +966,47 @@ describe('AgentContext', () => {
       expect(result).toEqual(tools);
     });
 
+    it('dedupes duplicate named tools before binding and logs a warning', () => {
+      const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+      const nativeWebSearch = {
+        name: 'web_search',
+        type: 'web_search_20250305',
+      } as unknown as t.GenericTool;
+
+      try {
+        const ctx = createBasicContext({
+          agentConfig: {
+            provider: Providers.ANTHROPIC,
+            toolDefinitions: [
+              {
+                name: 'web_search',
+                description: 'LibreChat search',
+                parameters: { type: 'object', properties: {} },
+              },
+            ],
+            tools: [nativeWebSearch],
+          },
+        });
+
+        const result = ctx.getToolsForBinding() as t.GenericTool[];
+
+        expect(result).toHaveLength(1);
+        expect(result.map((tool) => tool.name)).toEqual(['web_search']);
+        expect(result[0]).not.toBe(nativeWebSearch);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Removed duplicate tool binding(s)')
+        );
+
+        ctx.getToolsForBinding();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('excludes code_execution-only tools', () => {
       const tools = [
         createMockTool('direct_tool'),


### PR DESCRIPTION
## Summary

I added a generic duplicate-name guard in `AgentContext` so duplicate tool bindings are deduped before reaching the model, with logging as a safety net. Related to danny-avila/LibreChat#13162.

- Added name-based dedupe for tool binding output across schema-only, graph-managed, and instance tools.
- Logged duplicate removals once per agent/tool name to make fallback behavior visible without spamming repeated binds.
- Added focused coverage for a duplicate `web_search` binding where the schema-only LibreChat tool wins over the appended native instance.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `git diff --check HEAD~1..HEAD`
- Not run: `npx --no-install jest src/agents/__tests__/AgentContext.test.ts --runInBand` because this worktree is missing `ts-jest`.

### **Test Configuration**:

- Worktree: `/Users/danny/.codex/worktrees/0ae6/agents`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
