### PR TITLE
feat(openai): optional vision gating to strip images for non-vision models

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -57,14 +57,18 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
-import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
 import {
   hasReasoningKwargs,
   hasToolCallChunks,
   getReasoningKwargsText,
 } from '@/llm/stream/chunkAdapters';
+import {
+  isReasoningModel,
+  _convertMessagesToOpenAIParams,
+  stripImagesFromMessages,
+} from './utils';
+import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -129,11 +133,15 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   responsesPromptCacheTtl?: PromptCacheTtl;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  /** Whether the model can accept image input; false strips images (default true). */
+  vision?: boolean;
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  /** Whether the model can accept image input; false strips images (default true). */
+  vision?: boolean;
 };
 type ReasoningCallOptions = {
   reasoning?: OpenAIClient.Reasoning;
@@ -2403,12 +2411,19 @@ function withLibreChatOpenAIFields(
 }
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
+  /**
+   * Whether the target model can accept image input. Defaults to true, so existing
+   * callers are unaffected; set false to have image content stripped before the request.
+   */
+  protected visionCapable: boolean;
+
   _lc_stream_delay: number;
 
   constructor(
     fields?: LibreChatOpenAIFields & t.OpenAIChatInput['modelKwargs']
   ) {
     super(withLibreChatOpenAIFields(fields));
+    this.visionCapable = fields?.vision ?? true;
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
@@ -2472,7 +2487,11 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, undefined),
+      super._streamResponseChunks(
+        stripImagesFromMessages(messages, this.visionCapable),
+        options,
+        undefined
+      ),
       this._lc_stream_delay,
       options.signal,
       runManager,
@@ -2491,7 +2510,11 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     return delayStreamChunks(
-      super._streamResponseChunks(messages, options, undefined),
+      super._streamResponseChunks(
+        stripImagesFromMessages(messages, this.visionCapable),
+        options,
+        undefined
+      ),
       this._lc_stream_delay,
       options.signal,
       runManager
@@ -2500,10 +2523,17 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 }
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
+  /**
+   * Whether the target model can accept image input. Defaults to true, so existing
+   * callers are unaffected; set false to have image content stripped before the request.
+   */
+  protected visionCapable: boolean;
+
   _lc_stream_delay: number;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
+    this.visionCapable = fields?.vision ?? true;
     this.completions = new LibreChatAzureOpenAICompletions(fields);
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
@@ -2603,7 +2633,11 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, undefined),
+      super._streamResponseChunks(
+        stripImagesFromMessages(messages, this.visionCapable),
+        options,
+        undefined
+      ),
       this._lc_stream_delay,
       options.signal,
       runManager,
@@ -2612,14 +2646,23 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   }
 }
 export class ChatDeepSeek extends OriginalChatDeepSeek {
+  /**
+   * Whether the target model can accept image input. Defaults to true, so existing
+   * callers are unaffected; set false to have image content stripped before the request.
+   */
+  protected visionCapable: boolean;
+
   _lc_stream_delay: number;
 
   constructor(
     fields?: ConstructorParameters<typeof OriginalChatDeepSeek>[0] & {
       _lc_stream_delay?: number;
+      /** Whether the model can accept image input; false strips images (default true). */
+      vision?: boolean;
     }
   ) {
     super(fields);
+    this.visionCapable = fields?.vision ?? true;
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
@@ -3133,6 +3176,12 @@ export class ChatMoonshot extends ChatOpenAI {
 }
 
 export class ChatXAI extends OriginalChatXAI {
+  /**
+   * Whether the target model can accept image input. Defaults to true, so existing
+   * callers are unaffected; set false to have image content stripped before the request.
+   */
+  protected visionCapable: boolean;
+
   _lc_stream_delay: number;
 
   constructor(
@@ -3140,9 +3189,12 @@ export class ChatXAI extends OriginalChatXAI {
       configuration?: { baseURL?: string };
       clientConfig?: { baseURL?: string };
       _lc_stream_delay?: number;
+      /** Whether the model can accept image input; false strips images (default true). */
+      vision?: boolean;
     }
   ) {
     super(fields);
+    this.visionCapable = fields?.vision ?? true;
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     const customBaseURL =
       fields?.configuration?.baseURL ?? fields?.clientConfig?.baseURL;
@@ -3199,7 +3251,11 @@ export class ChatXAI extends OriginalChatXAI {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, undefined),
+      super._streamResponseChunks(
+        stripImagesFromMessages(messages, this.visionCapable),
+        options,
+        undefined
+      ),
       this._lc_stream_delay,
       options.signal,
       runManager,

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -341,6 +341,65 @@ export interface ConvertMessagesOptions {
   preserveToolCacheControl?: boolean;
 }
 
+/** Placeholder kept in place of stripped images so a message never ends up empty. */
+const IMAGE_OMITTED_PLACEHOLDER =
+  '(Image content omitted — model does not support vision)';
+
+/**
+ * True for image content parts a non-vision model cannot accept: OpenAI-style
+ * `image_url` parts and standard `image` data content blocks. Data content blocks are
+ * converted to `image_url` further downstream, so dropping only `image_url` here would
+ * still let them reach a text-only model.
+ */
+function isImageContentPart(part: unknown): boolean {
+  if (part == null || typeof part !== 'object' || !('type' in part)) {
+    return false;
+  }
+  const { type } = part as { type?: string };
+  return type === 'image_url' || type === 'image';
+}
+
+/**
+ * Removes image content from messages bound for a model without vision support.
+ *
+ * OpenAI-compatible providers reject the whole request when an image reaches a
+ * text-only model ("model is not a multimodal model", "No endpoints found that support
+ * image input"), and callers routinely cannot control the history: a tool that returns
+ * an image, or an agent handoff from a vision model to a text-only one, both put image
+ * parts into the messages.
+ *
+ * Returns the input untouched when `visionCapable` is true, and clones only the messages
+ * that actually carry an image. A message whose content was nothing but images keeps a
+ * short text placeholder so it does not become empty.
+ */
+export function stripImagesFromMessages(
+  messages: BaseMessage[],
+  visionCapable: boolean
+): BaseMessage[] {
+  if (visionCapable) {
+    return messages;
+  }
+  return messages.map((msg) => {
+    if (!Array.isArray(msg.content)) {
+      return msg;
+    }
+    if (!msg.content.some(isImageContentPart)) {
+      return msg;
+    }
+    const kept = msg.content.filter((part) => !isImageContentPart(part));
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(msg)),
+      msg
+    ) as BaseMessage;
+    clone.content = (
+      kept.length > 0
+        ? kept
+        : [{ type: 'text' as const, text: IMAGE_OMITTED_PLACEHOLDER }]
+    ) as BaseMessage['content'];
+    return clone;
+  });
+}
+
 // Used in LangSmith, export is important here
 export function _convertMessagesToOpenAIParams(
   messages: BaseMessage[],

--- a/src/llm/openai/utils/stripImages.test.ts
+++ b/src/llm/openai/utils/stripImages.test.ts
@@ -1,0 +1,89 @@
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import { stripImagesFromMessages } from './index';
+
+const imagePart = {
+  type: 'image_url' as const,
+  image_url: { url: 'data:image/png;base64,AAAA' },
+};
+
+describe('stripImagesFromMessages', () => {
+  it('returns the input unchanged when visionCapable is true', () => {
+    const messages = [
+      new HumanMessage({ content: [{ type: 'text', text: 'hi' }, imagePart] }),
+    ];
+    expect(stripImagesFromMessages(messages, true)).toBe(messages);
+  });
+
+  it('strips image_url parts but keeps text for non-vision models', () => {
+    const messages = [
+      new HumanMessage({
+        content: [{ type: 'text', text: 'describe this' }, imagePart],
+      }),
+    ];
+    const result = stripImagesFromMessages(messages, false);
+    const content = result[0].content as Array<{ type: string }>;
+    expect(content.some((p) => p.type === 'image_url')).toBe(false);
+    expect(content.some((p) => p.type === 'text')).toBe(true);
+  });
+
+  it('inserts a text placeholder when an image-only message is emptied', () => {
+    const messages = [new HumanMessage({ content: [imagePart] })];
+    const result = stripImagesFromMessages(messages, false);
+    const content = result[0].content as Array<{ type: string }>;
+    expect(content.some((p) => p.type === 'image_url')).toBe(false);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content[0].type).toBe('text');
+  });
+
+  it('leaves string content and image-free messages untouched', () => {
+    const stringMsg = new HumanMessage({ content: 'plain text' });
+    const noImageMsg = new AIMessage({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+    const result = stripImagesFromMessages([stringMsg, noImageMsg], false);
+    expect(result[0]).toBe(stringMsg);
+    expect(result[1]).toBe(noImageMsg);
+  });
+
+  it('does not mutate the original message when stripping', () => {
+    const original = new HumanMessage({
+      content: [{ type: 'text', text: 'q' }, imagePart],
+    });
+    stripImagesFromMessages([original], false);
+    const content = original.content as Array<{ type: string }>;
+    expect(content.some((p) => p.type === 'image_url')).toBe(true);
+  });
+
+  /**
+   * LangChain standard data content block: how an uploaded image can arrive. These are
+   * converted to `image_url` downstream, so they must be stripped here as well - missing
+   * this is what let images through on an agent handoff to a text-only model.
+   */
+  const imageDataBlock = {
+    type: 'image' as const,
+    source_type: 'base64' as const,
+    mime_type: 'image/png',
+    data: 'iVBORw0KGgo=',
+  };
+
+  it('strips image data content blocks for non-vision models', () => {
+    const [msg] = stripImagesFromMessages(
+      [
+        new HumanMessage({
+          content: [{ type: 'text', text: 'describe this' }, imageDataBlock],
+        }),
+      ],
+      false
+    );
+    expect(msg.content).toEqual([{ type: 'text', text: 'describe this' }]);
+  });
+
+  it('keeps data content blocks for vision-capable models', () => {
+    const content = [{ type: 'text', text: 'describe this' }, imageDataBlock];
+    const [msg] = stripImagesFromMessages(
+      [new HumanMessage({ content })],
+      true
+    );
+    expect(msg.content).toEqual(content);
+  });
+});


### PR DESCRIPTION
feat(openai): optional vision gating to strip images for non-vision models

Refs danny-avila/LibreChat#11418, danny-avila/LibreChat#14341

## Problem

When image content reaches a model without vision support, OpenAI-compatible
providers reject the entire request:

- `model is not a multimodal model` (Scaleway/Mistral)
- `No endpoints found that support image input` (OpenRouter)

The caller often cannot prevent the image from being in the history:

- a tool returns an image (an image-generation tool feeding its artifact back),
- or an agent hands off from a vision-capable model to a text-only one, carrying
  the user's original `image_url` block along - reported independently in
  LibreChat#14341.

There is currently no way to tell the client "this model cannot take images".

## Approach

An opt-in `vision` flag on the OpenAI-family chat classes. When `vision: false`,
image parts are stripped at a single choke point, immediately before the message
stream is delegated to the base class - so it does not depend on the internal
message-conversion path.

`stripImagesFromMessages(messages, visionCapable)`:

- returns the input unchanged when `visionCapable` is true (the default), so
  existing behaviour is untouched;
- clones only the messages that actually carry an image;
- keeps a short text placeholder when stripping would leave a message empty;
- covers **both** OpenAI-style `image_url` parts and standard `image` data
  content blocks. The latter matters: they are converted to `image_url` further
  downstream, so dropping only `image_url` still lets an uploaded image through
  to a text-only model.

Wired into `ChatOpenAI`, `AzureChatOpenAI`, `ChatDeepSeek` and `ChatXAI`.
`ChatOpenAI._streamRawResponseChunks` is covered too, which is the path
`ChatOpenRouter` streams through.

## API

```ts
new ChatOpenAI({ /* ...existing fields... */, vision: false });
```

Defaults to `true` everywhere - non-breaking.

## Tests

`src/llm/openai/utils/stripImages.test.ts`: 7 cases over `image_url` parts, data
content blocks, the placeholder substitution, and the vision-capable pass-through.
Full `src/llm/openai` + `src/messages` suites pass (623), tsc and eslint clean.

Signed-off-by: JumpLink <pascal@artandcode.studio>