### PR TITLE
feat: stateful sandbox sessions via toolExecution.sandbox sub-config

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -23,7 +23,6 @@ import {
 } from '@/common';
 import {
   buildToolExecutionRequestPlan,
-  resolveRuntimeSessionHint,
   coerceRecordArgs,
   normalizeError,
 } from '@/tools/eagerEventExecution';
@@ -143,7 +142,18 @@ function isEagerExecutionExcludedTool(
   // side-effecting: never prestart it speculatively (a revised/superseded turn
   // would leave the write applied). Implies exclusion without the host having
   // to also list the name in excludeToolNames.
-  return graph.codeSessionToolNames?.includes(name) === true;
+  if (graph.codeSessionToolNames?.includes(name) === true) {
+    return true;
+  }
+  // With stateful sessions on, execute_code/bash run against a DURABLE warm
+  // runtime. Speculative prestart there is unsafe: if the model revises the
+  // args, ToolNode discards the eager result but the mutation has already
+  // landed in the session workspace, corrupting later runs. Stateless mode
+  // uses a throwaway VM per call, so eager prestart stays safe there.
+  return (
+    graph.toolExecution?.sandbox?.statefulSessions === true &&
+    CODE_EXECUTION_TOOLS.has(name)
+  );
 }
 
 function isDirectGraphTool(
@@ -669,7 +679,11 @@ function createEagerToolExecutionPlan(args: {
     return undefined;
   }
 
-  const threadId = graph.config?.configurable?.thread_id as string | undefined;
+  /* No runtimeSessionHint here on purpose: the eager path is speculative, and
+   * code-session tools (the only ones that carry a hint) are excluded from
+   * eager prestart entirely when stateful sessions are on — see
+   * isEagerExecutionExcludedTool. The durable runtime is only ever touched by
+   * the committed ToolNode path. */
   const plan = buildToolExecutionRequestPlan({
     toolCalls: candidateToolCalls.map((toolCall) => ({
       id: toolCall.id,
@@ -677,13 +691,6 @@ function createEagerToolExecutionPlan(args: {
       args: toolCall.args,
       stepId: graph.toolCallStepIds.get(toolCall.id!) ?? '',
       codeSessionContext: getCodeSessionContext(graph, toolCall.name),
-      /* Same gate as ToolNode.participatesInCodeSession: code-execution tools
-       * (+ host tools sharing the session), not skill/read_file. */
-      runtimeSessionHint:
-        CODE_EXECUTION_TOOLS.has(toolCall.name) ||
-        graph.codeSessionToolNames?.includes(toolCall.name) === true
-          ? resolveRuntimeSessionHint(graph.toolExecution, threadId)
-          : undefined,
     })),
     usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
   });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -23,6 +23,7 @@ import {
 } from '@/common';
 import {
   buildToolExecutionRequestPlan,
+  resolveRuntimeSessionHint,
   coerceRecordArgs,
   normalizeError,
 } from '@/tools/eagerEventExecution';
@@ -668,6 +669,7 @@ function createEagerToolExecutionPlan(args: {
     return undefined;
   }
 
+  const threadId = graph.config?.configurable?.thread_id as string | undefined;
   const plan = buildToolExecutionRequestPlan({
     toolCalls: candidateToolCalls.map((toolCall) => ({
       id: toolCall.id,
@@ -675,6 +677,13 @@ function createEagerToolExecutionPlan(args: {
       args: toolCall.args,
       stepId: graph.toolCallStepIds.get(toolCall.id!) ?? '',
       codeSessionContext: getCodeSessionContext(graph, toolCall.name),
+      /* Same gate as ToolNode.participatesInCodeSession: code-execution tools
+       * (+ host tools sharing the session), not skill/read_file. */
+      runtimeSessionHint:
+        CODE_EXECUTION_TOOLS.has(toolCall.name) ||
+        graph.codeSessionToolNames?.includes(toolCall.name) === true
+          ? resolveRuntimeSessionHint(graph.toolExecution, threadId)
+          : undefined,
     })),
     usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
   });

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -58,6 +58,29 @@ Usage:
 `.trim();
 
 /**
+ * Bash statefulness is filesystem-tier: on a warm session the machine (files
+ * including /tmp, installed packages, background processes) persists between
+ * calls, but each call may start a fresh shell — so shell variables and cwd
+ * are NOT reliable, and the machine can be reset at any time. Only /mnt/data
+ * is durable.
+ */
+export const STATEFUL_BASH_NOTE =
+  'Session state (best-effort): commands in this conversation usually run on the same machine, so files (including /tmp), installed packages, and running background processes from earlier calls typically persist. Each call may still start a fresh shell — do not rely on shell variables or the working directory carrying over — and the machine may be reset at any time. Only /mnt/data is durable.';
+
+export const StatefulBashExecutionToolDescription = `
+Runs bash commands and returns stdout/stderr output from a session-based execution environment, similar to a long-running machine.
+
+${STATEFUL_BASH_NOTE}
+
+Usage:
+- No network access available.
+- Generated files are automatically delivered; **DO NOT** provide download links.
+- ${CODE_ARTIFACT_PATH_GUIDANCE}
+- ${BASH_SHELL_GUIDANCE}
+- NEVER use this tool to execute malicious commands.
+`.trim();
+
+/**
  * Supplemental prompt documenting the tool-output reference feature.
  *
  * Hosts should append this (separated by a blank line) to the base
@@ -87,11 +110,45 @@ Referencing previous tool outputs:
  */
 export function buildBashExecutionToolDescription(options?: {
   enableToolOutputReferences?: boolean;
+  statefulSessions?: boolean;
 }): string {
+  const base =
+    options?.statefulSessions === true
+      ? StatefulBashExecutionToolDescription
+      : BashExecutionToolDescription;
   if (options?.enableToolOutputReferences === true) {
-    return `${BashExecutionToolDescription}\n\n${BashToolOutputReferencesGuide}`;
+    return `${base}\n\n${BashToolOutputReferencesGuide}`;
   }
-  return BashExecutionToolDescription;
+  return base;
+}
+
+const STATELESS_BASH_PARAM_NOTE =
+  'The environment is stateless; variables and state don\'t persist between executions.';
+const STATEFUL_BASH_PARAM_NOTE =
+  'Files, installed packages, and background processes usually persist between calls, but each call may start a fresh shell (do not rely on shell variables or cwd) and the machine may reset. Only /mnt/data is durable.';
+
+export function buildBashExecutionToolSchema(opts?: {
+  statefulSessions?: boolean;
+}): typeof BashExecutionToolSchema {
+  const note =
+    opts?.statefulSessions === true
+      ? STATEFUL_BASH_PARAM_NOTE
+      : STATELESS_BASH_PARAM_NOTE;
+  const commandDescription =
+    BashExecutionToolSchema.properties.command.description.replace(
+      STATELESS_BASH_PARAM_NOTE,
+      note
+    );
+  return {
+    ...BashExecutionToolSchema,
+    properties: {
+      ...BashExecutionToolSchema.properties,
+      command: {
+        ...BashExecutionToolSchema.properties.command,
+        description: commandDescription,
+      },
+    },
+  } as typeof BashExecutionToolSchema;
 }
 
 export const BashExecutionToolName = Constants.BASH_TOOL;
@@ -117,15 +174,23 @@ function createBashExecutionTool(
 ): DynamicStructuredTool {
   return tool(
     async (rawInput, config) => {
-      const { authHeaders, ...executionParams } = params ?? {};
+      /* `statefulSessions` is prompt-only — keep it out of the wire body. */
+      const {
+        authHeaders,
+        statefulSessions: _statefulSessions,
+        ...executionParams
+      } = params ?? {};
+      void _statefulSessions;
       const { command, ...rest } = rawInput as {
         command: string;
         args?: string[];
       };
-      const { session_id, _injected_files } = (config.toolCall ?? {}) as {
-        session_id?: string;
-        _injected_files?: t.CodeEnvFile[];
-      };
+      const { session_id, _injected_files, _runtime_session_hint } =
+        (config.toolCall ?? {}) as {
+          session_id?: string;
+          _injected_files?: t.CodeEnvFile[];
+          _runtime_session_hint?: string;
+        };
 
       const postData: Record<string, unknown> = {
         lang: 'bash',
@@ -133,6 +198,13 @@ function createBashExecutionTool(
         ...rest,
         ...executionParams,
       };
+
+      if (
+        typeof _runtime_session_hint === 'string' &&
+        _runtime_session_hint !== ''
+      ) {
+        postData.runtime_session_hint = _runtime_session_hint;
+      }
 
       /* See `CodeExecutor.ts` for the rationale — `/files/<session_id>`
        * HTTP fallback was removed because codeapi's sessionAuth requires
@@ -187,12 +259,24 @@ function createBashExecutionTool(
           command
         );
         const hasFiles = result.files != null && result.files.length > 0;
+        const runtimeEcho =
+          result.runtime_session_id != null
+            ? {
+              runtime_session_id: result.runtime_session_id,
+              runtime_status: result.runtime_status,
+            }
+            : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
-            ? { session_id: result.session_id, files: result.files }
+            ? {
+              session_id: result.session_id,
+              files: result.files,
+              ...runtimeEcho,
+            }
             : {
               session_id: result.session_id,
+              ...runtimeEcho,
             }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
@@ -200,15 +284,15 @@ function createBashExecutionTool(
           (error as Error | undefined)?.message ?? '',
           command
         );
-        throw new Error(
-          `Execution error:\n\n${messageWithReminder}`
-        );
+        throw new Error(`Execution error:\n\n${messageWithReminder}`);
       }
     },
     {
       name: BashExecutionToolName,
-      description: BashExecutionToolDescription,
-      schema: BashExecutionToolSchema,
+      description: buildBashExecutionToolDescription({
+        statefulSessions: params?.statefulSessions,
+      }),
+      schema: buildBashExecutionToolSchema(params ?? undefined),
       responseFormat: Constants.CONTENT_AND_ARTIFACT,
     }
   );

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -181,10 +181,19 @@ function createBashExecutionTool(
         ...executionParams
       } = params ?? {};
       void _statefulSessions;
-      const { command, ...rest } = rawInput as {
+      /* Drop any model-supplied `runtime_session_hint` from the raw args: the
+       * hint must only come from ToolNode's injected `_runtime_session_hint`
+       * (below), never from the tool call itself. */
+      const {
+        command,
+        runtime_session_hint: _ignoredModelHint,
+        ...rest
+      } = rawInput as {
         command: string;
+        runtime_session_hint?: unknown;
         args?: string[];
       };
+      void _ignoredModelHint;
       const { session_id, _injected_files, _runtime_session_hint } =
         (config.toolCall ?? {}) as {
           session_id?: string;

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -304,8 +304,15 @@ export function createBashProgrammaticToolCallingTool(
         Partial<t.ProgrammaticCache> & {
           session_id?: string;
           _injected_files?: t.CodeEnvFile[];
+          _runtime_session_hint?: string;
         };
-      const { toolMap, toolDefs, session_id, _injected_files } = toolCall;
+      const {
+        toolMap,
+        toolDefs,
+        session_id,
+        _injected_files,
+        _runtime_session_hint,
+      } = toolCall;
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(
@@ -351,6 +358,15 @@ export function createBashProgrammaticToolCallingTool(
           );
         }
 
+        /* Stateful sessions: hint on the INITIAL request only (continuations
+         * bind via continuation_token). Wire-only in v1 — BashPTC keeps its
+         * stateless prompt. */
+        const runtimeSessionHint =
+          typeof _runtime_session_hint === 'string' &&
+          _runtime_session_hint !== ''
+            ? _runtime_session_hint
+            : undefined;
+
         let response = await makeRequest(
           EXEC_ENDPOINT,
           {
@@ -360,6 +376,9 @@ export function createBashProgrammaticToolCallingTool(
             session_id,
             timeout,
             ...(files && files.length > 0 ? { files } : {}),
+            ...(runtimeSessionHint != null
+              ? { runtime_session_hint: runtimeSessionHint }
+              : {}),
           },
           proxy,
           initParams.authHeaders

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -149,6 +149,64 @@ Usage:
 - NEVER use this tool to execute malicious code.
 `.trim();
 
+/**
+ * Best-effort statefulness note. Deliberately hedged: warm reuse is an
+ * optimization, not a guarantee (the runtime may be reset on idle timeout,
+ * eviction, or the 8h VM lifetime), so the model must never depend on carried
+ * state for correctness and must persist anything durable to /mnt/data.
+ */
+export const STATEFUL_ENV_NOTE =
+  'Session state (best-effort): consecutive executions in this conversation usually share one runtime, so variables, imports, and in-memory data from earlier successful calls are typically still available. The runtime may be reset at any time, so treat carried-over state as an optimization, never a guarantee. Anything that must survive MUST be written to /mnt/data. If a NameError/ImportError signals lost state, re-run the needed setup and continue.';
+
+export const StatefulCodeExecutionToolDescription = `
+Runs code and returns stdout/stderr output from a session-based execution environment, similar to a long-running command-line session.
+
+${STATEFUL_ENV_NOTE}
+
+Usage:
+- No network access available.
+- Generated files are automatically delivered; **DO NOT** provide download links.
+- ${CODE_ARTIFACT_PATH_GUIDANCE}
+- NEVER use this tool to execute malicious code.
+`.trim();
+
+export function buildCodeExecutionToolDescription(opts?: {
+  statefulSessions?: boolean;
+}): string {
+  return opts?.statefulSessions === true
+    ? StatefulCodeExecutionToolDescription
+    : CodeExecutionToolDescription;
+}
+
+const STATELESS_CODE_PARAM_NOTE =
+  'The environment is stateless; variables and imports don\'t persist between executions.';
+const STATEFUL_CODE_PARAM_NOTE =
+  'Executions in this conversation usually share one runtime: variables and imports from prior successful calls are typically still defined, but the runtime may reset between calls. Rebuild state on NameError/ImportError; persist anything important to /mnt/data.';
+
+export function buildCodeExecutionToolSchema(opts?: {
+  statefulSessions?: boolean;
+}): typeof CodeExecutionToolSchema {
+  const note =
+    opts?.statefulSessions === true
+      ? STATEFUL_CODE_PARAM_NOTE
+      : STATELESS_CODE_PARAM_NOTE;
+  const codeDescription =
+    CodeExecutionToolSchema.properties.code.description.replace(
+      STATELESS_CODE_PARAM_NOTE,
+      note
+    );
+  return {
+    ...CodeExecutionToolSchema,
+    properties: {
+      ...CodeExecutionToolSchema.properties,
+      code: {
+        ...CodeExecutionToolSchema.properties.code,
+        description: codeDescription,
+      },
+    },
+  } as typeof CodeExecutionToolSchema;
+}
+
 export const CodeExecutionToolName = Constants.EXECUTE_CODE;
 
 export const CodeExecutionToolDefinition = {
@@ -162,7 +220,14 @@ function createCodeExecutionTool(
 ): DynamicStructuredTool {
   return tool(
     async (rawInput, config) => {
-      const { authHeaders, ...executionParams } = params ?? {};
+      /* `statefulSessions` is a prompt-only flag (drives the description);
+       * keep it out of the wire body. */
+      const {
+        authHeaders,
+        statefulSessions: _statefulSessions,
+        ...executionParams
+      } = params ?? {};
+      void _statefulSessions;
       const { lang, code, ...rest } = rawInput as {
         lang: SupportedLanguage;
         code: string;
@@ -173,10 +238,12 @@ function createCodeExecutionTool(
        * - session_id: associates with the previous run.
        * - _injected_files: File refs to pass directly (avoids /files endpoint race condition).
        */
-      const { session_id, _injected_files } = (config.toolCall ?? {}) as {
-        session_id?: string;
-        _injected_files?: t.CodeEnvFile[];
-      };
+      const { session_id, _injected_files, _runtime_session_hint } =
+        (config.toolCall ?? {}) as {
+          session_id?: string;
+          _injected_files?: t.CodeEnvFile[];
+          _runtime_session_hint?: string;
+        };
 
       const postData: Record<string, unknown> = {
         lang,
@@ -184,6 +251,16 @@ function createCodeExecutionTool(
         ...rest,
         ...executionParams,
       };
+
+      /* Stateful sessions: forward the hint so the Code API can route this
+       * execution to a warm per-session runtime. Additive — stateless
+       * servers ignore the unknown field. */
+      if (
+        typeof _runtime_session_hint === 'string' &&
+        _runtime_session_hint !== ''
+      ) {
+        postData.runtime_session_hint = _runtime_session_hint;
+      }
 
       /* File injection: `_injected_files` from ToolNode (set when host
        * primes a CodeSessionContext) or `params.files` from tool
@@ -242,12 +319,27 @@ function createCodeExecutionTool(
           code
         );
         const hasFiles = result.files != null && result.files.length > 0;
+        /* Echo the durable runtime session (stateful backends only) so hosts
+         * can surface a "session active / was reset" signal later. Additive:
+         * absent on stateless servers. */
+        const runtimeEcho =
+          result.runtime_session_id != null
+            ? {
+              runtime_session_id: result.runtime_session_id,
+              runtime_status: result.runtime_status,
+            }
+            : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
-            ? { session_id: result.session_id, files: result.files }
+            ? {
+              session_id: result.session_id,
+              files: result.files,
+              ...runtimeEcho,
+            }
             : {
               session_id: result.session_id,
+              ...runtimeEcho,
             }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
@@ -260,8 +352,8 @@ function createCodeExecutionTool(
     },
     {
       name: CodeExecutionToolName,
-      description: CodeExecutionToolDescription,
-      schema: CodeExecutionToolSchema,
+      description: buildCodeExecutionToolDescription(params ?? undefined),
+      schema: buildCodeExecutionToolSchema(params ?? undefined),
       responseFormat: Constants.CONTENT_AND_ARTIFACT,
     }
   );

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -228,11 +228,23 @@ function createCodeExecutionTool(
         ...executionParams
       } = params ?? {};
       void _statefulSessions;
-      const { lang, code, ...rest } = rawInput as {
+      /* Drop any model-supplied `runtime_session_hint` from the raw args: the
+       * hint is host-controlled and must only ever come from ToolNode's
+       * injected `_runtime_session_hint` (below). Spreading `...rest` into
+       * postData would otherwise let a tool call opt itself into / pick a
+       * stateful runtime even when statefulSessions is off. */
+      const {
+        lang,
+        code,
+        runtime_session_hint: _ignoredModelHint,
+        ...rest
+      } = rawInput as {
         lang: SupportedLanguage;
         code: string;
+        runtime_session_hint?: unknown;
         args?: string[];
       };
+      void _ignoredModelHint;
       /**
        * Extract session context from config.toolCall (injected by ToolNode).
        * - session_id: associates with the previous run.

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -830,6 +830,12 @@ export function formatCompletedResponse(
     {
       session_id: response.session_id,
       files: response.files,
+      ...(response.runtime_session_id != null
+        ? {
+          runtime_session_id: response.runtime_session_id,
+          runtime_status: response.runtime_status,
+        }
+        : {}),
     } satisfies t.ProgrammaticExecutionArtifact,
   ];
 }
@@ -878,8 +884,15 @@ export function createProgrammaticToolCallingTool(
         Partial<t.ProgrammaticCache> & {
           session_id?: string;
           _injected_files?: t.CodeEnvFile[];
+          _runtime_session_hint?: string;
         };
-      const { toolMap, toolDefs, session_id, _injected_files } = toolCall;
+      const {
+        toolMap,
+        toolDefs,
+        session_id,
+        _injected_files,
+        _runtime_session_hint,
+      } = toolCall;
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(
@@ -928,6 +941,16 @@ export function createProgrammaticToolCallingTool(
           );
         }
 
+        /* Stateful sessions: hint rides the INITIAL request only; the server
+         * binds continuation round-trips to the same runtime via the
+         * continuation_token. Additive — ignored by stateless servers. PTC
+         * keeps its stateless prompt in v1; only the wire hint plumbs here. */
+        const runtimeSessionHint =
+          typeof _runtime_session_hint === 'string' &&
+          _runtime_session_hint !== ''
+            ? _runtime_session_hint
+            : undefined;
+
         let response = await makeRequest(
           EXEC_ENDPOINT,
           {
@@ -936,6 +959,9 @@ export function createProgrammaticToolCallingTool(
             session_id,
             timeout,
             ...(files && files.length > 0 ? { files } : {}),
+            ...(runtimeSessionHint != null
+              ? { runtime_session_hint: runtimeSessionHint }
+              : {}),
           },
           proxy,
           initParams.authHeaders

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -997,6 +997,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             );
           }
         }
+
+        /**
+         * Stateful runtime session hint — orthogonal to the transient
+         * exec-session above, and injected independently (a first call has a
+         * hint but no exec session yet). Explicit host hint wins; otherwise
+         * fall back to the conversation's thread_id.
+         */
+        const runtimeSessionHint = this.resolveRuntimeSessionHint(config);
+        if (runtimeSessionHint != null) {
+          invokeParams = {
+            ...invokeParams,
+            _runtime_session_hint: runtimeSessionHint,
+          };
+        }
       }
 
       /**
@@ -1783,6 +1797,26 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     );
   }
 
+  /**
+   * Resolves the stateful runtime session hint for the remote sandbox: only
+   * when `toolExecution.sandbox.statefulSessions` is on; explicit host hint
+   * else the conversation `thread_id`. Undefined disables the wire field.
+   */
+  private resolveRuntimeSessionHint(
+    config: RunnableConfig
+  ): string | undefined {
+    const sandbox = this.toolExecution?.sandbox;
+    if (sandbox?.statefulSessions !== true) {
+      return undefined;
+    }
+    const explicit = sandbox.runtimeSessionHint;
+    if (explicit != null && explicit !== '') {
+      return explicit;
+    }
+    const threadId = config.configurable?.thread_id as string | undefined;
+    return threadId != null && threadId !== '' ? threadId : undefined;
+  }
+
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
     requestMap: Map<string, t.ToolCallRequest>
@@ -2492,12 +2526,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             entry.call.name === Constants.READ_FILE
               ? this.getCodeSessionContext()
               : undefined;
+          const runtimeSessionHint = this.participatesInCodeSession(
+            entry.call.name
+          )
+            ? this.resolveRuntimeSessionHint(config)
+            : undefined;
           return {
             id: entry.call.id,
             name: entry.call.name,
             args: entry.args,
             stepId: entry.stepId,
             codeSessionContext,
+            runtimeSessionHint,
           };
         }),
         usageCount: this.toolUsageCount,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -38,6 +38,11 @@ import type {
 } from '@/hooks';
 import type * as t from '@/types';
 import {
+  buildToolExecutionRequestPlan,
+  resolveRuntimeSessionHint,
+  recordArgsEqual,
+} from '@/tools/eagerEventExecution';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -45,10 +50,6 @@ import {
   buildReferenceKey,
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
-import {
-  buildToolExecutionRequestPlan,
-  recordArgsEqual,
-} from '@/tools/eagerEventExecution';
 import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
@@ -1797,24 +1798,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     );
   }
 
-  /**
-   * Resolves the stateful runtime session hint for the remote sandbox: only
-   * when `toolExecution.sandbox.statefulSessions` is on; explicit host hint
-   * else the conversation `thread_id`. Undefined disables the wire field.
-   */
+  /** Delegates to the shared resolver so the direct and event-driven planning
+   *  paths derive the runtime session hint identically. */
   private resolveRuntimeSessionHint(
     config: RunnableConfig
   ): string | undefined {
-    const sandbox = this.toolExecution?.sandbox;
-    if (sandbox?.statefulSessions !== true) {
-      return undefined;
-    }
-    const explicit = sandbox.runtimeSessionHint;
-    if (explicit != null && explicit !== '') {
-      return explicit;
-    }
-    const threadId = config.configurable?.thread_id as string | undefined;
-    return threadId != null && threadId !== '' ? threadId : undefined;
+    return resolveRuntimeSessionHint(
+      this.toolExecution,
+      config.configurable?.thread_id as string | undefined
+    );
   }
 
   private storeCodeSessionFromResults(

--- a/src/tools/__tests__/BashExecutor.test.ts
+++ b/src/tools/__tests__/BashExecutor.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from '@jest/globals';
 import {
   BashExecutionToolDescription,
   BashToolOutputReferencesGuide,
+  StatefulBashExecutionToolDescription,
   buildBashExecutionToolDescription,
 } from '../BashExecutor';
+import { CODE_ARTIFACT_PATH_GUIDANCE } from '../CodeExecutor';
 
 describe('buildBashExecutionToolDescription', () => {
   it('returns the base description by default', () => {
@@ -54,5 +56,42 @@ describe('buildBashExecutionToolDescription', () => {
       enableToolOutputReferences: true,
     });
     expect(composed.includes(`${BashExecutionToolDescription}\n\n`)).toBe(true);
+  });
+
+  describe('stateful variant', () => {
+    it('selects the stateful description when statefulSessions is on', () => {
+      expect(
+        buildBashExecutionToolDescription({ statefulSessions: true })
+      ).toBe(StatefulBashExecutionToolDescription);
+    });
+
+    it('hedges: usually-persists but may-reset, and only /mnt/data is durable', () => {
+      const d = StatefulBashExecutionToolDescription;
+      expect(d).toContain('usually');
+      expect(d).toContain('may be reset');
+      expect(d).toContain('Only /mnt/data is durable');
+      /* filesystem-tier, not shell-variable-tier */
+      expect(d).toContain('do not rely on shell variables');
+    });
+
+    it('keeps the artifact-path guidance in both variants', () => {
+      expect(BashExecutionToolDescription).toContain(
+        CODE_ARTIFACT_PATH_GUIDANCE
+      );
+      expect(StatefulBashExecutionToolDescription).toContain(
+        CODE_ARTIFACT_PATH_GUIDANCE
+      );
+    });
+
+    it('still composes with the output-references guide', () => {
+      const composed = buildBashExecutionToolDescription({
+        statefulSessions: true,
+        enableToolOutputReferences: true,
+      });
+      expect(composed.startsWith(StatefulBashExecutionToolDescription)).toBe(
+        true
+      );
+      expect(composed).toContain(BashToolOutputReferencesGuide);
+    });
   });
 });

--- a/src/tools/__tests__/CodeExecutor.stateful.test.ts
+++ b/src/tools/__tests__/CodeExecutor.stateful.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type { RunnableConfig } from '@langchain/core/runnables';
+
+/* CodeExecutor imports the default export of node-fetch; capture POST bodies. */
+const fetchCalls: Array<Record<string, unknown>> = [];
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: async (_url: string, init?: { body?: string }) => {
+    fetchCalls.push(JSON.parse(init?.body ?? '{}'));
+    return {
+      ok: true,
+      json: async () => ({
+        session_id: 's1',
+        stdout: 'ok',
+        stderr: '',
+        files: [],
+      }),
+    };
+  },
+}));
+
+import {
+  CODE_ARTIFACT_PATH_GUIDANCE,
+  CodeExecutionToolDescription,
+  StatefulCodeExecutionToolDescription,
+  buildCodeExecutionToolDescription,
+  buildCodeExecutionToolSchema,
+  createCodeExecutionTool,
+} from '../CodeExecutor';
+
+describe('CodeExecutor stateful description', () => {
+  it('selects the stateful description only when statefulSessions is on', () => {
+    expect(buildCodeExecutionToolDescription()).toBe(
+      CodeExecutionToolDescription
+    );
+    expect(buildCodeExecutionToolDescription({ statefulSessions: false })).toBe(
+      CodeExecutionToolDescription
+    );
+    expect(buildCodeExecutionToolDescription({ statefulSessions: true })).toBe(
+      StatefulCodeExecutionToolDescription
+    );
+  });
+
+  it('hedges the stateful wording and keeps /mnt/data as the durable store', () => {
+    const d = StatefulCodeExecutionToolDescription;
+    expect(d).toContain('usually share one runtime');
+    expect(d).toContain('may be reset at any time');
+    expect(d).toContain('MUST be written to /mnt/data');
+    expect(d).toContain(CODE_ARTIFACT_PATH_GUIDANCE);
+  });
+
+  it('adjusts the code-param note per mode', () => {
+    const stateless =
+      buildCodeExecutionToolSchema().properties.code.description;
+    const stateful = buildCodeExecutionToolSchema({ statefulSessions: true })
+      .properties.code.description;
+    expect(stateless).toContain('variables and imports don\'t persist');
+    expect(stateful).toContain('typically still defined');
+    expect(stateful).toContain('may reset between calls');
+  });
+});
+
+describe('CodeExecutor runtime_session_hint wire field', () => {
+  afterEach(() => {
+    fetchCalls.length = 0;
+  });
+
+  async function run(
+    toolCall: Record<string, unknown>,
+    params: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown>[]> {
+    const codeTool = createCodeExecutionTool(params);
+    await codeTool.invoke({ lang: 'py', code: 'print(1)' }, {
+      toolCall,
+    } as unknown as RunnableConfig);
+    return fetchCalls;
+  }
+
+  it('sends runtime_session_hint when ToolNode injected it', async () => {
+    const calls = await run({ _runtime_session_hint: 'conv-42' });
+    expect(calls[0].runtime_session_hint).toBe('conv-42');
+  });
+
+  it('omits runtime_session_hint when not injected', async () => {
+    const calls = await run({});
+    expect('runtime_session_hint' in calls[0]).toBe(false);
+  });
+
+  it('does not leak the statefulSessions factory flag onto the wire', async () => {
+    const calls = await run({}, { statefulSessions: true });
+    expect('statefulSessions' in calls[0]).toBe(false);
+  });
+});

--- a/src/tools/__tests__/CodeExecutor.stateful.test.ts
+++ b/src/tools/__tests__/CodeExecutor.stateful.test.ts
@@ -90,4 +90,24 @@ describe('CodeExecutor runtime_session_hint wire field', () => {
     const calls = await run({}, { statefulSessions: true });
     expect('statefulSessions' in calls[0]).toBe(false);
   });
+
+  it('strips a model-supplied runtime_session_hint from the raw args', async () => {
+    const codeTool = createCodeExecutionTool({});
+    await codeTool.invoke(
+      { lang: 'py', code: 'print(1)', runtime_session_hint: 'model-picked' },
+      { toolCall: {} } as unknown as RunnableConfig
+    );
+    expect('runtime_session_hint' in fetchCalls[0]).toBe(false);
+  });
+
+  it('lets only the ToolNode-injected hint reach the wire, ignoring model args', async () => {
+    const codeTool = createCodeExecutionTool({});
+    await codeTool.invoke(
+      { lang: 'py', code: 'print(1)', runtime_session_hint: 'model-picked' },
+      {
+        toolCall: { _runtime_session_hint: 'host-conv' },
+      } as unknown as RunnableConfig
+    );
+    expect(fetchCalls[0].runtime_session_hint).toBe('host-conv');
+  });
 });

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -1263,4 +1263,90 @@ describe('ToolNode code execution session management', () => {
       );
     });
   });
+
+  describe('stateful runtime session hint injection', () => {
+    it('injects the explicit runtimeSessionHint when statefulSessions is on', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const mockTool = createMockCodeTool({ capturedConfigs });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions: new Map(),
+        toolExecution: {
+          engine: 'sandbox',
+          sandbox: {
+            statefulSessions: true,
+            runtimeSessionHint: 'conv-explicit',
+          },
+        },
+      });
+
+      await toolNode.invoke({ messages: [createAIMessageWithCodeCall('c1')] });
+
+      expect(capturedConfigs[0]._runtime_session_hint).toBe('conv-explicit');
+    });
+
+    it('falls back to configurable.thread_id when no explicit hint is given', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const mockTool = createMockCodeTool({ capturedConfigs });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions: new Map(),
+        toolExecution: {
+          engine: 'sandbox',
+          sandbox: { statefulSessions: true },
+        },
+      });
+
+      await toolNode.invoke(
+        { messages: [createAIMessageWithCodeCall('c1')] },
+        { configurable: { thread_id: 'thread-abc' } }
+      );
+
+      expect(capturedConfigs[0]._runtime_session_hint).toBe('thread-abc');
+    });
+
+    it('does not inject a hint when statefulSessions is off', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const mockTool = createMockCodeTool({ capturedConfigs });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions: new Map(),
+        toolExecution: {
+          engine: 'sandbox',
+          sandbox: { statefulSessions: false },
+        },
+      });
+
+      await toolNode.invoke(
+        { messages: [createAIMessageWithCodeCall('c1')] },
+        { configurable: { thread_id: 'thread-abc' } }
+      );
+
+      expect(capturedConfigs[0]._runtime_session_hint).toBeUndefined();
+    });
+
+    it('injects the hint independently of an existing exec session', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'exec-1',
+        files: [],
+        lastUpdated: 0,
+      });
+      const mockTool = createMockCodeTool({ capturedConfigs });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        toolExecution: {
+          engine: 'sandbox',
+          sandbox: { statefulSessions: true, runtimeSessionHint: 'conv-1' },
+        },
+      });
+
+      await toolNode.invoke({ messages: [createAIMessageWithCodeCall('c1')] });
+
+      expect(capturedConfigs[0].session_id).toBe('exec-1');
+      expect(capturedConfigs[0]._runtime_session_hint).toBe('conv-1');
+    });
+  });
 });

--- a/src/tools/__tests__/eagerEventExecution.session.test.ts
+++ b/src/tools/__tests__/eagerEventExecution.session.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from '@jest/globals';
+import type * as t from '@/types';
+import {
+  buildToolExecutionRequestPlan,
+  resolveRuntimeSessionHint,
+} from '../eagerEventExecution';
+
+describe('buildToolExecutionRequestPlan — runtimeSessionHint', () => {
+  const usageCount = () => new Map<string, number>();
+
+  it('carries runtimeSessionHint onto the built ToolCallRequest', () => {
+    const plan = buildToolExecutionRequestPlan({
+      toolCalls: [
+        {
+          id: 'call_1',
+          name: 'execute_code',
+          args: { lang: 'py', code: 'print(1)' },
+          runtimeSessionHint: 'conv-42',
+        },
+      ],
+      usageCount: usageCount(),
+    });
+    expect(plan?.requests[0].runtimeSessionHint).toBe('conv-42');
+  });
+
+  it('omits the field entirely when the hint is absent or empty', () => {
+    const plan = buildToolExecutionRequestPlan({
+      toolCalls: [{ id: 'c1', name: 'execute_code', args: {} }],
+      usageCount: usageCount(),
+    });
+    expect('runtimeSessionHint' in (plan?.requests[0] as object)).toBe(false);
+
+    const empty = buildToolExecutionRequestPlan({
+      toolCalls: [
+        { id: 'c2', name: 'execute_code', args: {}, runtimeSessionHint: '' },
+      ],
+      usageCount: usageCount(),
+    });
+    expect('runtimeSessionHint' in (empty?.requests[0] as object)).toBe(false);
+  });
+
+  it('carries the hint onto invalid-arg (rejected) requests too', () => {
+    const plan = buildToolExecutionRequestPlan({
+      toolCalls: [
+        {
+          id: 'c1',
+          name: 'execute_code',
+          args: 'not-an-object',
+          runtimeSessionHint: 'conv-9',
+        },
+      ],
+      usageCount: usageCount(),
+      invalidArgsBehavior: 'error-result',
+    });
+    expect(plan?.allRequests[0].runtimeSessionHint).toBe('conv-9');
+    expect(plan?.rejectedResults).toHaveLength(1);
+  });
+});
+
+describe('resolveRuntimeSessionHint', () => {
+  const sandbox = (
+    o: Partial<t.SandboxExecutionConfig>
+  ): t.ToolExecutionConfig => ({
+    sandbox: o,
+  });
+
+  it('returns undefined unless statefulSessions is on', () => {
+    expect(resolveRuntimeSessionHint(undefined, 'thread-1')).toBeUndefined();
+    expect(resolveRuntimeSessionHint(sandbox({}), 'thread-1')).toBeUndefined();
+    expect(
+      resolveRuntimeSessionHint(
+        sandbox({ statefulSessions: false }),
+        'thread-1'
+      )
+    ).toBeUndefined();
+  });
+
+  it('prefers an explicit hint, else falls back to thread_id', () => {
+    expect(
+      resolveRuntimeSessionHint(
+        sandbox({ statefulSessions: true, runtimeSessionHint: 'explicit' }),
+        'thread-1'
+      )
+    ).toBe('explicit');
+    expect(
+      resolveRuntimeSessionHint(sandbox({ statefulSessions: true }), 'thread-1')
+    ).toBe('thread-1');
+    expect(
+      resolveRuntimeSessionHint(sandbox({ statefulSessions: true }), '')
+    ).toBeUndefined();
+  });
+});

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -52,7 +52,29 @@ export type ToolExecutionPlanCall = {
   args: unknown;
   stepId?: string;
   codeSessionContext?: t.ToolCallRequest['codeSessionContext'];
+  runtimeSessionHint?: string;
 };
