### PR TITLE
🛰️ fix: Drop Google Server-Side Tool Blocks on Cross-Provider Handoff

### DIFF
--- a/src/llm/anthropic/utils/cross-provider-server-tools.test.ts
+++ b/src/llm/anthropic/utils/cross-provider-server-tools.test.ts
@@ -1,0 +1,110 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { _convertMessagesToAnthropicPayload } from './message_inputs';
+
+/**
+ * Regression for cross-provider agent handoffs (Google → Anthropic): a Gemini
+ * turn that used a server-side tool (URL context, Google Search) leaves
+ * `toolCall`/`toolResponse` content blocks in history. The Anthropic converter
+ * has no branch for them and previously threw
+ * "Unsupported message content format", crashing the handoff. Only Google can
+ * execute these blocks or validate their thought signatures, so they are
+ * dropped on assistant turns; any other unknown block still throws.
+ */
+type AnthropicPayload = ReturnType<typeof _convertMessagesToAnthropicPayload>;
+
+/** Minimal view of a converted Anthropic content block the assertions read. */
+interface TestBlock {
+  type?: string;
+  text?: string;
+}
+
+const assistantBlocks = (payload: AnthropicPayload): TestBlock[] => {
+  const content = payload.messages.find((m) => m.role === 'assistant')?.content;
+  return Array.isArray(content) ? (content as TestBlock[]) : [];
+};
+
+describe('_convertMessagesToAnthropicPayload — Google server-side tool blocks', () => {
+  it('drops toolCall/toolResponse on an assistant turn, keeping text', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('summarize this article'),
+      new AIMessage({
+        content: [
+          {
+            type: 'toolCall',
+            thoughtSignature: 'google-signature-not-valid-for-anthropic',
+            toolCall: {
+              toolType: 'URL_CONTEXT',
+              args: { urls: ['https://example.com/report'] },
+              id: 'j7pfyr6k',
+            },
+          },
+          {
+            type: 'toolResponse',
+            toolResponse: {
+              toolType: 'URL_CONTEXT',
+              id: 'j7pfyr6k',
+              result: { status: 'SUCCESS' },
+            },
+          },
+          {
+            type: 'text',
+            text: 'The article argues for dollar-cost averaging.',
+          },
+        ],
+      }),
+    ];
+
+    expect(() => _convertMessagesToAnthropicPayload(messages)).not.toThrow();
+    const blocks = assistantBlocks(
+      _convertMessagesToAnthropicPayload(messages)
+    );
+
+    const serialized = JSON.stringify(blocks);
+    expect(serialized).not.toContain('URL_CONTEXT');
+    expect(serialized).not.toContain(
+      'google-signature-not-valid-for-anthropic'
+    );
+    expect(
+      blocks.some(
+        (b) =>
+          b.type === 'text' &&
+          b.text === 'The article argues for dollar-cost averaging.'
+      )
+    ).toBe(true);
+  });
+
+  it('emits a placeholder (not empty content) when a server-tool-only turn is fully dropped', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'toolCall',
+            toolCall: { toolType: 'URL_CONTEXT', args: { urls: [] }, id: 'x1' },
+          },
+        ],
+      }),
+    ];
+    expect(() => _convertMessagesToAnthropicPayload(messages)).not.toThrow();
+    const blocks = assistantBlocks(
+      _convertMessagesToAnthropicPayload(messages)
+    );
+    expect(blocks.length).toBeGreaterThan(0);
+  });
+
+  it('still throws on a genuinely unknown assistant block', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('run code'),
+      new AIMessage({
+        content: [
+          { type: 'some_future_block_type', foo: 'bar' },
+          { type: 'text', text: 'done' },
+        ],
+      }),
+    ];
+    expect(() => _convertMessagesToAnthropicPayload(messages)).toThrow(
+      'Unsupported message content format'
+    );
+  });
+});

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -473,6 +473,13 @@ function _formatContent(message: BaseMessage) {
    * forwarding an unusable block. The receiving model produces its own thinking.
    */
   const foreignReasoningTypes = ['reasoning_content', 'reasoning', 'think'];
+  /**
+   * Google server-side tool blocks (`toolCall`/`toolResponse` parts from e.g.
+   * URL context or Google Search). Only Google can execute these and validate
+   * their thought signatures, so they are dropped on a cross-provider handoff
+   * (e.g. Google → Anthropic); the assistant's answer text is kept.
+   */
+  const foreignServerToolTypes = ['toolCall', 'toolResponse'];
   const { content } = message;
 
   if (typeof content === 'string') {
@@ -854,6 +861,14 @@ function _formatContent(message: BaseMessage) {
         // input and fall through to the throw below rather than being silently
         // dropped — as does any other unknown block (user media, Google
         // code-execution), which must be surfaced, not discarded.
+        return null;
+      } else if (
+        isAIMessage(message) &&
+        foreignServerToolTypes.some((t) => t === contentPart.type)
+      ) {
+        // Google server-side tool call/response (e.g. URL context) — only
+        // Google can execute it or validate its thought signature; drop it
+        // on a cross-provider handoff rather than crash.
         return null;
       } else {
         console.error(

--- a/src/llm/bedrock/utils/cross-provider-server-tools.test.ts
+++ b/src/llm/bedrock/utils/cross-provider-server-tools.test.ts
@@ -1,0 +1,122 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { convertToConverseMessages } from './message_inputs';
+
+/**
+ * Regression for cross-provider agent handoffs (Google → Bedrock): a Gemini
+ * turn that used a server-side tool (URL context, Google Search) leaves
+ * `toolCall`/`toolResponse` content blocks in history. The Bedrock Converse
+ * converter has no branch for them and previously threw
+ * "Unsupported content block type: toolCall", crashing the handoff. Only
+ * Google can execute these blocks or validate their thought signatures, so
+ * they are dropped on assistant turns; any other unknown block still throws.
+ */
+type ConverseResult = ReturnType<typeof convertToConverseMessages>;
+
+/** Minimal view of a converted Bedrock Converse content block the assertions read. */
+interface ConverseBlock {
+  text?: string;
+  toolUse?: {
+    toolUseId?: string;
+    name?: string;
+    input?: Record<string, string>;
+  };
+}
+
+const assistantContent = (result: ConverseResult): ConverseBlock[] => {
+  const msg = result.converseMessages.find((m) => m.role === 'assistant');
+  return (msg?.content ?? []) as ConverseBlock[];
+};
+
+describe('convertToConverseMessages — Google server-side tool blocks (Google → Bedrock)', () => {
+  it('drops toolCall/toolResponse on an assistant turn, keeping text and tool calls', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('summarize this article'),
+      new AIMessage({
+        content: [
+          {
+            type: 'toolCall',
+            thoughtSignature: 'google-signature-not-valid-for-bedrock',
+            toolCall: {
+              toolType: 'URL_CONTEXT',
+              args: { urls: ['https://example.com/report'] },
+              id: 'j7pfyr6k',
+            },
+          },
+          {
+            type: 'toolResponse',
+            toolResponse: {
+              toolType: 'URL_CONTEXT',
+              id: 'j7pfyr6k',
+              result: { status: 'SUCCESS' },
+            },
+          },
+          {
+            type: 'text',
+            text: 'The article argues for dollar-cost averaging.',
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'call_client_tool',
+            name: 'save_note',
+            args: { note: 'DCA summary' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+
+    const serialized = JSON.stringify(content);
+    expect(serialized).not.toContain('URL_CONTEXT');
+    expect(serialized).not.toContain('google-signature-not-valid-for-bedrock');
+
+    expect(
+      content.some(
+        (b) => b.text === 'The article argues for dollar-cost averaging.'
+      )
+    ).toBe(true);
+    const toolUse = content.find((b) => b.toolUse != null);
+    expect(toolUse?.toolUse).toMatchObject({
+      toolUseId: 'call_client_tool',
+      name: 'save_note',
+      input: { note: 'DCA summary' },
+    });
+  });
+
+  it('emits a placeholder (not empty content) when a server-tool-only turn is fully dropped', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: 'toolCall',
+            toolCall: { toolType: 'URL_CONTEXT', args: { urls: [] }, id: 'x1' },
+          },
+        ],
+      }),
+    ];
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const content = assistantContent(convertToConverseMessages(messages));
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.every((b) => typeof b.text === 'string')).toBe(true);
+  });
+
+  it('still throws on a genuinely unknown assistant block', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('run code'),
+      new AIMessage({
+        content: [
+          { type: 'some_future_block_type', foo: 'bar' },
+          { type: 'text', text: 'done' },
+        ],
+      }),
+    ];
+    expect(() => convertToConverseMessages(messages)).toThrow(
+      'Unsupported content block type'
+    );
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -42,6 +42,14 @@ const FOREIGN_REASONING_TYPES = [
 ];
 
 /**
+ * Google server-side tool blocks (`toolCall`/`toolResponse` parts from e.g.
+ * URL context or Google Search). Only Google can execute these and validate
+ * their thought signatures, so they are dropped on a cross-provider handoff
+ * (e.g. Google → Bedrock); the assistant's answer text is kept.
+ */
+const FOREIGN_SERVER_TOOL_TYPES = ['toolCall', 'toolResponse'];
+
+/**
  * Bedrock Converse rejects assistant messages with no content blocks. When
  * filtering (e.g. dropping foreign reasoning) empties an assistant turn that
  * also has no tool calls, fall back to this placeholder text.
@@ -726,6 +734,11 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
           // it on a cross-provider handoff (e.g. Anthropic → Bedrock) rather
           // than crash. The Bedrock model produces its own reasoning. Anything
           // else unknown still throws below — real content must be surfaced.
+          return;
+        } else if (FOREIGN_SERVER_TOOL_TYPES.some((t) => t === block.type)) {
+          // Google server-side tool call/response (e.g. URL context) — only
+          // Google can execute it or validate its thought signature; drop it
+          // on a cross-provider handoff rather than crash.
           return;
         } else {
           const blockValues = Object.fromEntries(


### PR DESCRIPTION
## Summary

Switching a conversation to a Bedrock or Anthropic agent crashed with `Unsupported content block type: toolCall` when the history contained a Gemini turn that used a server-side tool (URL context, Google Search). Gemini emits those as `toolCall`/`toolResponse` parts carrying a `thoughtSignature`; the Google provider round-trips them, but the Bedrock and Anthropic converters had no branch for them and threw. Only Google can execute these blocks or validate their signatures, so I drop them on cross-provider handoff, mirroring the existing foreign-reasoning handling. The assistant's answer text is preserved.

- Added `FOREIGN_SERVER_TOOL_TYPES` (`toolCall`, `toolResponse`) to the Bedrock Converse converter and dropped these blocks on assistant turns, next to the existing `FOREIGN_REASONING_TYPES` drop; the empty-turn placeholder already covers a fully dropped turn.
- Dropped the same block types in the Anthropic `_formatContent`, gated to assistant turns via `isAIMessage`, with the existing empty-content placeholder as fallback.
- Kept the throw for genuinely unknown block types so real content is surfaced rather than silently discarded.
- Added `cross-provider-server-tools.test.ts` regression suites for both converters, with the repro block shaped like the production error (`URL_CONTEXT` args plus `thoughtSignature`), plus placeholder and still-throws cases.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm test -- cross-provider --testPathIgnorePatterns=worktrees`: all suites pass, including the new regression tests.
- `npm test -- src/llm/bedrock src/llm/anthropic --testPathIgnorePatterns=worktrees`: 20 suites, 355 tests pass.
- `npx eslint` on touched files and `npx tsc --noEmit` are clean.
- Manual repro path: run a Gemini agent with URL context on a conversation, then switch the conversation to a Bedrock or Anthropic agent and send a message. Previously this crashed the run; with this change the model responds normally.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
