### PR TITLE
📏 fix: Accept Above-Budget Provider Usage for Prune Calibration

### DIFF
--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1470,9 +1470,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         calibrationSkipReason = 'input_below_instruction_overhead';
       } else if (providerInputTokens < minimumComparableInputTokens) {
         calibrationSkipReason = 'input_below_calibration_floor';
-      } else if (providerInputTokens > factoryParams.maxTokens) {
-        calibrationSkipReason = 'input_exceeds_context_window';
       }
+      // No upper-bound rejection: maxTokens is an application budget, not the
+      // provider's real context window.  Usage above the budget is a genuine
+      // measurement — and the one that must drive pruning/summarization.
 
       if (calibrationSkipReason == null) {
         cumulativeRawSent += rawSentThisTurn;
@@ -1515,7 +1516,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           minimumComparableInputTokens: Math.round(
             minimumComparableInputTokens
           ),
-          maxContextTokens: factoryParams.maxTokens,
           rawSentThisTurn,
           instructionOverhead,
         });

--- a/src/specs/token-accounting-pipeline.test.ts
+++ b/src/specs/token-accounting-pipeline.test.ts
@@ -823,6 +823,70 @@ describe('Token accounting pipeline — Anthropic vs OpenAI cache semantics', ()
     });
   });
 
+  it('accepts provider usage above the application budget and prunes', () => {
+    // maxTokens is an application budget, not the provider's context window.
+    // The provider accepts requests past the budget and reports true usage —
+    // exactly the turns where calibration must feed pruning/summarization.
+    const messages = [
+      new SystemMessage('system instructions'),
+      new HumanMessage('first user turn'),
+      new AIMessage('first response'),
+      new HumanMessage('second user turn'),
+      new AIMessage('second response'),
+    ];
+    const indexTokenCountMap: Record<string, number | undefined> = {
+      0: 40,
+      1: 120,
+      2: 110,
+      3: 120,
+      4: 80,
+    };
+    const rawTotal = 470;
+    const providerInputTokens = 620;
+    const logs: Array<{
+      level: string;
+      message: string;
+      data?: Record<string, unknown>;
+    }> = [];
+
+    const pruneMessages = createPruneMessages({
+      provider: Providers.ANTHROPIC,
+      maxTokens: 500,
+      startIndex: messages.length,
+      tokenCounter: charCounter,
+      indexTokenCountMap,
+      summarizationEnabled: true,
+      reserveRatio: 0,
+      log: (level, message, data) => logs.push({ level, message, data }),
+    });
+
+    const result = pruneMessages({
+      messages,
+      usageMetadata: {
+        input_tokens: providerInputTokens,
+        output_tokens: 25,
+      },
+    });
+
+    // The above-budget measurement calibrates instead of being discarded.
+    expect(
+      logs.find((entry) => entry.message === 'Calibration skipped')
+    ).toBeUndefined();
+    expect(
+      logs.find((entry) => entry.message === 'Calibration observed')?.data
+    ).toMatchObject({ providerInputTokens });
+    expect(result.calibrationRatio).toBeCloseTo(
+      providerInputTokens / rawTotal,
+      2
+    );
+
+    // Calibrated context (620) exceeds the budget (500), so messages are
+    // yielded for summarization instead of returning the full context.
+    expect(result.messagesToRefine).toBeDefined();
+    expect(result.messagesToRefine!.length).toBeGreaterThan(0);
+    expect(result.context.length).toBeLessThan(messages.length);
+  });
+
   it('OpenAI inclusive cache does NOT inflate calibration input', () => {
     const messages = [new HumanMessage('Hello'), new AIMessage('Hi')];
 


### PR DESCRIPTION
## Summary

I fixed a regression introduced by #296 where context-window calibration rejected the provider's reported usage whenever it exceeded the configured token budget — precisely the turns where pruning and summarization need that measurement most. `maxContextTokens` is an application budget, not the model's actual context window: the provider accepts the request and reports its real token count, but the `input_exceeds_context_window` guard discarded it, so `calibrationRatio` never rose above 1, calibrated totals stayed under budget, and `onSummarizeStart`/`onSummarizeComplete` were never invoked. Four consecutive credentialed post-#296 runs failed the same three Anthropic E2E cases this way (#296's Anthropic check was green only because its contributor run had no secrets and all 25 tests were skipped).

- Removed the `input_exceeds_context_window` calibration rejection in `src/messages/prune.ts`, with a comment documenting why no upper-bound rejection belongs there.
- Retained the lower-bound guards (`no_sent_messages`, `input_below_instruction_overhead`, `input_below_calibration_floor`) that reject tiny Bedrock cache-artifact values — #296's intended fix stays intact.
- Removed the `maxContextTokens` field from the `Calibration skipped` debug log, since it existed only to explain the removed skip reason.
- Added a deterministic regression test proving provider-reported input above the application budget is accepted for calibration and yields `messagesToRefine` for summarization; the test fails on pre-fix code with skip reason `input_exceeds_context_window`.
- Kept #296's Bedrock cache-artifact regression test unchanged and passing.

Independent of #300 (Bedrock streaming) — no code overlap.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the new regression test fails against pre-fix `prune.ts` (calibration skipped with reason `input_exceeds_context_window`) and passes with the fix.
- Ran `npx jest src/specs/token-accounting-pipeline.test.ts`: 25/25 pass, including #296's Bedrock cache-artifact regression.
- Ran the deterministic prune/summarization suites (`prune`, `summarize-prune`, `summarization-unit`, `thinking-prune`, `token-distribution-edge-case`, `src/messages`): 21 suites, 528 tests pass.
- Ran the credentialed live suite `npx jest src/specs/summarization.test.ts -t "Anthropic Summarization E2E"`: 5/5 pass — the previously failing cases now fire `onSummarizeStart`/`onSummarizeComplete`.
- `npx eslint` on changed files and `npx tsc --noEmit` are clean.

### **Test Configuration**:

- Node 24, Jest via `NODE_OPTIONS='--experimental-vm-modules'`
- `ANTHROPIC_API_KEY` set for the live E2E suite

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes