### PR TITLE
fix(anthropic): honor cumulative message_delta usage (input + cache fields) from Anthropic-compatible gateways

### DIFF
--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -6,6 +6,7 @@ import type {
   BaseMessage,
   MessageContentComplex,
 } from '@langchain/core/messages';
+import type { ChatModelStreamEvent } from '@langchain/core/language_models/event';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { AnthropicInput } from '@langchain/anthropic';
 import type { Anthropic } from '@anthropic-ai/sdk';
@@ -18,6 +19,7 @@ import type {
   AnthropicMCPServerURLDefinition,
   AnthropicContextManagementConfigParam,
   AnthropicRequestOptions,
+  AnthropicMessageStreamEvent,
 } from '@/llm/anthropic/types';
 import type { AnthropicUsageData } from './utils/message_outputs';
 import {
@@ -25,6 +27,7 @@ import {
   stripUnsupportedAssistantPrefill,
 } from './utils/message_inputs';
 import { _makeMessageChunkFromAnthropicEvent } from './utils/message_outputs';
+import { convertAnthropicStream } from './utils/stream_events';
 import { handleToolChoice } from './utils/tools';
 
 const DEFAULT_STREAM_DELAY = 25;
@@ -45,6 +48,11 @@ interface AnthropicStreamUsage {
 interface CumulativeUsageValue {
   cumulative: number;
   increment: number;
+}
+
+interface AnthropicEventStream
+  extends AsyncIterable<AnthropicMessageStreamEvent> {
+  controller?: { abort: () => void };
 }
 
 const ANTHROPIC_TOOL_BETAS: Partial<Record<string, AnthropicBeta>> = {
@@ -335,6 +343,19 @@ async function waitForStreamDelay(
 
 function isSignalAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true;
+}
+
+async function* abortableAnthropicStream(
+  source: AnthropicEventStream,
+  signal?: AbortSignal
+): AsyncGenerator<AnthropicMessageStreamEvent> {
+  for await (const data of source) {
+    if (isSignalAborted(signal)) {
+      source.controller?.abort();
+      return;
+    }
+    yield data;
+  }
 }
 
 function extractToken(
@@ -686,6 +707,29 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     return super.completionWithRetry(
       stripUnsupportedAssistantPrefill(request),
       options
+    );
+  }
+
+  async *_streamChatModelEvents(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatModelStreamEvent> {
+    const params = this.invocationParams(options);
+    const formattedMessages = _convertMessagesToAnthropicPayload(messages);
+    const payload = stripUnsupportedAssistantPrefill({
+      ...params,
+      ...formattedMessages,
+      stream: true,
+    } as const);
+    const stream = await this.createStreamWithRetry(payload, {
+      headers: options.headers,
+      signal: options.signal,
+    });
+    const shouldStreamUsage = options.streamUsage ?? this.streamUsage;
+    yield* convertAnthropicStream(
+      abortableAnthropicStream(stream, options.signal),
+      { streamUsage: shouldStreamUsage }
     );
   }
 

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -19,6 +19,7 @@ import type {
   AnthropicContextManagementConfigParam,
   AnthropicRequestOptions,
 } from '@/llm/anthropic/types';
+import type { AnthropicUsageData } from './utils/message_outputs';
 import {
   _convertMessagesToAnthropicPayload,
   stripUnsupportedAssistantPrefill,
@@ -33,6 +34,18 @@ const STREAM_CHUNK_MIN_SIZE = 4;
 const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
 
 type StreamTokenType = 'string' | 'input' | 'content';
+
+interface AnthropicStreamUsage {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  outputTokens: number;
+}
+
+interface CumulativeUsageValue {
+  cumulative: number;
+  increment: number;
+}
 
 const ANTHROPIC_TOOL_BETAS: Partial<Record<string, AnthropicBeta>> = {
   tool_search_tool_regex_20251119: 'advanced-tool-use-2025-11-20',
@@ -392,27 +405,77 @@ function cloneChunk(
   return chunk;
 }
 
+function resolveCumulativeUsageValue(
+  current: number | null | undefined,
+  previous: number
+): CumulativeUsageValue {
+  if (current == null) {
+    return { cumulative: previous, increment: 0 };
+  }
+  const cumulative = Math.max(previous, current);
+  return { cumulative, increment: cumulative - previous };
+}
+
 function withIncrementalMessageDeltaUsage(
   chunk: AIMessageChunk,
-  previousOutputTokens: number
-): { chunk: AIMessageChunk; outputTokens: number } {
+  previousUsage: AnthropicStreamUsage,
+  cumulativeUsage: AnthropicUsageData
+): { chunk: AIMessageChunk; usage: AnthropicStreamUsage } {
   const usage = chunk.usage_metadata;
   if (usage == null) {
-    return { chunk, outputTokens: previousOutputTokens };
+    return { chunk, usage: previousUsage };
   }
 
-  const outputTokens = Math.max(0, usage.output_tokens - previousOutputTokens);
+  const inputTokens = resolveCumulativeUsageValue(
+    cumulativeUsage.input_tokens,
+    previousUsage.inputTokens
+  );
+  const cacheCreationInputTokens = resolveCumulativeUsageValue(
+    cumulativeUsage.cache_creation_input_tokens,
+    previousUsage.cacheCreationInputTokens
+  );
+  const cacheReadInputTokens = resolveCumulativeUsageValue(
+    cumulativeUsage.cache_read_input_tokens,
+    previousUsage.cacheReadInputTokens
+  );
+  const outputTokens = resolveCumulativeUsageValue(
+    cumulativeUsage.output_tokens,
+    previousUsage.outputTokens
+  );
+  const incrementalInputTokens =
+    inputTokens.increment +
+    cacheCreationInputTokens.increment +
+    cacheReadInputTokens.increment;
+  const hasCacheUsage =
+    cumulativeUsage.cache_creation_input_tokens != null ||
+    cumulativeUsage.cache_read_input_tokens != null;
+  const inputTokenDetails = {
+    ...(cumulativeUsage.cache_creation_input_tokens != null && {
+      cache_creation: cacheCreationInputTokens.increment,
+    }),
+    ...(cumulativeUsage.cache_read_input_tokens != null && {
+      cache_read: cacheReadInputTokens.increment,
+    }),
+  };
+
   return {
     chunk: new AIMessageChunk(
       Object.assign({}, chunk, {
         usage_metadata: {
           ...usage,
-          output_tokens: outputTokens,
-          total_tokens: usage.input_tokens + outputTokens,
+          input_tokens: incrementalInputTokens,
+          output_tokens: outputTokens.increment,
+          total_tokens: incrementalInputTokens + outputTokens.increment,
+          input_token_details: hasCacheUsage ? inputTokenDetails : undefined,
         },
       })
     ),
-    outputTokens: usage.output_tokens,
+    usage: {
+      inputTokens: inputTokens.cumulative,
+      cacheCreationInputTokens: cacheCreationInputTokens.cumulative,
+      cacheReadInputTokens: cacheReadInputTokens.cumulative,
+      outputTokens: outputTokens.cumulative,
+    },
   };
 }
 
@@ -651,7 +714,12 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     });
 
     const shouldStreamUsage = options.streamUsage ?? this.streamUsage;
-    let messageDeltaOutputTokens = 0;
+    let streamUsage: AnthropicStreamUsage = {
+      inputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      outputTokens: 0,
+    };
     const queuedChunks: QueuedGenerationChunk[] = [];
     const producerState: {
       done: boolean;
@@ -833,13 +901,24 @@ export class CustomAnthropic extends ChatAnthropicMessages {
           }
 
           let { chunk } = result;
+          if (data.type === 'message_start') {
+            streamUsage = {
+              ...streamUsage,
+              inputTokens: data.message.usage.input_tokens,
+              cacheCreationInputTokens:
+                data.message.usage.cache_creation_input_tokens ?? 0,
+              cacheReadInputTokens:
+                data.message.usage.cache_read_input_tokens ?? 0,
+            };
+          }
           if (data.type === 'message_delta') {
             const incremental = withIncrementalMessageDeltaUsage(
               chunk,
-              messageDeltaOutputTokens
+              streamUsage,
+              data.usage
             );
             chunk = incremental.chunk;
-            messageDeltaOutputTokens = incremental.outputTokens;
+            streamUsage = incremental.usage;
           }
 
           const [token = '', tokenType] = extractToken(chunk);

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -949,6 +949,7 @@ export class CustomAnthropic extends ChatAnthropicMessages {
             streamUsage = {
               ...streamUsage,
               inputTokens: data.message.usage.input_tokens,
+              outputTokens: data.message.usage.output_tokens,
               cacheCreationInputTokens:
                 data.message.usage.cache_creation_input_tokens ?? 0,
               cacheReadInputTokens:

--- a/src/llm/anthropic/inherited-content-utils.spec.ts
+++ b/src/llm/anthropic/inherited-content-utils.spec.ts
@@ -185,7 +185,7 @@ describe('_makeMessageChunkFromAnthropicEvent (ported from message_outputs.test.
     expect(usage.input_token_details?.cache_read).toBe(1000);
   });
 
-  it('message_delta chunk has input_tokens=0 and no cache token details', () => {
+  it('message_delta chunk preserves cumulative input and cache usage', () => {
     const event = {
       type: 'message_delta' as const,
       delta: { stop_reason: 'end_turn' as const, stop_sequence: null },
@@ -202,10 +202,15 @@ describe('_makeMessageChunkFromAnthropicEvent (ported from message_outputs.test.
     expect(result).not.toBeNull();
 
     const usage = result!.chunk.usage_metadata!;
-    expect(usage.output_tokens).toBe(42);
-    expect(usage.input_tokens).toBe(0);
-    expect(usage.input_token_details?.cache_creation).toBeUndefined();
-    expect(usage.input_token_details?.cache_read).toBeUndefined();
+    expect(usage).toEqual({
+      input_tokens: 1600,
+      output_tokens: 42,
+      total_tokens: 1642,
+      input_token_details: {
+        cache_creation: 500,
+        cache_read: 1000,
+      },
+    });
   });
 });
 

--- a/src/llm/anthropic/inherited-stream-events.spec.ts
+++ b/src/llm/anthropic/inherited-stream-events.spec.ts
@@ -35,6 +35,7 @@ import type {
   AnthropicStreamingMessageCreateParams,
 } from './types';
 import type { CustomAnthropicCallOptions } from './index';
+import { _convertMessagesToAnthropicPayload } from './utils/message_inputs';
 import { CustomAnthropic as ChatAnthropic } from './index';
 
 // ─── Mock model ─────────────────────────────────────────────────
@@ -269,7 +270,7 @@ function cacheUsageEvents(): unknown[] {
         stop_sequence: null,
         usage: {
           input_tokens: 100,
-          output_tokens: 0,
+          output_tokens: 1,
           cache_creation_input_tokens: 500,
           cache_read_input_tokens: 200,
         },
@@ -309,7 +310,7 @@ function lateUsageEvents(): unknown[] {
         stop_sequence: null,
         usage: {
           input_tokens: 0,
-          output_tokens: 0,
+          output_tokens: 7,
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
         },
@@ -334,6 +335,49 @@ function lateUsageEvents(): unknown[] {
         cache_creation_input_tokens: 500,
         cache_read_input_tokens: 200,
       },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function webSearchResultEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_06PQR',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 25, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'web_search_tool_result',
+        tool_use_id: 'srvtoolu_01WEB',
+        content: [
+          {
+            type: 'web_search_result',
+            url: 'https://example.com',
+            title: 'Example',
+            encrypted_content: 'encrypted',
+            page_age: null,
+          },
+        ],
+        caller: { type: 'direct' },
+      },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 1 },
     },
     { type: 'message_stop' },
   ];
@@ -742,6 +786,46 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
 
       expect(message.tool_calls?.length).toBe(1);
       expect(message.tool_calls?.[0]?.name).toBe('web_search');
+    });
+
+    test('output preserves web search results for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(webSearchResultEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      expect(message.content).toEqual([
+        {
+          type: 'web_search_tool_result',
+          tool_use_id: 'srvtoolu_01WEB',
+          content: [
+            {
+              type: 'web_search_result',
+              url: 'https://example.com',
+              title: 'Example',
+              encrypted_content: 'encrypted',
+              page_age: null,
+            },
+          ],
+          caller: { type: 'direct' },
+        },
+      ]);
+
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual([
+        {
+          type: 'web_search_tool_result',
+          tool_use_id: 'srvtoolu_01WEB',
+          content: [
+            {
+              type: 'web_search_result',
+              url: 'https://example.com',
+              title: 'Example',
+              encrypted_content: 'encrypted',
+              page_age: null,
+            },
+          ],
+        },
+      ]);
     });
 
     test('usage sub-stream works end-to-end', async () => {

--- a/src/llm/anthropic/inherited-stream-events.spec.ts
+++ b/src/llm/anthropic/inherited-stream-events.spec.ts
@@ -426,6 +426,131 @@ function serverToolUseEvents(): unknown[] {
   ];
 }
 
+function citationEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_08VWX',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 25, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: {
+        type: 'citations_delta',
+        citation: {
+          type: 'web_search_result_location',
+          cited_text: 'Example source',
+          encrypted_index: 'encrypted-index',
+          title: 'Example',
+          url: 'https://example.com',
+        },
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'Cited answer.' },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 5 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function compactionEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_09YZA',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 25, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'compaction',
+        content: null,
+        encrypted_content: null,
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: {
+        type: 'compaction_delta',
+        content: 'Summary of the earlier conversation.',
+        encrypted_content: 'encrypted-summary',
+      },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 5 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function redactedThinkingEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_10BCD',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 25, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'redacted_thinking',
+        data: 'encrypted-thinking',
+      },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 5 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
 function contextWindowExceededEvents(): unknown[] {
   return [
     ...textOnlyEvents().slice(0, -2),
@@ -435,6 +560,18 @@ function contextWindowExceededEvents(): unknown[] {
         stop_reason: 'model_context_window_exceeded',
         stop_sequence: null,
       },
+      usage: { output_tokens: 2 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function refusalEvents(): unknown[] {
+  return [
+    ...textOnlyEvents().slice(0, -2),
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'refusal', stop_sequence: null },
       usage: { output_tokens: 2 },
     },
     { type: 'message_stop' },
@@ -863,6 +1000,88 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
       expect(message.tool_calls?.[0]?.name).toBe('web_search');
     });
 
+    test('output preserves client tool calls for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(toolCallEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual([
+        { type: 'text', text: 'Let me search.' },
+        {
+          type: 'tool_use',
+          id: 'toolu_01ABC',
+          name: 'web_search',
+          input: { query: 'weather' },
+        },
+      ]);
+    });
+
+    test('output preserves signed thinking for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(thinkingPlusTextEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual([
+        {
+          type: 'thinking',
+          thinking: 'Let me reason...',
+          signature: 'sig_abc',
+        },
+        { type: 'text', text: 'The answer is 42.' },
+      ]);
+    });
+
+    test('output preserves citations for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(citationEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+      const citation = {
+        type: 'web_search_result_location',
+        cited_text: 'Example source',
+        encrypted_index: 'encrypted-index',
+        title: 'Example',
+        url: 'https://example.com',
+      };
+
+      expect(message.content).toEqual([
+        { type: 'text', text: 'Cited answer.', citations: [citation] },
+      ]);
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual([
+        { type: 'text', text: 'Cited answer.', citations: [citation] },
+      ]);
+    });
+
+    test('output preserves compaction blocks for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(compactionEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      expect(message.content).toEqual([
+        {
+          type: 'compaction',
+          content: 'Summary of the earlier conversation.',
+          encrypted_content: 'encrypted-summary',
+        },
+      ]);
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual(message.content);
+    });
+
+    test('output preserves redacted thinking for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(redactedThinkingEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      expect(message.content).toEqual([
+        { type: 'redacted_thinking', data: 'encrypted-thinking' },
+      ]);
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual(message.content);
+    });
+
     test('output preserves web search results for follow-up turns', async () => {
       const model = new MockStreamChatAnthropic(webSearchResultEvents());
       const stream = new ChatModelStream(streamEvents(model));
@@ -985,13 +1204,20 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
     });
 
     test('maps model context exhaustion to a length finish reason', async () => {
-      const model = new MockStreamChatAnthropic(
-        contextWindowExceededEvents()
-      );
+      const model = new MockStreamChatAnthropic(contextWindowExceededEvents());
       const events = await collectEvents(model);
 
       expect(events.find((event) => event.event === 'message-finish')).toEqual(
         expect.objectContaining({ reason: 'length' })
+      );
+    });
+
+    test('maps Anthropic refusals to a content-filter finish reason', async () => {
+      const model = new MockStreamChatAnthropic(refusalEvents());
+      const events = await collectEvents(model);
+
+      expect(events.find((event) => event.event === 'message-finish')).toEqual(
+        expect.objectContaining({ reason: 'content_filter' })
       );
     });
   });

