### PR TITLE
test: cover custom OpenAI-compatible vLLM reasoning + qwen3_coder tool calls

### DIFF
--- a/src/specs/vllm-reasoning-toolcalls.test.ts
+++ b/src/specs/vllm-reasoning-toolcalls.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Regression coverage for a generic `custom` OpenAI-compatible endpoint
+ * (provider `openai`, default `reasoningKey`, non-standard model name) that
+ * streams reasoning in the modern vLLM `reasoning` field — `reasoning_content`
+ * is `null` throughout — and streams `tool_calls` with fragmented arguments
+ * (vLLM `--reasoning-parser qwen3` + `--tool-call-parser qwen3_coder`).
+ *
+ * The wire shapes mirror the captures in LibreChat discussion #13849:
+ *   - reasoning must surface as `think` content (the Thoughts block), and
+ *   - the fragmented streamed tool call must accumulate into a structured call.
+ */
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import type { OpenAIClient } from '@langchain/openai';
+import type * as t from '@/types';
+import { ContentTypes, GraphEvents, Providers } from '@/common';
+import { createContentAggregator } from '@/stream';
+import { ChatOpenAI } from '@/llm/openai';
+import { Run } from '@/run';
+
+type StreamingCompletionBackedModel = {
+  completions: {
+    completionWithRetry: () => Promise<
+      AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
+    >;
+  };
+};
+
+type DeltaConverterModel = {
+  completions: {
+    _convertCompletionsDeltaToBaseMessageChunk(
+      delta: Record<string, unknown>,
+      rawResponse: Record<string, unknown>,
+      defaultRole?: string
+    ): AIMessageChunk;
+  };
+};
+
+const MODEL = 'custom_llm_thinking';
+
+function completionChunk(
+  delta: Record<string, unknown>,
+  finishReason: string | null = null
+): OpenAIClient.Chat.Completions.ChatCompletionChunk {
+  return {
+    id: 'chatcmpl-vllm',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: MODEL,
+    choices: [
+      {
+        index: 0,
+        delta:
+          delta as OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['delta'],
+        finish_reason:
+          finishReason as OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'],
+      },
+    ],
+  };
+}
+
+function captureHandlers(
+  aggregateContent: t.ContentAggregator,
+  reasoningDeltas: t.ReasoningDeltaEvent[],
+  messageDeltas: t.MessageDeltaEvent[]
+): Record<string | GraphEvents, t.EventHandler> {
+  return {
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: GraphEvents.ON_RUN_STEP, data: t.StreamEventData): void =>
+        aggregateContent({ event, data: data as t.RunStep }),
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        messageDeltas.push(data as t.MessageDeltaEvent);
+        aggregateContent({ event, data: data as t.MessageDeltaEvent });
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        reasoningDeltas.push(data as t.ReasoningDeltaEvent);
+        aggregateContent({ event, data: data as t.ReasoningDeltaEvent });
+      },
+    },
+  };
+}
+
+describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool calls)', () => {
+  const config = {
+    configurable: { thread_id: 'vllm-reasoning-toolcalls' },
+    streamMode: 'values' as const,
+    version: 'v2' as const,
+  };
+
+  it('renders reasoning from delta.reasoning when reasoning_content is null', async () => {
+    const reasoningTokens = [
+      'Here',
+      '\'s a thinking',
+      ' process: 17*23',
+      ' = 391',
+    ];
+    const contentTokens = ['\n\nUm ', '17 ×', ' 23 = **391', '**.'];
+
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+
+    const run = await Run.create<t.IState>({
+      runId: 'vllm-reasoning',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: { provider: Providers.OPENAI, streamUsage: false },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: captureHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const model = new ChatOpenAI({
+      model: MODEL,
+      apiKey: 'test-key',
+      streaming: true,
+    });
+    const completions = (model as unknown as StreamingCompletionBackedModel)
+      .completions;
+    async function* streamChunks(): AsyncGenerator<OpenAIClient.Chat.Completions.ChatCompletionChunk> {
+      yield completionChunk({ role: 'assistant', content: '' });
+      for (const reasoning of reasoningTokens) {
+        yield completionChunk({
+          reasoning,
+          reasoning_content: null,
+          content: null,
+        });
+      }
+      for (let i = 0; i < contentTokens.length; i++) {
+        yield completionChunk(
+          {
+            reasoning: null,
+            reasoning_content: null,
+            content: contentTokens[i],
+          },
+          i === contentTokens.length - 1 ? 'stop' : null
+        );
+      }
+    }
+    completions.completionWithRetry = async () => streamChunks();
+    run.Graph.overrideModel = model as t.ChatModel;
+
+    await run.processStream(
+      {
+        messages: [
+          new HumanMessage('Was ist 17*23? Denk Schritt für Schritt.'),
+        ],
+      },
+      config
+    );
+
+    const thoughts = reasoningDeltas
+      .flatMap((delta) => delta.delta.content ?? [])
+      .map((part) => (part as { think?: string }).think ?? '')
+      .join('');
+    const answer = messageDeltas
+      .flatMap((delta) => delta.delta.content ?? [])
+      .map((part) => (part as { text?: string }).text ?? '')
+      .join('');
+
+    expect(reasoningDeltas).toHaveLength(reasoningTokens.length);
+    expect(thoughts).toBe(reasoningTokens.join(''));
+    expect(answer).toBe(contentTokens.join(''));
+    expect(contentParts.map((part) => part?.type)).toEqual([
+      ContentTypes.THINK,
+      ContentTypes.TEXT,
+    ]);
+  });
+
+  it('accumulates fragmented streamed tool_calls into a structured call', () => {
+    const model = new ChatOpenAI({ model: MODEL, apiKey: 'test-key' });
+    const converter = (model as unknown as DeltaConverterModel).completions;
+    const rawResponse = {
+      id: 'chatcmpl-vllm',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model: MODEL,
+      choices: [],
+    };
+
+    const deltas: Record<string, unknown>[] = [
+      { role: 'assistant', tool_calls: null, content: '\n\n' },
+      {
+        tool_calls: [
+          {
+            id: 'call_0065144d618f4f33be1491af',
+            type: 'function',
+            index: 0,
+            function: { name: 'get_weather', arguments: '' },
+          },
+        ],
+        content: null,
+      },
+      {
+        tool_calls: [{ index: 0, function: { arguments: '{' } }],
+        content: null,
+      },
+      {
+        tool_calls: [
+          { index: 0, function: { arguments: '"location": "Berlin"' } },
+        ],
+        content: null,
+      },
+      { tool_calls: [{ index: 0, function: { arguments: '}' } }] },
+    ];
+
+    const chunks = deltas.map((delta) =>
+      converter._convertCompletionsDeltaToBaseMessageChunk(
+        delta,
+        rawResponse,
+        'assistant'
+      )
+    );
+
+    const argFragments = chunks
+      .flatMap((chunk) => chunk.tool_call_chunks ?? [])
+      .map((toolCallChunk) => toolCallChunk.args ?? '')
+      .join('');
+    expect(argFragments).toBe('{"location": "Berlin"}');
+
+    let merged = chunks[0];
+    for (let i = 1; i < chunks.length; i++) {
+      merged = merged.concat(chunks[i]);
+    }
+    expect(merged.tool_calls).toEqual([
+      {
+        id: 'call_0065144d618f4f33be1491af',
+        name: 'get_weather',
+        args: { location: 'Berlin' },
+        type: 'tool_call',
+      },
+    ]);
+  });
+});

