### PR TITLE
fix(langfuse): Report prompt cache TTL usage buckets

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -11,6 +11,7 @@ import {
   resolveTraceIdSeedForSpan,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import { normalizePromptCacheUsageForLangfuse } from '@/langfuse/promptCacheUsage';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
@@ -105,6 +106,18 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleLLMStart']>
   ): ReturnType<CallbackHandler['handleLLMStart']> {
     return this.withRuntimeContext(() => super.handleLLMStart(...args));
+  }
+
+  override handleLLMEnd(
+    output: Parameters<CallbackHandler['handleLLMEnd']>[0],
+    runId: Parameters<CallbackHandler['handleLLMEnd']>[1],
+    parentRunId?: Parameters<CallbackHandler['handleLLMEnd']>[2]
+  ): ReturnType<CallbackHandler['handleLLMEnd']> {
+    return super.handleLLMEnd(
+      normalizePromptCacheUsageForLangfuse(output),
+      runId,
+      parentRunId
+    );
   }
 
   override handleToolStart(

--- a/src/langfuse/promptCacheUsage.ts
+++ b/src/langfuse/promptCacheUsage.ts
@@ -1,0 +1,231 @@
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { LLMResult, Generation } from '@langchain/core/outputs';
+import type { UsageMetadata } from '@langchain/core/messages';
+import {
+  PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY,
+  type PromptCacheTtl,
+} from '@/messages/cache';
+
+type PromptCacheInputTokenDetails = Record<string, unknown> & {
+  cache_creation?: number;
+  cache_creation_5m?: number;
+  cache_creation_1h?: number;
+};
+
+type PromptCacheCreationBuckets = {
+  cache_creation_5m: number;
+  cache_creation_1h: number;
+};
+
+type MessageConstructorParams = {
+  lc_kwargs?: Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value != null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function getFiniteTokenCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}
+
+function getPromptCacheTtl(value: unknown): PromptCacheTtl | undefined {
+  return value === '5m' || value === '1h' ? value : undefined;
+}
+
+function getAnthropicPromptCacheCreationBuckets(
+  responseMetadata: Record<string, unknown> | undefined
+): PromptCacheCreationBuckets {
+  const usage = asRecord(responseMetadata?.usage);
+  const cacheCreation = asRecord(usage?.cache_creation);
+  return {
+    cache_creation_5m: getFiniteTokenCount(
+      cacheCreation?.ephemeral_5m_input_tokens
+    ),
+    cache_creation_1h: getFiniteTokenCount(
+      cacheCreation?.ephemeral_1h_input_tokens
+    ),
+  };
+}
+
+function getExistingPromptCacheCreationBuckets(
+  inputTokenDetails: PromptCacheInputTokenDetails
+): PromptCacheCreationBuckets {
+  return {
+    cache_creation_5m: getFiniteTokenCount(inputTokenDetails.cache_creation_5m),
+    cache_creation_1h: getFiniteTokenCount(inputTokenDetails.cache_creation_1h),
+  };
+}
+
+function getInferredPromptCacheCreationBuckets(
+  inputTokenDetails: PromptCacheInputTokenDetails,
+  responseMetadata: Record<string, unknown> | undefined
+): PromptCacheCreationBuckets {
+  const cacheCreation = getFiniteTokenCount(inputTokenDetails.cache_creation);
+  const ttl = getPromptCacheTtl(
+    responseMetadata?.[PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]
+  );
+
+  if (cacheCreation <= 0 || ttl == null) {
+    return { cache_creation_5m: 0, cache_creation_1h: 0 };
+  }
+
+  return ttl === '5m'
+    ? { cache_creation_5m: cacheCreation, cache_creation_1h: 0 }
+    : { cache_creation_5m: 0, cache_creation_1h: cacheCreation };
+}
+
+function getPromptCacheCreationBuckets(
+  inputTokenDetails: PromptCacheInputTokenDetails,
+  responseMetadata: Record<string, unknown> | undefined
+): PromptCacheCreationBuckets {
+  const anthropicBuckets =
+    getAnthropicPromptCacheCreationBuckets(responseMetadata);
+  if (
+    anthropicBuckets.cache_creation_5m > 0 ||
+    anthropicBuckets.cache_creation_1h > 0
+  ) {
+    return anthropicBuckets;
+  }
+
+  // Keep this path for providers that already emit Langfuse-ready bucket keys
+  // in LangChain usage metadata. The normalizer remains idempotent if it sees
+  // an already-normalized message.
+  const existingBuckets =
+    getExistingPromptCacheCreationBuckets(inputTokenDetails);
+  if (
+    existingBuckets.cache_creation_5m > 0 ||
+    existingBuckets.cache_creation_1h > 0
+  ) {
+    return existingBuckets;
+  }
+
+  // Bedrock only reports generic cache write tokens; the TTL comes from the
+  // cache point we sent, not a provider-confirmed usage field.
+  return getInferredPromptCacheCreationBuckets(
+    inputTokenDetails,
+    responseMetadata
+  );
+}
+
+function normalizeUsageMetadataForLangfuse(
+  usageMetadata: UsageMetadata | undefined,
+  responseMetadata: Record<string, unknown> | undefined
+): UsageMetadata | undefined {
+  const inputTokenDetails = asRecord(usageMetadata?.input_token_details) as
+    | PromptCacheInputTokenDetails
+    | undefined;
+  if (usageMetadata == null || inputTokenDetails == null) {
+    return usageMetadata;
+  }
+
+  const buckets = getPromptCacheCreationBuckets(
+    inputTokenDetails,
+    responseMetadata
+  );
+  const bucketTotal = buckets.cache_creation_5m + buckets.cache_creation_1h;
+  if (bucketTotal <= 0) {
+    return usageMetadata;
+  }
+
+  const genericCacheCreation = getFiniteTokenCount(
+    inputTokenDetails.cache_creation
+  );
+  const normalizedInputTokenDetails: PromptCacheInputTokenDetails = {
+    ...inputTokenDetails,
+    cache_creation: Math.max(0, genericCacheCreation - bucketTotal),
+  };
+
+  if (buckets.cache_creation_5m > 0) {
+    normalizedInputTokenDetails.cache_creation_5m = buckets.cache_creation_5m;
+  }
+  if (buckets.cache_creation_1h > 0) {
+    normalizedInputTokenDetails.cache_creation_1h = buckets.cache_creation_1h;
+  }
+
+  return {
+    ...usageMetadata,
+    input_token_details:
+      normalizedInputTokenDetails as UsageMetadata['input_token_details'],
+  };
+}
+
+function cloneAIMessageWithUsageMetadata(
+  message: AIMessage | AIMessageChunk,
+  usageMetadata: UsageMetadata
+): AIMessage | AIMessageChunk {
+  const constructorParams = (message as MessageConstructorParams).lc_kwargs;
+  const baseParams =
+    constructorParams != null
+      ? { ...constructorParams }
+      : {
+        content: message.content,
+        additional_kwargs: message.additional_kwargs,
+        response_metadata: message.response_metadata,
+        id: message.id,
+        name: message.name,
+        tool_calls: message.tool_calls,
+        invalid_tool_calls: message.invalid_tool_calls,
+        ...(message instanceof AIMessageChunk
+          ? { tool_call_chunks: message.tool_call_chunks }
+          : {}),
+      };
+
+  return message instanceof AIMessageChunk
+    ? new AIMessageChunk({
+      ...baseParams,
+      usage_metadata: usageMetadata,
+    })
+    : new AIMessage({
+      ...baseParams,
+      usage_metadata: usageMetadata,
+    });
+}
+
+function normalizePromptCacheUsageGenerationForLangfuse(
+  generation: Generation
+): Generation {
+  if (!('message' in generation)) {
+    return generation;
+  }
+
+  const message = generation.message;
+  if (!(message instanceof AIMessage || message instanceof AIMessageChunk)) {
+    return generation;
+  }
+
+  const usageMetadata = normalizeUsageMetadataForLangfuse(
+    message.usage_metadata as UsageMetadata | undefined,
+    message.response_metadata as Record<string, unknown> | undefined
+  );
+  if (usageMetadata == null || usageMetadata === message.usage_metadata) {
+    return generation;
+  }
+
+  return {
+    ...generation,
+    message: cloneAIMessageWithUsageMetadata(message, usageMetadata),
+  } as Generation;
+}
+
+export function normalizePromptCacheUsageForLangfuse(
+  output: LLMResult
+): LLMResult {
+  let changed = false;
+  const generations = output.generations.map((generationList) =>
+    generationList.map((generation) => {
+      const normalized =
+        normalizePromptCacheUsageGenerationForLangfuse(generation);
+      if (normalized !== generation) {
+        changed = true;
+      }
+      return normalized;
+    })
+  );
+
+  return changed ? { ...output, generations } : output;
+}

--- a/src/llm/anthropic/utils/message_outputs.ts
+++ b/src/llm/anthropic/utils/message_outputs.ts
@@ -14,6 +14,11 @@ interface AnthropicUsageData {
   output_tokens?: number | null;
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
+  // Preserved in response_metadata.usage so Langfuse can split cache writes by TTL.
+  cache_creation?: {
+    ephemeral_5m_input_tokens?: number | null;
+    ephemeral_1h_input_tokens?: number | null;
+  } | null;
 }
 
 export function getAnthropicUsageMetadata(

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -22,7 +22,7 @@
  */
 
 import { ChatBedrockConverse } from '@langchain/aws';
-import { AIMessageChunk } from '@langchain/core/messages';
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import { ChatGenerationChunk, ChatResult } from '@langchain/core/outputs';
 import {
   ConverseStreamCommand,
@@ -40,6 +40,7 @@ import {
   handleConverseStreamMetadata,
 } from './utils';
 import {
+  createPromptCacheTtlResponseMetadata,
   resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
   type PromptCacheTtl,
@@ -216,7 +217,12 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     }
 
     try {
-      return await super._generateNonStreaming(messages, options, runManager);
+      const result = await super._generateNonStreaming(
+        messages,
+        options,
+        runManager
+      );
+      return this.withPromptCacheTtlMetadata(result);
     } finally {
       this.model = originalModel;
     }
@@ -242,6 +248,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     if ((options as Record<string, unknown>).streamUsage !== undefined) {
       streamUsage = (options as Record<string, unknown>).streamUsage as boolean;
     }
+    const promptCacheTtl = this.getPromptCacheTtl();
 
     const modelId = this.getModelId();
 
@@ -319,7 +326,10 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           { chunk: deltaChunk }
         );
       } else if (event.metadata != null) {
-        yield handleConverseStreamMetadata(event.metadata, { streamUsage });
+        yield handleConverseStreamMetadata(event.metadata, {
+          streamUsage,
+          promptCacheTtl,
+        });
       } else if (event.contentBlockStop != null) {
         const stopIdx = event.contentBlockStop.contentBlockIndex;
         if (stopIdx != null) {
@@ -410,6 +420,62 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
       }),
       generationInfo: chunk.generationInfo,
     });