--- a/src/llm/anthropic/inherited-stream-events.spec.ts
+++ b/src/llm/anthropic/inherited-stream-events.spec.ts
@@ -383,6 +383,78 @@ function webSearchResultEvents(): unknown[] {
   ];
 }
 
+function serverToolUseEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_07STU',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 25, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'server_tool_use',
+        id: 'srvtoolu_01SERVER',
+        name: 'web_search',
+        input: {},
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: {
+        type: 'input_json_delta',
+        partial_json: '{"query":"weather"}',
+      },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 8 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function contextWindowExceededEvents(): unknown[] {
+  return [
+    ...textOnlyEvents().slice(0, -2),
+    {
+      type: 'message_delta',
+      delta: {
+        stop_reason: 'model_context_window_exceeded',
+        stop_sequence: null,
+      },
+      usage: { output_tokens: 2 },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
+function streamErrorEvents(): unknown[] {
+  return [
+    textOnlyEvents()[0],
+    {
+      type: 'error',
+      error: {
+        type: 'overloaded_error',
+        message: 'Anthropic stream overloaded',
+      },
+      request_id: 'req_01ERROR',
+    },
+  ];
+}
+
 // ─── Tests ───────────────────────────────────────────────────────
 
 describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
@@ -769,6 +841,9 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
 
       expect(message.id).toBe('msg_03GHI');
       expect(message._getType()).toBe('ai');
+      expect(message.response_metadata).toMatchObject({
+        model_provider: 'anthropic',
+      });
 
       const content = message.content as Array<{
         type: string;
@@ -828,6 +903,31 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
       ]);
     });
 