+
+/**
+ * Stateful runtime session hint for the remote sandbox: only when
+ * `toolExecution.sandbox.statefulSessions` is on; explicit host hint else the
+ * conversation `thread_id`. Undefined disables the wire field. Shared by the
+ * direct ToolNode path and both event-driven planners so they stay in lockstep.
+ */
+export function resolveRuntimeSessionHint(
+  toolExecution: t.ToolExecutionConfig | undefined,
+  threadId: string | undefined
+): string | undefined {
+  const sandbox = toolExecution?.sandbox;
+  if (sandbox?.statefulSessions !== true) {
+    return undefined;
+  }
+  const explicit = sandbox.runtimeSessionHint;
+  if (explicit != null && explicit !== '') {
+    return explicit;
+  }
+  return threadId != null && threadId !== '' ? threadId : undefined;
+}
 
 export type ToolExecutionRequestPlan = {
   allRequests: t.ToolCallRequest[];
@@ -73,15 +95,12 @@ export function buildToolExecutionRequestPlan(args: {
     args: Record<string, unknown>;
     stepId?: string;
     codeSessionContext?: t.ToolCallRequest['codeSessionContext'];
+    runtimeSessionHint?: string;
     rejectedErrorMessage?: string;
   }> = [];
 
   for (const toolCall of args.toolCalls) {
-    if (
-      toolCall.id == null ||
-      toolCall.id === '' ||
-      toolCall.name === ''
-    ) {
+    if (toolCall.id == null || toolCall.id === '' || toolCall.name === '') {
       return undefined;
     }
     const coercedArgs = coerceRecordArgs(toolCall.args);
@@ -95,6 +114,7 @@ export function buildToolExecutionRequestPlan(args: {
         args: {},
         stepId: toolCall.stepId,
         codeSessionContext: toolCall.codeSessionContext,
+        runtimeSessionHint: toolCall.runtimeSessionHint,
         rejectedErrorMessage:
           'Invalid tool call arguments: expected a JSON object.',
       });
@@ -106,6 +126,7 @@ export function buildToolExecutionRequestPlan(args: {
       args: coercedArgs,
       stepId: toolCall.stepId,
       codeSessionContext: toolCall.codeSessionContext,
+      runtimeSessionHint: toolCall.runtimeSessionHint,
     });
   }
 
@@ -122,6 +143,12 @@ export function buildToolExecutionRequestPlan(args: {
     };
     if (toolCall.codeSessionContext != null) {
       request.codeSessionContext = toolCall.codeSessionContext;
+    }
+    if (
+      toolCall.runtimeSessionHint != null &&
+      toolCall.runtimeSessionHint !== ''
+    ) {
+      request.runtimeSessionHint = toolCall.runtimeSessionHint;
     }
     return request;
   });

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -292,6 +292,12 @@ export type CodeExecutionToolParams =
       files?: CodeEnvFile[];
       /** Optional host-supplied Code API auth headers. */
       authHeaders?: CodeApiAuthHeaders;
+      /**
+       * Advertise best-effort stateful sessions in the tool description
+       * (variables/files may persist between calls, may reset). Prompt text
+       * only; the wire hint is gated by `toolExecution.sandbox`.
+       */
+      statefulSessions?: boolean;
     };
 
 export type CodeApiAuthHeaderMap = Record<string, string>;
@@ -347,6 +353,13 @@ export type ExecuteResult = {
   stdout: string;
   stderr: string;
   files?: FileRefs;
+  /**
+   * Durable runtime session id echoed by a stateful Code API backend
+   * (hash of tenant+user+hint). Additive; absent on stateless servers.
+   */
+  runtime_session_id?: string;
+  /** Whether this execution reused a warm runtime session or started fresh. */
+  runtime_status?: 'new' | 'reused';
 };
 
 /** JSON Schema type definition for tool parameters */
@@ -413,6 +426,12 @@ export type ToolCallRequest = {
     session_id: string;
     files?: CodeEnvFile[];
   };
+  /**
+   * Stable runtime session hint for stateful sandbox sessions. Orthogonal to
+   * `codeSessionContext` (which threads the transient exec-session for file
+   * continuity): the hint identifies the durable server-side runtime session.
+   */
+  runtimeSessionHint?: string;
 };
 
 /** Batch request containing ALL tool calls for a graph step */
