### PR TITLE
fix(tools): stateful descriptions promise state the sandbox never keeps

### DIFF
--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -58,17 +58,18 @@ Usage:
 `.trim();
 
 /**
- * Bash statefulness is filesystem-tier: on a warm session the machine (files
- * including /tmp, installed packages, background processes) persists between
- * calls, but each call may start a fresh shell — so shell variables and cwd
- * are NOT reliable, and the machine can be reset at any time. Only /mnt/data
- * is durable.
+ * Bash statefulness is filesystem-tier and scoped to `/mnt/data`. The machine
+ * is warm across calls, but each call runs in a fresh sandbox (new process
+ * tree + private /tmp), so background processes are reaped when the call ends
+ * and anything written outside /mnt/data is discarded. The note must not
+ * promise otherwise: a model told background processes survive will start a
+ * server in one call and assume it is listening in the next.
  */
 export const STATEFUL_BASH_NOTE =
-  'Session state (best-effort): commands in this conversation usually run on the same machine, so files (including /tmp), installed packages, and running background processes from earlier calls typically persist. Each call may still start a fresh shell — do not rely on shell variables or the working directory carrying over — and the machine may be reset at any time. Only /mnt/data is durable.';
+  'Session state: commands in this conversation run on the same warm machine, so files written to /mnt/data persist between calls. Each call runs in a fresh, isolated sandbox: shell variables, the working directory, /tmp, and background processes do NOT survive after the call returns — a process started in one call is terminated when that call ends. Only /mnt/data is durable (the machine itself may also be reset at any time).';
 
 export const StatefulBashExecutionToolDescription = `
-Runs bash commands and returns stdout/stderr output from a session-based execution environment, similar to a long-running machine.
+Runs bash commands and returns stdout/stderr output. Commands in this conversation share one warm machine with a persistent /mnt/data, but each command runs in its own isolated sandbox (not a persistent shell session).
 
 ${STATEFUL_BASH_NOTE}
 