--- a/src/specs/vllm-reasoning-toolcalls.test.ts
+++ b/src/specs/vllm-reasoning-toolcalls.test.ts
@@ -1,92 +1,73 @@
 /**
  * Regression coverage for a generic `custom` OpenAI-compatible endpoint
- * (provider `openai`, default `reasoningKey`, non-standard model name) that
- * streams reasoning in the modern vLLM `reasoning` field — `reasoning_content`
- * is `null` throughout — and streams `tool_calls` with fragmented arguments
- * (vLLM `--reasoning-parser qwen3` + `--tool-call-parser qwen3_coder`).
+ * (provider `openai`, non-OpenAI `baseURL`, default `reasoningKey`,
+ * non-standard model name) that streams reasoning in the modern vLLM
+ * `reasoning` field — `reasoning_content` is `null` throughout — and streams
+ * `tool_calls` with fragmented arguments (vLLM `--reasoning-parser qwen3` +
+ * `--tool-call-parser qwen3_coder`).
+ *
+ * A non-OpenAI `baseURL` is required so the model stays on the custom-endpoint
+ * (final-signal) path rather than the official-OpenAI sequential-seal path.
  *
  * The wire shapes mirror the captures in LibreChat discussion #13849:
  *   - reasoning must surface as `think` content (the Thoughts block), and
- *   - the fragmented streamed tool call must accumulate into a structured call.
+ *   - the fragmented streamed tool call must be assembled by the graph into a
+ *     structured call and executed.
  */
-import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { UsageMetadata } from '@langchain/core/messages';
 import type { OpenAIClient } from '@langchain/openai';
 import type * as t from '@/types';
-import { ContentTypes, GraphEvents, Providers } from '@/common';
+import { ContentTypes, GraphEvents, Providers, StepTypes } from '@/common';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
 import { createContentAggregator } from '@/stream';
 import { ChatOpenAI } from '@/llm/openai';
 import { Run } from '@/run';
 
-type StreamingCompletionBackedModel = {
-  completions: {
-    completionWithRetry: () => Promise<
-      AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
-    >;
-  };
+type CompletionChunk = OpenAIClient.Chat.Completions.ChatCompletionChunk;
+type CompletionChoice =
+  OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice;
+type CompletionDelta = CompletionChoice['delta'] & {
+  reasoning?: string | null;
+  reasoning_content?: string | null;
 };
-
-type DeltaConverterModel = {
-  completions: {
-    _convertCompletionsDeltaToBaseMessageChunk(
-      delta: Record<string, unknown>,
-      rawResponse: Record<string, unknown>,
-      defaultRole?: string
-    ): AIMessageChunk;
-  };
+type StreamingCompletions = {
+  completionWithRetry: () => Promise<AsyncIterable<CompletionChunk>>;
 };
 
 const MODEL = 'custom_llm_thinking';
+const BASE_URL = 'http://vllm.internal:8000/v1';
 
 function completionChunk(
-  delta: Record<string, unknown>,
-  finishReason: string | null = null
-): OpenAIClient.Chat.Completions.ChatCompletionChunk {
+  delta: CompletionDelta,
+  finishReason: CompletionChoice['finish_reason'] = null
+): CompletionChunk {
   return {
     id: 'chatcmpl-vllm',
     object: 'chat.completion.chunk',
     created: 0,
     model: MODEL,
-    choices: [
-      {
-        index: 0,
-        delta:
-          delta as OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['delta'],
-        finish_reason:
-          finishReason as OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'],
-      },
-    ],
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
   };
 }
 
-function captureHandlers(
-  aggregateContent: t.ContentAggregator,
-  reasoningDeltas: t.ReasoningDeltaEvent[],
-  messageDeltas: t.MessageDeltaEvent[]
-): Record<string | GraphEvents, t.EventHandler> {
-  return {
-    [GraphEvents.ON_RUN_STEP]: {
-      handle: (event: GraphEvents.ON_RUN_STEP, data: t.StreamEventData): void =>
-        aggregateContent({ event, data: data as t.RunStep }),
-    },
-    [GraphEvents.ON_MESSAGE_DELTA]: {
-      handle: (
-        event: GraphEvents.ON_MESSAGE_DELTA,
-        data: t.StreamEventData
-      ): void => {
-        messageDeltas.push(data as t.MessageDeltaEvent);
-        aggregateContent({ event, data: data as t.MessageDeltaEvent });
-      },
-    },
-    [GraphEvents.ON_REASONING_DELTA]: {
-      handle: (
-        event: GraphEvents.ON_REASONING_DELTA,
-        data: t.StreamEventData
-      ): void => {
-        reasoningDeltas.push(data as t.ReasoningDeltaEvent);
-        aggregateContent({ event, data: data as t.ReasoningDeltaEvent });
-      },
-    },
-  };
+function customEndpointModel(): ChatOpenAI {
+  return new ChatOpenAI({
+    model: MODEL,
+    apiKey: 'test-key',
+    streaming: true,
+    configuration: { baseURL: BASE_URL },
+  });
+}
+
+function setCompletionStream(
+  model: ChatOpenAI,
+  stream: () => AsyncIterable<CompletionChunk>
+): void {
+  (
+    model as unknown as { completions: StreamingCompletions }
+  ).completions.completionWithRetry = async () => stream();
 }
 
 describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool calls)', () => {
@@ -117,44 +98,61 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
       },
       returnContent: true,
       skipCleanup: true,
-      customHandlers: captureHandlers(
-        aggregateContent,
-        reasoningDeltas,
-        messageDeltas
-      ),
+      customHandlers: {
+        [GraphEvents.ON_RUN_STEP]: {
+          handle: (
+            event: GraphEvents.ON_RUN_STEP,
+            data: t.StreamEventData
+          ): void => aggregateContent({ event, data: data as t.RunStep }),
+        },
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (
+            event: GraphEvents.ON_MESSAGE_DELTA,
+            data: t.StreamEventData
+          ): void => {
+            messageDeltas.push(data as t.MessageDeltaEvent);
+            aggregateContent({ event, data: data as t.MessageDeltaEvent });
+          },
+        },
+        [GraphEvents.ON_REASONING_DELTA]: {
+          handle: (
+            event: GraphEvents.ON_REASONING_DELTA,
+            data: t.StreamEventData
+          ): void => {
+            reasoningDeltas.push(data as t.ReasoningDeltaEvent);
+            aggregateContent({ event, data: data as t.ReasoningDeltaEvent });
+          },
+        },
+      },
     });
     if (!run.Graph) {
       throw new Error('Expected graph to be initialized');
     }
 
