### PR TITLE
feat: shared media token estimation + timed-media (video/audio) support

### DIFF
--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -204,6 +204,57 @@ describe('estimateTimedMediaBlockTokens', () => {
     ).toBe(32);
   });
 
+  test('standard type=video / type=audio blocks (Bedrock converter shape)', () => {
+    // 750,000 bytes video / 250,000 = 3s * 300 = 900
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video', mimeType: 'video/mp4', data: B64(1_000_000) }),
+    ).toBe(900);
+    // 240,000 bytes audio / 16,000 = 15s * 32 = 480
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mpeg', data: B64(320_000) }),
+    ).toBe(480);
+  });
+
+  test('reads Uint8Array data and base64 url payloads', () => {
+    // 240,000-byte Uint8Array audio -> 15s * 32 = 480
+    expect(
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        mimeType: 'audio/wav',
+        data: new Uint8Array(240_000),
+      }),
+    ).toBe(480);
+    // base64 data url on a bare video block
+    expect(
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        mimeType: 'video/mp4',
+        url: `data:video/mp4;base64,${B64(1_000_000)}`,
+      }),
+    ).toBe(900);
+  });
+
+  test('non-video/audio media (image/document MIME) is NOT priced as video', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'image/png', fileUri: 's3://x' }),
+    ).toBe(0);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'image/png', data: B64(400_000) }),
+    ).toBe(0);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'application/pdf', data: B64(400) }),
+    ).toBe(0);
+  });
+
+  test('fileId / bare URL with no size falls back to the ~30s estimate', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video', mimeType: 'video/mp4', fileId: 's3://v' }),
+    ).toBe(9000);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mp3', fileId: 's3://a' }),
+    ).toBe(960);
+  });
+
   test('returns 0 for non-timed-media blocks', () => {
     expect(estimateTimedMediaBlockTokens({ type: 'text' })).toBe(0);
   });

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -5,9 +5,7 @@ import {
   TokenEncoderManager,
   estimateImageBlockTokens,
   estimateDocumentBlockTokens,
-  estimateMediaTokensForMessage,
   estimateTimedMediaBlockTokens,
-  IMAGE_TOKEN_SAFETY_MARGIN,
 } from '@/utils/tokens';
 
 /** Builds a minimal PNG data URI whose IHDR encodes the given dimensions. */
@@ -133,43 +131,6 @@ describe('estimateDocumentBlockTokens', () => {
   });
 });
 
-describe('estimateMediaTokensForMessage', () => {
-  const countChars = (text: string): number => text.length;
-
-  test('sums image + document blocks with the safety margin, ignoring text/tool_call', () => {
-    const content = [
-      { type: 'text', text: 'describe these' },
-      { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } },
-      { type: 'file', source_type: 'text', text: 'hello world' },
-      { type: 'tool_call', tool_call: { name: 'x', args: '{}', output: 'ok' } },
-    ];
-    const image = Math.ceil(1049 * IMAGE_TOKEN_SAFETY_MARGIN); // 1102
-    const doc = Math.ceil(11 * IMAGE_TOKEN_SAFETY_MARGIN); // 12
-    expect(estimateMediaTokensForMessage(content, 'claude', countChars)).toBe(
-      image + doc
-    );
-  });
-
-  test('returns 0 for string content or empty arrays', () => {
-    expect(estimateMediaTokensForMessage('plain string')).toBe(0);
-    expect(estimateMediaTokensForMessage([])).toBe(0);
-    expect(estimateMediaTokensForMessage([{ type: 'text', text: 'hi' }])).toBe(0);
-  });
-
-  test('prices timed-media (video/audio) blocks with the margin', () => {
-    // 1,000,000 base64 chars -> 750,000 bytes -> 3s video -> 900 tokens
-    const video = [{ type: 'media', mimeType: 'video/mp4', data: 'A'.repeat(1_000_000) }];
-    expect(estimateMediaTokensForMessage(video)).toBe(Math.ceil(900 * IMAGE_TOKEN_SAFETY_MARGIN));
-  });
-
-  test('prices image_file blocks as images (1024 fallback), not documents (2000)', () => {
-    const content = [{ type: 'image_file', image_file: { file_id: 'file-abc' } }];
-    expect(estimateMediaTokensForMessage(content, 'claude')).toBe(
-      Math.ceil(1024 * IMAGE_TOKEN_SAFETY_MARGIN),
-    );
-  });
-});
-
 describe('estimateTimedMediaBlockTokens', () => {
   const B64 = (chars: number): string => 'A'.repeat(chars);
 
@@ -281,7 +242,19 @@ describe('estimateTimedMediaBlockTokens', () => {
     ).toBe(9000);
   });
 
+  test('classifies Google MIME-as-type blocks (type is the mime string)', () => {
+    // { type: 'audio/wav', data } -> 240,000 bytes / 16,000 = 15s * 32 = 480
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio/wav', data: B64(320_000) }),
+    ).toBe(480);
+    // { type: 'video/mp4', data } -> 750,000 / 250,000 = 3s * 300 = 900
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video/mp4', data: B64(1_000_000) }),
+    ).toBe(900);
+  });
+
   test('returns 0 for non-timed-media blocks', () => {
     expect(estimateTimedMediaBlockTokens({ type: 'text' })).toBe(0);
+    expect(estimateTimedMediaBlockTokens({ type: 'image/png', data: B64(400) })).toBe(0);
   });
 });

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -232,6 +232,24 @@ describe('estimateTimedMediaBlockTokens', () => {
     ).toBe(480); // 240,000 / 16,000 = 15s * 32
   });
 
+  test('reads nested video/audio data-URL and data payloads, remote stays fallback', () => {
+    // nested data URL sized by its bytes (750,000 -> 3s * 300)
+    expect(
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        video: { url: `data:video/mp4;base64,${B64(1_000_000)}` },
+      }),
+    ).toBe(900);
+    // nested base64 data (240,000 -> 15s * 32)
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio', audio: { data: B64(320_000) } }),
+    ).toBe(480);
+    // nested REMOTE url has no size -> ~30s fallback
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video', video: { url: 'https://x/v.mp4' } }),
+    ).toBe(9000);
+  });
+
   test('non-data URI schemes (gs://, s3://) are treated as remote, not base64', () => {
     // gs:// audio must hit the ~30s remote fallback, not clamp to 32
     expect(

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -161,6 +161,13 @@ describe('estimateMediaTokensForMessage', () => {
     const video = [{ type: 'media', mimeType: 'video/mp4', data: 'A'.repeat(1_000_000) }];
     expect(estimateMediaTokensForMessage(video)).toBe(Math.ceil(900 * IMAGE_TOKEN_SAFETY_MARGIN));
   });
+
+  test('prices image_file blocks as images (1024 fallback), not documents (2000)', () => {
+    const content = [{ type: 'image_file', image_file: { file_id: 'file-abc' } }];
+    expect(estimateMediaTokensForMessage(content, 'claude')).toBe(
+      Math.ceil(1024 * IMAGE_TOKEN_SAFETY_MARGIN),
+    );
+  });
 });
 
 describe('estimateTimedMediaBlockTokens', () => {
@@ -253,6 +260,25 @@ describe('estimateTimedMediaBlockTokens', () => {
     expect(
       estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mp3', fileId: 's3://a' }),
     ).toBe(960);
+  });
+
+  test('reads native Bedrock nested source.bytes (video/audio)', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video', video: { source: { bytes: new Uint8Array(750_000) } } }),
+    ).toBe(900); // 750,000 / 250,000 = 3s * 300
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio', audio: { source: { bytes: new Uint8Array(240_000) } } }),
+    ).toBe(480); // 240,000 / 16,000 = 15s * 32
+  });
+
+  test('non-data URI schemes (gs://, s3://) are treated as remote, not base64', () => {
+    // gs:// audio must hit the ~30s remote fallback, not clamp to 32
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mp3', url: 'gs://bucket/a.mp3' }),
+    ).toBe(960);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'video/mp4', data: 's3://bucket/v.mp4' }),
+    ).toBe(9000);
   });
 
   test('returns 0 for non-timed-media blocks', () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -3,7 +3,28 @@ import {
   encodingForModel,
   createTokenCounter,
   TokenEncoderManager,
+  estimateImageBlockTokens,
+  estimateDocumentBlockTokens,
+  estimateMediaTokensForMessage,
+  estimateTimedMediaBlockTokens,
+  IMAGE_TOKEN_SAFETY_MARGIN,
 } from '@/utils/tokens';
+
+/** Builds a minimal PNG data URI whose IHDR encodes the given dimensions. */
+function pngDataUri(width: number, height: number): string {
+  const buf = Buffer.alloc(48);
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  buf[4] = 0x0d;
+  buf[5] = 0x0a;
+  buf[6] = 0x1a;
+  buf[7] = 0x0a;
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return `data:image/png;base64,${buf.toString('base64')}`;
+}
 
 describe('encodingForModel', () => {
   test('returns claude for Claude model strings', () => {
@@ -60,5 +81,130 @@ describe('createTokenCounter with different encodings', () => {
     const msg = new HumanMessage('Test message for both encodings');
     expect(claudeCounter(msg)).toBeGreaterThan(0);
     expect(o200kCounter(msg)).toBeGreaterThan(0);
+  });
+});
+
+describe('estimateImageBlockTokens', () => {
+  test('claude: tokens = ceil(w*h/750), floored at 1024', () => {
+    const block = { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } };
+    // 1024*768/750 = 1048.58 -> ceil 1049 (> 1024 floor)
+    expect(estimateImageBlockTokens(block, 'claude')).toBe(1049);
+  });
+
+  test('openai: tokens = 85 + tiles*170 (512px tiles)', () => {
+    const block = { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } };
+    // ceil(1024/512)*ceil(768/512) = 2*2 = 4 tiles -> 85 + 680 = 765
+    expect(estimateImageBlockTokens(block, 'o200k_base')).toBe(765);
+  });
+
+  test('falls back to the Anthropic minimum (1024) without base64 data', () => {
+    expect(
+      estimateImageBlockTokens(
+        { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+        'claude'
+      )
+    ).toBe(1024);
+  });
+});
+
+describe('estimateDocumentBlockTokens', () => {
+  const countChars = (text: string): number => text.length;
+
+  test('text document is tokenized directly via getTokenCount', () => {
+    const block = { type: 'file', source_type: 'text', text: 'hello world' };
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(11);
+  });
+
+  test('base64 PDF is priced per estimated page', () => {
+    const block = {
+      type: 'file',
+      source_type: 'base64',
+      mime_type: 'application/pdf',
+      data: 'x'.repeat(150_000),
+    };
+    // ceil(150000/75000) = 2 pages
+    expect(estimateDocumentBlockTokens(block, 'claude', countChars)).toBe(4000); // 2 * 2000
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(3000); // 2 * 1500
+  });
+
+  test('url-referenced document uses the conservative fallback', () => {
+    const block = { type: 'file', source_type: 'url', url: 'https://x/y.pdf' };
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(2000);
+  });
+});
+
+describe('estimateMediaTokensForMessage', () => {
+  const countChars = (text: string): number => text.length;
+
+  test('sums image + document blocks with the safety margin, ignoring text/tool_call', () => {
+    const content = [
+      { type: 'text', text: 'describe these' },
+      { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } },
+      { type: 'file', source_type: 'text', text: 'hello world' },
+      { type: 'tool_call', tool_call: { name: 'x', args: '{}', output: 'ok' } },
+    ];
+    const image = Math.ceil(1049 * IMAGE_TOKEN_SAFETY_MARGIN); // 1102
+    const doc = Math.ceil(11 * IMAGE_TOKEN_SAFETY_MARGIN); // 12
+    expect(estimateMediaTokensForMessage(content, 'claude', countChars)).toBe(
+      image + doc
+    );
+  });
+
+  test('returns 0 for string content or empty arrays', () => {
+    expect(estimateMediaTokensForMessage('plain string')).toBe(0);
+    expect(estimateMediaTokensForMessage([])).toBe(0);
+    expect(estimateMediaTokensForMessage([{ type: 'text', text: 'hi' }])).toBe(0);
+  });
+
+  test('prices timed-media (video/audio) blocks with the margin', () => {
+    // 1,000,000 base64 chars -> 750,000 bytes -> 3s video -> 900 tokens
+    const video = [{ type: 'media', mimeType: 'video/mp4', data: 'A'.repeat(1_000_000) }];
+    expect(estimateMediaTokensForMessage(video)).toBe(Math.ceil(900 * IMAGE_TOKEN_SAFETY_MARGIN));
+  });
+});
+
+describe('estimateTimedMediaBlockTokens', () => {
+  const B64 = (chars: number): string => 'A'.repeat(chars);
+
+  test('Google video (type=media, video/*): duration from size at ~300 tok/s', () => {
+    // 1,000,000 b64 -> 750,000 bytes / 250,000 Bps = 3s * 300 = 900
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'video/mp4', data: B64(1_000_000) }),
+    ).toBe(900);
+  });
+
+  test('Google audio (type=media, audio/*): 32 tok/s at ~16KB/s', () => {
+    // 320,000 b64 -> 240,000 bytes / 16,000 Bps = 15s * 32 = 480
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'audio/mp3', data: B64(320_000) }),
+    ).toBe(480);
+  });
+
+  test('OpenRouter input_audio: estimates from base64 data', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'input_audio', input_audio: { data: B64(320_000) } }),
+    ).toBe(480);
+  });
+
+  test('OpenRouter video_url with a data: URL estimates from size', () => {
+    const url = `data:video/mp4;base64,${B64(1_000_000)}`;
+    expect(estimateTimedMediaBlockTokens({ type: 'video_url', video_url: { url } })).toBe(900);
+  });
+
+  test('bare remote URL falls back to the flat ~30s estimate', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video_url', video_url: { url: 'https://x/v.mp4' } }),
+    ).toBe(9000);
+    expect(estimateTimedMediaBlockTokens({ type: 'input_audio', input_audio: {} })).toBe(960);
+  });
+
+  test('clamps to at least one second of tokens for tiny payloads', () => {
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'audio/wav', data: 'AAAA' }),
+    ).toBe(32);
+  });
+
+  test('returns 0 for non-timed-media blocks', () => {
+    expect(estimateTimedMediaBlockTokens({ type: 'text' })).toBe(0);
   });
 });

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -347,9 +347,9 @@ function timedMediaTokens(
 }
 
 /** Decoded byte length of a media block payload — top-level `data` (base64
- *  string or `Uint8Array`) or base64 `url`, or the native Bedrock nested
- *  `video|audio.source.bytes` (`Uint8Array`); 0 for a bare remote URL,
- *  `fileId`/`fileUri`, S3 location, or empty. */
+ *  string or `Uint8Array`) or base64 `url`, or the nested `video|audio.{data,
+ *  url, source.bytes}` shapes (`formatMessage` media arrays / native Bedrock);
+ *  0 for a bare remote URL, `fileId`/`fileUri`, S3 location, or empty. */
 function mediaBlockByteLength(block: Record<string, unknown>): number {
   const data = block.data;
   if (typeof data === 'string') {
@@ -362,11 +362,18 @@ function mediaBlockByteLength(block: Record<string, unknown>): number {
     return base64ByteLength(block.url);
   }
   const nested = (block.video ?? block.audio) as
-    | { source?: { bytes?: unknown } }
+    | { data?: unknown; url?: unknown; source?: { bytes?: unknown } }
     | undefined;
-  const bytes = nested?.source?.bytes;
-  if (bytes instanceof Uint8Array) {
-    return bytes.length;
+  if (nested != null) {
+    if (typeof nested.data === 'string') {
+      return base64ByteLength(nested.data);
+    }
+    if (typeof nested.url === 'string') {
+      return base64ByteLength(nested.url);
+    }
+    if (nested.source?.bytes instanceof Uint8Array) {
+      return nested.source.bytes.length;
+    }
   }
   return 0;
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -314,7 +314,9 @@ export function estimateDocumentBlockTokens(
   return URL_DOCUMENT_FALLBACK_TOKENS;
 }
 
-/** Decoded byte length of base64 or a `data:` URL; 0 for a remote/empty URL. */
+/** Decoded byte length of base64 or a `data:` URL; 0 for any remote URI (http,
+ *  gs, s3, file, …) or empty. Base64 never contains `:`, so any scheme prefix
+ *  marks a remote reference with no local size. */
 function base64ByteLength(value: string | undefined): number {
   if (typeof value !== 'string' || value.length === 0) {
     return 0;
@@ -323,7 +325,7 @@ function base64ByteLength(value: string | undefined): number {
     const comma = value.indexOf(',');
     return comma < 0 ? 0 : Math.floor(((value.length - comma - 1) * 3) / 4);
   }
-  if (/^https?:\/\//i.test(value)) {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
     return 0;
   }
   return Math.floor((value.length * 3) / 4);
@@ -344,9 +346,10 @@ function timedMediaTokens(
   );
 }
 
-/** Decoded byte length of a media block payload — `data` (base64 string or
- *  `Uint8Array`) or a base64 `url`; 0 for a bare remote URL, `fileId`/`fileUri`,
- *  or empty. */
+/** Decoded byte length of a media block payload — top-level `data` (base64
+ *  string or `Uint8Array`) or base64 `url`, or the native Bedrock nested
+ *  `video|audio.source.bytes` (`Uint8Array`); 0 for a bare remote URL,
+ *  `fileId`/`fileUri`, S3 location, or empty. */
 function mediaBlockByteLength(block: Record<string, unknown>): number {
   const data = block.data;
   if (typeof data === 'string') {
@@ -357,6 +360,13 @@ function mediaBlockByteLength(block: Record<string, unknown>): number {
   }
   if (typeof block.url === 'string') {
     return base64ByteLength(block.url);
+  }
+  const nested = (block.video ?? block.audio) as
+    | { source?: { bytes?: unknown } }
+    | undefined;
+  const bytes = nested?.source?.bytes;
+  if (bytes instanceof Uint8Array) {
+    return bytes.length;
   }
   return 0;
 }
@@ -458,18 +468,15 @@ export function estimateMediaTokensForMessage(
     if (
       item.type === ContentTypes.IMAGE_URL ||
       item.type === 'image_url' ||
-      item.type === 'image'
+      item.type === 'image' ||
+      item.type === ContentTypes.IMAGE_FILE
     ) {
       total += Math.ceil(
         estimateImageBlockTokens(item, encoding) * IMAGE_TOKEN_SAFETY_MARGIN
       );
       continue;
     }
-    if (
-      item.type === 'document' ||
-      item.type === 'file' ||
-      item.type === ContentTypes.IMAGE_FILE
-    ) {
+    if (item.type === 'document' || item.type === 'file') {
       total += Math.ceil(
         estimateDocumentBlockTokens(item, encoding, getTokenCount) *
           IMAGE_TOKEN_SAFETY_MARGIN

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -373,26 +373,38 @@ function mediaBlockByteLength(block: Record<string, unknown>): number {
 
 /** Classifies a block as timed media, or null when it is not video/audio — e.g.
  *  a generic Google `media` block carrying an image/document MIME, which must
- *  NOT be priced as video. */
+ *  NOT be priced as video. Also handles the Google shape where `type` IS the
+ *  MIME string (e.g. `{ type: 'audio/wav', data }`). */
 function timedMediaKind(
   block: Record<string, unknown>
 ): 'video' | 'audio' | null {
-  if (block.type === 'input_audio' || block.type === 'audio') {
+  const type = typeof block.type === 'string' ? block.type : '';
+  if (type === 'input_audio' || type === 'audio') {
     return 'audio';
   }
-  if (block.type === 'video_url' || block.type === 'video') {
+  if (type === 'video_url' || type === 'video') {
     return 'video';
   }
-  if (block.type === 'media') {
-    const mime = typeof block.mimeType === 'string' ? block.mimeType : '';
-    if (mime.startsWith('audio/')) {
-      return 'audio';
-    }
-    if (mime.startsWith('video/')) {
-      return 'video';
-    }
+  const mime =
+    type === 'media' && typeof block.mimeType === 'string' ? block.mimeType : type;
+  if (mime.startsWith('audio/')) {
+    return 'audio';
+  }
+  if (mime.startsWith('video/')) {
+    return 'video';
   }
   return null;
+}
+
+/** Whether a content-block `type` can carry timed media — the fixed set plus the
+ *  Google MIME-as-type shape (`audio/*` / `video/*`). Gates callers before they
+ *  hand the block to {@link estimateTimedMediaBlockTokens}. */
+function isTimedMediaType(type: string): boolean {
+  return (
+    TIMED_MEDIA_TYPES.has(type) ||
+    type.startsWith('audio/') ||
+    type.startsWith('video/')
+  );
 }
 
 /**
@@ -437,59 +449,6 @@ export function estimateTimedMediaBlockTokens(
     VIDEO_TOKENS_PER_SECOND,
     VIDEO_URL_FALLBACK_TOKENS
   );
-}
-
-/**
- * Sums the estimated token cost of the image, document, and timed-media blocks
- * in a message content array (`image_url` / `image` / `image_file` via image
- * estimation; `document` / `file` via document estimation; `media` /
- * `video_url` / `input_audio` via timed-media estimation), applying the same
- * 5% safety margin as {@link getTokenCountForMessage}. Text, tool_call, and
- * other non-media blocks are ignored. Use this to price attachments that are
- * not already represented as inline content the caller counts elsewhere.
- */
-export function estimateMediaTokensForMessage(
-  content: unknown,
-  encoding: EncodingName = 'o200k_base',
-  getTokenCount: (text: string) => number = (text) => Math.ceil(text.length / 4)
-): number {
-  if (!Array.isArray(content)) {
-    return 0;
-  }
-  let total = 0;
-  for (const raw of content) {
-    const item = raw as
-      | (Record<string, unknown> & { type?: string })
-      | null
-      | undefined;
-    if (item == null || typeof item.type !== 'string') {
-      continue;
-    }
-    if (
-      item.type === ContentTypes.IMAGE_URL ||
-      item.type === 'image_url' ||
-      item.type === 'image' ||
-      item.type === ContentTypes.IMAGE_FILE
-    ) {
-      total += Math.ceil(
-        estimateImageBlockTokens(item, encoding) * IMAGE_TOKEN_SAFETY_MARGIN
-      );
-      continue;
-    }
-    if (item.type === 'document' || item.type === 'file') {
-      total += Math.ceil(
-        estimateDocumentBlockTokens(item, encoding, getTokenCount) *
-          IMAGE_TOKEN_SAFETY_MARGIN
-      );
-      continue;
-    }
-    if (TIMED_MEDIA_TYPES.has(item.type)) {
-      total += Math.ceil(
-        estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
-      );
-    }
-  }
-  return total;
 }
 
 const tokenizers: Partial<Record<EncodingName, Tokenizer>> = {};
@@ -563,7 +522,7 @@ export function getTokenCountForMessage(
           continue;
         }
 
-        if (TIMED_MEDIA_TYPES.has(item.type)) {
+        if (isTimedMediaType(item.type)) {
           numTokens += Math.ceil(
             estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
           );

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -50,8 +50,15 @@ const AUDIO_BYTES_PER_SECOND = 16_000; // ~128 kbps
 /** Flat fallback when only a URL is present (no size to estimate from) — ~30s. */
 const VIDEO_URL_FALLBACK_TOKENS = 9000;
 const AUDIO_URL_FALLBACK_TOKENS = 960;
-/** Content block types that carry timed media (video/audio). */
-const TIMED_MEDIA_TYPES = new Set(['media', 'video_url', 'input_audio']);
+/** Content block types that can carry timed media (video/audio). `media` is
+ *  generic (Google) so it is classified by MIME; the rest are unambiguous. */
+const TIMED_MEDIA_TYPES = new Set([
+  'media',
+  'video',
+  'audio',
+  'video_url',
+  'input_audio',
+]);
 
 /**
  * Extracts image dimensions from the first bytes of a base64-encoded
@@ -337,55 +344,89 @@ function timedMediaTokens(
   );
 }
 
+/** Decoded byte length of a media block payload — `data` (base64 string or
+ *  `Uint8Array`) or a base64 `url`; 0 for a bare remote URL, `fileId`/`fileUri`,
+ *  or empty. */
+function mediaBlockByteLength(block: Record<string, unknown>): number {
+  const data = block.data;
+  if (typeof data === 'string') {
+    return base64ByteLength(data);
+  }
+  if (data instanceof Uint8Array) {
+    return data.length;
+  }
+  if (typeof block.url === 'string') {
+    return base64ByteLength(block.url);
+  }
+  return 0;
+}
+
+/** Classifies a block as timed media, or null when it is not video/audio — e.g.
+ *  a generic Google `media` block carrying an image/document MIME, which must
+ *  NOT be priced as video. */
+function timedMediaKind(
+  block: Record<string, unknown>
+): 'video' | 'audio' | null {
+  if (block.type === 'input_audio' || block.type === 'audio') {
+    return 'audio';
+  }
+  if (block.type === 'video_url' || block.type === 'video') {
+    return 'video';
+  }
+  if (block.type === 'media') {
+    const mime = typeof block.mimeType === 'string' ? block.mimeType : '';
+    if (mime.startsWith('audio/')) {
+      return 'audio';
+    }
+    if (mime.startsWith('video/')) {
+      return 'video';
+    }
+  }
+  return null;
+}
+
 /**
  * Estimates token cost for a timed-media block (video/audio). Handles Google
- * `{ type: 'media', mimeType, data }`, OpenRouter `{ type: 'video_url' }` and
- * `{ type: 'input_audio' }`. Duration is inferred from encoded size (providers
- * price by duration, which the block does not carry); a bare URL falls back to
- * a ~30s flat estimate. Unknown `media` mime is treated as video (the larger
- * rate) to stay conservative.
+ * `{ type: 'media', mimeType, data|url|fileUri }`, OpenRouter
+ * `{ type: 'video_url' }` / `{ type: 'input_audio' }`, and standard
+ * `{ type: 'video' }` / `{ type: 'audio' }` blocks (payload as `data` base64 or
+ * `Uint8Array`, base64 `url`, or `fileId`). Duration is inferred from encoded
+ * size (providers price by duration, which the block does not carry) at Gemini's
+ * rates; a payload with no size (bare URL / file id) falls back to a ~30s
+ * estimate. Returns 0 for non-timed media (e.g. an image/document `media` block)
+ * so it is never mispriced as video.
  */
 export function estimateTimedMediaBlockTokens(
   block: Record<string, unknown>
 ): number {
+  const kind = timedMediaKind(block);
+  if (kind == null) {
+    return 0;
+  }
+  let bytes: number;
   if (block.type === 'input_audio') {
     const audio = block.input_audio as { data?: string } | undefined;
+    bytes = base64ByteLength(audio?.data);
+  } else if (block.type === 'video_url') {
+    const video = block.video_url as string | { url?: string } | undefined;
+    bytes = base64ByteLength(typeof video === 'string' ? video : video?.url);
+  } else {
+    bytes = mediaBlockByteLength(block);
+  }
+  if (kind === 'audio') {
     return timedMediaTokens(
-      base64ByteLength(audio?.data),
+      bytes,
       AUDIO_BYTES_PER_SECOND,
       AUDIO_TOKENS_PER_SECOND,
       AUDIO_URL_FALLBACK_TOKENS
     );
   }
-  if (block.type === 'video_url') {
-    const video = block.video_url as string | { url?: string } | undefined;
-    const url = typeof video === 'string' ? video : video?.url;
-    return timedMediaTokens(
-      base64ByteLength(url),
-      VIDEO_BYTES_PER_SECOND,
-      VIDEO_TOKENS_PER_SECOND,
-      VIDEO_URL_FALLBACK_TOKENS
-    );
-  }
-  if (block.type === 'media') {
-    const mime = typeof block.mimeType === 'string' ? block.mimeType : '';
-    const data = typeof block.data === 'string' ? block.data : undefined;
-    if (mime.startsWith('audio/')) {
-      return timedMediaTokens(
-        base64ByteLength(data),
-        AUDIO_BYTES_PER_SECOND,
-        AUDIO_TOKENS_PER_SECOND,
-        AUDIO_URL_FALLBACK_TOKENS
-      );
-    }
-    return timedMediaTokens(
-      base64ByteLength(data),
-      VIDEO_BYTES_PER_SECOND,
-      VIDEO_TOKENS_PER_SECOND,
-      VIDEO_URL_FALLBACK_TOKENS
-    );
-  }
-  return 0;
+  return timedMediaTokens(
+    bytes,
+    VIDEO_BYTES_PER_SECOND,
+    VIDEO_TOKENS_PER_SECOND,
+    VIDEO_URL_FALLBACK_TOKENS
+  );
 }
 
 /**

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -17,7 +17,7 @@ const OPENAI_IMAGE_TOKENS_PER_TILE = 170;
 /** Google Gemini fixed per-image cost. */
 const _GEMINI_IMAGE_TOKENS = 258;
 /** Safety margin for image and document token estimates (5% overestimate). */
-const IMAGE_TOKEN_SAFETY_MARGIN = 1.05;
+export const IMAGE_TOKEN_SAFETY_MARGIN = 1.05;
 
 /**
  * Anthropic PDF: each page costs image tokens + text tokens.
@@ -32,6 +32,26 @@ const _GEMINI_PDF_TOKENS_PER_PAGE = 258;
 const BASE64_BYTES_PER_PDF_PAGE = 75_000;
 /** Fallback token cost for URL-referenced documents without local data. */
 const URL_DOCUMENT_FALLBACK_TOKENS = 2000;
+
+/**
+ * Timed media (video/audio) is priced by DURATION, not size, and the content
+ * carries no duration — so duration is estimated from encoded size at
+ * representative bitrates and priced at Gemini's rates (the dominant provider
+ * for native video/audio). Deliberately rough; superseded by real provider
+ * usage after the first turn.
+ */
+/** Gemini video ≈ 258 tokens/frame (1 fps) + 32 tokens/s audio ≈ 300 tokens/s. */
+const VIDEO_TOKENS_PER_SECOND = 300;
+/** Gemini audio: 32 tokens/s (single channel). */
+const AUDIO_TOKENS_PER_SECOND = 32;
+/** Representative encoded byte rates for duration-from-size estimation. */
+const VIDEO_BYTES_PER_SECOND = 250_000; // ~2 Mbps
+const AUDIO_BYTES_PER_SECOND = 16_000; // ~128 kbps
+/** Flat fallback when only a URL is present (no size to estimate from) — ~30s. */
+const VIDEO_URL_FALLBACK_TOKENS = 9000;
+const AUDIO_URL_FALLBACK_TOKENS = 960;
+/** Content block types that carry timed media (video/audio). */
+const TIMED_MEDIA_TYPES = new Set(['media', 'video_url', 'input_audio']);
 
 /**
  * Extracts image dimensions from the first bytes of a base64-encoded
@@ -135,7 +155,7 @@ export function estimateOpenAIImageTokens(
  * Extracts dimensions from base64 header when available.
  * Falls back to Anthropic minimum (1024) when dimensions can't be determined.
  */
-function estimateImageBlockTokens(
+export function estimateImageBlockTokens(
   block: Record<string, unknown>,
   encoding: EncodingName
 ): number {
@@ -180,7 +200,7 @@ function estimateImageBlockTokens(
  * - Base64 PDF: page count estimated from base64 length × per-page cost.
  * - URL reference: conservative flat estimate.
  */
-function estimateDocumentBlockTokens(
+export function estimateDocumentBlockTokens(
   block: Record<string, unknown>,
   encoding: EncodingName,
   getTokenCount: (text: string) => number
@@ -287,6 +307,143 @@ function estimateDocumentBlockTokens(
   return URL_DOCUMENT_FALLBACK_TOKENS;
 }
 
+/** Decoded byte length of base64 or a `data:` URL; 0 for a remote/empty URL. */
+function base64ByteLength(value: string | undefined): number {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 0;
+  }
+  if (value.startsWith('data:')) {
+    const comma = value.indexOf(',');
+    return comma < 0 ? 0 : Math.floor(((value.length - comma - 1) * 3) / 4);
+  }
+  if (/^https?:\/\//i.test(value)) {
+    return 0;
+  }
+  return Math.floor((value.length * 3) / 4);
+}
+
+function timedMediaTokens(
+  bytes: number,
+  bytesPerSecond: number,
+  tokensPerSecond: number,
+  urlFallback: number
+): number {
+  if (bytes <= 0) {
+    return urlFallback;
+  }
+  return Math.max(
+    tokensPerSecond,
+    Math.ceil((bytes / bytesPerSecond) * tokensPerSecond)
+  );
+}
+
+/**
+ * Estimates token cost for a timed-media block (video/audio). Handles Google
+ * `{ type: 'media', mimeType, data }`, OpenRouter `{ type: 'video_url' }` and
+ * `{ type: 'input_audio' }`. Duration is inferred from encoded size (providers
+ * price by duration, which the block does not carry); a bare URL falls back to
+ * a ~30s flat estimate. Unknown `media` mime is treated as video (the larger
+ * rate) to stay conservative.
+ */
+export function estimateTimedMediaBlockTokens(
+  block: Record<string, unknown>
+): number {
+  if (block.type === 'input_audio') {
+    const audio = block.input_audio as { data?: string } | undefined;
+    return timedMediaTokens(
+      base64ByteLength(audio?.data),
+      AUDIO_BYTES_PER_SECOND,
+      AUDIO_TOKENS_PER_SECOND,
+      AUDIO_URL_FALLBACK_TOKENS
+    );
+  }
+  if (block.type === 'video_url') {
+    const video = block.video_url as string | { url?: string } | undefined;
+    const url = typeof video === 'string' ? video : video?.url;
+    return timedMediaTokens(
+      base64ByteLength(url),
+      VIDEO_BYTES_PER_SECOND,
+      VIDEO_TOKENS_PER_SECOND,
+      VIDEO_URL_FALLBACK_TOKENS
+    );
+  }
+  if (block.type === 'media') {
+    const mime = typeof block.mimeType === 'string' ? block.mimeType : '';
+    const data = typeof block.data === 'string' ? block.data : undefined;
+    if (mime.startsWith('audio/')) {
+      return timedMediaTokens(
+        base64ByteLength(data),
+        AUDIO_BYTES_PER_SECOND,
+        AUDIO_TOKENS_PER_SECOND,
+        AUDIO_URL_FALLBACK_TOKENS
+      );
+    }
+    return timedMediaTokens(
+      base64ByteLength(data),
+      VIDEO_BYTES_PER_SECOND,
+      VIDEO_TOKENS_PER_SECOND,
+      VIDEO_URL_FALLBACK_TOKENS
+    );
+  }
+  return 0;
+}
+
+/**
+ * Sums the estimated token cost of the image, document, and timed-media blocks
+ * in a message content array (`image_url` / `image` / `image_file` via image
+ * estimation; `document` / `file` via document estimation; `media` /
+ * `video_url` / `input_audio` via timed-media estimation), applying the same
+ * 5% safety margin as {@link getTokenCountForMessage}. Text, tool_call, and
+ * other non-media blocks are ignored. Use this to price attachments that are
+ * not already represented as inline content the caller counts elsewhere.
+ */
+export function estimateMediaTokensForMessage(
+  content: unknown,
+  encoding: EncodingName = 'o200k_base',
+  getTokenCount: (text: string) => number = (text) => Math.ceil(text.length / 4)
+): number {
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let total = 0;
+  for (const raw of content) {
+    const item = raw as
+      | (Record<string, unknown> & { type?: string })
+      | null
+      | undefined;
+    if (item == null || typeof item.type !== 'string') {
+      continue;
+    }
+    if (
+      item.type === ContentTypes.IMAGE_URL ||
+      item.type === 'image_url' ||
+      item.type === 'image'
+    ) {
+      total += Math.ceil(
+        estimateImageBlockTokens(item, encoding) * IMAGE_TOKEN_SAFETY_MARGIN
+      );
+      continue;
+    }
+    if (
+      item.type === 'document' ||
+      item.type === 'file' ||
+      item.type === ContentTypes.IMAGE_FILE
+    ) {
+      total += Math.ceil(
+        estimateDocumentBlockTokens(item, encoding, getTokenCount) *
+          IMAGE_TOKEN_SAFETY_MARGIN
+      );
+      continue;
+    }
+    if (TIMED_MEDIA_TYPES.has(item.type)) {
+      total += Math.ceil(
+        estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
+      );
+    }
+  }
+  return total;
+}
+
 const tokenizers: Partial<Record<EncodingName, Tokenizer>> = {};
 
 async function getTokenizer(
@@ -354,6 +511,13 @@ export function getTokenCountForMessage(
           numTokens += Math.ceil(
             estimateDocumentBlockTokens(item, encoding, getTokenCount) *
               IMAGE_TOKEN_SAFETY_MARGIN
+          );
+          continue;
+        }
+
+        if (TIMED_MEDIA_TYPES.has(item.type)) {
+          numTokens += Math.ceil(
+            estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
           );
           continue;
         }


### PR DESCRIPTION
## Summary

Consolidates media token estimation into a single exported source of truth so downstream consumers (LibreChat) price attachments identically to the SDK pruner, and adds estimation for previously-unhandled **video/audio**.

Complementary to #296 (different files — `tokens.ts` only, no overlap with the prune calibration work); mergeable independently.

## Changes

**Export the media estimators** (previously module-private), so consumers stop maintaining a drifting duplicate:
- `estimateImageBlockTokens`, `estimateDocumentBlockTokens`
- `IMAGE_TOKEN_SAFETY_MARGIN`
- new `estimateMediaTokensForMessage(content, encoding, getTokenCount?)` — sums image/document/timed-media blocks with the 5% safety margin

**Add timed-media (video/audio) estimation** — new `estimateTimedMediaBlockTokens`:
- Providers price video/audio by **duration**, but content blocks carry none — so duration is inferred from encoded size at representative bitrates and priced at **Gemini's rates** (the dominant native video/audio provider): video ≈ 258 tok/frame @1fps + 32/s audio ≈ **300 tok/s** (~250 KB/s), audio **32 tok/s** (~16 KB/s).
- Handles Google `{type:'media'}`, OpenRouter `{type:'video_url'}` / `{type:'input_audio'}`; a bare URL (no size) falls back to a ~30s flat estimate.
- Deliberately rough — superseded by real provider `usage_metadata` after the first turn; the estimate only fills the pre-first-response window.
- Wired into both `getTokenCountForMessage` (pruner counter) and `estimateMediaTokensForMessage`.

## Why

LibreChat reimplemented `estimateImageBlockTokens`/`estimateDocumentBlockTokens` verbatim (already drifting: named `ANTHROPIC_IMAGE_MIN_TOKENS` vs a hardcoded `1024`). Exporting the SDK's versions makes this package the single source of truth. Video/audio were previously counted as ~0 everywhere.

## Validation

- `npx tsc --noEmit`
- `npx eslint src/utils/tokens.ts src/specs/tokens.test.ts`
- `npx jest src/specs/tokens.test.ts` (24 passed; +15 new cases across the exported estimators and timed-media)
