### PR TITLE
fix(bedrock): gate explicit prompt-cache checkpoints to Claude models

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -846,6 +846,8 @@ export class AgentContext {
     const bedrockOptions = this.clientOptions as
       | t.BedrockAnthropicClientOptions
       | undefined;
+    // Nova accepts system/message cachePoints (only the tool checkpoint is
+    // Claude-only), so this is gated on promptCache alone.
     return bedrockOptions?.promptCache === true;
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1441,16 +1441,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.clientOptions as
             | t.BedrockAnthropicClientOptions
             | undefined
-        )?.promptCache === true &&
-        supportsBedrockToolCache(
-          (agentContext.clientOptions as { model?: string } | undefined)?.model
-        )
+        )?.promptCache === true
       ) {
-        toolsForBinding =
-          partitionAndMarkBedrockToolCache(
-            rawToolsForBinding,
-            makeIsDeferred(agentContext.toolDefinitions)
-          ) ?? rawToolsForBinding;
+        const bedrockModel = (
+          agentContext.clientOptions as { model?: string } | undefined
+        )?.model;
+        // An omitted model falls back to LangChain's default Claude model (which
+        // supports tool caching); only an explicit non-Claude model (e.g. Nova)
+        // skips tool marking so its stray marker never leaks into toolConfig.
+        if (bedrockModel == null || supportsBedrockToolCache(bedrockModel)) {
+          toolsForBinding =
+            partitionAndMarkBedrockToolCache(
+              rawToolsForBinding,
+              makeIsDeferred(agentContext.toolDefinitions)
+            ) ?? rawToolsForBinding;
+        }
       }
 
       let model =

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -28,6 +28,7 @@ import {
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
+  supportsBedrockToolCache,
   getMessageId,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
@@ -1440,7 +1441,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.clientOptions as
             | t.BedrockAnthropicClientOptions
             | undefined
-        )?.promptCache === true
+        )?.promptCache === true &&
+        supportsBedrockToolCache(
+          (agentContext.clientOptions as { model?: string } | undefined)?.model
+        )
       ) {
         toolsForBinding =
           partitionAndMarkBedrockToolCache(
@@ -1790,6 +1794,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             | t.ProviderOptionsMap[Providers.OPENROUTER]
             | undefined
         )?.promptCache === true;
+      // Message/system cache points work on all cache-capable Bedrock models,
+      // including Nova (verified live: HTTP 200 with cacheWriteInputTokens). Only
+      // the tool checkpoint is Claude-only, so this is gated on promptCache alone.
       const bedrockPromptCacheEnabled =
         agentContext.provider === Providers.BEDROCK &&
         (

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -152,7 +152,10 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     this.promptCacheTtl = fields?.promptCacheTtl;
     this.applicationInferenceProfile = fields?.applicationInferenceProfile;
     this.serviceTier = fields?.serviceTier;
-    this.cacheModelId = fields?.model ?? '';
+    // `super(fields)` initializes `this.model` to LangChain's default Claude
+    // model when `fields.model` is omitted, so fall back to it rather than ''
+    // (which would treat the default Claude model as tool-cache-unsupported).
+    this.cacheModelId = fields?.model ?? this.model;
   }
 
   static lc_name(): string {

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -39,7 +39,11 @@ import {
   handleConverseStreamContentBlockDelta,
   handleConverseStreamMetadata,
 } from './utils';
-import { resolvePromptCacheTtl, type PromptCacheTtl } from '@/messages/cache';
+import {
+  resolvePromptCacheTtl,
+  supportsBedrockToolCache,
+  type PromptCacheTtl,
+} from '@/messages/cache';
 import { insertBedrockToolCachePoint } from './toolCache';
 
 /**
@@ -134,12 +138,21 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
    */
   serviceTier?: ServiceTierType;
 
+  /**
+   * The configured model id, captured at construction so it survives the
+   * temporary `this.model` swap to an application-inference-profile ARN during
+   * generation. Used to gate the Bedrock tool cache point to Claude models
+   * (see {@link supportsBedrockToolCache}).
+   */
+  private readonly cacheModelId: string;
+
   constructor(fields?: CustomChatBedrockConverseInput) {
     super(fields);
     this.promptCache = fields?.promptCache;
     this.promptCacheTtl = fields?.promptCacheTtl;
     this.applicationInferenceProfile = fields?.applicationInferenceProfile;
     this.serviceTier = fields?.serviceTier;
+    this.cacheModelId = fields?.model ?? '';
   }
 
   static lc_name(): string {
@@ -164,7 +177,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
   } {
     const baseParams = super.invocationParams(options);
     const toolConfig =
-      this.promptCache === true
+      this.promptCache === true && supportsBedrockToolCache(this.cacheModelId)
         ? insertBedrockToolCachePoint(
           baseParams.toolConfig,
           true,

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -375,6 +375,7 @@ describe('CustomChatBedrockConverse', () => {
     test('adds a Bedrock cache point for directly-bound tools', () => {
       const model = new CustomChatBedrockConverse({
         ...baseConstructorArgs,
+        model: 'anthropic.claude-3-haiku-20240307-v1:0',
         promptCache: true,
       });
 
@@ -400,6 +401,7 @@ describe('CustomChatBedrockConverse', () => {
     test('defaults the tool cache point to the 1h extended TTL', () => {
       const model = new CustomChatBedrockConverse({
         ...baseConstructorArgs,
+        model: 'anthropic.claude-3-haiku-20240307-v1:0',
         promptCache: true,
       });
 
@@ -430,6 +432,7 @@ describe('CustomChatBedrockConverse', () => {
     test('honors an explicit 5m promptCacheTtl on the tool cache point', () => {
       const model = new CustomChatBedrockConverse({
         ...baseConstructorArgs,
+        model: 'anthropic.claude-3-haiku-20240307-v1:0',
         promptCache: true,
         promptCacheTtl: '5m',
       });
@@ -461,6 +464,7 @@ describe('CustomChatBedrockConverse', () => {
     test('adds the Bedrock cache point before deferred tools', () => {
       const model = new CustomChatBedrockConverse({
         ...baseConstructorArgs,
+        model: 'anthropic.claude-3-haiku-20240307-v1:0',
         promptCache: true,
       });
       const tools = partitionAndMarkBedrockToolCache(
@@ -500,6 +504,7 @@ describe('CustomChatBedrockConverse', () => {
     test('does not fall back to caching when Graph marks all tools deferred', () => {
       const model = new CustomChatBedrockConverse({
         ...baseConstructorArgs,
+        model: 'anthropic.claude-3-haiku-20240307-v1:0',
         promptCache: true,
       });
       const tools = partitionAndMarkBedrockToolCache(
@@ -524,6 +529,69 @@ describe('CustomChatBedrockConverse', () => {
       expect(JSON.stringify(params.toolConfig?.tools)).not.toContain(
         '__lc_bedrock_skip_tool_cache'
       );
+    });
+
+    test('does not add a tool cache point for Amazon Nova models', () => {
+      // Regression for danny-avila/LibreChat#13838: Nova rejects a cachePoint in
+      // toolConfig.tools ("Malformed input request: #/toolConfig/tools/0:
+      // extraneous key [cachePoint] is not permitted"). Only the tool checkpoint
+      // is Claude-only — Nova still caches system/messages — so promptCache: true
+      // on Nova must omit just the tool cache point.
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        model: 'us.amazon.nova-pro-v1:0',
+        promptCache: true,
+      });
+
+      const params = model.invocationParams({
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'direct_tool',
+              description: 'Direct tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+      });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'direct_tool',
+      ]);
+      expect(JSON.stringify(params.toolConfig?.tools ?? [])).not.toContain(
+        'cachePoint'
+      );
+    });
+
+    test('still adds a tool cache point for a Claude model behind an inference profile', () => {
+      // The configured Claude model id is captured at construction, so the gate
+      // survives the application-inference-profile ARN swap during generation.
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        applicationInferenceProfile:
+          'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test',
+        promptCache: true,
+      });
+
+      const params = model.invocationParams({
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'direct_tool',
+              description: 'Direct tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+      });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'direct_tool',
+        'cachePoint',
+      ]);
     });
   });
 

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -593,6 +593,35 @@ describe('CustomChatBedrockConverse', () => {
         'cachePoint',
       ]);
     });
+
+    test('still adds a tool cache point when model is omitted (default is Claude)', () => {
+      // When no model is provided, LangChain initializes this.model to a default
+      // Claude model, so the tool cache point must still apply.
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        promptCache: true,
+      });
+
+      expect(model.model).toMatch(/claude/i);
+
+      const params = model.invocationParams({
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'direct_tool',
+              description: 'Direct tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+      });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'direct_tool',
+        'cachePoint',
+      ]);
+    });
   });
 
   describe('contentBlockIndex cleanup', () => {

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -19,6 +19,7 @@ import {
   buildAnthropicCacheControl,
   buildBedrockCachePoint,
   resolvePromptCacheTtl,
+  supportsBedrockToolCache,
   DEFAULT_PROMPT_CACHE_TTL,
 } from './cache';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
@@ -892,6 +893,36 @@ describe('synthetic skill/meta messages are not cache-anchored', () => {
 
     expect(hasAnthropicMarker(result[2])).toBe(false);
     expect(hasAnthropicMarker(result[0])).toBe(true);
+  });
+});
+
+describe('supportsBedrockToolCache', () => {
+  test('returns true for Claude model ids (incl. cross-region + profile)', () => {
+    expect(
+      supportsBedrockToolCache('anthropic.claude-3-5-sonnet-20241022-v2:0')
+    ).toBe(true);
+    expect(
+      supportsBedrockToolCache('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+    ).toBe(true);
+    expect(supportsBedrockToolCache('anthropic.claude-opus-4-6-v1')).toBe(true);
+  });
+
+  test('returns false for Nova and other non-Claude families (tool cache only)', () => {
+    // Nova accepts system/message cachePoints but rejects the tool checkpoint.
+    expect(supportsBedrockToolCache('us.amazon.nova-pro-v1:0')).toBe(false);
+    expect(supportsBedrockToolCache('amazon.nova-lite-v1:0')).toBe(false);
+    expect(supportsBedrockToolCache('meta.llama3-1-70b-instruct-v1:0')).toBe(
+      false
+    );
+    expect(supportsBedrockToolCache('mistral.mistral-large-2407-v1:0')).toBe(
+      false
+    );
+  });
+
+  test('returns false for empty / missing model', () => {
+    expect(supportsBedrockToolCache('')).toBe(false);
+    expect(supportsBedrockToolCache(undefined)).toBe(false);
+    expect(supportsBedrockToolCache(null)).toBe(false);
   });
 });
 

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -80,6 +80,31 @@ export function buildBedrockCachePoint(
 }
 
 /**
+ * A `cachePoint` under `toolConfig.tools` is only accepted on Anthropic Claude
+ * models. Amazon Nova rejects it outright — `Malformed input request:
+ * #/toolConfig/tools/0: extraneous key [cachePoint] is not permitted` — even
+ * though it accepts `cachePoint` in `system` and `messages` (verified live:
+ * Nova returns HTTP 200 with real `cacheWriteInputTokens` for both). Per the AWS
+ * prompt-caching docs the support table lists `tools` for Claude only.
+ *
+ * Gate ONLY the tool checkpoint on this, so a `promptCache: true` config on Nova
+ * keeps its valid message/system caching instead of either 400-ing (tool point)
+ * or losing caching entirely. This is a capability gate (the key is rejected
+ * outright), distinct from the TTL value which Bedrock downgrades gracefully.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
+ * @see https://github.com/danny-avila/LibreChat/issues/13838
+ */
+export function supportsBedrockToolCache(
+  model: string | undefined | null
+): boolean {
+  if (typeof model !== 'string') {
+    return false;
+  }
+  return /claude|anthropic/i.test(model);
+}
+
+/**
  * Deep clones a message's content to prevent mutation of the original.
  */
 function deepCloneContent<T extends string | MessageContentComplex[]>(


### PR DESCRIPTION
## Problem

Fixes [danny-avila/LibreChat#13838](https://github.com/danny-avila/LibreChat/issues/13838). Amazon Nova requests failed with:

```
ValidationException: Malformed input request: #/toolConfig/tools/0: extraneous key [cachePoint] is not permitted
```

LibreChat auto-defaults Nova to `promptCache: true`, and the SDK then injected a `cachePoint` into `toolConfig.tools`, which Nova rejects.

## What Nova actually supports (live-probed, Converse, `us.amazon.nova-lite-v1:0`)

| cachePoint location | result |
| --- | --- |
| `toolConfig.tools` | ❌ 400 `extraneous key [cachePoint] is not permitted` |
| `messages` content | ✅ HTTP 200, `cacheWriteInputTokens=240` |
| `system` | ✅ HTTP 200, `cacheWriteInputTokens=241` |

So **only the tool checkpoint is Claude-only** — Nova caches system/messages fine (and it's real, paid caching). An earlier revision of this PR gated *all* Bedrock caching to Claude; that was too aggressive (it threw away valid Nova message/system caching), so it's been narrowed to the tool path only.

## Fix

Add `supportsBedrockToolCache(model)` (Claude-only) and gate **only** the tool cache point on it:

- **`bedrock/index.ts`** `invocationParams` — skip the `toolConfig` cache point on non-Claude models. Gated on a `cacheModelId` **captured at construction**, so it survives the `this.model` → application-inference-profile ARN swap during generation.
- **`Graph.ts`** — skip Bedrock tool *marking* on non-Claude models. The message/system tail cache (`bedrockPromptCacheEnabled`) stays gated on `promptCache` alone.
- **`AgentContext.ts`** summarization path — stays gated on `promptCache` alone.

Net: Nova keeps system/message caching; only the unsupported tool checkpoint is suppressed. Capability gate (key hard-rejected), distinct from the 1h/5m TTL value which downgrades gracefully on Claude.

## Testing

- **Live**: probe above — tool 400, message/system 200 with cache writes.
- **Unit**: `supportsBedrockToolCache` (Claude→true, Nova/Llama/Mistral/empty→false); `invocationParams` (Nova → no tool cachePoint; Claude behind an inference-profile ARN → still cached, swap-immune); existing Claude prompt-cache tests specify a Claude model.

`tsc --noEmit` clean; bedrock + messages + agents suites green.