### PR TITLE
🩹 fix: Drop Bedrock Reasoning Blocks With Null/Empty Text

### DIFF
--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -1,0 +1,129 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { convertToConverseMessages } from './message_inputs';
+
+/**
+ * Native-Bedrock reasoning serialization. A `reasoning_content` block whose
+ * `reasoningText.text` is null/empty (e.g. a signature-only block that never
+ * merged with its text) is invalid for Bedrock Converse — it rejects with
+ * `...reasoningContent.reasoningText.text ... Member must not be null`. Such a
+ * block must be dropped on replay rather than sent; a block carrying real text
+ * is still converted.
+ */
+type ConverseResult = ReturnType<typeof convertToConverseMessages>;
+
+/** Minimal view of a converted Bedrock Converse content block the assertions read. */
+interface ConverseBlock {
+  text?: string;
+  reasoningContent?: { reasoningText?: { text?: string; signature?: string } };
+  toolUse?: {
+    toolUseId?: string;
+    name?: string;
+    input?: Record<string, string>;
+  };
+}
+
+const assistantContent = (result: ConverseResult): ConverseBlock[] => {
+  const msg = result.converseMessages.find((m) => m.role === 'assistant');
+  return (msg?.content ?? []) as ConverseBlock[];
+};
+
+describe('convertToConverseMessages — native Bedrock reasoning serialization', () => {
+  it('drops a signature-only reasoning block, keeping text and tool calls', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('what data do you have?'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: { signature: 'sig-abc' },
+          },
+          { type: 'text', text: 'Let me check your databases.' },
+        ],
+        tool_calls: [
+          {
+            id: 'tooluse_list',
+            name: 'list_databases',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(JSON.stringify(content)).not.toContain('sig-abc');
+    expect(content.some((b) => b.text === 'Let me check your databases.')).toBe(
+      true
+    );
+    const toolUse = content.find((b) => b.toolUse != null);
+    expect(toolUse?.toolUse).toMatchObject({
+      toolUseId: 'tooluse_list',
+      name: 'list_databases',
+    });
+  });
+
+  it('drops a reasoning block whose text is empty', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: '', signature: 'sig' },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(content.some((b) => b.text === 'answer')).toBe(true);
+  });
+
+  it('emits a placeholder (not empty content) when the only block is a signature-only reasoning block', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          { type: 'reasoning_content', reasoningText: { signature: 'sig' } },
+        ],
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(content.every((b) => typeof b.text === 'string')).toBe(true);
+  });
+
+  it('still converts a reasoning block that carries text (not dropped)', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: {
+              text: 'native bedrock reasoning',
+              signature: 'sig',
+            },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    const reasoning = content.find((b) => b.reasoningContent != null);
+    expect(reasoning).toBeDefined();
+    expect(reasoning?.reasoningContent?.reasoningText?.text).toBe(
+      'native bedrock reasoning'
+    );
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -73,6 +73,22 @@ export function langchainReasoningBlockToBedrockReasoningBlock(
 }
 
 /**
+ * Whether a reasoning block can be serialized to a valid Bedrock
+ * `reasoningContent`. Bedrock Converse rejects `reasoningText` with a null/empty
+ * `text` (e.g. a signature-only block that never merged with its text), so such
+ * blocks must be dropped rather than sent.
+ */
+function isSerializableBedrockReasoningBlock(
+  content: MessageContentReasoningBlock
+): boolean {
+  if (content.reasoningText != null) {
+    const text = content.reasoningText.text;
+    return text != null && text !== '';
+  }
+  return content.redactedContent != null && content.redactedContent !== '';
+}
+
+/**
  * Concatenate consecutive reasoning blocks in content array.
  */
 export function concatenateLangchainReasoningBlocks(
@@ -653,10 +669,17 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
           contentBlocks.push({ text });
         }
       } else if (block.type === 'reasoning_content') {
+        const reasoningBlock = block as MessageContentReasoningBlock;
+        // Bedrock Converse rejects reasoningContent whose reasoningText.text is
+        // null/empty (a signature-only block that never merged with its text).
+        // Drop it rather than emit an invalid request; the empty-turn
+        // placeholder below covers a turn left with no content.
+        if (!isSerializableBedrockReasoningBlock(reasoningBlock)) {
+          return;
+        }
         contentBlocks.push({
-          reasoningContent: langchainReasoningBlockToBedrockReasoningBlock(
-            block as MessageContentReasoningBlock
-          ),
+          reasoningContent:
+            langchainReasoningBlockToBedrockReasoningBlock(reasoningBlock),
         } as BedrockContentBlock);
       } else if (isDefaultCachePoint(block)) {
         contentBlocks.push({


### PR DESCRIPTION
## Problem

A Bedrock-native assistant turn carrying a `reasoning_content` block whose `reasoningText.text` is null/empty — typically a **signature-only** block (`{ reasoningText: { signature } }`, no text) — is serialized verbatim and sent to Bedrock Converse, which rejects the entire request:

```
1 validation error detected: Value at 'messages.N.member.content.M.member.reasoningContent.reasoningText.text'
failed to satisfy constraint: Member must not be null
```

`langchainReasoningBlockToBedrockReasoningBlock` only checks `reasoningText != null`, not that `reasoningText.text` is a non-null string, so a text-less block passes straight through. `concatenateLangchainReasoningBlocks` folds a signature-only block into a *preceding* text-bearing reasoning block, so this only surfaces when such a block reaches the converter **unmerged** (nothing preceding it to absorb the signature).

The same gap exists upstream in `@langchain/aws` (`libs/providers/langchain-aws/.../message_inputs.ts`), from which this converter is ported — unreported and unfixed there too.

## Fix

In `convertAIMessageToConverseMessage`, drop a `reasoning_content` block when it has no serializable content — `reasoningText.text` null/empty **and** no `redactedContent`. A text-less, signature-only block is never valid to send to Bedrock, so forwarding it can only fail; a block carrying real text (or redacted content) is converted unchanged. #243's empty-turn placeholder already covers a turn left with no blocks after the drop.

This applies #243's "drop the unsendable block rather than crash the run" philosophy to the **native-Bedrock** path (#243 handled the cross-provider Anthropic converter; this is the reverse-side gap).

## Verification

**Unit** — new `message_inputs.test.ts` (4 cases): signature-only block dropped while text + tool calls survive; empty-text block dropped; reasoning-only turn falls back to the placeholder (not empty content); text-bearing reasoning still converted. Full `src/llm/bedrock` suite (43 suites / 1022 tests) green; `tsc`, eslint, prettier clean.

**Live** (real Bedrock Converse, `us-west-2`) — reproduced the exact reported error and confirmed the fix on the **streaming** path (the path LibreChat agents always take), on both `global.anthropic.claude-opus-4-8` and `us.anthropic.claude-sonnet-4-6`:

| path | result |
|---|---|
| raw Converse with a null-text reasoning block | ❌ `…messages.2…reasoningContent.reasoningText.text … Member must not be null` |
| agents `.stream()` — fixed converter, prod path | ✅ **200**, model replies normally |
| agents `.invoke()` non-streaming — base `@langchain/aws` | ❌ same validation error |

The raw error matches the original report byte-for-byte, including the `messages.2.member.content.1` index.

## Scope / remaining gap

This patches the **streaming** converter (`_streamResponseChunks` → `convertToConverseMessages`), the path LibreChat agents use. The **non-streaming** path (`_generateNonStreaming` → `super`) delegates to base `@langchain/aws`, whose converter has the identical unguarded gap — out of scope here, best fixed upstream (follow-up PR to `@langchain/aws`).

Known limit of "drop": if a text-less-but-signed block were the *only* reasoning in an interleaved-thinking-with-tools turn, dropping it could trip Bedrock's separate "thinking block required on replay" rule; the deeper fix there is to not lose `text` during stream aggregation. Still strictly better than the current guaranteed 400. Whether such an orphaned block actually arises in normal production flow (vs. needing a specific streaming race or inference-profile trigger) remains open — this is a converter-level backstop against the failure class.