### PR TITLE
fix(openai): preserve managed request metadata

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -134,6 +134,7 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
   promptCacheExplicit?: boolean;
+  promptCacheKey?: string;
   safety_identifier?: string;
 };
 type ReasoningCallOptions = {
@@ -362,6 +363,7 @@ function selectCacheBreakpointIndexes(
   roles: Array<string | undefined>,
   cacheable: boolean[]
 ): number[] {
+  const maxHistoryBreakpoints = 2;
   let instructionIndex = -1;
   let latestUserIndex = -1;
   for (let index = 0; index < roles.length; index++) {
@@ -378,11 +380,32 @@ function selectCacheBreakpointIndexes(
   if (instructionIndex >= 0) {
     indexes.add(instructionIndex);
   }
+  const completionIndexes: number[] = [];
+  const userIndexes: number[] = [];
   for (let index = latestUserIndex - 1; index >= 0; index--) {
-    if (cacheable[index]) {
-      indexes.add(index);
-      break;
+    const role = roles[index];
+    if (!cacheable[index] || role === 'system' || role === 'developer') {
+      continue;
     }
+    if (role === 'user') {
+      if (userIndexes.length < maxHistoryBreakpoints) {
+        userIndexes.push(index);
+      }
+      continue;
+    }
+    if (completionIndexes.length < maxHistoryBreakpoints) {
+      completionIndexes.push(index);
+      if (completionIndexes.length === maxHistoryBreakpoints) {
+        break;
+      }
+    }
+  }
+  const historyIndexes = [...completionIndexes, ...userIndexes].slice(
+    0,
+    maxHistoryBreakpoints
+  );
+  for (const index of historyIndexes) {
+    indexes.add(index);
   }
   return [...indexes];
 }
@@ -942,7 +965,10 @@ type ResponsesAnnotationsBoundaryEvent = {
 export function ensureResponsesOutputAnnotations(
   event: ResponsesAnnotationsBoundaryEvent
 ): void {
-  if (event.type !== 'response.completed' && event.type !== 'response.incomplete') {
+  if (
+    event.type !== 'response.completed' &&
+    event.type !== 'response.incomplete'
+  ) {
     return;
   }
   const output = event.response?.output;
@@ -1762,10 +1788,18 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     message: OpenAIClient.ChatCompletionMessage,
     rawResponse: OpenAIClient.ChatCompletion
   ): BaseMessage {
-    return attachLibreChatMessageFields(
+    const converted = attachLibreChatMessageFields(
       super._convertCompletionsMessageToBaseMessage(message, rawResponse),
       message as unknown as Record<string, unknown>
     );
+    if (rawResponse.service_tier == null) {
+      return converted;
+    }
+    converted.response_metadata = {
+      ...converted.response_metadata,
+      service_tier: rawResponse.service_tier,
+    };
+    return converted;
   }
 
   async _generate(

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -554,6 +554,29 @@ describe('convertCompletionsMessageToBaseMessage (fork delegate)', () => {
     );
   });
 
+  it('preserves the reported service tier for non-streaming completions', () => {
+    const mockMessage = {
+      role: 'assistant' as const,
+      content: 'Done',
+    };
+    const mockRawResponse = {
+      id: 'chatcmpl-priority',
+      model: 'gpt-5.6-sol',
+      service_tier: 'priority' as const,
+      choices: [{ index: 0, message: mockMessage }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+
+    const result = completionsDelegateOf(
+      newOpenAI()
+    )._convertCompletionsMessageToBaseMessage(
+      mockMessage,
+      mockRawResponse
+    ) as AIMessage;
+
+    expect(result.response_metadata.service_tier).toBe('priority');
+  });
+
   it('preserves delta reasoning_content in streaming chunks', () => {
     const delta = {
       role: 'assistant' as const,

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,13 +1,66 @@
 import OpenAI from 'openai';
 
 import {
+  AzureChatOpenAI,
+  ChatOpenAI,
   addChatCacheBreakpoints,
   addResponseCacheBreakpoints,
   shouldIncludeEncryptedReasoning,
 } from './index';
 
+type ManagedRequestDelegate = {
+  invocationParams(options?: Record<string, unknown>): Record<string, unknown>;
+};
+
+function managedRequestDelegates(model: unknown): ManagedRequestDelegate[] {
+  const delegates = model as {
+    completions: ManagedRequestDelegate;
+    responses: ManagedRequestDelegate;
+  };
+  return [delegates.completions, delegates.responses];
+}
+
 describe('managed GPT-5.6 request fields', () => {
-  it('places cache breakpoints after instructions and the prior history prefix', () => {
+  it('forwards prompt cache keys through OpenAI Chat and Responses requests', () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5.6',
+      apiKey: 'test-key',
+      promptCacheExplicit: true,
+      promptCacheKey: 'cache-key',
+      safety_identifier: 'safety-id',
+    });
+
+    for (const delegate of managedRequestDelegates(model)) {
+      expect(delegate.invocationParams()).toMatchObject({
+        prompt_cache_key: 'cache-key',
+        prompt_cache_options: { mode: 'explicit', ttl: '30m' },
+        safety_identifier: 'safety-id',
+      });
+    }
+  });
+
+  it('forwards prompt cache keys through Azure Chat and Responses requests', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test-key',
+      azureOpenAIApiInstanceName: 'test-instance',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-10-21',
+      promptCacheKey: 'cache-key',
+      safety_identifier: 'safety-id',
+    });
+
+    for (const delegate of managedRequestDelegates(model)) {
+      expect(delegate.invocationParams()).toMatchObject({
+        prompt_cache_key: 'cache-key',
+        safety_identifier: 'safety-id',
+      });
+      expect(delegate.invocationParams()).not.toHaveProperty(
+        'prompt_cache_options'
+      );
+    }
+  });
+
+  it('keeps the two latest history breakpoints alongside instructions', () => {
     const messages = addChatCacheBreakpoints([
       { role: 'system', content: 'Stable instructions.' },
       { role: 'user', content: 'First question.' },
@@ -33,12 +86,61 @@ describe('managed GPT-5.6 request fields', () => {
         },
       ],
     });
+    expect(messages[1]).toMatchObject({
+      content: [
+        {
+          type: 'text',
+          text: 'First question.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+    expect(JSON.stringify(messages[3])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+  });
+
+  it('preserves the prior assistant breakpoint during chat rollover', () => {
+    const messages = addChatCacheBreakpoints([
+      { role: 'system', content: 'Stable instructions.' },
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: 'First answer.' },
+      { role: 'user', content: 'Second question.' },
+      { role: 'assistant', content: 'Second answer.' },
+      { role: 'user', content: 'Current question.' },
+    ]);
+
+    expect(JSON.stringify(messages[0])).toContain('prompt_cache_breakpoint');
+    expect(JSON.stringify(messages[2])).toContain('prompt_cache_breakpoint');
+    expect(JSON.stringify(messages[4])).toContain('prompt_cache_breakpoint');
     expect(JSON.stringify(messages[1])).not.toContain(
       'prompt_cache_breakpoint'
     );
     expect(JSON.stringify(messages[3])).not.toContain(
       'prompt_cache_breakpoint'
     );
+    expect(JSON.stringify(messages[5])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+  });
+
+  it('keeps the two newest completion breakpoints in long chat histories', () => {
+    const messages = addChatCacheBreakpoints([
+      { role: 'system', content: 'Stable instructions.' },
+      { role: 'user', content: 'First question.' },
+      { role: 'assistant', content: 'First answer.' },
+      { role: 'user', content: 'Second question.' },
+      { role: 'assistant', content: 'Second answer.' },
+      { role: 'user', content: 'Third question.' },
+      { role: 'assistant', content: 'Third answer.' },
+      { role: 'user', content: 'Current question.' },
+    ]);
+
+    expect(JSON.stringify(messages[2])).not.toContain(
+      'prompt_cache_breakpoint'
+    );
+    expect(JSON.stringify(messages[4])).toContain('prompt_cache_breakpoint');
+    expect(JSON.stringify(messages[6])).toContain('prompt_cache_breakpoint');
   });
 
   it('uses supported Responses content blocks for the same stable prefixes', () => {
@@ -80,6 +182,43 @@ describe('managed GPT-5.6 request fields', () => {
         content: [{ type: 'input_text', text: 'Current question.' }],
       },
     ]);
+  });
+
+  it('retains the previous Responses breakpoint while adding the latest one', () => {
+    const input = [
+      { type: 'message', role: 'developer', content: 'Stable instructions.' },
+      { type: 'message', role: 'user', content: 'First question.' },
+      { type: 'message', role: 'assistant', content: 'First answer.' },
+      { type: 'message', role: 'user', content: 'Second question.' },
+      { type: 'message', role: 'assistant', content: 'Second answer.' },
+      { type: 'message', role: 'user', content: 'Current question.' },
+    ] as unknown as OpenAI.Responses.ResponseInput;
+    const result = addResponseCacheBreakpoints(input) as unknown as Array<{
+      content: unknown;
+    }>;
+
+    expect(result[0].content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Stable instructions.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+    expect(result[1].content).toEqual([
+      {
+        type: 'input_text',
+        text: 'First question.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+    expect(result[3].content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Second question.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+    expect(result[5].content).toBe('Current question.');
   });
 
   it('does not mark replayed assistant output blocks as breakpoints', () => {

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -80,6 +80,7 @@ export type GoogleThinkingConfig = {
  *  Azure wrappers that both read them. */
 export type ManagedRequestOptions = {
   promptCacheExplicit?: boolean;
+  promptCacheKey?: string;
   safety_identifier?: string;
 };
 /**


### PR DESCRIPTION
## Summary

Preserve the managed OpenAI request metadata that LibreChat needs for reliable explicit caching and tier-aware accounting.

- Forward the server-generated prompt cache key through OpenAI and Azure Chat Completions and Responses requests.
- Keep the instruction breakpoint and the two latest prior-history breakpoints, within OpenAI's marker limit.
- Preserve provider-reported `service_tier` on non-streaming Chat Completions messages.
- Keep the current user turn unmarked.
- Cover Chat Completions and Responses rollover behavior.

## Why

Live sequential-request testing showed that replacing the prior history marker on every turn could produce another cache write instead of a cache read. LibreChat's generated prompt cache key also needed to be represented in the shared managed-request options so it reaches all four OpenAI/Azure transport paths. Non-streaming Chat Completions dropped the response-level service tier during LangChain conversion, forcing downstream accounting to infer the requested tier instead of using the provider-reported tier.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/llm/openai/managedRequests.test.ts src/llm/openai/llm.spec.ts --runInBand` — 71 tests passed.
- `npx tsc --noEmit` — passed.
- `npm run build` — passed.
- ESLint on all changed files — passed.
- `git diff --check` — passed.

### Test Configuration

- Rebased onto current Agents `main` at v3.7.1.
- Node.js 24.x.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests and build pass with my changes