### PR TITLE
🎯 fix: Scope the Hook agentId Marker to Subagent Child Graphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
         "@langchain/anthropic": "^1.5.1",
         "@langchain/aws": "^1.4.2",
-        "@langchain/core": "^1.2.1",
+        "@langchain/core": "^1.2.2",
         "@langchain/deepseek": "^1.1.3",
         "@langchain/google-common": "2.2.0",
         "@langchain/google-gauth": "2.2.0",

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -870,6 +870,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * {@link t.StandardGraphInput.subagentUsageSink}.
    */
   subagentUsageSink?: t.SubagentUsageSink;
+  /** See {@link t.StandardGraphInput.subagentScope}. */
+  subagentScope: boolean;
 
   constructor({
     runId,
@@ -880,12 +882,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     indexTokenCountMap,
     calibrationRatio,
     subagentUsageSink,
+    subagentScope,
   }: t.StandardGraphInput) {
     super();
     this.runId = runId;
     this.signal = signal;
     this.langfuse = langfuse;
     this.subagentUsageSink = subagentUsageSink;
+    this.subagentScope = subagentScope === true;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -1272,7 +1276,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         eventDrivenMode: true,
         sessions: this.sessions,
         toolDefinitions: toolDefMap,
-        agentId: agentContext?.agentId,
+        // `agentId` is the subagent-scope marker — set ONLY for child-run
+        // graphs (hooks fire for child scopes too, via the inherited
+        // run_id); `executingAgentId` always identifies the owning agent.
+        agentId: this.subagentScope ? agentContext?.agentId : undefined,
         executingAgentId: agentContext?.agentId,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
@@ -1339,9 +1346,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       trace: traceToolNode,
       runLangfuse: this.langfuse,
       agentLangfuse: agentContext?.langfuse,
-      // `agentId` is intentionally left unset on this path (it is the
-      // subagent-scope marker); `executingAgentId` always identifies the owning
-      // agent so hooks can attribute the batch even at the top level.
+      // `agentId` is the subagent-scope marker — set ONLY for child-run
+      // graphs; `executingAgentId` always identifies the owning agent so
+      // hooks can attribute the batch even at the top level.
+      agentId: this.subagentScope ? agentContext?.agentId : undefined,
       executingAgentId: agentContext?.agentId,
       toolCallStepIds: this.toolCallStepIds,
       errorHandler: (data, metadata): Promise<boolean> =>

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2746,7 +2746,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             const batchRequest: t.ToolExecuteBatchRequest = {
               toolCalls: dispatchRequests,
               userId: config.configurable?.user_id as string | undefined,
-              agentId: this.agentId,
+              // Dispatch attribution, NOT the hook subagent-scope marker:
+              // hosts key tool/credential lookup on the owning agent, and
+              // the eager path sends `agentContext.agentId` — this must
+              // match it at the top level too.
+              agentId: this.executingAgentId,
               configurable: config.configurable as
                   | Record<string, unknown>
                   | undefined,

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -4,6 +4,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
   HookCallback,
   PermissionDeniedHookOutput,
+  PostToolBatchHookOutput,
   PostToolUseHookOutput,
   PreToolUseHookOutput,
   SubagentStartHookInput,
@@ -363,6 +364,124 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(preExecEvents).toContain('researcher-child:calculator');
     expect(postExecEvents).toContain('hook-parent:subagent');
     expect(postExecEvents).toContain('researcher-child:calculator');
+  });
+
+  it('top-level event-driven dispatches leave agentId unset (subagent-scope marker)', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeChatModel {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          constructor(_options: any) {
+            super({
+              responses: ['Calculating.', 'All done.'],
+              sleep: 1,
+              toolCalls: [createCalculatorToolCall()],
+            });
+          }
+          bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
+            const config = {
+              tools,
+            } as Parameters<FakeChatModel['withConfig']>[0];
+            return this.withConfig(config);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const registry = new HookRegistry();
+    const scopeEvents: string[] = [];
+
+    const preHook: HookCallback<'PreToolUse'> = async (
+      input
+    ): Promise<PreToolUseHookOutput> => {
+      scopeEvents.push(
+        `pre:${input.agentId ?? '-'}:${input.executingAgentId ?? '-'}`
+      );
+      return { decision: 'allow' };
+    };
+    registry.register('PreToolUse', { hooks: [preHook] });
+
+    const postHook: HookCallback<'PostToolUse'> = async (
+      input
+    ): Promise<PostToolUseHookOutput> => {
+      scopeEvents.push(
+        `post:${input.agentId ?? '-'}:${input.executingAgentId ?? '-'}`
+      );
+      return {};
+    };
+    registry.register('PostToolUse', { hooks: [postHook] });
+
+    const batchHook: HookCallback<'PostToolBatch'> = async (
+      input
+    ): Promise<PostToolBatchHookOutput> => {
+      scopeEvents.push(
+        `batch:${input.agentId ?? '-'}:${input.executingAgentId ?? '-'}`
+      );
+      return {};
+    };
+    registry.register('PostToolBatch', { hooks: [batchHook] });
+
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          const results: t.ToolExecuteResult[] = request.toolCalls.map(
+            (call) => ({
+              toolCallId: call.id,
+              status: 'success',
+              content: '42',
+            })
+          );
+          request.resolve(results);
+        },
+      },
+    };
+
+    /**
+     * The LibreChat shape: a TOP-LEVEL agent whose tools ride
+     * `toolDefinitions` (event-driven ToolNode, host executes via
+     * ON_TOOL_EXECUTE). Hook inputs here must NOT carry the subagent-scope
+     * marker — a host hook keying on `agentId != null` (e.g. a steering
+     * drain that must never inject into child state) would otherwise skip
+     * every top-level batch.
+     */
+    const run = await Run.create<t.IState>({
+      runId: `toplevel-event-hook-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'hook-parent',
+            provider: Providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'Use the calculator.',
+            maxContextTokens: 8000,
+            toolDefinitions: [calculatorDef],
+          },
+        ],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+      hooks: registry,
+    });
+
+    run.Graph!.overrideTestModel(['Calculating.', 'All done.'], 5, [
+      createCalculatorToolCall(),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('what is 21 * 2?')] },
+      callerConfig
+    );
+
+    expect(scopeEvents).toContain('pre:-:hook-parent');
+    expect(scopeEvents).toContain('post:-:hook-parent');
+    expect(scopeEvents).toContain('batch:-:hook-parent');
   });
 
   it('child subagent tool ask hooks fail closed instead of starting unsupported nested HITL', async () => {

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -423,12 +423,14 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     };
     registry.register('PostToolBatch', { hooks: [batchHook] });
 
+    const dispatchAgentIds: Array<string | undefined> = [];
     const customHandlers: Record<string, t.EventHandler> = {
       [GraphEvents.TOOL_END]: new ToolEndHandler(),
       [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
       [GraphEvents.ON_TOOL_EXECUTE]: {
         handle: (_event, rawData): void => {
           const request = rawData as t.ToolExecuteBatchRequest;
+          dispatchAgentIds.push(request.agentId);
           const results: t.ToolExecuteResult[] = request.toolCalls.map(
             (call) => ({
               toolCallId: call.id,
@@ -447,7 +449,9 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
      * ON_TOOL_EXECUTE). Hook inputs here must NOT carry the subagent-scope
      * marker — a host hook keying on `agentId != null` (e.g. a steering
      * drain that must never inject into child state) would otherwise skip
-     * every top-level batch.
+     * every top-level batch. The DISPATCH payload is the opposite: hosts
+     * key tool/credential lookup on `request.agentId`, so it must keep
+     * identifying the owning agent.
      */
     const run = await Run.create<t.IState>({
       runId: `toplevel-event-hook-${Date.now()}`,
@@ -482,6 +486,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(scopeEvents).toContain('pre:-:hook-parent');
     expect(scopeEvents).toContain('post:-:hook-parent');
     expect(scopeEvents).toContain('batch:-:hook-parent');
+    expect(dispatchAgentIds).toEqual(['hook-parent']);
   });
 
   it('child subagent tool ask hooks fail closed instead of starting unsupported nested HITL', async () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -373,6 +373,7 @@ export class SubagentExecutor {
       agents: [childInputs],
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
+      subagentScope: true,
       /**
        * Forwarded so the child graph's own `SubagentExecutor` (created in
        * its `createAgentNode` when `allowNested` keeps subagentConfigs)

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -336,6 +336,16 @@ export type StandardGraphInput = {
    * they already flow through the registry's `CHAT_MODEL_END` handler.
    */
   subagentUsageSink?: SubagentUsageSink;
+  /**
+   * True when this graph IS a subagent child run (set by `SubagentExecutor`
+   * when it constructs the child graph). Drives the hook-input `agentId`
+   * subagent-scope marker: hook dispatches from this graph's tool nodes
+   * carry `agentId` so run-scoped host hooks — which fire for child scopes
+   * too, because children inherit the parent's `run_id` — can tell child
+   * scope from the top level. Top-level graphs leave this unset and their
+   * hook inputs carry only `executingAgentId`.
+   */
+  subagentScope?: boolean;
 };
 
 export type GraphEdge = {


### PR DESCRIPTION
## Summary

I fixed a hook-contract violation that made the `agentId` subagent-scope marker meaningless in event-driven mode — and with it, broke any host hook that keys on `agentId != null` to avoid acting inside child scopes (LibreChat's steering drain skips every top-level tool-batch boundary on 3.2.62, so mid-run injection never happens).

- Documented contract (`BaseHookInput`): `agentId` is set ONLY when a hook fires inside a subagent scope; `executingAgentId` attributes the batch to its owning agent everywhere, including top level. The event-driven ToolNode construction stamped `agentId: agentContext?.agentId` unconditionally, so every top-level hook input carried the marker whenever tools rode `toolDefinitions` (every LibreChat run, MCP included). The traditional branch had the opposite latent gap: it never set the marker, even for child runs.
- Added `StandardGraphInput.subagentScope`, set by `SubagentExecutor` when it constructs child graphs. Each nesting level runs through its own executor, so grandchildren are marked too; run-scoped host hooks still fire in child scopes via the inherited `run_id`, which is exactly why the marker must be reliable.
- Stamped `agentId` on tool nodes only when `subagentScope` is set, in both the event-driven and traditional branches; `executingAgentId` is unchanged.
- Added a regression test: a top-level event-driven run (toolDefinitions + ON_TOOL_EXECUTE, the LibreChat shape) asserts `PreToolUse`/`PostToolUse`/`PostToolBatch` inputs carry `executingAgentId` but no `agentId`. Before the fix it fails with `pre:hook-parent:hook-parent`; after, `pre:-:hook-parent`. The existing subagent hook test pins the child side (`researcher-child:calculator` still marked).

Found by a LibreChat Playwright e2e driving a real MCP tool run: a 202-accepted steer never injected because the drain hook saw `agentId` set at the top level and skipped, verified empirically (`PostToolBatch agentId="Mock Provider C__mock-model-c___Mock Provider C"` on a single-agent run).

Needs a patch release (3.2.63) — LibreChat#14220 will bump its pin so mid-run steering actually injects.

## Testing

- `npm test -- src/tools src/hooks stream.eagerEventExecution`: 47 suites, 1230 tests pass.
- Fails-before verified by reverting the three src files and running the new test (agentId stamped at top level), then re-applying.
- `npx tsc --noEmit` clean; lint clean.