### PR TITLE
fix: report provider model to Langfuse

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -92,14 +92,15 @@ function getLangfuseBedrockUsage(
   };
 }
 
-function cloneMessageWithUsage(
+function cloneMessageForLangfuse(
   message: AIMessage | AIMessageChunk,
-  usageMetadata: UsageMetadata
+  usageMetadata: UsageMetadata | undefined,
+  responseMetadata: AIMessageFields['response_metadata']
 ): AIMessage | AIMessageChunk {
   const fields: AIMessageFields = {
     content: message.content,
     additional_kwargs: message.additional_kwargs,
-    response_metadata: message.response_metadata,
+    response_metadata: responseMetadata,
     id: message.id,
     name: message.name,
     tool_calls: message.tool_calls,
@@ -118,6 +119,21 @@ function cloneMessageWithUsage(
   return new AIMessage(fields);
 }
 
+function getLangfuseResponseModel(
+  message: AIMessage | AIMessageChunk
+): string | undefined {
+  const model = message.response_metadata.model;
+  if (typeof model !== 'string' || model.trim() === '') {
+    return;
+  }
+
+  const trimmed = model.trim();
+  const routedModel = trimmed.startsWith('model-router')
+    ? trimmed.slice('model-router'.length)
+    : trimmed;
+  return routedModel || trimmed;
+}
+
 function normalizeGenerationForLangfuse(generation: Generation): Generation {
   if (!('message' in generation)) {
     return generation;
@@ -129,18 +145,27 @@ function normalizeGenerationForLangfuse(generation: Generation): Generation {
   }
 
   const usageMetadata = getLangfuseBedrockUsage(message);
-  if (usageMetadata == null || usageMetadata === message.usage_metadata) {
+  const responseModel = getLangfuseResponseModel(message);
+  const responseMetadata =
+    responseModel != null &&
+    responseModel !== message.response_metadata.model_name
+      ? { ...message.response_metadata, model_name: responseModel }
+      : message.response_metadata;
+  if (
+    usageMetadata === message.usage_metadata &&
+    responseMetadata === message.response_metadata
+  ) {
     return generation;
   }
 
   const chatGeneration: ChatGeneration = {
     ...(generation as ChatGeneration),
-    message: cloneMessageWithUsage(message, usageMetadata),
+    message: cloneMessageForLangfuse(message, usageMetadata, responseMetadata),
   };
   return chatGeneration;
 }
 
-function normalizeBedrockUsageForLangfuse(output: LLMResult): LLMResult {
+function normalizeOutputForLangfuse(output: LLMResult): LLMResult {
   if (output.generations.length === 0) {
     return output;
   }
@@ -234,7 +259,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     parentRunId?: string
   ): Promise<void> {
     return super.handleLLMEnd(
-      normalizeBedrockUsageForLangfuse(output),
+      normalizeOutputForLangfuse(output),
       runId,
       parentRunId
     );

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,7 +1,8 @@
-import { HumanMessage } from '@langchain/core/messages';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
@@ -446,6 +447,62 @@ describe('Langfuse callback composition', () => {
         input_cache_creation: 10000,
       })
     );
+  });
+
+  it('uses the provider-reported routed model for Langfuse pricing', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+    });
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const runId = 'test-langfuse-routed-model';
+    const generation: ChatGeneration = {
+      text: 'hello',
+      message: new AIMessage({
+        content: 'hello',
+        response_metadata: {
+          model_name: 'model-router',
+          model: 'model-routergpt-5.5-2026-04-24',
+        },
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+        },
+      }),
+    };
+
+    await handler?.handleChatModelStart(
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['AzureModelRouter'],
+        kwargs: {},
+      },
+      [[new HumanMessage('hello')]],
+      runId
+    );
+    await handler?.handleLLMEnd(
+      {
+        generations: [[generation]],
+      },
+      runId
+    );
+
+    const model = mockSpanAttributeSets
+      .map(
+        (attributes) => attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL]
+      )
+      .find((value): value is string => typeof value === 'string');
+
+    expect(model).toBe('gpt-5.5-2026-04-24');
   });
 
   it('uses deterministic trace ids when tracing is configured from env only', async () => {


### PR DESCRIPTION
## Summary
- prefer the provider-reported response model when exporting Langfuse generations
- normalize Azure Model Router values such as `model-routergpt-5.5-2026-04-24` to the concrete model/version
- preserve the existing Bedrock usage normalization

## Why
Langfuse currently receives the configured alias (`model-router`) through `model_name`, while Azure returns the selected model/version in `response_metadata.model`. The generic alias prevents Langfuse from matching model pricing and leaves generation cost details empty.

## Verification
- focused Langfuse callback suite: 10 tests passed
- ESLint
- TypeScript type-check
- package build