### PR TITLE
fix: fail fast on tool calls truncated by the output token limit

### DIFF
--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -6,6 +6,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type * as t from '@/types';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
+import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { manualToolStreamProviders } from '@/llm/providers';
 import { modifyDeltaProperties } from '@/messages';
@@ -297,6 +298,7 @@ export async function attemptInvoke(
       );
     }
 
+    assertNotTruncatedToolCall(finalChunk);
     return { messages: [finalChunk as AIMessageChunk] };
   }
 
@@ -306,6 +308,7 @@ export async function attemptInvoke(
       (tool_call: ToolCall) => !!tool_call.name
     );
   }
+  assertNotTruncatedToolCall(finalMessage);
   return { messages: [finalMessage] };
 }
 

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -298,7 +298,7 @@ export async function attemptInvoke(
       );
     }
 
-    assertNotTruncatedToolCall(finalChunk);
+    assertNotTruncatedToolCall(finalChunk, provider);
     return { messages: [finalChunk as AIMessageChunk] };
   }
 
@@ -308,7 +308,7 @@ export async function attemptInvoke(
       (tool_call: ToolCall) => !!tool_call.name
     );
   }
-  assertNotTruncatedToolCall(finalMessage);
+  assertNotTruncatedToolCall(finalMessage, provider);
   return { messages: [finalMessage] };
 }
 

--- a/src/llm/truncation.test.ts
+++ b/src/llm/truncation.test.ts
@@ -53,6 +53,37 @@ describe('getTruncationStopReason', () => {
     expect(getTruncationStopReason(message)).toBe('max_tokens');
   });
 
+  it('detects Anthropic streaming shape (additional_kwargs.stop_reason)', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      additional_kwargs: { stop_reason: 'max_tokens' },
+      response_metadata: { model_provider: 'anthropic' },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('detects OpenAI Responses shape (incomplete_details.reason)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: {
+        status: 'incomplete',
+        incomplete_details: { reason: 'max_output_tokens' },
+      },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('returns null for a non-token incomplete reason (content_filter)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: {
+        status: 'incomplete',
+        incomplete_details: { reason: 'content_filter' },
+      },
+    });
+    expect(getTruncationStopReason(message)).toBeNull();
+  });
+
   it('returns null for normal stop reasons', () => {
     expect(
       getTruncationStopReason(
@@ -165,6 +196,32 @@ describe('assertNotTruncatedToolCall', () => {
     expect(() =>
       assertNotTruncatedToolCall(message, Providers.ANTHROPIC)
     ).toThrow(OutputTruncationError);
+  });
+
+  it('throws for an Anthropic streaming tool call truncated via additional_kwargs', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      tool_calls: [{ id: '1', name: 'create_file', args: { path: 'a' } }],
+      additional_kwargs: { stop_reason: 'max_tokens' },
+      response_metadata: { model_provider: 'anthropic' },
+    });
+    expect(() =>
+      assertNotTruncatedToolCall(message, Providers.ANTHROPIC)
+    ).toThrow(OutputTruncationError);
+  });
+
+  it('throws for an OpenAI Responses tool call truncated via incomplete_details', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [{ id: '1', name: 'create_file', args: { path: 'a' } }],
+      response_metadata: {
+        status: 'incomplete',
+        incomplete_details: { reason: 'max_output_tokens' },
+      },
+    });
+    expect(() => assertNotTruncatedToolCall(message, Providers.OPENAI)).toThrow(
+      OutputTruncationError
+    );
   });
 
   it('does not throw for providers that deliver complete tool calls (Google/Vertex)', () => {

--- a/src/llm/truncation.test.ts
+++ b/src/llm/truncation.test.ts
@@ -5,6 +5,7 @@ import {
   assertNotTruncatedToolCall,
   getTruncationStopReason,
 } from '@/llm/truncation';
+import { Providers } from '@/common';
 
 describe('getTruncationStopReason', () => {
   it('returns null when there is no response metadata', () => {
@@ -153,5 +154,32 @@ describe('assertNotTruncatedToolCall', () => {
     expect(() => assertNotTruncatedToolCall(message)).toThrow(
       OutputTruncationError
     );
+  });
+
+  it('still throws for a streaming-arg provider (Anthropic)', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [{ id: '1', name: 'create_file', args: { path: 'a' } }],
+      response_metadata: { stop_reason: 'max_tokens' },
+    });
+    expect(() =>
+      assertNotTruncatedToolCall(message, Providers.ANTHROPIC)
+    ).toThrow(OutputTruncationError);
+  });
+
+  it('does not throw for providers that deliver complete tool calls (Google/Vertex)', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        { id: '1', name: 'create_file', args: { path: 'a', content: 'b' } },
+      ],
+      response_metadata: { finishReason: 'MAX_TOKENS' },
+    });
+    expect(() =>
+      assertNotTruncatedToolCall(message, Providers.GOOGLE)
+    ).not.toThrow();
+    expect(() =>
+      assertNotTruncatedToolCall(message, Providers.VERTEXAI)
+    ).not.toThrow();
   });
 });

