### PR TITLE
fix(openai): repair streamed tool-call indices for OpenAI-compatible providers

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -312,10 +312,130 @@ async function* filterOpenAIChatCompletionStream(
   }
 }
 
+type OpenAIToolCallDelta = NonNullable<
+  NonNullable<OpenAIChatCompletionChunk['choices'][number]['delta']['tool_calls']>[number]
+>;
+
+/**
+ * Per-stream state for repairing streamed tool-call indices from
+ * OpenAI-compatible providers that do not assign a distinct `index` to each
+ * parallel tool call. Ollama, for example, streams `index: 0` for every call
+ * in a parallel batch (ollama/ollama#15457), and older builds omit `index`
+ * entirely (ollama/ollama#7881). LangChain merges streamed tool-call chunks by
+ * `index`, so without unique indices the sibling calls collapse into one — the
+ * extra calls lose their arguments and fail tool-input schema validation
+ * before any request is sent. Repair keys on the provider's tool-call `id`
+ * (which the affected providers still emit), falling back to call-start signals
+ * when even the `id` is absent.
+ */
+type ToolCallReindexState = {
+  assignedById: Map<string, number>;
+  firstIdByProviderIndex: Map<number, string>;
+  next: number;
+  active: boolean;
+  seeded: boolean;
+  lastIndex?: number;
+};
+
+function createToolCallReindexState(): ToolCallReindexState {
+  return {
+    assignedById: new Map(),
+    firstIdByProviderIndex: new Map(),
+    next: 0,
+    active: false,
+    seeded: false,
+  };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
+}
+
+/**
+ * Rewrites `index` on a delta's tool calls so siblings stay distinct. Repair
+ * only engages once the provider's indices prove unreliable — two different
+ * ids sharing one index, or a call start with no index at all — so well-behaved
+ * streams (official OpenAI, modern Ollama) pass through byte-for-byte.
+ */
+function reindexToolCallDeltas(
+  toolCalls: OpenAIToolCallDelta[],
+  state: ToolCallReindexState
+): void {
+  for (const toolCall of toolCalls) {
+    const id = isNonEmptyString(toolCall.id) ? toolCall.id : undefined;
+    const providerIndex =
+      typeof toolCall.index === 'number' ? toolCall.index : undefined;
+    const isCallStart = id != null || isNonEmptyString(toolCall.function?.name);
+
+    if (!state.active) {
+      if (isCallStart && providerIndex == null) {
+        state.active = true;
+      } else if (id != null && providerIndex != null) {
+        const firstId = state.firstIdByProviderIndex.get(providerIndex);
+        if (firstId == null) {
+          state.firstIdByProviderIndex.set(providerIndex, id);
+        } else if (firstId !== id) {
+          state.active = true;
+        }
+      }
+    }
+
+    if (!state.active) {
+      if (providerIndex != null) {
+        state.lastIndex = providerIndex;
+      }
+      continue;
+    }
+
+    if (!state.seeded) {
+      // Preserve indices already emitted before repair engaged.
+      for (const [index, firstId] of state.firstIdByProviderIndex) {
+        if (!state.assignedById.has(firstId)) {
+          state.assignedById.set(firstId, index);
+          state.next = Math.max(state.next, index + 1);
+        }
+      }
+      state.seeded = true;
+    }
+
+    let assigned: number;
+    if (id != null) {
+      assigned = state.assignedById.get(id) ?? state.next++;
+      state.assignedById.set(id, assigned);
+    } else if (isCallStart) {
+      assigned = state.next++;
+    } else {
+      assigned = state.lastIndex ?? 0;
+    }
+    toolCall.index = assigned;
+    state.lastIndex = assigned;
+  }
+}
+
+/**
+ * Repairs unreliable streamed tool-call indices in place. Exported (underscore
+ * prefix) for unit testing.
+ */
+export async function* _reindexToolCallStream(
+  stream: AsyncIterable<OpenAIChatCompletionChunk>
+): AsyncGenerator<OpenAIChatCompletionChunk> {
+  const state = createToolCallReindexState();
+  for await (const chunk of stream) {
+    for (const choice of chunk.choices) {
+      const toolCalls = choice.delta.tool_calls;
+      if (toolCalls != null && toolCalls.length > 0) {
+        reindexToolCallDeltas(toolCalls, state);
+      }
+    }
+    yield chunk;
+  }
+}
+
 async function completionWithFilteredOpenAIStream(
   request: OpenAIChatCompletionRequest,
   requestOptions: OpenAICoreRequestOptions | undefined,
-  completionWithRetry: OpenAIChatCompletionRetry
+  completionWithRetry: OpenAIChatCompletionRetry,
+  options?: { reindexToolCalls?: boolean }
 ): Promise<OpenAIChatCompletionResult> {
   if (request.stream !== true) {
     return (await completionWithRetry(
@@ -325,9 +445,12 @@ async function completionWithFilteredOpenAIStream(
   }
 
   const stream = await completionWithRetry(request, requestOptions);
-  return filterOpenAIChatCompletionStream(
+  const filtered = filterOpenAIChatCompletionStream(
     stream as AsyncIterable<OpenAIChatCompletionStreamItem>
   );
+  return options?.reindexToolCalls === true
+    ? _reindexToolCallStream(filtered)
+    : filtered;
 }
 
 function attachLibreChatDeltaFields(
@@ -779,7 +902,10 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     return completionWithFilteredOpenAIStream(
       request,
       requestOptions,
-      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
+      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry,
+      // Official OpenAI streams tool calls with correct distinct indices;
+      // OpenAI-compatible endpoints (Ollama, etc.) may not — repair those.
+      { reindexToolCalls: !isOfficialOpenAIBaseURL(this.clientConfig.baseURL) }
     );
   }
 
@@ -1264,7 +1390,15 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     return completionWithFilteredOpenAIStream(
       request,
       requestOptions,
-      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
+      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry,
+      // First-party Azure shares OpenAI's stream contract; a proxy / Azure-
+      // compatible endpoint may not — repair tool-call indices for those.
+      {
+        reindexToolCalls: !isFirstPartyAzureEndpoint({
+          baseURL: this.clientConfig.baseURL,
+          azureOpenAIBasePath: this.azureOpenAIBasePath,
+        }),
+      }
     );
   }
 }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -318,23 +318,9 @@ type OpenAIToolCallDelta = NonNullable<
 
 /**
  * Per-choice state for repairing streamed tool-call indices from
- * OpenAI-compatible providers that do not assign a distinct `index` to each
- * parallel tool call. Ollama, for example, streams `index: 0` for every call
- * in a parallel batch (ollama/ollama#15457), and older builds omit `index`
- * entirely (ollama/ollama#7881). LangChain merges streamed tool-call chunks by
- * `index`, so without unique indices the sibling calls collapse into one — the
- * extra calls lose their arguments and fail tool-input schema validation
- * before any request is sent.
- *
- * A streamed tool call is delivered as a *start* delta (carrying `id` and/or
- * `function.name`) followed by argument-fragment deltas; in a streaming
- * protocol a call's fragments arrive before the next call starts. So we assign
- * one repaired index per start (keyed by `id` when present, otherwise by start
- * order) and route id-less fragments to the call currently in progress. Repair
- * only engages once the provider's indices prove unreliable — a call start with
- * no index, or a second start reusing an index already opened — so well-behaved
- * streams (official OpenAI, modern Ollama, first-party Azure) pass through
- * unchanged.
+ * OpenAI-compatible providers that reuse or omit `index` across parallel calls
+ * (e.g. Ollama streams `index: 0` for every call, ollama/ollama#15457), which
+ * makes LangChain merge siblings into one and drop their args.
  */
 type ToolCallReindexState = {
   indexById: Map<string, number>;
@@ -358,9 +344,10 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
- * Rewrites `index` on a delta's tool calls so siblings stay distinct, mutating
- * in place. No-op for well-behaved streams: while the provider's indices remain
- * trustworthy nothing is rewritten.
+ * Rewrites `index` in place so sibling calls stay distinct. A no-op until the
+ * provider's indices prove unreliable. A call is a start delta (`id`/name)
+ * followed by arg fragments; we assign one index per start (by `id`, else order)
+ * and route id-less fragments to the in-progress call.
  */
 function reindexToolCallDeltas(
   toolCalls: OpenAIToolCallDelta[],
@@ -372,8 +359,8 @@ function reindexToolCallDeltas(
       typeof toolCall.index === 'number' ? toolCall.index : undefined;
     const isStart = id != null || isNonEmptyString(toolCall.function?.name);
 
-    // A start with no index, or reusing an index already opened by an earlier
-    // start, means the provider's indices can't be trusted to separate calls.
+    // A start with no index, or one reusing an already-opened index, means the
+    // provider's indices can't separate calls.
     if (
       !state.unreliable &&
       isStart &&
@@ -386,8 +373,8 @@ function reindexToolCallDeltas(
     }
 
     if (!state.unreliable) {
-      // Trust provider indices; only track the in-progress call so an
-      // index-less fragment can still be anchored if one shows up.
+      // Indices still trusted; track the in-progress call to anchor any
+      // index-less fragment.
       if (providerIndex != null) {
         state.current = providerIndex;
         if (isStart) {
@@ -418,10 +405,8 @@ function reindexToolCallDeltas(
 }
 
 /**
- * Repairs unreliable streamed tool-call indices in place. State is kept per
- * `choice.index` because `tool_calls[].index` is scoped to a choice, so
- * concurrent choices (`n > 1`) never influence one another. Exported
- * (underscore prefix) for unit testing.
+ * Repairs streamed tool-call indices in place, keeping state per `choice.index`
+ * (so `n > 1` choices don't interfere). Exported for unit testing.
  */
 export async function* _reindexToolCallStream(
   stream: AsyncIterable<OpenAIChatCompletionChunk>
@@ -916,8 +901,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
       request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry,
-      // Official OpenAI streams tool calls with correct distinct indices;
-      // OpenAI-compatible endpoints (Ollama, etc.) may not — repair those.
+      // Repair tool-call indices only for OpenAI-compatible endpoints.
       { reindexToolCalls: !isOfficialOpenAIBaseURL(this.clientConfig.baseURL) }
     );
   }
@@ -1404,8 +1388,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
       request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry,
-      // First-party Azure shares OpenAI's stream contract; a proxy / Azure-
-      // compatible endpoint may not — repair tool-call indices for those.
+      // Repair tool-call indices only for non-first-party Azure endpoints.
       {
         reindexToolCalls: !isFirstPartyAzureEndpoint({
           baseURL: this.clientConfig.baseURL,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -301,12 +301,19 @@ function getOpenAIChatCompletionChunk(
 }
 
 async function* filterOpenAIChatCompletionStream(
-  stream: AsyncIterable<OpenAIChatCompletionStreamItem>
+  stream: AsyncIterable<OpenAIChatCompletionStreamItem>,
+  reindexToolCalls = false
 ): AsyncGenerator<OpenAIChatCompletionChunk> {
+  const stateByChoice = reindexToolCalls
+    ? new Map<number, ToolCallReindexState>()
+    : null;
   for await (const item of stream) {
     const chunk = getOpenAIChatCompletionChunk(item);
     if (chunk == null) {
       continue;
+    }
+    if (stateByChoice != null) {
+      reindexChunkToolCalls(chunk, stateByChoice);
     }
     yield chunk;
   }
@@ -324,19 +331,13 @@ type OpenAIToolCallDelta = NonNullable<
  */
 type ToolCallReindexState = {
   indexById: Map<string, number>;
-  startedProviderIndices: Set<number>;
   next: number;
   unreliable: boolean;
   current?: number;
 };
 
 function createToolCallReindexState(): ToolCallReindexState {
-  return {
-    indexById: new Map(),
-    startedProviderIndices: new Set(),
-    next: 0,
-    unreliable: false,
-  };
+  return { indexById: new Map(), next: 0, unreliable: false };
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -359,17 +360,14 @@ function reindexToolCallDeltas(
       typeof toolCall.index === 'number' ? toolCall.index : undefined;
     const isStart = id != null || isNonEmptyString(toolCall.function?.name);
 
-    // A start with no index, or one reusing an already-opened index, means the
-    // provider's indices can't separate calls.
+    // A start with no index, or one at/below the highest index already opened
+    // (`next` is the high-water mark), means indices can't separate calls.
     if (
       !state.unreliable &&
       isStart &&
-      (providerIndex == null || state.startedProviderIndices.has(providerIndex))
+      (providerIndex == null || providerIndex < state.next)
     ) {
       state.unreliable = true;
-    }
-    if (isStart && providerIndex != null) {
-      state.startedProviderIndices.add(providerIndex);
     }
 
     if (!state.unreliable) {
@@ -405,26 +403,35 @@ function reindexToolCallDeltas(
 }
 
 /**
- * Repairs streamed tool-call indices in place, keeping state per `choice.index`
- * (so `n > 1` choices don't interfere). Exported for unit testing.
+ * Repairs one chunk's tool-call indices in place. State is kept per
+ * `choice.index` (`tool_calls[].index` is choice-scoped) so `n > 1` choices
+ * don't interfere.
  */
+function reindexChunkToolCalls(
+  chunk: OpenAIChatCompletionChunk,
+  stateByChoice: Map<number, ToolCallReindexState>
+): void {
+  for (const choice of chunk.choices) {
+    const toolCalls = choice.delta.tool_calls;
+    if (toolCalls == null || toolCalls.length === 0) {
+      continue;
+    }
+    let state = stateByChoice.get(choice.index);
+    if (state == null) {
+      state = createToolCallReindexState();
+      stateByChoice.set(choice.index, state);
+    }
+    reindexToolCallDeltas(toolCalls, state);
+  }
+}
+
+/** Standalone reindex generator, exported for unit testing. */
 export async function* _reindexToolCallStream(
   stream: AsyncIterable<OpenAIChatCompletionChunk>
 ): AsyncGenerator<OpenAIChatCompletionChunk> {
   const stateByChoice = new Map<number, ToolCallReindexState>();
   for await (const chunk of stream) {
-    for (const choice of chunk.choices) {
-      const toolCalls = choice.delta.tool_calls;
-      if (toolCalls == null || toolCalls.length === 0) {
-        continue;
-      }
-      let state = stateByChoice.get(choice.index);
-      if (state == null) {
-        state = createToolCallReindexState();
-        stateByChoice.set(choice.index, state);
-      }
-      reindexToolCallDeltas(toolCalls, state);
-    }
+    reindexChunkToolCalls(chunk, stateByChoice);
     yield chunk;
   }
 }
@@ -443,12 +450,10 @@ async function completionWithFilteredOpenAIStream(
   }
 
   const stream = await completionWithRetry(request, requestOptions);
-  const filtered = filterOpenAIChatCompletionStream(
-    stream as AsyncIterable<OpenAIChatCompletionStreamItem>
+  return filterOpenAIChatCompletionStream(
+    stream as AsyncIterable<OpenAIChatCompletionStreamItem>,
+    options?.reindexToolCalls === true
   );
-  return options?.reindexToolCalls === true
-    ? _reindexToolCallStream(filtered)
-    : filtered;
 }
 
 function attachLibreChatDeltaFields(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -317,33 +317,39 @@ type OpenAIToolCallDelta = NonNullable<
 >;
 
 /**
- * Per-stream state for repairing streamed tool-call indices from
+ * Per-choice state for repairing streamed tool-call indices from
  * OpenAI-compatible providers that do not assign a distinct `index` to each
  * parallel tool call. Ollama, for example, streams `index: 0` for every call
  * in a parallel batch (ollama/ollama#15457), and older builds omit `index`
  * entirely (ollama/ollama#7881). LangChain merges streamed tool-call chunks by
  * `index`, so without unique indices the sibling calls collapse into one — the
  * extra calls lose their arguments and fail tool-input schema validation
- * before any request is sent. Repair keys on the provider's tool-call `id`
- * (which the affected providers still emit), falling back to call-start signals
- * when even the `id` is absent.
+ * before any request is sent.
+ *
+ * A streamed tool call is delivered as a *start* delta (carrying `id` and/or
+ * `function.name`) followed by argument-fragment deltas; in a streaming
+ * protocol a call's fragments arrive before the next call starts. So we assign
+ * one repaired index per start (keyed by `id` when present, otherwise by start
+ * order) and route id-less fragments to the call currently in progress. Repair
+ * only engages once the provider's indices prove unreliable — a call start with
+ * no index, or a second start reusing an index already opened — so well-behaved
+ * streams (official OpenAI, modern Ollama, first-party Azure) pass through
+ * unchanged.
  */
 type ToolCallReindexState = {
-  assignedById: Map<string, number>;
-  firstIdByProviderIndex: Map<number, string>;
+  indexById: Map<string, number>;
+  startedProviderIndices: Set<number>;
   next: number;
-  active: boolean;
-  seeded: boolean;
-  lastIndex?: number;
+  unreliable: boolean;
+  current?: number;
 };
 
 function createToolCallReindexState(): ToolCallReindexState {
   return {
-    assignedById: new Map(),
-    firstIdByProviderIndex: new Map(),
+    indexById: new Map(),
+    startedProviderIndices: new Set(),
     next: 0,
-    active: false,
-    seeded: false,
+    unreliable: false,
   };
 }
 
@@ -352,10 +358,9 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
- * Rewrites `index` on a delta's tool calls so siblings stay distinct. Repair
- * only engages once the provider's indices prove unreliable — two different
- * ids sharing one index, or a call start with no index at all — so well-behaved
- * streams (official OpenAI, modern Ollama) pass through byte-for-byte.
+ * Rewrites `index` on a delta's tool calls so siblings stay distinct, mutating
+ * in place. No-op for well-behaved streams: while the provider's indices remain
+ * trustworthy nothing is rewritten.
  */
 function reindexToolCallDeltas(
   toolCalls: OpenAIToolCallDelta[],
@@ -365,67 +370,75 @@ function reindexToolCallDeltas(
     const id = isNonEmptyString(toolCall.id) ? toolCall.id : undefined;
     const providerIndex =
       typeof toolCall.index === 'number' ? toolCall.index : undefined;
-    const isCallStart = id != null || isNonEmptyString(toolCall.function?.name);
+    const isStart = id != null || isNonEmptyString(toolCall.function?.name);
 
-    if (!state.active) {
-      if (isCallStart && providerIndex == null) {
-        state.active = true;
-      } else if (id != null && providerIndex != null) {
-        const firstId = state.firstIdByProviderIndex.get(providerIndex);
-        if (firstId == null) {
-          state.firstIdByProviderIndex.set(providerIndex, id);
-        } else if (firstId !== id) {
-          state.active = true;
-        }
-      }
+    // A start with no index, or reusing an index already opened by an earlier
+    // start, means the provider's indices can't be trusted to separate calls.
+    if (
+      !state.unreliable &&
+      isStart &&
+      (providerIndex == null || state.startedProviderIndices.has(providerIndex))
+    ) {
+      state.unreliable = true;
+    }
+    if (isStart && providerIndex != null) {
+      state.startedProviderIndices.add(providerIndex);
     }
 
-    if (!state.active) {
+    if (!state.unreliable) {
+      // Trust provider indices; only track the in-progress call so an
+      // index-less fragment can still be anchored if one shows up.
       if (providerIndex != null) {
-        state.lastIndex = providerIndex;
+        state.current = providerIndex;
+        if (isStart) {
+          if (id != null) {
+            state.indexById.set(id, providerIndex);
+          }
+          state.next = Math.max(state.next, providerIndex + 1);
+        }
+      } else if (state.current != null) {
+        toolCall.index = state.current;
       }
       continue;
     }
 
-    if (!state.seeded) {
-      // Preserve indices already emitted before repair engaged.
-      for (const [index, firstId] of state.firstIdByProviderIndex) {
-        if (!state.assignedById.has(firstId)) {
-          state.assignedById.set(firstId, index);
-          state.next = Math.max(state.next, index + 1);
-        }
-      }
-      state.seeded = true;
-    }
-
     let assigned: number;
     if (id != null) {
-      assigned = state.assignedById.get(id) ?? state.next++;
-      state.assignedById.set(id, assigned);
-    } else if (isCallStart) {
+      assigned = state.indexById.get(id) ?? state.next++;
+      state.indexById.set(id, assigned);
+      state.current = assigned;
+    } else if (isStart) {
       assigned = state.next++;
+      state.current = assigned;
     } else {
-      assigned = state.lastIndex ?? 0;
+      assigned = state.current ?? 0;
     }
     toolCall.index = assigned;
-    state.lastIndex = assigned;
   }
 }
 
 /**
- * Repairs unreliable streamed tool-call indices in place. Exported (underscore
- * prefix) for unit testing.
+ * Repairs unreliable streamed tool-call indices in place. State is kept per
+ * `choice.index` because `tool_calls[].index` is scoped to a choice, so
+ * concurrent choices (`n > 1`) never influence one another. Exported
+ * (underscore prefix) for unit testing.
  */
 export async function* _reindexToolCallStream(
   stream: AsyncIterable<OpenAIChatCompletionChunk>
 ): AsyncGenerator<OpenAIChatCompletionChunk> {
-  const state = createToolCallReindexState();
+  const stateByChoice = new Map<number, ToolCallReindexState>();
   for await (const chunk of stream) {
     for (const choice of chunk.choices) {
       const toolCalls = choice.delta.tool_calls;
-      if (toolCalls != null && toolCalls.length > 0) {
-        reindexToolCallDeltas(toolCalls, state);
+      if (toolCalls == null || toolCalls.length === 0) {
+        continue;
       }
+      let state = stateByChoice.get(choice.index);
+      if (state == null) {
+        state = createToolCallReindexState();
+        stateByChoice.set(choice.index, state);
+      }
+      reindexToolCallDeltas(toolCalls, state);
     }
     yield chunk;
   }

--- a/src/llm/openai/toolCallReindex.test.ts
+++ b/src/llm/openai/toolCallReindex.test.ts
@@ -131,4 +131,59 @@ describe('streamed tool-call index repair', () => {
     // concatenated args are not valid JSON.
     expect(mergeByIndex(raw)).toEqual([null]);
   });
+
+  test('repairs id-less starts that reuse an index, via the name signal', async () => {
+    // No tool-call ids at all; each call start carries function.name and the
+    // provider stamps index 0 on every delta.
+    const out = await reindex([
+      [{ index: 0, type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ index: 0, function: { arguments: '{"message":"alpha"}' } }],
+      [{ index: 0, type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ index: 0, function: { arguments: '{"message":"beta"}' } }],
+    ]);
+    expect(mergeByIndex(out)).toEqual([{ message: 'alpha' }, { message: 'beta' }]);
+  });
+
+  test('repairs index-less argument fragments when starts carry distinct indices', async () => {
+    const out = await reindex([
+      [{ index: 0, id: 'a', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ function: { arguments: '{"message":"alpha"}' } }],
+      [{ index: 1, id: 'b', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ function: { arguments: '{"message":"beta"}' } }],
+    ]);
+    expect(mergeByIndex(out)).toEqual([{ message: 'alpha' }, { message: 'beta' }]);
+  });
+
+  test('keeps repair state separate per choice (n > 1)', async () => {
+    // Two choices each open a call at provider index 0. Shared state would
+    // mis-detect a reused index and bump choice 1 to index 1.
+    async function* source(): AsyncGenerator<Record<string, unknown>> {
+      yield {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        created: 1,
+        model: 'qwen',
+        choices: [
+          { index: 0, delta: { tool_calls: [{ index: 0, id: 'x', type: 'function', function: { name: TOOL, arguments: '{"message":"alpha"}' } }] }, finish_reason: null },
+          { index: 1, delta: { tool_calls: [{ index: 0, id: 'y', type: 'function', function: { name: TOOL, arguments: '{"message":"beta"}' } }] }, finish_reason: null },
+        ],
+      };
+    }
+    const choiceIndices = new Map<number, number[]>();
+    for await (const chunk of _reindexToolCallStream(
+      source() as unknown as AsyncIterable<never>,
+    )) {
+      const choices = (chunk as unknown as Record<string, unknown>)
+        .choices as Array<{ index: number; delta?: { tool_calls?: ToolCallDelta[] } }>;
+      for (const choice of choices) {
+        const indices = choiceIndices.get(choice.index) ?? [];
+        for (const tc of choice.delta?.tool_calls ?? []) {
+          indices.push(tc.index as number);
+        }
+        choiceIndices.set(choice.index, indices);
+      }
+    }
+    expect(choiceIndices.get(0)).toEqual([0]);
+    expect(choiceIndices.get(1)).toEqual([0]);
+  });
 });

--- a/src/llm/openai/toolCallReindex.test.ts
+++ b/src/llm/openai/toolCallReindex.test.ts
@@ -2,13 +2,9 @@ import { expect, test, describe } from '@jest/globals';
 import { _reindexToolCallStream } from './index';
 
 /**
- * Regression coverage for OpenAI-compatible providers (e.g. Ollama) that stream
- * parallel tool calls without a distinct, reliable `index` per call.
- * See ollama/ollama#15457 (index always 0) and #7881 (no index). Downstream,
- * LangChain merges streamed tool-call chunks by `index`, so without repair the
- * sibling calls collapse and the extra calls lose their arguments — surfacing
- * as "Received tool input did not match expected schema" before any request is
- * sent (LibreChat #13885).
+ * Coverage for OpenAI-compatible providers that stream parallel tool calls with
+ * unreliable `index` (e.g. Ollama, ollama/ollama#15457), which makes LangChain
+ * merge siblings and drop their args.
  */
 
 const TOOL = 'echo_mcp_everything-test';
@@ -50,10 +46,9 @@ async function reindex(chunks: ToolCallDelta[][]): Promise<ToolCallDelta[]> {
 }
 
 /**
- * Merge tool-call deltas the way an `index`-keyed accumulator (LangChain,
- * Vercel AI SDK) does: concatenate argument fragments per index, then parse.
- * Returns the parsed args per call ordered by index, or `null` for a call
- * whose accumulated arguments are not valid JSON.
+ * Merge deltas the way an `index`-keyed accumulator (LangChain) does:
+ * concatenate args per index and parse. Returns parsed args per call by index,
+ * or `null` when the accumulated args aren't valid JSON.
  */
 function mergeByIndex(deltas: ToolCallDelta[]): Array<unknown> {
   const byIndex = new Map<number, { args: string }>();

--- a/src/llm/openai/toolCallReindex.test.ts
+++ b/src/llm/openai/toolCallReindex.test.ts
@@ -1,0 +1,134 @@
+import { expect, test, describe } from '@jest/globals';
+import { _reindexToolCallStream } from './index';
+
+/**
+ * Regression coverage for OpenAI-compatible providers (e.g. Ollama) that stream
+ * parallel tool calls without a distinct, reliable `index` per call.
+ * See ollama/ollama#15457 (index always 0) and #7881 (no index). Downstream,
+ * LangChain merges streamed tool-call chunks by `index`, so without repair the
+ * sibling calls collapse and the extra calls lose their arguments — surfacing
+ * as "Received tool input did not match expected schema" before any request is
+ * sent (LibreChat #13885).
+ */
+
+const TOOL = 'echo_mcp_everything-test';
+
+type ToolCallDelta = {
+  index?: number;
+  id?: string;
+  type?: 'function';
+  function?: { name?: string; arguments?: string };
+};
+
+function chunkWith(toolCalls: ToolCallDelta[]): Record<string, unknown> {
+  return {
+    id: 'chatcmpl-1',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'qwen',
+    choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: null }],
+  };
+}
+
+async function reindex(chunks: ToolCallDelta[][]): Promise<ToolCallDelta[]> {
+  async function* source(): AsyncGenerator<Record<string, unknown>> {
+    for (const toolCalls of chunks) {
+      yield chunkWith(toolCalls);
+    }
+  }
+  const flat: ToolCallDelta[] = [];
+  for await (const chunk of _reindexToolCallStream(
+    source() as unknown as AsyncIterable<never>,
+  )) {
+    const choices = (chunk as unknown as Record<string, unknown>)
+      .choices as Array<{ delta?: { tool_calls?: ToolCallDelta[] } }>;
+    for (const choice of choices) {
+      flat.push(...(choice.delta?.tool_calls ?? []));
+    }
+  }
+  return flat;
+}
+
+/**
+ * Merge tool-call deltas the way an `index`-keyed accumulator (LangChain,
+ * Vercel AI SDK) does: concatenate argument fragments per index, then parse.
+ * Returns the parsed args per call ordered by index, or `null` for a call
+ * whose accumulated arguments are not valid JSON.
+ */
+function mergeByIndex(deltas: ToolCallDelta[]): Array<unknown> {
+  const byIndex = new Map<number, { args: string }>();
+  for (const d of deltas) {
+    const index = typeof d.index === 'number' ? d.index : 0;
+    const bucket = byIndex.get(index) ?? { args: '' };
+    bucket.args += d.function?.arguments ?? '';
+    byIndex.set(index, bucket);
+  }
+  return [...byIndex.keys()]
+    .sort((a, b) => a - b)
+    .map((index) => {
+      try {
+        return JSON.parse(byIndex.get(index)!.args) as unknown;
+      } catch {
+        return null;
+      }
+    });
+}
+
+describe('streamed tool-call index repair', () => {
+  test('repairs index: 0 on every call, fragmented args (ollama/ollama#15457)', async () => {
+    const out = await reindex([
+      [{ index: 0, id: 'a', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ index: 0, function: { arguments: '{"message":' } }],
+      [{ index: 0, function: { arguments: '"alpha"}' } }],
+      [{ index: 0, id: 'b', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ index: 0, function: { arguments: '{"message":' } }],
+      [{ index: 0, function: { arguments: '"beta"}' } }],
+      [{ index: 0, id: 'c', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ index: 0, function: { arguments: '{"message":' } }],
+      [{ index: 0, function: { arguments: '"gamma"}' } }],
+    ]);
+    expect(mergeByIndex(out)).toEqual([
+      { message: 'alpha' },
+      { message: 'beta' },
+      { message: 'gamma' },
+    ]);
+  });
+
+  test('repairs missing index, fragmented args (ollama/ollama#7881)', async () => {
+    const out = await reindex([
+      [{ id: 'a', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ function: { arguments: '{"message":"alpha"}' } }],
+      [{ id: 'b', type: 'function', function: { name: TOOL, arguments: '' } }],
+      [{ function: { arguments: '{"message":"beta"}' } }],
+    ]);
+    expect(mergeByIndex(out)).toEqual([{ message: 'alpha' }, { message: 'beta' }]);
+  });
+
+  test('leaves well-behaved streams (distinct indices) untouched', async () => {
+    const input: ToolCallDelta[][] = [
+      [{ index: 0, id: 'a', type: 'function', function: { name: TOOL, arguments: '{"message":' } }],
+      [{ index: 0, function: { arguments: '"alpha"}' } }],
+      [{ index: 1, id: 'b', type: 'function', function: { name: TOOL, arguments: '{"message":"beta"}' } }],
+      [{ index: 2, id: 'c', type: 'function', function: { name: TOOL, arguments: '{"message":"gamma"}' } }],
+    ];
+    const out = await reindex(input.map((c) => JSON.parse(JSON.stringify(c))));
+    expect(out.map((tc) => tc.index)).toEqual([0, 0, 1, 2]);
+    expect(mergeByIndex(out)).toEqual([
+      { message: 'alpha' },
+      { message: 'beta' },
+      { message: 'gamma' },
+    ]);
+  });
+
+  test('without repair, fragmented args + shared index 0 collapse (documents the bug)', () => {
+    const raw: ToolCallDelta[] = [
+      { index: 0, id: 'a', type: 'function', function: { name: TOOL, arguments: '' } },
+      { index: 0, function: { arguments: '{"message":"alpha"}' } },
+      { index: 0, id: 'b', type: 'function', function: { name: TOOL, arguments: '' } },
+      { index: 0, function: { arguments: '{"message":"beta"}' } },
+    ];
+    // Index-keyed merge with no repair collapses both calls into index 0, whose
+    // concatenated args are not valid JSON.
+    expect(mergeByIndex(raw)).toEqual([null]);
+  });
+});


### PR DESCRIPTION
## Problem

OpenAI-compatible endpoints don't always assign a distinct `index` to each parallel tool call in a streamed response:

- Ollama streams `index: 0` for **every** call in a parallel batch ([ollama/ollama#15457](https://github.com/ollama/ollama/issues/15457))
- older builds omit `index` entirely ([ollama/ollama#7881](https://github.com/ollama/ollama/issues/7881))

LangChain merges streamed tool-call chunks by `index`. When sibling calls share (or lack) an index **and** their arguments arrive in fragments, the continuation fragments collapse into the first call — the other calls end up with empty/garbled args and fail tool-input schema validation with `Received tool input did not match expected schema` **before any request is sent**.

This is the client-side mechanism behind [LibreChat #13885](https://github.com/danny-avila/LibreChat/issues/13885) (parallel MCP tool calls fail; the same calls succeed sequentially — a lone call has no sibling to collapse with).

## Fix

Repair the indices in the chat-completions stream **before** LangChain merges chunks (`_reindexToolCallStream` in `src/llm/openai/index.ts`):

- key on the provider's tool-call `id` (which the affected providers still emit), falling back to call-start signals when the `id` is absent;
- repair **only engages** once the provider's indices prove unreliable (two ids sharing one index, or a call start with no index), so well-behaved streams — official OpenAI, modern Ollama, first-party Azure — pass through unchanged;
- gated to non-official OpenAI / non-first-party Azure endpoints.

## Tests

- New `src/llm/openai/toolCallReindex.test.ts` (4 tests): repairs `index: 0`-for-all and missing-index streams, leaves well-behaved streams untouched, and documents the collapse without repair.
- Existing OpenAI suite still green (54 tests); lint clean.

## Validation

Reproduced #13885 end-to-end against the real `@modelcontextprotocol/server-everything` echo tool through the agent graph's event-driven `ON_TOOL_EXECUTE` path. With this build, the previously-failing shapes (fragmented args + shared/missing index) now execute and reach the server; well-formed streams (real current Ollama, which emits proper indices) are unaffected.

> Note: a provider that sends neither `id` nor `index` remains unsupported by design — index repair cannot anchor execution without an id, and no spec-compliant provider does this.