### PR TITLE
fix: honor proxy env vars in web search HTTP calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
         "openai": "^6.35.0",
+        "proxy-from-env": "^2.1.0",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -56,6 +57,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^24.13.1",
         "@types/node-fetch": "^2.6.13",
+        "@types/proxy-from-env": "^1.0.4",
         "@types/yargs-parser": "^21.0.3",
         "@typescript-eslint/eslint-plugin": "^8.24.0",
         "@typescript-eslint/parser": "^8.24.0",
@@ -7143,6 +7145,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/proxy-from-env": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/proxy-from-env/-/proxy-from-env-1.0.4.tgz",
+      "integrity": "sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "nanoid": "^3.3.7",
     "okapibm25": "^1.4.1",
     "openai": "^6.35.0",
+    "proxy-from-env": "^2.1.0",
     "uuid": "^11.1.1"
   },
   "peerDependencies": {
@@ -273,6 +274,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^24.13.1",
     "@types/node-fetch": "^2.6.13",
+    "@types/proxy-from-env": "^1.0.4",
     "@types/yargs-parser": "^21.0.3",
     "@typescript-eslint/eslint-plugin": "^8.24.0",
     "@typescript-eslint/parser": "^8.24.0",

--- a/src/tools/search/firecrawl.ts
+++ b/src/tools/search/firecrawl.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type * as t from './types';
+import { getAxiosProxyOptions } from './proxy';
 import { createDefaultLogger } from './utils';
 import { processContent } from './content';
 
@@ -121,6 +122,7 @@ export class FirecrawlScraper implements t.BaseScraper {
           Authorization: `Bearer ${this.apiKey}`,
         },
         timeout: this.timeout,
+        ...getAxiosProxyOptions(this.apiUrl),
       });
 
       return [url, response.data];

--- a/src/tools/search/proxy.test.ts
+++ b/src/tools/search/proxy.test.ts
@@ -1,0 +1,83 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+import { getAxiosProxyOptions } from './proxy';
+
+const PROXY_ENV_VARS = [
+  'PROXY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+] as const;
+
+describe('getAxiosProxyOptions', () => {
+  const savedEnv: Partial<Record<string, string>> = {};
+
+  beforeEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      savedEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      const value = savedEnv[name];
+      if (value == null) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
+  it('returns no options when no proxy is configured', () => {
+    expect(getAxiosProxyOptions('https://api.tavily.com/search')).toEqual({});
+  });
+
+  it('returns no options for non-HTTPS URLs', () => {
+    process.env.PROXY = 'http://proxy.internal:8080';
+    expect(getAxiosProxyOptions('http://searxng.local/search')).toEqual({});
+  });
+
+  it('tunnels through the PROXY environment variable', () => {
+    process.env.PROXY = 'http://proxy.internal:8080';
+    const options = getAxiosProxyOptions('https://api.tavily.com/search');
+    expect(options.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
+    expect(options.proxy).toBe(false);
+  });
+
+  it('tunnels through HTTPS_PROXY when PROXY is not set', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.internal:8080';
+    const options = getAxiosProxyOptions('https://api.cohere.com/v2/rerank');
+    expect(options.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
+    expect(options.proxy).toBe(false);
+  });
+
+  it('prefers PROXY over HTTPS_PROXY', () => {
+    process.env.PROXY = 'http://primary.internal:8080';
+    process.env.HTTPS_PROXY = 'http://secondary.internal:3128';
+    const options = getAxiosProxyOptions('https://api.jina.ai/v1/rerank');
+    expect(options.httpsAgent?.proxy.href).toBe(
+      'http://primary.internal:8080/'
+    );
+  });
+
+  it('ignores an empty PROXY value', () => {
+    process.env.PROXY = '';
+    expect(getAxiosProxyOptions('https://api.tavily.com/search')).toEqual({});
+  });
+
+  it('honors NO_PROXY exclusions for standard variables', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.internal:8080';
+    process.env.NO_PROXY = 'firecrawl.internal';
+    expect(
+      getAxiosProxyOptions('https://firecrawl.internal/v1/scrape')
+    ).toEqual({});
+    expect(
+      getAxiosProxyOptions('https://api.tavily.com/search').httpsAgent
+    ).toBeInstanceOf(HttpsProxyAgent);
+  });
+});

--- a/src/tools/search/proxy.ts
+++ b/src/tools/search/proxy.ts
@@ -1,0 +1,34 @@
+import { getProxyForUrl } from 'proxy-from-env';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+export interface AxiosProxyOptions {
+  httpsAgent?: HttpsProxyAgent<string>;
+  proxy?: false;
+}
+
+/**
+ * Resolves proxy options for axios requests to HTTPS search/reranker endpoints.
+ *
+ * Axios' built-in proxy handling does not establish a CONNECT tunnel for HTTPS
+ * targets, so requests through corporate forward proxies fail (typically with
+ * a 502). Tunneling through `HttpsProxyAgent` with axios' own proxy handling
+ * disabled matches how the rest of the codebase performs proxied requests.
+ *
+ * Resolution order: the `PROXY` environment variable (codebase convention,
+ * applied unconditionally), then the standard `HTTPS_PROXY`/`HTTP_PROXY`/
+ * `NO_PROXY` variables via `proxy-from-env`. Non-HTTPS URLs are left to
+ * axios' default behavior, which handles plain HTTP proxying correctly.
+ */
+export const getAxiosProxyOptions = (url: string): AxiosProxyOptions => {
+  if (!url.startsWith('https:')) {
+    return {};
+  }
+  const proxyUrl =
+    process.env.PROXY != null && process.env.PROXY !== ''
+      ? process.env.PROXY
+      : getProxyForUrl(url);
+  if (proxyUrl === '') {
+    return {};
+  }
+  return { httpsAgent: new HttpsProxyAgent(proxyUrl), proxy: false };
+};

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -1,8 +1,10 @@
 import axios from 'axios';
 import type * as t from './types';
 import { createDefaultLogger, formatErrorForLog } from './utils';
+import { getAxiosProxyOptions } from './proxy';
 
 const DEFAULT_JINA_API_URL = 'https://api.jina.ai/v1/rerank';
+const COHERE_API_URL = 'https://api.cohere.com/v2/rerank';
 
 const getDefaultJinaApiUrl = (): string =>
   process.env.JINA_API_URL != null && process.env.JINA_API_URL !== ''
@@ -56,7 +58,9 @@ export class JinaReranker extends BaseReranker {
     documents: string[],
     topK: number = 5
   ): Promise<t.Highlight[]> {
-    this.logger.debug(`Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`);
+    this.logger.debug(
+      `Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`
+    );
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
@@ -80,6 +84,7 @@ export class JinaReranker extends BaseReranker {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
           },
+          ...getAxiosProxyOptions(this.apiUrl),
         }
       );
 
