### PR TITLE
refactor: rename read/write/edit `file_path` param to `path`

### DIFF
--- a/src/hooks/__tests__/createWorkspacePolicyHook.test.ts
+++ b/src/hooks/__tests__/createWorkspacePolicyHook.test.ts
@@ -51,7 +51,7 @@ describe('createWorkspacePolicyHook', () => {
     const hook = createWorkspacePolicyHook({ root: workspace });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: 'src/x.ts' })
+      makeInput('read_file', { path: 'src/x.ts' })
     );
     expect(out.decision).toBe('allow');
   });
@@ -60,7 +60,7 @@ describe('createWorkspacePolicyHook', () => {
     const hook = createWorkspacePolicyHook({ root: workspace });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: join(workspace, 'src/x.ts') })
+      makeInput('read_file', { path: join(workspace, 'src/x.ts') })
     );
     expect(out.decision).toBe('allow');
   });
@@ -72,7 +72,7 @@ describe('createWorkspacePolicyHook', () => {
     });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: join(extra, 'lib/y.ts') })
+      makeInput('read_file', { path: join(extra, 'lib/y.ts') })
     );
     expect(out.decision).toBe('allow');
   });
@@ -81,7 +81,7 @@ describe('createWorkspacePolicyHook', () => {
     const hook = createWorkspacePolicyHook({ root: workspace });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: '/etc/passwd' })
+      makeInput('read_file', { path: '/etc/passwd' })
     );
     expect(out.decision).toBe('ask');
     expect(out.reason).toContain('/etc/passwd');
@@ -93,7 +93,7 @@ describe('createWorkspacePolicyHook', () => {
     const out = await call(
       hook,
       makeInput('write_file', {
-        file_path: '/etc/foo',
+        path: '/etc/foo',
         content: 'malicious',
       })
     );
@@ -107,7 +107,7 @@ describe('createWorkspacePolicyHook', () => {
     });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: '/etc/passwd' })
+      makeInput('read_file', { path: '/etc/passwd' })
     );
     expect(out.decision).toBe('deny');
     expect(out.reason).toContain('/etc/passwd');
@@ -121,7 +121,7 @@ describe('createWorkspacePolicyHook', () => {
     const out = await call(
       hook,
       makeInput('edit_file', {
-        file_path: '/etc/foo',
+        path: '/etc/foo',
         old_text: 'a',
         new_text: 'b',
       })
@@ -136,7 +136,7 @@ describe('createWorkspacePolicyHook', () => {
     });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: '/etc/passwd' })
+      makeInput('read_file', { path: '/etc/passwd' })
     );
     expect(out.decision).toBe('allow');
   });
@@ -184,7 +184,7 @@ describe('createWorkspacePolicyHook', () => {
     });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: '/somewhere/else.ts' })
+      makeInput('read_file', { path: '/somewhere/else.ts' })
     );
     expect(out.reason).toBe('read_file blocked from /somewhere/else.ts');
   });
@@ -212,7 +212,7 @@ describe('createWorkspacePolicyHook', () => {
     const hook = createWorkspacePolicyHook({ root: '.' });
     const out = await call(
       hook,
-      makeInput('read_file', { file_path: resolve('.', 'src/x.ts') })
+      makeInput('read_file', { path: resolve('.', 'src/x.ts') })
     );
     expect(out.decision).toBe('allow');
   });
@@ -228,7 +228,7 @@ describe('createWorkspacePolicyHook', () => {
       });
       const out = await call(
         hook,
-        makeInput('read_file', { file_path: 'escape' })
+        makeInput('read_file', { path: 'escape' })
       );
       expect(out.decision).toBe('deny');
       expect(out.reason).toContain('escape');
@@ -245,7 +245,7 @@ describe('createWorkspacePolicyHook', () => {
       });
       const out = await call(
         hook,
-        makeInput('read_file', { file_path: join(altMount, 'file.ts') })
+        makeInput('read_file', { path: join(altMount, 'file.ts') })
       );
       expect(out.decision).toBe('allow');
     });

--- a/src/hooks/createWorkspacePolicyHook.ts
+++ b/src/hooks/createWorkspacePolicyHook.ts
@@ -166,13 +166,14 @@ function extractCompileCheckPaths(input: Record<string, unknown>): string[] {
   return out;
 }
 
+// All built-in coding tools take their file/dir target in `path`.
+const extractPath: PathExtractor = (i) =>
+  typeof i.path === 'string' && i.path !== '' ? [i.path] : [];
+
 const DEFAULT_EXTRACTORS: Record<string, PathExtractor> = {
-  [Constants.READ_FILE]: (i) =>
-    typeof i.file_path === 'string' ? [i.file_path] : [],
-  [Constants.WRITE_FILE]: (i) =>
-    typeof i.file_path === 'string' ? [i.file_path] : [],
-  [Constants.EDIT_FILE]: (i) =>
-    typeof i.file_path === 'string' ? [i.file_path] : [],
+  [Constants.READ_FILE]: extractPath,
+  [Constants.WRITE_FILE]: extractPath,
+  [Constants.EDIT_FILE]: extractPath,
   [Constants.GREP_SEARCH]: (i) =>
     typeof i.path === 'string' && i.path !== '' ? [i.path] : [],
   [Constants.GLOB_SEARCH]: (i) =>

--- a/src/tools/ReadFile.ts
+++ b/src/tools/ReadFile.ts
@@ -22,13 +22,13 @@ CONSTRAINTS:
 export const ReadFileToolSchema = {
   type: 'object',
   properties: {
-    file_path: {
+    path: {
       type: 'string',
       description:
         'Path to the file. For skill files: "{skillName}/{path}" (e.g. "pdf-analyzer/src/utils.py"). For code execution output: the path as returned by the execution tool.',
     },
   },
-  required: ['file_path'],
+  required: ['path'],
 } as const;
 
 export const ReadFileToolDefinition = {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -175,8 +175,8 @@ describe('local execution tools', () => {
         aiMessageWithToolCall(Constants.PROGRAMMATIC_TOOL_CALLING, {
           lang: 'py',
           code: [
-            'await write_file(file_path="ptc.txt", content="from local ptc")',
-            'contents = await read_file(file_path="ptc.txt")',
+            'await write_file(path="ptc.txt", content="from local ptc")',
+            'contents = await read_file(path="ptc.txt")',
             'print(contents)',
           ].join('\n'),
         }),
@@ -205,8 +205,8 @@ describe('local execution tools', () => {
       messages: [
         aiMessageWithToolCall(Constants.PROGRAMMATIC_TOOL_CALLING, {
           code: [
-            'write_file \'{"file_path":"bash-ptc.txt","content":"from bash ptc"}\'',
-            'read_file \'{"file_path":"bash-ptc.txt"}\'',
+            'write_file \'{"path":"bash-ptc.txt","content":"from bash ptc"}\'',
+            'read_file \'{"path":"bash-ptc.txt"}\'',
           ].join('\n'),
         }),
       ],
@@ -335,8 +335,8 @@ describe('LocalFileCheckpointer', () => {
 
     const writeTool = bundle.tools.find((tool_) => tool_.name === 'write_file');
     expect(writeTool).toBeDefined();
-    await writeTool!.invoke({ file_path: 'cp.txt', content: 'first' });
-    await writeTool!.invoke({ file_path: 'cp.txt', content: 'second' });
+    await writeTool!.invoke({ path: 'cp.txt', content: 'first' });
+    await writeTool!.invoke({ path: 'cp.txt', content: 'second' });
 
     const restored = await bundle.checkpointer!.rewind();
     expect(restored).toBe(1);
@@ -352,7 +352,7 @@ describe('local read tool guards', () => {
 
     const bundle = createLocalCodingToolBundle({ cwd });
     const readTool = bundle.tools.find((t_) => t_.name === Constants.READ_FILE);
-    const result = await readTool!.invoke({ file_path: 'binary.bin' });
+    const result = await readTool!.invoke({ path: 'binary.bin' });
     expect(String(result)).toContain('binary file');
   });
 
@@ -366,7 +366,7 @@ describe('local read tool guards', () => {
       maxReadBytes: 1024,
     });
     const readTool = bundle.tools.find((t_) => t_.name === Constants.READ_FILE);
-    const result = await readTool!.invoke({ file_path: 'big.txt' });
+    const result = await readTool!.invoke({ path: 'big.txt' });
     expect(String(result)).toContain('exceeds the 1024-byte read cap');
   });
 
@@ -380,7 +380,7 @@ describe('local read tool guards', () => {
     const bundle = createLocalCodingToolBundle({ cwd });
     const readTool = bundle.tools.find((t_) => t_.name === Constants.READ_FILE);
     await expect(
-      readTool!.invoke({ file_path: 'escape/secret.txt' })
+      readTool!.invoke({ path: 'escape/secret.txt' })
     ).rejects.toThrow(/symlink escape/);
   });
 });
@@ -406,7 +406,7 @@ describe('local programmatic bridge auth', () => {
           code: [
             'import os, json, urllib.request, urllib.error',
             'url = os.environ["BRIDGE_PROBE_URL"] if "BRIDGE_PROBE_URL" in os.environ else __LIBRECHAT_TOOL_BRIDGE',
-            'body = json.dumps({"name":"read_file","input":{"file_path":"x"}}).encode("utf-8")',
+            'body = json.dumps({"name":"read_file","input":{"path":"x"}}).encode("utf-8")',
             'try:',
             '  req = urllib.request.Request(url, data=body, headers={"Content-Type":"application/json"}, method="POST")',
             '  urllib.request.urlopen(req, timeout=5)',
@@ -438,7 +438,7 @@ describe('local edit fuzzy matching', () => {
     const bundle = createLocalCodingToolBundle({ cwd });
     const editTool = bundle.tools.find((tt) => tt.name === 'edit_file');
     const result = await editTool!.invoke({
-      file_path: 'a.ts',
+      path: 'a.ts',
       // LLM emits a trailing-whitespace-stripped version.
       old_text:
         'function greet(name: string) {\n  return `Hello, ${name}!`;\n}',
@@ -461,7 +461,7 @@ describe('local edit fuzzy matching', () => {
     const bundle = createLocalCodingToolBundle({ cwd });
     const editTool = bundle.tools.find((tt) => tt.name === 'edit_file');
     const result = await editTool!.invoke({
-      file_path: 'a.ts',
+      path: 'a.ts',
       // LLM stripped the 4-space indent
       old_text: 'method() {\n    return 1;\n}',
       new_text: 'method() {\n    return 42;\n}',
@@ -480,7 +480,7 @@ describe('local edit fuzzy matching', () => {
     const bundle = createLocalCodingToolBundle({ cwd });
     const editTool = bundle.tools.find((tt) => tt.name === 'edit_file');
     const result = await editTool!.invoke({
-      file_path: 'a.txt',
+      path: 'a.txt',
       old_text: 'second',
       new_text: 'SECOND',
     });
@@ -497,7 +497,7 @@ describe('local edit fuzzy matching', () => {
     const bundle = createLocalCodingToolBundle({ cwd });
     const editTool = bundle.tools.find((tt) => tt.name === 'edit_file');
     await editTool!.invoke({
-      file_path: 'a.txt',
+      path: 'a.txt',
       old_text: 'two',
       new_text: 'TWO',
     });
@@ -512,7 +512,7 @@ describe('local edit fuzzy matching', () => {
     await fsWriteFile(file, BOM + 'hello\n', 'utf8');
     const bundle = createLocalCodingToolBundle({ cwd });
     const writeTool = bundle.tools.find((tt) => tt.name === 'write_file');
-    await writeTool!.invoke({ file_path: 'a.txt', content: 'goodbye\n' });
+    await writeTool!.invoke({ path: 'a.txt', content: 'goodbye\n' });
     const raw = await fsReadFile(file, 'utf8');
     expect(raw.startsWith(BOM)).toBe(true);
     expect(raw.slice(1)).toBe('goodbye\n');
@@ -532,7 +532,7 @@ describe('local read attachments', () => {
     await fsWriteFile(file, tinyPng);
     const bundle = createLocalCodingToolBundle({ cwd });
     const readTool = bundle.tools.find((tt) => tt.name === Constants.READ_FILE);
-    const result = await readTool!.invoke({ file_path: 'tiny.png' });
+    const result = await readTool!.invoke({ path: 'tiny.png' });
     expect(String(result)).toContain('binary file');
   });
 
@@ -552,7 +552,7 @@ describe('local read attachments', () => {
     const message = (await readTool!.invoke({
       id: 'call_image',
       name: Constants.READ_FILE,
-      args: { file_path: 'tiny.png' },
+      args: { path: 'tiny.png' },
       type: 'tool_call',
     })) as { content: unknown; artifact: unknown };
     expect(Array.isArray(message.content)).toBe(true);
@@ -589,7 +589,7 @@ describe('local read attachments', () => {
       maxAttachmentBytes: 100,
     });
     const readTool = bundle.tools.find((tt) => tt.name === Constants.READ_FILE);
-    const result = await readTool!.invoke({ file_path: 'big.png' });
+    const result = await readTool!.invoke({ path: 'big.png' });
     expect(String(result)).toMatch(/Refusing to embed/);
   });
 
@@ -602,7 +602,7 @@ describe('local read attachments', () => {
       attachReadAttachments: 'images-only',
     });
     const readTool = bundle.tools.find((tt) => tt.name === Constants.READ_FILE);
-    const result = await readTool!.invoke({ file_path: 'a.txt' });
+    const result = await readTool!.invoke({ path: 'a.txt' });
     expect(String(result)).toContain('hello world');
   });
 });
@@ -662,7 +662,7 @@ describe('post-edit syntax check', () => {
     const message = (await writeTool!.invoke({
       id: 'call_w',
       name: 'write_file',
-      args: { file_path: 'broken.js', content: 'function (\n' },
+      args: { path: 'broken.js', content: 'function (\n' },
       type: 'tool_call',
     })) as { content: string; artifact: { syntax_error?: string } };
     expect(message.content).toContain('[syntax-check warning');
@@ -680,7 +680,7 @@ describe('post-edit syntax check', () => {
       writeTool!.invoke({
         id: 'call_w',
         name: 'write_file',
-        args: { file_path: 'broken.js', content: 'function (\n' },
+        args: { path: 'broken.js', content: 'function (\n' },
         type: 'tool_call',
       })
     ).rejects.toThrow(/syntax check failed/);
@@ -850,7 +850,7 @@ describe('codex review fixes', () => {
       const result = await readTool!.invoke({
         id: 'c',
         name: Constants.READ_FILE,
-        args: { file_path: join(parent, 'shared/lib.ts') },
+        args: { path: join(parent, 'shared/lib.ts') },
         type: 'tool_call',
       });
       expect(JSON.stringify(result)).toContain('X');
@@ -2253,7 +2253,7 @@ describe('comprehensive review (round 14) — Codex P1 #37 + P2 #38/#40/#41', ()
         writeTool!.invoke({
           id: 'wf-strict',
           name: Constants.WRITE_FILE,
-          args: { file_path: file, content: 'function broken( {\n' },
+          args: { path: file, content: 'function broken( {\n' },
           type: 'tool_call',
         })
       ).rejects.toThrow(/syntax check failed.*reverted/i);
@@ -2281,7 +2281,7 @@ describe('comprehensive review (round 14) — Codex P1 #37 + P2 #38/#40/#41', ()
         writeTool!.invoke({
           id: 'wf-strict-new',
           name: Constants.WRITE_FILE,
-          args: { file_path: file, content: 'function broken( {\n' },
+          args: { path: file, content: 'function broken( {\n' },
           type: 'tool_call',
         })
       ).rejects.toThrow(/syntax check failed.*reverted/i);
@@ -2308,7 +2308,7 @@ describe('comprehensive review (round 14) — Codex P1 #37 + P2 #38/#40/#41', ()
           id: 'ef-strict',
           name: Constants.EDIT_FILE,
           args: {
-            file_path: file,
+            path: file,
             old_text: 'return 1;',
             new_text: 'return broken(',
           },

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1503,10 +1503,10 @@ for member in team:
         { registry, runId: 'r1' },
         'read_file',
         'call_1',
-        { file_path: '/tmp/x' }
+        { path: '/tmp/x' }
       );
       expect(gate.denyReason).toBeUndefined();
-      expect(gate.input).toEqual({ file_path: '/tmp/x' });
+      expect(gate.input).toEqual({ path: '/tmp/x' });
     });
 
     it('applies updatedInput to the inner tool args', async () => {
@@ -1520,7 +1520,7 @@ for member in team:
           // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async () => ({
             decision: 'allow',
-            updatedInput: { file_path: '/tmp/rewritten' },
+            updatedInput: { path: '/tmp/rewritten' },
           }),
         ],
       });
@@ -1529,10 +1529,10 @@ for member in team:
         { registry, runId: 'r1' },
         'read_file',
         'call_1',
-        { file_path: '/tmp/original' }
+        { path: '/tmp/original' }
       );
       expect(gate.denyReason).toBeUndefined();
-      expect(gate.input).toEqual({ file_path: '/tmp/rewritten' });
+      expect(gate.input).toEqual({ path: '/tmp/rewritten' });
     });
 
     it('treats `ask` as fail-closed deny (HITL not reachable from bridge)', async () => {

--- a/src/tools/__tests__/ReadFile.test.ts
+++ b/src/tools/__tests__/ReadFile.test.ts
@@ -9,9 +9,9 @@ import { Constants } from '@/common';
 
 describe('ReadFile', () => {
   describe('schema structure', () => {
-    it('has file_path as required string property', () => {
-      expect(ReadFileToolSchema.properties.file_path.type).toBe('string');
-      expect(ReadFileToolSchema.required).toContain('file_path');
+    it('has path as required string property', () => {
+      expect(ReadFileToolSchema.properties.path.type).toBe('string');
+      expect(ReadFileToolSchema.required).toContain('path');
     });
 
     it('is an object type schema', () => {

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -1021,7 +1021,7 @@ describe('ToolNode code execution session management', () => {
           {
             id: 'call_rf',
             name: Constants.READ_FILE,
-            args: { file_path: '/mnt/data/data.csv' },
+            args: { path: '/mnt/data/data.csv' },
           },
         ],
       });
@@ -1062,7 +1062,7 @@ describe('ToolNode code execution session management', () => {
           {
             id: 'call_rf2',
             name: Constants.READ_FILE,
-            args: { file_path: 'some-skill/notes.md' },
+            args: { path: 'some-skill/notes.md' },
           },
         ],
       });

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -125,7 +125,7 @@ describe('workspace seam', () => {
       await writeTool.invoke({
         id: 'c1',
         name: 'write_file',
-        args: { file_path: 'note.md', content: 'hi\n' },
+        args: { path: 'note.md', content: 'hi\n' },
         type: 'tool_call',
       });
       expect(tracked.writeFile).toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('workspace seam', () => {
       await readTool.invoke({
         id: 'c2',
         name: Constants.READ_FILE,
-        args: { file_path: 'note.md' },
+        args: { path: 'note.md' },
         type: 'tool_call',
       });
       expect(tracked.stat).toHaveBeenCalled();

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -478,30 +478,30 @@ async def execute_code(lang, code, args=None):
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
-async def read_file(file_path, offset=None, limit=None):
-    resolved = _resolve(file_path)
+async def read_file(path, offset=None, limit=None):
+    resolved = _resolve(path)
     with open(resolved, encoding="utf-8") as handle:
         return _line_window(handle.read(), offset, limit)
 
-async def write_file(file_path, content):
+async def write_file(path, content):
     _assert_writable("write_file")
-    resolved = _resolve(file_path)
+    resolved = _resolve(path)
     os.makedirs(os.path.dirname(resolved), exist_ok=True)
     existed = os.path.exists(resolved)
     with open(resolved, "w", encoding="utf-8") as handle:
         handle.write(content)
     return f"{'Overwrote' if existed else 'Created'} {resolved} ({len(content)} chars)."
 
-async def edit_file(file_path, old_text=None, new_text=None, edits=None):
+async def edit_file(path, old_text=None, new_text=None, edits=None):
     _assert_writable("edit_file")
-    resolved = _resolve(file_path)
+    resolved = _resolve(path)
     edits = edits or [{"old_text": old_text, "new_text": new_text}]
     content = open(resolved, encoding="utf-8").read()
     for edit in edits:
         old = edit.get("old_text") or ""
         new = edit.get("new_text") or ""
         if content.count(old) != 1:
-            raise ValueError(f"Could not locate old_text exactly once in {file_path}")
+            raise ValueError(f"Could not locate old_text exactly once in {path}")
         content = content.replace(old, new, 1)
     open(resolved, "w", encoding="utf-8").write(content)
     return f"Applied {len(edits)} edit(s) to {resolved}."
@@ -881,13 +881,13 @@ async function execute_code(payload) {
 }
 
 async function read_file(payload) {
-  const resolved = resolvePath(payload.file_path);
+  const resolved = resolvePath(payload.path);
   return lineWindow(await fsp.readFile(resolved, "utf8"), payload.offset, payload.limit);
 }
 
 async function write_file(payload) {
   assertWritable("write_file");
-  const resolved = resolvePath(payload.file_path);
+  const resolved = resolvePath(payload.path);
   await fsp.mkdir(path.dirname(resolved), { recursive: true });
   const existed = fs.existsSync(resolved);
   await fsp.writeFile(resolved, payload.content, "utf8");
@@ -896,14 +896,14 @@ async function write_file(payload) {
 
 async function edit_file(payload) {
   assertWritable("edit_file");
-  const resolved = resolvePath(payload.file_path);
+  const resolved = resolvePath(payload.path);
   const edits = payload.edits || [{ old_text: payload.old_text, new_text: payload.new_text }];
   let content = await fsp.readFile(resolved, "utf8");
   for (const edit of edits) {
     const oldText = edit.old_text || "";
     const newText = edit.new_text || "";
     if (oldText === "" || content.split(oldText).length - 1 !== 1) {
-      throw new Error("Could not locate old_text exactly once in " + payload.file_path);
+      throw new Error("Could not locate old_text exactly once in " + payload.path);
     }
     content = content.replace(oldText, newText);
   }

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -49,7 +49,7 @@ export const LocalListDirectoryToolName = Constants.LIST_DIRECTORY;
 export const LocalReadFileToolSchema: t.JsonSchemaType = {
   type: 'object',
   properties: {
-    file_path: {
+    path: {
       type: 'string',
       description:
         'Path to a local file, relative to the configured cwd unless absolute paths are allowed.',
@@ -63,13 +63,13 @@ export const LocalReadFileToolSchema: t.JsonSchemaType = {
       description: 'Optional maximum number of lines to return.',
     },
   },
-  required: ['file_path'],
+  required: ['path'],
 };
 
 export const LocalWriteFileToolSchema: t.JsonSchemaType = {
   type: 'object',
   properties: {
-    file_path: {
+    path: {
       type: 'string',
       description:
         'Path to write, relative to the configured cwd unless absolute paths are allowed.',
@@ -79,13 +79,13 @@ export const LocalWriteFileToolSchema: t.JsonSchemaType = {
       description: 'Complete file contents to write.',
     },
   },
-  required: ['file_path', 'content'],
+  required: ['path', 'content'],
 };
 
 export const LocalEditFileToolSchema: t.JsonSchemaType = {
   type: 'object',
   properties: {
-    file_path: {
+    path: {
       type: 'string',
       description:
         'Path to edit, relative to the configured cwd unless absolute paths are allowed.',
@@ -112,7 +112,7 @@ export const LocalEditFileToolSchema: t.JsonSchemaType = {
       },
     },
   },
-  required: ['file_path'],
+  required: ['path'],
 };
 
 export const LocalGrepSearchToolSchema: t.JsonSchemaType = {
@@ -391,18 +391,18 @@ export function createLocalReadFileTool(
   return tool(
     async (rawInput) => {
       const input = rawInput as {
-        file_path: string;
+        path: string;
         offset?: number;
         limit?: number;
       };
       const path = await resolveWorkspacePathSafe(
-        input.file_path,
+        input.path,
         config,
         'read'
       );
       const fileStat = await fs.stat(path);
       if (!fileStat.isFile()) {
-        throw new Error(`Path is not a file: ${input.file_path}`);
+        throw new Error(`Path is not a file: ${input.path}`);
       }
       const maxBytes = Math.max(
         config.maxReadBytes ?? DEFAULT_MAX_READ_BYTES,
@@ -514,12 +514,12 @@ export function createLocalWriteFileTool(
   const fs = getWorkspaceFS(config);
   return tool(
     async (rawInput) => {
-      const input = rawInput as { file_path: string; content: string };
+      const input = rawInput as { path: string; content: string };
       if (config.readOnly === true) {
         throw new Error('write_file is blocked in read-only local mode.');
       }
       const path = await resolveWorkspacePathSafe(
-        input.file_path,
+        input.path,
         config,
         'write'
       );
@@ -598,7 +598,7 @@ export function createLocalEditFileTool(
   return tool(
     async (rawInput) => {
       const input = rawInput as {
-        file_path: string;
+        path: string;
         old_text?: string;
         new_text?: string;
         edits?: Array<{ old_text?: string; new_text?: string }>;
@@ -612,7 +612,7 @@ export function createLocalEditFileTool(
       }
 
       const path = await resolveWorkspacePathSafe(
-        input.file_path,
+        input.path,
         config,
         'write'
       );
@@ -627,7 +627,7 @@ export function createLocalEditFileTool(
         const match = locateEdit(next, edit.oldText);
         if (match == null) {
           throw new Error(
-            `Edit ${i + 1}/${edits.length}: could not locate old_text in ${input.file_path}. ` +
+            `Edit ${i + 1}/${edits.length}: could not locate old_text in ${input.path}. ` +
               'Tried exact, line-trimmed, whitespace-normalized, and indentation-flexible matching. ' +
               'Re-read the file and copy the literal lines.'
           );


### PR DESCRIPTION
## Problem

Models intermittently emit the very common `path` instead of `file_path` for the `read_file` / `write_file` / `edit_file` tools, which fails Zod validation:

```
Error: Received tool input did not match expected schema
```

The model then retries or returns empty, so the agent loop investigates nothing. Observed reliably with **Kimi K2 (kimi-k2p7-code) via Fireworks/ClickHouse Inference** — the investigator dies right after the first tool call.

## Approach

The first cut coerced `path`→`file_path` at execution time, but that has to be repeated at every execution path (direct, event-dispatch, eager prestart, Send, programmatic bridge, plus the policy extractors) — whack-a-mole.

Instead, **align the schema with what models actually emit**, and with the sibling search tools (`grep_search`/`glob_search`/`list_directory`) that **already use `path`**. Now every built-in coding tool takes its file/dir target in `path`.

- `ReadFileToolSchema` + `Local{Read,Write,Edit}FileToolSchema`: `file_path` → `path`
- handlers read `input.path`
- workspace-policy extractors collapse to a single `path` extractor for all coding tools
- tests updated

## ⚠️ Breaking change

The `read_file`/`write_file`/`edit_file` parameter is now **`path`** (was `file_path`). Consumers that construct or read these tool-call args must update (LibreChat update incoming alongside).

## Verification

- End-to-end against ClickHouse Inference (kimi-k2p7-code): a real investigator loop goes **4/10 → 10/10** with **zero coercion** — the model reliably sends `path` once the schema declares it.
- Tool + hook suites green. (The one failing suite, `directToolHITLResumeScope`, fails identically on clean `main` — pre-existing, unrelated.)