### PR TITLE
feat(hooks): support injectedMessages in hook outputs at PostToolBatch

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -21,6 +21,13 @@ import {
 import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
+import { HookRegistry } from '@/hooks';
+
+function createResultAlteringRegistry(): HookRegistry {
+  const registry = new HookRegistry();
+  registry.register('PreToolUse', { hooks: [async () => ({})] });
+  return registry;
+}
 
 function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   const runSteps = new Map<string, t.RunStep>();
@@ -3223,7 +3230,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {
     const graph = createGraph({
-      hookRegistry: {} as StandardGraph['hookRegistry'],
+      hookRegistry: createResultAlteringRegistry(),
     });
     const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
 
@@ -3251,6 +3258,56 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       expect.anything()
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('prestarts when the registry only has observation hooks (PostToolBatch)', async () => {
+    const observationRegistry = new HookRegistry();
+    observationRegistry.register('PostToolBatch', {
+      hooks: [async () => ({})],
+    });
+    const graph = createGraph({ hookRegistry: observationRegistry });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(graph.eagerEventToolExecutions.get('call_weather')).toMatchObject({
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+    });
   });
 
   it('does not buffer streamed chunks when eager execution is disabled', async () => {
@@ -4418,7 +4475,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
   it('does not prestart on-arrival sealed calls when batch-sensitive hooks are configured', async () => {
     const graph = createGraph({
-      hookRegistry: {} as StandardGraph['hookRegistry'],
+      hookRegistry: createResultAlteringRegistry(),
     });
     const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
 

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -14,6 +14,17 @@ import type { HookEvent, HookMatcher } from './types';
 type MatcherBucket = Partial<Record<HookEvent, HookMatcher<HookEvent>[]>>;
 
 /**
+ * Events whose hooks can change a tool call's input or output. Presence of
+ * any of these disables eager tool execution and early completion emission;
+ * observation-only events (`PostToolBatch`, `Stop`, telemetry hooks) do not.
+ */
+const RESULT_ALTERING_HOOK_EVENTS = [
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+] as const satisfies readonly HookEvent[];
+
+/**
  * Snapshot of a halt request raised by a hook returning
  * `preventContinuation: true`. The SDK's run loop polls for this between
  * stream events and exits cleanly when set, skipping the `Stop` hook
@@ -196,6 +207,31 @@ export class HookRegistry {
     this.haltSignals.delete(sessionId);
   }
 
+  /**
+   * True when any registered hook can alter a tool result before or after
+   * execution (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`). Eager
+   * tool execution and early completion emission gate on this instead of
+   * registry presence, so observation-only registries (e.g. a
+   * `PostToolBatch` steering drain) keep those fast paths. With
+   * `sessionId`, checks global + that session; without it, conservatively
+   * scans every session bucket.
+   */
+  hasResultAlteringHooks(sessionId?: string): boolean {
+    if (hasResultAlteringInBucket(this.global)) {
+      return true;
+    }
+    if (sessionId !== undefined) {
+      const bucket = this.sessions.get(sessionId);
+      return bucket !== undefined && hasResultAlteringInBucket(bucket);
+    }
+    for (const bucket of this.sessions.values()) {
+      if (hasResultAlteringInBucket(bucket)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** True if at least one matcher exists for `event` (global + session). */
   hasHookFor(event: HookEvent, sessionId?: string): boolean {
     if (readList(this.global, event).length > 0) {
@@ -240,6 +276,15 @@ function readList(
   event: HookEvent
 ): HookMatcher<HookEvent>[] {
   return bucket[event] ?? [];
+}
+
+function hasResultAlteringInBucket(bucket: MatcherBucket): boolean {
+  for (const event of RESULT_ALTERING_HOOK_EVENTS) {
+    if (readList(bucket, event).length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function removeFromList<E extends HookEvent>(

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -187,4 +187,52 @@ describe('HookRegistry', () => {
       }
     });
   });
+
+  describe('hasResultAlteringHooks', () => {
+    it('returns false for an empty registry', () => {
+      const registry = new HookRegistry();
+      expect(registry.hasResultAlteringHooks()).toBe(false);
+      expect(registry.hasResultAlteringHooks('run-1')).toBe(false);
+    });
+
+    it('returns false when only observation hooks are registered', () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolBatch', { hooks: [async () => ({})] });
+      registry.register('Stop', { hooks: [async () => ({})] });
+      expect(registry.hasResultAlteringHooks()).toBe(false);
+      expect(registry.hasResultAlteringHooks('run-1')).toBe(false);
+    });
+
+    it('returns true for each result-altering event registered globally', () => {
+      for (const event of [
+        'PreToolUse',
+        'PostToolUse',
+        'PostToolUseFailure',
+      ] as const) {
+        const registry = new HookRegistry();
+        registry.register(event, { hooks: [async () => ({})] });
+        expect(registry.hasResultAlteringHooks()).toBe(true);
+        expect(registry.hasResultAlteringHooks('any-session')).toBe(true);
+      }
+    });
+
+    it('scopes session lookups to the given sessionId', () => {
+      const registry = new HookRegistry();
+      registry.registerSession('run-a', 'PreToolUse', makePreToolUseMatcher());
+      expect(registry.hasResultAlteringHooks('run-a')).toBe(true);
+      expect(registry.hasResultAlteringHooks('run-b')).toBe(false);
+    });
+
+    it('conservatively scans all sessions when no sessionId is given', () => {
+      const registry = new HookRegistry();
+      registry.registerSession(
+        'run-a',
+        'PostToolUse',
+        makePostToolUseMatcher()
+      );
+      expect(registry.hasResultAlteringHooks()).toBe(true);
+      registry.clearSession('run-a');
+      expect(registry.hasResultAlteringHooks()).toBe(false);
+    });
+  });
 });

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -155,7 +155,11 @@ describe('executeHooks', () => {
         input: preToolUseInput('Bash'),
         matchQuery: 'Bash',
       });
-      expect(result).toEqual({ additionalContexts: [], errors: [] });
+      expect(result).toEqual({
+        additionalContexts: [],
+        injectedMessages: [],
+        errors: [],
+      });
     });
 
     it('returns an empty result when no matcher pattern matches the query', async () => {
@@ -176,7 +180,11 @@ describe('executeHooks', () => {
         matchQuery: 'Bash',
       });
       expect(called).toBe(false);
-      expect(result).toEqual({ additionalContexts: [], errors: [] });
+      expect(result).toEqual({
+        additionalContexts: [],
+        injectedMessages: [],
+        errors: [],
+      });
     });
   });
 
@@ -436,6 +444,81 @@ describe('executeHooks', () => {
         'context one',
         'context two',
       ]);
+    });
+  });
+
+  describe('injectedMessages accumulation', () => {
+    it('accumulates injectedMessages from every hook in registration order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              injectedMessages: [
+                { role: 'user', content: 'steer one', source: 'steer' },
+              ],
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => emptyPreOutput
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              injectedMessages: [
+                { role: 'user', content: 'steer two', source: 'steer' },
+                { role: 'system', content: 'hint', source: 'hook' },
+              ],
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.injectedMessages).toEqual([
+        { role: 'user', content: 'steer one', source: 'steer' },
+        { role: 'user', content: 'steer two', source: 'steer' },
+        { role: 'system', content: 'hint', source: 'hook' },
+      ]);
+    });
+
+    it('returns an empty array when no hook sets injectedMessages', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', { hooks: [noopPreHook] });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.injectedMessages).toEqual([]);
+    });
+
+    it('skips injectedMessages from fire-and-forget (async) outputs', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              async: true,
+              injectedMessages: [
+                { role: 'user', content: 'ignored', source: 'steer' },
+              ],
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.injectedMessages).toEqual([]);
     });
   });
 

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -54,6 +54,7 @@ interface AbortRace {
 function freshResult(): AggregatedHookResult {
   return {
     additionalContexts: [],
+    injectedMessages: [],
     errors: [],
   };
 }
@@ -244,6 +245,19 @@ function applyContext(agg: AggregatedHookResult, output: HookOutput): void {
   }
 }
 
