### PR TITLE
feat: trace hosted web search in Langfuse

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -66,6 +66,61 @@ type BedrockResponseMetadata = {
   };
 };
 
+type HostedWebSearchCall = {
+  id: string;
+  status?: string;
+  action?: Record<string, unknown>;
+};
+
+const HOSTED_WEB_SEARCH_TOOL = {
+  lc: 1,
+  type: 'not_implemented',
+  id: ['openai', 'web_search'],
+} as Parameters<CallbackHandler['handleToolStart']>[0];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getHostedWebSearchCalls(output: LLMResult): HostedWebSearchCall[] {
+  const generationList = output.generations.at(-1);
+  const generation = generationList?.at(-1);
+  if (generation == null || !('message' in generation)) {
+    return [];
+  }
+
+  const message = (generation as ChatGeneration).message;
+  if (!(message instanceof AIMessage || message instanceof AIMessageChunk)) {
+    return [];
+  }
+
+  const toolOutputs = message.additional_kwargs.tool_outputs;
+  if (!Array.isArray(toolOutputs)) {
+    return [];
+  }
+
+  const calls = new Map<string, HostedWebSearchCall>();
+  for (const item of toolOutputs) {
+    if (
+      !isRecord(item) ||
+      item.type !== 'web_search_call' ||
+      typeof item.id !== 'string' ||
+      !isPresent(item.id) ||
+      calls.has(item.id)
+    ) {
+      continue;
+    }
+    calls.set(item.id, {
+      id: item.id,
+      ...(typeof item.status === 'string' && isPresent(item.status)
+        ? { status: item.status }
+        : {}),
+      ...(isRecord(item.action) ? { action: item.action } : {}),
+    });
+  }
+  return [...calls.values()];
+}
+
 function getLangfuseBedrockUsage(
   message: AIMessage | AIMessageChunk
 ): UsageMetadata | undefined {
@@ -195,6 +250,41 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     );
   }
 
+  private async traceHostedWebSearchCalls(
+    output: LLMResult,
+    parentRunId: string
+  ): Promise<void> {
+    for (const call of getHostedWebSearchCalls(output)) {
+      const { sources, ...action } = call.action ?? {};
+      const sourceList = Array.isArray(sources) ? sources : [];
+      const toolRunId = `${parentRunId}:web_search:${call.id}`;
+      await this.withRuntimeContext(() =>
+        super.handleToolStart(
+          HOSTED_WEB_SEARCH_TOOL,
+          JSON.stringify(action),
+          toolRunId,
+          parentRunId,
+          undefined,
+          {
+            hosted: true,
+            provider: 'openai',
+            providerCallId: call.id,
+          },
+          'web_search'
+        )
+      );
+      await super.handleToolEnd(
+        JSON.stringify({
+          status: call.status,
+          sourceCount: sourceList.length,
+          sources: sourceList,
+        }),
+        toolRunId,
+        parentRunId
+      );
+    }
+  }
+
   // LangChain may invoke callback handlers outside the caller's OTEL context.
   // Re-enter tenant scope only for callbacks that start Langfuse observations;
   // end/error/token callbacks use spans already bound to a processor at start.
@@ -228,16 +318,20 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     return this.withRuntimeContext(() => super.handleLLMStart(...args));
   }
 
