### PR TITLE
feat(run): add UserTraceContext to RunConfig for backend-agnostic trace attribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/**/*
 .cursor/
 .claude/
 .codex/
+.idea/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ const customHandlers = composeEventHandlers(
 );
 ```
 
+## Observability
+
+When Langfuse, LangSmith, or OTel tracing is configured, each run is attributed to the user that triggered it. By default the `userId` field in your trace backend is set to the user's **email address**.
+
+Set `LIBRECHAT_TRACE_USER_ID_FIELD` to change which field is used:
+
+| Value             | What appears as `userId`                                           |
+| ----------------- | ------------------------------------------------------------------ |
+| `email` (default) | `alice@example.com`                                                |
+| `name`            | `Alice Johnson` (OIDC `name` claim or display name)                |
+| `username`        | `alice` — varies by OIDC provider (e.g. Cognito uses the sub UUID) |
+| `id`              | Internal host-assigned user ID                                     |
+
+```bash
+LIBRECHAT_TRACE_USER_ID_FIELD=name   # show display name in Langfuse
+```
+
+The host can also supply a fully resolved `userId` directly via `RunConfig.user.userId`, which takes precedence over this env var.
+
 ## Development
 
 ```bash

--- a/src/run.ts
+++ b/src/run.ts
@@ -72,7 +72,7 @@ type ConfigurableUser = {
 
 /**
  * Resolve the trace userId from a configurable user object.
- * Reads LIBRECHAT_TRACE_USER_ID_FIELD env var (email | username | id) to
+ * Reads LIBRECHAT_TRACE_USER_ID_FIELD env var (email | username | name | id) to
  * pick the field; falls back to email → username when the env var is unset.
  * This is the fallback path used when RunConfig.user.userId is not set by
  * the host (e.g. older LibreChat versions). The host-provided value in

--- a/src/run.ts
+++ b/src/run.ts
@@ -67,7 +67,6 @@ type ConfigurableUser = {
   email?: string;
   username?: string;
   name?: string;
-  groups?: string[];
 };
 
 /**
@@ -775,9 +774,6 @@ export class Run<_T extends t.BaseGraphState> {
     const userId =
       this.user?.userId ??
       resolveConfigurableUserId(configurableUser, config.configurable?.user_id);
-    const userGroups: string[] =
-      this.user?.groups ??
-      (Array.isArray(configurableUser?.groups) ? configurableUser.groups : []);
     const sessionId =
       typeof config.configurable?.thread_id === 'string'
         ? config.configurable.thread_id
@@ -796,7 +792,7 @@ export class Run<_T extends t.BaseGraphState> {
       userId,
       sessionId,
       traceMetadata,
-      tags: ['librechat', 'agent', ...userGroups.map((g) => `group:${g}`)],
+      tags: ['librechat', 'agent'],
       traceIdSeed:
         streamLangfuseConfig?.deterministicTraceId === true
           ? this.id
@@ -1384,11 +1380,6 @@ export class Run<_T extends t.BaseGraphState> {
           titleConfigurableUser,
           chainOptions.configurable?.user_id
         );
-      const titleUserGroups: string[] =
-        this.user?.groups ??
-        (Array.isArray(titleConfigurableUser?.groups)
-          ? titleConfigurableUser.groups
-          : []);
       titleSessionId =
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
@@ -1403,11 +1394,7 @@ export class Run<_T extends t.BaseGraphState> {
         userId: titleUserId,
         sessionId: titleSessionId,
         traceMetadata,
-        tags: [
-          'librechat',
-          'title',
-          ...titleUserGroups.map((g) => `group:${g}`),
-        ],
+        tags: ['librechat', 'title'],
         traceIdSeed:
           titleLangfuseConfig?.deterministicTraceId === true
             ? 'title-' + this.id

--- a/src/run.ts
+++ b/src/run.ts
@@ -63,6 +63,41 @@ export const defaultOmitOptions = new Set([
   'additionalModelRequestFields',
 ]);
 
+type ConfigurableUser = {
+  email?: string;
+  username?: string;
+  name?: string;
+  groups?: string[];
+};
+
+/**
+ * Resolve the trace userId from a configurable user object.
+ * Reads LIBRECHAT_TRACE_USER_ID_FIELD env var (email | username | id) to
+ * pick the field; falls back to email → username when the env var is unset.
+ * This is the fallback path used when RunConfig.user.userId is not set by
+ * the host (e.g. older LibreChat versions). The host-provided value in
+ * RunConfig.user.userId always takes precedence.
+ */
+function resolveConfigurableUserId(
+  user: ConfigurableUser | undefined,
+  rawUserId?: unknown
+): string | undefined {
+  const field =
+    typeof process !== 'undefined'
+      ? (process.env.LIBRECHAT_TRACE_USER_ID_FIELD ?? 'email')
+      : 'email';
+  if (field === 'name') {
+    return user?.name || user?.email || undefined;
+  }
+  if (field === 'username') {
+    return user?.username || user?.email || undefined;
+  }
+  if (field === 'id') {
+    return typeof rawUserId === 'string' ? rawUserId : user?.email || undefined;
+  }
+  return user?.email || user?.username || undefined;
+}
+
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_AGENT_UPDATE,
   GraphEvents.ON_RUN_STEP,
@@ -734,11 +769,15 @@ export class Run<_T extends t.BaseGraphState> {
     );
 
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
+    const configurableUser = config.configurable?.user as
+      | ConfigurableUser
+      | undefined;
     const userId =
       this.user?.userId ??
-      (typeof config.configurable?.user_id === 'string'
-        ? config.configurable.user_id
-        : undefined);
+      resolveConfigurableUserId(configurableUser, config.configurable?.user_id);
+    const userGroups: string[] =
+      this.user?.groups ??
+      (Array.isArray(configurableUser?.groups) ? configurableUser.groups : []);
     const sessionId =
       typeof config.configurable?.thread_id === 'string'
         ? config.configurable.thread_id
@@ -757,11 +796,7 @@ export class Run<_T extends t.BaseGraphState> {
       userId,
       sessionId,
       traceMetadata,
-      tags: [
-        'librechat',
-        'agent',
-        ...(this.user?.groups?.map((g) => `group:${g}`) ?? []),
-      ],
+      tags: ['librechat', 'agent', ...userGroups.map((g) => `group:${g}`)],
       traceIdSeed:
         streamLangfuseConfig?.deterministicTraceId === true
           ? this.id
@@ -1340,11 +1375,20 @@ export class Run<_T extends t.BaseGraphState> {
     const titleRunName = getLangfuseTraceName(traceMetadata, 'LibreChat Title');
 
     if (chainOptions != null) {
+      const titleConfigurableUser = chainOptions.configurable?.user as
+        | ConfigurableUser
+        | undefined;
       titleUserId =
         this.user?.userId ??
-        (typeof chainOptions.configurable?.user_id === 'string'
-          ? chainOptions.configurable.user_id
-          : undefined);
+        resolveConfigurableUserId(
+          titleConfigurableUser,
+          chainOptions.configurable?.user_id
+        );
+      const titleUserGroups: string[] =
+        this.user?.groups ??
+        (Array.isArray(titleConfigurableUser?.groups)
+          ? titleConfigurableUser.groups
+          : []);
       titleSessionId =
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
@@ -1362,7 +1406,7 @@ export class Run<_T extends t.BaseGraphState> {
         tags: [
           'librechat',
           'title',
-          ...(this.user?.groups?.map((g) => `group:${g}`) ?? []),
+          ...titleUserGroups.map((g) => `group:${g}`),
         ],
         traceIdSeed:
           titleLangfuseConfig?.deterministicTraceId === true

--- a/src/run.ts
+++ b/src/run.ts
@@ -81,20 +81,21 @@ function resolveConfigurableUserId(
   user: ConfigurableUser | undefined,
   rawUserId?: unknown
 ): string | undefined {
+  const raw = typeof rawUserId === 'string' ? rawUserId : undefined;
   const field =
     typeof process !== 'undefined'
       ? (process.env.LIBRECHAT_TRACE_USER_ID_FIELD ?? 'email')
       : 'email';
   if (field === 'name') {
-    return user?.name || user?.email || undefined;
+    return user?.name || user?.email || raw;
   }
   if (field === 'username') {
-    return user?.username || user?.email || undefined;
+    return user?.username || user?.email || raw;
   }
   if (field === 'id') {
-    return typeof rawUserId === 'string' ? rawUserId : user?.email || undefined;
+    return raw || user?.email;
   }
-  return user?.email || user?.username || undefined;
+  return user?.email || user?.username || raw;
 }
 
 const CUSTOM_GRAPH_EVENTS = new Set<string>([

--- a/src/run.ts
+++ b/src/run.ts
@@ -125,6 +125,7 @@ export class Run<_T extends t.BaseGraphState> {
   private hookRegistry?: HookRegistry;
   private humanInTheLoop?: t.HumanInTheLoopConfig;
   private langfuse?: t.LangfuseConfig;
+  private user?: t.UserTraceContext;
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   private codeSessionToolNames?: string[];
@@ -182,6 +183,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.hookRegistry = config.hooks;
     this.humanInTheLoop = config.humanInTheLoop;
     this.langfuse = config.langfuse;
+    this.user = config.user;
     this.toolOutputReferences = config.toolOutputReferences;
     this.eagerEventToolExecution = config.eagerEventToolExecution;
     this.codeSessionToolNames = config.codeSessionToolNames;
@@ -733,9 +735,10 @@ export class Run<_T extends t.BaseGraphState> {
 
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
     const userId =
-      typeof config.configurable?.user_id === 'string'
+      this.user?.userId ??
+      (typeof config.configurable?.user_id === 'string'
         ? config.configurable.user_id
-        : undefined;
+        : undefined);
     const sessionId =
       typeof config.configurable?.thread_id === 'string'
         ? config.configurable.thread_id
@@ -754,7 +757,11 @@ export class Run<_T extends t.BaseGraphState> {
       userId,
       sessionId,
       traceMetadata,
-      tags: ['librechat', 'agent'],
+      tags: [
+        'librechat',
+        'agent',
+        ...(this.user?.groups?.map((g) => `group:${g}`) ?? []),
+      ],
       traceIdSeed:
         streamLangfuseConfig?.deterministicTraceId === true
           ? this.id
@@ -1334,9 +1341,10 @@ export class Run<_T extends t.BaseGraphState> {
 
     if (chainOptions != null) {
       titleUserId =
-        typeof chainOptions.configurable?.user_id === 'string'
+        this.user?.userId ??
+        (typeof chainOptions.configurable?.user_id === 'string'
           ? chainOptions.configurable.user_id
-          : undefined;
+          : undefined);
       titleSessionId =
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
@@ -1351,7 +1359,11 @@ export class Run<_T extends t.BaseGraphState> {
         userId: titleUserId,
         sessionId: titleSessionId,
         traceMetadata,
-        tags: ['librechat', 'title'],
+        tags: [
+          'librechat',
+          'title',
+          ...(this.user?.groups?.map((g) => `group:${g}`) ?? []),
+        ],
         traceIdSeed:
           titleLangfuseConfig?.deterministicTraceId === true
             ? 'title-' + this.id

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -124,8 +124,6 @@ export type StandardGraphConfig = Omit<
 export type UserTraceContext = {
   /** Human-readable identifier — e.g. email address or username. */
   userId?: string;
-  /** OIDC group memberships, emitted as `group:<name>` tags in trace backends that support them. */
-  groups?: string[];
 };
 
 export type RunConfig = {
@@ -133,8 +131,7 @@ export type RunConfig = {
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
   /**
    * Authenticated user identity for trace attribution.
-   * When provided, tracing backends use `userId` as the trace owner and
-   * emit one `group:<name>` tag per entry in `groups`.
+   * When provided, tracing backends use `userId` as the trace owner.
    */
   user?: UserTraceContext;
   /**

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -115,9 +115,28 @@ export type StandardGraphConfig = Omit<
   'edges' | 'type'
 > & { type?: 'standard'; signal?: AbortSignal };
 
+/**
+ * Backend-agnostic user identity context for observability.
+ * Passed to `RunConfig.user` so all configured tracing backends
+ * (Langfuse, LangSmith, OTel, etc.) can attribute traces to the
+ * authenticated user without each backend re-deriving the same mapping.
+ */
+export type UserTraceContext = {
+  /** Human-readable identifier — e.g. email address or username. */
+  userId?: string;
+  /** OIDC group memberships, emitted as `group:<name>` tags in trace backends that support them. */
+  groups?: string[];
+};
+
 export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
+  /**
+   * Authenticated user identity for trace attribution.
+   * When provided, tracing backends use `userId` as the trace owner and
+   * emit one `group:<name>` tag per entry in `groups`.
+   */
+  user?: UserTraceContext;
   /**
    * Run-scoped Langfuse configuration. Per-agent `AgentInputs.langfuse`
    * takes precedence for agent-specific spans; this object supplies defaults


### PR DESCRIPTION
## Summary
Also see: https://github.com/danny-avila/LibreChat/issues/13529#issuecomment-4836097866

Adds `UserTraceContext { userId? }` to `RunConfig` so hosts can pass a human-readable user identifier to all configured trace backends (Langfuse, LangSmith, OTel, etc.) from a single place, rather than each backend re-deriving the same mapping.

When `RunConfig.user` is not set, the SDK falls back to resolving the userId from fields already present in `config.configurable` — so the improvement works without requiring a host upgrade.

## Breaking Change

Traces that previously showed a raw `user_id` string (e.g. a MongoDB ObjectId) from `configurable.user_id` will now show the user's email by default. Set `LIBRECHAT_TRACE_USER_ID_FIELD=id` to preserve the old behaviour.

## How to test

1. Configure a Langfuse (or LangSmith) backend and run an agent via LibreChat.
2. Open the Langfuse UI — the trace should show a human-readable `userId` (email by default) instead of a raw ObjectId.
3. Set `LIBRECHAT_TRACE_USER_ID_FIELD=name` (or `username` / `id`) and restart — verify the correct field appears.
4. Run unit tests: `npm test`

## Companion PR

danny-avila/LibreChat#14012 — wires `buildUserTraceContext(user)` into `createRun` and adds `tracing.userIdField` to the `librechat.yaml` config schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)