### PR TITLE
🧮 fix: Preserve Bedrock Cache Usage in Langfuse

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,9 +1,20 @@
 import { CallbackHandler } from '@langfuse/langchain';
 import { context as otelContext } from '@opentelemetry/api';
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import {
   getLangfuseTracerProvider,
   propagateAttributes,
 } from '@langfuse/tracing';
+import type {
+  AIMessageChunkFields,
+  AIMessageFields,
+  UsageMetadata,
+} from '@langchain/core/messages';
+import type {
+  ChatGeneration,
+  Generation,
+  LLMResult,
+} from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
 import {
@@ -42,6 +53,116 @@ type LangfuseAttributeParams = AgentLangfuseHandlerParams & {
 type FlushableTracerProvider = {
   forceFlush?: () => Promise<void> | void;
 };
+
+type BedrockResponseUsage = {
+  inputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
+};
+
+type BedrockResponseMetadata = {
+  metadata?: {
+    usage?: BedrockResponseUsage;
+  };
+};
+
+function getLangfuseBedrockUsage(
+  message: AIMessage | AIMessageChunk
+): UsageMetadata | undefined {
+  const usageMetadata = message.usage_metadata;
+  const bedrockUsage = (message.response_metadata as BedrockResponseMetadata)
+    .metadata?.usage;
+  if (
+    usageMetadata == null ||
+    bedrockUsage == null ||
+    usageMetadata.input_tokens !== bedrockUsage.inputTokens
+  ) {
+    return usageMetadata;
+  }
+
+  const cacheRead = bedrockUsage.cacheReadInputTokens ?? 0;
+  const cacheCreation = bedrockUsage.cacheWriteInputTokens ?? 0;
+  if (cacheRead === 0 && cacheCreation === 0) {
+    return usageMetadata;
+  }
+
+  return {
+    ...usageMetadata,
+    input_tokens: usageMetadata.input_tokens + cacheRead + cacheCreation,
+  };
+}
+
+function cloneMessageWithUsage(
+  message: AIMessage | AIMessageChunk,
+  usageMetadata: UsageMetadata
+): AIMessage | AIMessageChunk {
+  const fields: AIMessageFields = {
+    content: message.content,
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+    id: message.id,
+    name: message.name,
+    tool_calls: message.tool_calls,
+    invalid_tool_calls: message.invalid_tool_calls,
+    usage_metadata: usageMetadata,
+  };
+
+  if (message instanceof AIMessageChunk) {
+    const chunkFields: AIMessageChunkFields = {
+      ...fields,
+      tool_call_chunks: message.tool_call_chunks,
+    };
+    return new AIMessageChunk(chunkFields);
+  }
+
+  return new AIMessage(fields);
+}
+
+function normalizeGenerationForLangfuse(generation: Generation): Generation {
+  if (!('message' in generation)) {
+    return generation;
+  }
+
+  const message = (generation as ChatGeneration).message;
+  if (!(message instanceof AIMessage || message instanceof AIMessageChunk)) {
+    return generation;
+  }
+
+  const usageMetadata = getLangfuseBedrockUsage(message);
+  if (usageMetadata == null || usageMetadata === message.usage_metadata) {
+    return generation;
+  }
+
+  const chatGeneration: ChatGeneration = {
+    ...(generation as ChatGeneration),
+    message: cloneMessageWithUsage(message, usageMetadata),
+  };
+  return chatGeneration;
+}
+
+function normalizeBedrockUsageForLangfuse(output: LLMResult): LLMResult {
+  if (output.generations.length === 0) {
+    return output;
+  }
+
+  const listIndex = output.generations.length - 1;
+  const generationList = output.generations[listIndex];
+  if (generationList.length === 0) {
+    return output;
+  }
+
+  const generationIndex = generationList.length - 1;
+  const generation = generationList[generationIndex];
+  const normalized = normalizeGenerationForLangfuse(generation);
+  if (normalized === generation) {
+    return output;
+  }
+
+  const generations = [...output.generations];
+  generations[listIndex] = [...generationList];
+  generations[listIndex][generationIndex] = normalized;
+  return { ...output, generations };
+}
 
 class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly langfuse?: t.LangfuseConfig;
@@ -105,6 +226,18 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleLLMStart']>
   ): ReturnType<CallbackHandler['handleLLMStart']> {
     return this.withRuntimeContext(() => super.handleLLMStart(...args));
+  }
+
+  override handleLLMEnd(
+    output: LLMResult,
+    runId: string,
+    parentRunId?: string
+  ): Promise<void> {
+    return super.handleLLMEnd(
+      normalizeBedrockUsageForLangfuse(output),
+      runId,
+      parentRunId
+    );
   }
 
   override handleToolStart(
@@ -351,7 +484,7 @@ export function isLangfuseCallbackHandler(value: unknown): boolean {
 export async function disposeLangfuseHandler(value: unknown): Promise<void> {
   if (
     value == null ||
-    !parseBooleanEnv(process.env[LANGFUSE_FORCE_FLUSH_ON_DISPOSE])
+    parseBooleanEnv(process.env[LANGFUSE_FORCE_FLUSH_ON_DISPOSE]) !== true
   ) {
     return;
   }

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,7 +1,9 @@
 import { HumanMessage } from '@langchain/core/messages';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import type * as t from '@/types';
+import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { Providers } from '@/common';
 import { Run } from '@/run';
@@ -385,6 +387,60 @@ describe('Langfuse callback composition', () => {
       'librechat.langfuse.tenant_export.enabled': 'true',
       'librechat.langfuse.destination': 'eu',
     });
+  });
+
+  it('exports Bedrock prompt-cache usage buckets to Langfuse', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const runId = 'test-langfuse-bedrock-cache-usage';
+
+    await handler?.handleChatModelStart(
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['LibreChatBedrockConverse'],
+        kwargs: {},
+      },
+      [[new HumanMessage('hello')]],
+      runId
+    );
+
+    const generation = handleConverseStreamMetadata(
+      {
+        usage: {
+          inputTokens: 13,
+          outputTokens: 5,
+          totalTokens: 20849,
+          cacheReadInputTokens: 10831,
+          cacheWriteInputTokens: 10000,
+        },
+        metrics: { latencyMs: 1000 },
+      },
+      { streamUsage: true }
+    );
+    await handler?.handleLLMEnd({ generations: [[generation]] }, runId);
+
+    const usageDetails = mockSpanAttributeSets
+      .map(
+        (attributes) =>
+          attributes[LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]
+      )
+      .find((value): value is string => typeof value === 'string');
+
+    expect(usageDetails).toBe(
+      JSON.stringify({
+        input: 0,
+        output: 5,
+        total: 20849,
+        input_cache_read: 10831,
+        input_cache_creation: 10000,
+      })
+    );
   });
 
   it('uses deterministic trace ids when tracing is configured from env only', async () => {

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -391,6 +391,11 @@ describe('Langfuse callback composition', () => {
 
   it('exports Bedrock prompt-cache usage buckets to Langfuse', async () => {
     const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+    });
     const handler = createLangfuseHandler({
       langfuse: {
         publicKey: 'pk-test',
@@ -434,7 +439,7 @@ describe('Langfuse callback composition', () => {
 
     expect(usageDetails).toBe(
       JSON.stringify({
-        input: 0,
+        input: 13,
         output: 5,
         total: 20849,
         input_cache_read: 10831,


### PR DESCRIPTION
## Summary

I fixed Bedrock prompt-cache accounting at the Langfuse callback boundary and added an end-to-end regression test for the full provider-to-observation path.

- Normalize Bedrock's exclusive fresh-input count to the inclusive input contract expected by `@langfuse/langchain`, only on the cloned callback payload.
- Preserve core Bedrock usage metadata while exporting fresh input, cache reads, and cache writes as mutually exclusive Langfuse buckets.
- Exercise the real Bedrock streaming metadata converter and real Langfuse callback while mocking only OTEL export.
- Initialize tracing inside the regression so it remains order-independent and passes in isolation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm test -- --runInBand src/specs/langfuse-callbacks.test.ts`
- `npm test -- --runInBand src/llm/bedrock/llm.spec.ts -t "cache token extraction"`
- `npx tsc --noEmit`
- `npx eslint src/langfuse.ts src/specs/langfuse-callbacks.test.ts`
- `RUN_BEDROCK_PROMPT_CACHE_LIVE_TESTS=1 npm test -- --runInBand src/agents/__tests__/AgentContext.bedrock.live.test.ts -t "caches only the stable system prefix"`

### **Test Configuration**:

- Node.js 24.16.0
- macOS
- AWS Bedrock live prompt-cache validation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes