### PR TITLE
chore: bump @langchain/langgraph to 1.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@langchain/google-gauth": "2.2.0",
         "@langchain/google-genai": "2.2.0",
         "@langchain/google-vertexai": "2.2.0",
-        "@langchain/langgraph": "^1.2.9",
+        "@langchain/langgraph": "^1.4.5",
         "@langchain/mistralai": "^1.2.0",
         "@langchain/openai": "1.5.3",
         "@langchain/textsplitters": "^1.0.1",
@@ -2277,21 +2277,21 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
-      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.5.tgz",
+      "integrity": "sha512-V+o29JPBaMoK/e+8R/m81XaC8h5iNuwWymvgLFhXfJbf7E2xt2mQUkcVXTi4cudGRHbRd14kidCpfaQbfPoYCw==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.9",
-        "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.2",
+        "@langchain/langgraph-sdk": "~1.9.24",
+        "@langchain/protocol": "^0.0.18",
+        "@standard-schema/spec": "1.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.40",
+        "@langchain/core": "^1.1.48",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -2302,42 +2302,36 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
-      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.2.tgz",
+      "integrity": "sha512-m5Xd7W3G9JrlEhFZ5WAcqZPgE46R9gr1gFDFaVqEKeuwin3tgEp0jlPbru+iFXCug338DcQjFS/Kuuci21ydvw==",
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^10.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1"
+        "@langchain/core": "^1.1.48"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.10.tgz",
-      "integrity": "sha512-wrB3rkRw5KAmsqezwvKP3midT4qJrV6Hj9XJMYo+cbvXC4HYpSAmyY/VriSyeTFRbLG/OP/pY2Yz+9Z54nSaXQ==",
+      "version": "1.9.24",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.24.tgz",
+      "integrity": "sha512-WhM6QdxNipndQjl5nkvqnBt9Wl16oO2p0KiVhndAFLJMwO3bZLEx++lwtbqUFQu1sHyNxiWixgRGm8qZsuHCeA==",
       "license": "MIT",
       "dependencies": {
+        "@langchain/protocol": "^0.0.18",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
-        "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "p-retry": "^7.1.1"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.16",
+        "@langchain/core": "^1.1.48",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
         "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
         "react": {
           "optional": true
         },
@@ -2353,9 +2347,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
-      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -2378,19 +2372,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
-      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@langchain/mistralai": {
@@ -2433,6 +2414,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+      "integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
+      "license": "MIT"
     },
     "node_modules/@langchain/textsplitters": {
       "version": "1.0.1",
@@ -7914,9 +7901,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "license": "MIT",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "@langchain/google-gauth": "2.2.0",
     "@langchain/google-genai": "2.2.0",
     "@langchain/google-vertexai": "2.2.0",
-    "@langchain/langgraph": "^1.2.9",
+    "@langchain/langgraph": "^1.4.5",
     "@langchain/mistralai": "^1.2.0",
     "@langchain/openai": "1.5.3",
     "@langchain/textsplitters": "^1.0.1",


### PR DESCRIPTION
## Summary

Bumps `@langchain/langgraph` `^1.2.9 → ^1.4.5`. langgraph is the graph runtime (no LLM fork), so this is a version-only bump like mistralai — but the 1.3/1.4 additions unlock several upcoming features (HITL e2e, stream consolidation, tool state) and are being scoped separately.

- Single 1.4.5 copy, install + build **clean**, **2461 deterministic tests pass** locally. Live `*.spec`/`*.simple`/`*.int` suites (need provider keys) run in CI.

Notable 1.3/1.4 capabilities now available: native in-process `streamEvents` runtime + `@langchain/langgraph/stream` toolkit (1.3.x), `ToolNode` `runtime.state` (1.4.1), `RunControl` cooperative draining + node error handlers/timeouts (1.4.0), `DeltaChannel` writes-history saver (1.4.0, beta), and HITL `respond(resume, update, goto)` in one superstep (1.4.5).

## Testing

`npm run build` clean; deterministic suite green (133 suites / 2461 tests). No fork changes (no provider fork depends on langgraph directly).