+  }
+
+  private getPromptCacheTtl(): PromptCacheTtl | undefined {
+    return this.promptCache === true
+      ? resolveBedrockPromptCacheTtl(this.promptCacheTtl, this.cacheModelId)
+      : undefined;
+  }
+
+  private withPromptCacheTtlMetadata(result: ChatResult): ChatResult {
+    const promptCacheTtl = this.getPromptCacheTtl();
+    if (promptCacheTtl == null) {
+      return result;
+    }
+
+    let changed = false;
+    const generations = result.generations.map((generation) => {
+      const message = generation.message;
+      if (!(message instanceof AIMessage)) {
+        return generation;
+      }
+
+      const inputTokenDetails = message.usage_metadata?.input_token_details as
+        | Record<string, unknown>
+        | undefined;
+      const cacheCreation = inputTokenDetails?.cache_creation;
+      if (
+        typeof cacheCreation !== 'number' ||
+        !Number.isFinite(cacheCreation) ||
+        cacheCreation <= 0
+      ) {
+        return generation;
+      }
+
+      changed = true;
+      return {
+        ...generation,
+        message: new AIMessage({
+          content: message.content,
+          additional_kwargs: message.additional_kwargs,
+          response_metadata: {
+            ...message.response_metadata,
+            ...createPromptCacheTtlResponseMetadata(
+              cacheCreation,
+              promptCacheTtl
+            ),
+          },
+          id: message.id,
+          name: message.name,
+          tool_calls: message.tool_calls,
+          invalid_tool_calls: message.invalid_tool_calls,
+          usage_metadata: message.usage_metadata,
+        }),
+      };
+    });
+
+    return changed ? { ...result, generations } : result;
   }
 
   /**

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -12,7 +12,7 @@ import {
   type MessageContentComplex,
 } from '@langchain/core/messages';
 import { concat } from '@langchain/core/utils/stream';
-import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { ChatGenerationChunk, type ChatResult } from '@langchain/core/outputs';
 import {
   BedrockRuntimeClient,
   ConverseCommand,
@@ -26,6 +26,7 @@ import {
 } from './utils';
 import type { GraphTools } from '@/types';
 import { toLangChainContent } from '@/messages/langchain';
+import { PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY } from '@/messages/cache';
 import { CustomChatBedrockConverse, ServiceTierType } from './index';
 import { partitionAndMarkBedrockToolCache } from './toolCache';
 
@@ -916,12 +917,16 @@ describe('handleConverseStreamMetadata - cache token extraction', () => {
 
     const chunk = handleConverseStreamMetadata(metadata, {
       streamUsage: true,
+      promptCacheTtl: '1h',
     });
     const msg = chunk.message as AIMessageChunk;
 
     expect(msg.usage_metadata?.input_token_details).toEqual({
       cache_read: 0,
       cache_creation: 10000,
+    });
+    expect(msg.response_metadata).toMatchObject({
+      [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '1h',
     });
   });
 
@@ -943,6 +948,46 @@ describe('handleConverseStreamMetadata - cache token extraction', () => {
     const msg = chunk.message as AIMessageChunk;
 
     expect(msg.usage_metadata).toBeUndefined();
+  });
+});
+
+describe('CustomChatBedrockConverse prompt-cache TTL metadata', () => {
+  test('stamps non-streaming cache writes with the resolved prompt-cache TTL', () => {
+    const model = new CustomChatBedrockConverse({
+      ...baseConstructorArgs,
+      model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      promptCache: true,
+      promptCacheTtl: '5m',
+    });
+    const result: ChatResult = {
+      generations: [
+        {
+          text: 'Hello!',
+          message: new AIMessage({
+            content: 'Hello!',
+            usage_metadata: {
+              input_tokens: 100,
+              output_tokens: 5,
+              total_tokens: 105,
+              input_token_details: {
+                cache_creation: 20,
+              },
+            },
+          }),
+        },
+      ],
+    };
+
+    const enriched = (
+      model as unknown as {
+        withPromptCacheTtlMetadata: (result: ChatResult) => ChatResult;
+      }
+    ).withPromptCacheTtlMetadata(result);
+
+    expect(enriched.generations[0].message.response_metadata).toMatchObject({
+      [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '5m',
+    });
+    expect(result.generations[0].message.response_metadata).toEqual({});
   });
 });
 

--- a/src/llm/bedrock/utils/message_outputs.ts
+++ b/src/llm/bedrock/utils/message_outputs.ts
@@ -22,6 +22,10 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import {
+  createPromptCacheTtlResponseMetadata,
+  type PromptCacheTtl,
+} from '@/messages/cache';
 import { toLangChainContent } from '@/messages/langchain';
 
 /**
@@ -349,7 +353,7 @@ export function createConverseToolUseStopChunk(
  */
 export function handleConverseStreamMetadata(
   metadata: ConverseStreamMetadataEvent,
-  extra: { streamUsage: boolean }
+  extra: { streamUsage: boolean; promptCacheTtl?: PromptCacheTtl }
 ): ChatGenerationChunk {
   const usage = metadata.usage as
     | (NonNullable<ConverseStreamMetadataEvent['usage']> & {
@@ -385,6 +389,10 @@ export function handleConverseStreamMetadata(
       response_metadata: {
         // Use the same key as returned from the Converse API
         metadata,
+        ...createPromptCacheTtlResponseMetadata(
+          cacheWrite,
+          extra.promptCacheTtl
+        ),
       },
     }),
   });

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -39,6 +39,26 @@ export type PromptCacheTtl = '5m' | '1h';
 export const DEFAULT_PROMPT_CACHE_TTL: PromptCacheTtl = '1h';
 
 /**
+ * Response metadata key used to tell observability sinks which prompt-cache
+ * TTL produced provider-reported cache write tokens.
+ */
+export const PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY = 'prompt_cache_ttl';
+
+export function createPromptCacheTtlResponseMetadata(
+  cacheCreation: unknown,
+  ttl: PromptCacheTtl | undefined
+): Partial<
+  Record<typeof PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY, PromptCacheTtl>
+> {
+  return typeof cacheCreation === 'number' &&
+    Number.isFinite(cacheCreation) &&
+    cacheCreation > 0 &&
+    ttl != null
+    ? { [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: ttl }
+    : {};
+}
+
+/**
  * Resolve an optionally-configured TTL to a concrete value, defaulting to the
  * 1-hour extended cache. Used at the Anthropic/Bedrock prompt-cache call sites.
  */

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,7 +1,14 @@
-import { HumanMessage } from '@langchain/core/messages';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
+import { CallbackHandler as LangfuseCallbackHandler } from '@langfuse/langchain';
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from '@langchain/core/messages';
+import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import type * as t from '@/types';
+import { PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY } from '@/messages/cache';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { Providers } from '@/common';
 import { Run } from '@/run';
@@ -505,5 +512,257 @@ describe('Langfuse callback composition', () => {
         agentName: 'Specialist Agent',
       })
     );
