### PR TITLE
ci: parallelize summarization tests by provider

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -130,9 +130,21 @@ jobs:
           BEDROCK_AWS_SECRET_ACCESS_KEY: ${{ secrets.BEDROCK_AWS_SECRET_ACCESS_KEY }}
 
   summarization-tests:
-    name: 'summarization tests'
+    name: 'summarization tests (${{ matrix.group }})'
     needs: install
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: anthropic
+            pattern: 'Anthropic Summarization E2E|Token accounting audit'
+          - group: openai
+            pattern: 'OpenAI Summarization E2E'
+          - group: bedrock
+            pattern: 'Bedrock Summarization E2E'
+          - group: local
+            pattern: 'no API keys'
     steps:
       - uses: actions/checkout@v4
 
@@ -146,8 +158,8 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run summarization tests
-        run: npx jest src/specs/summarization.test.ts --maxWorkers=50%
+      - name: Run summarization tests (${{ matrix.group }})
+        run: npx jest src/specs/summarization.test.ts -t "${{ matrix.pattern }}" --maxWorkers=50%
         env:
           NODE_OPTIONS: '--experimental-vm-modules'
           NODE_ENV: test


### PR DESCRIPTION
## Summary

`src/specs/summarization.test.ts` is a single ~3.7k-line file, and Jest runs tests *within* a single file sequentially — `--maxWorkers` only parallelizes across files. So the `summarization-tests` job ran every provider E2E suite (Anthropic, Bedrock, OpenAI) **plus** all local suites back-to-back on one runner.

This reworks `summarization-tests` in `.github/workflows/validate.yml` into a `fail-fast: false` matrix that runs four groups as independent parallel jobs, selected via Jest `-t` name patterns:

| group | `-t` pattern | tests |
| --- | --- | --- |
| `anthropic` | `Anthropic Summarization E2E\|Token accounting audit` | 8 |
| `openai` | `OpenAI Summarization E2E` | 1 |
| `bedrock` | `Bedrock Summarization E2E` | 1 |
| `local` | `no API keys` | 15 |

- The Anthropic E2E suite and the **Token accounting audit** share one job because both hit the Anthropic API (the audit uses `ANTHROPIC_API_KEY` when present, as it is in CI). Keeping each provider in its own serial job avoids cross-job rate-limit contention, while wall-clock time drops from the *sum* of all suites to just the *slowest* group.
- `fail-fast: false` mirrors the existing sharded `unit-tests` job so a transient failure in one provider doesn't cancel the others.

## Validation

- Workflow YAML parses; the matrix resolves to the four groups above.
- Static partition check over the file's **25 tests**: every test maps to exactly one group — **0 gaps, 0 overlaps** (anthropic=8, openai=1, bedrock=1, local=15).
- Confirmed there are no top-level/orphan tests outside the covered `describe` blocks.

## Notes

- Purely a CI workflow change — no source or test files were touched.
- The `local` group is hermetic (uses `FakeListChatModel`, no network). A natural follow-up would be to extract those `(no API keys)` suites into their own file so they can join the sharded `unit-tests` job, leaving `summarization.test.ts` for E2E only.

## Test plan

- [ ] On this PR, confirm four `summarization tests (<group>)` checks appear and run in parallel.
- [ ] Each provider group runs its expected tests; the `local` group passes without needing provider secrets.