+function applyInjectedMessages(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (
+    output.injectedMessages === undefined ||
+    output.injectedMessages.length === 0
+  ) {
+    return;
+  }
+  agg.injectedMessages.push(...output.injectedMessages);
+}
+
 function applyStopFlag(agg: AggregatedHookResult, output: HookOutput): void {
   if (output.preventContinuation !== true) {
     return;
@@ -310,6 +324,7 @@ function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
       continue;
     }
     applyContext(agg, output);
+    applyInjectedMessages(agg, output);
     applyStopFlag(agg, output);
     applyDecision(agg, output);
     applyUpdatedInput(agg, output);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,6 +9,13 @@
 export { HookRegistry } from './HookRegistry';
 export type { HookHaltSignal } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
+/**
+ * Feature probe for hosts: hook outputs support `injectedMessages`
+ * (per-message graph-state injection at the `PostToolBatch` boundary).
+ * Hosts must gate drain-style hooks on this so a queued message can never
+ * be consumed by an SDK version that would silently drop it.
+ */
+export const HOOK_INJECTED_MESSAGES_CAPABLE = true;
 export {
   matchesQuery,
   hasNestedQuantifier,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,5 +1,6 @@
 // src/hooks/types.ts
 import type { BaseMessage } from '@langchain/core/messages';
+import type { InjectedMessage } from '@/types/tools';
 
 /**
  * Closed set of hook lifecycle events supported by the hooks system.
@@ -134,7 +135,9 @@ export interface PostToolBatchEntry {
  *
  * Order: fires AFTER all per-tool PostToolUse / PostToolUseFailure hooks
  * for the same batch have completed, BEFORE the next model call. Pass an
- * `additionalContext` to inject context for that next model turn.
+ * `additionalContext` to inject context for that next model turn, or
+ * `injectedMessages` to inject standalone per-message user speech (e.g.
+ * mid-run steering) that must not be consolidated with hook context.
  */
 export interface PostToolBatchHookInput extends BaseHookInput {
   hook_event_name: 'PostToolBatch';
@@ -246,6 +249,18 @@ export type HookInputByEvent = {
 export interface BaseHookOutput {
   /** Context string to inject into the conversation. Accumulated across hooks. */
   additionalContext?: string;
+  /**
+   * Messages to inject into graph state, one `HumanMessage` per entry
+   * (converted via `ToolNode.convertInjectedMessages`, which preserves
+   * `role`/`source`/`isMeta` in `additional_kwargs`). Unlike
+   * `additionalContext` — which is consolidated across hooks into a single
+   * system-flavored message — each entry keeps its own identity and role,
+   * making this the channel for injecting verbatim user speech (e.g. a
+   * mid-run steering message). Accumulated across hooks in registration
+   * order. Currently consumed only at the `PostToolBatch` dispatch site;
+   * other events ignore the field.
+   */
+  injectedMessages?: InjectedMessage[];
   /** True to prevent the next model turn. Any hook can set this. */
   preventContinuation?: boolean;
   /** Reason reported alongside `preventContinuation`. */
@@ -508,6 +523,8 @@ export interface AggregatedHookResult {
   updatedOutput?: unknown;
   /** Accumulated `additionalContext` strings from every hook, in order. */
   additionalContexts: string[];
+  /** Accumulated `injectedMessages` from every hook, in registration order. */
+  injectedMessages: InjectedMessage[];
   /** True if any hook returned `preventContinuation`. */
   preventContinuation?: boolean;
   /**

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -109,7 +109,10 @@ function getNonEmptyValue(possibleValues: string[]): string | undefined {
 }
 
 function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
-  return graph.hookRegistry != null || graph.humanInTheLoop?.enabled === true;
+  return (
+    graph.hookRegistry?.hasResultAlteringHooks() === true ||
+    graph.humanInTheLoop?.enabled === true
+  );
 }
 
 function hasToolOutputReference(value: unknown): boolean {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -110,7 +110,7 @@ function getNonEmptyValue(possibleValues: string[]): string | undefined {
 
 function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
   return (
-    graph.hookRegistry?.hasResultAlteringHooks() === true ||
+    graph.hookRegistry?.hasResultAlteringHooks(graph.runId) === true ||
     graph.humanInTheLoop?.enabled === true
   );
 }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2091,6 +2091,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const postToolBatchEntryByCallId = new Map<string, PostToolBatchEntry>();
     const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
       additionalContexts: [] as string[],
+      injectedMessages: [] as t.InjectedMessage[],
       errors: [] as string[],
     });
 
@@ -2637,7 +2638,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * released if the dispatch fails, letting the batch path re-emit.
        */
       const canEmitEarlyCompletions =
-        this.hookRegistry == null && this.humanInTheLoop?.enabled !== true;
+        this.hookRegistry?.hasResultAlteringHooks() !== true &&
+        this.humanInTheLoop?.enabled !== true;
       const earlyCompletionDispatchedIds = new Set<string>();
       const earlyCompletionDispatches: Array<Promise<void>> = [];
       const dispatchRequestById = new Map(
@@ -2975,7 +2977,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return (
       this.eventDrivenMode &&
       this.eagerEventToolExecution?.enabled === true &&
-      this.hookRegistry == null &&
+      this.hookRegistry?.hasResultAlteringHooks() !== true &&
       this.humanInTheLoop?.enabled !== true
     );
   }
@@ -3098,6 +3100,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         orderedBatchEntries.push(entry);
       }
     }
+    const hookInjectedMessages: t.InjectedMessage[] = [];
     if (
       this.hookRegistry?.hasHookFor('PostToolBatch', runId) === true &&
       orderedBatchEntries.length > 0
@@ -3118,6 +3121,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         for (const ctx of batchHookResult.additionalContexts) {
           batchAdditionalContexts.push(ctx);
         }
+        for (const msg of batchHookResult.injectedMessages) {
+          hookInjectedMessages.push(msg);
+        }
       }
     }
 
@@ -3136,6 +3142,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           additional_kwargs: { role: 'system', source: 'hook' },
         })
       );
+    }
+
+    /**
+     * Hook-returned `injectedMessages` land AFTER the consolidated context
+     * message: one converted `HumanMessage` per entry (role/source kept in
+     * `additional_kwargs`), preserving per-message identity so verbatim
+     * user speech (e.g. steering) sits closest to the next model call.
+     */
+    if (hookInjectedMessages.length > 0) {
+      try {
+        injected.push(...this.convertInjectedMessages(hookInjectedMessages));
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[ToolNode] Failed to convert PostToolBatch injectedMessages:',
+          e instanceof Error ? e.message : e
+        );
+      }
     }
   }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -822,10 +822,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private recordEventToolPlanningTurn(
     toolName: string,
     turn: number,
-    callId?: string
+    callId?: string,
+    runId?: string
   ): void {
     this.recordToolUsageTurn(toolName, turn, callId);
-    if (this.canConsumeEagerEventExecution()) {
+    if (this.canConsumeEagerEventExecution(runId)) {
       this.eagerEventToolUsageCount?.set(
         toolName,
         Math.max(this.eagerEventToolUsageCount.get(toolName) ?? 0, turn + 1)
@@ -2593,7 +2594,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         usageCount: this.toolUsageCount,
         invalidArgsBehavior: 'error-result',
         recordTurn: (toolName, reservedTurn, callId) => {
-          this.recordEventToolPlanningTurn(toolName, reservedTurn, callId);
+          this.recordEventToolPlanningTurn(
+            toolName,
+            reservedTurn,
+            callId,
+            runId
+          );
         },
       });
       if (plan == null) {
@@ -2638,7 +2644,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * released if the dispatch fails, letting the batch path re-emit.
        */
       const canEmitEarlyCompletions =
-        this.hookRegistry?.hasResultAlteringHooks() !== true &&
+        this.hookRegistry?.hasResultAlteringHooks(runId) !== true &&
         this.humanInTheLoop?.enabled !== true;
       const earlyCompletionDispatchedIds = new Set<string>();
       const earlyCompletionDispatches: Array<Promise<void>> = [];
@@ -2973,11 +2979,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return { toolMessages, injected };
   }
 
-  private canConsumeEagerEventExecution(): boolean {
+  /** Run-scoped so another run's session hooks can't flip this run's gate. */
+  private canConsumeEagerEventExecution(runId?: string): boolean {
     return (
       this.eventDrivenMode &&
       this.eagerEventToolExecution?.enabled === true &&
-      this.hookRegistry?.hasResultAlteringHooks() !== true &&
+      this.hookRegistry?.hasResultAlteringHooks(runId) !== true &&
       this.humanInTheLoop?.enabled !== true
     );
   }
@@ -2985,7 +2992,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private takeMatchingEagerEventExecution(
     request: t.ToolCallRequest
   ): t.EagerEventToolExecution | undefined {
-    if (!this.canConsumeEagerEventExecution()) {
+    // Static enablement only: a stored record means the reservation-time
+    // gates passed and the host already dispatched the execution. Re-checking
+    // the dynamic hook gate here could decline consumption after a mid-run
+    // registration and send the same call through normal dispatch — executing
+    // the tool twice. PostToolUse hooks still process consumed results below.
+    if (
+      !this.eventDrivenMode ||
+      this.eagerEventToolExecution?.enabled !== true
+    ) {
       return undefined;
     }
 

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -685,4 +685,107 @@ describe('ToolNode eager event tool execution', () => {
     const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
     expect(toolMessage?.content).toBe('eager result');
   });
+
+  it('ignores another run session-scoped result-altering hooks when consuming', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.registerSession('some-other-run', 'PreToolUse', {
+      hooks: [async () => ({ decision: 'allow' as const })],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('eager result');
+  });
+
+  it('consumes a prestarted eager result even after a result-altering hook registers mid-run', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    // The record exists => the host already dispatched this execution before
+    // the hook below was registered. Declining to consume would re-dispatch
+    // the same call and run the tool's side effects twice.
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [async () => ({ decision: 'allow' as const })],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('eager result');
+  });
 });

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -634,4 +634,55 @@ describe('ToolNode eager event tool execution', () => {
     ]);
     expect(eagerUsageCount.size).toBe(0);
   });
+
+  it('consumes a prestarted eager result when the registry only has observation hooks', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolBatch', {
+      hooks: [async () => ({})],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('eager result');
+  });
 });

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -182,7 +182,7 @@ describe('ToolNode per-call onResult completion emission', () => {
     expect(byId.filter((id) => id === 'call_unknown')).toHaveLength(0);
   });
 
