### PR TITLE
chore: Add Brave as a search provider

### DIFF
--- a/src/tools/search/brave-search.ts
+++ b/src/tools/search/brave-search.ts
@@ -1,0 +1,402 @@
+import axios from 'axios';
+import type * as t from './types';
+import { getHostname } from './utils';
+
+const DEFAULT_BRAVE_API_URL = 'https://api.search.brave.com/res';
+const DEFAULT_BRAVE_TIMEOUT = 15000;
+
+const BRAVE_WEB_MAX_COUNT = 20;
+const BRAVE_NEWS_MAX_COUNT = 50;
+const BRAVE_IMAGES_MAX_COUNT = 200;
+const BRAVE_VIDEOS_MAX_COUNT = 50;
+
+const BRAVE_SUPPORTED_COUNTRIES = new Set([
+  'AR',
+  'AU',
+  'AT',
+  'BE',
+  'BR',
+  'CA',
+  'CL',
+  'DK',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HK',
+  'IN',
+  'ID',
+  'IT',
+  'JP',
+  'KR',
+  'MY',
+  'MX',
+  'NL',
+  'NZ',
+  'NO',
+  'CN',
+  'PL',
+  'PT',
+  'PH',
+  'RU',
+  'SA',
+  'ZA',
+  'ES',
+  'SE',
+  'CH',
+  'TW',
+  'TR',
+  'GB',
+  'US',
+  'ALL',
+]);
+const BRAVE_SAFE_SEARCH_OPTIONS: t.BraveSafeSearch[] = [
+  'off',
+  'moderate',
+  'strict',
+];
+
+const mapTimeRangeToBraveFreshnessParam = (
+  date?: t.GetSourcesParams['date']
+): t.BraveTimeRange | undefined => {
+  switch (date) {
+  case 'h':
+  case 'd':
+    return 'pd';
+  case 'w':
+    return 'pw';
+  case 'm':
+    return 'pm';
+  case 'y':
+    return 'py';
+  default:
+    return undefined;
+  }
+};
+
+const normalizeBraveCountry = (country?: string): string | undefined => {
+  if (country == null) {
+    return undefined;
+  }
+  const trimmed = country.trim();
+  if (trimmed === '' || !/^[a-zA-Z]{2}$/.test(trimmed)) {
+    return undefined;
+  }
+  const upper = trimmed.toUpperCase();
+  return BRAVE_SUPPORTED_COUNTRIES.has(upper) ? upper : undefined;
+};
+
+const convertResponseToOrganicResult = (
+  results: t.BraveWebResult[] | undefined
+): t.OrganicResult[] =>
+  (results ?? []).reduce<t.OrganicResult[]>((acc, result) => {
+    if (typeof result.url !== 'string' || result.url === '') {
+      return acc;
+    }
+    acc.push({
+      position: acc.length + 1,
+      title: result.title ?? '',
+      link: result.url,
+      snippet: result.description ?? result.extra_snippets?.[0] ?? '',
+      date: result.age ?? result.page_age,
+    });
+    return acc;
+  }, []);
+
+const convertResponseToNewsResult = (
+  results: t.BraveNewsResult[] | undefined
+): t.NewsResult[] =>
+  (results ?? []).reduce<t.NewsResult[]>((acc, result) => {
+    if (typeof result.url !== 'string' || result.url === '') {
+      return acc;
+    }
+    acc.push({
+      position: acc.length + 1,
+      title: result.title,
+      link: result.url,
+      snippet: result.description ?? result.extra_snippets?.[0],
+      date: result.age ?? result.page_age,
+      source:
+        result.source ??
+        result.profile?.name ??
+        result.meta_url?.hostname ??
+        getHostname(result.url),
+      imageUrl: result.thumbnail?.src,
+    });
+    return acc;
+  }, []);
+
+const convertResponseToImageResult = (
+  results: t.BraveImageResult[] | undefined
+): t.ImageResult[] =>
+  (results ?? []).reduce<t.ImageResult[]>((acc, result) => {
+    const imageUrl = result.properties?.url ?? result.thumbnail?.src;
+    if (imageUrl == null || imageUrl === '') {
+      return acc;
+    }
+    acc.push({
+      position: acc.length + 1,
+      title: result.title,
+      imageUrl,
+      thumbnailUrl: result.thumbnail?.src,
+      thumbnailWidth: result.thumbnail?.width,
+      thumbnailHeight: result.thumbnail?.height,
+      source: result.source,
+      link: result.url,
+    });
+    return acc;
+  }, []);
+
+const convertResponseToVideoResult = (
+  results: t.BraveVideoResult[] | undefined
+): t.VideoResult[] =>
+  (results ?? []).reduce<t.VideoResult[]>((acc, result) => {
+    if (typeof result.url !== 'string' || result.url === '') {
+      return acc;
+    }
+    acc.push({
+      position: acc.length + 1,
+      title: result.title,
+      link: result.url,
+      snippet: result.description,
+      duration: result.video?.duration,
+      channel: result.video?.creator ?? result.video?.author?.name,
+      source:
+        result.video?.publisher ??
+        result.meta_url?.hostname ??
+        getHostname(result.url),
+      date: result.age ?? result.page_age,
+      imageUrl: result.thumbnail?.src,
+    });
+    return acc;
+  }, []);
+
+export const createBraveAPI = (
+  apiKey?: string,
+  apiUrl?: string,
+  options?: t.BraveSearchOptions
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  const config = {
+    apiKey: apiKey ?? process.env.BRAVE_API_KEY,
+    apiUrl: apiUrl ?? process.env.BRAVE_API_URL ?? DEFAULT_BRAVE_API_URL,
+    timeout: options?.timeout ?? DEFAULT_BRAVE_TIMEOUT,
+  };
+
+  if (config.apiKey == null || config.apiKey === '') {
+    throw new Error('BRAVE_API_KEY is required for Brave API');
+  }
+
+  const headers = {
+    Accept: 'application/json',
+    'X-Subscription-Token': config.apiKey,
+  };
+
+  const fetchWeb = async (
+    query: string,
+    freshness: t.BraveTimeRange | undefined,
+    country: string | undefined,
+    safeSearch: t.BraveSafeSearch,
+    count: number,
+    goggles: string | undefined
+  ): Promise<{
+    organic: t.OrganicResult[];
+    news: t.NewsResult[];
+    videos: t.VideoResult[];
+  }> => {
+    const params: Record<string, string | number> = {
+      q: query,
+      ...(freshness != null ? { freshness } : {}),
+      ...(country != null ? { country } : {}),
+      safesearch: safeSearch,
+      count: Math.min(Math.max(1, count), BRAVE_WEB_MAX_COUNT),
+      ...(goggles != null && goggles !== '' ? { goggles } : {}),
+    };
+    const response = await axios.get<t.BraveWebSearchResponse>(
+      `${config.apiUrl}/v1/web/search`,
+      { headers, params, timeout: config.timeout }
+    );
+    return {
+      organic: convertResponseToOrganicResult(response.data.web?.results),
+      news: convertResponseToNewsResult(response.data.news?.results),
+      videos: convertResponseToVideoResult(response.data.videos?.results),
+    };
+  };
+
+  const fetchNews = async (
+    query: string,
+    freshness: t.BraveTimeRange | undefined,
+    country: string | undefined,
+    safeSearch: t.BraveSafeSearch,
+    count: number
+  ): Promise<t.NewsResult[]> => {
+    const params: Record<string, string | number> = {
+      q: query,
+      ...(freshness != null ? { freshness } : {}),
+      ...(country != null ? { country } : {}),
+      safesearch: safeSearch,
+      count: Math.min(Math.max(1, count), BRAVE_NEWS_MAX_COUNT),
+    };
+    const response = await axios.get<t.BraveNewsSearchResponse>(
+      `${config.apiUrl}/v1/news/search`,
+      { headers, params, timeout: config.timeout }
+    );
+    return convertResponseToNewsResult(response.data.results);
+  };
+
+  /** Brave's image-search API only supports 'strict' or 'off'. Default to 'strict'. */
+  const fetchImages = async (
+    query: string,
+    country: string | undefined,
+    safeSearch: t.BraveSafeSearch,
+    count: number
+  ): Promise<t.ImageResult[]> => {
+    const params: Record<string, string | number> = {
+      q: query,
+      ...(country != null ? { country } : {}),
+      safesearch: safeSearch === 'off' ? 'off' : 'strict',
+      count: Math.min(Math.max(1, count), BRAVE_IMAGES_MAX_COUNT),
+    };
+    const response = await axios.get<t.BraveImageSearchResponse>(
+      `${config.apiUrl}/v1/images/search`,
+      { headers, params, timeout: config.timeout }
+    );
+    return convertResponseToImageResult(response.data.results);
+  };
+
+  const fetchVideos = async (
+    query: string,
+    freshness: t.BraveTimeRange | undefined,
+    country: string | undefined,
+    safeSearch: t.BraveSafeSearch,
+    count: number
+  ): Promise<t.VideoResult[]> => {
+    const params: Record<string, string | number> = {
+      q: query,
+      ...(freshness != null ? { freshness } : {}),
+      ...(country != null ? { country } : {}),
+      safesearch: safeSearch,
+      count: Math.min(Math.max(1, count), BRAVE_VIDEOS_MAX_COUNT),
+    };
+    const response = await axios.get<t.BraveVideoSearchResponse>(
+      `${config.apiUrl}/v1/videos/search`,
+      { headers, params, timeout: config.timeout }
+    );
+    return convertResponseToVideoResult(response.data.results);
+  };
+
+  const getSources = async ({
+    query,
+    date,
+    country,
+    numResults = 20,
+    safeSearch,
+    type,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    try {
+      const effectiveCount = options?.count ?? numResults;
+      const effectiveFreshness =
+        options?.freshness ?? mapTimeRangeToBraveFreshnessParam(date);
+      const effectiveSafeSearch =
+        options?.safesearch ?? BRAVE_SAFE_SEARCH_OPTIONS[safeSearch ?? 1];
+      const normalizedCountry = normalizeBraveCountry(country);
+
+      if (type === 'images') {
+        const images = await fetchImages(
+          query,
+          normalizedCountry,
+          effectiveSafeSearch,
+          effectiveCount
+        );
+        return {
+          success: true,
+          data: {
+            organic: [],
+            images,
+            videos: [],
+            news: [],
+            topStories: [],
+            relatedSearches: [],
+          },
+        };
+      }
+
+      if (type === 'videos') {
+        const videos = await fetchVideos(
+          query,
+          effectiveFreshness,
+          normalizedCountry,
+          effectiveSafeSearch,
+          effectiveCount
+        );
+        return {
+          success: true,
+          data: {
+            organic: [],
+            images: [],
+            videos,
+            news: [],
+            topStories: [],
+            relatedSearches: [],
+          },
+        };
+      }
+
+      if (type === 'news') {
+        const news = await fetchNews(
+          query,
+          effectiveFreshness,
+          normalizedCountry,
+          effectiveSafeSearch,
+          effectiveCount
+        );
+        return {
+          success: true,
+          data: {
+            organic: [],
+            images: [],
+            videos: [],
+            news,
+            topStories: [],
+            relatedSearches: [],
+          },
+        };
+      }
+
+      const webResponse = await fetchWeb(
+        query,
+        effectiveFreshness,
+        normalizedCountry,
+        effectiveSafeSearch,
+        effectiveCount,
+        options?.goggles
+      );
+
+      const results: t.SearchResultData = {
+        organic: webResponse.organic,
+        images: [],
+        topStories: [],
+        videos: webResponse.videos,
+        news: webResponse.news,
+        answerBox: undefined,
+        relatedSearches: [],
+      };
+
+      return { success: true, data: results };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Brave API request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/brave.test.ts
+++ b/src/tools/search/brave.test.ts
@@ -1,0 +1,642 @@
+import axios from 'axios';
+import type * as t from './types';
+import { DATE_RANGE } from './schema';
+import { createSearchAPI } from './search';
+import { createSearchTool } from './tool';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+} as unknown as t.Logger;
+
+describe('Brave search API', () => {
+  beforeEach(jest.clearAllMocks);
+
+  afterEach(() => {
+    delete process.env.BRAVE_API_KEY;
+    delete process.env.BRAVE_API_URL;
+  });
+
+  it('throws when Brave API key is missing', () => {
+    expect(() =>
+      createSearchAPI({
+        searchProvider: 'brave',
+        braveApiKey: '',
+      })
+    ).toThrow('BRAVE_API_KEY is required for Brave API');
+  });
+
+  it('falls back to the BRAVE_API_KEY env var', () => {
+    process.env.BRAVE_API_KEY = 'env-key';
+    expect(() =>
+      createSearchAPI({
+        searchProvider: 'brave',
+      })
+    ).not.toThrow();
+  });
+
+  it('defaults the braveApiUrl to https://api.search.brave.com/res', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+    await searchAPI.getSources({ query: 'q' });
+
+    const [url] = mockedAxios.get.mock.calls[0];
+    expect(url).toBe('https://api.search.brave.com/res/v1/web/search');
+  });
+
+  it('uses the braveApiUrl override when provided', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveApiUrl: 'https://internal.example.com/brave/res',
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const [url] = mockedAxios.get.mock.calls[0];
+    expect(url).toBe('https://internal.example.com/brave/res/v1/web/search');
+  });
+
+  it('uses the BRAVE_API_URL env var when provided', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+    process.env.BRAVE_API_URL = 'https://internal.example.com/brave/res';
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const [url] = mockedAxios.get.mock.calls[0];
+    expect(url).toBe('https://internal.example.com/brave/res/v1/web/search');
+  });
+
+  it('returns an error for empty Brave search queries', async () => {
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Query cannot be empty',
+    });
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the Brave search request fails', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Brave API request failed: Network error');
+  });
+
+  it('maps web search response data to organic, news, and videos', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        web: {
+          results: [
+            {
+              title: 'Example',
+              url: 'https://example.com',
+              description: 'Example summary',
+              page_age: '2026-01-02',
+            },
+          ],
+        },
+        news: {
+          results: [
+            {
+              title: 'Breaking story',
+              url: 'https://news.example.com/story',
+              description: 'A news result',
+              age: '1 hour ago',
+              source: 'Example News',
+              thumbnail: { src: 'https://news.example.com/thumb.png' },
+            },
+          ],
+        },
+        videos: {
+          results: [
+            {
+              title: 'A video',
+              url: 'https://video.example.com/clip',
+              description: 'Watch this',
+              video: { duration: '3:14', publisher: 'Example TV' },
+              thumbnail: { src: 'https://video.example.com/thumb.png' },
+            },
+          ],
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'example query',
+      country: 'GB',
+      date: DATE_RANGE.PAST_24_HOURS,
+    });
+    const [url, options] = mockedAxios.get.mock.calls[0];
+
+    expect(url).toBe('https://api.search.brave.com/res/v1/web/search');
+    expect(options?.headers).toMatchObject({
+      'X-Subscription-Token': 'test-key',
+    });
+    expect(options?.params).toMatchObject({
+      q: 'example query',
+      country: 'GB',
+      freshness: 'pd',
+      safesearch: 'moderate',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.organic?.[0]).toMatchObject({
+      title: 'Example',
+      link: 'https://example.com',
+      snippet: 'Example summary',
+      date: '2026-01-02',
+    });
+    expect(result.data?.news?.[0]).toMatchObject({
+      title: 'Breaking story',
+      link: 'https://news.example.com/story',
+      source: 'Example News',
+      date: '1 hour ago',
+    });
+    expect(result.data?.videos?.[0]).toMatchObject({
+      title: 'A video',
+      link: 'https://video.example.com/clip',
+      duration: '3:14',
+      source: 'Example TV',
+    });
+  });
+
+  it.each([
+    [DATE_RANGE.PAST_HOUR, 'pd'],
+    [DATE_RANGE.PAST_24_HOURS, 'pd'],
+    [DATE_RANGE.PAST_WEEK, 'pw'],
+    [DATE_RANGE.PAST_MONTH, 'pm'],
+    [DATE_RANGE.PAST_YEAR, 'py'],
+  ])('maps DATE_RANGE %s to Brave freshness %s', async (date, expected) => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { web: { results: [] } },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q', date });
+    expect(mockedAxios.get.mock.calls[0][1]?.params).toMatchObject({
+      freshness: expected,
+    });
+  });
+
+  it.each(['United States', 'ZZ'])(
+    'omits malformed country code "%s"',
+    async (country) => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+      const searchAPI = createSearchAPI({
+        searchProvider: 'brave',
+        braveApiKey: 'test-key',
+      });
+
+      await searchAPI.getSources({ query: 'q', country });
+      const params = mockedAxios.get.mock.calls[0][1]?.params;
+      expect(params.country).toBeUndefined();
+    }
+  );
+
+  it('uppercases supported country codes', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q', country: 'us' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.country).toBe('US');
+  });
+
+  it('routes news searches to /v1/news/search', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'News headline',
+            url: 'https://news.example.com/a',
+            description: 'A news snippet',
+            age: '2 hours ago',
+            meta_url: { hostname: 'news.example.com' },
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'q',
+      type: 'news',
+    });
+    const [url] = mockedAxios.get.mock.calls[0];
+
+    expect(url).toBe('https://api.search.brave.com/res/v1/news/search');
+    expect(result.data?.news?.[0]).toMatchObject({
+      title: 'News headline',
+      link: 'https://news.example.com/a',
+      source: 'news.example.com',
+    });
+  });
+
+  it('routes images searches to /v1/images/search', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'Cute cat',
+            url: 'https://example.com/cats',
+            source: 'example.com',
+            thumbnail: {
+              src: 'https://example.com/thumb.jpg',
+              width: 200,
+              height: 100,
+            },
+            properties: { url: 'https://example.com/full.jpg' },
+          },
+          {
+            title: 'No image',
+            url: 'https://example.com/empty',
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'q',
+      type: 'images',
+    });
+    const [url] = mockedAxios.get.mock.calls[0];
+
+    expect(url).toBe('https://api.search.brave.com/res/v1/images/search');
+    expect(result.data?.images).toHaveLength(1);
+    expect(result.data?.images?.[0]).toMatchObject({
+      imageUrl: 'https://example.com/full.jpg',
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      thumbnailWidth: 200,
+      thumbnailHeight: 100,
+      source: 'example.com',
+      link: 'https://example.com/cats',
+    });
+  });
+
+  it('routes videos searches to /v1/videos/search', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'A clip',
+            url: 'https://video.example.com/x',
+            description: 'desc',
+            video: { duration: '1:23', publisher: 'pub' },
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'q',
+      type: 'videos',
+    });
+    const [url] = mockedAxios.get.mock.calls[0];
+
+    expect(url).toBe('https://api.search.brave.com/res/v1/videos/search');
+    expect(result.data?.videos?.[0]).toMatchObject({
+      title: 'A clip',
+      link: 'https://video.example.com/x',
+      duration: '1:23',
+      source: 'pub',
+    });
+  });
+
+  it('lets braveSearchOptions.count override the getSources numResults argument', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: {
+        count: 15,
+      },
+    });
+
+    await searchAPI.getSources({ query: 'q', numResults: 3 });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.count).toBe(15);
+  });
+
+  it.each([
+    { endpoint: 'web', type: undefined, expectedMaximum: 20 },
+    { endpoint: 'news', type: 'news', expectedMaximum: 50 },
+    { endpoint: 'images', type: 'images', expectedMaximum: 200 },
+    { endpoint: 'videos', type: 'videos', expectedMaximum: 50 },
+  ] as const)(
+    'caps braveSearchOptions.count for the $endpoint endpoint at its maximum: $expectedMaximum',
+    async ({ type, expectedMaximum }) => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: type == null ? { web: { results: [] } } : { results: [] },
+      });
+
+      const searchAPI = createSearchAPI({
+        searchProvider: 'brave',
+        braveApiKey: 'test-key',
+        braveSearchOptions: { count: 999 },
+      });
+
+      await searchAPI.getSources({ query: 'q', type });
+      const params = mockedAxios.get.mock.calls[0][1]?.params;
+      expect(params.count).toBe(expectedMaximum);
+    }
+  );
+
+  it('lets braveSearchOptions.freshness override the getSources argument', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: {
+        freshness: 'py',
+      },
+    });
+
+    await searchAPI.getSources({ query: 'q', date: DATE_RANGE.PAST_HOUR });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.freshness).toBe('py');
+  });
+
+  it('lets braveSearchOptions.safesearch override the getSources argument', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: {
+        safesearch: 'strict',
+      },
+    });
+
+    await searchAPI.getSources({ query: 'q', safeSearch: 1 });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.safesearch).toBe('strict');
+  });
+
+  it('falls back to braveSearchOptions.safesearch when no getSources argument is provided', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: {
+        safesearch: 'strict',
+      },
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.safesearch).toBe('strict');
+  });
+
+  it.each([
+    [0, 'off'],
+    [1, 'moderate'],
+    [2, 'strict'],
+  ] as const)(
+    'maps SafeSearchLevel %i to Brave safesearch %s',
+    async (level, expected) => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { web: { results: [] } },
+      });
+
+      const searchAPI = createSearchAPI({
+        searchProvider: 'brave',
+        braveApiKey: 'test-key',
+      });
+
+      await searchAPI.getSources({ query: 'q', safeSearch: level });
+      const params = mockedAxios.get.mock.calls[0][1]?.params;
+      expect(params.safesearch).toBe(expected);
+    }
+  );
+
+  it('defaults safesearch to moderate when no value is provided', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.safesearch).toBe('moderate');
+  });
+
+  it('defaults safesearch to `strict` on the images endpoint', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { results: [] } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q', type: 'images', safeSearch: 1 });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.safesearch).toBe('strict');
+  });
+
+  it('maps the explicit tool safeSearch argument to the API safesearch value', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { web: { results: [] } } });
+
+    const searchTool = createSearchTool({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      scraperProvider: 'tavily',
+      tavilyApiKey: 'test-key',
+      rerankerType: 'none',
+      logger: mockLogger,
+      safeSearch: 2,
+    });
+
+    await searchTool.invoke({ query: 'q' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.safesearch).toBe('strict');
+  });
+
+  it('forwards braveSearchOptions.goggles verbatim to the web endpoint', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { web: { results: [] } } });
+
+    const goggles =
+      'https://raw.githubusercontent.com/brave/goggles-quickstart/main/goggles/tech_blogs.goggle';
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: { goggles },
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params.goggles).toBe(goggles);
+  });
+
+  it.each([
+    { name: 'undefined', goggles: undefined },
+    { name: 'empty', goggles: '' },
+  ])('omits goggles when the option is $name', async ({ goggles }) => {
+    mockedAxios.get.mockResolvedValue({ data: { web: { results: [] } } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+      braveSearchOptions: { goggles },
+    });
+    await searchAPI.getSources({ query: 'q' });
+    const params = mockedAxios.get.mock.calls[0][1]?.params;
+    expect(params).not.toHaveProperty('goggles');
+  });
+
+  it('falls back to extra_snippets[0] when an organic result has no description', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        web: {
+          results: [
+            {
+              title: 'No description',
+              url: 'https://example.com',
+              extra_snippets: ['First snippet', 'Second snippet'],
+            },
+          ],
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'q' });
+    expect(result.data?.organic?.[0]?.snippet).toBe('First snippet');
+  });
+
+  it('prefers age over page_age for organic result date', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        web: {
+          results: [
+            {
+              title: 'Aged result',
+              url: 'https://example.com',
+              age: '2 weeks ago',
+              page_age: '2026-06-01T00:00:00',
+            },
+          ],
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'q' });
+    expect(result.data?.organic?.[0]?.date).toBe('2 weeks ago');
+  });
+
+  it('uses news profile.name as a source fallback', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'Headline',
+            url: 'https://apnews.com/story',
+            description: 'Body',
+            profile: { name: 'AP News', url: 'https://apnews.com/story' },
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'q', type: 'news' });
+    expect(result.data?.news?.[0]?.source).toBe('AP News');
+  });
+
+  it('falls back to video.author.name when video.creator is missing', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'A clip',
+            url: 'https://video.example.com/x',
+            video: {
+              duration: '1:23',
+              author: { name: 'Author Channel' },
+            },
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'brave',
+      braveApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'q', type: 'videos' });
+    expect(result.data?.videos?.[0]?.channel).toBe('Author Channel');
+  });
+});

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -4,6 +4,7 @@ import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
 import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
