### PR TITLE
🧭 feat: Steer Replay in formatAgentMessages + Eager-Path Race Hardening

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -3230,9 +3230,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
   it('does not prestart when parent-run session hooks alter results', async () => {
     // A subagent child graph has its own runId, but ToolNode executes hooks
-    // under the PARENT run id inherited via metadata/configurable — the
-    // prestart gate must resolve the same id or it prestarts calls the
-    // parent's hooks intend to rewrite or block.
+    // under the PARENT run id from `configurable.run_id` ONLY — the prestart
+    // gate must read the same source (a differing metadata run id here is a
+    // deliberate distractor pinning the precedence).
     const sessionRegistry = new HookRegistry();
     sessionRegistry.registerSession('parent-run', 'PreToolUse', {
       hooks: [async () => ({ decision: 'allow' as const })],
@@ -3240,7 +3240,11 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph({
       runId: 'child-run',
       hookRegistry: sessionRegistry,
-    });
+      config: {
+        configurable: { user_id: 'user_1', run_id: 'parent-run' },
+        metadata: { run_id: 'run_1' },
+      },
+    } as Partial<StandardGraph>);
     const sessionDispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
 
     await new ChatModelStreamHandler().handle(
@@ -3253,7 +3257,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
           ],
         } as unknown as t.StreamChunk,
       },
