### PR TITLE
⏱️ fix: Honor Stream Delay for Bedrock

### DIFF
--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -512,13 +512,19 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
       const enqueueDelta = async (
         contentBlockDelta: ContentBlockDeltaEvent
       ): Promise<void> => {
+        const delta = contentBlockDelta.delta;
+        if (delta == null) {
+          throw new Error('No delta found in content block.');
+        }
+
         const idx = contentBlockDelta.contentBlockIndex;
         if (idx != null) {
           seenBlockIndices.add(idx);
         }
 
-        const text = contentBlockDelta.delta?.text;
-        const reasoningText = contentBlockDelta.delta?.reasoningContent?.text;
+        const text = delta.text;
+        const reasoningContent = delta.reasoningContent;
+        const reasoningText = reasoningContent?.text;
         const visibleText =
           typeof text === 'string'
             ? text
@@ -535,15 +541,17 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           if (typeof text === 'string') {
             splitDelta = {
               ...contentBlockDelta,
-              delta: { ...contentBlockDelta.delta, text: token },
+              delta: { text: token },
             };
-          } else if (typeof reasoningText === 'string') {
+          } else if (
+            typeof reasoningText === 'string' &&
+            reasoningContent != null
+          ) {
             splitDelta = {
               ...contentBlockDelta,
               delta: {
-                ...contentBlockDelta.delta,
                 reasoningContent: {
-                  ...contentBlockDelta.delta.reasoningContent,
+                  ...reasoningContent,
                   text: token,
                 },
               },

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -39,6 +39,7 @@ import {
   handleConverseStreamContentBlockDelta,
   handleConverseStreamMetadata,
 } from './utils';
+import type { ContentBlockDeltaEvent } from './types';
 import {
   resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
@@ -56,6 +57,50 @@ export type ServiceTierType = 'priority' | 'default' | 'flex' | 'reserved';
 
 export type CustomGuardrailConfiguration = GuardrailConfiguration &
   Pick<GuardrailStreamConfiguration, 'streamProcessingMode'>;
+
+const MAX_STREAM_QUEUE_CHUNKS = 256;
+const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
+const STREAM_CHUNK_MIN_SIZE = 4;
+const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
+
+type QueuedGenerationChunk = {
+  chunk: ChatGenerationChunk;
+  callbackChunk?: ChatGenerationChunk;
+  callbackToken: string;
+  smooth: boolean;
+  textLength: number;
+};
+
+function findStreamChunkBoundary(text: string, minSize: number): number {
+  if (minSize >= text.length) {
+    return text.length;
+  }
+
+  for (let position = minSize; position < text.length; position++) {
+    if (STREAM_BOUNDARIES.has(text[position])) {
+      return position + 1;
+    }
+  }
+
+  return text.length;
+}
+
+function splitStreamToken(text: string): string[] {
+  const chunks: string[] = [];
+  let currentIndex = 0;
+
+  while (currentIndex < text.length) {
+    const remainingText = text.slice(currentIndex);
+    const chunkSize = findStreamChunkBoundary(
+      remainingText,
+      STREAM_CHUNK_MIN_SIZE
+    );
+    chunks.push(text.slice(currentIndex, currentIndex + chunkSize));
+    currentIndex += chunkSize;
+  }
+
+  return chunks;
+}
 
 function getCadencedStreamDelay({
   targetDelay,
@@ -237,10 +282,10 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     const toolConfig =
       this.promptCache === true && supportsBedrockToolCache(this.cacheModelId)
         ? insertBedrockToolCachePoint(
-          baseParams.toolConfig,
-          true,
-          resolveBedrockPromptCacheTtl(this.promptCacheTtl, this.cacheModelId)
-        )
+            baseParams.toolConfig,
+            true,
+            resolveBedrockPromptCacheTtl(this.promptCacheTtl, this.cacheModelId)
+          )
         : baseParams.toolConfig;
 
     /** Service tier from options or fall back to class-level setting */
@@ -315,128 +360,346 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
       ...(params as Record<string, unknown>),
     });
 
-    const response = await this.client.send(command, {
-      abortSignal: options.signal,
-    });
-
-    if (!response.stream) {
-      return;
+    const streamAbortController = new AbortController();
+    const abortStream = (): void => streamAbortController.abort();
+    options.signal?.addEventListener('abort', abortStream, { once: true });
+    if (isSignalAborted(options.signal)) {
+      abortStream();
     }
 
-    const seenBlockIndices = new Set<number>();
-    const toolUseBlockIndices = new Set<number>();
-    let hasEmittedVisibleContent = false;
-    let lastVisibleContentAt: number | undefined;
-    /**
-     * Guardrails can reject an already-streamed toolUse block at
-     * `messageStop` (`guardrail_intervened`), after `contentBlockStop` has
-     * passed. Only emit eager-execution seals when no guardrails are
-     * configured, so a later intervention can't race an eagerly started tool.
-     */
-    const sealToolUseOnStop =
-      options.guardrailConfig == null && this.guardrailConfig == null;
+    try {
+      const response = await this.client.send(command, {
+        abortSignal: streamAbortController.signal,
+      });
 
-    for await (const event of response.stream) {
-      if (event.contentBlockStart != null) {
-        const startChunk = handleConverseStreamContentBlockStart(
-          event.contentBlockStart
-        );
-        if (startChunk != null) {
-          const idx = event.contentBlockStart.contentBlockIndex;
-          if (idx != null) {
-            seenBlockIndices.add(idx);
-            if (event.contentBlockStart.start?.toolUse != null) {
-              toolUseBlockIndices.add(idx);
-            }
-          }
-          yield this.enrichChunk(startChunk, seenBlockIndices);
+      const stream = response.stream;
+      if (!stream) {
+        return;
+      }
 
-          // Registered stream handlers receive chunks through callback
-          // events, not the yielded generator — dispatch the start chunk so
-          // they see the tool call's id/name (eager chunk state needs both).
-          await runManager?.handleLLMNewToken(
-            startChunk.text,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            { chunk: startChunk }
-          );
+      const seenBlockIndices = new Set<number>();
+      const toolUseBlockIndices = new Set<number>();
+      const queuedChunks: QueuedGenerationChunk[] = [];
+      const producerState: { done: boolean; error?: unknown } = { done: false };
+      let queuedChunkIndex = 0;
+      let bufferedTextLength = 0;
+      let consumerClosed = false;
+      let notifyConsumer: (() => void) | undefined;
+      let notifyProducer: (() => void) | undefined;
+      let hasEmittedVisibleContent = false;
+      let lastVisibleContentAt: number | undefined;
+
+      /**
+       * Guardrails can reject an already-streamed toolUse block at
+       * `messageStop` (`guardrail_intervened`), after `contentBlockStop` has
+       * passed. Only emit eager-execution seals when no guardrails are
+       * configured, so a later intervention can't race an eagerly started tool.
+       */
+      const sealToolUseOnStop =
+        options.guardrailConfig == null && this.guardrailConfig == null;
+
+      const notifyConsumerForChunk = (): void => {
+        notifyConsumer?.();
+        notifyConsumer = undefined;
+      };
+
+      const notifyProducerForSpace = (): void => {
+        notifyProducer?.();
+        notifyProducer = undefined;
+      };
+
+      const hasQueuedChunks = (): boolean =>
+        queuedChunkIndex < queuedChunks.length;
+
+      const getQueuedChunkCount = (): number =>
+        queuedChunks.length - queuedChunkIndex;
+
+      const isQueueAtCapacity = (): boolean =>
+        getQueuedChunkCount() >= MAX_STREAM_QUEUE_CHUNKS ||
+        bufferedTextLength >= MAX_STREAM_QUEUE_TEXT_CHARS;
+
+      const waitForNextChunk = async (): Promise<void> => {
+        if (
+          hasQueuedChunks() ||
+          producerState.done ||
+          producerState.error != null
+        ) {
+          return;
         }
-      } else if (event.contentBlockDelta != null) {
-        const deltaChunk = handleConverseStreamContentBlockDelta(
-          event.contentBlockDelta
-        );
+        await new Promise<void>((resolve) => {
+          notifyConsumer = resolve;
+        });
+      };
 
-        const idx = event.contentBlockDelta.contentBlockIndex;
+      const waitForQueueSpace = async (): Promise<void> => {
+        while (
+          isQueueAtCapacity() &&
+          !consumerClosed &&
+          !isSignalAborted(options.signal)
+        ) {
+          await new Promise<void>((resolve) => {
+            const signal = options.signal;
+            const onAbort = (): void => {
+              signal?.removeEventListener('abort', onAbort);
+              resolve();
+            };
+            const onSpace = (): void => {
+              signal?.removeEventListener('abort', onAbort);
+              resolve();
+            };
+            notifyProducer = onSpace;
+            signal?.addEventListener('abort', onAbort, { once: true });
+            if (isSignalAborted(signal)) {
+              onAbort();
+            }
+          });
+        }
+      };
+
+      const dequeue = (): QueuedGenerationChunk | undefined => {
+        if (!hasQueuedChunks()) {
+          return undefined;
+        }
+        const queuedChunk = queuedChunks[queuedChunkIndex];
+        queuedChunkIndex++;
+        if (
+          queuedChunkIndex > 128 &&
+          queuedChunkIndex * 2 >= queuedChunks.length
+        ) {
+          queuedChunks.splice(0, queuedChunkIndex);
+          queuedChunkIndex = 0;
+        }
+        return queuedChunk;
+      };
+
+      const enqueue = async (
+        queuedChunk: QueuedGenerationChunk
+      ): Promise<void> => {
+        await waitForQueueSpace();
+        if (consumerClosed || isSignalAborted(options.signal)) {
+          abortStream();
+          throw new Error('AbortError: User aborted the request.');
+        }
+        queuedChunks.push(queuedChunk);
+        if (queuedChunk.smooth) {
+          bufferedTextLength += queuedChunk.textLength;
+        }
+        notifyConsumerForChunk();
+      };
+
+      const enqueueChunk = async ({
+        chunk,
+        callbackChunk,
+        callbackToken = '',
+        smooth = false,
+        textLength = 0,
+      }: {
+        chunk: ChatGenerationChunk;
+        callbackChunk?: ChatGenerationChunk;
+        callbackToken?: string;
+        smooth?: boolean;
+        textLength?: number;
+      }): Promise<void> => {
+        await enqueue({
+          chunk,
+          callbackChunk,
+          callbackToken,
+          smooth,
+          textLength: smooth ? textLength : 0,
+        });
+      };
+
+      const enqueueDelta = async (
+        contentBlockDelta: ContentBlockDeltaEvent
+      ): Promise<void> => {
+        const idx = contentBlockDelta.contentBlockIndex;
         if (idx != null) {
           seenBlockIndices.add(idx);
         }
 
-        const reasoningContent =
-          deltaChunk.message.additional_kwargs.reasoning_content;
-        const hasVisibleContent =
-          deltaChunk.text !== '' ||
-          (typeof reasoningContent === 'string' && reasoningContent !== '');
+        const text = contentBlockDelta.delta?.text;
+        const reasoningText = contentBlockDelta.delta?.reasoningContent?.text;
+        const visibleText =
+          typeof text === 'string'
+            ? text
+            : typeof reasoningText === 'string'
+              ? reasoningText
+              : '';
+        const smooth = this._lc_stream_delay > 0 && visibleText !== '';
+        const tokenChunks = smooth
+          ? splitStreamToken(visibleText)
+          : [visibleText];
 
-        if (hasVisibleContent) {
-          await waitForStreamDelay(
-            getCadencedStreamDelay({
-              targetDelay: hasEmittedVisibleContent
-                ? this._lc_stream_delay
-                : 0,
-              lastVisibleContentAt,
-              now: Date.now(),
-            }),
-            options.signal
-          );
+        for (const token of tokenChunks) {
+          let splitDelta = contentBlockDelta;
+          if (typeof text === 'string') {
+            splitDelta = {
+              ...contentBlockDelta,
+              delta: { ...contentBlockDelta.delta, text: token },
+            };
+          } else if (typeof reasoningText === 'string') {
+            splitDelta = {
+              ...contentBlockDelta,
+              delta: {
+                ...contentBlockDelta.delta,
+                reasoningContent: {
+                  ...contentBlockDelta.delta.reasoningContent,
+                  text: token,
+                },
+              },
+            };
+          }
+
+          const deltaChunk = handleConverseStreamContentBlockDelta(splitDelta);
+          await enqueueChunk({
+            chunk: this.enrichChunk(deltaChunk, seenBlockIndices),
+            callbackChunk: deltaChunk,
+            callbackToken: deltaChunk.text,
+            smooth,
+            textLength: token.length,
+          });
+        }
+      };
+
+      const producer = (async (): Promise<void> => {
+        try {
+          for await (const event of stream) {
+            if (isSignalAborted(options.signal)) {
+              abortStream();
+              throw new Error('AbortError: User aborted the request.');
+            }
+
+            if (event.contentBlockStart != null) {
+              const startChunk = handleConverseStreamContentBlockStart(
+                event.contentBlockStart
+              );
+              if (startChunk != null) {
+                const idx = event.contentBlockStart.contentBlockIndex;
+                if (idx != null) {
+                  seenBlockIndices.add(idx);
+                  if (event.contentBlockStart.start?.toolUse != null) {
+                    toolUseBlockIndices.add(idx);
+                  }
+                }
+                await enqueueChunk({
+                  chunk: this.enrichChunk(startChunk, seenBlockIndices),
+                  callbackChunk: startChunk,
+                  callbackToken: startChunk.text,
+                });
+              }
+            } else if (event.contentBlockDelta != null) {
+              await enqueueDelta(event.contentBlockDelta);
+            } else if (event.metadata != null) {
+              await enqueueChunk({
+                chunk: handleConverseStreamMetadata(event.metadata, {
+                  streamUsage,
+                }),
+              });
+            } else if (event.contentBlockStop != null) {
+              const stopIdx = event.contentBlockStop.contentBlockIndex;
+              if (stopIdx != null) {
+                seenBlockIndices.add(stopIdx);
+                if (sealToolUseOnStop && toolUseBlockIndices.has(stopIdx)) {
+                  const sealChunk = createConverseToolUseStopChunk(stopIdx);
+                  await enqueueChunk({
+                    chunk: sealChunk,
+                    callbackChunk: sealChunk,
+                    callbackToken: sealChunk.text,
+                  });
+                }
+              }
+            } else {
+              await enqueueChunk({
+                chunk: new ChatGenerationChunk({
+                  text: '',
+                  message: new AIMessageChunk({
+                    content: '',
+                    response_metadata: { ...event } as ResponseMetadata,
+                  }),
+                }),
+              });
+            }
+          }
+        } catch (error) {
+          producerState.error = error;
+        } finally {
+          producerState.done = true;
+          notifyConsumerForChunk();
+        }
+      })();
+
+      try {
+        let keepStreaming = true;
+        while (keepStreaming) {
           if (isSignalAborted(options.signal)) {
+            abortStream();
             throw new Error('AbortError: User aborted the request.');
           }
-          hasEmittedVisibleContent = true;
-          lastVisibleContentAt = Date.now();
-        }
 
-        yield this.enrichChunk(deltaChunk, seenBlockIndices);
+          await waitForNextChunk();
+          const queuedChunk = dequeue();
 
-        await runManager?.handleLLMNewToken(
-          deltaChunk.text,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { chunk: deltaChunk }
-        );
-      } else if (event.metadata != null) {
-        yield handleConverseStreamMetadata(event.metadata, { streamUsage });
-      } else if (event.contentBlockStop != null) {
-        const stopIdx = event.contentBlockStop.contentBlockIndex;
-        if (stopIdx != null) {
-          seenBlockIndices.add(stopIdx);
-          if (sealToolUseOnStop && toolUseBlockIndices.has(stopIdx)) {
-            // Converse guarantees the block's input is complete at stop, so
-            // emit an explicit seal chunk for eager tool execution — through
-            // the callback path too, for registered stream handlers.
-            const sealChunk = createConverseToolUseStopChunk(stopIdx);
-            yield sealChunk;
+          if (!queuedChunk) {
+            if (producerState.error != null) {
+              throw producerState.error;
+            }
+            if (producerState.done) {
+              keepStreaming = false;
+            }
+            continue;
+          }
+
+          if (queuedChunk.smooth) {
+            bufferedTextLength = Math.max(
+              0,
+              bufferedTextLength - queuedChunk.textLength
+            );
+            notifyProducerForSpace();
+            await waitForStreamDelay(
+              getCadencedStreamDelay({
+                targetDelay: hasEmittedVisibleContent
+                  ? this._lc_stream_delay
+                  : 0,
+                lastVisibleContentAt,
+                now: Date.now(),
+              }),
+              options.signal
+            );
+            if (isSignalAborted(options.signal)) {
+              abortStream();
+              throw new Error('AbortError: User aborted the request.');
+            }
+            hasEmittedVisibleContent = true;
+            lastVisibleContentAt = Date.now();
+          } else {
+            notifyProducerForSpace();
+          }
+
+          yield queuedChunk.chunk;
+
+          if (queuedChunk.callbackChunk != null) {
             await runManager?.handleLLMNewToken(
-              sealChunk.text,
+              queuedChunk.callbackToken,
               undefined,
               undefined,
               undefined,
               undefined,
-              { chunk: sealChunk }
+              { chunk: queuedChunk.callbackChunk }
             );
           }
         }
-      } else {
-        yield new ChatGenerationChunk({
-          text: '',
-          message: new AIMessageChunk({
-            content: '',
-            response_metadata: { ...event } as ResponseMetadata,
-          }),
-        });
+      } finally {
+        consumerClosed = true;
+        if (!producerState.done) {
+          abortStream();
+          notifyProducerForSpace();
+        }
+        await producer;
+      }
+    } finally {
+      options.signal?.removeEventListener('abort', abortStream);
+      if (!streamAbortController.signal.aborted) {
+        streamAbortController.abort();
       }
     }
   }

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -59,17 +59,17 @@ export type CustomGuardrailConfiguration = GuardrailConfiguration &
 
 function getCadencedStreamDelay({
   targetDelay,
-  lastVisibleTextAt,
+  lastVisibleContentAt,
   now,
 }: {
   targetDelay: number;
-  lastVisibleTextAt?: number;
+  lastVisibleContentAt?: number;
   now: number;
 }): number {
-  if (targetDelay <= 0 || lastVisibleTextAt == null) {
+  if (targetDelay <= 0 || lastVisibleContentAt == null) {
     return 0;
   }
-  return Math.max(0, targetDelay - (now - lastVisibleTextAt));
+  return Math.max(0, targetDelay - (now - lastVisibleContentAt));
 }
 
 async function waitForStreamDelay(
@@ -125,7 +125,7 @@ export interface CustomChatBedrockConverseInput
   promptCacheTtl?: PromptCacheTtl;
 
   /**
-   * Minimum delay in milliseconds between visible streamed text deltas.
+   * Minimum delay in milliseconds between visible streamed content deltas.
    */
   _lc_stream_delay?: number;
 
@@ -325,8 +325,8 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
 
     const seenBlockIndices = new Set<number>();
     const toolUseBlockIndices = new Set<number>();
-    let hasEmittedText = false;
-    let lastVisibleTextAt: number | undefined;
+    let hasEmittedVisibleContent = false;
+    let lastVisibleContentAt: number | undefined;
     /**
      * Guardrails can reject an already-streamed toolUse block at
      * `messageStop` (`guardrail_intervened`), after `contentBlockStop` has
@@ -373,11 +373,19 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           seenBlockIndices.add(idx);
         }
 
-        if (deltaChunk.text !== '') {
+        const reasoningContent =
+          deltaChunk.message.additional_kwargs.reasoning_content;
+        const hasVisibleContent =
+          deltaChunk.text !== '' ||
+          (typeof reasoningContent === 'string' && reasoningContent !== '');
+
+        if (hasVisibleContent) {
           await waitForStreamDelay(
             getCadencedStreamDelay({
-              targetDelay: hasEmittedText ? this._lc_stream_delay : 0,
-              lastVisibleTextAt,
+              targetDelay: hasEmittedVisibleContent
+                ? this._lc_stream_delay
+                : 0,
+              lastVisibleContentAt,
               now: Date.now(),
             }),
             options.signal
@@ -385,8 +393,8 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           if (isSignalAborted(options.signal)) {
             throw new Error('AbortError: User aborted the request.');
           }
-          hasEmittedText = true;
-          lastVisibleTextAt = Date.now();
+          hasEmittedVisibleContent = true;
+          lastVisibleContentAt = Date.now();
         }
 
         yield this.enrichChunk(deltaChunk, seenBlockIndices);

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -57,6 +57,52 @@ export type ServiceTierType = 'priority' | 'default' | 'flex' | 'reserved';
 export type CustomGuardrailConfiguration = GuardrailConfiguration &
   Pick<GuardrailStreamConfiguration, 'streamProcessingMode'>;
 
+function getCadencedStreamDelay({
+  targetDelay,
+  lastVisibleTextAt,
+  now,
+}: {
+  targetDelay: number;
+  lastVisibleTextAt?: number;
+  now: number;
+}): number {
+  if (targetDelay <= 0 || lastVisibleTextAt == null) {
+    return 0;
+  }
+  return Math.max(0, targetDelay - (now - lastVisibleTextAt));
+}
+
+async function waitForStreamDelay(
+  delay: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (delay <= 0 || isSignalAborted(signal)) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
+    const onAbort = (): void => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    timeoutRef.current = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delay);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (isSignalAborted(signal)) {
+      onAbort();
+    }
+  });
+}
+
+function isSignalAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
 /**
  * Extended input interface with additional features:
  * - applicationInferenceProfile: Use an inference profile ARN instead of model ID
@@ -77,6 +123,11 @@ export interface CustomChatBedrockConverseInput
    * on; use `'5m'` for any model that rejects it.
    */
   promptCacheTtl?: PromptCacheTtl;
+
+  /**
+   * Minimum delay in milliseconds between visible streamed text deltas.
+   */
+  _lc_stream_delay?: number;
 
   /**
    * Guardrail configuration for Converse and ConverseStream invocations.
@@ -119,6 +170,8 @@ export interface CustomChatBedrockConverseCallOptions {
 }
 
 export class CustomChatBedrockConverse extends ChatBedrockConverse {
+  _lc_stream_delay: number;
+
   /**
    * Whether to insert Bedrock prompt cache checkpoints when available.
    */
@@ -151,6 +204,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     super(fields);
     this.promptCache = fields?.promptCache;
     this.promptCacheTtl = fields?.promptCacheTtl;
+    this._lc_stream_delay = Math.max(0, fields?._lc_stream_delay ?? 0);
     this.applicationInferenceProfile = fields?.applicationInferenceProfile;
     this.serviceTier = fields?.serviceTier;
     // `super(fields)` initializes `this.model` to LangChain's default Claude
@@ -271,6 +325,8 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
 
     const seenBlockIndices = new Set<number>();
     const toolUseBlockIndices = new Set<number>();
+    let hasEmittedText = false;
+    let lastVisibleTextAt: number | undefined;
     /**
      * Guardrails can reject an already-streamed toolUse block at
      * `messageStop` (`guardrail_intervened`), after `contentBlockStop` has
@@ -315,6 +371,22 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
         const idx = event.contentBlockDelta.contentBlockIndex;
         if (idx != null) {
           seenBlockIndices.add(idx);
+        }
+
+        if (deltaChunk.text !== '') {
+          await waitForStreamDelay(
+            getCadencedStreamDelay({
+              targetDelay: hasEmittedText ? this._lc_stream_delay : 0,
+              lastVisibleTextAt,
+              now: Date.now(),
+            }),
+            options.signal
+          );
+          if (isSignalAborted(options.signal)) {
+            throw new Error('AbortError: User aborted the request.');
+          }
+          hasEmittedText = true;
+          lastVisibleTextAt = Date.now();
         }
 
         yield this.enrichChunk(deltaChunk, seenBlockIndices);

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -191,4 +191,44 @@ describe('Converse stream seal dispatch', () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  test('paces visible reasoning deltas with configured stream delay', async () => {
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+
+    try {
+      const { yielded, dispatched } = await runStream(
+        [
+          {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { reasoningContent: { text: 'First thought' } },
+            },
+          },
+          {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { reasoningContent: { text: 'Second thought' } },
+            },
+          },
+        ],
+        { _lc_stream_delay: 35 }
+      );
+
+      expect(
+        yielded.map((m) => m.additional_kwargs.reasoning_content)
+      ).toEqual(['First thought', 'Second thought']);
+      expect(
+        dispatched.map((m) => m.additional_kwargs.reasoning_content)
+      ).toEqual(['First thought', 'Second thought']);
+
+      const timeoutDelays = setTimeoutSpy.mock.calls
+        .map(([, delay]) => delay)
+        .filter((delay): delay is number => typeof delay === 'number');
+      expect(timeoutDelays.some((delay) => delay > 0 && delay <= 35)).toBe(
+        true
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -155,4 +155,40 @@ describe('Converse stream seal dispatch', () => {
     expect(dispatched.some(hasSeal)).toBe(false);
     expect(dispatched).toHaveLength(1);
   });
+
+  test('paces visible text deltas with configured stream delay', async () => {
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+
+    try {
+      const { yielded, dispatched } = await runStream(
+        [
+          {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { text: 'hello' },
+            },
+          },
+          {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { text: ' world' },
+            },
+          },
+        ],
+        { _lc_stream_delay: 35 }
+      );
+
+      expect(yielded.map((m) => m.content)).toEqual(['hello', ' world']);
+      expect(dispatched.map((m) => m.content)).toEqual(['hello', ' world']);
+
+      const timeoutDelays = setTimeoutSpy.mock.calls
+        .map(([, delay]) => delay)
+        .filter((delay): delay is number => typeof delay === 'number');
+      expect(timeoutDelays.some((delay) => delay > 0 && delay <= 35)).toBe(
+        true
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -192,6 +192,27 @@ describe('Converse stream seal dispatch', () => {
     }
   });
 
+  test('splits large text deltas at Anthropic stream boundaries', async () => {
+    const { yielded, dispatched } = await runStream(
+      [
+        {
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: { text: 'alpha beta gamma' },
+          },
+        },
+      ],
+      { _lc_stream_delay: 1 }
+    );
+
+    expect(yielded.map((m) => m.content)).toEqual(['alpha ', 'beta ', 'gamma']);
+    expect(dispatched.map((m) => m.content)).toEqual([
+      'alpha ',
+      'beta ',
+      'gamma',
+    ]);
+  });
+
   test('paces visible reasoning deltas with configured stream delay', async () => {
     const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout');
 
@@ -201,25 +222,25 @@ describe('Converse stream seal dispatch', () => {
           {
             contentBlockDelta: {
               contentBlockIndex: 0,
-              delta: { reasoningContent: { text: 'First thought' } },
+              delta: { reasoningContent: { text: 'One' } },
             },
           },
           {
             contentBlockDelta: {
               contentBlockIndex: 0,
-              delta: { reasoningContent: { text: 'Second thought' } },
+              delta: { reasoningContent: { text: 'Two' } },
             },
           },
         ],
         { _lc_stream_delay: 35 }
       );
 
-      expect(
-        yielded.map((m) => m.additional_kwargs.reasoning_content)
-      ).toEqual(['First thought', 'Second thought']);
+      expect(yielded.map((m) => m.additional_kwargs.reasoning_content)).toEqual(
+        ['One', 'Two']
+      );
       expect(
         dispatched.map((m) => m.additional_kwargs.reasoning_content)
-      ).toEqual(['First thought', 'Second thought']);
+      ).toEqual(['One', 'Two']);
 
       const timeoutDelays = setTimeoutSpy.mock.calls
         .map(([, delay]) => delay)

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -1077,12 +1077,19 @@ describe('custom chat model class smoke tests', () => {
       model: 'anthropic.claude-3-haiku-20240307-v1:0',
       applicationInferenceProfile,
       serviceTier: 'priority',
+      _lc_stream_delay: 12,
+    });
+    const defaultStreamDelayModel = new CustomChatBedrockConverse({
+      ...baseBedrockFields,
+      model: 'anthropic.claude-3-haiku-20240307-v1:0',
     });
 
     expect(CustomChatBedrockConverse.lc_name()).toBe(
       'LibreChatBedrockConverse'
     );
     expect(model.applicationInferenceProfile).toBe(applicationInferenceProfile);
+    expect(model._lc_stream_delay).toBe(12);
+    expect(defaultStreamDelayModel._lc_stream_delay).toBe(0);
     expect(model.invocationParams({}).serviceTier).toEqual({
       type: 'priority',
     });

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -100,6 +100,10 @@ export type BedrockAnthropicInput = ChatBedrockConverseInput & {
    * server-side, so the default is safe to leave on.
    */
   promptCacheTtl?: PromptCacheTtl;
+  /**
+   * Minimum delay in milliseconds between visible streamed text deltas.
+   */
+  _lc_stream_delay?: number;
 };
 export type BedrockConverseClientOptions = BedrockAnthropicInput;
 export type BedrockAnthropicClientOptions = BedrockAnthropicInput;

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -101,7 +101,7 @@ export type BedrockAnthropicInput = ChatBedrockConverseInput & {
    */
   promptCacheTtl?: PromptCacheTtl;
   /**
-   * Minimum delay in milliseconds between visible streamed text deltas.
+   * Minimum delay in milliseconds between visible streamed content deltas.
    */
   _lc_stream_delay?: number;
 };


### PR DESCRIPTION
## Summary

I fixed Bedrock Converse streaming so configured stream delays use the same bounded smoothing behavior as Anthropic instead of being ignored.

- Added `_lc_stream_delay` support to the Bedrock client input and shared Bedrock option types.
- Buffered Bedrock stream events with the same 256-chunk and 8192-character limits used by Anthropic.
- Split oversized text and reasoning deltas at the same natural boundaries after a 4-character minimum.
- Drained visible content at the configured minimum cadence while allowing provider stalls to pass through naturally.
- Preserved immediate, ordered delivery for tool-use deltas, metadata, seals, and zero-delay configurations.
- Aborted the underlying Bedrock stream when the consumer closes or the request signal aborts.
- Added focused coverage for text pacing, reasoning pacing, boundary splitting, callback dispatch, and constructor defaults.

The root cause was that `CustomChatBedrockConverse` neither retained `_lc_stream_delay` nor applied Anthropic's producer/consumer smoothing model while consuming ConverseStream events, so LibreChat's `streamRate` setting had no effect for Bedrock models.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran a source-level live Bedrock integration against the PR worktree with credentials loaded from the main local worktree's `.env` without logging secret values.
- Measured the raw Bedrock SDK stream: 134 text chunks, 10 gaps below 20 ms, 48 ms median gap, 61 ms p95 gap, and 5.3 average characters per chunk.
- Measured the buffered Bedrock text stream at 25 ms: 135 text chunks, zero gaps below 20 ms, 25 ms minimum gap, 50 ms median gap, and 56 ms p95 gap.
- Measured the buffered Bedrock reasoning stream at 25 ms: 72 reasoning chunks, zero gaps below 20 ms, 24 ms minimum gap, 26 ms median gap, and 55 ms p95 gap.
- Confirmed provider stalls remain visible rather than being hidden or accelerated.
- Did not run local repository suites after the buffer refactor; GitHub CI is the repository-wide validation source for the latest commit.

### **Test Configuration**:

- Node.js 24.16.0
- AWS region `us-east-1`
- Bedrock model `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Stream delay `25` ms

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have written tests demonstrating that my changes are effective
