### PR TITLE
fix: Scope Langfuse tracing per run

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -35,11 +35,6 @@ import {
   partitionAndMarkAnthropicToolCache,
 } from '@/messages';
 import {
-  resolveLangfuseConfig,
-  shouldTraceToolNodeForLangfuse,
-  withLangfuseToolOutputTracingConfig,
-} from '@/langfuseToolOutputTracing';
-import {
   createLangfuseHandler,
   createLangfuseTraceMetadata,
   disposeLangfuseHandler,
@@ -55,6 +50,10 @@ import {
   sleep,
 } from '@/utils';
 import {
+  resolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+import {
   GraphNodeKeys,
   ContentTypes,
   GraphEvents,
@@ -67,6 +66,7 @@ import {
   type CallbackEntry,
 } from '@/utils/callbacks';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
+import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
@@ -81,6 +81,7 @@ import { shouldTriggerSummarization } from '@/summarization';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
 import { messagesStateReducer } from '@/messages/reducer';
+import { resolveLangfuseConfig } from '@/langfuseConfig';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
@@ -2079,6 +2080,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           sessionId: config.configurable?.thread_id as string | undefined,
           traceMetadata,
           tags: ['librechat', 'agent'],
+          traceIdSeed:
+            langfuse?.deterministicTraceId === true ? this.runId : undefined,
         });
         if (langfuseHandler != null) {
           invokeConfig = {
@@ -2092,8 +2095,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const metadata = config.metadata as Record<string, unknown>;
 
       try {
-        result = await withLangfuseToolOutputTracingConfig(
-          this.langfuse,
+        result = await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: agentContext.langfuse,
+          }),
           () =>
             attemptInvoke(
               {
@@ -2103,16 +2109,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 context: this,
               },
               invokeConfig
-            ),
-          agentContext.langfuse
+            )
         );
       } catch (primaryError) {
         clearCurrentDeltaStepMarkers({
           graph: this,
           metadata,
         });
-        result = await withLangfuseToolOutputTracingConfig(
-          this.langfuse,
+        result = await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: agentContext.langfuse,
+          }),
           () =>
             tryFallbackProviders({
               fallbacks,
@@ -2121,8 +2129,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               config: invokeConfig,
               primaryError,
               context: this,
-            }),
-          agentContext.langfuse
+            })
         );
       } finally {
         await disposeLangfuseHandler(langfuseHandler);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -13,6 +13,7 @@ import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
+  createLibreChatTraceAttributes,
   hasLangfuseConfigCredentials,
   hasLangfuseEnvCredentials,
   hasLangfuseEnvConfig,
@@ -152,11 +153,17 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
-    const processor = this.ensureProcessor(
-      resolveLangfuseConfigForSpan(parentContext)
-    );
+    const langfuse = resolveLangfuseConfigForSpan(parentContext);
+    const processor = this.ensureProcessor(langfuse);
     if (processor == null) {
       return;
+    }
+
+    const librechatTraceAttributes = createLibreChatTraceAttributes(
+      langfuse?.librechatTraceAttributes ?? {}
+    );
+    if (Object.keys(librechatTraceAttributes).length > 0) {
+      span.setAttributes(librechatTraceAttributes);
     }
 
     this.spanProcessors.set(span, processor);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash, randomBytes } from 'node:crypto';
 import { setLangfuseTracerProvider } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
@@ -19,38 +18,27 @@ import {
   hasLangfuseEnvConfig,
 } from '@/langfuse';
 import {
-  createLangfuseSpanProcessor,
-  getContextLangfuseConfig,
-} from '@/langfuseToolOutputTracing';
+  resolveLangfuseConfigForSpan,
+  resolveTraceIdSeedForSpan,
+} from '@/langfuseRuntimeScope';
+import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
+import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { isPresent } from '@/utils/misc';
 
 /**
  * Per-run seed for deterministic Langfuse trace ids. When a run opts in
  * (`LangfuseConfig.deterministicTraceId`), it executes its stream inside
- * `runWithTraceIdSeed(runId, …)` and the IdGenerator below derives the root
- * trace id from that seed instead of a random one. This lets external systems
- * (e.g. a host app recording user feedback after the fact) attach scores or
- * observations to the trace by regenerating the same id from the run/message
- * id — no trace lookup required. With no active seed it falls back to random
- * ids, so default behavior is unchanged.
+ * `runWithTraceIdSeed(runId, ...)` from `./langfuseRuntimeContext`, and the
+ * IdGenerator below derives the root trace id from that seed instead of a
+ * random one. This lets external systems (e.g. a host app recording user
+ * feedback after the fact) attach scores or observations to the trace by
+ * regenerating the same id from the run/message id; no trace lookup required.
+ * With no active seed it falls back to random ids, so default behavior is
+ * unchanged.
  */
