### PR TITLE
feat: host-suppliable AgentInputs.graphTools for in-graph direct tools

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -85,6 +85,7 @@ export class AgentContext {
       toolSchemaTokens,
       subagentConfigs,
       maxSubagentDepth,
+      graphTools,
     } = agentConfig;
 
     const agentContext = new AgentContext({
@@ -116,6 +117,14 @@ export class AgentContext {
     agentContext._sourceInputs = agentConfig;
     agentContext.subagentConfigs = subagentConfigs;
     agentContext.maxSubagentDepth = maxSubagentDepth;
+    /**
+     * Host-supplied direct tools (see `AgentInputs.graphTools`). Copied — never
+     * aliased — because the SDK later pushes graph-managed tools (handoff /
+     * subagent) into this same array and must not mutate the host's input.
+     */
+    if (graphTools && graphTools.length > 0) {
+      agentContext.graphTools = [...graphTools];
+    }
 
     if (initialSummary?.text != null && initialSummary.text !== '') {
       agentContext.setInitialSummary(

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -42,6 +42,46 @@ describe('AgentContext', () => {
       schema: { type: 'object', properties: {} },
     }) as unknown as t.GenericTool;
 
+  describe('fromConfig — host-supplied graphTools', () => {
+    it('copies graphTools onto the context without aliasing the host array', () => {
+      const askTool = createMockTool('ask_user_question');
+      const hostGraphTools = [askTool];
+      const ctx = createBasicContext({
+        agentConfig: { graphTools: hostGraphTools },
+      });
+
+      expect(ctx.graphTools).toEqual([askTool]);
+      expect(ctx.graphTools).not.toBe(hostGraphTools);
+
+      /** The SDK pushes graph-managed tools (handoff/subagent) into this
+       *  array later — that must never mutate the host's input. */
+      (ctx.graphTools as t.GenericTool[]).push(createMockTool('subagent'));
+      expect(hostGraphTools).toHaveLength(1);
+    });
+
+    it('leaves graphTools undefined when the host supplies none (or an empty list)', () => {
+      expect(createBasicContext().graphTools).toBeUndefined();
+      expect(
+        createBasicContext({ agentConfig: { graphTools: [] } }).graphTools
+      ).toBeUndefined();
+    });
+
+    it('binds host graphTools to the model in event-driven mode', () => {
+      const askTool = createMockTool('ask_user_question');
+      const ctx = createBasicContext({
+        agentConfig: {
+          graphTools: [askTool],
+          toolDefinitions: [{ name: 'echo', description: 'host event tool' }],
+        },
+      });
+
+      const bound = ctx.getToolsForBinding() ?? [];
+      const names = (bound as Array<{ name?: string }>).map((t) => t.name);
+      expect(names).toContain('ask_user_question');
+      expect(names).toContain('echo');
+    });
+  });
+
   describe('System Runnable - Lazy Creation', () => {
     it('creates system runnable on first access', () => {
       const ctx = createBasicContext({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1294,10 +1294,25 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       graphTools && graphTools.length > 0
         ? [...baseTools, ...graphTools]
         : baseTools;
+    /**
+     * ToolNode treats a supplied `toolMap` as authoritative (it only derives
+     * one from `tools` when the param is undefined), so when graphTools force
+     * us to build a merged map here, an absent `currentToolMap` must be
+     * seeded from the BASE tools first — otherwise ordinary tools stay bound
+     * to the model but vanish from the execution map and every call to them
+     * fails as an unknown tool (Codex #289 round 2).
+     */
     const traditionalToolMap =
       graphTools && graphTools.length > 0
         ? new Map([
-          ...(currentToolMap ?? new Map()),
+          ...(currentToolMap ??
+              new Map(
+                baseTools
+                  .filter(
+                    (t): t is t.GenericTool & { name: string } => 'name' in t
+                  )
+                  .map((t) => [t.name, t] as [string, t.GenericTool])
+              )),
           ...graphTools
             .filter((t): t is t.GenericTool & { name: string } => 'name' in t)
             .map((t) => [t.name, t] as [string, t.GenericTool]),

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1140,7 +1140,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   getToolCount(): number {
     const context = this.agentContexts.get(this.defaultAgentId);
     return (
-      (context?.tools?.length ?? 0) + (context?.toolDefinitions?.length ?? 0)
+      (context?.tools?.length ?? 0) +
+      (context?.toolDefinitions?.length ?? 0) +
+      /**
+       * Graph-managed + host-supplied direct tools (handoff, subagent,
+       * `AgentInputs.graphTools`) are bound to the model and token-accounted,
+       * so a count that omits them under-reports the run's tool surface
+       * (Codex #289 P3).
+       */
+      (context?.graphTools?.length ?? 0)
     );
   }
 

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -73,6 +73,28 @@ const expectCompiledWorkflow = (
 };
 
 describe('LangGraph composition smoke tests', () => {
+  it('getToolCount includes direct graph tools (host-supplied graphTools) alongside instances and definitions', () => {
+    const askLikeTool = { name: 'ask_user_question' } as unknown as NonNullable<
+      t.AgentInputs['graphTools']
+    >[number];
+    const graph = new StandardGraph({
+      runId: 'toolcount-smoke',
+      agents: [
+        {
+          ...makeAgent('agent'),
+          toolDefinitions: [
+            { name: 'evt1', description: 'event tool one' },
+            { name: 'evt2', description: 'event tool two' },
+          ],
+          graphTools: [askLikeTool],
+        },
+      ],
+    });
+    // 2 schema-only event tools + 1 in-process direct tool — all bound to the
+    // model and token-accounted, so all must be counted (Codex #289 P3).
+    expect(graph.getToolCount()).toBe(3);
+  });
+
   it('clears run-scoped eager tool state on reset', () => {
     const graph = new StandardGraph({
       runId: 'standard-eager-reset',

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -95,6 +95,37 @@ describe('LangGraph composition smoke tests', () => {
     expect(graph.getToolCount()).toBe(3);
   });
 
+  it('keeps ordinary tools executable when graphTools are added without a host toolMap (traditional mode)', () => {
+    type HostTool = NonNullable<t.AgentInputs['graphTools']>[number];
+    const echoTool = { name: 'echo_tool' } as unknown as HostTool;
+    const askLikeTool = { name: 'ask_user_question' } as unknown as HostTool;
+    const graph = new StandardGraph({
+      runId: 'toolmap-merge-smoke',
+      agents: [
+        {
+          ...makeAgent('agent'),
+          tools: [echoTool],
+          graphTools: [askLikeTool],
+        },
+      ],
+    });
+    const agentContext = graph.agentContexts.get('agent');
+    const node = graph.initializeTools({
+      currentTools: agentContext?.tools,
+      currentToolMap: undefined,
+      agentContext,
+    });
+    /**
+     * ToolNode treats a provided toolMap as authoritative — if the merged map
+     * built for graphTools drops the base tools, they stay bound to the model
+     * but every call fails as an unknown tool (Codex #289 round 2).
+     */
+    const toolMap = (node as unknown as { toolMap: Map<string, unknown> })
+      .toolMap;
+    expect(toolMap.has('echo_tool')).toBe(true);
+    expect(toolMap.has('ask_user_question')).toBe(true);
+  });
+
   it('clears run-scoped eager tool state on reset', () => {
     const graph = new StandardGraph({
       runId: 'standard-eager-reset',

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -292,6 +292,31 @@ describe('buildChildInputs', () => {
     expect(result.toolDefinitions).toBeUndefined();
   });
 
+  it('strips host-supplied graphTools (children compile without a checkpointer, so interrupt-capable direct tools cannot work there)', () => {
+    const askLikeTool = { name: 'ask_user_question' } as unknown as NonNullable<
+      AgentInputs['graphTools']
+    >[number];
+    const inputsWithGraphTools: AgentInputs = {
+      ...parentAgentInputs,
+      graphTools: [askLikeTool],
+    };
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: inputsWithGraphTools,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    /**
+     * Covers the self-spawn shape too: its config resolves `agentInputs`
+     * from the parent's `_sourceInputs` via shallow spread, so without this
+     * clear the child would inherit the direct tool and deterministically
+     * fail with `No checkpointer set` on first use.
+     */
+    expect(result.graphTools).toBeUndefined();
+    expect(inputsWithGraphTools.graphTools).toHaveLength(1); // parent untouched
+  });
+
   it('strips parent-run-scoped initialSummary and discoveredTools from child inputs', () => {
     /**
      * Codex P1: a child inheriting `initialSummary` or `discoveredTools` from

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -292,7 +292,7 @@ describe('buildChildInputs', () => {
     expect(result.toolDefinitions).toBeUndefined();
   });
 
-  it('strips host-supplied graphTools (children compile without a checkpointer, so interrupt-capable direct tools cannot work there)', () => {
+  it('scrubs INHERITED graphTools on self-spawn (parent-spread config) but keeps an explicit child config’s own', () => {
     const askLikeTool = { name: 'ask_user_question' } as unknown as NonNullable<
       AgentInputs['graphTools']
     >[number];
@@ -300,20 +300,39 @@ describe('buildChildInputs', () => {
       ...parentAgentInputs,
       graphTools: [askLikeTool],
     };
-    const config: ResolvedSubagentConfig = {
+
+    /**
+     * Self-spawn: `resolveSubagentConfigs` fills `agentInputs` as a shallow
+     * spread of the parent's `_sourceInputs`, so the parent-scoped direct
+     * tool would leak into a checkpointer-less child graph and fail with
+     * `No checkpointer set` — must be scrubbed.
+     */
+    const selfConfig: ResolvedSubagentConfig = {
+      type: 'self',
+      name: 'Self',
+      description: 'd',
+      self: true,
+      agentInputs: { ...inputsWithGraphTools },
+    };
+    expect(
+      buildChildInputs(selfConfig, 'child-self', 3).graphTools
+    ).toBeUndefined();
+
+    /**
+     * Explicit child config: a host that deliberately attaches its own
+     * in-process direct tools to a child keeps them (Codex #289 P2 —
+     * interrupt-capable tools still fail in children, but non-interrupting
+     * direct tools are legitimate there).
+     */
+    const explicitConfig: ResolvedSubagentConfig = {
       type: 'researcher',
       name: 'R',
       description: 'd',
       agentInputs: inputsWithGraphTools,
     };
-    const result = buildChildInputs(config, 'child', 3);
-    /**
-     * Covers the self-spawn shape too: its config resolves `agentInputs`
-     * from the parent's `_sourceInputs` via shallow spread, so without this
-     * clear the child would inherit the direct tool and deterministically
-     * fail with `No checkpointer set` on first use.
-     */
-    expect(result.graphTools).toBeUndefined();
+    expect(
+      buildChildInputs(explicitConfig, 'child-explicit', 3).graphTools
+    ).toEqual([askLikeTool]);
     expect(inputsWithGraphTools.graphTools).toHaveLength(1); // parent untouched
   });
 

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -3996,6 +3996,91 @@ describe('AskUserQuestion — interrupt + resume', () => {
     expect(resumedAnswer).toBe('production');
   });
 
+  it('a DIRECT tool in event-driven mode can raise ask_user_question from its body and resume with the answer as its ToolMessage', async () => {
+    /**
+     * The production host shape (e.g. LibreChat's `AgentInputs.graphTools`
+     * plumb): the run is event-driven (other tools are schema-only
+     * definitions dispatched to the host), but an interrupt-capable tool is
+     * supplied as a real instance and marked direct so it executes inside
+     * the Pregel task frame. Event dispatch must never see the call — a
+     * host-side handler runs outside the graph, where `interrupt()` throws.
+     */
+    const { askUserQuestion } = await import('@/hitl');
+
+    const dispatchSpy = jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async () => {});
+
+    let bodyRuns = 0;
+    const askTool = tool(
+      async (input: { question: string }) => {
+        bodyRuns += 1;
+        const resolution = askUserQuestion(input);
+        return resolution.answer;
+      },
+      {
+        name: 'ask_user_question',
+        description: 'Ask the user a clarifying question.',
+        schema: z.object({ question: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo'), askTool],
+      toolMap: new Map([
+        ['echo', createSchemaStub('echo')],
+        ['ask_user_question', askTool],
+      ]),
+      eventDrivenMode: true,
+      agentId: 'agent-ask-direct',
+      toolCallStepIds: new Map([['call_ask_1', 'step_call_ask_1']]),
+      directToolNames: new Set(['ask_user_question']),
+    });
+
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_ask_1',
+        name: 'ask_user_question',
+        args: { question: 'Which environment?' },
+      },
+    ]);
+    const config = { configurable: { thread_id: 'thread-ask-direct' } };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted<t.HumanInterruptPayload>(interrupted)).toBe(true);
+    if (!isInterrupted<t.HumanInterruptPayload>(interrupted)) {
+      throw new Error('expected interrupt');
+    }
+    const payload = interrupted.__interrupt__[0].value!;
+    if (payload.type !== 'ask_user_question') {
+      throw new Error('expected ask_user_question payload');
+    }
+    expect(payload.question.question).toBe('Which environment?');
+    expect(bodyRuns).toBe(1);
+
+    /** The interrupt came from the direct path — never dispatched to the host. */
+    const toolExecuteDispatches = dispatchSpy.mock.calls.filter(
+      ([event]) => event === 'on_tool_execute'
+    );
+    expect(toolExecuteDispatches).toHaveLength(0);
+
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      { answer: 'staging' } satisfies t.AskUserQuestionResolution,
+      config
+    )) as MessagesUpdate;
+
+    expect(bodyRuns).toBe(2); // body re-runs from the top on the resume pass
+    const toolMessage = resumed.messages.find(
+      (m): m is ToolMessage =>
+        m._getType() === 'tool' &&
+        (m as ToolMessage).tool_call_id === 'call_ask_1'
+    );
+    expect(toolMessage).toBeDefined();
+    expect(String(toolMessage!.content)).toBe('staging');
+  });
+
   it('isAskUserQuestionInterrupt narrows the payload union correctly', async () => {
     const { isAskUserQuestionInterrupt, isToolApprovalInterrupt } =
       await import('@/types/hitl');

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1422,6 +1422,15 @@ export function buildChildInputs(
      */
     initialSummary: undefined,
     discoveredTools: undefined,
+    /**
+     * Host-supplied direct tools are parent-scoped: child graphs compile
+     * WITHOUT a checkpointer, so an interrupt-capable graph tool (the whole
+     * reason `AgentInputs.graphTools` exists) would deterministically throw
+     * `No checkpointer set` inside the child. Cleared for every child —
+     * including self-spawn, whose config is resolved from the parent's
+     * `_sourceInputs` and would otherwise inherit these silently.
+     */
+    graphTools: undefined,
   };
 
   if (config.allowNested === true) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1423,14 +1423,16 @@ export function buildChildInputs(
     initialSummary: undefined,
     discoveredTools: undefined,
     /**
-     * Host-supplied direct tools are parent-scoped: child graphs compile
-     * WITHOUT a checkpointer, so an interrupt-capable graph tool (the whole
-     * reason `AgentInputs.graphTools` exists) would deterministically throw
-     * `No checkpointer set` inside the child. Cleared for every child —
-     * including self-spawn, whose config is resolved from the parent's
-     * `_sourceInputs` and would otherwise inherit these silently.
+     * Host-supplied direct tools are scrubbed from INHERITED configs only.
+     * A self-spawn config's `agentInputs` is a shallow spread of the parent's
+     * `_sourceInputs`, so without this a parent-scoped graph tool (e.g. an
+     * interrupt-raising ask_user_question, which needs the parent's
+     * checkpointer — child graphs compile without one) would silently leak
+     * into the child and deterministically throw `No checkpointer set`. An
+     * EXPLICIT child config that lists its own `graphTools` is a deliberate
+     * host choice and keeps them (Codex #289 P2).
      */
-    graphTools: undefined,
+    graphTools: config.self === true ? undefined : agentInputs.graphTools,
   };
 
   if (config.allowNested === true) {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -619,11 +619,19 @@ export interface AgentInputs {
    * raise a LangGraph `interrupt()` (e.g. a tool built on `askUserQuestion()`) —
    * the host-side event handler runs outside the graph task, where `interrupt()`
    * throws. Do NOT also list these tools in `toolDefinitions` (they would be bound
-   * twice). NOT inherited by subagent child graphs: children compile without a
-   * checkpointer, so an interrupt-capable tool could never pause there —
-   * `buildChildInputs` clears this field along with the other parent-scoped state.
+   * twice). NOT inherited by SELF-SPAWNED subagent children (their config is a
+   * shallow spread of the parent's inputs, and child graphs compile without a
+   * checkpointer, so an interrupt-capable tool could never pause there) —
+   * `buildChildInputs` scrubs the inherited copy; an EXPLICIT child config that
+   * lists its own `graphTools` keeps them.
+   *
+   * Deliberately `GenericTool[]`, not `GraphTools`: the wider union admits
+   * schema-only shapes (OpenAI `BindToolsInput`, Google tool objects) that
+   * `initializeTools` cannot register in the ToolNode direct map — the model
+   * would bind a tool the SDK advertised as in-process but cannot execute.
+   * Every entry must be a real executable tool instance with a `name`.
    */
-  graphTools?: GraphTools;
+  graphTools?: GenericTool[];
 }
 
 export interface ContextPruningConfig {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -610,6 +610,20 @@ export interface AgentInputs {
   subagentConfigs?: SubagentConfig[];
   /** Maximum subagent nesting depth. Default 1 means top-level agents can spawn subagents but subagents cannot nest further. */
   maxSubagentDepth?: number;
+  /**
+   * Host-supplied tool instances that must execute IN-PROCESS inside the graph's
+   * ToolNode even when the run is event-driven (`toolDefinitions` non-empty). Each
+   * instance is bound to the model alongside the schema-only event tools and its
+   * name is marked direct, so calls bypass ON_TOOL_EXECUTE dispatch and run inside
+   * the Pregel task frame. This is the only execution mode where a tool body may
+   * raise a LangGraph `interrupt()` (e.g. a tool built on `askUserQuestion()`) —
+   * the host-side event handler runs outside the graph task, where `interrupt()`
+   * throws. Do NOT also list these tools in `toolDefinitions` (they would be bound
+   * twice). NOT inherited by subagent child graphs: children compile without a
+   * checkpointer, so an interrupt-capable tool could never pause there —
+   * `buildChildInputs` clears this field along with the other parent-scoped state.
+   */
+  graphTools?: GraphTools;
 }
 
 export interface ContextPruningConfig {


### PR DESCRIPTION
## Why

Hosts running event-driven (definitions-only) tool execution have no way to make a specific tool execute **in-process** inside the graph's ToolNode: the event partition routes purely by `directToolNames` (`ToolNode.ts` — name-based), and the host-side `ON_TOOL_EXECUTE` handler runs **outside the Pregel task frame**, where a tool body calling LangGraph `interrupt()` (e.g. one built on the SDK's `askUserQuestion()` helper) throws `Called interrupt() outside the context of a graph.`

Concretely: LibreChat's ask_user_question tool (agent-initiated HITL questions) is dead on the agents endpoint without this — the interrupt becomes an error ToolMessage and the run never pauses.

## What

- **`AgentInputs.graphTools`** — host-supplied tool instances that join the *existing* graph-managed direct path: bound to the model alongside schema-only event tools, added to the ToolNode `toolMap`, and marked direct. `Graph.createToolNode` already wires `agentContext.graphTools` exactly this way for handoff/subagent tools; this exposes the same seam to hosts.
- **`AgentContext.fromConfig`** copies the array (never aliases) — the SDK pushes subagent tools into `agentContext.graphTools` later and must not mutate host input.
- **`buildChildInputs` clears `graphTools`** for subagent children — including the **self-spawn** shape, which shallow-spreads the parent's `_sourceInputs`. Child graphs compile without a checkpointer, so an interrupt-capable direct tool would deterministically fail with `No checkpointer set` there.

## Tests

- `hitl.test.ts`: a **direct tool in event-driven mode** raises `ask_user_question` from its body — the interrupt surfaces, event dispatch never sees the call, the body re-runs once on resume, and the answer becomes the ToolMessage content.
- `AgentContext.test.ts`: `fromConfig` copy semantics (no aliasing) + event-mode binding includes host graphTools.
- `SubagentExecutor.test.ts`: child inputs clear `graphTools`; parent input untouched.

## Consumer

LibreChat's ask_user_question PR (pending on this release) wires `createRun` to pass the ask tool instance via this field on HITL-capable routes.