### PR TITLE
feat: reshape Langfuse observation tree

### DIFF
--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -16,6 +16,10 @@ import {
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
+import {
+  shapeLangfuseSpan,
+  shouldDropLangfuseSpan,
+} from '@/langfuseTraceShaping';
 import { resolveToolOutputTracingConfigForSpan } from '@/langfuseRuntimeScope';
 
 export { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT, resolveLangfuseConfig };
@@ -407,6 +411,9 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   }
 
   onStart(span: Span, parentContext: Context): void {
+    if (shouldDropLangfuseSpan(span.name)) {
+      return;
+    }
     const config =
       resolveToolOutputTracingConfigForSpan(parentContext) ??
       this.fallbackConfig;
@@ -417,7 +424,11 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
+    if (shouldDropLangfuseSpan(span.name)) {
+      return;
+    }
     classifyLangfuseToolNodeSpan(span);
+    shapeLangfuseSpan(span);
     const config = this.spanConfigs.get(span) ?? this.fallbackConfig;
     if (config != null) {
       redactLangfuseSpanToolOutputs(span, config);

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -1,0 +1,280 @@
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+
+const LANGGRAPH_START_NODE = '__start__';
+const ANONYMOUS_LAMBDA_NAME = 'RunnableLambda';
+const LANGGRAPH_AGENT_NODE_PREFIX = 'agent=';
+const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
+const TOOL_BATCH_RUN_NAME = 'tool_batch';
+const AGENT_NODE_SPAN_NAME = 'agent';
+
+type MutableSpan = ReadableSpan & {
+  name: string;
+  attributes: Record<string, unknown>;
+};
+
+type SerializedToolCall = {
+  name: string;
+  args: unknown;
+  id?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseAttributeValue(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return value;
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function getMessageArray(
+  value: unknown
+): Record<string, unknown>[] | undefined {
+  if (Array.isArray(value)) {
+    const records = value.filter(isRecord);
+    return records.length > 0 ? records : undefined;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return (
+    getMessageArray(value.messages) ??
+    getMessageArray(value.input) ??
+    getMessageArray(value.output)
+  );
+}
+
+function getMessageRole(message: Record<string, unknown>): string | undefined {
+  const id = message.id;
+  if (Array.isArray(id)) {
+    const className = id[id.length - 1];
+    if (typeof className === 'string') {
+      if (className.includes('Human')) {
+        return 'user';
+      }
+      if (className.includes('AI')) {
+        return 'assistant';
+      }
+      if (className.includes('System')) {
+        return 'system';
+      }
+      if (className.includes('Tool')) {
+        return 'tool';
+      }
+    }
+  }
+  const rawRole =
+    message.type ?? message._type ?? message.role ?? message.sender;
+  if (typeof rawRole !== 'string') {
+    const kwargs = message.kwargs;
+    return isRecord(kwargs) ? getMessageRole(kwargs) : undefined;
+  }
+  const normalized = rawRole.toLowerCase();
+  if (normalized === 'human') {
+    return 'user';
+  }
+  if (normalized === 'ai') {
+    return 'assistant';
+  }
+  return normalized;
+}
+
+function getMessageText(message: Record<string, unknown>): string | undefined {
+  const content =
+    message.content ??
+    (isRecord(message.kwargs) ? message.kwargs.content : undefined) ??
+    (isRecord(message.data) ? message.data.content : undefined);
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .filter(isRecord)
+    .map((part) => (typeof part.text === 'string' ? part.text : ''))
+    .join('');
+  return text === '' ? undefined : text;
+}
+
+function findLastMessageText(value: unknown, role: string): string | undefined {
+  const messages = getMessageArray(value);
+  if (messages == null) {
+    return undefined;
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (getMessageRole(messages[i]) !== role) {
+      continue;
+    }
+    const text = getMessageText(messages[i]);
+    if (text != null && text.trim() !== '') {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function normalizeToolCall(value: unknown): SerializedToolCall | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const fn = value.function;
+  if (isRecord(fn) && typeof fn.name === 'string') {
+    return {
+      name: fn.name,
+      args: parseAttributeValue(fn.arguments),
+      ...(typeof value.id === 'string' ? { id: value.id } : {}),
+    };
+  }
+  if (typeof value.name !== 'string') {
+    return undefined;
+  }
+  return {
+    name: value.name,
+    args: value.args ?? {},
+    ...(typeof value.id === 'string' ? { id: value.id } : {}),
+  };
+}
+
+function getMessageToolCalls(
+  message: Record<string, unknown>
+): SerializedToolCall[] {
+  const rawCalls =
+    message.tool_calls ??
+    (isRecord(message.kwargs) ? message.kwargs.tool_calls : undefined) ??
+    (isRecord(message.additional_kwargs)
+      ? message.additional_kwargs.tool_calls
+      : undefined) ??
+    (isRecord(message.data) ? message.data.tool_calls : undefined);
+  if (!Array.isArray(rawCalls)) {
+    return [];
+  }
+  const calls: SerializedToolCall[] = [];
+  for (const rawCall of rawCalls) {
+    const call = normalizeToolCall(rawCall);
+    if (call != null) {
+      calls.push(call);
+    }
+  }
+  return calls;
+}
+
+/** Latest assistant turn's tool calls — the calls this tool node is executing. */
+function findPendingToolCalls(value: unknown): SerializedToolCall[] {
+  const messages = getMessageArray(value);
+  if (messages == null) {
+    return [];
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (getMessageRole(messages[i]) !== 'assistant') {
+      continue;
+    }
+    const calls = getMessageToolCalls(messages[i]);
+    if (calls.length > 0) {
+      return calls;
+    }
+  }
+  return [];
+}
+
+function getRootSpanParentId(span: ReadableSpan): string | undefined {
+  const legacyParent = (span as { parentSpanId?: string }).parentSpanId;
+  if (typeof legacyParent === 'string' && legacyParent !== '') {
+    return legacyParent;
+  }
+  const parentContext = (span as { parentSpanContext?: { spanId?: string } })
+    .parentSpanContext;
+  const spanId = parentContext?.spanId;
+  return typeof spanId === 'string' && spanId !== '' ? spanId : undefined;
+}
+
+function isRootSpan(span: ReadableSpan): boolean {
+  return getRootSpanParentId(span) == null;
+}
+
+/**
+ * LangGraph plumbing observations that add noise without information:
+ * the duplicated `__start__` channel-seed nodes and anonymous
+ * `RunnableLambda` pass-throughs (Langfuse team feedback items 4 & 5).
+ */
+export function shouldDropLangfuseSpan(spanName: string): boolean {
+  return (
+    spanName === LANGGRAPH_START_NODE || spanName === ANONYMOUS_LAMBDA_NAME
+  );
+}
+
+function shapeToolNodeSpan(span: MutableSpan): void {
+  const inputKey = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
+  const calls = findPendingToolCalls(
+    parseAttributeValue(span.attributes[inputKey])
+  );
+  if (calls.length === 0) {
+    return;
+  }
+  span.name = [...new Set(calls.map((call) => call.name))].join(', ');
+  span.attributes[inputKey] = JSON.stringify(
+    calls.map(({ name, args }) => ({ name, args }))
+  );
+}
+
+function shapeRootSpan(span: MutableSpan): void {
+  const inputKey = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
+  const outputKey = LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT;
+  const question = findLastMessageText(
+    parseAttributeValue(span.attributes[inputKey]),
+    'user'
+  );
+  const answer = findLastMessageText(
+    parseAttributeValue(span.attributes[outputKey]),
+    'assistant'
+  );
+  if (question != null) {
+    span.attributes[inputKey] = question;
+    span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT] = question;
+  }
+  if (answer != null) {
+    span.attributes[outputKey] = answer;
+    span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT] = answer;
+  }
+}
+
+/**
+ * Reshapes spans per Langfuse-team feedback before export:
+ * - `agent=<id>` / `tools=<id>` node names carry the ephemeral agent id
+ *   (`provider__model`) — strip it so switching models doesn't break
+ *   name-based logic (item 1).
+ * - Tool node spans are renamed to the actual tool name(s) and their
+ *   input scoped to the pending tool-call args instead of the whole
+ *   chat history (items 3 & 4).
+ * - The root span (and trace) input/output become the user question and
+ *   assistant response so the session view reads as a conversation
+ *   (item 2).
+ */
+export function shapeLangfuseSpan(span: ReadableSpan): void {
+  const mutable = span as MutableSpan;
+  if (mutable.name.startsWith(LANGGRAPH_AGENT_NODE_PREFIX)) {
+    mutable.name = AGENT_NODE_SPAN_NAME;
+    return;
+  }
+  if (
+    mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX) ||
+    mutable.name === TOOL_BATCH_RUN_NAME
+  ) {
+    shapeToolNodeSpan(mutable);
+    return;
+  }
+  if (isRootSpan(span)) {
+    shapeRootSpan(mutable);
+  }
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1403,7 +1403,7 @@ export class Run<_T extends t.BaseGraphState> {
         inputText,
         skipLanguage,
       }),
-    }).withConfig({ runName: 'ConvoTransform' });
+    }).withConfig({ runName: 'PrepareTitleInput' });
 
     const titleChain =
       titleMethod === TitleMethod.COMPLETION