-const traceIdSeedStore = new AsyncLocalStorage<string>();
-
-export function runWithTraceIdSeed<T>(
-  seed: string | undefined,
-  fn: () => T
-): T {
-  return isPresent(seed) ? traceIdSeedStore.run(seed, fn) : fn();
-}
-
-/** sha256(seed) → first 32 hex chars; matches `@langfuse/tracing` `createTraceId`. */
-function traceIdFromSeed(seed: string): string {
-  return createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 32);
-}
-
 class SeededTraceIdGenerator implements IdGenerator {
   generateTraceId(): string {
-    const seed = traceIdSeedStore.getStore();
+    const seed = resolveTraceIdSeedForSpan(context.active());
     return isPresent(seed)
       ? traceIdFromSeed(seed)
       : randomBytes(16).toString('hex');
@@ -120,13 +108,19 @@ function getLangfuseSpanProcessorParams(
   return undefined;
 }
 
+function hashCacheKeyValue(value: string | undefined): string | undefined {
+  return isPresent(value)
+    ? createHash('sha256').update(value, 'utf8').digest('hex')
+    : undefined;
+}
+
 function getLangfuseTracerProviderKey(
   params: LangfuseSpanProcessorParams,
   langfuse?: t.LangfuseConfig
 ): string {
   return JSON.stringify({
     publicKey: params.publicKey,
-    secretKey: params.secretKey,
+    secretKeyHash: hashCacheKeyValue(params.secretKey),
     baseUrl: params.baseUrl,
     environment: params.environment,
     toolOutputTracing: langfuse?.toolOutputTracing,
@@ -134,6 +128,9 @@ function getLangfuseTracerProviderKey(
 }
 
 class RoutingLangfuseSpanProcessor implements SpanProcessor {
+  // Processors live for the process lifetime. LibreChat tenant Langfuse
+  // destinations are expected to be a bounded admin-managed set, and shutdown
+  // drains every cached processor when the provider is disposed.
   private readonly processors = new Map<string, SpanProcessor>();
   private readonly spanProcessors = new WeakMap<object, SpanProcessor>();
 
@@ -156,7 +153,7 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     const processor = this.ensureProcessor(
-      getContextLangfuseConfig(parentContext)
+      resolveLangfuseConfigForSpan(parentContext)
     );
     if (processor == null) {
       return;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -8,7 +8,7 @@ import type { Generation, LLMResult } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
 import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
-import { isPresent } from '@/utils/misc';
+import { isPresent, parseBooleanEnv } from '@/utils/misc';
 import { ContentTypes } from '@/common';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
@@ -61,13 +61,6 @@ type MessageWithReasoning = BaseMessage & {
 type ChatGenerationWithMessage = Generation & {
   message: MessageWithReasoning;
 };
-
-function parseBooleanEnv(value?: string): boolean {
-  if (value == null) {
-    return false;
-  }
-  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -3,13 +3,10 @@ import {
   getLangfuseTracerProvider,
   propagateAttributes,
 } from '@langfuse/tracing';
-import type { BaseMessage, MessageContent } from '@langchain/core/messages';
-import type { Generation, LLMResult } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
 import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
-import { ContentTypes } from '@/common';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
@@ -41,164 +38,7 @@ type FlushableTracerProvider = {
   forceFlush?: () => Promise<void> | void;
 };
 
-type ReasoningSummary = {
-  summary?: Array<{ text?: string | null }>;
-};
-
-type ReasoningDetail = {
-  type?: string;
-  text?: string | null;
-};
-
-type MessageWithReasoning = BaseMessage & {
-  additional_kwargs?: BaseMessage['additional_kwargs'] & {
-    reasoning?: string | ReasoningSummary | null;
-    reasoning_content?: string | ReasoningSummary | null;
-    reasoning_details?: ReasoningDetail[] | null;
-  };
-};
-
-type ChatGenerationWithMessage = Generation & {
-  message: MessageWithReasoning;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function getReasoningText(
-  value: string | ReasoningSummary | null | undefined
-): string | undefined {
-  if (typeof value === 'string') {
-    return isPresent(value) ? value : undefined;
-  }
-  const summaryText = value?.summary
-    ?.map((summary) => summary.text ?? '')
-    .filter((text) => text !== '')
-    .join('');
-  return summaryText != null && summaryText !== '' ? summaryText : undefined;
-}
-
-function getReasoningDetailsText(
-  value: ReasoningDetail[] | null | undefined
-): string | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const reasoningText = value
-    .filter((detail) => detail.type === 'reasoning.text')
-    .map((detail) => detail.text ?? '')
-    .filter((text) => text !== '')
-    .join('');
-  return reasoningText !== '' ? reasoningText : undefined;
-}
-
-function getMessageReasoningText(
-  message: MessageWithReasoning
-): string | undefined {
-  const additionalKwargs = message.additional_kwargs;
-  if (additionalKwargs == null) {
-    return undefined;
-  }
-
-  return (
-    getReasoningText(additionalKwargs.reasoning_content) ??
-    getReasoningText(additionalKwargs.reasoning) ??
-    getReasoningDetailsText(additionalKwargs.reasoning_details)
-  );
-}
-
-function hasReasoningContentPart(content: MessageContent): boolean {
-  return (
-    Array.isArray(content) &&
-    content.some((part) => {
-      if (!isRecord(part) || typeof part.type !== 'string') {
-        return false;
-      }
-      return (
-        part.type === ContentTypes.THINK ||
-        part.type === ContentTypes.THINKING ||
-        part.type === ContentTypes.REASONING ||
-        part.type === ContentTypes.REASONING_CONTENT ||
-        part.type === 'redacted_thinking'
-      );
-    })
-  );
-}
-
-function withReasoningContent(
-  content: MessageContent,
-  reasoningText: string
-): MessageContent {
-  if (hasReasoningContentPart(content)) {
-    return content;
-  }
-
-  const reasoningPart = {
-    type: ContentTypes.THINK,
-    think: reasoningText,
-  };
-  return Array.isArray(content)
-    ? [reasoningPart, ...content]
-    : [reasoningPart, { type: ContentTypes.TEXT, text: content }];
-}
-
-function hasMessage(
-  generation: Generation
-): generation is ChatGenerationWithMessage {
-  return (
-    'message' in generation &&
-    isRecord(generation.message) &&
-    'additional_kwargs' in generation.message &&
-    'content' in generation.message
-  );
-}
-
-function cloneMessageWithContent(
-  message: MessageWithReasoning,
-  content: MessageContent
-): MessageWithReasoning {
-  return Object.assign(Object.create(Object.getPrototypeOf(message)), message, {
-    content,
-  });
-}
-
-function withReasoningForLangfuseOutput(output: LLMResult): LLMResult {
-  let changed = false;
-  const generations = output.generations.map((generationList) => {
-    return generationList.map((generation) => {
-      if (!hasMessage(generation)) {
-        return generation;
-      }
-      const reasoningText = getMessageReasoningText(generation.message);
-      if (!isPresent(reasoningText)) {
-        return generation;
-      }
-
-      const originalContent = generation.message.content;
-      const nextContent = withReasoningContent(originalContent, reasoningText);
-      if (nextContent === originalContent) {
-        return generation;
-      }
-
-      changed = true;
-      return {
-        ...generation,
-        message: cloneMessageWithContent(generation.message, nextContent),
-      };
-    });
-  });
-
-  if (!changed) {
-    return output;
-  }
-  return {
-    ...output,
-    generations,
-  };
-}
-
-class ReasoningAwareLangfuseCallbackHandler extends CallbackHandler {
+class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly langfuse?: t.LangfuseConfig;
   private readonly traceIdSeed?: string;
 
@@ -266,18 +106,6 @@ class ReasoningAwareLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleRetrieverStart']>
   ): ReturnType<CallbackHandler['handleRetrieverStart']> {
     return this.withRuntimeContext(() => super.handleRetrieverStart(...args));
-  }
-
-  override async handleLLMEnd(
-    output: LLMResult,
-    runId: string,
-    parentRunId?: string | undefined
-  ): Promise<void> {
-    await super.handleLLMEnd(
-      withReasoningForLangfuseOutput(output),
-      runId,
-      parentRunId
-    );
   }
 }
 
@@ -440,7 +268,7 @@ export function shouldCreateLangfuseHandler(
 export function createLegacyLangfuseHandler(
   params: LangfuseHandlerParams
 ): CallbackHandler {
-  return new ReasoningAwareLangfuseCallbackHandler(params);
+  return new ScopedLangfuseCallbackHandler(params);
 }
 
 export function createLangfuseHandler({
@@ -454,7 +282,7 @@ export function createLangfuseHandler({
   if (!shouldCreateLangfuseHandler(langfuse)) {
     return undefined;
   }
-  return new ReasoningAwareLangfuseCallbackHandler({
+  return new ScopedLangfuseCallbackHandler({
     userId,
     sessionId,
     traceMetadata: mergeLangfuseTraceMetadata(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -7,6 +7,7 @@ import type { BaseMessage, MessageContent } from '@langchain/core/messages';
 import type { Generation, LLMResult } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
+import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
 import { isPresent } from '@/utils/misc';
 import { ContentTypes } from '@/common';
 
@@ -21,6 +22,7 @@ type LangfuseHandlerParams = {
   sessionId?: string;
   traceMetadata?: LangfuseTraceMetadata;
   tags?: string[];
+  traceIdSeed?: string;
 };
 
 type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
@@ -200,6 +202,75 @@ function withReasoningForLangfuseOutput(output: LLMResult): LLMResult {
 }
 
 class ReasoningAwareLangfuseCallbackHandler extends CallbackHandler {
+  private readonly langfuse?: t.LangfuseConfig;
+  private readonly traceIdSeed?: string;
+
+  constructor(params?: AgentLangfuseHandlerParams) {
+    const { langfuse, traceIdSeed, ...handlerParams } = params ?? {};
+    super(handlerParams);
+    this.langfuse = langfuse;
+    this.traceIdSeed = traceIdSeed;
+  }
+
+  private getDeterministicTraceSeed(): string | undefined {
+    return this.langfuse?.deterministicTraceId === true
+      ? this.traceIdSeed
+      : undefined;
+  }
+
+  private withRuntimeContext<T>(action: () => T): T {
+    const seed = this.getDeterministicTraceSeed();
+    return withLangfuseRuntimeScope(
+      { langfuse: this.langfuse, traceIdSeed: seed },
+      action
+    );
+  }
+
+  // LangChain may invoke callback handlers outside the caller's OTEL context.
+  // Re-enter tenant scope only for callbacks that start Langfuse observations;
+  // end/error/token callbacks use spans already bound to a processor at start.
+  override handleChainStart(
+    ...args: Parameters<CallbackHandler['handleChainStart']>
+  ): ReturnType<CallbackHandler['handleChainStart']> {
+    return this.withRuntimeContext(() => super.handleChainStart(...args));
+  }
+
+  override handleAgentAction(
+    ...args: Parameters<CallbackHandler['handleAgentAction']>
+  ): ReturnType<CallbackHandler['handleAgentAction']> {
+    return this.withRuntimeContext(() => super.handleAgentAction(...args));
+  }
+
+  override handleGenerationStart(
+    ...args: Parameters<CallbackHandler['handleGenerationStart']>
+  ): ReturnType<CallbackHandler['handleGenerationStart']> {
+    return this.withRuntimeContext(() => super.handleGenerationStart(...args));
+  }
+
+  override handleChatModelStart(
+    ...args: Parameters<CallbackHandler['handleChatModelStart']>
+  ): ReturnType<CallbackHandler['handleChatModelStart']> {
+    return this.withRuntimeContext(() => super.handleChatModelStart(...args));
+  }
+
+  override handleLLMStart(
+    ...args: Parameters<CallbackHandler['handleLLMStart']>
+  ): ReturnType<CallbackHandler['handleLLMStart']> {
+    return this.withRuntimeContext(() => super.handleLLMStart(...args));
+  }
+
+  override handleToolStart(
+    ...args: Parameters<CallbackHandler['handleToolStart']>
+  ): ReturnType<CallbackHandler['handleToolStart']> {
+    return this.withRuntimeContext(() => super.handleToolStart(...args));
+  }
+
+  override handleRetrieverStart(
+    ...args: Parameters<CallbackHandler['handleRetrieverStart']>
+  ): ReturnType<CallbackHandler['handleRetrieverStart']> {
+    return this.withRuntimeContext(() => super.handleRetrieverStart(...args));
+  }
+
   override async handleLLMEnd(
     output: LLMResult,
     runId: string,
@@ -358,6 +429,7 @@ export function createLangfuseHandler({
   sessionId,
   traceMetadata,
   tags,
+  traceIdSeed,
 }: AgentLangfuseHandlerParams): CallbackHandler | undefined {
   if (!shouldCreateLangfuseHandler(langfuse)) {
     return undefined;
@@ -370,6 +442,8 @@ export function createLangfuseHandler({
       langfuse?.metadata
     ),
     tags: mergeLangfuseTags(tags, langfuse?.tags),
+    langfuse,
+    traceIdSeed,
   });
 }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -15,7 +15,11 @@ const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
 
 export type LangfuseTraceMetadata = Record<string, string>;
+export type LangfuseTraceAttributes = Record<string, string | number | boolean>;
 type LangfuseMetadata = NonNullable<t.LangfuseConfig['metadata']>;
+type LangfuseConfigTraceAttributes = NonNullable<
+  t.LangfuseConfig['librechatTraceAttributes']
+>;
 
 type LangfuseHandlerParams = {
   userId?: string;
@@ -293,6 +297,9 @@ function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
 function hasLangfuseTraceAttributes(langfuse?: t.LangfuseConfig): boolean {
   return (
     Object.keys(createTraceMetadata(langfuse?.metadata ?? {})).length > 0 ||
+    Object.keys(
+      createLibreChatTraceAttributes(langfuse?.librechatTraceAttributes ?? {})
+    ).length > 0 ||
     (mergeLangfuseTags(undefined, langfuse?.tags)?.length ?? 0) > 0
   );
 }
@@ -343,6 +350,26 @@ function createTraceMetadata(
     traceMetadata[key] = stringValue;
   }
   return traceMetadata;
+}
+
+export function createLibreChatTraceAttributes(
+  attributes: LangfuseConfigTraceAttributes
+): LangfuseTraceAttributes {
+  const librechatTraceAttributes: LangfuseTraceAttributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value == null || key.trim() === '') {
+      continue;
+    }
+    if (typeof value === 'string') {
+      if (value.trim() === '' || value.length > TRACE_METADATA_MAX_LENGTH) {
+        continue;
+      }
+      librechatTraceAttributes[key] = value;
+      continue;
+    }
+    librechatTraceAttributes[key] = value;
+  }
+  return librechatTraceAttributes;
 }
 
 export function createLangfuseTraceMetadata({

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -3,9 +3,12 @@ import {
   getLangfuseTracerProvider,
   propagateAttributes,
 } from '@langfuse/tracing';
+import type { BaseMessage, MessageContent } from '@langchain/core/messages';
+import type { Generation, LLMResult } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
 import { isPresent } from '@/utils/misc';
+import { ContentTypes } from '@/common';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
@@ -32,11 +35,182 @@ type FlushableTracerProvider = {
   forceFlush?: () => Promise<void> | void;
 };
 
+type ReasoningSummary = {
+  summary?: Array<{ text?: string | null }>;
+};
+
+type ReasoningDetail = {
+  type?: string;
+  text?: string | null;
+};
+
+type MessageWithReasoning = BaseMessage & {
+  additional_kwargs?: BaseMessage['additional_kwargs'] & {
+    reasoning?: string | ReasoningSummary | null;
+    reasoning_content?: string | ReasoningSummary | null;
+    reasoning_details?: ReasoningDetail[] | null;
+  };
+};
+
+type ChatGenerationWithMessage = Generation & {
+  message: MessageWithReasoning;
+};
+
 function parseBooleanEnv(value?: string): boolean {
   if (value == null) {
     return false;
   }
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getReasoningText(
+  value: string | ReasoningSummary | null | undefined
+): string | undefined {
+  if (typeof value === 'string') {
+    return isPresent(value) ? value : undefined;
+  }
+  const summaryText = value?.summary
+    ?.map((summary) => summary.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return summaryText != null && summaryText !== '' ? summaryText : undefined;
+}
+
+function getReasoningDetailsText(
+  value: ReasoningDetail[] | null | undefined
+): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const reasoningText = value
+    .filter((detail) => detail.type === 'reasoning.text')
+    .map((detail) => detail.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return reasoningText !== '' ? reasoningText : undefined;
+}
+
+function getMessageReasoningText(
+  message: MessageWithReasoning
+): string | undefined {
+  const additionalKwargs = message.additional_kwargs;
+  if (additionalKwargs == null) {
+    return undefined;
+  }
+
+  return (
+    getReasoningText(additionalKwargs.reasoning_content) ??
+    getReasoningText(additionalKwargs.reasoning) ??
+    getReasoningDetailsText(additionalKwargs.reasoning_details)
+  );
+}
+
+function hasReasoningContentPart(content: MessageContent): boolean {
+  return (
+    Array.isArray(content) &&
+    content.some((part) => {
+      if (!isRecord(part) || typeof part.type !== 'string') {
+        return false;
+      }
+      return (
+        part.type === ContentTypes.THINK ||
+        part.type === ContentTypes.THINKING ||
+        part.type === ContentTypes.REASONING ||
+        part.type === ContentTypes.REASONING_CONTENT ||
+        part.type === 'redacted_thinking'
+      );
+    })
+  );
+}
+
+function withReasoningContent(
+  content: MessageContent,
+  reasoningText: string
+): MessageContent {
+  if (hasReasoningContentPart(content)) {
+    return content;
+  }
+
+  const reasoningPart = {
+    type: ContentTypes.THINK,
+    think: reasoningText,
+  };
+  return Array.isArray(content)
+    ? [reasoningPart, ...content]
+    : [reasoningPart, { type: ContentTypes.TEXT, text: content }];
+}
+
+function hasMessage(
+  generation: Generation
+): generation is ChatGenerationWithMessage {
+  return (
+    'message' in generation &&
+    isRecord(generation.message) &&
+    'additional_kwargs' in generation.message &&
+    'content' in generation.message
+  );
+}
+
+function cloneMessageWithContent(
+  message: MessageWithReasoning,
+  content: MessageContent
+): MessageWithReasoning {
+  return Object.assign(Object.create(Object.getPrototypeOf(message)), message, {
+    content,
+  });
+}
+
+function withReasoningForLangfuseOutput(output: LLMResult): LLMResult {
+  let changed = false;
+  const generations = output.generations.map((generationList) => {
+    return generationList.map((generation) => {
+      if (!hasMessage(generation)) {
+        return generation;
+      }
+      const reasoningText = getMessageReasoningText(generation.message);
+      if (!isPresent(reasoningText)) {
+        return generation;
+      }
+
+      const originalContent = generation.message.content;
+      const nextContent = withReasoningContent(originalContent, reasoningText);
+      if (nextContent === originalContent) {
+        return generation;
+      }
+
+      changed = true;
+      return {
+        ...generation,
+        message: cloneMessageWithContent(generation.message, nextContent),
+      };
+    });
+  });
+
+  if (!changed) {
+    return output;
+  }
+  return {
+    ...output,
+    generations,
+  };
+}
+
+class ReasoningAwareLangfuseCallbackHandler extends CallbackHandler {
+  override async handleLLMEnd(
+    output: LLMResult,
+    runId: string,
+    parentRunId?: string | undefined
+  ): Promise<void> {
+    await super.handleLLMEnd(
+      withReasoningForLangfuseOutput(output),
+      runId,
+      parentRunId
+    );
+  }
 }
 
 function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
@@ -175,7 +349,7 @@ export function shouldCreateLangfuseHandler(
 export function createLegacyLangfuseHandler(
   params: LangfuseHandlerParams
 ): CallbackHandler {
-  return new CallbackHandler(params);
+  return new ReasoningAwareLangfuseCallbackHandler(params);
 }
 
 export function createLangfuseHandler({
@@ -188,7 +362,7 @@ export function createLangfuseHandler({
   if (!shouldCreateLangfuseHandler(langfuse)) {
     return undefined;
   }
-  return new CallbackHandler({
+  return new ReasoningAwareLangfuseCallbackHandler({
     userId,
     sessionId,
     traceMetadata: mergeLangfuseTraceMetadata(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,11 +1,16 @@
 import { CallbackHandler } from '@langfuse/langchain';
+import { context as otelContext } from '@opentelemetry/api';
 import {
   getLangfuseTracerProvider,
   propagateAttributes,
 } from '@langfuse/tracing';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
-import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
+import {
+  resolveLangfuseConfigForSpan,
+  resolveTraceIdSeedForSpan,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
@@ -56,9 +61,15 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   }
 
   private withRuntimeContext<T>(action: () => T): T {
+    const activeContext = otelContext.active();
+    const langfuse =
+      resolveLangfuseConfigForSpan(activeContext) ?? this.langfuse;
     const seed = this.getDeterministicTraceSeed();
     return withLangfuseRuntimeScope(
-      { langfuse: this.langfuse, traceIdSeed: seed },
+      {
+        langfuse,
+        traceIdSeed: resolveTraceIdSeedForSpan(activeContext) ?? seed,
+      },
       action
     );
   }

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -86,6 +86,41 @@ function hasEnvToolOutputTracingConfig(): boolean {
   );
 }
 
+function resolveToolOutputTracingEnabled(
+  runConfig?: t.LangfuseToolOutputTracingConfig,
+  agentConfig?: t.LangfuseToolOutputTracingConfig
+): boolean {
+  return (
+    agentConfig?.enabled ??
+    runConfig?.enabled ??
+    getEnvToolOutputTracingEnabled() ??
+    true
+  );
+}
+
+function resolveRedactedToolNames(
+  runConfig?: t.LangfuseToolOutputTracingConfig,
+  agentConfig?: t.LangfuseToolOutputTracingConfig
+): Set<string> {
+  return normalizeToolNames([
+    ...(getEnvRedactedToolNames() ?? []),
+    ...(runConfig?.redactedToolNames ?? []),
+    ...(agentConfig?.redactedToolNames ?? []),
+  ]);
+}
+
+function resolveToolNameMatchMode(
+  runConfig?: t.LangfuseToolOutputTracingConfig,
+  agentConfig?: t.LangfuseToolOutputTracingConfig
+): 'exact' | 'partial' {
+  const modes = [
+    getEnvToolNameMatchMode(),
+    runConfig?.redactedToolNameMatchMode,
+    agentConfig?.redactedToolNameMatchMode,
+  ];
+  return modes.includes('partial') ? 'partial' : 'exact';
+}
+
 export function hasToolOutputTracingConfig(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
@@ -105,21 +140,9 @@ export function resolveToolOutputTracingConfig(
   const agentConfig = agentLangfuse?.toolOutputTracing;
 
   return {
-    enabled:
-      agentConfig?.enabled ??
-      runConfig?.enabled ??
-      getEnvToolOutputTracingEnabled() ??
-      true,
-    redactedToolNames: normalizeToolNames(
-      agentConfig?.redactedToolNames ??
-        runConfig?.redactedToolNames ??
-        getEnvRedactedToolNames()
-    ),
-    redactedToolNameMatchMode:
-      agentConfig?.redactedToolNameMatchMode ??
-      runConfig?.redactedToolNameMatchMode ??
-      getEnvToolNameMatchMode() ??
-      'exact',
+    enabled: resolveToolOutputTracingEnabled(runConfig, agentConfig),
+    redactedToolNames: resolveRedactedToolNames(runConfig, agentConfig),
+    redactedToolNameMatchMode: resolveToolNameMatchMode(runConfig, agentConfig),
     redactionText:
       agentConfig?.redactionText ??
       runConfig?.redactionText ??
@@ -161,6 +184,14 @@ export function resolveLangfuseConfig(
         ...agentLangfuse.metadata,
       }
       : undefined;
+  const librechatTraceAttributes =
+    runLangfuse.librechatTraceAttributes != null ||
+    agentLangfuse.librechatTraceAttributes != null
+      ? {
+        ...runLangfuse.librechatTraceAttributes,
+        ...agentLangfuse.librechatTraceAttributes,
+      }
+      : undefined;
   const tags =
     runLangfuse.tags != null || agentLangfuse.tags != null
       ? [
@@ -175,6 +206,7 @@ export function resolveLangfuseConfig(
     ...runLangfuse,
     ...agentLangfuse,
     ...(metadata != null ? { metadata } : {}),
+    ...(librechatTraceAttributes != null ? { librechatTraceAttributes } : {}),
     ...(tags != null ? { tags } : {}),
     ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
     ...(toolOutputTracing != null ? { toolOutputTracing } : {}),

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -1,26 +1,11 @@
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
+import { parseBooleanEnv } from '@/utils/misc';
 
 export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
 
 function isPresent(value: unknown): value is string {
   return typeof value === 'string' && value.trim() !== '';
-}
-
-function parseBoolean(value: string | undefined): boolean | undefined {
-  if (value == null) {
-    return undefined;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
-    return true;
-  }
-  if (['0', 'false', 'no', 'off'].includes(normalized)) {
-    return false;
-  }
-
-  return undefined;
 }
 
 export function normalizeToolName(name: string): string {
@@ -49,21 +34,21 @@ function parseToolNames(value: string | undefined): string[] | undefined {
 }
 
 function getEnvToolOutputTracingEnabled(): boolean | undefined {
-  const traceToolOutputs = parseBoolean(
+  const traceToolOutputs = parseBooleanEnv(
     process.env.LANGFUSE_TRACE_TOOL_OUTPUTS
   );
   if (traceToolOutputs != null) {
     return traceToolOutputs;
   }
 
-  const redactToolOutputs = parseBoolean(
+  const redactToolOutputs = parseBooleanEnv(
     process.env.LANGFUSE_REDACT_TOOL_OUTPUTS
   );
   if (redactToolOutputs != null) {
     return !redactToolOutputs;
   }
 
-  return parseBoolean(process.env.LANGFUSE_TOOL_OUTPUT_TRACING_ENABLED);
+  return parseBooleanEnv(process.env.LANGFUSE_TOOL_OUTPUT_TRACING_ENABLED);
 }
 
 function getEnvRedactedToolNames(): string[] | undefined {

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -1,0 +1,177 @@
+import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
+import type * as t from '@/types';
+
+export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
+
+function isPresent(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+export function normalizeToolName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function normalizeToolNames(names: string[] | undefined): Set<string> {
+  const normalized = new Set<string>();
+  for (const name of names ?? []) {
+    if (isPresent(name)) {
+      normalized.add(normalizeToolName(name));
+    }
+  }
+  return normalized;
+}
+
+function parseToolNames(value: string | undefined): string[] | undefined {
+  if (!isPresent(value)) {
+    return undefined;
+  }
+
+  return value
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name !== '');
+}
+
+function getEnvToolOutputTracingEnabled(): boolean | undefined {
+  const traceToolOutputs = parseBoolean(
+    process.env.LANGFUSE_TRACE_TOOL_OUTPUTS
+  );
+  if (traceToolOutputs != null) {
+    return traceToolOutputs;
+  }
+
+  const redactToolOutputs = parseBoolean(
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS
+  );
+  if (redactToolOutputs != null) {
+    return !redactToolOutputs;
+  }
+
+  return parseBoolean(process.env.LANGFUSE_TOOL_OUTPUT_TRACING_ENABLED);
+}
+
+function getEnvRedactedToolNames(): string[] | undefined {
+  return (
+    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAMES) ??
+    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_NAMES)
+  );
+}
+
+function getEnvRedactionText(): string | undefined {
+  return isPresent(process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT)
+    ? process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    : undefined;
+}
+
+function getEnvToolNameMatchMode(): 'exact' | 'partial' | undefined {
+  const mode = (
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAME_MATCH_MODE ??
+    process.env.LANGFUSE_REDACT_TOOL_NAME_MATCH_MODE
+  )
+    ?.trim()
+    .toLowerCase();
+  if (mode === 'exact' || mode === 'partial') {
+    return mode;
+  }
+  return undefined;
+}
+
+export function resolveToolOutputTracingConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): ResolvedLangfuseToolOutputTracingConfig {
+  const runConfig = runLangfuse?.toolOutputTracing;
+  const agentConfig = agentLangfuse?.toolOutputTracing;
+
+  return {
+    enabled:
+      agentConfig?.enabled ??
+      runConfig?.enabled ??
+      getEnvToolOutputTracingEnabled() ??
+      true,
+    redactedToolNames: normalizeToolNames(
+      agentConfig?.redactedToolNames ??
+        runConfig?.redactedToolNames ??
+        getEnvRedactedToolNames()
+    ),
+    redactedToolNameMatchMode:
+      agentConfig?.redactedToolNameMatchMode ??
+      runConfig?.redactedToolNameMatchMode ??
+      getEnvToolNameMatchMode() ??
+      'exact',
+    redactionText:
+      agentConfig?.redactionText ??
+      runConfig?.redactionText ??
+      getEnvRedactionText() ??
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  };
+}
+
+export function resolveLangfuseConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): t.LangfuseConfig | undefined {
+  if (runLangfuse == null) {
+    return agentLangfuse;
+  }
+  if (agentLangfuse == null) {
+    return runLangfuse;
+  }
+
+  const toolNodeTracing =
+    runLangfuse.toolNodeTracing != null || agentLangfuse.toolNodeTracing != null
+      ? {
+        ...runLangfuse.toolNodeTracing,
+        ...agentLangfuse.toolNodeTracing,
+      }
+      : undefined;
+  const toolOutputTracing =
+    runLangfuse.toolOutputTracing != null ||
+    agentLangfuse.toolOutputTracing != null
+      ? {
+        ...runLangfuse.toolOutputTracing,
+        ...agentLangfuse.toolOutputTracing,
+      }
+      : undefined;
+  const metadata =
+    runLangfuse.metadata != null || agentLangfuse.metadata != null
+      ? {
+        ...runLangfuse.metadata,
+        ...agentLangfuse.metadata,
+      }
+      : undefined;
+  const tags =
+    runLangfuse.tags != null || agentLangfuse.tags != null
+      ? [
+        ...new Set([
+          ...(runLangfuse.tags ?? []),
+          ...(agentLangfuse.tags ?? []),
+        ]),
+      ]
+      : undefined;
+
+  return {
+    ...runLangfuse,
+    ...agentLangfuse,
+    ...(metadata != null ? { metadata } : {}),
+    ...(tags != null ? { tags } : {}),
+    ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
+    ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
+  };
+}

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -92,6 +92,26 @@ function getEnvToolNameMatchMode(): 'exact' | 'partial' | undefined {
   return undefined;
 }
 
+function hasEnvToolOutputTracingConfig(): boolean {
+  return (
+    getEnvToolOutputTracingEnabled() != null ||
+    getEnvRedactedToolNames() != null ||
+    getEnvRedactionText() != null ||
+    getEnvToolNameMatchMode() != null
+  );
+}
+
+export function hasToolOutputTracingConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): boolean {
+  return (
+    runLangfuse?.toolOutputTracing != null ||
+    agentLangfuse?.toolOutputTracing != null ||
+    hasEnvToolOutputTracingConfig()
+  );
+}
+
 export function resolveToolOutputTracingConfig(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig

--- a/src/langfuseRuntimeContext.ts
+++ b/src/langfuseRuntimeContext.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type * as t from '@/types';
+
+export type ResolvedLangfuseToolOutputTracingConfig = {
+  enabled: boolean;
+  redactedToolNames: Set<string>;
+  redactedToolNameMatchMode: 'exact' | 'partial';
+  redactionText: string;
+};
+
+export type LangfuseRuntimeContext = {
+  langfuse?: t.LangfuseConfig;
+  traceIdSeed?: string;
+  toolOutputTracing?: ResolvedLangfuseToolOutputTracingConfig;
+};
+
+const langfuseRuntimeContextStore =
+  new AsyncLocalStorage<LangfuseRuntimeContext>();
+
+function hasText(value: string | undefined): value is string {
+  return value != null && value.trim() !== '';
+}
+
+export function hasLangfuseRuntimeContextValue(
+  context: LangfuseRuntimeContext
+): boolean {
+  return (
+    context.langfuse != null ||
+    hasText(context.traceIdSeed) ||
+    context.toolOutputTracing != null
+  );
+}
+
+/** sha256(seed) -> first 32 hex chars; matches `@langfuse/tracing` `createTraceId`. */
+export function traceIdFromSeed(seed: string): string {
+  return createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 32);
+}
+
+export function getLangfuseRuntimeContext():
+  | LangfuseRuntimeContext
+  | undefined {
+  return langfuseRuntimeContextStore.getStore();
+}
+
+export function getLangfuseRuntimeConfig(): t.LangfuseConfig | undefined {
+  return getLangfuseRuntimeContext()?.langfuse;
+}
+
+export function getTraceIdSeed(): string | undefined {
+  return getLangfuseRuntimeContext()?.traceIdSeed;
+}
+
+export function getLangfuseRuntimeToolOutputTracingConfig():
+  | ResolvedLangfuseToolOutputTracingConfig
+  | undefined {
+  return getLangfuseRuntimeContext()?.toolOutputTracing;
+}
+
+/**
+ * Runs `fn` with a merged Langfuse runtime context. Undefined fields inherit
+ * from the parent scope; callers intentionally cannot clear parent values by
+ * passing `undefined`.
+ */
+export function runWithLangfuseRuntimeContext<T>(
+  context: LangfuseRuntimeContext,
+  fn: () => T
+): T {
+  const current = getLangfuseRuntimeContext();
+  const next = {
+    ...(current ?? {}),
+    ...(context.langfuse !== undefined ? { langfuse: context.langfuse } : {}),
+    ...(hasText(context.traceIdSeed)
+      ? { traceIdSeed: context.traceIdSeed }
+      : {}),
+    ...(context.toolOutputTracing !== undefined
+      ? { toolOutputTracing: context.toolOutputTracing }
+      : {}),
+  };
+
+  return hasLangfuseRuntimeContextValue(next)
+    ? langfuseRuntimeContextStore.run(next, fn)
+    : fn();
+}
+
+export function runWithTraceIdSeed<T>(
+  seed: string | undefined,
+  fn: () => T
+): T {
+  return hasText(seed)
+    ? runWithLangfuseRuntimeContext({ traceIdSeed: seed }, fn)
+    : fn();
+}

--- a/src/langfuseRuntimeScope.ts
+++ b/src/langfuseRuntimeScope.ts
@@ -1,0 +1,134 @@
+import { context, createContextKey } from '@opentelemetry/api';
+import type { Context } from '@opentelemetry/api';
+import type {
+  LangfuseRuntimeContext,
+  ResolvedLangfuseToolOutputTracingConfig,
+} from '@/langfuseRuntimeContext';
+import type * as t from '@/types';
+import {
+  getLangfuseRuntimeConfig,
+  getLangfuseRuntimeToolOutputTracingConfig,
+  getTraceIdSeed,
+  hasLangfuseRuntimeContextValue,
+  runWithLangfuseRuntimeContext,
+} from '@/langfuseRuntimeContext';
+import {
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
+
+export type LangfuseRuntimeScope = LangfuseRuntimeContext;
+
+export type ResolveLangfuseRuntimeScopeParams = {
+  runLangfuse?: t.LangfuseConfig;
+  langfuseOverlay?: t.LangfuseConfig;
+  traceIdSeed?: string;
+};
+
+const langfuseToolOutputTracingConfigKey = createContextKey(
+  'librechat.langfuse.tool-output-tracing'
+);
+const langfuseConfigKey = createContextKey('librechat.langfuse.config');
+const langfuseTraceIdSeedKey = createContextKey(
+  'librechat.langfuse.trace-id-seed'
+);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasText(value: string | undefined): value is string {
+  return value != null && value.trim() !== '';
+}
+
+export function getOtelLangfuseConfig(
+  activeContext: Context
+): t.LangfuseConfig | undefined {
+  const value = activeContext.getValue(langfuseConfigKey);
+  return isRecord(value) ? (value as t.LangfuseConfig) : undefined;
+}
+
+export function getOtelTraceIdSeed(activeContext: Context): string | undefined {
+  const value = activeContext.getValue(langfuseTraceIdSeedKey);
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+export function getOtelToolOutputTracingConfig(
+  activeContext: Context
+): ResolvedLangfuseToolOutputTracingConfig | undefined {
+  const value = activeContext.getValue(langfuseToolOutputTracingConfigKey);
+  return isRecord(value)
+    ? (value as ResolvedLangfuseToolOutputTracingConfig)
+    : undefined;
+}
+
+export function resolveLangfuseConfigForSpan(
+  activeContext: Context
+): t.LangfuseConfig | undefined {
+  return getLangfuseRuntimeConfig() ?? getOtelLangfuseConfig(activeContext);
+}
+
+export function resolveTraceIdSeedForSpan(
+  activeContext: Context
+): string | undefined {
+  return getTraceIdSeed() ?? getOtelTraceIdSeed(activeContext);
+}
+
+export function resolveToolOutputTracingConfigForSpan(
+  activeContext: Context
+): ResolvedLangfuseToolOutputTracingConfig | undefined {
+  return (
+    getLangfuseRuntimeToolOutputTracingConfig() ??
+    getOtelToolOutputTracingConfig(activeContext)
+  );
+}
+
+export function withLangfuseRuntimeScope<T>(
+  scope: LangfuseRuntimeScope,
+  action: () => T
+): T {
+  if (!hasLangfuseRuntimeContextValue(scope)) {
+    return action();
+  }
+
+  let activeContext = context.active();
+  if (scope.langfuse != null) {
+    activeContext = activeContext.setValue(langfuseConfigKey, scope.langfuse);
+  }
+  if (scope.toolOutputTracing != null) {
+    activeContext = activeContext.setValue(
+      langfuseToolOutputTracingConfigKey,
+      scope.toolOutputTracing
+    );
+  }
+  if (hasText(scope.traceIdSeed)) {
+    activeContext = activeContext.setValue(
+      langfuseTraceIdSeedKey,
+      scope.traceIdSeed
+    );
+  }
+
+  // Span processors receive the OTel parent context in `onStart`, while
+  // LangChain callback handlers may run outside that context and need ALS.
+  // The trace id generator reads the seed from ALS or OTel context so SDK
+  // callbacks that preserve only one of those contexts still keep trace/score
+  // cohesion.
+  return runWithLangfuseRuntimeContext(scope, () =>
+    context.with(activeContext, action)
+  );
+}
+
+export function resolveLangfuseRuntimeScope({
+  runLangfuse,
+  langfuseOverlay,
+  traceIdSeed,
+}: ResolveLangfuseRuntimeScopeParams): LangfuseRuntimeScope {
+  const langfuse = resolveLangfuseConfig(runLangfuse, langfuseOverlay);
+  const hasNoToolOutputConfig =
+    runLangfuse?.toolOutputTracing == null &&
+    langfuseOverlay?.toolOutputTracing == null;
+  const toolOutputTracing = hasNoToolOutputConfig
+    ? undefined
+    : resolveToolOutputTracingConfig(runLangfuse, langfuseOverlay);
+  return { langfuse, traceIdSeed, toolOutputTracing };
+}

--- a/src/langfuseRuntimeScope.ts
+++ b/src/langfuseRuntimeScope.ts
@@ -13,6 +13,7 @@ import {
   runWithLangfuseRuntimeContext,
 } from '@/langfuseRuntimeContext';
 import {
+  hasToolOutputTracingConfig,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
@@ -124,10 +125,10 @@ export function resolveLangfuseRuntimeScope({
   traceIdSeed,
 }: ResolveLangfuseRuntimeScopeParams): LangfuseRuntimeScope {
   const langfuse = resolveLangfuseConfig(runLangfuse, langfuseOverlay);
-  const hasNoToolOutputConfig =
-    runLangfuse?.toolOutputTracing == null &&
-    langfuseOverlay?.toolOutputTracing == null;
-  const toolOutputTracing = hasNoToolOutputConfig
+  const toolOutputTracing = !hasToolOutputTracingConfig(
+    runLangfuse,
+    langfuseOverlay
+  )
     ? undefined
     : resolveToolOutputTracingConfig(runLangfuse, langfuseOverlay);
   return { langfuse, traceIdSeed, toolOutputTracing };

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -1,6 +1,4 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
-import { context, createContextKey } from '@opentelemetry/api';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import type {
   ReadableSpan,
@@ -9,17 +7,18 @@ import type {
 } from '@opentelemetry/sdk-trace-base';
 import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Context } from '@opentelemetry/api';
+import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
+import {
+  LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  normalizeToolName,
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
+import { resolveToolOutputTracingConfigForSpan } from '@/langfuseRuntimeScope';
 
-export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
+export { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT, resolveLangfuseConfig };
 
-const langfuseToolOutputTracingConfigKey = createContextKey(
-  'librechat.langfuse.tool-output-tracing'
-);
-const langfuseConfigKey = createContextKey('librechat.langfuse.config');
-const toolOutputTracingStorage =
-  new AsyncLocalStorage<ResolvedLangfuseToolOutputTracingConfig>();
-const langfuseConfigStorage = new AsyncLocalStorage<t.LangfuseConfig>();
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
 
 const CHAT_ROLES = new Set([
@@ -29,13 +28,6 @@ const CHAT_ROLES = new Set([
   'system',
   'user',
 ]);
-
-export type ResolvedLangfuseToolOutputTracingConfig = {
-  enabled: boolean;
-  redactedToolNames: Set<string>;
-  redactedToolNameMatchMode: 'exact' | 'partial';
-  redactionText: string;
-};
 
 type SpanWithAttributes = ReadableSpan & {
   attributes: Record<string, unknown>;
@@ -58,122 +50,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isPresent(value: unknown): value is string {
   return typeof value === 'string' && value.trim() !== '';
-}
-
-function parseBoolean(value: string | undefined): boolean | undefined {
-  if (value == null) {
-    return undefined;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
-    return true;
-  }
-  if (['0', 'false', 'no', 'off'].includes(normalized)) {
-    return false;
-  }
-
-  return undefined;
-}
-
-function normalizeToolName(name: string): string {
-  return name.trim().toLowerCase();
-}
-
-function normalizeToolNames(names: string[] | undefined): Set<string> {
-  const normalized = new Set<string>();
-  for (const name of names ?? []) {
-    if (isPresent(name)) {
-      normalized.add(normalizeToolName(name));
-    }
-  }
-  return normalized;
-}
-
-function parseToolNames(value: string | undefined): string[] | undefined {
-  if (!isPresent(value)) {
-    return undefined;
-  }
-
-  return value
-    .split(',')
-    .map((name) => name.trim())
-    .filter((name) => name !== '');
-}
-
-function getEnvToolOutputTracingEnabled(): boolean | undefined {
-  const traceToolOutputs = parseBoolean(
-    process.env.LANGFUSE_TRACE_TOOL_OUTPUTS
-  );
-  if (traceToolOutputs != null) {
-    return traceToolOutputs;
-  }
-
-  const redactToolOutputs = parseBoolean(
-    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS
-  );
-  if (redactToolOutputs != null) {
-    return !redactToolOutputs;
-  }
-
-  return parseBoolean(process.env.LANGFUSE_TOOL_OUTPUT_TRACING_ENABLED);
-}
-
-function getEnvRedactedToolNames(): string[] | undefined {
-  return (
-    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAMES) ??
-    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_NAMES)
-  );
-}
-
-function getEnvRedactionText(): string | undefined {
-  return isPresent(process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT)
-    ? process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
-    : undefined;
-}
-
-function getEnvToolNameMatchMode(): 'exact' | 'partial' | undefined {
-  const mode = (
-    process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAME_MATCH_MODE ??
-    process.env.LANGFUSE_REDACT_TOOL_NAME_MATCH_MODE
-  )
-    ?.trim()
-    .toLowerCase();
-  if (mode === 'exact' || mode === 'partial') {
-    return mode;
-  }
-  return undefined;
-}
-
-function resolveToolOutputTracingConfig(
-  runLangfuse?: t.LangfuseConfig,
-  agentLangfuse?: t.LangfuseConfig
-): ResolvedLangfuseToolOutputTracingConfig {
-  const runConfig = runLangfuse?.toolOutputTracing;
-  const agentConfig = agentLangfuse?.toolOutputTracing;
-
-  return {
-    enabled:
-      agentConfig?.enabled ??
-      runConfig?.enabled ??
-      getEnvToolOutputTracingEnabled() ??
-      true,
-    redactedToolNames: normalizeToolNames(
-      agentConfig?.redactedToolNames ??
-        runConfig?.redactedToolNames ??
-        getEnvRedactedToolNames()
-    ),
-    redactedToolNameMatchMode:
-      agentConfig?.redactedToolNameMatchMode ??
-      runConfig?.redactedToolNameMatchMode ??
-      getEnvToolNameMatchMode() ??
-      'exact',
-    redactionText:
-      agentConfig?.redactionText ??
-      runConfig?.redactionText ??
-      getEnvRedactionText() ??
-      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
-  };
 }
 
 function shouldApplyToolOutputRedaction(
@@ -509,32 +385,6 @@ export function redactLangfuseSpanToolOutputs(
   }
 }
 
-function getContextToolOutputTracingConfig(
-  activeContext: Context
-): ResolvedLangfuseToolOutputTracingConfig | undefined {
-  const asyncConfig = toolOutputTracingStorage.getStore();
-  if (asyncConfig != null) {
-    return asyncConfig;
-  }
-
-  const value = activeContext.getValue(langfuseToolOutputTracingConfigKey);
-  return isRecord(value)
-    ? (value as ResolvedLangfuseToolOutputTracingConfig)
-    : undefined;
-}
-
-export function getContextLangfuseConfig(
-  activeContext: Context
-): t.LangfuseConfig | undefined {
-  const asyncConfig = langfuseConfigStorage.getStore();
-  if (asyncConfig != null) {
-    return asyncConfig;
-  }
-
-  const value = activeContext.getValue(langfuseConfigKey);
-  return isRecord(value) ? (value as t.LangfuseConfig) : undefined;
-}
-
 class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   private readonly processor: LangfuseSpanProcessor;
   private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
@@ -553,7 +403,8 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     const config =
-      getContextToolOutputTracingConfig(parentContext) ?? this.fallbackConfig;
+      resolveToolOutputTracingConfigForSpan(parentContext) ??
+      this.fallbackConfig;
     if (config != null) {
       this.spanConfigs.set(span, config);
     }
@@ -561,12 +412,10 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
-    const config =
-      this.spanConfigs.get(span) ??
-      toolOutputTracingStorage.getStore() ??
-      this.fallbackConfig ??
-      resolveToolOutputTracingConfig();
-    redactLangfuseSpanToolOutputs(span, config);
+    const config = this.spanConfigs.get(span) ?? this.fallbackConfig;
+    if (config != null) {
+      redactLangfuseSpanToolOutputs(span, config);
+    }
     this.processor.onEnd(span);
   }
 
@@ -589,45 +438,6 @@ export function createLangfuseSpanProcessor(
       ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
       : undefined;
   return new ToolOutputRedactingLangfuseSpanProcessor(params, fallbackConfig);
-}
-
-export function withLangfuseToolOutputTracingConfig<T>(
-  runLangfuse: t.LangfuseConfig | undefined,
-  action: () => T,
-  agentLangfuse?: t.LangfuseConfig
-): T {
-  const langfuse = resolveLangfuseConfig(runLangfuse, agentLangfuse);
-  const hasNoToolOutputConfig =
-    runLangfuse?.toolOutputTracing == null &&
-    agentLangfuse?.toolOutputTracing == null;
-
-  if (langfuse == null && hasNoToolOutputConfig) {
-    return action();
-  }
-
-  const config = hasNoToolOutputConfig
-    ? undefined
-    : resolveToolOutputTracingConfig(runLangfuse, agentLangfuse);
-  let activeContext = context.active();
-  if (langfuse != null) {
-    activeContext = activeContext.setValue(langfuseConfigKey, langfuse);
-  }
-  if (config != null) {
-    activeContext = activeContext.setValue(
-      langfuseToolOutputTracingConfigKey,
-      config
-    );
-  }
-
-  const runWithContext = (): T => context.with(activeContext, action);
-  const runWithToolOutputConfig = (): T =>
-    config != null
-      ? toolOutputTracingStorage.run(config, runWithContext)
-      : runWithContext();
-
-  return langfuse != null
-    ? langfuseConfigStorage.run(langfuse, runWithToolOutputConfig)
-    : runWithToolOutputConfig();
 }
 
 function hasLangfuseEnvKeys(): boolean {
@@ -664,57 +474,4 @@ export function shouldTraceToolNodeForLangfuse({
   }
 
   return hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys();
-}
-
-export function resolveLangfuseConfig(
-  runLangfuse?: t.LangfuseConfig,
-  agentLangfuse?: t.LangfuseConfig
-): t.LangfuseConfig | undefined {
-  if (runLangfuse == null) {
-    return agentLangfuse;
-  }
-  if (agentLangfuse == null) {
-    return runLangfuse;
-  }
-
-  const toolNodeTracing =
-    runLangfuse.toolNodeTracing != null || agentLangfuse.toolNodeTracing != null
-      ? {
-        ...runLangfuse.toolNodeTracing,
-        ...agentLangfuse.toolNodeTracing,
-      }
-      : undefined;
-  const toolOutputTracing =
-    runLangfuse.toolOutputTracing != null ||
-    agentLangfuse.toolOutputTracing != null
-      ? {
-        ...runLangfuse.toolOutputTracing,
-        ...agentLangfuse.toolOutputTracing,
-      }
-      : undefined;
-  const metadata =
-    runLangfuse.metadata != null || agentLangfuse.metadata != null
-      ? {
-        ...runLangfuse.metadata,
-        ...agentLangfuse.metadata,
-      }
-      : undefined;
-  const tags =
-    runLangfuse.tags != null || agentLangfuse.tags != null
-      ? [
-        ...new Set([
-          ...(runLangfuse.tags ?? []),
-          ...(agentLangfuse.tags ?? []),
-        ]),
-      ]
-      : undefined;
-
-  return {
-    ...runLangfuse,
-    ...agentLangfuse,
-    ...(metadata != null ? { metadata } : {}),
-    ...(tags != null ? { tags } : {}),
-    ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
-    ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
-  };
 }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -344,6 +344,10 @@ function classifyLangGraphToolNodeSpan(
   }
 }
 
+export function classifyLangfuseToolNodeSpan(span: ReadableSpan): void {
+  classifyLangGraphToolNodeSpan((span as SpanWithAttributes).attributes);
+}
+
 function redactToolObservationOutput(
   span: ReadableSpan,
   attributes: Record<string, unknown>,
@@ -368,7 +372,7 @@ export function redactLangfuseSpanToolOutputs(
   config: ResolvedLangfuseToolOutputTracingConfig
 ): void {
   const attributes = (span as SpanWithAttributes).attributes;
-  classifyLangGraphToolNodeSpan(attributes);
+  classifyLangfuseToolNodeSpan(span);
 
   if (!shouldApplyToolOutputRedaction(config)) {
     return;
@@ -413,6 +417,7 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
+    classifyLangfuseToolNodeSpan(span);
     const config = this.spanConfigs.get(span) ?? this.fallbackConfig;
     if (config != null) {
       redactLangfuseSpanToolOutputs(span, config);

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -11,6 +11,7 @@ import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeC
 import type * as t from '@/types';
 import {
   LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  hasToolOutputTracingConfig,
   normalizeToolName,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
@@ -433,10 +434,9 @@ export function createLangfuseSpanProcessor(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
 ): SpanProcessor {
-  const fallbackConfig =
-    runLangfuse != null || agentLangfuse != null
-      ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
-      : undefined;
+  const fallbackConfig = hasToolOutputTracingConfig(runLangfuse, agentLangfuse)
+    ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
+    : undefined;
   return new ToolOutputRedactingLangfuseSpanProcessor(params, fallbackConfig);
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -27,9 +27,9 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
-  resolveLangfuseConfig,
-  withLangfuseToolOutputTracingConfig,
-} from '@/langfuseToolOutputTracing';
+  resolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
 import {
   appendCallbacks,
   findCallback,
@@ -39,13 +39,11 @@ import {
   createCompletionTitleRunnable,
   createTitleRunnable,
 } from '@/utils/title';
-import {
-  initializeLangfuseTracing,
-  runWithTraceIdSeed,
-} from './instrumentation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
+import { initializeLangfuseTracing } from './instrumentation';
 import { GraphEvents, Callback, TitleMethod } from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
+import { resolveLangfuseConfig } from '@/langfuseConfig';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -746,6 +744,10 @@ export class Run<_T extends t.BaseGraphState> {
       sessionId,
       traceMetadata,
       tags: ['librechat', 'agent'],
+      traceIdSeed:
+        streamLangfuseConfig?.deterministicTraceId === true
+          ? this.id
+          : undefined,
     });
     if (langfuseHandler != null) {
       config.runName = traceName;
@@ -915,26 +917,26 @@ export class Run<_T extends t.BaseGraphState> {
       // When opted in, seed the root trace id from this run's id so feedback /
       // other external signals can be attached to the trace later without a
       // lookup (see SeededTraceIdGenerator in ./instrumentation).
-      await runWithTraceIdSeed(
-        streamLangfuseConfig?.deterministicTraceId === true
-          ? this.id
-          : undefined,
+      await withLangfuseRuntimeScope(
+        resolveLangfuseRuntimeScope({
+          runLangfuse: streamLangfuseConfig,
+          langfuseOverlay: this.getStreamToolOutputTracingLangfuseConfig(graph),
+          traceIdSeed:
+            streamLangfuseConfig?.deterministicTraceId === true
+              ? this.id
+              : undefined,
+        }),
         () =>
-          withLangfuseToolOutputTracingConfig(
-            streamLangfuseConfig,
-            () =>
-              withLangfuseAttributes(
-                {
-                  langfuse: streamLangfuseConfig,
-                  userId,
-                  sessionId,
-                  traceName,
-                  traceMetadata,
-                  tags: ['librechat', 'agent'],
-                },
-                consumeStream
-              ),
-            this.getStreamToolOutputTracingLangfuseConfig(graph)
+          withLangfuseAttributes(
+            {
+              langfuse: streamLangfuseConfig,
+              userId,
+              sessionId,
+              traceName,
+              traceMetadata,
+              tags: ['librechat', 'agent'],
+            },
+            consumeStream
           )
       );
     } catch (err) {
@@ -1312,6 +1314,10 @@ export class Run<_T extends t.BaseGraphState> {
         sessionId: titleSessionId,
         traceMetadata,
         tags: ['librechat', 'title'],
+        traceIdSeed:
+          titleLangfuseConfig?.deterministicTraceId === true
+            ? 'title-' + this.id
+            : undefined,
       });
 
       if (titleLangfuseHandler != null) {
@@ -1404,10 +1410,12 @@ export class Run<_T extends t.BaseGraphState> {
 
     try {
       try {
-        return await withLangfuseToolOutputTracingConfig(
-          this.langfuse,
-          () => invokeTitleChain(invokeConfig),
-          titleContext?.langfuse
+        return await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: titleContext?.langfuse,
+          }),
+          () => invokeTitleChain(invokeConfig)
         );
       } catch (_e) {
         // Fallback: strip callbacks to avoid EventStream tracer errors in certain environments
@@ -1420,10 +1428,12 @@ export class Run<_T extends t.BaseGraphState> {
         const safeConfig = Object.assign({}, rest, {
           callbacks: langfuseHandler ? [langfuseHandler] : [],
         });
-        return await withLangfuseToolOutputTracingConfig(
-          this.langfuse,
-          () => invokeTitleChain(safeConfig as Partial<RunnableConfig>),
-          titleContext?.langfuse
+        return await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: titleContext?.langfuse,
+          }),
+          () => invokeTitleChain(safeConfig as Partial<RunnableConfig>)
         );
       }
     } finally {

--- a/src/specs/deterministic-trace-id.test.ts
+++ b/src/specs/deterministic-trace-id.test.ts
@@ -1,18 +1,11 @@
-import { createHash } from 'node:crypto';
-import {
-  initializeLangfuseTracing,
-  runWithTraceIdSeed,
-} from '@/instrumentation';
+import { runWithTraceIdSeed, traceIdFromSeed } from '@/langfuseRuntimeContext';
+import { initializeLangfuseTracing } from '@/instrumentation';
 
 const langfuse = {
   publicKey: 'pk-lf-test',
   secretKey: 'sk-lf-test',
   baseUrl: 'http://localhost:3999',
 };
-
-/** sha256(seed) → first 32 hex chars; what `@langfuse/tracing` `createTraceId` produces. */
-const expectedTraceId = (seed: string): string =>
-  createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 32);
 
 describe('deterministic Langfuse trace ids', () => {
   it('derives the root trace id from the seed when run inside runWithTraceIdSeed', () => {
@@ -28,7 +21,7 @@ describe('deterministic Langfuse trace ids', () => {
       span.end();
     });
 
-    expect(traceId).toBe(expectedTraceId(seed));
+    expect(traceId).toBe(traceIdFromSeed(seed));
   });
 
   it('falls back to a random trace id when no seed is active', () => {
@@ -40,7 +33,7 @@ describe('deterministic Langfuse trace ids', () => {
     span.end();
 
     expect(traceId).toMatch(/^[0-9a-f]{32}$/);
-    expect(traceId).not.toBe(expectedTraceId('response-message-id-1234'));
+    expect(traceId).not.toBe(traceIdFromSeed('response-message-id-1234'));
   });
 
   it('runWithTraceIdSeed is a passthrough when the seed is undefined', () => {

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -10,6 +10,7 @@ const mockProcessorStarts: Array<{
   params: unknown;
   traceId: string;
 }> = [];
+const mockSpanAttributeSets: Array<Record<string, unknown>> = [];
 let mockProviderInput:
   | {
       spanProcessors?: Array<{
@@ -40,7 +41,9 @@ const createMockSpan = (traceIdOverride?: string) => {
       spanId,
       traceFlags: 1,
     })),
-    setAttributes: jest.fn(),
+    setAttributes: jest.fn((attributes: Record<string, unknown>) => {
+      mockSpanAttributeSets.push(attributes);
+    }),
     setStatus: jest.fn(),
     attributes: {},
   };
@@ -96,6 +99,7 @@ describe('Langfuse callback composition', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockProcessorStarts.length = 0;
+    mockSpanAttributeSets.length = 0;
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_BASE_URL;
@@ -298,6 +302,34 @@ describe('Langfuse callback composition', () => {
         }),
       ])
     );
+  });
+
+  it('attaches configured trace attributes to Langfuse callback spans', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-tenant-a',
+      secretKey: 'sk-tenant-a',
+      baseUrl: 'https://langfuse.proxy',
+      librechatTraceAttributes: {
+        'librechat.langfuse.tenant_export.enabled': 'true',
+        'librechat.langfuse.destination': 'eu',
+        ignored: '',
+      },
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['TenantAChain'] },
+      { input: 'tenant a' },
+      'lc-run-a'
+    );
+
+    expect(mockSpanAttributeSets).toContainEqual({
+      'librechat.langfuse.tenant_export.enabled': 'true',
+      'librechat.langfuse.destination': 'eu',
+    });
   });
 
   it('uses deterministic trace ids when tracing is configured from env only', async () => {

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,50 +1,105 @@
 import { HumanMessage } from '@langchain/core/messages';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
+import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import type * as t from '@/types';
+import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { Providers } from '@/common';
 import { Run } from '@/run';
 
-const mockSpan = {
-  end: jest.fn(),
-  spanContext: jest.fn(() => ({
-    traceId: 'trace-id',
-    spanId: 'span-id',
-    traceFlags: 1,
-  })),
-  setAttributes: jest.fn(),
-  setStatus: jest.fn(),
+const mockProcessorStarts: Array<{
+  params: unknown;
+  traceId: string;
+}> = [];
+let mockProviderInput:
+  | {
+      spanProcessors?: Array<{
+        onStart?: (span: unknown, parentContext: unknown) => void;
+        onEnd?: (span: unknown) => void;
+      }>;
+      idGenerator?: {
+        generateTraceId: () => string;
+        generateSpanId: () => string;
+      };
+    }
+  | undefined;
+
+const createMockSpan = (traceIdOverride?: string) => {
+  const traceId =
+    traceIdOverride ??
+    mockProviderInput?.idGenerator?.generateTraceId() ??
+    'trace-id';
+  const spanId = mockProviderInput?.idGenerator?.generateSpanId() ?? 'span-id';
+  const span = {
+    end: jest.fn(() => {
+      for (const processor of mockProviderInput?.spanProcessors ?? []) {
+        processor.onEnd?.(span);
+      }
+    }),
+    spanContext: jest.fn(() => ({
+      traceId,
+      spanId,
+      traceFlags: 1,
+    })),
+    setAttributes: jest.fn(),
+    setStatus: jest.fn(),
+    attributes: {},
+  };
+  for (const processor of mockProviderInput?.spanProcessors ?? []) {
+    processor.onStart?.(span, otelContext.active());
+  }
+  return span;
 };
-const mockStartSpan = jest.fn(() => mockSpan);
+
+const mockStartSpan = jest.fn(() => createMockSpan());
 const mockStartActiveSpan = jest.fn(
   (
     _name: string,
     _options: unknown,
-    _context: unknown,
-    callback: (span: typeof mockSpan) => unknown
-  ) => callback(mockSpan)
+    activeContext: Parameters<typeof otelTrace.getSpanContext>[0],
+    callback: (span: ReturnType<typeof createMockSpan>) => unknown
+  ) =>
+    callback(createMockSpan(otelTrace.getSpanContext(activeContext)?.traceId))
 );
 const mockForceFlush = jest.fn();
 const mockShutdown = jest.fn();
 
 jest.mock('@langfuse/otel', () => ({
-  LangfuseSpanProcessor: jest.fn().mockImplementation(() => ({})),
+  LangfuseSpanProcessor: jest.fn().mockImplementation((params) => ({
+    forceFlush: jest.fn(),
+    onEnd: jest.fn(),
+    onStart: jest.fn((span) => {
+      mockProcessorStarts.push({
+        params,
+        traceId: span.spanContext().traceId,
+      });
+    }),
+    shutdown: jest.fn(),
+  })),
   isDefaultExportSpan: jest.fn(() => false),
 }));
 
 jest.mock('@opentelemetry/sdk-trace-base', () => ({
-  BasicTracerProvider: jest.fn().mockImplementation(() => ({
-    forceFlush: mockForceFlush,
-    getTracer: jest.fn(() => ({
-      startActiveSpan: mockStartActiveSpan,
-      startSpan: mockStartSpan,
-    })),
-    shutdown: mockShutdown,
-  })),
+  BasicTracerProvider: jest.fn().mockImplementation((input) => {
+    mockProviderInput = input;
+    return {
+      forceFlush: mockForceFlush,
+      getTracer: jest.fn(() => ({
+        startActiveSpan: mockStartActiveSpan,
+        startSpan: mockStartSpan,
+      })),
+      shutdown: mockShutdown,
+    };
+  }),
 }));
 
 describe('Langfuse callback composition', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockProcessorStarts.length = 0;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_BASEURL;
     delete process.env.LANGFUSE_FORCE_FLUSH_ON_DISPOSE;
   });
 
@@ -180,6 +235,120 @@ describe('Langfuse callback composition', () => {
         secretKey: 'sk-agent',
         baseUrl: 'https://langfuse.agent',
       })
+    );
+  });
+
+  it('binds handler callback spans to their own Langfuse config and trace seed', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const tenantA = {
+      publicKey: 'pk-tenant-a',
+      secretKey: 'sk-tenant-a',
+      baseUrl: 'https://langfuse.proxy',
+      deterministicTraceId: true,
+    };
+    const tenantB = {
+      publicKey: 'pk-tenant-b',
+      secretKey: 'sk-tenant-b',
+      baseUrl: 'https://langfuse.proxy',
+      deterministicTraceId: true,
+    };
+    initializeLangfuseTracing(tenantA);
+    initializeLangfuseTracing(tenantB);
+
+    const handlerA = createLangfuseHandler({
+      langfuse: tenantA,
+      traceIdSeed: 'run-tenant-a',
+    });
+    const handlerB = createLangfuseHandler({
+      langfuse: tenantB,
+      traceIdSeed: 'run-tenant-b',
+    });
+
+    await Promise.all([
+      handlerA?.handleChainStart(
+        { lc: 1, type: 'not_implemented', id: ['TenantAChain'] },
+        { input: 'tenant a' },
+        'lc-run-a'
+      ),
+      handlerB?.handleChainStart(
+        { lc: 1, type: 'not_implemented', id: ['TenantBChain'] },
+        { input: 'tenant b' },
+        'lc-run-b'
+      ),
+    ]);
+
+    expect(mockProcessorStarts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            publicKey: 'pk-tenant-a',
+            secretKey: 'sk-tenant-a',
+            baseUrl: 'https://langfuse.proxy',
+          }),
+          traceId: traceIdFromSeed('run-tenant-a'),
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            publicKey: 'pk-tenant-b',
+            secretKey: 'sk-tenant-b',
+            baseUrl: 'https://langfuse.proxy',
+          }),
+          traceId: traceIdFromSeed('run-tenant-b'),
+        }),
+      ])
+    );
+  });
+
+  it('uses deterministic trace ids when tracing is configured from env only', async () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.env';
+
+    const runId = 'test-langfuse-env-deterministic-run';
+    const run = await Run.create<t.IState>({
+      runId,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'agent_abc123',
+            name: 'DWAINE',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            tools: [],
+          },
+        ],
+      },
+      langfuse: {
+        deterministicTraceId: true,
+        metadata: { 'librechat.tenant.id': 'tenant-env' },
+        tags: ['tenant:tenant-env'],
+      },
+      skipCleanup: true,
+    });
+
+    run.Graph?.overrideTestModel(['hello']);
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello')] },
+      {
+        configurable: { thread_id: 'thread-1', user_id: 'user-1' },
+        version: 'v2' as const,
+      }
+    );
+
+    expect(mockProcessorStarts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            publicKey: 'pk-env',
+            secretKey: 'sk-env',
+            baseUrl: 'https://langfuse.env',
+          }),
+          traceId: traceIdFromSeed(runId),
+        }),
+      ])
     );
   });
 

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -304,6 +304,61 @@ describe('Langfuse callback composition', () => {
     );
   });
 
+  it('preserves an active agent Langfuse runtime scope for callback-created spans', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const { withLangfuseRuntimeScope } = await import('@/langfuseRuntimeScope');
+    const runLangfuse = {
+      publicKey: 'pk-run',
+      secretKey: 'sk-run',
+      baseUrl: 'https://langfuse.run',
+      deterministicTraceId: true,
+    };
+    const agentLangfuse = {
+      publicKey: 'pk-agent',
+      secretKey: 'sk-agent',
+      baseUrl: 'https://langfuse.agent',
+      deterministicTraceId: true,
+    };
+    initializeLangfuseTracing(runLangfuse);
+    initializeLangfuseTracing(agentLangfuse);
+    const streamHandler = createLangfuseHandler({
+      langfuse: runLangfuse,
+      traceIdSeed: 'run-seed',
+    });
+
+    await withLangfuseRuntimeScope(
+      { langfuse: agentLangfuse, traceIdSeed: 'agent-seed' },
+      () =>
+        streamHandler?.handleChainStart(
+          { lc: 1, type: 'not_implemented', id: ['AgentScopedChain'] },
+          { input: 'agent scoped' },
+          'lc-agent-run'
+        )
+    );
+
+    expect(mockProcessorStarts).toContainEqual(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          publicKey: 'pk-agent',
+          secretKey: 'sk-agent',
+          baseUrl: 'https://langfuse.agent',
+        }),
+        traceId: traceIdFromSeed('agent-seed'),
+      })
+    );
+    expect(mockProcessorStarts).not.toContainEqual(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          publicKey: 'pk-run',
+          secretKey: 'sk-run',
+          baseUrl: 'https://langfuse.run',
+        }),
+        traceId: traceIdFromSeed('run-seed'),
+      })
+    );
+  });
+
   it('attaches configured trace attributes to Langfuse callback spans', async () => {
     const { createLangfuseHandler } = await import('@/langfuse');
     const { initializeLangfuseTracing } = await import('@/instrumentation');

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -1,6 +1,4 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { AIMessageChunk } from '@langchain/core/messages';
-import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import {
   hasLangfuseConfigCredentials,
   shouldCreateLangfuseHandler,
@@ -8,10 +6,8 @@ import {
   disposeLangfuseHandler,
   createLangfuseHandler,
 } from '@/langfuse';
-import { ContentTypes } from '@/common';
 
 const mockForceFlush = jest.fn();
-const mockHandleLLMEnd = jest.fn();
 
 jest.mock('@langfuse/langchain', () => {
   const CallbackHandler = jest.fn(function (
@@ -21,8 +17,6 @@ jest.mock('@langfuse/langchain', () => {
     this.params = params;
     this.name = 'LangfuseCallbackHandler';
   });
-  CallbackHandler.prototype.handleLLMEnd = (...args: unknown[]) =>
-    mockHandleLLMEnd(...args);
   return { CallbackHandler };
 });
 
@@ -41,7 +35,6 @@ describe('createLangfuseHandler', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockHandleLLMEnd.mockResolvedValue(undefined);
     process.env = { ...originalEnv };
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_SECRET_KEY;
@@ -126,141 +119,6 @@ describe('createLangfuseHandler', () => {
 
     expect(handler).toBeDefined();
     expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
-  });
-
-  it('adds exposed reasoning text to Langfuse generation output without mutating the message', async () => {
-    let tracedContent: AIMessageChunk['content'] | undefined;
-    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
-      const tracedMessage = llmOutput.generations[0][0] as unknown as {
-        message: AIMessageChunk;
-      };
-      tracedContent = tracedMessage.message.content;
-    });
-    const handler = createLangfuseHandler({
-      langfuse: {
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-    });
-    const message = new AIMessageChunk({
-      content: 'Visible answer.',
-      additional_kwargs: {
-        reasoning_content: 'Inspect the data first.',
-      },
-    });
-    const output: LLMResult = {
-      generations: [
-        [
-          {
-            text: 'Visible answer.',
-            message,
-          } as ChatGeneration,
-        ],
-      ],
-    };
-
-    await handler?.handleLLMEnd(output, 'run-1');
-
-    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
-    expect(tracedContent).toEqual([
-      {
-        type: ContentTypes.THINK,
-        think: 'Inspect the data first.',
-      },
-      {
-        type: ContentTypes.TEXT,
-        text: 'Visible answer.',
-      },
-    ]);
-    expect(message.content).toBe('Visible answer.');
-  });
-
-  it('does not duplicate Bedrock reasoning_content blocks already in message content', async () => {
-    let tracedContent: AIMessageChunk['content'] | undefined;
-    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
-      const tracedMessage = llmOutput.generations[0][0] as unknown as {
-        message: AIMessageChunk;
-      };
-      tracedContent = tracedMessage.message.content;
-    });
-    const content = [
-      {
-        type: ContentTypes.REASONING_CONTENT,
-        reasoningText: { text: 'Use Bedrock native reasoning.' },
-      },
-      { type: ContentTypes.TEXT, text: 'Visible answer.' },
-    ];
-    const handler = createLangfuseHandler({
-      langfuse: {
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-    });
-    const message = new AIMessageChunk({
-      content,
-      additional_kwargs: {
-        reasoning_content: 'Use Bedrock native reasoning.',
-      },
-    });
-    const output: LLMResult = {
-      generations: [
-        [
-          {
-            text: 'Visible answer.',
-            message,
-          } as ChatGeneration,
-        ],
-      ],
-    };
-
-    await handler?.handleLLMEnd(output, 'run-1');
-
-    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
-    expect(tracedContent).toBe(content);
-    expect(message.content).toBe(content);
-  });
-
-  it('passes Anthropic thinking blocks already in message content unchanged', async () => {
-    let tracedContent: AIMessageChunk['content'] | undefined;
-    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
-      const tracedMessage = llmOutput.generations[0][0] as unknown as {
-        message: AIMessageChunk;
-      };
-      tracedContent = tracedMessage.message.content;
-    });
-    const content = [
-      {
-        type: ContentTypes.THINKING,
-        thinking: 'Use Anthropic native thinking.',
-        signature: 'sig',
-      },
-      { type: ContentTypes.TEXT, text: 'Visible answer.' },
-    ];
-    const handler = createLangfuseHandler({
-      langfuse: {
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-    });
-    const message = new AIMessageChunk({
-      content,
-    });
-    const output: LLMResult = {
-      generations: [
-        [
-          {
-            text: 'Visible answer.',
-            message,
-          } as ChatGeneration,
-        ],
-      ],
-    };
-
-    await handler?.handleLLMEnd(output, 'run-1');
-
-    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
-    expect(tracedContent).toBe(content);
-    expect(message.content).toBe(content);
   });
 
   it('hydrates redaction-only config from env keys', () => {

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -1,4 +1,6 @@
 import { CallbackHandler } from '@langfuse/langchain';
+import { AIMessageChunk } from '@langchain/core/messages';
+import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import {
   hasLangfuseConfigCredentials,
   shouldCreateLangfuseHandler,
@@ -6,12 +8,23 @@ import {
   disposeLangfuseHandler,
   createLangfuseHandler,
 } from '@/langfuse';
+import { ContentTypes } from '@/common';
 
 const mockForceFlush = jest.fn();
+const mockHandleLLMEnd = jest.fn();
 
-jest.mock('@langfuse/langchain', () => ({
-  CallbackHandler: jest.fn().mockImplementation((params) => ({ params })),
-}));
+jest.mock('@langfuse/langchain', () => {
+  const CallbackHandler = jest.fn(function (
+    this: { params?: unknown; name?: string },
+    params: unknown
+  ) {
+    this.params = params;
+    this.name = 'LangfuseCallbackHandler';
+  });
+  CallbackHandler.prototype.handleLLMEnd = (...args: unknown[]) =>
+    mockHandleLLMEnd(...args);
+  return { CallbackHandler };
+});
 
 jest.mock('@langfuse/tracing', () => ({
   getLangfuseTracerProvider: jest.fn(() => ({
@@ -28,6 +41,7 @@ describe('createLangfuseHandler', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHandleLLMEnd.mockResolvedValue(undefined);
     process.env = { ...originalEnv };
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_SECRET_KEY;
@@ -112,6 +126,141 @@ describe('createLangfuseHandler', () => {
 
     expect(handler).toBeDefined();
     expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds exposed reasoning text to Langfuse generation output without mutating the message', async () => {
+    let tracedContent: AIMessageChunk['content'] | undefined;
+    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
+      const tracedMessage = llmOutput.generations[0][0] as unknown as {
+        message: AIMessageChunk;
+      };
+      tracedContent = tracedMessage.message.content;
+    });
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const message = new AIMessageChunk({
+      content: 'Visible answer.',
+      additional_kwargs: {
+        reasoning_content: 'Inspect the data first.',
+      },
+    });
+    const output: LLMResult = {
+      generations: [
+        [
+          {
+            text: 'Visible answer.',
+            message,
+          } as ChatGeneration,
+        ],
+      ],
+    };
+
+    await handler?.handleLLMEnd(output, 'run-1');
+
+    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
+    expect(tracedContent).toEqual([
+      {
+        type: ContentTypes.THINK,
+        think: 'Inspect the data first.',
+      },
+      {
+        type: ContentTypes.TEXT,
+        text: 'Visible answer.',
+      },
+    ]);
+    expect(message.content).toBe('Visible answer.');
+  });
+
+  it('does not duplicate Bedrock reasoning_content blocks already in message content', async () => {
+    let tracedContent: AIMessageChunk['content'] | undefined;
+    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
+      const tracedMessage = llmOutput.generations[0][0] as unknown as {
+        message: AIMessageChunk;
+      };
+      tracedContent = tracedMessage.message.content;
+    });
+    const content = [
+      {
+        type: ContentTypes.REASONING_CONTENT,
+        reasoningText: { text: 'Use Bedrock native reasoning.' },
+      },
+      { type: ContentTypes.TEXT, text: 'Visible answer.' },
+    ];
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const message = new AIMessageChunk({
+      content,
+      additional_kwargs: {
+        reasoning_content: 'Use Bedrock native reasoning.',
+      },
+    });
+    const output: LLMResult = {
+      generations: [
+        [
+          {
+            text: 'Visible answer.',
+            message,
+          } as ChatGeneration,
+        ],
+      ],
+    };
+
+    await handler?.handleLLMEnd(output, 'run-1');
+
+    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
+    expect(tracedContent).toBe(content);
+    expect(message.content).toBe(content);
+  });
+
+  it('passes Anthropic thinking blocks already in message content unchanged', async () => {
+    let tracedContent: AIMessageChunk['content'] | undefined;
+    mockHandleLLMEnd.mockImplementation(async (llmOutput: LLMResult) => {
+      const tracedMessage = llmOutput.generations[0][0] as unknown as {
+        message: AIMessageChunk;
+      };
+      tracedContent = tracedMessage.message.content;
+    });
+    const content = [
+      {
+        type: ContentTypes.THINKING,
+        thinking: 'Use Anthropic native thinking.',
+        signature: 'sig',
+      },
+      { type: ContentTypes.TEXT, text: 'Visible answer.' },
+    ];
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const message = new AIMessageChunk({
+      content,
+    });
+    const output: LLMResult = {
+      generations: [
+        [
+          {
+            text: 'Visible answer.',
+            message,
+          } as ChatGeneration,
+        ],
+      ],
+    };
+
+    await handler?.handleLLMEnd(output, 'run-1');
+
+    expect(mockHandleLLMEnd).toHaveBeenCalledTimes(1);
+    expect(tracedContent).toBe(content);
+    expect(message.content).toBe(content);
   });
 
   it('hydrates redaction-only config from env keys', () => {

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -33,16 +33,17 @@ type BasicTracerProviderInput = {
     shutdown?: unknown;
   }>;
 };
-type RoutingSpanProcessorForTest = BasicTracerProviderInput['spanProcessors'][0] & {
-  processors: Map<
-    string,
-    {
-      fallbackConfig?: {
-        enabled?: boolean;
-      };
-    }
-  >;
-};
+type RoutingSpanProcessorForTest =
+  BasicTracerProviderInput['spanProcessors'][0] & {
+    processors: Map<
+      string,
+      {
+        fallbackConfig?: {
+          enabled?: boolean;
+        };
+      }
+    >;
+  };
 const mockBasicTracerProvider = jest.fn(
   (_input?: BasicTracerProviderInput) => mockTracerProvider
 );
@@ -217,6 +218,25 @@ describe('Langfuse instrumentation', () => {
     expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(1);
   });
 
+  it('does not store raw secret keys in processor cache keys', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-cache',
+      secretKey: 'sk-cache-secret',
+      baseUrl: 'https://langfuse.cache',
+    });
+
+    const providerInput = mockBasicTracerProvider.mock
+      .calls[0][0] as BasicTracerProviderInput;
+    const routingProcessor = providerInput
+      .spanProcessors[0] as RoutingSpanProcessorForTest;
+    const processorKeys = Array.from(routingProcessor.processors.keys());
+
+    expect(processorKeys).toHaveLength(1);
+    expect(processorKeys[0]).toContain('secretKeyHash');
+    expect(processorKeys[0]).not.toContain('sk-cache-secret');
+  });
+
   it('passes explicit redaction config into the redacting processor fallback', async () => {
     const { initializeLangfuseTracing } = await import('@/instrumentation');
     initializeLangfuseTracing({
@@ -228,8 +248,8 @@ describe('Langfuse instrumentation', () => {
 
     const providerInput = mockBasicTracerProvider.mock
       .calls[0][0] as BasicTracerProviderInput;
-    const routingProcessor =
-      providerInput.spanProcessors[0] as RoutingSpanProcessorForTest;
+    const routingProcessor = providerInput
+      .spanProcessors[0] as RoutingSpanProcessorForTest;
     const childProcessors = Array.from(routingProcessor.processors.values());
     expect(childProcessors[0]?.fallbackConfig).toMatchObject({
       enabled: false,

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -1,0 +1,543 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { Context } from '@opentelemetry/api';
+import type * as t from '@/types';
+import { Constants, ContentTypes, Providers, TitleMethod } from '@/common';
+import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
+import { initializeLangfuseTracing } from '@/instrumentation';
+import { traceIdFromSeed } from '@/langfuseRuntimeContext';
+import * as providers from '@/llm/providers';
+import { Run } from '@/run';
+
+type ProcessorParams = {
+  publicKey?: string;
+  secretKey?: string;
+  baseUrl?: string;
+};
+
+type SpanStartRecord = {
+  name: string;
+  params: ProcessorParams;
+  traceId: string;
+};
+
+const spanStarts: SpanStartRecord[] = [];
+let providerInput:
+  | {
+      spanProcessors?: SpanProcessor[];
+      idGenerator?: {
+        generateTraceId: () => string;
+        generateSpanId: () => string;
+      };
+    }
+  | undefined;
+
+type MockSpan = {
+  name: string;
+  attributes: Record<string, unknown>;
+  addEvent: jest.Mock;
+  end: jest.Mock;
+  isRecording: jest.Mock;
+  recordException: jest.Mock;
+  setAttribute: jest.Mock;
+  setAttributes: jest.Mock;
+  setStatus: jest.Mock;
+  spanContext: jest.Mock;
+  updateName: jest.Mock;
+};
+
+function isOtelContext(value: unknown): value is Context {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { getValue?: unknown }).getValue === 'function'
+  );
+}
+
+function createMockSpan(
+  name: string,
+  parentContext: Context = otelContext.active()
+): MockSpan {
+  const parentTraceId = otelTrace.getSpanContext(parentContext)?.traceId;
+  const traceId =
+    parentTraceId ??
+    providerInput?.idGenerator?.generateTraceId() ??
+    'trace-id';
+  const spanId = providerInput?.idGenerator?.generateSpanId() ?? 'span-id';
+  const attributes: Record<string, unknown> = {};
+  const span = {} as MockSpan;
+  Object.assign(span, {
+    name,
+    attributes,
+    addEvent: jest.fn(),
+    end: jest.fn(() => {
+      for (const processor of providerInput?.spanProcessors ?? []) {
+        processor.onEnd(span as never);
+      }
+    }),
+    isRecording: jest.fn(() => true),
+    recordException: jest.fn(),
+    setAttribute: jest.fn((key: string, value: unknown) => {
+      attributes[key] = value;
+      return span;
+    }),
+    setAttributes: jest.fn((next: Record<string, unknown>) => {
+      Object.assign(attributes, next);
+      return span;
+    }),
+    setStatus: jest.fn(),
+    spanContext: jest.fn(() => ({
+      traceId,
+      spanId,
+      traceFlags: 1,
+    })),
+    updateName: jest.fn((nextName: string) => {
+      span.name = nextName;
+      return span;
+    }),
+  });
+
+  for (const processor of providerInput?.spanProcessors ?? []) {
+    processor.onStart(span as never, parentContext);
+  }
+  return span;
+}
+
+const startSpan = jest.fn((name: string, _options?: unknown, ctx?: unknown) =>
+  createMockSpan(name, isOtelContext(ctx) ? ctx : otelContext.active())
+);
+
+function getParentContextFromStartActiveSpanArgs(args: unknown[]): Context {
+  if (args.length >= 3 && isOtelContext(args[1])) {
+    return args[1];
+  }
+  if (args.length >= 4 && isOtelContext(args[2])) {
+    return args[2];
+  }
+  return otelContext.active();
+}
+
+const startActiveSpan = jest.fn((name: string, ...args: unknown[]) => {
+  const callback = args[args.length - 1];
+  const parentContext = getParentContextFromStartActiveSpanArgs(args);
+
+  if (typeof callback !== 'function') {
+    throw new Error('startActiveSpan mock expected a callback');
+  }
+
+  const span = createMockSpan(name, parentContext);
+  const activeContext = otelTrace.setSpan(parentContext, span as never);
+  return otelContext.with(activeContext, () => callback(span));
+});
+
+jest.mock('@langfuse/otel', () => ({
+  LangfuseSpanProcessor: jest.fn().mockImplementation((params) => ({
+    forceFlush: jest.fn(),
+    onEnd: jest.fn(),
+    onStart: jest.fn((span) => {
+      spanStarts.push({
+        name: span.name,
+        params,
+        traceId: span.spanContext().traceId,
+      });
+    }),
+    shutdown: jest.fn(),
+  })),
+  isDefaultExportSpan: jest.fn(() => false),
+}));
+
+jest.mock('@opentelemetry/sdk-trace-base', () => ({
+  BasicTracerProvider: jest.fn().mockImplementation((input) => {
+    providerInput = input;
+    return {
+      forceFlush: jest.fn(),
+      getTracer: jest.fn(() => ({
+        startActiveSpan,
+        startSpan,
+      })),
+      shutdown: jest.fn(),
+    };
+  }),
+}));
+
+const echoTool = tool(async ({ text }) => `echo:${text}`, {
+  name: 'echo',
+  description: 'Echoes text for routing tests.',
+  schema: z.object({ text: z.string() }),
+});
+
+const callerConfig: Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} = {
+  configurable: { thread_id: 'routing-thread', user_id: 'routing-user' },
+  streamMode: 'values',
+  version: 'v2',
+};
+
+function tenantLangfuse(tenantId: string): t.LangfuseConfig {
+  return {
+    enabled: true,
+    publicKey: `pk-${tenantId}`,
+    secretKey: `sk-${tenantId}`,
+    baseUrl: 'https://langfuse.proxy',
+    deterministicTraceId: true,
+    metadata: { tenantId },
+    tags: [`tenant:${tenantId}`],
+    toolNodeTracing: { enabled: true },
+    toolOutputTracing: { enabled: true },
+  };
+}
+
+function startsForTenant(tenantId: string): SpanStartRecord[] {
+  return spanStarts.filter(
+    (record) => record.params.publicKey === `pk-${tenantId}`
+  );
+}
+
+function expectTenantCredentials(
+  starts: SpanStartRecord[],
+  tenantId: string
+): void {
+  expect(starts).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          publicKey: `pk-${tenantId}`,
+          secretKey: `sk-${tenantId}`,
+          baseUrl: 'https://langfuse.proxy',
+        }),
+      }),
+    ])
+  );
+}
+
+function expectNamedSpansUseTraceId({
+  starts,
+  names,
+  traceId,
+}: {
+  starts: SpanStartRecord[];
+  names: string[];
+  traceId: string;
+}): void {
+  for (const name of names) {
+    const matching = starts.filter((record) => record.name === name);
+    expect(matching).not.toHaveLength(0);
+    expect(matching.map((record) => record.traceId)).toEqual(
+      expect.arrayContaining([traceId])
+    );
+    expect(
+      matching.filter((record) => record.traceId !== traceId)
+    ).toHaveLength(0);
+  }
+}
+
+function expectOnlyTraceIds(
+  starts: SpanStartRecord[],
+  allowedTraceIds: string[]
+): void {
+  const allowed = new Set(allowedTraceIds);
+  expect(starts.filter((record) => !allowed.has(record.traceId))).toHaveLength(
+    0
+  );
+}
+
+function expectNoCrossTenantTrace({
+  tenantId,
+  otherTenantId,
+  traceId,
+}: {
+  tenantId: string;
+  otherTenantId: string;
+  traceId: string;
+}): void {
+  expect(
+    startsForTenant(otherTenantId).filter(
+      (record) => record.traceId === traceId
+    )
+  ).toHaveLength(0);
+  expect(startsForTenant(tenantId)).toEqual(
+    expect.arrayContaining([expect.objectContaining({ traceId })])
+  );
+}
+
+function createAgent(tenantId: string): t.AgentInputs {
+  return {
+    agentId: 'parent',
+    name: `Parent ${tenantId}`,
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+    instructions: 'Use tools when asked.',
+    maxContextTokens: 8000,
+    tools: [echoTool],
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Researcher',
+        description: 'Answers delegated research tasks.',
+        agentInputs: {
+          agentId: 'researcher',
+          name: `Researcher ${tenantId}`,
+          provider: Providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'Answer delegated tasks briefly.',
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+}
+
+async function runTenantFlow(tenantId: string): Promise<void> {
+  const runId = `routing-${tenantId}`;
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      agents: [createAgent(tenantId)],
+    },
+    langfuse: tenantLangfuse(tenantId),
+    returnContent: true,
+    skipCleanup: true,
+  });
+
+  const toolCalls: ToolCall[] = [
+    {
+      id: `call_echo_${tenantId}`,
+      name: 'echo',
+      args: { text: `hello ${tenantId}` },
+      type: 'tool_call',
+    },
+    {
+      id: `call_subagent_${tenantId}`,
+      name: Constants.SUBAGENT,
+      args: {
+        description: `Research ${tenantId}`,
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call',
+    },
+  ];
+  run.Graph?.overrideTestModel(
+    [`Using tools for ${tenantId}.`, `Final answer for ${tenantId}.`],
+    1,
+    toolCalls
+  );
+
+  await run.processStream(
+    { messages: [new HumanMessage(`Use tools for ${tenantId}`)] },
+    {
+      ...callerConfig,
+      configurable: {
+        thread_id: `thread-${tenantId}`,
+        user_id: `user-${tenantId}`,
+      },
+    }
+  );
+
+  await run.generateTitle({
+    provider: Providers.OPENAI,
+    inputText: `Use tools for ${tenantId}`,
+    titleMethod: TitleMethod.COMPLETION,
+    contentParts: [
+      { type: ContentTypes.TEXT, text: `Final answer for ${tenantId}.` },
+    ],
+    chainOptions: {
+      configurable: {
+        thread_id: `thread-${tenantId}`,
+        user_id: `user-${tenantId}`,
+      },
+    },
+  });
+}
+
+const compactingTokenCounter: t.TokenCounter = (message) => {
+  if (message._getType() === 'system') {
+    return 1;
+  }
+  const content = message.content;
+  return typeof content === 'string'
+    ? content.length
+    : JSON.stringify(content).length;
+};
+
+async function runTenantSummarizationFlow(tenantId: string): Promise<void> {
+  const runId = `routing-summary-${tenantId}`;
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      agents: [
+        {
+          agentId: 'parent',
+          name: `Parent ${tenantId}`,
+          provider: Providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'Summarize when context is full.',
+          maxContextTokens: 120,
+          summarizationEnabled: true,
+          summarizationConfig: {
+            retainRecent: { turns: 0 },
+          },
+        },
+      ],
+    },
+    langfuse: tenantLangfuse(tenantId),
+    tokenCounter: compactingTokenCounter,
+    returnContent: true,
+    skipCleanup: true,
+  });
+
+  run.Graph?.overrideTestModel([`After summary for ${tenantId}.`], 1);
+
+  await run.processStream(
+    {
+      messages: [
+        new HumanMessage(`${tenantId} old context `.repeat(8)),
+        new HumanMessage(`${tenantId} more old context `.repeat(8)),
+        new HumanMessage(`Continue for ${tenantId}`),
+      ],
+    },
+    {
+      ...callerConfig,
+      configurable: {
+        thread_id: `summary-thread-${tenantId}`,
+        user_id: `summary-user-${tenantId}`,
+      },
+    }
+  );
+}
+
+describe('Langfuse per-run routing integration', () => {
+  let getChatModelClassSpy: jest.SpyInstance;
+  const originalGetChatModelClass = providers.getChatModelClass;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    spanStarts.length = 0;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_BASEURL;
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: ['provider response'] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('routes parallel root, model, tool, subagent, and title spans to each run config', async () => {
+    await Promise.all([runTenantFlow('tenant-a'), runTenantFlow('tenant-b')]);
+
+    for (const tenantId of ['tenant-a', 'tenant-b']) {
+      const starts = startsForTenant(tenantId);
+      const otherTenantId = tenantId === 'tenant-a' ? 'tenant-b' : 'tenant-a';
+      const runTraceId = traceIdFromSeed(`routing-${tenantId}`);
+      const titleTraceId = traceIdFromSeed(`title-routing-${tenantId}`);
+
+      expectTenantCredentials(starts, tenantId);
+      expectNamedSpansUseTraceId({
+        starts,
+        traceId: runTraceId,
+        names: [
+          `LibreChat Agent: Parent ${tenantId}`,
+          'FakeChatModel',
+          'tool_batch',
+          'subagent',
+        ],
+      });
+      expectNamedSpansUseTraceId({
+        starts,
+        traceId: titleTraceId,
+        names: [`LibreChat Title: Parent ${tenantId}`, 'CompletionTitleChain'],
+      });
+      expectNoCrossTenantTrace({
+        tenantId,
+        otherTenantId,
+        traceId: runTraceId,
+      });
+      expectNoCrossTenantTrace({
+        tenantId,
+        otherTenantId,
+        traceId: titleTraceId,
+      });
+    }
+  });
+
+  it('routes parallel summarization spans to each run config', async () => {
+    await Promise.all([
+      runTenantSummarizationFlow('tenant-a'),
+      runTenantSummarizationFlow('tenant-b'),
+    ]);
+
+    for (const tenantId of ['tenant-a', 'tenant-b']) {
+      const otherTenantId = tenantId === 'tenant-a' ? 'tenant-b' : 'tenant-a';
+      const starts = startsForTenant(tenantId);
+      const summaryTraceId = traceIdFromSeed(`routing-summary-${tenantId}`);
+
+      expectTenantCredentials(starts, tenantId);
+      expectOnlyTraceIds(starts, [summaryTraceId]);
+      expectNamedSpansUseTraceId({
+        starts,
+        traceId: summaryTraceId,
+        names: [
+          `LibreChat Agent: Parent ${tenantId}`,
+          'summarize=parent',
+          'summarization:cache_hit_compaction',
+          'FakeChatModel',
+        ],
+      });
+      expectNoCrossTenantTrace({
+        tenantId,
+        otherTenantId,
+        traceId: summaryTraceId,
+      });
+    }
+  });
+
+  it('routes spans from captured OTel context after ALS scope exits', () => {
+    const langfuse = tenantLangfuse('tenant-otel');
+    initializeLangfuseTracing(langfuse);
+
+    let capturedContext: Context | undefined;
+    withLangfuseRuntimeScope({ langfuse }, () => {
+      capturedContext = otelContext.active();
+    });
+
+    expect(capturedContext).toBeDefined();
+    createMockSpan('otel-context-only', capturedContext);
+
+    expect(startsForTenant('tenant-otel')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'otel-context-only',
+          params: expect.objectContaining({
+            publicKey: 'pk-tenant-otel',
+            secretKey: 'sk-tenant-otel',
+            baseUrl: 'https://langfuse.proxy',
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/src/specs/langfuse-runtime-context.test.ts
+++ b/src/specs/langfuse-runtime-context.test.ts
@@ -1,0 +1,92 @@
+import { context } from '@opentelemetry/api';
+import {
+  getLangfuseRuntimeConfig,
+  getLangfuseRuntimeToolOutputTracingConfig,
+  getTraceIdSeed,
+  runWithLangfuseRuntimeContext,
+  runWithTraceIdSeed,
+  traceIdFromSeed,
+} from '@/langfuseRuntimeContext';
+import {
+  resolveTraceIdSeedForSpan,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+
+describe('Langfuse runtime context', () => {
+  it('exposes tenant config and deterministic trace seed inside the scope', () => {
+    const langfuse = {
+      publicKey: 'pk-runtime',
+      secretKey: 'sk-runtime',
+      baseUrl: 'https://langfuse.runtime',
+    };
+
+    runWithLangfuseRuntimeContext(
+      { langfuse, traceIdSeed: 'run-runtime' },
+      () => {
+        expect(getLangfuseRuntimeConfig()).toBe(langfuse);
+        expect(getTraceIdSeed()).toBe('run-runtime');
+      }
+    );
+
+    expect(getLangfuseRuntimeConfig()).toBeUndefined();
+    expect(getTraceIdSeed()).toBeUndefined();
+  });
+
+  it('merges nested scopes without dropping inherited tenant config', () => {
+    const langfuse = {
+      publicKey: 'pk-parent',
+      secretKey: 'sk-parent',
+      baseUrl: 'https://langfuse.parent',
+    };
+
+    runWithLangfuseRuntimeContext(
+      { langfuse, traceIdSeed: 'parent-run' },
+      () => {
+        runWithTraceIdSeed('child-run', () => {
+          expect(getLangfuseRuntimeConfig()).toBe(langfuse);
+          expect(getTraceIdSeed()).toBe('child-run');
+        });
+
+        expect(getLangfuseRuntimeConfig()).toBe(langfuse);
+        expect(getTraceIdSeed()).toBe('parent-run');
+      }
+    );
+  });
+
+  it('carries resolved tool-output tracing config in the same runtime scope', () => {
+    const toolOutputTracing = {
+      enabled: false,
+      redactedToolNames: new Set(['search']),
+      redactedToolNameMatchMode: 'exact' as const,
+      redactionText: '[redacted]',
+    };
+
+    runWithLangfuseRuntimeContext({ toolOutputTracing }, () => {
+      expect(getLangfuseRuntimeToolOutputTracingConfig()).toBe(
+        toolOutputTracing
+      );
+    });
+
+    expect(getLangfuseRuntimeToolOutputTracingConfig()).toBeUndefined();
+  });
+
+  it('also exposes deterministic trace seeds through OTel context', () => {
+    withLangfuseRuntimeScope({ traceIdSeed: 'run-otel' }, () => {
+      expect(resolveTraceIdSeedForSpan(context.active())).toBe('run-otel');
+    });
+
+    expect(resolveTraceIdSeedForSpan(context.active())).toBeUndefined();
+  });
+
+  it('ignores empty trace seeds', () => {
+    const result = runWithTraceIdSeed(' ', () => getTraceIdSeed());
+
+    expect(result).toBeUndefined();
+  });
+
+  it('derives Langfuse-compatible deterministic trace ids', () => {
+    expect(traceIdFromSeed('run-runtime')).toBe(
+      '5b8a8af5718b2eba96b83a2b8fbfa7f4'
+    );
+  });
+});

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -1,15 +1,26 @@
+import { context } from '@opentelemetry/api';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { AIMessage, ToolMessage, HumanMessage } from '@langchain/core/messages';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { Context } from '@opentelemetry/api';
 import type { TPayload } from '@/types';
 import {
   LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
   redactLangfuseSpanToolOutputs,
-  resolveLangfuseConfig,
   shouldTraceToolNodeForLangfuse,
-  type ResolvedLangfuseToolOutputTracingConfig,
 } from '@/langfuseToolOutputTracing';
+import {
+  resolveLangfuseConfigForSpan,
+  resolveToolOutputTracingConfigForSpan,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+import {
+  runWithLangfuseRuntimeContext,
+  type ResolvedLangfuseToolOutputTracingConfig,
+} from '@/langfuseRuntimeContext';
+import { ensureOpenTelemetryContextManager } from '@/instrumentation';
+import { resolveLangfuseConfig } from '@/langfuseConfig';
 import { formatAgentMessages } from '@/messages/format';
 import { ContentTypes } from '@/common';
 
@@ -618,5 +629,93 @@ describe('Langfuse tool output tracing redaction', () => {
         redactionText: '[redacted]',
       },
     });
+  });
+
+  it('keeps OTEL context fallback for spans outside callback runtime scope', () => {
+    ensureOpenTelemetryContextManager();
+    const langfuse = {
+      publicKey: 'pk-context',
+      secretKey: 'sk-context',
+      baseUrl: 'https://langfuse.context',
+    };
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope({ langfuse }, () => {
+      capturedContext = context.active();
+    });
+
+    expect(capturedContext).toBeDefined();
+    expect(resolveLangfuseConfigForSpan(capturedContext!)).toBe(langfuse);
+  });
+
+  it('keeps OTEL tool-output fallback for spans outside callback runtime scope', () => {
+    ensureOpenTelemetryContextManager();
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope(
+      { toolOutputTracing: createConfig({ enabled: false }) },
+      () => {
+        capturedContext = context.active();
+      }
+    );
+
+    expect(capturedContext).toBeDefined();
+    expect(
+      resolveToolOutputTracingConfigForSpan(capturedContext!)
+    ).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it('prefers ALS runtime tenant config over OTEL fallback config', () => {
+    ensureOpenTelemetryContextManager();
+    const otelLangfuse = {
+      publicKey: 'pk-otel',
+      secretKey: 'sk-otel',
+      baseUrl: 'https://langfuse.otel',
+    };
+    const runtimeLangfuse = {
+      publicKey: 'pk-runtime',
+      secretKey: 'sk-runtime',
+      baseUrl: 'https://langfuse.runtime',
+    };
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope({ langfuse: otelLangfuse }, () => {
+      capturedContext = context.active();
+    });
+
+    runWithLangfuseRuntimeContext({ langfuse: runtimeLangfuse }, () => {
+      expect(resolveLangfuseConfigForSpan(capturedContext!)).toBe(
+        runtimeLangfuse
+      );
+    });
+  });
+
+  it('prefers ALS runtime tool-output config over OTEL fallback config', () => {
+    ensureOpenTelemetryContextManager();
+    const runtimeToolOutputTracing = {
+      enabled: false,
+      redactedToolNames: new Set(['runtime_tool']),
+      redactedToolNameMatchMode: 'exact' as const,
+      redactionText: '[runtime]',
+    };
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope(
+      { toolOutputTracing: createConfig({ enabled: true }) },
+      () => {
+        capturedContext = context.active();
+      }
+    );
+
+    runWithLangfuseRuntimeContext(
+      { toolOutputTracing: runtimeToolOutputTracing },
+      () => {
+        expect(resolveToolOutputTracingConfigForSpan(capturedContext!)).toBe(
+          runtimeToolOutputTracing
+        );
+      }
+    );
   });
 });

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -6,15 +6,16 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Context } from '@opentelemetry/api';
 import type { TPayload } from '@/types';
 import {
+  resolveLangfuseConfigForSpan,
+  resolveLangfuseRuntimeScope,
+  resolveToolOutputTracingConfigForSpan,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+import {
   LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
   redactLangfuseSpanToolOutputs,
   shouldTraceToolNodeForLangfuse,
 } from '@/langfuseToolOutputTracing';
-import {
-  resolveLangfuseConfigForSpan,
-  resolveToolOutputTracingConfigForSpan,
-  withLangfuseRuntimeScope,
-} from '@/langfuseRuntimeScope';
 import {
   runWithLangfuseRuntimeContext,
   type ResolvedLangfuseToolOutputTracingConfig,
@@ -665,6 +666,67 @@ describe('Langfuse tool output tracing redaction', () => {
     ).toMatchObject({
       enabled: false,
     });
+  });
+
+  it('honors env-only tool-output redaction in runtime scope', () => {
+    ensureOpenTelemetryContextManager();
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS = 'true';
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope(resolveLangfuseRuntimeScope({}), () => {
+      capturedContext = context.active();
+    });
+
+    expect(capturedContext).toBeDefined();
+    const config = resolveToolOutputTracingConfigForSpan(capturedContext!);
+    expect(config).toMatchObject({
+      enabled: false,
+      redactedToolNameMatchMode: 'exact',
+      redactionText: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(config?.redactedToolNames.size).toBe(0);
+  });
+
+  it('applies agent tool-output redaction override through runtime scope', () => {
+    ensureOpenTelemetryContextManager();
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope(
+      resolveLangfuseRuntimeScope({
+        runLangfuse: {
+          toolOutputTracing: {
+            enabled: true,
+            redactionText: '[agent redacted]',
+          },
+        },
+        langfuseOverlay: {
+          toolOutputTracing: {
+            enabled: false,
+          },
+        },
+      }),
+      () => {
+        capturedContext = context.active();
+      }
+    );
+
+    expect(capturedContext).toBeDefined();
+    const config = resolveToolOutputTracingConfigForSpan(capturedContext!);
+    expect(config).toMatchObject({
+      enabled: false,
+      redactionText: '[agent redacted]',
+    });
+
+    const span = createSpan('execute_sql', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(span, config!);
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      '[agent redacted]'
+    );
   });
 
   it('prefers ALS runtime tenant config over OTEL fallback config', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -6,22 +6,26 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Context } from '@opentelemetry/api';
 import type { TPayload } from '@/types';
 import {
+  LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  classifyLangfuseToolNodeSpan,
+  redactLangfuseSpanToolOutputs,
+  shouldTraceToolNodeForLangfuse,
+} from '@/langfuseToolOutputTracing';
+import {
   resolveLangfuseConfigForSpan,
   resolveLangfuseRuntimeScope,
   resolveToolOutputTracingConfigForSpan,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
 import {
-  LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
-  redactLangfuseSpanToolOutputs,
-  shouldTraceToolNodeForLangfuse,
-} from '@/langfuseToolOutputTracing';
-import {
   runWithLangfuseRuntimeContext,
   type ResolvedLangfuseToolOutputTracingConfig,
 } from '@/langfuseRuntimeContext';
+import {
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
 import { ensureOpenTelemetryContextManager } from '@/instrumentation';
-import { resolveLangfuseConfig } from '@/langfuseConfig';
 import { formatAgentMessages } from '@/messages/format';
 import { ContentTypes } from '@/common';
 
@@ -200,6 +204,20 @@ describe('Langfuse tool output tracing redaction', () => {
     });
 
     redactLangfuseSpanToolOutputs(span, createConfig());
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]).toBe(
+      'tool'
+    );
+  });
+
+  it('classifies LangGraph tool-node spans without requiring redaction config', () => {
+    const span = createSpan('tool_batch', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'span',
+      [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`]:
+        'tools=agent_1',
+    });
+
+    classifyLangfuseToolNodeSpan(span);
 
     expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]).toBe(
       'tool'
@@ -599,7 +617,12 @@ describe('Langfuse tool output tracing redaction', () => {
         secretKey: 'sk-run',
         baseUrl: 'https://langfuse.test',
         metadata: { tenantId: 'tenant-run' },
+        librechatTraceAttributes: {
+          'librechat.langfuse.destination': 'eu',
+          'librechat.langfuse.tenant_export.enabled': true,
+        },
         tags: ['tenant:tenant-run', 'shared'],
+        deterministicTraceId: true,
         toolNodeTracing: { enabled: true },
         toolOutputTracing: {
           enabled: true,
@@ -607,7 +630,13 @@ describe('Langfuse tool output tracing redaction', () => {
         },
       },
       {
+        publicKey: 'pk-agent',
+        secretKey: 'sk-agent',
+        baseUrl: 'https://langfuse.agent',
         metadata: { agentId: 'agent-1' },
+        librechatTraceAttributes: {
+          'librechat.langfuse.public_key': 'pk-agent',
+        },
         tags: ['shared', 'agent:agent-1'],
         toolOutputTracing: {
           enabled: false,
@@ -618,11 +647,17 @@ describe('Langfuse tool output tracing redaction', () => {
 
     expect(resolved).toMatchObject({
       enabled: true,
-      publicKey: 'pk-run',
-      secretKey: 'sk-run',
-      baseUrl: 'https://langfuse.test',
+      publicKey: 'pk-agent',
+      secretKey: 'sk-agent',
+      baseUrl: 'https://langfuse.agent',
       metadata: { tenantId: 'tenant-run', agentId: 'agent-1' },
+      librechatTraceAttributes: {
+        'librechat.langfuse.destination': 'eu',
+        'librechat.langfuse.tenant_export.enabled': true,
+        'librechat.langfuse.public_key': 'pk-agent',
+      },
       tags: ['tenant:tenant-run', 'shared', 'agent:agent-1'],
+      deterministicTraceId: true,
       toolNodeTracing: { enabled: true },
       toolOutputTracing: {
         enabled: false,
@@ -630,6 +665,158 @@ describe('Langfuse tool output tracing redaction', () => {
         redactionText: '[redacted]',
       },
     });
+  });
+
+  it('inherits deterministic trace ids when tenant config only supplies connection settings', () => {
+    const resolved = resolveLangfuseConfig(
+      {
+        deterministicTraceId: true,
+      },
+      {
+        publicKey: 'pk-tenant',
+        secretKey: 'sk-tenant',
+        baseUrl: 'https://langfuse.tenant',
+      }
+    );
+
+    expect(resolved).toMatchObject({
+      publicKey: 'pk-tenant',
+      secretKey: 'sk-tenant',
+      baseUrl: 'https://langfuse.tenant',
+      deterministicTraceId: true,
+    });
+  });
+
+  it('inherits application-level redaction when tenant config does not explicitly opt out', () => {
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS = 'true';
+    process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[app redacted]';
+
+    const config = resolveToolOutputTracingConfig(
+      {
+        publicKey: 'pk-tenant',
+        secretKey: 'sk-tenant',
+        baseUrl: 'https://langfuse.tenant',
+        toolOutputTracing: {
+          redactionText: '[tenant redacted]',
+        },
+      },
+      undefined
+    );
+
+    expect(config).toMatchObject({
+      enabled: false,
+      redactionText: '[tenant redacted]',
+    });
+  });
+
+  it('keeps application redacted tool names when tenant adds its own names', () => {
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAMES = 'run_sql';
+
+    const config = resolveToolOutputTracingConfig(
+      {
+        toolOutputTracing: {
+          redactedToolNames: ['execute_sql'],
+        },
+      },
+      {
+        toolOutputTracing: {
+          redactedToolNames: ['web_search'],
+        },
+      }
+    );
+
+    expect([...config.redactedToolNames].sort()).toEqual([
+      'execute_sql',
+      'run_sql',
+      'web_search',
+    ]);
+  });
+
+  it('keeps application partial redaction matching when tenant adds exact redaction config', () => {
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAME_MATCH_MODE = 'partial';
+
+    const config = resolveToolOutputTracingConfig(
+      {
+        toolOutputTracing: {
+          redactedToolNames: ['execute'],
+        },
+      },
+      {
+        toolOutputTracing: {
+          redactedToolNameMatchMode: 'exact',
+          redactedToolNames: ['web_search'],
+        },
+      }
+    );
+
+    expect(config.redactedToolNameMatchMode).toBe('partial');
+
+    const span = createSpan('execute_sql', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(span, config);
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+  });
+
+  it('lets tenant explicitly opt out of application-level redact-all outputs', () => {
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS = 'true';
+
+    const config = resolveToolOutputTracingConfig(
+      {
+        publicKey: 'pk-tenant',
+        secretKey: 'sk-tenant',
+        toolOutputTracing: {
+          enabled: true,
+        },
+      },
+      undefined
+    );
+
+    expect(config.enabled).toBe(true);
+    expect(config.redactedToolNames.size).toBe(0);
+  });
+
+  it('applies application-level redaction through tenant runtime scope unless tenant opts out', () => {
+    ensureOpenTelemetryContextManager();
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS = 'true';
+    process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[app redacted]';
+    let capturedContext: Context | undefined;
+
+    withLangfuseRuntimeScope(
+      resolveLangfuseRuntimeScope({
+        runLangfuse: {
+          publicKey: 'pk-tenant',
+          secretKey: 'sk-tenant',
+          baseUrl: 'https://langfuse.tenant',
+        },
+      }),
+      () => {
+        capturedContext = context.active();
+      }
+    );
+
+    expect(capturedContext).toBeDefined();
+    const config = resolveToolOutputTracingConfigForSpan(capturedContext!);
+    expect(config).toMatchObject({
+      enabled: false,
+      redactionText: '[app redacted]',
+    });
+
+    const span = createSpan('execute_sql', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'tenant secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(span, config!);
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      '[app redacted]'
+    );
   });
 
   it('keeps OTEL context fallback for spans outside callback runtime scope', () => {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -34,6 +34,10 @@ import type {
 } from '@/hooks';
 import type * as t from '@/types';
 import {
+  resolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+import {
   buildReferenceKey,
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
@@ -49,7 +53,6 @@ import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
-import { withLangfuseToolOutputTracingConfig } from '@/langfuseToolOutputTracing';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { toLangChainContent } from '@/messages/langchain';
@@ -577,10 +580,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     options?: Partial<RunnableConfig>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    return withLangfuseToolOutputTracingConfig(
-      this.runLangfuse,
-      () => super.invoke(input, options),
-      this.agentLangfuse
+    return withLangfuseRuntimeScope(
+      resolveLangfuseRuntimeScope({
+        runLangfuse: this.runLangfuse,
+        langfuseOverlay: this.agentLangfuse,
+      }),
+      () => super.invoke(input, options)
     );
   }
 

--- a/src/tools/__tests__/ToolNode.langfuse.test.ts
+++ b/src/tools/__tests__/ToolNode.langfuse.test.ts
@@ -1,18 +1,25 @@
-const mockWithLangfuseToolOutputTracingConfig = jest.fn(
-  (_runLangfuse: unknown, action: () => unknown, _agentLangfuse: unknown) =>
-    action()
+const mockWithLangfuseRuntimeScope = jest.fn(
+  (_scope: unknown, action: () => unknown) => action()
 );
+const mockResolvedScope = {
+  langfuse: {
+    toolOutputTracing: { enabled: false },
+  },
+};
+const mockResolveLangfuseRuntimeScope = jest.fn(() => mockResolvedScope);
 
-jest.mock('@/langfuseToolOutputTracing', () => ({
-  ...jest.requireActual('@/langfuseToolOutputTracing'),
-  withLangfuseToolOutputTracingConfig: mockWithLangfuseToolOutputTracingConfig,
+jest.mock('@/langfuseRuntimeScope', () => ({
+  ...jest.requireActual('@/langfuseRuntimeScope'),
+  resolveLangfuseRuntimeScope: mockResolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope: mockWithLangfuseRuntimeScope,
 }));
 
 import { ToolNode } from '../ToolNode';
 
 describe('ToolNode Langfuse redaction context', () => {
   beforeEach(() => {
-    mockWithLangfuseToolOutputTracingConfig.mockClear();
+    mockWithLangfuseRuntimeScope.mockClear();
+    mockResolveLangfuseRuntimeScope.mockClear();
   });
 
   it('uses a stable default run name for tracing', () => {
@@ -38,10 +45,13 @@ describe('ToolNode Langfuse redaction context', () => {
       'ToolNode only accepts AIMessages'
     );
 
-    expect(mockWithLangfuseToolOutputTracingConfig).toHaveBeenCalledWith(
+    expect(mockResolveLangfuseRuntimeScope).toHaveBeenCalledWith({
       runLangfuse,
-      expect.any(Function),
-      agentLangfuse
+      langfuseOverlay: agentLangfuse,
+    });
+    expect(mockWithLangfuseRuntimeScope).toHaveBeenCalledWith(
+      mockResolvedScope,
+      expect.any(Function)
     );
   });
 });

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -537,6 +537,15 @@ export interface LangfuseConfig {
   secretKey?: string;
   baseUrl?: string;
   metadata?: Record<string, string | number | boolean | null | undefined>;
+  /**
+   * Internal OTLP span attributes to attach to Langfuse observations before
+   * export. Intended for collector-side routing/filtering; strip these in the
+   * collector before forwarding spans to Langfuse.
+   */
+  librechatTraceAttributes?: Record<
+    string,
+    string | number | boolean | null | undefined
+  >;
   tags?: string[];
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -2,6 +2,24 @@ export function isPresent(value: string | null | undefined): value is string {
   return value != null && value !== '';
 }
 
+export function parseBooleanEnv(
+  value: string | undefined
+): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
 /**
  * Unescapes a c-escaped string
  * @param str The string to unescape


### PR DESCRIPTION
Parallel LibreChat agent runs need to export Langfuse traces to tenant-specific destinations in the same Node process. The existing Langfuse config was attached to OpenTelemetry context, but that context was not reliably present when LangChain later invoked callback span-start methods. As a result, `getContextLangfuseConfig(...)` could be missing at the exact point where the Langfuse exporter chooses auth/base URL, causing parallel runs to fall back to shared/env Langfuse config instead of their per-run tenant config.

This PR makes the per-run Langfuse config available at span creation time by capturing it in a runtime scope and re-entering that scope from the Langfuse callback start methods, so observations are created/exported with the correct run-specific Langfuse destination.

What changed:
- Refactor the previous `src/langfuseToolOutputTracing.ts` helper into shared runtime context/scope helpers that carry tool-output tracing settings, per-run Langfuse config, and deterministic trace id seed.
- Re-enter that scope inside Langfuse callback start methods before observations are created.
- Resolve Langfuse exporter config from the restored per-run scope/context at span start.
- Preserve existing env-based Langfuse behavior when no per-run config is provided.
- Keep deterministic trace ids cohesive by deriving root trace ids from the scoped run/message seed when `deterministicTraceId` is enabled.
- Hash Langfuse secret keys in internal processor cache keys instead of storing raw secrets.

Review map:
- `src/langfuseRuntimeContext.ts`, `src/langfuseRuntimeScope.ts`, `src/langfuseConfig.ts`: runtime/config helpers.
- `src/langfuse.ts`: callback wrapper that restores run scope before callback-created spans.
- `src/instrumentation.ts`: scoped exporter routing and deterministic trace id generation.
- `src/run.ts`, `src/graphs/Graph.ts`, `src/tools/ToolNode.ts`: call sites that enter the scoped runtime.
- Tests cover parallel tenant isolation, env-only Langfuse behavior, deterministic trace ids, OTel fallback context, and tool-output redaction.

Validation:
- `npm test -- src/specs/langfuse-runtime-context.test.ts src/specs/deterministic-trace-id.test.ts src/specs/langfuse-callbacks.test.ts src/specs/langfuse-instrumentation.test.ts src/specs/langfuse-tool-output-tracing.test.ts src/tools/__tests__/ToolNode.langfuse.test.ts src/tools/__tests__/ToolNode.langfuse-runtime.test.ts --runInBand`
- `npm run build`
- End-to-end LibreChat run on a local kind k8s cluster along with an otel collector showed central and tenant traces/scores routing correctly, including parallel tenant runs in the same process.