### PR TITLE
🗓️ fix: Prevent Tavily Recency Overfiltering

### DIFF
--- a/src/tools/search/schema.test.ts
+++ b/src/tools/search/schema.test.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_DATE_DESCRIPTION, dateSchema } from './schema';
+
+describe('web search schema', () => {
+  it('warns models that date filtering can exclude undated results', () => {
+    expect(dateSchema.description).toBe(DEFAULT_DATE_DESCRIPTION);
+    expect(dateSchema.description).toContain(
+      'Only provide this when the user explicitly requests recent results'
+    );
+    expect(dateSchema.description).toContain(
+      'pages without a detectable publication or update date'
+    );
+  });
+});

--- a/src/tools/search/schema.test.ts
+++ b/src/tools/search/schema.test.ts
@@ -1,4 +1,10 @@
-import { DEFAULT_DATE_DESCRIPTION, dateSchema } from './schema';
+import {
+  DEFAULT_DATE_DESCRIPTION,
+  TAVILY_DATE_DESCRIPTION,
+  tavilyDateSchema,
+  dateSchema,
+  DATE_RANGE,
+} from './schema';
 
 describe('web search schema', () => {
   it('warns models that date filtering can exclude undated results', () => {
@@ -9,5 +15,11 @@ describe('web search schema', () => {
     expect(dateSchema.description).toContain(
       'pages without a detectable publication or update date'
     );
+  });
+
+  it('does not advertise unsupported hourly filtering for Tavily', () => {
+    expect(tavilyDateSchema.description).toBe(TAVILY_DATE_DESCRIPTION);
+    expect(tavilyDateSchema.enum).not.toContain(DATE_RANGE.PAST_HOUR);
+    expect(tavilyDateSchema.description).not.toContain('past hour');
   });
 });

--- a/src/tools/search/schema.ts
+++ b/src/tools/search/schema.ts
@@ -36,16 +36,20 @@ Examples:
 - "in" for India
 `.trim();
 
-export const DEFAULT_DATE_DESCRIPTION =
-  `Optional publication or update date filter.
+const DATE_FILTER_GUIDANCE = `Optional publication or update date filter.
 Only provide this when the user explicitly requests recent results. Search providers filter using detected dates, which may exclude relevant pages without a detectable publication or update date. Otherwise, omit this parameter.
-Values:
-- "h": past hour
+Values:`;
+
+const TAVILY_DATE_RANGE_DESCRIPTION = `
 - "d": past 24 hours
 - "w": past week
 - "m": past month
-- "y": past year
-`.trim();
+- "y": past year`;
+
+export const DEFAULT_DATE_DESCRIPTION = `${DATE_FILTER_GUIDANCE}
+- "h": past hour${TAVILY_DATE_RANGE_DESCRIPTION}`;
+
+export const TAVILY_DATE_DESCRIPTION = `${DATE_FILTER_GUIDANCE}${TAVILY_DATE_RANGE_DESCRIPTION}`;
 
 export const querySchema = {
   type: 'string',
@@ -56,6 +60,17 @@ export const dateSchema = {
   type: 'string',
   enum: Object.values(DATE_RANGE),
   description: DEFAULT_DATE_DESCRIPTION,
+} as const;
+
+export const tavilyDateSchema = {
+  type: 'string',
+  enum: [
+    DATE_RANGE.PAST_24_HOURS,
+    DATE_RANGE.PAST_WEEK,
+    DATE_RANGE.PAST_MONTH,
+    DATE_RANGE.PAST_YEAR,
+  ],
+  description: TAVILY_DATE_DESCRIPTION,
 } as const;
 
 export const countrySchema = {

--- a/src/tools/search/schema.ts
+++ b/src/tools/search/schema.ts
@@ -36,6 +36,17 @@ Examples:
 - "in" for India
 `.trim();
 
+export const DEFAULT_DATE_DESCRIPTION =
+  `Optional publication or update date filter.
+Only provide this when the user explicitly requests recent results. Search providers filter using detected dates, which may exclude relevant pages without a detectable publication or update date. Otherwise, omit this parameter.
+Values:
+- "h": past hour
+- "d": past 24 hours
+- "w": past week
+- "m": past month
+- "y": past year
+`.trim();
+
 export const querySchema = {
   type: 'string',
   description: DEFAULT_QUERY_DESCRIPTION,
@@ -44,7 +55,7 @@ export const querySchema = {
 export const dateSchema = {
   type: 'string',
   enum: Object.values(DATE_RANGE),
-  description: 'Date range for search results.',
+  description: DEFAULT_DATE_DESCRIPTION,
 } as const;
 
 export const countrySchema = {

--- a/src/tools/search/tavily-search.ts
+++ b/src/tools/search/tavily-search.ts
@@ -3,7 +3,7 @@ import type * as t from './types';
 
 const DEFAULT_TAVILY_TIMEOUT = 15000;
 
-const TAVILY_COUNTRY_ALIASES: Record<string, string> = {
+const TAVILY_COUNTRY_ALIASES: Partial<Record<string, string>> = {
   ba: 'bosnia and herzegovina',
   cg: 'congo',
   cz: 'czech republic',
@@ -287,9 +287,12 @@ export const createTavilyAPI = (
     }
 
     try {
+      const configuredTimeRange = options?.timeRange;
       const timeRange =
-        normalizeTavilyTimeRange(options?.timeRange) ??
-        (date != null ? (normalizeTavilyTimeRange(date) ?? 'day') : undefined);
+        configuredTimeRange === false
+          ? undefined
+          : normalizeTavilyTimeRange(configuredTimeRange) ??
+            normalizeTavilyTimeRange(date);
       const topic =
         news === true || type === 'news'
           ? 'news'
@@ -319,7 +322,7 @@ export const createTavilyAPI = (
       if (tavilyCountry != null) {
         payload.country = tavilyCountry;
       }
-      if (type === 'images' || options?.includeImages) {
+      if (type === 'images' || options?.includeImages === true) {
         payload.include_images = true;
       }
       if (options?.includeAnswer != null) {

--- a/src/tools/search/tavily.test.ts
+++ b/src/tools/search/tavily.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import type * as t from './types';
 import { TavilyScraper, createTavilyScraper } from './tavily-scraper';
 import { createSearchAPI } from './search';
+import { DATE_RANGE } from './schema';
 import { createSearchTool } from './tool';
 
 jest.mock('axios');
@@ -98,6 +99,7 @@ describe('Tavily search API', () => {
     const result = await searchAPI.getSources({
       query: 'example query',
       country: 'US',
+      date: DATE_RANGE.PAST_YEAR,
     });
     const [, payload] = mockedAxios.post.mock.calls[0];
 
@@ -128,6 +130,43 @@ describe('Tavily search API', () => {
       imageUrl: 'https://example.com/second.png',
       position: 2,
     });
+  });
+
+  it('maps a requested date range to Tavily time_range', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { results: [] } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'tavily',
+      tavilyApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({
+      query: 'example query',
+      date: DATE_RANGE.PAST_YEAR,
+    });
+    const [, payload] = mockedAxios.post.mock.calls[0];
+
+    expect(payload).toMatchObject({ time_range: 'year' });
+  });
+
+  it('allows configured Tavily options to disable model time ranges', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { results: [] } });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'tavily',
+      tavilyApiKey: 'test-key',
+      tavilySearchOptions: {
+        timeRange: false,
+      },
+    });
+
+    await searchAPI.getSources({
+      query: 'example query',
+      date: DATE_RANGE.PAST_YEAR,
+    });
+    const [, payload] = mockedAxios.post.mock.calls[0];
+
+    expect(payload).not.toHaveProperty('time_range');
   });
 
   it('omits country for Tavily news searches', async () => {

--- a/src/tools/search/tavily.test.ts
+++ b/src/tools/search/tavily.test.ts
@@ -169,6 +169,24 @@ describe('Tavily search API', () => {
     expect(payload).not.toHaveProperty('time_range');
   });
 
+  it('omits unsupported hourly filtering from the Tavily tool schema', () => {
+    const searchTool = createSearchTool({
+      searchProvider: 'tavily',
+      tavilyApiKey: 'test-key',
+      scraperProvider: 'tavily',
+      rerankerType: 'none',
+      logger: mockLogger,
+    });
+
+    expect(searchTool.schema).toMatchObject({
+      properties: {
+        date: {
+          enum: ['d', 'w', 'm', 'y'],
+        },
+      },
+    });
+  });
+
   it('omits country for Tavily news searches', async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -4,6 +4,7 @@ import type * as t from './types';
 import {
   WebSearchToolDescription,
   WebSearchToolName,
+  tavilyDateSchema,
   countrySchema,
   imagesSchema,
   videosSchema,
@@ -369,7 +370,7 @@ export const createSearchTool = (
 
   const schemaProperties: Record<string, unknown> = {
     query: querySchema,
-    date: dateSchema,
+    date: searchProvider === 'tavily' ? tavilyDateSchema : dateSchema,
     images: imagesSchema,
     videos: videosSchema,
     news: newsSchema,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -80,7 +80,8 @@ export interface TavilySearchOptions {
   includeDomains?: string[];
   excludeDomains?: string[];
   topic?: 'general' | 'news' | 'finance';
-  timeRange?: TavilyTimeRangeInput;
+  /** Pin a time range, or set false to ignore tool-requested date filters. */
+  timeRange?: TavilyTimeRangeInput | false;
   includeImageDescriptions?: boolean;
   includeFavicon?: boolean;
   chunksPerSource?: number;


### PR DESCRIPTION
I fixed Tavily recency filtering so models receive safer date guidance and operators can disable model-selected time ranges.

- Clarified the shared date schema with explicit recency guidance, detected-date filtering risks, and supported shorthand values.
- Added `timeRange: false` as an operator override that suppresses model-requested Tavily date filters.
- Removed the invalid-date fallback that silently selected Tavily's narrowest `day` range.
- Added regression coverage for schema guidance, model-provided ranges, configured precedence, and explicit disabling.
- Tightened Tavily option checks so the touched files pass the strict ESLint rules.

Closes #320

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest src/tools/search --runInBand`: 51 tests passed.
- Ran ESLint on all changed TypeScript files: passed with no warnings or errors.
- Ran `npx tsc --noEmit`: blocked by existing unrelated errors in `src/llm/openrouter/index.ts` and `src/utils/logging.ts`.

### **Test Configuration**:

- Node.js: v24.16.0
- npm: 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes