### PR TITLE
feat: add fastCRW (crw) search + scrape provider

### DIFF
--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -3,6 +3,10 @@ import type * as t from './types';
 import { createDefaultLogger } from './utils';
 import { processContent } from './content';
 
+/** HTTP headroom over the payload render budget: fastCRW's queue/verification
+ * overhead is not counted against `timeout`, so the client must wait longer. */
+const CRW_TIMEOUT_BUFFER = 5000;
+
 /**
  * fastCRW scraper. Firecrawl-compatible web scraper; single binary;
  * self-host or cloud. Posts to {base}/v1/scrape.
@@ -61,6 +65,7 @@ export class CrwScraper implements t.BaseScraper {
     options: t.CrwScrapeOptions = {}
   ): Promise<[string, t.CrwScrapeResponse]> {
     try {
+      const payloadTimeout = options.timeout ?? this.timeout;
       const payload = omitUndefined({
         url,
         formats: options.formats ?? this.defaultFormats,
@@ -75,7 +80,7 @@ export class CrwScraper implements t.BaseScraper {
         proxy: options.proxy ?? this.proxy,
         stealth: options.stealth ?? this.stealth,
         jsonSchema: options.jsonSchema ?? this.jsonSchema,
-        timeout: options.timeout ?? this.timeout,
+        timeout: payloadTimeout,
       });
 
       const headers: Record<string, string> = {
@@ -90,7 +95,7 @@ export class CrwScraper implements t.BaseScraper {
         payload,
         {
           headers,
-          timeout: this.timeout,
+          timeout: payloadTimeout + CRW_TIMEOUT_BUFFER,
         }
       );
 
@@ -175,14 +180,9 @@ export const createCrwScraper = (config: t.CrwScraperConfig = {}): CrwScraper =>
   new CrwScraper(config);
 
 /**
- * fastCRW returns scrape fields at the TOP LEVEL ({success, markdown, ...}),
- * whereas this engine's scrapers expect them nested under `data`. Normalize so
- * extractContent/extractMetadata (Firecrawl-shaped) work unchanged.
- *
- * IMPORTANT: this ALWAYS wraps top-level fields — it never short-circuits on a
- * top-level `data` key. CRW scrape responses have no legitimate top-level `data`
- * (only Firecrawl nests under `data`); a `jsonSchema` extraction keyed `data`
- * must NOT bypass normalization.
+ * fastCRW cloud nests scrape fields under `data` ({success, data: {markdown,
+ * ...}}, live-verified 2026-07-02), matching Firecrawl. Prefer the nested
+ * container and fall back to top-level fields for self-host/legacy responses.
  */
 function normalizeCrwResponse(
   raw: t.CrwRawScrapeResponse | null | undefined
@@ -200,16 +200,17 @@ function normalizeCrwResponse(
       error_code: raw.error_code,
     };
   }
+  const data = raw.data ?? raw;
   return {
     success: true,
     data: {
-      markdown: raw.markdown,
-      html: raw.html,
-      rawHtml: raw.rawHtml,
-      plainText: raw.plainText,
-      screenshot: raw.screenshot,
-      links: raw.links,
-      metadata: raw.metadata,
+      markdown: data.markdown,
+      html: data.html,
+      rawHtml: data.rawHtml,
+      plainText: data.plainText,
+      screenshot: data.screenshot,
+      links: data.links,
+      metadata: data.metadata,
     },
   };
 }

--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -1,0 +1,217 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+import { processContent } from './content';
+
+/**
+ * fastCRW scraper. Firecrawl-compatible web scraper; single binary;
+ * self-host or cloud. Posts to {base}/v1/scrape.
+ */
+export class CrwScraper implements t.BaseScraper {
+  private apiKey: string;
+  private apiUrl: string;
+  private defaultFormats: string[];
+  private timeout: number;
+  private logger: t.Logger;
+  private onlyMainContent?: boolean;
+  private includeTags?: string[];
+  private excludeTags?: string[];
+  private waitFor?: number;
+  private headers?: Record<string, string>;
+  private renderJs?: boolean | null;
+  private cssSelector?: string;
+  private xpath?: string;
+  private proxy?: string;
+  private stealth?: boolean;
+  private jsonSchema?: object;
+
+  constructor(config: t.CrwScraperConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.CRW_API_KEY ?? '';
+
+    const baseUrl =
+      config.apiUrl ?? process.env.CRW_API_URL ?? 'https://fastcrw.com/api';
+    this.apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/scrape`;
+
+    this.defaultFormats = config.formats ?? ['markdown', 'rawHtml'];
+    this.timeout = config.timeout ?? 7500;
+    this.logger = config.logger || createDefaultLogger();
+
+    this.onlyMainContent = config.onlyMainContent;
+    this.includeTags = config.includeTags;
+    this.excludeTags = config.excludeTags;
+    this.waitFor = config.waitFor;
+    this.headers = config.headers;
+    this.renderJs = config.renderJs;
+    this.cssSelector = config.cssSelector;
+    this.xpath = config.xpath;
+    this.proxy = config.proxy;
+    this.stealth = config.stealth;
+    this.jsonSchema = config.jsonSchema;
+
+    // Self-host fastCRW may run without auth, so a missing key is only a
+    // warning — unlike Firecrawl/Tavily, scrapeUrl does NOT early-return on it.
+    if (!this.apiKey) {
+      this.logger.warn('CRW_API_KEY is not set. Scraping will not work.');
+    }
+    this.logger.debug(`CRW scraper initialized with API URL: ${this.apiUrl}`);
+  }
+
+  async scrapeUrl(
+    url: string,
+    options: t.CrwScrapeOptions = {}
+  ): Promise<[string, t.CrwScrapeResponse]> {
+    try {
+      const payload = omitUndefined({
+        url,
+        formats: options.formats ?? this.defaultFormats,
+        onlyMainContent: options.onlyMainContent ?? this.onlyMainContent,
+        includeTags: options.includeTags ?? this.includeTags,
+        excludeTags: options.excludeTags ?? this.excludeTags,
+        waitFor: options.waitFor ?? this.waitFor,
+        headers: options.headers ?? this.headers,
+        renderJs: options.renderJs ?? this.renderJs,
+        cssSelector: options.cssSelector ?? this.cssSelector,
+        xpath: options.xpath ?? this.xpath,
+        proxy: options.proxy ?? this.proxy,
+        stealth: options.stealth ?? this.stealth,
+        jsonSchema: options.jsonSchema ?? this.jsonSchema,
+        timeout: options.timeout ?? this.timeout,
+      });
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      const response = await axios.post(this.apiUrl, payload, {
+        headers,
+        timeout: this.timeout,
+      });
+
+      return [url, normalizeCrwResponse(response.data)];
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return [
+        url,
+        {
+          success: false,
+          error: `fastCRW API request failed: ${errorMessage}`,
+        },
+      ];
+    }
+  }
+
+  /**
+   * Extract content from scrape response. Mirrors FirecrawlScraper — reads
+   * response.data.*, which normalizeCrwResponse guarantees, preserving the
+   * processContent ref-markers used by the reranker. Parameter is typed as the
+   * NARROWER t.CrwScrapeResponse, exactly like TavilyScraper/FirecrawlScraper:
+   * TS class-method bivariance accepts this against BaseScraper's
+   * AnyScraperResponse, AND it lets us read response.data.plainText (a
+   * CrwScrapeResponse-only field) with no cast.
+   */
+  extractContent(
+    response: t.CrwScrapeResponse
+  ): [string, undefined | t.References] {
+    if (!response.success || !response.data) {
+      return ['', undefined];
+    }
+
+    if (response.data.markdown != null && response.data.html != null) {
+      try {
+        const { markdown, ...rest } = processContent(
+          response.data.html,
+          response.data.markdown
+        );
+        return [markdown, rest];
+      } catch (error) {
+        this.logger.error('Error processing content:', error);
+        return [response.data.markdown, undefined];
+      }
+    } else if (response.data.markdown != null) {
+      return [response.data.markdown, undefined];
+    }
+
+    // Fall back to HTML content
+    if (response.data.html != null) {
+      return [response.data.html, undefined];
+    }
+
+    // Fall back to raw HTML content
+    if (response.data.rawHtml != null) {
+      return [response.data.rawHtml, undefined];
+    }
+
+    // CRW-only fallback (no Firecrawl equivalent): plain-text body.
+    if (response.data.plainText != null) {
+      return [response.data.plainText, undefined];
+    }
+
+    return ['', undefined];
+  }
+
+  extractMetadata(response: t.CrwScrapeResponse): t.ScrapeMetadata {
+    if (!response.success || !response.data || !response.data.metadata) {
+      return {};
+    }
+
+    return response.data.metadata;
+  }
+}
+
+/**
+ * Create a fastCRW scraper instance
+ * @param config Scraper configuration
+ * @returns fastCRW scraper instance
+ */
+export const createCrwScraper = (
+  config: t.CrwScraperConfig = {}
+): CrwScraper => new CrwScraper(config);
+
+/**
+ * fastCRW returns scrape fields at the TOP LEVEL ({success, markdown, ...}),
+ * whereas this engine's scrapers expect them nested under `data`. Normalize so
+ * extractContent/extractMetadata (Firecrawl-shaped) work unchanged.
+ *
+ * IMPORTANT: this ALWAYS wraps top-level fields — it never short-circuits on a
+ * top-level `data` key. CRW scrape responses have no legitimate top-level `data`
+ * (only Firecrawl nests under `data`); a `jsonSchema` extraction keyed `data`
+ * must NOT bypass normalization.
+ */
+function normalizeCrwResponse(raw: any): t.CrwScrapeResponse {
+  if (raw == null) {
+    return { success: false, error: 'Empty fastCRW response' };
+  }
+  if (raw.success === false) {
+    return {
+      success: false,
+      error:
+        raw.error_code != null
+          ? `[${raw.error_code}] ${raw.error ?? 'Unknown error'}`
+          : (raw.error ?? 'fastCRW scrape failed'),
+      error_code: raw.error_code,
+    };
+  }
+  return {
+    success: true,
+    data: {
+      markdown: raw.markdown,
+      html: raw.html,
+      rawHtml: raw.rawHtml,
+      plainText: raw.plainText,
+      screenshot: raw.screenshot,
+      links: raw.links,
+      metadata: raw.metadata,
+    },
+  };
+}
+
+// Helper function to clean up payload for fastCRW
+function omitUndefined<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>;
+}

--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -35,7 +35,7 @@ export class CrwScraper implements t.BaseScraper {
       config.apiUrl ?? process.env.CRW_API_URL ?? 'https://api.fastcrw.com';
     this.apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/scrape`;
 
-    this.defaultFormats = config.formats ?? ['markdown', 'rawHtml'];
+    this.defaultFormats = config.formats ?? ['markdown', 'html'];
     this.timeout = config.timeout ?? 7500;
     this.logger = config.logger || createDefaultLogger();
 
@@ -77,7 +77,10 @@ export class CrwScraper implements t.BaseScraper {
         xpath: options.xpath ?? this.xpath,
         proxy: options.proxy ?? this.proxy,
         stealth: options.stealth ?? this.stealth,
+        // Cloud honors `timeout` (live-verified); the published OpenAPI
+        // documents `deadlineMs` (1..60000) instead. Send both.
         timeout: payloadTimeout,
+        deadlineMs: Math.max(1, Math.min(payloadTimeout, 60000)),
       });
 
       const headers: Record<string, string> = {
@@ -126,10 +129,11 @@ export class CrwScraper implements t.BaseScraper {
       return ['', undefined];
     }
 
-    if (response.data.markdown != null && response.data.html != null) {
+    const htmlSource = response.data.html ?? response.data.rawHtml;
+    if (response.data.markdown != null && htmlSource != null) {
       try {
         const { markdown, ...rest } = processContent(
-          response.data.html,
+          htmlSource,
           response.data.markdown
         );
         return [markdown, rest];

--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -27,13 +27,12 @@ export class CrwScraper implements t.BaseScraper {
   private xpath?: string;
   private proxy?: string;
   private stealth?: boolean;
-  private jsonSchema?: object;
 
   constructor(config: t.CrwScraperConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.CRW_API_KEY ?? '';
 
     const baseUrl =
-      config.apiUrl ?? process.env.CRW_API_URL ?? 'https://fastcrw.com/api';
+      config.apiUrl ?? process.env.CRW_API_URL ?? 'https://api.fastcrw.com';
     this.apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/scrape`;
 
     this.defaultFormats = config.formats ?? ['markdown', 'rawHtml'];
@@ -50,7 +49,6 @@ export class CrwScraper implements t.BaseScraper {
     this.xpath = config.xpath;
     this.proxy = config.proxy;
     this.stealth = config.stealth;
-    this.jsonSchema = config.jsonSchema;
 
     // Self-host fastCRW may run without auth, so a missing key is only a
     // warning — unlike Firecrawl/Tavily, scrapeUrl does NOT early-return on it.
@@ -79,7 +77,6 @@ export class CrwScraper implements t.BaseScraper {
         xpath: options.xpath ?? this.xpath,
         proxy: options.proxy ?? this.proxy,
         stealth: options.stealth ?? this.stealth,
-        jsonSchema: options.jsonSchema ?? this.jsonSchema,
         timeout: payloadTimeout,
       });
 

--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -205,15 +205,35 @@ function normalizeCrwResponse(
   return {
     success: true,
     data: {
-      markdown: data.markdown,
-      html: data.html,
-      rawHtml: data.rawHtml,
-      plainText: data.plainText,
+      // Strip inline base64 image payloads from text content (not `screenshot`,
+      // which is base64 by design and never reaches the content processor).
+      markdown: stripBase64DataUris(data.markdown),
+      html: stripBase64DataUris(data.html),
+      rawHtml: stripBase64DataUris(data.rawHtml),
+      plainText: stripBase64DataUris(data.plainText),
       screenshot: data.screenshot,
       links: data.links,
       metadata: data.metadata,
     },
   };
+}
+
+/**
+ * Replace inline base64 data-URI payloads (typically images) in scraped text
+ * with a short placeholder. Such payloads can be hundreds of KB; the content
+ * processor builds a per-link RegExp from each URL, and one that large overflows
+ * the engine's pattern-size limit ("Invalid regular expression"). Firecrawl
+ * drops them via removeBase64Images — mirror that so image-heavy pages stay
+ * processable (and don't bloat the LLM context with base64 noise).
+ */
+function stripBase64DataUris(text: string | undefined): string | undefined {
+  if (text == null) {
+    return text;
+  }
+  return text.replace(
+    /data:[\w.+-]+\/[\w.+-]+;base64,[A-Za-z0-9+/=]+/g,
+    'data:base64-content-removed'
+  );
 }
 
 // Helper function to clean up payload for fastCRW

--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -1,0 +1,222 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+import { processContent } from './content';
+
+/**
+ * fastCRW scraper. Firecrawl-compatible web scraper; single binary;
+ * self-host or cloud. Posts to {base}/v1/scrape.
+ */
+export class CrwScraper implements t.BaseScraper {
+  private apiKey: string;
+  private apiUrl: string;
+  private defaultFormats: string[];
+  private timeout: number;
+  private logger: t.Logger;
+  private onlyMainContent?: boolean;
+  private includeTags?: string[];
+  private excludeTags?: string[];
+  private waitFor?: number;
+  private headers?: Record<string, string>;
+  private renderJs?: boolean | null;
+  private cssSelector?: string;
+  private xpath?: string;
+  private proxy?: string;
+  private stealth?: boolean;
+  private jsonSchema?: object;
+
+  constructor(config: t.CrwScraperConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.CRW_API_KEY ?? '';
+
+    const baseUrl =
+      config.apiUrl ?? process.env.CRW_API_URL ?? 'https://fastcrw.com/api';
+    this.apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/scrape`;
+
+    this.defaultFormats = config.formats ?? ['markdown', 'rawHtml'];
+    this.timeout = config.timeout ?? 7500;
+    this.logger = config.logger || createDefaultLogger();
+
+    this.onlyMainContent = config.onlyMainContent;
+    this.includeTags = config.includeTags;
+    this.excludeTags = config.excludeTags;
+    this.waitFor = config.waitFor;
+    this.headers = config.headers;
+    this.renderJs = config.renderJs;
+    this.cssSelector = config.cssSelector;
+    this.xpath = config.xpath;
+    this.proxy = config.proxy;
+    this.stealth = config.stealth;
+    this.jsonSchema = config.jsonSchema;
+
+    // Self-host fastCRW may run without auth, so a missing key is only a
+    // warning — unlike Firecrawl/Tavily, scrapeUrl does NOT early-return on it.
+    if (!this.apiKey) {
+      this.logger.warn('CRW_API_KEY is not set. Scraping will not work.');
+    }
+    this.logger.debug(`CRW scraper initialized with API URL: ${this.apiUrl}`);
+  }
+
+  async scrapeUrl(
+    url: string,
+    options: t.CrwScrapeOptions = {}
+  ): Promise<[string, t.CrwScrapeResponse]> {
+    try {
+      const payload = omitUndefined({
+        url,
+        formats: options.formats ?? this.defaultFormats,
+        onlyMainContent: options.onlyMainContent ?? this.onlyMainContent,
+        includeTags: options.includeTags ?? this.includeTags,
+        excludeTags: options.excludeTags ?? this.excludeTags,
+        waitFor: options.waitFor ?? this.waitFor,
+        headers: options.headers ?? this.headers,
+        renderJs: options.renderJs ?? this.renderJs,
+        cssSelector: options.cssSelector ?? this.cssSelector,
+        xpath: options.xpath ?? this.xpath,
+        proxy: options.proxy ?? this.proxy,
+        stealth: options.stealth ?? this.stealth,
+        jsonSchema: options.jsonSchema ?? this.jsonSchema,
+        timeout: options.timeout ?? this.timeout,
+      });
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.apiKey) {
+        headers.Authorization = `Bearer ${this.apiKey}`;
+      }
+
+      const response = await axios.post<t.CrwRawScrapeResponse>(
+        this.apiUrl,
+        payload,
+        {
+          headers,
+          timeout: this.timeout,
+        }
+      );
+
+      return [url, normalizeCrwResponse(response.data)];
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return [
+        url,
+        {
+          success: false,
+          error: `fastCRW API request failed: ${errorMessage}`,
+        },
+      ];
+    }
+  }
+
+  /**
+   * Extract content from scrape response. Mirrors FirecrawlScraper — reads
+   * response.data.*, which normalizeCrwResponse guarantees, preserving the
+   * processContent ref-markers used by the reranker. Parameter is typed as the
+   * NARROWER t.CrwScrapeResponse, exactly like TavilyScraper/FirecrawlScraper:
+   * TS class-method bivariance accepts this against BaseScraper's
+   * AnyScraperResponse, AND it lets us read response.data.plainText (a
+   * CrwScrapeResponse-only field) with no cast.
+   */
+  extractContent(
+    response: t.CrwScrapeResponse
+  ): [string, undefined | t.References] {
+    if (!response.success || !response.data) {
+      return ['', undefined];
+    }
+
+    if (response.data.markdown != null && response.data.html != null) {
+      try {
+        const { markdown, ...rest } = processContent(
+          response.data.html,
+          response.data.markdown
+        );
+        return [markdown, rest];
+      } catch (error) {
+        this.logger.error('Error processing content:', error);
+        return [response.data.markdown, undefined];
+      }
+    } else if (response.data.markdown != null) {
+      return [response.data.markdown, undefined];
+    }
+
+    // Fall back to HTML content
+    if (response.data.html != null) {
+      return [response.data.html, undefined];
+    }
+
+    // Fall back to raw HTML content
+    if (response.data.rawHtml != null) {
+      return [response.data.rawHtml, undefined];
+    }
+
+    // CRW-only fallback (no Firecrawl equivalent): plain-text body.
+    if (response.data.plainText != null) {
+      return [response.data.plainText, undefined];
+    }
+
+    return ['', undefined];
+  }
+
+  extractMetadata(response: t.CrwScrapeResponse): t.ScrapeMetadata {
+    if (!response.success || !response.data || !response.data.metadata) {
+      return {};
+    }
+
+    return response.data.metadata;
+  }
+}
+
+/**
+ * Create a fastCRW scraper instance
+ * @param config Scraper configuration
+ * @returns fastCRW scraper instance
+ */
+export const createCrwScraper = (config: t.CrwScraperConfig = {}): CrwScraper =>
+  new CrwScraper(config);
+
+/**
+ * fastCRW returns scrape fields at the TOP LEVEL ({success, markdown, ...}),
+ * whereas this engine's scrapers expect them nested under `data`. Normalize so
+ * extractContent/extractMetadata (Firecrawl-shaped) work unchanged.
+ *
+ * IMPORTANT: this ALWAYS wraps top-level fields — it never short-circuits on a
+ * top-level `data` key. CRW scrape responses have no legitimate top-level `data`
+ * (only Firecrawl nests under `data`); a `jsonSchema` extraction keyed `data`
+ * must NOT bypass normalization.
+ */
+function normalizeCrwResponse(
+  raw: t.CrwRawScrapeResponse | null | undefined
+): t.CrwScrapeResponse {
+  if (raw == null) {
+    return { success: false, error: 'Empty fastCRW response' };
+  }
+  if (raw.success === false) {
+    return {
+      success: false,
+      error:
+        raw.error_code != null
+          ? `[${raw.error_code}] ${raw.error ?? 'Unknown error'}`
+          : (raw.error ?? 'fastCRW scrape failed'),
+      error_code: raw.error_code,
+    };
+  }
+  return {
+    success: true,
+    data: {
+      markdown: raw.markdown,
+      html: raw.html,
+      rawHtml: raw.rawHtml,
+      plainText: raw.plainText,
+      screenshot: raw.screenshot,
+      links: raw.links,
+      metadata: raw.metadata,
+    },
+  };
+}
+
+// Helper function to clean up payload for fastCRW
+function omitUndefined<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>;
+}

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -11,6 +11,22 @@ const getHostname = (link: string): string => {
   }
 };
 
+/** The published OpenAPI (docs.fastcrw.com) documents `data` as a flat
+ * SearchResult[] with a `category` field; route rows into source groups. */
+const splitByCategory = (rows: t.CrwSearchResult[]): t.CrwSearchGroups => {
+  const groups: Required<t.CrwSearchGroups> = { web: [], images: [], news: [] };
+  for (const row of rows) {
+    if (row.category === 'news') {
+      groups.news.push(row);
+    } else if (row.category === 'images') {
+      groups.images.push({ ...row, imageUrl: row.url });
+    } else {
+      groups.web.push(row);
+    }
+  }
+  return groups;
+};
+
 export const createCrwAPI = (
   apiKey?: string,
   apiUrl?: string,
@@ -88,13 +104,16 @@ export const createCrwAPI = (
         };
       }
 
-      // fastCRW keys results by source: {data: {web: [...], images: [...],
-      // news: [...]}} (cloud, live-verified 2026-07-02); tolerate a
-      // {data: {results: {...groups}}} wrapper for self-host variants.
+      // fastCRW cloud keys results by source: {data: {web: [...], images:
+      // [...], news: [...]}} (live-verified 2026-07-02); the published
+      // OpenAPI documents a flat SearchResult[] instead (self-host), and a
+      // {data: {results: {...groups}}} wrapper also exists. Accept all three.
       // OrganicResult.link is a REQUIRED string (types.ts), so defend against
       // null/empty urls to never feed a broken '' link into the scraper.
       const container = body.data ?? {};
-      const data = container.results ?? container;
+      const data: t.CrwSearchGroups = Array.isArray(container)
+        ? splitByCategory(container)
+        : (container.results ?? container);
       const organicResults: t.OrganicResult[] = (data.web ?? [])
         .filter((r) => r.url != null && r.url !== '')
         .map((r) => ({

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -25,7 +25,7 @@ export const createCrwAPI = (
   const base = (
     apiUrl ??
     process.env.CRW_API_URL ??
-    'https://fastcrw.com/api'
+    'https://api.fastcrw.com'
   ).replace(/\/+$/, '');
   const config = {
     apiKey: apiKey ?? process.env.CRW_API_KEY,
@@ -35,6 +35,7 @@ export const createCrwAPI = (
 
   const getSources = async ({
     query,
+    date,
     numResults = 8,
     type,
   }: t.GetSourcesParams): Promise<t.SearchResult> => {
@@ -59,6 +60,10 @@ export const createCrwAPI = (
       }
 
       const payload: t.CrwSearchPayload = { query, limit, sources };
+      if (date != null) {
+        // Serper-style qdr filter; live-verified to constrain results.
+        payload.tbs = `qdr:${date}`;
+      }
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -1,0 +1,118 @@
+import axios from 'axios';
+import type * as t from './types';
+
+const DEFAULT_CRW_TIMEOUT = 15000;
+
+const getHostname = (link: string): string => {
+  try {
+    return new URL(link).hostname;
+  } catch {
+    return link;
+  }
+};
+
+export const createCrwAPI = (
+  apiKey?: string,
+  apiUrl?: string,
+  options?: t.CrwSearchOptions
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  // NOTE: fastCRW /v1/search is cloud-only, but we still allow a base-URL
+  // override for parity with the scraper. Self-host may have no auth, so —
+  // unlike Tavily (createTavilyAPI throws on missing key) — we do NOT throw
+  // here; we only attach the Authorization header when a key is present.
+  const base = (apiUrl ?? process.env.CRW_API_URL ?? 'https://fastcrw.com/api')
+    .replace(/\/+$/, '');
+  const config = {
+    apiKey: apiKey ?? process.env.CRW_API_KEY,
+    apiUrl: `${base}/v1/search`,
+    timeout: options?.timeout ?? DEFAULT_CRW_TIMEOUT,
+  };
+
+  const getSources = async ({
+    query,
+    numResults = 8,
+    type,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    try {
+      const limit = Math.min(Math.max(1, options?.maxResults ?? numResults), 20);
+      const sources: Array<'web' | 'images'> =
+        type === 'images' || options?.includeImages === true
+          ? ['web', 'images']
+          : ['web'];
+
+      const payload: t.CrwSearchPayload = { query, limit, sources };
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (config.apiKey != null && config.apiKey !== '') {
+        headers.Authorization = `Bearer ${config.apiKey}`;
+      }
+
+      const response = await axios.post<t.CrwSearchResponse>(
+        config.apiUrl,
+        payload,
+        { headers, timeout: config.timeout }
+      );
+
+      const body = response.data;
+      if (body.success === false) {
+        return {
+          success: false,
+          error: `fastCRW search failed: ${
+            body.error_code != null ? `[${body.error_code}] ` : ''
+          }${body.error ?? 'Unknown error'}`,
+        };
+      }
+
+      // OrganicResult.link is a REQUIRED string (types.ts). fastCRW marks
+      // result.url as present, but defend against null/empty so we never feed a
+      // broken '' link into the scraper.
+      const organicResults: t.OrganicResult[] = (body.data ?? [])
+        .filter((r) => r.url != null && r.url !== '')
+        .map((r) => ({
+          title: r.title ?? '',
+          link: r.url as string,
+          snippet: r.description ?? '',
+        }));
+
+      // fastCRW /v1/search exposes no native news/video verticals.
+      // Mirror Tavily by deriving `news` from organic when news is requested.
+      const newsResults: t.NewsResult[] =
+        type === 'news'
+          ? organicResults.map((r) => ({
+            title: r.title,
+            link: r.link,
+            snippet: r.snippet,
+            source: getHostname(r.link),
+          }))
+          : [];
+
+      const results: t.SearchResultData = {
+        organic: organicResults,
+        images: [],
+        topStories: [],
+        videos: [],
+        news: newsResults,
+        relatedSearches: [],
+      };
+
+      return { success: true, data: results };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `fastCRW search request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -22,8 +22,11 @@ export const createCrwAPI = (
   // override for parity with the scraper. Self-host may have no auth, so —
   // unlike Tavily (createTavilyAPI throws on missing key) — we do NOT throw
   // here; we only attach the Authorization header when a key is present.
-  const base = (apiUrl ?? process.env.CRW_API_URL ?? 'https://fastcrw.com/api')
-    .replace(/\/+$/, '');
+  const base = (
+    apiUrl ??
+    process.env.CRW_API_URL ??
+    'https://fastcrw.com/api'
+  ).replace(/\/+$/, '');
   const config = {
     apiKey: apiKey ?? process.env.CRW_API_KEY,
     apiUrl: `${base}/v1/search`,
@@ -40,11 +43,20 @@ export const createCrwAPI = (
     }
 
     try {
-      const limit = Math.min(Math.max(1, options?.maxResults ?? numResults), 20);
-      const sources: Array<'web' | 'images'> =
-        type === 'images' || options?.includeImages === true
-          ? ['web', 'images']
-          : ['web'];
+      const limit = Math.min(
+        Math.max(1, options?.maxResults ?? numResults),
+        20
+      );
+      // Mirror Serper's verticals: image/news requests hit only their native
+      // fastCRW source; plain web optionally adds images via includeImages.
+      let sources: t.CrwSearchSource[];
+      if (type === 'images') {
+        sources = ['images'];
+      } else if (type === 'news') {
+        sources = ['news'];
+      } else {
+        sources = options?.includeImages === true ? ['web', 'images'] : ['web'];
+      }
 
       const payload: t.CrwSearchPayload = { query, limit, sources };
 
@@ -71,32 +83,43 @@ export const createCrwAPI = (
         };
       }
 
-      // OrganicResult.link is a REQUIRED string (types.ts). fastCRW marks
-      // result.url as present, but defend against null/empty so we never feed a
-      // broken '' link into the scraper.
-      const organicResults: t.OrganicResult[] = (body.data ?? [])
+      // fastCRW keys results by source: {data: {web: [...], images: [...],
+      // news: [...]}} (live-verified 2026-07-02). OrganicResult.link is a
+      // REQUIRED string (types.ts), so defend against null/empty urls to never
+      // feed a broken '' link into the scraper.
+      const data = body.data ?? {};
+      const organicResults: t.OrganicResult[] = (data.web ?? [])
         .filter((r) => r.url != null && r.url !== '')
         .map((r) => ({
           title: r.title ?? '',
           link: r.url as string,
-          snippet: r.description ?? '',
+          snippet: r.description ?? r.snippet ?? '',
+          position: r.position,
         }));
 
-      // fastCRW /v1/search exposes no native news/video verticals.
-      // Mirror Tavily by deriving `news` from organic when news is requested.
-      const newsResults: t.NewsResult[] =
-        type === 'news'
-          ? organicResults.map((r) => ({
-            title: r.title,
-            link: r.link,
-            snippet: r.snippet,
-            source: getHostname(r.link),
-          }))
-          : [];
+      const imageResults: t.ImageResult[] = (data.images ?? [])
+        .filter((r) => r.imageUrl != null && r.imageUrl !== '')
+        .map((r) => ({
+          title: r.title,
+          imageUrl: r.imageUrl,
+          link: r.url,
+          position: r.position,
+        }));
+
+      const newsResults: t.NewsResult[] = (data.news ?? [])
+        .filter((r) => r.url != null && r.url !== '')
+        .map((r) => ({
+          title: r.title ?? '',
+          link: r.url as string,
+          snippet: r.description ?? r.snippet ?? '',
+          date: r.publishedDate,
+          source: getHostname(r.url as string),
+          position: r.position,
+        }));
 
       const results: t.SearchResultData = {
         organic: organicResults,
-        images: [],
+        images: imageResults,
         topStories: [],
         videos: [],
         news: newsResults,

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -89,10 +89,12 @@ export const createCrwAPI = (
       }
 
       // fastCRW keys results by source: {data: {web: [...], images: [...],
-      // news: [...]}} (live-verified 2026-07-02). OrganicResult.link is a
-      // REQUIRED string (types.ts), so defend against null/empty urls to never
-      // feed a broken '' link into the scraper.
-      const data = body.data ?? {};
+      // news: [...]}} (cloud, live-verified 2026-07-02); tolerate a
+      // {data: {results: {...groups}}} wrapper for self-host variants.
+      // OrganicResult.link is a REQUIRED string (types.ts), so defend against
+      // null/empty urls to never feed a broken '' link into the scraper.
+      const container = body.data ?? {};
+      const data = container.results ?? container;
       const organicResults: t.OrganicResult[] = (data.web ?? [])
         .filter((r) => r.url != null && r.url !== '')
         .map((r) => ({

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -3,6 +3,7 @@ import type * as t from './types';
 import { CrwScraper, createCrwScraper } from './crw-scraper';
 import { createSearchAPI } from './search';
 import { createSearchTool } from './tool';
+import { DATE_RANGE } from './schema';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -106,7 +107,7 @@ describe('CRW search API', () => {
     const result = await searchAPI.getSources({ query: 'example query' });
 
     const [url, payload, config] = mockedAxios.post.mock.calls[0];
-    expect(url).toBe('https://fastcrw.com/api/v1/search');
+    expect(url).toBe('https://api.fastcrw.com/v1/search');
     expect(payload).toEqual({
       query: 'example query',
       limit: 8,
@@ -221,6 +222,41 @@ describe('CRW search API', () => {
         position: 1,
       },
     ]);
+  });
+
+  it('maps the date parameter to a qdr tbs filter', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { web: [] } },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({
+      query: 'example query',
+      date: DATE_RANGE.PAST_24_HOURS,
+    });
+
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect((payload as t.CrwSearchPayload).tbs).toBe('qdr:d');
+  });
+
+  it('omits tbs when no date is given', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { web: [] } },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'example query' });
+
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect(payload as Record<string, unknown>).not.toHaveProperty('tbs');
   });
 
   it('surfaces an envelope failure with the error code', async () => {
@@ -338,7 +374,7 @@ describe('CrwScraper', () => {
       const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
       await scraper.scrapeUrl('https://example.com');
       const [url] = mockedAxios.post.mock.calls[0];
-      expect(url).toBe('https://fastcrw.com/api/v1/scrape');
+      expect(url).toBe('https://api.fastcrw.com/v1/scrape');
     });
 
     it('honors the CRW_API_URL env override', async () => {
@@ -671,7 +707,7 @@ describe('CRW search tool wiring', () => {
 
     const [searchUrl] = mockedAxios.post.mock.calls[0];
     const [scrapeUrl] = mockedAxios.post.mock.calls[1];
-    expect(searchUrl).toBe('https://fastcrw.com/api/v1/search');
+    expect(searchUrl).toBe('https://api.fastcrw.com/v1/search');
     expect(scrapeUrl).toBe('http://localhost:3000/v1/scrape');
   });
 });

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -224,6 +224,44 @@ describe('CRW search API', () => {
     ]);
   });
 
+  it('routes a flat data array by category (documented OpenAPI shape)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [
+          {
+            title: 'W',
+            url: 'https://e.com/w',
+            snippet: 'S',
+            category: 'general',
+          },
+          {
+            title: 'N',
+            url: 'https://e.com/n',
+            snippet: 'S',
+            category: 'news',
+          },
+          { title: 'I', url: 'https://e.com/i.png', category: 'images' },
+          { title: 'U', url: 'https://e.com/u', snippet: 'S' },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.data?.organic?.map((r) => r.link)).toEqual([
+      'https://e.com/w',
+      'https://e.com/u',
+    ]);
+    expect(result.data?.news?.[0].link).toBe('https://e.com/n');
+    expect(result.data?.images?.[0].imageUrl).toBe('https://e.com/i.png');
+  });
+
   it('unwraps a data.results wrapper (self-host shape)', async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {
@@ -418,7 +456,36 @@ describe('CrwScraper', () => {
       await scraper.scrapeUrl('https://example.com');
       const [, payload, config] = mockedAxios.post.mock.calls[0];
       expect((payload as { timeout: number }).timeout).toBe(7500);
+      expect((payload as { deadlineMs: number }).deadlineMs).toBe(7500);
       expect((config as { timeout: number }).timeout).toBe(12500);
+    });
+
+    it('clamps deadlineMs to the documented 60000 max', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, markdown: '# Hi' },
+      });
+      const scraper = createCrwScraper({
+        apiKey: 'k',
+        timeout: 90000,
+        logger: mockLogger,
+      });
+      await scraper.scrapeUrl('https://example.com');
+      const [, payload] = mockedAxios.post.mock.calls[0];
+      expect((payload as { timeout: number }).timeout).toBe(90000);
+      expect((payload as { deadlineMs: number }).deadlineMs).toBe(60000);
+    });
+
+    it('requests markdown + html by default', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, markdown: '# Hi' },
+      });
+      const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+      await scraper.scrapeUrl('https://example.com');
+      const [, payload] = mockedAxios.post.mock.calls[0];
+      expect((payload as { formats: string[] }).formats).toEqual([
+        'markdown',
+        'html',
+      ]);
     });
   });
 
@@ -527,6 +594,15 @@ describe('CrwScraper', () => {
       expect(references).toHaveProperty('links');
       expect(references).toHaveProperty('images');
       expect(references).toHaveProperty('videos');
+    });
+
+    it('runs the ref-marker pass from rawHtml when html is absent', () => {
+      const [content, references] = scraper.extractContent({
+        success: true,
+        data: { markdown: '# Hi', rawHtml: '<p>x</p>' },
+      });
+      expect(typeof content).toBe('string');
+      expect(references).toHaveProperty('links');
     });
 
     it('returns empty on a failed response', () => {

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -224,6 +224,28 @@ describe('CRW search API', () => {
     ]);
   });
 
+  it('unwraps a data.results wrapper (self-host shape)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          results: {
+            web: [{ title: 'T', url: 'https://e.com', description: 'D' }],
+          },
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.data?.organic?.[0].link).toBe('https://e.com');
+  });
+
   it('maps the date parameter to a qdr tbs filter', async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: { success: true, data: { web: [] } },

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -582,6 +582,31 @@ describe('CrwScraper', () => {
     ]);
   });
 
+  it('strips inline base64 image data-URIs from text content but keeps the screenshot', async () => {
+    const bigB64 = 'A'.repeat(5000);
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          markdown: `![logo](data:image/png;base64,${bigB64}) text`,
+          html: `<img src="data:image/jpeg;base64,${bigB64}"><p>x</p>`,
+          screenshot: `data:image/png;base64,${bigB64}`,
+        },
+      },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const [, res] = await scraper.scrapeUrl('https://example.com');
+    expect(res.data?.markdown).toBe(
+      '![logo](data:base64-content-removed) text'
+    );
+    expect(res.data?.html).toBe(
+      '<img src="data:base64-content-removed"><p>x</p>'
+    );
+    // `screenshot` is base64 by design and never reaches the content processor.
+    expect(res.data?.screenshot).toBe(`data:image/png;base64,${bigB64}`);
+    expect(res.data?.markdown).not.toContain(bigB64);
+  });
+
   describe('extractContent', () => {
     const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
 

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -1,0 +1,549 @@
+import axios from 'axios';
+import type * as t from './types';
+import { CrwScraper, createCrwScraper } from './crw-scraper';
+import { createSearchAPI } from './search';
+import { createSearchTool } from './tool';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+} as unknown as t.Logger;
+
+describe('CRW search API', () => {
+  const originalKey = process.env.CRW_API_KEY;
+  const originalUrl = process.env.CRW_API_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CRW_API_KEY;
+    delete process.env.CRW_API_URL;
+  });
+
+  afterAll(() => {
+    if (originalKey === undefined) {
+      delete process.env.CRW_API_KEY;
+    } else {
+      process.env.CRW_API_KEY = originalKey;
+    }
+    if (originalUrl === undefined) {
+      delete process.env.CRW_API_URL;
+    } else {
+      process.env.CRW_API_URL = originalUrl;
+    }
+  });
+
+  it('does not throw when the CRW API key is missing', () => {
+    expect(() =>
+      createSearchAPI({
+        searchProvider: 'crw',
+        crwApiKey: '',
+      })
+    ).not.toThrow();
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: '',
+    });
+    expect(typeof searchAPI.getSources).toBe('function');
+  });
+
+  it('throws for an invalid search provider with an updated message', () => {
+    expect(() =>
+      createSearchAPI({ searchProvider: 'bogus' as t.SearchProvider })
+    ).toThrow(/'crw'/);
+  });
+
+  it('returns an error for empty CRW search queries', async () => {
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Query cannot be empty',
+    });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the CRW search request fails', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('fastCRW search request failed: Network error');
+  });
+
+  it('maps the CRW search response fields', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [{ title: 'T', url: 'https://e.com', description: 'D' }],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    const [url, payload, config] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('https://fastcrw.com/api/v1/search');
+    expect(payload).toEqual({
+      query: 'example query',
+      limit: 8,
+      sources: ['web'],
+    });
+    expect(
+      (config as { headers: Record<string, string> }).headers.Authorization
+    ).toBe('Bearer test-key');
+    expect(result.success).toBe(true);
+    expect(result.data?.organic?.[0]).toEqual({
+      title: 'T',
+      link: 'https://e.com',
+      snippet: 'D',
+    });
+  });
+
+  it('adds images to the sources array when images are requested', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'example query', type: 'images' });
+
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect((payload as t.CrwSearchPayload).sources).toEqual(['web', 'images']);
+  });
+
+  it('surfaces an envelope failure with the error code', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: false,
+        error: 'rate limited',
+        error_code: 'RATE_LIMIT',
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'fastCRW search failed: [RATE_LIMIT] rate limited',
+    });
+  });
+
+  it('honors the base-URL override for search', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+      crwApiUrl: 'http://localhost:3000',
+    });
+
+    await searchAPI.getSources({ query: 'example query' });
+
+    const [url] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/search');
+  });
+
+  it('omits the Authorization header when keyless', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: '',
+      crwApiUrl: 'http://localhost:3000',
+    });
+
+    await searchAPI.getSources({ query: 'example query' });
+
+    const [, , config] = mockedAxios.post.mock.calls[0];
+    expect(
+      (config as { headers: Record<string, string> }).headers.Authorization
+    ).toBeUndefined();
+  });
+
+  it('drops results with an empty url', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [
+          { title: 'A', url: '', description: 'x' },
+          { title: 'B', url: 'https://ok.com', description: 'y' },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.data?.organic).toHaveLength(1);
+    expect(result.data?.organic?.[0].link).toBe('https://ok.com');
+  });
+});
+
+describe('CrwScraper', () => {
+  const originalUrl = process.env.CRW_API_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.CRW_API_URL;
+  });
+
+  afterAll(() => {
+    if (originalUrl === undefined) {
+      delete process.env.CRW_API_URL;
+    } else {
+      process.env.CRW_API_URL = originalUrl;
+    }
+  });
+
+  describe('constructor', () => {
+    it('warns when CRW_API_KEY is not set', () => {
+      const logger = { ...mockLogger, warn: jest.fn() } as unknown as t.Logger;
+      new CrwScraper({ apiKey: '', logger });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'CRW_API_KEY is not set. Scraping will not work.'
+      );
+    });
+
+    it('uses the default base URL', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, markdown: '# Hi' },
+      });
+      const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+      await scraper.scrapeUrl('https://example.com');
+      const [url] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe('https://fastcrw.com/api/v1/scrape');
+    });
+
+    it('honors the CRW_API_URL env override', async () => {
+      process.env.CRW_API_URL = 'http://localhost:3000';
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, markdown: '# Hi' },
+      });
+      const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+      await scraper.scrapeUrl('https://example.com');
+      const [url] = mockedAxios.post.mock.calls[0];
+      expect(url).toBe('http://localhost:3000/v1/scrape');
+    });
+
+    it('uses the default timeout', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { success: true, markdown: '# Hi' },
+      });
+      const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+      await scraper.scrapeUrl('https://example.com');
+      const [, , config] = mockedAxios.post.mock.calls[0];
+      expect((config as { timeout: number }).timeout).toBe(7500);
+    });
+  });
+
+  it('does not early-return on a missing key', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, markdown: '# Hi' },
+    });
+    const scraper = createCrwScraper({ apiKey: '', logger: mockLogger });
+    await scraper.scrapeUrl('https://example.com');
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('attaches the Bearer header only when a key is present', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { success: true, markdown: '# Hi' },
+    });
+
+    const withKey = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    await withKey.scrapeUrl('https://example.com');
+    const [, , withKeyConfig] = mockedAxios.post.mock.calls[0];
+    expect(
+      (withKeyConfig as { headers: Record<string, string> }).headers
+        .Authorization
+    ).toBe('Bearer k');
+
+    mockedAxios.post.mockClear();
+
+    const keyless = createCrwScraper({ apiKey: '', logger: mockLogger });
+    await keyless.scrapeUrl('https://example.com');
+    const [, , keylessConfig] = mockedAxios.post.mock.calls[0];
+    expect(
+      (keylessConfig as { headers: Record<string, string> }).headers
+        .Authorization
+    ).toBeUndefined();
+  });
+
+  it('normalizes top-level fields into the nested data shape', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        markdown: '# Hi',
+        html: '<p>x</p>',
+        metadata: { title: 't' },
+        links: [],
+      },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const result = await scraper.scrapeUrl('https://example.com');
+    expect(result).toEqual([
+      'https://example.com',
+      {
+        success: true,
+        data: {
+          markdown: '# Hi',
+          html: '<p>x</p>',
+          metadata: { title: 't' },
+          links: [],
+          rawHtml: undefined,
+          plainText: undefined,
+          screenshot: undefined,
+        },
+      },
+    ]);
+  });
+
+  describe('extractContent', () => {
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+
+    it('processes markdown + html into ref markers', () => {
+      const [content, references] = scraper.extractContent({
+        success: true,
+        data: { markdown: '# Hi', html: '<p>x</p>' },
+      });
+      expect(typeof content).toBe('string');
+      expect(references).toHaveProperty('links');
+      expect(references).toHaveProperty('images');
+      expect(references).toHaveProperty('videos');
+    });
+
+    it('returns empty on a failed response', () => {
+      expect(scraper.extractContent({ success: false })).toEqual([
+        '',
+        undefined,
+      ]);
+    });
+
+    it('falls back to plainText when no markdown/html/rawHtml', () => {
+      expect(
+        scraper.extractContent({
+          success: true,
+          data: {
+            plainText: 'plain body',
+            markdown: undefined,
+            html: undefined,
+            rawHtml: undefined,
+          },
+        })
+      ).toEqual(['plain body', undefined]);
+    });
+
+    it('falls back to rawHtml when no markdown/html', () => {
+      expect(
+        scraper.extractContent({
+          success: true,
+          data: { rawHtml: '<x>', markdown: undefined, html: undefined },
+        })
+      ).toEqual(['<x>', undefined]);
+    });
+  });
+
+  describe('extractMetadata', () => {
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+
+    it('returns the metadata object', () => {
+      expect(
+        scraper.extractMetadata({
+          success: true,
+          data: { metadata: { title: 't' } },
+        })
+      ).toEqual({ title: 't' });
+    });
+
+    it('returns {} on a failed response', () => {
+      expect(scraper.extractMetadata({ success: false })).toEqual({});
+    });
+
+    it('returns {} when metadata is missing', () => {
+      expect(
+        scraper.extractMetadata({ success: true, data: {} })
+      ).toEqual({});
+    });
+  });
+
+  it('normalizes an envelope failure with an error code', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: false, error: 'blocked', error_code: 'X' },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const result = await scraper.scrapeUrl('https://example.com');
+    expect(result).toEqual([
+      'https://example.com',
+      { success: false, error: '[X] blocked', error_code: 'X' },
+    ]);
+  });
+
+  it('normalizes an envelope failure without an error code', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: false, error: 'oops' },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const result = await scraper.scrapeUrl('https://example.com');
+    expect(result).toEqual([
+      'https://example.com',
+      { success: false, error: 'oops', error_code: undefined },
+    ]);
+  });
+
+  it('returns a failure tuple on a network error', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const [url, response] = await scraper.scrapeUrl('https://example.com');
+    expect(url).toBe('https://example.com');
+    expect(response.success).toBe(false);
+    expect(response.error).toBe(
+      'fastCRW API request failed: Network error'
+    );
+  });
+
+  it('assembles the payload via omitUndefined', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, markdown: '# Hi' },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    await scraper.scrapeUrl('https://example.com', {
+      onlyMainContent: true,
+      waitFor: 1000,
+      formats: ['markdown'],
+      renderJs: true,
+    });
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect(payload).toMatchObject({
+      url: 'https://example.com',
+      onlyMainContent: true,
+      waitFor: 1000,
+      formats: ['markdown'],
+      renderJs: true,
+    });
+    expect(payload as Record<string, unknown>).not.toHaveProperty('proxy');
+    expect(payload as Record<string, unknown>).not.toHaveProperty('cssSelector');
+  });
+});
+
+describe('CRW search tool wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs the search then scrape sequence', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          markdown: '# A',
+          html: '<p>a</p>',
+          metadata: { title: 'T' },
+          links: [],
+        },
+      });
+
+    const searchTool = createSearchTool({
+      searchProvider: 'crw',
+      scraperProvider: 'crw',
+      crwApiKey: 'k',
+      topResults: 1,
+      rerankerType: 'none',
+      logger: mockLogger,
+    });
+
+    await searchTool.invoke({ query: 'hello' });
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    const [searchUrl, , searchConfig] = mockedAxios.post.mock.calls[0];
+    const [scrapeUrl, , scrapeConfig] = mockedAxios.post.mock.calls[1];
+    expect((searchUrl as string).endsWith('/v1/search')).toBe(true);
+    expect(
+      (searchConfig as { headers: Record<string, string> }).headers
+        .Authorization
+    ).toBe('Bearer k');
+    expect((scrapeUrl as string).endsWith('/v1/scrape')).toBe(true);
+    expect(
+      (scrapeConfig as { headers: Record<string, string> }).headers
+        .Authorization
+    ).toBe('Bearer k');
+  });
+
+  it('keeps the shared base and scraper override independent', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          markdown: '# A',
+          html: '<p>a</p>',
+          metadata: { title: 'T' },
+          links: [],
+        },
+      });
+
+    const searchTool = createSearchTool({
+      searchProvider: 'crw',
+      scraperProvider: 'crw',
+      crwApiKey: 'k',
+      crwScraperOptions: { apiUrl: 'http://localhost:3000' },
+      topResults: 1,
+      rerankerType: 'none',
+      logger: mockLogger,
+    });
+
+    await searchTool.invoke({ query: 'hello' });
+
+    const [searchUrl] = mockedAxios.post.mock.calls[0];
+    const [scrapeUrl] = mockedAxios.post.mock.calls[1];
+    expect(searchUrl).toBe('https://fastcrw.com/api/v1/search');
+    expect(scrapeUrl).toBe('http://localhost:3000/v1/scrape');
+  });
+});

--- a/src/tools/search/crw.test.ts
+++ b/src/tools/search/crw.test.ts
@@ -90,7 +90,11 @@ describe('CRW search API', () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {
         success: true,
-        data: [{ title: 'T', url: 'https://e.com', description: 'D' }],
+        data: {
+          web: [
+            { title: 'T', url: 'https://e.com', description: 'D', position: 1 },
+          ],
+        },
       },
     });
 
@@ -116,12 +120,26 @@ describe('CRW search API', () => {
       title: 'T',
       link: 'https://e.com',
       snippet: 'D',
+      position: 1,
     });
   });
 
-  it('adds images to the sources array when images are requested', async () => {
+  it('uses the images source and maps image results', async () => {
     mockedAxios.post.mockResolvedValueOnce({
-      data: { success: true, data: [] },
+      data: {
+        success: true,
+        data: {
+          images: [
+            {
+              title: 'I',
+              url: 'https://e.com/page',
+              imageUrl: 'https://e.com/i.png',
+              position: 1,
+            },
+            { title: 'no-image-url', url: 'https://e.com/x' },
+          ],
+        },
+      },
     });
 
     const searchAPI = createSearchAPI({
@@ -129,10 +147,80 @@ describe('CRW search API', () => {
       crwApiKey: 'test-key',
     });
 
-    await searchAPI.getSources({ query: 'example query', type: 'images' });
+    const result = await searchAPI.getSources({
+      query: 'example query',
+      type: 'images',
+    });
+
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect((payload as t.CrwSearchPayload).sources).toEqual(['images']);
+    expect(result.data?.images).toEqual([
+      {
+        title: 'I',
+        imageUrl: 'https://e.com/i.png',
+        link: 'https://e.com/page',
+        position: 1,
+      },
+    ]);
+  });
+
+  it('adds images to a web search when includeImages is set', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { web: [] } },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+      crwSearchOptions: { includeImages: true },
+    });
+
+    await searchAPI.getSources({ query: 'example query' });
 
     const [, payload] = mockedAxios.post.mock.calls[0];
     expect((payload as t.CrwSearchPayload).sources).toEqual(['web', 'images']);
+  });
+
+  it('uses the news source and maps news results', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          news: [
+            {
+              title: 'N',
+              url: 'https://news.example.com/story',
+              description: 'D',
+              publishedDate: '2026-07-01T20:40:00',
+              position: 1,
+            },
+          ],
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'crw',
+      crwApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'example query',
+      type: 'news',
+    });
+
+    const [, payload] = mockedAxios.post.mock.calls[0];
+    expect((payload as t.CrwSearchPayload).sources).toEqual(['news']);
+    expect(result.data?.news).toEqual([
+      {
+        title: 'N',
+        link: 'https://news.example.com/story',
+        snippet: 'D',
+        date: '2026-07-01T20:40:00',
+        source: 'news.example.com',
+        position: 1,
+      },
+    ]);
   });
 
   it('surfaces an envelope failure with the error code', async () => {
@@ -159,7 +247,7 @@ describe('CRW search API', () => {
 
   it('honors the base-URL override for search', async () => {
     mockedAxios.post.mockResolvedValueOnce({
-      data: { success: true, data: [] },
+      data: { success: true, data: { web: [] } },
     });
 
     const searchAPI = createSearchAPI({
@@ -176,7 +264,7 @@ describe('CRW search API', () => {
 
   it('omits the Authorization header when keyless', async () => {
     mockedAxios.post.mockResolvedValueOnce({
-      data: { success: true, data: [] },
+      data: { success: true, data: { web: [] } },
     });
 
     const searchAPI = createSearchAPI({
@@ -197,10 +285,12 @@ describe('CRW search API', () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {
         success: true,
-        data: [
-          { title: 'A', url: '', description: 'x' },
-          { title: 'B', url: 'https://ok.com', description: 'y' },
-        ],
+        data: {
+          web: [
+            { title: 'A', url: '', description: 'x' },
+            { title: 'B', url: 'https://ok.com', description: 'y' },
+          ],
+        },
       },
     });
 
@@ -262,14 +352,15 @@ describe('CrwScraper', () => {
       expect(url).toBe('http://localhost:3000/v1/scrape');
     });
 
-    it('uses the default timeout', async () => {
+    it('sends the render budget and pads the HTTP timeout', async () => {
       mockedAxios.post.mockResolvedValueOnce({
         data: { success: true, markdown: '# Hi' },
       });
       const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
       await scraper.scrapeUrl('https://example.com');
-      const [, , config] = mockedAxios.post.mock.calls[0];
-      expect((config as { timeout: number }).timeout).toBe(7500);
+      const [, payload, config] = mockedAxios.post.mock.calls[0];
+      expect((payload as { timeout: number }).timeout).toBe(7500);
+      expect((config as { timeout: number }).timeout).toBe(12500);
     });
   });
 
@@ -304,6 +395,37 @@ describe('CrwScraper', () => {
       (keylessConfig as { headers: Record<string, string> }).headers
         .Authorization
     ).toBeUndefined();
+  });
+
+  it('reads the nested data container from cloud responses', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          markdown: '# Hi',
+          html: '<p>x</p>',
+          metadata: { title: 't' },
+          links: [],
+        },
+      },
+    });
+    const scraper = createCrwScraper({ apiKey: 'k', logger: mockLogger });
+    const result = await scraper.scrapeUrl('https://example.com');
+    expect(result).toEqual([
+      'https://example.com',
+      {
+        success: true,
+        data: {
+          markdown: '# Hi',
+          html: '<p>x</p>',
+          metadata: { title: 't' },
+          links: [],
+          rawHtml: undefined,
+          plainText: undefined,
+          screenshot: undefined,
+        },
+      },
+    ]);
   });
 
   it('normalizes top-level fields into the nested data shape', async () => {
@@ -397,9 +519,7 @@ describe('CrwScraper', () => {
     });
 
     it('returns {} when metadata is missing', () => {
-      expect(
-        scraper.extractMetadata({ success: true, data: {} })
-      ).toEqual({});
+      expect(scraper.extractMetadata({ success: true, data: {} })).toEqual({});
     });
   });
 
@@ -433,9 +553,7 @@ describe('CrwScraper', () => {
     const [url, response] = await scraper.scrapeUrl('https://example.com');
     expect(url).toBe('https://example.com');
     expect(response.success).toBe(false);
-    expect(response.error).toBe(
-      'fastCRW API request failed: Network error'
-    );
+    expect(response.error).toBe('fastCRW API request failed: Network error');
   });
 
   it('assembles the payload via omitUndefined', async () => {
@@ -458,7 +576,9 @@ describe('CrwScraper', () => {
       renderJs: true,
     });
     expect(payload as Record<string, unknown>).not.toHaveProperty('proxy');
-    expect(payload as Record<string, unknown>).not.toHaveProperty('cssSelector');
+    expect(payload as Record<string, unknown>).not.toHaveProperty(
+      'cssSelector'
+    );
   });
 });
 
@@ -472,16 +592,20 @@ describe('CRW search tool wiring', () => {
       .mockResolvedValueOnce({
         data: {
           success: true,
-          data: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+          data: {
+            web: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+          },
         },
       })
       .mockResolvedValueOnce({
         data: {
           success: true,
-          markdown: '# A',
-          html: '<p>a</p>',
-          metadata: { title: 'T' },
-          links: [],
+          data: {
+            markdown: '# A',
+            html: '<p>a</p>',
+            metadata: { title: 'T' },
+            links: [],
+          },
         },
       });
 
@@ -516,16 +640,20 @@ describe('CRW search tool wiring', () => {
       .mockResolvedValueOnce({
         data: {
           success: true,
-          data: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+          data: {
+            web: [{ title: 'T', url: 'https://ex.com/a', description: 'D' }],
+          },
         },
       })
       .mockResolvedValueOnce({
         data: {
           success: true,
-          markdown: '# A',
-          html: '<p>a</p>',
-          metadata: { title: 'T' },
-          links: [],
+          data: {
+            markdown: '# A',
+            html: '<p>a</p>',
+            metadata: { title: 'T' },
+            links: [],
+          },
         },
       });
 

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -3,6 +3,7 @@ import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
 import { createTavilyAPI } from './tavily-search';
+import { createCrwAPI } from './crw-search';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -445,6 +446,9 @@ export const createSearchAPI = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
   } = config;
 
   if (searchProvider.toLowerCase() === 'serper') {
@@ -453,9 +457,11 @@ export const createSearchAPI = (
     return createSearXNGAPI(searxngInstanceUrl, searxngApiKey);
   } else if (searchProvider.toLowerCase() === 'tavily') {
     return createTavilyAPI(tavilyApiKey, tavilySearchUrl, tavilySearchOptions);
+  } else if (searchProvider.toLowerCase() === 'crw') {
+    return createCrwAPI(crwApiKey, crwApiUrl, crwSearchOptions);
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', or 'tavily'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'crw'`
     );
   }
 };

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -4,6 +4,7 @@ import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
 import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
+import { createCrwAPI } from './crw-search';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -489,6 +490,9 @@ export const createSearchAPI = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
   } = config;
 
   if (searchProvider.toLowerCase() === 'serper') {
@@ -503,9 +507,11 @@ export const createSearchAPI = (
       keenableApiUrl,
       keenableSearchOptions
     );
+  } else if (searchProvider.toLowerCase() === 'crw') {
+    return createCrwAPI(crwApiKey, crwApiUrl, crwSearchOptions);
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'keenable'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', 'keenable', or 'crw'`
     );
   }
 };

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -16,6 +16,7 @@ import { createSearchAPI, createSourceProcessor } from './search';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
+import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
@@ -339,8 +340,8 @@ function createTool({
 /**
  * Creates a search tool with configurable search and scraper providers.
  *
- * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized).
- * Scraper providers: Firecrawl (default, full-featured), Serper (lightweight), Tavily (batch extraction).
+ * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized), fastCRW (Firecrawl-compatible, self-host or cloud).
+ * Scraper providers: Firecrawl (default, full-featured), Serper (lightweight), Tavily (batch extraction), fastCRW (Firecrawl-compatible, self-host or cloud).
  *
  * The country schema field is exposed to the LLM for providers that support localized results.
  */
@@ -386,6 +387,10 @@ export const createSearchTool = (
     firecrawlOptions,
     serperScraperOptions,
     tavilyScraperOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
+    crwScraperOptions,
     scraperTimeout,
     jinaApiKey,
     jinaApiUrl,
@@ -432,6 +437,9 @@ export const createSearchTool = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */
@@ -453,6 +461,16 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
+      logger,
+    });
+  } else if (scraperProvider === 'crw') {
+    scraperInstance = createCrwScraper({
+      ...crwScraperOptions,
+      apiKey:
+        crwScraperOptions?.apiKey ?? crwApiKey ?? process.env.CRW_API_KEY,
+      apiUrl: crwScraperOptions?.apiUrl ?? crwApiUrl,
+      timeout: scraperTimeout ?? crwScraperOptions?.timeout,
+      formats: crwScraperOptions?.formats ?? ['markdown', 'rawHtml'],
       logger,
     });
   } else {
@@ -501,7 +519,9 @@ export const createSearchTool = (
     // sub-searches would spend rate limit and merge nothing.
     supportsImages: searchProvider !== 'keenable',
     supportsVideos:
-      searchProvider !== 'tavily' && searchProvider !== 'keenable',
+      searchProvider !== 'tavily' &&
+      searchProvider !== 'keenable' &&
+      searchProvider !== 'crw',
     supportsNews: searchProvider !== 'keenable',
     sourceProcessor,
     onGetHighlights,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -16,6 +16,7 @@ import { createSearchAPI, createSourceProcessor } from './search';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
+import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
@@ -329,8 +330,8 @@ function createTool({
 /**
  * Creates a search tool with configurable search and scraper providers.
  *
- * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized).
- * Scraper providers: Firecrawl (default, full-featured), Serper (lightweight), Tavily (batch extraction).
+ * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized), fastCRW (Firecrawl-compatible, self-host or cloud).
+ * Scraper providers: Firecrawl (default, full-featured), Serper (lightweight), Tavily (batch extraction), fastCRW (Firecrawl-compatible, self-host or cloud).
  *
  * The country schema field is exposed to the LLM for providers that support localized results.
  */
@@ -369,6 +370,10 @@ export const createSearchTool = (
     firecrawlOptions,
     serperScraperOptions,
     tavilyScraperOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
+    crwScraperOptions,
     scraperTimeout,
     jinaApiKey,
     jinaApiUrl,
@@ -412,6 +417,9 @@ export const createSearchTool = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions: effectiveTavilySearchOptions,
+    crwApiKey,
+    crwApiUrl,
+    crwSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */
@@ -433,6 +441,16 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
+      logger,
+    });
+  } else if (scraperProvider === 'crw') {
+    scraperInstance = createCrwScraper({
+      ...crwScraperOptions,
+      apiKey:
+        crwScraperOptions?.apiKey ?? crwApiKey ?? process.env.CRW_API_KEY,
+      apiUrl: crwScraperOptions?.apiUrl ?? crwApiUrl,
+      timeout: scraperTimeout ?? crwScraperOptions?.timeout,
+      formats: crwScraperOptions?.formats ?? ['markdown', 'rawHtml'],
       logger,
     });
   } else {
@@ -474,7 +492,7 @@ export const createSearchTool = (
   const search = createSearchProcessor({
     searchAPI,
     safeSearch,
-    supportsVideos: searchProvider !== 'tavily',
+    supportsVideos: searchProvider !== 'tavily' && searchProvider !== 'crw',
     sourceProcessor,
     onGetHighlights,
     logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,8 +3,8 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily';
-export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'crw';
+export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily' | 'crw';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -106,6 +106,34 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
+export interface CrwSearchOptions {
+  /** Max results to request (maps to `limit`; clamped 1..20). */
+  maxResults?: number;
+  /** Add 'images' to the sources array. */
+  includeImages?: boolean;
+  timeout?: number;
+}
+
+export interface CrwSearchPayload {
+  query: string;
+  limit: number;
+  sources?: Array<'web' | 'images'>;
+}
+
+export interface CrwSearchResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  markdown?: string;
+}
+
+export interface CrwSearchResponse {
+  success: boolean;
+  data?: CrwSearchResult[];
+  error?: string;
+  error_code?: string;
+}
+
 export interface SearchConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
@@ -115,6 +143,9 @@ export interface SearchConfig {
   tavilySearchUrl?: string;
   tavilyExtractUrl?: string;
   tavilySearchOptions?: TavilySearchOptions;
+  crwApiKey?: string;
+  crwApiUrl?: string;
+  crwSearchOptions?: CrwSearchOptions;
 }
 
 export type References = {
@@ -218,6 +249,7 @@ export interface SearchToolConfig
     ProcessSourcesConfig,
     FirecrawlConfig {
   tavilyScraperOptions?: TavilyScraperConfig;
+  crwScraperOptions?: CrwScraperConfig;
   logger?: Logger;
   safeSearch?: SafeSearchLevel;
   jinaApiKey?: string;
@@ -248,7 +280,8 @@ export type UsedReferences = {
 export type AnyScraperResponse =
   | FirecrawlScrapeResponse
   | SerperScrapeResponse
-  | TavilyScrapeResponse;
+  | TavilyScrapeResponse
+  | CrwScrapeResponse;
 
 /** Base Scraper Interface */
 export interface BaseScraper {
@@ -272,6 +305,30 @@ export interface BaseScraper {
 export type FirecrawlScrapeOptions = Omit<
   FirecrawlScraperConfig,
   'apiKey' | 'apiUrl' | 'version' | 'logger'
+>;
+
+export interface CrwScraperConfig {
+  apiKey?: string;
+  apiUrl?: string;
+  formats?: string[];
+  timeout?: number;
+  logger?: Logger;
+  onlyMainContent?: boolean;
+  includeTags?: string[];
+  excludeTags?: string[];
+  waitFor?: number;
+  headers?: Record<string, string>;
+  renderJs?: boolean | null;
+  cssSelector?: string;
+  xpath?: string;
+  proxy?: string;
+  stealth?: boolean;
+  jsonSchema?: object;
+}
+
+export type CrwScrapeOptions = Omit<
+  CrwScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
 >;
 
 export type SerperScrapeOptions = Omit<
@@ -371,6 +428,21 @@ export interface FirecrawlScrapeResponse {
     metadata?: ScrapeMetadata;
   };
   error?: string;
+}
+
+export interface CrwScrapeResponse {
+  success: boolean;
+  data?: {
+    markdown?: string;
+    html?: string;
+    rawHtml?: string;
+    plainText?: string;
+    screenshot?: string;
+    links?: string[];
+    metadata?: ScrapeMetadata;
+  };
+  error?: string;
+  error_code?: string;
 }
 
 export interface SerperScrapeResponse {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -114,22 +114,38 @@ export interface CrwSearchOptions {
   timeout?: number;
 }
 
+export type CrwSearchSource = 'web' | 'images' | 'news';
+
 export interface CrwSearchPayload {
   query: string;
   limit: number;
-  sources?: Array<'web' | 'images'>;
+  sources?: CrwSearchSource[];
 }
 
 export interface CrwSearchResult {
   title?: string;
   url?: string;
   description?: string;
-  markdown?: string;
+  snippet?: string;
+  position?: number;
+}
+
+export interface CrwImageSearchResult extends CrwSearchResult {
+  imageUrl?: string;
+  imageFormat?: string;
+}
+
+export interface CrwNewsSearchResult extends CrwSearchResult {
+  publishedDate?: string;
 }
 
 export interface CrwSearchResponse {
   success: boolean;
-  data?: CrwSearchResult[];
+  data?: {
+    web?: CrwSearchResult[];
+    images?: CrwImageSearchResult[];
+    news?: CrwNewsSearchResult[];
+  };
   error?: string;
   error_code?: string;
 }
@@ -478,23 +494,7 @@ export interface FirecrawlScrapeResponse {
   error?: string;
 }
 
-export interface CrwScrapeResponse {
-  success: boolean;
-  data?: {
-    markdown?: string;
-    html?: string;
-    rawHtml?: string;
-    plainText?: string;
-    screenshot?: string;
-    links?: string[];
-    metadata?: ScrapeMetadata;
-  };
-  error?: string;
-  error_code?: string;
-}
-
-export interface CrwRawScrapeResponse {
-  success?: boolean;
+export interface CrwScrapeData {
   markdown?: string;
   html?: string;
   rawHtml?: string;
@@ -502,6 +502,18 @@ export interface CrwRawScrapeResponse {
   screenshot?: string;
   links?: string[];
   metadata?: ScrapeMetadata;
+}
+
+export interface CrwScrapeResponse {
+  success: boolean;
+  data?: CrwScrapeData;
+  error?: string;
+  error_code?: string;
+}
+
+export interface CrwRawScrapeResponse extends CrwScrapeData {
+  success?: boolean;
+  data?: CrwScrapeData;
   error?: string;
   error_code?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,8 +3,8 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable';
-export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable' | 'crw';
+export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily' | 'crw';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -106,6 +106,34 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
+export interface CrwSearchOptions {
+  /** Max results to request (maps to `limit`; clamped 1..20). */
+  maxResults?: number;
+  /** Add 'images' to the sources array. */
+  includeImages?: boolean;
+  timeout?: number;
+}
+
+export interface CrwSearchPayload {
+  query: string;
+  limit: number;
+  sources?: Array<'web' | 'images'>;
+}
+
+export interface CrwSearchResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  markdown?: string;
+}
+
+export interface CrwSearchResponse {
+  success: boolean;
+  data?: CrwSearchResult[];
+  error?: string;
+  error_code?: string;
+}
+
 export interface SearchConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
@@ -118,6 +146,9 @@ export interface SearchConfig {
   keenableApiKey?: string;
   keenableApiUrl?: string;
   keenableSearchOptions?: KeenableSearchOptions;
+  crwApiKey?: string;
+  crwApiUrl?: string;
+  crwSearchOptions?: CrwSearchOptions;
 }
 
 export interface KeenableSearchOptions {
@@ -257,6 +288,7 @@ export interface SearchToolConfig
     ProcessSourcesConfig,
     FirecrawlConfig {
   tavilyScraperOptions?: TavilyScraperConfig;
+  crwScraperOptions?: CrwScraperConfig;
   /** Max chars of highlight content this tool feeds the MODEL per search (the
    * dominant, otherwise-unbounded part of the output). Distinct from
    * `maxContentLength`, which caps scraped/reranked content per source — full
@@ -296,7 +328,8 @@ export type UsedReferences = {
 export type AnyScraperResponse =
   | FirecrawlScrapeResponse
   | SerperScrapeResponse
-  | TavilyScrapeResponse;
+  | TavilyScrapeResponse
+  | CrwScrapeResponse;
 
 /** Base Scraper Interface */
 export interface BaseScraper {
@@ -320,6 +353,30 @@ export interface BaseScraper {
 export type FirecrawlScrapeOptions = Omit<
   FirecrawlScraperConfig,
   'apiKey' | 'apiUrl' | 'version' | 'logger'
+>;
+
+export interface CrwScraperConfig {
+  apiKey?: string;
+  apiUrl?: string;
+  formats?: string[];
+  timeout?: number;
+  logger?: Logger;
+  onlyMainContent?: boolean;
+  includeTags?: string[];
+  excludeTags?: string[];
+  waitFor?: number;
+  headers?: Record<string, string>;
+  renderJs?: boolean | null;
+  cssSelector?: string;
+  xpath?: string;
+  proxy?: string;
+  stealth?: boolean;
+  jsonSchema?: object;
+}
+
+export type CrwScrapeOptions = Omit<
+  CrwScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
 >;
 
 export type SerperScrapeOptions = Omit<
@@ -419,6 +476,34 @@ export interface FirecrawlScrapeResponse {
     metadata?: ScrapeMetadata;
   };
   error?: string;
+}
+
+export interface CrwScrapeResponse {
+  success: boolean;
+  data?: {
+    markdown?: string;
+    html?: string;
+    rawHtml?: string;
+    plainText?: string;
+    screenshot?: string;
+    links?: string[];
+    metadata?: ScrapeMetadata;
+  };
+  error?: string;
+  error_code?: string;
+}
+
+export interface CrwRawScrapeResponse {
+  success?: boolean;
+  markdown?: string;
+  html?: string;
+  rawHtml?: string;
+  plainText?: string;
+  screenshot?: string;
+  links?: string[];
+  metadata?: ScrapeMetadata;
+  error?: string;
+  error_code?: string;
 }
 
 export interface SerperScrapeResponse {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -129,6 +129,7 @@ export interface CrwSearchResult {
   description?: string;
   snippet?: string;
   position?: number;
+  category?: string;
 }
 
 export interface CrwImageSearchResult extends CrwSearchResult {
@@ -148,7 +149,7 @@ export interface CrwSearchGroups {
 
 export interface CrwSearchResponse {
   success: boolean;
-  data?: CrwSearchGroups & { results?: CrwSearchGroups };
+  data?: (CrwSearchGroups & { results?: CrwSearchGroups }) | CrwSearchResult[];
   error?: string;
   error_code?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -140,13 +140,15 @@ export interface CrwNewsSearchResult extends CrwSearchResult {
   publishedDate?: string;
 }
 
+export interface CrwSearchGroups {
+  web?: CrwSearchResult[];
+  images?: CrwImageSearchResult[];
+  news?: CrwNewsSearchResult[];
+}
+
 export interface CrwSearchResponse {
   success: boolean;
-  data?: {
-    web?: CrwSearchResult[];
-    images?: CrwImageSearchResult[];
-    news?: CrwNewsSearchResult[];
-  };
+  data?: CrwSearchGroups & { results?: CrwSearchGroups };
   error?: string;
   error_code?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -120,6 +120,7 @@ export interface CrwSearchPayload {
   query: string;
   limit: number;
   sources?: CrwSearchSource[];
+  tbs?: string;
 }
 
 export interface CrwSearchResult {
@@ -387,7 +388,6 @@ export interface CrwScraperConfig {
   xpath?: string;
   proxy?: string;
   stealth?: boolean;
-  jsonSchema?: object;
 }
 
 export type CrwScrapeOptions = Omit<


### PR DESCRIPTION
## What

Adds **fastCRW** (`crw`) as a first-class provider for both **web search** (`/v1/search`) and **scraping** (`/v1/scrape`), mirroring the existing `tavily-search` and `firecrawl` providers.

## Why

This is the engine side that lets `@librechat/agents` consumers (e.g. LibreChat) actually use fastCRW. Today, selecting a `crw` provider downstream authenticates but throws here because `createSearchTool` has no `crw` branch — this PR adds it.

**Why fastCRW over Firecrawl?**

- **Runs 100% locally, open core (AGPL).** Anti-bot/stealth, BYO-proxy + rotation, and JS rendering all ship in the open-source binary — no cloud flag required. Firecrawl OSS gates its stealth engine behind a cloud-only flag, so a self-hosted Firecrawl instance can't reliably reach protected or JS-heavy sites. fastCRW's self-host can.
- **Faster and more accurate — measured on Firecrawl's own benchmark dataset.** Truth-recall 63.74% vs 56.04%; median latency p50 ~1.9 s vs ~2.3 s. Ships as a single ~8 MB Rust binary with ~6 MB RAM idle footprint.
- **Search built on SearXNG, with a quality layer on top.** crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content rather than SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable with configurable engines.
- **Flat, honest pricing.** 1 credit = 1 page. No 4× stealth surcharge, no billed-on-failure.

The integration diff is intentionally small because fastCRW exposes a Firecrawl-compatible API — `crw` closely mirrors the existing `firecrawl` provider with a configurable base URL.

## Changes (additive only — no existing provider touched)

- `src/tools/search/crw-search.ts` — search provider (mirrors `tavily-search.ts`).
- `src/tools/search/crw-scraper.ts` — scraper (mirrors `firecrawl.ts`).
- `src/tools/search/types.ts` — `crw` added to the provider enums/types.
- `src/tools/search/tool.ts`, `search.ts` — wired `crw` into `createSearchTool` dispatch for search + scrape.
- `src/tools/search/crw.test.ts` — unit tests (mocked HTTP, no network) for both search and scrape paths.

Self-host base URL is configurable; key via `CRW_API_KEY`. Happy to adjust anything to fit your conventions — I maintain the integration and can provide free credits to evaluate.