@@ -1412,10 +1412,10 @@ export class Run<_T extends t.BaseGraphState> {
 
     /** Pipes `convoTemplate` -> `transformer` -> `titleChain` */
     const fullChain = convoTemplate
-      .withConfig({ runName: 'ConvoTemplate' })
+      .withConfig({ runName: 'FormatConversation' })
       .pipe(convoToTitleInput)
       .pipe(titleChain)
-      .withConfig({ runName: 'TitleChain' });
+      .withConfig({ runName: 'GenerateConversationTitle' });
 
     const invokeConfig = Object.assign({}, chainOptions, {
       run_id: this.id,

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -469,7 +469,7 @@ describe('Langfuse per-run routing integration', () => {
       expectNamedSpansUseTraceId({
         starts,
         traceId: titleTraceId,
-        names: [`LibreChat Title: Parent ${tenantId}`, 'CompletionTitleChain'],
+        names: [`LibreChat Title: Parent ${tenantId}`, 'GenerateTitle'],
       });
       expectNoCrossTenantTrace({
         tenantId,

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -1,0 +1,194 @@
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  shapeLangfuseSpan,
+  shouldDropLangfuseSpan,
+} from '@/langfuseTraceShaping';
+
+type TestSpan = ReadableSpan & {
+  name: string;
+  attributes: Record<string, unknown>;
+};
+
+function createSpan(
+  name: string,
+  attributes: Record<string, unknown> = {},
+  parentSpanId?: string
+): TestSpan {
+  return {
+    name,
+    attributes,
+    ...(parentSpanId != null ? { parentSpanId } : {}),
+  } as unknown as TestSpan;
+}
+
+const INPUT = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
+const OUTPUT = LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT;
+const TRACE_INPUT = LangfuseOtelSpanAttributes.TRACE_INPUT;
+const TRACE_OUTPUT = LangfuseOtelSpanAttributes.TRACE_OUTPUT;
+
+describe('shouldDropLangfuseSpan', () => {
+  it('drops langgraph __start__ seed spans', () => {
+    expect(shouldDropLangfuseSpan('__start__')).toBe(true);
+  });
+
+  it('drops anonymous RunnableLambda pass-throughs', () => {
+    expect(shouldDropLangfuseSpan('RunnableLambda')).toBe(true);
+  });
+
+  it('keeps named observations', () => {
+    expect(shouldDropLangfuseSpan('GenerateTitle')).toBe(false);
+    expect(shouldDropLangfuseSpan('agent=openAI__gpt-5.4')).toBe(false);
+    expect(shouldDropLangfuseSpan('ChatOpenAI')).toBe(false);
+  });
+});
+
+describe('shapeLangfuseSpan', () => {
+  it('strips the ephemeral agent id (provider__model) from agent node names', () => {
+    const span = createSpan('agent=openAI__gpt-5.4', {}, 'parent-1');
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('agent');
+  });
+
+  it('renames tool node spans to the pending tool names and scopes input to args', () => {
+    const messages = [
+      { type: 'human', content: 'hello' },
+      {
+        type: 'ai',
+        content: '',
+        tool_calls: [
+          {
+            name: 'get_service_details',
+            args: { path: 'organizations/1' },
+            id: 'call_1',
+          },
+        ],
+      },
+    ];
+    const span = createSpan(
+      'tools=openAI__gpt-5.4',
+      { [INPUT]: JSON.stringify({ messages }) },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('get_service_details');
+    expect(JSON.parse(span.attributes[INPUT] as string)).toEqual([
+      { name: 'get_service_details', args: { path: 'organizations/1' } },
+    ]);
+  });
+
+  it('joins multiple pending tool names and dedupes repeats', () => {
+    const messages = [
+      {
+        type: 'ai',
+        tool_calls: [
+          { name: 'web_search', args: { q: 'a' }, id: '1' },
+          { name: 'web_search', args: { q: 'b' }, id: '2' },
+          { name: 'execute_code', args: { code: '1+1' }, id: '3' },
+        ],
+      },
+    ];
+    const span = createSpan(
+      'tool_batch',
+      { [INPUT]: JSON.stringify({ messages }) },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('web_search, execute_code');
+  });
+
+  it('reads tool calls from serialized langchain message kwargs', () => {
+    const messages = [
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['langchain_core', 'messages', 'AIMessage'],
+        kwargs: {
+          content: '',
+          tool_calls: [{ name: 'lookup', args: { id: 7 }, id: 'call_7' }],
+        },
+      },
+    ];
+    const span = createSpan(
+      'tools=agent_abc',
+      { [INPUT]: JSON.stringify({ messages }) },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('lookup');
+  });
+
+  it('leaves tool node spans untouched when no tool calls are found', () => {
+    const original = JSON.stringify({
+      messages: [{ type: 'human', content: 'hi' }],
+    });
+    const span = createSpan(
+      'tools=agent_abc',
+      { [INPUT]: original },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('tools=agent_abc');
+    expect(span.attributes[INPUT]).toBe(original);
+  });
+
+  it('sets root span and trace input/output to the question and answer', () => {
+    const span = createSpan('LibreChat Agent', {
+      [INPUT]: JSON.stringify({
+        messages: [
+          { type: 'system', content: 'You are helpful.' },
+          { type: 'human', content: 'What is ClickHouse?' },
+        ],
+      }),
+      [OUTPUT]: JSON.stringify({
+        messages: [
+          { type: 'human', content: 'What is ClickHouse?' },
+          { type: 'ai', content: 'A columnar OLAP database.' },
+        ],
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[INPUT]).toBe('What is ClickHouse?');
+    expect(span.attributes[TRACE_INPUT]).toBe('What is ClickHouse?');
+    expect(span.attributes[OUTPUT]).toBe('A columnar OLAP database.');
+    expect(span.attributes[TRACE_OUTPUT]).toBe('A columnar OLAP database.');
+  });
+
+  it('extracts answer text from content part arrays', () => {
+    const span = createSpan('LibreChat Agent', {
+      [INPUT]: JSON.stringify([{ type: 'human', content: 'hi' }]),
+      [OUTPUT]: JSON.stringify({
+        messages: [
+          {
+            id: ['langchain_core', 'messages', 'AIMessage'],
+            kwargs: {
+              content: [
+                { type: 'text', text: 'Hello ' },
+                { type: 'text', text: 'there.' },
+              ],
+            },
+          },
+        ],
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[INPUT]).toBe('hi');
+    expect(span.attributes[OUTPUT]).toBe('Hello there.');
+  });
+
+  it('does not rewrite non-root spans with message payloads', () => {
+    const original = JSON.stringify({
+      messages: [{ type: 'human', content: 'hi' }],
+    });
+    const span = createSpan('ChatOpenAI', { [INPUT]: original }, 'parent-1');
+    shapeLangfuseSpan(span);
+    expect(span.attributes[INPUT]).toBe(original);
+  });
+
+  it('preserves root attributes when extraction finds nothing', () => {
+    const span = createSpan('LibreChat Agent', { [INPUT]: 'plain text' });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[INPUT]).toBe('plain text');
+    expect(span.attributes[TRACE_INPUT]).toBeUndefined();
+  });
+});

--- a/src/utils/title.ts
+++ b/src/utils/title.ts
@@ -53,7 +53,7 @@ export const createTitleRunnable = async (
 
   const titlePrompt = ChatPromptTemplate.fromTemplate(
     _titlePrompt ?? defaultTitlePrompt
-  ).withConfig({ runName: 'TitlePrompt' });
+  ).withConfig({ runName: 'BuildTitlePrompt' });
 
   const titleOnlyInnerChain = RunnableSequence.from([titlePrompt, titleLLM]);
   const combinedInnerChain = RunnableSequence.from([titlePrompt, combinedLLM]);
@@ -67,7 +67,7 @@ export const createTitleRunnable = async (
       const result = await titleOnlyInnerChain.invoke(input, config);
       return result as { title: string };
     },
-  }).withConfig({ runName: 'TitleOnlyChain' });
+  }).withConfig({ runName: 'GenerateTitleOnly' });
 
   /** Wrap combinedChain in RunnableLambda to create parent span */
   const combinedChain = new RunnableLambda({
@@ -78,7 +78,7 @@ export const createTitleRunnable = async (
       const result = await combinedInnerChain.invoke(input, config);
       return result as { language: string; title: string };
     },
-  }).withConfig({ runName: 'TitleLanguageChain' });
+  }).withConfig({ runName: 'GenerateTitleAndDetectLanguage' });
 
   /** Runnable to add default values if needed */
   const addDefaults = new RunnableLambda({
@@ -88,7 +88,7 @@ export const createTitleRunnable = async (
       language: result?.language ?? 'English',
       title: result?.title ?? '',
     }),
-  }).withConfig({ runName: 'AddDefaults' });
+  }).withConfig({ runName: 'ApplyTitleDefaults' });
 
   const combinedChainInner = RunnableSequence.from([
     combinedChain,
@@ -103,7 +103,7 @@ export const createTitleRunnable = async (
     ): Promise<{ language: string; title: string }> => {
       return await combinedChainInner.invoke(input, config);
     },
-  }).withConfig({ runName: 'CombinedChainWithDefaults' });
+  }).withConfig({ runName: 'GenerateTitleAndDetectLanguageWithDefaults' });
 
   return new RunnableLambda({
     func: async (
@@ -124,7 +124,7 @@ export const createTitleRunnable = async (
 
       return await combinedChainWithDefaults.invoke(invokeInput, config);
     },
-  }).withConfig({ runName: 'TitleGenerator' });
+  }).withConfig({ runName: 'GenerateTitle' });
 };
 
 const defaultCompletionPrompt = `Provide a concise, 5-word-or-less title for the conversation, using title case conventions. Only return the title itself.
@@ -138,7 +138,7 @@ export const createCompletionTitleRunnable = async (
 ): Promise<Runnable> => {
   const completionPrompt = ChatPromptTemplate.fromTemplate(
     titlePrompt ?? defaultCompletionPrompt
-  ).withConfig({ runName: 'CompletionTitlePrompt' });
+  ).withConfig({ runName: 'BuildTitlePrompt' });
 
   /** Runnable to extract content from model response */
   const extractContent = new RunnableLambda({
@@ -157,7 +157,7 @@ export const createCompletionTitleRunnable = async (
       }
       return { title: content.trim() };
     },
-  }).withConfig({ runName: 'ExtractTitle' });
+  }).withConfig({ runName: 'ParseTitleFromResponse' });
 
   const innerChain = RunnableSequence.from([
     completionPrompt,
@@ -173,5 +173,5 @@ export const createCompletionTitleRunnable = async (
     ): Promise<{ title: string }> => {
       return await innerChain.invoke(input, config);
     },
-  }).withConfig({ runName: 'CompletionTitleChain' });
+  }).withConfig({ runName: 'GenerateTitle' });
 };


### PR DESCRIPTION
Cleans up the observation tree exported to Langfuse (follows an upstream review of LibreChat traces). Previously: node observations were named after ephemeral agent ids (`agent=openAI__gpt-5.4`), tool observations were generic (`tools=<id>` / `tool_batch`) with the full message history as input, every trace opened with two `__start__` spans plus an anonymous `RunnableLambda`, and trace input/output were raw graph state.

- `langfuseTraceShaping.ts` (new): span-shaping helpers applied before export:
  - drops `__start__` seed spans and anonymous `RunnableLambda` spans
  - renames `agent=<id>` node spans to `agent`; ephemeral agent ids embed `provider__model`, so observation names changed whenever the model changed
  - renames tool node spans to the pending tool name(s), parsed from the latest assistant turn's tool calls, and sets their input to `[{ name, args }]`
  - sets root span and trace input/output to the latest user message text and the final assistant text
- `langfuseToolOutputTracing.ts`: applies the drop/shape hooks in `ToolOutputRedactingLangfuseSpanProcessor.onStart`/`onEnd`, ahead of the existing tool-span classification and redaction passes
- `utils/title.ts` / `run.ts`: renames title-chain observations (`ExtractTitle` -> `ParseTitleFromResponse`, `TitleGenerator`/`CompletionTitleChain` -> `GenerateTitle`, `ConvoTransform` -> `PrepareTitleInput`, `ConvoTemplate` -> `FormatConversation`)
- `specs/langfuse-trace-shaping.test.ts`: drop rules, renames, repeated-tool-name dedup, plain and langchain-serialized message shapes, root I/O extraction, and passthrough when input can't be parsed

Validation: eslint, tsc, build:dev, and the jest unit suite (CI shard config) clean; durability checkpoint integration test passes.