### PR TITLE
fix: guard StandardGraph content accessors against disposed graphs

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1130,6 +1130,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /* Misc.*/
 
   getRunMessages(): BaseMessage[] | undefined {
+    if (this.messages == null) {
+      return this.cachedRunMessages;
+    }
     if (this.messages.length === 0 && this.cachedRunMessages != null) {
       return this.cachedRunMessages;
     }
@@ -1137,6 +1140,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   }
 
   getContentParts(): t.MessageContentComplex[] | undefined {
+    // `messages` can be null/undefined on a graph that has been disposed
+    // (clearHeavyState) but is still reachable via a cache (e.g. RedisJobStore's
+    // WeakRef) during a HITL resume/reconnect. Guard instead of dereferencing null.
+    if (this.messages == null) {
+      return undefined;
+    }
     return convertMessagesToContent(this.messages.slice(this.startIndex));
   }
 
@@ -1169,6 +1178,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * Get all run steps, optionally filtered by agent ID
    */
   getRunSteps(agentId?: string): t.RunStep[] {
+    // `contentData` can be null/undefined on a disposed-but-cached graph during a
+    // HITL resume/reconnect; without this guard `[...this.contentData]` throws
+    // "this.contentData is not iterable".
+    if (this.contentData == null) {
+      return [];
+    }
     if (agentId == null || agentId === '') {
       return [...this.contentData];
     }


### PR DESCRIPTION
## Summary
`StandardGraph.getContentParts()`, `getRunMessages()` and `getRunSteps()`
dereference `this.messages` / `this.contentData` without a null check. A graph
that has been disposed via `clearHeavyState()` but is still reachable (e.g. a
host that caches the graph behind a `WeakRef` and re-reads it on a HITL
resume/reconnect) has these arrays nulled out, so the accessors throw:

- `Cannot read properties of null (reading 'slice')` (getContentParts / getRunMessages)
- `this.contentData is not iterable` (getRunSteps)

## Changes
- `getContentParts()` returns `undefined` when `messages` is null.
- `getRunMessages()` falls back to `cachedRunMessages` when `messages` is null.
- `getRunSteps()` returns `[]` when `contentData` is null.

No behavior change for a live graph; this only makes the accessors safe to call
on a disposed-but-cached instance.

## Test plan
- Existing graph unit tests pass.
- Reproduced downstream in LibreChat: `ask_user_question` resume no longer throws
  `reading 'slice'` / `contentData is not iterable`.


## Related
https://github.com/danny-avila/LibreChat/pull/14254