+    test('output preserves server tool arguments for follow-up turns', async () => {
+      const model = new MockStreamChatAnthropic(serverToolUseEvents());
+      const stream = new ChatModelStream(streamEvents(model));
+      const message = await stream.output;
+
+      expect(message.content).toEqual([
+        {
+          type: 'server_tool_call',
+          id: 'srvtoolu_01SERVER',
+          name: 'web_search',
+          args: { query: 'weather' },
+        },
+      ]);
+
+      const payload = _convertMessagesToAnthropicPayload([message]);
+      expect(payload.messages[0]?.content).toEqual([
+        {
+          type: 'server_tool_use',
+          id: 'srvtoolu_01SERVER',
+          name: 'web_search',
+          input: { query: 'weather' },
+        },
+      ]);
+    });
+
     test('usage sub-stream works end-to-end', async () => {
       const model = new MockStreamChatAnthropic(cacheUsageEvents());
       const stream = new ChatModelStream(
@@ -873,6 +973,26 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
       expect(text).toBe('Let me search.');
       expect(tools.length).toBe(1);
       expect(tools[0]!.name).toBe('web_search');
+    });
+  });
+
+  describe('failure and finish semantics', () => {
+    test('throws Anthropic errors emitted after the stream starts', async () => {
+      const model = new MockStreamChatAnthropic(streamErrorEvents());
+      await expect(collectEvents(model)).rejects.toThrow(
+        'Anthropic stream overloaded'
+      );
+    });
+
+    test('maps model context exhaustion to a length finish reason', async () => {
+      const model = new MockStreamChatAnthropic(
+        contextWindowExceededEvents()
+      );
+      const events = await collectEvents(model);
+
+      expect(events.find((event) => event.event === 'message-finish')).toEqual(
+        expect.objectContaining({ reason: 'length' })
+      );
     });
   });
 

--- a/src/llm/anthropic/inherited-stream-events.spec.ts
+++ b/src/llm/anthropic/inherited-stream-events.spec.ts
@@ -7,14 +7,11 @@
 //
 // Applicability to our fork:
 //   Our `CustomAnthropic` (imported here as `ChatAnthropic` from `@/llm/anthropic`)
-//   extends upstream `ChatAnthropicMessages` (1.5.1). It overrides the LEGACY
-//   `_streamResponseChunks` path (used by `.stream()` / `.invoke()`), but does NOT
-//   override `_streamChatModelEvents`. That native method is therefore inherited
-//   verbatim: it calls `invocationParams` -> `_convertMessagesToAnthropicPayload`
-//   -> `createStreamWithRetry` -> `convertAnthropicStream`. Our `createStreamWithRetry`
-//   override only strips unsupported assistant prefill before delegating to super, so
-//   mocking it (as upstream's `MockStreamChatAnthropic` does) drives the real native
-//   conversion path. A probe confirmed the lifecycle/sub-streams resolve correctly.
+//   extends upstream `ChatAnthropicMessages` (1.5.1). It overrides both the legacy
+//   `_streamResponseChunks` path and `_streamChatModelEvents`, whose request setup
+//   mirrors upstream while using the local cumulative-usage converter. Mocking
+//   `createStreamWithRetry` (as upstream's `MockStreamChatAnthropic` does) drives
+//   the real native conversion path without making API calls.
 //
 // Adaptation:
 //   - vitest -> jest (`@jest/globals`; `vi.*` -> `jest.*`).
@@ -298,6 +295,50 @@ function cacheUsageEvents(): unknown[] {
   ];
 }
 
+function lateUsageEvents(): unknown[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_05MNO',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-20250514',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200,
+      },
+    },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 42,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200,
+      },
+    },
+    { type: 'message_stop' },
+  ];
+}
+
 // ─── Tests ───────────────────────────────────────────────────────
 
 describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
