### PR TITLE
feat: Explicit `preserveReasoningContent` option for `formatAgentMessages`

### DIFF
--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -334,6 +334,10 @@ interface FormatAssistantMessageOptions {
 
 interface FormatAgentMessagesOptions {
   provider?: Providers;
+  /** Reconstruct hidden `reasoning_content` from `THINK` parts onto prior
+   *  tool-call messages. Explicit opt-in for OpenAI-compatible endpoints that
+   *  replay reasoning across turns; defaults to on for DeepSeek thinking-mode. */
+  preserveReasoningContent?: boolean;
   /** Skill names already primed fresh this turn (manual/always-apply). Their
    *  historical `skill` tool_calls are not reconstructed into a HumanMessage,
    *  so the same SKILL.md body is not injected twice in one request. */
@@ -1435,7 +1439,8 @@ export const formatAgentMessages = (
 
     const formattedMessages = formatAssistantMessage(processedMessage, {
       preserveUnpairedServerToolUses: i === payload.length - 1,
-      preserveReasoningContent: options?.provider === Providers.DEEPSEEK,
+      preserveReasoningContent:
+        options?.preserveReasoningContent ?? options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
     });
     if (sourceMessageId != null && sourceMessageId !== '') {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -2189,6 +2189,82 @@ describe('formatAgentMessages', () => {
     );
   });
 
+  it('should preserve hidden reasoning_content via explicit preserveReasoningContent without a provider', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.THINK,
+            [ContentTypes.THINK]: 'Need calculator.',
+          },
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Using calculator.',
+            tool_call_ids: ['call_1'],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'call_1',
+              name: 'calculator',
+              args: '{"input":"127 * 453"}',
+              output: '57531',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload, undefined, undefined, undefined, {
+      preserveReasoningContent: true,
+    });
+
+    const toolCallMessage = result.messages[0] as AIMessage;
+    expect(toolCallMessage.tool_calls).toHaveLength(1);
+    expect(toolCallMessage.additional_kwargs.reasoning_content).toBe(
+      'Need calculator.'
+    );
+  });
+
+  it('should not reconstruct reasoning_content when preserveReasoningContent is explicitly false for DeepSeek', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.THINK,
+            [ContentTypes.THINK]: 'Need calculator.',
+          },
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Using calculator.',
+            tool_call_ids: ['call_1'],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'call_1',
+              name: 'calculator',
+              args: '{"input":"127 * 453"}',
+              output: '57531',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload, undefined, undefined, undefined, {
+      provider: Providers.DEEPSEEK,
+      preserveReasoningContent: false,
+    });
+
+    const toolCallMessage = result.messages[0] as AIMessage;
+    expect(
+      toolCallMessage.additional_kwargs.reasoning_content
+    ).toBeUndefined();
+  });
+
   it('should preserve DeepSeek reasoning from supported hidden content blocks', () => {
     const payload: TPayload = [
       {


### PR DESCRIPTION
## Summary

Adds an explicit `preserveReasoningContent` option to `formatAgentMessages`, so OpenAI-compatible callers can opt into cross-turn `reasoning_content` reconstruction without spoofing `provider: deepseek`.

Today, `formatAgentMessages` only reconstructs hidden `reasoning_content` from `THINK` parts when `provider === Providers.DEEPSEEK`. Downstream (LibreChat), the only way to enable this for a non-DeepSeek reasoning endpoint (e.g. Xiaomi MiMo, Kimi) is to pass `provider: Providers.DEEPSEEK` purely to flip that boolean — which is misleading and only stays safe because no other provider-keyed branch happens to fire for that value.

- Added `preserveReasoningContent?: boolean` to `FormatAgentMessagesOptions`.
- The explicit option wins; falls back to the existing DeepSeek thinking-mode default when unset: `options?.preserveReasoningContent ?? options?.provider === Providers.DEEPSEEK`.
- Fully backward compatible — existing DeepSeek callers (and the `provider: DEEPSEEK` path) are unchanged.

This lets a caller pass `{ preserveReasoningContent: true }` directly instead of laundering intent through a fake provider.

## Testing

- `should preserve hidden reasoning_content via explicit preserveReasoningContent without a provider` — reconstructs reasoning with no `provider` set.
- `should not reconstruct reasoning_content when preserveReasoningContent is explicitly false for DeepSeek` — explicit `false` overrides the DeepSeek default (validates the `??` precedence).
- `src/messages/` suite: 402 passed (+2 new); `tsc --noEmit` clean; eslint clean.

## Downstream

Consumed by LibreChat to replace its `provider: DEEPSEEK` format spoof with `{ preserveReasoningContent: true }` once this ships in a release (paired with the `@librechat/agents` version bump).
