### PR TITLE
feat(search): add Keenable as a search provider

### DIFF
--- a/src/tools/search/keenable-search.ts
+++ b/src/tools/search/keenable-search.ts
@@ -1,0 +1,86 @@
+import axios from 'axios';
+import type * as t from './types';
+
+const DEFAULT_KEENABLE_TIMEOUT = 15000;
+
+/** Authenticated and keyless endpoints. Keenable works without an API key by
+ * falling back to the public endpoint; a key only lifts rate limits. */
+const KEENABLE_DEFAULT_API_URL = 'https://api.keenable.ai/v1/search';
+const KEENABLE_PUBLIC_API_URL = 'https://api.keenable.ai/v1/search/public';
+
+export const createKeenableAPI = (
+  apiKey?: string,
+  apiUrl?: string,
+  options?: t.KeenableSearchOptions
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  const resolvedKey = apiKey ?? process.env.KEENABLE_API_KEY;
+  const hasKey = resolvedKey != null && resolvedKey !== '';
+  const timeout = options?.timeout ?? DEFAULT_KEENABLE_TIMEOUT;
+  const resolvedUrl =
+    apiUrl ??
+    process.env.KEENABLE_API_URL ??
+    (hasKey ? KEENABLE_DEFAULT_API_URL : KEENABLE_PUBLIC_API_URL);
+
+  /** Constant for the provider's lifetime. X-Keenable-Title is required for
+   * keyless requests and used for traffic attribution; the API key only lifts
+   * rate limits, so it is sent only when present. */
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'X-Keenable-Title': options?.attributionTitle ?? 'LibreChat',
+  };
+  if (hasKey) {
+    headers['X-API-Key'] = resolvedKey;
+  }
+
+  const getSources = async ({
+    query,
+    numResults = 8,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    try {
+      /** Keenable's endpoint has no result-count parameter; the count is
+       * applied client-side after the response (see slice below). */
+      const payload: t.KeenableSearchPayload = { query };
+      if (options?.site != null && options.site !== '') {
+        payload.site = options.site;
+      }
+
+      const response = await axios.post<t.KeenableSearchResponse>(
+        resolvedUrl,
+        payload,
+        { headers, timeout }
+      );
+
+      const maxResults = Math.min(
+        Math.max(1, options?.maxResults ?? numResults),
+        20
+      );
+      const rawResults = Array.isArray(response.data.results)
+        ? response.data.results.slice(0, maxResults)
+        : [];
+
+      const organic: t.OrganicResult[] = rawResults.map((result) => ({
+        title: result.title ?? '',
+        link: result.url ?? '',
+        snippet: result.description ?? result.snippet ?? '',
+        date: result.published_at,
+      }));
+
+      return { success: true, data: { organic } };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Keenable API request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/keenable.test.ts
+++ b/src/tools/search/keenable.test.ts
@@ -1,0 +1,131 @@
+import axios from 'axios';
+import { createSearchAPI } from './search';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const sampleResponse = {
+  data: {
+    results: [
+      {
+        title: 'TypeScript Best Practices 2026',
+        url: 'https://example.com/ts',
+        description: 'A comprehensive guide to TypeScript.',
+        published_at: '2026-01-15T10:30:00Z',
+      },
+      {
+        title: 'Second result',
+        url: 'https://example.com/second',
+        snippet: 'Snippet fallback when description is absent.',
+      },
+    ],
+  },
+};
+
+describe('Keenable search API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.KEENABLE_API_KEY;
+    delete process.env.KEENABLE_API_URL;
+  });
+
+  it('returns an error for empty queries without calling the API', async () => {
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({ success: false, error: 'Query cannot be empty' });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('hits the public endpoint and omits the API key header when keyless', async () => {
+    mockedAxios.post.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.keenable.ai/v1/search/public',
+      { query: 'typescript' },
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Keenable-Title': 'LibreChat' }),
+      })
+    );
+    const headers = mockedAxios.post.mock.calls[0][2]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers['X-API-Key']).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('hits the authenticated endpoint and sends the API key when a key is set', async () => {
+    mockedAxios.post.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'keenable',
+      keenableApiKey: 'secret-key',
+    });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.keenable.ai/v1/search',
+      { query: 'typescript' },
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'secret-key' }),
+      })
+    );
+  });
+
+  it('maps results into organic sources (description and snippet fallback)', async () => {
+    mockedAxios.post.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.organic).toEqual([
+      {
+        title: 'TypeScript Best Practices 2026',
+        link: 'https://example.com/ts',
+        snippet: 'A comprehensive guide to TypeScript.',
+        date: '2026-01-15T10:30:00Z',
+      },
+      {
+        title: 'Second result',
+        link: 'https://example.com/second',
+        snippet: 'Snippet fallback when description is absent.',
+        date: undefined,
+      },
+    ]);
+  });
+
+  it('applies the site filter and limits results client-side', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        results: [{ url: '1' }, { url: '2' }, { url: '3' }],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'keenable',
+      keenableSearchOptions: { site: 'github.com', maxResults: 2 },
+    });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      { query: 'typescript', site: 'github.com' },
+      expect.any(Object)
+    );
+    expect(result.data?.organic).toHaveLength(2);
+  });
+
+  it('surfaces request failures as a structured error', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Keenable API request failed: Network error');
+  });
+});

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
+import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
 import { BaseReranker } from './rerankers';
 
@@ -445,6 +446,9 @@ export const createSearchAPI = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions,
+    keenableApiKey,
+    keenableApiUrl,
+    keenableSearchOptions,
   } = config;
 
   if (searchProvider.toLowerCase() === 'serper') {
@@ -453,9 +457,15 @@ export const createSearchAPI = (
     return createSearXNGAPI(searxngInstanceUrl, searxngApiKey);
   } else if (searchProvider.toLowerCase() === 'tavily') {
     return createTavilyAPI(tavilyApiKey, tavilySearchUrl, tavilySearchOptions);
+  } else if (searchProvider.toLowerCase() === 'keenable') {
+    return createKeenableAPI(
+      keenableApiKey,
+      keenableApiUrl,
+      keenableSearchOptions
+    );
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', or 'tavily'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'keenable'`
     );
   }
 };

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -315,7 +315,11 @@ function createTool({
         }),
       });
       const turn = runnableConfig.toolCall?.turn ?? 0;
-      const { output, references } = formatResultsForLLM(turn, searchResult, maxOutputChars);
+      const { output, references } = formatResultsForLLM(
+        turn,
+        searchResult,
+        maxOutputChars
+      );
       const data: t.SearchResultData = { turn, ...searchResult, references };
       return [output, { [Constants.WEB_SEARCH]: data }];
     },
@@ -358,6 +362,9 @@ export const createSearchTool = (
     tavilySearchUrl,
     tavilyExtractUrl,
     tavilySearchOptions,
+    keenableApiKey,
+    keenableApiUrl,
+    keenableSearchOptions,
     rerankerType = 'cohere',
     topResults = 5,
     maxContentLength,
@@ -415,6 +422,9 @@ export const createSearchTool = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions: effectiveTavilySearchOptions,
+    keenableApiKey,
+    keenableApiUrl,
+    keenableSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */
@@ -477,7 +487,8 @@ export const createSearchTool = (
   const search = createSearchProcessor({
     searchAPI,
     safeSearch,
-    supportsVideos: searchProvider !== 'tavily',
+    supportsVideos:
+      searchProvider !== 'tavily' && searchProvider !== 'keenable',
     sourceProcessor,
     onGetHighlights,
     logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,7 +3,7 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable';
 export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
@@ -115,6 +115,35 @@ export interface SearchConfig {
   tavilySearchUrl?: string;
   tavilyExtractUrl?: string;
   tavilySearchOptions?: TavilySearchOptions;
+  keenableApiKey?: string;
+  keenableApiUrl?: string;
+  keenableSearchOptions?: KeenableSearchOptions;
+}
+
+export interface KeenableSearchOptions {
+  maxResults?: number;
+  /** Restrict results to a single domain, e.g. "github.com". */
+  site?: string;
+  /** Sent as the X-Keenable-Title attribution header. Defaults to "LibreChat". */
+  attributionTitle?: string;
+  timeout?: number;
+}
+
+export interface KeenableSearchPayload {
+  query: string;
+  site?: string;
+}
+
+export interface KeenableSearchResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  snippet?: string;
+  published_at?: string;
+}
+
+export interface KeenableSearchResponse {
+  results?: KeenableSearchResult[];
 }
 
 export type References = {


### PR DESCRIPTION
Adds Keenable as a first-class search provider, modeled on the existing Tavily provider.

Context: this comes out of danny-avila/LibreChat#13805, where @danny-avila pointed out that the right home for Keenable is a provider here rather than a standalone tool in LibreChat, so it inherits the shared scraping/reranking/highlighting pipeline. This is that move.

What's here:
- `keenable-search.ts` — `createKeenableAPI`, maps Keenable's `/v1/search` results into `organic` sources. The rest of the pipeline (scraping, reranking, highlights, formatting) is reused unchanged.
- `types.ts` — `'keenable'` added to `SearchProvider`; `KeenableSearchOptions` plus payload/response types.
- `search.ts` / `tool.ts` — wired into `createSearchAPI` and `createSearchTool`. No video search for Keenable, same as Tavily.
- `keenable.test.ts` — keyless vs authenticated endpoint, field mapping, `site` filter, client-side result count, error handling.

Notes:
- Keyless by default: with no key it hits the public endpoint; `X-API-Key` is only sent when a key is set. A key just lifts rate limits.
- The endpoint has no result-count parameter, so the count is applied client-side.
- LibreChat-side config (the `SearchProviders` enum, schema, and auth wiring) is a separate follow-up PR once this is released.

Tests pass, lint and typecheck clean.
