### PR TITLE
feat(hitl): guard sibling double-execution when ask_user_question interrupts mid-batch

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -609,6 +609,14 @@ export abstract class Graph<
    */
   eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
   codeSessionToolNames: string[] | undefined;
+  /**
+   * Run-scoped names of tools whose in-process body may raise a LangGraph
+   * `interrupt()` (e.g. `ask_user_question`). Threaded from
+   * `RunConfig.interruptingToolNames` into every ToolNode this graph
+   * compiles so a mid-batch interrupt cannot double-execute non-idempotent
+   * siblings on resume. See {@link t.ToolNodeOptions.interruptingToolNames}.
+   */
+  interruptingToolNames: string[] | undefined;
   eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
   eagerEventToolUsageCount: Map<string, number> = new Map();
   private eagerEventToolUsageCountsByAgentId: Map<string, Map<string, number>> =
@@ -658,6 +666,7 @@ export abstract class Graph<
     this.toolOutputReferences = undefined;
     this.eagerEventToolExecution = undefined;
     this.codeSessionToolNames = undefined;
+    this.interruptingToolNames = undefined;
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
@@ -1277,6 +1286,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ),
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
+        interruptingToolNames:
+          this.interruptingToolNames != null &&
+          this.interruptingToolNames.length > 0
+            ? new Set(this.interruptingToolNames)
+            : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
@@ -1336,6 +1350,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessions: this.sessions,
       toolExecution: this.toolExecution,
       codeSessionToolNames: this.codeSessionToolNames,
+      interruptingToolNames:
+        this.interruptingToolNames != null &&
+        this.interruptingToolNames.length > 0
+          ? new Set(this.interruptingToolNames)
+          : undefined,
       hookRegistry: this.hookRegistry,
       humanInTheLoop: this.humanInTheLoop,
       maxContextTokens: agentContext?.maxContextTokens,
@@ -2361,6 +2380,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
             childGraph.codeSessionToolNames = this.codeSessionToolNames;
+            // Pure execution-ordering hint (unlike `humanInTheLoop` above):
+            // it only ever schedules an interrupting tool ahead of its
+            // siblings, so propagating it into subagents can prevent a
+            // double side effect but never introduce one.
+            childGraph.interruptingToolNames = this.interruptingToolNames;
             childGraph.toolExecution = this.toolExecution;
             childGraph.eventToolExecutionAvailable =
               this.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2380,10 +2380,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
             childGraph.codeSessionToolNames = this.codeSessionToolNames;
-            // Pure execution-ordering hint (unlike `humanInTheLoop` above):
-            // it only ever schedules an interrupting tool ahead of its
-            // siblings, so propagating it into subagents can prevent a
-            // double side effect but never introduce one.
+            // Pure execution-ordering hint (unlike `humanInTheLoop` above).
+            // It ONLY reorders tools already in the child's direct group;
+            // it does not force a name onto the direct path (that fold-in
+            // was removed — Codex review of #294). So for a self-spawned
+            // child that scrubs inherited `graphTools` (keeping only the
+            // event `toolDefinition` / schema-only stub for a name like
+            // `ask_user_question`), the name isn't in the child's direct
+            // group and this is a no-op — the stub is still dispatched via
+            // ON_TOOL_EXECUTE, never invoked directly. Where the child DOES
+            // have the executable graphTool, the guard correctly applies.
             childGraph.interruptingToolNames = this.interruptingToolNames;
             childGraph.toolExecution = this.toolExecution;
             childGraph.eventToolExecutionAvailable =