+import { createBraveAPI } from './brave-search';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -489,6 +490,9 @@ export const createSearchAPI = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    braveApiKey,
+    braveApiUrl,
+    braveSearchOptions,
   } = config;
 
   if (searchProvider.toLowerCase() === 'serper') {
@@ -503,9 +507,11 @@ export const createSearchAPI = (
       keenableApiUrl,
       keenableSearchOptions
     );
+  } else if (searchProvider.toLowerCase() === 'brave') {
+    return createBraveAPI(braveApiKey, braveApiUrl, braveSearchOptions);
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'keenable'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', 'keenable', or 'brave'`
     );
   }
 };

--- a/src/tools/search/tavily-search.ts
+++ b/src/tools/search/tavily-search.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type * as t from './types';
+import { getHostname } from './utils';
 
 const DEFAULT_TAVILY_TIMEOUT = 15000;
 
@@ -243,14 +244,6 @@ const normalizeTavilyTimeRange = (
     return timeRange;
   default:
     return undefined;
-  }
-};
-
-const getHostname = (link: string): string => {
-  try {
-    return new URL(link).hostname;
-  } catch {
-    return link;
   }
 };
 

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -339,7 +339,7 @@ function createTool({
 /**
  * Creates a search tool with configurable search and scraper providers.
  *
- * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized).
+ * Search providers: Serper (Google results), SearXNG (self-hosted meta-search), Tavily (AI-optimized), Brave (independent index).
  * Scraper providers: Firecrawl (default, full-featured), Serper (lightweight), Tavily (batch extraction).
  *
  * The country schema field is exposed to the LLM for providers that support localized results.
@@ -369,6 +369,9 @@ export const createSearchTool = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    braveApiKey,
+    braveApiUrl,
+    braveSearchOptions,
     rerankerType = 'cohere',
     rerankerTimeout,
     topResults = 5,
@@ -411,7 +414,11 @@ export const createSearchTool = (
     news: newsSchema,
   };
 
-  if (searchProvider === 'serper' || searchProvider === 'tavily') {
+  if (
+    searchProvider === 'serper' ||
+    searchProvider === 'tavily' ||
+    searchProvider === 'brave'
+  ) {
     schemaProperties.country = countrySchema;
   }
 
@@ -432,6 +439,9 @@ export const createSearchTool = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    braveApiKey,
+    braveApiUrl,
+    braveSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,7 +3,7 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable' | 'brave';
 export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
@@ -106,6 +106,18 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
+export type BraveTimeRange = 'pd' | 'pw' | 'pm' | 'py';
+export type BraveSafeSearch = 'off' | 'moderate' | 'strict';
+
+export interface BraveSearchOptions {
+  count?: number;
+  freshness?: BraveTimeRange;
+  safesearch?: BraveSafeSearch;
+  /** https://api-dashboard.search.brave.com/documentation/resources/goggles */
+  goggles?: string;
+  timeout?: number;
+}
+
 export interface SearchConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
@@ -118,6 +130,9 @@ export interface SearchConfig {
   keenableApiKey?: string;
   keenableApiUrl?: string;
   keenableSearchOptions?: KeenableSearchOptions;
+  braveApiKey?: string;
+  braveApiUrl?: string;
+  braveSearchOptions?: BraveSearchOptions;
 }
 
 export interface KeenableSearchOptions {
@@ -469,6 +484,95 @@ export interface TavilyExtractResult {
   images?: string[];
   favicon?: string;
   error?: string;
+}
+
+export interface BraveThumbnail {
+  src?: string;
+  original?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface BraveProfile {
+  name?: string;
+  url?: string;
+  long_name?: string;
+  img?: string;
+}
+
+export interface BraveWebResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  age?: string;
+  page_age?: string;
+  profile?: BraveProfile;
+  meta_url?: { hostname?: string };
+  thumbnail?: BraveThumbnail;
+  extra_snippets?: string[];
+}
+
+export interface BraveNewsResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  age?: string;
+  page_age?: string;
+  source?: string;
+  profile?: BraveProfile;
+  meta_url?: { hostname?: string };
+  thumbnail?: BraveThumbnail;
+  extra_snippets?: string[];
+}
+
+export interface BraveImageResult {
+  title?: string;
+  url?: string;
+  source?: string;
+  thumbnail?: BraveThumbnail;
+  properties?: {
+    url?: string;
+    placeholder?: string;
+    width?: number;
+    height?: number;
+  };
+}
+
+export interface BraveVideoResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  age?: string;
+  page_age?: string;
+  video?: {
+    duration?: string;
+    views?: number;
+    creator?: string;
+    publisher?: string;
+    requires_subscription?: boolean;
+    tags?: string[];
+    author?: BraveProfile;
+  };
+  meta_url?: { hostname?: string };
+  thumbnail?: BraveThumbnail;
+}
+
+export interface BraveWebSearchResponse {
+  web?: { results?: BraveWebResult[] };
+  news?: { results?: BraveNewsResult[] };
+  videos?: { results?: BraveVideoResult[] };
+}
+
+export interface BraveNewsSearchResponse {
+  results?: BraveNewsResult[];
+}
+
+export interface BraveImageSearchResponse {
+  results?: BraveImageResult[];
+}
+
+export interface BraveVideoSearchResponse {
+  results?: BraveVideoResult[];
 }
 
 export interface FirecrawlScraperConfig {

--- a/src/tools/search/utils.ts
+++ b/src/tools/search/utils.ts
@@ -175,3 +175,11 @@ export function getAttribution(
 
   return getDomainName(link, metadata, logger);
 }
+
+export const getHostname = (link: string): string => {
+  try {
+    return new URL(link).hostname;
+  } catch {
+    return link;
+  }
+};


### PR DESCRIPTION
## Summary

Adds [Brave Search](https://brave.com/search/api/) as a search provider. Wires up four of the documented Brave endpoints into the existing `createSearchAPI`/`createSearchTool` flow so that `searchProvider: 'brave'` is supported:
- [/v1/web/search](https://api-dashboard.search.brave.com/api-reference/web/search/get)
- [/v1/news/search](https://api-dashboard.search.brave.com/api-reference/news/news_search/get)
- [/v1/images/search](https://api-dashboard.search.brave.com/api-reference/images/image_search)
- [/v1/videos/search](https://api-dashboard.search.brave.com/api-reference/videos/video_search/get)

## Changes

**New provider:** `src/tools/search/brave-search.ts`
- `createBraveAPI(apiKey, apiUrl?, options?)` exposes the `getSources` interface
- Supports the generic web-search which returns `web`, `news`, and `video` results, and also routes by type (`images`, `videos`, `news`) to hit dedicated endpoints
- Country normalization: Filtered based on [Brave's supported countries](https://api-dashboard.search.brave.com/api-reference/web/search/get#parameter-country)
- Exposes various Brave API options

**Configuration:**
- New SearchConfig fields: `braveApiKey`, `braveApiUrl`, `braveSearchOptions`
- BraveSearchOptions:
  - `count` (num-results)
  - `freshness` (date-range)
  - `safesearch`
  - `goggles` (see: [Brave's goggles documentation](https://api-dashboard.search.brave.com/documentation/resources/goggles))
  - `timeout`

**Wiring:** (`src/tools/search/search.ts`, `src/tools/search/tool.ts`)
- `createSearchAPI` dispatches `'brave'` to `createBraveAPI`

**Refactor:** (`src/tools/search/utils.ts`)
- Extracted the `getHostname` helper out of `tavily-search.ts` and `brave-search.ts`

## Testing

- Unit tests in `src/tools/search/brave.test.ts` cover provider construction, error handling, response mapping, country/freshness/safesearch normalization, options precedence, per-endpoint count capping, and result-field fallbacks
- Smoke-tested end-to-end against the live Brave API