### PR TITLE
feat(run): forward update + goto on resume (langgraph 1.4.5)

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -1139,6 +1139,20 @@ export class Run<_T extends t.BaseGraphState> {
     return cp == null ? 0 : cp.rewind();
   }
 
+  /**
+   * Resume an interrupted run. `commandOptions` forwards langgraph 1.4.5
+   * `Command` fields applied together with `resume` in one superstep:
+   * - `update`: channel updates committed at the resume point. On a *rebuilt*
+   *   Run (new instance + durable checkpointer), `update.messages` are the first
+   *   write the fresh wrapper sees, so they seed the `getRunMessages()` /
+   *   `returnContent` baseline and are excluded from them (still committed to the
+   *   checkpoint). Hosts that rebuild + inject messages should persist them
+   *   directly or read from `getState`. Unreachable without a durable checkpointer.
+   * - `goto`: a *dynamic* edge that does not cancel static `addEdge` routes. On
+   *   the built-in standard graph the fixed `toolNode -> agentNode/END` edge still
+   *   fires, so `goto` adds rather than replaces (e.g. `goto: END` will not stop a
+   *   tool-node resume). Intended for custom, Command-routed graphs.
+   */
   async resume<TResume = t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap>(
     resumeValue: TResume,
     callerConfig: Partial<RunnableConfig> & {

--- a/src/run.ts
+++ b/src/run.ts
@@ -667,7 +667,7 @@ export class Run<_T extends t.BaseGraphState> {
     const graph = this.Graph;
 
     /**
-     * `Command` inputs (currently only `Command({ resume })`) are
+     * `Command` inputs (`Command({ resume, update?, goto? })`) are
      * resume-mode invocations: LangGraph rebuilds graph state from the
      * checkpointer, so we skip RunStart / UserPromptSubmit hooks (no
      * new prompt to evaluate) and read run-state from the Graph wrapper
@@ -1145,7 +1145,11 @@ export class Run<_T extends t.BaseGraphState> {
       version: 'v1' | 'v2';
       run_id?: string;
     },
-    streamOptions?: t.EventStreamOptions
+    streamOptions?: t.EventStreamOptions,
+    commandOptions?: Pick<
+      ConstructorParameters<typeof Command>[0],
+      'update' | 'goto'
+    >
   ): Promise<MessageContentComplex[] | undefined> {
     const interruptId = this._interrupt?.interruptId;
     const scopedResume =
@@ -1155,8 +1159,18 @@ export class Run<_T extends t.BaseGraphState> {
         ? { [interruptId]: resumeValue }
         : resumeValue;
     const resumeConfig = await this.resolveInterruptResumeConfig(callerConfig);
+    // langgraph 1.4.5 applies resume + state update + reroute in one superstep
+    // (single checkpoint). `update`/`goto` are omitted unless the caller sets them.
     return this.processStream(
-      new Command({ resume: scopedResume }),
+      new Command({
+        resume: scopedResume,
+        ...(commandOptions?.update !== undefined
+          ? { update: commandOptions.update }
+          : {}),
+        ...(commandOptions?.goto !== undefined
+          ? { goto: commandOptions.goto }
+          : {}),
+      }),
       resumeConfig,
       streamOptions
     );

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -951,6 +951,120 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     expect(run.getHaltReason()).toBeUndefined();
   });
 
+  it('Run.resume() forwards `update` so langgraph applies the channel edit through streamEvents', async () => {
+    /** Executing proof (not a spy): interrupt on a tool, resume with an
+     * injected message via `update`, then read the committed checkpoint.
+     * langgraph 1.4.5 maps an INPUT resume Command through `mapCommand`
+     * (pregel/io.js), which applies resume AND update AND goto, so the
+     * injected message must land in the messages channel. */
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        const request = data as {
+          toolCalls: t.ToolCallRequest[];
+          resolve: (r: t.ToolExecuteResult[]) => void;
+        };
+        request.resolve(
+          request.toolCalls.map((c) => ({
+            toolCallId: c.id,
+            content: 'host-result',
+            status: 'success' as const,
+          }))
+        );
+      });
+
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review',
+        }),
+      ],
+    });
+
+    const hexToolCallId = '0123456789abcdef0123456789abcdef';
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo')],
+      eventDrivenMode: true,
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([[hexToolCallId, 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+
+    const builder = new StateGraph(MessagesAnnotation)
+      .addNode(
+        'agent',
+        (): MessagesUpdate => ({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                { id: hexToolCallId, name: 'echo', args: { command: 'x' } },
+              ],
+            }),
+          ],
+        })
+      )
+      .addNode('tools', node)
+      .addEdge(START, 'agent')
+      .addEdge('agent', 'tools')
+      .addEdge('tools', END);
+    const graph = builder.compile({ checkpointer: new MemorySaver() });
+
+    const { Run } = await import('@/run');
+    const { HumanMessage } = await import('@langchain/core/messages');
+    const run = await Run.create<t.IState>({
+      runId: 'run-resume-update',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+
+    const callerConfig = {
+      configurable: { thread_id: 'run-resume-update-thread' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, callerConfig);
+    expect(run.getInterrupt()).toBeDefined();
+
+    const injected = new HumanMessage({ content: 'human-injected-on-resume' });
+    await run.resume(
+      { [hexToolCallId]: { type: 'approve' } },
+      callerConfig,
+      undefined,
+      { update: { messages: [injected] } }
+    );
+
+    expect(run.getInterrupt()).toBeUndefined();
+
+    const state = await graph.getState(callerConfig);
+    const contents = (state.values.messages as BaseMessage[]).map(
+      (m) => m.content
+    );
+    /** Proves langgraph honored `update` on the INPUT resume Command. */
+    expect(contents).toContain('human-injected-on-resume');
+    /** Resume itself still completed: the approved tool produced its result. */
+    expect(contents).toContain('host-result');
+  });
+
   it('Run.getHaltReason() reports prompt_denied when UserPromptSubmit denies the prompt', async () => {
     const registry = new HookRegistry();
     registry.register('UserPromptSubmit', {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -761,6 +761,54 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     expect(run.Graph?.compileOptions?.checkpointer).toBe(hostCheckpointer);
   });
 
+  it('Run.resume forwards update + goto into the resume Command (langgraph 1.4.5)', async () => {
+    const { Run } = await import('@/run');
+    const { Providers } = await import('@/common');
+
+    const run = await Run.create<t.IState>({
+      runId: 'hitl-resume-update-goto',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: Providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+    });
+
+    const spy = jest.spyOn(run, 'processStream').mockResolvedValue(undefined);
+
+    const decision = [{ type: 'approve' as const }];
+    const update = { messages: [new AIMessage('host-edit')] };
+    await run.resume(
+      decision,
+      { version: 'v1', configurable: { thread_id: 't' } },
+      undefined,
+      { update, goto: 'agent' }
+    );
+
+    const cmd = spy.mock.calls[0]?.[0] as Command;
+    expect(cmd).toBeInstanceOf(Command);
+    // No interrupt was captured, so the resume value passes through unscoped.
+    expect(cmd.resume).toEqual(decision);
+    expect(cmd.update).toEqual(update);
+    expect(cmd.goto).toEqual(['agent']); // langgraph normalizes goto to an array
+
+    // Backward-compat: omitting commandOptions leaves update unset, goto empty.
+    await run.resume(decision, {
+      version: 'v1',
+      configurable: { thread_id: 't' },
+    });
+    const cmd2 = spy.mock.calls[1]?.[0] as Command;
+    expect(cmd2.update).toBeUndefined();
+    expect(cmd2.goto).toEqual([]);
+  });
+
   it('re-exports langgraph HITL primitives from the SDK barrel for host use', async () => {
     const indexExports = await import('@/index');
     expect(indexExports.MemorySaver).toBe(MemorySaver);


### PR DESCRIPTION
## Summary

Extends the SDK's `Run.resume()` to forward `update` + `goto` into the resume `Command` (langgraph 1.4.5), so a human-in-the-loop approval can **commit a state edit and reroute in the same superstep** (one checkpoint, no flicker) — not just resume.

- `resume()` gains an optional 4th param `commandOptions?: Pick<ConstructorParameters<typeof Command>[0], 'update' | 'goto'>`, threaded into `new Command({ resume, update?, goto? })` (`src/run.ts`).
- **Backward-compatible:** existing `resume(value, config, streamOptions?)` callers are untouched — `update` is omitted and `goto` stays `[]` unless the caller sets them.
- This is the concrete HITL-resume capability flagged in the durable-substrate design (#271): `resume()` previously only built `Command({ resume })`.

Self-contained in `run.ts` — no overlap with the in-flight `runtime.state` (ToolNode/MultiAgentGraph) or stream-dispatch work, and doesn't depend on the durable-checkpointer decisions.

## Testing

`npm run build` clean. New `Run.create`-harness test asserts the resume `Command` carries `update` + (array-normalized) `goto`, and that omitting `commandOptions` leaves `update` undefined / `goto` `[]`. Full deterministic suite green (135 suites / 2481 tests).