@@ -570,6 +611,39 @@ describe('CustomAnthropic._streamChatModelEvents (inherited native)', () => {
       };
       expect(finish.usage.input_tokens).toBe(800);
       expect(finish.usage.output_tokens).toBe(3);
+    });
+
+    test('usage events preserve cumulative message_delta totals', async () => {
+      const model = new MockStreamChatAnthropic(lateUsageEvents());
+      const events = await collectEvents(model, {
+        streamUsage: true,
+      } as BaseChatModelCallOptions);
+
+      const usageEvents = events.filter((event) => event.event === 'usage');
+      const lastUsage = usageEvents[usageEvents.length - 1] as {
+        usage: {
+          input_tokens: number;
+          output_tokens: number;
+          total_tokens: number;
+          input_token_details: {
+            cache_creation: number;
+            cache_read: number;
+          };
+        };
+      };
+      const expectedUsage = {
+        input_tokens: 800,
+        output_tokens: 42,
+        total_tokens: 842,
+        input_token_details: {
+          cache_creation: 500,
+          cache_read: 200,
+        },
+      };
+      expect(lastUsage.usage).toEqual(expectedUsage);
+      expect(
+        events.find((event) => event.event === 'message-finish')
+      ).toMatchObject({ usage: expectedUsage });
     });
 
     test('no usage events when streamUsage is false', async () => {

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -1021,7 +1021,7 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
           inference_geo: null,
           input_tokens: 243,
           iterations: null,
-          output_tokens: 0,
+          output_tokens: 7,
           server_tool_use: null,
           service_tier: null,
           speed: null,
@@ -1163,7 +1163,7 @@ test('Anthropic stream usage handles multiple cumulative message_delta events', 
           inference_geo: null,
           input_tokens: 243,
           iterations: null,
-          output_tokens: 0,
+          output_tokens: 7,
           server_tool_use: null,
           service_tier: null,
           speed: null,
@@ -1313,9 +1313,10 @@ test('Anthropic live stream usage matches raw cumulative output snapshots', asyn
   expect(model.messageDeltaOutputTokens.length).toBeGreaterThan(0);
   const rawOutputTokens =
     model.messageDeltaOutputTokens[model.messageDeltaOutputTokens.length - 1];
-  expect(full?.usage_metadata?.output_tokens).toBe(
-    model.messageStartOutputTokens + rawOutputTokens
+  expect(rawOutputTokens).toBeGreaterThanOrEqual(
+    model.messageStartOutputTokens
   );
+  expect(full?.usage_metadata?.output_tokens).toBe(rawOutputTokens);
   expect(full?.usage_metadata?.total_tokens).toBe(
     (full?.usage_metadata?.input_tokens ?? 0) +
       (full?.usage_metadata?.output_tokens ?? 0)
@@ -1327,7 +1328,7 @@ test('Anthropic live stream usage matches raw cumulative output snapshots', asyn
       0
     );
     expect(full?.usage_metadata?.output_tokens).toBeLessThan(
-      model.messageStartOutputTokens + summedOutputTokens
+      summedOutputTokens
     );
   }
 });

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -961,7 +961,7 @@ class RecordingStreamingAnthropic extends ChatAnthropic {
   }
 }
 
-test('Anthropic message_delta usage emits only output token totals', () => {
+test('Anthropic message_delta usage preserves cumulative input totals', () => {
   const event: AnthropicStreamEvent = {
     type: 'message_delta',
     context_management: null,
@@ -978,6 +978,7 @@ test('Anthropic message_delta usage emits only output token totals', () => {
       cache_read_input_tokens: 13,
       server_tool_use: null,
       iterations: null,
+      output_tokens_details: null,
     },
   };
 
@@ -987,9 +988,13 @@ test('Anthropic message_delta usage emits only output token totals', () => {
   });
 
   expect(result?.chunk.usage_metadata).toEqual({
-    input_tokens: 0,
+    input_tokens: 267,
     output_tokens: 375,
-    total_tokens: 375,
+    total_tokens: 642,
+    input_token_details: {
+      cache_creation: 11,
+      cache_read: 13,
+    },
   });
 });
 
@@ -1002,6 +1007,7 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
         container: null,
         context_management: null,
         content: [],
+        diagnostics: null,
         model: modelName,
         role: 'assistant',
         stop_details: null,
@@ -1010,8 +1016,8 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
         type: 'message',
         usage: {
           cache_creation: null,
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 20,
+          cache_read_input_tokens: 30,
           inference_geo: null,
           input_tokens: 243,
           iterations: null,
@@ -1019,6 +1025,7 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
           server_tool_use: null,
           service_tier: null,
           speed: null,
+          output_tokens_details: null,
         },
       },
     },
@@ -1034,10 +1041,11 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
       usage: {
         input_tokens: 243,
         output_tokens: 375,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 20,
+        cache_read_input_tokens: 30,
         server_tool_use: null,
         iterations: null,
+        output_tokens_details: null,
       },
     },
     { type: 'message_stop' },
@@ -1050,12 +1058,83 @@ test('Anthropic stream usage does not double-count cumulative input tokens', asy
   }
 
   expect(full?.usage_metadata).toEqual({
-    input_tokens: 243,
+    input_tokens: 293,
     output_tokens: 375,
-    total_tokens: 618,
+    total_tokens: 668,
     input_token_details: {
-      cache_creation: 0,
-      cache_read: 0,
+      cache_creation: 20,
+      cache_read: 30,
+    },
+    output_token_details: {},
+  });
+});
+
+test('Anthropic stream usage accepts input first reported at message_delta', async () => {
+  const events: AnthropicStreamEvent[] = [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_late_input_usage',
+        container: null,
+        context_management: null,
+        content: [],
+        diagnostics: null,
+        model: modelName,
+        role: 'assistant',
+        stop_details: null,
+        stop_reason: null,
+        stop_sequence: null,
+        type: 'message',
+        usage: {
+          cache_creation: null,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          inference_geo: null,
+          input_tokens: 0,
+          iterations: null,
+          output_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+          speed: null,
+          output_tokens_details: null,
+        },
+      },
+    },
+    {
+      type: 'message_delta',
+      context_management: null,
+      delta: {
+        container: null,
+        stop_details: null,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+      },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 42,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 200,
+        server_tool_use: null,
+        iterations: null,
+        output_tokens_details: null,
+      },
+    },
+    { type: 'message_stop' },
+  ];
+  const model = new MockStreamingAnthropic(events);
+
+  let full: AIMessageChunk | undefined;
+  for await (const chunk of await model.stream('hello')) {
+    full = !full ? chunk : concat(full, chunk);
+  }
+
+  expect(full?.usage_metadata).toEqual({
+    input_tokens: 800,
+    output_tokens: 42,
+    total_tokens: 842,
+    input_token_details: {
+      cache_creation: 500,
+      cache_read: 200,
     },
     output_token_details: {},
   });
@@ -1070,6 +1149,7 @@ test('Anthropic stream usage handles multiple cumulative message_delta events', 
         container: null,
         context_management: null,
         content: [],
+        diagnostics: null,
         model: modelName,
         role: 'assistant',
         stop_details: null,
@@ -1087,6 +1167,7 @@ test('Anthropic stream usage handles multiple cumulative message_delta events', 
           server_tool_use: null,
           service_tier: null,
           speed: null,
+          output_tokens_details: null,
         },
       },
     },
@@ -1106,6 +1187,7 @@ test('Anthropic stream usage handles multiple cumulative message_delta events', 
         cache_read_input_tokens: 0,
         server_tool_use: null,
         iterations: null,
+        output_tokens_details: null,
       },
     },
     {
@@ -1124,6 +1206,7 @@ test('Anthropic stream usage handles multiple cumulative message_delta events', 
         cache_read_input_tokens: 0,
         server_tool_use: null,
         iterations: null,
+        output_tokens_details: null,
       },
     },
     { type: 'message_stop' },

--- a/src/llm/anthropic/types.ts
+++ b/src/llm/anthropic/types.ts
@@ -61,6 +61,9 @@ export type AnthropicSearchResultBlockParam =
   Anthropic.Beta.BetaSearchResultBlockParam;
 export type AnthropicCompactionBlockParam =
   Anthropic.Beta.BetaCompactionBlockParam;
