### PR TITLE
Support Langfuse trace metadata config

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -11,6 +11,7 @@ const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
 
 export type LangfuseTraceMetadata = Record<string, string>;
+type LangfuseMetadata = NonNullable<t.LangfuseConfig['metadata']>;
 
 type LangfuseHandlerParams = {
   userId?: string;
@@ -44,6 +45,13 @@ function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
   );
 }
 
+function hasLangfuseTraceAttributes(langfuse?: t.LangfuseConfig): boolean {
+  return (
+    Object.keys(langfuse?.metadata ?? {}).length > 0 ||
+    (langfuse?.tags?.length ?? 0) > 0
+  );
+}
+
 export function hasLangfuseConfigCredentials(
   langfuse?: t.LangfuseConfig
 ): langfuse is t.LangfuseConfig & {
@@ -67,6 +75,7 @@ export function isExplicitLangfuseConfig(langfuse?: t.LangfuseConfig): boolean {
     isPresent(langfuse?.publicKey) ||
     isPresent(langfuse?.secretKey) ||
     isPresent(langfuse?.baseUrl) ||
+    hasLangfuseTraceAttributes(langfuse) ||
     hasLangfuseTracingConfig(langfuse)
   );
 }
@@ -108,6 +117,27 @@ export function createLangfuseTraceMetadata({
     agentId,
     agentName,
   });
+}
+
+function mergeLangfuseTraceMetadata(
+  traceMetadata?: LangfuseTraceMetadata,
+  metadata?: LangfuseMetadata
+): LangfuseTraceMetadata | undefined {
+  const merged = createTraceMetadata({
+    ...(metadata ?? {}),
+    ...(traceMetadata ?? {}),
+  });
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function mergeLangfuseTags(
+  tags?: string[],
+  configTags?: string[]
+): string[] | undefined {
+  const merged = [...(tags ?? []), ...(configTags ?? [])].filter(
+    (tag) => tag.trim() !== ''
+  );
+  return merged.length > 0 ? [...new Set(merged)] : undefined;
 }
 
 export function getLangfuseTraceName(
@@ -161,12 +191,16 @@ export function createLangfuseHandler({
   return new CallbackHandler({
     userId,
     sessionId,
-    traceMetadata,
-    tags,
+    traceMetadata: mergeLangfuseTraceMetadata(
+      traceMetadata,
+      langfuse?.metadata
+    ),
+    tags: mergeLangfuseTags(tags, langfuse?.tags),
   });
 }
 
 function createPropagateAttributeParams({
+  langfuse,
   userId,
   sessionId,
   traceMetadata,
@@ -177,8 +211,8 @@ function createPropagateAttributeParams({
     userId,
     sessionId,
     traceName,
-    tags,
-    metadata: traceMetadata,
+    tags: mergeLangfuseTags(tags, langfuse?.tags),
+    metadata: mergeLangfuseTraceMetadata(traceMetadata, langfuse?.metadata),
   };
 }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -47,8 +47,8 @@ function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
 
 function hasLangfuseTraceAttributes(langfuse?: t.LangfuseConfig): boolean {
   return (
-    Object.keys(langfuse?.metadata ?? {}).length > 0 ||
-    (langfuse?.tags?.length ?? 0) > 0
+    Object.keys(createTraceMetadata(langfuse?.metadata ?? {})).length > 0 ||
+    (mergeLangfuseTags(undefined, langfuse?.tags)?.length ?? 0) > 0
   );
 }
 

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -680,33 +680,33 @@ export function resolveLangfuseConfig(
   const toolNodeTracing =
     runLangfuse.toolNodeTracing != null || agentLangfuse.toolNodeTracing != null
       ? {
-          ...runLangfuse.toolNodeTracing,
-          ...agentLangfuse.toolNodeTracing,
-        }
+        ...runLangfuse.toolNodeTracing,
+        ...agentLangfuse.toolNodeTracing,
+      }
       : undefined;
   const toolOutputTracing =
     runLangfuse.toolOutputTracing != null ||
     agentLangfuse.toolOutputTracing != null
       ? {
-          ...runLangfuse.toolOutputTracing,
-          ...agentLangfuse.toolOutputTracing,
-        }
+        ...runLangfuse.toolOutputTracing,
+        ...agentLangfuse.toolOutputTracing,
+      }
       : undefined;
   const metadata =
     runLangfuse.metadata != null || agentLangfuse.metadata != null
       ? {
-          ...runLangfuse.metadata,
-          ...agentLangfuse.metadata,
-        }
+        ...runLangfuse.metadata,
+        ...agentLangfuse.metadata,
+      }
       : undefined;
   const tags =
     runLangfuse.tags != null || agentLangfuse.tags != null
       ? [
-          ...new Set([
-            ...(runLangfuse.tags ?? []),
-            ...(agentLangfuse.tags ?? []),
-          ]),
-        ]
+        ...new Set([
+          ...(runLangfuse.tags ?? []),
+          ...(agentLangfuse.tags ?? []),
+        ]),
+      ]
       : undefined;
 
   return {

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -680,22 +680,40 @@ export function resolveLangfuseConfig(
   const toolNodeTracing =
     runLangfuse.toolNodeTracing != null || agentLangfuse.toolNodeTracing != null
       ? {
-        ...runLangfuse.toolNodeTracing,
-        ...agentLangfuse.toolNodeTracing,
-      }
+          ...runLangfuse.toolNodeTracing,
+          ...agentLangfuse.toolNodeTracing,
+        }
       : undefined;
   const toolOutputTracing =
     runLangfuse.toolOutputTracing != null ||
     agentLangfuse.toolOutputTracing != null
       ? {
-        ...runLangfuse.toolOutputTracing,
-        ...agentLangfuse.toolOutputTracing,
-      }
+          ...runLangfuse.toolOutputTracing,
+          ...agentLangfuse.toolOutputTracing,
+        }
+      : undefined;
+  const metadata =
+    runLangfuse.metadata != null || agentLangfuse.metadata != null
+      ? {
+          ...runLangfuse.metadata,
+          ...agentLangfuse.metadata,
+        }
+      : undefined;
+  const tags =
+    runLangfuse.tags != null || agentLangfuse.tags != null
+      ? [
+          ...new Set([
+            ...(runLangfuse.tags ?? []),
+            ...(agentLangfuse.tags ?? []),
+          ]),
+        ]
       : undefined;
 
   return {
     ...runLangfuse,
     ...agentLangfuse,
+    ...(metadata != null ? { metadata } : {}),
+    ...(tags != null ? { tags } : {}),
     ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
     ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
   };

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -3,6 +3,7 @@ import {
   createLangfuseHandler,
   disposeLangfuseHandler,
   hasLangfuseConfigCredentials,
+  isExplicitLangfuseConfig,
   shouldCreateLangfuseHandler,
 } from '@/langfuse';
 
@@ -187,6 +188,39 @@ describe('createLangfuseHandler', () => {
       shouldCreateLangfuseHandler({
         baseUrl: 'https://langfuse.config',
         toolOutputTracing: { enabled: false },
+      })
+    ).toBe(true);
+  });
+
+  it('does not treat sanitized-away trace attributes as explicit config', () => {
+    expect(
+      isExplicitLangfuseConfig({
+        metadata: {
+          empty: '',
+          whitespace: '   ',
+          missing: null,
+          tooLong: 'x'.repeat(201),
+        },
+        tags: ['', '   '],
+      })
+    ).toBe(false);
+  });
+
+  it('treats valid trace metadata or tags as explicit config', () => {
+    expect(
+      isExplicitLangfuseConfig({
+        metadata: {
+          tenantId: 'tenant-1',
+        },
+        tags: ['', '   '],
+      })
+    ).toBe(true);
+    expect(
+      isExplicitLangfuseConfig({
+        metadata: {
+          empty: '',
+        },
+        tags: ['tenant:tenant-1'],
       })
     ).toBe(true);
   });

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -68,6 +68,39 @@ describe('createLangfuseHandler', () => {
     });
   });
 
