### PR TITLE
fix: find camelCase tools in tool search

### DIFF
--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -529,43 +529,43 @@ function performLocalSearch(
   const maxScore = Math.max(...scores.filter((s) => s > 0), 1);
   const queryLower = query.toLowerCase().trim();
   const queryIdentifier = queryTokens.join('');
+  const matchesIdentifiers = fields.includes('name');
 
   const results: Array<{
     result: t.ToolSearchResult;
     identifierPriority: number;
   }> = [];
   for (let i = 0; i < tools.length; i++) {
-    const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
-    const rawFullName = tools[i].name.toLowerCase();
-    const baseIdentifier = tokenize(rawBaseName).join('');
-    const fullIdentifier = tokenize(rawFullName).join('');
     let identifierPriority = 0;
     let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
 
-    if (rawFullName === queryLower) {
-      identifierPriority = 4;
-      normalizedScore = 1.0;
-    } else if (rawBaseName === queryLower) {
-      identifierPriority = 3;
-      normalizedScore = 1.0;
-    } else if (
-      baseIdentifier === queryIdentifier ||
-      fullIdentifier === queryIdentifier
-    ) {
-      identifierPriority = 2;
-      normalizedScore = 1.0;
-    } else if (baseIdentifier.startsWith(queryIdentifier)) {
-      identifierPriority = 1;
-      normalizedScore = Math.max(normalizedScore, 0.95);
+    if (matchesIdentifiers) {
+      const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
+      const rawFullName = tools[i].name.toLowerCase();
+      const baseIdentifier = tokenize(rawBaseName).join('');
+      const fullIdentifier = tokenize(rawFullName).join('');
+
+      if (rawFullName === queryLower) {
+        identifierPriority = 4;
+        normalizedScore = 1.0;
+      } else if (rawBaseName === queryLower) {
+        identifierPriority = 3;
+        normalizedScore = 1.0;
+      } else if (
+        baseIdentifier === queryIdentifier ||
+        fullIdentifier === queryIdentifier
+      ) {
+        identifierPriority = 2;
+        normalizedScore = 1.0;
+      } else if (baseIdentifier.startsWith(queryIdentifier)) {
+        identifierPriority = 1;
+        normalizedScore = Math.max(normalizedScore, 0.95);
+      }
     }
 
     if (scores[i] <= 0 && identifierPriority === 0) continue;
 
-    const { field, snippet } = findMatchedField(
-      tools[i],
-      queryTokens,
-      fields
-    );
+    const { field, snippet } = findMatchedField(tools[i], queryTokens, fields);
     results.push({
       result: {
         tool_name: tools[i].name,
@@ -582,9 +582,7 @@ function performLocalSearch(
       b.identifierPriority - a.identifierPriority ||
       b.result.match_score - a.result.match_score
   );
-  const topResults = results
-    .slice(0, maxResults)
-    .map(({ result }) => result);
+  const topResults = results.slice(0, maxResults).map(({ result }) => result);
 
   return {
     tool_references: topResults,

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -535,47 +535,46 @@ function performLocalSearch(
     identifierPriority: number;
   }> = [];
   for (let i = 0; i < tools.length; i++) {
-    if (scores[i] > 0) {
-      const { field, snippet } = findMatchedField(
-        tools[i],
-        queryTokens,
-        fields
-      );
-      let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
+    const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
+    const rawFullName = tools[i].name.toLowerCase();
+    const baseIdentifier = tokenize(rawBaseName).join('');
+    const fullIdentifier = tokenize(rawFullName).join('');
+    let identifierPriority = 0;
+    let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
 
-      const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
-      const rawFullName = tools[i].name.toLowerCase();
-      const baseIdentifier = tokenize(rawBaseName).join('');
-      const fullIdentifier = tokenize(rawFullName).join('');
-      let identifierPriority = 0;
-
-      if (rawFullName === queryLower) {
-        identifierPriority = 4;
-        normalizedScore = 1.0;
-      } else if (rawBaseName === queryLower) {
-        identifierPriority = 3;
-        normalizedScore = 1.0;
-      } else if (
-        baseIdentifier === queryIdentifier ||
-        fullIdentifier === queryIdentifier
-      ) {
-        identifierPriority = 2;
-        normalizedScore = 1.0;
-      } else if (baseIdentifier.startsWith(queryIdentifier)) {
-        identifierPriority = 1;
-        normalizedScore = Math.max(normalizedScore, 0.95);
-      }
-
-      results.push({
-        result: {
-          tool_name: tools[i].name,
-          match_score: normalizedScore,
-          matched_field: field,
-          snippet,
-        },
-        identifierPriority,
-      });
+    if (rawFullName === queryLower) {
+      identifierPriority = 4;
+      normalizedScore = 1.0;
+    } else if (rawBaseName === queryLower) {
+      identifierPriority = 3;
+      normalizedScore = 1.0;
+    } else if (
+      baseIdentifier === queryIdentifier ||
+      fullIdentifier === queryIdentifier
+    ) {
+      identifierPriority = 2;
+      normalizedScore = 1.0;
+    } else if (baseIdentifier.startsWith(queryIdentifier)) {
+      identifierPriority = 1;
+      normalizedScore = Math.max(normalizedScore, 0.95);
     }
+
+    if (scores[i] <= 0 && identifierPriority === 0) continue;
+
+    const { field, snippet } = findMatchedField(
+      tools[i],
+      queryTokens,
+      fields
+    );
+    results.push({
+      result: {
+        tool_name: tools[i].name,
+        match_score: normalizedScore,
+        matched_field: field,
+        snippet,
+      },
+      identifierPriority,
+    });
   }
 
   results.sort(

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -360,6 +360,37 @@ function simplifyParametersForSearch(
 }
 
 /**
+ * Splits one alphanumeric identifier segment on case boundaries without
+ * emitting artificial one-character acronym fragments.
+ */
+function splitCaseSegment(segment: string): string[] {
+  const splitTokens = segment
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (splitTokens.length < 2) return splitTokens;
+
+  const mergedTokens: string[] = [];
+  let prefix = '';
+  for (const token of splitTokens) {
+    if (token.length === 1) {
+      prefix += token;
+      continue;
+    }
+    mergedTokens.push(`${prefix}${token}`);
+    prefix = '';
+  }
+
+  if (prefix && mergedTokens.length > 0) {
+    mergedTokens[mergedTokens.length - 1] += prefix;
+  }
+  return mergedTokens.length > 0 ? mergedTokens : [prefix];
+}
+
+/**
  * Tokenizes a string into lowercase words for BM25.
  * Splits camelCase, underscores, and non-alphanumeric characters for consistent matching.
  * @param text - The text to tokenize
@@ -367,12 +398,9 @@ function simplifyParametersForSearch(
  */
 function tokenize(text: string): string[] {
   return text
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, ' ')
-    .split(/\s+/)
-    .filter((token) => token.length > 0);
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .flatMap(splitCaseSegment);
 }
 
 /**
@@ -499,9 +527,13 @@ function performLocalSearch(
   const scores = BM25(documents, queryTokens, { k1: 1.5, b: 0.75 }) as number[];
 
   const maxScore = Math.max(...scores.filter((s) => s > 0), 1);
+  const queryLower = query.toLowerCase().trim();
   const queryIdentifier = queryTokens.join('');
 
-  const results: t.ToolSearchResult[] = [];
+  const results: Array<{
+    result: t.ToolSearchResult;
+    identifierPriority: number;
+  }> = [];
   for (let i = 0; i < tools.length; i++) {
     if (scores[i] > 0) {
       const { field, snippet } = findMatchedField(
@@ -511,25 +543,49 @@ function performLocalSearch(
       );
       let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
 
-      const baseName = tokenize(getBaseToolName(tools[i].name)).join('');
-      const fullName = tokenize(tools[i].name).join('');
-      if (baseName === queryIdentifier || fullName === queryIdentifier) {
+      const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
+      const rawFullName = tools[i].name.toLowerCase();
+      const baseIdentifier = tokenize(rawBaseName).join('');
+      const fullIdentifier = tokenize(rawFullName).join('');
+      let identifierPriority = 0;
+
+      if (rawFullName === queryLower) {
+        identifierPriority = 4;
         normalizedScore = 1.0;
-      } else if (baseName.startsWith(queryIdentifier)) {
+      } else if (rawBaseName === queryLower) {
+        identifierPriority = 3;
+        normalizedScore = 1.0;
+      } else if (
+        baseIdentifier === queryIdentifier ||
+        fullIdentifier === queryIdentifier
+      ) {
+        identifierPriority = 2;
+        normalizedScore = 1.0;
+      } else if (baseIdentifier.startsWith(queryIdentifier)) {
+        identifierPriority = 1;
         normalizedScore = Math.max(normalizedScore, 0.95);
       }
 
       results.push({
-        tool_name: tools[i].name,
-        match_score: normalizedScore,
-        matched_field: field,
-        snippet,
+        result: {
+          tool_name: tools[i].name,
+          match_score: normalizedScore,
+          matched_field: field,
+          snippet,
+        },
+        identifierPriority,
       });
     }
   }
 
-  results.sort((a, b) => b.match_score - a.match_score);
-  const topResults = results.slice(0, maxResults);
+  results.sort(
+    (a, b) =>
+      b.identifierPriority - a.identifierPriority ||
+      b.result.match_score - a.result.match_score
+  );
+  const topResults = results
+    .slice(0, maxResults)
+    .map(({ result }) => result);
 
   return {
     tool_references: topResults,

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -361,12 +361,14 @@ function simplifyParametersForSearch(
 
 /**
  * Tokenizes a string into lowercase words for BM25.
- * Splits on underscores and non-alphanumeric characters for consistent matching.
+ * Splits camelCase, underscores, and non-alphanumeric characters for consistent matching.
  * @param text - The text to tokenize
  * @returns Array of lowercase tokens
  */
 function tokenize(text: string): string[] {
   return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
     .toLowerCase()
     .replace(/[^a-z0-9]/g, ' ')
     .split(/\s+/)
@@ -396,7 +398,7 @@ function createToolDocument(tool: t.ToolMetadata, fields: string[]): string {
     parts.push(paramNames);
   }
 
-  return parts.join(' ');
+  return tokenize(parts.join(' ')).join(' ');
 }
 
 /**
@@ -497,7 +499,7 @@ function performLocalSearch(
   const scores = BM25(documents, queryTokens, { k1: 1.5, b: 0.75 }) as number[];
 
   const maxScore = Math.max(...scores.filter((s) => s > 0), 1);
-  const queryLower = query.toLowerCase().trim();
+  const queryIdentifier = queryTokens.join('');
 
   const results: t.ToolSearchResult[] = [];
   for (let i = 0; i < tools.length; i++) {
@@ -509,10 +511,11 @@ function performLocalSearch(
       );
       let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
 
-      const baseName = getBaseToolName(tools[i].name).toLowerCase();
-      if (baseName === queryLower) {
+      const baseName = tokenize(getBaseToolName(tools[i].name)).join('');
+      const fullName = tokenize(tools[i].name).join('');
+      if (baseName === queryIdentifier || fullName === queryIdentifier) {
         normalizedScore = 1.0;
-      } else if (baseName.startsWith(queryLower)) {
+      } else if (baseName.startsWith(queryIdentifier)) {
         normalizedScore = Math.max(normalizedScore, 0.95);
       }
 

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -536,8 +536,10 @@ function performLocalSearch(
     identifierPriority: number;
   }> = [];
   for (let i = 0; i < tools.length; i++) {
+    const score = scores[i];
+    const hasSearchScore = Number.isFinite(score) && score > 0;
     let identifierPriority = 0;
-    let normalizedScore = Math.min(scores[i] / maxScore, 1.0);
+    let normalizedScore = hasSearchScore ? Math.min(score / maxScore, 1.0) : 0;
 
     if (matchesIdentifiers) {
       const rawBaseName = getBaseToolName(tools[i].name).toLowerCase();
@@ -563,7 +565,7 @@ function performLocalSearch(
       }
     }
 
-    if (scores[i] <= 0 && identifierPriority === 0) continue;
+    if (!hasSearchScore && identifierPriority === 0) continue;
 
     const { field, snippet } = findMatchedField(tools[i], queryTokens, fields);
     results.push({

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -360,6 +360,33 @@ describe('ToolSearch', () => {
       expect(result.tool_references[0].match_score).toBeGreaterThan(0);
     });
 
+    it('does not match tool names when searching only parameters', () => {
+      const tools: ToolMetadata[] = [
+        {
+          name: 'query',
+          description: 'A tool whose name matches but parameters do not',
+          parameters: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+          },
+        },
+        {
+          name: 'run_database_query',
+          description: 'Run a database query',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+          },
+        },
+      ];
+
+      const result = performLocalSearch(tools, 'query', ['parameters'], 1);
+
+      expect(result.tool_references).toHaveLength(1);
+      expect(result.tool_references[0].tool_name).toBe('run_database_query');
+      expect(result.tool_references[0].matched_field).toBe('parameters');
+    });
+
     it('prioritizes name matches over description matches', () => {
       const result = performLocalSearch(
         mockTools,
@@ -929,9 +956,9 @@ describe('ToolSearch', () => {
 
         const result = performLocalSearch(tools, matchingTool, ['name'], 10);
 
-        expect(result.tool_references.map(({ tool_name }) => tool_name)).toEqual(
-          [matchingTool]
-        );
+        expect(
+          result.tool_references.map(({ tool_name }) => tool_name)
+        ).toEqual([matchingTool]);
       }
     );
 

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -850,6 +850,27 @@ describe('ToolSearch', () => {
       expect(result.tool_references[0].match_score).toBe(1.0);
     });
 
+    it('finds camelCase tools by a lowercased exact name', () => {
+      const tools: ToolMetadata[] = [
+        {
+          name: 'addActivity',
+          description: 'Create an activity',
+          parameters: undefined,
+        },
+        {
+          name: 'addPerson',
+          description: 'Create a person',
+          parameters: undefined,
+        },
+      ];
+
+      const result = performLocalSearch(tools, 'addperson', ['name'], 10);
+
+      expect(result.tool_references).toHaveLength(1);
+      expect(result.tool_references[0].tool_name).toBe('addPerson');
+      expect(result.tool_references[0].match_score).toBe(1.0);
+    });
+
     it('prioritizes an exact full camelCase MCP tool ID', () => {
       const tools: ToolMetadata[] = [
         {

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -853,6 +853,11 @@ describe('ToolSearch', () => {
     it('prioritizes an exact full camelCase MCP tool ID', () => {
       const tools: ToolMetadata[] = [
         {
+          name: 'add_person_mcp_pipedrive',
+          description: 'Create a person with a separator variant',
+          parameters: undefined,
+        },
+        {
           name: 'addActivity_mcp_pipedrive',
           description: 'Create an activity',
           parameters: undefined,
@@ -881,6 +886,33 @@ describe('ToolSearch', () => {
       );
       expect(result.tool_references[0].match_score).toBe(1.0);
     });
+
+    it.each([
+      ['OAuthToken', 'close_order'],
+      ['iOSApp', 'inspect_inventory'],
+    ])(
+      'does not return tools matching only an acronym fragment from %s',
+      (matchingTool, unrelatedTool) => {
+        const tools: ToolMetadata[] = [
+          {
+            name: matchingTool,
+            description: 'Expected acronym tool',
+            parameters: undefined,
+          },
+          {
+            name: unrelatedTool,
+            description: 'Unrelated tool',
+            parameters: undefined,
+          },
+        ];
+
+        const result = performLocalSearch(tools, matchingTool, ['name'], 10);
+
+        expect(result.tool_references.map(({ tool_name }) => tool_name)).toEqual(
+          [matchingTool]
+        );
+      }
+    );
 
     it('searches across all tools including MCP tools', () => {
       const result = performLocalSearch(

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -387,6 +387,25 @@ describe('ToolSearch', () => {
       expect(result.tool_references[0].matched_field).toBe('parameters');
     });
 
+    it('returns no matches when every selected field is empty', () => {
+      const tools: ToolMetadata[] = [
+        {
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: undefined,
+        },
+        {
+          name: 'send_email',
+          description: 'Send an email',
+          parameters: undefined,
+        },
+      ];
+
+      const result = performLocalSearch(tools, 'query', ['parameters'], 10);
+
+      expect(result.tool_references).toEqual([]);
+    });
+
     it('prioritizes name matches over description matches', () => {
       const result = performLocalSearch(
         mockTools,

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -830,6 +830,58 @@ describe('ToolSearch', () => {
       },
     ];
 
+    it('finds camelCase tools by exact name', () => {
+      const tools: ToolMetadata[] = [
+        {
+          name: 'addActivity',
+          description: 'Create an activity',
+          parameters: undefined,
+        },
+        {
+          name: 'addPerson',
+          description: 'Create a person',
+          parameters: undefined,
+        },
+      ];
+
+      const result = performLocalSearch(tools, 'addPerson', ['name'], 10);
+
+      expect(result.tool_references[0].tool_name).toBe('addPerson');
+      expect(result.tool_references[0].match_score).toBe(1.0);
+    });
+
+    it('prioritizes an exact full camelCase MCP tool ID', () => {
+      const tools: ToolMetadata[] = [
+        {
+          name: 'addActivity_mcp_pipedrive',
+          description: 'Create an activity',
+          parameters: undefined,
+        },
+        {
+          name: 'addPerson_mcp_pipedrive',
+          description: 'Create a person',
+          parameters: undefined,
+        },
+        {
+          name: 'updatePerson_mcp_pipedrive',
+          description: 'Update a person',
+          parameters: undefined,
+        },
+      ];
+
+      const result = performLocalSearch(
+        tools,
+        'addPerson_mcp_pipedrive',
+        ['name'],
+        1
+      );
+
+      expect(result.tool_references[0].tool_name).toBe(
+        'addPerson_mcp_pipedrive'
+      );
+      expect(result.tool_references[0].match_score).toBe(1.0);
+    });
+
     it('searches across all tools including MCP tools', () => {
       const result = performLocalSearch(
         mcpTools,


### PR DESCRIPTION
## Problem

Agents could fail to find available tools whose names use camelCase.

For example, searching for `addPerson` returned no result. Searching for the full tool ID, `addPerson_mcp_pipedrive`, could return a different Pipedrive tool such as `addActivity_mcp_pipedrive` instead. In a deferred-tool workflow, this can make an agent stop without calling a tool that is actually available.

## Cause

Tool-search queries were converted to lowercase before BM25 scoring, but indexed tool names kept their original capitalization. Because `okapibm25` matches case-sensitively, the query token `addperson` did not match `addPerson`.

Full MCP tool IDs could still match generic tokens such as `mcp` and `pipedrive`. That gave several unrelated tools similar scores and allowed the wrong one to rank first.

## Fix

- split camelCase and acronym boundaries during tokenization
- normalize indexed metadata with the same tokenizer used for queries
- recognize exact matches against both base names and full MCP tool IDs

Existing underscore-based searches continue to work as before.

## Validation

Added regressions proving that:

- `addPerson` finds the camelCase tool directly
- `addPerson_mcp_pipedrive` ranks the exact tool above other Pipedrive tools

Checks run:

- `npx jest src/tools/__tests__/ToolSearch.test.ts --runInBand` (93 tests)
- `npx eslint src/tools/ToolSearch.ts src/tools/__tests__/ToolSearch.test.ts`
- `npx tsc --noEmit`
- `npm run build`