+export type AnthropicCompactionBlock = Anthropic.Beta.BetaCompactionBlock;
+export type AnthropicCompactionContentBlockDelta =
+  Anthropic.Beta.BetaCompactionContentBlockDelta;
 export type AnthropicOutputConfig = Anthropic.Messages.OutputConfig;
 export type ChatAnthropicOutputFormat = Anthropic.Messages.JSONOutputFormat;
 

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -550,6 +550,60 @@ function _formatContent(message: BaseMessage) {
       }
 
       /**
+       * Native ChatModelStream output standardizes client tool uses as
+       * `tool_call` blocks. Convert those blocks back to Anthropic's wire shape
+       * before the generic content formatter sees them.
+       */
+      if (
+        contentPart.type === 'tool_call' &&
+        'id' in contentPart &&
+        typeof contentPart.id === 'string' &&
+        'name' in contentPart &&
+        typeof contentPart.name === 'string' &&
+        'args' in contentPart
+      ) {
+        let args = contentPart.args;
+        if (typeof args === 'string') {
+          try {
+            args = JSON.parse(args);
+          } catch {
+            args = {};
+          }
+        }
+        if (args == null || typeof args !== 'object' || Array.isArray(args)) {
+          args = {};
+        }
+        return _convertLangChainToolCallToAnthropic({
+          id: contentPart.id,
+          name: contentPart.name,
+          args: args as Record<string, unknown>,
+        });
+      }
+
+      /**
+       * Native Anthropic thinking is exposed through the standard reasoning
+       * stream, but its signature makes it safe and necessary to round-trip.
+       * Keep unsigned or cross-provider reasoning on the existing drop path.
+       */
+      if (
+        contentPart.type === 'reasoning' &&
+        isAIMessage(message) &&
+        message.response_metadata.model_provider === 'anthropic' &&
+        'reasoning' in contentPart &&
+        typeof contentPart.reasoning === 'string' &&
+        'signature' in contentPart &&
+        typeof contentPart.signature === 'string' &&
+        contentPart.signature !== ''
+      ) {
+        const block: AnthropicThinkingBlockParam = {
+          type: 'thinking',
+          thinking: contentPart.reasoning,
+          signature: contentPart.signature,
+        };
+        return block;
+      }
+
+      /**
        * Skip non-server malformed blocks that have tool fields mixed with text type.
        */
       if (
@@ -665,6 +719,9 @@ function _formatContent(message: BaseMessage) {
         const block: AnthropicCompactionBlockParam = {
           type: 'compaction' as const,
           content: compactionPart.content,
+          ...('encrypted_content' in compactionPart
+            ? { encrypted_content: compactionPart.encrypted_content }
+            : {}),
           ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
         return block;

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -482,8 +482,8 @@ function _formatContent(message: BaseMessage) {
     const contentBlocks = contentParts.map((contentPart) => {
       /**
        * Normalize server_tool_use blocks into a clean shape the API accepts.
-       * These blocks may arrive with the correct type (server_tool_use) or mislabeled
-       * as text/tool_use after chunk concatenation or state serialization.
+       * These blocks may arrive with the correct type (server_tool_use), as a
+       * standardized server_tool_call, or mislabeled after state serialization.
        * Regardless of current type, if the id starts with 'srvtoolu_' we rebuild
        * a clean block with only the properties the API expects.
        */
@@ -496,7 +496,7 @@ function _formatContent(message: BaseMessage) {
         'name' in contentPart
       ) {
         const rawPart = contentPart as Record<string, unknown>;
-        let input = rawPart.input;
+        let input = rawPart.input ?? rawPart.args;
         if (typeof input === 'string') {
           try {
             input = JSON.parse(input);

--- a/src/llm/anthropic/utils/message_outputs.ts
+++ b/src/llm/anthropic/utils/message_outputs.ts
@@ -9,7 +9,7 @@ import type { MessageContentComplex } from '@/types';
 import { toLangChainContent } from '@/messages/langchain';
 import { extractToolCalls } from './output_parsers';
 
-interface AnthropicUsageData {
+export interface AnthropicUsageData {
   input_tokens?: number | null;
   output_tokens?: number | null;
   cache_creation_input_tokens?: number | null;
@@ -92,31 +92,18 @@ export function _makeMessageChunkFromAnthropicEvent(
         context_management: data.delta.context_management,
       });
     }
-    // `message_delta.usage` is cumulative and may carry input-side fields
-    // (input_tokens, cache_creation_input_tokens, cache_read_input_tokens) —
-    // notably from OpenAI-backed Anthropic-compatible gateways (LiteLLM,
-    // Bedrock proxies), which only know usage at stream end.
-    const deltaUsage = data.usage as typeof data.usage & {
-      input_tokens?: number | null;
-      cache_creation_input_tokens?: number | null;
-      cache_read_input_tokens?: number | null;
-    };
-    const cacheCreation = deltaUsage.cache_creation_input_tokens;
-    const cacheRead = deltaUsage.cache_read_input_tokens;
-    const inputTokens =
-      (deltaUsage.input_tokens ?? 0) + (cacheCreation ?? 0) + (cacheRead ?? 0);
-    const usageMetadata: UsageMetadata = {
-      input_tokens: inputTokens,
+    const deltaUsage: AnthropicUsageData = data.usage;
+    const hasInputUsage =
+      deltaUsage.input_tokens != null ||
+      deltaUsage.cache_creation_input_tokens != null ||
+      deltaUsage.cache_read_input_tokens != null;
+    const cumulativeUsageMetadata = hasInputUsage
+      ? getAnthropicUsageMetadata(deltaUsage)
+      : undefined;
+    const usageMetadata: UsageMetadata = cumulativeUsageMetadata ?? {
+      input_tokens: 0,
       output_tokens: data.usage.output_tokens,
-      total_tokens: inputTokens + data.usage.output_tokens,
-      ...(cacheCreation != null || cacheRead != null
-        ? {
-            input_token_details: {
-              ...(cacheCreation != null && { cache_creation: cacheCreation }),
-              ...(cacheRead != null && { cache_read: cacheRead }),
-            },
-          }
-        : {}),
+      total_tokens: data.usage.output_tokens,
     };
     return {
       chunk: new AIMessageChunk({

--- a/src/llm/anthropic/utils/message_outputs.ts
+++ b/src/llm/anthropic/utils/message_outputs.ts
@@ -92,10 +92,31 @@ export function _makeMessageChunkFromAnthropicEvent(
         context_management: data.delta.context_management,
       });
     }
+    // `message_delta.usage` is cumulative and may carry input-side fields
+    // (input_tokens, cache_creation_input_tokens, cache_read_input_tokens) —
+    // notably from OpenAI-backed Anthropic-compatible gateways (LiteLLM,
+    // Bedrock proxies), which only know usage at stream end.
+    const deltaUsage = data.usage as typeof data.usage & {
+      input_tokens?: number | null;
+      cache_creation_input_tokens?: number | null;
+      cache_read_input_tokens?: number | null;
+    };
+    const cacheCreation = deltaUsage.cache_creation_input_tokens;
+    const cacheRead = deltaUsage.cache_read_input_tokens;
+    const inputTokens =
+      (deltaUsage.input_tokens ?? 0) + (cacheCreation ?? 0) + (cacheRead ?? 0);
     const usageMetadata: UsageMetadata = {
-      input_tokens: 0,
+      input_tokens: inputTokens,
       output_tokens: data.usage.output_tokens,
-      total_tokens: data.usage.output_tokens,
+      total_tokens: inputTokens + data.usage.output_tokens,
+      ...(cacheCreation != null || cacheRead != null
+        ? {
+            input_token_details: {
+              ...(cacheCreation != null && { cache_creation: cacheCreation }),
+              ...(cacheRead != null && { cache_read: cacheRead }),
+            },
+          }
+        : {}),
     };
     return {
       chunk: new AIMessageChunk({

--- a/src/llm/anthropic/utils/stream_events.ts
+++ b/src/llm/anthropic/utils/stream_events.ts
@@ -26,6 +26,19 @@ type AnthropicContentDelta =
     >['delta']
   | ({ type: 'compaction_delta' } & Record<string, unknown>);
 
+interface AnthropicStreamErrorEvent {
+  type: 'error';
+  error: {
+    type: string;
+    message: string;
+  };
+  request_id?: string | null;
+}
+
+type AnthropicStreamInputEvent =
+  | AnthropicMessageStreamEvent
+  | AnthropicStreamErrorEvent;
+
 type BlockAccumulator = Record<string, unknown>;
 
 interface AnthropicEventUsage {
@@ -46,7 +59,7 @@ export interface ConvertAnthropicStreamOptions {
  * LangChain `ChatModelStreamEvent`s with typed deltas.
  */
 export async function* convertAnthropicStream(
-  source: AsyncIterable<AnthropicMessageStreamEvent>,
+  source: AsyncIterable<AnthropicStreamInputEvent>,
   options: ConvertAnthropicStreamOptions = {}
 ): AsyncGenerator<ChatModelStreamEvent> {
   const shouldStreamUsage = options.streamUsage ?? true;
@@ -111,10 +124,16 @@ export async function* convertAnthropicStream(
         event: 'message-finish' as const,
         reason: mapStopReason(stopReason),
         ...(usageSnapshot ? { usage: usageSnapshot } : {}),
-        metadata: { model_provider: 'anthropic' },
+        responseMetadata: { model_provider: 'anthropic' },
       };
-      yield finishEvent as unknown as ChatModelStreamEvent;
+      yield finishEvent;
       break;
+    }
+
+    case 'error': {
+      const streamError = new Error(data.error.message);
+      streamError.name = data.error.type;
+      throw streamError;
     }
 
     // ── Content block lifecycle ───────────────────────────
@@ -186,6 +205,7 @@ function mapStopReason(stopReason: string | null | undefined): FinishReason {
   case 'tool_use':
     return 'tool_use';
   case 'max_tokens':
+  case 'model_context_window_exceeded':
     return 'length';
   default:
     return 'stop';

--- a/src/llm/anthropic/utils/stream_events.ts
+++ b/src/llm/anthropic/utils/stream_events.ts
@@ -1,0 +1,446 @@
+/**
+ * Converts a raw Anthropic SSE event stream into LangChain ChatModelStreamEvents.
+ *
+ * @module
+ */
+
+import type {
+  ChatModelStreamEvent,
+  ContentBlockDelta,
+  FinishReason,
+} from '@langchain/core/language_models/event';
+import type { ContentBlock, UsageMetadata } from '@langchain/core/messages';
+import type { AnthropicMessageStreamEvent } from '../types';
+import type { AnthropicUsageData } from './message_outputs';
+import { getAnthropicUsageMetadata } from './message_outputs';
+
+type AnthropicContentBlock = Extract<
+  AnthropicMessageStreamEvent,
+  { type: 'content_block_start' }
+>['content_block'];
+
+type AnthropicContentDelta =
+  | Extract<
+      AnthropicMessageStreamEvent,
+      { type: 'content_block_delta' }
+    >['delta']
+  | ({ type: 'compaction_delta' } & Record<string, unknown>);
+
+type BlockAccumulator = Record<string, unknown>;
+
+interface AnthropicEventUsage {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  messageStartOutputTokens: number;
+  messageDeltaOutputTokens: number;
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+export interface ConvertAnthropicStreamOptions {
+  streamUsage?: boolean;
+}
+
+/**
+ * Convert an async iterable of raw Anthropic stream events into
+ * LangChain `ChatModelStreamEvent`s with typed deltas.
+ */
+export async function* convertAnthropicStream(
+  source: AsyncIterable<AnthropicMessageStreamEvent>,
+  options: ConvertAnthropicStreamOptions = {}
+): AsyncGenerator<ChatModelStreamEvent> {
+  const shouldStreamUsage = options.streamUsage ?? true;
+
+  // Track accumulated state per content block (for finalization)
+  const blockAccumulators = new Map<number, BlockAccumulator>();
+  let usageSnapshot: UsageMetadata | undefined;
+  let eventUsage: AnthropicEventUsage | undefined;
+  let stopReason: string | null = null;
+
+  for await (const data of source) {
+    switch (data.type) {
+    // ── Message lifecycle ──────────────────────────────────
+    case 'message_start': {
+      const { usage, id, model } = data.message;
+      if (shouldStreamUsage) {
+        eventUsage = {
+          inputTokens: usage.input_tokens,
+          cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
+          cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
+          messageStartOutputTokens: usage.output_tokens,
+          messageDeltaOutputTokens: 0,
+        };
+        usageSnapshot = buildUsageSnapshot(eventUsage);
+      }
+      yield {
+        event: 'message-start' as const,
+        id,
+        ...(usageSnapshot ? { usage: usageSnapshot } : {}),
+      };
+      yield {
+        event: 'provider' as const,
+        provider: 'anthropic',
+        name: 'message_start',
+        payload: { model, id },
+      };
+      break;
+    }
+
+    case 'message_delta': {
+      stopReason = data.delta.stop_reason;
+      if (shouldStreamUsage) {
+        eventUsage = updateEventUsage(eventUsage, data.usage);
+        usageSnapshot = buildUsageSnapshot(eventUsage);
+        yield { event: 'usage' as const, usage: usageSnapshot };
+      }
+      if (
+        'context_management' in data.delta &&
+          data.delta.context_management != null
+      ) {
+        yield {
+          event: 'provider' as const,
+          provider: 'anthropic',
+          name: 'context_management',
+          payload: data.delta.context_management,
+        };
+      }
+      break;
+    }
+
+    case 'message_stop': {
+      const finishEvent = {
+        event: 'message-finish' as const,
+        reason: mapStopReason(stopReason),
+        ...(usageSnapshot ? { usage: usageSnapshot } : {}),
+        metadata: { model_provider: 'anthropic' },
+      };
+      yield finishEvent as unknown as ChatModelStreamEvent;
+      break;
+    }
+
+    // ── Content block lifecycle ───────────────────────────
+    case 'content_block_start': {
+      const { index, content_block } = data;
+      const mapped = mapBlockToContentBlock(content_block, index);
+      blockAccumulators.set(index, { ...mapped });
+      yield {
+        event: 'content-block-start' as const,
+        index,
+        content: mapped as unknown as ContentBlock,
+      };
+      break;
+    }
+
+    case 'content_block_delta': {
+      const { index, delta } = data;
+      const acc = blockAccumulators.get(index);
+      if (!acc) break;
+
+      const { contentDelta, accumulated } = applyAnthropicDelta(acc, delta);
+      blockAccumulators.set(index, accumulated);
+
+      yield {
+        event: 'content-block-delta' as const,
+        index,
+        delta: contentDelta,
+      };
+      break;
+    }
+
+    case 'content_block_stop': {
+      const { index } = data;
+      const acc = blockAccumulators.get(index);
+      if (!acc) break;
+
+      const finalized = finalizeBlock(acc);
+      yield {
+        event: 'content-block-finish' as const,
+        index,
+        content: finalized,
+      };
+      blockAccumulators.delete(index);
+      break;
+    }
+
+    // ── Unhandled → provider passthrough ───────────────────
+    default: {
+      const providerData = data as AnthropicMessageStreamEvent;
+      yield {
+        event: 'provider' as const,
+        provider: 'anthropic',
+        name: providerData.type,
+        payload: providerData,
+      };
+      break;
+    }
+    }
+  }
+}
+
+// ─── Internal helpers ───────────────────────────────────────────
+
+function mapStopReason(stopReason: string | null | undefined): FinishReason {
+  switch (stopReason) {
+  case 'end_turn':
+  case 'stop_sequence':
+    return 'stop';
+  case 'tool_use':
+    return 'tool_use';
+  case 'max_tokens':
+    return 'length';
+  default:
+    return 'stop';
+  }
+}
+
+function updateEventUsage(
+  previous: AnthropicEventUsage | undefined,
+  current: AnthropicUsageData
+): AnthropicEventUsage {
+  return {
+    inputTokens: getCumulativeUsageValue(
+      current.input_tokens,
+      previous?.inputTokens
+    ),
+    cacheCreationInputTokens: getCumulativeUsageValue(
+      current.cache_creation_input_tokens,
+      previous?.cacheCreationInputTokens
+    ),
+    cacheReadInputTokens: getCumulativeUsageValue(
+      current.cache_read_input_tokens,
+      previous?.cacheReadInputTokens
+    ),
+    messageStartOutputTokens: previous?.messageStartOutputTokens ?? 0,
+    messageDeltaOutputTokens: getCumulativeUsageValue(
+      current.output_tokens,
+      previous?.messageDeltaOutputTokens
+    ),
+  };
+}
+
+function getCumulativeUsageValue(
+  current: number | null | undefined,
+  previous: number | undefined
+): number {
+  return Math.max(previous ?? 0, current ?? 0);
+}
+
+function buildUsageSnapshot(usage: AnthropicEventUsage): UsageMetadata {
+  const metadata = getAnthropicUsageMetadata({
+    input_tokens: usage.inputTokens,
+    output_tokens:
+      usage.messageStartOutputTokens + usage.messageDeltaOutputTokens,
+    cache_creation_input_tokens: usage.cacheCreationInputTokens,
+    cache_read_input_tokens: usage.cacheReadInputTokens,
+  });
+  if (metadata == null) {
+    throw new Error('Anthropic usage metadata was not created');
+  }
+  return metadata;
+}
+
+function getStringField(record: BlockAccumulator, key: string): string {
+  const value = record[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function getArrayField(record: BlockAccumulator, key: string): unknown[] {
+  const value = record[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function getObjectField(
+  record: BlockAccumulator,
+  key: string
+): BlockAccumulator {
+  const value = record[key];
+  return typeof value === 'object' && value !== null
+    ? (value as BlockAccumulator)
+    : {};
+}
+
+function mapBlockToContentBlock(
+  block: AnthropicContentBlock,
+  index: number
+): BlockAccumulator {
+  switch (block.type) {
+  case 'text':
+    return { type: 'text' as const, text: block.text, index };
+  case 'thinking':
+    return {
+      type: 'reasoning' as const,
+      reasoning: block.thinking,
+      index,
+    };
+  case 'redacted_thinking':
+    return { type: 'non_standard' as const, value: { ...block }, index };
+  case 'tool_use':
+    return {
+      type: 'tool_call_chunk' as const,
+      id: block.id,
+      name: block.name,
+      args: '',
+      index,
+    };
+  case 'server_tool_use':
+    return {
+      type: 'server_tool_call_chunk' as const,
+      id: block.id,
+      name: block.name,
+      args: '',
+      index,
+    };
+  default:
+    return { type: 'non_standard' as const, value: { ...block }, index };
+  }
+}
+
+/**
+ * Map an Anthropic content_block_delta to a content block delta
+ * and update the accumulated state.
+ */
+function applyAnthropicDelta(
+  accumulated: BlockAccumulator,
+  delta: AnthropicContentDelta
+): {
+  contentDelta: ContentBlockDelta;
+  accumulated: BlockAccumulator;
+} {
+  const rawDelta = delta as Record<string, unknown>;
+  switch (delta.type) {
+  case 'text_delta':
+    return {
+      contentDelta: { type: 'text-delta' as const, text: delta.text },
+      accumulated: {
+        ...accumulated,
+        text: getStringField(accumulated, 'text') + delta.text,
+      },
+    };
+
+  case 'thinking_delta':
+    return {
+      contentDelta: {
+        type: 'reasoning-delta' as const,
+        reasoning: delta.thinking,
+      },
+      accumulated: {
+        ...accumulated,
+        reasoning: getStringField(accumulated, 'reasoning') + delta.thinking,
+      },
+    };
+
+  case 'input_json_delta': {
+    const newArgs = getStringField(accumulated, 'args') + delta.partial_json;
+    return {
+      contentDelta: {
+        type: 'block-delta' as const,
+        fields: {
+          type: getStringField(accumulated, 'type'),
+          args: newArgs,
+        },
+      },
+      accumulated: { ...accumulated, args: newArgs },
+    };
+  }
+
+  case 'citations_delta': {
+    const annotations = [
+      ...getArrayField(accumulated, 'annotations'),
+      delta.citation,
+    ];
+    return {
+      contentDelta: {
+        type: 'block-delta' as const,
+        fields: {
+          type: getStringField(accumulated, 'type'),
+          annotations,
+        },
+      },
+      accumulated: {
+        ...accumulated,
+        annotations,
+      },
+    };
+  }
+
+  case 'signature_delta':
+    return {
+      contentDelta: {
+        type: 'block-delta' as const,
+        fields: {
+          type: getStringField(accumulated, 'type'),
+          signature: delta.signature,
+        },
+      },
+      accumulated: { ...accumulated, signature: delta.signature },
+    };
+
+  case 'compaction_delta':
+    return {
+      contentDelta: {
+        type: 'block-delta' as const,
+        fields: {
+          type: 'non_standard',
+          value: {
+            ...getObjectField(accumulated, 'value'),
+            compaction: delta,
+          },
+        },
+      },
+      accumulated: {
+        ...accumulated,
+        value: {
+          ...getObjectField(accumulated, 'value'),
+          compaction: delta,
+        },
+      },
+    };
+
+  default:
+    return {
+      contentDelta: {
+        type: 'block-delta' as const,
+        fields: {
+          type: getStringField(accumulated, 'type'),
+          ...rawDelta,
+        },
+      },
+      accumulated,
+    };
+  }
+}
+
+function finalizeBlock(accumulated: BlockAccumulator): ContentBlock {
+  if (
+    accumulated.type === 'tool_call_chunk' ||
+    accumulated.type === 'server_tool_call_chunk'
+  ) {
+    const finalType =
+      accumulated.type === 'tool_call_chunk'
+        ? ('tool_call' as const)
+        : ('server_tool_call' as const);
+    const args = getStringField(accumulated, 'args');
+    let parsedArgs: unknown;
+    try {
+      parsedArgs = JSON.parse(args || '{}');
+    } catch {
+      return {
+        type: 'invalid_tool_call' as const,
+        id: getStringField(accumulated, 'id'),
+        name: getStringField(accumulated, 'name'),
+        args,
+        error: 'Failed to parse tool call arguments as JSON',
+      } as ContentBlock.Tools.InvalidToolCall;
+    }
+    return {
+      type: finalType,
+      id: getStringField(accumulated, 'id'),
+      name: getStringField(accumulated, 'name'),
+      args: parsedArgs,
+    } as ContentBlock;
+  }
+
+  const { index: _index, ...rest } = accumulated;
+  return rest as ContentBlock;
+}

--- a/src/llm/anthropic/utils/stream_events.ts
+++ b/src/llm/anthropic/utils/stream_events.ts
@@ -32,8 +32,7 @@ interface AnthropicEventUsage {
   inputTokens: number;
   cacheCreationInputTokens: number;
   cacheReadInputTokens: number;
-  messageStartOutputTokens: number;
-  messageDeltaOutputTokens: number;
+  outputTokens: number;
 }
 
 // ─── Public API ─────────────────────────────────────────────────
@@ -68,8 +67,7 @@ export async function* convertAnthropicStream(
           inputTokens: usage.input_tokens,
           cacheCreationInputTokens: usage.cache_creation_input_tokens ?? 0,
           cacheReadInputTokens: usage.cache_read_input_tokens ?? 0,
-          messageStartOutputTokens: usage.output_tokens,
-          messageDeltaOutputTokens: 0,
+          outputTokens: usage.output_tokens,
         };
         usageSnapshot = buildUsageSnapshot(eventUsage);
       }
@@ -211,10 +209,9 @@ function updateEventUsage(
       current.cache_read_input_tokens,
       previous?.cacheReadInputTokens
     ),
-    messageStartOutputTokens: previous?.messageStartOutputTokens ?? 0,
-    messageDeltaOutputTokens: getCumulativeUsageValue(
+    outputTokens: getCumulativeUsageValue(
       current.output_tokens,
-      previous?.messageDeltaOutputTokens
+      previous?.outputTokens
     ),
   };
 }
@@ -229,8 +226,7 @@ function getCumulativeUsageValue(
 function buildUsageSnapshot(usage: AnthropicEventUsage): UsageMetadata {
   const metadata = getAnthropicUsageMetadata({
     input_tokens: usage.inputTokens,
-    output_tokens:
-      usage.messageStartOutputTokens + usage.messageDeltaOutputTokens,
+    output_tokens: usage.outputTokens,
     cache_creation_input_tokens: usage.cacheCreationInputTokens,
     cache_read_input_tokens: usage.cacheReadInputTokens,
   });
@@ -291,6 +287,8 @@ function mapBlockToContentBlock(
       args: '',
       index,
     };
+  case 'web_search_tool_result':
+    return { ...block, index };
   default:
     return { type: 'non_standard' as const, value: { ...block }, index };
   }

--- a/src/llm/anthropic/utils/stream_events.ts
+++ b/src/llm/anthropic/utils/stream_events.ts
@@ -10,21 +10,27 @@ import type {
   FinishReason,
 } from '@langchain/core/language_models/event';
 import type { ContentBlock, UsageMetadata } from '@langchain/core/messages';
-import type { AnthropicMessageStreamEvent } from '../types';
+import type {
+  AnthropicCompactionBlock,
+  AnthropicCompactionContentBlockDelta,
+  AnthropicMessageStreamEvent,
+} from '../types';
 import type { AnthropicUsageData } from './message_outputs';
 import { getAnthropicUsageMetadata } from './message_outputs';
 
-type AnthropicContentBlock = Extract<
-  AnthropicMessageStreamEvent,
-  { type: 'content_block_start' }
->['content_block'];
+type AnthropicContentBlock =
+  | Extract<
+      AnthropicMessageStreamEvent,
+      { type: 'content_block_start' }
+    >['content_block']
+  | AnthropicCompactionBlock;
 
 type AnthropicContentDelta =
   | Extract<
       AnthropicMessageStreamEvent,
       { type: 'content_block_delta' }
     >['delta']
-  | ({ type: 'compaction_delta' } & Record<string, unknown>);
+  | AnthropicCompactionContentBlockDelta;
 
 interface AnthropicStreamErrorEvent {
   type: 'error';
@@ -207,6 +213,8 @@ function mapStopReason(stopReason: string | null | undefined): FinishReason {
   case 'max_tokens':
   case 'model_context_window_exceeded':
     return 'length';
+  case 'refusal':
+    return 'content_filter';
   default:
     return 'stop';
   }
@@ -266,23 +274,18 @@ function getArrayField(record: BlockAccumulator, key: string): unknown[] {
   return Array.isArray(value) ? value : [];
 }
 
-function getObjectField(
-  record: BlockAccumulator,
-  key: string
-): BlockAccumulator {
-  const value = record[key];
-  return typeof value === 'object' && value !== null
-    ? (value as BlockAccumulator)
-    : {};
-}
-
 function mapBlockToContentBlock(
   block: AnthropicContentBlock,
   index: number
 ): BlockAccumulator {
   switch (block.type) {
   case 'text':
-    return { type: 'text' as const, text: block.text, index };
+    return {
+      type: 'text' as const,
+      text: block.text,
+      ...(block.citations != null ? { citations: block.citations } : {}),
+      index,
+    };
   case 'thinking':
     return {
       type: 'reasoning' as const,
@@ -290,7 +293,7 @@ function mapBlockToContentBlock(
       index,
     };
   case 'redacted_thinking':
-    return { type: 'non_standard' as const, value: { ...block }, index };
+    return { ...block, index };
   case 'tool_use':
     return {
       type: 'tool_call_chunk' as const,
@@ -309,6 +312,8 @@ function mapBlockToContentBlock(
     };
   case 'web_search_tool_result':
     return { ...block, index };
+  case 'compaction':
+    return { ...block, index };
   default:
     return { type: 'non_standard' as const, value: { ...block }, index };
   }
@@ -325,7 +330,7 @@ function applyAnthropicDelta(
   contentDelta: ContentBlockDelta;
   accumulated: BlockAccumulator;
 } {
-  const rawDelta = delta as Record<string, unknown>;
+  const rawDelta = delta as unknown as Record<string, unknown>;
   switch (delta.type) {
   case 'text_delta':
     return {
@@ -363,8 +368,8 @@ function applyAnthropicDelta(
   }
 
   case 'citations_delta': {
-    const annotations = [
-      ...getArrayField(accumulated, 'annotations'),
+    const citations = [
+      ...getArrayField(accumulated, 'citations'),
       delta.citation,
     ];
     return {
@@ -372,12 +377,12 @@ function applyAnthropicDelta(
         type: 'block-delta' as const,
         fields: {
           type: getStringField(accumulated, 'type'),
-          annotations,
+          citations,
         },
       },
       accumulated: {
         ...accumulated,
-        annotations,
+        citations,
       },
     };
   }
@@ -394,26 +399,28 @@ function applyAnthropicDelta(
       accumulated: { ...accumulated, signature: delta.signature },
     };
 
-  case 'compaction_delta':
+  case 'compaction_delta': {
+    const previousContent = accumulated.content;
+    const content =
+        delta.content == null
+          ? (previousContent ?? null)
+          : getStringField(accumulated, 'content') + delta.content;
     return {
       contentDelta: {
         type: 'block-delta' as const,
         fields: {
-          type: 'non_standard',
-          value: {
-            ...getObjectField(accumulated, 'value'),
-            compaction: delta,
-          },
+          type: 'compaction',
+          content,
+          encrypted_content: delta.encrypted_content,
         },
       },
       accumulated: {
         ...accumulated,
-        value: {
-          ...getObjectField(accumulated, 'value'),
-          compaction: delta,
-        },
+        content,
+        encrypted_content: delta.encrypted_content,
       },
     };
+  }
 
   default:
     return {


### PR DESCRIPTION
## Summary

I fixed Anthropic cumulative `message_delta.usage` handling for both legacy chunk streams and native chat-model event streams, including compatible gateways that first report input and cache usage at stream end.

- Preserve cumulative input, cache-creation, cache-read, and output snapshots emitted by Anthropic-compatible gateways.
- Convert cumulative snapshots into per-chunk increments before LangChain concatenation so repeated deltas are not double-counted.
- Carry forward omitted cumulative fields and reject counter regressions without losing the last valid snapshot.
- Override the native `_streamChatModelEvents` path so `.streamEvents()` consumers receive the same corrected usage.
- Preserve native thinking, redacted thinking, client/server tool calls, citations, web-search results, and compaction summaries with encrypted state for follow-up Anthropic turns.
- Propagate in-stream provider errors, map context-window exhaustion and refusals accurately, and retain Anthropic response metadata.
- Add regressions for late-only gateway usage, repeated cumulative deltas, nonzero message-start output, cache buckets, output-to-follow-up replay, provider errors, finish reasons, and final native event snapshots.
- Keep the original end-to-end gateway verification: fresh and hot Bedrock cache calls report the provider-billed cache-write and cache-read fields.

Related upstream work: langchain-ai/langchainjs#11195 remains open and does not yet cover cumulative native output usage or replay safety.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run build`
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/llm/anthropic/types.ts src/llm/anthropic/index.ts src/llm/anthropic/utils/message_inputs.ts src/llm/anthropic/utils/message_outputs.ts src/llm/anthropic/utils/stream_events.ts`
- Passed 121 focused Anthropic tests across eight suites, including all 40 native stream-event cases.
- Ran live Claude legacy streaming, prompt-cache creation/read, native event streaming, and a signed-thinking output-to-follow-up round trip against the main-worktree `.env` credentials.
- Confirmed a native live stream with nonzero message-start output (`2`) and final cumulative output (`13`) assembled to `13`, retained `model_provider: anthropic`, and reconciled its total.
- Confirmed a live signed-thinking native stream assembled replayable output, completed a follow-up Anthropic request, and reported `57` input / `59` output / `116` total tokens.
- Confirmed all 13 GitHub Actions CI jobs pass on `dd26e5c1`.

### **Test Configuration**:

- Node 24
- `claude-haiku-4-5-20251001` and `claude-sonnet-4-5-20250929`
- GitHub Actions CI on the pull-request head

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