@@ -969,6 +988,23 @@ export type CloudflareSandboxExecutionConfig = {
   postEditSyntaxCheck?: LocalExecutionConfig['postEditSyntaxCheck'];
 };
 
+export type SandboxExecutionConfig = {
+  /**
+   * Opt into best-effort stateful runtime sessions on the remote Code API
+   * (its warm per-session MicroVM backend). The transport is unchanged — this
+   * only sends a stable session hint and, paired with the `statefulSessions`
+   * tool factory param, adjusts the model-facing description.
+   */
+  statefulSessions?: boolean;
+  /**
+   * Stable identity for the runtime session (e.g. the conversation id). The
+   * server derives the real session id as hash(tenant, user, hint), so this
+   * is never a security boundary. Falls back to `configurable.thread_id` when
+   * omitted.
+   */
+  runtimeSessionHint?: string;
+};
+
 export type ToolExecutionConfig = {
   /** `sandbox` preserves the remote Code API behavior and is the default. */
   engine?: ToolExecutionEngine;
@@ -976,6 +1012,8 @@ export type ToolExecutionConfig = {
   local?: LocalExecutionConfig;
   /** Cloudflare Sandbox execution settings used when `engine` is `cloudflare-sandbox`. */
   cloudflare?: CloudflareSandboxExecutionConfig;
+  /** Remote sandbox settings; applies when `engine` is `sandbox` or omitted. */
+  sandbox?: SandboxExecutionConfig;
 };
 
 export type ProgrammaticCache = {
@@ -1099,6 +1137,10 @@ export type ProgrammaticExecutionResponse = {
   stderr?: string;
   files?: FileRefs;
 
+  /** Durable runtime session echo from a stateful backend (additive). */
+  runtime_session_id?: string;
+  runtime_status?: 'new' | 'reused';
+
   /** Present when status='error' */
   error?: string;
 };
@@ -1110,6 +1152,9 @@ export type ProgrammaticExecutionArtifact = {
   /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
+  /** Durable runtime session echo from a stateful backend (additive). */
+  runtime_session_id?: string;
+  runtime_status?: 'new' | 'reused';
 };
 
 /** Parameters for creating a bash execution tool (same API as CodeExecutor, bash-only) */
@@ -1134,6 +1179,13 @@ export type ProgrammaticToolCallingParams = {
   debug?: boolean;
   /** Optional host-supplied Code API auth headers. */
   authHeaders?: CodeApiAuthHeaders;
+  /**
+   * Send the runtime session hint on the initial /exec/programmatic request
+   * for stateful sessions. PTC keeps its stateless prompt in v1 — the wire
+   * hint plumbs through, but the "each call is a fresh interpreter" wording
+   * is intentionally unchanged until server-side session behavior is proven.
+   */
+  statefulSessions?: boolean;
 };
 
 // ============================================================================
@@ -1166,6 +1218,9 @@ export type CodeExecutionArtifact = {
   /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
+  /** Durable runtime session echo from a stateful backend (additive). */
+  runtime_session_id?: string;
+  runtime_status?: 'new' | 'reused';
 };
 
 /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -295,7 +295,10 @@ export type CodeExecutionToolParams =
       /**
        * Advertise best-effort stateful sessions in the tool description
        * (variables/files may persist between calls, may reset). Prompt text
-       * only; the wire hint is gated by `toolExecution.sandbox`.
+       * only, and it must be set here because the description is bound to the
+       * LLM at construction time. Pair it with the run-scoped
+       * `toolExecution.sandbox.statefulSessions` gate, which drives the wire
+       * hint — set both from one flag so the prompt and the backend agree.
        */
       statefulSessions?: boolean;
     };
@@ -991,9 +994,18 @@ export type CloudflareSandboxExecutionConfig = {
 export type SandboxExecutionConfig = {
   /**
    * Opt into best-effort stateful runtime sessions on the remote Code API
-   * (its warm per-session MicroVM backend). The transport is unchanged — this
-   * only sends a stable session hint and, paired with the `statefulSessions`
-   * tool factory param, adjusts the model-facing description.
+   * (its warm per-session MicroVM backend). This gate is run-scoped: it only
+   * controls the wire behavior (ToolNode injecting the session hint on
+   * execute_code/bash calls). The transport is otherwise unchanged.
+   *
+   * It does NOT change the model-facing tool description. Tool descriptions are
+   * bound to the LLM at construction time (`createCodeExecutionTool` /
+   * `createBashExecutionTool`), before this run config is applied inside the
+   * graph, so they can only be adjusted via the tools' own `statefulSessions`
+   * factory param. Set BOTH from one flag (as LibreChat does): with this on but
+   * the factory param off, the backend runs statefully while the model is still
+   * told the environment is stateless (non-corrupting — the model just won't
+   * exploit persistence).
    */
   statefulSessions?: boolean;
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1179,13 +1179,11 @@ export type ProgrammaticToolCallingParams = {
   debug?: boolean;
   /** Optional host-supplied Code API auth headers. */
   authHeaders?: CodeApiAuthHeaders;
-  /**
-   * Send the runtime session hint on the initial /exec/programmatic request
-   * for stateful sessions. PTC keeps its stateless prompt in v1 — the wire
-   * hint plumbs through, but the "each call is a fresh interpreter" wording
-   * is intentionally unchanged until server-side session behavior is proven.
-   */
-  statefulSessions?: boolean;
+  /* No `statefulSessions` here: PTC is stateless in v1. The initial
+   * /exec/programmatic request still forwards a ToolNode-injected
+   * `_runtime_session_hint` when present, but there is no factory-level opt-in
+   * to advertise (it would be a no-op). Re-add with real behavior when PTC
+   * stateful prompting lands. */
 };
 
 // ============================================================================


### PR DESCRIPTION
## What

Adds opt-in, best-effort stateful runtime sessions for the remote Code API sandbox, so a conversation's `execute_code`/`bash` calls can reuse one warm per-session workspace instead of a fresh sandbox per call. The transport is unchanged; this only sends a stable session hint and hedges the model-facing tool descriptions.

## How

- New `toolExecution.sandbox` sub-config (`SandboxExecutionConfig { statefulSessions?, runtimeSessionHint? }`). This is intentionally not a new engine value: the host constructs the sandbox tools with closure-held auth/files, so `engine: 'sandbox'` stays the default and dispatch is untouched.
- `ToolNode` stamps `_runtime_session_hint` onto the tool call only when `sandbox.statefulSessions` is true (explicit `runtimeSessionHint`, else `configurable.thread_id`).
- The four remote tools send `runtime_session_hint` on the initial request (PTC/BashPTC on the initial request only; continuations bind server-side).
- A `statefulSessions` tool-factory param adds hedged descriptions for `execute_code` + `bash_tool` (usually share one runtime, may reset at any time, anything durable must be written to `/mnt/data`). PTC keeps its stateless prompt in v1.
- Artifacts pass through `runtime_session_id` / `runtime_status` for future UI.

## Safety

Fully additive and off by default. Old-SDK + new-server and new-SDK + old-server both degrade to stateless. The server derives the real session id as `hash(tenant, user, hint)`, so the hint is never a trust boundary.

## Tests

45 tests across `ToolNode.session`, `CodeExecutor.stateful`, and `BashExecutor`.
