### PR TITLE
fix: bridge tool image artifacts with an assistant message for strict providers

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3432,7 +3432,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ) {
           artifactCandidate = trackProviderMessageOrigins(
             finalMessages,
-            projectArtifactPayload(finalMessages, maxProviderToolResultChars)
+            projectArtifactPayload(finalMessages, maxProviderToolResultChars, {
+              /* A custom OpenAI-compatible endpoint can front anything, and Mistral-backed
+               * ones (Scaleway) reject a `user` message straight after a `tool` message.
+               * The provider string cannot tell us which, and the extra assistant turn is
+               * valid for the providers that do not need it, so it is enabled for the whole
+               * OpenAI-like/Google branch. */
+              bridgeUserAfterTool: true,
+            })
           );
         }
 

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -2338,9 +2338,25 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
   }
 }
 
+/**
+ * Short assistant turn placed between the tool results and the projected user message.
+ * Strict OpenAI-compatible providers (Mistral, and Scaleway which fronts it) reject a
+ * `user` message that directly follows a `tool` message, so the alternation needs a
+ * bridge; OpenAI and Google accept it either way.
+ */
+const ARTIFACT_BRIDGE_TEXT = 'Here is the tool output:';
+
 export function projectArtifactPayload(
   messages: BaseMessage[],
-  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS,
+  options?: {
+    /**
+     * Insert an assistant bridge before the projected user message. Required by providers
+     * that enforce role alternation after `tool`; harmless elsewhere. Defaults to false so
+     * existing callers keep the current message shape.
+     */
+    bridgeUserAfterTool?: boolean;
+  }
 ): BaseMessage[] {
   const lastMessageY = messages[messages.length - 1];
   if (!(lastMessageY instanceof ToolMessage)) return messages;
@@ -2397,6 +2413,9 @@ export function projectArtifactPayload(
   }
 
   if (aggregatedContent != null) {
+    if (options?.bridgeUserAfterTool === true) {
+      formattedMessages?.push(new AIMessage({ content: ARTIFACT_BRIDGE_TEXT }));
+    }
     formattedMessages?.push(new HumanMessage({ content: aggregatedContent }));
   }
   return formattedMessages ?? messages;

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -8109,3 +8109,56 @@ describe('formatAgentMessages', () => {
     });
   });
 });
+
+describe('projectArtifactPayload bridgeUserAfterTool', () => {
+  /** Mirrors the fixture style used by the projectArtifactPayload cases above. */
+  const buildToolRun = (): BaseMessage[] => [
+    new HumanMessage({ content: 'draw a cat' }),
+    new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'call_1', name: 'image_gen', args: {} }],
+    }),
+    new ToolMessage({
+      content: 'generated',
+      tool_call_id: 'call_1',
+      artifact: {
+        content: [
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      },
+    }),
+  ];
+
+  it('places an assistant bridge before the projected user message', () => {
+    const formatted = projectArtifactPayload(buildToolRun(), 200, {
+      bridgeUserAfterTool: true,
+    });
+    const roles = formatted.map((m) => m.getType());
+    /** No `user` directly after `tool` - that is what Mistral/Scaleway reject. */
+    expect(roles).toEqual(['human', 'ai', 'tool', 'ai', 'human']);
+  });
+
+  it('omits the bridge by default, preserving the existing shape', () => {
+    const formatted = projectArtifactPayload(buildToolRun(), 200);
+    expect(formatted.map((m) => m.getType())).toEqual([
+      'human',
+      'ai',
+      'tool',
+      'human',
+    ]);
+  });
+
+  it('adds nothing when there is no artifact to project', () => {
+    const messages = [
+      new HumanMessage({ content: 'hi' }),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_1', name: 'noop', args: {} }],
+      }),
+      new ToolMessage({ content: 'done', tool_call_id: 'call_1' }),
+    ];
+    expect(
+      projectArtifactPayload(messages, 200, { bridgeUserAfterTool: true })
+    ).toBe(messages);
+  });
+});


### PR DESCRIPTION
fix: bridge tool image artifacts with an assistant message for strict providers

Closes #344

## Problem

`projectArtifactPayload` replaces a tool result carrying an artifact with a note
and appends the artifact as a `HumanMessage` directly after the `ToolMessage`.
Strict OpenAI-compatible providers reject a `user` message that immediately
follows a `tool` message, so the whole request fails. On Scaleway (Mistral
backend):

```
400 Unexpected role 'user' after role 'tool'
```

Putting the image inside the tool message instead fails differently on the same
provider (`content.list[TextChunk].1.type Input should be <ChunkTypes.text>`), so
the image can live neither in the tool result nor directly after it — tool-
generated images are simply unusable there today.

## Fix

An opt-in `bridgeUserAfterTool` option that emits a short assistant turn between
the tool results and the projected user message, satisfying role alternation.

- defaults to **false**, so every existing caller keeps the current message shape
- enabled at the Graph call site for the OpenAI-like/Google branch: a custom
  OpenAI-compatible endpoint can front anything, the provider string cannot tell
  us whether it is Mistral-backed, and the extra assistant turn is valid for the
  providers that do not need it

## Tests

Three cases in `formatAgentMessages.test.ts`: the bridged role sequence
(`human, ai, tool, ai, human` — no `user` after `tool`), the unchanged default
shape, and the no-artifact case returning the input untouched.
`src/messages` + `src/graphs` suites pass (537), tsc and eslint clean.

Signed-off-by: JumpLink <pascal@artandcode.studio>