### PR TITLE
feat: add ZeroEntropy reranker

### DIFF
--- a/src/tools/search/jina-reranker.test.ts
+++ b/src/tools/search/jina-reranker.test.ts
@@ -1,18 +1,25 @@
-import { JinaReranker } from './rerankers';
+import axios from 'axios';
+import { createReranker, JinaReranker, ZeroEntropyReranker } from './rerankers';
 import { createDefaultLogger } from './utils';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('JinaReranker', () => {
   const mockLogger = createDefaultLogger();
-  
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('constructor', () => {
     it('should use default API URL when no apiUrl is provided', () => {
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         logger: mockLogger,
       });
-      
-      // Access private property for testing
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = reranker.getApiUrl();
       expect(apiUrl).toBe('https://api.jina.ai/v1/rerank');
     });
 
@@ -23,25 +30,24 @@ describe('JinaReranker', () => {
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = reranker.getApiUrl();
       expect(apiUrl).toBe(customUrl);
     });
 
     it('should use environment variable JINA_API_URL when available', () => {
       const originalEnv = process.env.JINA_API_URL;
       process.env.JINA_API_URL = 'https://env-jina-endpoint.com/v1/rerank';
-      
+
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = reranker.getApiUrl();
       expect(apiUrl).toBe('https://env-jina-endpoint.com/v1/rerank');
-      
-      // Restore original environment
-      if (originalEnv) {
+
+      if (originalEnv !== undefined) {
         process.env.JINA_API_URL = originalEnv;
       } else {
         delete process.env.JINA_API_URL;
@@ -51,19 +57,18 @@ describe('JinaReranker', () => {
     it('should prioritize explicit apiUrl over environment variable', () => {
       const originalEnv = process.env.JINA_API_URL;
       process.env.JINA_API_URL = 'https://env-jina-endpoint.com/v1/rerank';
-      
+
       const customUrl = 'https://explicit-jina-endpoint.com/v1/rerank';
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = reranker.getApiUrl();
       expect(apiUrl).toBe(customUrl);
-      
-      // Restore original environment
-      if (originalEnv) {
+
+      if (originalEnv !== undefined) {
         process.env.JINA_API_URL = originalEnv;
       } else {
         delete process.env.JINA_API_URL;
@@ -79,27 +84,113 @@ describe('JinaReranker', () => {
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
+
       const logSpy = jest.spyOn(mockLogger, 'debug');
-      
-      try {
-        await reranker.rerank('test query', ['document1', 'document2'], 2);
-      } catch (error) {
-        // Expected to fail due to missing API key, but we can check the log
-      }
-      
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          model: 'jina-reranker-v2-base-multilingual',
+          usage: {
+            total_tokens: 1,
+          },
+          results: [],
+        },
+      });
+
+      await reranker.rerank('test query', ['document1', 'document2'], 2);
+
       expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Reranking 2 chunks with Jina using API URL: ${customUrl}`)
+        expect.stringContaining(
+          `Reranking 2 chunks with Jina using API URL: ${customUrl}`
+        )
       );
-      
+
       logSpy.mockRestore();
     });
   });
 });
 
+describe('ZeroEntropyReranker', () => {
+  const mockLogger = createDefaultLogger();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use default API URL and model when not provided', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            index: 1,
+            relevance_score: 0.91,
+          },
+        ],
+      },
+    });
+
+    const reranker = new ZeroEntropyReranker({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const highlights = await reranker.rerank(
+      'test query',
+      ['document1', 'document2'],
+      1
+    );
+    const [requestUrl, requestData, requestConfig] =
+      mockedAxios.post.mock.calls[0];
+
+    expect(requestUrl).toBe('https://api.zeroentropy.dev/v1/models/rerank');
+    expect(requestData).toMatchObject({
+      model: 'zerank-2',
+      query: 'test query',
+      documents: ['document1', 'document2'],
+      top_n: 1,
+    });
+    expect(requestConfig).toMatchObject({
+      headers: {
+        Authorization: 'Bearer test-key',
+      },
+    });
+    expect(highlights).toEqual([
+      {
+        text: 'document2',
+        score: 0.91,
+      },
+    ]);
+  });
+
+  it('should use custom API URL and model when provided', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            index: 0,
+            relevance_score: 0.88,
+          },
+        ],
+      },
+    });
+
+    const reranker = new ZeroEntropyReranker({
+      apiKey: 'test-key',
+      apiUrl: 'https://proxy.example.com/rerank',
+      model: 'zerank-1-small',
+      logger: mockLogger,
+    });
+
+    await reranker.rerank('test query', ['document1', 'document2'], 1);
+    const [requestUrl, requestData] = mockedAxios.post.mock.calls[0];
+
+    expect(requestUrl).toBe('https://proxy.example.com/rerank');
+    expect(requestData).toMatchObject({
+      model: 'zerank-1-small',
+    });
+  });
+});
+
 describe('createReranker', () => {
-  const { createReranker } = require('./rerankers');
-  
   it('should create JinaReranker with jinaApiUrl when provided', () => {
     const customUrl = 'https://custom-jina-endpoint.com/v1/rerank';
     const reranker = createReranker({
@@ -107,9 +198,10 @@ describe('createReranker', () => {
       jinaApiKey: 'test-key',
       jinaApiUrl: customUrl,
     });
-    
+
     expect(reranker).toBeInstanceOf(JinaReranker);
-    const apiUrl = (reranker as any).apiUrl;
+    const apiUrl =
+      reranker instanceof JinaReranker ? reranker.getApiUrl() : undefined;
     expect(apiUrl).toBe(customUrl);
   });
 
@@ -118,9 +210,21 @@ describe('createReranker', () => {
       rerankerType: 'jina',
       jinaApiKey: 'test-key',
     });
-    
+
     expect(reranker).toBeInstanceOf(JinaReranker);
-    const apiUrl = (reranker as any).apiUrl;
+    const apiUrl =
+      reranker instanceof JinaReranker ? reranker.getApiUrl() : undefined;
     expect(apiUrl).toBe('https://api.jina.ai/v1/rerank');
+  });
+
+  it('should create ZeroEntropyReranker with explicit config', () => {
+    const reranker = createReranker({
+      rerankerType: 'zeroentropy',
+      zeroEntropyApiKey: 'test-key',
+      zeroEntropyApiUrl: 'https://proxy.example.com/rerank',
+      zeroEntropyModel: 'zerank-1',
+    });
+
+    expect(reranker).toBeInstanceOf(ZeroEntropyReranker);
   });
 });

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -32,7 +32,7 @@ export class JinaReranker extends BaseReranker {
 
   constructor({
     apiKey = process.env.JINA_API_KEY,
-    apiUrl = process.env.JINA_API_URL || 'https://api.jina.ai/v1/rerank',
+    apiUrl = process.env.JINA_API_URL ?? 'https://api.jina.ai/v1/rerank',
     logger,
   }: {
     apiKey?: string;
@@ -44,12 +44,18 @@ export class JinaReranker extends BaseReranker {
     this.apiUrl = apiUrl;
   }
 
+  getApiUrl(): string {
+    return this.apiUrl;
+  }
+
   async rerank(
     query: string,
     documents: string[],
     topK: number = 5
   ): Promise<t.Highlight[]> {
-    this.logger.debug(`Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`);
+    this.logger.debug(
+      `Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`
+    );
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
@@ -200,6 +206,81 @@ export class InfinityReranker extends BaseReranker {
   }
 }
 
+export class ZeroEntropyReranker extends BaseReranker {
+  private apiUrl: string;
+  private model: string;
+
+  constructor({
+    apiKey = process.env.ZEROENTROPY_API_KEY,
+    apiUrl = process.env.ZEROENTROPY_API_URL ??
+      'https://api.zeroentropy.dev/v1/models/rerank',
+    model = process.env.ZEROENTROPY_MODEL ?? 'zerank-2',
+    logger,
+  }: {
+    apiKey?: string;
+    apiUrl?: string;
+    model?: string;
+    logger?: t.Logger;
+  }) {
+    super(logger);
+    this.apiKey = apiKey;
+    this.apiUrl = apiUrl;
+    this.model = model;
+  }
+
+  async rerank(
+    query: string,
+    documents: string[],
+    topK: number = 5
+  ): Promise<t.Highlight[]> {
+    this.logger.debug(
+      `Reranking ${documents.length} chunks with ZeroEntropy using API URL: ${this.apiUrl}`
+    );
+
+    try {
+      if (this.apiKey == null || this.apiKey === '') {
+        this.logger.warn(
+          'ZEROENTROPY_API_KEY is not set. Using default ranking.'
+        );
+        return this.getDefaultRanking(documents, topK);
+      }
+
+      const response = await axios.post<
+        t.ZeroEntropyRerankerResponse | undefined
+      >(
+        this.apiUrl,
+        {
+          model: this.model,
+          query,
+          documents,
+          top_n: topK,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+        }
+      );
+
+      if (response.data != null && response.data.results.length > 0) {
+        return response.data.results.map((result) => ({
+          text: documents[result.index],
+          score: result.relevance_score,
+        }));
+      }
+
+      this.logger.warn(
+        'Unexpected response format from ZeroEntropy API. Using default ranking.'
+      );
+      return this.getDefaultRanking(documents, topK);
+    } catch (error) {
+      this.logger.error('Error using ZeroEntropy reranker:', error);
+      return this.getDefaultRanking(documents, topK);
+    }
+  }
+}
+
 /**
  * Creates the appropriate reranker based on type and configuration
  */
@@ -208,19 +289,42 @@ export const createReranker = (config: {
   jinaApiKey?: string;
   jinaApiUrl?: string;
   cohereApiKey?: string;
+  zeroEntropyApiKey?: string;
+  zeroEntropyApiUrl?: string;
+  zeroEntropyModel?: string;
   logger?: t.Logger;
 }): BaseReranker | undefined => {
-  const { rerankerType, jinaApiKey, jinaApiUrl, cohereApiKey, logger } = config;
+  const {
+    rerankerType,
+    jinaApiKey,
+    jinaApiUrl,
+    cohereApiKey,
+    zeroEntropyApiKey,
+    zeroEntropyApiUrl,
+    zeroEntropyModel,
+    logger,
+  } = config;
 
   // Create a default logger if none is provided
   const defaultLogger = logger || createDefaultLogger();
 
   switch (rerankerType.toLowerCase()) {
   case 'jina':
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   case 'cohere':
     return new CohereReranker({
       apiKey: cohereApiKey,
+      logger: defaultLogger,
+    });
+  case 'zeroentropy':
+    return new ZeroEntropyReranker({
+      apiKey: zeroEntropyApiKey,
+      apiUrl: zeroEntropyApiUrl,
+      model: zeroEntropyModel,
       logger: defaultLogger,
     });
   case 'infinity':
@@ -232,7 +336,11 @@ export const createReranker = (config: {
     defaultLogger.warn(
       `Unknown reranker type: ${rerankerType}. Defaulting to InfinityReranker.`
     );
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   }
 };
 

--- a/src/tools/search/tavily.test.ts
+++ b/src/tools/search/tavily.test.ts
@@ -436,6 +436,73 @@ describe('Tavily search API', () => {
       },
     });
   });
+
+  it('passes ZeroEntropy reranker config through the search tool', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          results: [
+            {
+              title: 'Example',
+              url: 'https://example.com',
+              content: 'Example summary',
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          results: [
+            {
+              url: 'https://example.com',
+              raw_content: 'Extracted content for ZeroEntropy reranking.',
+              images: [],
+            },
+          ],
+          failed_results: [],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          results: [
+            {
+              index: 0,
+              relevance_score: 0.95,
+            },
+          ],
+        },
+      });
+
+    const searchTool = createSearchTool({
+      searchProvider: 'tavily',
+      tavilyApiKey: 'search-key',
+      scraperProvider: 'tavily',
+      rerankerType: 'zeroentropy',
+      zeroEntropyApiKey: 'zero-key',
+      zeroEntropyApiUrl: 'https://proxy.example.com/zerank',
+      zeroEntropyModel: 'zerank-1-small',
+      logger: mockLogger,
+    });
+
+    await searchTool.invoke({
+      query: 'example query',
+    });
+    const [rerankUrl, rerankPayload, rerankConfig] =
+      mockedAxios.post.mock.calls[2];
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+    expect(rerankUrl).toBe('https://proxy.example.com/zerank');
+    expect(rerankPayload).toMatchObject({
+      model: 'zerank-1-small',
+      query: 'example query',
+      top_n: 5,
+    });
+    expect(rerankConfig).toMatchObject({
+      headers: {
+        Authorization: 'Bearer zero-key',
+      },
+    });
+  });
 });
 
 describe('TavilyScraper', () => {

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -354,6 +354,9 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    zeroEntropyApiKey,
+    zeroEntropyApiUrl,
+    zeroEntropyModel,
     onSearchResults: _onSearchResults,
     onGetHighlights,
   } = config;
@@ -433,6 +436,9 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    zeroEntropyApiKey,
+    zeroEntropyApiUrl,
+    zeroEntropyModel,
     logger,
   });
 

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -5,7 +5,12 @@ import { DATE_RANGE } from './schema';
 
 export type SearchProvider = 'serper' | 'searxng' | 'tavily';
 export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
-export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
+export type RerankerType =
+  | 'infinity'
+  | 'jina'
+  | 'cohere'
+  | 'zeroentropy'
+  | 'none';
 
 export interface Highlight {
   score: number;
@@ -206,6 +211,20 @@ export interface CohereRerankerResponse {
   };
 }
 
+export interface ZeroEntropyRerankerResult {
+  index: number;
+  relevance_score: number;
+}
+
+export interface ZeroEntropyRerankerResponse {
+  results: ZeroEntropyRerankerResult[];
+  total_bytes?: number;
+  total_tokens?: number;
+  actual_latency_mode?: string;
+  e2e_latency?: number;
+  inference_latency?: number;
+}
+
 export type SafeSearchLevel = 0 | 1 | 2;
 
 export type Logger = WinstonLogger;
@@ -219,6 +238,9 @@ export interface SearchToolConfig
   jinaApiKey?: string;
   jinaApiUrl?: string;
   cohereApiKey?: string;
+  zeroEntropyApiKey?: string;
+  zeroEntropyApiUrl?: string;
+  zeroEntropyModel?: string;
   rerankerType?: RerankerType;
   scraperProvider?: ScraperProvider;
   scraperTimeout?: number;


### PR DESCRIPTION
Target: `danny-avila/agents:main`
Branch: `feature/zeroentropy-reranker`
Commit: `b673d8103cea9b8d0d86ca63964658df3de935e0`

Companion PR:
- Companion LibreChat PR: `danny-avila/LibreChat#13263`
- Companion branch: `feat/zeroentropy-reranker`
- Companion target: `dev`
- Merge/publish order: merge and publish this agents package before merging the LibreChat ZeroEntropy plumbing PR.

## Why This Matters

ZeroEntropy documents `zerank-2` as its flagship state-of-the-art reranker. Adding it here gives LibreChat's agent search path access to a modern cross-encoder reranker that can improve result ordering after first-pass retrieval, with configurable API URL/model support for teams that want ZeroEntropy Cloud, EU endpoints, or self-hosted/commercial-license deployments.

This is a high-leverage upgrade for web search and RAG-style tool use: better reranking means the model sees more relevant sources earlier, without changing the search provider itself.

References:
- ZeroEntropy model docs: https://docs.zeroentropy.dev/models
- ZeroEntropy rerank API: https://docs.zeroentropy.dev/api-reference/models/rerank

## Summary

Adds a ZeroEntropy reranker implementation using the rerank API, including:

- `zerank-2`-ready request/response mapping
- ZeroEntropy reranker config fields
- `createSearchTool` / `createReranker` wiring
- focused coverage for request shape, response mapping, and config passthrough

## Tests

- NODE_OPTIONS='--experimental-vm-modules' npx jest src/tools/search/jina-reranker.test.ts src/tools/search/tavily.test.ts --runInBand: pass, 47 tests
- npx tsc --noEmit: pass
- npx eslint src/tools/search/rerankers.ts src/tools/search/types.ts src/tools/search/tool.ts src/tools/search/jina-reranker.test.ts src/tools/search/tavily.test.ts: pass
- npm run build: pass, existing Rollup empty-chunk warning only
- git diff --check: pass

## Dependency Notes

No separate ZeroEntropy SDK dependency is added; implementation uses existing HTTP client utilities. The companion LibreChat PR requires a published `@librechat/agents` version that supports `rerankerType: "zeroentropy"`, `zeroEntropyApiKey`, `zeroEntropyApiUrl`, and `zeroEntropyModel`.

## Residual Risks

No live ZeroEntropy API validation was run.
