### PR TITLE
🩹 fix: Drop Null/Empty Reasoning Blocks in the v1 Bedrock Converter

### DIFF
--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -234,24 +234,26 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
   });
 
   it('merges split v1 reasoning_content text and signature blocks before serialization', () => {
+    const splitContent = [
+      {
+        type: 'reasoning_content',
+        reasoningText: { text: 'first ' },
+      },
+      {
+        type: 'reasoning_content',
+        reasoningText: { text: 'second' },
+      },
+      {
+        type: 'reasoning_content',
+        reasoningText: { signature: 'sig-abc' },
+      },
+      { type: 'text', text: 'answer' },
+    ];
+    const originalContent = structuredClone(splitContent);
     const messages: BaseMessage[] = [
       new HumanMessage('hi'),
       new AIMessage({
-        content: [
-          {
-            type: 'reasoning_content',
-            reasoningText: { text: 'first ' },
-          },
-          {
-            type: 'reasoning_content',
-            reasoningText: { text: 'second' },
-          },
-          {
-            type: 'reasoning_content',
-            reasoningText: { signature: 'sig-abc' },
-          },
-          { type: 'text', text: 'answer' },
-        ],
+        content: splitContent,
         response_metadata: v1Metadata,
       }),
     ];
@@ -263,9 +265,10 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
       text: 'first second',
       signature: 'sig-abc',
     });
+    expect(splitContent).toEqual(originalContent);
   });
 
-  it('does not replace unhandled v1 content with the empty-turn placeholder', () => {
+  it('throws instead of returning empty assistant content for an unhandled v1 block', () => {
     const messages: BaseMessage[] = [
       new HumanMessage('hi'),
       new AIMessage({
@@ -281,8 +284,9 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
       }),
     ];
 
-    const content = assistantContent(convertToConverseMessages(messages));
-    expect(content).toEqual([]);
+    expect(() => convertToConverseMessages(messages)).toThrow(
+      'Unsupported v1 content block type: image'
+    );
   });
 
   it('still converts v1 reasoning and reasoning_content blocks that carry text', () => {

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -233,6 +233,58 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
     expect(content.every((b) => typeof b.text === 'string')).toBe(true);
   });
 
+  it('merges split v1 reasoning_content text and signature blocks before serialization', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: 'first ' },
+          },
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: 'second' },
+          },
+          {
+            type: 'reasoning_content',
+            reasoningText: { signature: 'sig-abc' },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    const reasoning = content.filter((b) => b.reasoningContent != null);
+    expect(reasoning).toHaveLength(1);
+    expect(reasoning[0].reasoningContent?.reasoningText).toEqual({
+      text: 'first second',
+      signature: 'sig-abc',
+    });
+  });
+
+  it('does not replace unhandled v1 content with the empty-turn placeholder', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'image',
+            source_type: 'base64',
+            data: 'aGVsbG8=',
+            mime_type: 'image/png',
+          } as never,
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content).toEqual([]);
+  });
+
   it('still converts v1 reasoning and reasoning_content blocks that carry text', () => {
     const messages: BaseMessage[] = [
       new HumanMessage('hi'),

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -233,6 +233,38 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
     expect(content.every((b) => typeof b.text === 'string')).toBe(true);
   });
 
+  it.each(['', ' \n '])(
+    'emits a placeholder for invalid v1 text %j',
+    (text) => {
+      const messages: BaseMessage[] = [
+        new HumanMessage('hi'),
+        new AIMessage({
+          content: [{ type: 'text', text }],
+          response_metadata: v1Metadata,
+        }),
+      ];
+
+      const content = assistantContent(convertToConverseMessages(messages));
+      expect(content).toEqual([{ text: '_' }]);
+    }
+  );
+
+  it('merges whitespace-only v1 text into the preceding text block', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'answer' },
+          { type: 'text', text: ' \n ' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content).toEqual([{ text: 'answer \n ' }]);
+  });
+
   it('merges split v1 reasoning_content text and signature blocks before serialization', () => {
     const splitContent = [
       {

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -300,6 +300,36 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
     expect(splitContent).toEqual(originalContent);
   });
 
+  it('keeps independently signed v1 reasoning blocks separate', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: 'first', signature: 'sig-first' },
+          },
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: 'second', signature: 'sig-second' },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(
+      content
+        .filter((block) => block.reasoningContent != null)
+        .map((block) => block.reasoningContent?.reasoningText)
+    ).toEqual([
+      { text: 'first', signature: 'sig-first' },
+      { text: 'second', signature: 'sig-second' },
+    ]);
+  });
+
   it('throws instead of returning empty assistant content for an unhandled v1 block', () => {
     const messages: BaseMessage[] = [
       new HumanMessage('hi'),

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -127,3 +127,136 @@ describe('convertToConverseMessages — native Bedrock reasoning serialization',
     );
   });
 });
