### PR TITLE
fix: forward event tools through nested agents

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -96,6 +96,18 @@ const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
+function createToolHandlerRegistry(
+  source: HandlerRegistry | undefined
+): HandlerRegistry | undefined {
+  const toolHandler = source?.getHandler(GraphEvents.ON_TOOL_EXECUTE);
+  if (toolHandler == null) {
+    return undefined;
+  }
+  const registry = new HandlerRegistry();
+  registry.register(GraphEvents.ON_TOOL_EXECUTE, toolHandler);
+  return registry;
+}
+
 /**
  * Start index of the span post-prune formatters can mutate in place: the
  * trailing tool batch plus its owning AI message (artifact formatting touches
@@ -2396,7 +2408,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
-            const toolHandlerRegistry = getParentHandlerRegistry();
+            const toolHandlerRegistry = createToolHandlerRegistry(
+              getParentHandlerRegistry()
+            );
             childGraph.hookRegistry = this.hookRegistry;
             /**
              * Do not propagate `humanInTheLoop` into the child graph yet:
@@ -2421,8 +2435,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             childGraph.toolExecution = this.toolExecution;
             childGraph.parentToolHandlerRegistry = toolHandlerRegistry;
             childGraph.eventToolExecutionAvailable =
-              toolHandlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
-              null;
+              toolHandlerRegistry != null;
             return childGraph;
           },
         });

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -576,6 +576,8 @@ export abstract class Graph<
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
   handlerRegistry: HandlerRegistry | undefined;
+  /** Host registry retained only for forwarding tools from nested child graphs. */
+  protected parentToolHandlerRegistry: HandlerRegistry | undefined;
   /**
    * True when event-driven tool execution can be routed through callbacks even
    * though this graph intentionally does not own the full handler registry.
@@ -661,6 +663,7 @@ export abstract class Graph<
     this.prelimMessageIdsByStepKey = new Map();
     this.invokedToolIds = undefined;
     this.handlerRegistry = undefined;
+    this.parentToolHandlerRegistry = undefined;
     this.hookRegistry = undefined;
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
@@ -2376,7 +2379,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       );
       if (resolvedConfigs.length > 0) {
         const getParentHandlerRegistry = (): HandlerRegistry | undefined =>
-          this.handlerRegistry;
+          this.handlerRegistry ?? this.parentToolHandlerRegistry;
         const executor = new SubagentExecutor({
           configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
           parentSignal: this.signal,
@@ -2393,6 +2396,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
+            const toolHandlerRegistry = getParentHandlerRegistry();
             childGraph.hookRegistry = this.hookRegistry;
             /**
              * Do not propagate `humanInTheLoop` into the child graph yet:
@@ -2415,8 +2419,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             // have the executable graphTool, the guard correctly applies.
             childGraph.interruptingToolNames = this.interruptingToolNames;
             childGraph.toolExecution = this.toolExecution;
+            childGraph.parentToolHandlerRegistry = toolHandlerRegistry;
             childGraph.eventToolExecutionAvailable =
-              this.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
+              toolHandlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
               null;
             return childGraph;
           },

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -326,6 +326,7 @@ describe('Subagent Integration', () => {
         );
       }
     );
+    const parentUpdateHandler = jest.fn();
     let specialistToolDefinitions: t.LCTool[] | undefined;
     let forwardedToolResults: t.ToolExecuteResult[] | undefined;
 
@@ -391,6 +392,11 @@ describe('Subagent Integration', () => {
                     );
                   }
                 );
+                await forwarder.handleCustomEvent(
+                  GraphEvents.ON_RUN_STEP,
+                  { id: 'specialist-step', type: 'tool_calls' },
+                  'specialist-run'
+                );
               }
               return { messages: [new AIMessage('specialist done')] };
             }),
@@ -447,6 +453,9 @@ describe('Subagent Integration', () => {
         graphConfig: { type: 'standard', agents: [rootAgent] },
         customHandlers: {
           [GraphEvents.ON_TOOL_EXECUTE]: { handle: parentToolHandler },
+          [GraphEvents.ON_SUBAGENT_UPDATE]: {
+            handle: parentUpdateHandler,
+          },
         },
         returnContent: true,
         skipCleanup: true,
@@ -473,6 +482,11 @@ describe('Subagent Integration', () => {
           content: 'ran mcp_lookup',
         },
       ]);
+      const forwardedSubagentTypes = parentUpdateHandler.mock.calls.map(
+        ([, data]) => (data as t.SubagentUpdateEvent).subagentType
+      );
+      expect(forwardedSubagentTypes).toContain('router');
+      expect(forwardedSubagentTypes).not.toContain('specialist');
     } finally {
       createWorkflowSpy.mockRestore();
     }

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -312,6 +312,172 @@ describe('Subagent Integration', () => {
     createWorkflowSpy.mockRestore();
   });
 
+  it('forwards event-driven tools through nested child graphs', async () => {
+    const originalCreateWorkflow = StandardGraph.prototype.createWorkflow;
+    const parentToolHandler = jest.fn(
+      (_event: string, rawData: unknown): void => {
+        const request = rawData as t.ToolExecuteBatchRequest;
+        request.resolve(
+          request.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success' as const,
+            content: `ran ${call.name}`,
+          }))
+        );
+      }
+    );
+    let specialistToolDefinitions: t.LCTool[] | undefined;
+    let forwardedToolResults: t.ToolExecuteResult[] | undefined;
+
+    const createWorkflowSpy = jest
+      .spyOn(StandardGraph.prototype, 'createWorkflow')
+      .mockImplementation(function (this: StandardGraph) {
+        const workflow = originalCreateWorkflow.call(this);
+        if (this.defaultAgentId === 'router') {
+          return {
+            invoke: jest.fn(async () => {
+              const routerContext = this.agentContexts.get('router');
+              const nestedTool = (
+                routerContext?.graphTools as t.GenericTool[] | undefined
+              )?.find(
+                (tool) => 'name' in tool && tool.name === Constants.SUBAGENT
+              );
+              if (nestedTool == null) {
+                throw new Error('Nested subagent tool was not created');
+              }
+              await nestedTool.invoke(
+                {
+                  description: 'Use the event-driven lookup tool.',
+                  subagent_type: 'specialist',
+                },
+                callerConfig
+              );
+              return { messages: [new AIMessage('router done')] };
+            }),
+          } as unknown as ReturnType<StandardGraph['createWorkflow']>;
+        }
+        if (this.defaultAgentId === 'specialist') {
+          specialistToolDefinitions =
+            this.agentContexts.get('specialist')?.toolDefinitions;
+          return {
+            invoke: jest.fn(async (_state, options) => {
+              const invokeOptions = options as
+                | { callbacks?: unknown[] }
+                | undefined;
+              const forwarder = (invokeOptions?.callbacks ?? [])[0] as
+                | {
+                    handleCustomEvent?: (
+                      eventName: string,
+                      data: unknown,
+                      runId: string
+                    ) => Promise<void> | void;
+                  }
+                | undefined;
+              if (forwarder?.handleCustomEvent != null) {
+                forwardedToolResults = await new Promise<t.ToolExecuteResult[]>(
+                  (resolve, reject) => {
+                    const request: t.ToolExecuteBatchRequest = {
+                      toolCalls: [
+                        { id: 'nested-call', name: 'mcp_lookup', args: {} },
+                      ],
+                      agentId: 'specialist',
+                      resolve,
+                      reject,
+                    };
+                    void forwarder.handleCustomEvent?.(
+                      GraphEvents.ON_TOOL_EXECUTE,
+                      request,
+                      'specialist-run'
+                    );
+                  }
+                );
+              }
+              return { messages: [new AIMessage('specialist done')] };
+            }),
+          } as unknown as ReturnType<StandardGraph['createWorkflow']>;
+        }
+        return workflow;
+      });
+
+    const rootAgent: t.AgentInputs = {
+      agentId: 'root',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Delegate through the router.',
+      maxContextTokens: 8000,
+      maxSubagentDepth: 2,
+      subagentConfigs: [
+        {
+          type: 'router',
+          name: 'Router',
+          description: 'Routes work to specialists.',
+          allowNested: true,
+          agentInputs: {
+            agentId: 'router',
+            provider: Providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'Delegate to the specialist.',
+            maxContextTokens: 8000,
+            subagentConfigs: [
+              {
+                type: 'specialist',
+                name: 'Specialist',
+                description: 'Uses an event-driven tool.',
+                agentInputs: {
+                  agentId: 'specialist',
+                  provider: Providers.OPENAI,
+                  clientOptions: {
+                    modelName: 'gpt-4o-mini',
+                    apiKey: 'test-key',
+                  },
+                  instructions: 'Use the lookup tool.',
+                  maxContextTokens: 8000,
+                  toolDefinitions: [{ name: 'mcp_lookup' }],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    try {
+      const run = await Run.create<t.IState>({
+        runId: `nested-event-tools-${Date.now()}`,
+        graphConfig: { type: 'standard', agents: [rootAgent] },
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: { handle: parentToolHandler },
+        },
+        returnContent: true,
+        skipCleanup: true,
+      });
+      const rootContext = (run.Graph as StandardGraph).agentContexts.get(
+        'root'
+      );
+      const rootSubagentTool = (
+        rootContext?.graphTools as t.GenericTool[] | undefined
+      )?.find((tool) => 'name' in tool && tool.name === Constants.SUBAGENT);
+      expect(rootSubagentTool).toBeDefined();
+
+      await rootSubagentTool!.invoke(
+        { description: 'Route this task.', subagent_type: 'router' },
+        callerConfig
+      );
+
+      expect(specialistToolDefinitions).toEqual([{ name: 'mcp_lookup' }]);
+      expect(parentToolHandler).toHaveBeenCalledTimes(1);
+      expect(forwardedToolResults).toEqual([
+        {
+          toolCallId: 'nested-call',
+          status: 'success',
+          content: 'ran mcp_lookup',
+        },
+      ]);
+    } finally {
+      createWorkflowSpy.mockRestore();
+    }
+  });
+
   it('should not create subagent tool when maxSubagentDepth is 0', async () => {
     const agentWithZeroDepth: t.AgentInputs = {
       ...createParentAgent(),


### PR DESCRIPTION
## What this fixes

Nested subagents lose host-executed tools after the first delegation level.

For example, a root agent can delegate to a router, which then delegates to a specialist. The router can use event-driven tools, but the specialist cannot: the isolated child graph does not carry forward the host handler needed to execute those tools. The specialist therefore removes the tool definitions and cannot call them.

This affects any root → router → specialist topology using host-executed tools. It is not specific to MCP or any tool provider.

## Change

Carry a derived registry containing only the host's `ON_TOOL_EXECUTE` handler through isolated child graphs. Descendant executors can retain event-driven tool definitions and forward their execution to the original host without receiving any other root handlers.

The child graph does not install the host registry as its own `handlerRegistry`, and it never receives root handlers such as `ON_SUBAGENT_UPDATE`. Child lifecycle and step events therefore cannot bypass the router or attach directly to the root. The tool-only reference is cleared with the other run-scoped state in `clearHeavyState()`.

## Behavior

Before:

`root → router → specialist` → the specialist's host-executed tools are removed and cannot run.

After:

`root → router → specialist` → the tools remain available and their execution reaches the original host handler.

Direct subagents and non-event-driven tools keep their existing behavior.

## Verification

- Added a root → router → specialist regression proving the specialist call reaches the host tool handler.
- The same regression registers `ON_SUBAGENT_UPDATE` and proves router updates remain visible while specialist lifecycle/step events do not bypass the router.
- `npm test -- src/specs/subagent.test.ts --runInBand` — 9 passed
- `npm test -- src/tools/__tests__/SubagentExecutor.test.ts --runInBand` — 78 passed
- `npx tsc --noEmit`
- `npm run build`
- Targeted ESLint: no errors; three pre-existing warnings in unchanged `Graph.ts` lines
- `git diff --check`