### PR TITLE
feat(langfuse): refine agent trace shaping and restore environment fallback

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -75,17 +75,29 @@ export function ensureOpenTelemetryContextManager(): void {
   }
 }
 
+function resolveLangfuseEnvironment(
+  langfuse?: t.LangfuseConfig
+): string | undefined {
+  return (
+    langfuse?.environment ??
+    process.env.LANGFUSE_TRACING_ENVIRONMENT ??
+    process.env.NODE_ENV
+  );
+}
+
 function getLangfuseSpanProcessorParams(
   langfuse?: t.LangfuseConfig
 ): LangfuseSpanProcessorParams | undefined {
   if (langfuse?.enabled === false) {
     return undefined;
   }
+  const environment = resolveLangfuseEnvironment(langfuse);
   if (hasLangfuseConfigCredentials(langfuse)) {
     return {
       publicKey: langfuse.publicKey,
       secretKey: langfuse.secretKey,
       ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
+      ...(isPresent(environment) ? { environment } : {}),
     };
   }
   if (hasLangfuseEnvConfig()) {
@@ -97,6 +109,7 @@ function getLangfuseSpanProcessorParams(
       publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       ...(isPresent(baseUrl) ? { baseUrl } : {}),
+      ...(isPresent(environment) ? { environment } : {}),
     };
   }
   if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
@@ -104,6 +117,7 @@ function getLangfuseSpanProcessorParams(
       publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       baseUrl: langfuse.baseUrl,
+      ...(isPresent(environment) ? { environment } : {}),
     };
   }
   return undefined;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -78,11 +78,17 @@ export function ensureOpenTelemetryContextManager(): void {
 function resolveLangfuseEnvironment(
   langfuse?: t.LangfuseConfig
 ): string | undefined {
-  return (
-    langfuse?.environment ??
-    process.env.LANGFUSE_TRACING_ENVIRONMENT ??
-    process.env.NODE_ENV
-  );
+  const candidates = [
+    langfuse?.environment,
+    process.env.LANGFUSE_TRACING_ENVIRONMENT,
+    process.env.NODE_ENV,
+  ];
+  for (const candidate of candidates) {
+    if (candidate != null && candidate.trim() !== '') {
+      return candidate.trim();
+    }
+  }
+  return undefined;
 }
 
 function getLangfuseSpanProcessorParams(

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -483,10 +483,8 @@ export function shouldTraceToolNodeForLangfuse({
   }
 
   const explicit = langfuse?.toolNodeTracing?.enabled;
-  if (explicit != null) {
-    return (
-      explicit && (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
-    );
+  if (explicit !== true) {
+    return false;
   }
 
   return hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys();

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -7,6 +7,8 @@ const LANGGRAPH_AGENT_NODE_PREFIX = 'agent=';
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
 const TOOL_BATCH_RUN_NAME = 'tool_batch';
 const AGENT_NODE_SPAN_NAME = 'agent';
+const GENERATION_SPAN_NAME = 'llm';
+const ROOT_OBSERVATION_TYPE = 'agent';
 
 type MutableSpan = ReadableSpan & {
   name: string;
@@ -205,12 +207,15 @@ function isRootSpan(span: ReadableSpan): boolean {
 
 /**
  * LangGraph plumbing observations that add noise without information:
- * the duplicated `__start__` channel-seed nodes and anonymous
- * `RunnableLambda` pass-throughs (Langfuse team feedback items 4 & 5).
+ * the duplicated `__start__` channel-seed nodes, anonymous `RunnableLambda`
+ * pass-throughs, and the `tool_batch` run that duplicates its parent
+ * `tools=<id>` node span verbatim (Langfuse team feedback items 4 & 5).
  */
 export function shouldDropLangfuseSpan(spanName: string): boolean {
   return (
-    spanName === LANGGRAPH_START_NODE || spanName === ANONYMOUS_LAMBDA_NAME
+    spanName === LANGGRAPH_START_NODE ||
+    spanName === ANONYMOUS_LAMBDA_NAME ||
+    spanName === TOOL_BATCH_RUN_NAME
   );
 }
 
@@ -249,17 +254,26 @@ function shapeRootSpan(span: MutableSpan): void {
   }
 }
 
+function isGenerationSpan(span: MutableSpan): boolean {
+  const type = span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE];
+  return typeof type === 'string' && type.toLowerCase() === 'generation';
+}
+
 /**
  * Reshapes spans per Langfuse-team feedback before export:
  * - `agent=<id>` / `tools=<id>` node names carry the ephemeral agent id
  *   (`provider__model`) — strip it so switching models doesn't break
  *   name-based logic (item 1).
+ * - LLM generation spans keep the provider client class name (`ChatOpenAI`,
+ *   `AzureChatOpenAI`, …); rename them to a provider-agnostic `llm` so the
+ *   name reflects the operation, not the model (the model stays on the
+ *   generation's model attribute).
  * - Tool node spans are renamed to the actual tool name(s) and their
  *   input scoped to the pending tool-call args instead of the whole
  *   chat history (items 3 & 4).
- * - The root span (and trace) input/output become the user question and
- *   assistant response so the session view reads as a conversation
- *   (item 2).
+ * - The root span becomes a top-level `agent` observation whose input/output
+ *   (and the trace input/output derived from it) are the user question and
+ *   assistant response, so the session view reads as a conversation (item 2).
  */
 export function shapeLangfuseSpan(span: ReadableSpan): void {
   const mutable = span as MutableSpan;
@@ -267,14 +281,17 @@ export function shapeLangfuseSpan(span: ReadableSpan): void {
     mutable.name = AGENT_NODE_SPAN_NAME;
     return;
   }
-  if (
-    mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX) ||
-    mutable.name === TOOL_BATCH_RUN_NAME
-  ) {
+  if (mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)) {
     shapeToolNodeSpan(mutable);
     return;
   }
+  if (isGenerationSpan(mutable)) {
+    mutable.name = GENERATION_SPAN_NAME;
+    return;
+  }
   if (isRootSpan(span)) {
+    mutable.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+      ROOT_OBSERVATION_TYPE;
     shapeRootSpan(mutable);
   }
 }

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -5,10 +5,13 @@ const LANGGRAPH_START_NODE = '__start__';
 const ANONYMOUS_LAMBDA_NAME = 'RunnableLambda';
 const LANGGRAPH_AGENT_NODE_PREFIX = 'agent=';
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
-const TOOL_BATCH_RUN_NAME = 'tool_batch';
 const AGENT_NODE_SPAN_NAME = 'agent';
+const TOOL_DISPATCH_SPAN_NAME = 'tool-dispatch';
 const GENERATION_SPAN_NAME = 'llm';
 const ROOT_OBSERVATION_TYPE = 'agent';
+const CHAIN_OBSERVATION_TYPE = 'chain';
+const AGENT_TRACE_TAG = 'agent';
+const TITLE_TRACE_TAG = 'title';
 
 type MutableSpan = ReadableSpan & {
   name: string;
@@ -207,30 +210,37 @@ function isRootSpan(span: ReadableSpan): boolean {
 
 /**
  * LangGraph plumbing observations that add noise without information:
- * the duplicated `__start__` channel-seed nodes, anonymous `RunnableLambda`
- * pass-throughs, and the `tool_batch` run that duplicates its parent
- * `tools=<id>` node span verbatim (Langfuse team feedback items 4 & 5).
+ * the duplicated `__start__` channel-seed nodes and anonymous
+ * `RunnableLambda` pass-throughs (Langfuse team feedback items 4 & 5).
+ * Internal ToolNode batch spans are disabled at their source so traced child
+ * tools retain an exported parent. Explicitly traced ToolNodes are preserved.
  */
 export function shouldDropLangfuseSpan(spanName: string): boolean {
   return (
-    spanName === LANGGRAPH_START_NODE ||
-    spanName === ANONYMOUS_LAMBDA_NAME ||
-    spanName === TOOL_BATCH_RUN_NAME
+    spanName === LANGGRAPH_START_NODE || spanName === ANONYMOUS_LAMBDA_NAME
   );
 }
 
 function shapeToolNodeSpan(span: MutableSpan): void {
   const inputKey = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
+  span.name = TOOL_DISPATCH_SPAN_NAME;
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    CHAIN_OBSERVATION_TYPE;
   const calls = findPendingToolCalls(
     parseAttributeValue(span.attributes[inputKey])
   );
   if (calls.length === 0) {
     return;
   }
-  span.name = [...new Set(calls.map((call) => call.name))].join(', ');
   span.attributes[inputKey] = JSON.stringify(
     calls.map(({ name, args }) => ({ name, args }))
   );
+}
+
+function shapeAgentNodeSpan(span: MutableSpan): void {
+  span.name = AGENT_NODE_SPAN_NAME;
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    ROOT_OBSERVATION_TYPE;
 }
 
 function shapeRootSpan(span: MutableSpan): void {
@@ -246,17 +256,48 @@ function shapeRootSpan(span: MutableSpan): void {
   );
   if (question != null) {
     span.attributes[inputKey] = question;
-    span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT] = question;
   }
   if (answer != null) {
     span.attributes[outputKey] = answer;
-    span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT] = answer;
+  }
+  const traceInput = question ?? span.attributes[inputKey];
+  const traceOutput = answer ?? span.attributes[outputKey];
+  if (traceInput != null) {
+    span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT] = traceInput;
+  }
+  if (traceOutput != null) {
+    span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT] = traceOutput;
   }
 }
 
 function isGenerationSpan(span: MutableSpan): boolean {
   const type = span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE];
   return typeof type === 'string' && type.toLowerCase() === 'generation';
+}
+
+function hasTraceTag(span: MutableSpan, expectedTag: string): boolean {
+  const tags = parseAttributeValue(
+    span.attributes[LangfuseOtelSpanAttributes.TRACE_TAGS]
+  );
+  return (
+    Array.isArray(tags) &&
+    tags.some((tag) => typeof tag === 'string' && tag === expectedTag)
+  );
+}
+
+function shapeRootObservationType(span: MutableSpan): void {
+  if (isGenerationSpan(span)) {
+    return;
+  }
+  if (hasTraceTag(span, AGENT_TRACE_TAG)) {
+    span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+      ROOT_OBSERVATION_TYPE;
+    return;
+  }
+  if (hasTraceTag(span, TITLE_TRACE_TAG)) {
+    span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+      CHAIN_OBSERVATION_TYPE;
+  }
 }
 
 /**
@@ -268,30 +309,25 @@ function isGenerationSpan(span: MutableSpan): boolean {
  *   `AzureChatOpenAI`, …); rename them to a provider-agnostic `llm` so the
  *   name reflects the operation, not the model (the model stays on the
  *   generation's model attribute).
- * - Tool node spans are renamed to the actual tool name(s) and their
- *   input scoped to the pending tool-call args instead of the whole
- *   chat history (items 3 & 4).
- * - The root span becomes a top-level `agent` observation whose input/output
- *   (and the trace input/output derived from it) are the user question and
- *   assistant response, so the session view reads as a conversation (item 2).
+ * - Agent nodes become `agent` observations, while tool-dispatch nodes become
+ *   stable `chain` observations whose input is scoped to the pending calls.
+ *   Individual child calls remain `tool` observations (items 3 & 4).
+ * - Agent trace roots become `agent` observations and title trace roots become
+ *   `chain` observations. Root and trace input/output are reduced to the user
+ *   question and assistant response when chat messages are available (item 2).
  */
 export function shapeLangfuseSpan(span: ReadableSpan): void {
   const mutable = span as MutableSpan;
   if (mutable.name.startsWith(LANGGRAPH_AGENT_NODE_PREFIX)) {
-    mutable.name = AGENT_NODE_SPAN_NAME;
-    return;
-  }
-  if (mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)) {
+    shapeAgentNodeSpan(mutable);
+  } else if (mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)) {
     shapeToolNodeSpan(mutable);
-    return;
-  }
-  if (isGenerationSpan(mutable)) {
+  } else if (isGenerationSpan(mutable)) {
     mutable.name = GENERATION_SPAN_NAME;
+  }
+  if (!isRootSpan(span)) {
     return;
   }