+
+/**
+ * Same failure class, v1 converter path. Assistant messages carrying
+ * `response_metadata.output_version === 'v1'` are converted by
+ * `convertFromV1ToChatBedrockConverseMessage`, which serialized `reasoning` /
+ * `reasoning_content` blocks without the null/empty-text guard applied to the
+ * non-v1 path — a `reasoning` block whose `reasoning` is null/empty (e.g. a
+ * model responding with `thinking.display: "omitted"`, the Opus 4.7+ /
+ * Sonnet 5 default) reached Bedrock as `reasoningText: { text: null }` and the
+ * whole request was rejected with `Member must not be null`.
+ */
+describe('convertToConverseMessages — v1 reasoning serialization', () => {
+  const v1Metadata = {
+    output_version: 'v1',
+    model_provider: 'anthropic',
+  } as const;
+
+  it('drops a v1 reasoning block whose reasoning text is missing, keeping text and tool calls', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('what data do you have?'),
+      new AIMessage({
+        content: [
+          { type: 'reasoning', reasoning: undefined } as never,
+          { type: 'text', text: 'Let me check your databases.' },
+        ],
+        tool_calls: [
+          {
+            id: 'tooluse_list',
+            name: 'list_databases',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(content.some((b) => b.text === 'Let me check your databases.')).toBe(
+      true
+    );
+    const toolUse = content.find((b) => b.toolUse != null);
+    expect(toolUse?.toolUse).toMatchObject({
+      toolUseId: 'tooluse_list',
+      name: 'list_databases',
+    });
+  });
+
+  it('drops a v1 reasoning block whose reasoning text is empty', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          { type: 'reasoning', reasoning: '' },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(content.some((b) => b.text === 'answer')).toBe(true);
+  });
+
+  it('drops a v1 signature-only reasoning_content block', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'reasoning_content',
+            reasoningText: { signature: 'sig-abc' },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(JSON.stringify(content)).not.toContain('sig-abc');
+    expect(content.some((b) => b.text === 'answer')).toBe(true);
+  });
+
+  it('emits a placeholder (not empty content) when dropping empties a v1 turn', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [{ type: 'reasoning', reasoning: undefined } as never],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.find((b) => b.reasoningContent != null)).toBeUndefined();
+    expect(content.every((b) => typeof b.text === 'string')).toBe(true);
+  });
+
+  it('still converts v1 reasoning and reasoning_content blocks that carry text', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          { type: 'reasoning', reasoning: 'v1 standard reasoning' },
+          {
+            type: 'reasoning_content',
+            reasoningText: { text: 'native reasoning', signature: 'sig' },
+          },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    const reasoningTexts = content
+      .filter((b) => b.reasoningContent != null)
+      .map((b) => b.reasoningContent?.reasoningText?.text);
+    expect(reasoningTexts).toEqual([
+      'v1 standard reasoning',
+      'native reasoning',
+    ]);
+    expect(content.some((b) => b.text === 'answer')).toBe(true);
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -15,7 +15,10 @@ type ConverseResult = ReturnType<typeof convertToConverseMessages>;
 /** Minimal view of a converted Bedrock Converse content block the assertions read. */
 interface ConverseBlock {
   text?: string;
-  reasoningContent?: { reasoningText?: { text?: string; signature?: string } };
+  reasoningContent?: {
+    reasoningText?: { text?: string; signature?: string };
+    redactedContent?: Uint8Array;
+  };
   toolUse?: {
     toolUseId?: string;
     name?: string;
@@ -328,6 +331,27 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
       { text: 'first', signature: 'sig-first' },
       { text: 'second', signature: 'sig-second' },
     ]);
+  });
+
+  it('keeps adjacent redacted v1 reasoning payloads separate', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          { type: 'reasoning_content', redactedContent: 'YQ==' },
+          { type: 'reasoning_content', redactedContent: 'Yg==' },
+          { type: 'text', text: 'answer' },
+        ],
+        response_metadata: v1Metadata,
+      }),
+    ];
+
+    const content = assistantContent(convertToConverseMessages(messages));
+    const redacted = content
+      .map((block) => block.reasoningContent?.redactedContent)
+      .filter((value): value is Uint8Array => value != null)
+      .map((value) => Buffer.from(value).toString('utf8'));
+    expect(redacted).toEqual(['a', 'b']);
   });
 
   it('throws instead of returning empty assistant content for an unhandled v1 block', () => {

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -132,7 +132,12 @@ export function concatenateLangchainReasoningBlocks(
         }
       }
 
-      result.push({ ...block } as MessageContentReasoningBlock);
+      result.push({
+        ...currentReasoning,
+        ...(currentReasoning.reasoningText == null
+          ? {}
+          : { reasoningText: { ...currentReasoning.reasoningText } }),
+      });
     } else {
       result.push(block);
     }