@@ -154,13 +159,14 @@ export class CohereReranker extends BaseReranker {
       };
 
       const response = await axios.post<t.CohereRerankerResponse | undefined>(
-        'https://api.cohere.com/v2/rerank',
+        COHERE_API_URL,
         requestData,
         {
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${this.apiKey}`,
           },
+          ...getAxiosProxyOptions(COHERE_API_URL),
         }
       );
 
@@ -227,7 +233,11 @@ export const createReranker = (config: {
 
   switch (rerankerType.toLowerCase()) {
   case 'jina':
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   case 'cohere':
     return new CohereReranker({
       apiKey: cohereApiKey,
@@ -242,7 +252,11 @@ export const createReranker = (config: {
     defaultLogger.warn(
       `Unknown reranker type: ${rerankerType}. Defaulting to InfinityReranker.`
     );
-    return new JinaReranker({ apiKey: jinaApiKey, apiUrl: jinaApiUrl, logger: defaultLogger });
+    return new JinaReranker({
+      apiKey: jinaApiKey,
+      apiUrl: jinaApiUrl,
+      logger: defaultLogger,
+    });
   }
 };
 

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -3,6 +3,7 @@ import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
 import { createTavilyAPI } from './tavily-search';
+import { getAxiosProxyOptions } from './proxy';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -186,6 +187,7 @@ const createSerperAPI = (
             'Content-Type': 'application/json',
           },
           timeout: config.timeout,
+          ...getAxiosProxyOptions(apiEndpoint),
         }
       );
 
@@ -284,6 +286,7 @@ const createSearXNGAPI = (
         headers,
         params,
         timeout: config.timeout,
+        ...getAxiosProxyOptions(searchUrl),
       });
 
       const data = response.data;

--- a/src/tools/search/serper-scraper.ts
+++ b/src/tools/search/serper-scraper.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type * as t from './types';
+import { getAxiosProxyOptions } from './proxy';
 import { createDefaultLogger } from './utils';
 
 /**
@@ -88,6 +89,7 @@ export class SerperScraper implements t.BaseScraper {
           'Content-Type': 'application/json',
         },
         timeout: options.timeout ?? this.timeout,
+        ...getAxiosProxyOptions(this.apiUrl),
       });
 
       return [url, { success: true, data: response.data }];

--- a/src/tools/search/tavily-scraper.ts
+++ b/src/tools/search/tavily-scraper.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type * as t from './types';
+import { getAxiosProxyOptions } from './proxy';
 import { createDefaultLogger } from './utils';
 
 const DEFAULT_BASIC_TIMEOUT = 15000;
@@ -140,6 +141,7 @@ export class TavilyScraper implements t.BaseScraper {
           'Content-Type': 'application/json',
         },
         timeout: effectiveTimeout,
+        ...getAxiosProxyOptions(this.apiUrl),
       });
 
       const data = response.data;

--- a/src/tools/search/tavily-search.ts
+++ b/src/tools/search/tavily-search.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type * as t from './types';
+import { getAxiosProxyOptions } from './proxy';
 
 const DEFAULT_TAVILY_TIMEOUT = 15000;
 
@@ -359,6 +360,7 @@ export const createTavilyAPI = (
             'Content-Type': 'application/json',
           },
           timeout: config.timeout,
+          ...getAxiosProxyOptions(config.apiUrl),
         }
       );
 


### PR DESCRIPTION
## Problem

The web search pipeline's HTTP calls (Tavily search/extract, Serper search/scrape, SearXNG, Firecrawl, Jina and Cohere rerankers) go through `axios` without any proxy handling. In corporate/enterprise deployments where outbound traffic must pass through a forward proxy, these calls bypass the proxy and fail with `502`:

```
error: Error in search: Tavily API request failed: Request failed with status code 502
```

Reported in danny-avila/LibreChat#13483. Notably, axios' built-in env-var proxy support doesn't help here because it does not establish a CONNECT tunnel for HTTPS targets — the standard workaround is `HttpsProxyAgent` with axios' own proxy handling disabled (`proxy: false`), which the reporter verified works in their environment.

## Solution

- New `getAxiosProxyOptions(url)` helper in `src/tools/search/proxy.ts`:
  - honors the `PROXY` variable first — same convention as the existing `HttpsProxyAgent` usage in `ToolSearch`, `CodeExecutor`, and `BashExecutor`
  - falls back to the standard `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` variables via `proxy-from-env`, so self-hosted endpoints (SearXNG, Firecrawl) can be excluded with `NO_PROXY` exactly like MCP connections already allow
  - only applies to `https:` URLs — plain-HTTP targets keep axios' default behavior, which handles HTTP proxying correctly
- Spread the resolved options into all eight axios call sites in `src/tools/search/`
- `https-proxy-agent` was already a dependency; `proxy-from-env` is added (it's tiny and already in the tree as an axios dependency)

## Testing

- `npx jest src/tools/search/` — 56 tests pass, including new coverage for: no-proxy default, `PROXY` precedence over `HTTPS_PROXY`, empty-string handling, `NO_PROXY` exclusions, and non-HTTPS passthrough
- `npx tsc --noEmit` and `npx eslint` clean, `npm run build` succeeds

Closes danny-avila/LibreChat#13483 (the affected code lives here).