### PR TITLE
fix(reducer): skip null/undefined entries before coerceMessageLikeToMessage

### DIFF
--- a/src/messages/reducer.spec.ts
+++ b/src/messages/reducer.spec.ts
@@ -1,0 +1,32 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { messagesStateReducer } from './reducer';
+
+describe('messagesStateReducer', () => {
+  it('drops null/undefined entries and preserves order', () => {
+    const a = new HumanMessage({ id: 'a', content: 'a' });
+    const b = new HumanMessage({ id: 'b', content: 'b' });
+    const c = new HumanMessage({ id: 'c', content: 'c' });
+
+    const result = messagesStateReducer(
+      [a, null, b] as never,
+      [undefined, c] as never
+    );
+
+    expect(result.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not throw when every entry is null/undefined', () => {
+    expect(() =>
+      messagesStateReducer(
+        [null, undefined] as never,
+        [undefined, null] as never
+      )
+    ).not.toThrow();
+
+    const result = messagesStateReducer(
+      [null, undefined] as never,
+      [undefined, null] as never
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/src/messages/reducer.ts
+++ b/src/messages/reducer.ts
@@ -35,6 +35,26 @@ export type Messages =
   | BaseMessageLike;
 
 /**
+ * Coerce each entry to a {@link BaseMessage} in a single pass, skipping
+ * null/undefined entries. Providers can emit empty/partial stream chunks that
+ * arrive as `undefined`; passing those to `coerceMessageLikeToMessage` throws
+ * "Cannot read properties of undefined (reading 'role')" and crashes the run.
+ * Folding the null check into the coercion loop avoids a second pass over the
+ * array. Refs LibreChat Discussion #12284.
+ */
+function coerceMessages(
+  messages: ReadonlyArray<BaseMessageLike | null | undefined>
+): BaseMessage[] {
+  const coerced: BaseMessage[] = [];
+  for (const message of messages) {
+    if (message != null) {
+      coerced.push(coerceMessageLikeToMessage(message));
+    }
+  }
+  return coerced;
+}
+
+/**
  * Prebuilt reducer that combines returned messages.
  * Can handle standard messages and special modifiers like {@link RemoveMessage}
  * instances.
@@ -45,17 +65,9 @@ export function messagesStateReducer(
 ): BaseMessage[] {
   const leftArray = Array.isArray(left) ? left : [left];
   const rightArray = Array.isArray(right) ? right : [right];
-  // coerce to message
-  // Filter out null/undefined entries before coercion: providers can emit
-  // empty/partial stream chunks that arrive as `undefined`, and
-  // coerceMessageLikeToMessage throws "Cannot read properties of undefined
-  // (reading 'role')", crashing the run. Refs LibreChat Discussion #12284.
-  const leftMessages = (leftArray as BaseMessageLike[])
-    .filter((m) => m != null)
-    .map(coerceMessageLikeToMessage);
-  const rightMessages = (rightArray as BaseMessageLike[])
-    .filter((m) => m != null)
-    .map(coerceMessageLikeToMessage);
+  // coerce to message, skipping null/undefined entries in the same pass
+  const leftMessages = coerceMessages(leftArray as BaseMessageLike[]);
+  const rightMessages = coerceMessages(rightArray as BaseMessageLike[]);
   // assign missing ids
   for (const m of leftMessages) {
     if (m.id === null || m.id === undefined) {

--- a/src/messages/reducer.ts
+++ b/src/messages/reducer.ts
@@ -46,12 +46,16 @@ export function messagesStateReducer(
   const leftArray = Array.isArray(left) ? left : [left];
   const rightArray = Array.isArray(right) ? right : [right];
   // coerce to message
-  const leftMessages = (leftArray as BaseMessageLike[]).map(
-    coerceMessageLikeToMessage
-  );
-  const rightMessages = (rightArray as BaseMessageLike[]).map(
-    coerceMessageLikeToMessage
-  );
+  // Filter out null/undefined entries before coercion: providers can emit
+  // empty/partial stream chunks that arrive as `undefined`, and
+  // coerceMessageLikeToMessage throws "Cannot read properties of undefined
+  // (reading 'role')", crashing the run. Refs LibreChat Discussion #12284.
+  const leftMessages = (leftArray as BaseMessageLike[])
+    .filter((m) => m != null)
+    .map(coerceMessageLikeToMessage);
+  const rightMessages = (rightArray as BaseMessageLike[])
+    .filter((m) => m != null)
+    .map(coerceMessageLikeToMessage);
   // assign missing ids
   for (const m of leftMessages) {
     if (m.id === null || m.id === undefined) {


### PR DESCRIPTION
`messagesStateReducer` maps both input arrays through `coerceMessageLikeToMessage` without first checking for null/undefined entries. When a provider emits an empty or partial stream chunk, that entry arrives as `undefined`, and `coerceMessageLikeToMessage` throws `Cannot read properties of undefined (reading 'role')`, which crashes the LangGraph run.

We hit this consistently on tool-heavy runs with certain providers. Filtering out null/undefined before coercion is a minimal, defensive fix that preserves message order and leaves all existing behavior (id assignment, REMOVE_ALL handling, merge/dedupe) untouched.

Refs LibreChat Discussion #12284.
