### PR TITLE
fix: skip prefilled model turn for no-prefill Gemini models

### DIFF
--- a/src/llm/google/index.ts
+++ b/src/llm/google/index.ts
@@ -19,6 +19,7 @@ import type { GoogleClientOptions, GoogleThinkingConfig } from '@/types';
 import {
   convertResponseContentToChatGenerationChunk,
   convertBaseMessagesToContent,
+  dropUnsupportedModelTurnPrefill,
   mapGenerateContentResultToChatResult,
 } from './utils/common';
 
@@ -254,6 +255,7 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
       this.client.systemInstruction = systemInstruction;
       actualPrompt = prompt.slice(1);
     }
+    actualPrompt = dropUnsupportedModelTurnPrefill(actualPrompt, this.model);
     const parameters = this.invocationParams(options);
     const request = {
       ...parameters,
@@ -308,6 +310,7 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
       this.client.systemInstruction = systemInstruction;
       actualPrompt = prompt.slice(1);
     }
+    actualPrompt = dropUnsupportedModelTurnPrefill(actualPrompt, this.model);
     const parameters = this.invocationParams(options);
     const request = {
       ...parameters,

--- a/src/llm/google/utils/common.test.ts
+++ b/src/llm/google/utils/common.test.ts
@@ -1,12 +1,16 @@
 import { expect, test, describe } from '@jest/globals';
 import { AIMessageChunk } from '@langchain/core/messages';
-import type { EnhancedGenerateContentResponse } from '@google/generative-ai';
+import type { Content, EnhancedGenerateContentResponse } from '@google/generative-ai';
 import {
   STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { convertResponseContentToChatGenerationChunk } from './common';
+import {
+  convertResponseContentToChatGenerationChunk,
+  dropUnsupportedModelTurnPrefill,
+  rejectsModelTurnPrefill,
+} from './common';
 
 function buildResponse(
   parts: Array<Record<string, unknown>>
@@ -60,5 +64,56 @@ describe('convertResponseContentToChatGenerationChunk seal metadata', () => {
       .response_metadata as Record<string, unknown>;
     expect(metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]).toBeUndefined();
     expect(metadata[STREAMED_TOOL_CALL_SEAL_METADATA_KEY]).toBeUndefined();
+  });
+});
+
+describe('rejectsModelTurnPrefill', () => {
+  test('is true for models that reject a trailing model turn', () => {
+    expect(rejectsModelTurnPrefill('gemini-3.6-flash')).toBe(true);
+    expect(rejectsModelTurnPrefill('gemini-3.5-flash-lite')).toBe(true);
+    expect(rejectsModelTurnPrefill('models/gemini-3.6-flash')).toBe(true);
+    expect(rejectsModelTurnPrefill('google/gemini-3.5-flash-lite-latest')).toBe(true);
+  });
+
+  test('is false for models that still accept prefill and for empty input', () => {
+    expect(rejectsModelTurnPrefill('gemini-3.5-flash')).toBe(false);
+    expect(rejectsModelTurnPrefill('gemini-2.5-flash')).toBe(false);
+    expect(rejectsModelTurnPrefill('gemini-3-pro-preview')).toBe(false);
+    expect(rejectsModelTurnPrefill(undefined)).toBe(false);
+    expect(rejectsModelTurnPrefill('')).toBe(false);
+  });
+});
+
+describe('dropUnsupportedModelTurnPrefill', () => {
+  const userTurn: Content = { role: 'user', parts: [{ text: 'Hi' }] };
+  const modelTurn: Content = { role: 'model', parts: [{ text: 'Hello, I am' }] };
+
+  test('drops a trailing model turn for no-prefill models', () => {
+    const contents: Content[] = [userTurn, modelTurn];
+    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.6-flash');
+    expect(result).toEqual([userTurn]);
+  });
+
+  test('drops multiple consecutive trailing model turns but keeps one turn', () => {
+    const contents: Content[] = [userTurn, modelTurn, modelTurn];
+    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.5-flash-lite');
+    expect(result).toEqual([userTurn]);
+  });
+
+  test('leaves a trailing model turn for models that accept prefill', () => {
+    const contents: Content[] = [userTurn, modelTurn];
+    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.5-flash');
+    expect(result).toBe(contents);
+  });
+
+  test('is a no-op when the request already ends with a user turn', () => {
+    const contents: Content[] = [modelTurn, userTurn];
+    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.6-flash');
+    expect(result).toBe(contents);
+  });
+
+  test('is a no-op for empty or undefined contents', () => {
+    expect(dropUnsupportedModelTurnPrefill([], 'gemini-3.6-flash')).toEqual([]);
+    expect(dropUnsupportedModelTurnPrefill(undefined, 'gemini-3.6-flash')).toBeUndefined();
   });
 });

--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -631,6 +631,50 @@ export function convertBaseMessagesToContent(
   ).content;
 }
 
+/**
+ * Gemini models that reject a request whose `contents` end with a `model`-role
+ * turn (a "prefill"). Google enforces this on newer generations (Gemini 3.6
+ * Flash, Gemini 3.5 Flash-Lite) while older/sibling models still accept a
+ * trailing model turn, so the rule is model-scoped rather than version-wide.
+ * Extend this list as Google applies the restriction to further models.
+ * @see https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates
+ */
+const NO_PREFILL_GEMINI_MODELS = [
+  'gemini-3.6-flash',
+  'gemini-3.5-flash-lite',
+] as const;
+
+export function rejectsModelTurnPrefill(model?: string): boolean {
+  if (model == null || model === '') {
+    return false;
+  }
+  const modelId = model.toLowerCase().split('/').pop() ?? '';
+  return NO_PREFILL_GEMINI_MODELS.some(
+    (id) => modelId === id || modelId.startsWith(`${id}-`)
+  );
+}
+
+/**
+ * Drops trailing `model`-role turns for models that reject prefill (see
+ * {@link rejectsModelTurnPrefill}). Such a turn is only produced by prefill
+ * flows (e.g. editing an assistant reply and resubmitting); these models return
+ * HTTP 400 for it, so we drop it and let the model generate fresh from the
+ * preceding user turn. No-op for every other model, preserving working prefill.
+ */
+export function dropUnsupportedModelTurnPrefill(
+  contents: Content[] | undefined,
+  model?: string
+): Content[] | undefined {
+  if (contents == null || contents.length === 0 || !rejectsModelTurnPrefill(model)) {
+    return contents;
+  }
+  let end = contents.length;
+  while (end > 1 && contents[end - 1]?.role === 'model') {
+    end -= 1;
+  }
+  return end === contents.length ? contents : contents.slice(0, end);
+}
+
 export function convertResponseContentToChatGenerationChunk(
   response: EnhancedGenerateContentResponse,
   extra: {


### PR DESCRIPTION
## Summary

Gemini **3.6 Flash** and **Gemini 3.5 Flash-Lite** newly reject (HTTP 400) any request whose `contents` array ends with a `model`-role turn:

> `Requests ending with a model turn are not supported unless the last part is a function response.`

This is **model-scoped**, not version-wide. Verified live against the Gemini API with identical prefilled requests:

| Model | Trailing `model` turn |
|---|---|
| `gemini-3.6-flash` | **400** |
| `gemini-3.5-flash-lite` | **400** |
| `gemini-3.5-flash` | 200 |
| `gemini-2.5-flash` | 200 |

A trailing model turn is only produced by prefill/continuation flows (e.g. a host editing an assistant reply and resubmitting it); normal chat and tool turns end with a user/function turn.

## Change

- `rejectsModelTurnPrefill(model)` — matches the no-prefill Gemini models (exact + versioned aliases), extensible as Google widens the restriction.
- `dropUnsupportedModelTurnPrefill(contents, model)` — for those models only, drops trailing `model` turns so the model generates fresh from the preceding user turn. **Strict no-op for every other model**, preserving working prefill behavior.
- Applied in `ChatGoogleGenerativeAI._generate` and `_streamResponseChunks` right before the request is built, where `this.model` is available.

## Tests

- 7 new unit tests in `src/llm/google/utils/common.test.ts` (predicate + strip behavior, including multi-turn, no-op cases, versioned aliases). Suite green.
- `tsc` clean; `npm run build` succeeds.
- The live integration suite (`llm.spec.ts`) only exercises `gemini-1.5/2.0/2.5/3-pro/3.5-flash` — none in the no-prefill list — so this change is a no-op for it.

Ref: https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates

Consumed by LibreChat's Gemini 3.6 Flash / 3.5 Flash-Lite support (danny-avila/LibreChat#14367).