-  it('does not offer onResult when batch-sensitive hooks are configured', async () => {
+  it('does not offer onResult when result-altering hooks are configured', async () => {
     let observedBatch: t.ToolExecuteBatchRequest | undefined;
 
     jest
@@ -202,10 +202,14 @@ describe('ToolNode per-call onResult completion emission', () => {
         ]);
       });
 
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolUse', {
+      hooks: [async () => ({})],
+    });
     const toolNode = new ToolNode({
       tools: [createDummyTool('weather')],
       eventDrivenMode: true,
-      hookRegistry: new HookRegistry(),
+      hookRegistry,
       toolCallStepIds: new Map([['call_weather', 'step_weather']]),
     });
 
@@ -219,6 +223,49 @@ describe('ToolNode per-call onResult completion emission', () => {
 
     expect(observedBatch).toBeDefined();
     expect(observedBatch?.onResult).toBeUndefined();
+  });
+
+  it('offers onResult when the registry only has observation hooks (PostToolBatch)', async () => {
+    let observedBatch: t.ToolExecuteBatchRequest | undefined;
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        observedBatch = batch;
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolBatch', {
+      hooks: [async () => ({})],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    expect(observedBatch).toBeDefined();
+    expect(observedBatch?.onResult).toBeDefined();
   });
 
   it('does not offer onResult when human-in-the-loop is enabled', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1566,6 +1566,118 @@ describe('ToolNode HITL — PostToolBatch hook', () => {
     expect(injected).toBeDefined();
     expect(String(injected!.content)).toContain('format the response as JSON');
   });
+
+  it('PostToolBatch injectedMessages land as individual HumanMessages after the consolidated context', async () => {
+    mockEventDispatch([
+      { toolCallId: 'call_1', content: 'ok', status: 'success' },
+    ]);
+
+    const registry = new HookRegistry();
+    registry.register('PostToolBatch', {
+      hooks: [
+        async (): Promise<PostToolBatchHookOutput> => ({
+          additionalContext: 'batch convention',
+          injectedMessages: [
+            { role: 'user', content: 'steer one', source: 'steer' },
+            { role: 'user', content: 'steer two', source: 'steer' },
+          ],
+        }),
+      ],
+    });
+
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo')],
+      eventDrivenMode: true,
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: false },
+    });
+
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'echo', args: { command: 'a' } },
+    ]);
+    const result = (await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'batch-steer-thread' } }
+    )) as { messages: BaseMessage[] };
+
+    type KwargMessage = {
+      additional_kwargs?: { source?: string; role?: string };
+    };
+    const humanMessages = result.messages.filter(
+      (m) => m._getType() === 'human'
+    );
+    const contextIndex = humanMessages.findIndex(
+      (m) => (m as KwargMessage).additional_kwargs?.source === 'hook'
+    );
+    const steerMessages = humanMessages.filter(
+      (m) => (m as KwargMessage).additional_kwargs?.source === 'steer'
+    );
+
+    expect(contextIndex).toBeGreaterThanOrEqual(0);
+    expect(steerMessages).toHaveLength(2);
+    expect(String(steerMessages[0].content)).toBe('steer one');
+    expect(String(steerMessages[1].content)).toBe('steer two');
+    for (const steer of steerMessages) {
+      expect((steer as KwargMessage).additional_kwargs?.role).toBe('user');
+      expect(humanMessages.indexOf(steer)).toBeGreaterThan(contextIndex);
+    }
+    const toolIndex = result.messages.findIndex((m) => m._getType() === 'tool');
+    const firstSteerIndex = result.messages.indexOf(steerMessages[0]);
+    expect(firstSteerIndex).toBeGreaterThan(toolIndex);
+  });
+
+  it('PostToolBatch injectedMessages work without additionalContext', async () => {
+    mockEventDispatch([
+      { toolCallId: 'call_1', content: 'ok', status: 'success' },
+    ]);
+
+    const registry = new HookRegistry();
+    registry.register('PostToolBatch', {
+      hooks: [
+        async (): Promise<PostToolBatchHookOutput> => ({
+          injectedMessages: [
+            { role: 'user', content: 'solo steer', source: 'steer' },
+          ],
+        }),
+      ],
+    });
+
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo')],
+      eventDrivenMode: true,
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: false },
+    });
+
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'echo', args: { command: 'a' } },
+    ]);
+    const result = (await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'solo-steer-thread' } }
+    )) as { messages: BaseMessage[] };
+
+    type KwargMessage = {
+      additional_kwargs?: { source?: string; role?: string };
+    };
+    const consolidated = result.messages.find(
+      (m) =>
+        m._getType() === 'human' &&
+        (m as KwargMessage).additional_kwargs?.source === 'hook'
+    );
+    const steer = result.messages.find(
+      (m) =>
+        m._getType() === 'human' &&
+        (m as KwargMessage).additional_kwargs?.source === 'steer'
+    );
+    expect(consolidated).toBeUndefined();
+    expect(steer).toBeDefined();
+    expect(String(steer!.content)).toBe('solo steer');
+  });
 });
 
 describe('ToolNode HITL — per-hook allowedDecisions override', () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -6,6 +6,7 @@ import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type {
   AgentInputs,
+  InjectedMessage,
   MessageDeltaEvent,
   ProcessedToolCall,
   ReasoningDeltaEvent,
@@ -36,6 +37,7 @@ const MAX_PENDING_SUBAGENT_UPDATES = 64;
 
 const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
   additionalContexts: [] as string[],
+  injectedMessages: [] as InjectedMessage[],
   errors: [] as string[],
 });
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -516,7 +516,7 @@ export type InjectedMessage = {
   /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
   isMeta?: boolean;
   /** Origin tag for downstream consumers (UI, pruner, compaction) */
-  source?: 'skill' | 'hook' | 'system';
+  source?: 'skill' | 'hook' | 'system' | 'steer';
   /** Only set when source is 'skill', for compaction preservation */
   skillName?: string;
 };


### PR DESCRIPTION
## Summary

Adds a per-message graph-state injection channel to the hooks system, the SDK seam for LibreChat's mid-run steering feature (a user message submitted while a run is generating, injected at the next tool-batch boundary).

- **`injectedMessages` on hook outputs** (`BaseHookOutput`, aggregated across hooks in registration order in `executeHooks`). At the `PostToolBatch` dispatch site, `ToolNode` converts each entry via the existing `convertInjectedMessages` into its own `HumanMessage` (role/source preserved in `additional_kwargs`) and appends them **after** the consolidated `additionalContext` message — so verbatim user speech keeps per-message identity, is never merged into system-flavored hook context, and lands closest to the next model call. `InjectedMessage.source` gains `'steer'`.
- **Eager gates key on result-altering hooks, not registry presence.** `HookRegistry.hasResultAlteringHooks()` (any `PreToolUse`/`PostToolUse`/`PostToolUseFailure` matcher; session-scoped with a conservative all-sessions scan when no id is given) now drives `isBatchSensitiveToolExecution`, `canEmitEarlyCompletions`, and `canConsumeEagerEventExecution`. An observation-only registry — e.g. a host registering just a `PostToolBatch` steering drain — keeps eager prestart, early completion emission, and eager event consumption. Behavior-preserving for HITL hosts (their PreToolUse policy hook trips the gate exactly as before); sound because `PostToolBatchHookOutput` cannot rewrite per-call results.
- **`HOOK_INJECTED_MESSAGES_CAPABLE` capability export** so hosts can hard-gate drain-style hooks: a queued message must never be consumed by an SDK version that would silently ignore `injectedMessages`.

Backwards compatible: new optional output field, additive aggregation, additive export. No graph-topology change; injection merges through the messages reducer inside the tool node, so it needs no checkpointer.

## Testing

- `executeHooks`: aggregation across matchers in registration order, absent-field → empty array, `async: true` outputs skipped.
- `hitl.test.ts`: `PostToolBatch` `injectedMessages` land as individual `HumanMessage`s after ToolMessages and after the consolidated context message, kwargs `{role:'user', source:'steer'}`; works without `additionalContext`.
- `HookRegistry`: `hasResultAlteringHooks` matrix (empty, observation-only, each result-altering event, session scoping, all-sessions scan).
- Eager regression guards: `PostToolBatch`-only registry keeps prestart (`stream.eagerEventExecution`), early completions (`ToolNode.onResultCompletion`), and eager consumption (`ToolNode.eagerEventExecution`); `PreToolUse` still disables all three.
- Full suite: only the live-provider specs fail locally (no credentials), unchanged from `main`.