@@ -762,7 +767,7 @@ function convertFromV1ToChatBedrockConverseMessage(
     content: [],
   };
   let droppedUnserializableReasoning = false;
-  let hasUnconvertedContent = false;
+  let unconvertedContentType: string | undefined;
 
   if (Array.isArray(msg.content)) {
     const concatenatedBlocks = concatenateLangchainReasoningBlocks(
@@ -811,7 +816,7 @@ function convertFromV1ToChatBedrockConverseMessage(
             langchainReasoningBlockToBedrockReasoningBlock(reasoningBlock),
         } as BedrockContentBlock);
       } else {
-        hasUnconvertedContent = true;
+        unconvertedContentType ??= block.type;
       }
     }
   } else if (typeof msg.content === 'string' && msg.content !== '') {
@@ -842,11 +847,14 @@ function convertFromV1ToChatBedrockConverseMessage(
     }
   }
 
-  if (
-    (assistantMsg.content == null || assistantMsg.content.length === 0) &&
-    droppedUnserializableReasoning &&
-    !hasUnconvertedContent
-  ) {
+  const hasNoContent =
+    assistantMsg.content == null || assistantMsg.content.length === 0;
+  if (hasNoContent && unconvertedContentType != null) {
+    throw new Error(
+      `Unsupported v1 content block type: ${unconvertedContentType}`
+    );
+  }
+  if (hasNoContent && droppedUnserializableReasoning) {
     assistantMsg.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
   }
 

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -88,6 +88,29 @@ function isSerializableBedrockReasoningBlock(
   return content.redactedContent != null && content.redactedContent !== '';
 }
 
+function appendSerializableBedrockTextBlock(
+  contentBlocks: BedrockContentBlock[],
+  text: string
+): boolean {
+  if (text === '') {
+    return false;
+  }
+  const cleanedText = text.replace(/\n/g, '').trim();
+  if (cleanedText !== '') {
+    contentBlocks.push({ text });
+    return true;
+  }
+  const lastBlock = contentBlocks[contentBlocks.length - 1] as
+    | BedrockContentBlock
+    | undefined;
+  if (lastBlock == null || !('text' in lastBlock)) {
+    return false;
+  }
+  const mergedTextContent = `${lastBlock.text}${text}`;
+  (lastBlock as { text: string }).text = mergedTextContent;
+  return true;
+}
+
 /**
  * Concatenate consecutive reasoning blocks in content array.
  */
@@ -671,23 +694,7 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
     concatenatedBlocks.forEach((block) => {
       if (block.type === 'text') {
         const text = (block as { text?: string }).text ?? '';
-        // Skip completely empty text blocks (common in AI messages with tool_use blocks)
-        if (text === '') {
-          return;
-        }
-        // Merge whitespace/newlines with previous text blocks to avoid validation errors.
-        const cleanedText = text.replace(/\n/g, '').trim();
-        if (cleanedText === '') {
-          if (contentBlocks.length > 0) {
-            const lastBlock = contentBlocks[contentBlocks.length - 1];
-            if ('text' in lastBlock) {
-              const mergedTextContent = `${lastBlock.text}${text}`;
-              (lastBlock as { text: string }).text = mergedTextContent;
-            }
-          }
-        } else {
-          contentBlocks.push({ text });
-        }
+        appendSerializableBedrockTextBlock(contentBlocks, text);
       } else if (block.type === 'reasoning_content') {
         const reasoningBlock = block as MessageContentReasoningBlock;
         // Bedrock Converse rejects reasoningContent whose reasoningText.text is
@@ -762,11 +769,12 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
 function convertFromV1ToChatBedrockConverseMessage(
   msg: BaseMessage
 ): BedrockMessage {
+  const contentBlocks: BedrockContentBlock[] = [];
   const assistantMsg: BedrockMessage = {
     role: 'assistant',
-    content: [],
+    content: contentBlocks,
   };
-  let droppedUnserializableReasoning = false;
+  let droppedUnserializableContent = false;
   let unconvertedContentType: string | undefined;
 
   if (Array.isArray(msg.content)) {
@@ -775,16 +783,21 @@ function convertFromV1ToChatBedrockConverseMessage(
     );
     for (const block of concatenatedBlocks) {
       if (typeof block === 'string') {
-        assistantMsg.content?.push({ text: block });
+        if (!appendSerializableBedrockTextBlock(contentBlocks, block)) {
+          droppedUnserializableContent = true;
+        }
       } else if (block.type === 'text') {
-        assistantMsg.content?.push({ text: (block as { text: string }).text });
+        const text = (block as { text?: string }).text ?? '';
+        if (!appendSerializableBedrockTextBlock(contentBlocks, text)) {
+          droppedUnserializableContent = true;
+        }
       } else if (block.type === 'tool_call') {
         const toolCall = block as {
           id: string;
           name: string;
           args: Record<string, unknown>;
         };
-        assistantMsg.content?.push({
+        contentBlocks.push({
           toolUse: {
             toolUseId: toolCall.id,
             name: toolCall.name,
@@ -797,10 +810,10 @@ function convertFromV1ToChatBedrockConverseMessage(
          * (`Member must not be null`), e.g. when the producing model omitted
          * reasoning text (`thinking.display: "omitted"`) — drop rather than send. */
         if (reasoning.reasoning == null || reasoning.reasoning === '') {
-          droppedUnserializableReasoning = true;
+          droppedUnserializableContent = true;
           continue;
         }
-        assistantMsg.content?.push({
+        contentBlocks.push({
           reasoningContent: {
             reasoningText: { text: reasoning.reasoning },
           },
@@ -808,10 +821,10 @@ function convertFromV1ToChatBedrockConverseMessage(
       } else if (block.type === 'reasoning_content') {
         const reasoningBlock = block as MessageContentReasoningBlock;
         if (!isSerializableBedrockReasoningBlock(reasoningBlock)) {
-          droppedUnserializableReasoning = true;
+          droppedUnserializableContent = true;
           continue;
         }
-        assistantMsg.content?.push({
+        contentBlocks.push({
           reasoningContent:
             langchainReasoningBlockToBedrockReasoningBlock(reasoningBlock),
         } as BedrockContentBlock);
@@ -819,24 +832,24 @@ function convertFromV1ToChatBedrockConverseMessage(
         unconvertedContentType ??= block.type;
       }
     }
-  } else if (typeof msg.content === 'string' && msg.content !== '') {
-    assistantMsg.content?.push({ text: msg.content });
+  } else if (typeof msg.content === 'string') {
+    if (!appendSerializableBedrockTextBlock(contentBlocks, msg.content)) {
+      droppedUnserializableContent = true;
+    }
   }
 
   // Also handle tool_calls from the message
   if (isAIMessage(msg) && msg.tool_calls != null && msg.tool_calls.length > 0) {
     // Check if tool calls are already in content
     const existingToolUseIds = new Set(
-      assistantMsg.content
-        ?.filter((c) => 'toolUse' in c)
-        .map(
-          (c) => (c as { toolUse: { toolUseId: string } }).toolUse.toolUseId
-        ) ?? []
+      contentBlocks
+        .filter((c) => 'toolUse' in c)
+        .map((c) => (c as { toolUse: { toolUseId: string } }).toolUse.toolUseId)
     );
 
     for (const tc of msg.tool_calls) {
       if (!existingToolUseIds.has(tc.id ?? '')) {
-        assistantMsg.content?.push({
+        contentBlocks.push({
           toolUse: {
             toolUseId: tc.id,
             name: tc.name,
@@ -847,15 +860,14 @@ function convertFromV1ToChatBedrockConverseMessage(
     }
   }
 
-  const hasNoContent =
-    assistantMsg.content == null || assistantMsg.content.length === 0;
+  const hasNoContent = contentBlocks.length === 0;
   if (hasNoContent && unconvertedContentType != null) {
     throw new Error(
       `Unsupported v1 content block type: ${unconvertedContentType}`
     );
   }
-  if (hasNoContent && droppedUnserializableReasoning) {
-    assistantMsg.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
+  if (hasNoContent && droppedUnserializableContent) {
+    contentBlocks.push({ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER });
   }
 
   return assistantMsg;

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -137,10 +137,6 @@ export function concatenateLangchainReasoningBlocks(
 
     const currentReasoning = block as MessageContentReasoningBlock;
     if (currentReasoning.reasoningText != null) {
-      if (pendingReasoning?.redactedContent != null) {
-        flushPendingReasoning();
-      }
-
       const previousText = pendingReasoning?.reasoningText?.text;
       const previousSignature = pendingReasoning?.reasoningText?.signature;
       const { text, signature } = currentReasoning.reasoningText;
@@ -165,15 +161,11 @@ export function concatenateLangchainReasoningBlocks(
     }
 
     if (currentReasoning.redactedContent != null) {
-      if (pendingReasoning?.reasoningText != null) {
-        flushPendingReasoning();
-      }
-      pendingReasoning = {
+      flushPendingReasoning();
+      result.push({
         type: 'reasoning_content',
-        redactedContent:
-          (pendingReasoning?.redactedContent ?? '') +
-          currentReasoning.redactedContent,
-      };
+        redactedContent: currentReasoning.redactedContent,
+      });
     }
   }
 

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -784,17 +784,26 @@ function convertFromV1ToChatBedrockConverseMessage(
           },
         } as BedrockContentBlock);
       } else if (block.type === 'reasoning') {
-        const reasoning = block as { reasoning: string };
+        const reasoning = block as { reasoning?: string };
+        /** Bedrock Converse rejects `reasoningText` with a null/empty `text`
+         * (`Member must not be null`), e.g. when the producing model omitted
+         * reasoning text (`thinking.display: "omitted"`) — drop rather than send. */
+        if (reasoning.reasoning == null || reasoning.reasoning === '') {
+          continue;
+        }
         assistantMsg.content?.push({
           reasoningContent: {
             reasoningText: { text: reasoning.reasoning },
           },
         } as BedrockContentBlock);
       } else if (block.type === 'reasoning_content') {
+        const reasoningBlock = block as MessageContentReasoningBlock;
+        if (!isSerializableBedrockReasoningBlock(reasoningBlock)) {
+          continue;
+        }
         assistantMsg.content?.push({
-          reasoningContent: langchainReasoningBlockToBedrockReasoningBlock(
-            block as MessageContentReasoningBlock
-          ),
+          reasoningContent:
+            langchainReasoningBlockToBedrockReasoningBlock(reasoningBlock),
         } as BedrockContentBlock);
       }
     }
@@ -824,6 +833,10 @@ function convertFromV1ToChatBedrockConverseMessage(
         } as BedrockContentBlock);
       }
     }
+  }
+
+  if (assistantMsg.content == null || assistantMsg.content.length === 0) {
+    assistantMsg.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
   }
 
   return assistantMsg;

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -119,53 +119,65 @@ export function concatenateLangchainReasoningBlocks(
 ): Array<MessageContentComplex | MessageContentReasoningBlock> {
   const result: Array<MessageContentComplex | MessageContentReasoningBlock> =
     [];
+  let pendingReasoning: MessageContentReasoningBlock | undefined;
+
+  const flushPendingReasoning = (): void => {
+    if (pendingReasoning != null) {
+      result.push(pendingReasoning);
+      pendingReasoning = undefined;
+    }
+  };
 
   for (const block of content) {
-    if (block.type === 'reasoning_content') {
-      const currentReasoning = block as MessageContentReasoningBlock;
-      const lastIndex = result.length - 1;
+    if (block.type !== 'reasoning_content') {
+      flushPendingReasoning();
+      result.push(block);
+      continue;
+    }
 
-      // Check if we can merge with the previous block
-      if (lastIndex >= 0) {
-        const lastBlock = result[lastIndex];
-        if (
-          lastBlock.type === 'reasoning_content' &&
-          (lastBlock as MessageContentReasoningBlock).reasoningText != null &&
-          currentReasoning.reasoningText != null
-        ) {
-          const lastReasoning = lastBlock as MessageContentReasoningBlock;
-          // Merge consecutive reasoning text blocks
-          const lastText = lastReasoning.reasoningText?.text;
-          const currentText = currentReasoning.reasoningText.text;
-          if (
-            lastText != null &&
-            lastText !== '' &&
-            currentText != null &&
-            currentText !== ''
-          ) {
-            lastReasoning.reasoningText!.text = lastText + currentText;
-          } else if (
-            currentReasoning.reasoningText.signature != null &&
-            currentReasoning.reasoningText.signature !== ''
-          ) {
-            lastReasoning.reasoningText!.signature =
-              currentReasoning.reasoningText.signature;
-          }
-          continue;
-        }
+    const currentReasoning = block as MessageContentReasoningBlock;
+    if (currentReasoning.reasoningText != null) {
+      if (pendingReasoning?.redactedContent != null) {
+        flushPendingReasoning();
       }
 
-      result.push({
-        ...currentReasoning,
-        ...(currentReasoning.reasoningText == null
-          ? {}
-          : { reasoningText: { ...currentReasoning.reasoningText } }),
-      });
-    } else {
-      result.push(block);
+      const previousText = pendingReasoning?.reasoningText?.text;
+      const previousSignature = pendingReasoning?.reasoningText?.signature;
+      const { text, signature } = currentReasoning.reasoningText;
+      const mergedReasoningText: { text?: string; signature?: string } = {};
+      if (previousText !== undefined || text !== undefined) {
+        mergedReasoningText.text = (previousText ?? '') + (text ?? '');
+      }
+      if (previousSignature !== undefined || signature !== undefined) {
+        mergedReasoningText.signature =
+          (previousSignature ?? '') + (signature ?? '');
+      }
+      pendingReasoning = {
+        type: 'reasoning_content',
+        reasoningText: mergedReasoningText,
+      };
+
+      // A signature seals the accumulated reasoning text. Any following
+      // reasoning block starts a new independently signed Bedrock block.
+      if ('signature' in currentReasoning.reasoningText) {
+        flushPendingReasoning();
+      }
+    }
+
+    if (currentReasoning.redactedContent != null) {
+      if (pendingReasoning?.reasoningText != null) {
+        flushPendingReasoning();
+      }
+      pendingReasoning = {
+        type: 'reasoning_content',
+        redactedContent:
+          (pendingReasoning?.redactedContent ?? '') +
+          currentReasoning.redactedContent,
+      };
     }
   }
 
+  flushPendingReasoning();
   return result;
 }
 

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -761,11 +761,14 @@ function convertFromV1ToChatBedrockConverseMessage(
     role: 'assistant',
     content: [],
   };
+  let droppedUnserializableReasoning = false;
+  let hasUnconvertedContent = false;
 
   if (Array.isArray(msg.content)) {
-    for (const block of msg.content as Array<
-      MessageContentComplex | MessageContentReasoningBlock
-    >) {
+    const concatenatedBlocks = concatenateLangchainReasoningBlocks(
+      msg.content as Array<MessageContentComplex | MessageContentReasoningBlock>
+    );
+    for (const block of concatenatedBlocks) {
       if (typeof block === 'string') {
         assistantMsg.content?.push({ text: block });
       } else if (block.type === 'text') {
@@ -789,6 +792,7 @@ function convertFromV1ToChatBedrockConverseMessage(
          * (`Member must not be null`), e.g. when the producing model omitted
          * reasoning text (`thinking.display: "omitted"`) — drop rather than send. */
         if (reasoning.reasoning == null || reasoning.reasoning === '') {
+          droppedUnserializableReasoning = true;
           continue;
         }
         assistantMsg.content?.push({
@@ -799,12 +803,15 @@ function convertFromV1ToChatBedrockConverseMessage(
       } else if (block.type === 'reasoning_content') {
         const reasoningBlock = block as MessageContentReasoningBlock;
         if (!isSerializableBedrockReasoningBlock(reasoningBlock)) {
+          droppedUnserializableReasoning = true;
           continue;
         }
         assistantMsg.content?.push({
           reasoningContent:
             langchainReasoningBlockToBedrockReasoningBlock(reasoningBlock),
         } as BedrockContentBlock);
+      } else {
+        hasUnconvertedContent = true;
       }
     }
   } else if (typeof msg.content === 'string' && msg.content !== '') {
@@ -835,7 +842,11 @@ function convertFromV1ToChatBedrockConverseMessage(
     }
   }
 
-  if (assistantMsg.content == null || assistantMsg.content.length === 0) {
+  if (
+    (assistantMsg.content == null || assistantMsg.content.length === 0) &&
+    droppedUnserializableReasoning &&
+    !hasUnconvertedContent
+  ) {
     assistantMsg.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
   }
 


### PR DESCRIPTION
## Problem

#248 guarded the native-Bedrock converter (`convertAIMessageToConverseMessage`) against reasoning blocks whose `reasoningText.text` is null/empty, but the **v1 converter** (`convertFromV1ToChatBedrockConverseMessage`, taken when `response_metadata.output_version === 'v1'`) still serializes reasoning unguarded in both of its branches:

```ts
} else if (block.type === 'reasoning') {
  const reasoning = block as { reasoning: string };
  assistantMsg.content?.push({
    reasoningContent: { reasoningText: { text: reasoning.reasoning } }, // ← no null/empty check
  } as BedrockContentBlock);
} else if (block.type === 'reasoning_content') {
  assistantMsg.content?.push({
    reasoningContent: langchainReasoningBlockToBedrockReasoningBlock(block), // ← no isSerializableBedrockReasoningBlock guard
  } as BedrockContentBlock);
}
```

A v1 `reasoning` block whose `reasoning` is null/empty — e.g. produced by a model that omits reasoning text by default (`thinking.display: "omitted"`, the default on Claude Opus 4.7+ / Sonnet 5) — reaches Bedrock as `reasoningText: { text: null }` and the whole request is rejected:

```
1 validation error detected: Value at 'messages.N.member.content.M.member.reasoningContent.reasoningText.text'
failed to satisfy constraint: Member must not be null
```

We hit exactly this in a LibreChat deployment: Bedrock `anthropic.claude-sonnet-5` + MCP tools fails on the tool-call replay turn with the error above. It is the same failure class #248 fixed — #248's "Scope / remaining gap" section covers the non-streaming `@langchain/aws` delegation but not this v1 path in the same file, which is still unguarded on `main` / 3.2.63.

## Fix

Apply #248's drop-the-unsendable-block approach to the v1 converter:

- `reasoning` (v1 standard block): drop when `reasoning` is null/empty.
- `reasoning_content`: gate on the existing `isSerializableBedrockReasoningBlock` before converting, same as the non-v1 path.
- Add the `BEDROCK_EMPTY_TEXT_PLACEHOLDER` fallback (from #243) when the drop leaves a turn with no content blocks and no tool calls — mirroring the non-v1 converter, so the drop can't trade the null-text 400 for an empty-content 400.

Blocks carrying real text (or redacted content) are converted unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Test-first: added a `convertToConverseMessages — v1 reasoning serialization` describe block to `message_inputs.test.ts` (5 cases; 4 fail without the fix, reproducing `reasoningText: { text: undefined }` passing through):

- v1 `reasoning` block with missing `reasoning` → dropped; sibling text + tool calls survive
- v1 `reasoning` block with empty `reasoning` → dropped
- v1 signature-only `reasoning_content` block → dropped
- v1 turn emptied by the drop → placeholder emitted, not empty content
- v1 `reasoning` / `reasoning_content` blocks carrying real text → still converted (not over-dropped)

### **Test Configuration**:

- `npx jest src/llm/bedrock`: 9 suites / 106 passed, 4 skipped, 0 failed
- Wider `npx jest src/llm src/messages`: only failures are 4 pre-existing env-dependent suites (`invoke`, `google`, `anthropic`, `vertexai`) that fail identically on a clean `main` checkout without this change
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` on changed files: clean
- Verification is unit-level; no live Bedrock run was performed for this PR (the production error above is from a real deployment, and the raw-Converse repro in #248 already demonstrates Bedrock's rejection of null-text reasoning blocks)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
