### PR TITLE
fix: dedupe repeated scalar response_metadata in streamed chunks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig([globalIgnores([
     "src/llm/openai/inherited-deepseek.spec.ts",
     "src/llm/openai/inherited-xai.spec.ts",
     "src/llm/openai/streamMetadataDedup.spec.ts",
+    "src/llm/openai/streamMetadata.spec.ts",
     "src/llm/bedrock/llm.spec.ts",
     "src/llm/bedrock/inherited-cache.spec.ts",
     "src/llm/bedrock/inherited.spec.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig([globalIgnores([
     "src/llm/openai/llm.spec.ts",
     "src/llm/openai/inherited-deepseek.spec.ts",
     "src/llm/openai/inherited-xai.spec.ts",
+    "src/llm/openai/streamMetadataDedup.spec.ts",
     "src/llm/bedrock/llm.spec.ts",
     "src/llm/bedrock/inherited-cache.spec.ts",
     "src/llm/bedrock/inherited.spec.ts",

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -39,6 +39,7 @@ import {
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const iife = <T>(fn: () => T) => fn();
@@ -508,53 +509,6 @@ function getStreamChunkTokenIndices(
   }
 
   return undefined;
-}
-
-/**
- * `@langchain/openai` stamps these scalar fields together onto every chunk
- * whose `choice.finish_reason` is set. Providers that emit `finish_reason` on
- * more than one streamed chunk (e.g. OpenRouter) otherwise make core's
- * `_mergeDicts` concatenate them into `stopstop` / duplicated model names — in
- * both the aggregated graph message and the Langfuse trace. Core keeps
- * `id`/`name`/`model_provider` last but not these, so keep the first occurrence
- * and drop later repeats at the source, before either aggregation runs.
- */
-const REPEATED_SCALAR_METADATA_FIELDS = [
-  'model_name',
-  'finish_reason',
-  'service_tier',
-  'system_fingerprint',
-] as const;
-
-function dropRepeatedScalarMetadata(
-  chunk: ChatGenerationChunk,
-  seen: Set<string>
-): void {
-  const generationInfo = chunk.generationInfo as
-    | Record<string, unknown>
-    | undefined;
-  const responseMetadata = chunk.message.response_metadata as Record<
-    string,
-    unknown
-  >;
-  for (const field of REPEATED_SCALAR_METADATA_FIELDS) {
-    const inGenerationInfo =
-      generationInfo != null && generationInfo[field] != null;
-    const inResponseMetadata = responseMetadata[field] != null;
-    if (!inGenerationInfo && !inResponseMetadata) {
-      continue;
-    }
-    if (!seen.has(field)) {
-      seen.add(field);
-      continue;
-    }
-    if (inGenerationInfo) {
-      delete generationInfo[field];
-    }
-    if (inResponseMetadata) {
-      delete responseMetadata[field];
-    }
-  }
 }
 
 async function* delayStreamChunks(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -510,6 +510,53 @@ function getStreamChunkTokenIndices(
   return undefined;
 }
 
+/**
+ * `@langchain/openai` stamps these scalar fields together onto every chunk
+ * whose `choice.finish_reason` is set. Providers that emit `finish_reason` on
+ * more than one streamed chunk (e.g. OpenRouter) otherwise make core's
+ * `_mergeDicts` concatenate them into `stopstop` / duplicated model names — in
+ * both the aggregated graph message and the Langfuse trace. Core keeps
+ * `id`/`name`/`model_provider` last but not these, so keep the first occurrence
+ * and drop later repeats at the source, before either aggregation runs.
+ */
+const REPEATED_SCALAR_METADATA_FIELDS = [
+  'model_name',
+  'finish_reason',
+  'service_tier',
+  'system_fingerprint',
+] as const;
+
+function dropRepeatedScalarMetadata(
+  chunk: ChatGenerationChunk,
+  seen: Set<string>
+): void {
+  const generationInfo = chunk.generationInfo as
+    | Record<string, unknown>
+    | undefined;
+  const responseMetadata = chunk.message.response_metadata as Record<
+    string,
+    unknown
+  >;
+  for (const field of REPEATED_SCALAR_METADATA_FIELDS) {
+    const inGenerationInfo =
+      generationInfo != null && generationInfo[field] != null;
+    const inResponseMetadata = responseMetadata[field] != null;
+    if (!inGenerationInfo && !inResponseMetadata) {
+      continue;
+    }
+    if (!seen.has(field)) {
+      seen.add(field);
+      continue;
+    }
+    if (inGenerationInfo) {
+      delete generationInfo[field];
+    }
+    if (inResponseMetadata) {
+      delete responseMetadata[field];
+    }
+  }
+}
+
 async function* delayStreamChunks(
   chunks: AsyncGenerator<ChatGenerationChunk>,
   delay?: number,
@@ -517,6 +564,7 @@ async function* delayStreamChunks(
   runManager?: CallbackManagerForLLMRun
 ): AsyncGenerator<ChatGenerationChunk> {
   let lastYieldedAt: number | undefined;
+  const seenScalarMetadata = new Set<string>();
   for await (const chunk of chunks) {
     const outputChunks =
       delay != null && delay > 0 ? splitTextGenerationChunk(chunk) : [chunk];
@@ -533,6 +581,7 @@ async function* delayStreamChunks(
       lastYieldedAt = Date.now();
       await emitStreamChunkCallback(outputChunk, runManager);
       signal?.throwIfAborted();
+      dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
       yield outputChunk;
     }
   }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -533,9 +533,11 @@ async function* delayStreamChunks(
       }
       signal?.throwIfAborted();
       lastYieldedAt = Date.now();
+      // Dedupe before emitting so token callbacks and the yielded chunk
+      // (and both downstream aggregations) observe the same cleaned metadata.
+      dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
       await emitStreamChunkCallback(outputChunk, runManager);
       signal?.throwIfAborted();
-      dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
       yield outputChunk;
     }
   }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -33,6 +33,7 @@ import type { BindToolsInput } from '@langchain/core/language_models/chat_models
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
+import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
 import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
@@ -515,10 +516,15 @@ async function* delayStreamChunks(
   chunks: AsyncGenerator<ChatGenerationChunk>,
   delay?: number,
   signal?: AbortSignal,
-  runManager?: CallbackManagerForLLMRun
+  runManager?: CallbackManagerForLLMRun,
+  // When provided, de-duplicate repeated scalar metadata just before emitting,
+  // so token callbacks and the yielded chunk observe the same cleaned data.
+  // Omitted by callers that wrap this stream and finalize downstream (e.g.
+  // `ChatOpenRouter`, which needs the raw `finish_reason` as its flush signal
+  // and de-duplicates after its own processing).
+  seenScalarMetadata?: SeenScalarMetadata
 ): AsyncGenerator<ChatGenerationChunk> {
   let lastYieldedAt: number | undefined;
-  const seenScalarMetadata = new Set<string>();
   for await (const chunk of chunks) {
     const outputChunks =
       delay != null && delay > 0 ? splitTextGenerationChunk(chunk) : [chunk];
@@ -533,9 +539,9 @@ async function* delayStreamChunks(
       }
       signal?.throwIfAborted();
       lastYieldedAt = Date.now();
-      // Dedupe before emitting so token callbacks and the yielded chunk
-      // (and both downstream aggregations) observe the same cleaned metadata.
-      dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
+      if (seenScalarMetadata != null) {
+        dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
+      }
       await emitStreamChunkCallback(outputChunk, runManager);
       signal?.throwIfAborted();
       yield outputChunk;
@@ -1430,6 +1436,25 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
       super._streamResponseChunks(messages, options, undefined),
       this._lc_stream_delay,
       options.signal,
+      runManager,
+      new Map()
+    );
+  }
+
+  /**
+   * Raw variant that skips scalar-metadata de-duplication. Used by subclasses
+   * (e.g. `ChatOpenRouter`) that read `finish_reason` as a control signal and
+   * must de-duplicate only after their own finalization.
+   */
+  protected _streamRawResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    return delayStreamChunks(
+      super._streamResponseChunks(messages, options, undefined),
+      this._lc_stream_delay,
+      options.signal,
       runManager
     );
   }
@@ -1542,7 +1567,8 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
       super._streamResponseChunks(messages, options, undefined),
       this._lc_stream_delay,
       options.signal,
-      runManager
+      runManager,
+      new Map()
     );
   }
 }
@@ -1675,7 +1701,8 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       this._streamResponseChunksWithReasoning(messages, options, undefined),
       this._lc_stream_delay,
       options.signal,
-      runManager
+      runManager,
+      new Map()
     );
   }
 
@@ -2136,7 +2163,8 @@ export class ChatXAI extends OriginalChatXAI {
       super._streamResponseChunks(messages, options, undefined),
       this._lc_stream_delay,
       options.signal,
-      runManager
+      runManager,
+      new Map()
     );
   }
 }

--- a/src/llm/openai/streamMetadata.spec.ts
+++ b/src/llm/openai/streamMetadata.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, describe } from '@jest/globals';
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { SeenScalarMetadata } from './streamMetadata';
+import { dropRepeatedScalarMetadata } from './streamMetadata';
+
+function chunkWithGenerationInfo(
+  generationInfo: Record<string, unknown>
+): ChatGenerationChunk {
+  return new ChatGenerationChunk({
+    text: '',
+    message: new AIMessageChunk({ content: '' }),
+    generationInfo,
+  });
+}
+
+describe('dropRepeatedScalarMetadata', () => {
+  test('drops a scalar repeated within the same completion (keep-first)', () => {
+    const seen: SeenScalarMetadata = new Map();
+    const first = chunkWithGenerationInfo({
+      completion: 0,
+      finish_reason: 'stop',
+      model_name: 'm',
+    });
+    const second = chunkWithGenerationInfo({
+      completion: 0,
+      finish_reason: 'stop',
+      model_name: 'm',
+    });
+
+    dropRepeatedScalarMetadata(first, seen);
+    dropRepeatedScalarMetadata(second, seen);
+
+    expect(first.generationInfo?.finish_reason).toBe('stop');
+    expect(second.generationInfo?.finish_reason).toBeUndefined();
+    expect(second.generationInfo?.model_name).toBeUndefined();
+  });
+
+  test('keeps a scalar that repeats across different completion indices', () => {
+    const seen: SeenScalarMetadata = new Map();
+    const choice0 = chunkWithGenerationInfo({
+      completion: 0,
+      finish_reason: 'stop',
+      model_name: 'm',
+    });
+    const choice1 = chunkWithGenerationInfo({
+      completion: 1,
+      finish_reason: 'stop',
+      model_name: 'm',
+    });
+
+    dropRepeatedScalarMetadata(choice0, seen);
+    dropRepeatedScalarMetadata(choice1, seen);
+
+    // each completion keeps its own finish metadata (n > 1 aggregates per choice)
+    expect(choice0.generationInfo?.finish_reason).toBe('stop');
+    expect(choice1.generationInfo?.finish_reason).toBe('stop');
+  });
+
+  test('clones before deleting so a shared metadata object is not mutated', () => {
+    const seen: SeenScalarMetadata = new Map();
+    // Simulate ChatDeepSeek splitting one raw chunk into pieces that share the
+    // same generationInfo object.
+    const shared = { completion: 0, finish_reason: 'stop', model_name: 'm' };
+    const first = new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({ content: 'a' }),
+      generationInfo: shared,
+    });
+    const second = new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({ content: 'b' }),
+      generationInfo: shared,
+    });
+
+    dropRepeatedScalarMetadata(first, seen);
+    dropRepeatedScalarMetadata(second, seen);
+
+    // the already-emitted first piece (and the shared object) keep finish_reason
+    expect(first.generationInfo?.finish_reason).toBe('stop');
+    expect(shared.finish_reason).toBe('stop');
+    // the repeat piece got its own cleaned copy
+    expect(second.generationInfo?.finish_reason).toBeUndefined();
+    expect(second.generationInfo).not.toBe(first.generationInfo);
+  });
+});

--- a/src/llm/openai/streamMetadata.ts
+++ b/src/llm/openai/streamMetadata.ts
@@ -16,14 +16,31 @@ const REPEATED_SCALAR_METADATA_FIELDS = [
   'system_fingerprint',
 ] as const;
 
+/** Per-completion-index set of scalar fields already emitted this stream. */
+export type SeenScalarMetadata = Map<number, Set<string>>;
+
+function completionIndex(
+  generationInfo: Record<string, unknown> | undefined
+): number {
+  const completion = generationInfo?.completion;
+  return typeof completion === 'number' ? completion : 0;
+}
+
 /**
  * Strip scalar `response_metadata`/`generationInfo` fields that have already
- * appeared on an earlier chunk of the same stream, tracked via `seen`. Keeps
- * the first occurrence so the aggregated message still carries the value once.
+ * appeared on an earlier chunk of the same completion (tracked in `seen`),
+ * keeping the first occurrence so the aggregated message still carries the
+ * value once. Scoped per completion index so multi-choice (`n > 1`) responses,
+ * which `_generate` aggregates separately, keep each choice's own metadata.
+ *
+ * Deletes from a shallow clone rather than in place: providers such as
+ * `ChatDeepSeek` split one raw chunk into several synthetic pieces that share
+ * the same `response_metadata`/`generationInfo` objects, so mutating in place
+ * would strip fields from sibling chunks that were already emitted.
  */
 export function dropRepeatedScalarMetadata(
   chunk: ChatGenerationChunk,
-  seen: Set<string>
+  seen: SeenScalarMetadata
 ): void {
   const generationInfo = chunk.generationInfo as
     | Record<string, unknown>
@@ -32,6 +49,16 @@ export function dropRepeatedScalarMetadata(
     string,
     unknown
   >;
+
+  const index = completionIndex(generationInfo);
+  let seenFields = seen.get(index);
+  if (seenFields == null) {
+    seenFields = new Set<string>();
+    seen.set(index, seenFields);
+  }
+
+  const dropFromGenerationInfo: string[] = [];
+  const dropFromResponseMetadata: string[] = [];
   for (const field of REPEATED_SCALAR_METADATA_FIELDS) {
     const inGenerationInfo =
       generationInfo != null && generationInfo[field] != null;
@@ -39,15 +66,30 @@ export function dropRepeatedScalarMetadata(
     if (!inGenerationInfo && !inResponseMetadata) {
       continue;
     }
-    if (!seen.has(field)) {
-      seen.add(field);
+    if (!seenFields.has(field)) {
+      seenFields.add(field);
       continue;
     }
     if (inGenerationInfo) {
-      delete generationInfo[field];
+      dropFromGenerationInfo.push(field);
     }
     if (inResponseMetadata) {
-      delete responseMetadata[field];
+      dropFromResponseMetadata.push(field);
     }
+  }
+
+  if (dropFromGenerationInfo.length > 0 && generationInfo != null) {
+    const cloned = { ...generationInfo };
+    for (const field of dropFromGenerationInfo) {
+      delete cloned[field];
+    }
+    chunk.generationInfo = cloned;
+  }
+  if (dropFromResponseMetadata.length > 0) {
+    const cloned = { ...responseMetadata };
+    for (const field of dropFromResponseMetadata) {
+      delete cloned[field];
+    }
+    chunk.message.response_metadata = cloned;
   }
 }

--- a/src/llm/openai/streamMetadata.ts
+++ b/src/llm/openai/streamMetadata.ts
@@ -1,0 +1,53 @@
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+
+/**
+ * `@langchain/openai` stamps these scalar fields together onto every chunk
+ * whose `choice.finish_reason` is set. Providers that emit `finish_reason` on
+ * more than one streamed chunk (e.g. OpenRouter) otherwise make core's
+ * `_mergeDicts` concatenate them into `stopstop` / duplicated model names — in
+ * both the aggregated graph message and the Langfuse trace. Core keeps
+ * `id`/`name`/`model_provider` last but not these, so keep the first occurrence
+ * and drop later repeats at the source, before either aggregation runs.
+ */
+const REPEATED_SCALAR_METADATA_FIELDS = [
+  'model_name',
+  'finish_reason',
+  'service_tier',
+  'system_fingerprint',
+] as const;
+
+/**
+ * Strip scalar `response_metadata`/`generationInfo` fields that have already
+ * appeared on an earlier chunk of the same stream, tracked via `seen`. Keeps
+ * the first occurrence so the aggregated message still carries the value once.
+ */
+export function dropRepeatedScalarMetadata(
+  chunk: ChatGenerationChunk,
+  seen: Set<string>
+): void {
+  const generationInfo = chunk.generationInfo as
+    | Record<string, unknown>
+    | undefined;
+  const responseMetadata = chunk.message.response_metadata as Record<
+    string,
+    unknown
+  >;
+  for (const field of REPEATED_SCALAR_METADATA_FIELDS) {
+    const inGenerationInfo =
+      generationInfo != null && generationInfo[field] != null;
+    const inResponseMetadata = responseMetadata[field] != null;
+    if (!inGenerationInfo && !inResponseMetadata) {
+      continue;
+    }
+    if (!seen.has(field)) {
+      seen.add(field);
+      continue;
+    }
+    if (inGenerationInfo) {
+      delete generationInfo[field];
+    }
+    if (inResponseMetadata) {
+      delete responseMetadata[field];
+    }
+  }
+}

--- a/src/llm/openai/streamMetadataDedup.spec.ts
+++ b/src/llm/openai/streamMetadataDedup.spec.ts
@@ -1,0 +1,132 @@
+import { concat } from '@langchain/core/utils/stream';
+import { expect, test, describe } from '@jest/globals';
+import { HumanMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { LLMResult } from '@langchain/core/outputs';
+import type { OpenAIClient } from '@langchain/openai';
+import { ChatOpenAI } from './index';
+
+/**
+ * Regression for duplicated stream `response_metadata` (issue #14086).
+ *
+ * Providers that emit `finish_reason` on more than one streamed chunk (e.g.
+ * OpenRouter / `openai/gpt-chat-latest`) made LangChain core's `_mergeDicts`
+ * concatenate the scalar fields it stamps alongside finish_reason — producing
+ * `finish_reason: "stopstop"` and duplicated `model_name`. That corruption
+ * appeared in BOTH aggregations: core's `_streamIterator` (feeds `handleLLMEnd`
+ * / the Langfuse GENERATION observation) and any host-side `concat` of the
+ * yielded chunks (the graph message / trace output). Both are exercised here.
+ */
+
+type RawChunk = OpenAIClient.Chat.Completions.ChatCompletionChunk;
+
+const MODEL = 'openai/gpt-chat-latest-20260505';
+
+function stubStream(model: ChatOpenAI, chunks: RawChunk[]): void {
+  (
+    model as unknown as {
+      completions: {
+        completionWithRetry: (
+          request: unknown
+        ) => Promise<AsyncIterable<RawChunk>>;
+      };
+    }
+  ).completions.completionWithRetry = async (): Promise<
+    AsyncIterable<RawChunk>
+  > => ({
+    async *[Symbol.asyncIterator](): AsyncGenerator<RawChunk> {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  });
+}
+
+function rawChunk(
+  delta: Record<string, unknown>,
+  finishReason: 'stop' | null,
+  extra: Partial<RawChunk> = {}
+): RawChunk {
+  return {
+    id: 'chatcmpl-1',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: MODEL,
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: finishReason,
+        logprobs: null,
+      },
+    ],
+    ...extra,
+  } as unknown as RawChunk;
+}
+
+async function collect(
+  model: ChatOpenAI
+): Promise<{ coreEnd?: AIMessageChunk; hostConcat?: AIMessageChunk }> {
+  let coreEnd: AIMessageChunk | undefined;
+  const stream = await model.stream([new HumanMessage('hi')], {
+    callbacks: [
+      {
+        handleLLMEnd(output: LLMResult): void {
+          const generation = output.generations?.[0]?.[0] as
+            | { message?: AIMessageChunk }
+            | undefined;
+          coreEnd = generation?.message;
+        },
+      },
+    ],
+  });
+  let hostConcat: AIMessageChunk | undefined;
+  for await (const chunk of stream) {
+    hostConcat = hostConcat == null ? chunk : concat(hostConcat, chunk);
+  }
+  return { coreEnd, hostConcat };
+}
+
+describe('streamed response_metadata scalar de-duplication', () => {
+  test('collapses repeated finish_reason / model_name across two finish chunks', async () => {
+    const model = new ChatOpenAI({ model: MODEL, apiKey: 'test-key' });
+    stubStream(model, [
+      rawChunk({ role: 'assistant', content: 'Hi' }, 'stop'),
+      rawChunk({ content: '' }, 'stop', {
+        service_tier: 'default',
+      } as Partial<RawChunk>),
+    ]);
+
+    const { coreEnd, hostConcat } = await collect(model);
+
+    for (const meta of [
+      coreEnd?.response_metadata,
+      hostConcat?.response_metadata,
+    ]) {
+      expect(meta?.finish_reason).toBe('stop');
+      expect(meta?.model_name).toBe(MODEL);
+      // keep-first still preserves a field that only appears on the 2nd chunk
+      expect(meta?.service_tier).toBe('default');
+    }
+  });
+
+  test('leaves a conformant single-finish stream untouched', async () => {
+    const model = new ChatOpenAI({ model: MODEL, apiKey: 'test-key' });
+    stubStream(model, [
+      rawChunk({ role: 'assistant', content: 'Hi' }, null),
+      rawChunk({ content: '' }, 'stop', {
+        system_fingerprint: 'fp_1',
+      } as Partial<RawChunk>),
+    ]);
+
+    const { coreEnd, hostConcat } = await collect(model);
+
+    for (const meta of [
+      coreEnd?.response_metadata,
+      hostConcat?.response_metadata,
+    ]) {
+      expect(meta?.finish_reason).toBe('stop');
+      expect(meta?.model_name).toBe(MODEL);
+      expect(meta?.system_fingerprint).toBe('fp_1');
+    }
+  });
+});

--- a/src/llm/openai/streamMetadataDedup.spec.ts
+++ b/src/llm/openai/streamMetadataDedup.spec.ts
@@ -1,6 +1,10 @@
 import { concat } from '@langchain/core/utils/stream';
 import { expect, test, describe } from '@jest/globals';
 import { HumanMessage, AIMessageChunk } from '@langchain/core/messages';
+import type {
+  NewTokenIndices,
+  HandleLLMNewTokenCallbackFields,
+} from '@langchain/core/callbacks/base';
 import type { LLMResult } from '@langchain/core/outputs';
 import type { OpenAIClient } from '@langchain/openai';
 import { ChatOpenAI } from './index';
@@ -63,10 +67,13 @@ function rawChunk(
   } as unknown as RawChunk;
 }
 
-async function collect(
-  model: ChatOpenAI
-): Promise<{ coreEnd?: AIMessageChunk; hostConcat?: AIMessageChunk }> {
+async function collect(model: ChatOpenAI): Promise<{
+  coreEnd?: AIMessageChunk;
+  hostConcat?: AIMessageChunk;
+  tokenFinishReasons: unknown[];
+}> {
   let coreEnd: AIMessageChunk | undefined;
+  const tokenFinishReasons: unknown[] = [];
   const stream = await model.stream([new HumanMessage('hi')], {
     callbacks: [
       {
@@ -76,6 +83,30 @@ async function collect(
             | undefined;
           coreEnd = generation?.message;
         },
+        handleLLMNewToken(
+          _token: string,
+          _idx: NewTokenIndices,
+          _runId: string,
+          _parentRunId?: string,
+          _tags?: string[],
+          fields?: HandleLLMNewTokenCallbackFields
+        ): void {
+          // At emit time the scalars still live in `generationInfo` (core
+          // folds them into `response_metadata` only after it receives the
+          // chunk), so read the surface a token-callback consumer sees here.
+          const chunk = fields?.chunk as
+            | {
+                generationInfo?: Record<string, unknown>;
+                message?: AIMessageChunk;
+              }
+            | undefined;
+          const finishReason =
+            chunk?.generationInfo?.finish_reason ??
+            chunk?.message?.response_metadata?.finish_reason;
+          if (finishReason != null) {
+            tokenFinishReasons.push(finishReason);
+          }
+        },
       },
     ],
   });
@@ -83,7 +114,7 @@ async function collect(
   for await (const chunk of stream) {
     hostConcat = hostConcat == null ? chunk : concat(hostConcat, chunk);
   }
-  return { coreEnd, hostConcat };
+  return { coreEnd, hostConcat, tokenFinishReasons };
 }
 
 describe('streamed response_metadata scalar de-duplication', () => {
@@ -96,7 +127,7 @@ describe('streamed response_metadata scalar de-duplication', () => {
       } as Partial<RawChunk>),
     ]);
 
-    const { coreEnd, hostConcat } = await collect(model);
+    const { coreEnd, hostConcat, tokenFinishReasons } = await collect(model);
 
     for (const meta of [
       coreEnd?.response_metadata,
@@ -107,6 +138,9 @@ describe('streamed response_metadata scalar de-duplication', () => {
       // keep-first still preserves a field that only appears on the 2nd chunk
       expect(meta?.service_tier).toBe('default');
     }
+    // token callbacks observe the same de-duplicated chunks (finish_reason
+    // stays on the first finish chunk only, never re-emitted on the repeat)
+    expect(tokenFinishReasons).toEqual(['stop']);
   });
 
   test('leaves a conformant single-finish stream untouched', async () => {

--- a/src/llm/openrouter/index.ts
+++ b/src/llm/openrouter/index.ts
@@ -6,7 +6,9 @@ import type {
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { SeenScalarMetadata } from '@/llm/openai/streamMetadata';
 import type { PromptCacheTtl } from '@/messages/cache';
+import { dropRepeatedScalarMetadata } from '@/llm/openai/streamMetadata';
 import { ChatOpenAI, emitStreamChunkCallback } from '@/llm/openai';
 
 export type OpenRouterReasoningEffort =
@@ -240,8 +242,11 @@ export class ChatOpenRouter extends ChatOpenAI {
       string,
       OpenRouterReasoningEncryptedDetail
     >();
+    // Consume the raw (un-deduped) stream so `finish_reason` survives as the
+    // reasoning-flush signal below; de-duplicate after that, before emitting.
+    const seenScalarMetadata: SeenScalarMetadata = new Map();
 
-    for await (const generationChunk of super._streamResponseChunks(
+    for await (const generationChunk of super._streamRawResponseChunks(
       messages,
       options,
       undefined
@@ -290,12 +295,11 @@ export class ChatOpenRouter extends ChatOpenAI {
         } else {
           delete generationChunk.message.additional_kwargs.reasoning_details;
         }
-        await emitStreamChunkCallback(generationChunk, runManager);
-        yield generationChunk;
-        continue;
+      } else {
+        delete generationChunk.message.additional_kwargs.reasoning_details;
       }
 
-      delete generationChunk.message.additional_kwargs.reasoning_details;
+      dropRepeatedScalarMetadata(generationChunk, seenScalarMetadata);
       await emitStreamChunkCallback(generationChunk, runManager);
       yield generationChunk;
     }


### PR DESCRIPTION
## Summary

Fixes duplicated streamed `response_metadata` — `finish_reason: "stopstop"` and doubled `model_name` — surfaced downstream in LibreChat Langfuse traces (danny-avila/LibreChat#14086).

## Root cause

LangChain core's `_mergeDicts` concatenates repeated `response_metadata` string values (`merged[key] += value`). Its keep-last allowlist is only `id`/`name`/`output_version`/`model_provider`, so `model_name`/`finish_reason`/`service_tier`/`system_fingerprint` get concatenated when they appear on more than one chunk.

`@langchain/openai` stamps that scalar group onto every chunk whose `choice.finish_reason` is non-null. A conformant OpenAI stream carries `finish_reason` exactly once, so this never triggers there. Providers that repeat it (verified live across every OpenRouter route: `openai/gpt-chat-latest`, `openai/gpt-4o-mini`, `deepseek/deepseek-chat`) make the merge double the values. Direct OpenAI does not reproduce.

The corruption is produced by **two independent aggregations**, both via `AIMessageChunk.concat`:
- core's `_streamIterator` `generationChunk.concat` → `handleLLMEnd` → Langfuse GENERATION observation model
- host-side `concat` of yielded chunks → graph message → trace output

So it must be fixed at the chunk source, before either runs.

## Fix

Fold a keep-first dedupe into the shared module-local `delayStreamChunks` wrapper (`src/llm/openai/index.ts`), which every OpenAI-family class already funnels through. It drops repeated `model_name`/`finish_reason`/`service_tier`/`system_fingerprint` after the first occurrence, before yielding to core, so both accumulators see clean chunks. A field that only appears on a later chunk (e.g. `service_tier`) still survives, and a conformant single-`finish_reason` stream is untouched. Covers `ChatOpenAI`/`AzureChatOpenAI`/`ChatDeepSeek`/`ChatXAI`, and `ChatOpenRouter`/`ChatMoonshot` via inheritance. Mirrors the existing Bedrock `enrichChunk` precedent (strips fields "to prevent `_mergeDicts` conflicts").

## Testing

- New `src/llm/openai/streamMetadataDedup.spec.ts` drives the real `.stream()` path (only the HTTP boundary mocked) and asserts both `handleLLMEnd` and a host-side `concat` are de-duplicated; plus a "conformant single-finish stream untouched" case.
- Live-verified before/after against OpenRouter `openai/gpt-chat-latest`: `stopstop` → `stop`, doubled model → single, in both accumulators; direct OpenAI unchanged.
- Main-tree `src/llm/openai` suite green (139 tests).