-      { langgraph_node: 'agent', run_id: 'parent-run' },
+      { langgraph_node: 'agent', run_id: 'some-other-run' },
       graph
     );
 

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -3228,6 +3228,43 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
+  it('does not prestart when parent-run session hooks alter results', async () => {
+    // A subagent child graph has its own runId, but ToolNode executes hooks
+    // under the PARENT run id inherited via metadata/configurable — the
+    // prestart gate must resolve the same id or it prestarts calls the
+    // parent's hooks intend to rewrite or block.
+    const sessionRegistry = new HookRegistry();
+    sessionRegistry.registerSession('parent-run', 'PreToolUse', {
+      hooks: [async () => ({ decision: 'allow' as const })],
+    });
+    const graph = createGraph({
+      runId: 'child-run',
+      hookRegistry: sessionRegistry,
+    });
+    const sessionDispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent', run_id: 'parent-run' },
+      graph
+    );
+
+    expect(sessionDispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
   it('does not prestart when batch-sensitive hooks are configured', async () => {
     const graph = createGraph({
       hookRegistry: createResultAlteringRegistry(),

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -140,6 +140,8 @@ export enum ContentTypes {
   SUMMARY = 'summary',
   /** Bedrock */
   REASONING_CONTENT = 'reasoning_content',
+  /** Mid-run user steer persisted inline in an assistant message; replayed as a user turn */
+  STEER = 'steer',
 }
 
 export enum ToolCallTypes {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -738,9 +738,12 @@ function formatAssistantMessage(
         assistant content first so ordering is preserved, then replay the
         steer as a standalone user message — multimodal when the host stamped
         a pre-encoded `media` content array (attachment refs are re-encoded
-        per turn host-side, like any other user media). `lastAIMessage` is NOT
-        reset: preceding tool_call parts already emitted their ToolMessages,
-        so the HumanMessage lands after them in valid provider order.
+        per turn host-side, like any other user media). `lastAIMessage` is
+        reset AFTER the HumanMessage: a post-steer tool_call must mint a
+        FRESH assistant anchor (the heal path) so its AIMessage lands after
+        the user turn — attaching it to the pre-steer anchor would emit its
+        ToolMessage after the HumanMessage while the call itself sat before
+        it, an invalid provider ordering.
         */
         if (currentContent.length > 0) {
           if (
@@ -776,6 +779,7 @@ function formatAssistantMessage(
             'user'
           )
         );
+        lastAIMessage = null;
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -761,6 +761,16 @@ function formatAssistantMessage(
             }
           }
           currentContent = [];
+        } else if (shouldPreserveReasoningContent && pendingReasoningContent) {
+          /**
+           * Reasoning directly preceding a steer has no `currentContent`
+           * flush to consume it and the anchor resets below — emit an anchor
+           * AIMessage now (createAIMessage folds the pending reasoning into
+           * `additional_kwargs.reasoning_content`) or the persisted
+           * assistant reasoning silently vanishes on replay.
+           */
+          lastAIMessage = createAIMessage('');
+          formattedMessages.push(lastAIMessage);
         }
         const steerPart = part as {
           steer?: string;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -790,6 +790,11 @@ function formatAssistantMessage(
           )
         );
         lastAIMessage = null;
+        /** The steer splits the assistant message: the post-steer segment
+         *  starts with fresh reasoning state (pre-steer reasoning was either
+         *  flushed above or intentionally dropped when not preserving). */
+        hasReasoning = false;
+        pendingReasoningContent = '';
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||
@@ -917,6 +922,12 @@ function labelAllAgentContent(
     }
 
     currentAgentId = agentId;
+    if (part.type === ContentTypes.STEER) {
+      /** User speech is never agent content — see the transfer path above. */
+      flushAgentBuffer();
+      result.push(part);
+      continue;
+    }
     agentContentBuffer.push(part);
   }
 
@@ -1052,6 +1063,15 @@ export const labelContentByAgent = (
       transferToolCallIndex = result.length - 1;
       transferToolCallId = (part as ToolCallContent).tool_call?.id;
       currentAgentId = undefined; // Reset to capture the next agent
+    } else if (part.type === ContentTypes.STEER) {
+      /**
+       * User speech is never agent content: flush the buffer in place and
+       * pass the steer through verbatim so `formatAssistantMessage` replays
+       * it as a user turn. Folding it into a labeled transfer summary would
+       * both drop the user's words and misattribute them to the agent.
+       */
+      flushAgentBuffer();
+      result.push(part);
     } else {
       agentContentBuffer.push(part);
     }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1069,8 +1069,15 @@ export const labelContentByAgent = (
        * pass the steer through verbatim so `formatAssistantMessage` replays
        * it as a user turn. Folding it into a labeled transfer summary would
        * both drop the user's words and misattribute them to the agent.
+       * The steer also CLOSES any open transfer capture — `flushAgentBuffer`
+       * no-ops on an empty buffer, and leaving the capture live would fold
+       * post-steer agent content into the pre-steer transfer output,
+       * replaying it BEFORE the user's redirect.
        */
       flushAgentBuffer();
+      transferToolCallIndex = undefined;
+      transferToolCallId = undefined;
+      currentAgentId = undefined;
       result.push(part);
     } else {
       agentContentBuffer.push(part);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -466,9 +466,15 @@ function hasToolCallOutput(part: MessageContentComplex): boolean {
 function formatAssistantMessage(
   message: Partial<TMessage>,
   options?: FormatAssistantMessageOptions
-): Array<RoleBearingMessage<AIMessage> | RoleBearingMessage<ToolMessage>> {
+): Array<
+  | RoleBearingMessage<AIMessage>
+  | RoleBearingMessage<ToolMessage>
+  | RoleBearingMessage<HumanMessage>
+> {
   const formattedMessages: Array<
-    RoleBearingMessage<AIMessage> | RoleBearingMessage<ToolMessage>
+    | RoleBearingMessage<AIMessage>
+    | RoleBearingMessage<ToolMessage>
+    | RoleBearingMessage<HumanMessage>
   > = [];
   let currentContent: MessageContentComplex[] = [];
   let lastAIMessage: RoleBearingMessage<AIMessage> | null = null;
@@ -725,6 +731,51 @@ function formatAssistantMessage(
         hasReasoning = true;
         pendingReasoningContent += extractReasoningContent(part);
         continue;
+      } else if (part.type === ContentTypes.STEER) {
+        /*
+        A mid-run steer: user speech persisted inline in the assistant message
+        at the tool-batch boundary it was injected. Flush accumulated
+        assistant content first so ordering is preserved, then replay the
+        steer as a standalone user message — multimodal when the host stamped
+        a pre-encoded `media` content array (attachment refs are re-encoded
+        per turn host-side, like any other user media). `lastAIMessage` is NOT
+        reset: preceding tool_call parts already emitted their ToolMessages,
+        so the HumanMessage lands after them in valid provider order.
+        */
+        if (currentContent.length > 0) {
+          if (
+            currentContent.some((content) => content.type !== ContentTypes.TEXT)
+          ) {
+            lastAIMessage = createAIMessage(toLangChainContent(currentContent));
+            formattedMessages.push(lastAIMessage);
+          } else {
+            const flushed = currentContent
+              .reduce((acc, curr) => `${acc}${getTextContent(curr)}\n`, '')
+              .trim();
+            if (flushed.length > 0) {
+              lastAIMessage = createAIMessage(flushed);
+              formattedMessages.push(lastAIMessage);
+            }
+          }
+          currentContent = [];
+        }
+        const steerPart = part as {
+          steer?: string;
+          media?: MessageContentComplex[];
+        };
+        const steerContent =
+          Array.isArray(steerPart.media) && steerPart.media.length > 0
+            ? toLangChainContent(steerPart.media)
+            : (steerPart.steer ?? '');
+        formattedMessages.push(
+          withMessageRole(
+            new HumanMessage({
+              content: steerContent as MessageContent,
+              additional_kwargs: { role: 'user', source: 'steer' },
+            }),
+            'user'
+          )
+        );
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||
@@ -1440,7 +1491,8 @@ export const formatAgentMessages = (
     const formattedMessages = formatAssistantMessage(processedMessage, {
       preserveUnpairedServerToolUses: i === payload.length - 1,
       preserveReasoningContent:
-        options?.preserveReasoningContent ?? options?.provider === Providers.DEEPSEEK,
+        options?.preserveReasoningContent ??
+        options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
     });
     if (sourceMessageId != null && sourceMessageId !== '') {

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -1,0 +1,148 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import { formatAgentMessages } from './format';
+import { ContentTypes } from '@/common';
+
+function toolCallPart(
+  id: string,
+  name = 'search',
+  output = 'result'
+): Record<string, unknown> {
+  return {
+    type: ContentTypes.TOOL_CALL,
+    tool_call: { id, name, args: '{}', output },
+  };
+}
+
+describe('formatAgentMessages steer replay', () => {
+  it('replays a steer part as a user message after preceding tool messages', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Working on it.',
+            tool_call_ids: ['call_1'],
+          },
+          toolCallPart('call_1'),
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Actually, focus on the second item.',
+            steerId: 's1',
+          } as unknown as Record<string, unknown>,
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Focusing on item two.',
+          },
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    const steerIndex = messages.findIndex(
+      (message) =>
+        message instanceof HumanMessage &&
+        message.additional_kwargs.source === 'steer'
+    );
+    expect(steerIndex).toBeGreaterThan(0);
+    expect(messages[steerIndex].content).toBe(
+      'Actually, focus on the second item.'
+    );
+    expect(messages[steerIndex - 1]).toBeInstanceOf(ToolMessage);
+    const trailing = messages[steerIndex + 1];
+    expect(trailing).toBeInstanceOf(AIMessage);
+  });
+
+  it('flushes accumulated assistant text before the steer user message', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Partial answer.' },
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Change of plans.',
+          } as unknown as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBeInstanceOf(AIMessage);
+    expect(messages[0].content).toBe('Partial answer.');
+    expect(messages[1]).toBeInstanceOf(HumanMessage);
+    expect(messages[1].content).toBe('Change of plans.');
+  });
+
+  it('uses the host-stamped media array for multimodal steers', () => {
+    const media = [
+      { type: 'text', text: 'Look at this screenshot.' },
+      {
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,abc123', detail: 'auto' },
+      },
+    ];
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Look at this screenshot.',
+            media,
+          } as unknown as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toBeInstanceOf(HumanMessage);
+    expect(messages[0].content).toEqual(media);
+    expect((messages[0] as HumanMessage).additional_kwargs.source).toBe(
+      'steer'
+    );
+  });
+
+  it('never leaks a steer part into assistant content sent to the provider', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Before.' },
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Steer text.',
+          } as unknown as Record<string, unknown>,
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'After.' },
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    for (const message of messages) {
+      if (message instanceof HumanMessage) {
+        continue;
+      }
+      const content = message.content;
+      if (Array.isArray(content)) {
+        expect(
+          content.some((part) => (part as { type?: string }).type === 'steer')
+        ).toBe(false);
+      }
+    }
+    // Trailing content after the steer keeps the end-of-loop array form.
+    expect(messages.map((message) => message.content)).toEqual([
+      'Before.',
+      'Steer text.',
+      [{ type: 'text', text: 'After.' }],
+    ]);
+  });
+});

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -121,6 +121,42 @@ describe('formatAgentMessages steer replay', () => {
     expect(messages[1].content).toBe('Change of plans.');
   });
 
+  it('preserves pending reasoning that directly precedes a steer', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.THINK,
+            [ContentTypes.THINK]: 'chain of thought',
+          },
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Stop and reconsider.',
+          } as unknown as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      {
+        preserveReasoningContent: true,
+      }
+    );
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBeInstanceOf(AIMessage);
+    expect(messages[0].additional_kwargs.reasoning_content).toBe(
+      'chain of thought'
+    );
+    expect(messages[1]).toBeInstanceOf(HumanMessage);
+    expect(messages[1].content).toBe('Stop and reconsider.');
+  });
+
   it('uses the host-stamped media array for multimodal steers', () => {
     const media = [
       { type: 'text', text: 'Look at this screenshot.' },

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -56,6 +56,48 @@ describe('formatAgentMessages steer replay', () => {
     expect(trailing).toBeInstanceOf(AIMessage);
   });
 
+  it('mints a fresh assistant anchor for a tool call after a steer', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'First step.',
+            tool_call_ids: ['call_1'],
+          },
+          toolCallPart('call_1'),
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Do the second thing instead.',
+          } as unknown as Record<string, unknown>,
+          toolCallPart('call_2', 'search', 'second result'),
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    // AI(call_1), Tool(call_1), Human(steer), AI(call_2), Tool(call_2) —
+    // the post-steer tool call must NOT attach to the pre-steer anchor, or
+    // its ToolMessage would trail the user turn while the call precedes it.
+    expect(messages.map((message) => message.constructor.name)).toEqual([
+      'AIMessage',
+      'ToolMessage',
+      'HumanMessage',
+      'AIMessage',
+      'ToolMessage',
+    ]);
+    const postSteerAnchor = messages[3] as AIMessage;
+    expect(postSteerAnchor.tool_calls?.map((call) => call.id)).toEqual([
+      'call_2',
+    ]);
+    const preSteerAnchor = messages[0] as AIMessage;
+    expect(preSteerAnchor.tool_calls?.map((call) => call.id)).toEqual([
+      'call_1',
+    ]);
+  });
+
   it('flushes accumulated assistant text before the steer user message', () => {
     const payload: TPayload = [
       {

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -1,7 +1,7 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { TPayload } from '@/types';
+import { ContentTypes, Constants, Providers } from '@/common';
 import { formatAgentMessages } from './format';
-import { ContentTypes } from '@/common';
 
 function toolCallPart(
   id: string,
@@ -186,6 +186,106 @@ describe('formatAgentMessages steer replay', () => {
     expect((messages[0] as HumanMessage).additional_kwargs.source).toBe(
       'steer'
     );
+  });
+
+  it('replays [THINK, STEER, TEXT] without duplicating the trailing text', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.THINK,
+            [ContentTypes.THINK]: 'chain of thought',
+          },
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Redirect now.',
+          } as unknown as Record<string, unknown>,
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Post-steer answer.',
+          },
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      {
+        preserveReasoningContent: true,
+      }
+    );
+
+    expect(messages.map((message) => message.constructor.name)).toEqual([
+      'AIMessage',
+      'HumanMessage',
+      'AIMessage',
+    ]);
+    expect(messages[0].additional_kwargs.reasoning_content).toBe(
+      'chain of thought'
+    );
+    // Post-steer segment starts with fresh reasoning state: the trailing
+    // text appears exactly once (end-of-loop array form) and carries no
+    // pre-steer reasoning.
+    expect(messages[2].content).toEqual([
+      { type: 'text', text: 'Post-steer answer.' },
+    ]);
+    expect(messages[2].additional_kwargs.reasoning_content).toBeUndefined();
+  });
+
+  it('keeps a paired Anthropic server-tool use/result together after the steer', () => {
+    const useId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}search1`;
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: { id: useId, name: 'web_search', args: '{"query":"x"}' },
+          },
+          {
+            type: ContentTypes.STEER,
+            [ContentTypes.STEER]: 'Also check the docs.',
+          } as unknown as Record<string, unknown>,
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: useId,
+            content: [
+              { type: 'web_search_result', url: 'https://example.com' },
+            ],
+          } as unknown as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+
+    // The pair may not split across the user turn (invalid for Anthropic);
+    // it emits together in the post-steer assistant segment instead.
+    expect(messages[0]).toBeInstanceOf(HumanMessage);
+    expect(messages[0].content).toBe('Also check the docs.');
+    const assistant = messages[1];
+    expect(assistant).toBeInstanceOf(AIMessage);
+    const parts = assistant.content as Array<{
+      type?: string;
+      tool_use_id?: string;
+      id?: string;
+    }>;
+    const useIndex = parts.findIndex((part) => part.type === 'server_tool_use');
+    const resultIndex = parts.findIndex(
+      (part) => part.type === 'web_search_tool_result'
+    );
+    expect(useIndex).toBeGreaterThanOrEqual(0);
+    expect(resultIndex).toBe(useIndex + 1);
   });
 
   it('never leaks a steer part into assistant content sent to the provider', () => {

--- a/src/messages/labelContentByAgent.test.ts
+++ b/src/messages/labelContentByAgent.test.ts
@@ -54,6 +54,32 @@ describe('labelContentByAgent', () => {
     });
   });
 
+  describe('steer pass-through', () => {
+    it('passes steer parts through the parallel labeler verbatim', () => {
+      const steerPart = {
+        type: ContentTypes.STEER,
+        steer: 'User redirect mid-run',
+        steerId: 's1',
+      } as unknown as MessageContentComplex;
+      const contentParts: MessageContentComplex[] = [
+        { type: ContentTypes.TEXT, text: 'agent output' },
+        steerPart,
+        { type: ContentTypes.TEXT, text: 'post-steer output' },
+      ];
+
+      const result = labelContentByAgent(
+        contentParts,
+        { 0: 'agent_a', 1: 'agent_a', 2: 'agent_a' },
+        { agent_a: 'Alpha' },
+        { labelNonTransferContent: true }
+      );
+
+      // The user's words survive verbatim (not folded into a labeled
+      // summary) so formatAssistantMessage can replay them as a user turn.
+      expect(result).toContain(steerPart);
+    });
+  });
+
   describe('Transfer-based labeling (default)', () => {
     it('should consolidate transferred agent content into transfer tool output', () => {
       const contentParts: MessageContentComplex[] = [

--- a/src/messages/labelContentByAgent.test.ts
+++ b/src/messages/labelContentByAgent.test.ts
@@ -80,6 +80,55 @@ describe('labelContentByAgent', () => {
     });
   });
 
+  describe('steer vs transfer capture', () => {
+    it('closes an open transfer capture at a steer boundary', () => {
+      const transferPart: MessageContentComplex = {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_transfer',
+          name: 'lc_transfer_to_beta',
+          args: '{}',
+          output: 'original output',
+        },
+      } as MessageContentComplex;
+      const steerPart = {
+        type: ContentTypes.STEER,
+        steer: 'Actually, stop and summarize.',
+      } as unknown as MessageContentComplex;
+      const contentParts: MessageContentComplex[] = [
+        transferPart,
+        steerPart,
+        { type: ContentTypes.TEXT, text: 'post-steer agent output' },
+      ];
+
+      const result = labelContentByAgent(
+        contentParts,
+        { 0: 'agent_a', 1: 'agent_a', 2: 'agent_b' },
+        { agent_b: 'Beta' }
+      );
+
+      // The steer passes through and post-steer content stays AFTER it —
+      // never folded into the pre-steer transfer output, which would replay
+      // it ahead of the user's redirect.
+      expect(result).toContain(steerPart);
+      const transferInResult = result.find(
+        (part) =>
+          isToolCallContent(part) && part.tool_call?.id === 'call_transfer'
+      );
+      expect(
+        isToolCallContent(transferInResult!)
+          ? transferInResult.tool_call?.output
+          : undefined
+      ).toBe('original output');
+      const steerIndex = result.indexOf(steerPart);
+      const textIndex = result.findIndex(
+        (part) =>
+          hasTextProperty(part) && part.text === 'post-steer agent output'
+      );
+      expect(textIndex).toBeGreaterThan(steerIndex);
+    });
+  });
+
   describe('Transfer-based labeling (default)', () => {
     it('should consolidate transferred agent content into transfer tool output', () => {
       const contentParts: MessageContentComplex[] = [

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -113,16 +113,17 @@ function isBatchSensitiveToolExecution(
   metadata?: Record<string, unknown>
 ): boolean {
   /**
-   * Resolve the hook-session id exactly the way ToolNode will
-   * (`configurable.run_id` first): a subagent child graph carries its own
-   * `graph.runId`, but its ToolNode executes hooks under the PARENT's
-   * inherited run id — gating on the child id would miss parent
-   * session-scoped result-altering hooks and prestart a call those hooks
-   * intend to rewrite or block.
+   * Resolve the hook-session id exactly the way ToolNode will: its hook
+   * lookups read `config.configurable.run_id` ONLY, so that source wins here
+   * too (a subagent child graph carries its own `graph.runId`, but its
+   * ToolNode executes hooks under the PARENT's inherited configurable run
+   * id). The metadata / graph.runId fallbacks only apply when no
+   * configurable id exists and can only be conservative — a false positive
+   * merely skips eager prestart.
    */
   const runId =
-    (metadata?.run_id as string | undefined) ??
     (graph.config?.configurable?.run_id as string | undefined) ??
+    (metadata?.run_id as string | undefined) ??
     graph.runId;
   return (
     graph.hookRegistry?.hasResultAlteringHooks(runId) === true ||

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -108,9 +108,24 @@ function getNonEmptyValue(possibleValues: string[]): string | undefined {
   return undefined;
 }
 
-function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
+function isBatchSensitiveToolExecution(
+  graph: StandardGraph,
+  metadata?: Record<string, unknown>
+): boolean {
+  /**
+   * Resolve the hook-session id exactly the way ToolNode will
+   * (`configurable.run_id` first): a subagent child graph carries its own
+   * `graph.runId`, but its ToolNode executes hooks under the PARENT's
+   * inherited run id — gating on the child id would miss parent
+   * session-scoped result-altering hooks and prestart a call those hooks
+   * intend to rewrite or block.
+   */
+  const runId =
+    (metadata?.run_id as string | undefined) ??
+    (graph.config?.configurable?.run_id as string | undefined) ??
+    graph.runId;
   return (
-    graph.hookRegistry?.hasResultAlteringHooks(graph.runId) === true ||
+    graph.hookRegistry?.hasResultAlteringHooks(runId) === true ||
     graph.humanInTheLoop?.enabled === true
   );
 }
@@ -249,7 +264,7 @@ function isEagerToolExecutionEnabledForBatch(args: {
   if ((agentContext?.toolDefinitions?.length ?? 0) === 0) {
     return false;
   }
-  if (isBatchSensitiveToolExecution(graph)) {
+  if (isBatchSensitiveToolExecution(graph, metadata)) {
     return false;
   }
   if (

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2103,6 +2103,32 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * to defensively `?.` it across every reference inside.
        */
       const hookRegistry = this.hookRegistry;
+      /**
+       * Pull each call's prestarted eager record BEFORE awaiting the hooks:
+       * an async deny must never race the eager host promise into emitting a
+       * successful completion (`dispatchEagerToolCompletions`' map-identity
+       * check skips deleted records). Allowed entries get their record
+       * restored in the decision loop below so consumption still works;
+       * denied entries stay deleted. Ask/interrupt configs never have eager
+       * records (HITL disables the reservation gate).
+       */
+      const preemptedEagerRecords = new Map<
+        string,
+        t.EagerEventToolExecution
+      >();
+      if (this.eagerEventToolExecutions != null) {
+        for (const entry of preToolCalls) {
+          const callId = entry.call.id;
+          if (callId == null) {
+            continue;
+          }
+          const record = this.eagerEventToolExecutions.get(callId);
+          if (record != null) {
+            preemptedEagerRecords.set(callId, record);
+            this.eagerEventToolExecutions.delete(callId);
+          }
+        }
+      }
       const preResults = await Promise.all(
         preToolCalls.map((entry) =>
           executeHooks({
@@ -2321,6 +2347,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         if (hookResult.updatedInput != null) {
           applyInputOverride(entry, hookResult.updatedInput);
+        }
+        if (entry.call.id != null) {
+          const preempted = preemptedEagerRecords.get(entry.call.id);
+          if (preempted != null) {
+            this.eagerEventToolExecutions?.set(entry.call.id, preempted);
+          }
         }
         approvedEntries.push(entry);
       }
@@ -2748,20 +2780,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             request,
             execution
           );
+          /**
+           * Force a corrected batch-time re-emission ONLY when an active hook
+           * can actually rewrite this consumed result: `PostToolUse` rewrites
+           * success outputs via `updatedOutput`, while failure hooks cannot
+           * replace output — a duplicate completion there would change
+           * nothing. The stream already emitted the raw eager completion
+           * before the hook existed; treating a rewritable one as NOT
+           * dispatched converges host/UI step output to the final
+           * ToolMessage.
+           */
+          const rewritable =
+            hasPostHook && results.some((result) => result.status !== 'error');
           return {
             results,
             completionDispatched:
               execution.completionDispatched === true &&
               execution.request.turn === request.turn &&
-              /**
-               * A result-altering hook active THIS batch may rewrite the
-               * consumed output below, but the stream already emitted the raw
-               * eager completion before the hook existed. Treating it as NOT
-               * dispatched forces a corrected batch-time re-emission, so
-               * host/UI step output converges to the final ToolMessage.
-               */
-              !hasPostHook &&
-              !hasFailureHook,
+              !rewritable,
             toolCallId: request.id,
           };
         })

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2780,24 +2780,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             request,
             execution
           );
-          /**
-           * Force a corrected batch-time re-emission ONLY when an active hook
-           * can actually rewrite this consumed result: `PostToolUse` rewrites
-           * success outputs via `updatedOutput`, while failure hooks cannot
-           * replace output — a duplicate completion there would change
-           * nothing. The stream already emitted the raw eager completion
-           * before the hook existed; treating a rewritable one as NOT
-           * dispatched converges host/UI step output to the final
-           * ToolMessage.
-           */
-          const rewritable =
-            hasPostHook && results.some((result) => result.status !== 'error');
           return {
             results,
             completionDispatched:
               execution.completionDispatched === true &&
-              execution.request.turn === request.turn &&
-              !rewritable,
+              execution.request.turn === request.turn,
             toolCallId: request.id,
           };
         })
@@ -2963,6 +2950,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 this.maxToolResultChars
               );
               finalToolOutput = hookResult.updatedOutput;
+              /**
+               * The hook ACTUALLY rewrote this output: any completion the
+               * stream already emitted for the consumed eager result showed
+               * the raw content, so un-mark it and let the dispatch below
+               * re-emit the corrected version. Hooks that merely observe or
+               * add context leave the original emission final — no
+               * duplicates.
+               */
+              eagerCompletionDispatchedIds.delete(result.toolCallId);
             }
           }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2185,6 +2185,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           contentString,
           reason,
         });
+        /**
+         * A prestarted eager execution for a now-blocked call must neither be
+         * consumed nor emit its completion — the run reports this call as
+         * blocked. Deleting the record makes `dispatchEagerToolCompletions`'
+         * map-identity check skip the pending emission (same pattern as the
+         * rejected-results cleanup below).
+         */
+        this.eagerEventToolExecutions?.delete(entry.call.id!);
       };
 
       const flushDeferredBlockedSideEffects = async (): Promise<void> => {
@@ -2646,6 +2654,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const canEmitEarlyCompletions =
         this.hookRegistry?.hasResultAlteringHooks(runId) !== true &&
         this.humanInTheLoop?.enabled !== true;
+      /**
+       * Snapshot the post-hook gates at the same instant as the early-emission
+       * gate: a result-altering hook registered while this batch is in flight
+       * applies from the NEXT batch. Evaluating these after results settle
+       * would let a late hook rewrite the ToolMessage AFTER an early
+       * completion already emitted the pre-hook output — two views of the
+       * same call.
+       */
+      const hasPostHook =
+        this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
+      const hasFailureHook =
+        this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
       const earlyCompletionDispatchedIds = new Set<string>();
       const earlyCompletionDispatches: Array<Promise<void>> = [];
       const dispatchRequestById = new Map(
@@ -2760,11 +2780,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       ];
 
       this.storeCodeSessionFromResults(results, requestMap);
-
-      const hasPostHook =
-        this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
-      const hasFailureHook =
-        this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
       for (const result of results) {
         if (result.injectedMessages && result.injectedMessages.length > 0) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2752,7 +2752,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             results,
             completionDispatched:
               execution.completionDispatched === true &&
-              execution.request.turn === request.turn,
+              execution.request.turn === request.turn &&
+              /**
+               * A result-altering hook active THIS batch may rewrite the
+               * consumed output below, but the stream already emitted the raw
+               * eager completion before the hook existed. Treating it as NOT
+               * dispatched forces a corrected batch-time re-emission, so
+               * host/UI step output converges to the final ToolMessage.
+               */
+              !hasPostHook &&
+              !hasFailureHook,
             toolCallId: request.id,
           };
         })

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -832,6 +832,74 @@ describe('ToolNode eager event tool execution', () => {
     expect(toolMessage?.content).toBe('raw output');
   });
 
+  it('re-emits a corrected completion when hooks rewrite a consumed eager result', async () => {
+    const stepCompletions: Array<{
+      result?: { tool_call?: { output?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          stepCompletions.push(data as (typeof stepCompletions)[number]);
+          return true;
+        }
+      });
+
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    // The stream already emitted the RAW eager completion before the hook
+    // below registered; the batch must re-emit with the rewritten output so
+    // host/UI state converges to the ToolMessage.
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      completionDispatched: true,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'raw eager output',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolUse', {
+      hooks: [async () => ({ updatedOutput: 'REWRITTEN' })],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('REWRITTEN');
+    expect(
+      stepCompletions.some(
+        (completion) => completion.result?.tool_call?.output === 'REWRITTEN'
+      )
+    ).toBe(true);
+  });
+
   it('consumes a prestarted eager result even after a result-altering hook registers mid-run', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -1005,6 +1005,69 @@ describe('ToolNode eager event tool execution', () => {
     expect(stepCompletions).toHaveLength(0);
   });
 
+  it('keeps the original emission final for observe-only PostToolUse hooks', async () => {
+    const stepCompletions: Array<{
+      result?: { tool_call?: { output?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          stepCompletions.push(data as (typeof stepCompletions)[number]);
+          return true;
+        }
+      });
+
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      completionDispatched: true,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'raw eager output',
+          },
+        ],
+      }),
+    });
+
+    // The hook runs but returns no updatedOutput — the already-emitted
+    // eager completion is final and must not be duplicated.
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolUse', {
+      hooks: [async () => ({})],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('raw eager output');
+    expect(stepCompletions).toHaveLength(0);
+  });
+
   it('re-emits a corrected completion when hooks rewrite a consumed eager result', async () => {
     const stepCompletions: Array<{
       result?: { tool_call?: { output?: string } };

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -832,6 +832,179 @@ describe('ToolNode eager event tool execution', () => {
     expect(toolMessage?.content).toBe('raw output');
   });
 
+  it('removes prestarted records while PreToolUse hooks are in flight', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const seenDuringHook: boolean[] = [];
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [
+        async () => {
+          // The record must be OUT of the map while this hook is pending, so
+          // a resolving eager promise cannot emit a successful completion for
+          // a call this hook is about to deny.
+          seenDuringHook.push(eagerExecutions.has('call_weather'));
+          return { decision: 'deny' as const, reason: 'no' };
+        },
+      ],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(seenDuringHook).toEqual([false]);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(toolExecuteCalls).toHaveLength(0);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(String(toolMessage?.content)).toContain('Blocked');
+  });
+
+  it('restores preempted records for allowed calls and consumes them', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [async () => ({ decision: 'allow' as const })],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('eager result');
+  });
+
+  it('does not duplicate completions for hooks that cannot rewrite the result', async () => {
+    const stepCompletions: Array<{
+      result?: { tool_call?: { output?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          stepCompletions.push(data as (typeof stepCompletions)[number]);
+          return true;
+        }
+      });
+
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      completionDispatched: true,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'raw eager output',
+          },
+        ],
+      }),
+    });
+
+    // A failure hook cannot replace a SUCCESS result's output — the already
+    // emitted eager completion is final, so no batch re-emission may fire.
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolUseFailure', {
+      hooks: [async () => ({})],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('raw eager output');
+    expect(stepCompletions).toHaveLength(0);
+  });
+
   it('re-emits a corrected completion when hooks rewrite a consumed eager result', async () => {
     const stepCompletions: Array<{
       result?: { tool_call?: { output?: string } };

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -736,6 +736,102 @@ describe('ToolNode eager event tool execution', () => {
     expect(toolMessage?.content).toBe('eager result');
   });
 
+  it('discards a prestarted eager record when a PreToolUse hook blocks the call', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [
+        async () => ({ decision: 'deny' as const, reason: 'not allowed' }),
+      ],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map(),
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    // The record must be gone so the prestarted promise can never emit a
+    // successful completion for a call the run reported as blocked.
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(toolExecuteCalls).toHaveLength(0);
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(String(toolMessage?.content)).toContain('Blocked');
+  });
+
+  it('skips post hooks registered while the batch is in flight (snapshot semantics)', async () => {
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PostToolBatch', { hooks: [async () => ({})] });
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        // A result-altering hook lands while the host tool is executing: the
+        // whole batch keeps the gate snapshot from dispatch start, so the
+        // rewrite applies from the NEXT batch and cannot diverge from any
+        // already-emitted early completion.
+        hookRegistry.register('PostToolUse', {
+          hooks: [async () => ({ updatedOutput: 'REWRITTEN' })],
+        });
+        batch.resolve(
+          batch.toolCalls.map((toolCall) => ({
+            toolCallId: toolCall.id,
+            status: 'success' as const,
+            content: 'raw output',
+          }))
+        );
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      hookRegistry,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    const toolMessage = result.messages.find((m) => m instanceof ToolMessage);
+    expect(toolMessage?.content).toBe('raw output');
+  });
+
   it('consumes a prestarted eager result even after a result-altering hook registers mid-run', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();


### PR DESCRIPTION
## Summary

Follow-up to the squash-merged injectedMessages PR (the `feat/hook-injected-messages` branch had two commits pushed after the merge landed; they are rebased here onto main, plus one new fix from the latest Codex review round). This must land before the next release: the merged code exports `HOOK_INJECTED_MESSAGES_CAPABLE`, so hosts can persist inline `steer` content parts, but without the replay branch here those parts leak into the assistant's provider payload on every later turn.

- Added `ContentTypes.STEER` and a steer replay branch to `formatAssistantMessage`: accumulated assistant content is flushed, then the steer is reconstructed as a standalone `HumanMessage` (`role`/`source` kwargs matching `convertInjectedMessages`), multimodal when the host stamped a pre-encoded `media` content array. `lastAIMessage` is not reset, preserving valid provider ordering around tool steps. Previously an unrecognized `steer` part fell through the catch-all into provider-facing assistant content.
- Snapshotted `hasPostHook`/`hasFailureHook` at dispatch start beside the early-emission gate, so a result-altering hook registered while a batch is in flight applies from the next batch instead of rewriting a ToolMessage whose early completion already emitted.
- Deleted a call's prestarted eager record in `blockEntry`: a call the run reports as blocked can neither be consumed nor emit its pending eager completion (`dispatchEagerToolCompletions`' map-identity check).
- Resolved the stream prestart gate's hook-session id with ToolNode's exact precedence (`metadata.run_id ?? configurable.run_id ?? graph.runId`), so subagent child streams gate on the parent run's session hooks (addresses the P1 from the latest review).
- Treated a consumed eager record as not-dispatched whenever the batch-start snapshot shows result-altering hooks, forcing a corrected batch-time completion re-emission so host/UI step output converges to the rewritten ToolMessage (addresses the P2 from the latest review).

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`npm test -- --testPathPatterns "eagerEventExecution|onResultCompletion|formatAgentMessages|HookRegistry"` — 9 suites, 239 passed. New coverage: steer replay position/flush/media/no-leak (`formatAgentMessages.steer.test.ts`), blocked-call eager-record cleanup, mid-flight hook snapshot semantics, parent-run session-hook prestart gating, corrected-completion re-emission for hook-rewritten eager results. Full `npx tsc --noEmit` clean.

### **Test Configuration**:

Node v24, jest with `--experimental-vm-modules` (repo test script).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes