### PR TITLE
Add Microsoft Web IQ as a search and scraper provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "memory": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/memory.ts --provider 'openAI' --name 'Jo' --location 'New York, NY'",
     "tool": "node --trace-warnings -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tools.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/search.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
+    "search:microsoft": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/microsoft_search.ts",
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",

--- a/src/scripts/microsoft_search.ts
+++ b/src/scripts/microsoft_search.ts
@@ -4,25 +4,37 @@ config();
 import { createMicrosoftSearchAPI } from '@/tools/search/microsoft-search';
 import { createMicrosoftScraper } from '@/tools/search/microsoft-scraper';
 import { createSearchTool } from '@/tools/search';
+import { Constants } from '@/common';
 
 const apiKey = process.env.MICROSOFT_WEBIQ_API_KEY;
 const baseUrl = process.env.MICROSOFT_WEBIQ_BASE_URL;
 
 const QUERY = process.env.SMOKE_QUERY ?? 'latest typescript release notes';
 const SCRAPE_URL = process.env.SMOKE_URL ?? 'https://www.typescriptlang.org/';
+/** Comma-separated subset of steps to run, e.g. SMOKE_ONLY=videos,images */
+const ONLY = (process.env.SMOKE_ONLY ?? '')
+  .split(',')
+  .map((step) => step.trim().toLowerCase())
+  .filter((step) => step !== '');
+
+const createApi = (): ReturnType<typeof createMicrosoftSearchAPI> =>
+  createMicrosoftSearchAPI({
+    searchProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+  });
 
 function header(title: string): void {
   console.log(`\n========== ${title} ==========`);
 }
 
