### PR TITLE
feat(openai): persist GPT-5.6 Responses state (inherit upstream converter)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@langchain/google-vertexai": "2.2.0",
         "@langchain/langgraph": "^1.4.6",
         "@langchain/mistralai": "^1.2.0",
-        "@langchain/openai": "1.5.3",
+        "@langchain/openai": "1.5.5",
         "@langchain/textsplitters": "^1.0.1",
         "@langchain/xai": "^1.4.3",
         "@langfuse/langchain": "^5.4.1",
@@ -40,7 +40,7 @@
         "mathjs": "^15.2.0",
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
-        "openai": "^6.35.0",
+        "openai": "^6.46.0",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -2186,9 +2186,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-KfjEOT6sCg0vvItagfEtGpmrGoLMGfma4Affb5BGEqPmS2YR3AxW54pABSkhQlzCehTB+0BnLquAe1lGF4J9zQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2410,9 +2410,9 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.3.tgz",
-      "integrity": "sha512-OStS2AUvy9oe/hEf/3ndBOFztUDOfuJYLNXh89m3iiJAI2Cp5Dp0n/pvpO27MO0b+VgENd+xSHVyQZ7fe+ulxg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.5.tgz",
+      "integrity": "sha512-wX7dwb9z4nf5FHXlIl/X2mk08pzonvRHCt1D4+s1zXLP0duYDC95j7dulPIQJ6fmhbyYQc9Ki8mEhY/D1lB8kw==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
@@ -2423,7 +2423,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.1"
+        "@langchain/core": "^1.2.2"
       }
     },
     "node_modules/@langchain/openai/node_modules/zod": {
@@ -11416,15 +11416,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "version": "6.46.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
+      "integrity": "sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "README.md"
   ],
   "scripts": {
-    "prepare": "node husky-setup.js && npm run build",
+    "prepare": "node husky-setup.js",
     "prepublishOnly": "npm run build",
     "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
     "@langchain/anthropic": "^1.5.1",
     "@langchain/aws": "^1.4.2",
-    "@langchain/core": "^1.2.1",
+    "@langchain/core": "^1.2.2",
     "@langchain/deepseek": "^1.1.3",
     "@langchain/google-common": "2.2.0",
     "@langchain/google-gauth": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     "README.md"
   ],
   "scripts": {
-    "prepare": "node husky-setup.js",
+    "prepare": "node husky-setup.js && npm run build",
     "prepublishOnly": "npm run build",
-    "build": "rm -rf ./dist && tsdown && tsc -p tsconfig.build.json",
+    "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",
     "sort-imports": "node scripts/sort-imports.ts",
     "sort-imports:check": "node scripts/sort-imports.ts --check",
@@ -200,7 +200,7 @@
     "format": "prettier --write ."
   },
   "overrides": {
-    "@langchain/openai": "1.5.3",
+    "@langchain/openai": "1.5.5",
     "@browserbasehq/stagehand": {
       "openai": "$openai"
     },
@@ -224,7 +224,7 @@
     "@langchain/google-vertexai": "2.2.0",
     "@langchain/langgraph": "^1.4.6",
     "@langchain/mistralai": "^1.2.0",
-    "@langchain/openai": "1.5.3",
+    "@langchain/openai": "1.5.5",
     "@langchain/textsplitters": "^1.0.1",
     "@langchain/xai": "^1.4.3",
     "@langfuse/langchain": "^5.4.1",
@@ -243,7 +243,7 @@
     "mathjs": "^15.2.0",
     "nanoid": "^3.3.7",
     "okapibm25": "^1.4.1",
-    "openai": "^6.35.0",
+    "openai": "^6.46.0",
     "uuid": "^11.1.1"
   },
   "peerDependencies": {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -406,6 +406,16 @@ export function addResponseCacheBreakpoints(
         if (!isResponseMessage(item)) {
           return false;
         }
+        /** Only input roles take a Responses breakpoint. Assistant/tool turns
+         *  carry output content (string or output_text) that the API rejects
+         *  under an input marker, so they're never eligible. */
+        if (
+          item.role !== 'system' &&
+          item.role !== 'developer' &&
+          item.role !== 'user'
+        ) {
+          return false;
+        }
         const content = item.content as
           | string
           | OpenAIClient.Responses.ResponseInputMessageContentList;

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -336,18 +336,55 @@ function isResponseMessage(
   return item.type === 'message';
 }
 
+/** Only `input_text`/`input_image`/`input_file` accept a Responses breakpoint;
+ *  `output_text`/`refusal` (replayed assistant blocks) are rejected with a 400. */
+function isCacheableResponsePart(part: unknown): part is CacheableResponsePart {
+  if (typeof part !== 'object' || part == null || !('type' in part)) {
+    return false;
+  }
+  return (
+    part.type === 'input_text' ||
+    part.type === 'input_image' ||
+    part.type === 'input_file'
+  );
+}
+
 function addResponseBreakpoint(
   item: OpenAIClient.Responses.ResponseInputItem
 ): OpenAIClient.Responses.ResponseInputItem {
   if (!isResponseMessage(item)) {
     return item;
   }
-  if (!Array.isArray(item.content) || item.content.length === 0) {
+  const rawContent = item.content as
+    | string
+    | OpenAIClient.Responses.ResponseInputMessageContentList;
+  if (typeof rawContent === 'string') {
+    if (rawContent.length === 0) {
+      return item;
+    }
+    return {
+      ...item,
+      content: [
+        {
+          type: 'input_text',
+          text: rawContent,
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    } as OpenAIClient.Responses.ResponseInputItem;
+  }
+  if (!Array.isArray(rawContent) || rawContent.length === 0) {
     return item;
   }
 
-  const content = [...item.content];
-  const index = content.length - 1;
+  const content = [...rawContent];
+  let index = content.length - 1;
+  while (index >= 0 && !isCacheableResponsePart(content[index])) {
+    index--;
+  }
+  if (index < 0) {
+    return item;
+  }
   content[index] = {
     ...(content[index] as CacheableResponsePart),
     prompt_cache_breakpoint: { mode: 'explicit' },
@@ -365,12 +402,18 @@ export function addResponseCacheBreakpoints(
   const indexes = new Set(
     selectCacheBreakpointIndexes(
       input.map((item) => (isResponseMessage(item) ? item.role : undefined)),
-      input.map(
-        (item) =>
-          isResponseMessage(item) &&
-          Array.isArray(item.content) &&
-          item.content.length > 0
-      )
+      input.map((item) => {
+        if (!isResponseMessage(item)) {
+          return false;
+        }
+        const content = item.content as
+          | string
+          | OpenAIClient.Responses.ResponseInputMessageContentList;
+        return typeof content === 'string'
+          ? content.length > 0
+          : Array.isArray(content) &&
+              content.some((part) => isCacheableResponsePart(part));
+      })
     )
   );
   return input.map((item, index) =>

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -102,9 +102,13 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
 };
 type ReasoningCallOptions = {
   reasoning?: OpenAIClient.Reasoning;
@@ -153,6 +157,313 @@ type OpenAIChatCompletionRetry = (
 ) => Promise<
   AsyncIterable<OpenAIChatCompletionStreamItem> | OpenAIChatCompletion
 >;
+type OpenAIManagedRequestFields = {
+  promptCacheExplicit?: boolean;
+  safetyIdentifier?: string;
+};
+type OpenAIManagedRequestParams = {
+  prompt_cache_options?: {
+    mode: 'explicit';
+    ttl: '30m';
+  };
+  safety_identifier?: string;
+};
+type ResponsesRequest =
+  | OpenAIClient.Responses.ResponseCreateParamsStreaming
+  | OpenAIClient.Responses.ResponseCreateParamsNonStreaming;
+type ResponsesResult =
+  | AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>
+  | OpenAIClient.Responses.Response;
+type CacheableChatPart = {
+  type: 'text' | 'image_url' | 'input_audio' | 'file' | 'refusal';
+  prompt_cache_breakpoint?: { mode: 'explicit' };
+  [key: string]: unknown;
+};
+type CacheableResponsePart = (
+  | OpenAIClient.Responses.ResponseInputText
+  | OpenAIClient.Responses.ResponseInputImage
+  | OpenAIClient.Responses.ResponseInputFile
+) & {
+  prompt_cache_breakpoint?: { mode: 'explicit' };
+};
+type ResponsesUsageWithCacheWrite = OpenAIClient.Responses.ResponseUsage & {
+  input_tokens_details?: OpenAIClient.Responses.ResponseUsage['input_tokens_details'] & {
+    cache_write_tokens?: number;
+  };
+};
+const CACHE_WRITE_METADATA_KEY = '__librechat_cache_write_tokens';
+
+function applyManagedRequestParams<T extends object>(
+  params: T,
+  fields: OpenAIManagedRequestFields
+): T & OpenAIManagedRequestParams {
+  return {
+    ...params,
+    ...(fields.promptCacheExplicit === true && {
+      prompt_cache_options: {
+        mode: 'explicit' as const,
+        ttl: '30m' as const,
+      },
+    }),
+    ...(fields.safetyIdentifier != null && {
+      safety_identifier: fields.safetyIdentifier,
+    }),
+  };
+}
+
+function isCacheableChatPart(part: unknown): part is CacheableChatPart {
+  if (typeof part !== 'object' || part == null || !('type' in part)) {
+    return false;
+  }
+  return (
+    part.type === 'text' ||
+    part.type === 'image_url' ||
+    part.type === 'input_audio' ||
+    part.type === 'file' ||
+    part.type === 'refusal'
+  );
+}
+
+function canAddChatBreakpoint(
+  message: OpenAIClient.Chat.Completions.ChatCompletionMessageParam
+): boolean {
+  if (
+    message.role !== 'system' &&
+    message.role !== 'developer' &&
+    message.role !== 'user' &&
+    message.role !== 'assistant' &&
+    message.role !== 'tool'
+  ) {
+    return false;
+  }
+  if (typeof message.content === 'string') {
+    return message.content.length > 0;
+  }
+  return (
+    Array.isArray(message.content) &&
+    message.content.some((part) => isCacheableChatPart(part))
+  );
+}
+
+function addChatBreakpoint(
+  message: OpenAIClient.Chat.Completions.ChatCompletionMessageParam
+): OpenAIClient.Chat.Completions.ChatCompletionMessageParam {
+  if (!canAddChatBreakpoint(message)) {
+    return message;
+  }
+
+  if (typeof message.content === 'string') {
+    return {
+      ...message,
+      content: [
+        {
+          type: 'text',
+          text: message.content,
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    } as unknown as OpenAIClient.Chat.Completions.ChatCompletionMessageParam;
+  }
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return message;
+  }
+
+  const content = [...message.content] as unknown as CacheableChatPart[];
+  let index = content.length - 1;
+  while (index >= 0 && !isCacheableChatPart(content[index])) {
+    index--;
+  }
+  if (index < 0) {
+    return message;
+  }
+  content[index] = {
+    ...content[index],
+    prompt_cache_breakpoint: { mode: 'explicit' },
+  };
+  return {
+    ...message,
+    content,
+  } as unknown as OpenAIClient.Chat.Completions.ChatCompletionMessageParam;
+}
+
+function selectCacheBreakpointIndexes(
+  roles: Array<string | undefined>,
+  cacheable: boolean[]
+): number[] {
+  let instructionIndex = -1;
+  let latestUserIndex = -1;
+  for (let index = 0; index < roles.length; index++) {
+    const role = roles[index];
+    if ((role === 'system' || role === 'developer') && cacheable[index]) {
+      instructionIndex = index;
+    }
+    if (role === 'user') {
+      latestUserIndex = index;
+    }
+  }
+
+  const indexes = new Set<number>();
+  if (instructionIndex >= 0) {
+    indexes.add(instructionIndex);
+  }
+  for (let index = latestUserIndex - 1; index >= 0; index--) {
+    if (cacheable[index]) {
+      indexes.add(index);
+      break;
+    }
+  }
+  return [...indexes];
+}
+
+/** @internal */
+export function addChatCacheBreakpoints(
+  messages: OpenAIClient.Chat.Completions.ChatCompletionMessageParam[]
+): OpenAIClient.Chat.Completions.ChatCompletionMessageParam[] {
+  const indexes = new Set(
+    selectCacheBreakpointIndexes(
+      messages.map((message) => message.role),
+      messages.map((message) => canAddChatBreakpoint(message))
+    )
+  );
+  return messages.map((message, index) =>
+    indexes.has(index) ? addChatBreakpoint(message) : message
+  );
+}
+
+function isResponseMessage(
+  item: OpenAIClient.Responses.ResponseInputItem
+): item is OpenAIClient.Responses.ResponseInputItem.Message {
+  return item.type === 'message';
+}
+
+function addResponseBreakpoint(
+  item: OpenAIClient.Responses.ResponseInputItem
+): OpenAIClient.Responses.ResponseInputItem {
+  if (!isResponseMessage(item)) {
+    return item;
+  }
+  if (!Array.isArray(item.content) || item.content.length === 0) {
+    return item;
+  }
+
+  const content = [...item.content];
+  const index = content.length - 1;
+  content[index] = {
+    ...(content[index] as CacheableResponsePart),
+    prompt_cache_breakpoint: { mode: 'explicit' },
+  };
+  return { ...item, content };
+}
+
+/** @internal */
+export function addResponseCacheBreakpoints(
+  input: OpenAIClient.Responses.ResponseCreateParams['input']
+): OpenAIClient.Responses.ResponseCreateParams['input'] {
+  if (!Array.isArray(input)) {
+    return input;
+  }
+  const indexes = new Set(
+    selectCacheBreakpointIndexes(
+      input.map((item) => (isResponseMessage(item) ? item.role : undefined)),
+      input.map(
+        (item) =>
+          isResponseMessage(item) &&
+          Array.isArray(item.content) &&
+          item.content.length > 0
+      )
+    )
+  );
+  return input.map((item, index) =>
+    indexes.has(index) ? addResponseBreakpoint(item) : item
+  );
+}
+
+/** @internal */
+export function shouldIncludeEncryptedReasoning(
+  model: string,
+  params: {
+    store?: boolean | null;
+    reasoning?: unknown;
+  }
+): boolean {
+  const reasoningContext = (
+    params.reasoning as
+      | { context?: 'auto' | 'current_turn' | 'all_turns' }
+      | undefined
+  )?.context;
+  return (
+    /^gpt-5\.6(?:-|$)/i.test(model) &&
+    (params.store === false || reasoningContext !== 'current_turn')
+  );
+}
+
+function getCacheWriteTokens(message: BaseMessage): number | undefined {
+  const responseMetadata = message.response_metadata as {
+    usage?: ResponsesUsageWithCacheWrite;
+    metadata?: Record<string, string>;
+  };
+  const reported =
+    responseMetadata.usage?.input_tokens_details.cache_write_tokens;
+  if (reported != null) {
+    return reported;
+  }
+  const serialized = responseMetadata.metadata?.[CACHE_WRITE_METADATA_KEY];
+  if (serialized == null) {
+    return;
+  }
+  const parsed = Number(serialized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function attachCacheWriteUsage(message: BaseMessage): void {
+  const cacheWriteTokens = getCacheWriteTokens(message);
+  if (
+    cacheWriteTokens == null ||
+    !isAIMessage(message) ||
+    message.usage_metadata == null
+  ) {
+    return;
+  }
+  message.usage_metadata.input_token_details = {
+    ...message.usage_metadata.input_token_details,
+    cache_creation: cacheWriteTokens,
+  };
+  const responseMetadata = message.response_metadata as {
+    metadata?: Record<string, string>;
+  };
+  if (responseMetadata.metadata?.[CACHE_WRITE_METADATA_KEY] == null) {
+    return;
+  }
+  const metadata = { ...responseMetadata.metadata };
+  delete metadata[CACHE_WRITE_METADATA_KEY];
+  message.response_metadata = {
+    ...message.response_metadata,
+    metadata,
+  };
+}
+
+function attachCacheWriteMetadata(
+  response: OpenAIClient.Responses.Response
+): OpenAIClient.Responses.Response {
+  const usage = response.usage as ResponsesUsageWithCacheWrite | undefined;
+  const cacheWriteTokens = usage?.input_tokens_details.cache_write_tokens;
+  if (cacheWriteTokens == null) {
+    return response;
+  }
+  return {
+    ...response,
+    metadata: {
+      ...(response.metadata ?? {}),
+      [CACHE_WRITE_METADATA_KEY]: String(cacheWriteTokens),
+    },
+  };
+}
+
+function isResponsesStream(
+  result: ResponsesResult
+): result is AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent> {
+  return Symbol.asyncIterator in result;
+}
 
 function createUsageMetadata(
   usage?: OpenAIClient.Completions.CompletionUsage
@@ -752,6 +1063,8 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
   private convertReasoningDetailsToContent?: boolean;
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
@@ -759,6 +1072,18 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.includeReasoningDetails = fields?.includeReasoningDetails;
     this.convertReasoningDetailsToContent =
       fields?.convertReasoningDetailsToContent;
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions'],
+    extra?: { streaming?: boolean }
+  ): ReturnType<OriginalChatOpenAICompletions['invocationParams']> {
+    return applyManagedRequestParams(super.invocationParams(options, extra), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
   }
 
   protected _getReasoningParams(
@@ -788,7 +1113,9 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
     return completionWithFilteredOpenAIStream(
-      request,
+      this.promptCacheExplicit === true
+        ? { ...request, messages: addChatCacheBreakpoints(request.messages) }
+        : request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
     );
@@ -1152,6 +1479,88 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 }
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions']
+  ): ReturnType<OriginalChatOpenAIResponses['invocationParams']> {
+    const params = applyManagedRequestParams(super.invocationParams(options), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'reasoning.encrypted_content' as const,
+        ]),
+      ];
+    }
+    return params;
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIClient.Responses.Response>;
+  async completionWithRetry(
+    request: ResponsesRequest,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<ResponsesResult> {
+    const managedRequest = {
+      ...request,
+      input:
+        this.promptCacheExplicit === true
+          ? addResponseCacheBreakpoints(request.input)
+          : request.input,
+    };
+    const result = await super.completionWithRetry(
+      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+      requestOptions
+    );
+    return isResponsesStream(result)
+      ? result
+      : attachCacheWriteMetadata(result);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const result = await super._generate(messages, options, runManager);
+    for (const generation of result.generations) {
+      attachCacheWriteUsage(generation.message);
+    }
+    return result;
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    for await (const chunk of super._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      attachCacheWriteUsage(chunk.message);
+      yield chunk;
+    }
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
@@ -1166,6 +1575,25 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 }
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatAzureOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions'],
+    extra?: { streaming?: boolean }
+  ): ReturnType<OriginalAzureChatOpenAICompletions['invocationParams']> {
+    return applyManagedRequestParams(super.invocationParams(options, extra), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
@@ -1273,7 +1701,9 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
     return completionWithFilteredOpenAIStream(
-      request,
+      this.promptCacheExplicit === true
+        ? { ...request, messages: addChatCacheBreakpoints(request.messages) }
+        : request,
       requestOptions,
       super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
     );
@@ -1281,6 +1711,88 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 }
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
+  private promptCacheExplicit?: boolean;
+  private safetyIdentifier?: string;
+
+  constructor(fields?: LibreChatAzureOpenAIFields) {
+    super(fields);
+    this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.safetyIdentifier = fields?.safety_identifier;
+  }
+
+  invocationParams(
+    options?: this['ParsedCallOptions']
+  ): ReturnType<OriginalAzureChatOpenAIResponses['invocationParams']> {
+    const params = applyManagedRequestParams(super.invocationParams(options), {
+      promptCacheExplicit: this.promptCacheExplicit,
+      safetyIdentifier: this.safetyIdentifier,
+    });
+    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'reasoning.encrypted_content' as const,
+        ]),
+      ];
+    }
+    return params;
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+  async completionWithRetry(
+    request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIClient.Responses.Response>;
+  async completionWithRetry(
+    request: ResponsesRequest,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<ResponsesResult> {
+    const managedRequest = {
+      ...request,
+      input:
+        this.promptCacheExplicit === true
+          ? addResponseCacheBreakpoints(request.input)
+          : request.input,
+    };
+    const result = await super.completionWithRetry(
+      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+      requestOptions
+    );
+    return isResponsesStream(result)
+      ? result
+      : attachCacheWriteMetadata(result);
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const result = await super._generate(messages, options, runManager);
+    for (const generation of result.generations) {
+      attachCacheWriteUsage(generation.message);
+    }
+    return result;
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    for await (const chunk of super._streamResponseChunks(
+      messages,
+      options,
+      runManager
+    )) {
+      attachCacheWriteUsage(chunk.message);
+      yield chunk;
+    }
+  }
+
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,0 +1,105 @@
+import OpenAI from 'openai';
+
+import {
+  addChatCacheBreakpoints,
+  addResponseCacheBreakpoints,
+  shouldIncludeEncryptedReasoning,
+} from './index';
+
+describe('managed GPT-5.6 request fields', () => {
+  it('places cache breakpoints after instructions and the prior history prefix', () => {
+    const messages = addChatCacheBreakpoints([
+      { role: 'system', content: 'Stable instructions.' },
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: 'First answer.' },
+      { role: 'user', content: 'Current question.' },
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: 'Stable instructions.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+    expect(messages[2]).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: 'First answer.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+    expect(JSON.stringify(messages[1])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+    expect(JSON.stringify(messages[3])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+  });
+
+  it('uses supported Responses content blocks for the same stable prefixes', () => {
+    const input = [
+      {
+        type: 'message',
+        role: 'developer',
+        content: [{ type: 'input_text', text: 'Stable instructions.' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'input_text', text: 'Prior answer.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Current question.' }],
+      },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input);
+
+    expect(result).toMatchObject([
+      {
+        content: [
+          {
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+      },
+      {
+        content: [
+          {
+            prompt_cache_breakpoint: { mode: 'explicit' },
+          },
+        ],
+      },
+      {
+        content: [{ type: 'input_text', text: 'Current question.' }],
+      },
+    ]);
+  });
+
+  it('requests encrypted reasoning whenever persisted or stateless replay may be needed', () => {
+    expect(shouldIncludeEncryptedReasoning('gpt-5.6', {})).toBe(true);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        reasoning: { context: 'all_turns' },
+      })
+    ).toBe(true);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        reasoning: { context: 'current_turn' },
+      })
+    ).toBe(false);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-5.6', {
+        store: false,
+        reasoning: { context: 'current_turn' },
+      })
+    ).toBe(true);
+    expect(shouldIncludeEncryptedReasoning('gpt-5.5', {})).toBe(false);
+  });
+});

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -82,6 +82,59 @@ describe('managed GPT-5.6 request fields', () => {
     ]);
   });
 
+  it('does not mark replayed assistant output blocks as breakpoints', () => {
+    const input = [
+      {
+        type: 'message',
+        role: 'developer',
+        content: [{ type: 'input_text', text: 'Stable instructions.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'First question.' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Prior answer.' }],
+      },
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Current question.' }],
+      },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input) as unknown as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+
+    // output_text is rejected with a 400 by OpenAI, so it must stay unmarked;
+    // the stable prefix falls back to the prior user input message.
+    expect(result[2].content[0]).not.toHaveProperty('prompt_cache_breakpoint');
+    expect(result[1].content[0]).toHaveProperty('prompt_cache_breakpoint');
+    expect(result[0].content[0]).toHaveProperty('prompt_cache_breakpoint');
+  });
+
+  it('marks string-content Responses messages by wrapping them in input_text', () => {
+    const input = [
+      { type: 'message', role: 'system', content: 'Stable system prompt.' },
+      { type: 'message', role: 'user', content: 'Prior turn.' },
+      { type: 'message', role: 'user', content: 'Current question.' },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input) as unknown as Array<{
+      content: unknown;
+    }>;
+
+    expect(result[0].content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Stable system prompt.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+  });
+
   it('requests encrypted reasoning whenever persisted or stateless replay may be needed', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-5.6', {})).toBe(true);
     expect(

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -50,8 +50,8 @@ describe('managed GPT-5.6 request fields', () => {
       },
       {
         type: 'message',
-        role: 'assistant',
-        content: [{ type: 'input_text', text: 'Prior answer.' }],
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Prior question.' }],
       },
       {
         type: 'message',
@@ -130,6 +130,30 @@ describe('managed GPT-5.6 request fields', () => {
       {
         type: 'input_text',
         text: 'Stable system prompt.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+  });
+
+  it('does not rewrite assistant string content as input_text', () => {
+    const input = [
+      { type: 'message', role: 'system', content: 'Stable system prompt.' },
+      { type: 'message', role: 'user', content: 'First question.' },
+      { type: 'message', role: 'assistant', content: 'Prior answer.' },
+      { type: 'message', role: 'user', content: 'Current question.' },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input) as unknown as Array<{
+      content: unknown;
+    }>;
+
+    // input_text under role:assistant is rejected with a 400, so assistant
+    // string content must stay a string and the breakpoint falls back to the
+    // prior user turn.
+    expect(result[2].content).toBe('Prior answer.');
+    expect(result[1].content).toEqual([
+      {
+        type: 'input_text',
+        text: 'First question.',
         prompt_cache_breakpoint: { mode: 'explicit' },
       },
     ]);

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -73,7 +73,10 @@ export type GoogleThinkingConfig = {
   includeThoughts?: boolean;
   thinkingLevel?: 'THINKING_LEVEL_UNSPECIFIED' | 'LOW' | 'MEDIUM' | 'HIGH';
 };
-export type OpenAIClientOptions = ChatOpenAIFields;
+export type OpenAIClientOptions = ChatOpenAIFields & {
+  promptCacheExplicit?: boolean;
+  safety_identifier?: string;
+};
 export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> & {
   thinking?: ThinkingConfig;
   promptCache?: boolean;

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -45,7 +45,7 @@ export type AzureClientOptions = Partial<OpenAIChatInput> &
     deploymentName?: string;
   } & BaseChatModelParams & {
     configuration?: OAIClientOptions;
-  };
+  } & ManagedRequestOptions;
 /**
  * Controls whether Claude's reasoning content is returned in adaptive
  * thinking responses. Added for Claude Opus 4.7, which omits thinking by
@@ -73,10 +73,13 @@ export type GoogleThinkingConfig = {
   includeThoughts?: boolean;
   thinkingLevel?: 'THINKING_LEVEL_UNSPECIFIED' | 'LOW' | 'MEDIUM' | 'HIGH';
 };
-export type OpenAIClientOptions = ChatOpenAIFields & {
+/** GPT-5.6 managed-request passthrough fields, shared by the OpenAI and
+ *  Azure wrappers that both read them. */
+export type ManagedRequestOptions = {
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
+export type OpenAIClientOptions = ChatOpenAIFields & ManagedRequestOptions;
 export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> & {
   thinking?: ThinkingConfig;
   promptCache?: boolean;

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsdown';
+import { isAbsolute } from 'node:path';
 
 const entry = {
   main: 'src/index.ts',
@@ -6,7 +7,8 @@ const entry = {
   'responses/index': 'src/responses/index.ts',
   'langchain/index': 'src/langchain/index.ts',
   'langchain/google-common': 'src/langchain/google-common.ts',
-  'langchain/language_models/chat_models': 'src/langchain/language_models/chat_models.ts',
+  'langchain/language_models/chat_models':
+    'src/langchain/language_models/chat_models.ts',
   'langchain/messages': 'src/langchain/messages.ts',
   'langchain/messages/tool': 'src/langchain/messages/tool.ts',
   'langchain/openai': 'src/langchain/openai.ts',
@@ -37,7 +39,8 @@ const shared = {
   // Match the prior Rollup build (`external: [/node_modules/]`): bundle nothing
   // third-party, compile only this package's own modules.
   deps: {
-    neverBundle: (id) => !id.startsWith('.') && !id.startsWith('@/') && !id.startsWith('/'),
+    neverBundle: (id) =>
+      !id.startsWith('.') && !id.startsWith('@/') && !isAbsolute(id),
     onlyBundle: false,
   },
 };


### PR DESCRIPTION
Supersedes #301, building on @usnavy13's work (tests reused, `Co-authored-by`).

## What changed vs #301

Same GPT-5.6 Responses-state functionality, but it **inherits `@langchain/openai`'s Responses converter instead of forking it.**

The key finding: `@langchain/openai` (1.5.3 already; bumped here to 1.5.5) already implements the reasoning-continuity mechanics — `convertMessagesToResponsesInput` does the encrypted-content reasoning replay + `response.output` reuse (converters/responses.js), and the Responses chat model already sends `previous_response_id` / `include` / `store` and passes the whole `reasoning` object through (so `reasoning.mode`/`reasoning.context` ride for free). Our `LibreChatOpenAIResponses` only overrides `_getReasoningParams` + `_getClientOptions`, so it **already inherits** that converter. #301 forked and re-implemented it, which would mean re-syncing every future upstream Responses fix by hand.

## Kept (the genuine fork-specific deltas)

- Managed prompt-cache: `prompt_cache_options` + breakpoint injection (`addChatCacheBreakpoints` / `addResponseCacheBreakpoints`), injected **over upstream's converter output at `completionWithRetry`**.
- `safety_identifier` passthrough.
- Cache-write usage metadata: `cache_write_tokens` → `input_token_details.cache_creation`, surfaced by thin `_generate` / `_streamResponseChunks` wraps.
- Encrypted-reasoning request: `shouldIncludeEncryptedReasoning` adds `include: ["reasoning.encrypted_content"]` for GPT-5.6.
- Bump `@langchain/openai` → 1.5.5.

## Dropped

- The forked `convertMessagesToResponsesInput` — `utils/index.ts` is unchanged from `main` (reasoning replay / `encrypted_content` / `response.output` reuse all inherited).
- The `_generate`/`_streamResponseChunks` input-rebuild, two now-dead helpers, and the fork-converter test file.

## Validation

- `tsdown` build clean
- managed-request tests 3/3 (reused from #301)
- full `src/llm/openai` suite: 1774 tests pass

Native PTC remains out of scope (separate stacked PR), same as #301.