### PR TITLE
🎚️ fix: Calibrate Context Pruning From Last-Call Usage, Not Accumulated Cache Reads

### DIFF
--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -135,9 +135,10 @@ export type PruneMessagesParams = {
   usageMetadata?: Partial<UsageMetadata>;
   startType?: ReturnType<BaseMessage['getType']>;
   /**
-   * Usage from the most recent LLM call only (not accumulated).
-   * When provided, calibration uses this instead of usageMetadata
-   * to avoid inflated ratios from N×cacheRead accumulation.
+   * Fallback usage from the most recent LLM call only (not accumulated).
+   * Calibration prefers the provider's raw `usageMetadata.input_tokens`
+   * when available, because cache detail fields may use non-window
+   * accounting units.
    */
   lastCallUsage?: {
     totalTokens: number;
@@ -1436,8 +1437,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // no per-turn oscillation, no map mutation.
     if (currentUsage && params.totalTokensFresh !== false) {
       const instructionOverhead = factoryParams.getInstructionTokens?.() ?? 0;
-      const providerInputTokens =
-        params.lastCallUsage?.inputTokens ?? currentUsage.input_tokens;
+      const rawProviderInputTokens = Number(params.usageMetadata?.input_tokens);
+      const providerInputTokens = checkValidNumber(rawProviderInputTokens)
+        ? rawProviderInputTokens
+        : (params.lastCallUsage?.inputTokens ?? currentUsage.input_tokens);
 
       // Sum raw tiktoken counts for messages the provider saw (excludes
       // new outputs from this turn — the provider hasn't seen them yet).
@@ -1458,8 +1461,20 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         0,
         providerInputTokens - instructionOverhead
       );
+      const minimumComparableInputTokens =
+        instructionOverhead + rawSentThisTurn * CALIBRATION_RATIO_MIN;
+      let calibrationSkipReason: string | undefined;
+      if (rawSentThisTurn <= 0) {
+        calibrationSkipReason = 'no_sent_messages';
+      } else if (providerMessageTokens <= 0) {
+        calibrationSkipReason = 'input_below_instruction_overhead';
+      } else if (providerInputTokens < minimumComparableInputTokens) {
+        calibrationSkipReason = 'input_below_calibration_floor';
+      } else if (providerInputTokens > factoryParams.maxTokens) {
+        calibrationSkipReason = 'input_exceeds_context_window';
+      }
 
-      if (rawSentThisTurn > 0 && providerMessageTokens > 0) {
+      if (calibrationSkipReason == null) {
         cumulativeRawSent += rawSentThisTurn;
         cumulativeProviderReported += providerMessageTokens;
         const newRatio = cumulativeProviderReported / cumulativeRawSent;
@@ -1467,33 +1482,44 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           CALIBRATION_RATIO_MIN,
           Math.min(CALIBRATION_RATIO_MAX, newRatio)
         );
+
+        const calibratedOurTotal =
+          instructionOverhead + rawSentThisTurn * calibrationRatio;
+        const overallRatio =
+          calibratedOurTotal > 0 ? providerInputTokens / calibratedOurTotal : 0;
+        const variancePct = Math.round((overallRatio - 1) * 100);
+
+        const absVariance = Math.abs(overallRatio - 1);
+        if (absVariance < bestVarianceAbs) {
+          bestVarianceAbs = absVariance;
+          bestInstructionOverhead = Math.max(
+            0,
+            Math.round(providerInputTokens - rawSentThisTurn * calibrationRatio)
+          );
+          bestInstructionEstimate = factoryParams.getInstructionTokens?.() ?? 0;
+        }
+
+        factoryParams.log?.('debug', 'Calibration observed', {
+          providerInputTokens,
+          calibratedEstimate: Math.round(calibratedOurTotal),
+          variance: `${variancePct > 0 ? '+' : ''}${variancePct}%`,
+          calibrationRatio: Math.round(calibrationRatio * 100) / 100,
+          instructionOverhead,
+          cumulativeRawSent,
+          cumulativeProviderReported,
+        });
+      } else {
+        factoryParams.log?.('debug', 'Calibration skipped', {
+          reason: calibrationSkipReason,
+          providerInputTokens,
+          minimumComparableInputTokens: Math.round(
+            minimumComparableInputTokens
+          ),
+          maxContextTokens: factoryParams.maxTokens,
+          rawSentThisTurn,
+          instructionOverhead,
+        });
       }
-
-      const calibratedOurTotal =
-        instructionOverhead + rawSentThisTurn * calibrationRatio;
-      const overallRatio =
-        calibratedOurTotal > 0 ? providerInputTokens / calibratedOurTotal : 0;
-      const variancePct = Math.round((overallRatio - 1) * 100);
-
-      const absVariance = Math.abs(overallRatio - 1);
-      if (absVariance < bestVarianceAbs && rawSentThisTurn > 0) {
-        bestVarianceAbs = absVariance;
-        bestInstructionOverhead = Math.max(
-          0,
-          Math.round(providerInputTokens - rawSentThisTurn * calibrationRatio)
-        );
-        bestInstructionEstimate = factoryParams.getInstructionTokens?.() ?? 0;
-      }
-
-      factoryParams.log?.('debug', 'Calibration observed', {
-        providerInputTokens,
-        calibratedEstimate: Math.round(calibratedOurTotal),
-        variance: `${variancePct > 0 ? '+' : ''}${variancePct}%`,
-        calibrationRatio: Math.round(calibrationRatio * 100) / 100,
-        instructionOverhead,
-        cumulativeRawSent,
-        cumulativeProviderReported,
-      });
     }
 
     // Computed BEFORE pre-flight truncation so the effective budget can drive

--- a/src/specs/anthropic.simple.test.ts
+++ b/src/specs/anthropic.simple.test.ts
@@ -16,14 +16,16 @@ import {
   createMetadataAggregator,
 } from '@/events';
 import { ContentTypes, GraphEvents, Providers, TitleMethod } from '@/common';
-import { capitalizeFirstLetter } from './spec.utils';
+import { capitalizeFirstLetter, hasEnv } from './spec.utils';
 import { createContentAggregator } from '@/stream';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { getArgs } from '@/scripts/args';
 import { Run } from '@/run';
 
 const provider = Providers.ANTHROPIC;
-describe(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
+const describeIf = hasEnv('ANTHROPIC_API_KEY') ? describe : describe.skip;
+
+describeIf(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
   jest.setTimeout(90000);
   let run: Run<t.IState>;
   let runningHistory: BaseMessage[];

--- a/src/specs/cache.simple.test.ts
+++ b/src/specs/cache.simple.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
-import { capitalizeFirstLetter } from './spec.utils';
+import { capitalizeFirstLetter, hasEnv, hasEveryEnv } from './spec.utils';
 import { createContentAggregator } from '@/stream';
 import { GraphEvents, Providers } from '@/common';
 import { getLLMConfig } from '@/utils/llmConfig';
@@ -82,7 +82,20 @@ describe('Prompt Caching Integration Tests', () => {
     version: 'v2' as const,
   };
 
-  describe('Anthropic Prompt Caching', () => {
+  const requiredBedrockEnv = [
+    'BEDROCK_AWS_REGION',
+    'BEDROCK_AWS_ACCESS_KEY_ID',
+    'BEDROCK_AWS_SECRET_ACCESS_KEY',
+  ];
+  const hasAnthropicApiKey = hasEnv('ANTHROPIC_API_KEY');
+  const hasBedrockCredentials = hasEveryEnv(requiredBedrockEnv);
+
+  const describeIfAnthropic = hasAnthropicApiKey ? describe : describe.skip;
+  const describeIfBedrock = hasBedrockCredentials ? describe : describe.skip;
+  const describeIfAnthropicAndBedrock =
+    hasAnthropicApiKey && hasBedrockCredentials ? describe : describe.skip;
+
+  describeIfAnthropic('Anthropic Prompt Caching', () => {
     const provider = Providers.ANTHROPIC;
 
     test(`${capitalizeFirstLetter(provider)}: multi-turn conversation with caching should not corrupt messages`, async () => {
@@ -212,7 +225,7 @@ describe('Prompt Caching Integration Tests', () => {
     });
   });
 
-  describe('Bedrock Prompt Caching', () => {
+  describeIfBedrock('Bedrock Prompt Caching', () => {
     const provider = Providers.BEDROCK;
 
     test(`${capitalizeFirstLetter(provider)}: multi-turn conversation with caching should not corrupt messages`, async () => {
@@ -340,7 +353,7 @@ describe('Prompt Caching Integration Tests', () => {
     });
   });
 
-  describe('Cross-provider message isolation', () => {
+  describeIfAnthropicAndBedrock('Cross-provider message isolation', () => {
     test('Messages processed by Anthropic should not affect Bedrock processing', async () => {
       const anthropicConfig = getLLMConfig(Providers.ANTHROPIC);
       const bedrockConfig = getLLMConfig(Providers.BEDROCK);

--- a/src/specs/openai.simple.test.ts
+++ b/src/specs/openai.simple.test.ts
@@ -16,14 +16,16 @@ import {
   createMetadataAggregator,
 } from '@/events';
 import { ContentTypes, GraphEvents, Providers, TitleMethod } from '@/common';
-import { capitalizeFirstLetter } from './spec.utils';
+import { capitalizeFirstLetter, hasEnv } from './spec.utils';
 import { createContentAggregator } from '@/stream';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { getArgs } from '@/scripts/args';
 import { Run } from '@/run';
 
 const provider = Providers.OPENAI;
-describe(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
+const describeIfOpenAI = hasEnv('OPENAI_API_KEY') ? describe : describe.skip;
+
+describeIfOpenAI(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
   jest.setTimeout(30000);
   let run: Run<t.IState>;
   let runningHistory: BaseMessage[];

--- a/src/specs/spec.utils.ts
+++ b/src/specs/spec.utils.ts
@@ -1,3 +1,15 @@
 export function capitalizeFirstLetter(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
+
+export function hasEnv(key: string): boolean {
+  return (process.env[key]?.trim() ?? '') !== '';
+}
+
+export function hasEveryEnv(keys: readonly string[]): boolean {
+  return keys.every(hasEnv);
+}
+
+export function hasAnyEnv(keys: readonly string[]): boolean {
+  return keys.some(hasEnv);
+}

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -21,6 +21,7 @@ import { Run } from '@/run';
 import { formatAgentMessages } from '@/messages/format';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import * as providers from '@/llm/providers';
+import { hasAnyEnv, hasEnv, hasEveryEnv } from './spec.utils';
 
 const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
 
@@ -287,7 +288,7 @@ function logTurn(
 // Anthropic Summarization Tests
 // ---------------------------------------------------------------------------
 
-const hasAnthropic = process.env.ANTHROPIC_API_KEY != null;
+const hasAnthropic = hasEnv('ANTHROPIC_API_KEY');
 (hasAnthropic ? describe : describe.skip)('Anthropic Summarization E2E', () => {
   jest.setTimeout(180_000);
 
@@ -599,7 +600,7 @@ const hasAnthropic = process.env.ANTHROPIC_API_KEY != null;
   }, 180_000);
 
   test('cross-provider summarization: Anthropic agent with OpenAI summarizer', async () => {
-    const hasOpenAI = process.env.OPENAI_API_KEY != null;
+    const hasOpenAI = hasEnv('OPENAI_API_KEY');
     if (!hasOpenAI) {
       console.log('  Skipping cross-provider test (no OPENAI_API_KEY)');
       return;
@@ -1026,7 +1027,7 @@ const requiredBedrockEnv = [
   'BEDROCK_AWS_ACCESS_KEY_ID',
   'BEDROCK_AWS_SECRET_ACCESS_KEY',
 ];
-const hasBedrock = requiredBedrockEnv.every((k) => process.env[k] != null);
+const hasBedrock = hasEveryEnv(requiredBedrockEnv);
 
 (hasBedrock ? describe : describe.skip)('Bedrock Summarization E2E', () => {
   jest.setTimeout(180_000);
@@ -1159,7 +1160,7 @@ const hasBedrock = requiredBedrockEnv.every((k) => process.env[k] != null);
 // OpenAI Summarization Tests
 // ---------------------------------------------------------------------------
 
-const hasOpenAI = process.env.OPENAI_API_KEY != null;
+const hasOpenAI = hasEnv('OPENAI_API_KEY');
 (hasOpenAI ? describe : describe.skip)('OpenAI Summarization E2E', () => {
   jest.setTimeout(120_000);
 
@@ -2111,7 +2112,6 @@ describe('Tight context with oversized tool results (no API keys)', () => {
             constructor(_options: any) {
               super({ responses: [SUMMARY_RESPONSE] });
             }
-            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             async *_streamResponseChunks(
               messages: any[],
               options: any,
@@ -2419,17 +2419,14 @@ describe('Tight context with oversized tool results (no API keys)', () => {
 // Token accounting audit (requires API keys)
 // ---------------------------------------------------------------------------
 
-const hasAnyApiKey =
-  process.env.ANTHROPIC_API_KEY != null || process.env.OPENAI_API_KEY != null;
+const hasAnyApiKey = hasAnyEnv(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
 
 (hasAnyApiKey ? describe : describe.skip)('Token accounting audit', () => {
   jest.setTimeout(180_000);
 
-  const agentProvider =
-    process.env.ANTHROPIC_API_KEY != null &&
-    process.env.ANTHROPIC_API_KEY !== ''
-      ? Providers.ANTHROPIC
-      : Providers.OPENAI;
+  const agentProvider = hasEnv('ANTHROPIC_API_KEY')
+    ? Providers.ANTHROPIC
+    : Providers.OPENAI;
   const summarizationProvider = agentProvider;
   const summarizationModel =
     agentProvider === Providers.ANTHROPIC ? 'claude-haiku-4-5' : 'gpt-4.1-mini';
@@ -2960,7 +2957,6 @@ describe('Summarization deduplication correctness (no API keys)', () => {
               chunkCallCount++;
               super({ responses: [response] });
             }
-            // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
             async *_streamResponseChunks(
               messages: any[],
               options: any,

--- a/src/specs/token-accounting-pipeline.test.ts
+++ b/src/specs/token-accounting-pipeline.test.ts
@@ -727,7 +727,7 @@ describe('Token accounting pipeline — end-to-end multi-turn with calibration',
 });
 
 describe('Token accounting pipeline — Anthropic vs OpenAI cache semantics', () => {
-  it('Anthropic additive cache inflates calibration input correctly', () => {
+  it('Anthropic normalized cache input calibrates from input_tokens only', () => {
     const messages = [new HumanMessage('Hello'), new AIMessage('Hi')];
 
     const indexTokenCountMap: Record<string, number | undefined> = {
@@ -744,12 +744,12 @@ describe('Token accounting pipeline — Anthropic vs OpenAI cache semantics', ()
       reserveRatio: 0,
     });
 
-    // Anthropic: input_tokens=30, cache_read=60, cache_creation=20
-    // cacheSum=80 > baseInput=30 → additive → totalInput=30+80=110
+    // Anthropic output normalization stores cache-inclusive prompt tokens in
+    // input_tokens and repeats the cache components in input_token_details.
     const result = pruneMessages({
       messages,
       usageMetadata: {
-        input_tokens: 30,
+        input_tokens: 110,
         output_tokens: 15,
         input_token_details: { cache_read: 60, cache_creation: 20 },
       },
@@ -759,6 +759,68 @@ describe('Token accounting pipeline — Anthropic vs OpenAI cache semantics', ()
     expect(result.indexTokenCountMap[0]).toBe(50);
     expect(result.indexTokenCountMap[1]).toBe(50);
     expect(result.calibrationRatio).toBeCloseTo(1.1, 1);
+  });
+
+  it('skips Bedrock cache-artifact turns instead of poisoning instruction overhead', () => {
+    const messages = [
+      new SystemMessage('system instructions'),
+      new HumanMessage('first user turn'),
+      new AIMessage('first response'),
+      new HumanMessage('second user turn'),
+      new AIMessage('second response'),
+    ];
+    const indexTokenCountMap: Record<string, number | undefined> = {
+      0: 3197,
+      1: 8000,
+      2: 7000,
+      3: 9506,
+      4: 1,
+    };
+    const instructionTokens = 5450;
+    const logs: Array<{
+      level: string;
+      message: string;
+      data?: Record<string, unknown>;
+    }> = [];
+
+    const pruneMessages = createPruneMessages({
+      provider: Providers.BEDROCK,
+      maxTokens: 126935,
+      startIndex: messages.length,
+      tokenCounter: charCounter,
+      indexTokenCountMap,
+      reserveRatio: 0.05,
+      getInstructionTokens: () => instructionTokens,
+      log: (level, message, data) => logs.push({ level, message, data }),
+    });
+
+    const result = pruneMessages({
+      messages,
+      usageMetadata: {
+        input_tokens: 6,
+        output_tokens: 1,
+        input_token_details: {
+          cache_creation: 380974,
+          cache_read: 13165,
+        },
+      },
+    });
+
+    expect(result.calibrationRatio).toBe(1);
+    expect(result.resolvedInstructionOverhead).toBeUndefined();
+    expect(result.remainingContextTokens).toBeGreaterThan(0);
+    expect(
+      logs.find((entry) => entry.message === 'Calibration skipped')?.data
+    ).toMatchObject({
+      reason: 'input_below_instruction_overhead',
+      providerInputTokens: 6,
+      instructionOverhead: instructionTokens,
+    });
+    expect(
+      logs.find((entry) => entry.message === 'Budget')?.data
+    ).toMatchObject({
+      instructionTokens,
+    });
   });
 
   it('OpenAI inclusive cache does NOT inflate calibration input', () => {


### PR DESCRIPTION
## Summary

Fixes prune calibration when provider usage includes prompt-cache detail fields that are not directly comparable with the active context window.

The pruner now prefers the provider-reported `usageMetadata.input_tokens` for calibration and skips calibration for turns where the reported input is clearly not comparable, such as Bedrock cache-artifact turns with tiny `input_tokens` and very large cache creation/read detail fields.

## Root Cause

Cache detail fields can represent provider billing/cache accounting rather than the actual prompt window size. Folding those details into calibration could inflate the observed input and poison the running calibration ratio or resolved instruction overhead.

## Impact

This keeps pruning budget estimates stable when prompt caching is active, while preserving raw token maps and existing provider-specific cache semantics.

## Validation

- `npx tsc --noEmit`
- `npx eslint src/messages/prune.ts src/specs/token-accounting-pipeline.test.ts`
- `git diff --check HEAD^ HEAD`
- `npx jest src/specs/token-accounting-pipeline.test.ts`
- `npx jest src/specs/summarize-prune.test.ts src/specs/token-distribution-edge-case.test.ts src/specs/thinking-prune.test.ts`