--- a/src/run.ts
+++ b/src/run.ts
@@ -128,6 +128,7 @@ export class Run<_T extends t.BaseGraphState> {
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   private codeSessionToolNames?: string[];
+  private interruptingToolNames?: string[];
   private toolExecution?: t.ToolExecutionConfig;
   private subagentUsageSink?: t.SubagentUsageSink;
   private indexTokenCountMap?: Record<string, number>;
@@ -184,6 +185,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.toolOutputReferences = config.toolOutputReferences;
     this.eagerEventToolExecution = config.eagerEventToolExecution;
     this.codeSessionToolNames = config.codeSessionToolNames;
+    this.interruptingToolNames = config.interruptingToolNames;
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
 
@@ -271,6 +273,7 @@ export class Run<_T extends t.BaseGraphState> {
     standardGraph.toolOutputReferences = this.toolOutputReferences;
     standardGraph.eagerEventToolExecution = this.eagerEventToolExecution;
     standardGraph.codeSessionToolNames = this.codeSessionToolNames;
+    standardGraph.interruptingToolNames = this.interruptingToolNames;
     standardGraph.toolExecution = this.toolExecution;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
@@ -301,6 +304,7 @@ export class Run<_T extends t.BaseGraphState> {
     multiAgentGraph.toolOutputReferences = this.toolOutputReferences;
     multiAgentGraph.eagerEventToolExecution = this.eagerEventToolExecution;
     multiAgentGraph.codeSessionToolNames = this.codeSessionToolNames;
+    multiAgentGraph.interruptingToolNames = this.interruptingToolNames;
     multiAgentGraph.toolExecution = this.toolExecution;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();

--- a/src/specs/ask-user-question-batch.test.ts
+++ b/src/specs/ask-user-question-batch.test.ts
@@ -1,0 +1,224 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import {
+  END,
+  START,
+  Command,
+  StateGraph,
+  MemorySaver,
+  isInterrupted,
+  MessagesAnnotation,
+} from '@langchain/langgraph';
+import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { askUserQuestion } from '@/hitl';
+import { ToolNode } from '@/tools/ToolNode';
+
+/**
+ * Pins the `interruptingToolNames` guard for the `ask_user_question`
+ * shape: a normal tool whose BODY raises a LangGraph `interrupt()`
+ * mid-execution (via {@link askUserQuestion}) to collect a human answer.
+ *
+ * When such a tool shares a tool-call batch with a NON-idempotent
+ * sibling (send_email, billing), LangGraph's resume contract — re-run
+ * the whole interrupted node from the top — would otherwise execute the
+ * sibling once on the first pass and AGAIN on resume, duplicating the
+ * side effect. Declaring the interrupter in `interruptingToolNames`
+ * schedules it ahead of its siblings, so the batch unwinds before any
+ * sibling runs and the sibling executes exactly once (on resume).
+ *
+ * Runs entirely in-memory (StateGraph + MemorySaver) — no LLM, no Run
+ * machinery — so it exercises the ToolNode batch-execution change
+ * directly. Companion dist probe: `node -e` against dist/cjs/main.cjs.
+ */
+
+type MessagesUpdate = { messages: BaseMessage[] };
+type CompiledMessagesGraph = Runnable<unknown, { messages: BaseMessage[] }> & {
+  invoke(input: unknown, config?: RunnableConfig): Promise<unknown>;
+};
+
+/** Tool whose body suspends the run to ask the user (no side effect). */
+function makeAskTool(): StructuredToolInterface {
+  return tool(
+    async () => {
+      const { answer } = askUserQuestion({ question: 'Proceed?' });
+      return `answered: ${answer}`;
+    },
+    {
+      name: 'ask_user_question',
+      description: 'suspends to collect a human answer',
+      schema: z.object({}).passthrough(),
+    }
+  ) as unknown as StructuredToolInterface;
+}
+
+/** Non-idempotent sibling — records every body invocation. */
+function makeSideEffectTool(sideEffect: () => string): StructuredToolInterface {
+  return tool(async () => sideEffect(), {
+    name: 'side_effect',
+    description: 'non-idempotent side effect (e.g. send_email)',
+    schema: z.object({}).passthrough(),
+  }) as unknown as StructuredToolInterface;
+}
+
+function buildGraph(
+  node: ToolNode,
+  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>
+): CompiledMessagesGraph {
+  const builder = new StateGraph(MessagesAnnotation)
+    .addNode(
+      'agent',
+      (): MessagesUpdate => ({
+        messages: [new AIMessage({ content: '', tool_calls: toolCalls })],
+      })
+    )
+    .addNode('tools', node)
+    .addEdge(START, 'agent')
+    .addEdge('agent', 'tools')
+    .addEdge('tools', END);
+  return builder.compile({
+    checkpointer: new MemorySaver(),
+  }) as unknown as CompiledMessagesGraph;
+}
+
+const ASK = { id: 'ask1', name: 'ask_user_question', args: {} };
+const SIDE_EFFECT = { id: 'se1', name: 'side_effect', args: {} };
+
+describe('ask_user_question batched with a sibling tool', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('direct sibling — guarded by interruptingToolNames', () => {
+    // The exposed shape: both tools run in-process, so absent the guard
+    // they share one Promise.all and the sibling double-executes.
+    for (const order of [
+      { label: '[ask, side_effect]', calls: [ASK, SIDE_EFFECT] },
+      { label: '[side_effect, ask]', calls: [SIDE_EFFECT, ASK] },
+    ]) {
+      it(`runs the sibling exactly once across pause→resume — order ${order.label}`, async () => {
+        const sideEffect = jest.fn(() => 'EXECUTED');
+        const node = new ToolNode({
+          tools: [makeAskTool(), makeSideEffectTool(sideEffect)],
+          eventDrivenMode: true,
+          directToolNames: new Set(['ask_user_question', 'side_effect']),
+          interruptingToolNames: new Set(['ask_user_question']),
+        });
+        const graph = buildGraph(node, order.calls);
+        const config = {
+          configurable: { thread_id: `guarded-${order.label}` },
+        };
+
+        const first = await graph.invoke({ messages: [] }, config);
+        expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+        // Guard: the interrupter is scheduled first, so the sibling has
+        // NOT run when the batch unwinds on the first pass.
+        expect(sideEffect).not.toHaveBeenCalled();
+
+        const second = await graph.invoke(
+          new Command({ resume: { answer: 'yes' } }),
+          config
+        );
+
+        // Sibling ran exactly once, on the resume pass.
+        expect(sideEffect).toHaveBeenCalledTimes(1);
+
+        const messages = (second as { messages: ToolMessage[] }).messages;
+        const seMsg = messages.find(
+          (m) => m instanceof ToolMessage && m.name === 'side_effect'
+        ) as ToolMessage;
+        expect(String(seMsg.content)).toBe('EXECUTED');
+        const askMsg = messages.find(
+          (m) => m instanceof ToolMessage && m.name === 'ask_user_question'
+        ) as ToolMessage;
+        expect(String(askMsg.content)).toBe('answered: yes');
+      });
+    }
+  });
+
+  describe('baseline (no guard) — documents the defect the guard closes', () => {
+    it('double-executes an unguarded direct sibling on resume', async () => {
+      const sideEffect = jest.fn(() => 'EXECUTED');
+      const node = new ToolNode({
+        tools: [makeAskTool(), makeSideEffectTool(sideEffect)],
+        eventDrivenMode: true,
+        directToolNames: new Set(['ask_user_question', 'side_effect']),
+        // interruptingToolNames intentionally omitted.
+      });
+      const graph = buildGraph(node, [ASK, SIDE_EFFECT]);
+      const config = { configurable: { thread_id: 'baseline-unguarded' } };
+
+      const first = await graph.invoke({ messages: [] }, config);
+      expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+      // Unguarded: the sibling shared the interrupter's Promise.all and
+      // already ran its side effect before the pause.
+      expect(sideEffect).toHaveBeenCalledTimes(1);
+
+      await graph.invoke(new Command({ resume: { answer: 'yes' } }), config);
+      // LangGraph re-runs the batch → the side effect fires a SECOND time.
+      expect(sideEffect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('event-dispatched sibling — already safe without the guard', () => {
+    it('never runs the event sibling on the first pass', async () => {
+      const sideEffect = jest.fn(() => 'EXECUTED');
+      // Host executes event-dispatched tools; record side_effect there.
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const req = data as {
+            toolCalls: Array<{ id: string; name: string }>;
+            resolve: (results: t.ToolExecuteResult[]) => void;
+          };
+          const results = req.toolCalls.map((tc) => {
+            if (tc.name === 'side_effect') {
+              sideEffect();
+            }
+            return {
+              toolCallId: tc.id,
+              content: 'EXECUTED',
+              status: 'success' as const,
+            };
+          });
+          req.resolve(results);
+          return true;
+        });
+
+      const node = new ToolNode({
+        tools: [
+          makeAskTool(),
+          // schema-only stub; the host "executes" side_effect via event.
+          tool(async () => 'unused', {
+            name: 'side_effect',
+            description: 'event tool',
+            schema: z.object({}).passthrough(),
+          }) as unknown as StructuredToolInterface,
+        ],
+        eventDrivenMode: true,
+        // side_effect is NOT direct → dispatched as an event.
+        directToolNames: new Set(['ask_user_question']),
+        interruptingToolNames: new Set(['ask_user_question']),
+      });
+      const graph = buildGraph(node, [SIDE_EFFECT, ASK]);
+      const config = { configurable: { thread_id: 'event-sibling' } };
+
+      const first = await graph.invoke({ messages: [] }, config);
+      expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+      // The direct interrupter unwinds the batch before event tools are
+      // dispatched, so the host never executed side_effect.
+      expect(sideEffect).not.toHaveBeenCalled();
+
+      await graph.invoke(new Command({ resume: { answer: 'yes' } }), config);
+      expect(sideEffect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/specs/ask-user-question-batch.test.ts
+++ b/src/specs/ask-user-question-batch.test.ts
@@ -221,4 +221,69 @@ describe('ask_user_question batched with a sibling tool', () => {
       expect(sideEffect).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('interruptingToolNames only reorders; never forces direct (Codex #294)', () => {
+    // A self-spawned child scrubs inherited `graphTools` but keeps the
+    // event `toolDefinition`, so a name like `ask_user_question` exists
+    // only as a schema-only stub. Propagating `interruptingToolNames`
+    // must NOT force that name onto the direct path — invoking the stub
+    // throws "should not be invoked directly". It must stay dispatched.
+    it('dispatches an interrupting name that has no in-process implementation', async () => {
+      const directlyInvoked = jest.fn();
+      // Mirrors createSchemaOnlyTool: throws if invoked in-process.
+      const stub = tool(
+        async () => {
+          directlyInvoked();
+          throw new Error(
+            'Tool "ask_user_question" should not be invoked directly in event-driven mode.'
+          );
+        },
+        {
+          name: 'ask_user_question',
+          description: 'schema-only event stub',
+          schema: z.object({}).passthrough(),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const req = data as {
+            toolCalls: Array<{ id: string; name: string }>;
+            resolve: (results: t.ToolExecuteResult[]) => void;
+          };
+          req.resolve(
+            req.toolCalls.map((tc) => ({
+              toolCallId: tc.id,
+              content: 'HOST-HANDLED',
+              status: 'success' as const,
+            }))
+          );
+          return true;
+        });
+
+      const node = new ToolNode({
+        tools: [stub],
+        eventDrivenMode: true,
+        // NOT in directToolNames → it is an event tool, even though it is
+        // named in interruptingToolNames.
+        interruptingToolNames: new Set(['ask_user_question']),
+      });
+      const graph = buildGraph(node, [ASK]);
+      const config = { configurable: { thread_id: 'stub-stays-event' } };
+
+      const result = await graph.invoke({ messages: [] }, config);
+
+      // Dispatched to the host, NOT invoked in-process.
+      expect(directlyInvoked).not.toHaveBeenCalled();
+      const msg = (result as { messages: ToolMessage[] }).messages.find(
+        (m) => m instanceof ToolMessage
+      ) as ToolMessage;
+      expect(msg.status).toBe('success');
+      expect(String(msg.content)).toBe('HOST-HANDLED');
+    });
+  });
 });

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -458,6 +458,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /** Tool names that bypass event dispatch and execute directly (e.g., graph-managed handoff tools) */
   private directToolNames?: Set<string>;
   /**
+   * Tool names whose in-process body may raise a LangGraph `interrupt()`
+   * mid-execution (e.g. `ask_user_question`). Treated as direct (so the
+   * body actually runs in-process where `interrupt()` works) and, within
+   * a batch, scheduled ahead of non-interrupting direct siblings so a
+   * mid-body interrupt unwinds the ToolNode before a non-idempotent
+   * sibling executes — preventing the double side effect LangGraph's
+   * resume-time batch re-execution would otherwise cause. See
+   * {@link t.ToolNodeOptions.interruptingToolNames}.
+   */
+  private interruptingToolNames?: Set<string>;
+  /**
    * File checkpointer extracted from the local coding tool bundle when
    * `toolExecution.local.fileCheckpointing === true`. Exposed via
    * {@link getFileCheckpointer}. Undefined when checkpointing is off
@@ -518,6 +529,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     agentId,
     executingAgentId,
     directToolNames,
+    interruptingToolNames,
     codeSessionToolNames,
     maxContextTokens,
     maxToolResultChars,
@@ -556,6 +568,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // existing agentId option) still get attribution without knowing the new option.
     this.executingAgentId = executingAgentId ?? agentId;
     this.directToolNames = directToolNames;
+    this.interruptingToolNames =
+      interruptingToolNames != null && interruptingToolNames.size > 0
+        ? interruptingToolNames
+        : undefined;
     this.codeSessionToolNames =
       codeSessionToolNames != null && codeSessionToolNames.length > 0
         ? new Set(codeSessionToolNames)
@@ -3181,6 +3197,94 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
+   * Execute a group of direct (in-process) tool calls with interrupt-safe
+   * ordering, returning outputs aligned 1:1 with `directCalls`.
+   *
+   * Fast path (the common case): when no call in the group is in
+   * `interruptingToolNames`, this is a single `Promise.all` — byte-for-byte
+   * the prior behavior, so ordinary batches are unaffected.
+   *
+   * Interrupt-safe path: when the group contains an interrupting tool (e.g.
+   * `ask_user_question`, whose body raises a LangGraph `interrupt()` to
+   * collect a human answer), the interrupting calls run as their own awaited
+   * group **first**; only after they all settle without interrupting do the
+   * remaining (potentially non-idempotent) siblings run. If an interrupting
+   * call throws a `GraphInterrupt`, the `await` below rejects and unwinds the
+   * whole ToolNode *before* any non-interrupting sibling has started — so a
+   * sibling with real side effects (send_email, billing) never executes on
+   * the first pass. On the resume pass LangGraph re-runs the batch from the
+   * top; the interrupting tool resolves with the host's answer instead of
+   * throwing, and the siblings execute for the FIRST time, exactly once.
+   *
+   * Without this ordering, a flat `Promise.all` starts every sibling
+   * concurrently, so a non-idempotent sibling can complete its side effect
+   * before the interrupt unwinds and then run a SECOND time on resume — the
+   * duplicate side effect this method exists to prevent. Interrupting tools
+   * are expected to be side-effect-free (they only suspend), so running them
+   * as a group and re-running them on resume is harmless.
+   *
+   * `batchIndices[i]` is `directCalls[i]`'s position within the parent
+   * ToolNode batch (used for `{{tool<i>turn<n>}}` registration); it is
+   * preserved regardless of execution order. `baseContext` carries the
+   * batch-scoped fields every call shares; `batchIndex` is filled in
+   * per-call here.
+   */
+  private async runDirectBatchInterruptSafe(
+    directCalls: ToolCall[],
+    batchIndices: number[],
+    config: RunnableConfig,
+    baseContext: Omit<RunToolBatchContext<T>, 'batchIndex'>
+  ): Promise<(BaseMessage | Command)[]> {
+    const runOne = (
+      call: ToolCall,
+      position: number
+    ): Promise<BaseMessage | Command> =>
+      this.runDirectToolWithLifecycleHooks(call, config, {
+        ...baseContext,
+        batchIndex: batchIndices[position],
+      });
+
+    const interrupting = this.interruptingToolNames;
+    const hasInterrupting =
+      interrupting != null &&
+      directCalls.some((call) => interrupting.has(call.name));
+
+    if (!hasInterrupting) {
+      return Promise.all(directCalls.map((call, i) => runOne(call, i)));
+    }
+
+    const outputs: (BaseMessage | Command)[] = new Array(directCalls.length);
+    const interruptingPositions: number[] = [];
+    const regularPositions: number[] = [];
+    for (let i = 0; i < directCalls.length; i++) {
+      if (interrupting.has(directCalls[i].name)) {
+        interruptingPositions.push(i);
+      } else {
+        regularPositions.push(i);
+      }
+    }
+
+    // Interrupting group first. A GraphInterrupt here propagates out of the
+    // `await` before any regular sibling is dispatched below.
+    const interruptingOutputs = await Promise.all(
+      interruptingPositions.map((i) => runOne(directCalls[i], i))
+    );
+    interruptingPositions.forEach((i, k) => {
+      outputs[i] = interruptingOutputs[k];
+    });
+
+    // No interrupting call suspended — safe to run the remaining siblings.
+    const regularOutputs = await Promise.all(
+      regularPositions.map((i) => runOne(directCalls[i], i))
+    );
+    regularPositions.forEach((i, k) => {
+      outputs[i] = regularOutputs[k];
+    });
+
+    return outputs;
+  }
+
+  /**
    * Execute all tool calls via ON_TOOL_EXECUTE event dispatch.
    * Injected messages are placed AFTER ToolMessages to respect provider
    * message ordering (AIMessage tool_calls must be immediately followed
@@ -3235,6 +3339,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (this.isSendInput(input)) {
       const isLocalTool =
         this.directToolNames?.has(input.lg_tool_call.name) === true ||
+        this.interruptingToolNames?.has(input.lg_tool_call.name) === true ||
         this.shouldHandleUnknownHandoffLocally(input.lg_tool_call.name);
       if (this.eventDrivenMode && !isLocalTool) {
         return this.executeViaEvent([input.lg_tool_call], config, input, {
@@ -3355,6 +3460,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const entry = { call, batchIndex: i };
           if (
             directToolNames?.has(call.name) === true ||
+            this.interruptingToolNames?.has(call.name) === true ||
             this.shouldHandleUnknownHandoffLocally(
               call.name,
               hasRegisteredHandoffTool
@@ -3426,18 +3532,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directAdditionalContexts: string[] = [];
         const directOutputs: (BaseMessage | Command)[] =
           directCalls.length > 0
-            ? await Promise.all(
-              directCalls.map((call, i) =>
-                this.runDirectToolWithLifecycleHooks(call, config, {
-                  batchIndex: directIndices[i],
-                  turn,
-                  batchScopeId,
-                  resolvedArgsByCallId,
-                  preBatchSnapshot,
-                  additionalContextsSink: directAdditionalContexts,
-                  runInput: input as T,
-                })
-              )
+            ? await this.runDirectBatchInterruptSafe(
+              directCalls,
+              directIndices,
+              config,
+              {
+                turn,
+                batchScopeId,
+                resolvedArgsByCallId,
+                preBatchSnapshot,
+                additionalContextsSink: directAdditionalContexts,
+                runInput: input as T,
+              }
             )
             : [];
 
@@ -3491,18 +3597,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const preBatchSnapshot =
           this.toolOutputRegistry?.snapshot(batchScopeId);
         const directAdditionalContexts: string[] = [];
-        const toolOutputs = await Promise.all(
-          filteredCalls.map((call, i) =>
-            this.runDirectToolWithLifecycleHooks(call, config, {
-              batchIndex: i,
-              turn,
-              batchScopeId,
-              resolvedArgsByCallId,
-              preBatchSnapshot,
-              additionalContextsSink: directAdditionalContexts,
-              runInput: input as T,
-            })
-          )
+        const toolOutputs = await this.runDirectBatchInterruptSafe(
+          filteredCalls,
+          filteredCalls.map((_call, i) => i),
+          config,
+          {
+            turn,
+            batchScopeId,
+            resolvedArgsByCallId,
+            preBatchSnapshot,
+            additionalContextsSink: directAdditionalContexts,
+            runInput: input as T,
+          }
         );
         await this.handleRunToolCompletions(
           filteredCalls,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -459,13 +459,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private directToolNames?: Set<string>;
   /**
    * Tool names whose in-process body may raise a LangGraph `interrupt()`
-   * mid-execution (e.g. `ask_user_question`). Treated as direct (so the
-   * body actually runs in-process where `interrupt()` works) and, within
-   * a batch, scheduled ahead of non-interrupting direct siblings so a
-   * mid-body interrupt unwinds the ToolNode before a non-idempotent
-   * sibling executes — preventing the double side effect LangGraph's
-   * resume-time batch re-execution would otherwise cause. See
-   * {@link t.ToolNodeOptions.interruptingToolNames}.
+   * mid-execution (e.g. `ask_user_question`). Used only to REORDER within
+   * the direct group: a tool named here that is *already* direct (a real
+   * in-process graphTool — the only kind whose body can reach
+   * `interrupt()`) is scheduled ahead of its non-interrupting direct
+   * siblings, so a mid-body interrupt unwinds the ToolNode before a
+   * non-idempotent sibling executes and LangGraph's resume-time batch
+   * re-execution can't double it. This set is deliberately NOT folded
+   * into direct classification: a name that resolves to a schema-only
+   * event stub (an inherited `toolDefinition` with no executable
+   * instance) stays event-dispatched — forcing it direct would invoke
+   * the stub, which throws. See {@link t.ToolNodeOptions.interruptingToolNames}.
    */
   private interruptingToolNames?: Set<string>;
   /**
@@ -3339,7 +3343,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (this.isSendInput(input)) {
       const isLocalTool =
         this.directToolNames?.has(input.lg_tool_call.name) === true ||
-        this.interruptingToolNames?.has(input.lg_tool_call.name) === true ||
         this.shouldHandleUnknownHandoffLocally(input.lg_tool_call.name);
       if (this.eventDrivenMode && !isLocalTool) {
         return this.executeViaEvent([input.lg_tool_call], config, input, {
@@ -3460,7 +3463,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const entry = { call, batchIndex: i };
           if (
             directToolNames?.has(call.name) === true ||
-            this.interruptingToolNames?.has(call.name) === true ||
             this.shouldHandleUnknownHandoffLocally(
               call.name,
               hasRegisteredHandoffTool

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -295,6 +295,36 @@ export function isAskUserQuestionInterrupt(
  * an interrupt. This applies equally to direct tools (handoffs,
  * subagents) and to event tools.
  *
+ * ### Guarding non-idempotent siblings via `interruptingToolNames`
+ *
+ * The "must be idempotent" rule above is unavoidable in the general
+ * case, but the SDK can protect siblings against the one interrupt
+ * shape it can predict: a tool whose *body* raises `interrupt()`
+ * mid-execution — the `ask_user_question` shape, where the tool
+ * suspends the run to collect a human answer. Declare such tools in
+ * `RunConfig.interruptingToolNames`
+ * ({@link ToolNodeOptions.interruptingToolNames}) and the ToolNode
+ * schedules them, within each batch, **ahead of** their
+ * non-interrupting direct siblings. When one interrupts, the batch
+ * unwinds before any declared-safe sibling has run, so the sibling
+ * executes exactly once (on resume) instead of twice. Empirically:
+ *
+ *   - A **direct** sibling sharing the interrupter's in-process
+ *     `Promise.all` is the only shape that double-executes; declaring
+ *     the interrupter closes it.
+ *   - An **event-dispatched** sibling is already safe without any
+ *     config: the ToolNode awaits the whole direct group (where the
+ *     body interrupt unwinds) before it dispatches event tools, so a
+ *     dispatched sibling never runs on the first pass.
+ *
+ * This is a *scheduling* guard, not full resume idempotency: it only
+ * covers tools that interrupt from their own body and only protects
+ * siblings scheduled after them. It does not retroactively make a
+ * `PreToolUse` `'ask'` gate on tool B stop tool A (already executed)
+ * from re-running — unless B is itself declared interrupting, so it
+ * runs first. Tools with side effects should still be written
+ * idempotent as defense in depth.
+ *
  * ## Note on idempotency
  *
  * Same root cause as the resume re-execution above: LangGraph

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -325,6 +325,14 @@ export function isAskUserQuestionInterrupt(
  * runs first. Tools with side effects should still be written
  * idempotent as defense in depth.
  *
+ * The guard only REORDERS the direct group — declaring a name does not
+ * force it onto the direct path. The interrupting tool must already be a
+ * real in-process graphTool (the only kind whose body can reach
+ * `interrupt()`). A name that resolves to a schema-only event stub (an
+ * inherited `toolDefinition` with no executable instance, e.g. in a
+ * self-spawned child that scrubs `graphTools`) stays event-dispatched
+ * and the ordering is a no-op for it.
+ *
  * ## Note on idempotency
  *
  * Same root cause as the resume re-execution above: LangGraph

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -197,15 +197,21 @@ export type RunConfig = {
    * Names of host tools whose in-process body may raise a LangGraph
    * `interrupt()` mid-execution — the canonical example is an
    * `ask_user_question` tool that suspends the run to collect a human
-   * answer. Declaring a tool here does two things: it is always executed
-   * in-process (a body `interrupt()` only fires for a tool that runs inside
-   * the graph node, never for one dispatched to the host), and within a
-   * single tool-call batch it is scheduled **ahead of** its non-interrupting
-   * siblings. That ordering guarantees a mid-body interrupt unwinds the tool
-   * batch before a non-idempotent sibling (send_email, billing) executes, so
-   * the sibling cannot run once on the first pass and AGAIN when LangGraph
-   * re-runs the interrupted batch on resume. Host-declared so the SDK stays
-   * name-agnostic; omit to keep the prior (unguarded) behavior.
+   * answer. Within a single tool-call batch, a named tool that is a real
+   * in-process graphTool (the only kind whose body can reach `interrupt()`;
+   * graphTools are auto-marked direct) is scheduled **ahead of** its
+   * non-interrupting direct siblings. That ordering guarantees a mid-body
+   * interrupt unwinds the tool batch before a non-idempotent sibling
+   * (send_email, billing) executes, so the sibling cannot run once on the
+   * first pass and AGAIN when LangGraph re-runs the interrupted batch on
+   * resume.
+   *
+   * This only reorders the direct group — it does NOT force a name onto
+   * the direct path. A name that is only an inherited event `toolDefinition`
+   * (schema-only stub, e.g. in a self-spawned child) stays event-dispatched;
+   * the guard applies only to tools that are independently direct.
+   * Host-declared so the SDK stays name-agnostic; omit to keep the prior
+   * (unguarded) behavior.
    */
   interruptingToolNames?: string[];
   /**

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -194,6 +194,21 @@ export type RunConfig = {
    */
   codeSessionToolNames?: string[];
   /**
+   * Names of host tools whose in-process body may raise a LangGraph
+   * `interrupt()` mid-execution — the canonical example is an
+   * `ask_user_question` tool that suspends the run to collect a human
+   * answer. Declaring a tool here does two things: it is always executed
+   * in-process (a body `interrupt()` only fires for a tool that runs inside
+   * the graph node, never for one dispatched to the host), and within a
+   * single tool-call batch it is scheduled **ahead of** its non-interrupting
+   * siblings. That ordering guarantees a mid-body interrupt unwinds the tool
+   * batch before a non-idempotent sibling (send_email, billing) executes, so
+   * the sibling cannot run once on the first pass and AGAIN when LangGraph
+   * re-runs the interrupted batch on resume. Host-declared so the SDK stays
+   * name-agnostic; omit to keep the prior (unguarded) behavior.
+   */
+  interruptingToolNames?: string[];
+  /**
    * Selects the execution backend for built-in code tools. Omit this to keep
    * the remote LibreChat Code API sandbox. Set `{ engine: 'local' }` to run
    * code execution locally and auto-bind the local coding tool suite unless

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -111,19 +111,26 @@ export type ToolNodeOptions = {
   /**
    * Tool names whose in-process body may raise a LangGraph `interrupt()`
    * mid-execution — e.g. an `ask_user_question` tool that suspends the
-   * run to collect a human answer. Membership has two effects:
-   *   1. The tool is always executed in-process (folded into the direct
-   *      partition), since a body `interrupt()` only works for a tool
-   *      that runs inside the graph node — an event-dispatched tool
-   *      runs on the host and never reaches `interrupt()`.
-   *   2. Within a single tool-call batch, these tools are executed as
-   *      their own awaited group **before** their non-interrupting
-   *      direct siblings. If one interrupts, the ToolNode unwinds before
-   *      any sibling runs, so a non-idempotent sibling (send_email,
-   *      billing) cannot execute once on the first pass and AGAIN when
-   *      LangGraph re-runs the interrupted batch on resume.
+   * run to collect a human answer.
    *
-   * Opt-in and empty by default: when unset (or when no batch call
+   * Within a single tool-call batch, a named tool that is *already*
+   * direct (a real in-process graphTool — the only kind whose body can
+   * reach `interrupt()`; graphTools are auto-marked direct by the graph)
+   * is executed as its own awaited group **before** its non-interrupting
+   * direct siblings. If it interrupts, the ToolNode unwinds before any
+   * sibling runs, so a non-idempotent sibling (send_email, billing)
+   * cannot execute once on the first pass and AGAIN when LangGraph re-runs
+   * the interrupted batch on resume.
+   *
+   * This set only REORDERS the direct group; it does NOT promote a name
+   * into it. A name that resolves to a schema-only event stub (an
+   * inherited `toolDefinition` with no executable instance — e.g. in a
+   * self-spawned child that scrubs `graphTools`) stays event-dispatched.
+   * Forcing such a name direct would invoke the stub, which throws
+   * "should not be invoked directly in event-driven mode". For the guard
+   * to apply, the interrupting tool must independently be direct.
+   *
+   * Opt-in and empty by default: when unset (or when no direct batch call
    * matches), direct-batch execution is byte-for-byte unchanged. See the
    * "Resume re-execution" section of {@link HumanInTheLoopConfig} for the
    * batch re-execution contract this guards against.

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -108,6 +108,27 @@ export type ToolNodeOptions = {
   executingAgentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
+  /**
+   * Tool names whose in-process body may raise a LangGraph `interrupt()`
+   * mid-execution — e.g. an `ask_user_question` tool that suspends the
+   * run to collect a human answer. Membership has two effects:
+   *   1. The tool is always executed in-process (folded into the direct
+   *      partition), since a body `interrupt()` only works for a tool
+   *      that runs inside the graph node — an event-dispatched tool
+   *      runs on the host and never reaches `interrupt()`.
+   *   2. Within a single tool-call batch, these tools are executed as
+   *      their own awaited group **before** their non-interrupting
+   *      direct siblings. If one interrupts, the ToolNode unwinds before
+   *      any sibling runs, so a non-idempotent sibling (send_email,
+   *      billing) cannot execute once on the first pass and AGAIN when
+   *      LangGraph re-runs the interrupted batch on resume.
+   *
+   * Opt-in and empty by default: when unset (or when no batch call
+   * matches), direct-batch execution is byte-for-byte unchanged. See the
+   * "Resume re-execution" section of {@link HumanInTheLoopConfig} for the
+   * batch re-execution contract this guards against.
+   */
+  interruptingToolNames?: Set<string>;
   /** Opt-in eager execution for event-driven tool calls. */
   eagerEventToolExecution?: EagerEventToolExecutionConfig;
   /**


### PR DESCRIPTION
## Problem

A tool whose **body** raises a LangGraph `interrupt()` mid-execution — the `ask_user_question` shape, which suspends the run to collect a human answer — shares its in-process `Promise.all` with its sibling direct tools. When it interrupts, LangGraph's resume contract re-runs the whole interrupted node from the top, so a **non-idempotent sibling** (send_email, billing) that already completed on the first pass runs a **second time on resume**, duplicating the side effect.

This guards the double-execution Codex flagged on LibreChat **#14139** (`danny-avila/LibreChat#14139`, thread on `packages/api/src/agents/hitl/askUserQuestionTool.ts`). Unlike the tool-approval HITL path (which gates the batch in `PreToolUse` *before* any tool runs), `ask_user_question` interrupts *mid-batch*, so a sibling's side effect can already have landed before the pause.

## Empirical scoping (dist probe, not source-reading)

A runnable probe drove `[ask_user_question, side_effect]` through pause→resume against a real graph + `MemorySaver`, across batch shapes:

| Shape | Mode | sibling | Result (baseline) |
|---|---|---|---|
| all-direct | legacy | direct | **double (2×)** |
| direct+direct | event-driven | direct | **double (2×)** |
| ask(direct) + sibling(**event**) | event-driven | event | **safe (1×)** |

The exposure is **narrow**: only a sibling sharing the interrupter's in-process `Promise.all` double-executes. An event-dispatched sibling is already safe — the ToolNode awaits the whole direct group (where a body interrupt unwinds) *before* it dispatches event tools, so a dispatched sibling never runs on the first pass. Confirmed empirically: a direct tool body's `interrupt()` does suspend (no ALS-frame issue), and the double-execution is order-independent.

## Fix — schedule interrupting tools first (not idempotent resume)

Add an opt-in `RunConfig.interruptingToolNames` (threaded `Run → Graph → ToolNode`, mirroring `codeSessionToolNames`). Tools named there are:

1. **always executed in-process** — a body `interrupt()` only fires for a tool that runs inside the graph node, never for one dispatched to the host; and
2. within a batch, **scheduled as their own awaited group before** their non-interrupting direct siblings. If one interrupts, the batch unwinds before any sibling runs, so the sibling executes **exactly once** (on resume).

**Opt-out is byte-for-byte the prior behavior**: when the set is empty or no batch call matches, direct-batch execution is an unchanged single `Promise.all`.

Idempotent resume (the other candidate) was rejected: the completed sibling `ToolMessage`s aren't in graph state at interrupt time (the node hasn't returned), so it would require persisting per-call completion into checkpoint/store state — the exact machinery the tool-error-resume work took several rounds to stabilize — for a defect this narrow and prompt-mitigated. The scheduling guard stays entirely in execution order.

## Validation

- **New spec** `src/specs/ask-user-question-batch.test.ts` — pins `[ask_user_question, side_effect]` through pause→resume asserting the sibling runs **exactly once** (both orderings), plus the unguarded baseline (double) and the event-sibling-safe shape. Runs in-memory (`StateGraph` + `MemorySaver`), no LLM/Run machinery.
- **Dist probe** (`node -e` against `dist/cjs/main.cjs`, per the tool-error-resume convention): without the set the exposed direct shapes double-execute (2×); with it they run exactly once (1×), order-independent, in both modes; the event-dispatched sibling stays safe. ✅ all cases pass.
- Existing ToolNode batch/HITL suites (`directToolHITLResumeScope`, `directToolHooks`, `ToolNode.outputReferences`, `ToolNode.onResultCompletion`, `ToolNode.eagerEventExecution`, `toolOutputReferences`) — **112 passed, 0 regressions**. Typecheck + ESLint clean.

## Host wiring

The host opts in by passing the `ask_user_question` tool name in `RunConfig.interruptingToolNames`. The `HumanInTheLoopConfig` JSDoc (which previously documented sibling re-execution as an unavoidable "must be idempotent" contract) is updated to describe the guard and its precise scope.