+  it('adds configured trace metadata and tags to the callback handler', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+
+    const handler = createLangfuseHandler({
+      langfuse: {
+        metadata: {
+          tenantId: 'tenant-1',
+          empty: '',
+          skipped: null,
+        },
+        tags: ['tenant:tenant-1', 'agent'],
+      },
+      traceMetadata: {
+        messageId: 'message-1',
+        agentId: 'agent-1',
+      },
+      tags: ['librechat', 'agent'],
+    });
+
+    expect(handler).toBeDefined();
+    expect(MockedCallbackHandler).toHaveBeenCalledWith({
+      userId: undefined,
+      sessionId: undefined,
+      traceMetadata: {
+        tenantId: 'tenant-1',
+        messageId: 'message-1',
+        agentId: 'agent-1',
+      },
+      tags: ['librechat', 'agent', 'tenant:tenant-1'],
+    });
+  });
+
   it('creates a handler for explicit credentials supplied in config', () => {
     const handler = createLangfuseHandler({
       langfuse: {

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -1,10 +1,10 @@
 import { CallbackHandler } from '@langfuse/langchain';
 import {
-  createLangfuseHandler,
-  disposeLangfuseHandler,
   hasLangfuseConfigCredentials,
-  isExplicitLangfuseConfig,
   shouldCreateLangfuseHandler,
+  isExplicitLangfuseConfig,
+  disposeLangfuseHandler,
+  createLangfuseHandler,
 } from '@/langfuse';
 
 const mockForceFlush = jest.fn();

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -108,6 +108,50 @@ describe('Langfuse trace metadata includes agentName', () => {
     });
   });
 
+  it('propagates configured Langfuse metadata and tags around processStream observations', async () => {
+    const run = await createTestRun(
+      'DWAINE',
+      {},
+      {
+        langfuse: {
+          metadata: { tenantId: 'tenant-1' },
+          tags: ['tenant:tenant-1'],
+        },
+      }
+    );
+    await run.processStream(
+      { messages: [] },
+      {
+        configurable: {
+          thread_id: 'thread-123',
+          user_id: 'user-456',
+        },
+        version: 'v2',
+      }
+    );
+
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+    const ctorArgs = MockedCallbackHandler.mock.calls[0][0];
+    expect(ctorArgs).toMatchObject({
+      traceMetadata: {
+        tenantId: 'tenant-1',
+        messageId: 'test-run-id',
+        agentId: 'agent_abc123',
+        agentName: 'DWAINE',
+      },
+      tags: ['librechat', 'agent', 'tenant:tenant-1'],
+    });
+    expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
+      tags: ['librechat', 'agent', 'tenant:tenant-1'],
+      metadata: {
+        tenantId: 'tenant-1',
+        messageId: 'test-run-id',
+        agentId: 'agent_abc123',
+        agentName: 'DWAINE',
+      },
+    });
+  });
+
   it('falls back to agentId when agent has no explicit name', async () => {
     const run = await createTestRun();
     await run.processStream(

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -586,6 +586,8 @@ describe('Langfuse tool output tracing redaction', () => {
         publicKey: 'pk-run',
         secretKey: 'sk-run',
         baseUrl: 'https://langfuse.test',
+        metadata: { tenantId: 'tenant-run' },
+        tags: ['tenant:tenant-run', 'shared'],
         toolNodeTracing: { enabled: true },
         toolOutputTracing: {
           enabled: true,
@@ -593,6 +595,8 @@ describe('Langfuse tool output tracing redaction', () => {
         },
       },
       {
+        metadata: { agentId: 'agent-1' },
+        tags: ['shared', 'agent:agent-1'],
         toolOutputTracing: {
           enabled: false,
           redactedToolNames: ['execute_sql'],
@@ -605,6 +609,8 @@ describe('Langfuse tool output tracing redaction', () => {
       publicKey: 'pk-run',
       secretKey: 'sk-run',
       baseUrl: 'https://langfuse.test',
+      metadata: { tenantId: 'tenant-run', agentId: 'agent-1' },
+      tags: ['tenant:tenant-run', 'shared', 'agent:agent-1'],
       toolNodeTracing: { enabled: true },
       toolOutputTracing: {
         enabled: false,

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -536,6 +536,8 @@ export interface LangfuseConfig {
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
+  metadata?: Record<string, string | number | boolean | null | undefined>;
+  tags?: string[];
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;
   /**


### PR DESCRIPTION
## Summary

Adds optional run/agent-level Langfuse trace attributes to LangfuseConfig:

- metadata?: Record<string, string | number | boolean | null | undefined>
- tags?: string[]

The SDK now merges configured metadata/tags into Langfuse callback handlers and propagated attributes while preserving existing LibreChat defaults like messageId, agentName, and the librechat/agent tags. Run-level metadata/tags also survive per-agent Langfuse overrides through resolveLangfuseConfig.

## Why

LibreChat needs a way to pass an authenticated tenant id into Langfuse traces as both readable trace metadata and a Metrics API-filterable tag. This PR supplies the SDK support for that app-side wiring.

## Validation

- jest src/specs/langfuse-config.test.ts src/specs/langfuse-metadata.test.ts src/specs/langfuse-tool-output-tracing.test.ts --runInBand

Companion LibreChat PR: https://github.com/danny-avila/LibreChat/pull/13808