### PR TITLE
fix: tool error completion contract across interrupt/resume passes

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1281,7 +1281,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         maxToolResultChars: agentContext?.maxToolResultChars,
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
         fileCheckpointer: this.getOrCreateFileCheckpointer(),
-        errorHandler: (data, metadata): Promise<void> =>
+        errorHandler: (data, metadata): Promise<boolean> =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
       this.registerCompiledToolNode(node);
@@ -1330,7 +1330,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // agent so hooks can attribute the batch even at the top level.
       executingAgentId: agentContext?.agentId,
       toolCallStepIds: this.toolCallStepIds,
-      errorHandler: (data, metadata): Promise<void> =>
+      errorHandler: (data, metadata): Promise<boolean> =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       toolRegistry: agentContext?.toolRegistry,
       sessions: this.sessions,
@@ -2715,32 +2715,38 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /**
    * Static version of handleToolCallError to avoid creating strong references
-   * that prevent garbage collection
+   * that prevent garbage collection.
+   *
+   * Returns whether the error completion event was actually dispatched. A
+   * tool can error before this graph instance has a run step for the call —
+   * on a resume pass the interrupted batch re-executes IMMEDIATELY on graph
+   * re-entry, before any step replay has registered `toolCallStepIds` (a
+   * fast-failing tool, e.g. a schema-validation reject, loses that race).
+   * That is a caller-recoverable condition, not an invariant violation: the
+   * ToolNode falls back to its normal completion dispatch for the error
+   * ToolMessage when this returns `false`, so throwing here would only
+   * replace a recoverable miss with a lost completion event and a scary log.
    */
   static async handleToolCallErrorStatic(
     graph: StandardGraph,
     data: t.ToolErrorData,
     metadata?: Record<string, unknown>
-  ): Promise<void> {
-    if (!graph.config) {
-      throw new Error('No config provided');
-    }
-
+  ): Promise<boolean> {
     if (!data.id) {
       console.warn('No Tool ID provided for Tool Error');
-      return;
+      return false;
     }
 
     const stepId = graph.toolCallStepIds.get(data.id) ?? '';
     if (!stepId) {
-      throw new Error(`No stepId found for tool_call_id ${data.id}`);
+      return false;
     }
 
     const { name, input: args, error } = data;
 
     const runStep = graph.getRunStep(stepId);
     if (!runStep) {
-      throw new Error(`No run step found for stepId ${stepId}`);
+      return false;
     }
 
     const tool_call: t.ProcessedToolCall = {
@@ -2766,6 +2772,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         metadata,
         graph
       );
+    return true;
   }
 
   /**
@@ -2775,8 +2782,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   async handleToolCallError(
     data: t.ToolErrorData,
     metadata?: Record<string, unknown>
-  ): Promise<void> {
-    await StandardGraph.handleToolCallErrorStatic(this, data, metadata);
+  ): Promise<boolean> {
+    return StandardGraph.handleToolCallErrorStatic(this, data, metadata);
   }
 
   async dispatchRunStepDelta(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2757,21 +2757,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       progress: 1,
     };
 
-    await graph.handlerRegistry
-      ?.getHandler(GraphEvents.ON_RUN_STEP_COMPLETED)
-      ?.handle(
-        GraphEvents.ON_RUN_STEP_COMPLETED,
-        {
-          result: {
-            id: stepId,
-            index: runStep.index,
-            type: 'tool_call',
-            tool_call,
-          } as t.ToolCompleteEvent,
-        },
-        metadata,
-        graph
-      );
+    // No registered ON_RUN_STEP_COMPLETED handler ⇒ nothing was dispatched.
+    // Report `false` so the ToolNode runs its own fallback dispatch; returning
+    // `true` here would silently drop the error completion for hosts that wire
+    // completions through callback-based custom events instead of a handler.
+    const handler = graph.handlerRegistry?.getHandler(
+      GraphEvents.ON_RUN_STEP_COMPLETED
+    );
+    if (!handler) {
+      return false;
+    }
+
+    await handler.handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: stepId,
+          index: runStep.index,
+          type: 'tool_call',
+          tool_call,
+        } as t.ToolCompleteEvent,
+      },
+      metadata,
+      graph
+    );
     return true;
   }
 

--- a/src/specs/tool-error-resume.test.ts
+++ b/src/specs/tool-error-resume.test.ts
@@ -38,11 +38,16 @@ const askTool = tool(
   }
 );
 
-const strictTool = tool(async ({ n }: { n: number }) => `got ${n}`, {
-  name: 'strict_tool',
-  description: 'A tool with a strict schema.',
-  schema: z.object({ n: z.number().max(1) }),
-});
+const strictTool = tool(
+  async ({ items }: { items: string[] }) => `got ${items.length}`,
+  {
+    name: 'strict_tool',
+    // Array cap mirrors the field repro: an ask_user_question sibling whose
+    // `options` array exceeded the 12-option schema cap.
+    description: 'A tool with a strict array-cap schema.',
+    schema: z.object({ items: z.array(z.string()).max(1) }),
+  }
+);
 
 describe('Direct tool schema error across interrupt/resume', () => {
   jest.setTimeout(30000);
@@ -119,7 +124,7 @@ describe('Direct tool schema error across interrupt/resume', () => {
         },
         {
           name: 'strict_tool',
-          args: { n: 5 },
+          args: { items: ['a', 'b', 'c'] },
           id: 'call_strict_1',
           type: 'tool_call',
         },
@@ -148,7 +153,11 @@ describe('Direct tool schema error across interrupt/resume', () => {
           e.output?.includes('Error processing tool') === true
       );
       expect(strictCompletions).toHaveLength(1);
-      expect(strictCompletions[0].output).toContain('at most 1');
+      // Stable LangChain wrapper text (version-independent), proving the
+      // completion carried the schema-validation failure.
+      expect(strictCompletions[0].output).toContain(
+        'did not match expected schema'
+      );
 
       /** Pass 2: fresh instance (host restart shape), resume with the
        *  answer. The batch re-executes; the strict tool fails again before

--- a/src/specs/tool-error-resume.test.ts
+++ b/src/specs/tool-error-resume.test.ts
@@ -1,0 +1,185 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import { MemorySaver, Command } from '@langchain/langgraph';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import { FakeChatModel } from '@/llm/fake';
+import { askUserQuestion } from '@/hitl';
+import { StandardGraph } from '@/graphs';
+import { Run } from '@/run';
+
+/**
+ * Regression: a DIRECT (graphTools) tool that fails schema validation during
+ * the RESUME pass of an interrupted batch.
+ *
+ * LangGraph re-executes the whole interrupted batch on resume, and a
+ * fast-failing sibling (e.g. a zod reject) errors BEFORE the rebuilt graph
+ * has registered run steps for the replayed calls. `handleToolCallErrorStatic`
+ * used to throw (`No config provided`) in that state, which surfaced as a
+ * scary `Error in errorHandler` log on every such resume — the error itself
+ * was already handled (the model receives the error ToolMessage either way).
+ * It now reports `false` (nothing dispatched) so the ToolNode can decide, and
+ * the client-facing contract stays: the error completion event dispatches
+ * exactly ONCE, on the pass where the call's run step is live (the first
+ * pass), never zero times and never twice.
+ */
+const askTool = tool(
+  async (input) => {
+    const { answer } = askUserQuestion(input as { question: string });
+    return answer;
+  },
+  {
+    name: 'ask_user_question',
+    description:
+      'Ask the user a clarifying question and wait for their answer.',
+    schema: z.object({ question: z.string() }),
+  }
+);
+
+const strictTool = tool(async ({ n }: { n: number }) => `got ${n}`, {
+  name: 'strict_tool',
+  description: 'A tool with a strict schema.',
+  schema: z.object({ n: z.number().max(1) }),
+});
+
+describe('Direct tool schema error across interrupt/resume', () => {
+  jest.setTimeout(30000);
+
+  const threadConfig: Partial<RunnableConfig> & {
+    version: 'v1' | 'v2';
+    streamMode: string;
+  } = {
+    configurable: { thread_id: 'tool-error-resume-thread' },
+    streamMode: 'values',
+    version: 'v2' as const,
+  };
+
+  const completedToolEvents: Array<{ name?: string; output?: string }> = [];
+  const customHandlers = {
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (_event: GraphEvents, data: t.StreamEventData): void => {
+        const result = (data as { result?: t.ToolCompleteEvent }).result;
+        if (result?.type === 'tool_call') {
+          completedToolEvents.push({
+            name: result.tool_call.name,
+            output: result.tool_call.output,
+          });
+        }
+      },
+    },
+  };
+
+  async function buildRun(
+    saver: MemorySaver,
+    runId: string
+  ): Promise<Run<t.IState>> {
+    const run = await Run.create<t.IState>({
+      runId,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'resume-error-agent',
+            provider: Providers.OPENAI,
+            clientOptions: {
+              model: 'gpt-4o-mini',
+              streaming: true,
+              streamUsage: false,
+            },
+            instructions: 'You are a helpful assistant.',
+            maxContextTokens: 8000,
+            /** Non-empty toolDefinitions flips the ToolNode to event dispatch —
+             *  the production shape — while graphTools ride the direct path. */
+            toolDefinitions: [
+              { name: 'dummy_event_tool', description: 'host tool' },
+            ],
+            graphTools: [askTool, strictTool],
+          },
+        ],
+        compileOptions: { checkpointer: saver },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+      eagerEventToolExecution: {
+        enabled: true,
+        excludeToolNames: ['ask_user_question', 'strict_tool'],
+      },
+    });
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['calling tools', 'done after resume'],
+      toolCalls: [
+        {
+          name: 'ask_user_question',
+          args: { question: 'pick one' },
+          id: 'call_ask_1',
+          type: 'tool_call',
+        },
+        {
+          name: 'strict_tool',
+          args: { n: 5 },
+          id: 'call_strict_1',
+          type: 'tool_call',
+        },
+      ],
+    });
+    return run;
+  }
+
+  test('error completion dispatches exactly once; resume-pass handler reports false instead of throwing', async () => {
+    const saver = new MemorySaver();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const staticSpy = jest.spyOn(StandardGraph, 'handleToolCallErrorStatic');
+
+    try {
+      /** Pass 1: the strict tool rejects its args while the ask tool
+       *  interrupts — the run pauses AND the schema error completes. */
+      const run1 = await buildRun(saver, 'run-pass-1');
+      await run1.processStream(
+        { messages: [new HumanMessage('go')] },
+        threadConfig
+      );
+
+      const strictCompletions = completedToolEvents.filter(
+        (e) =>
+          e.name === 'strict_tool' &&
+          e.output?.includes('Error processing tool') === true
+      );
+      expect(strictCompletions).toHaveLength(1);
+      expect(strictCompletions[0].output).toContain('at most 1');
+
+      /** Pass 2: fresh instance (host restart shape), resume with the
+       *  answer. The batch re-executes; the strict tool fails again before
+       *  any run step is registered on the rebuilt graph. */
+      const run2 = await buildRun(saver, 'run-pass-2');
+      await run2.processStream(
+        new Command({ resume: { answer: 'blue' } }) as unknown as t.IState,
+        threadConfig
+      );
+
+      /** The handler reported "not dispatched" (no run step yet) rather than
+       *  throwing — so nothing was logged and no duplicate completion event
+       *  reached the client. */
+      const resumeResults = await Promise.all(
+        staticSpy.mock.results.map((r) => r.value as Promise<boolean>)
+      );
+      expect(resumeResults).toContain(false);
+      const handlerFailures = errorSpy.mock.calls.filter((args) =>
+        String(args[0]).includes('Error in errorHandler')
+      );
+      expect(handlerFailures).toHaveLength(0);
+      expect(
+        completedToolEvents.filter(
+          (e) =>
+            e.name === 'strict_tool' &&
+            e.output?.includes('Error processing tool') === true
+        )
+      ).toHaveLength(1);
+    } finally {
+      errorSpy.mockRestore();
+      staticSpy.mockRestore();
+    }
+  });
+});

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3243,11 +3243,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
-    // Per-batch: a fresh run (including a resume re-execution) owns its own
-    // undispatched-error markers. Clearing here reclaims any left behind when a
-    // prior invocation interrupted before its completion loop ran, so a stale id
-    // can't survive to double-dispatch or accumulate across the node's lifetime.
-    this.undispatchedToolErrors.clear();
     /**
      * Per-batch local map for resolved (post-substitution) args.
      * Lives on the stack so concurrent `run()` calls on the same

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -416,6 +416,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private agentLangfuse?: t.LangfuseConfig;
   toolCallStepIds?: Map<string, string>;
   errorHandler?: t.ToolNodeConstructorParams['errorHandler'];
+  /**
+   * Tool call ids whose `errorHandler` did NOT dispatch the error completion
+   * event (it returned `false` or threw). The output loop must dispatch the
+   * completion for these itself — skipping them there would strand the
+   * client's tool-call part without a terminal event.
+   */
+  private undispatchedToolErrors: Set<string> = new Set();
   private toolUsageCount: Map<string, number>;
   /** Maps toolCallId → turn captured in runTool, used by handleRunToolCompletions */
   private toolCallTurns: Map<string, number> = new Map();
@@ -1140,7 +1147,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       if (this.errorHandler) {
         try {
-          await this.errorHandler(
+          const dispatched = await this.errorHandler(
             {
               error: e,
               id: call.id!,
@@ -1149,7 +1156,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             config.metadata
           );
+          if (dispatched === false && call.id != null && call.id !== '') {
+            /**
+             * The handler could not dispatch the error completion (typically
+             * a resume pass, where a fast-failing tool errors before the
+             * step replay registers its run step). Remember the call so the
+             * output loop dispatches the completion itself instead of
+             * assuming the handler covered it.
+             */
+            this.undispatchedToolErrors.add(call.id);
+          }
         } catch (handlerError) {
+          if (call.id != null && call.id !== '') {
+            this.undispatchedToolErrors.add(call.id);
+          }
           // eslint-disable-next-line no-console
           console.error('Error in errorHandler:', {
             toolName: call.name,
@@ -1875,8 +1895,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const toolCallId = call.id ?? '';
 
       // Skip error ToolMessages when errorHandler already dispatched ON_RUN_STEP_COMPLETED
-      // via handleToolCallErrorStatic. Without this check, errors would be double-dispatched.
-      if (toolMessage.status === 'error' && this.errorHandler != null) {
+      // via handleToolCallErrorStatic — dispatching again here would double-dispatch.
+      // When the handler reported it could NOT dispatch (no run step registered yet at
+      // error time, e.g. a fast-failing tool on a resume pass), fall through: by now the
+      // step replay has usually registered the id, so this loop's dispatch is the only
+      // terminal event the client's tool-call part will ever get.
+      if (
+        toolMessage.status === 'error' &&
+        this.errorHandler != null &&
+        !this.undispatchedToolErrors.has(toolCallId)
+      ) {
         continue;
       }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1167,9 +1167,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             this.undispatchedToolErrors.add(call.id);
           }
         } catch (handlerError) {
-          if (call.id != null && call.id !== '') {
-            this.undispatchedToolErrors.add(call.id);
-          }
+          // A THROWN handler is not proof the completion wasn't dispatched: the
+          // built-in session handler emits `tool.completed` BEFORE invoking a
+          // user ON_RUN_STEP_COMPLETED callback, so a throw from that callback
+          // has already dispatched. Marking it undispatched would make the
+          // fallback loop re-emit a duplicate completion — only an explicit
+          // `false` return (handled above) means "nothing dispatched"; a throw
+          // is just logged.
           // eslint-disable-next-line no-console
           console.error('Error in errorHandler:', {
             toolName: call.name,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1900,12 +1900,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // error time, e.g. a fast-failing tool on a resume pass), fall through: by now the
       // step replay has usually registered the id, so this loop's dispatch is the only
       // terminal event the client's tool-call part will ever get.
-      if (
-        toolMessage.status === 'error' &&
-        this.errorHandler != null &&
-        !this.undispatchedToolErrors.has(toolCallId)
-      ) {
-        continue;
+      if (toolMessage.status === 'error' && this.errorHandler != null) {
+        if (this.undispatchedToolErrors.has(toolCallId)) {
+          // CONSUME the marker: this loop now owns the dispatch for this id.
+          // Leaving it set would let a later re-entry (same ToolNode instance
+          // re-executing the batch, where the handler CAN dispatch) fall
+          // through here too and double-dispatch — and the set would grow
+          // unbounded across a long-lived graph's fast-failing calls.
+          this.undispatchedToolErrors.delete(toolCallId);
+        } else {
+          continue;
+        }
       }
 
       if (this.sessions && this.participatesInCodeSession(call.name)) {
@@ -3238,6 +3243,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
+    // Per-batch: a fresh run (including a resume re-execution) owns its own
+    // undispatched-error markers. Clearing here reclaims any left behind when a
+    // prior invocation interrupted before its completion loop ran, so a stale id
+    // can't survive to double-dispatch or accumulate across the node's lifetime.
+    this.undispatchedToolErrors.clear();
     /**
      * Per-batch local map for resolved (post-substitution) args.
      * Lives on the stack so concurrent `run()` calls on the same

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -89,10 +89,18 @@ export type ToolNodeOptions = {
   handleToolErrors?: boolean;
   loadRuntimeTools?: ToolRefGenerator;
   toolCallStepIds?: Map<string, string>;
+  /**
+   * Dispatches the error completion event for a failed tool call. Returns
+   * whether the event was actually dispatched — `false` (e.g. no run step is
+   * registered for the call yet, which happens when a tool fails fast on a
+   * resume pass) tells the ToolNode to fall back to its own completion
+   * dispatch for the error ToolMessage. A `void` resolution is treated as
+   * dispatched for backward compatibility.
+   */
   errorHandler?: (
     data: ToolErrorData,
     metadata?: Record<string, unknown>
-  ) => Promise<void>;
+  ) => Promise<boolean | void>;
   /** Tool registry for lazy computation of programmatic tools and tool search */
   toolRegistry?: LCToolRegistry;
   /** Reference to Graph's sessions map for automatic session injection */


### PR DESCRIPTION
## Problem

Field report from LibreChat [#14139](https://github.com/danny-avila/LibreChat/pull/14139): a **direct (graphTools) tool** that fails schema validation on the **resume pass** of an interrupted batch produces:

```
Error in errorHandler: { ..., handlerError: { message: 'No config provided' } }
```

LangGraph re-executes the whole interrupted batch on resume, and a fast-failing sibling (e.g. a zod reject — 13 options against a 12-option cap) errors **before** the rebuilt graph has registered run steps for the replayed calls (`stepId: undefined` in the report). `handleToolCallErrorStatic` treated that recoverable state as an invariant violation and threw.

Reproduced with a dist probe: pass 1 (pause) handles the error cleanly and dispatches the error completion; the resume pass on a fresh instance throws exactly the reported error.

## Fix

- `handleToolCallErrorStatic` returns **whether it dispatched** the error completion instead of throwing on missing config/stepId/runStep. The `config` precondition is dropped entirely — the dispatch path never consumed it.
- `ToolNode` records calls whose errorHandler did **not** dispatch (returned `false` or threw) and lets its own completion loop dispatch for exactly those. The previous skip (`status === 'error' && errorHandler != null`) assumed the handler always succeeded — when it didn't, the client's tool-call part never received a terminal event.
- `errorHandler` type widens to `Promise<boolean | void>` (`void` = dispatched, for back-compat with external implementers).

**Net contract**: the error completion dispatches exactly once — on the pass where the call's run step is live (the first pass). Resume re-executions of an already-reported error stay silent toward the client (no duplicate cards), and the model receives the error ToolMessage on every pass, unchanged.

## Verification

- New regression spec `src/specs/tool-error-resume.test.ts`: FakeChatModel scripts a parallel batch (interrupting ask + schema-failing strict tool) through pause → resume on a fresh instance over a MemorySaver; asserts exactly one error completion, no `Error in errorHandler` log, and a `false` handler result on the resume pass.
- Dist probe of the same scenario: resume-pass handler failures went 1 → 0; pass-1 completion unchanged.
- LibreChat's `askUserQuestion.e2e.spec.js` + `hitlCheckpoint.e2e.spec.js` (7 tests) pass against this branch's built dist.