-  if (isRootSpan(span)) {
-    mutable.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
-      ROOT_OBSERVATION_TYPE;
-    shapeRootSpan(mutable);
-  }
+  shapeRootObservationType(mutable);
+  shapeRootSpan(mutable);
 }

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -184,6 +184,53 @@ describe('Langfuse instrumentation', () => {
     expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves environment from LANGFUSE_TRACING_ENVIRONMENT', async () => {
+    process.env.LANGFUSE_TRACING_ENVIRONMENT = 'staging';
+
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: 'staging' })
+    );
+  });
+
+  it('falls back to NODE_ENV when LANGFUSE_TRACING_ENVIRONMENT is unset', async () => {
+    delete process.env.LANGFUSE_TRACING_ENVIRONMENT;
+    process.env.NODE_ENV = 'production';
+
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: 'production' })
+    );
+  });
+
+  it('prefers an explicit config environment over environment variables', async () => {
+    process.env.LANGFUSE_TRACING_ENVIRONMENT = 'staging';
+
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+      environment: 'canary',
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: 'canary' })
+    );
+  });
+
   it('does not replace the global provider when explicit credentials change', async () => {
     const { initializeLangfuseTracing } = await import('@/instrumentation');
     initializeLangfuseTracing({

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -215,6 +215,23 @@ describe('Langfuse instrumentation', () => {
     );
   });
 
+  it('falls through blank environment overrides and trims the selected value', async () => {
+    process.env.LANGFUSE_TRACING_ENVIRONMENT = '   ';
+    process.env.NODE_ENV = ' production ';
+
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+      environment: '',
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: 'production' })
+    );
+  });
+
   it('prefers an explicit config environment over environment variables', async () => {
     process.env.LANGFUSE_TRACING_ENVIRONMENT = 'staging';
 

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -25,6 +25,8 @@ type SpanStartRecord = {
   name: string;
   params: ProcessorParams;
   traceId: string;
+  spanId: string;
+  parentSpanId?: string;
 };
 
 const spanStarts: SpanStartRecord[] = [];
@@ -140,11 +142,15 @@ jest.mock('@langfuse/otel', () => ({
   LangfuseSpanProcessor: jest.fn().mockImplementation((params) => ({
     forceFlush: jest.fn(),
     onEnd: jest.fn(),
-    onStart: jest.fn((span) => {
+    onStart: jest.fn((span, parentContext) => {
+      const spanContext = span.spanContext();
+      const parentSpanId = otelTrace.getSpanContext(parentContext)?.spanId;
       spanStarts.push({
         name: span.name,
         params,
-        traceId: span.spanContext().traceId,
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+        ...(parentSpanId != null ? { parentSpanId } : {}),
       });
     }),
     shutdown: jest.fn(),
@@ -190,7 +196,6 @@ function tenantLangfuse(tenantId: string): t.LangfuseConfig {
     deterministicTraceId: true,
     metadata: { tenantId },
     tags: [`tenant:${tenantId}`],
-    toolNodeTracing: { enabled: true },
     toolOutputTracing: { enabled: true },
   };
 }
@@ -236,6 +241,23 @@ function expectNamedSpansUseTraceId({
     expect(
       matching.filter((record) => record.traceId !== traceId)
     ).toHaveLength(0);
+  }
+}
+
+function expectChildSpanParentName({
+  starts,
+  childName,
+  parentNamePrefix,
+}: {
+  starts: SpanStartRecord[];
+  childName: string;
+  parentNamePrefix: string;
+}): void {
+  const children = starts.filter((record) => record.name === childName);
+  expect(children).not.toHaveLength(0);
+  for (const child of children) {
+    const parent = starts.find((record) => record.spanId === child.parentSpanId);
+    expect(parent?.name.startsWith(parentNamePrefix)).toBe(true);
   }
 }
 
@@ -446,6 +468,23 @@ describe('Langfuse per-run routing integration', () => {
     getChatModelClassSpy.mockRestore();
   });
 
+  it('keeps tool observations attached to the exported dispatch parent', async () => {
+    await runTenantFlow('tenant-hierarchy');
+
+    const starts = startsForTenant('tenant-hierarchy');
+    expect(starts.some((record) => record.name === 'tool_batch')).toBe(false);
+    expectChildSpanParentName({
+      starts,
+      childName: 'echo',
+      parentNamePrefix: 'tools=',
+    });
+    expectChildSpanParentName({
+      starts,
+      childName: 'subagent',
+      parentNamePrefix: 'tools=',
+    });
+  });
+
   it('routes parallel root, model, tool, subagent, and title spans to each run config', async () => {
     await Promise.all([runTenantFlow('tenant-a'), runTenantFlow('tenant-b')]);
 
@@ -462,9 +501,15 @@ describe('Langfuse per-run routing integration', () => {
         names: [
           `LibreChat Agent: Parent ${tenantId}`,
           'FakeChatModel',
-          'tool_batch',
+          'echo',
           'subagent',
         ],
+      });
+      expect(starts.some((record) => record.name === 'tool_batch')).toBe(false);
+      expectChildSpanParentName({
+        starts,
+        childName: 'echo',
+        parentNamePrefix: 'tools=',
       });
       expectNamedSpansUseTraceId({
         starts,

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -118,7 +118,7 @@ describe('Langfuse tool output tracing redaction', () => {
     process.env = originalEnv;
   });
 
-  it('enables ToolNode tracing only when Langfuse is active by default', () => {
+  it('keeps internal ToolNode batch tracing opt-in', () => {
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_BASE_URL;
@@ -132,7 +132,7 @@ describe('Langfuse tool output tracing redaction', () => {
           secretKey: 'sk-run',
         },
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldTraceToolNodeForLangfuse({
         agentLangfuse: {
@@ -149,7 +149,7 @@ describe('Langfuse tool output tracing redaction', () => {
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
     process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
 
-    expect(shouldTraceToolNodeForLangfuse({})).toBe(true);
+    expect(shouldTraceToolNodeForLangfuse({})).toBe(false);
     expect(
       shouldTraceToolNodeForLangfuse({
         runLangfuse: { toolNodeTracing: { enabled: true } },
@@ -162,7 +162,7 @@ describe('Langfuse tool output tracing redaction', () => {
     ).toBe(false);
   });
 
-  it('lets agent Langfuse enablement override disabled run defaults for ToolNode tracing', () => {
+  it('lets an agent explicitly opt into ToolNode batch tracing', () => {
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_BASE_URL;
@@ -177,6 +177,7 @@ describe('Langfuse tool output tracing redaction', () => {
           publicKey: 'pk-agent',
           secretKey: 'sk-agent',
           baseUrl: 'https://langfuse.test',
+          toolNodeTracing: { enabled: true },
         },
       })
     ).toBe(true);

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -26,6 +26,7 @@ const INPUT = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
 const OUTPUT = LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT;
 const TRACE_INPUT = LangfuseOtelSpanAttributes.TRACE_INPUT;
 const TRACE_OUTPUT = LangfuseOtelSpanAttributes.TRACE_OUTPUT;
+const OBSERVATION_TYPE = LangfuseOtelSpanAttributes.OBSERVATION_TYPE;
 
 describe('shouldDropLangfuseSpan', () => {
   it('drops langgraph __start__ seed spans', () => {
@@ -34,6 +35,10 @@ describe('shouldDropLangfuseSpan', () => {
 
   it('drops anonymous RunnableLambda pass-throughs', () => {
     expect(shouldDropLangfuseSpan('RunnableLambda')).toBe(true);
+  });
+
+  it('drops the tool_batch run that duplicates its parent tools node', () => {
+    expect(shouldDropLangfuseSpan('tool_batch')).toBe(true);
   });
 
   it('keeps named observations', () => {
@@ -89,7 +94,7 @@ describe('shapeLangfuseSpan', () => {
       },
     ];
     const span = createSpan(
-      'tool_batch',
+      'tools=openAI__gpt-5.4',
       { [INPUT]: JSON.stringify({ messages }) },
       'parent-1'
     );
@@ -190,5 +195,25 @@ describe('shapeLangfuseSpan', () => {
     shapeLangfuseSpan(span);
     expect(span.attributes[INPUT]).toBe('plain text');
     expect(span.attributes[TRACE_INPUT]).toBeUndefined();
+  });
+
+  it('renames generation spans to a provider-agnostic name', () => {
+    const span = createSpan(
+      'ChatOpenAI',
+      { [OBSERVATION_TYPE]: 'generation' },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('llm');
+  });
+
+  it('marks the root span as an agent observation', () => {
+    const span = createSpan('LibreChat Agent', {
+      [INPUT]: JSON.stringify({
+        messages: [{ type: 'human', content: 'hi' }],
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
   });
 });

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -27,6 +27,7 @@ const OUTPUT = LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT;
 const TRACE_INPUT = LangfuseOtelSpanAttributes.TRACE_INPUT;
 const TRACE_OUTPUT = LangfuseOtelSpanAttributes.TRACE_OUTPUT;
 const OBSERVATION_TYPE = LangfuseOtelSpanAttributes.OBSERVATION_TYPE;
+const TRACE_TAGS = LangfuseOtelSpanAttributes.TRACE_TAGS;
 
 describe('shouldDropLangfuseSpan', () => {
   it('drops langgraph __start__ seed spans', () => {
@@ -37,14 +38,11 @@ describe('shouldDropLangfuseSpan', () => {
     expect(shouldDropLangfuseSpan('RunnableLambda')).toBe(true);
   });
 
-  it('drops the tool_batch run that duplicates its parent tools node', () => {
-    expect(shouldDropLangfuseSpan('tool_batch')).toBe(true);
-  });
-
   it('keeps named observations', () => {
     expect(shouldDropLangfuseSpan('GenerateTitle')).toBe(false);
     expect(shouldDropLangfuseSpan('agent=openAI__gpt-5.4')).toBe(false);
     expect(shouldDropLangfuseSpan('ChatOpenAI')).toBe(false);
+    expect(shouldDropLangfuseSpan('tool_batch')).toBe(false);
   });
 });
 
@@ -53,9 +51,10 @@ describe('shapeLangfuseSpan', () => {
     const span = createSpan('agent=openAI__gpt-5.4', {}, 'parent-1');
     shapeLangfuseSpan(span);
     expect(span.name).toBe('agent');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
   });
 
-  it('renames tool node spans to the pending tool names and scopes input to args', () => {
+  it('shapes tool nodes as stable dispatch chains with scoped call inputs', () => {
     const messages = [
       { type: 'human', content: 'hello' },
       {
@@ -76,13 +75,14 @@ describe('shapeLangfuseSpan', () => {
       'parent-1'
     );
     shapeLangfuseSpan(span);
-    expect(span.name).toBe('get_service_details');
+    expect(span.name).toBe('tool-dispatch');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
     expect(JSON.parse(span.attributes[INPUT] as string)).toEqual([
       { name: 'get_service_details', args: { path: 'organizations/1' } },
     ]);
   });
 
-  it('joins multiple pending tool names and dedupes repeats', () => {
+  it('preserves every pending call in a multi-tool dispatch input', () => {
     const messages = [
       {
         type: 'ai',
@@ -99,7 +99,11 @@ describe('shapeLangfuseSpan', () => {
       'parent-1'
     );
     shapeLangfuseSpan(span);
-    expect(span.name).toBe('web_search, execute_code');
+    expect(JSON.parse(span.attributes[INPUT] as string)).toEqual([
+      { name: 'web_search', args: { q: 'a' } },
+      { name: 'web_search', args: { q: 'b' } },
+      { name: 'execute_code', args: { code: '1+1' } },
+    ]);
   });
 
   it('reads tool calls from serialized langchain message kwargs', () => {
@@ -120,10 +124,10 @@ describe('shapeLangfuseSpan', () => {
       'parent-1'
     );
     shapeLangfuseSpan(span);
-    expect(span.name).toBe('lookup');
+    expect(span.name).toBe('tool-dispatch');
   });
 
-  it('leaves tool node spans untouched when no tool calls are found', () => {
+  it('keeps a stable tool-dispatch shape when no tool calls are found', () => {
     const original = JSON.stringify({
       messages: [{ type: 'human', content: 'hi' }],
     });
@@ -133,12 +137,14 @@ describe('shapeLangfuseSpan', () => {
       'parent-1'
     );
     shapeLangfuseSpan(span);
-    expect(span.name).toBe('tools=agent_abc');
+    expect(span.name).toBe('tool-dispatch');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
     expect(span.attributes[INPUT]).toBe(original);
   });
 
   it('sets root span and trace input/output to the question and answer', () => {
     const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
       [INPUT]: JSON.stringify({
         messages: [
           { type: 'system', content: 'You are helpful.' },
@@ -161,6 +167,7 @@ describe('shapeLangfuseSpan', () => {
 
   it('extracts answer text from content part arrays', () => {
     const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
       [INPUT]: JSON.stringify([{ type: 'human', content: 'hi' }]),
       [OUTPUT]: JSON.stringify({
         messages: [
@@ -194,7 +201,7 @@ describe('shapeLangfuseSpan', () => {
     const span = createSpan('LibreChat Agent', { [INPUT]: 'plain text' });
     shapeLangfuseSpan(span);
     expect(span.attributes[INPUT]).toBe('plain text');
-    expect(span.attributes[TRACE_INPUT]).toBeUndefined();
+    expect(span.attributes[TRACE_INPUT]).toBe('plain text');
   });
 
   it('renames generation spans to a provider-agnostic name', () => {
@@ -207,13 +214,52 @@ describe('shapeLangfuseSpan', () => {
     expect(span.name).toBe('llm');
   });
 
-  it('marks the root span as an agent observation', () => {
+  it('marks only agent-tagged root spans as agent observations', () => {
     const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
       [INPUT]: JSON.stringify({
         messages: [{ type: 'human', content: 'hi' }],
       }),
     });
     shapeLangfuseSpan(span);
     expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
+  });
+
+  it('marks title-tagged root spans as chain observations', () => {
+    const span = createSpan('LibreChat Title', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'title']),
+      [INPUT]: 'Conversation text',
+      [OUTPUT]: 'Conversation title',
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
+    expect(span.attributes[TRACE_INPUT]).toBe('Conversation text');
+    expect(span.attributes[TRACE_OUTPUT]).toBe('Conversation title');
+  });
+
+  it('does not classify untagged root spans as agents', () => {
+    const span = createSpan('Custom root', { [INPUT]: 'input' });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.attributes[OBSERVATION_TYPE]).toBeUndefined();
+  });
+
+  it('shapes standalone generation roots without replacing their type', () => {
+    const span = createSpan('ChatOpenAI', {
+      [OBSERVATION_TYPE]: 'generation',
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'title']),
+      [INPUT]: 'Generate a title',
+      [OUTPUT]: 'A useful title',
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.name).toBe('llm');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('generation');
+    expect(span.attributes[TRACE_INPUT]).toBe('Generate a title');
+    expect(span.attributes[TRACE_OUTPUT]).toBe('A useful title');
   });
 });

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -546,6 +546,13 @@ export interface LangfuseConfig {
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
+  /**
+   * Environment identifier attached to exported traces (Langfuse
+   * `environment`). When unset, falls back to `LANGFUSE_TRACING_ENVIRONMENT`
+   * then `NODE_ENV`, so production traces are not collapsed under the
+   * `default` environment.
+   */
+  environment?: string;
   metadata?: Record<string, string | number | boolean | null | undefined>;
   /**
    * Internal OTLP span attributes to attach to Langfuse observations before

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -534,9 +534,9 @@ export type LangfuseToolOutputTracingConfig = {
 
 export type LangfuseToolNodeTracingConfig = {
   /**
-   * Overrides ToolNode callback tracing. ToolNode spans are exported by the
-   * env-backed Langfuse callback, so this only enables tracing when that
-   * callback is configured.
+   * Opts into the internal ToolNode batch observation. Graph tool-dispatch
+   * and individual tool observations are exported without this wrapper, so
+   * the default is false to avoid a redundant hierarchy level.
    */
   enabled?: boolean;
 };


### PR DESCRIPTION
## Summary

Builds on the Langfuse trace-shaping added in v3.2.65 so exported agent traces read as the agent's actual work (LLM calls + tool calls) rather than LangGraph's internal execution graph, and restores an environment-tagging behaviour lost in the v4→v5 Langfuse SDK upgrade.

Two independent changes, one per commit.

### 1. `feat(langfuse)`: trace-shaping refinements (`langfuseTraceShaping.ts`)

- **Drop the duplicate `tool_batch` span.** LangGraph's `ToolNode` emits both the `tools=<id>` node span and a nested `tool_batch` run that duplicates it verbatim (byte-identical input/output). The `tool_batch` child is now dropped, so each tool call appears exactly once. It is the leaf child, so nothing needs reparenting.
- **Rename LLM generation spans to `llm`.** Generations were named after the provider client class (`ChatOpenAI`, `AzureChatOpenAI`, …). They are renamed to a provider-agnostic `llm`, so the observation name reflects the operation rather than the model — the model still lives on the generation's model attribute. This mirrors the existing `agent=<id>` → `agent` stripping.
- **Type the root span as `agent`.** The root run was a generic `span`; it is now marked as an `agent` observation.

### 2. `fix(langfuse)`: restore `NODE_ENV` fallback for the tracing environment (`instrumentation.ts`, `types/graph.ts`)

The v4 Langfuse SDK derived the tracing `environment` from `NODE_ENV`; the v5 SDK only reads `LANGFUSE_TRACING_ENVIRONMENT`. Deployments that set only `NODE_ENV` (e.g. `production`) had their traces collapse under the `default` environment. Environment is now resolved as `config.environment ?? LANGFUSE_TRACING_ENVIRONMENT ?? NODE_ENV`, and `LangfuseConfig` gains an optional `environment` field for programmatic control.

## Before / after

Single-agent run querying data through an MCP tool:

**Before**
```
[SPAN] AgentRun
  └─ [SPAN] openAI__gpt-5.4
       └─ [SPAN] LangGraph
            ├─ [SPAN] agent
            │    └─ [GENERATION] ChatOpenAI
            └─ [TOOL] run_select_query…
                 └─ [TOOL] run_select_query…   ← duplicate
```

**After**
```
[AGENT] AgentRun
  └─ [SPAN] openAI__gpt-5.4
       └─ [SPAN] LangGraph
            ├─ [SPAN] agent
            │    └─ [GENERATION] llm
            └─ [TOOL] run_select_query…        ← single
```

## Notes

- Unit tests added/updated in `src/specs/langfuse-trace-shaping.test.ts` and `src/specs/langfuse-instrumentation.test.ts`.
- The remaining wrapper spans (`openAI__gpt-5.4`, `LangGraph`, and the per-turn `agent` node) are intentionally left in place. Collapsing those into a flat `agent → [llm, tool, …]` tree requires span reparenting in the processor and needs care around genuine subagent grouping — happy to follow up in a separate PR if that direction is wanted.
