### PR TITLE
⚡ feat: Single Tail Prompt-Cache Breakpoint

### DIFF
--- a/docs/prompt-cache-benchmark.md
+++ b/docs/prompt-cache-benchmark.md
@@ -29,6 +29,29 @@ regardless of where that call's own breakpoints sit.
 This is the dominant agent shape (one request → many tool calls), which is
 exactly where the legacy approach degrades hardest.
 
+### Truncation and compaction
+
+Two harness behaviours mutate the transcript rather than append to it, so they
+deserve explicit treatment:
+
+- **Tool-output truncation** is applied **once, at tool-execution time**
+  ([`ToolNode`](../src/tools/ToolNode.ts) via
+  [`truncateToolResultContent`](../src/utils/truncation.ts)) with a cap derived
+  from the model's **fixed context window**, and the truncated string is what's
+  persisted. It is a pure, deterministic function (covered by
+  [`truncation.test.ts`](../src/utils/__tests__/truncation.test.ts)) and the cap
+  does not vary turn to turn, so a truncated result is a stable block in the
+  prefix — it never re-truncates differently and so never busts the cache.
+- **Compaction (summarization)** replaces the head with a durable summary
+  (`AgentContext.summaryText`, re-injected identically each turn). The
+  compaction event is a one-time cache miss for **any** strategy — the cached
+  prefix genuinely changed. Afterwards the summary is the new stable head and
+  the tail strategy re-establishes append-only caching over the continued
+  transcript. The benchmark's **post-compaction** scenario exercises exactly
+  this transition, and it is one of the largest wins (after compaction the
+  summary is the only user message, so legacy re-sends all continued tool work
+  uncached).
+
 ## Metric
 
 For each model call the provider reports a token breakdown. Summed per scenario:
@@ -56,29 +79,34 @@ direction is stable). `effective` is the headline — lower is cheaper.
 
 | Scenario                                     | strategy |    read |  write |      fresh |          effective |
 | -------------------------------------------- | -------- | ------: | -----: | ---------: | -----------------: |
-| Agent tool loop (1 user turn, N tool rounds) | legacy   |  98,352 | 24,588 | **46,221** |             86,791 |
-|                                              | tail     | 137,363 | 31,801 |     **33** |  **53,521** (−38%) |
+| Agent tool loop (1 user turn, N tool rounds) | legacy   |  92,348 | 23,087 | **44,705** |             82,799 |
+|                                              | tail     | 129,823 | 30,284 |     **33** |  **50,870** (−39%) |
 | Multi-turn chat (frequent user messages)     | legacy   |  90,478 | 23,662 | **21,595** |             60,220 |
-|                                              | tail     | 104,555 | 22,162 |     **18** |  **38,176** (−37%) |
-| Realistic agent (user turns + tool rounds)   | legacy   | 498,440 | 39,525 | **50,654** |            149,904 |
-|                                              | tail     | 519,827 | 41,702 |     **90** | **104,200** (−30%) |
+|                                              | tail     | 118,765 | 25,004 |     **18** |  **43,150** (−28%) |
+| Realistic agent (user turns + tool rounds)   | legacy   | 498,344 | 39,514 | **50,635** |            149,862 |
+|                                              | tail     | 545,327 | 43,202 |     **90** | **108,625** (−28%) |
+| Post-compaction (summary head + tool loop)   | legacy   |  69,852 | 40,538 | **63,346** |            121,004 |
+|                                              | tail     | 123,118 | 47,576 |     **42** |  **71,824** (−41%) |
 
 ### Bedrock (Converse)
 
-| Scenario                                     | strategy |    read |  write |      fresh |         effective |
-| -------------------------------------------- | -------- | ------: | -----: | ---------: | ----------------: |
-| Agent tool loop (1 user turn, N tool rounds) | legacy   | 100,430 | 20,086 | **21,618** |            56,768 |
-|                                              | tail     | 122,308 | 28,778 |     **33** | **48,236** (−15%) |
-| Multi-turn chat (frequent user messages)     | legacy   | 119,565 | 25,164 |         18 |            43,430 |
-|                                              | tail     | 104,555 | 22,162 |         18 | **38,176** (−12%) |
-| Realistic agent (user turns + tool rounds)   | legacy   | 521,423 | 39,514 | **27,556** |           129,091 |
-|                                              | tail     | 596,553 | 46,228 |     **90** | **117,530** (−9%) |
+| Scenario                                     | strategy |    read |  write |      fresh |          effective |
+| -------------------------------------------- | -------- | ------: | -----: | ---------: | -----------------: |
+| Agent tool loop (1 user turn, N tool rounds) | legacy   | 122,940 | 24,588 | **21,633** |             64,662 |
+|                                              | tail     | 121,518 | 28,623 |     **33** |  **47,964** (−26%) |
+| Multi-turn chat (frequent user messages)     | legacy   | 119,560 | 25,163 |         18 |             43,428 |
+|                                              | tail     | 104,555 | 22,162 |         18 |  **38,176** (−12%) |
+| Realistic agent (user turns + tool rounds)   | legacy   | 495,826 | 38,003 | **27,538** |            124,624 |
+|                                              | tail     | 545,327 | 43,202 |     **90** | **108,625** (−13%) |
+| Post-compaction (summary head + tool loop)   | legacy   |  96,139 | 35,287 | **22,808** |             76,531 |
+|                                              | tail     | 123,118 | 47,576 |     **42** |   **71,824** (−6%) |
 
 The tail strategy is cheaper (lower `effective`) in **every** scenario on both
-providers. The clearest signal is `fresh`: the legacy approach reprocesses tens
-of thousands of full-price tokens in any tool-bearing conversation, which the
-tail strategy reduces to near zero. Even the legacy strong case (frequent user
-messages, no tools) is a tie-or-win for the tail strategy.
+providers (4/4 each). The clearest signal is `fresh`: the legacy approach
+reprocesses tens of thousands of full-price tokens in any tool-bearing
+conversation, which the tail strategy reduces to near zero. Even the legacy
+strong case (frequent user messages, no tools) is a tie-or-win for the tail
+strategy.
 
 ## Reproduce
 

--- a/docs/prompt-cache-benchmark.md
+++ b/docs/prompt-cache-benchmark.md
@@ -1,0 +1,98 @@
+# Prompt-cache strategy benchmark
+
+This documents _why_ the default prompt-cache strategy is a **single tail
+breakpoint** anchored on the conversation tail (the Claude Code approach),
+rather than the legacy **"last two user messages"** markers — and how to
+reproduce the comparison live against a real provider.
+
+- Tail strategy: [`addTailCacheControl`](../src/messages/cache.ts) /
+  [`addBedrockTailCacheControl`](../src/messages/cache.ts)
+- Legacy strategy: `addCacheControl` / `addBedrockCacheControl` (still exported
+  for back-compat)
+- Benchmark: [`src/scripts/bench-prompt-cache.ts`](../src/scripts/bench-prompt-cache.ts)
+
+## Why the tail strategy wins
+
+A prompt-cache breakpoint caches everything _before_ it; the provider then
+reads back the longest matching cached prefix on the next call, automatically,
+regardless of where that call's own breakpoints sit.
+
+- **Legacy** pins markers on the **last two user messages**. In an agent tool
+  loop there is often only **one** user message for many turns, so the only
+  breakpoint sits at the top of the conversation. Every assistant/tool turn
+  appended afterwards falls _outside_ the cached prefix and is re-sent
+  **uncached (full price) on every subsequent call**. Cache write/fresh ≫ read.
+- **Tail** rides the true tail, so the transcript is written to cache once and
+  read back as history grows append-only. Freshly appended turns enter the
+  cached prefix on the next call instead of being reprocessed.
+
+This is the dominant agent shape (one request → many tool calls), which is
+exactly where the legacy approach degrades hardest.
+
+## Metric
+
+For each model call the provider reports a token breakdown. Summed per scenario:
+
+- `read` — tokens served from cache (**higher is better**)
+- `write` — tokens written to cache (`cache_creation`)
+- `fresh` — uncached input processed at full price; this balloons when caching
+  fails to cover the transcript (**lower is better**)
+- `effective` — a cost proxy in input-token-equivalents using the published
+  multipliers: `read ×0.1 + write ×1.25 + fresh ×1.0` (**lower is better**)
+
+`fresh` is computed provider-agnostically as
+`(total_tokens − output_tokens) − cache_read − cache_creation`. This matters
+because the two providers report `input_tokens` differently: Anthropic folds the
+cached tokens _into_ `input_tokens`, while Bedrock reports `input_tokens` as the
+fresh delta only with the cache buckets separate. Deriving `fresh` from
+`total_tokens` is correct on both.
+
+## Representative results
+
+Live, `claude-sonnet-4-5`, `rounds=6` (exact counts vary run to run; the
+direction is stable). `effective` is the headline — lower is cheaper.
+
+### Anthropic
+
+| Scenario                                     | strategy |    read |  write |      fresh |          effective |
+| -------------------------------------------- | -------- | ------: | -----: | ---------: | -----------------: |
+| Agent tool loop (1 user turn, N tool rounds) | legacy   |  98,352 | 24,588 | **46,221** |             86,791 |
+|                                              | tail     | 137,363 | 31,801 |     **33** |  **53,521** (−38%) |
+| Multi-turn chat (frequent user messages)     | legacy   |  90,478 | 23,662 | **21,595** |             60,220 |
+|                                              | tail     | 104,555 | 22,162 |     **18** |  **38,176** (−37%) |
+| Realistic agent (user turns + tool rounds)   | legacy   | 498,440 | 39,525 | **50,654** |            149,904 |
+|                                              | tail     | 519,827 | 41,702 |     **90** | **104,200** (−30%) |
+
+### Bedrock (Converse)
+
+| Scenario                                     | strategy |    read |  write |      fresh |         effective |
+| -------------------------------------------- | -------- | ------: | -----: | ---------: | ----------------: |
+| Agent tool loop (1 user turn, N tool rounds) | legacy   | 100,430 | 20,086 | **21,618** |            56,768 |
+|                                              | tail     | 122,308 | 28,778 |     **33** | **48,236** (−15%) |
+| Multi-turn chat (frequent user messages)     | legacy   | 119,565 | 25,164 |         18 |            43,430 |
+|                                              | tail     | 104,555 | 22,162 |         18 | **38,176** (−12%) |
+| Realistic agent (user turns + tool rounds)   | legacy   | 521,423 | 39,514 | **27,556** |           129,091 |
+|                                              | tail     | 596,553 | 46,228 |     **90** | **117,530** (−9%) |
+
+The tail strategy is cheaper (lower `effective`) in **every** scenario on both
+providers. The clearest signal is `fresh`: the legacy approach reprocesses tens
+of thousands of full-price tokens in any tool-bearing conversation, which the
+tail strategy reduces to near zero. Even the legacy strong case (frequent user
+messages, no tools) is a tie-or-win for the tail strategy.
+
+## Reproduce
+
+Requires real credentials in `.env` (or point `BENCH_ENV_FILE` at one):
+`ANTHROPIC_API_KEY` for Anthropic, `BEDROCK_AWS_ACCESS_KEY_ID` /
+`BEDROCK_AWS_SECRET_ACCESS_KEY` (and a region) for Bedrock. It makes real, paid
+API calls and is **not** a unit test (CI never runs it).
+
+```bash
+npm run bench:cache                          # Anthropic (default)
+npm run bench:cache -- --provider bedrock     # Bedrock Converse
+npm run bench:cache -- --rounds 10 --model claude-sonnet-4-5
+```
+
+Each scenario runs the _same_ conversation under both strategies in separate
+cache namespaces (unique per run), then prints the per-strategy totals and the
+delta.

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "tool": "node --trace-warnings -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tools.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/search.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
+    "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",
     "subagent:tools": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-tools-debug.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -16,7 +16,7 @@ import {
   Providers,
 } from '@/common';
 import {
-  addCacheControl,
+  addTailCacheControl,
   addCacheControlToStablePrefixMessages,
   cloneMessage,
 } from '@/messages/cache';
@@ -689,7 +689,7 @@ export class AgentContext {
         dynamicTail.length === 0 &&
         body.length >= 2
       ) {
-        body = addCacheControl(body);
+        body = addTailCacheControl(body);
       }
       return [...prefix, ...body];
     }).withConfig({ runName: 'prompt' });

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -274,16 +274,11 @@ describe('AgentContext', () => {
         new HumanMessage('First'),
         new HumanMessage('Second'),
       ]);
-      const firstContent = result[1].content as TestSystemContentBlock[];
       const secondContent = result[2].content as TestSystemContentBlock[];
 
       expect(result).toHaveLength(3);
       expect(result[0].content).toBe('Dynamic only');
-      expect(firstContent[0]).toMatchObject({
-        type: 'text',
-        text: 'First',
-        cache_control: { type: 'ephemeral' },
-      });
+      expect(result[1].content).toBe('First');
       expect(secondContent[0]).toMatchObject({
         type: 'text',
         text: 'Second',
@@ -686,7 +681,7 @@ describe('AgentContext', () => {
       expect(result[8].content).toBe('Now answer without tools');
     });
 
-    it('adds OpenRouter body cache points when there is no dynamic tail', async () => {
+    it('adds a single OpenRouter body cache point on the tail when there is no dynamic tail', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.OPENROUTER,
@@ -702,9 +697,8 @@ describe('AgentContext', () => {
         new HumanMessage('First'),
         new HumanMessage('Second'),
       ]);
-      const firstContent = result[1].content as TestSystemContentBlock[];
       const secondContent = result[2].content as TestSystemContentBlock[];
-      expect(firstContent[0]).toHaveProperty('cache_control');
+      expect(result[1].content).toBe('First');
       expect(secondContent[0]).toHaveProperty('cache_control');
     });
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -19,14 +19,14 @@ import {
   convertMessagesToContent,
   sanitizeOrphanToolBlocks,
   extractToolDiscoveries,
-  addBedrockCacheControl,
+  addBedrockTailCacheControl,
   formatArtifactPayload,
   enforceOriginalContentCap,
   formatContentStrings,
   isLegacyConvertible,
   createPruneMessages,
   syncBudgetDerivedFields,
-  addCacheControl,
+  addTailCacheControl,
   getMessageId,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
@@ -1741,14 +1741,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           anthropicOptions?.promptCache === true &&
           !agentContext.systemRunnable
         ) {
-          finalMessages = addCacheControl<BaseMessage>(finalMessages);
+          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
         }
       } else if (agentContext.provider === Providers.BEDROCK) {
         const bedrockOptions = agentContext.clientOptions as
           | t.BedrockAnthropicClientOptions
           | undefined;
         if (bedrockOptions?.promptCache === true) {
-          finalMessages = addBedrockCacheControl<BaseMessage>(finalMessages);
+          finalMessages = addBedrockTailCacheControl<BaseMessage>(finalMessages);
         }
       } else if (agentContext.provider === Providers.OPENROUTER) {
         const openRouterOptions = agentContext.clientOptions as
@@ -1758,7 +1758,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           openRouterOptions?.promptCache === true &&
           !agentContext.systemRunnable
         ) {
-          finalMessages = addCacheControl<BaseMessage>(finalMessages);
+          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
         }
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1754,13 +1754,48 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
-      // Intentionally broad: runs when the pruner wasn't used OR any post-pruning
-      // transform (ensureThinkingBlock, etc.) reassigned finalMessages.
-      // sanitizeOrphanToolBlocks fast-paths to a Set diff check when no orphans exist,
-      // so the cost is negligible and this acts as a safety net for Anthropic/Bedrock.
+      // Determine the prompt-cache strategy up front. The tail breakpoint must
+      // be applied AFTER thinking normalization and orphan sanitization (see
+      // below), but orphan sanitization must still run for prompt-cached sends —
+      // so its gate has to know a cache marker is coming. Anthropic/OpenRouter
+      // (which both use the ephemeral cache_control marker) skip when a system
+      // runnable owns the system-prompt breakpoint.
+      const anthropicPromptCache =
+        agentContext.provider === Providers.ANTHROPIC &&
+        (agentContext.clientOptions as t.AnthropicClientOptions | undefined)
+          ?.promptCache === true &&
+        !agentContext.systemRunnable;
+      const openRouterPromptCache =
+        agentContext.provider === Providers.OPENROUTER &&
+        (
+          agentContext.clientOptions as
+            | t.ProviderOptionsMap[Providers.OPENROUTER]
+            | undefined
+        )?.promptCache === true &&
+        !agentContext.systemRunnable;
+      const bedrockPromptCache =
+        agentContext.provider === Providers.BEDROCK &&
+        (
+          agentContext.clientOptions as
+            | t.BedrockAnthropicClientOptions
+            | undefined
+        )?.promptCache === true;
+      const willAddTailCache =
+        anthropicPromptCache || openRouterPromptCache || bedrockPromptCache;
+
+      // Intentionally broad: runs when the pruner wasn't used, when any
+      // post-pruning transform (ensureThinkingBlock, etc.) reassigned
+      // finalMessages, OR when a prompt-cache marker is about to be added. The
+      // last clause matters because the marker is now applied AFTER this gate:
+      // without it, a prompt-cached send whose pruner returned the context
+      // unchanged would skip cleanup and could ship orphaned AI/tool pairs from
+      // persisted history. sanitizeOrphanToolBlocks fast-paths to a Set diff
+      // check when no orphans exist, so the cost is negligible.
       const needsOrphanSanitize =
         anthropicLike &&
-        (!agentContext.pruneMessages || finalMessages !== messagesToUse);
+        (!agentContext.pruneMessages ||
+          finalMessages !== messagesToUse ||
+          willAddTailCache);
       if (needsOrphanSanitize) {
         const beforeSanitize = finalMessages.length;
         finalMessages = sanitizeOrphanToolBlocks(finalMessages);
@@ -1788,34 +1823,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // marking earlier would let the only breakpoint vanish before the model
       // call (zero message caching). Anchoring on the final message list keeps
       // the marker on a block that actually ships.
-      if (agentContext.provider === Providers.ANTHROPIC) {
-        const anthropicOptions = agentContext.clientOptions as
-          | t.AnthropicClientOptions
-          | undefined;
-        if (
-          anthropicOptions?.promptCache === true &&
-          !agentContext.systemRunnable
-        ) {
-          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
-        }
-      } else if (agentContext.provider === Providers.BEDROCK) {
-        const bedrockOptions = agentContext.clientOptions as
-          | t.BedrockAnthropicClientOptions
-          | undefined;
-        if (bedrockOptions?.promptCache === true) {
-          finalMessages =
-            addBedrockTailCacheControl<BaseMessage>(finalMessages);
-        }
-      } else if (agentContext.provider === Providers.OPENROUTER) {
-        const openRouterOptions = agentContext.clientOptions as
-          | t.ProviderOptionsMap[Providers.OPENROUTER]
-          | undefined;
-        if (
-          openRouterOptions?.promptCache === true &&
-          !agentContext.systemRunnable
-        ) {
-          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
-        }
+      if (anthropicPromptCache || openRouterPromptCache) {
+        finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
+      } else if (bedrockPromptCache) {
+        finalMessages = addBedrockTailCacheControl<BaseMessage>(finalMessages);
       }
 
       if (

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1754,48 +1754,53 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
-      // Determine the prompt-cache strategy up front. The tail breakpoint must
-      // be applied AFTER thinking normalization and orphan sanitization (see
-      // below), but orphan sanitization must still run for prompt-cached sends —
-      // so its gate has to know a cache marker is coming. Anthropic/OpenRouter
-      // (which both use the ephemeral cache_control marker) skip when a system
-      // runnable owns the system-prompt breakpoint.
-      const anthropicPromptCache =
+      // Determine the prompt-cache strategy up front. Two distinct facts:
+      //
+      //   `providerPromptCacheEnabled` — prompt caching is on for this provider
+      //   at all. This drives orphan cleanup, because EVERY cached send must be
+      //   sanitized — including the system-runnable path, where AgentContext (not
+      //   this node) adds the body marker.
+      //
+      //   `willAddTailCache` — THIS node will add the marker itself. Anthropic /
+      //   OpenRouter defer to the system runnable when one owns the system-prompt
+      //   breakpoint, so they exclude that case; Bedrock always marks here.
+      const anthropicPromptCacheEnabled =
         agentContext.provider === Providers.ANTHROPIC &&
         (agentContext.clientOptions as t.AnthropicClientOptions | undefined)
-          ?.promptCache === true &&
-        !agentContext.systemRunnable;
-      const openRouterPromptCache =
+          ?.promptCache === true;
+      const openRouterPromptCacheEnabled =
         agentContext.provider === Providers.OPENROUTER &&
         (
           agentContext.clientOptions as
             | t.ProviderOptionsMap[Providers.OPENROUTER]
             | undefined
-        )?.promptCache === true &&
-        !agentContext.systemRunnable;
-      const bedrockPromptCache =
+        )?.promptCache === true;
+      const bedrockPromptCacheEnabled =
         agentContext.provider === Providers.BEDROCK &&
         (
           agentContext.clientOptions as
             | t.BedrockAnthropicClientOptions
             | undefined
         )?.promptCache === true;
-      const willAddTailCache =
-        anthropicPromptCache || openRouterPromptCache || bedrockPromptCache;
+      const providerPromptCacheEnabled =
+        anthropicPromptCacheEnabled ||
+        openRouterPromptCacheEnabled ||
+        bedrockPromptCacheEnabled;
 
       // Intentionally broad: runs when the pruner wasn't used, when any
       // post-pruning transform (ensureThinkingBlock, etc.) reassigned
-      // finalMessages, OR when a prompt-cache marker is about to be added. The
-      // last clause matters because the marker is now applied AFTER this gate:
-      // without it, a prompt-cached send whose pruner returned the context
-      // unchanged would skip cleanup and could ship orphaned AI/tool pairs from
-      // persisted history. sanitizeOrphanToolBlocks fast-paths to a Set diff
-      // check when no orphans exist, so the cost is negligible.
+      // finalMessages, OR when this is a prompt-cached send. The last clause
+      // matters because the marker is now applied AFTER this gate (and, for the
+      // system-runnable path, in AgentContext entirely): without it, a cached
+      // send whose pruner returned the context unchanged would skip cleanup and
+      // could ship orphaned AI/tool pairs from persisted history.
+      // sanitizeOrphanToolBlocks fast-paths to a Set diff check when no orphans
+      // exist, so the cost is negligible.
       const needsOrphanSanitize =
         anthropicLike &&
         (!agentContext.pruneMessages ||
           finalMessages !== messagesToUse ||
-          willAddTailCache);
+          providerPromptCacheEnabled);
       if (needsOrphanSanitize) {
         const beforeSanitize = finalMessages.length;
         finalMessages = sanitizeOrphanToolBlocks(finalMessages);
@@ -1822,10 +1827,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // cachePoint, and sanitizeOrphanToolBlocks can drop the anchored block — so
       // marking earlier would let the only breakpoint vanish before the model
       // call (zero message caching). Anchoring on the final message list keeps
-      // the marker on a block that actually ships.
-      if (anthropicPromptCache || openRouterPromptCache) {
+      // the marker on a block that actually ships. The system-runnable path
+      // adds its body marker in AgentContext, so this node skips it there.
+      if (
+        (anthropicPromptCacheEnabled || openRouterPromptCacheEnabled) &&
+        !agentContext.systemRunnable
+      ) {
         finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
-      } else if (bedrockPromptCache) {
+      } else if (bedrockPromptCacheEnabled) {
         finalMessages = addBedrockTailCacheControl<BaseMessage>(finalMessages);
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1733,35 +1733,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
       }
 
-      if (agentContext.provider === Providers.ANTHROPIC) {
-        const anthropicOptions = agentContext.clientOptions as
-          | t.AnthropicClientOptions
-          | undefined;
-        if (
-          anthropicOptions?.promptCache === true &&
-          !agentContext.systemRunnable
-        ) {
-          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
-        }
-      } else if (agentContext.provider === Providers.BEDROCK) {
-        const bedrockOptions = agentContext.clientOptions as
-          | t.BedrockAnthropicClientOptions
-          | undefined;
-        if (bedrockOptions?.promptCache === true) {
-          finalMessages = addBedrockTailCacheControl<BaseMessage>(finalMessages);
-        }
-      } else if (agentContext.provider === Providers.OPENROUTER) {
-        const openRouterOptions = agentContext.clientOptions as
-          | t.ProviderOptionsMap[Providers.OPENROUTER]
-          | undefined;
-        if (
-          openRouterOptions?.promptCache === true &&
-          !agentContext.systemRunnable
-        ) {
-          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
-        }
-      }
-
       if (
         isThinkingEnabled(agentContext.provider, agentContext.clientOptions)
       ) {
@@ -1784,7 +1755,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       // Intentionally broad: runs when the pruner wasn't used OR any post-pruning
-      // transform (addCacheControl, ensureThinkingBlock, etc.) reassigned finalMessages.
+      // transform (ensureThinkingBlock, etc.) reassigned finalMessages.
       // sanitizeOrphanToolBlocks fast-paths to a Set diff check when no orphans exist,
       // so the cost is negligible and this acts as a safety net for Anthropic/Bedrock.
       const needsOrphanSanitize =
@@ -1806,6 +1777,44 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             },
             { runId: this.runId, agentId }
           );
+        }
+      }
+
+      // Place the single tail prompt-cache breakpoint LAST, after thinking
+      // normalization and orphan sanitization. ensureThinkingBlockInMessages can
+      // fold a trailing non-thinking AI→Tool chain into a `[Previous agent
+      // context]` HumanMessage whose builder copies text but not cache_control /
+      // cachePoint, and sanitizeOrphanToolBlocks can drop the anchored block — so
+      // marking earlier would let the only breakpoint vanish before the model
+      // call (zero message caching). Anchoring on the final message list keeps
+      // the marker on a block that actually ships.
+      if (agentContext.provider === Providers.ANTHROPIC) {
+        const anthropicOptions = agentContext.clientOptions as
+          | t.AnthropicClientOptions
+          | undefined;
+        if (
+          anthropicOptions?.promptCache === true &&
+          !agentContext.systemRunnable
+        ) {
+          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
+        }
+      } else if (agentContext.provider === Providers.BEDROCK) {
+        const bedrockOptions = agentContext.clientOptions as
+          | t.BedrockAnthropicClientOptions
+          | undefined;
+        if (bedrockOptions?.promptCache === true) {
+          finalMessages =
+            addBedrockTailCacheControl<BaseMessage>(finalMessages);
+        }
+      } else if (agentContext.provider === Providers.OPENROUTER) {
+        const openRouterOptions = agentContext.clientOptions as
+          | t.ProviderOptionsMap[Providers.OPENROUTER]
+          | undefined;
+        if (
+          openRouterOptions?.promptCache === true &&
+          !agentContext.systemRunnable
+        ) {
+          finalMessages = addTailCacheControl<BaseMessage>(finalMessages);
         }
       }
 

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -142,6 +142,35 @@ export function normalizeAnthropicToolCallId(
   return `${sanitized.slice(0, prefixMaxLength)}_${hash}`;
 }
 
+/**
+ * Lift any `cache_control` off the inner blocks of a tool result onto the
+ * `tool_result` block itself. Anthropic documents the top-level
+ * `messages.content` block as the cacheable position and does not document
+ * caching of sub-content blocks; the API currently honors a nested marker, but
+ * anchoring on the documented position keeps the single tail breakpoint robust
+ * (and mirrors the Bedrock cachePoint hoist). The first marker found wins; it is
+ * stripped from every inner block so exactly one survives, on the outer block.
+ */
+function hoistToolResultCacheControl(
+  content: string | MessageContentComplex[]
+): { content: string | MessageContentComplex[]; cacheControl: unknown } {
+  if (!Array.isArray(content)) {
+    return { content, cacheControl: undefined };
+  }
+  let cacheControl: unknown;
+  const stripped = content.map((block) => {
+    if ('cache_control' in block) {
+      cacheControl ??= (block as Record<string, unknown>).cache_control;
+      const clone = { ...(block as Record<string, unknown>) };
+      delete clone.cache_control;
+      return clone as MessageContentComplex;
+    }
+    return block;
+  });
+  // `stripped` is element-equal to `content` when no marker was present.
+  return { content: stripped, cacheControl };
+}
+
 function _ensureMessageContents(
   messages: BaseMessage[]
 ): (SystemMessage | HumanMessage | AIMessage)[] {
@@ -185,13 +214,20 @@ function _ensureMessageContents(
         const toolMessageContent = (
           message as { content?: BaseMessage['content'] | null }
         ).content;
+        // Hoist a tail cache_control off the inner content onto the
+        // tool_result block itself (the documented cacheable position).
+        const { content: hoistedContent, cacheControl } =
+          toolMessageContent != null
+            ? hoistToolResultCacheControl(_formatContent(message))
+            : { content: undefined, cacheControl: undefined };
         updatedMsgs.push(
           new HumanMessage({
             content: [
               {
                 type: 'tool_result',
-                ...(toolMessageContent != null
-                  ? { content: _formatContent(message) }
+                ...(hoistedContent != null ? { content: hoistedContent } : {}),
+                ...(cacheControl != null
+                  ? { cache_control: cacheControl as { type: 'ephemeral' } }
                   : {}),
                 tool_use_id: normalizeAnthropicToolCallId(
                   (message as ToolMessage).tool_call_id

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -19,6 +19,7 @@ import {
   convertToProviderContentBlock,
   parseBase64DataUrl,
 } from '@langchain/core/messages';
+import type { AnthropicMessage } from '@/types/messages';
 import {
   AnthropicImageBlockParam,
   AnthropicMessageCreateParams,
@@ -33,6 +34,7 @@ import {
   AnthropicCompactionBlockParam,
   AnthropicToolResponse,
 } from '../types';
+import { addTailCacheControl } from '@/messages/cache';
 import { Constants } from '@/common';
 
 type StandardTextBlock = Data.StandardTextBlock;
@@ -917,6 +919,16 @@ export function modelDisallowsAssistantPrefill(model?: string): boolean {
   return Number(match[1]) >= 6;
 }
 
+function messagesHaveCacheControl(
+  messages: AnthropicMessageCreateParams['messages']
+): boolean {
+  return messages.some(
+    (message) =>
+      Array.isArray(message.content) &&
+      message.content.some((block) => 'cache_control' in block)
+  );
+}
+
 export function stripUnsupportedAssistantPrefill<
   T extends Pick<AnthropicMessageCreateParams, 'messages'> & { model?: string },
 >(request: T): T {
@@ -940,9 +952,23 @@ export function stripUnsupportedAssistantPrefill<
     nextMessages.pop();
   }
 
+  /**
+   * If a single tail prompt-cache breakpoint rode the stripped assistant
+   * prefill, the survivors may now carry no `cache_control` at all, dropping
+   * message caching for this request. Re-anchor the breakpoint on the new tail
+   * (only when one was actually lost, so caching-off requests stay untouched).
+   * Reuses `addTailCacheControl` so the re-anchor honors the same block
+   * exclusions (reasoning / dropped deltas) as the original placement.
+   */
+  const reanchored =
+    messagesHaveCacheControl(messages) &&
+    !messagesHaveCacheControl(nextMessages)
+      ? addTailCacheControl(nextMessages as AnthropicMessage[])
+      : nextMessages;
+
   return {
     ...request,
-    messages: nextMessages,
+    messages: reanchored,
   };
 }
 

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -19,7 +19,6 @@ import {
   convertToProviderContentBlock,
   parseBase64DataUrl,
 } from '@langchain/core/messages';
-import type { AnthropicMessage } from '@/types/messages';
 import {
   AnthropicImageBlockParam,
   AnthropicMessageCreateParams,
@@ -34,7 +33,6 @@ import {
   AnthropicCompactionBlockParam,
   AnthropicToolResponse,
 } from '../types';
-import { addTailCacheControl } from '@/messages/cache';
 import { Constants } from '@/common';
 
 type StandardTextBlock = Data.StandardTextBlock;
@@ -965,6 +963,76 @@ function messagesHaveCacheControl(
   );
 }
 
+/** Anthropic rejects cache_control on these reasoning blocks. */
+const NON_CACHEABLE_PAYLOAD_BLOCK_TYPES = new Set([
+  'thinking',
+  'redacted_thinking',
+]);
+
+/**
+ * Place one ephemeral `cache_control` on the last cacheable block of the final
+ * message of an already-converted Anthropic payload. Used to re-anchor the tail
+ * breakpoint after a trailing assistant prefill is stripped. Operates on the
+ * post-conversion payload, where blocks the converter drops (foreign reasoning,
+ * input_json_delta) are already gone — only native thinking blocks must be
+ * skipped. Returns a new array only when it actually places a marker.
+ */
+function reanchorTailCacheControl(
+  messages: AnthropicMessageCreateParams['messages']
+): AnthropicMessageCreateParams['messages'] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  const lastIndex = messages.length - 1;
+  const tail = messages[lastIndex];
+  const content = tail.content;
+
+  if (typeof content === 'string') {
+    if (content.trim() === '') {
+      return messages;
+    }
+    const next = [...messages];
+    next[lastIndex] = {
+      ...tail,
+      content: [
+        { type: 'text', text: content, cache_control: { type: 'ephemeral' } },
+      ],
+    } as (typeof messages)[number];
+    return next;
+  }
+
+  if (!Array.isArray(content)) {
+    return messages;
+  }
+
+  let anchor = -1;
+  for (let i = 0; i < content.length; i++) {
+    const type = (content[i] as { type?: string }).type;
+    if (type == null || NON_CACHEABLE_PAYLOAD_BLOCK_TYPES.has(type)) {
+      continue;
+    }
+    if (
+      type === 'text' &&
+      ((content[i] as { text?: string }).text ?? '').trim() === ''
+    ) {
+      continue;
+    }
+    anchor = i;
+  }
+  if (anchor < 0) {
+    return messages;
+  }
+
+  const next = [...messages];
+  next[lastIndex] = {
+    ...tail,
+    content: content.map((block, i) =>
+      i === anchor ? { ...block, cache_control: { type: 'ephemeral' } } : block
+    ),
+  } as (typeof messages)[number];
+  return next;
+}
+
 export function stripUnsupportedAssistantPrefill<
   T extends Pick<AnthropicMessageCreateParams, 'messages'> & { model?: string },
 >(request: T): T {
@@ -993,13 +1061,11 @@ export function stripUnsupportedAssistantPrefill<
    * prefill, the survivors may now carry no `cache_control` at all, dropping
    * message caching for this request. Re-anchor the breakpoint on the new tail
    * (only when one was actually lost, so caching-off requests stay untouched).
-   * Reuses `addTailCacheControl` so the re-anchor honors the same block
-   * exclusions (reasoning / dropped deltas) as the original placement.
    */
   const reanchored =
     messagesHaveCacheControl(messages) &&
     !messagesHaveCacheControl(nextMessages)
-      ? addTailCacheControl(nextMessages as AnthropicMessage[])
+      ? reanchorTailCacheControl(nextMessages)
       : nextMessages;
 
   return {

--- a/src/llm/anthropic/utils/stripPrefillCache.test.ts
+++ b/src/llm/anthropic/utils/stripPrefillCache.test.ts
@@ -1,0 +1,111 @@
+import type { AnthropicMessageCreateParams } from '../types';
+import { stripUnsupportedAssistantPrefill } from './message_inputs';
+
+/**
+ * When a model disallows assistant prefill (Claude 4.6+), the trailing
+ * assistant message is stripped right before the API call. If the single tail
+ * prompt-cache breakpoint rode that assistant prefill, the survivors would lose
+ * their only message-level `cache_control` — so the strip must re-anchor the
+ * breakpoint onto the new tail.
+ */
+
+type Msgs = AnthropicMessageCreateParams['messages'];
+
+function cacheControlBlocks(messages: Msgs): number {
+  let n = 0;
+  for (const m of messages) {
+    if (!Array.isArray(m.content)) continue;
+    for (const b of m.content) {
+      if ('cache_control' in b) n++;
+    }
+  }
+  return n;
+}
+
+describe('stripUnsupportedAssistantPrefill — cache re-anchoring', () => {
+  test('re-anchors the breakpoint onto the new tail when the prefill carried it', () => {
+    const request = {
+      model: 'claude-opus-4-6',
+      max_tokens: 100,
+      messages: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'q' }],
+        },
+        {
+          role: 'assistant' as const,
+          content: [
+            {
+              type: 'text' as const,
+              text: 'prefill',
+              cache_control: { type: 'ephemeral' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const out = stripUnsupportedAssistantPrefill(request);
+
+    // Prefill removed, and exactly one breakpoint survives — on the new tail.
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe('user');
+    expect(cacheControlBlocks(out.messages)).toBe(1);
+    const tail = out.messages[0].content as Array<{ cache_control?: unknown }>;
+    expect(tail[tail.length - 1].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('does not add a breakpoint when caching was off (no marker present)', () => {
+    const request = {
+      model: 'claude-opus-4-6',
+      max_tokens: 100,
+      messages: [
+        { role: 'user' as const, content: 'q' },
+        { role: 'assistant' as const, content: 'prefill' },
+      ],
+    };
+
+    const out = stripUnsupportedAssistantPrefill(request);
+
+    expect(out.messages).toHaveLength(1);
+    expect(cacheControlBlocks(out.messages)).toBe(0);
+  });
+
+  test('leaves a surviving breakpoint untouched (no double-anchor)', () => {
+    const request = {
+      model: 'claude-opus-4-6',
+      max_tokens: 100,
+      messages: [
+        {
+          role: 'user' as const,
+          content: [
+            {
+              type: 'text' as const,
+              text: 'q',
+              cache_control: { type: 'ephemeral' as const },
+            },
+          ],
+        },
+        { role: 'assistant' as const, content: 'prefill' },
+      ],
+    };
+
+    const out = stripUnsupportedAssistantPrefill(request);
+
+    expect(out.messages).toHaveLength(1);
+    expect(cacheControlBlocks(out.messages)).toBe(1);
+  });
+
+  test('older models keep the assistant prefill (no strip, no re-anchor)', () => {
+    const request = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 100,
+      messages: [
+        { role: 'user' as const, content: 'q' },
+        { role: 'assistant' as const, content: '{' },
+      ],
+    };
+
+    expect(stripUnsupportedAssistantPrefill(request)).toBe(request);
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -832,15 +832,34 @@ function convertToolMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
     content = [{ text: String(msg.content) }];
   }
 
+  // A `cachePoint` is a message-level ContentBlock — it is NOT a valid
+  // ToolResultContentBlock. A tail prompt-cache breakpoint that anchors on a
+  // tool result therefore ends up nested inside `toolResult.content`, which
+  // Bedrock silently ignores (no cache write, no cache read). Hoist any
+  // cachePoint(s) out of the tool result body so they sit as siblings after
+  // it, which is the only position Bedrock honors.
+  const toolResultContent: BedrockContentBlock[] = [];
+  const trailingCachePoints: BedrockContentBlock[] = [];
+  for (const block of content) {
+    if (isDefaultCachePoint(block)) {
+      trailingCachePoints.push({
+        cachePoint: { type: 'default' },
+      } as BedrockContentBlock);
+    } else {
+      toolResultContent.push(block);
+    }
+  }
+
   return {
     role: 'user',
     content: [
       {
         toolResult: {
           toolUseId: toolCallId,
-          content: content as { text: string }[],
+          content: toolResultContent as { text: string }[],
         },
       },
+      ...trailingCachePoints,
     ],
   };
 }

--- a/src/llm/bedrock/utils/toolResultCachePoint.test.ts
+++ b/src/llm/bedrock/utils/toolResultCachePoint.test.ts
@@ -1,0 +1,103 @@
+import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
+import type {
+  BaseMessage,
+  MessageContentComplex,
+} from '@langchain/core/messages';
+import { addBedrockTailCacheControl } from '@/messages/cache';
+import { convertToConverseMessages } from './message_inputs';
+import { toLangChainContent } from '@/messages/langchain';
+
+/**
+ * A Bedrock `cachePoint` is a message-level ContentBlock and is NOT a valid
+ * `ToolResultContentBlock`. When the single tail prompt-cache breakpoint
+ * anchors on a tool result (the common agent-loop shape), the cachePoint must
+ * be hoisted out of `toolResult.content` to a message-level sibling — otherwise
+ * Bedrock silently drops the breakpoint (no cache write, no cache read),
+ * verified live against Bedrock Converse.
+ */
+
+interface ConverseBlock {
+  text?: string;
+  cachePoint?: { type?: string };
+  toolResult?: {
+    toolUseId?: string;
+    content?: Array<{ text?: string; cachePoint?: { type?: string } }>;
+  };
+}
+
+function toolUserMessage(
+  result: ReturnType<typeof convertToConverseMessages>
+): ConverseBlock[] {
+  const msg = result.converseMessages.find(
+    (m) =>
+      m.role === 'user' && m.content?.some((c) => 'toolResult' in c) === true
+  );
+  return (msg?.content ?? []) as ConverseBlock[];
+}
+
+describe('convertToConverseMessages — tool-result cachePoint hoisting', () => {
+  it('hoists a cachePoint out of toolResult.content to a message-level sibling', () => {
+    const toolMsg = new ToolMessage({
+      tool_call_id: 't1',
+      content: toLangChainContent([
+        { type: 'text', text: 'result body' },
+        { cachePoint: { type: 'default' } },
+      ] as MessageContentComplex[]),
+    });
+
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('go'),
+      toolMsg,
+    ]);
+
+    const content = toolUserMessage({ converseMessages, converseSystem: [] });
+
+    // toolResult body must NOT contain the cachePoint
+    const toolResult = content.find((c) => 'toolResult' in c)?.toolResult;
+    expect(toolResult?.content?.some((b) => 'cachePoint' in b)).toBe(false);
+    expect(toolResult?.content).toEqual([{ text: 'result body' }]);
+
+    // cachePoint must be a sibling AFTER the toolResult block
+    expect(content[content.length - 1]).toEqual({
+      cachePoint: { type: 'default' },
+    });
+  });
+
+  it('leaves tool results without a cachePoint untouched', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('go'),
+      new ToolMessage({ tool_call_id: 't1', content: 'plain result' }),
+    ]);
+
+    const content = toolUserMessage({ converseMessages, converseSystem: [] });
+    expect(content).toEqual([
+      { toolResult: { toolUseId: 't1', content: [{ text: 'plain result' }] } },
+    ]);
+  });
+
+  it('end-to-end: tail breakpoint on a string tool result renders as a valid sibling cachePoint', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('What is 15 * 23? Use the calculator.'),
+      new AIMessage({
+        content: 'Calculating.',
+        tool_calls: [
+          { id: 't1', name: 'calculator', args: { expression: '15 * 23' } },
+        ],
+      }),
+      new ToolMessage({ tool_call_id: 't1', content: '345' }),
+    ];
+
+    const cached = addBedrockTailCacheControl(messages);
+    const { converseMessages } = convertToConverseMessages(cached);
+
+    const content = toolUserMessage({ converseMessages, converseSystem: [] });
+    const toolResult = content.find((c) => 'toolResult' in c)?.toolResult;
+
+    // Exactly one cachePoint, at the message level, never nested in the body.
+    expect(toolResult?.content?.some((b) => 'cachePoint' in b)).toBe(false);
+    expect(content.filter((c) => 'cachePoint' in c)).toHaveLength(1);
+    expect(content[content.length - 1]).toEqual({
+      cachePoint: { type: 'default' },
+    });
+  });
+});

--- a/src/messages/cache.tail.test.ts
+++ b/src/messages/cache.tail.test.ts
@@ -135,6 +135,33 @@ describe('addTailCacheControl (single tail breakpoint)', () => {
     expect(blocksOf(result[1])[1]).not.toHaveProperty('cache_control');
   });
 
+  test.each(['reasoning_content', 'reasoning', 'think'])(
+    'does not anchor on a trailing foreign reasoning block (%s)',
+    (reasoningType) => {
+      // Foreign reasoning (Bedrock/Google/LibreChat) is dropped by the
+      // Anthropic converter on assistant turns; anchoring the only breakpoint
+      // there would silently lose tail caching on a cross-provider handoff.
+      const messages: BaseMessage[] = [
+        new HumanMessage('Hi'),
+        new AIMessage({
+          content: toLangChainContent([
+            { type: 'text', text: 'Here is my answer.' },
+            { type: reasoningType, text: 'foreign reasoning' },
+          ] as MessageContentComplex[]),
+        }),
+      ];
+
+      const result = addTailCacheControl(messages);
+
+      expect(countCacheMarkers(result)).toBe(1);
+      // Marker must land on the surviving text block, not the reasoning block.
+      expect(blocksOf(result[1])[0].cache_control).toEqual({
+        type: 'ephemeral',
+      });
+      expect(blocksOf(result[1])[1]).not.toHaveProperty('cache_control');
+    }
+  );
+
   test('skips synthetic meta tail and anchors on the previous real message', () => {
     const realTail = new AIMessage({ content: 'real answer' });
     const metaTail = new HumanMessage({ content: 'reinjected skill body' });

--- a/src/messages/cache.tail.test.ts
+++ b/src/messages/cache.tail.test.ts
@@ -4,11 +4,11 @@ import {
   SystemMessage,
   ToolMessage,
 } from '@langchain/core/messages';
-import type Anthropic from '@anthropic-ai/sdk';
 import type {
   BaseMessage,
   MessageContentComplex,
 } from '@langchain/core/messages';
+import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicMessages } from '@/types/messages';
 import { addTailCacheControl, addBedrockTailCacheControl } from './cache';
 import { toLangChainContent } from './langchain';
@@ -235,9 +235,7 @@ describe('addBedrockTailCacheControl (single tail cachePoint)', () => {
     expect(countCachePoints(result)).toBe(1);
     const tail = blocksOf(result[2]);
     expect(tail[tail.length - 1]).toEqual({ cachePoint: { type: 'default' } });
-    expect(
-      blocksOf(result[0]).some((b) => 'cachePoint' in b)
-    ).toBe(false);
+    expect(blocksOf(result[0]).some((b) => 'cachePoint' in b)).toBe(false);
   });
 
   test('strips Anthropic cache_control from a system message but never anchors it', () => {
@@ -289,6 +287,26 @@ describe('addBedrockTailCacheControl (single tail cachePoint)', () => {
     expect(countCachePoints(result)).toBe(1);
     expect(blocksOf(result[1])).toEqual([
       { type: 'text', text: 'Final' },
+      { cachePoint: { type: 'default' } },
+    ]);
+  });
+
+  test('anchors on a trailing string tool result (agent-loop tail)', () => {
+    const result = addBedrockTailCacheControl([
+      new HumanMessage('Run the tool'),
+      new AIMessage({
+        content: 'Calling it',
+        tool_calls: [{ id: 't1', name: 'search', args: {} }],
+      }),
+      new ToolMessage({ tool_call_id: 't1', content: 'result body' }),
+    ]);
+
+    // The single cachePoint must land on the trailing tool result so the
+    // tool output is part of the cached prefix; the converter later hoists it
+    // out of toolResult.content (see toolResultCachePoint.test.ts).
+    expect(countCachePoints(result)).toBe(1);
+    expect(blocksOf(result[2])).toEqual([
+      { type: 'text', text: 'result body' },
       { cachePoint: { type: 'default' } },
     ]);
   });

--- a/src/messages/cache.tail.test.ts
+++ b/src/messages/cache.tail.test.ts
@@ -1,0 +1,295 @@
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import type Anthropic from '@anthropic-ai/sdk';
+import type {
+  BaseMessage,
+  MessageContentComplex,
+} from '@langchain/core/messages';
+import type { AnthropicMessages } from '@/types/messages';
+import { addTailCacheControl, addBedrockTailCacheControl } from './cache';
+import { toLangChainContent } from './langchain';
+
+type CacheControlBlock = MessageContentComplex & {
+  cache_control?: { type: 'ephemeral'; ttl?: '1h' };
+};
+
+/** Count every block across all messages that carries a cache_control marker. */
+function countCacheMarkers(
+  messages: ReadonlyArray<{ content: unknown }>
+): number {
+  let count = 0;
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (block && typeof block === 'object' && 'cache_control' in block) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function blocksOf(message: { content: unknown }): CacheControlBlock[] {
+  return message.content as CacheControlBlock[];
+}
+
+describe('addTailCacheControl (single tail breakpoint)', () => {
+  test('places exactly one marker on the last message', () => {
+    const messages: AnthropicMessages = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] },
+      { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Doing well' }] },
+      { role: 'user', content: [{ type: 'text', text: 'Great!' }] },
+    ];
+
+    const result = addTailCacheControl(messages);
+
+    expect(countCacheMarkers(result)).toBe(1);
+    expect(
+      (result[4].content[0] as Anthropic.TextBlockParam).cache_control
+    ).toEqual({ type: 'ephemeral' });
+    expect(result[2].content[0]).not.toHaveProperty('cache_control');
+  });
+
+  test('anchors on a trailing tool_result block (tail is a tool turn)', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Run the tool'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'Calling it' },
+          { type: 'tool_use', id: 't1', name: 'search', input: {} },
+        ] as MessageContentComplex[]),
+        tool_calls: [{ id: 't1', name: 'search', args: {} }],
+      }),
+      new ToolMessage({
+        tool_call_id: 't1',
+        content: toLangChainContent([
+          {
+            type: 'tool_result',
+            tool_use_id: 't1',
+            content: 'result body',
+          },
+        ] as MessageContentComplex[]),
+      }),
+    ];
+
+    const result = addTailCacheControl(messages);
+
+    expect(countCacheMarkers(result)).toBe(1);
+    expect(blocksOf(result[2])[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('strips ALL stale markers and re-anchors a single one at the tail', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'old marker',
+            cache_control: { type: 'ephemeral' },
+          },
+        ] as MessageContentComplex[]),
+      }),
+      new HumanMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'another old marker',
+            cache_control: { type: 'ephemeral' },
+          },
+        ] as MessageContentComplex[]),
+      }),
+      new AIMessage({ content: 'reply' }),
+    ];
+
+    const result = addTailCacheControl(messages);
+
+    expect(countCacheMarkers(result)).toBe(1);
+    expect(blocksOf(result[2])[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(blocksOf(result[0])[0]).not.toHaveProperty('cache_control');
+    expect(blocksOf(result[1])[0]).not.toHaveProperty('cache_control');
+  });
+
+  test('does not anchor on thinking blocks', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Hi'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'thought through it' },
+          { type: 'thinking', thinking: 'secret reasoning' },
+        ] as MessageContentComplex[]),
+      }),
+    ];
+
+    const result = addTailCacheControl(messages);
+
+    expect(countCacheMarkers(result)).toBe(1);
+    expect(blocksOf(result[1])[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(blocksOf(result[1])[1]).not.toHaveProperty('cache_control');
+  });
+
+  test('skips synthetic meta tail and anchors on the previous real message', () => {
+    const realTail = new AIMessage({ content: 'real answer' });
+    const metaTail = new HumanMessage({ content: 'reinjected skill body' });
+    (
+      metaTail as unknown as { additional_kwargs: Record<string, unknown> }
+    ).additional_kwargs = { isMeta: true };
+
+    const result = addTailCacheControl([
+      new HumanMessage({ content: 'question' }),
+      realTail,
+      metaTail,
+    ]);
+
+    expect(countCacheMarkers(result)).toBe(1);
+    expect(blocksOf(result[1])[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('handles string content on the tail', () => {
+    const messages: AnthropicMessages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Final' },
+    ];
+
+    const result = addTailCacheControl(messages);
+
+    expect(result[0].content).toBe('Hello');
+    expect(result[1].content[0]).toEqual({
+      type: 'text',
+      text: 'Final',
+      cache_control: { type: 'ephemeral' },
+    });
+  });
+
+  test('does not mutate the original messages', () => {
+    const original: AnthropicMessages = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'World' }] },
+    ];
+
+    addTailCacheControl(original);
+
+    expect(original[1].content[0]).not.toHaveProperty('cache_control');
+  });
+
+  test('returns input unchanged for empty array', () => {
+    const messages: AnthropicMessages = [];
+    expect(addTailCacheControl(messages)).toEqual([]);
+  });
+});
+
+/** Count every Bedrock cachePoint block across all messages. */
+function countCachePoints(
+  messages: ReadonlyArray<{ content: unknown }>
+): number {
+  let count = 0;
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (block && typeof block === 'object' && 'cachePoint' in block) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+describe('addBedrockTailCacheControl (single tail cachePoint)', () => {
+  test('inserts exactly one cachePoint after the last text block of the tail', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('First question'),
+      new AIMessage('First answer'),
+      new HumanMessage('Second question'),
+    ];
+
+    const result = addBedrockTailCacheControl(messages);
+
+    expect(countCachePoints(result)).toBe(1);
+    const tail = blocksOf(result[2]);
+    expect(tail[tail.length - 1]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  test('strips stale cachePoints and re-anchors a single one at the tail', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'old' },
+          { cachePoint: { type: 'default' } },
+        ] as MessageContentComplex[]),
+      }),
+      new AIMessage('reply'),
+      new HumanMessage('newest'),
+    ];
+
+    const result = addBedrockTailCacheControl(messages);
+
+    expect(countCachePoints(result)).toBe(1);
+    const tail = blocksOf(result[2]);
+    expect(tail[tail.length - 1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(
+      blocksOf(result[0]).some((b) => 'cachePoint' in b)
+    ).toBe(false);
+  });
+
+  test('strips Anthropic cache_control from a system message but never anchors it', () => {
+    const messages: BaseMessage[] = [
+      new SystemMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'system rules',
+            cache_control: { type: 'ephemeral' },
+          },
+        ] as MessageContentComplex[]),
+      }),
+      new HumanMessage('hi'),
+    ];
+
+    const result = addBedrockTailCacheControl(messages);
+
+    expect(blocksOf(result[0])[0]).not.toHaveProperty('cache_control');
+    expect(countCachePoints(result)).toBe(1);
+    expect(blocksOf(result[1])[1]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  test('skips synthetic meta tail and anchors on the previous real message', () => {
+    const metaTail = new HumanMessage({ content: 'reinjected skill body' });
+    (
+      metaTail as unknown as { additional_kwargs: Record<string, unknown> }
+    ).additional_kwargs = { source: 'skill' };
+
+    const result = addBedrockTailCacheControl([
+      new HumanMessage('question'),
+      new AIMessage('real answer'),
+      metaTail,
+    ]);
+
+    expect(countCachePoints(result)).toBe(1);
+    const realTail = blocksOf(result[1]);
+    expect(realTail[realTail.length - 1]).toEqual({
+      cachePoint: { type: 'default' },
+    });
+  });
+
+  test('handles string content on the tail', () => {
+    const result = addBedrockTailCacheControl([
+      new HumanMessage('Hello'),
+      new AIMessage('Final'),
+    ]);
+
+    expect(countCachePoints(result)).toBe(1);
+    expect(blocksOf(result[1])).toEqual([
+      { type: 'text', text: 'Final' },
+      { cachePoint: { type: 'default' } },
+    ]);
+  });
+});

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -254,20 +254,37 @@ function isCachePoint(block: MessageContentComplex): boolean {
   return 'cachePoint' in block && !('type' in block);
 }
 
