### PR TITLE
feat(openai): add native GPT-5.6 programmatic tool calling

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -507,6 +507,9 @@ export class AgentContext {
 
   /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
+    if (this.usesNativeProgrammaticToolCalling()) {
+      return '';
+    }
     const programmaticTools = this.getProgrammaticToolInstructionTargets();
     if (programmaticTools.length === 0) return '';
     const directProgrammaticTools = programmaticTools.filter(
@@ -549,7 +552,6 @@ export class AgentContext {
         .join('')
     );
   }
-
   private buildProgrammaticToolGroupInstructions(
     programmaticTools: ProgrammaticToolInstructionTarget[],
     capabilities: CallerCapabilityProjection
@@ -1260,23 +1262,25 @@ export class AgentContext {
     );
   }
 
-  /** Active tool definitions for token accounting (excludes deferred-and-undiscovered entries). */
+  /** Active tool definitions for binding and token accounting. */
   private getActiveToolDefinitions(): t.LCTool[] {
     const effectiveToolDefinitions = this.getEffectiveToolDefinitions();
     if (!effectiveToolDefinitions) {
       return [];
     }
     /**
-     * Mirror `getEventDrivenToolsForBinding`'s gate: a definition is only
-     * bound to the model when its `allowed_callers` include `'direct'` and
-     * (if deferred) it has been discovered. Filtering by `defer_loading`
-     * alone left programmatic-only definitions counted in
-     * `toolSchemaTokens` even though they were never bound.
+     * Mirror `getEventDrivenToolsForBinding`'s gate. Ordinarily a definition
+     * is bound only when it allows `direct`; native PTC also binds active
+     * `code_execution`-only definitions so the OpenAI adapter can expose them
+     * as programmatic callers. Deferred definitions still require discovery.
      */
-    return resolveCallerCapabilityProjection(
+    const capabilities = resolveCallerCapabilityProjection(
       effectiveToolDefinitions,
       (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
-    ).directTools;
+    );
+    return this.usesNativeProgrammaticToolCalling()
+      ? [...capabilities.directTools, ...capabilities.codeExecutionOnlyTools]
+      : capabilities.directTools;
   }
 
   /**
@@ -2010,6 +2014,8 @@ export class AgentContext {
 
   /** Filters tool instances for binding based on registry config */
   private filterToolsForBinding(tools: t.GraphTools): t.GraphTools {
+    const nativeProgrammaticToolCalling =
+      this.usesNativeProgrammaticToolCalling();
     return tools.filter((tool) => {
       if (!('name' in tool)) {
         return true;
@@ -2020,10 +2026,34 @@ export class AgentContext {
         return true;
       }
 
-      return (
-        allowsToolCaller(toolDef, 'direct') &&
-        isToolDefinitionActive(toolDef, this.discoveredToolNames)
-      );
+      const allowsDirect = allowsToolCaller(toolDef, 'direct');
+      const allowsCodeExecution = allowsToolCaller(toolDef, 'code_execution');
+      const shouldBind =
+        (allowsDirect ||
+          (nativeProgrammaticToolCalling && allowsCodeExecution)) &&
+        isToolDefinitionActive(toolDef, this.discoveredToolNames);
+      if (!shouldBind) {
+        return false;
+      }
+
+      if (nativeProgrammaticToolCalling && allowsCodeExecution) {
+        const boundTool = tool as t.GenericTool & {
+          metadata?: Record<string, unknown>;
+        };
+        boundTool.metadata = {
+          ...boundTool.metadata,
+          allowed_callers: [...(toolDef.allowed_callers ?? ['direct'])],
+        };
+      }
+      return true;
     });
+  }
+
+  private usesNativeProgrammaticToolCalling(): boolean {
+    const options = this.clientOptions as t.OpenAIClientOptions | undefined;
+    return (
+      options?.nativeProgrammaticToolCalling === true &&
+      options.useResponsesApi === true
+    );
   }
 }

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1045,6 +1045,35 @@ describe('AgentContext', () => {
       expect(result[0].content).not.toContain('run_tools_with_bash');
     });
 
+    it('omits LibreChat PTC guidance when native PTC is enabled', async () => {
+      const toolRegistry: t.LCToolRegistry = new Map([
+        [
+          'programmatic_tool',
+          {
+            name: 'programmatic_tool',
+            description: 'Only callable via code execution',
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]);
+
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          clientOptions: {
+            model: 'gpt-5.6',
+            nativeProgrammaticToolCalling: true,
+            useResponsesApi: true,
+          },
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry,
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe('Base');
+    });
+
     it('makes mixed direct and programmatic caller boundaries explicit', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
@@ -1488,6 +1517,73 @@ describe('AgentContext', () => {
       expect((result?.[0] as t.GenericTool).name).toBe('direct_tool');
     });
 
+    it('includes code_execution-only tools when native PTC is enabled', () => {
+      const tools = [
+        createMockTool('direct_tool'),
+        createMockTool('code_only_tool'),
+      ];
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['direct_tool', { name: 'direct_tool', allowed_callers: ['direct'] }],
+        [
+          'code_only_tool',
+          { name: 'code_only_tool', allowed_callers: ['code_execution'] },
+        ],
+      ]);
+
+      const ctx = createBasicContext({
+        agentConfig: {
+          clientOptions: {
+            model: 'gpt-5.6',
+            nativeProgrammaticToolCalling: true,
+            useResponsesApi: true,
+          },
+          tools,
+          toolRegistry,
+        },
+      });
+      const result = ctx.getToolsForBinding();
+      expect(
+        result?.map((tool) => (tool as t.GenericTool).name).sort()
+      ).toEqual(['code_only_tool', 'direct_tool']);
+      expect(
+        (
+          result?.find(
+            (tool) => (tool as t.GenericTool).name === 'code_only_tool'
+          ) as t.GenericTool & { metadata?: Record<string, unknown> }
+        ).metadata
+      ).toMatchObject({ allowed_callers: ['code_execution'] });
+    });
+
+    it('keeps code_execution-only tools off Chat Completions', () => {
+      const tools = [
+        createMockTool('direct_tool'),
+        createMockTool('code_only_tool'),
+      ];
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['direct_tool', { name: 'direct_tool', allowed_callers: ['direct'] }],
+        [
+          'code_only_tool',
+          { name: 'code_only_tool', allowed_callers: ['code_execution'] },
+        ],
+      ]);
+
+      const ctx = createBasicContext({
+        agentConfig: {
+          clientOptions: {
+            model: 'gpt-5.6',
+            nativeProgrammaticToolCalling: true,
+            useResponsesApi: false,
+          },
+          tools,
+          toolRegistry,
+        },
+      });
+
+      expect(
+        ctx.getToolsForBinding()?.map((tool) => (tool as t.GenericTool).name)
+      ).toEqual(['direct_tool']);
+    });
+
     it('excludes deferred tools until discovered', () => {
       const tools = [
         createMockTool('immediate_tool'),
@@ -1577,6 +1673,38 @@ describe('AgentContext', () => {
         directToolNames: [],
         codeExecutionToolNames: ['event_tool'],
       });
+    });
+
+    it('binds event-driven code_execution tools for native PTC', () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          clientOptions: {
+            model: 'gpt-5.6',
+            nativeProgrammaticToolCalling: true,
+            useResponsesApi: true,
+          },
+          toolDefinitions: [
+            { name: 'direct_tool', allowed_callers: ['direct'] },
+            {
+              name: 'code_only_tool',
+              allowed_callers: ['code_execution'],
+            },
+          ],
+        },
+      });
+
+      const result = ctx.getToolsForBinding();
+      expect(result).toBeDefined();
+      expect(
+        result?.map((tool) => (tool as t.GenericTool).name).sort()
+      ).toEqual(['code_only_tool', 'direct_tool']);
+      expect(
+        (
+          result?.find(
+            (tool) => (tool as t.GenericTool).name === 'code_only_tool'
+          ) as t.GenericTool & { metadata?: Record<string, unknown> }
+        ).metadata
+      ).toMatchObject({ allowed_callers: ['code_execution'] });
     });
 
     it('exposes effective defer metadata for provider cache partitioning', () => {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -67,9 +67,16 @@ import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
+import { Constants } from '@/common';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const iife = <T>(fn: () => T) => fn();
+
+const nativeProgrammaticWrapperNames = new Set<string>([
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+]);
+const NATIVE_PROGRAM_CONTINUATION_LIMIT = 8;
 
 export function isHeaders(headers: unknown): headers is Headers {
   return (
@@ -130,11 +137,13 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   responsesPromptCacheTtl?: PromptCacheTtl;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  nativeProgrammaticToolCalling?: boolean;
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  nativeProgrammaticToolCalling?: boolean;
 };
 type ReasoningCallOptions = {
   reasoning?: OpenAIClient.Reasoning;
@@ -228,6 +237,9 @@ function projectOpenAIResponsesProviderMessages(
   );
 }
 
+type ResponsesTool = NonNullable<
+  OpenAIClient.Responses.ResponseCreateParams['tools']
+>[number];
 type ResponsesRequest =
   | OpenAIClient.Responses.ResponseCreateParamsStreaming
   | OpenAIClient.Responses.ResponseCreateParamsNonStreaming;
@@ -237,6 +249,11 @@ type ResponsesResult =
 type ResponsesStreamChunkOptions = {
   promptIndex?: number;
   signal?: AbortSignal;
+};
+type ToolWithCallerMetadata = BindToolsInput & {
+  metadata?: {
+    allowed_callers?: Array<'direct' | 'code_execution'>;
+  };
 };
 type CacheableChatPart = {
   type: 'text' | 'image_url' | 'input_audio' | 'file' | 'refusal';
@@ -281,6 +298,62 @@ function applyManagedRequestParams<T extends object>(
       safety_identifier: fields.safetyIdentifier,
     }),
   };
+}
+
+/** @internal */
+export function getNativeResponsesTools(
+  tools: BindToolsInput[],
+  reduced: ResponsesTool[],
+  enabled: boolean
+): ResponsesTool[] {
+  if (enabled !== true) {
+    return reduced;
+  }
+
+  const callerMetadata = new Map<string, ToolWithCallerMetadata['metadata']>();
+  for (const tool of tools) {
+    const candidate = tool as ToolWithCallerMetadata & {
+      name?: string;
+      function?: { name?: string };
+    };
+    const name = candidate.name ?? candidate.function?.name;
+    if (name != null && name !== '') {
+      callerMetadata.set(name, candidate.metadata);
+    }
+  }
+
+  const mapped = reduced.flatMap((tool): ResponsesTool[] => {
+    if (
+      tool.type === 'function' &&
+      nativeProgrammaticWrapperNames.has(tool.name)
+    ) {
+      return [];
+    }
+    if (tool.type === 'programmatic_tool_calling' || tool.type !== 'function') {
+      return [tool];
+    }
+
+    const metadata = callerMetadata.get(tool.name);
+    const configured = metadata?.allowed_callers;
+    if (configured?.includes('code_execution') !== true) {
+      return [tool];
+    }
+
+    return [
+      {
+        ...tool,
+        allowed_callers: [
+          ...(configured.includes('direct') ? (['direct'] as const) : []),
+          'programmatic' as const,
+        ],
+      },
+    ];
+  });
+
+  if (!mapped.some((tool) => tool.type === 'programmatic_tool_calling')) {
+    mapped.push({ type: 'programmatic_tool_calling' });
+  }
+  return mapped;
 }
 
 function isCacheableChatPart(part: unknown): part is CacheableChatPart {
@@ -501,6 +574,30 @@ export function addResponseCacheBreakpoints(
   return input.map((item, index) =>
     indexes.has(index) ? addResponseBreakpoint(item) : item
   );
+}
+
+/** @internal */
+export function addProgrammaticCallerLinkage(
+  input: OpenAIClient.Responses.ResponseCreateParams['input']
+): OpenAIClient.Responses.ResponseCreateParams['input'] {
+  if (!Array.isArray(input)) {
+    return input;
+  }
+
+  const callers = new Map<string, { type: 'program'; caller_id: string }>();
+  for (const item of input) {
+    if (item.type === 'function_call' && item.caller?.type === 'program') {
+      callers.set(item.call_id, item.caller);
+    }
+  }
+
+  return input.map((item) => {
+    if (item.type !== 'function_call_output' || item.caller != null) {
+      return item;
+    }
+    const caller = callers.get(item.call_id);
+    return caller ? { ...item, caller } : item;
+  });
 }
 
 /** @internal */
@@ -1029,6 +1126,246 @@ async function* convertLibreChatResponsesStream(
   } catch (e) {
     throw wrapOpenAIClientError(e);
   }
+}
+
+function isNativeProgramOnlyResponse(
+  response: OpenAIClient.Responses.Response
+): boolean {
+  const hasMessage = response.output.some((item) => item.type === 'message');
+  const hasPendingFunctionCall = response.output.some(
+    (item) => item.type === 'function_call'
+  );
+  const hasProgramState = response.output.some(
+    (item) => item.type === 'program' || item.type === 'program_output'
+  );
+  return !hasMessage && !hasPendingFunctionCall && hasProgramState;
+}
+
+function shouldContinueNativeProgram(
+  response: OpenAIClient.Responses.Response
+): boolean {
+  return (
+    response.status === 'completed' && isNativeProgramOnlyResponse(response)
+  );
+}
+
+function assertNativeProgramResponseComplete(
+  response: OpenAIClient.Responses.Response
+): void {
+  if (
+    response.status !== 'incomplete' ||
+    !isNativeProgramOnlyResponse(response)
+  ) {
+    return;
+  }
+  const reason = response.incomplete_details?.reason;
+  throw new Error(
+    `Native Programmatic Tool Calling response was incomplete${
+      reason ? `: ${reason}` : ''
+    }.`
+  );
+}
+
+function getNativeProgramReplayInput(
+  input: OpenAIClient.Responses.ResponseCreateParams['input']
+): OpenAIClient.Responses.ResponseInput {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (input == null) {
+    return [];
+  }
+  return [{ role: 'user', content: input }];
+}
+
+function getNativeProgramReplayOutput(
+  output: OpenAIClient.Responses.ResponseOutputItem[]
+): OpenAIClient.Responses.ResponseInput {
+  /** OpenAI accepts prior `response.output` items verbatim as the next input.
+   * The generated SDK keeps several output/input variants nominally separate,
+   * so the documented round trip needs this boundary assertion. */
+  return output as unknown as OpenAIClient.Responses.ResponseInput;
+}
+
+function getNativeProgramContinuationRequest(
+  request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
+  response: OpenAIClient.Responses.Response
+): OpenAIClient.Responses.ResponseCreateParamsStreaming;
+function getNativeProgramContinuationRequest(
+  request: OpenAIClient.Responses.ResponseCreateParamsNonStreaming,
+  response: OpenAIClient.Responses.Response
+): OpenAIClient.Responses.ResponseCreateParamsNonStreaming;
+function getNativeProgramContinuationRequest(
+  request: ResponsesRequest,
+  response: OpenAIClient.Responses.Response
+): ResponsesRequest {
+  if (request.store === false) {
+    return {
+      ...request,
+      input: [
+        ...getNativeProgramReplayInput(request.input),
+        ...getNativeProgramReplayOutput(response.output),
+      ],
+      previous_response_id: request.previous_response_id,
+    };
+  }
+  return {
+    ...request,
+    input: [],
+    previous_response_id: response.id,
+  };
+}
+
+function mergeResponsesUsage(
+  responses: OpenAIClient.Responses.Response[]
+): OpenAIClient.Responses.ResponseUsage | undefined {
+  const usages: ResponsesUsageWithCacheWrite[] = responses.flatMap(
+    (response) => (response.usage == null ? [] : [response.usage])
+  );
+  const lastUsage = usages.at(-1);
+  if (lastUsage == null) {
+    return;
+  }
+  return {
+    ...lastUsage,
+    input_tokens: usages.reduce(
+      (total, usage) => total + usage.input_tokens,
+      0
+    ),
+    output_tokens: usages.reduce(
+      (total, usage) => total + usage.output_tokens,
+      0
+    ),
+    total_tokens: usages.reduce(
+      (total, usage) => total + usage.total_tokens,
+      0
+    ),
+    input_tokens_details: {
+      ...lastUsage.input_tokens_details,
+      cached_tokens: usages.reduce(
+        (total, usage) =>
+          total + (usage.input_tokens_details?.cached_tokens ?? 0),
+        0
+      ),
+      cache_write_tokens: usages.reduce(
+        (total, usage) =>
+          total + (usage.input_tokens_details?.cache_write_tokens ?? 0),
+        0
+      ),
+    },
+    output_tokens_details: {
+      ...lastUsage.output_tokens_details,
+      reasoning_tokens: usages.reduce(
+        (total, usage) => total + usage.output_tokens_details.reasoning_tokens,
+        0
+      ),
+    },
+  };
+}
+
+function mergeNativeProgramResponses(
+  responses: OpenAIClient.Responses.Response[]
+): OpenAIClient.Responses.Response {
+  const finalResponse = responses.at(-1);
+  if (finalResponse == null) {
+    throw new Error('Cannot merge an empty native PTC response sequence.');
+  }
+  return {
+    ...finalResponse,
+    output: responses.flatMap((response) => response.output),
+    usage: mergeResponsesUsage(responses),
+  };
+}
+
+type CompleteResponsesRequest = (
+  request: ResponsesRequest,
+  requestOptions?: OpenAICoreRequestOptions
+) => Promise<ResponsesResult>;
+
+type ResponsesTerminalEvent = Extract<
+  OpenAIClient.Responses.ResponseStreamEvent,
+  { type: 'response.completed' | 'response.incomplete' }
+>;
+
+/** @internal */
+export async function completeResponsesWithNativeContinuation(
+  request: ResponsesRequest,
+  requestOptions: OpenAICoreRequestOptions | undefined,
+  enabled: boolean,
+  complete: CompleteResponsesRequest
+): Promise<ResponsesResult> {
+  if (enabled !== true) {
+    return complete(request, requestOptions);
+  }
+
+  if (request.stream === true) {
+    return (async function* (): AsyncGenerator<OpenAIClient.Responses.ResponseStreamEvent> {
+      const responses: OpenAIClient.Responses.Response[] = [];
+      let nextRequest = request;
+      for (
+        let continuation = 0;
+        continuation < NATIVE_PROGRAM_CONTINUATION_LIMIT;
+        continuation++
+      ) {
+        const result = await complete(nextRequest, requestOptions);
+        if (!isResponsesStream(result)) {
+          throw new Error('Expected a streaming OpenAI Responses result.');
+        }
+        let terminalEvent: ResponsesTerminalEvent | undefined;
+        for await (const event of result) {
+          if (
+            event.type === 'response.completed' ||
+            event.type === 'response.incomplete'
+          ) {
+            terminalEvent = event;
+            continue;
+          }
+          yield event;
+        }
+        if (terminalEvent == null) {
+          return;
+        }
+        responses.push(terminalEvent.response);
+        assertNativeProgramResponseComplete(terminalEvent.response);
+        if (!shouldContinueNativeProgram(terminalEvent.response)) {
+          yield {
+            ...terminalEvent,
+            response: mergeNativeProgramResponses(responses),
+          };
+          return;
+        }
+        nextRequest = getNativeProgramContinuationRequest(
+          nextRequest,
+          terminalEvent.response
+        );
+      }
+      throw new Error(
+        'Native Programmatic Tool Calling exceeded the continuation limit.'
+      );
+    })();
+  }
+
+  const responses: OpenAIClient.Responses.Response[] = [];
+  let nextRequest = request;
+  for (
+    let continuation = 0;
+    continuation < NATIVE_PROGRAM_CONTINUATION_LIMIT;
+    continuation++
+  ) {
+    const result = await complete(nextRequest, requestOptions);
+    if (isResponsesStream(result)) {
+      throw new Error('Expected a non-streaming OpenAI Responses result.');
+    }
+    responses.push(result);
+    assertNativeProgramResponseComplete(result);
+    if (!shouldContinueNativeProgram(result)) {
+      return mergeNativeProgramResponses(responses);
+    }
+    nextRequest = getNativeProgramContinuationRequest(nextRequest, result);
+  }
+  throw new Error(
+    'Native Programmatic Tool Calling exceeded the continuation limit.'
+  );
 }
 
 function createUsageMetadata(
@@ -2103,6 +2440,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   private responsesPromptCache?: boolean;
   private responsesPromptCacheTtl?: PromptCacheTtl;
   private safetyIdentifier?: string;
+  private nativeProgrammaticToolCalling?: boolean;
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
@@ -2110,6 +2448,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     this.responsesPromptCache = fields?.responsesPromptCache;
     this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
     this.safetyIdentifier = fields?.safety_identifier;
+    this.nativeProgrammaticToolCalling = fields?.nativeProgrammaticToolCalling;
   }
 
   invocationParams(
@@ -2157,6 +2496,17 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     return stripIntentFromStrictTools(params);
   }
 
+  protected _reduceChatOpenAITools(
+    tools: BindToolsInput[],
+    fields: { stream?: boolean; strict?: boolean }
+  ): ResponsesTool[] {
+    return getNativeResponsesTools(
+      tools,
+      super._reduceChatOpenAITools(tools, fields),
+      this.nativeProgrammaticToolCalling === true
+    );
+  }
+
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
     requestOptions?: OpenAICoreRequestOptions
@@ -2169,16 +2519,26 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     request: ResponsesRequest,
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<ResponsesResult> {
+    const linkedInput =
+      this.nativeProgrammaticToolCalling === true
+        ? addProgrammaticCallerLinkage(request.input)
+        : request.input;
     const managedRequest = {
       ...request,
       input:
         this.promptCacheExplicit === true
-          ? addResponseCacheBreakpoints(request.input)
-          : request.input,
+          ? addResponseCacheBreakpoints(linkedInput)
+          : linkedInput,
     };
-    const result = await super.completionWithRetry(
-      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
-      requestOptions
+    const result = await completeResponsesWithNativeContinuation(
+      managedRequest,
+      requestOptions,
+      this.nativeProgrammaticToolCalling === true,
+      (nextRequest, nextOptions) =>
+        super.completionWithRetry(
+          nextRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+          nextOptions
+        )
     );
     return isResponsesStream(result)
       ? result
@@ -2388,11 +2748,13 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
   private promptCacheExplicit?: boolean;
   private safetyIdentifier?: string;
+  private nativeProgrammaticToolCalling?: boolean;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.safetyIdentifier = fields?.safety_identifier;
+    this.nativeProgrammaticToolCalling = fields?.nativeProgrammaticToolCalling;
   }
 
   invocationParams(
@@ -2413,6 +2775,17 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     return stripIntentFromStrictTools(params);
   }
 
+  protected _reduceChatOpenAITools(
+    tools: BindToolsInput[],
+    fields: { stream?: boolean; strict?: boolean }
+  ): ResponsesTool[] {
+    return getNativeResponsesTools(
+      tools,
+      super._reduceChatOpenAITools(tools, fields),
+      this.nativeProgrammaticToolCalling === true
+    );
+  }
+
   async completionWithRetry(
     request: OpenAIClient.Responses.ResponseCreateParamsStreaming,
     requestOptions?: OpenAICoreRequestOptions
@@ -2425,16 +2798,26 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     request: ResponsesRequest,
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<ResponsesResult> {
+    const linkedInput =
+      this.nativeProgrammaticToolCalling === true
+        ? addProgrammaticCallerLinkage(request.input)
+        : request.input;
     const managedRequest = {
       ...request,
       input:
         this.promptCacheExplicit === true
-          ? addResponseCacheBreakpoints(request.input)
-          : request.input,
+          ? addResponseCacheBreakpoints(linkedInput)
+          : linkedInput,
     };
-    const result = await super.completionWithRetry(
-      managedRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
-      requestOptions
+    const result = await completeResponsesWithNativeContinuation(
+      managedRequest,
+      requestOptions,
+      this.nativeProgrammaticToolCalling === true,
+      (nextRequest, nextOptions) =>
+        super.completionWithRetry(
+          nextRequest as OpenAIClient.Responses.ResponseCreateParamsStreaming,
+          nextOptions
+        )
     );
     return isResponsesStream(result)
       ? result

--- a/src/llm/openai/nativeProgramContinuation.test.ts
+++ b/src/llm/openai/nativeProgramContinuation.test.ts
@@ -1,0 +1,438 @@
+import OpenAI from 'openai';
+
+import {
+  addProgrammaticCallerLinkage,
+  completeResponsesWithNativeContinuation,
+  getNativeResponsesTools,
+} from './index';
+import { Constants } from '@/common';
+
+type ResponsesRequest =
+  | OpenAI.Responses.ResponseCreateParamsStreaming
+  | OpenAI.Responses.ResponseCreateParamsNonStreaming;
+type ResponsesResult =
+  | OpenAI.Responses.Response
+  | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
+
+function createResponse({
+  id,
+  output,
+  inputTokens,
+  outputTokens,
+}: {
+  id: string;
+  output: unknown[];
+  inputTokens: number;
+  outputTokens: number;
+}): OpenAI.Responses.Response {
+  return {
+    id,
+    object: 'response',
+    created_at: 1,
+    status: 'completed',
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    max_output_tokens: null,
+    model: 'gpt-5.6',
+    output,
+    parallel_tool_calls: true,
+    previous_response_id: null,
+    reasoning: null,
+    store: false,
+    temperature: null,
+    text: { format: { type: 'text' } },
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    truncation: 'disabled',
+    usage: {
+      input_tokens: inputTokens,
+      input_tokens_details: {
+        cached_tokens: 1,
+      },
+      output_tokens: outputTokens,
+      output_tokens_details: {
+        reasoning_tokens: 2,
+      },
+      total_tokens: inputTokens + outputTokens,
+    },
+    user: null,
+    metadata: {},
+    output_text: '',
+  } as unknown as OpenAI.Responses.Response;
+}
+
+function createTerminalEvent(
+  response: OpenAI.Responses.Response
+): OpenAI.Responses.ResponseCompletedEvent {
+  return {
+    type: 'response.completed',
+    sequence_number: 1,
+    response,
+  };
+}
+
+describe('native program continuation', () => {
+  const programOutput = [
+    {
+      type: 'program',
+      id: 'prog_1',
+      call_id: 'program_call_1',
+      code: 'await tools.lookup({})',
+      fingerprint: 'fingerprint',
+    },
+    {
+      type: 'program_output',
+      id: 'program_output_1',
+      call_id: 'program_call_1',
+      result: '{"ok":true}',
+      status: 'completed',
+    },
+  ];
+  const messageOutput = [
+    {
+      type: 'message',
+      id: 'msg_1',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'Done.', annotations: [] }],
+    },
+  ];
+
+  it('maps LibreChat caller eligibility to native OpenAI tools', () => {
+    const tools = [
+      {
+        name: 'programmatic_only',
+        metadata: { allowed_callers: ['code_execution'] },
+      },
+      {
+        name: 'hybrid',
+        metadata: { allowed_callers: ['direct', 'code_execution'] },
+      },
+      {
+        name: 'direct_only',
+        metadata: { allowed_callers: ['direct'] },
+      },
+    ];
+    const reduced = tools.map(({ name }) => ({
+      type: 'function' as const,
+      name,
+      description: name,
+      parameters: { type: 'object' as const, properties: {} },
+      strict: false,
+    }));
+
+    expect(
+      getNativeResponsesTools(
+        tools as Parameters<typeof getNativeResponsesTools>[0],
+        reduced,
+        true
+      )
+    ).toEqual([
+      { ...reduced[0], allowed_callers: ['programmatic'] },
+      { ...reduced[1], allowed_callers: ['direct', 'programmatic'] },
+      reduced[2],
+      { type: 'programmatic_tool_calling' },
+    ]);
+  });
+
+  it('omits LibreChat programmatic wrappers from native tool declarations', () => {
+    const tools = [
+      { name: Constants.PROGRAMMATIC_TOOL_CALLING },
+      { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING },
+      { name: 'direct_tool' },
+    ];
+    const reduced = tools.map(({ name }) => ({
+      type: 'function' as const,
+      name,
+      description: name,
+      parameters: { type: 'object' as const, properties: {} },
+      strict: false,
+    }));
+
+    expect(
+      getNativeResponsesTools(
+        tools as Parameters<typeof getNativeResponsesTools>[0],
+        reduced,
+        true
+      )
+    ).toEqual([reduced[2], { type: 'programmatic_tool_calling' }]);
+  });
+
+  it('restores caller linkage on reconstructed function outputs', () => {
+    const caller = { type: 'program' as const, caller_id: 'program_call_1' };
+    expect(
+      addProgrammaticCallerLinkage([
+        {
+          type: 'function_call',
+          call_id: 'tool_call_1',
+          name: 'lookup',
+          arguments: '{}',
+          caller,
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'tool_call_1',
+          output: '{"ok":true}',
+        },
+      ])
+    ).toEqual([
+      {
+        type: 'function_call',
+        call_id: 'tool_call_1',
+        name: 'lookup',
+        arguments: '{}',
+        caller,
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'tool_call_1',
+        output: '{"ok":true}',
+        caller,
+      },
+    ]);
+  });
+
+  it('continues stateless responses with replayed program output and merged usage', async () => {
+    const first = createResponse({
+      id: 'resp_1',
+      output: programOutput,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    const second = createResponse({
+      id: 'resp_2',
+      output: messageOutput,
+      inputTokens: 20,
+      outputTokens: 7,
+    });
+    const requests: ResponsesRequest[] = [];
+    const responses = [first, second];
+    const result = await completeResponsesWithNativeContinuation(
+      {
+        model: 'gpt-5.6',
+        input: [{ role: 'user', content: 'Look it up.' }],
+        store: false,
+        previous_response_id: 'resp_prior',
+        stream: false,
+      },
+      undefined,
+      true,
+      async (request): Promise<ResponsesResult> => {
+        requests.push(request);
+        const response = responses.shift();
+        if (response == null) {
+          throw new Error('Unexpected continuation request.');
+        }
+        return response;
+      }
+    );
+
+    expect(Symbol.asyncIterator in result).toBe(false);
+    const response = result as OpenAI.Responses.Response;
+    expect(requests).toHaveLength(2);
+    expect(requests[1].previous_response_id).toBe('resp_prior');
+    expect(requests[1].input).toEqual([
+      { role: 'user', content: 'Look it up.' },
+      ...programOutput,
+    ]);
+    expect(response.output).toEqual([...programOutput, ...messageOutput]);
+    expect(response.usage).toMatchObject({
+      input_tokens: 30,
+      output_tokens: 12,
+      total_tokens: 42,
+      input_tokens_details: { cached_tokens: 2 },
+      output_tokens_details: { reasoning_tokens: 4 },
+    });
+  });
+
+  it('replays string input for stateless continuations', async () => {
+    const first = createResponse({
+      id: 'resp_1',
+      output: programOutput,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    const second = createResponse({
+      id: 'resp_2',
+      output: messageOutput,
+      inputTokens: 20,
+      outputTokens: 7,
+    });
+    const requests: ResponsesRequest[] = [];
+    const responses = [first, second];
+
+    await completeResponsesWithNativeContinuation(
+      {
+        model: 'gpt-5.6',
+        input: 'Look it up.',
+        store: false,
+        stream: false,
+      },
+      undefined,
+      true,
+      async (request): Promise<ResponsesResult> => {
+        requests.push(request);
+        const response = responses.shift();
+        if (response == null) {
+          throw new Error('Unexpected continuation request.');
+        }
+        return response;
+      }
+    );
+
+    expect(requests[1].input).toEqual([
+      { role: 'user', content: 'Look it up.' },
+      ...programOutput,
+    ]);
+  });
+
+  it('continues stored responses by response id', async () => {
+    const first = createResponse({
+      id: 'resp_1',
+      output: programOutput,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    const second = createResponse({
+      id: 'resp_2',
+      output: messageOutput,
+      inputTokens: 20,
+      outputTokens: 7,
+    });
+    const requests: ResponsesRequest[] = [];
+    const responses = [first, second];
+    await completeResponsesWithNativeContinuation(
+      {
+        model: 'gpt-5.6',
+        input: [{ role: 'user', content: 'Look it up.' }],
+        stream: false,
+      },
+      undefined,
+      true,
+      async (request): Promise<ResponsesResult> => {
+        requests.push(request);
+        const response = responses.shift();
+        if (response == null) {
+          throw new Error('Unexpected continuation request.');
+        }
+        return response;
+      }
+    );
+
+    expect(requests[1]).toMatchObject({
+      input: [],
+      previous_response_id: 'resp_1',
+    });
+  });
+
+  it('reports incomplete native program responses with the provider reason', async () => {
+    const incomplete = {
+      ...createResponse({
+        id: 'resp_incomplete',
+        output: programOutput,
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+      status: 'incomplete' as const,
+      incomplete_details: { reason: 'max_output_tokens' as const },
+    };
+
+    await expect(
+      completeResponsesWithNativeContinuation(
+        {
+          model: 'gpt-5.6',
+          input: [{ role: 'user', content: 'Look it up.' }],
+          stream: false,
+        },
+        undefined,
+        true,
+        async (): Promise<ResponsesResult> => incomplete
+      )
+    ).rejects.toThrow(
+      'Native Programmatic Tool Calling response was incomplete: max_output_tokens.'
+    );
+  });
+
+  it('returns incomplete responses that include a terminal message', async () => {
+    const incomplete = {
+      ...createResponse({
+        id: 'resp_incomplete',
+        output: messageOutput,
+        inputTokens: 10,
+        outputTokens: 5,
+      }),
+      status: 'incomplete' as const,
+      incomplete_details: { reason: 'max_output_tokens' as const },
+    };
+
+    const result = await completeResponsesWithNativeContinuation(
+      {
+        model: 'gpt-5.6',
+        input: [{ role: 'user', content: 'Look it up.' }],
+        stream: false,
+      },
+      undefined,
+      true,
+      async (): Promise<ResponsesResult> => incomplete
+    );
+
+    expect(result).toMatchObject({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: messageOutput,
+    });
+  });
+
+  it('emits one terminal streaming event with merged output and usage', async () => {
+    const first = createResponse({
+      id: 'resp_1',
+      output: programOutput,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    const second = createResponse({
+      id: 'resp_2',
+      output: messageOutput,
+      inputTokens: 20,
+      outputTokens: 7,
+    });
+    const responses = [first, second];
+    const result = await completeResponsesWithNativeContinuation(
+      {
+        model: 'gpt-5.6',
+        input: [{ role: 'user', content: 'Look it up.' }],
+        store: false,
+        stream: true,
+      },
+      undefined,
+      true,
+      async (): Promise<ResponsesResult> => {
+        const response = responses.shift();
+        if (response == null) {
+          throw new Error('Unexpected continuation request.');
+        }
+        return (async function* () {
+          yield createTerminalEvent(response);
+        })();
+      }
+    );
+
+    expect(Symbol.asyncIterator in result).toBe(true);
+    const events: OpenAI.Responses.ResponseStreamEvent[] = [];
+    for await (const event of result as AsyncIterable<OpenAI.Responses.ResponseStreamEvent>) {
+      events.push(event);
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('response.completed');
+    if (events[0].type !== 'response.completed') {
+      throw new Error('Expected a completed response.');
+    }
+    expect(events[0].response.output).toEqual([
+      ...programOutput,
+      ...messageOutput,
+    ]);
+    expect(events[0].response.usage?.total_tokens).toBe(42);
+  });
+});

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -23,6 +23,10 @@ export function createSchemaOnlyTool(
       description: description ?? '',
       schema: parameters ?? { type: 'object', properties: {} },
       responseFormat: responseFormat ?? 'content_and_artifact',
+      metadata:
+        definition.allowed_callers != null
+          ? { allowed_callers: definition.allowed_callers }
+          : undefined,
     }
   );
 }

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -81,6 +81,7 @@ export type GoogleThinkingConfig = {
 export type ManagedRequestOptions = {
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  nativeProgrammaticToolCalling?: boolean;
 };
 /**
  * Adaptive stream-smoothing configuration shared by every provider client.


### PR DESCRIPTION
## Summary

Adds opt-in native GPT-5.6 Programmatic Tool Calling (PTC) to the OpenAI and Azure Responses adapters while preserving LibreChat's existing local PTC path as the default.

This branch is rebuilt directly on current `main` (`ca9110a3`, Agents 3.7.1). It uses the current centralized caller-capability projection and existing Responses replay pipeline rather than replacing either implementation.

## Changes

- Adds the native OpenAI `programmatic_tool_calling` declaration when explicitly enabled.
- Maps LibreChat `allowed_callers: ['code_execution']` to OpenAI `allowed_callers: ['programmatic']` only while constructing the provider request.
- Preserves hybrid `direct` + `programmatic` eligibility.
- Keeps active code-execution-only tools bound in native Responses mode, including current event-driven/schema-only tools.
- Carries caller metadata from registry-backed and schema-only tools into OpenAI reduction.
- Removes LibreChat's reserved local PTC wrapper tools from native OpenAI declarations.
- Restores the provider's program caller linkage on reconstructed function outputs.
- Continues completed program-only Responses until the provider returns a message or pending function call.
- Supports both streaming and non-streaming continuation.
- Uses `previous_response_id` for stored continuation and replays prior input plus provider output for `store: false`.
- Merges output and token usage across internal continuation requests.
- Reports incomplete program-only responses clearly while passing through normal incomplete message/tool responses.

## Compatibility and scope

- Opt-in via `nativeProgrammaticToolCalling: true`.
- Active only with the Responses API; Chat Completions keeps code-execution-only tools hidden.
- Existing LibreChat/local programmatic tools are unchanged when native mode is off.
- Existing reasoning replay, encrypted reasoning, provider-output projection, streamed replay capture, and cache metadata handling remain intact.
- This is the Agents-side foundation for a separate LibreChat native-PTC integration; danny-avila/LibreChat#14224 intentionally excludes native PTC.
- Independent of #306 functionally; both touch the OpenAI adapter, so whichever merges second should be rebased.

## Validation

Against Agents 3.7.1:

- 17 relevant suites / 319 tests passed (all OpenAI adapter tests plus AgentContext and caller-capability coverage).
- `npx tsc --noEmit` passed.
- ESLint passed for all six changed files.
- Import-order checks passed for all six changed files.
- `npm run build` passed.
- Working tree and diff checks are clean.