-    const model = new ChatOpenAI({
-      model: MODEL,
-      apiKey: 'test-key',
-      streaming: true,
-    });
-    const completions = (model as unknown as StreamingCompletionBackedModel)
-      .completions;
-    async function* streamChunks(): AsyncGenerator<OpenAIClient.Chat.Completions.ChatCompletionChunk> {
-      yield completionChunk({ role: 'assistant', content: '' });
-      for (const reasoning of reasoningTokens) {
-        yield completionChunk({
-          reasoning,
-          reasoning_content: null,
-          content: null,
-        });
-      }
-      for (let i = 0; i < contentTokens.length; i++) {
-        yield completionChunk(
-          {
-            reasoning: null,
+    const model = customEndpointModel();
+    setCompletionStream(
+      model,
+      async function* streamChunks(): AsyncGenerator<CompletionChunk> {
+        yield completionChunk({ role: 'assistant', content: '' });
+        for (const reasoning of reasoningTokens) {
+          yield completionChunk({
+            reasoning,
             reasoning_content: null,
-            content: contentTokens[i],
-          },
-          i === contentTokens.length - 1 ? 'stop' : null
-        );
+            content: null,
+          });
+        }
+        for (let i = 0; i < contentTokens.length; i++) {
+          yield completionChunk(
+            {
+              reasoning: null,
+              reasoning_content: null,
+              content: contentTokens[i],
+            },
+            i === contentTokens.length - 1 ? 'stop' : null
+          );
+        }
       }
-    }
-    completions.completionWithRetry = async () => streamChunks();
+    );
     run.Graph.overrideModel = model as t.ChatModel;
 
     await run.processStream(
@@ -184,20 +182,78 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
     ]);
   });
 