-const THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking']);
+/**
+ * Reasoning block types that must never anchor the tail cache breakpoint:
+ * - `thinking` / `redacted_thinking`: native Anthropic reasoning — the API
+ *   rejects `cache_control` on these blocks.
+ * - `reasoning_content` / `reasoning` / `think`: foreign reasoning (Bedrock,
+ *   Google, LibreChat) that `_convertMessagesToAnthropicPayload` DROPS on
+ *   assistant turns during a cross-provider handoff. Anchoring the only
+ *   breakpoint on a block that is about to disappear silently loses tail
+ *   caching, so these are excluded too.
+ */
+const NON_ANCHORABLE_REASONING_TYPES = new Set([
+  'thinking',
+  'redacted_thinking',
+  'reasoning_content',
+  'reasoning',
+  'think',
+]);
 
 /**
  * A block can anchor the tail cache breakpoint when it is a real content block
- * that the Anthropic API accepts `cache_control` on. Thinking/redacted_thinking
- * blocks reject cache_control, and empty text blocks are not cacheable, so both
- * are excluded.
+ * that the Anthropic API accepts `cache_control` on and that survives provider
+ * conversion. Native/foreign reasoning blocks are excluded (see
+ * {@link NON_ANCHORABLE_REASONING_TYPES}), and empty text blocks are not
+ * cacheable, so both are skipped.
  */
 function isTailCacheableBlock(block: MessageContentComplex): boolean {
   if (isCachePoint(block)) {
     return false;
   }
   const type = (block as { type?: string }).type;
-  if (type == null || THINKING_BLOCK_TYPES.has(type)) {
+  if (type == null || NON_ANCHORABLE_REASONING_TYPES.has(type)) {
     return false;
   }
   if (type === 'text') {
@@ -335,16 +352,20 @@ export function addTailCacheControl<T extends AnthropicMessage | BaseMessage>(
           delete (cloned as Record<string, unknown>).cache_control;
           modified = true;
         }
-        if (canPlaceMarker && isTailCacheableBlock(cloned as MessageContentComplex)) {
+        if (
+          canPlaceMarker &&
+          isTailCacheableBlock(cloned as MessageContentComplex)
+        ) {
           tailIndex = workingContent.length;
         }
         workingContent.push(cloned as MessageContentComplex);
       }
 
       if (canPlaceMarker && tailIndex >= 0) {
-        (workingContent[tailIndex] as Anthropic.TextBlockParam).cache_control = {
-          type: 'ephemeral',
-        };
+        (workingContent[tailIndex] as Anthropic.TextBlockParam).cache_control =
+          {
+            type: 'ephemeral',
+          };
         markerPlaced = true;
         modified = true;
       }

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -254,6 +254,126 @@ function isCachePoint(block: MessageContentComplex): boolean {
   return 'cachePoint' in block && !('type' in block);
 }
 
+const THINKING_BLOCK_TYPES = new Set(['thinking', 'redacted_thinking']);
+
+/**
+ * A block can anchor the tail cache breakpoint when it is a real content block
+ * that the Anthropic API accepts `cache_control` on. Thinking/redacted_thinking
+ * blocks reject cache_control, and empty text blocks are not cacheable, so both
+ * are excluded.
+ */
+function isTailCacheableBlock(block: MessageContentComplex): boolean {
+  if (isCachePoint(block)) {
+    return false;
+  }
+  const type = (block as { type?: string }).type;
+  if (type == null || THINKING_BLOCK_TYPES.has(type)) {
+    return false;
+  }
+  if (type === 'text') {
+    const text = (block as { text?: string }).text;
+    return text != null && text.trim() !== '';
+  }
+  return true;
+}
+
+/**
+ * Anthropic API: single tail cache breakpoint (default strategy).
+ *
+ * Places exactly ONE `cache_control` marker on the last cacheable block of the
+ * final non-synthetic message, mirroring the Claude Code strategy
+ * (`markerIndex = messages.length - 1`). Because the marker always rides the
+ * true tail, the entire conversation prefix is written once and read back on
+ * the next turn as the history grows append-only — instead of the rolling
+ * "last two user messages" markers, which leave freshly appended tool/assistant
+ * turns outside the cached prefix and re-write large spans every step.
+ *
+ * Stale markers (Anthropic `cache_control` and Bedrock cache points) are
+ * stripped from every message in a single backward pass so exactly one marker
+ * survives. Synthetic skill/meta messages are skipped as anchors (their volatile
+ * content must not pin the cache) but still have stale markers removed.
+ *
+ * Returns a new array; only messages that require modification are cloned.
+ */
+export function addTailCacheControl<T extends AnthropicMessage | BaseMessage>(
+  messages: T[]
+): T[] {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return messages;
+  }
+
+  const updatedMessages: T[] = [...messages];
+  let markerPlaced = false;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const originalMessage = updatedMessages[i];
+    const content = originalMessage.content;
+    const hasArrayContent = Array.isArray(content);
+    const canPlaceMarker =
+      !markerPlaced && !isSyntheticMetaMessage(originalMessage);
+
+    // Earlier string-content messages carry no markers to strip.
+    if (!canPlaceMarker && !hasArrayContent) {
+      continue;
+    }
+
+    let workingContent: MessageContentComplex[];
+    let modified = false;
+
+    if (hasArrayContent) {
+      const src = content as MessageContentComplex[];
+      workingContent = [];
+      let tailIndex = -1;
+      for (let j = 0; j < src.length; j++) {
+        const block = src[j];
+        if (isCachePoint(block)) {
+          modified = true;
+          continue;
+        }
+        const cloned = { ...block };
+        if ('cache_control' in cloned) {
+          delete (cloned as Record<string, unknown>).cache_control;
+          modified = true;
+        }
+        if (canPlaceMarker && isTailCacheableBlock(cloned as MessageContentComplex)) {
+          tailIndex = workingContent.length;
+        }
+        workingContent.push(cloned as MessageContentComplex);
+      }
+
+      if (canPlaceMarker && tailIndex >= 0) {
+        (workingContent[tailIndex] as Anthropic.TextBlockParam).cache_control = {
+          type: 'ephemeral',
+        };
+        markerPlaced = true;
+        modified = true;
+      }
+
+      if (!modified) {
+        continue;
+      }
+    } else if (
+      typeof content === 'string' &&
+      canPlaceMarker &&
+      content.trim() !== ''
+    ) {
+      workingContent = [
+        { type: 'text', text: content, cache_control: { type: 'ephemeral' } },
+      ] as unknown as MessageContentComplex[];
+      markerPlaced = true;
+    } else {
+      continue;
+    }
+
+    updatedMessages[i] = cloneMessage(
+      originalMessage as MessageWithContent,
+      workingContent
+    ) as T;
+  }
+
+  return updatedMessages;
+}
+
 function getMessageRole(message: MessageWithContent): string | undefined {
   if (message instanceof BaseMessage) {
     return message.getType();
@@ -614,6 +734,126 @@ export function addBedrockCacheControl<
         { cachePoint: { type: 'default' } } as MessageContentComplex,
       ];
       cachePointsAdded++;
+    } else if (typeof content === 'string' && hasSerializationProps) {
+      workingContent = content;
+    } else {
+      continue;
+    }
+
+    updatedMessages[i] = cloneMessage(originalMessage, workingContent);
+  }
+
+  return updatedMessages;
+}
+
+/**
+ * Bedrock Converse API: single tail cache breakpoint (default strategy).
+ *
+ * The Bedrock counterpart of {@link addTailCacheControl}. Strips ALL existing
+ * cache control (Bedrock cache points and Anthropic `cache_control`) from every
+ * message, then inserts exactly ONE `{ cachePoint: { type: 'default' } }` block
+ * immediately after the last non-empty text block of the most recent
+ * non-synthetic, non-system message. Anchoring on the rolling tail keeps the
+ * cached prefix append-only as the conversation grows, instead of re-writing
+ * large spans every turn with the legacy "last two user messages" cache points.
+ *
+ * System messages are sanitized (Anthropic `cache_control` stripped) but never
+ * anchored. Synthetic skill/meta messages are skipped as anchors so their
+ * volatile content cannot pin the cache.
+ *
+ * Returns a new array - only clones messages that require modification.
+ */
+export function addBedrockTailCacheControl<
+  T extends MessageWithContent & { getType?: () => string; role?: string },
+>(messages: T[]): T[] {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return messages;
+  }
+
+  const updatedMessages: T[] = [...messages];
+  let cachePointPlaced = false;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const originalMessage = updatedMessages[i];
+    const messageType =
+      'getType' in originalMessage &&
+      typeof originalMessage.getType === 'function'
+        ? originalMessage.getType()
+        : undefined;
+    const messageRole =
+      'role' in originalMessage && typeof originalMessage.role === 'string'
+        ? originalMessage.role
+        : undefined;
+
+    const isSystemMessage =
+      messageType === 'system' || messageRole === 'system';
+    if (isSystemMessage) {
+      updatedMessages[i] = sanitizeBedrockSystemMessage(originalMessage);
+      continue;
+    }
+
+    const content = originalMessage.content;
+    const hasSerializationProps =
+      'lc_kwargs' in originalMessage ||
+      'lc_serializable' in originalMessage ||
+      'lc_namespace' in originalMessage;
+    const hasArrayContent = Array.isArray(content);
+    const isEmptyString = typeof content === 'string' && content === '';
+    const canPlaceCachePoint =
+      !cachePointPlaced &&
+      !isEmptyString &&
+      !isSyntheticMetaMessage(originalMessage) &&
+      (typeof content === 'string' || hasArrayContent);
+
+    if (!canPlaceCachePoint && !hasArrayContent && !hasSerializationProps) {
+      continue;
+    }
+
+    let workingContent: string | MessageContentComplex[];
+    let modified = hasSerializationProps;
+
+    if (hasArrayContent) {
+      const src = content as MessageContentComplex[];
+      workingContent = [];
+      let lastNonEmptyTextIndex = -1;
+      for (let j = 0; j < src.length; j++) {
+        const block = src[j];
+        if (isCachePoint(block)) {
+          modified = true;
+          continue;
+        }
+        const cloned = { ...block };
+        if ('cache_control' in cloned) {
+          delete (cloned as Record<string, unknown>).cache_control;
+          modified = true;
+        }
+        const type = (cloned as { type?: string }).type;
+        if (type === ContentTypes.TEXT || type === 'text') {
+          const text = (cloned as { text?: string }).text;
+          if (text != null && text.trim() !== '') {
+            lastNonEmptyTextIndex = workingContent.length;
+          }
+        }
+        workingContent.push(cloned as MessageContentComplex);
+      }
+
+      if (!modified && !canPlaceCachePoint) {
+        continue;
+      }
+
+      if (canPlaceCachePoint && lastNonEmptyTextIndex >= 0) {
+        workingContent.splice(lastNonEmptyTextIndex + 1, 0, {
+          cachePoint: { type: 'default' },
+        } as MessageContentComplex);
+        cachePointPlaced = true;
+        modified = true;
+      }
+    } else if (typeof content === 'string' && canPlaceCachePoint) {
+      workingContent = [
+        { type: ContentTypes.TEXT, text: content },
+        { cachePoint: { type: 'default' } } as MessageContentComplex,
+      ];
+      cachePointPlaced = true;
     } else if (typeof content === 'string' && hasSerializationProps) {
       workingContent = content;
     } else {

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -255,36 +255,41 @@ function isCachePoint(block: MessageContentComplex): boolean {
 }
 
 /**
- * Reasoning block types that must never anchor the tail cache breakpoint:
+ * Block types that must never anchor the tail cache breakpoint, because the
+ * marker would not survive to the model call:
  * - `thinking` / `redacted_thinking`: native Anthropic reasoning — the API
  *   rejects `cache_control` on these blocks.
  * - `reasoning_content` / `reasoning` / `think`: foreign reasoning (Bedrock,
  *   Google, LibreChat) that `_convertMessagesToAnthropicPayload` DROPS on
- *   assistant turns during a cross-provider handoff. Anchoring the only
- *   breakpoint on a block that is about to disappear silently loses tail
- *   caching, so these are excluded too.
+ *   assistant turns during a cross-provider handoff.
+ * - `input_json_delta`: persisted partial tool-input deltas, also DROPPED by
+ *   `_convertMessagesToAnthropicPayload` (the assembled input is restored onto
+ *   the tool_use block).
+ * Anchoring the only breakpoint on a block that is about to disappear silently
+ * loses tail caching, so all of these are excluded.
  */
-const NON_ANCHORABLE_REASONING_TYPES = new Set([
+const NON_ANCHORABLE_BLOCK_TYPES = new Set([
   'thinking',
   'redacted_thinking',
   'reasoning_content',
   'reasoning',
   'think',
+  'input_json_delta',
 ]);
 
 /**
  * A block can anchor the tail cache breakpoint when it is a real content block
  * that the Anthropic API accepts `cache_control` on and that survives provider
- * conversion. Native/foreign reasoning blocks are excluded (see
- * {@link NON_ANCHORABLE_REASONING_TYPES}), and empty text blocks are not
- * cacheable, so both are skipped.
+ * conversion. Reasoning / dropped-delta blocks are excluded (see
+ * {@link NON_ANCHORABLE_BLOCK_TYPES}), and empty text blocks are not cacheable,
+ * so both are skipped.
  */
 function isTailCacheableBlock(block: MessageContentComplex): boolean {
   if (isCachePoint(block)) {
     return false;
   }
   const type = (block as { type?: string }).type;
-  if (type == null || NON_ANCHORABLE_REASONING_TYPES.has(type)) {
+  if (type == null || NON_ANCHORABLE_BLOCK_TYPES.has(type)) {
     return false;
   }
   if (type === 'text') {

--- a/src/messages/tailCacheConversion.test.ts
+++ b/src/messages/tailCacheConversion.test.ts
@@ -1,0 +1,140 @@
+import {
+  HumanMessage,
+  AIMessage,
+  ToolMessage,
+  type BaseMessage,
+  type MessageContentComplex,
+} from '@langchain/core/messages';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
+import { ensureThinkingBlockInMessages } from './format';
+import { toLangChainContent } from './langchain';
+import { addTailCacheControl } from './cache';
+import { Providers } from '@/common';
+
+/**
+ * Regression coverage for the single tail prompt-cache breakpoint surviving all
+ * the way into the final Anthropic payload — i.e. the marker must land on a
+ * block that actually ships, not one that downstream conversion / folding
+ * removes. Two ways the breakpoint was silently lost:
+ *
+ *  - Foreign reasoning tail: addTailCacheControl anchored on a
+ *    `reasoning_content`/`reasoning`/`think` block, which the Anthropic
+ *    converter drops on assistant turns (cross-provider handoff).
+ *  - Thinking-fold ordering: marking before ensureThinkingBlockInMessages let
+ *    the fold rewrite the anchored AI→Tool tail into a `[Previous agent
+ *    context]` HumanMessage that copies text but not cache_control.
+ */
+
+type PayloadMessage = { content: unknown };
+
+function hasCacheControl(block: unknown): boolean {
+  return (
+    typeof block === 'object' && block !== null && 'cache_control' in block
+  );
+}
+
+/** Does any block (top-level or nested in tool_result) carry cache_control? */
+function breakpointSurvives(messages: PayloadMessage[]): boolean {
+  for (const m of messages) {
+    if (!Array.isArray(m.content)) {
+      continue;
+    }
+    for (const block of m.content as unknown[]) {
+      if (hasCacheControl(block)) {
+        return true;
+      }
+      const inner = (block as { content?: unknown }).content;
+      if (Array.isArray(inner) && inner.some(hasCacheControl)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe('tail breakpoint survives Anthropic conversion', () => {
+  test('foreign reasoning tail keeps a usable breakpoint (anchored on text)', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hello'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'Here is my answer.' },
+          { type: 'reasoning_content', reasoningText: { text: 'r' } },
+        ] as MessageContentComplex[]),
+      }),
+    ];
+
+    const payload = _convertMessagesToAnthropicPayload(
+      addTailCacheControl(messages)
+    );
+
+    expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(true);
+  });
+
+  test('string tool-result tail keeps a usable breakpoint', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('run it'),
+      new AIMessage({
+        content: 'calling',
+        tool_calls: [{ id: 't1', name: 'search', args: {} }],
+      }),
+      new ToolMessage({ tool_call_id: 't1', content: 'result body' }),
+    ];
+
+    const payload = _convertMessagesToAnthropicPayload(
+      addTailCacheControl(messages)
+    );
+
+    expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(true);
+  });
+
+  test('marking AFTER the thinking fold preserves the breakpoint (Graph order)', () => {
+    // A historical non-thinking AI→Tool chain at the tail (no trailing human).
+    const messages: BaseMessage[] = [
+      new HumanMessage('do the thing'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 't1', name: 'search', args: { q: 'x' } }],
+      }),
+      new ToolMessage({ tool_call_id: 't1', content: 'tool output text' }),
+    ];
+
+    // Graph applies the fold first, THEN the tail marker.
+    const folded = ensureThinkingBlockInMessages(
+      messages,
+      Providers.ANTHROPIC,
+      undefined,
+      messages.length
+    );
+    const payload = _convertMessagesToAnthropicPayload(
+      addTailCacheControl(folded)
+    );
+
+    expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(true);
+  });
+
+  test('marking BEFORE the fold loses the breakpoint (guards the ordering)', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('do the thing'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 't1', name: 'search', args: { q: 'x' } }],
+      }),
+      new ToolMessage({ tool_call_id: 't1', content: 'tool output text' }),
+    ];
+
+    // The buggy order: mark first, then fold drops the marker.
+    const marked = addTailCacheControl(messages);
+    const folded = ensureThinkingBlockInMessages(
+      marked,
+      Providers.ANTHROPIC,
+      undefined,
+      messages.length
+    );
+    const payload = _convertMessagesToAnthropicPayload(folded);
+
+    expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(
+      false
+    );
+  });
+});

