### PR TITLE
🛂 fix: Honor Explicit Ask Rules in Tool Policies

### DIFF
--- a/src/hooks/__tests__/createToolPolicyHook.test.ts
+++ b/src/hooks/__tests__/createToolPolicyHook.test.ts
@@ -98,12 +98,12 @@ describe('createToolPolicyHook — bypass mode', () => {
     expect((await callHook(hook, 'read_file')).decision).toBe('allow');
   });
 
-  it('overrides explicit ask patterns (bypass means stop asking)', async () => {
+  it('still asks tools that match an explicit ask pattern', async () => {
     const hook = createToolPolicyHook({
       mode: 'bypass',
       ask: ['execute_*'],
     });
-    expect((await callHook(hook, 'execute_code')).decision).toBe('allow');
+    expect((await callHook(hook, 'execute_code')).decision).toBe('ask');
   });
 });
 
@@ -154,6 +154,15 @@ describe('createToolPolicyHook — pattern matching', () => {
 });
 
 describe('createToolPolicyHook — precedence', () => {
+  it('deny wins over ask', async () => {
+    const hook = createToolPolicyHook({
+      mode: 'default',
+      deny: ['execute_delete'],
+      ask: ['execute_*'],
+    });
+    expect((await callHook(hook, 'execute_delete')).decision).toBe('deny');
+  });
+
   it('deny wins over allow', async () => {
     const hook = createToolPolicyHook({
       mode: 'default',
@@ -173,13 +182,13 @@ describe('createToolPolicyHook — precedence', () => {
     expect((await callHook(hook, 'anything_else')).decision).toBe('allow');
   });
 
-  it('allow wins over ask in default mode', async () => {
+  it('ask wins over allow in default mode', async () => {
     const hook = createToolPolicyHook({
       mode: 'default',
       allow: ['execute_safe'],
       ask: ['execute_*'],
     });
-    expect((await callHook(hook, 'execute_safe')).decision).toBe('allow');
+    expect((await callHook(hook, 'execute_safe')).decision).toBe('ask');
     expect((await callHook(hook, 'execute_dangerous')).decision).toBe('ask');
   });
 });

--- a/src/hooks/createToolPolicyHook.ts
+++ b/src/hooks/createToolPolicyHook.ts
@@ -3,11 +3,11 @@
  * permission policies (allow / deny / ask lists + a global mode) without
  * hand-rolling matching, precedence, and decision logic per-host.
  *
- * Maps directly to the Claude Code Agent SDK permission vocabulary
- * (`allowed_tools` / `disallowed_tools` / `permissionMode`) so users of
- * either SDK can think in the same terms. See the README's HITL section
- * for the cross-walk and `docs/hooks-design-report.md` for the broader
- * hook system context.
+ * Uses the Claude Code Agent SDK permission vocabulary (`allowed_tools` /
+ * `disallowed_tools` / `permissionMode`) while treating modes as fallbacks
+ * for calls that match no explicit rule. See the README's HITL section for
+ * the cross-walk and `docs/hooks-design-report.md` for the broader hook
+ * system context.
  */
 
 import type { HookCallback, PreToolUseHookOutput, ToolDecision } from './types';
@@ -20,10 +20,8 @@ import type { HookCallback, PreToolUseHookOutput, ToolDecision } from './types';
  *   - `dontAsk`  — unmatched tools are denied; the human is never
  *                  prompted. Useful for headless / API agents where a
  *                  silent denial is preferable to a hung interrupt.
- *   - `bypass`   — every tool is approved, except those matching `deny`
- *                  patterns. The kill switch you flip when you trust
- *                  the agent and want to stop being asked. Equivalent to
- *                  Claude Code's `bypassPermissions`.
+ *   - `bypass`   — unmatched tools are approved. Explicit `deny` and `ask`
+ *                  rules still apply.
  */
 export type ToolPolicyMode = 'default' | 'dontAsk' | 'bypass';
 
@@ -46,9 +44,8 @@ export interface ToolPolicyConfig {
    */
   deny?: readonly string[];
   /**
-   * Tool name patterns that always trigger human approval, regardless
-   * of `mode: 'default'` vs `'dontAsk'`. In `mode: 'bypass'` these are
-   * still bypassed (because that's what bypass means).
+   * Tool name patterns that always trigger human approval. Wins over
+   * `allow` and every mode, but not `deny`.
    */
   ask?: readonly string[];
   /**
@@ -115,12 +112,12 @@ function formatReason(
  * registry.register('PreToolUse', { hooks: [policyHook] });
  * ```
  *
- * Evaluation order matches Claude Code's permission flow:
+ * Explicit rules take precedence over fallback modes:
  *
  *   1. `deny` rule match → `'deny'` (always wins, even in `bypass`).
- *   2. `mode === 'bypass'` → `'allow'`.
+ *   2. `ask` rule match → `'ask'`.
  *   3. `allow` rule match → `'allow'`.
- *   4. `ask` rule match → `'ask'`.
+ *   4. `mode === 'bypass'` → `'allow'`.
  *   5. `mode === 'dontAsk'` → `'deny'`.
  *   6. fallthrough → `'ask'`.
  *
@@ -168,14 +165,14 @@ function decide(
   if (denyMatch(toolName)) {
     return 'deny';
   }
-  if (mode === 'bypass') {
-    return 'allow';
+  if (askMatch(toolName)) {
+    return 'ask';
   }
   if (allowMatch(toolName)) {
     return 'allow';
   }
-  if (askMatch(toolName)) {
-    return 'ask';
+  if (mode === 'bypass') {
+    return 'allow';
   }
   if (mode === 'dontAsk') {
     return 'deny';

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -34,7 +34,7 @@ import type {
 import type * as t from '@/types';
 import { Providers as providers, GraphEvents } from '@/common';
 import * as events from '@/utils/events';
-import { HookRegistry } from '@/hooks';
+import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import { ToolNode } from '../ToolNode';
 
 async function flushAsyncWork(): Promise<void> {
@@ -253,6 +253,119 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
         allowed_decisions: ['approve', 'reject', 'edit', 'respond'],
       },
     ]);
+  });
+
+  it('waits for approval before executing an explicit ask rule in bypass mode', async () => {
+    let toolExecuted = false;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        toolExecuted = true;
+        const request = data as {
+          resolve: (results: t.ToolExecuteResult[]) => void;
+        };
+        request.resolve([
+          { toolCallId: 'call_1', content: 'deleted', status: 'success' },
+        ]);
+      });
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        createToolPolicyHook({
+          mode: 'bypass',
+          ask: ['dangerous_*'],
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [createSchemaStub('dangerous_tool')],
+      eventDrivenMode: true,
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([['call_1', 'step_call_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_1',
+        name: 'dangerous_tool',
+        args: { command: 'delete data' },
+      },
+    ]);
+    const config = {
+      configurable: { thread_id: 'thread-bypass-explicit-ask' },
+    };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+
+    expect(isInterrupted<t.HumanInterruptPayload>(interrupted)).toBe(true);
+    expect(toolExecuted).toBe(false);
+
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'approve' }],
+      config
+    )) as { messages: BaseMessage[] };
+
+    expect(toolExecuted).toBe(true);
+    expect(
+      resumed.messages.some(
+        (message) =>
+          message._getType() === 'tool' &&
+          (message as ToolMessage).tool_call_id === 'call_1' &&
+          message.content === 'deleted'
+      )
+    ).toBe(true);
+  });
+
+  it('executes an unmatched tool without interruption in bypass mode', async () => {
+    let toolExecuted = false;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        toolExecuted = true;
+        const request = data as {
+          resolve: (results: t.ToolExecuteResult[]) => void;
+        };
+        request.resolve([
+          { toolCallId: 'call_1', content: 'read result', status: 'success' },
+        ]);
+      });
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        createToolPolicyHook({
+          mode: 'bypass',
+          ask: ['dangerous_*'],
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [createSchemaStub('read_tool')],
+      eventDrivenMode: true,
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([['call_1', 'step_call_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'read_tool', args: { command: 'read data' } },
+    ]);
+
+    const result = await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'thread-bypass-unmatched' } }
+    );
+
+    expect(isInterrupted(result)).toBe(false);
+    expect(toolExecuted).toBe(true);
   });
 
   it('resume with approve runs the tool through the host event path', async () => {


### PR DESCRIPTION
I fixed declarative tool-policy precedence so explicit safety rules cannot be silently erased by broad fallback modes. This resolves AI-1460 and addresses LibreChat issue #14192.

- Evaluate policy decisions as `deny > ask > allow > bypass > dontAsk > default ask`.
- Treat `bypass` and `dontAsk` as fallbacks only for tools that match no explicit rule.
- Clarify the public SDK documentation for mode and rule precedence.
- Add unit coverage for `deny + ask`, `ask + allow`, and `ask + bypass` overlaps.
- Add ToolNode/LangGraph coverage proving a matched ask rule pauses before execution, resumes after approval, and leaves unmatched bypass calls uninterrupted.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- Ran `npx jest src/hooks/__tests__/createToolPolicyHook.test.ts --runInBand` — 22 passed.
- Ran the two new ToolNode HITL cases from `src/tools/__tests__/hitl.test.ts` — 2 passed.
- Ran the built ESM package through a seven-case precedence matrix — all passed.
- Ran ESLint for all touched files.
- Ran `npx tsc --noEmit`.
- Ran `npm run build`.
- Ran Prettier and `git diff --check`.

The broader HITL/hooks Jest run currently reaches a pre-existing `@mistralai/mistralai` ESM-through-CJS parse failure on `main`; unaffected test cases ran successfully before that unrelated import boundary.

### **Test Configuration**:

- Node.js: repository-supported Node 24 runtime
- Package: `@librechat/agents@3.2.66`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works