@@ -125,7 +126,7 @@ export function buildBashExecutionToolDescription(options?: {
 const STATELESS_BASH_PARAM_NOTE =
   'The environment is stateless; variables and state don\'t persist between executions.';
 const STATEFUL_BASH_PARAM_NOTE =
-  'Files, installed packages, and background processes usually persist between calls, but each call may start a fresh shell (do not rely on shell variables or cwd) and the machine may reset. Only /mnt/data is durable.';
+  'Files written to /mnt/data persist between calls on the same warm machine. Each call runs in a fresh sandbox: shell variables, cwd, /tmp, and background processes do NOT survive the call. Only /mnt/data is durable.';
 
 export function buildBashExecutionToolSchema(opts?: {
   statefulSessions?: boolean;

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -150,16 +150,18 @@ Usage:
 `.trim();
 
 /**
- * Best-effort statefulness note. Deliberately hedged: warm reuse is an
- * optimization, not a guarantee (the runtime may be reset on idle timeout,
- * eviction, or the 8h VM lifetime), so the model must never depend on carried
- * state for correctness and must persist anything durable to /mnt/data.
+ * Statefulness here is FILESYSTEM-tier, not runtime-tier. Executions in a
+ * session reuse one warm machine, so `/mnt/data` carries across calls — but
+ * every execution is a brand-new interpreter process in a fresh sandbox, so
+ * variables and imports never survive. The note must not imply otherwise: a
+ * model told its in-memory state persists writes `df = ...` in one call and
+ * `df.head()` in the next, then hits a NameError it was told to treat as rare.
  */
 export const STATEFUL_ENV_NOTE =
-  'Session state (best-effort): consecutive executions in this conversation usually share one runtime, so variables, imports, and in-memory data from earlier successful calls are typically still available. The runtime may be reset at any time, so treat carried-over state as an optimization, never a guarantee. Anything that must survive MUST be written to /mnt/data. If a NameError/ImportError signals lost state, re-run the needed setup and continue.';
+  'Session state: executions in this conversation run on the same warm machine, so files persist between calls — but each execution is a NEW process. Variables, imports, and in-memory data NEVER carry over: every call must re-import and rebuild the state it needs. Only /mnt/data is durable (the machine itself may also be reset at any time), so write anything that must survive there and read it back next call.';
 
 export const StatefulCodeExecutionToolDescription = `
-Runs code and returns stdout/stderr output from a session-based execution environment, similar to a long-running command-line session.
+Runs code and returns stdout/stderr output. Executions in this conversation share one warm machine with a persistent /mnt/data, but each execution runs as a separate process (not a notebook-style kernel).
 
 ${STATEFUL_ENV_NOTE}
 
@@ -181,7 +183,7 @@ export function buildCodeExecutionToolDescription(opts?: {
 const STATELESS_CODE_PARAM_NOTE =
   'The environment is stateless; variables and imports don\'t persist between executions.';
 const STATEFUL_CODE_PARAM_NOTE =
-  'Executions in this conversation usually share one runtime: variables and imports from prior successful calls are typically still defined, but the runtime may reset between calls. Rebuild state on NameError/ImportError; persist anything important to /mnt/data.';
+  'Executions in this conversation share one warm machine, so files written to /mnt/data persist between calls. Each execution is a new process: variables and imports do NOT carry over — re-import and reload from /mnt/data every call.';
 
 export function buildCodeExecutionToolSchema(opts?: {
   statefulSessions?: boolean;

--- a/src/tools/__tests__/BashExecutor.test.ts
+++ b/src/tools/__tests__/BashExecutor.test.ts
@@ -65,13 +65,24 @@ describe('buildBashExecutionToolDescription', () => {
       ).toBe(StatefulBashExecutionToolDescription);
     });
 
-    it('hedges: usually-persists but may-reset, and only /mnt/data is durable', () => {
+    /* Filesystem-tier only: each call runs in a fresh sandbox (new process
+     * tree + private /tmp), so background processes are reaped and non-
+     * /mnt/data writes are discarded. The description must not promise
+     * otherwise. */
+    it('promises /mnt/data persistence WITHOUT promising surviving processes or /tmp', () => {
       const d = StatefulBashExecutionToolDescription;
-      expect(d).toContain('usually');
-      expect(d).toContain('may be reset');
+      expect(d).toContain('same warm machine');
       expect(d).toContain('Only /mnt/data is durable');
-      /* filesystem-tier, not shell-variable-tier */
-      expect(d).toContain('do not rely on shell variables');
+      expect(d).toContain('background processes do NOT survive');
+      expect(d).toContain('/tmp');
+    });
+
+    it('never claims /tmp or background processes persist between calls', () => {
+      const d = StatefulBashExecutionToolDescription;
+      expect(d).not.toContain('files (including /tmp)');
+      expect(d).not.toContain(
+        'background processes from earlier calls typically persist'
+      );
     });
 
     it('keeps the artifact-path guidance in both variants', () => {

--- a/src/tools/__tests__/CodeExecutor.stateful.test.ts
+++ b/src/tools/__tests__/CodeExecutor.stateful.test.ts
@@ -41,12 +41,22 @@ describe('CodeExecutor stateful description', () => {
     );
   });
 
-  it('hedges the stateful wording and keeps /mnt/data as the durable store', () => {
+  /* Statefulness is filesystem-tier only: the machine is warm across calls,
+   * but every execution is a new interpreter process, so in-memory state never
+   * carries over. The description must not imply a notebook-style kernel. */
+  it('promises filesystem persistence WITHOUT promising a shared runtime', () => {
     const d = StatefulCodeExecutionToolDescription;
-    expect(d).toContain('usually share one runtime');
-    expect(d).toContain('may be reset at any time');
-    expect(d).toContain('MUST be written to /mnt/data');
+    expect(d).toContain('same warm machine');
+    expect(d).toContain('/mnt/data');
+    expect(d).toContain('NEW process');
+    expect(d).toContain('NEVER carry over');
     expect(d).toContain(CODE_ARTIFACT_PATH_GUIDANCE);
+  });
+
+  it('never claims variables/imports survive between executions', () => {
+    const d = StatefulCodeExecutionToolDescription;
+    expect(d).not.toContain('share one runtime');
+    expect(d).not.toContain('typically still available');
   });
 
   it('adjusts the code-param note per mode', () => {
@@ -55,8 +65,9 @@ describe('CodeExecutor stateful description', () => {
     const stateful = buildCodeExecutionToolSchema({ statefulSessions: true })
       .properties.code.description;
     expect(stateless).toContain('variables and imports don\'t persist');
-    expect(stateful).toContain('typically still defined');
-    expect(stateful).toContain('may reset between calls');
+    expect(stateful).toContain('do NOT carry over');
+    expect(stateful).toContain('/mnt/data');
+    expect(stateful).not.toContain('typically still defined');
   });
 });
 


### PR DESCRIPTION
## Summary

The stateful `execute_code` / `bash_tool` descriptions promise the model in-memory state that the sandbox never keeps. Statefulness here is **filesystem-tier**: a session reuses one warm MicroVM (so `/mnt/data` persists), but every execution runs in a **fresh nsjail sandbox with its own PID + mount namespace** — when the call returns, that namespace is torn down and everything in it is reaped.

Measured against a live stateful backend, in one **warm** session (identical `/proc/sys/kernel/random/boot_id` across calls) with a filesystem control passing in the same run:

**`execute_code`** claimed *"variables, imports, and in-memory data from earlier successful calls are typically still available"*:
```
exec1: x = 42; import math      -> ok
exec2: print(x)                 -> NameError: name 'x' is not defined
exec3: print(math)              -> NameError: name 'math' is not defined
exec4: write /mnt/data/f.txt    -> ok      # control: same warm session
exec5: read  /mnt/data/f.txt    -> ok      # filesystem does persist
```
The shell PID is `2` on **every** call — a fresh PID namespace each time. There is no shared runtime; this isn't "occasionally resets," it never holds.

**`bash_tool`** claimed *"files (including /tmp) ... and running background processes from earlier calls typically persist"*:
- `/tmp` written in one call is **empty** in the next (private mount namespace)
- a backgrounded loop writing a heartbeat file **froze at its last tick** and never advanced (PID namespace reaped)

Both notes hedge with *"usually/typically ... may reset"*, which reads as rare degradation rather than a guarantee that never holds. A model trusting them writes `df = ...` in one call and `df.head()` in the next, or starts a server and assumes it's still listening — then hits an error the description told it to treat as unlikely.

- Rewrote `STATEFUL_ENV_NOTE` + `STATEFUL_CODE_PARAM_NOTE` (`CodeExecutor`) and `STATEFUL_BASH_NOTE` + `STATEFUL_BASH_PARAM_NOTE` (`BashExecutor`) to state what's true: the machine is warm and `/mnt/data` persists; each call is a new process, so variables, imports, shell state, cwd, `/tmp`, and background processes never carry over.
- Updated the JSDoc above each note to explain the architecture (warm VM + per-call jail) so the next editor doesn't reintroduce the claim.
- **Stateless variants are unchanged.**

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`bun test src/tools/__tests__/CodeExecutor.stateful.test.ts src/tools/__tests__/BashExecutor.test.ts` — **19 pass / 0 fail**. `tsc --noEmit` clean.

Note for reviewers: the existing tests **asserted the false wording** (`expect(d).toContain('usually share one runtime')`, `expect(stateful).toContain('typically still defined')`) — they encoded the bug, so they're updated as part of the fix. Added negative assertions (`.not.toContain(...)`) so the old claims can't silently return.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