-  override handleLLMEnd(
+  override async handleLLMEnd(
     output: LLMResult,
     runId: string,
     parentRunId?: string
   ): Promise<void> {
-    return super.handleLLMEnd(
-      normalizeBedrockUsageForLangfuse(output),
-      runId,
-      parentRunId
-    );
+    const normalizedOutput = normalizeBedrockUsageForLangfuse(output);
+    try {
+      await this.traceHostedWebSearchCalls(normalizedOutput, runId);
+    } catch (error) {
+      this.logger.debug(
+        `Failed to trace hosted web search: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    return super.handleLLMEnd(normalizedOutput, runId, parentRunId);
   }
 
   override handleToolStart(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -450,6 +450,14 @@ export function shouldIncludeEncryptedReasoning(
   );
 }
 
+function usesHostedWebSearch(tools?: OpenAIClient.Responses.Tool[]): boolean {
+  return (
+    tools?.some(
+      (tool) => tool.type === 'web_search' || tool.type === 'web_search_preview'
+    ) === true
+  );
+}
+
 function getCacheWriteTokens(message: BaseMessage): number | undefined {
   const responseMetadata = message.response_metadata as {
     usage?: ResponsesUsageWithCacheWrite;
@@ -1548,6 +1556,14 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
       promptCacheExplicit: this.promptCacheExplicit,
       safetyIdentifier: this.safetyIdentifier,
     });
+    if (usesHostedWebSearch(params.tools)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'web_search_call.action.sources' as const,
+        ]),
+      ];
+    }
     if (shouldIncludeEncryptedReasoning(this.model, params)) {
       params.include = [
         ...new Set([
@@ -1780,6 +1796,14 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       promptCacheExplicit: this.promptCacheExplicit,
       safetyIdentifier: this.safetyIdentifier,
     });
+    if (usesHostedWebSearch(params.tools)) {
+      params.include = [
+        ...new Set([
+          ...(params.include ?? []),
+          'web_search_call.action.sources' as const,
+        ]),
+      ];
+    }
     if (shouldIncludeEncryptedReasoning(this.model, params)) {
       params.include = [
         ...new Set([

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -59,7 +59,7 @@ import type { BaseMessage, BaseMessageChunk } from '@langchain/core/messages';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { OpenAIClient } from '@langchain/openai';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
-import { ChatOpenAI } from '@/llm/openai';
+import { AzureChatOpenAI, ChatOpenAI } from '@/llm/openai';
 
 type CompletionsDelegate = {
   _convertCompletionsMessageToBaseMessage(
@@ -89,6 +89,12 @@ type InvocationParamsDelegate = {
   ) => { tools?: { function: { strict?: boolean } }[] };
 };
 
+type ResponsesInvocationParamsDelegate = {
+  invocationParams: (options: Record<string, unknown>) => {
+    include?: string[];
+  };
+};
+
 type RawChunk = OpenAIClient.Chat.Completions.ChatCompletionChunk;
 
 type StreamEventsModel = {
@@ -109,9 +115,40 @@ function completionsDelegateOf(model: ChatOpenAI): CompletionsDelegate {
 const completionsOf = <T>(model: ChatOpenAI): T =>
   (model as unknown as { completions: T }).completions;
 
+const responsesOf = <T>(model: ChatOpenAI | AzureChatOpenAI): T =>
+  (model as unknown as { responses: T }).responses;
+
 function newOpenAI(): ChatOpenAI {
   return new ChatOpenAI({ model: 'gpt-4o-mini', apiKey: 'test-key' });
 }
+
+describe('Responses hosted web search sources', () => {
+  const models = [
+    new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' }),
+    new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiInstanceName: 'test-instance',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+    }),
+  ];
+
+  test.each(models)('requests sources for hosted web search', (model) => {
+    const params = responsesOf<ResponsesInvocationParamsDelegate>(
+      model
+    ).invocationParams({ tools: [{ type: 'web_search' }] });
+
+    expect(params.include).toContain('web_search_call.action.sources');
+  });
+
+  test('does not request web sources without a hosted web search tool', () => {
+    const params = responsesOf<ResponsesInvocationParamsDelegate>(
+      models[0]
+    ).invocationParams({});
+
+    expect(params.include).toBeUndefined();
+  });
+});
 
 function createStreamModel(mockChunks: RawChunk[]): ChatOpenAI {
   const model = new ChatOpenAI({ model: 'gpt-4o-mini', apiKey: 'test-key' });

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,7 +1,8 @@
-import { HumanMessage } from '@langchain/core/messages';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
@@ -445,6 +446,82 @@ describe('Langfuse callback composition', () => {
         input_cache_read: 10831,
         input_cache_creation: 10000,
       })
+    );
+  });
+
+  it('exports one hosted web search tool observation with its sources', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+    });
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const runId = 'test-langfuse-hosted-web-search';
+    const webSearchCall = {
+      type: 'web_search_call',
+      id: 'ws_abc123',
+      status: 'completed',
+      action: {
+        type: 'search',
+        query: 'weather in Munich today',
+        sources: [{ type: 'url', url: 'https://example.com/weather' }],
+      },
+    };
+    const generation: ChatGeneration = {
+      text: 'Sunny.',
+      message: new AIMessage({
+        content: 'Sunny.',
+        additional_kwargs: {
+          tool_outputs: [webSearchCall, webSearchCall],
+        },
+      }),
+    };
+
+    await handler?.handleChatModelStart(
+      {
+        lc: 1,
+        type: 'constructor',
+        id: ['AzureChatOpenAI'],
+        kwargs: {},
+      },
+      [[new HumanMessage('What is the weather in Munich today?')]],
+      runId
+    );
+    await handler?.handleLLMEnd(
+      {
+        generations: [[generation]],
+      },
+      runId
+    );
+
+    expect(
+      mockStartActiveSpan.mock.calls.filter(([name]) => name === 'web_search')
+    ).toHaveLength(1);
+    expect(mockSpanAttributeSets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+          [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify({
+            type: 'search',
+            query: 'weather in Munich today',
+          }),
+          [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.providerCallId`]:
+            'ws_abc123',
+        }),
+        expect.objectContaining({
+          [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+            status: 'completed',
+            sourceCount: 1,
+            sources: [{ type: 'url', url: 'https://example.com/weather' }],
+          }),
+        }),
+      ])
     );
   });
 


### PR DESCRIPTION
## Summary

- request `web_search_call.action.sources` for OpenAI and Azure Responses calls using hosted web search
- emit each provider `web_search_call` as one child Langfuse `tool` observation
- record the action, provider call ID, status, source count, and source URLs without fetched page bodies
- deduplicate repeated streamed output items by provider call ID
- keep telemetry best-effort so tracing failures cannot block model responses

This is independent from #317. It does not change web-search routing or execute an additional search.

## Verification

- `npm test -- --runInBand src/llm/openai/llm.spec.ts src/llm/openai/contentBlocks.test.ts src/specs/langfuse-callbacks.test.ts` (71 passed)
- `npm run build`
- Prettier, ESLint, and staged-file checks passed.