### PR TITLE
feat(hitl): declare multiSelect on AskUserQuestionRequest

### DIFF
--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -3996,6 +3996,54 @@ describe('AskUserQuestion — interrupt + resume', () => {
     expect(resumedAnswer).toBe('production');
   });
 
+  it('carries multiSelect through the interrupt payload and resumes with the joined option values', async () => {
+    const { askUserQuestion } = await import('@/hitl');
+
+    let resumedAnswer: string | undefined;
+
+    const builder = new StateGraph(MessagesAnnotation)
+      .addNode('clarifier', () => {
+        const resolution = askUserQuestion({
+          question: 'Which environments?',
+          options: [
+            { label: 'Staging', value: 'staging' },
+            { label: 'Production', value: 'production' },
+          ],
+          multiSelect: true,
+        });
+        resumedAnswer = resolution.answer;
+        return { messages: [] };
+      })
+      .addEdge(START, 'clarifier')
+      .addEdge('clarifier', END);
+    const graph = builder.compile({ checkpointer: new MemorySaver() });
+
+    const config = { configurable: { thread_id: 'ask-q-multi-thread' } };
+
+    const interrupted = (await graph.invoke({ messages: [] }, config)) as {
+      __interrupt__?: Array<{ id?: string; value?: t.HumanInterruptPayload }>;
+    };
+    const payload = interrupted.__interrupt__![0].value!;
+    if (payload.type !== 'ask_user_question') {
+      throw new Error('expected ask_user_question');
+    }
+    expect(payload.question.multiSelect).toBe(true);
+    expect(payload.question.options).toHaveLength(2);
+
+    // Host joins the selected option values with ", ".
+    const resolution: t.AskUserQuestionResolution = {
+      answer: 'staging, production',
+    };
+    await resumeGraph(
+      graph as unknown as CompiledMessagesGraph,
+      interrupted,
+      resolution,
+      config
+    );
+
+    expect(resumedAnswer).toBe('staging, production');
+  });
+
   it('a DIRECT tool in event-driven mode can raise ask_user_question from its body and resume with the answer as its ToolMessage', async () => {
     /**
      * The production host shape (e.g. LibreChat's `AgentInputs.graphTools`

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -140,6 +140,13 @@ export interface AskUserQuestionRequest {
    * UI allows it. Omit to require a free-form answer.
    */
   options?: AskUserQuestionOption[];
+  /**
+   * When `true`, the host UI may let the user pick several options; the
+   * resulting `AskUserQuestionResolution.answer` is the selected option
+   * values joined by `", "`. When omitted or `false`, hosts render a
+   * single-select picker. Only meaningful alongside `options`.
+   */
+  multiSelect?: boolean;
 }
 
 /**
@@ -168,9 +175,10 @@ export type HumanInterruptPayload =
 export interface AskUserQuestionResolution {
   /**
    * The human's answer. Free-form text, or — when `options` were
-   * provided — one of the option `value`s. Hosts may also send any
-   * structured object their custom UI defines; see the host docs for
-   * what your downstream consumer expects.
+   * provided — one of the option `value`s (or, when the request set
+   * `multiSelect`, several option `value`s joined by `", "`). Hosts may
+   * also send any structured object their custom UI defines; see the
+   * host docs for what your downstream consumer expects.
    */
   answer: string;
 }


### PR DESCRIPTION
## Summary

Adds `multiSelect?: boolean` to the SDK's `AskUserQuestionRequest` interface (`src/types/hitl.ts`, source for `dist/types/types/hitl.d.ts`).

When `true`, the host UI may let the user pick several options; the resulting `AskUserQuestionResolution.answer` is the selected option `value`s joined by `", "`. Omitted/`false` → single-select. Only meaningful alongside `options`.

## Why

LibreChat's ask-user-question feature ([#14139](https://github.com/danny-avila/LibreChat/pull/14139)) passes a tool input containing `multiSelect` into `askUserQuestion()`. It works today only because the helper forwards the object verbatim into `interrupt()`, and librechat-data-provider's `Agents.AskUserQuestionRequest` mirror already declares `multiSelect?: boolean`.

Declaring the field in the SDK closes the type-contract gap so a future SDK change that validates or picks declared fields cannot silently drop it.

## Changes

- `src/types/hitl.ts`: add `multiSelect?: boolean` with doc comment; update `AskUserQuestionResolution.answer` JSDoc to cover the joined-values case.
- `src/tools/__tests__/hitl.test.ts`: new case asserting `multiSelect` rides through the `ask_user_question` interrupt payload and resumes with the `", "`-joined answer.

## Verification

- `jest` AskUserQuestion suite: 5 passed (incl. new test).
- `npm run build`: confirmed `multiSelect?: boolean;` lands in generated `dist/types/types/hitl.d.ts`.

## Related

Sibling to [#292](https://github.com/danny-avila/agents/pull/292) — both stem from the LibreChat #14139 ask_user_question rollout. That PR fixes the tool-error-completion contract across interrupt/resume; this one closes the type-contract gap. No file overlap; independent.