--- a/src/llm/truncation.test.ts
+++ b/src/llm/truncation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from '@jest/globals';
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import {
+  OutputTruncationError,
+  assertNotTruncatedToolCall,
+  getTruncationStopReason,
+} from '@/llm/truncation';
+
+describe('getTruncationStopReason', () => {
+  it('returns null when there is no response metadata', () => {
+    expect(getTruncationStopReason(new AIMessage('hi'))).toBeNull();
+    expect(getTruncationStopReason(undefined)).toBeNull();
+  });
+
+  it('detects Bedrock Converse streaming shape (messageStop.stopReason)', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      response_metadata: { messageStop: { stopReason: 'max_tokens' } },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('detects Bedrock Converse non-streaming shape (stopReason)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: { stopReason: 'max_tokens' },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('detects Anthropic shape (stop_reason)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: { stop_reason: 'max_tokens' },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('detects OpenAI shape (finish_reason: length)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: { finish_reason: 'length' },
+    });
+    expect(getTruncationStopReason(message)).toBe('length');
+  });
+
+  it('detects Google shape (finishReason: MAX_TOKENS, case-insensitive)', () => {
+    const message = new AIMessage({
+      content: '',
+      response_metadata: { finishReason: 'MAX_TOKENS' },
+    });
+    expect(getTruncationStopReason(message)).toBe('max_tokens');
+  });
+
+  it('returns null for normal stop reasons', () => {
+    expect(
+      getTruncationStopReason(
+        new AIMessage({
+          content: 'x',
+          response_metadata: { stopReason: 'end_turn' },
+        })
+      )
+    ).toBeNull();
+    expect(
+      getTruncationStopReason(
+        new AIMessage({
+          content: 'x',
+          response_metadata: { finish_reason: 'stop' },
+        })
+      )
+    ).toBeNull();
+    expect(
+      getTruncationStopReason(
+        new AIMessage({
+          content: 'x',
+          response_metadata: { stopReason: 'tool_use' },
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('assertNotTruncatedToolCall', () => {
+  it('no-ops for a normal completion', () => {
+    expect(() =>
+      assertNotTruncatedToolCall(
+        new AIMessage({
+          content: 'done',
+          response_metadata: { stopReason: 'end_turn' },
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('no-ops for a truncated plain-text turn (no tool calls)', () => {
+    expect(() =>
+      assertNotTruncatedToolCall(
+        new AIMessage({
+          content: 'partial...',
+          response_metadata: { stopReason: 'max_tokens' },
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('no-ops for a complete tool call (normal stop reason)', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        { id: '1', name: 'create_file', args: { path: 'a', content: 'b' } },
+      ],
+      response_metadata: { stopReason: 'tool_use' },
+    });
+    expect(() => assertNotTruncatedToolCall(message)).not.toThrow();
+  });
+
+  it('throws when a tool call is present and the turn was truncated', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [{ id: '1', name: 'create_file', args: { path: 'a' } }],
+      response_metadata: { messageStop: { stopReason: 'max_tokens' } },
+    });
+    expect(() => assertNotTruncatedToolCall(message)).toThrow(
+      OutputTruncationError
+    );
+    try {
+      assertNotTruncatedToolCall(message);
+    } catch (err) {
+      expect(err).toBeInstanceOf(OutputTruncationError);
+      expect((err as OutputTruncationError).stopReason).toBe('max_tokens');
+      expect((err as OutputTruncationError).toolCallNames).toContain(
+        'create_file'
+      );
+      expect((err as OutputTruncationError).message).toMatch(
+        /max output tokens/i
+      );
+    }
+  });
+
+  it('throws when only incomplete tool_call_chunks survived truncation', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          name: 'create_file',
+          args: '{"path":"a"',
+          index: 0,
+          type: 'tool_call_chunk',
+        },
+      ],
+      response_metadata: { messageStop: { stopReason: 'max_tokens' } },
+    });
+    expect(() => assertNotTruncatedToolCall(message)).toThrow(
+      OutputTruncationError
+    );
+  });
+});

--- a/src/llm/truncation.ts
+++ b/src/llm/truncation.ts
@@ -1,0 +1,141 @@
+import type { AIMessageChunk, BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Normalized truncation reasons across providers. Providers disagree on the
+ * key and the value: Anthropic/Bedrock use `max_tokens`, OpenAI uses `length`,
+ * Google uses `MAX_TOKENS`.
+ */
+export type TruncationStopReason = 'max_tokens' | 'length';
+
+const MAX_TOKEN_VALUES = new Set(['max_tokens', 'max_token', 'maxtokens']);
+const LENGTH_VALUES = new Set(['length']);
+
+function normalizeStopValue(value: unknown): TruncationStopReason | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (MAX_TOKEN_VALUES.has(normalized)) {
+    return 'max_tokens';
+  }
+  if (LENGTH_VALUES.has(normalized)) {
+    return 'length';
+  }
+  return null;
+}
+
+/**
+ * Reads the truncation stop reason off a message's `response_metadata`,
+ * covering every provider shape we stream:
+ * - `stopReason` (Bedrock Converse, non-streaming)
+ * - `messageStop.stopReason` (Bedrock Converse, streaming `messageStop` event)
+ * - `stop_reason` (Anthropic)
+ * - `finish_reason` (OpenAI / OpenAI-compatible)
+ * - `finishReason` (Google)
+ *
+ * Returns the normalized reason when the model stopped because it hit the
+ * output token ceiling, otherwise `null`.
+ */
+export function getTruncationStopReason(
+  message: Pick<BaseMessage, 'response_metadata'> | undefined | null
+): TruncationStopReason | null {
+  const meta = message?.response_metadata as
+    | Record<string, unknown>
+    | undefined;
+  if (meta == null) {
+    return null;
+  }
+
+  const messageStop = meta.messageStop as { stopReason?: unknown } | undefined;
+  const candidates: unknown[] = [
+    meta.stopReason,
+    meta.stop_reason,
+    meta.finish_reason,
+    meta.finishReason,
+    messageStop?.stopReason,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeStopValue(candidate);
+    if (normalized != null) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function hasOpenToolCall(message: AIMessageChunk | BaseMessage): boolean {
+  const m = message as AIMessageChunk & {
+    tool_calls?: unknown[];
+    tool_call_chunks?: unknown[];
+    invalid_tool_calls?: unknown[];
+  };
+  return (
+    (m.tool_calls?.length ?? 0) > 0 ||
+    (m.tool_call_chunks?.length ?? 0) > 0 ||
+    (m.invalid_tool_calls?.length ?? 0) > 0
+  );
+}
+
+/**
+ * Error raised when a model turn is cut off by the output token limit while it
+ * was still emitting a tool call. The arguments are necessarily incomplete, so
+ * executing or re-prompting the call would loop on a malformed request. Failing
+ * fast with this surfaces an actionable message to the caller instead.
+ */
+export class OutputTruncationError extends Error {
+  readonly stopReason: TruncationStopReason;
+  readonly toolCallNames: string[];
+
+  constructor(stopReason: TruncationStopReason, toolCallNames: string[]) {
+    const named =
+      toolCallNames.length > 0
+        ? ` (tool call: ${toolCallNames.join(', ')})`
+        : '';
+    super(
+      'The model response was truncated at the maximum output token limit before ' +
+        `the tool call arguments were complete${named}. Increase the model's max ` +
+        'output tokens, or have the model produce smaller arguments — for large ' +
+        'files, write a lean main file and move bulky content into separate files.'
+    );
+    this.name = 'OutputTruncationError';
+    this.stopReason = stopReason;
+    this.toolCallNames = toolCallNames;
+  }
+}
+
+function collectToolCallNames(message: AIMessageChunk | BaseMessage): string[] {
+  const m = message as AIMessageChunk & {
+    tool_calls?: Array<{ name?: string }>;
+    tool_call_chunks?: Array<{ name?: string }>;
+    invalid_tool_calls?: Array<{ name?: string }>;
+  };
+  const names = [
+    ...(m.tool_calls ?? []),
+    ...(m.tool_call_chunks ?? []),
+    ...(m.invalid_tool_calls ?? []),
+  ]
+    .map((tc) => tc.name)
+    .filter((name): name is string => typeof name === 'string' && name !== '');
+  return [...new Set(names)];
+}
+
+/**
+ * Throws {@link OutputTruncationError} when `message` was truncated by the
+ * output token limit AND still carries a tool call. A tool call emitted under
+ * truncation has incomplete arguments (the tool-use block is the last thing the
+ * model streams), so letting it through makes the agent loop on a malformed
+ * call. No-ops for normal completions and for truncated plain-text turns.
+ */
+export function assertNotTruncatedToolCall(
+  message: AIMessageChunk | BaseMessage | undefined | null
+): void {
+  if (message == null) {
+    return;
+  }
+  const stopReason = getTruncationStopReason(message);
+  if (stopReason == null || !hasOpenToolCall(message)) {
+    return;
+  }
+  throw new OutputTruncationError(stopReason, collectToolCallNames(message));
+}

--- a/src/llm/truncation.ts
+++ b/src/llm/truncation.ts
@@ -1,4 +1,16 @@
 import type { AIMessageChunk, BaseMessage } from '@langchain/core/messages';
+import { Providers } from '@/common';
+
+/**
+ * Providers whose adapters deliver tool calls as complete, atomic objects
+ * rather than streamed argument deltas. Google/Vertex (GenAI) emit each
+ * `functionCall` whole and seal it on arrival, so a `MAX_TOKENS` finish does
+ * NOT imply the arguments were cut off — the truncation guard must skip them.
+ */
+const ATOMIC_TOOL_CALL_ARG_PROVIDERS = new Set<Providers>([
+  Providers.GOOGLE,
+  Providers.VERTEXAI,
+]);
 
 /**
  * Normalized truncation reasons across providers. Providers disagree on the
@@ -122,15 +134,22 @@ function collectToolCallNames(message: AIMessageChunk | BaseMessage): string[] {
 
 /**
  * Throws {@link OutputTruncationError} when `message` was truncated by the
- * output token limit AND still carries a tool call. A tool call emitted under
- * truncation has incomplete arguments (the tool-use block is the last thing the
- * model streams), so letting it through makes the agent loop on a malformed
- * call. No-ops for normal completions and for truncated plain-text turns.
+ * output token limit AND still carries a tool call. For providers that stream
+ * tool arguments incrementally (Anthropic, Bedrock, OpenAI), a tool call
+ * emitted under truncation has incomplete arguments — the tool-use block is the
+ * last thing the model streams — so letting it through makes the agent loop on a
+ * malformed call. No-ops for normal completions, truncated plain-text turns, and
+ * providers that deliver complete tool calls atomically (Google/Vertex), where
+ * `MAX_TOKENS` does not imply the arguments were cut off.
  */
 export function assertNotTruncatedToolCall(
-  message: AIMessageChunk | BaseMessage | undefined | null
+  message: AIMessageChunk | BaseMessage | undefined | null,
+  provider?: Providers
 ): void {
   if (message == null) {
+    return;
+  }
+  if (provider != null && ATOMIC_TOOL_CALL_ARG_PROVIDERS.has(provider)) {
     return;
   }
   const stopReason = getTruncationStopReason(message);

--- a/src/llm/truncation.ts
+++ b/src/llm/truncation.ts
@@ -19,7 +19,12 @@ const ATOMIC_TOOL_CALL_ARG_PROVIDERS = new Set<Providers>([
  */
 export type TruncationStopReason = 'max_tokens' | 'length';
 
-const MAX_TOKEN_VALUES = new Set(['max_tokens', 'max_token', 'maxtokens']);
+const MAX_TOKEN_VALUES = new Set([
+  'max_tokens',
+  'max_token',
+  'maxtokens',
+  'max_output_tokens',
+]);
 const LENGTH_VALUES = new Set(['length']);
 
 function normalizeStopValue(value: unknown): TruncationStopReason | null {
@@ -37,34 +42,47 @@ function normalizeStopValue(value: unknown): TruncationStopReason | null {
 }
 
 /**
- * Reads the truncation stop reason off a message's `response_metadata`,
- * covering every provider shape we stream:
- * - `stopReason` (Bedrock Converse, non-streaming)
- * - `messageStop.stopReason` (Bedrock Converse, streaming `messageStop` event)
- * - `stop_reason` (Anthropic)
- * - `finish_reason` (OpenAI / OpenAI-compatible)
- * - `finishReason` (Google)
+ * Reads the truncation stop reason off a message, covering every provider
+ * shape we stream:
+ * - `response_metadata.stopReason` (Bedrock Converse, non-streaming)
+ * - `response_metadata.messageStop.stopReason` (Bedrock Converse streaming)
+ * - `response_metadata.stop_reason` (Anthropic, non-streaming)
+ * - `additional_kwargs.stop_reason` (Anthropic streaming `message_delta`)
+ * - `response_metadata.finish_reason` (OpenAI chat-completions / compatible)
+ * - `response_metadata.incomplete_details.reason` (OpenAI Responses API)
+ * - `response_metadata.finishReason` (Google)
  *
  * Returns the normalized reason when the model stopped because it hit the
  * output token ceiling, otherwise `null`.
  */
 export function getTruncationStopReason(
-  message: Pick<BaseMessage, 'response_metadata'> | undefined | null
+  message:
+    | Pick<BaseMessage, 'response_metadata' | 'additional_kwargs'>
+    | undefined
+    | null
 ): TruncationStopReason | null {
   const meta = message?.response_metadata as
     | Record<string, unknown>
     | undefined;
-  if (meta == null) {
+  const additionalKwargs = message?.additional_kwargs as
+    | Record<string, unknown>
+    | undefined;
+  if (meta == null && additionalKwargs == null) {
     return null;
   }
 
-  const messageStop = meta.messageStop as { stopReason?: unknown } | undefined;
+  const messageStop = meta?.messageStop as { stopReason?: unknown } | undefined;
+  const incompleteDetails = meta?.incomplete_details as
+    | { reason?: unknown }
+    | undefined;
   const candidates: unknown[] = [
-    meta.stopReason,
-    meta.stop_reason,
-    meta.finish_reason,
-    meta.finishReason,
+    meta?.stopReason,
+    meta?.stop_reason,
+    meta?.finish_reason,
+    meta?.finishReason,
     messageStop?.stopReason,
+    incompleteDetails?.reason,
+    additionalKwargs?.stop_reason,
   ];
 
   for (const candidate of candidates) {

--- a/src/specs/bedrock-truncation.live.test.ts
+++ b/src/specs/bedrock-truncation.live.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Live Bedrock tool-call truncation verification.
+ *
+ * Reproduces the production failure where a large tool argument (`content`)
+ * gets cut off by the max output token limit, leaving the handler with a
+ * well-formed-but-incomplete tool call and no truncation signal.
+ *
+ * Run with:
+ * RUN_BEDROCK_TRUNCATION_LIVE=1 npm test -- bedrock-truncation.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { z } from 'zod';
+import { HumanMessage } from '@langchain/core/messages';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { describe, expect, it, jest } from '@jest/globals';
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import { ChatModelStreamHandler } from '@/stream';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_BEDROCK_TRUNCATION_LIVE === '1' &&
+  (process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? '') !== '' &&
+  (process.env.BEDROCK_AWS_SECRET_ACCESS_KEY ?? '') !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+
+const REGION =
+  [
+    process.env.BEDROCK_AWS_REGION,
+    process.env.BEDROCK_AWS_DEFAULT_REGION,
+    process.env.AWS_DEFAULT_REGION,
+  ].find(
+    (value): value is string => typeof value === 'string' && value !== ''
+  ) ?? 'us-east-1';
+const MODEL = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const MAX_TOKENS = Number(process.env.REPRO_MAX_TOKENS ?? 350);
+
+const schema = z.object({
+  path: z.string().describe('Path to write.'),
+  content: z.string().describe('Complete file contents.'),
+  overwrite: z.boolean().optional(),
+});
+
+describeIfLive('Bedrock tool-call truncation (live)', () => {
+  jest.setTimeout(120_000);
+
+  it('fails fast with a truncation error instead of looping', async () => {
+    const received: Array<{ keys: string[]; contentLen: number | null }> = [];
+    const stepToolCalls: string[][] = [];
+    let invocations = 0;
+
+    const createFile = new DynamicStructuredTool({
+      name: 'create_file',
+      description: 'Create a new file. Requires path and content.',
+      schema,
+      func: async (input: z.infer<typeof schema>) => {
+        invocations += 1;
+        const hasContent =
+          typeof input.content === 'string' && input.content.length > 0;
+        received.push({
+          keys: Object.keys(input as Record<string, unknown>),
+          contentLen: hasContent ? input.content.length : null,
+        });
+        if (!hasContent) {
+          return 'Error: content is required\n Please fix your mistakes.';
+        }
+        return `Wrote ${input.content.length} bytes to ${input.path}`;
+      },
+    });
+
+    const llmConfig = {
+      provider: Providers.BEDROCK,
+      model: MODEL,
+      region: REGION,
+      credentials: {
+        accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
+      },
+      maxTokens: MAX_TOKENS,
+      streaming: true,
+      streamUsage: true,
+    } as t.LLMConfig;
+
+    const run = await Run.create<t.IState>({
+      runId: 'bedrock-truncation-live',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        tools: [createFile],
+        instructions: 'You are a ClickHouse assistant. Use tools when asked.',
+        maxContextTokens: 89000,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.TOOL_END]: new ToolEndHandler(
+          async (toolEndData: t.ToolEndData) => {
+            const out = toolEndData.output as
+              | { content?: unknown; name?: string; status?: string }
+              | undefined;
+            const content =
+              typeof out?.content === 'string'
+                ? out.content.slice(0, 120)
+                : JSON.stringify(out?.content).slice(0, 120);
+            // eslint-disable-next-line no-console
+            console.log(
+              `TOOL_END name=${out?.name} status=${out?.status} content=${content}`
+            );
+          }
+        ),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+        [GraphEvents.ON_RUN_STEP]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            const step = data as unknown as {
+              stepDetails?: {
+                type?: string;
+                tool_calls?: Array<{ name?: string; args?: unknown }>;
+              };
+            };
+            const tcs = step.stepDetails?.tool_calls;
+            if ((tcs?.length ?? 0) > 0 && tcs != null) {
+              for (const tc of tcs) {
+                if (tc.name === 'create_file') {
+                  stepToolCalls.push(
+                    typeof tc.args === 'string'
+                      ? ['<raw-string>']
+                      : Object.keys((tc.args ?? {}) as Record<string, unknown>)
+                  );
+                }
+              }
+              // eslint-disable-next-line no-console
+              console.log(
+                'ON_RUN_STEP tool_calls=',
+                JSON.stringify(
+                  tcs.map((tc) => ({
+                    name: tc.name,
+                    args:
+                      typeof tc.args === 'string'
+                        ? tc.args.slice(0, 80)
+                        : Object.keys(
+                            (tc.args ?? {}) as Record<string, unknown>
+                        ),
+                  }))
+                )
+              );
+            }
+          },
+        },
+      },
+    });
+
+    const prompt =
+      'Call create_file once: path="skills/clickhouse-demo/SKILL.md", content=a complete ' +
+      '3000-word ClickHouse guide (schema design, MergeTree, partitioning, 10 example queries). ' +
+      'Put the entire guide in the content argument.';
+
+    let loopError: string | null = null;
+    try {
+      await run.processStream(
+        { messages: [new HumanMessage(prompt)] },
+        {
+          configurable: { provider: Providers.BEDROCK, thread_id: 'trunc' },
+          version: 'v2',
+          recursionLimit: 8,
+        }
+      );
+    } catch (err) {
+      loopError = err instanceof Error ? err.message : String(err);
+    }
+
+    // eslint-disable-next-line no-console
+    console.log('LIVE RESULT', {
+      invocations,
+      received,
+      stepToolCalls,
+      loopError,
+    });
+
+    // The run fails fast with the actionable truncation error...
+    expect(loopError).toMatch(/truncated at the maximum output token limit/i);
+    // ...instead of looping until the recursion limit.
+    expect(loopError).not.toMatch(/Recursion limit/i);
+    // No truncated create_file call ever carried a usable `content` arg.
+    expect(stepToolCalls.every((keys) => !keys.includes('content'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

When a model turn is cut off by the **max output token limit** while it is still streaming a tool call, the arguments are necessarily incomplete (the tool-use block is the last thing the model emits). The partial args parse into a **well-formed-but-empty** tool call — e.g. `create_file` arriving with only `{path}` and no `content` — so the downstream handler rejects it ("content is required"), the model retries, and the agent **loops until the recursion limit**.

The truncation signal exists but is easy to miss because providers disagree on where it lives:
- Bedrock Converse (streaming) buries it in `response_metadata.messageStop.stopReason`
- Bedrock Converse (non-streaming) uses `response_metadata.stopReason`
- Anthropic uses `stop_reason`
- OpenAI / OpenAI-compatible use `finish_reason: "length"`
- Google uses `finishReason: "MAX_TOKENS"`

## Live reproduction (Bedrock, `us.anthropic.claude-sonnet-4-5`)

With `maxTokens=350` and a `create_file` tool requiring a large `content`:
- Raw `ChatBedrockConverse` stream: output hit exactly 350 tokens; the tool-arg JSON was cut mid-object (`{"path": "skills/clickhouse-demo/SKILL.md"`, unterminated, `content` never started); `messageStop.stopReason === "max_tokens"`; `parsePartialJson` recovered a **valid** `create_file({path})` with `content` missing.
- Through the SDK `Run`/StandardGraph: every turn emits `create_file` with no content and the run **loops to `GraphRecursionError`**.

## Fix

Add a cross-provider truncation detector (`src/llm/truncation.ts`) and, from the single invoke funnel (`attemptInvoke`), throw an actionable `OutputTruncationError` when a turn is truncated **and** still carries a tool call — instead of executing/looping on the incomplete call. Normal completions and truncated plain-text turns are unaffected.

## Tests

- `src/llm/truncation.test.ts` — unit coverage for the detector across all provider shapes + the assertion guard (no creds needed).
- `src/specs/bedrock-truncation.live.test.ts` — gated live Bedrock reproduction (`RUN_BEDROCK_TRUNCATION_LIVE=1`); asserts the run now fails fast with the truncation error instead of looping.

After the fix, the live repro fails fast on the first truncated call with:
> The model response was truncated at the maximum output token limit before the tool call arguments were complete (tool call: create_file). Increase the model's max output tokens, or have the model produce smaller arguments...

## Companion change

LibreChat PR makes the `create_file` "content is required" error truncation-aware so users on the currently-published SDK get an actionable hint until this lands and is bumped.
