### PR TITLE
feat: forward runtime.state to tools (langgraph 1.4.1), drop getCurrentTaskInput

### DIFF
--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -12,12 +12,11 @@ import {
   Command,
   StateGraph,
   Annotation,
-  getCurrentTaskInput,
   messagesStateReducer,
 } from '@langchain/langgraph';
 import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
-import type { ToolRunnableConfig } from '@langchain/core/tools';
+import type { ToolRuntime } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { StandardGraph } from './Graph';
 import { Constants } from '@/common';
@@ -330,12 +329,10 @@ export class MultiAgentGraph extends StandardGraph {
 
       tools.push(
         tool(
-          async (rawInput, config) => {
+          async (rawInput, runtime: ToolRuntime) => {
             const input = rawInput as Record<string, unknown>;
-            const state = getCurrentTaskInput() as t.BaseGraphState;
-            const toolCallId =
-              (config as ToolRunnableConfig | undefined)?.toolCall?.id ??
-              'unknown';
+            const state = runtime.state as t.BaseGraphState;
+            const toolCallId = runtime.toolCall?.id ?? 'unknown';
 
             /** Evaluated condition */
             const result = edge.condition!(state);
@@ -414,11 +411,9 @@ export class MultiAgentGraph extends StandardGraph {
 
         tools.push(
           tool(
-            async (rawInput, config) => {
+            async (rawInput, runtime: ToolRuntime) => {
               const input = rawInput as Record<string, unknown>;
-              const toolCallId =
-                (config as ToolRunnableConfig | undefined)?.toolCall?.id ??
-                'unknown';
+              const toolCallId = runtime.toolCall?.id ?? 'unknown';
 
               let content = `Successfully transferred to ${destination}`;
               if (
@@ -439,7 +434,7 @@ export class MultiAgentGraph extends StandardGraph {
                 },
               });
 
-              const state = getCurrentTaskInput() as t.BaseGraphState;
+              const state = runtime.state as t.BaseGraphState;
 
               /**
                * For parallel handoff support:

--- a/src/scripts/handoff-test.ts
+++ b/src/scripts/handoff-test.ts
@@ -10,10 +10,10 @@ import {
   MessagesAnnotation,
   Command,
   START,
-  getCurrentTaskInput,
   END,
 } from '@langchain/langgraph';
 import { ToolMessage } from '@langchain/core/messages';
+import type { ToolRuntime } from '@langchain/core/tools';
 
 interface CreateHandoffToolParams {
   agentName: string;
@@ -28,16 +28,15 @@ const createHandoffTool = ({
   const toolDescription = description || `Ask agent '${agentName}' for help`;
 
   const handoffTool = tool(
-    async (_, config) => {
+    async (_, runtime: ToolRuntime) => {
       const toolMessage = new ToolMessage({
         content: `Successfully transferred to ${agentName}`,
         name: toolName,
-        tool_call_id: config.toolCall.id,
+        tool_call_id: runtime.toolCallId,
       });
 
-      // inject the current agent state
-      const state =
-        getCurrentTaskInput() as (typeof MessagesAnnotation)['State'];
+      // inject the current agent state via langgraph 1.4 `runtime.state`
+      const state = runtime.state as (typeof MessagesAnnotation)['State'];
       return new Command({
         goto: agentName,
         update: { messages: state.messages.concat(toolMessage) },

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -19,8 +19,12 @@ import type {
   RunnableConfig,
   RunnableToolLike,
 } from '@langchain/core/runnables';
+import type {
+  ToolRuntime,
+  StructuredToolInterface,
+} from '@langchain/core/tools';
 import type { BaseMessage, AIMessage } from '@langchain/core/messages';
-import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type {
   ToolOutputResolveView,
   PreResolvedArgsMap,
@@ -65,7 +69,7 @@ import { executeHooks } from '@/hooks';
  * batch-scoped value the method needs so the signature stays at
  * three positional parameters even as new context fields are added.
  */
-type RunToolBatchContext = {
+type RunToolBatchContext<T = unknown> = {
   /** Position of this call within the parent ToolNode batch. */
   batchIndex?: number;
   /** Batch turn shared across every call in the batch. */
@@ -104,6 +108,13 @@ type RunToolBatchContext = {
    * contract for hosts relying on it for policy / recovery guidance.
    */
   additionalContextsSink?: string[];
+  /**
+   * Graph state the ToolNode was invoked with, threaded from `run()`
+   * so `tool.invoke` can forward it as langgraph 1.4's `runtime.state`
+   * (the deprecation-free replacement for `getCurrentTaskInput()`,
+   * which relies on `node:async_hooks` and is browser-incompatible).
+   */
+  runInput?: T;
 };
 
 const TOOL_NODE_RUN_NAME = 'tool_batch';
@@ -798,7 +809,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   protected async runTool(
     call: ToolCall,
     config: RunnableConfig,
-    batchContext: RunToolBatchContext = {}
+    batchContext: RunToolBatchContext<T> = {}
   ): Promise<BaseMessage | Command> {
     const {
       batchIndex,
@@ -806,6 +817,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       batchScopeId,
       resolvedArgsByCallId,
       preBatchSnapshot,
+      runInput,
     } = batchContext;
     const tool = this.toolMap.get(call.name);
     const registry = this.toolOutputRegistry;
@@ -980,7 +992,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       }
 
-      const output = await tool.invoke(invokeParams, config);
+      /**
+       * Forward the graph state as langgraph 1.4's `runtime.state` so
+       * tools can read it off their second argument instead of the
+       * deprecated `getCurrentTaskInput()` (which relies on
+       * `node:async_hooks` and is browser-incompatible). Shape mirrors
+       * langgraph's prebuilt ToolNode runtime exactly.
+       */
+      const lgConfig = config as LangGraphRunnableConfig;
+      const runtime: ToolRuntime<T> = {
+        ...config,
+        state: runInput as ToolRuntime<T>['state'],
+        toolCallId: call.id ?? '',
+        config,
+        context: lgConfig.context as ToolRuntime<T>['context'],
+        store: (lgConfig.store ?? null) as ToolRuntime<T>['store'],
+        writer:
+          lgConfig.writer ??
+          (config.configurable?.writer as ToolRuntime<T>['writer']) ??
+          null,
+      };
+      const output = await tool.invoke(invokeParams, runtime);
       if (isCommand(output)) {
         return output;
       }
@@ -1192,7 +1224,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private async runDirectToolWithLifecycleHooks(
     call: ToolCall,
     config: RunnableConfig,
-    batchContext: RunToolBatchContext = {}
+    batchContext: RunToolBatchContext<T> = {}
   ): Promise<BaseMessage | Command> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const hookRegistry = this.hookRegistry;
@@ -3162,6 +3194,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // branch, so direct tools dispatched via Send (a supported
       // input shape) still silently dropped hook context.
       const directAdditionalContexts: string[] = [];
+      // Mirror langgraph's prebuilt ToolNode: the Send-input state is
+      // the input minus the `lg_tool_call` envelope key.
+      const { lg_tool_call: _sendToolCall, ...sendState } = input;
       const sendOutput = await this.runDirectToolWithLifecycleHooks(
         input.lg_tool_call,
         config,
@@ -3171,6 +3206,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           batchScopeId,
           resolvedArgsByCallId,
           additionalContextsSink: directAdditionalContexts,
+          runInput: sendState as T,
         }
       );
       outputs =
@@ -3343,6 +3379,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                   resolvedArgsByCallId,
                   preBatchSnapshot,
                   additionalContextsSink: directAdditionalContexts,
+                  runInput: input as T,
                 })
               )
             )
@@ -3407,6 +3444,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               resolvedArgsByCallId,
               preBatchSnapshot,
               additionalContextsSink: directAdditionalContexts,
+              runInput: input as T,
             })
           )
         );

--- a/src/tools/__tests__/ToolNode.runtimeState.test.ts
+++ b/src/tools/__tests__/ToolNode.runtimeState.test.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { describe, it, expect } from '@jest/globals';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ToolRuntime } from '@langchain/core/tools';
+import { ToolNode } from '../ToolNode';
+
+type CapturedRuntime = {
+  state: unknown;
+  toolCallId: string;
+  toolCallIdFromConfig: string | undefined;
+};
+
+/**
+ * Tool that records the langgraph runtime it received as its second
+ * argument. Proves our forked ToolNode forwards `runtime.state` (the
+ * deprecation-free replacement for `getCurrentTaskInput()`).
+ */
+function createRuntimeProbeTool(captured: CapturedRuntime[]) {
+  return tool(
+    async (_input, runtime: ToolRuntime) => {
+      captured.push({
+        state: runtime.state,
+        toolCallId: runtime.toolCallId,
+        toolCallIdFromConfig: runtime.toolCall?.id,
+      });
+      return 'ok';
+    },
+    {
+      name: 'probe_runtime',
+      description: 'Records the runtime forwarded by the ToolNode',
+      schema: z.object({ value: z.string() }),
+    }
+  );
+}
+
+function aiMessageWithProbeCall(callId: string): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: [
+      {
+        id: callId,
+        name: 'probe_runtime',
+        args: { value: 'hello' },
+      },
+    ],
+  });
+}
+
+describe('ToolNode runtime.state forwarding (langgraph 1.4)', () => {
+  it('forwards the message-state input as runtime.state', async () => {
+    const captured: CapturedRuntime[] = [];
+    const toolNode = new ToolNode({
+      tools: [createRuntimeProbeTool(captured)],
+    });
+
+    const messages: BaseMessage[] = [
+      new HumanMessage('start'),
+      aiMessageWithProbeCall('call_1'),
+    ];
+    const input = { messages };
+
+    await toolNode.invoke(input);
+
+    expect(captured).toHaveLength(1);
+    /* state is the exact run input object the ToolNode was invoked with */
+    expect(captured[0].state).toBe(input);
+    expect((captured[0].state as { messages: BaseMessage[] }).messages).toBe(
+      messages
+    );
+    /* toolCallId and the langchain-extracted toolCall both resolve */
+    expect(captured[0].toolCallId).toBe('call_1');
+    expect(captured[0].toolCallIdFromConfig).toBe('call_1');
+  });
+
+  it('forwards the array-shaped input as runtime.state', async () => {
+    const captured: CapturedRuntime[] = [];
+    const toolNode = new ToolNode({
+      tools: [createRuntimeProbeTool(captured)],
+    });
+
+    const input: BaseMessage[] = [
+      new HumanMessage('start'),
+      aiMessageWithProbeCall('call_2'),
+    ];
+
+    await toolNode.invoke(input);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].state).toBe(input);
+    expect(captured[0].toolCallId).toBe('call_2');
+  });
+
+  it('forwards the de-enveloped state for Send-shaped input', async () => {
+    const captured: CapturedRuntime[] = [];
+    const toolNode = new ToolNode({
+      tools: [createRuntimeProbeTool(captured)],
+    });
+
+    const sidecar = { tenant: 'acme' };
+    await toolNode.invoke({
+      lg_tool_call: {
+        id: 'call_3',
+        name: 'probe_runtime',
+        args: { value: 'hi' },
+        type: 'tool_call',
+      },
+      ...sidecar,
+    });
+
+    expect(captured).toHaveLength(1);
+    /* The `lg_tool_call` envelope key is stripped, the rest is state */
+    expect(captured[0].state).toEqual(sidecar);
+    expect(
+      (captured[0].state as Record<string, unknown>).lg_tool_call
+    ).toBeUndefined();
+    expect(captured[0].toolCallId).toBe('call_3');
+  });
+});


