### PR TITLE
feat(openai): persist GPT-5.6 Responses state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@langchain/google-vertexai": "2.2.0",
         "@langchain/langgraph": "^1.4.6",
         "@langchain/mistralai": "^1.2.0",
-        "@langchain/openai": "1.5.3",
+        "@langchain/openai": "1.5.5",
         "@langchain/textsplitters": "^1.0.1",
         "@langchain/xai": "^1.4.3",
         "@langfuse/langchain": "^5.4.1",
@@ -40,7 +40,7 @@
         "mathjs": "^15.2.0",
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
-        "openai": "^6.35.0",
+        "openai": "^6.46.0",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -2186,9 +2186,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-KfjEOT6sCg0vvItagfEtGpmrGoLMGfma4Affb5BGEqPmS2YR3AxW54pABSkhQlzCehTB+0BnLquAe1lGF4J9zQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.3.tgz",
-      "integrity": "sha512-OStS2AUvy9oe/hEf/3ndBOFztUDOfuJYLNXh89m3iiJAI2Cp5Dp0n/pvpO27MO0b+VgENd+xSHVyQZ7fe+ulxg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.5.tgz",
+      "integrity": "sha512-wX7dwb9z4nf5FHXlIl/X2mk08pzonvRHCt1D4+s1zXLP0duYDC95j7dulPIQJ6fmhbyYQc9Ki8mEhY/D1lB8kw==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
@@ -2423,7 +2423,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.1"
+        "@langchain/core": "^1.2.2"
       }
     },
     "node_modules/@langchain/openai/node_modules/zod": {
@@ -11416,15 +11416,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     "README.md"
   ],
   "scripts": {
-    "prepare": "node husky-setup.js",
+    "prepare": "node husky-setup.js && npm run build",
     "prepublishOnly": "npm run build",
-    "build": "rm -rf ./dist && tsdown && tsc -p tsconfig.build.json",
+    "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",
     "sort-imports": "node scripts/sort-imports.ts",
     "sort-imports:check": "node scripts/sort-imports.ts --check",
@@ -200,7 +200,7 @@
     "format": "prettier --write ."
   },
   "overrides": {
-    "@langchain/openai": "1.5.3",
+    "@langchain/openai": "1.5.5",
     "@browserbasehq/stagehand": {
       "openai": "$openai"
     },
@@ -224,7 +224,7 @@
     "@langchain/google-vertexai": "2.2.0",
     "@langchain/langgraph": "^1.4.6",
     "@langchain/mistralai": "^1.2.0",
-    "@langchain/openai": "1.5.3",
+    "@langchain/openai": "1.5.5",
     "@langchain/textsplitters": "^1.0.1",
     "@langchain/xai": "^1.4.3",
     "@langfuse/langchain": "^5.4.1",
@@ -243,7 +243,7 @@
     "mathjs": "^15.2.0",
     "nanoid": "^3.3.7",
     "okapibm25": "^1.4.1",
-    "openai": "^6.35.0",
+    "openai": "^6.46.0",
     "uuid": "^11.1.1"
   },
   "peerDependencies": {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -36,10 +36,16 @@ import type * as t from '@langchain/openai';
 import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
 import {
+  isReasoningModel,
+  _convertMessagesToOpenAIParams,
+  _convertMessagesToOpenAIResponsesParams,
+  _convertOpenAIResponsesDeltaToBaseMessageChunk,
+  _convertOpenAIResponsesMessageToBaseMessage,
+} from './utils';
+import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -102,9 +108,13 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
 };
 type ReasoningCallOptions = {
   reasoning?: OpenAIClient.Reasoning;
@@ -153,6 +163,320 @@ type OpenAIChatCompletionRetry = (
 ) => Promise<
   AsyncIterable<OpenAIChatCompletionStreamItem> | OpenAIChatCompletion
 >;
+type OpenAIManagedRequestFields = {
+  promptCacheExplicit?: boolean;
+  safetyIdentifier?: string;
+};
+type OpenAIManagedRequestParams = {
+  prompt_cache_options?: {
+    mode: 'explicit';
+    ttl: '30m';
+  };
+  safety_identifier?: string;
+};
+type ResponsesRequest =
+  | OpenAIClient.Responses.ResponseCreateParamsStreaming
+  | OpenAIClient.Responses.ResponseCreateParamsNonStreaming;
+type ResponsesResult =
+  | AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>
+  | OpenAIClient.Responses.Response;
+type CacheableChatPart = {
+  type: 'text' | 'image_url' | 'input_audio' | 'file' | 'refusal';
+  prompt_cache_breakpoint?: { mode: 'explicit' };
+  [key: string]: unknown;
+};
+type CacheableResponsePart = (
+  | OpenAIClient.Responses.ResponseInputText
+  | OpenAIClient.Responses.ResponseInputImage
+  | OpenAIClient.Responses.ResponseInputFile
+) & {
+  prompt_cache_breakpoint?: { mode: 'explicit' };
+};
+type ResponsesUsageWithCacheWrite = OpenAIClient.Responses.ResponseUsage & {
+  input_tokens_details?: OpenAIClient.Responses.ResponseUsage['input_tokens_details'] & {
+    cache_write_tokens?: number;
+  };
+};
+const CACHE_WRITE_METADATA_KEY = '__librechat_cache_write_tokens';
+
+function applyManagedRequestParams<T extends object>(
+  params: T,
+  fields: OpenAIManagedRequestFields
+): T & OpenAIManagedRequestParams {
+  return {
+    ...params,
+    ...(fields.promptCacheExplicit === true && {
+      prompt_cache_options: {
+        mode: 'explicit' as const,
+        ttl: '30m' as const,
+      },
+    }),
+    ...(fields.safetyIdentifier != null && {
+      safety_identifier: fields.safetyIdentifier,
+    }),
+  };
+}
+
+function isCacheableChatPart(part: unknown): part is CacheableChatPart {
+  if (typeof part !== 'object' || part == null || !('type' in part)) {
+    return false;
+  }
+  return (
+    part.type === 'text' ||
+    part.type === 'image_url' ||
+    part.type === 'input_audio' ||
+    part.type === 'file' ||
+    part.type === 'refusal'
+  );
+}
+
+function canAddChatBreakpoint(
+  message: OpenAIClient.Chat.Completions.ChatCompletionMessageParam
+): boolean {
+  if (
+    message.role !== 'system' &&
+    message.role !== 'developer' &&
+    message.role !== 'user' &&
+    message.role !== 'assistant' &&
+    message.role !== 'tool'
+  ) {
+    return false;
+  }
+  if (typeof message.content === 'string') {
+    return message.content.length > 0;
+  }
+  return (
+    Array.isArray(message.content) &&
+    message.content.some((part) => isCacheableChatPart(part))
+  );
+}
+
+function addChatBreakpoint(
+  message: OpenAIClient.Chat.Completions.ChatCompletionMessageParam
+): OpenAIClient.Chat.Completions.ChatCompletionMessageParam {
+  if (!canAddChatBreakpoint(message)) {
+    return message;
+  }
+
+  if (typeof message.content === 'string') {
+    return {
+      ...message,
+      content: [
+        {
+          type: 'text',
+          text: message.content,
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    } as unknown as OpenAIClient.Chat.Completions.ChatCompletionMessageParam;
+  }
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return message;
+  }
+
+  const content = [...message.content] as unknown as CacheableChatPart[];
+  let index = content.length - 1;
+  while (index >= 0 && !isCacheableChatPart(content[index])) {
+    index--;
+  }
+  if (index < 0) {
+    return message;
+  }
+  content[index] = {
+    ...content[index],
+    prompt_cache_breakpoint: { mode: 'explicit' },
+  };
+  return {
+    ...message,
+    content,
+  } as unknown as OpenAIClient.Chat.Completions.ChatCompletionMessageParam;
+}
+
+function selectCacheBreakpointIndexes(
+  roles: Array<string | undefined>,
+  cacheable: boolean[]
+): number[] {
+  let instructionIndex = -1;
+  let latestUserIndex = -1;
+  for (let index = 0; index < roles.length; index++) {
+    const role = roles[index];
+    if ((role === 'system' || role === 'developer') && cacheable[index]) {
+      instructionIndex = index;
+    }
+    if (role === 'user') {
+      latestUserIndex = index;
+    }
+  }
+
+  const indexes = new Set<number>();
+  if (instructionIndex >= 0) {
+    indexes.add(instructionIndex);
+  }
+  for (let index = latestUserIndex - 1; index >= 0; index--) {
+    if (cacheable[index]) {
+      indexes.add(index);
+      break;
+    }
+  }
+  return [...indexes];
+}
+
+/** @internal */
+export function addChatCacheBreakpoints(
+  messages: OpenAIClient.Chat.Completions.ChatCompletionMessageParam[]
+): OpenAIClient.Chat.Completions.ChatCompletionMessageParam[] {
+  const indexes = new Set(
+    selectCacheBreakpointIndexes(
+      messages.map((message) => message.role),
+      messages.map((message) => canAddChatBreakpoint(message))
+    )
+  );
+  return messages.map((message, index) =>
+    indexes.has(index) ? addChatBreakpoint(message) : message
+  );
+}
+
+function isResponseMessage(
+  item: OpenAIClient.Responses.ResponseInputItem
+): item is OpenAIClient.Responses.ResponseInputItem.Message {
+  return item.type === 'message';
+}
+
+function addResponseBreakpoint(
+  item: OpenAIClient.Responses.ResponseInputItem
+): OpenAIClient.Responses.ResponseInputItem {
+  if (!isResponseMessage(item)) {
+    return item;
+  }
+  if (!Array.isArray(item.content) || item.content.length === 0) {
+    return item;
+  }
+
+  const content = [...item.content];
+  const index = content.length - 1;
+  content[index] = {
+    ...(content[index] as CacheableResponsePart),
+    prompt_cache_breakpoint: { mode: 'explicit' },
+  };
+  return { ...item, content };
+}
+
+/** @internal */
+export function addResponseCacheBreakpoints(
+  input: OpenAIClient.Responses.ResponseCreateParams['input']
+): OpenAIClient.Responses.ResponseCreateParams['input'] {
+  if (!Array.isArray(input)) {
+    return input;
+  }
+  const indexes = new Set(
+    selectCacheBreakpointIndexes(
+      input.map((item) => (isResponseMessage(item) ? item.role : undefined)),
+      input.map(
+        (item) =>
+          isResponseMessage(item) &&
+          Array.isArray(item.content) &&
+          item.content.length > 0
+      )
+    )
+  );
+  return input.map((item, index) =>
+    indexes.has(index) ? addResponseBreakpoint(item) : item
+  );
+}
+
+/** @internal */
+export function shouldIncludeEncryptedReasoning(
+  model: string,
+  params: {
+    store?: boolean | null;
+    reasoning?: unknown;
+  }
+): boolean {
+  const reasoningContext = (
+    params.reasoning as
+      | { context?: 'auto' | 'current_turn' | 'all_turns' }
+      | undefined
+  )?.context;
+  return (
+    /^gpt-5\.6(?:-|$)/i.test(model) &&
+    (params.store === false || reasoningContext !== 'current_turn')
+  );
+}
+
+function getCacheWriteTokens(message: BaseMessage): number | undefined {
+  const responseMetadata = message.response_metadata as {
+    usage?: ResponsesUsageWithCacheWrite;
+    metadata?: Record<string, string>;
+  };
+  const reported =
+    responseMetadata.usage?.input_tokens_details.cache_write_tokens;
+  if (reported != null) {
+    return reported;
+  }
+  const serialized = responseMetadata.metadata?.[CACHE_WRITE_METADATA_KEY];
+  if (serialized == null) {
+    return;
+  }
+  const parsed = Number(serialized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function attachCacheWriteUsage(message: BaseMessage): void {
+  const cacheWriteTokens = getCacheWriteTokens(message);
+  if (
+    cacheWriteTokens == null ||
+    !isAIMessage(message) ||
+    message.usage_metadata == null
+  ) {
+    return;
+  }
+  message.usage_metadata.input_token_details = {
+    ...message.usage_metadata.input_token_details,
+    cache_creation: cacheWriteTokens,
+  };
+  const responseMetadata = message.response_metadata as {
+    metadata?: Record<string, string>;
+  };
+  if (responseMetadata.metadata?.[CACHE_WRITE_METADATA_KEY] == null) {
+    return;
+  }
+  const metadata = { ...responseMetadata.metadata };
+  delete metadata[CACHE_WRITE_METADATA_KEY];
+  message.response_metadata = {
+    ...message.response_metadata,
+    metadata,
+  };
+}
+
+function attachCacheWriteMetadata(
+  response: OpenAIClient.Responses.Response
+): OpenAIClient.Responses.Response {
+  const usage = response.usage as ResponsesUsageWithCacheWrite | undefined;
+  const cacheWriteTokens = usage?.input_tokens_details.cache_write_tokens;
+  if (cacheWriteTokens == null) {
+    return response;
+  }
+  return {
+    ...response,
+    metadata: {
+      ...(response.metadata ?? {}),
+      [CACHE_WRITE_METADATA_KEY]: String(cacheWriteTokens),
+    },
+  };
+}
+
+function isResponsesStream(
+  result: ResponsesResult
+): result is AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent> {
+  return Symbol.asyncIterator in result;
+}
+
+function hasResponsesReplayItems(messages: BaseMessage[]): boolean {
+  return messages.some((message) => {
+    const output = (message.response_metadata as { output?: unknown }).output;
+    return Array.isArray(output) && output.length > 0;
+  });
+}
 
 function createUsageMetadata(
   usage?: OpenAIClient.Completions.CompletionUsage
@@ -210,6 +534,38 @@ function createUsageMetadata(
   }
 
   return usageMetadata;
+}
+
+function createResponsesUsageMetadata(
+  usage?: OpenAIClient.Responses.ResponseUsage
+): UsageMetadata {
+  const usageWithCacheWrite = usage as ResponsesUsageWithCacheWrite | undefined;
+  const inputDetails: UsageMetadata['input_token_details'] = {
+    ...(usage?.input_tokens_details.cached_tokens != null && {
+      cache_read: usage.input_tokens_details.cached_tokens,
+    }),
+    ...(usageWithCacheWrite?.input_tokens_details.cache_write_tokens !=
+      null && {
+      cache_creation:
+        usageWithCacheWrite.input_tokens_details.cache_write_tokens,
+    }),
+  };
+  const outputDetails: UsageMetadata['output_token_details'] = {
+    ...(usage?.output_tokens_details.reasoning_tokens != null && {
+      reasoning: usage.output_tokens_details.reasoning_tokens,
+    }),
+  };
+  return {
+    input_tokens: usage?.input_tokens ?? 0,
+    output_tokens: usage?.output_tokens ?? 0,
+    total_tokens: usage?.total_tokens ?? 0,
+    ...(Object.keys(inputDetails).length > 0 && {
+      input_token_details: inputDetails,
+    }),
+    ...(Object.keys(outputDetails).length > 0 && {
+      output_token_details: outputDetails,
+    }),
+  };
 }
 
 function getExposedOpenAIClient(
@@ -752,6 +1108,8 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
   private convertReasoningDetailsToContent?: boolean;
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
@@ -759,6 +1117,18 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.includeReasoningDetails = fields?.includeReasoningDetails;
     this.convertReasoningDetailsToContent =
       fields?.convertReasoningDetailsToContent;
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions'],
+    extra?: { streaming?: boolean }
+  ): ReturnType<OriginalChatOpenAICompletions['invocationParams']> {
+    return applyManagedRequestParams(super.invocationParams(options, extra), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
   }
 
   protected _getReasoningParams(
@@ -788,7 +1158,9 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
     return completionWithFilteredOpenAIStream(
-      request,
+      this.promptCacheExplicit === true
+        ? { ...request, messages: addChatCacheBreakpoints(request.messages) }
+        : request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
     );
@@ -1152,6 +1524,168 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 }
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions']
+  ): ReturnType<OriginalChatOpenAIResponses['invocationParams']> {
+    const params = applyManagedRequestParams(super.invocationParams(options), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'reasoning.encrypted_content' as const,
+        ]),
+      ];
+    }
+    return params;
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIClient.Responses.Response>;
+  async completionWithRetry(
+    request: ResponsesRequest,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<ResponsesResult> {
+    const managedRequest = {
+      ...request,
+      input:
+        this.promptCacheExplicit === true
+          ? addResponseCacheBreakpoints(request.input)
+          : request.input,
+    };
+    const result = await super.completionWithRetry(
+      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+      requestOptions
+    );
+    return isResponsesStream(result)
+      ? result
+      : attachCacheWriteMetadata(result);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const useManagedResponsesInput = hasResponsesReplayItems(messages);
+    if (
+      useManagedResponsesInput &&
+      this.invocationParams(options).stream !== true
+    ) {
+      const data = await this.completionWithRetry(
+        {
+          input: _convertMessagesToOpenAIResponsesParams(
+            messages,
+            this.model,
+            this.zdrEnabled
+          ),
+          ...this.invocationParams(options),
+          stream: false,
+        },
+        {
+          signal: options.signal,
+          ...options.options,
+        }
+      );
+      const message = _convertOpenAIResponsesMessageToBaseMessage(data);
+      const usageMetadata = createResponsesUsageMetadata(data.usage);
+      if (isAIMessage(message)) {
+        message.usage_metadata = usageMetadata;
+        attachCacheWriteUsage(message);
+      }
+      return {
+        generations: [{ text: data.output_text, message }],
+        llmOutput: {
+          id: data.id,
+          estimatedTokenUsage: usageMetadata,
+        },
+      };
+    }
+
+    const result = await super._generate(messages, options, runManager);
+    for (const generation of result.generations) {
+      attachCacheWriteUsage(generation.message);
+    }
+    return result;
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    if (hasResponsesReplayItems(messages)) {
+      const streamIterable = await this.completionWithRetry(
+        {
+          ...this.invocationParams(options),
+          input: _convertMessagesToOpenAIResponsesParams(
+            messages,
+            this.model,
+            this.zdrEnabled
+          ),
+          stream: true,
+        },
+        options
+      );
+      for await (const data of streamIterable) {
+        if (options.signal?.aborted === true) {
+          return;
+        }
+        const chunk = _convertOpenAIResponsesDeltaToBaseMessageChunk(data);
+        if (chunk == null) {
+          continue;
+        }
+        if (
+          data.type === 'response.completed' ||
+          data.type === 'response.incomplete'
+        ) {
+          if (AIMessageChunk.isInstance(chunk.message)) {
+            chunk.message.usage_metadata = createResponsesUsageMetadata(
+              data.response.usage
+            );
+          }
+        }
+        attachCacheWriteUsage(chunk.message);
+        yield chunk;
+        await runManager?.handleLLMNewToken(
+          chunk.text || '',
+          { prompt: options.promptIndex ?? 0, completion: 0 },
+          undefined,
+          undefined,
+          undefined,
+          { chunk }
+        );
+      }
+      return;
+    }
+
+    for await (const chunk of super._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      attachCacheWriteUsage(chunk.message);
+      yield chunk;
+    }
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
@@ -1166,6 +1700,25 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 }
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatAzureOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions'],
+    extra?: { streaming?: boolean }
+  ): ReturnType<OriginalAzureChatOpenAICompletions['invocationParams']> {
+    return applyManagedRequestParams(super.invocationParams(options, extra), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
@@ -1273,7 +1826,9 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
     return completionWithFilteredOpenAIStream(
-      request,
+      this.promptCacheExplicit === true
+        ? { ...request, messages: addChatCacheBreakpoints(request.messages) }
+        : request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
     );
@@ -1281,6 +1836,168 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 }
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatAzureOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions']
+  ): ReturnType<OriginalAzureChatOpenAIResponses['invocationParams']> {
+    const params = applyManagedRequestParams(super.invocationParams(options), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'reasoning.encrypted_content' as const,
+        ]),
+      ];
+    }
+    return params;
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIClient.Responses.Response>;
+  async completionWithRetry(
+    request: ResponsesRequest,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<ResponsesResult> {
+    const managedRequest = {
+      ...request,
+      input:
+        this.promptCacheExplicit === true
+          ? addResponseCacheBreakpoints(request.input)
+          : request.input,
+    };
+    const result = await super.completionWithRetry(
+      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+      requestOptions
+    );
+    return isResponsesStream(result)
+      ? result
+      : attachCacheWriteMetadata(result);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const useManagedResponsesInput = hasResponsesReplayItems(messages);
+    if (
+      useManagedResponsesInput &&
+      this.invocationParams(options).stream !== true
+    ) {
+      const data = await this.completionWithRetry(
+        {
+          input: _convertMessagesToOpenAIResponsesParams(
+            messages,
+            this.model,
+            this.zdrEnabled
+          ),
+          ...this.invocationParams(options),
+          stream: false,
+        },
+        {
+          signal: options.signal,
+          ...options.options,
+        }
+      );
+      const message = _convertOpenAIResponsesMessageToBaseMessage(data);
+      const usageMetadata = createResponsesUsageMetadata(data.usage);
+      if (isAIMessage(message)) {
+        message.usage_metadata = usageMetadata;
+        attachCacheWriteUsage(message);
+      }
+      return {
+        generations: [{ text: data.output_text, message }],
+        llmOutput: {
+          id: data.id,
+          estimatedTokenUsage: usageMetadata,
+        },
+      };
+    }
+
+    const result = await super._generate(messages, options, runManager);
+    for (const generation of result.generations) {
+      attachCacheWriteUsage(generation.message);
+    }
+    return result;
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    if (hasResponsesReplayItems(messages)) {
+      const streamIterable = await this.completionWithRetry(
+        {
+          ...this.invocationParams(options),
+          input: _convertMessagesToOpenAIResponsesParams(
+            messages,
+            this.model,
+            this.zdrEnabled
+          ),
+          stream: true,
+        },
+        options
+      );
+      for await (const data of streamIterable) {
+        if (options.signal?.aborted === true) {
+          return;
+        }
+        const chunk = _convertOpenAIResponsesDeltaToBaseMessageChunk(data);
+        if (chunk == null) {
+          continue;
+        }
+        if (
+          data.type === 'response.completed' ||
+          data.type === 'response.incomplete'
+        ) {
+          if (AIMessageChunk.isInstance(chunk.message)) {
+            chunk.message.usage_metadata = createResponsesUsageMetadata(
+              data.response.usage
+            );
+          }
+        }
+        attachCacheWriteUsage(chunk.message);
+        yield chunk;
+        await runManager?.handleLLMNewToken(
+          chunk.text || '',
+          { prompt: options.promptIndex ?? 0, completion: 0 },
+          undefined,
+          undefined,
+          undefined,
+          { chunk }
+        );
+      }
+      return;
+    }
+
+    for await (const chunk of super._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      attachCacheWriteUsage(chunk.message);
+      yield chunk;
+    }
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,0 +1,105 @@
+import OpenAI from 'openai';
+
+import {
+  addChatCacheBreakpoints,
+  addResponseCacheBreakpoints,
+  shouldIncludeEncryptedReasoning,
+} from './index';
+
+describe('managed GPT-5.6 request fields', () => {
+  it('places cache breakpoints after instructions and the prior history prefix', () => {
+    const messages = addChatCacheBreakpoints([
+      { role: 'system', content: 'Stable instructions.' },
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: 'First answer.' },
+      { role: 'user', content: 'Current question.' },
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: 'Stable instructions.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+    expect(messages[2]).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: 'First answer.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+    expect(JSON.stringify(messages[1])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+    expect(JSON.stringify(messages[3])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+  });
+
+  it('uses supported Responses content blocks for the same stable prefixes', () => {
+    const input = [
+      {
+        type: 'message',
+        role: 'developer',
+        content: [{ type: 'input_text', text: 'Stable instructions.' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'input_text', text: 'Prior answer.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Current question.' }],
+      },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input);
+
+    expect(result).toMatchObject([
+      {
+        content: [
+          {
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+      },
+      {
+        content: [
+          {
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+      },
+      {
+        content: [{ type: 'input_text', text: 'Current question.' }],
+      },
+    ]);
+  });
+
+  it('requests encrypted reasoning whenever persisted or stateless replay may be needed', () => {
+    expect(shouldIncludeEncryptedReasoning('gpt-5.6', {})).toBe(true);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        reasoning: { context: 'all_turns' },
+      })
+    ).toBe(true);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        reasoning: { context: 'current_turn' },
+      })
+    ).toBe(false);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        store: false,
+        reasoning: { context: 'current_turn' },
+      })
+    ).toBe(true);
+    expect(shouldIncludeEncryptedReasoning('gpt-5.5', {})).toBe(false);
+  });
+});

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -527,7 +527,7 @@ export function _convertMessagesToOpenAIResponsesParams(
   model?: string,
   zdrEnabled?: boolean
 ): ResponsesInputItem[] {
-  return messages.flatMap(
+  const input = messages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
       const additional_kwargs =
         lcMsg.additional_kwargs as BaseMessageFields['additional_kwargs'] & {
@@ -604,23 +604,30 @@ export function _convertMessagesToOpenAIResponsesParams(
       }
 
       if (role === 'assistant') {
-        // if we have the original response items, just reuse them
-        if (
-          !zdrEnabled &&
+        const input: ResponsesInputItem[] = [];
+        const replayOutput =
           responseMetadata.output != null &&
           Array.isArray(responseMetadata.output) &&
           responseMetadata.output.length > 0 &&
           responseMetadata.output.every((item) => 'type' in item)
-        ) {
-          return responseMetadata.output;
+            ? responseMetadata.output
+            : [];
+        if (replayOutput.some((item) => item.type === 'message')) {
+          return replayOutput;
         }
-
-        // otherwise, try to reconstruct the response from what we have
-
-        const input: ResponsesInputItem[] = [];
+        input.push(...replayOutput);
+        const replayedFunctionCalls = new Set(
+          replayOutput
+            .filter((item) => item.type === 'function_call')
+            .map((item) => item.call_id)
+        );
 
         // reasoning items
-        if (additional_kwargs.reasoning && !zdrEnabled) {
+        if (
+          additional_kwargs.reasoning &&
+          !replayOutput.some((item) => item.type === 'reasoning') &&
+          (!zdrEnabled || additional_kwargs.reasoning.encrypted_content != null)
+        ) {
           const reasoningItem = _convertReasoningSummaryToOpenAIResponsesParams(
             additional_kwargs.reasoning
           );
@@ -645,60 +652,75 @@ export function _convertMessagesToOpenAIResponsesParams(
           ];
         }
 
-        input.push({
-          type: 'message',
-          role: 'assistant',
-          ...(lcMsg.id && !zdrEnabled && lcMsg.id.startsWith('msg_')
-            ? { id: lcMsg.id }
-            : {}),
-          content:
-            typeof content === 'string'
-              ? content
-              : content.flatMap((item) => {
-                if (item.type === 'text') {
-                  const textItem = item as MessageContentComplex & {
-                      annotations?: unknown[];
+        if (
+          typeof content === 'string' ? content.length > 0 : content.length > 0
+        ) {
+          input.push({
+            type: 'message',
+            role: 'assistant',
+            ...(lcMsg.id && !zdrEnabled && lcMsg.id.startsWith('msg_')
+              ? { id: lcMsg.id }
+              : {}),
+            content:
+              typeof content === 'string'
+                ? content
+                : content.flatMap((item) => {
+                  if (item.type === 'text') {
+                    const textItem = item as MessageContentComplex & {
+                        annotations?: unknown[];
+                      };
+                    return {
+                      type: 'output_text',
+                      text: item.text,
+                      annotations: textItem.annotations ?? [],
                     };
-                  return {
-                    type: 'output_text',
-                    text: item.text,
-                    annotations: textItem.annotations ?? [],
-                  };
-                }
+                  }
 
-                if (item.type === 'output_text' || item.type === 'refusal') {
-                  return item;
-                }
+                  if (
+                    item.type === 'output_text' ||
+                      item.type === 'refusal'
+                  ) {
+                    return item;
+                  }
 
-                return [];
-              }),
-        } as ResponsesInputItem);
+                  return [];
+                }),
+          } as ResponsesInputItem);
+        }
 
         const functionCallIds = additional_kwargs[_FUNCTION_CALL_IDS_MAP_KEY];
 
         if (isAIMessage(lcMsg) && !!lcMsg.tool_calls?.length) {
           input.push(
-            ...lcMsg.tool_calls.map(
-              (toolCall): ResponsesInputItem => ({
-                type: 'function_call',
-                name: toolCall.name,
-                arguments: JSON.stringify(toolCall.args),
-                call_id: toolCall.id!,
-                ...(zdrEnabled ? { id: functionCallIds?.[toolCall.id!] } : {}),
-              })
-            )
+            ...lcMsg.tool_calls
+              .filter((toolCall) => !replayedFunctionCalls.has(toolCall.id!))
+              .map(
+                (toolCall): ResponsesInputItem => ({
+                  type: 'function_call',
+                  name: toolCall.name,
+                  arguments: JSON.stringify(toolCall.args),
+                  call_id: toolCall.id!,
+                  ...(!zdrEnabled
+                    ? { id: functionCallIds?.[toolCall.id!] }
+                    : {}),
+                })
+              )
           );
         } else if (additional_kwargs.tool_calls) {
           input.push(
-            ...additional_kwargs.tool_calls.map(
-              (toolCall): ResponsesInputItem => ({
-                type: 'function_call',
-                name: toolCall.function.name,
-                call_id: toolCall.id,
-                arguments: toolCall.function.arguments,
-                ...(zdrEnabled ? { id: functionCallIds?.[toolCall.id] } : {}),
-              })
-            )
+            ...additional_kwargs.tool_calls
+              .filter((toolCall) => !replayedFunctionCalls.has(toolCall.id))
+              .map(
+                (toolCall): ResponsesInputItem => ({
+                  type: 'function_call',
+                  name: toolCall.function.name,
+                  call_id: toolCall.id,
+                  arguments: toolCall.function.arguments,
+                  ...(!zdrEnabled
+                    ? { id: functionCallIds?.[toolCall.id] }
+                    : {}),
+                })
+              )
           );
         }
 
@@ -802,13 +824,14 @@ export function _convertMessagesToOpenAIResponsesParams(
       return [];
     }
   );
+  return input;
 }
 
 export function isReasoningModel(model?: string) {
   return model != null && model !== '' && /\b(o\d|gpt-[5-9])\b/i.test(model);
 }
 
-function _convertOpenAIResponsesMessageToBaseMessage(
+export function _convertOpenAIResponsesMessageToBaseMessage(
   response: ResponsesCreateInvoke | ResponsesParseInvoke
 ): BaseMessage {
   if (response.error) {
@@ -829,6 +852,8 @@ function _convertOpenAIResponsesMessageToBaseMessage(
     incomplete_details: response.incomplete_details,
     metadata: response.metadata,
     object: response.object,
+    output: response.output,
+    usage: response.usage,
     status: response.status,
     user: response.user,
     service_tier: response.service_tier,
@@ -984,7 +1009,10 @@ export function _convertOpenAIResponsesDeltaToBaseMessageChunk(
     response_metadata.id = chunk.response.id;
     response_metadata.model_name = chunk.response.model;
     response_metadata.model = chunk.response.model;
-  } else if (chunk.type === 'response.completed') {
+  } else if (
+    chunk.type === 'response.completed' ||
+    chunk.type === 'response.incomplete'
+  ) {
     const msg = _convertOpenAIResponsesMessageToBaseMessage(chunk.response);
 
     usage_metadata = chunk.response.usage;

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -1,5 +1,8 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
-import { _convertMessagesToOpenAIParams } from './index';
+import {
+  _convertMessagesToOpenAIParams,
+  _convertMessagesToOpenAIResponsesParams,
+} from './index';
 
 describe('_convertMessagesToOpenAIParams', () => {
   it('includes reasoning_content for assistant messages in tool-call context when requested', () => {
@@ -155,5 +158,73 @@ describe('_convertMessagesToOpenAIParams', () => {
         reasoning_content: 'The prior calculator result is available.',
       })
     );
+  });
+});
+
+describe('_convertMessagesToOpenAIResponsesParams', () => {
+  it('combines persisted reasoning items with reconstructed standard tool calls', () => {
+    const firstReasoning = {
+      type: 'reasoning' as const,
+      id: 'rs_1',
+      summary: [],
+      encrypted_content: 'encrypted-1',
+    };
+    const finalReasoning = {
+      type: 'reasoning' as const,
+      id: 'rs_2',
+      summary: [],
+      encrypted_content: 'encrypted-2',
+    };
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'lookup',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+        response_metadata: {
+          model_provider: 'openai',
+          output: [firstReasoning],
+        },
+      }),
+      new ToolMessage({
+        content: '{"ok":true}',
+        tool_call_id: 'call_1',
+      }),
+      new AIMessage({
+        content: 'Done.',
+        response_metadata: {
+          model_provider: 'openai',
+          output: [finalReasoning],
+        },
+      }),
+    ];
+
+    expect(
+      _convertMessagesToOpenAIResponsesParams(messages, 'gpt-5.6', true)
+    ).toEqual([
+      firstReasoning,
+      {
+        type: 'function_call',
+        name: 'lookup',
+        arguments: '{}',
+        call_id: 'call_1',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '{"ok":true}',
+      },
+      finalReasoning,
+      {
+        type: 'message',
+        role: 'assistant',
+        content: 'Done.',
+      },
+    ]);
   });
 });

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -73,7 +73,10 @@ export type GoogleThinkingConfig = {
   includeThoughts?: boolean;
   thinkingLevel?: 'THINKING_LEVEL_UNSPECIFIED' | 'LOW' | 'MEDIUM' | 'HIGH';
 };
-export type OpenAIClientOptions = ChatOpenAIFields;
+export type OpenAIClientOptions = ChatOpenAIFields & {
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
+};
 export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> & {
   thinking?: ThinkingConfig;
   promptCache?: boolean;

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsdown';
+import { isAbsolute } from 'node:path';
 
 const entry = {
   main: 'src/index.ts',
@@ -6,7 +7,8 @@ const entry = {
   'responses/index': 'src/responses/index.ts',
   'langchain/index': 'src/langchain/index.ts',
   'langchain/google-common': 'src/langchain/google-common.ts',
-  'langchain/language_models/chat_models': 'src/langchain/language_models/chat_models.ts',
+  'langchain/language_models/chat_models':
+    'src/langchain/language_models/chat_models.ts',
   'langchain/messages': 'src/langchain/messages.ts',
   'langchain/messages/tool': 'src/langchain/messages/tool.ts',
   'langchain/openai': 'src/langchain/openai.ts',
@@ -37,7 +39,8 @@ const shared = {
   // Match the prior Rollup build (`external: [/node_modules/]`): bundle nothing
   // third-party, compile only this package's own modules.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('@/') && !id.startsWith('/'),
+    neverBundle: (id) =>
+      !id.startsWith('.') && !id.startsWith('@/') && !isAbsolute(id),
     onlyBundle: false,
   },
 };


### PR DESCRIPTION
## Summary

Adds the OpenAI adapter support required for GPT-5.6 Responses reasoning continuity without native Programmatic Tool Calling.

- passes managed prompt-cache and safety fields through Chat Completions and Responses
- preserves `response.output` metadata for streaming and non-streaming Responses
- requests and replays encrypted reasoning for stateless/ZDR calls
- carries `reasoning.mode` and `reasoning.context`
- preserves cache-write usage metadata

## Scope

This is the base Agents change for the LibreChat GPT-5.6 Responses-state PR. Native PTC is intentionally excluded and is reviewed in a separate stacked PR.

## Verification

- focused managed-request and message-replay tests pass
- package build and TypeScript declaration build pass