### PR TITLE
feat: let host tools share the code-execution session (codeSessionToolNames)

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -4772,6 +4772,50 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.has('call_file')).toBe(false);
   });
 
+  it('does not prestart codeSessionToolNames tools even without excludeToolNames', async () => {
+    // A declared session-writing host tool is side-effecting, so it must not be
+    // eagerly prestarted even when the host didn't also list it in excludeToolNames.
+    const graph = createGraph({
+      eagerEventToolExecution: { enabled: true },
+      codeSessionToolNames: ['create_file', 'edit_file'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          { toolCallId: 'call_cf2', status: 'success', content: 'ok' },
+        ]);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_cf2',
+              name: 'create_file',
+              args: { path: '/mnt/data/y.py', content: 'print(2)' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_cf2')).toBe(false);
+  });
+
   it('keeps the direct-tool batch guard when an excluded tool is also direct', async () => {
     // edit_file is both a direct graph tool AND excluded from eager. A mixed
     // batch with a direct tool must suppress eager for the whole batch, so the

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1312,6 +1312,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       toolRegistry: agentContext?.toolRegistry,
       sessions: this.sessions,
       toolExecution: this.toolExecution,
+      codeSessionToolNames: this.codeSessionToolNames,
       hookRegistry: this.hookRegistry,
       humanInTheLoop: this.humanInTheLoop,
       maxContextTokens: agentContext?.maxContextTokens,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -66,8 +66,8 @@ import {
   type CallbackEntry,
 } from '@/utils/callbacks';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
-import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
+import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
@@ -608,6 +608,7 @@ export abstract class Graph<
    * consumes the settled promises while preserving final ToolMessage order.
    */
   eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
+  codeSessionToolNames: string[] | undefined;
   eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
   eagerEventToolUsageCount: Map<string, number> = new Map();
   private eagerEventToolUsageCountsByAgentId: Map<string, Map<string, number>> =
@@ -656,6 +657,7 @@ export abstract class Graph<
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
     this.eagerEventToolExecution = undefined;
+    this.codeSessionToolNames = undefined;
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
@@ -1260,6 +1262,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         hookRegistry: this.hookRegistry,
         humanInTheLoop: this.humanInTheLoop,
         eagerEventToolExecution: this.eagerEventToolExecution,
+        codeSessionToolNames: this.codeSessionToolNames,
         eagerEventToolExecutions: this.eagerEventToolExecutions,
         eagerEventToolUsageCount: this.getEagerEventToolUsageCount(
           agentContext?.agentId
@@ -2333,6 +2336,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
              */
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
+            childGraph.codeSessionToolNames = this.codeSessionToolNames;
             childGraph.toolExecution = this.toolExecution;
             childGraph.eventToolExecutionAvailable =
               this.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=

--- a/src/run.ts
+++ b/src/run.ts
@@ -127,6 +127,7 @@ export class Run<_T extends t.BaseGraphState> {
   private langfuse?: t.LangfuseConfig;
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
+  private codeSessionToolNames?: string[];
   private toolExecution?: t.ToolExecutionConfig;
   private subagentUsageSink?: t.SubagentUsageSink;
   private indexTokenCountMap?: Record<string, number>;
@@ -182,6 +183,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.langfuse = config.langfuse;
     this.toolOutputReferences = config.toolOutputReferences;
     this.eagerEventToolExecution = config.eagerEventToolExecution;
+    this.codeSessionToolNames = config.codeSessionToolNames;
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
 
@@ -268,6 +270,7 @@ export class Run<_T extends t.BaseGraphState> {
     standardGraph.humanInTheLoop = this.humanInTheLoop;
     standardGraph.toolOutputReferences = this.toolOutputReferences;
     standardGraph.eagerEventToolExecution = this.eagerEventToolExecution;
+    standardGraph.codeSessionToolNames = this.codeSessionToolNames;
     standardGraph.toolExecution = this.toolExecution;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
@@ -297,6 +300,7 @@ export class Run<_T extends t.BaseGraphState> {
     multiAgentGraph.humanInTheLoop = this.humanInTheLoop;
     multiAgentGraph.toolOutputReferences = this.toolOutputReferences;
     multiAgentGraph.eagerEventToolExecution = this.eagerEventToolExecution;
+    multiAgentGraph.codeSessionToolNames = this.codeSessionToolNames;
     multiAgentGraph.toolExecution = this.toolExecution;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -135,7 +135,14 @@ function isEagerExecutionExcludedTool(
     return false;
   }
   const excluded = graph.eagerEventToolExecution?.excludeToolNames;
-  return excluded != null && excluded.includes(name);
+  if (excluded != null && excluded.includes(name)) {
+    return true;
+  }
+  // A code-session participant writes to the shared sandbox, so it is
+  // side-effecting: never prestart it speculatively (a revised/superseded turn
+  // would leave the write applied). Implies exclusion without the host having
+  // to also list the name in excludeToolNames.
+  return graph.codeSessionToolNames?.includes(name) === true;
 }
 
 function isDirectGraphTool(

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -195,7 +195,8 @@ function getCodeSessionContext(
   if (
     !CODE_EXECUTION_TOOLS.has(name) &&
     name !== Constants.SKILL_TOOL &&
-    name !== Constants.READ_FILE
+    name !== Constants.READ_FILE &&
+    graph.codeSessionToolNames?.includes(name) !== true
   ) {
     return undefined;
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2487,7 +2487,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const plan = buildToolExecutionRequestPlan({
         toolCalls: approvedEntries.map((entry) => {
           const codeSessionContext =
-            CODE_EXECUTION_TOOLS.has(entry.call.name) ||
+            this.participatesInCodeSession(entry.call.name) ||
             entry.call.name === Constants.SKILL_TOOL ||
             entry.call.name === Constants.READ_FILE
               ? this.getCodeSessionContext()

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -980,7 +980,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * still need to travel through `_injected_files`; the legacy
        * `/files/<session_id>` fallback was removed from the executors.
        */
-      if (CODE_EXECUTION_TOOLS.has(call.name)) {
+      if (this.participatesInCodeSession(call.name)) {
         const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
           | t.CodeSessionContext
           | undefined;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -439,6 +439,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private eventDrivenMode: boolean = false;
   /** Opt-in stream-layer prestart config for event-driven tools. */
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
+  /** Host tools that write to the code sandbox and share its exec session. */
+  private codeSessionToolNames?: ReadonlySet<string>;
   /** Shared per-run prestarted tool registry populated by ChatModelStreamHandler. */
   private eagerEventToolExecutions?: Map<string, t.EagerEventToolExecution>;
   /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */
@@ -515,6 +517,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     agentId,
     executingAgentId,
     directToolNames,
+    codeSessionToolNames,
     maxContextTokens,
     maxToolResultChars,
     hookRegistry,
@@ -552,6 +555,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // existing agentId option) still get attribution without knowing the new option.
     this.executingAgentId = executingAgentId ?? agentId;
     this.directToolNames = directToolNames;
+    this.codeSessionToolNames =
+      codeSessionToolNames != null && codeSessionToolNames.length > 0
+        ? new Set(codeSessionToolNames)
+        : undefined;
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
     this.hookRegistry = hookRegistry;
@@ -1759,6 +1766,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * Extracts code execution session context from tool results and stores in Graph.sessions.
    * Mirrors the session storage logic in handleRunToolCompletions for direct execution.
    */
+  /**
+   * True when a tool's successful result should fold its returned exec
+   * `session_id` into the shared code session: built-in `CODE_EXECUTION_TOOLS`,
+   * plus host-declared sandbox-writing tools (`codeSessionToolNames`, e.g.
+   * create_file/edit_file). Kept name-scoped rather than a blanket artifact
+   * opt-in so only host-declared tools can influence the shared session.
+   */
+  private participatesInCodeSession(name: string): boolean {
+    if (name === '') {
+      return false;
+    }
+    return (
+      CODE_EXECUTION_TOOLS.has(name) ||
+      this.codeSessionToolNames?.has(name) === true
+    );
+  }
+
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
     requestMap: Map<string, t.ToolCallRequest>
@@ -1777,7 +1801,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (
         request?.name == null ||
         request.name === '' ||
-        (!CODE_EXECUTION_TOOLS.has(request.name) &&
+        (!this.participatesInCodeSession(request.name) &&
           request.name !== Constants.SKILL_TOOL)
       ) {
         continue;
@@ -1830,7 +1854,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      if (this.sessions && CODE_EXECUTION_TOOLS.has(call.name)) {
+      if (this.sessions && this.participatesInCodeSession(call.name)) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -140,6 +140,52 @@ describe('ToolNode code execution session management', () => {
       expect(capturedConfigs[0]._injected_files).toBeUndefined();
     });
 
+    it('injects the existing session into declared host tools on the direct path', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'host-session',
+        files: [
+          { id: 'g1', name: 'gen.png', storage_session_id: 'host-session' },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const cfTool = tool(
+        async (_input, config) => {
+          capturedConfigs.push({ ...(config.toolCall ?? {}) });
+          return 'Created /mnt/data/x.py';
+        },
+        {
+          name: 'create_file',
+          description: 'write a file',
+          schema: z.object({ path: z.string(), content: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const toolNode = new ToolNode({
+        tools: [cfTool],
+        sessions,
+        codeSessionToolNames: ['create_file', 'edit_file'],
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_cf',
+            name: 'create_file',
+            args: { path: '/mnt/data/x.py', content: 'print(1)' },
+          },
+        ],
+      });
+      await toolNode.invoke({ messages: [aiMsg] });
+
+      // Declared host tool writes into the current sandbox, not a fresh one.
+      expect(capturedConfigs).toHaveLength(1);
+      expect(capturedConfigs[0].session_id).toBe('host-session');
+    });
+
     it('preserves per-file storage_session_id for multi-session files', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -774,6 +774,78 @@ describe('ToolNode code execution session management', () => {
       expect(sessions.has(Constants.EXECUTE_CODE)).toBe(false);
     });
 
+    it('stores the exec session for host tools declared in codeSessionToolNames', () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const toolNode = new ToolNode({
+        tools: [createMockCodeTool({ capturedConfigs: [] })],
+        sessions,
+        eventDrivenMode: true,
+        codeSessionToolNames: ['create_file', 'edit_file'],
+      });
+
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-cf',
+            content: 'Created /mnt/data/x.py (10 chars).',
+            artifact: { session_id: 'authoring-session' },
+            status: 'success',
+          },
+        ],
+        new Map([['tc-cf', { id: 'tc-cf', name: 'create_file', args: {} }]])
+      );
+
+      // create_file's exec session is folded into the shared code session, so a
+      // later bash_tool/execute_code call reuses the same sandbox.
+      const stored = sessions.get(Constants.EXECUTE_CODE) as
+        | t.CodeSessionContext
+        | undefined;
+      expect(stored?.session_id).toBe('authoring-session');
+    });
+
+    it('does not store a host authoring tool session when not declared', () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const toolNode = new ToolNode({
+        tools: [createMockCodeTool({ capturedConfigs: [] })],
+        sessions,
+        eventDrivenMode: true,
+        // codeSessionToolNames omitted — create_file must NOT be treated as a
+        // code-session participant.
+      });
+
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-cf2',
+            content: 'Created /mnt/data/x.py (10 chars).',
+            artifact: { session_id: 'authoring-session' },
+            status: 'success',
+          },
+        ],
+        new Map([['tc-cf2', { id: 'tc-cf2', name: 'create_file', args: {} }]])
+      );
+
+      expect(sessions.has(Constants.EXECUTE_CODE)).toBe(false);
+    });
+
     it('ignores error results', () => {
       const sessions: t.ToolSessionMap = new Map();
 

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -1174,5 +1174,47 @@ describe('ToolNode code execution session management', () => {
       expect(capturedRequests[0].name).toBe('web_search');
       expect(capturedRequests[0].codeSessionContext).toBeUndefined();
     });
+
+    it('attaches codeSessionContext to declared host tools so they write into the current sandbox', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'cf-session',
+        files: [
+          { id: 'g1', name: 'gen.png', storage_session_id: 'cf-session' },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const { capturedRequests } = captureBatchRequests();
+
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('create_file')],
+        sessions,
+        eventDrivenMode: true,
+        codeSessionToolNames: ['create_file', 'edit_file'],
+        toolCallStepIds: new Map([['call_cf', 'step_cf']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_cf',
+            name: 'create_file',
+            args: { path: '/mnt/data/x.py', content: 'print(1)' },
+          },
+        ],
+      });
+
+      await toolNode.invoke({ messages: [aiMsg] });
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0].name).toBe('create_file');
+      // Existing session is injected so create_file writes into the current
+      // sandbox instead of spawning a separate one.
+      expect(capturedRequests[0].codeSessionContext?.session_id).toBe(
+        'cf-session'
+      );
+    });
   });
 });

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -185,6 +185,15 @@ export type RunConfig = {
    */
   eagerEventToolExecution?: EagerEventToolExecutionConfig;
   /**
+   * Names of host tools that write to the code-execution sandbox but are not
+   * built-in `CODE_EXECUTION_TOOLS` (e.g. LibreChat's create_file/edit_file).
+   * Their successful results fold the returned exec `session_id` into the
+   * shared code session, so a file such a tool writes is visible to later
+   * bash_tool/execute_code calls running in the same sandbox. Host-declared so
+   * the SDK stays name-agnostic.
+   */
+  codeSessionToolNames?: string[];
+  /**
    * Selects the execution backend for built-in code tools. Omit this to keep
    * the remote LibreChat Code API sandbox. Set `{ engine: 'local' }` to run
    * code execution locally and auto-bind the local coding tool suite unless

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -110,6 +110,12 @@ export type ToolNodeOptions = {
   directToolNames?: Set<string>;
   /** Opt-in eager execution for event-driven tool calls. */
   eagerEventToolExecution?: EagerEventToolExecutionConfig;
+  /**
+   * Host tool names that write to the code-execution sandbox but are not
+   * built-in `CODE_EXECUTION_TOOLS`. Their exec `session_id` is folded into the
+   * shared code session so later bash_tool/execute_code calls see written files.
+   */
+  codeSessionToolNames?: string[];
   /** Shared per-run eager execution registry populated by the stream handler. */
   eagerEventToolExecutions?: Map<string, EagerEventToolExecution>;
   /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */


### PR DESCRIPTION
## Problem

Files written by a host sandbox tool (LibreChat's `create_file`/`edit_file`) were **invisible to later `bash_tool`/`execute_code` calls**. Observed live: an agent ran `create_file` → "Created /mnt/data/measure_from_photo.py (5845 chars)", then `bash_tool ls /mnt/data/` showed the file wasn't there, and the model fell back to a bash heredoc.

Root cause: every code tool reads/writes a shared session id, `sessions[EXECUTE_CODE]`, so they all land in the same sandbox container. That shared session is updated by `updateCodeSession()` in `ToolNode`, but **only for tools in `CODE_EXECUTION_TOOLS`** (`ToolNode.ts` `storeCodeSessionFromResults` + `handleRunToolCompletions`). `create_file` writes to the sandbox and returns its exec `session_id` in its artifact, but because it isn't a `CODE_EXECUTION_TOOL`, that id is dropped — so `bash_tool` starts its own session and never sees the file.

## Fix

Add `RunConfig.codeSessionToolNames`: a **host-declared** set of tool names that write to the code-execution sandbox but aren't built-ins. Their successful results fold the returned exec `session_id` into `sessions[EXECUTE_CODE]`, so subsequent code tools reuse the same sandbox and see the written file.

- **Name-scoped, not a blanket artifact opt-in** — only tools the host explicitly declares can influence the shared session, so a third-party/rogue tool can't hijack it. The SDK stays name-agnostic; the host declares exactly which tools (LibreChat will pass `['create_file','edit_file']`).
- Threaded `RunConfig → Graph → ToolNode` exactly like `eagerEventToolExecution` (incl. child-graph inheritance and heavy-state cleanup).
- `SKILL_TOOL`'s existing inclusion in the event-driven gate is preserved.

## Tests

`ToolNode.session.test.ts`: a host tool declared in `codeSessionToolNames` folds its exec session into the shared session; the same tool **undeclared** does not. All existing ToolNode/session/eager suites pass (231 tests across 8 suites).

## Companion

LibreChat will pass `codeSessionToolNames: ['create_file','edit_file']` (alongside the existing `excludeToolNames`) once this is released and bumped. This is the last link so "write a script with create_file, then run it with bash_tool/execute_code" works end to end in one sandbox.

Future (separate): thin-wrapper primitive/event versions of these host tools for first-class handling.