### PR DESCRIPTION
## Summary

Adopts langgraph 1.4.1's `ToolRuntime.state` so tools read graph state off their second argument, replacing the deprecated `getCurrentTaskInput()` (which relies on `node:async_hooks` and is browser-incompatible). First consumer of the new langgraph 1.4 APIs.

- **`ToolNode`** (our fork extends `RunnableCallable`, *not* langgraph's prebuilt ToolNode, so it didn't forward state): now threads the run input (graph state) through `run() → runTool → tool.invoke`, building langgraph's exact runtime shape `{ ...config, state, toolCallId, config, context, store, writer }` as the tool's 2nd arg.
- **`MultiAgentGraph`** handoff tools (2) and the `handoff-test` dev script: `getCurrentTaskInput()` → `runtime.state`. **Zero `getCurrentTaskInput()` calls remain** in `src/`.
- New `ToolNode.runtimeState.test.ts` proves forwarding for message-state, array, and `Send`-de-enveloped inputs (+ `toolCallId`).

### Deliberately NOT changed (verified independent — removing them would be wrong)
- `run.ts` `__pregel_scratchpad.currentTaskInput` leak cleanup — langgraph populates `currentTaskInput` **unconditionally** for every task (`pregel/algo.js`), regardless of `getCurrentTaskInput` usage, so the cleanup stays.
- `ToolNode` `interrupt()` `AsyncLocalStorage` shim — `interrupt()` hard-requires the ALS frame (`interrupt.js` throws without it); unrelated to state access.

## Testing

`npm run build` + full `tsc --noEmit` clean; new forwarding test green; multi-agent/handoff/ToolNode suites green; full deterministic suite green (135 suites / 2454 tests — one unrelated pre-existing parallel-worker flake that passes on isolation/re-run). Live suites run in CI.