+function shouldRun(step: string): boolean {
+  return ONLY.length === 0 || ONLY.includes(step);
+}
+
 async function testWebSearch(): Promise<void> {
   header('1. Web Search (/v3/search/web)');
-  const api = createMicrosoftSearchAPI({
-    searchProvider: 'microsoftWebIQ',
-    microsoftWebIQApiKey: apiKey,
-    microsoftWebIQBaseUrl: baseUrl,
-  });
-  const result = await api.getSources({ query: QUERY });
+  const result = await createApi().getSources({ query: QUERY });
   console.log('success:', result.success);
   if (!result.success) {
     console.log('error:', result.error);
@@ -34,12 +46,7 @@ async function testWebSearch(): Promise<void> {
 
 async function testNewsSearch(): Promise<void> {
   header('2. News Search (/v3/search/news)');
-  const api = createMicrosoftSearchAPI({
-    searchProvider: 'microsoftWebIQ',
-    microsoftWebIQApiKey: apiKey,
-    microsoftWebIQBaseUrl: baseUrl,
-  });
-  const result = await api.getSources({ query: QUERY, news: true });
+  const result = await createApi().getSources({ query: QUERY, news: true });
   console.log('success:', result.success);
   if (!result.success) {
     console.log('error:', result.error);
@@ -51,12 +58,7 @@ async function testNewsSearch(): Promise<void> {
 
 async function testVideoSearch(): Promise<void> {
   header('3. Video Search (/v3/search/videos)');
-  const api = createMicrosoftSearchAPI({
-    searchProvider: 'microsoftWebIQ',
-    microsoftWebIQApiKey: apiKey,
-    microsoftWebIQBaseUrl: baseUrl,
-  });
-  const result = await api.getSources({ query: QUERY, type: 'videos' });
+  const result = await createApi().getSources({ query: QUERY, type: 'videos' });
   console.log('success:', result.success);
   if (!result.success) {
     console.log('error:', result.error);
@@ -68,12 +70,7 @@ async function testVideoSearch(): Promise<void> {
 
 async function testImageSearch(): Promise<void> {
   header('4. Image Search (/v3/search/images)');
-  const api = createMicrosoftSearchAPI({
-    searchProvider: 'microsoftWebIQ',
-    microsoftWebIQApiKey: apiKey,
-    microsoftWebIQBaseUrl: baseUrl,
-  });
-  const result = await api.getSources({ query: QUERY, type: 'images' });
+  const result = await createApi().getSources({ query: QUERY, type: 'images' });
   console.log('success:', result.success);
   if (!result.success) {
     console.log('error:', result.error);
@@ -85,10 +82,7 @@ async function testImageSearch(): Promise<void> {
 
 async function testBrowse(): Promise<void> {
   header('5. Browse scraper (/v3/browse)');
-  const scraper = createMicrosoftScraper({
-    apiKey,
-    baseUrl,
-  });
+  const scraper = createMicrosoftScraper({ apiKey, baseUrl });
   const [url, response] = await scraper.scrapeUrl(SCRAPE_URL);
   console.log('url:', url);
   console.log('success:', response.success);
@@ -105,7 +99,7 @@ async function testBrowse(): Promise<void> {
 
 async function testFullTool(): Promise<void> {
   header(
-    '6. Full search tool (search -> scrape -> rerank, no LLM, no reranker)'
+    '6. Full search tool (web + news + videos + images -> scrape, no LLM, no reranker)'
   );
   const tool = createSearchTool({
     searchProvider: 'microsoftWebIQ',
@@ -115,8 +109,19 @@ async function testFullTool(): Promise<void> {
     rerankerType: 'none',
     topResults: 3,
   });
-  const output = await tool.invoke({ query: QUERY });
-  console.dir(output, { depth: 4 });
+  const message = await tool.invoke({
+    name: tool.name,
+    args: { query: QUERY, news: true, videos: true, images: true },
+    id: 'smoke-full-tool',
+    type: 'tool_call',
+  });
+  const data = message.artifact?.[Constants.WEB_SEARCH];
+  console.log('organic:', data?.organic?.length ?? 0);
+  console.log('topStories:', data?.topStories?.length ?? 0);
+  console.log('videos:', data?.videos?.length ?? 0);
+  console.log('images:', data?.images?.length ?? 0);
+  console.log('\n--- formatted content sent to the model ---');
+  console.log(message.content);
 }
 
 async function main(): Promise<void> {
@@ -127,13 +132,24 @@ async function main(): Promise<void> {
   console.log('baseUrl:', baseUrl ?? 'https://api.microsoft.ai/v3 (default)');
   console.log('query:', QUERY);
   console.log('scrape url:', SCRAPE_URL);
+  if (ONLY.length > 0) {
+    console.log('only:', ONLY.join(', '));
+  }
 
-  await testWebSearch();
-  await testNewsSearch();
-  await testVideoSearch();
-  await testImageSearch();
-  await testBrowse();
-  await testFullTool();
+  const steps: Array<[string, () => Promise<void>]> = [
+    ['web', testWebSearch],
+    ['news', testNewsSearch],
+    ['videos', testVideoSearch],
+    ['images', testImageSearch],
+    ['browse', testBrowse],
+    ['tool', testFullTool],
+  ];
+
+  for (const [name, run] of steps) {
+    if (shouldRun(name)) {
+      await run();
+    }
+  }
 }
 
 main().catch((err) => {

--- a/src/scripts/microsoft_search.ts
+++ b/src/scripts/microsoft_search.ts
@@ -49,8 +49,42 @@ async function testNewsSearch(): Promise<void> {
   console.dir(result.data?.topStories?.slice(0, 3), { depth: null });
 }
 
+async function testVideoSearch(): Promise<void> {
+  header('3. Video Search (/v3/search/videos)');
+  const api = createMicrosoftSearchAPI({
+    searchProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+  });
+  const result = await api.getSources({ query: QUERY, type: 'videos' });
+  console.log('success:', result.success);
+  if (!result.success) {
+    console.log('error:', result.error);
+    return;
+  }
+  console.log('videos count:', result.data?.videos?.length ?? 0);
+  console.dir(result.data?.videos?.slice(0, 3), { depth: null });
+}
+
+async function testImageSearch(): Promise<void> {
+  header('4. Image Search (/v3/search/images)');
+  const api = createMicrosoftSearchAPI({
+    searchProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+  });
+  const result = await api.getSources({ query: QUERY, type: 'images' });
+  console.log('success:', result.success);
+  if (!result.success) {
+    console.log('error:', result.error);
+    return;
+  }
+  console.log('images count:', result.data?.images?.length ?? 0);
+  console.dir(result.data?.images?.slice(0, 3), { depth: null });
+}
+
 async function testBrowse(): Promise<void> {
-  header('3. Browse scraper (/v3/browse)');
+  header('5. Browse scraper (/v3/browse)');
   const scraper = createMicrosoftScraper({
     apiKey,
     baseUrl,
@@ -71,7 +105,7 @@ async function testBrowse(): Promise<void> {
 
 async function testFullTool(): Promise<void> {
   header(
-    '4. Full search tool (search -> scrape -> rerank, no LLM, no reranker)'
+    '6. Full search tool (search -> scrape -> rerank, no LLM, no reranker)'
   );
   const tool = createSearchTool({
     searchProvider: 'microsoftWebIQ',
@@ -96,6 +130,8 @@ async function main(): Promise<void> {
 
   await testWebSearch();
   await testNewsSearch();
+  await testVideoSearch();
+  await testImageSearch();
   await testBrowse();
   await testFullTool();
 }

--- a/src/scripts/microsoft_search.ts
+++ b/src/scripts/microsoft_search.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-console */
+import { config } from 'dotenv';
+config();
+import { createMicrosoftSearchAPI } from '@/tools/search/microsoft-search';
+import { createMicrosoftScraper } from '@/tools/search/microsoft-scraper';
+import { createSearchTool } from '@/tools/search';
+
+const apiKey = process.env.MICROSOFT_WEBIQ_API_KEY;
+const baseUrl = process.env.MICROSOFT_WEBIQ_BASE_URL;
+
+const QUERY = process.env.SMOKE_QUERY ?? 'latest typescript release notes';
+const SCRAPE_URL = process.env.SMOKE_URL ?? 'https://www.typescriptlang.org/';
+
+function header(title: string): void {
+  console.log(`\n========== ${title} ==========`);
+}
+
+async function testWebSearch(): Promise<void> {
+  header('1. Web Search (/v3/search/web)');
+  const api = createMicrosoftSearchAPI({
+    searchProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+  });
+  const result = await api.getSources({ query: QUERY });
+  console.log('success:', result.success);
+  if (!result.success) {
+    console.log('error:', result.error);
+    return;
+  }
+  console.log('organic count:', result.data?.organic?.length ?? 0);
+  console.dir(result.data?.organic?.slice(0, 3), { depth: null });
+}
+
+async function testNewsSearch(): Promise<void> {
+  header('2. News Search (/v3/search/news)');
+  const api = createMicrosoftSearchAPI({
+    searchProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+  });
+  const result = await api.getSources({ query: QUERY, news: true });
+  console.log('success:', result.success);
+  if (!result.success) {
+    console.log('error:', result.error);
+    return;
+  }
+  console.log('topStories count:', result.data?.topStories?.length ?? 0);
+  console.dir(result.data?.topStories?.slice(0, 3), { depth: null });
+}
+
+async function testBrowse(): Promise<void> {
+  header('3. Browse scraper (/v3/browse)');
+  const scraper = createMicrosoftScraper({
+    apiKey,
+    baseUrl,
+  });
+  const [url, response] = await scraper.scrapeUrl(SCRAPE_URL);
+  console.log('url:', url);
+  console.log('success:', response.success);
+  if (!response.success) {
+    console.log('error:', response.error);
+    return;
+  }
+  const [content] = scraper.extractContent(response);
+  const metadata = scraper.extractMetadata(response);
+  console.log('content length:', content.length);
+  console.log('content preview:', content.slice(0, 300));
+  console.log('metadata:', metadata);
+}
+
+async function testFullTool(): Promise<void> {
+  header(
+    '4. Full search tool (search -> scrape -> rerank, no LLM, no reranker)'
+  );
+  const tool = createSearchTool({
+    searchProvider: 'microsoftWebIQ',
+    scraperProvider: 'microsoftWebIQ',
+    microsoftWebIQApiKey: apiKey,
+    microsoftWebIQBaseUrl: baseUrl,
+    rerankerType: 'none',
+    topResults: 3,
+  });
+  const output = await tool.invoke({ query: QUERY });
+  console.dir(output, { depth: 4 });
+}
+
+async function main(): Promise<void> {
+  if (apiKey == null || apiKey === '') {
+    console.error('MICROSOFT_WEBIQ_API_KEY is not set. Add it to .env first.');
+    process.exit(1);
+  }
+  console.log('baseUrl:', baseUrl ?? 'https://api.microsoft.ai/v3 (default)');
+  console.log('query:', QUERY);
+  console.log('scrape url:', SCRAPE_URL);
+
+  await testWebSearch();
+  await testNewsSearch();
+  await testBrowse();
+  await testFullTool();
+}
+
+main().catch((err) => {
+  console.error('Smoke test failed:', err);
+  process.exit(1);
+});

--- a/src/tools/search/microsoft-scraper.ts
+++ b/src/tools/search/microsoft-scraper.ts
@@ -1,0 +1,151 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+
+const DEFAULT_BASE_URL = 'https://api.microsoft.ai/v3';
+const DEFAULT_TIMEOUT = 15000;
+const DEFAULT_MAX_LENGTH = 10000;
+
+/**
+ * Microsoft Web IQ Browse scraper.
+ *
+ * Calls `POST /v3/browse` with `liveCrawl: 'none'` so only indexed content is
+ * returned. A 202 (on-demand crawl in progress) or 404 (URL not indexed) is
+ * treated as a scrape failure — the source is skipped by the upstream pipeline
+ * rather than retried.
+ */
+export class MicrosoftScraper implements t.BaseScraper {
+  private apiKey: string;
+  private baseUrl: string;
+  private timeout: number;
+  private maxLength: number;
+  private contentFormat: 'text' | 'html' | 'markdown';
+  private logger: t.Logger;
+
+  constructor(config: t.MicrosoftScraperConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.MICROSOFT_WEBIQ_API_KEY ?? '';
+    this.baseUrl =
+      config.baseUrl ??
+      process.env.MICROSOFT_WEBIQ_BASE_URL ??
+      DEFAULT_BASE_URL;
+    this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
+    this.maxLength = config.maxLength ?? DEFAULT_MAX_LENGTH;
+    this.contentFormat = config.contentFormat ?? 'markdown';
+    this.logger = config.logger || createDefaultLogger();
+
+    if (!this.apiKey) {
+      this.logger.warn(
+        'MICROSOFT_WEBIQ_API_KEY is not set. Scraping will not work.'
+      );
+    }
+  }
+
+  async scrapeUrl(
+    url: string,
+    options: t.MicrosoftScrapeOptions = {}
+  ): Promise<[string, t.MicrosoftBrowseResponse]> {
+    if (!this.apiKey) {
+      return [
+        url,
+        { success: false, error: 'MICROSOFT_WEBIQ_API_KEY is not set' },
+      ];
+    }
+
+    try {
+      const payload = {
+        url,
+        contentFormat: options.contentFormat ?? this.contentFormat,
+        maxLength: options.maxLength ?? this.maxLength,
+        liveCrawl: 'none',
+      };
+
+      const response = await axios.post(`${this.baseUrl}/browse`, payload, {
+        headers: {
+          'x-apikey': this.apiKey,
+          'content-type': 'application/json',
+        },
+        timeout: options.timeout ?? this.timeout,
+        validateStatus: (status) => status >= 200 && status < 500,
+      });
+
+      if (response.status === 200) {
+        const data = response.data;
+        return [
+          url,
+          {
+            success: true,
+            data: {
+              url: data.url ?? url,
+              title: data.title,
+              content: data.content,
+              language: data.language,
+              lastUpdatedAt: data.lastUpdatedAt,
+              crawledAt: data.crawledAt,
+              isAdult: data.isAdult,
+            },
+          },
+        ];
+      }
+
+      return [
+        url,
+        {
+          success: false,
+          error: `Microsoft Browse returned status ${response.status}`,
+        },
+      ];
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return [
+        url,
+        {
+          success: false,
+          error: `Microsoft Browse API request failed: ${errorMessage}`,
+        },
+      ];
+    }
+  }
+
+  extractContent(
+    response: t.MicrosoftBrowseResponse
+  ): [string, undefined | t.References] {
+    if (!response.success || !response.data) {
+      return ['', undefined];
+    }
+    return [response.data.content ?? '', undefined];
+  }
+
+  extractMetadata(
+    response: t.MicrosoftBrowseResponse
+  ): t.GenericScrapeMetadata {
+    if (!response.success || !response.data) {
+      return {};
+    }
+
+    const { url, title, language, lastUpdatedAt, crawledAt } = response.data;
+    const metadata: t.GenericScrapeMetadata = {};
+    if (url != null) {
+      metadata.url = url;
+    }
+    if (title != null) {
+      metadata.title = title;
+    }
+    if (language != null) {
+      metadata.language = language;
+    }
+    if (lastUpdatedAt != null) {
+      metadata.modifiedTime = lastUpdatedAt;
+    }
+    if (crawledAt != null) {
+      metadata.crawledAt = crawledAt;
+    }
+    return metadata;
+  }
+}
+
+export const createMicrosoftScraper = (
+  config: t.MicrosoftScraperConfig = {}
+): MicrosoftScraper => {
+  return new MicrosoftScraper(config);
+};

--- a/src/tools/search/microsoft-search.ts
+++ b/src/tools/search/microsoft-search.ts
@@ -1,0 +1,200 @@
+import axios from 'axios';
+import type * as t from './types';
+
+const DEFAULT_BASE_URL = 'https://api.microsoft.ai/v3';
+const DEFAULT_MAX_RESULTS = 10;
+const DEFAULT_SNIPPET_LENGTH = 2000;
+const REQUEST_TIMEOUT = 15000;
+
+interface MicrosoftWebResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  crawledAt?: string;
+  lastUpdatedAt?: string;
+  language?: string;
+  isAdult?: boolean;
+}
+
+interface MicrosoftNewsResult {
+  title?: string;
+  url?: string;
+  content?: string;
+  snippet?: string;
+  thumbnail?: { url?: string; width?: number; height?: number };
+  lastUpdatedAt?: string;
+  source?: string;
+  isAdult?: boolean;
+}
+
+interface MicrosoftWebResponse {
+  webResults?: MicrosoftWebResult[];
+  traceId?: string;
+}
+
+interface MicrosoftNewsResponse {
+  newsResults?: MicrosoftNewsResult[];
+  traceId?: string;
+}
+
+const truncate = (text: string, maxLength: number): string =>
+  text.length > maxLength ? text.slice(0, maxLength) : text;
+
+/**
+ * Microsoft Web IQ search API.
+ *
+ * Web search hits `POST /v3/search/web` with `contentFormat: 'passage'` so the
+ * returned `content` is a query-relevant extract used as the organic snippet;
+ * full-text grounding is left to the Browse scraper. News search hits
+ * `POST /v3/search/news` and is mapped to topStories, mirroring how Serper
+ * folds news results into topStories.
+ */
+export const createMicrosoftSearchAPI = (
+  config: t.SearchConfig
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  const apiKey =
+    config.microsoftWebIQApiKey ?? process.env.MICROSOFT_WEBIQ_API_KEY;
+  const baseUrl =
+    config.microsoftWebIQBaseUrl ??
+    process.env.MICROSOFT_WEBIQ_BASE_URL ??
+    DEFAULT_BASE_URL;
+  const options = config.microsoftWebIQSearchOptions ?? {};
+
+  if (apiKey == null || apiKey === '') {
+    throw new Error(
+      'MICROSOFT_WEBIQ_API_KEY is required for Microsoft Web IQ search'
+    );
+  }
+
+  const headers = {
+    'x-apikey': apiKey,
+    'content-type': 'application/json',
+  };
+
+  const buildBasePayload = (
+    query: string,
+    numResults: number
+  ): Record<string, string | number> => {
+    const payload: Record<string, string | number> = {
+      query,
+      maxResults: options.maxResults ?? numResults,
+      language: options.language ?? 'en',
+      region: options.region ?? 'US',
+      maxLength: options.maxLength ?? 10000,
+    };
+    if (options.location != null && options.location !== '') {
+      payload.location = options.location;
+    }
+    return payload;
+  };
+
+  const searchNews = async (
+    query: string,
+    numResults: number
+  ): Promise<t.SearchResult> => {
+    const payload = buildBasePayload(query, numResults);
+    const response = await axios.post<MicrosoftNewsResponse>(
+      `${baseUrl}/search/news`,
+      payload,
+      { headers, timeout: REQUEST_TIMEOUT }
+    );
+
+    const newsResults = response.data.newsResults ?? [];
+    const news: t.NewsResult[] = newsResults
+      .filter((item) => item.url != null && item.url !== '')
+      .map((item, index) => ({
+        title: item.title ?? '',
+        link: item.url ?? '',
+        snippet: item.snippet ?? '',
+        date: item.lastUpdatedAt ?? '',
+        source: item.source ?? '',
+        imageUrl: item.thumbnail?.url ?? '',
+        position: index + 1,
+      }));
+
+    const topStories: t.TopStoryResult[] = news.map((item) => ({
+      title: item.title ?? '',
+      link: item.link ?? '',
+      source: item.source ?? '',
+      date: item.date ?? '',
+      imageUrl: item.imageUrl ?? '',
+    }));
+
+    const data: t.SearchResultData = {
+      organic: [],
+      topStories,
+      news,
+      images: [],
+      videos: [],
+      relatedSearches: [],
+    };
+
+    return { success: true, data };
+  };
+
+  const searchWeb = async (
+    query: string,
+    numResults: number
+  ): Promise<t.SearchResult> => {
+    const payload = {
+      ...buildBasePayload(query, numResults),
+      contentFormat: options.contentFormat ?? 'passage',
+    };
+    const response = await axios.post<MicrosoftWebResponse>(
+      `${baseUrl}/search/web`,
+      payload,
+      { headers, timeout: REQUEST_TIMEOUT }
+    );
+
+    const webResults = response.data.webResults ?? [];
+    const organic: t.OrganicResult[] = webResults
+      .filter((item) => item.url != null && item.url !== '')
+      .map((item, index) => ({
+        position: index + 1,
+        title: item.title ?? '',
+        link: item.url ?? '',
+        snippet: truncate(item.content ?? '', DEFAULT_SNIPPET_LENGTH),
+        date: item.lastUpdatedAt ?? '',
+      }));
+
+    const data: t.SearchResultData = {
+      organic,
+      topStories: [],
+      images: [],
+      videos: [],
+      news: [],
+      relatedSearches: [],
+    };
+
+    return { success: true, data };
+  };
+
+  const getSources = async ({
+    query,
+    numResults = DEFAULT_MAX_RESULTS,
+    type,
+    news,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    try {
+      if (news === true || type === 'news') {
+        return await searchNews(query, numResults);
+      }
+      return await searchWeb(query, numResults);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Microsoft Web IQ search request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/microsoft-search.ts
+++ b/src/tools/search/microsoft-search.ts
@@ -27,6 +27,30 @@ interface MicrosoftNewsResult {
   isAdult?: boolean;
 }
 
+interface MicrosoftVideoResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  summary?: string;
+  publishedBy?: string;
+  length?: string;
+  lastUpdatedAt?: string;
+  thumbnailUrl?: string;
+  isAdult?: boolean;
+}
+
+interface MicrosoftImageResult {
+  title?: string;
+  url?: string;
+  hostPageUrl?: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+  thumbnailUrl?: string;
+  lastUpdatedAt?: string;
+  isAdult?: boolean;
+}
+
 interface MicrosoftWebResponse {
   webResults?: MicrosoftWebResult[];
   traceId?: string;
@@ -37,8 +61,26 @@ interface MicrosoftNewsResponse {
   traceId?: string;
 }
 
+interface MicrosoftVideosResponse {
+  videoResults?: MicrosoftVideoResult[];
+  traceId?: string;
+}
+
+interface MicrosoftImagesResponse {
+  imageResults?: MicrosoftImageResult[];
+  traceId?: string;
+}
+
 const truncate = (text: string, maxLength: number): string =>
   text.length > maxLength ? text.slice(0, maxLength) : text;
+
+const getHostname = (link: string): string => {
+  try {
+    return new URL(link).hostname;
+  } catch {
+    return '';
+  }
+};
 
 /**
  * Microsoft Web IQ search API.
@@ -47,7 +89,10 @@ const truncate = (text: string, maxLength: number): string =>
  * returned `content` is a query-relevant extract used as the organic snippet;
  * full-text grounding is left to the Browse scraper. News search hits
  * `POST /v3/search/news` and is mapped to topStories, mirroring how Serper
- * folds news results into topStories.
+ * folds news results into topStories. Video search hits
+ * `POST /v3/search/videos` and is mapped to the `videos` collection; image
+ * search hits `POST /v3/search/images` and is mapped to the `images`
+ * collection.
  */
 export const createMicrosoftSearchAPI = (
   config: t.SearchConfig
@@ -171,17 +216,117 @@ export const createMicrosoftSearchAPI = (
     return { success: true, data };
   };
 
+  const searchVideos = async (
+    query: string,
+    numResults: number,
+    safeSearch?: t.SafeSearchLevel
+  ): Promise<t.SearchResult> => {
+    const payload: Record<string, string | number> = {
+      query,
+      maxResults: options.maxResults ?? numResults,
+      language: options.language ?? 'en',
+      region: options.region ?? 'US',
+      safeSearch: safeSearch === 0 ? 'off' : 'strict',
+    };
+    if (options.freshness != null && options.freshness !== '') {
+      payload.freshness = options.freshness;
+    }
+    const response = await axios.post<MicrosoftVideosResponse>(
+      `${baseUrl}/search/videos`,
+      payload,
+      { headers, timeout: REQUEST_TIMEOUT }
+    );
+
+    const videoResults = response.data.videoResults ?? [];
+    const videos: t.VideoResult[] = videoResults
+      .filter((item) => item.url != null && item.url !== '')
+      .map((item, index) => ({
+        position: index + 1,
+        title: item.title ?? '',
+        link: item.url ?? '',
+        snippet: item.description ?? item.summary ?? '',
+        imageUrl: item.thumbnailUrl ?? '',
+        duration: item.length ?? '',
+        channel: item.publishedBy ?? '',
+        source: getHostname(item.url ?? ''),
+        date: item.lastUpdatedAt ?? '',
+      }));
+
+    const data: t.SearchResultData = {
+      organic: [],
+      topStories: [],
+      images: [],
+      videos,
+      news: [],
+      relatedSearches: [],
+    };
+
+    return { success: true, data };
+  };
+
+  const searchImages = async (
+    query: string,
+    numResults: number,
+    safeSearch?: t.SafeSearchLevel
+  ): Promise<t.SearchResult> => {
+    const payload: Record<string, string | number> = {
+      query,
+      maxResults: options.maxResults ?? numResults,
+      language: options.language ?? 'en',
+      region: options.region ?? 'US',
+      safeSearch: safeSearch === 0 ? 'off' : 'strict',
+    };
+    const response = await axios.post<MicrosoftImagesResponse>(
+      `${baseUrl}/search/images`,
+      payload,
+      { headers, timeout: REQUEST_TIMEOUT }
+    );
+
+    const imageResults = response.data.imageResults ?? [];
+    const images: t.ImageResult[] = imageResults
+      .filter((item) => item.url != null && item.url !== '')
+      .map((item, index) => ({
+        position: index + 1,
+        title: item.title ?? '',
+        imageUrl: item.url ?? '',
+        imageWidth: item.width,
+        imageHeight: item.height,
+        thumbnailUrl: item.thumbnailUrl ?? '',
+        link: item.hostPageUrl ?? '',
+        source: getHostname(item.hostPageUrl ?? ''),
+        domain: getHostname(item.hostPageUrl ?? ''),
+      }));
+
+    const data: t.SearchResultData = {
+      organic: [],
+      topStories: [],
+      images,
+      videos: [],
+      news: [],
+      relatedSearches: [],
+    };
+
+    return { success: true, data };
+  };
+
   const getSources = async ({
     query,
     numResults = DEFAULT_MAX_RESULTS,
     type,
     news,
+    safeSearch,
   }: t.GetSourcesParams): Promise<t.SearchResult> => {
     if (!query.trim()) {
       return { success: false, error: 'Query cannot be empty' };
     }
 
     try {
+      if (type === 'images') {
+        return await searchImages(query, numResults, safeSearch);
+      }
+      if (type === 'videos') {
+        return await searchVideos(query, numResults, safeSearch);
+      }
       if (news === true || type === 'news') {
         return await searchNews(query, numResults);
       }

--- a/src/tools/search/microsoft.test.ts
+++ b/src/tools/search/microsoft.test.ts
@@ -131,9 +131,117 @@ describe('Microsoft Web IQ search API', () => {
     expect(result.data?.news?.[0]?.snippet).toBe('terse news snippet');
   });
 
+  it('hits the videos endpoint and maps videoResults to videos when type is videos', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        videoResults: [
+          {
+            title: 'Cute Puppies',
+            url: 'https://videos.example.com/watch?v=abc',
+            description: 'A compilation of puppies.',
+            publishedBy: 'Puppy Channel',
+            length: '00:03:21',
+            thumbnailUrl: 'https://img.example.com/thumb.jpg',
+            lastUpdatedAt: '2026-01-06T00:00:00Z',
+          },
+          {
+            title: 'No URL',
+            url: '',
+            description: 'should be filtered out',
+          },
+        ],
+        traceId: 'trace-videos',
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'cute puppy videos',
+      type: 'videos',
+      safeSearch: 0,
+    });
+
+    const [url, payload] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('https://api.microsoft.ai/v3/search/videos');
+    expect(payload).toMatchObject({
+      query: 'cute puppy videos',
+      safeSearch: 'off',
+    });
+    expect(result.data?.videos).toEqual([
+      {
+        position: 1,
+        title: 'Cute Puppies',
+        link: 'https://videos.example.com/watch?v=abc',
+        snippet: 'A compilation of puppies.',
+        imageUrl: 'https://img.example.com/thumb.jpg',
+        duration: '00:03:21',
+        channel: 'Puppy Channel',
+        source: 'videos.example.com',
+        date: '2026-01-06T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('hits the images endpoint and maps imageResults to images when type is images', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        imageResults: [
+          {
+            title: 'A Cat',
+            url: 'https://img.example.com/cat.jpg',
+            hostPageUrl: 'https://cats.example.com/gallery',
+            caption: 'a fluffy cat',
+            width: 800,
+            height: 600,
+            thumbnailUrl: 'https://img.example.com/cat-thumb.jpg',
+            lastUpdatedAt: '2026-01-07T00:00:00Z',
+          },
+          {
+            title: 'No URL',
+            url: '',
+            hostPageUrl: 'https://cats.example.com/missing',
+          },
+        ],
+        traceId: 'trace-images',
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'cats',
+      type: 'images',
+    });
+
+    const [url, payload] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('https://api.microsoft.ai/v3/search/images');
+    expect(payload).toMatchObject({ query: 'cats', safeSearch: 'strict' });
+    expect(result.data?.images).toEqual([
+      {
+        position: 1,
+        title: 'A Cat',
+        imageUrl: 'https://img.example.com/cat.jpg',
+        imageWidth: 800,
+        imageHeight: 600,
+        thumbnailUrl: 'https://img.example.com/cat-thumb.jpg',
+        link: 'https://cats.example.com/gallery',
+        source: 'cats.example.com',
+        domain: 'cats.example.com',
+      },
+    ]);
+  });
+
   it('returns a failure result when the request throws', async () => {
     mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
-
     const searchAPI = createSearchAPI({
       searchProvider: 'microsoftWebIQ',
       microsoftWebIQApiKey: 'test-key',

--- a/src/tools/search/microsoft.test.ts
+++ b/src/tools/search/microsoft.test.ts
@@ -1,0 +1,244 @@
+import axios from 'axios';
+import type * as t from './types';
+import { MicrosoftScraper, createMicrosoftScraper } from './microsoft-scraper';
+import { createSearchAPI } from './search';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+} as unknown as t.Logger;
+
+describe('Microsoft Web IQ search API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when the API key is missing', () => {
+    expect(() =>
+      createSearchAPI({
+        searchProvider: 'microsoftWebIQ',
+        microsoftWebIQApiKey: '',
+      })
+    ).toThrow(
+      'MICROSOFT_WEBIQ_API_KEY is required for Microsoft Web IQ search'
+    );
+  });
+
+  it('returns an error for empty queries without calling the API', async () => {
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({ success: false, error: 'Query cannot be empty' });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('hits the web endpoint with x-apikey and passage format, mapping webResults to organic', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        webResults: [
+          {
+            title: 'Result One',
+            url: 'https://example.com/one',
+            content: 'Relevant passage about the query.',
+            lastUpdatedAt: '2026-01-02T00:00:00Z',
+          },
+          {
+            title: 'No URL',
+            url: '',
+            content: 'should be filtered out',
+          },
+        ],
+        traceId: 'trace-123',
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, payload, requestConfig] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('https://api.microsoft.ai/v3/search/web');
+    expect(payload).toMatchObject({
+      query: 'example query',
+      contentFormat: 'passage',
+    });
+    expect(requestConfig?.headers).toMatchObject({ 'x-apikey': 'test-key' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.organic).toEqual([
+      {
+        position: 1,
+        title: 'Result One',
+        link: 'https://example.com/one',
+        snippet: 'Relevant passage about the query.',
+        date: '2026-01-02T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('hits the news endpoint and maps newsResults to topStories when news is true', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        newsResults: [
+          {
+            title: 'Breaking',
+            url: 'https://news.example.com/a',
+            snippet: 'terse news snippet',
+            source: 'Example News',
+            lastUpdatedAt: '2026-01-03T00:00:00Z',
+            thumbnail: { url: 'https://img.example.com/a.jpg' },
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({
+      query: 'tech funding',
+      news: true,
+    });
+
+    const [url] = mockedAxios.post.mock.calls[0];
+    expect(url).toBe('https://api.microsoft.ai/v3/search/news');
+    expect(result.data?.topStories).toEqual([
+      {
+        title: 'Breaking',
+        link: 'https://news.example.com/a',
+        source: 'Example News',
+        date: '2026-01-03T00:00:00Z',
+        imageUrl: 'https://img.example.com/a.jpg',
+      },
+    ]);
+    expect(result.data?.news?.[0]?.snippet).toBe('terse news snippet');
+  });
+
+  it('returns a failure result when the request throws', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'microsoftWebIQ',
+      microsoftWebIQApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      'Microsoft Web IQ search request failed: Network error'
+    );
+  });
+});
+
+describe('Microsoft Web IQ Browse scraper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a failure response when the API key is missing', async () => {
+    const scraper = new MicrosoftScraper({ apiKey: '', logger: mockLogger });
+
+    const [url, response] = await scraper.scrapeUrl('https://example.com');
+
+    expect(url).toBe('https://example.com');
+    expect(response).toEqual({
+      success: false,
+      error: 'MICROSOFT_WEBIQ_API_KEY is not set',
+    });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('maps a 200 response to content and metadata', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        url: 'https://example.com/page',
+        title: 'Example Page',
+        content: '# Heading\n\nBody text.',
+        language: 'en',
+        lastUpdatedAt: '2026-01-04T00:00:00Z',
+        crawledAt: '2026-01-05T00:00:00Z',
+        isAdult: false,
+      },
+    });
+
+    const scraper = createMicrosoftScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const [, response] = await scraper.scrapeUrl('https://example.com/page');
+
+    const [requestUrl, payload, requestConfig] = mockedAxios.post.mock.calls[0];
+    expect(requestUrl).toBe('https://api.microsoft.ai/v3/browse');
+    expect(payload).toMatchObject({
+      url: 'https://example.com/page',
+      contentFormat: 'markdown',
+      liveCrawl: 'none',
+    });
+    expect(requestConfig?.headers).toMatchObject({ 'x-apikey': 'test-key' });
+
+    expect(response.success).toBe(true);
+    const [content] = scraper.extractContent(response);
+    expect(content).toBe('# Heading\n\nBody text.');
+    const metadata = scraper.extractMetadata(response);
+    expect(metadata).toMatchObject({
+      url: 'https://example.com/page',
+      title: 'Example Page',
+      modifiedTime: '2026-01-04T00:00:00Z',
+    });
+  });
+
+  it('treats a 202 (live crawl in progress) as a scrape failure', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 202,
+      data: { retryAfter: '60s' },
+    });
+
+    const scraper = createMicrosoftScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const [, response] = await scraper.scrapeUrl('https://example.com/slow');
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe('Microsoft Browse returned status 202');
+    expect(scraper.extractContent(response)).toEqual(['', undefined]);
+  });
+
+  it('treats a 404 (URL not indexed) as a scrape failure', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      status: 404,
+      data: {},
+    });
+
+    const scraper = createMicrosoftScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const [, response] = await scraper.scrapeUrl('https://example.com/missing');
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe('Microsoft Browse returned status 404');
+  });
+});

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
+import { createMicrosoftSearchAPI } from './microsoft-search';
 import { createTavilyAPI } from './tavily-search';
 import { BaseReranker } from './rerankers';
 
@@ -453,9 +454,11 @@ export const createSearchAPI = (
     return createSearXNGAPI(searxngInstanceUrl, searxngApiKey);
   } else if (searchProvider.toLowerCase() === 'tavily') {
     return createTavilyAPI(tavilyApiKey, tavilySearchUrl, tavilySearchOptions);
+  } else if (searchProvider.toLowerCase() === 'microsoftwebiq') {
+    return createMicrosoftSearchAPI(config);
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', or 'tavily'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'microsoftWebIQ'`
     );
   }
 };

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -13,6 +13,7 @@ import {
   DATE_RANGE,
 } from './schema';
 import { createSearchAPI, createSourceProcessor } from './search';
+import { createMicrosoftScraper } from './microsoft-scraper';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
@@ -315,7 +316,11 @@ function createTool({
         }),
       });
       const turn = runnableConfig.toolCall?.turn ?? 0;
-      const { output, references } = formatResultsForLLM(turn, searchResult, maxOutputChars);
+      const { output, references } = formatResultsForLLM(
+        turn,
+        searchResult,
+        maxOutputChars
+      );
       const data: t.SearchResultData = { turn, ...searchResult, references };
       return [output, { [Constants.WEB_SEARCH]: data }];
     },
@@ -372,6 +377,9 @@ export const createSearchTool = (
     firecrawlOptions,
     serperScraperOptions,
     tavilyScraperOptions,
+    microsoftScraperOptions,
+    microsoftWebIQApiKey,
+    microsoftWebIQBaseUrl,
     scraperTimeout,
     jinaApiKey,
     jinaApiUrl,
@@ -415,6 +423,9 @@ export const createSearchTool = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions: effectiveTavilySearchOptions,
+    microsoftWebIQApiKey,
+    microsoftWebIQBaseUrl,
+    microsoftWebIQSearchOptions: config.microsoftWebIQSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */
@@ -436,6 +447,14 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
+      logger,
+    });
+  } else if (scraperProvider === 'microsoftWebIQ') {
+    scraperInstance = createMicrosoftScraper({
+      ...microsoftScraperOptions,
+      apiKey: microsoftScraperOptions?.apiKey ?? microsoftWebIQApiKey,
+      baseUrl: microsoftScraperOptions?.baseUrl ?? microsoftWebIQBaseUrl,
+      timeout: scraperTimeout ?? microsoftScraperOptions?.timeout,
       logger,
     });
   } else {
@@ -477,7 +496,8 @@ export const createSearchTool = (
   const search = createSearchProcessor({
     searchAPI,
     safeSearch,
-    supportsVideos: searchProvider !== 'tavily',
+    supportsVideos:
+      searchProvider !== 'tavily' && searchProvider !== 'microsoftWebIQ',
     sourceProcessor,
     onGetHighlights,
     logger,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -496,8 +496,7 @@ export const createSearchTool = (
   const search = createSearchProcessor({
     searchAPI,
     safeSearch,
-    supportsVideos:
-      searchProvider !== 'tavily' && searchProvider !== 'microsoftWebIQ',
+    supportsVideos: searchProvider !== 'tavily',
     sourceProcessor,
     onGetHighlights,
     logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,8 +3,12 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily';
-export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'microsoftWebIQ';
+export type ScraperProvider =
+  | 'firecrawl'
+  | 'serper'
+  | 'tavily'
+  | 'microsoftWebIQ';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -106,6 +110,15 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
+export interface MicrosoftWebIQSearchOptions {
+  maxResults?: number;
+  language?: string;
+  region?: string;
+  contentFormat?: 'passage' | 'text' | 'html' | 'markdown';
+  maxLength?: number;
+  location?: string;
+}
+
 export interface SearchConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
@@ -115,6 +128,9 @@ export interface SearchConfig {
   tavilySearchUrl?: string;
   tavilyExtractUrl?: string;
   tavilySearchOptions?: TavilySearchOptions;
+  microsoftWebIQApiKey?: string;
+  microsoftWebIQBaseUrl?: string;
+  microsoftWebIQSearchOptions?: MicrosoftWebIQSearchOptions;
 }
 
 export type References = {
@@ -169,6 +185,15 @@ export interface TavilyScraperConfig {
   format?: 'markdown' | 'text';
 }
 
+export interface MicrosoftScraperConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  timeout?: number;
+  logger?: Logger;
+  maxLength?: number;
+  contentFormat?: 'text' | 'html' | 'markdown';
+}
+
 export interface ScraperContentResult {
   content: string;
 }
@@ -218,6 +243,7 @@ export interface SearchToolConfig
     ProcessSourcesConfig,
     FirecrawlConfig {
   tavilyScraperOptions?: TavilyScraperConfig;
+  microsoftScraperOptions?: MicrosoftScraperConfig;
   /** Max chars of highlight content this tool feeds the MODEL per search (the
    * dominant, otherwise-unbounded part of the output). Distinct from
    * `maxContentLength`, which caps scraped/reranked content per source — full
@@ -255,7 +281,8 @@ export type UsedReferences = {
 export type AnyScraperResponse =
   | FirecrawlScrapeResponse
   | SerperScrapeResponse
-  | TavilyScrapeResponse;
+  | TavilyScrapeResponse
+  | MicrosoftBrowseResponse;
 
 /** Base Scraper Interface */
 export interface BaseScraper {
@@ -397,6 +424,25 @@ export interface TavilyScrapeResponse {
     rawContent?: string;
     images?: string[];
     favicon?: string;
+  };
+  error?: string;
+}
+
+export type MicrosoftScrapeOptions = Omit<
+  MicrosoftScraperConfig,
+  'apiKey' | 'baseUrl' | 'logger'
+>;
+
+export interface MicrosoftBrowseResponse {
+  success: boolean;
+  data?: {
+    url?: string;
+    title?: string;
+    content?: string;
+    language?: string;
+    lastUpdatedAt?: string;
+    crawledAt?: string;
+    isAdult?: boolean;
   };
   error?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -117,6 +117,7 @@ export interface MicrosoftWebIQSearchOptions {
   contentFormat?: 'passage' | 'text' | 'html' | 'markdown';
   maxLength?: number;
   location?: string;
+  freshness?: string;
 }
 
 export interface SearchConfig {


### PR DESCRIPTION
### Summary

Adds [microsoftWebIQ](https://webiq.microsoft.ai/) as a new option for both the search provider and the scraper provider in the search tool, alongside the existing Serper / SearXNG / Tavily / Firecrawl integrations.

core logic is `src/tools/search/microsoft-scraper.ts` & `src/tools/search/microsoft-search.ts`(~ 500 lines), most of the rest code is for ut & local test script

### What's included

- **Search API** (`microsoft-search.ts`) — wraps the Web IQ search endpoints:
  - `POST /v3/search/web` (with `contentFormat: 'passage'` for query-relevant snippets) → `organic`.
  - `POST /v3/search/news` → `topStories` + `news`, mirroring how Serper folds news into top stories.
  - `POST /v3/search/videos` → `videos` (title, link, snippet, thumbnail, duration, channel, source, date).
  - `POST /v3/search/images` → `images` (title, image url, dimensions, thumbnail, host page link, source/domain).
  - `safeSearch` is mapped to the API's `off` / `strict` enum for the videos and images endpoints.
- **Browse scraper** (`microsoft-scraper.ts`) — implements `BaseScraper` over `POST /v3/browse` with `liveCrawl: 'none'` (indexed content only). Non-200 responses (202 crawl-in-progress, 404 not-indexed) are treated as scrape failures so the source is skipped rather than retried.
- **Wiring** — registers the provider in `createSearchAPI` and the scraper selector in `tool.ts`, including config plumbing (`microsoftWebIQApiKey`, `microsoftWebIQBaseUrl`, `microsoftWebIQSearchOptions`, `microsoftScraperOptions`). Videos and images are supported, so the parallel `type: 'videos'` / `type: 'images'` sub-searches fan out and merge into the result.
- **Types** — adds `MicrosoftWebIQSearchOptions`, `MicrosoftScraperConfig`, `MicrosoftScrapeOptions`, and `MicrosoftBrowseResponse`; extends the `SearchProvider` / `ScraperProvider` unions.
- **Tests** (`microsoft.test.ts`) — covers missing API key, empty query, web→organic, news→topStories, videos→videos, images→images mapping, request failure, and scraper 200/202/404 handling (11 tests).
- **Smoke script** (`scripts/microsoft_search.ts`, `npm run search:microsoft`) — exercises web, news, video, and image search, the Browse scraper, and the full search tool against the live API.

### Configuration

Credentials are read from config or `MICROSOFT_WEBIQ_API_KEY` / `MICROSOFT_WEBIQ_BASE_URL` (defaults to `https://api.microsoft.ai/v3`).

### Testing

- `npx jest src/tools/search/microsoft.test.ts` — 11/11 passing
- `tsc --noEmit` and ESLint clean
- Local linked to the LibreChat app, demo videos below (will raise PR when agent is merged and published).

search

https://github.com/user-attachments/assets/02ce2263-36d3-4b35-aa83-c112ae270f08

scraper

https://github.com/user-attachments/assets/ac6c22b6-60ea-443e-b0fe-62cdc7b52324