+  });
+
+  it('normalizes Bedrock cache write tokens into Langfuse TTL usage details', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessage({
+      content: 'done',
+      response_metadata: {
+        [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '1h',
+      },
+      usage_metadata: {
+        input_tokens: 8283,
+        output_tokens: 58,
+        total_tokens: 8341,
+        input_token_details: {
+          cache_read: 7618,
+          cache_creation: 604,
+        },
+      },
+    });
+    const output: LLMResult = {
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    };
+
+    const normalized = normalizePromptCacheUsageForLangfuse(output);
+    const normalizedMessage = (normalized.generations[0][0] as ChatGeneration)
+      .message as AIMessage;
+
+    expect(normalizedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_read: 7618,
+      cache_creation: 0,
+      cache_creation_1h: 604,
+    });
+    expect(message.usage_metadata?.input_token_details).toEqual({
+      cache_read: 7618,
+      cache_creation: 604,
+    });
+  });
+
+  it('normalizes Bedrock 5m cache write tokens for Langfuse', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessage({
+      content: 'done',
+      response_metadata: {
+        [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '5m',
+      },
+      usage_metadata: {
+        input_tokens: 100,
+        output_tokens: 10,
+        total_tokens: 110,
+        input_token_details: {
+          cache_creation: 25,
+        },
+      },
+    });
+
+    const normalized = normalizePromptCacheUsageForLangfuse({
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    });
+    const normalizedMessage = (normalized.generations[0][0] as ChatGeneration)
+      .message as AIMessage;
+
+    expect(normalizedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_creation: 0,
+      cache_creation_5m: 25,
+    });
+  });
+
+  it('leaves generic cache creation untouched when Bedrock TTL is missing', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessage({
+      content: 'done',
+      usage_metadata: {
+        input_tokens: 100,
+        output_tokens: 10,
+        total_tokens: 110,
+        input_token_details: {
+          cache_creation: 25,
+        },
+      },
+    });
+
+    const output: LLMResult = {
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    };
+
+    expect(normalizePromptCacheUsageForLangfuse(output)).toBe(output);
+  });
+
+  it('normalizes Anthropic explicit cache creation buckets for Langfuse', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessage({
+      content: 'done',
+      response_metadata: {
+        model_provider: 'anthropic',
+        usage: {
+          cache_creation: {
+            ephemeral_5m_input_tokens: 10,
+            ephemeral_1h_input_tokens: 20,
+          },
+        },
+      },
+      usage_metadata: {
+        input_tokens: 40,
+        output_tokens: 5,
+        total_tokens: 45,
+        input_token_details: {
+          cache_read: 3,
+          cache_creation: 30,
+        },
+      },
+    });
+    const output: LLMResult = {
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    };
+
+    const normalized = normalizePromptCacheUsageForLangfuse(output);
+    const normalizedMessage = (normalized.generations[0][0] as ChatGeneration)
+      .message as AIMessage;
+
+    expect(normalizedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_read: 3,
+      cache_creation: 0,
+      cache_creation_5m: 10,
+      cache_creation_1h: 20,
+    });
+    expect(message.usage_metadata?.input_token_details).toEqual({
+      cache_read: 3,
+      cache_creation: 30,
+    });
+  });
+
+  it('keeps any unbucketed cache creation remainder on the generic key', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessage({
+      content: 'done',
+      response_metadata: {
+        model_provider: 'anthropic',
+        usage: {
+          cache_creation: {
+            ephemeral_5m_input_tokens: 10,
+            ephemeral_1h_input_tokens: 20,
+          },
+        },
+      },
+      usage_metadata: {
+        input_tokens: 50,
+        output_tokens: 5,
+        total_tokens: 55,
+        input_token_details: {
+          cache_creation: 35,
+        },
+      },
+    });
+
+    const normalized = normalizePromptCacheUsageForLangfuse({
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    });
+    const normalizedMessage = (normalized.generations[0][0] as ChatGeneration)
+      .message as AIMessage;
+
+    expect(normalizedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_creation: 5,
+      cache_creation_5m: 10,
+      cache_creation_1h: 20,
+    });
+  });
+
+  it('normalizes AIMessageChunk usage metadata', async () => {
+    const { normalizePromptCacheUsageForLangfuse } = await import(
+      '@/langfuse/promptCacheUsage'
+    );
+    const message = new AIMessageChunk({
+      content: 'done',
+      response_metadata: {
+        [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '1h',
+      },
+      usage_metadata: {
+        input_tokens: 50,
+        output_tokens: 5,
+        total_tokens: 55,
+        input_token_details: {
+          cache_creation: 12,
+        },
+      },
+    });
+
+    const normalized = normalizePromptCacheUsageForLangfuse({
+      generations: [[{ text: 'done', message } as ChatGeneration]],
+    });
+    const normalizedMessage = (normalized.generations[0][0] as ChatGeneration)
+      .message as AIMessageChunk;
+
+    expect(normalizedMessage).toBeInstanceOf(AIMessageChunk);
+    expect(normalizedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_creation: 0,
+      cache_creation_1h: 12,
+    });
+  });
+
+  it('normalizes prompt cache usage before delegating to Langfuse handleLLMEnd', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const handleLLMEndSpy = jest
+      .spyOn(LangfuseCallbackHandler.prototype, 'handleLLMEnd')
+      .mockResolvedValue(undefined);
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const message = new AIMessage({
+      content: 'done',
+      response_metadata: {
+        [PROMPT_CACHE_TTL_RESPONSE_METADATA_KEY]: '1h',
+      },
+      usage_metadata: {
+        input_tokens: 50,
+        output_tokens: 5,
+        total_tokens: 55,
+        input_token_details: {
+          cache_creation: 12,
+        },
+      },
+    });
+
+    await handler?.handleLLMEnd(
+      { generations: [[{ text: 'done', message } as ChatGeneration]] },
+      'llm-run'
+    );
+
+    const delegatedOutput = handleLLMEndSpy.mock.calls[0]?.[0] as LLMResult;
+    handleLLMEndSpy.mockRestore();
+    const delegatedMessage = (
+      delegatedOutput.generations[0][0] as ChatGeneration
+    ).message as AIMessage;
+    expect(delegatedMessage.usage_metadata?.input_token_details).toEqual({
+      cache_creation: 0,
+      cache_creation_1h: 12,
+    });
+    expect(message.usage_metadata?.input_token_details).toEqual({
+      cache_creation: 12,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- normalize prompt cache creation tokens into Langfuse TTL-specific usage buckets
- infer Bedrock cache-write TTL from the configured prompt cache TTL
- preserve Anthropic explicit 5m/1h cache creation buckets when available
- keep LibreChat usage metadata unchanged outside the Langfuse callback path

## Root cause
Langfuse's LangChain callback maps `usage_metadata.input_token_details` keys directly into `input_*` usage details. The agents provider paths only emitted generic `cache_creation`, so TTL-specific Langfuse model pricing keys such as `input_cache_creation_5m` and `input_cache_creation_1h` were never populated.

## Validation
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- src/specs/langfuse-callbacks.test.ts --runInBand`
- `npm test -- src/llm/bedrock/llm.spec.ts --runInBand`