-  it('accumulates fragmented streamed tool_calls into a structured call', () => {
-    const model = new ChatOpenAI({ model: MODEL, apiKey: 'test-key' });
-    const converter = (model as unknown as DeltaConverterModel).completions;
-    const rawResponse = {
-      id: 'chatcmpl-vllm',
-      object: 'chat.completion.chunk',
-      created: 0,
-      model: MODEL,
-      choices: [],
-    };
+  it('assembles fragmented streamed tool_calls and executes the tool through the graph', async () => {
+    let weatherArgs: unknown;
+    const getWeather = new DynamicStructuredTool({
+      name: 'get_weather',
+      description: 'Get the current weather for a location',
+      schema: {
+        type: 'object',
+        properties: { location: { type: 'string' } },
+        required: ['location'],
+      },
+      func: async (input: unknown): Promise<string> => {
+        weatherArgs = input;
+        return JSON.stringify({
+          location: 'Berlin',
+          summary: 'sunny',
+          temp_c: 18,
+        });
+      },
+    });
 
-    const deltas: Record<string, unknown>[] = [
-      { role: 'assistant', tool_calls: null, content: '\n\n' },
-      {
+    const { aggregateContent } = createContentAggregator();
+    const collectedUsage: UsageMetadata[] = [];
+    const runSteps: t.RunStep[] = [];
+
+    const run = await Run.create<t.IState>({
+      runId: 'vllm-tool-calls',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: { provider: Providers.OPENAI, streamUsage: false },
+        tools: [getWeather],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+        [GraphEvents.ON_RUN_STEP]: {
+          handle: (
+            event: GraphEvents.ON_RUN_STEP,
+            data: t.StreamEventData
+          ): void => {
+            runSteps.push(data as t.RunStep);
+            aggregateContent({ event, data: data as t.RunStep });
+          },
+        },
+        [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+          handle: (
+            event: GraphEvents.ON_RUN_STEP_COMPLETED,
+            data: t.StreamEventData
+          ): void =>
+            aggregateContent({
+              event,
+              data: data as unknown as { result: t.ToolEndEvent },
+            }),
+        },
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (
+            event: GraphEvents.ON_MESSAGE_DELTA,
+            data: t.StreamEventData
+          ): void =>
+            aggregateContent({ event, data: data as t.MessageDeltaEvent }),
+        },
+      },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const model = customEndpointModel();
+    async function* toolCallStream(): AsyncGenerator<CompletionChunk> {
+      yield completionChunk({ role: 'assistant', content: '\n\n' });
+      yield completionChunk({
         tool_calls: [
           {
             id: 'call_0065144d618f4f33be1491af',
@@ -206,46 +262,58 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
             function: { name: 'get_weather', arguments: '' },
           },
         ],
-        content: null,
-      },
-      {
+      });
+      yield completionChunk({
         tool_calls: [{ index: 0, function: { arguments: '{' } }],
-        content: null,
-      },
-      {
+      });
+      yield completionChunk({
         tool_calls: [
           { index: 0, function: { arguments: '"location": "Berlin"' } },
         ],
-        content: null,
-      },
-      { tool_calls: [{ index: 0, function: { arguments: '}' } }] },
-    ];
+      });
+      yield completionChunk(
+        { tool_calls: [{ index: 0, function: { arguments: '}' } }] },
+        'tool_calls'
+      );
+    }
+    async function* finalAnswerStream(): AsyncGenerator<CompletionChunk> {
+      yield completionChunk({
+        role: 'assistant',
+        content: 'Das Wetter in Berlin ist sonnig.',
+      });
+      yield completionChunk({ content: '' }, 'stop');
+    }
+    let modelCall = 0;
+    setCompletionStream(model, () => {
+      modelCall += 1;
+      return modelCall === 1 ? toolCallStream() : finalAnswerStream();
+    });
+    run.Graph.overrideModel = model as t.ChatModel;
 
-    const chunks = deltas.map((delta) =>
-      converter._convertCompletionsDeltaToBaseMessageChunk(
-        delta,
-        rawResponse,
-        'assistant'
-      )
+    await run.processStream(
+      { messages: [new HumanMessage('Wie ist das Wetter in Berlin?')] },
+      config
     );
 
-    const argFragments = chunks
-      .flatMap((chunk) => chunk.tool_call_chunks ?? [])
-      .map((toolCallChunk) => toolCallChunk.args ?? '')
-      .join('');
-    expect(argFragments).toBe('{"location": "Berlin"}');
+    const toolCallStepNames = runSteps
+      .filter((step) => step.stepDetails.type === StepTypes.TOOL_CALLS)
+      .flatMap(
+        (step) => (step.stepDetails as t.ToolCallsDetails).tool_calls ?? []
+      )
+      .map((call) => ('function' in call ? call.function.name : call.name));
 
-    let merged = chunks[0];
-    for (let i = 1; i < chunks.length; i++) {
-      merged = merged.concat(chunks[i]);
-    }
-    expect(merged.tool_calls).toEqual([
-      {
-        id: 'call_0065144d618f4f33be1491af',
-        name: 'get_weather',
-        args: { location: 'Berlin' },
-        type: 'tool_call',
-      },
-    ]);
+    const messages = run.getRunMessages() ?? [];
+    const finalAnswer = messages
+      .filter((message): message is AIMessage => message.getType() === 'ai')
+      .map((message) =>
+        typeof message.content === 'string' ? message.content : ''
+      )
+      .join('');
+
+    expect(modelCall).toBe(2);
+    expect(toolCallStepNames).toContain('get_weather');
+    expect(weatherArgs).toEqual({ location: 'Berlin' });
+    expect(messages.some((message) => message.getType() === 'tool')).toBe(true);
+    expect(finalAnswer).toContain('Das Wetter in Berlin ist sonnig.');
   });
 });

--- a/src/specs/vllm-reasoning-toolcalls.test.ts
+++ b/src/specs/vllm-reasoning-toolcalls.test.ts
@@ -205,6 +205,7 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
     const { aggregateContent } = createContentAggregator();
     const collectedUsage: UsageMetadata[] = [];
     const runSteps: t.RunStep[] = [];
+    const streamedToolArgs: string[] = [];
 
     const run = await Run.create<t.IState>({
       runId: 'vllm-tool-calls',
@@ -225,6 +226,25 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
           ): void => {
             runSteps.push(data as t.RunStep);
             aggregateContent({ event, data: data as t.RunStep });
+          },
+        },
+        [GraphEvents.ON_RUN_STEP_DELTA]: {
+          handle: (
+            _event: GraphEvents.ON_RUN_STEP_DELTA,
+            data: t.StreamEventData
+          ): void => {
+            const { delta } = data as t.RunStepDeltaEvent;
+            if (
+              delta.type !== StepTypes.TOOL_CALLS ||
+              delta.tool_calls == null
+            ) {
+              return;
+            }
+            for (const toolCallDelta of delta.tool_calls) {
+              if (typeof toolCallDelta.args === 'string') {
+                streamedToolArgs.push(toolCallDelta.args);
+              }
+            }
           },
         },
         [GraphEvents.ON_RUN_STEP_COMPLETED]: {
@@ -312,6 +332,7 @@ describe('custom OpenAI-compatible endpoint (vLLM reasoning + qwen3_coder tool c
 
     expect(modelCall).toBe(2);
     expect(toolCallStepNames).toContain('get_weather');
+    expect(streamedToolArgs.join('')).toBe('{"location": "Berlin"}');
     expect(weatherArgs).toEqual({ location: 'Berlin' });
     expect(messages.some((message) => message.getType() === 'tool')).toBe(true);
     expect(finalAnswer).toContain('Das Wetter in Berlin ist sonnig.');


### PR DESCRIPTION
## Summary

Adds a regression spec for a generic `custom` OpenAI-compatible endpoint (provider `openai`, **default** `reasoningKey`, non-standard model name) that:

1. **Streams reasoning in the modern vLLM `reasoning` field** — `reasoning_content` is `null` throughout. Current vLLM emits CoT only in `reasoning` (`DeltaMessage.reasoning` / `ChatMessage.reasoning`); `reasoning_content` survives just as a deprecated *input* alias that vLLM renames to `reasoning` ([RFC vllm#27755](https://github.com/vllm-project/vllm/issues/27755)).
2. **Streams `tool_calls` with fragmented arguments** (`--tool-call-parser qwen3_coder`): id/name on the first delta, args split across subsequent role-less continuation deltas.

The spec locks in that:
- `delta.reasoning` surfaces as `think` content (the Thoughts block) ahead of the answer `text`, through the real `Run`/`StandardGraph` streaming path; and
- the fragmented streamed tool call accumulates into a structured `get_weather({"location":"Berlin"})`.

Both exercise real SDK code paths (graph dispatch + the actual per-delta `_convertCompletionsDeltaToBaseMessageChunk` conversion); the only mocked boundary is the upstream HTTP stream.

## Motivation

Wire shapes mirror the captures in LibreChat discussion [#13849](https://github.com/danny-avila/LibreChat/discussions/13849), which reported reasoning/tool-calling breaking on a custom vLLM endpoint after upgrading LibreChat. Replaying the exact deltas shows both render/parse correctly on current code, so this guards the `reasoning`-field normalization and the fragmented-`tool_calls` accumulation against future regressions.

## Test plan

- [x] `npx jest src/specs/vllm-reasoning-toolcalls.test.ts` — 2 passed
- [x] `npx eslint src/specs/vllm-reasoning-toolcalls.test.ts` — clean
- [x] `npx tsc --noEmit` — clean