--- a/src/messages/tailCacheConversion.test.ts
+++ b/src/messages/tailCacheConversion.test.ts
@@ -71,7 +71,7 @@ describe('tail breakpoint survives Anthropic conversion', () => {
     expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(true);
   });
 
-  test('string tool-result tail keeps a usable breakpoint', () => {
+  test('string tool-result tail keeps a usable breakpoint on the tool_result block', () => {
     const messages: BaseMessage[] = [
       new HumanMessage('run it'),
       new AIMessage({
@@ -86,6 +86,27 @@ describe('tail breakpoint survives Anthropic conversion', () => {
     );
 
     expect(breakpointSurvives(payload.messages as PayloadMessage[])).toBe(true);
+
+    // The marker must sit on the top-level tool_result block (the documented
+    // cacheable position), NOT nested inside tool_result.content.
+    const toolResult = (payload.messages as PayloadMessage[])
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .find(
+        (b): b is Record<string, unknown> =>
+          b != null &&
+          typeof b === 'object' &&
+          'type' in b &&
+          (b as { type?: string }).type === 'tool_result'
+      ) as { cache_control?: unknown; content?: unknown } | undefined;
+    expect(toolResult?.cache_control).toEqual({ type: 'ephemeral' });
+    const inner = toolResult?.content;
+    if (Array.isArray(inner)) {
+      expect(
+        inner.some(
+          (b) => b != null && typeof b === 'object' && 'cache_control' in b
+        )
+      ).toBe(false);
+    }
   });
 
   test('marking AFTER the thinking fold preserves the breakpoint (Graph order)', () => {

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -1,0 +1,397 @@
+/**
+ * Live, reproducible benchmark: single tail prompt-cache breakpoint (new
+ * default) vs. the legacy "last two user messages" strategy.
+ *
+ * It replays realistic harness conversations against a real provider and, for
+ * each model call, records the cache token breakdown the API reports. The two
+ * strategies are run over the SAME conversations (only the cache MARKING
+ * differs) under distinct cache namespaces, then compared.
+ *
+ * What it demonstrates
+ * --------------------
+ *  - Agent tool loop (one user turn, many tool rounds): the legacy strategy
+ *    pins its only message breakpoint on the lone user message, so every
+ *    appended assistant/tool turn is re-sent UNCACHED on the next call — cache
+ *    write/fresh ≫ read. The tail strategy rides the true tail, so the growing
+ *    transcript is written once and read back. This is the dominant agent shape
+ *    and where the legacy approach breaks down hardest.
+ *  - Multi-turn chat (frequent user messages): legacy's two rolling markers do
+ *    fine here; the tail strategy ties (never worse).
+ *  - Realistic agent (user turns interleaved with tool rounds): tail wins.
+ *
+ * Metrics (per strategy, summed over all calls in a scenario)
+ *  - cache_read   : tokens served from cache (HIGHER is better).
+ *  - cache_write  : tokens written to cache (cache_creation).
+ *  - fresh        : uncached input processed at full price
+ *                   (= input_tokens - cache_read - cache_write); this is what
+ *                   balloons when caching fails to cover the transcript.
+ *  - effective    : a cost proxy in input-token-equivalents using Anthropic's
+ *                   published multipliers — read x0.1, write x1.25, fresh x1.0.
+ *                   LOWER is better.
+ *
+ * Usage
+ *   # Anthropic (default). Needs ANTHROPIC_API_KEY in .env (or BENCH_ENV_FILE).
+ *   npm run bench:cache
+ *   # Bedrock. Needs BEDROCK_AWS_* creds.
+ *   npm run bench:cache -- --provider bedrock
+ *   # Options: --provider anthropic|bedrock  --rounds <N>  --model <id>
+ *
+ * Not a unit test (no `.test.` suffix) so CI never runs it; it makes real,
+ * paid API calls.
+ */
+import { config } from 'dotenv';
+config({ path: process.env.BENCH_ENV_FILE || '.env' });
+
+import {
+  HumanMessage,
+  AIMessage,
+  ToolMessage,
+  type BaseMessage,
+} from '@langchain/core/messages';
+import { CustomAnthropic } from '@/llm/anthropic';
+import { CustomChatBedrockConverse } from '@/llm/bedrock';
+import {
+  addCacheControl,
+  addTailCacheControl,
+  addBedrockCacheControl,
+  addBedrockTailCacheControl,
+} from '@/messages/cache';
+
+type ProviderName = 'anthropic' | 'bedrock';
+
+interface Args {
+  provider: ProviderName;
+  rounds: number;
+  model?: string;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const out: Args = { provider: 'anthropic', rounds: 6 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--provider') out.provider = argv[++i] as ProviderName;
+    else if (a === '--rounds') out.rounds = Number(argv[++i]);
+    else if (a === '--model') out.model = argv[++i];
+  }
+  return out;
+}
+
+/** Deterministic filler of roughly `tokens` tokens (~0.75 words/token). */
+function filler(tokens: number, tag: string): string {
+  const words = Math.max(1, Math.round(tokens * 0.75));
+  const out: string[] = [];
+  for (let i = 0; i < words; i++) {
+    out.push(`${tag}${i % 97}`);
+  }
+  return out.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios. Each returns the message list for every model call (call `i`
+// sends step `i`; the transcript grows append-only between calls), built under
+// a per-run nonce so the two strategy runs never share a cache namespace.
+// ---------------------------------------------------------------------------
+
+const STABLE_TOKENS = 2000; // big stable context (instructions / first request)
+const TOOL_RESULT_TOKENS = 600; // realistic agent tool output (file/search)
+
+function processToolCall(id: string, batch: number) {
+  return { id, name: 'process_records', args: { batch } };
+}
+
+/** Agent tool loop: ONE user turn, then `rounds` assistant→tool rounds. */
+function toolLoopScenario(nonce: string, rounds: number): BaseMessage[][] {
+  const steps: BaseMessage[][] = [];
+  const conv: BaseMessage[] = [
+    new HumanMessage(
+      `Session ${nonce}. Reference data follows.\n${filler(STABLE_TOKENS, `ref${nonce}`)}\n\n` +
+        'Process every batch using the process_records tool until done.'
+    ),
+  ];
+  for (let i = 1; i <= rounds; i++) {
+    steps.push([...conv]);
+    conv.push(
+      new AIMessage({
+        content: `Processing batch ${i}.`,
+        tool_calls: [processToolCall(`tl_${nonce}_${i}`, i)],
+      })
+    );
+    conv.push(
+      new ToolMessage({
+        tool_call_id: `tl_${nonce}_${i}`,
+        content: `Batch ${i} of session ${nonce} complete. ${filler(TOOL_RESULT_TOKENS, `out${i}`)}`,
+      })
+    );
+  }
+  return steps;
+}
+
+/** Multi-turn chat: frequent user messages, no tools (legacy's good case). */
+function chatScenario(nonce: string, rounds: number): BaseMessage[][] {
+  const steps: BaseMessage[][] = [];
+  const conv: BaseMessage[] = [
+    new HumanMessage(
+      `Session ${nonce}.\n${filler(STABLE_TOKENS, `doc${nonce}`)}\n\nQuestion 1: summarize.`
+    ),
+  ];
+  for (let i = 1; i <= rounds; i++) {
+    steps.push([...conv]);
+    conv.push(new AIMessage(`Answer ${i}. ${filler(120, `ans${i}`)}`));
+    conv.push(
+      new HumanMessage(`Question ${i + 1}: ${filler(60, `q${i + 1}`)}`)
+    );
+  }
+  return steps;
+}
+
+/** Realistic agent: each user turn triggers two tool rounds, then a new user. */
+function agentMixedScenario(nonce: string, rounds: number): BaseMessage[][] {
+  const steps: BaseMessage[][] = [];
+  const conv: BaseMessage[] = [
+    new HumanMessage(
+      `Session ${nonce}. Project context:\n${filler(STABLE_TOKENS, `ctx${nonce}`)}\n\nTask 1: investigate.`
+    ),
+  ];
+  let tc = 0;
+  for (let turn = 1; turn <= rounds; turn++) {
+    // two tool rounds within this user turn
+    for (let r = 0; r < 2; r++) {
+      steps.push([...conv]);
+      tc++;
+      const id = `am_${nonce}_${tc}`;
+      conv.push(
+        new AIMessage({
+          content: `Turn ${turn} step ${r + 1}.`,
+          tool_calls: [{ id, name: 'process_records', args: { step: tc } }],
+        })
+      );
+      conv.push(
+        new ToolMessage({
+          tool_call_id: id,
+          content: `Result ${tc} (${nonce}). ${filler(TOOL_RESULT_TOKENS, `r${tc}`)}`,
+        })
+      );
+    }
+    // model summarizes, user asks the next task
+    steps.push([...conv]);
+    conv.push(new AIMessage(`Turn ${turn} summary. ${filler(80, `s${turn}`)}`));
+    conv.push(
+      new HumanMessage(`Task ${turn + 1}: ${filler(60, `t${turn + 1}`)}`)
+    );
+  }
+  return steps;
+}
+
+const SCENARIOS: Array<{
+  name: string;
+  build: (nonce: string, rounds: number) => BaseMessage[][];
+}> = [
+  {
+    name: 'Agent tool loop (1 user turn, N tool rounds)',
+    build: toolLoopScenario,
+  },
+  { name: 'Multi-turn chat (frequent user messages)', build: chatScenario },
+  {
+    name: 'Realistic agent (user turns + tool rounds)',
+    build: agentMixedScenario,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Provider plumbing.
+// ---------------------------------------------------------------------------
+
+const PROCESS_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'process_records',
+    description: 'Process a batch of records.',
+    parameters: {
+      type: 'object',
+      properties: { batch: { type: 'number' }, step: { type: 'number' } },
+    },
+  },
+};
+
+interface StrategyPair {
+  legacy: (m: BaseMessage[]) => BaseMessage[];
+  tail: (m: BaseMessage[]) => BaseMessage[];
+}
+
+function makeProvider(args: Args): {
+  invoke: (messages: BaseMessage[]) => Promise<Usage | undefined>;
+  strategies: StrategyPair;
+  label: string;
+} {
+  if (args.provider === 'bedrock') {
+    const model = args.model ?? 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+    const llm = new CustomChatBedrockConverse({
+      model,
+      region:
+        process.env.BEDROCK_AWS_REGION ??
+        process.env.AWS_DEFAULT_REGION ??
+        'us-east-1',
+      credentials: {
+        accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
+      },
+      streaming: true,
+      streamUsage: true,
+      maxTokens: 32,
+      promptCache: true,
+    }).bindTools([PROCESS_TOOL]);
+    return {
+      label: `bedrock:${model}`,
+      invoke: async (messages) =>
+        (await llm.invoke(messages)).usage_metadata as Usage,
+      strategies: {
+        legacy: (m) => addBedrockCacheControl<BaseMessage>(m),
+        tail: (m) => addBedrockTailCacheControl<BaseMessage>(m),
+      },
+    };
+  }
+
+  const model = args.model ?? 'claude-sonnet-4-5';
+  const llm = new CustomAnthropic({
+    model,
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    maxTokens: 32,
+    promptCache: true,
+    streaming: true,
+    streamUsage: true,
+  } as never).bindTools([PROCESS_TOOL]);
+  return {
+    label: `anthropic:${model}`,
+    invoke: async (messages) =>
+      (await llm.invoke(messages)).usage_metadata as Usage,
+    strategies: {
+      legacy: (m) => addCacheControl<BaseMessage>(m),
+      tail: (m) => addTailCacheControl<BaseMessage>(m),
+    },
+  };
+}
+
+type Usage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  input_token_details?: { cache_creation?: number; cache_read?: number };
+};
+
+interface Totals {
+  read: number;
+  write: number;
+  fresh: number;
+  effective: number;
+}
+
+function emptyTotals(): Totals {
+  return { read: 0, write: 0, fresh: 0, effective: 0 };
+}
+
+function addUsage(t: Totals, u: Usage | undefined): void {
+  const d = u?.input_token_details ?? {};
+  const read = d.cache_read ?? 0;
+  const write = d.cache_creation ?? 0;
+  // Provider-agnostic fresh: total prompt tokens minus cached buckets. Avoids
+  // the `input_tokens` ambiguity — Anthropic folds cache tokens INTO
+  // input_tokens, while Bedrock reports input_tokens as fresh-only with cache
+  // tokens separate. `total_tokens - output_tokens` is the full prompt size on
+  // both, so subtracting read+write leaves the truly fresh (full-price) input.
+  const promptTotal = (u?.total_tokens ?? 0) - (u?.output_tokens ?? 0);
+  const fresh = Math.max(0, promptTotal - read - write);
+  t.read += read;
+  t.write += write;
+  t.fresh += fresh;
+  // Anthropic/Bedrock price multipliers: read 0.1x, write 1.25x, fresh 1x.
+  t.effective += fresh + write * 1.25 + read * 0.1;
+}
+
+async function runStrategy(
+  steps: BaseMessage[][],
+  apply: (m: BaseMessage[]) => BaseMessage[],
+  invoke: (m: BaseMessage[]) => Promise<Usage | undefined>
+): Promise<Totals> {
+  const totals = emptyTotals();
+  for (const step of steps) {
+    const usage = await invoke(apply(step));
+    addUsage(totals, usage);
+  }
+  return totals;
+}
+
+function pct(legacy: number, tail: number): string {
+  if (legacy === 0) return tail === 0 ? '0%' : 'n/a';
+  const delta = ((tail - legacy) / legacy) * 100;
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(0)}%`;
+}
+
+function uniqueNonce(tag: string): string {
+  return `${tag}-${Date.now().toString(36)}-${Math.floor(Math.random() * 1e6).toString(36)}`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (args.provider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
+    console.error('Set ANTHROPIC_API_KEY (in .env or via BENCH_ENV_FILE).');
+    process.exit(1);
+  }
+  if (args.provider === 'bedrock' && !process.env.BEDROCK_AWS_ACCESS_KEY_ID) {
+    console.error(
+      'Set BEDROCK_AWS_ACCESS_KEY_ID / BEDROCK_AWS_SECRET_ACCESS_KEY.'
+    );
+    process.exit(1);
+  }
+
+  const { invoke, strategies, label } = makeProvider(args);
+  console.log(`\nProvider: ${label}   rounds=${args.rounds}`);
+  console.log(
+    'Metrics summed over all calls in a scenario. read↑ better; fresh↓ and effective↓ better.\n'
+  );
+
+  let tailWins = 0;
+  let scenarioCount = 0;
+
+  for (const scenario of SCENARIOS) {
+    // Distinct nonce per strategy run so legacy and tail never share a cache.
+    const legacySteps = scenario.build(uniqueNonce('legacy'), args.rounds);
+    const legacy = await runStrategy(legacySteps, strategies.legacy, invoke);
+    const tailSteps = scenario.build(uniqueNonce('tail'), args.rounds);
+    const tail = await runStrategy(tailSteps, strategies.tail, invoke);
+
+    console.log(`SCENARIO: ${scenario.name}  (${legacySteps.length} calls)`);
+    const row = (name: string, t: Totals): string =>
+      `  ${name.padEnd(8)} read=${String(t.read).padStart(7)}  write=${String(
+        t.write
+      ).padStart(7)}  fresh=${String(t.fresh).padStart(7)}  effective=${String(
+        Math.round(t.effective)
+      ).padStart(7)}`;
+    console.log(row('legacy', legacy));
+    console.log(row('tail', tail));
+    console.log(
+      `  Δ tail vs legacy:  read ${pct(legacy.read, tail.read)}   ` +
+        `fresh ${pct(legacy.fresh, tail.fresh)}   ` +
+        `effective ${pct(legacy.effective, tail.effective)} (lower=cheaper)`
+    );
+
+    const better = tail.effective <= legacy.effective;
+    const tie =
+      Math.abs(tail.effective - legacy.effective) / (legacy.effective || 1) <
+      0.03;
+    console.log(
+      `  → ${better ? (tie ? '≈ TIE' : '✅ TAIL WINS') : '❌ legacy better'}\n`
+    );
+    scenarioCount++;
+    if (better) tailWins++;
+  }
+
+  console.log(
+    `RESULT: tail strategy is better-or-equal in ${tailWins}/${scenarioCount} scenarios.`
+  );
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -183,6 +183,84 @@ function agentMixedScenario(nonce: string, rounds: number): BaseMessage[][] {
   return steps;
 }
 
+const SUMMARY_TOKENS = 1500; // compacted-history summary injected post-compaction
+
+/**
+ * Post-compaction (summarization): a few tool rounds on the original context,
+ * then a compaction event replaces the head with a summary message, then the
+ * agent continues. The compaction step is a deliberate cache miss for BOTH
+ * strategies (the cached prefix genuinely changed — unavoidable). What matters
+ * is the POST-compaction phase: the summary becomes the new stable head and the
+ * tail strategy re-establishes append-only caching over the continuing tool
+ * loop, whereas legacy pins on the lone summary user-message and re-sends the
+ * new tool work uncached. (Tool results here are already the truncated,
+ * persisted strings ToolNode stores — truncation is applied once at exec time
+ * with a model-fixed cap, so it does not mutate the prefix across turns.)
+ */
+function postCompactionScenario(
+  nonce: string,
+  rounds: number
+): BaseMessage[][] {
+  const steps: BaseMessage[][] = [];
+
+  // Phase 1: pre-compaction growth on the original context.
+  const pre: BaseMessage[] = [
+    new HumanMessage(
+      `Session ${nonce}. ${filler(STABLE_TOKENS, `pre${nonce}`)}\n\nAnalyze the dataset.`
+    ),
+  ];
+  for (let i = 1; i <= 2; i++) {
+    steps.push([...pre]);
+    pre.push(
+      new AIMessage({
+        content: `Pre ${i}.`,
+        tool_calls: [
+          {
+            id: `pc_${nonce}_${i}`,
+            name: 'process_records',
+            args: { batch: i },
+          },
+        ],
+      })
+    );
+    pre.push(
+      new ToolMessage({
+        tool_call_id: `pc_${nonce}_${i}`,
+        content: `Pre result ${i}. ${filler(TOOL_RESULT_TOKENS, `pr${i}`)}`,
+      })
+    );
+  }
+
+  // Compaction: head replaced by a durable summary; continue from there.
+  const post: BaseMessage[] = [
+    new HumanMessage(
+      `Session ${nonce} (resumed after compaction).\n<summary>\n${filler(SUMMARY_TOKENS, `sum${nonce}`)}\n</summary>\n\nContinue the analysis.`
+    ),
+  ];
+  for (let i = 1; i <= rounds; i++) {
+    steps.push([...post]);
+    post.push(
+      new AIMessage({
+        content: `Post ${i}.`,
+        tool_calls: [
+          {
+            id: `po_${nonce}_${i}`,
+            name: 'process_records',
+            args: { batch: i },
+          },
+        ],
+      })
+    );
+    post.push(
+      new ToolMessage({
+        tool_call_id: `po_${nonce}_${i}`,
+        content: `Post result ${i}. ${filler(TOOL_RESULT_TOKENS, `po${i}`)}`,
+      })
+    );
+  }
+  return steps;
+}
+
 const SCENARIOS: Array<{
   name: string;
   build: (nonce: string, rounds: number) => BaseMessage[][];
@@ -195,6 +273,10 @@ const SCENARIOS: Array<{
   {
     name: 'Realistic agent (user turns + tool rounds)',
     build: agentMixedScenario,
+  },
+  {
+    name: 'Post-compaction (summary head + continued tool loop)',
+    build: postCompactionScenario,
   },
 ];
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -22,7 +22,7 @@ import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { splitAtRecencyBoundary } from '@/messages/recency';
 import { getMaxOutputTokensKey } from '@/llm/request';
-import { addCacheControl } from '@/messages/cache';
+import { addTailCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
@@ -1227,7 +1227,7 @@ async function summarizeWithCacheHit({
 
   const fullMessages = [...messages, new HumanMessage(instruction)];
   const invokeMessages =
-    usePromptCache === true ? addCacheControl(fullMessages) : fullMessages;
+    usePromptCache === true ? addTailCacheControl(fullMessages) : fullMessages;
 
   const result = await attemptInvoke(
     {

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -173,6 +173,56 @@ describe('annotateMessagesForLLM', () => {
     expect(out[0].content).toBe('[ref: tool0turn0]\nplain output');
   });
 
+  it('annotates a live ref on multi-part content (prompt-cache-rewritten tool tail)', () => {
+    /**
+     * A tail tool result that prompt caching rewrote from a string into a
+     * text-block array (to host the cache_control / cachePoint marker) keeps
+     * its `_refKey` on additional_kwargs. The live-ref marker must still be
+     * projected as a leading text block; otherwise the common tool-result
+     * tail silently loses its reference annotation once cached.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: [
+        { type: 'text', text: 'output', cache_control: { type: 'ephemeral' } },
+      ] as unknown as ToolMessage['content'],
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const blocks = out[0].content as Array<{
+      type: string;
+      text?: string;
+      cache_control?: unknown;
+    }>;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ type: 'text', text: '[ref: tool0turn0]' });
+    // The original block (and its cache marker) is preserved after the prefix.
+    expect(blocks[1].text).toBe('output');
+    expect(blocks[1].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('annotates both live ref and unresolved on multi-part content', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: [
+        { type: 'text', text: 'output' },
+      ] as unknown as ToolMessage['content'],
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _unresolvedRefs: ['tool9turn9'],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const blocks = out[0].content as Array<{ type: string; text?: string }>;
+    expect(blocks.map((b) => b.text)).toEqual([
+      '[ref: tool0turn0]',
+      '[unresolved refs: tool9turn9]',
+      'output',
+    ]);
+  });
+
   it('prepends an unresolved-refs warning text block to multi-part content', () => {
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -682,28 +682,42 @@ export function annotateMessagesForLLM(
         liveRef,
         unresolved
       );
-    } else if (
-      annotates &&
-      Array.isArray(tm.content) &&
-      unresolved.length > 0
-    ) {
-      const warningBlock = {
-        type: 'text' as const,
-        text: `[unresolved refs: ${unresolved.join(', ')}]`,
-      };
+    } else if (annotates && Array.isArray(tm.content)) {
       /**
-       * `as unknown as ToolMessage['content']` is unavoidable here:
-       * LangChain's content union (`MessageContentComplex[] |
-       * DataContentBlock[] | string`) does not accept a freshly built
-       * mixed array literal even though the structural shape is valid
-       * at runtime. The double-cast is structurally safe — we
-       * preserve every block from `tm.content` and prepend a single
-       * `{ type: 'text', text }` block that all providers accept.
+       * Array tool content. The string annotator can't run — this notably
+       * includes a tail tool result that prompt caching rewrote from a string
+       * into a text-block array to host its `cache_control` / `cachePoint`
+       * marker (the `_refKey` survives on `additional_kwargs`). Project the
+       * same markers the string path would, as leading text blocks: the live
+       * `[ref: …]` prefix and/or the unresolved-refs warning. Without this the
+       * common tool-result tail loses its reference marker once cached.
+       *
+       * `as unknown as ToolMessage['content']` is unavoidable: LangChain's
+       * content union does not accept a freshly built mixed array literal even
+       * though the structural shape is valid at runtime. The double-cast is
+       * structurally safe — every original block is preserved and only
+       * `{ type: 'text', text }` blocks (which all providers accept) are
+       * prepended.
        */
-      nextContent = [
-        warningBlock,
-        ...tm.content,
-      ] as unknown as ToolMessage['content'];
+      const prefixBlocks: Array<{ type: 'text'; text: string }> = [];
+      if (liveRef != null) {
+        prefixBlocks.push({
+          type: 'text',
+          text: buildReferencePrefix(liveRef),
+        });
+      }
+      if (unresolved.length > 0) {
+        prefixBlocks.push({
+          type: 'text',
+          text: `[unresolved refs: ${unresolved.join(', ')}]`,
+        });
+      }
+      if (prefixBlocks.length > 0) {
+        nextContent = [
+          ...prefixBlocks,
+          ...tm.content,
+        ] as unknown as ToolMessage['content'];
+      }
     }
 
     /**


### PR DESCRIPTION
## Summary

Replaces the rolling **"last two user messages"** prompt-cache strategy with a **single breakpoint anchored on the conversation tail**, mirroring the approach used by Claude Code. This is now the default for all prompt-cached providers — no flag.

Motivation: on real multi-turn agent traffic the two-marker strategy was writing tens of thousands of cache tokens every turn while reading almost none back (cache `write` ≫ `read`), because freshly-appended assistant/tool turns fell outside the cached prefix and the prefix kept re-writing. A single tail breakpoint keeps the prefix append-only: the whole conversation is written once and read back as history grows.

## Changes

- **`addTailCacheControl`** (Anthropic/OpenRouter): strips all stale markers in one backward pass, then places exactly **one** `cache_control: { type: 'ephemeral' }` on the last cacheable block of the final non-synthetic message. Skips `thinking`/`redacted_thinking` blocks (API rejects `cache_control` there) and synthetic skill/meta messages as anchors.
- **`addBedrockTailCacheControl`** (Bedrock Converse): the counterpart — inserts a single `{ cachePoint: { type: 'default' } }` after the last non-empty text block of the tail; sanitizes (but never anchors) system messages.
- **Wiring**: `Graph` (Anthropic, OpenRouter, Bedrock), `AgentContext` system-runnable body path, and `summarization` now use the tail strategy by default.
- Legacy `addCacheControl` / `addBedrockCacheControl` remain exported for backward compatibility.
- Updated affected `AgentContext` tests; added `src/messages/cache.tail.test.ts` (13 cases).

## Test plan

- [x] `cache.tail.test.ts` — 13 new cases (single marker on tail, anchors on trailing tool_result, strips stale markers, skips thinking blocks, skips synthetic-meta tail, string tails, immutability, Bedrock variants)
- [x] `cache.test.ts` — 63 existing pass (legacy fns unchanged)
- [x] `AgentContext.test.ts` — 96 pass (two body-cache assertions updated to single-tail)
- [x] `summarization.test.ts` / `summarize-prune.test.ts` / `token-accounting-pipeline.test.ts` — pass
- [x] `tsc -p tsconfig.build.json` clean
- [ ] Live validation: compare `cache_read` / `cache_creation` token counts old-vs-new on a real Anthropic/Bedrock multi-turn session

## Notes / follow-ups

- Tail breakpoint alone won't fully fix hit-rate if volatile content (dynamic instructions, re-injected meta) still sits inside the cached prefix, or when the 5-min TTL lapses between turns. Recommended follow-ups: move dynamic content strictly behind the last breakpoint, and opt into `ttl: "1h"` for interactive sessions.