### PR TITLE
📝 ci: Skip Workflows for Markdown-Only Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

I updated the automatic GitHub Actions triggers so Markdown-only changes, including documentation updates like #324, do not consume CI resources.

- Added a Markdown path exclusion to pull request CI for `main` and `dev`.
- Added the same exclusion to automatic `main` branch publish runs, which also invoke validation jobs.
- Preserved manual publish runs through `workflow_dispatch`.
- Preserved CI and publish runs for changes that include any non-Markdown file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I verified both edited workflow files with Prettier and confirmed the staged diff has no whitespace errors.

### **Test Configuration**:

- Prettier workflow validation: `npx prettier --check .github/workflows/ci.yml .github/workflows/publish.yml`
- Git diff validation: `git diff --cached --check`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
