### PR TITLE
ci: make anthropic stream spec immune to dual SDK type identity

### DIFF
--- a/src/llm/anthropic/inherited-stream-events.spec.ts
+++ b/src/llm/anthropic/inherited-stream-events.spec.ts
@@ -32,7 +32,6 @@ import { HumanMessage } from '@langchain/core/messages';
 import { ChatModelStream } from '@langchain/core/language_models/stream';
 import type { BaseChatModelCallOptions } from '@langchain/core/language_models/chat_models';
 import type { ChatModelStreamEvent } from '@langchain/core/language_models/event';
-import type { Stream } from '@anthropic-ai/sdk/streaming';
 import type {
   AnthropicMessageStreamEvent,
   AnthropicRequestOptions,
@@ -57,10 +56,14 @@ class MockStreamChatAnthropic extends ChatAnthropic {
     this.mockEvents = mockEvents;
   }
 
+  // Inherit the base method's own Stream identity instead of importing
+  // @anthropic-ai/sdk/streaming here: the SDK ships dual .d.ts/.d.mts types,
+  // and an independent import can resolve to the other format's identity
+  // depending on compile order (flaky TS2416 in sharded CI).
   protected override async createStreamWithRetry(
     request: AnthropicStreamingMessageCreateParams,
     _options?: AnthropicRequestOptions
-  ): Promise<Stream<AnthropicMessageStreamEvent>> {
+  ): ReturnType<ChatAnthropic['createStreamWithRetry']> {
     this.capturedRequest = request;
     const events = this.mockEvents;
     return {
@@ -70,7 +73,7 @@ class MockStreamChatAnthropic extends ChatAnthropic {
           yield event as AnthropicMessageStreamEvent;
         }
       },
-    } as unknown as Stream<AnthropicMessageStreamEvent>;
+    } as unknown as Awaited<ReturnType<ChatAnthropic['createStreamWithRetry']>>;
   }
 }
 


### PR DESCRIPTION
The anthropic inherited-stream-events spec types its mock override by importing `Stream` from `@anthropic-ai/sdk/streaming`, while the base `createStreamWithRetry` gets its `Stream` identity through the `@langchain/anthropic` fork chain. The SDK ships dual `.d.ts`/`.d.mts` declarations, so the two imports can resolve to different type identities depending on ts-jest compile order. When they diverge, the suite fails to compile with TS2416 ("Two different types with this name exist, but they are unrelated" on `Stream<RawMessageStreamEvent>`).

This is order-dependent: it surfaced twice consecutively on `validate / unit tests (shard 2/4)` in https://github.com/danny-avila/agents/pull/285 (whose new test file shifts shard composition), while the identical spec passes on main, locally, and in other PRs.

Fix: derive the mock override types from the base method (`ReturnType<ChatAnthropic["createStreamWithRetry"]>`) — the same pattern `CustomAnthropic` itself uses — and drop the independent SDK import. No runtime change; spec passes, tsc clean.

Unblocks CI for the Keenable provider PR, which should be rebased once this lands.