### PR TITLE
fix(bedrock): clamp the extended 1h TTL to 5m on non-Claude models

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -14,6 +14,7 @@ import {
   buildAnthropicCacheControl,
   buildBedrockCachePoint,
   resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   cloneMessage,
   type PromptCacheTtl,
 } from '@/messages/cache';
@@ -869,14 +870,18 @@ export class AgentContext {
   }
 
   /**
-   * Resolved TTL for Bedrock prompt-cache checkpoints (default `'1h'`).
-   * Models that don't support the 1-hour TTL downgrade to 5m server-side.
+   * Resolved TTL for Bedrock prompt-cache checkpoints (default `'1h'` on Claude).
+   * Claude models downgrade an unsupported 1h to 5m server-side; non-Claude
+   * models (Nova) reject the extended TTL, so they are clamped to 5m.
    */
   private getBedrockPromptCacheTtl(): PromptCacheTtl {
     const bedrockOptions = this.clientOptions as
       | t.BedrockAnthropicClientOptions
       | undefined;
-    return resolvePromptCacheTtl(bedrockOptions?.promptCacheTtl);
+    return resolveBedrockPromptCacheTtl(
+      bedrockOptions?.promptCacheTtl,
+      (bedrockOptions as { model?: string } | undefined)?.model
+    );
   }
 
   private buildSystemMessage({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -28,6 +28,7 @@ import {
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
   getMessageId,
   makeIsDeferred,
@@ -1880,9 +1881,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const bedrockOptions = agentContext.clientOptions as
           | t.BedrockAnthropicClientOptions
           | undefined;
+        // Non-Claude models (Nova) reject the extended 1h TTL, so resolve it
+        // against the model — message/system caching stays on, clamped to 5m.
         finalMessages = addBedrockTailCacheControl<BaseMessage>(
           finalMessages,
-          resolvePromptCacheTtl(bedrockOptions?.promptCacheTtl)
+          resolveBedrockPromptCacheTtl(
+            bedrockOptions?.promptCacheTtl,
+            (bedrockOptions as { model?: string } | undefined)?.model
+          )
         );
       }
 

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -40,7 +40,7 @@ import {
   handleConverseStreamMetadata,
 } from './utils';
 import {
-  resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
   type PromptCacheTtl,
 } from '@/messages/cache';
@@ -184,7 +184,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
         ? insertBedrockToolCachePoint(
           baseParams.toolConfig,
           true,
-          resolvePromptCacheTtl(this.promptCacheTtl)
+          resolveBedrockPromptCacheTtl(this.promptCacheTtl, this.cacheModelId)
         )
         : baseParams.toolConfig;
 

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -19,6 +19,7 @@ import {
   buildAnthropicCacheControl,
   buildBedrockCachePoint,
   resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
   DEFAULT_PROMPT_CACHE_TTL,
 } from './cache';
@@ -923,6 +924,37 @@ describe('supportsBedrockToolCache', () => {
     expect(supportsBedrockToolCache('')).toBe(false);
     expect(supportsBedrockToolCache(undefined)).toBe(false);
     expect(supportsBedrockToolCache(null)).toBe(false);
+  });
+});
+
+describe('resolveBedrockPromptCacheTtl', () => {
+  test('Claude: defaults to 1h and honors an explicit ttl', () => {
+    const claude = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+    expect(resolveBedrockPromptCacheTtl(undefined, claude)).toBe('1h');
+    expect(resolveBedrockPromptCacheTtl('1h', claude)).toBe('1h');
+    expect(resolveBedrockPromptCacheTtl('5m', claude)).toBe('5m');
+  });
+
+  test('Nova: clamps to 5m even when 1h is configured (extended TTL Anthropic-only)', () => {
+    const nova = 'us.amazon.nova-lite-v1:0';
+    expect(resolveBedrockPromptCacheTtl(undefined, nova)).toBe('5m');
+    expect(resolveBedrockPromptCacheTtl('1h', nova)).toBe('5m');
+    expect(resolveBedrockPromptCacheTtl('5m', nova)).toBe('5m');
+  });
+
+  test('other non-Claude families clamp to 5m', () => {
+    expect(
+      resolveBedrockPromptCacheTtl('1h', 'meta.llama3-1-70b-instruct-v1:0')
+    ).toBe('5m');
+    expect(
+      resolveBedrockPromptCacheTtl('1h', 'mistral.mistral-large-2407-v1:0')
+    ).toBe('5m');
+  });
+
+  test('omitted model defaults to Claude behavior (1h)', () => {
+    expect(resolveBedrockPromptCacheTtl(undefined, undefined)).toBe('1h');
+    expect(resolveBedrockPromptCacheTtl(undefined, null)).toBe('1h');
+    expect(resolveBedrockPromptCacheTtl('1h', undefined)).toBe('1h');
   });
 });
 

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -80,6 +80,16 @@ export function buildBedrockCachePoint(
 }
 
 /**
+ * Whether a Bedrock model id is an Anthropic Claude model. Claude is the only
+ * Bedrock family that accepts the explicit cache features below; Amazon Nova and
+ * others reject them. Matches both the `anthropic.` and cross-region
+ * (`us.anthropic.`) / bare `claude` forms.
+ */
+function isBedrockAnthropicModel(model: string | undefined | null): boolean {
+  return typeof model === 'string' && /claude|anthropic/i.test(model);
+}
+
+/**
  * A `cachePoint` under `toolConfig.tools` is only accepted on Anthropic Claude
  * models. Amazon Nova rejects it outright — `Malformed input request:
  * #/toolConfig/tools/0: extraneous key [cachePoint] is not permitted` — even
@@ -89,8 +99,7 @@ export function buildBedrockCachePoint(
  *
  * Gate ONLY the tool checkpoint on this, so a `promptCache: true` config on Nova
  * keeps its valid message/system caching instead of either 400-ing (tool point)
- * or losing caching entirely. This is a capability gate (the key is rejected
- * outright), distinct from the TTL value which Bedrock downgrades gracefully.
+ * or losing caching entirely.
  *
  * @see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
  * @see https://github.com/danny-avila/LibreChat/issues/13838
@@ -98,10 +107,27 @@ export function buildBedrockCachePoint(
 export function supportsBedrockToolCache(
   model: string | undefined | null
 ): boolean {
-  if (typeof model !== 'string') {
-    return false;
+  return isBedrockAnthropicModel(model);
+}
+
+/**
+ * Resolve the Bedrock `cachePoint` TTL for a model. The extended `1h` TTL is
+ * Anthropic-only: non-Claude models (e.g. Nova) hard-reject it with
+ * `Extended TTL prompt caching is only supported for Anthropic models`, so they
+ * are clamped to `5m` even when `1h` is configured (verified live). An omitted
+ * model defaults to a Claude model, and Claude downgrades an unsupported `1h` to
+ * `5m` server-side, so the `1h` default is safe for the Claude/undefined paths.
+ *
+ * @see https://github.com/danny-avila/LibreChat/issues/13838
+ */
+export function resolveBedrockPromptCacheTtl(
+  ttl: PromptCacheTtl | undefined,
+  model: string | undefined | null
+): PromptCacheTtl {
+  if (model != null && !isBedrockAnthropicModel(model)) {
+    return '5m';
   }
-  return /claude|anthropic/i.test(model);
+  return resolvePromptCacheTtl(ttl);
 }
 
 /**


### PR DESCRIPTION
## Problem

Follow-up to [#253](https://github.com/danny-avila/agents/pull/253), which fixed the Nova **tool** cachePoint but landed before this change. The remaining issue: the extended **1h** prompt-cache TTL is Anthropic-only on Bedrock. Non-Claude models reject it —

```
ValidationException: Extended TTL prompt caching is only supported for Anthropic models
```

— so the 1h default (from the prompt-cache TTL work) breaks Nova's **system/message** caching, which #253 deliberately keeps enabled. Nova caching worked before at 5m; the 1h default regressed it to a 400.

## Fix

Add `resolveBedrockPromptCacheTtl(ttl, model)`:
- **Claude** (and the omitted-model default, which resolves to Claude) → keep the `1h` default / configured ttl. Claude downgrades an unsupported 1h to 5m server-side.
- **Non-Claude (Nova, Llama, Mistral, …)** → clamp to `5m`, even when `1h` is explicitly configured.

Wired into the three Bedrock cachePoint TTL sites: `bedrock/index.ts` (tool — already Claude-gated), `Graph.ts` (message tail), `AgentContext.ts` (summary). Shares one `isBedrockAnthropicModel` predicate with `supportsBedrockToolCache`.

## Testing

**Live, end-to-end** through the built SDK (`resolveBedrockPromptCacheTtl` + `addBedrockTailCacheControl` → AWS Converse):

```
[NOVA]   resolved ttl 5m -> cachePoint {"type":"default"}        -> HTTP 200, cacheWrite=240
[CLAUDE] resolved ttl 1h -> cachePoint {"type":"default","ttl":"1h"} -> HTTP 200
```

**Unit:** `resolveBedrockPromptCacheTtl` — Claude defaults to 1h / honors explicit ttl; Nova + others clamp to 5m even with explicit 1h; omitted model → 1h.

`tsc --noEmit` clean; cache + bedrock + agents suites green (260 passing).

Fixes the extended-TTL half of danny-avila/LibreChat#13838.