### PR TITLE
fix: fold tool history to text for tool-less agents (Bedrock toolConfig)

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -16,6 +16,7 @@ import type * as t from '@/types';
 import {
   formatAnthropicArtifactContent,
   ensureThinkingBlockInMessages,
+  foldToolBlocksForToollessAgent,
   convertMessagesToContent,
   sanitizeOrphanToolBlocks,
   extractToolDiscoveries,
@@ -1862,6 +1863,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           config,
           this.startIndex
         );
+      }
+
+      /**
+       * A destination that binds no tools is invoked without a tool schema, but
+       * in a multi-agent graph it can still inherit a prior agent's toolUse/
+       * toolResult history. Bedrock's Converse API (and other tool-schema-strict
+       * providers) reject such a request when no top-level toolConfig is sent.
+       * Fold that historical tool content into plain text so the tool-less agent
+       * receives valid, context-preserving messages. Handoff tools count as
+       * bound tools, so a tool-less router mid-handoff is not affected.
+       */
+      if (toolsForBinding == null || toolsForBinding.length === 0) {
+        finalMessages = foldToolBlocksForToollessAgent(finalMessages, config);
       }
 
       // Determine the prompt-cache strategy up front. Two distinct facts:

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1876,6 +1876,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        */
       if (toolsForBinding == null || toolsForBinding.length === 0) {
         finalMessages = foldToolBlocksForToollessAgent(finalMessages, config);
+        // The fold emits structured (array) content; re-flatten for agents that
+        // opted into string-only messages (`useLegacyContent`, run earlier at
+        // the top of this block) so the folded turn isn't the lone exception.
+        if (agentContext.useLegacyContent) {
+          finalMessages = formatContentStrings(finalMessages);
+        }
       }
 
       // Determine the prompt-cache strategy up front. Two distinct facts:

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -34,11 +34,17 @@ function hasResidualToolContent(messages: BaseMessage[]): boolean {
     if (ai.tool_calls != null && ai.tool_calls.length > 0) {
       return true;
     }
+    const rawToolCalls = ai.additional_kwargs.tool_calls;
+    if (Array.isArray(rawToolCalls) && rawToolCalls.length > 0) {
+      return true;
+    }
     if (Array.isArray(m.content)) {
       return (m.content as ExtendedMessageContent[]).some(
         (b) =>
           typeof b === 'object' &&
-          (b.type === 'tool_use' || b.type === 'tool_call')
+          (b.type === 'tool_use' ||
+            b.type === 'tool_call' ||
+            b.type === 'tool_result')
       );
     }
     return false;
@@ -177,6 +183,79 @@ describe('foldToolBlocksForToollessAgent', () => {
     const folded = getTextContent(result[result.length - 1]);
     expect(folded).toContain('Let me search.');
     expect(folded).toContain('file_search');
+  });
+
+  test('folds an AI message whose tool call is only in additional_kwargs', () => {
+    const messages = [
+      new HumanMessage('Search my files'),
+      // Parsed `tool_calls` is empty; the call survives only in the raw
+      // additional_kwargs. The OpenAI converter still serializes it, so the
+      // parent AI message must fold with its ToolMessage — otherwise the fold
+      // would leave an orphan assistant(tool_calls) -> user(...) sequence.
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: {
+                name: 'file_search',
+                arguments: '{"query":"roadmap"}',
+              },
+            },
+          ],
+        },
+      }),
+      new ToolMessage({
+        content: 'Found roadmap.md',
+        tool_call_id: 'call_1',
+        name: 'file_search',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    expect(result).toHaveLength(2);
+    const folded = getTextContent(result[1]);
+    expect(folded).toContain('file_search');
+    expect(folded).toContain('roadmap');
+    expect(folded).toContain('Found roadmap.md');
+  });
+
+  test('folds a standard tool_result content block on a user message', () => {
+    const messages = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'file_search',
+            args: { query: 'roadmap' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      // Tool result stored as a content block on a user message (the shape the
+      // Anthropic converter produces/accepts) rather than a ToolMessage.
+      new HumanMessage({
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            content: 'Found roadmap.md',
+          },
+        ],
+      }),
+      new HumanMessage('thanks'),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    expect(result.map(getTextContent).join('\n')).toContain('Found roadmap.md');
   });
 
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -36,7 +36,9 @@ function hasResidualToolContent(messages: BaseMessage[]): boolean {
     }
     if (Array.isArray(m.content)) {
       return (m.content as ExtendedMessageContent[]).some(
-        (b) => typeof b === 'object' && b.type === 'tool_use'
+        (b) =>
+          typeof b === 'object' &&
+          (b.type === 'tool_use' || b.type === 'tool_call')
       );
     }
     return false;
@@ -175,6 +177,40 @@ describe('foldToolBlocksForToollessAgent', () => {
     const folded = getTextContent(result[result.length - 1]);
     expect(folded).toContain('Let me search.');
     expect(folded).toContain('file_search');
+  });
+
+  test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {
+    const messages = [
+      new HumanMessage('Search'),
+      // LangChain v1 standard content: the tool call lives only as a
+      // `tool_call` content block; @langchain/aws still serializes it to a
+      // Converse toolUse, so a tool-less destination must fold it too.
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_call',
+            id: 'call_1',
+            name: 'file_search',
+            args: { query: 'roadmap' },
+          },
+        ],
+        response_metadata: { output_version: 'v1' },
+      }),
+      new ToolMessage({
+        content: 'Found roadmap.md',
+        tool_call_id: 'call_1',
+        name: 'file_search',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    const folded = getTextContent(result[result.length - 1]);
+    expect(folded).toContain('file_search');
+    expect(folded).toContain('roadmap');
+    expect(folded).toContain('Found roadmap.md');
   });
 
   test('preserves image blocks in a tool result instead of stringifying them', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -292,6 +292,102 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded).toContain('Found roadmap.md');
   });
 
+  test('preserves name/args/output of the nested ToolCallContent shape', () => {
+    const messages = [
+      new HumanMessage('Search'),
+      // Shape produced by convertMessagesToContent / persisted LibreChat history:
+      // the call (and its output) are nested under `tool_call`, not top level.
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_call',
+            tool_call: {
+              type: 'tool_call',
+              name: 'file_search',
+              args: { query: 'roadmap' },
+              output: 'Found roadmap.md',
+            },
+          },
+        ],
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    const folded = result.map(getTextContent).join('\n');
+    expect(folded).toContain('file_search');
+    expect(folded).toContain('roadmap');
+    // The embedded tool output is preserved, not dropped.
+    expect(folded).toContain('Found roadmap.md');
+  });
+
+  test('folds a split AIMessage(tool_call) + tool_result user message as one turn', () => {
+    const messages = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          {
+            type: 'tool_call',
+            id: 'c1',
+            name: 'file_search',
+            args: { query: 'roadmap' },
+          },
+        ],
+      }),
+      new HumanMessage({
+        content: [
+          { type: 'tool_result', tool_use_id: 'c1', content: 'Found roadmap.md' },
+        ],
+      }),
+      new HumanMessage('thanks'),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    // Call + result collapse into ONE folded turn (not split/mislabelled).
+    expect(result).toHaveLength(3);
+    const folded = getTextContent(result[1]);
+    expect(folded).toContain('file_search');
+    expect(folded).toContain('Found roadmap.md');
+    expect(getTextContent(result[2])).toBe('thanks');
+  });
+
+  test('preserves image blocks nested inside a tool_result content block', () => {
+    const messages = [
+      new HumanMessage('Chart'),
+      new AIMessage({
+        content: [{ type: 'tool_call', id: 'c1', name: 'chart', args: {} }],
+      }),
+      new HumanMessage({
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'c1',
+            content: [
+              { type: 'text', text: 'chart:' },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,AAAA' },
+              },
+            ],
+          },
+        ],
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    const folded = result[result.length - 1].content;
+    expect(Array.isArray(folded)).toBe(true);
+    expect(
+      (folded as ExtendedMessageContent[]).some((b) => b.type === 'image_url')
+    ).toBe(true);
+  });
+
   test('preserves image blocks in a tool result instead of stringifying them', () => {
     const messages = [
       new HumanMessage('Render a chart'),

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -1,0 +1,227 @@
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import type { ExtendedMessageContent } from '@/types';
+import { foldToolBlocksForToollessAgent } from './format';
+
+/** Concatenated text across a message's content (string or structured array). */
+function getTextContent(msg: {
+  content: string | ExtendedMessageContent[];
+}): string {
+  if (typeof msg.content === 'string') {
+    return msg.content;
+  }
+  if (Array.isArray(msg.content)) {
+    return (msg.content as ExtendedMessageContent[])
+      .filter((b) => b.type === 'text')
+      .map((b) => String(b.text ?? ''))
+      .join('\n');
+  }
+  return '';
+}
+
+/** Any residual tool content that a tool-less agent cannot legally send. */
+function hasResidualToolContent(messages: BaseMessage[]): boolean {
+  return messages.some((m) => {
+    if (m instanceof ToolMessage) {
+      return true;
+    }
+    const ai = m as AIMessage;
+    if (ai.tool_calls != null && ai.tool_calls.length > 0) {
+      return true;
+    }
+    if (Array.isArray(m.content)) {
+      return (m.content as ExtendedMessageContent[]).some(
+        (b) => typeof b === 'object' && b.type === 'tool_use'
+      );
+    }
+    return false;
+  });
+}
+
+describe('foldToolBlocksForToollessAgent', () => {
+  test('returns the same array reference when there is no tool content', () => {
+    const messages = [
+      new SystemMessage('You are helpful.'),
+      new HumanMessage('Hi'),
+      new AIMessage('Hello!'),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).toBe(messages);
+  });
+
+  test('folds an AI tool call plus its ToolMessage into one HumanMessage', () => {
+    const messages = [
+      new HumanMessage('Search my files for "roadmap"'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'file_search',
+            args: { query: 'roadmap' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'Found roadmap.md',
+        tool_call_id: 'call_1',
+        name: 'file_search',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    // Human prompt kept, AI+Tool collapsed into a single HumanMessage.
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBeInstanceOf(HumanMessage);
+    const folded = getTextContent(result[1]);
+    expect(folded).toContain('[Previous tool interaction]');
+    expect(folded).toContain('file_search');
+    expect(folded).toContain('roadmap');
+    expect(folded).toContain('Found roadmap.md');
+  });
+
+  test('folds historical tool content that precedes the last human turn (the reported bug)', () => {
+    const messages = [
+      new HumanMessage('Search my files for "roadmap"'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'file_search',
+            args: { query: 'roadmap' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'Found roadmap.md',
+        tool_call_id: 'call_1',
+        name: 'file_search',
+      }),
+      new AIMessage('Here is what I found in roadmap.md.'),
+      new HumanMessage('thanks'),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    // The trailing plain-text turns survive untouched.
+    const last = result[result.length - 1];
+    expect(last).toBeInstanceOf(HumanMessage);
+    expect(getTextContent(last)).toBe('thanks');
+    expect(
+      result.some((m) => getTextContent(m).includes('Here is what I found'))
+    ).toBe(true);
+  });
+
+  test('folds parallel tool calls and all their results together', () => {
+    const messages = [
+      new HumanMessage('Look up A and B'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'a', name: 'lookup', args: { key: 'A' }, type: 'tool_call' },
+          { id: 'b', name: 'lookup', args: { key: 'B' }, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({ content: 'A=1', tool_call_id: 'a', name: 'lookup' }),
+      new ToolMessage({ content: 'B=2', tool_call_id: 'b', name: 'lookup' }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    expect(result).toHaveLength(2);
+    const folded = getTextContent(result[1]);
+    expect(folded).toContain('A=1');
+    expect(folded).toContain('B=2');
+  });
+
+  test('detects Anthropic-style tool_use content blocks', () => {
+    const messages = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'file_search',
+            input: { query: 'roadmap' },
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'Found roadmap.md',
+        tool_call_id: 'call_1',
+        name: 'file_search',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    const folded = getTextContent(result[result.length - 1]);
+    expect(folded).toContain('Let me search.');
+    expect(folded).toContain('file_search');
+  });
+
+  test('preserves image blocks in a tool result instead of stringifying them', () => {
+    const messages = [
+      new HumanMessage('Render a chart'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'c', name: 'chart', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: 'text', text: 'chart:' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAAA' },
+          },
+        ],
+        tool_call_id: 'c',
+        name: 'chart',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    const foldedContent = result[result.length - 1].content;
+    expect(Array.isArray(foldedContent)).toBe(true);
+    expect(
+      (foldedContent as ExtendedMessageContent[]).some(
+        (b) => b.type === 'image_url'
+      )
+    ).toBe(true);
+  });
+
+  test('leaves non-tool conversations untouched', () => {
+    const messages = [
+      new SystemMessage('sys'),
+      new HumanMessage('hi'),
+      new AIMessage('hello'),
+      new HumanMessage('bye'),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).toBe(messages);
+    expect(hasResidualToolContent(result)).toBe(false);
+  });
+});

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1806,6 +1806,16 @@ function appendMessageContent(
       continue;
     }
 
+    // v1 standard-content tool call (`@langchain/aws` serializes it to a
+    // Converse toolUse), so serialize it here rather than via the fallback.
+    if (block.type === 'tool_call') {
+      hasToolUseBlock = true;
+      textChunks.push(
+        `${role}: [tool_use] ${String(block.name ?? '')} ${JSON.stringify(block.args ?? {})}`
+      );
+      continue;
+    }
+
     const text = block.text ?? block.input;
     if (typeof text === 'string' && text) {
       textChunks.push(`${role}: ${text}`);
@@ -2025,8 +2035,10 @@ export function ensureThinkingBlockInMessages(
 }
 
 /** Whether a message carries tool_use / tool_result content that a tool-less
- *  agent cannot legally send (AI tool_calls, a tool_use content block, or a
- *  ToolMessage). */
+ *  agent cannot legally send: a ToolMessage, AI `tool_calls`, or a `tool_use`
+ *  / `tool_call` content block. Both block types matter — `@langchain/aws`
+ *  serializes each to a Converse `toolUse` (the latter via the v1
+ *  standard-content converter, `content: [{ type: 'tool_call' }]`). */
 function messageHasToolContent(msg: BaseMessage): boolean {
   if (isToolMessage(msg)) {
     return true;
@@ -2037,7 +2049,10 @@ function messageHasToolContent(msg: BaseMessage): boolean {
   }
   if (Array.isArray(msg.content)) {
     for (const block of msg.content as ExtendedMessageContent[]) {
-      if (typeof block === 'object' && block.type === 'tool_use') {
+      if (
+        typeof block === 'object' &&
+        (block.type === 'tool_use' || block.type === 'tool_call')
+      ) {
         return true;
       }
     }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -2024,6 +2024,105 @@ export function ensureThinkingBlockInMessages(
   return result;
 }
 
+/** Whether a message carries tool_use / tool_result content that a tool-less
+ *  agent cannot legally send (AI tool_calls, a tool_use content block, or a
+ *  ToolMessage). */
+function messageHasToolContent(msg: BaseMessage): boolean {
+  if (isToolMessage(msg)) {
+    return true;
+  }
+  const aiMsg = msg as AIMessage;
+  if (aiMsg.tool_calls != null && aiMsg.tool_calls.length > 0) {
+    return true;
+  }
+  if (Array.isArray(msg.content)) {
+    for (const block of msg.content as ExtendedMessageContent[]) {
+      if (typeof block === 'object' && block.type === 'tool_use') {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Folds tool_use / tool_result content into plain text for an agent that binds
+ * no tools.
+ *
+ * In a multi-agent graph, a tool-less destination still inherits the prior
+ * agent's conversation history, which can contain toolUse/toolResult blocks.
+ * Because it binds no tools, the model is invoked with no tool schema — and
+ * Bedrock's Converse API rejects any request that carries toolUse/toolResult
+ * blocks without a top-level toolConfig ("The toolConfig field must be defined
+ * when using toolUse and toolResult content blocks"). Adding a dummy toolConfig
+ * is not an option: AWS requires at least one tool, and it would expose a
+ * capability the destination was intentionally denied.
+ *
+ * Each AI tool-call turn plus its trailing ToolMessages is collapsed into a
+ * single `[Previous tool interaction]` HumanMessage that preserves the tool
+ * name, arguments and result as text (image blocks are kept as-is). Non-tool
+ * messages pass through untouched, and the original array is returned unchanged
+ * when it holds no tool content, so the common (fresh tool-less agent) case is
+ * a single cheap scan.
+ */
+export function foldToolBlocksForToollessAgent(
+  messages: BaseMessage[],
+  config?: RunnableConfig
+): BaseMessage[] {
+  let firstToolIndex = -1;
+  for (let i = 0; i < messages.length; i++) {
+    if (messageHasToolContent(messages[i])) {
+      firstToolIndex = i;
+      break;
+    }
+  }
+  if (firstToolIndex === -1) {
+    return messages;
+  }
+
+  const result: BaseMessage[] = messages.slice(0, firstToolIndex);
+  let foldedCount = 0;
+  let i = firstToolIndex;
+  while (i < messages.length) {
+    const msg = messages[i];
+    if (!messageHasToolContent(msg)) {
+      result.push(msg);
+      i++;
+      continue;
+    }
+
+    const parts: MessageContentComplex[] = [];
+    const textChunks: string[] = ['[Previous tool interaction]'];
+    appendMessageContent(msg, isToolMessage(msg) ? 'Tool' : 'AI', textChunks, parts);
+    foldedCount++;
+
+    let j = i + 1;
+    while (j < messages.length && isToolMessage(messages[j])) {
+      appendMessageContent(messages[j], 'Tool', textChunks, parts);
+      foldedCount++;
+      j++;
+    }
+
+    flushTextChunks(textChunks, parts);
+    result.push(
+      withMessageRole(
+        new HumanMessage({ content: toLangChainContent(parts) }),
+        'user'
+      )
+    );
+    i = j;
+  }
+
+  emitAgentLog(
+    config,
+    'warn',
+    'format',
+    `foldToolBlocksForToollessAgent: folded ${foldedCount} tool message(s) into text for a tool-less agent`
+  );
+
+  return result;
+}
+
 /**
  * Walks backwards from `currentIndex` through the message array to check
  * whether an earlier AI message in the same "chain" (no HumanMessage boundary)

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1844,11 +1844,26 @@ function appendToolCalls(
     return;
   }
   const aiMsg = msg as AIMessage;
-  if (!aiMsg.tool_calls || aiMsg.tool_calls.length === 0) {
+  if (aiMsg.tool_calls && aiMsg.tool_calls.length > 0) {
+    for (const tc of aiMsg.tool_calls) {
+      textChunks.push(`AI: [tool_call] ${tc.name}(${JSON.stringify(tc.args)})`);
+    }
     return;
   }
-  for (const tc of aiMsg.tool_calls) {
-    textChunks.push(`AI: [tool_call] ${tc.name}(${JSON.stringify(tc.args)})`);
+  // Fall back to raw provider tool calls kept only in additional_kwargs.
+  const rawToolCalls = aiMsg.additional_kwargs.tool_calls;
+  if (!Array.isArray(rawToolCalls)) {
+    return;
+  }
+  for (const tc of rawToolCalls) {
+    const fn = (tc as { function?: { name?: string; arguments?: string } })
+      .function;
+    if (fn == null) {
+      continue;
+    }
+    textChunks.push(
+      `AI: [tool_call] ${String(fn.name ?? '')}(${String(fn.arguments ?? '')})`
+    );
   }
 }
 
@@ -2034,11 +2049,15 @@ export function ensureThinkingBlockInMessages(
   return result;
 }
 
-/** Whether a message carries tool_use / tool_result content that a tool-less
- *  agent cannot legally send: a ToolMessage, AI `tool_calls`, or a `tool_use`
- *  / `tool_call` content block. Both block types matter — `@langchain/aws`
- *  serializes each to a Converse `toolUse` (the latter via the v1
- *  standard-content converter, `content: [{ type: 'tool_call' }]`). */
+/** Whether a message carries tool content a tool-less agent cannot legally
+ *  send. Covers every representation a provider converter will serialize back
+ *  into a request: a ToolMessage, parsed `AIMessage.tool_calls`, raw
+ *  `additional_kwargs.tool_calls` (OpenAI keeps calls here when the parsed
+ *  array is empty), and `tool_use` / `tool_call` / `tool_result` content
+ *  blocks (`@langchain/aws` and the Anthropic converter map these to Converse
+ *  `toolUse` / `toolResult`). Missing the parent AI message is not just a
+ *  passthrough: folding its ToolMessage alone would leave an orphan
+ *  `assistant(tool_calls) -> user(...)` sequence. */
 function messageHasToolContent(msg: BaseMessage): boolean {
   if (isToolMessage(msg)) {
     return true;
@@ -2047,11 +2066,17 @@ function messageHasToolContent(msg: BaseMessage): boolean {
   if (aiMsg.tool_calls != null && aiMsg.tool_calls.length > 0) {
     return true;
   }
+  const rawToolCalls = aiMsg.additional_kwargs.tool_calls;
+  if (Array.isArray(rawToolCalls) && rawToolCalls.length > 0) {
+    return true;
+  }
   if (Array.isArray(msg.content)) {
     for (const block of msg.content as ExtendedMessageContent[]) {
       if (
         typeof block === 'object' &&
-        (block.type === 'tool_use' || block.type === 'tool_call')
+        (block.type === 'tool_use' ||
+          block.type === 'tool_call' ||
+          block.type === 'tool_result')
       ) {
         return true;
       }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -22,6 +22,7 @@ import type {
   SummaryContentBlock,
   ThinkingContentText,
   ToolCallContent,
+  ToolResultContent,
   ToolCallPart,
   TPayload,
   TMessage,
@@ -1806,13 +1807,62 @@ function appendMessageContent(
       continue;
     }
 
-    // v1 standard-content tool call (`@langchain/aws` serializes it to a
-    // Converse toolUse), so serialize it here rather than via the fallback.
+    // A `tool_call` content block appears either as the v1 standard shape
+    // (`{ name, args }` at top level, which `@langchain/aws` maps to a Converse
+    // toolUse) or this repo's `ToolCallContent` (`{ tool_call: { name, args,
+    // output } }`, from `convertMessagesToContent` / persisted history). Handle
+    // both, and emit any embedded output, so the name/args/result survive.
     if (block.type === 'tool_call') {
       hasToolUseBlock = true;
-      textChunks.push(
-        `${role}: [tool_use] ${String(block.name ?? '')} ${JSON.stringify(block.args ?? {})}`
-      );
+      const nested = (block as { tool_call?: ToolCallPart }).tool_call;
+      const name = String(nested?.name ?? block.name ?? '');
+      const rawArgs = nested?.args ?? block.args ?? {};
+      const argsText =
+        typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs);
+      textChunks.push(`${role}: [tool_use] ${name} ${argsText}`.trimEnd());
+      const output = nested?.output;
+      if (output != null && output !== '') {
+        textChunks.push(`Tool: ${String(output)}`);
+      }
+      continue;
+    }
+
+    // A `tool_result` content block (e.g. an AIMessage(tool_call) followed by a
+    // user message carrying the result). Preserve nested image blocks as-is
+    // instead of JSON-stringifying them through the generic fallback.
+    if (block.type === 'tool_result') {
+      hasToolUseBlock = true;
+      const inner = (block as { content?: ToolResultContent['content'] })
+        .content;
+      if (typeof inner === 'string') {
+        if (inner) {
+          textChunks.push(`${role}: [tool_result] ${inner}`);
+        }
+      } else if (Array.isArray(inner)) {
+        for (const innerBlock of inner as Array<
+          string | ExtendedMessageContent
+        >) {
+          if (typeof innerBlock === 'string') {
+            if (innerBlock) {
+              textChunks.push(`${role}: [tool_result] ${innerBlock}`);
+            }
+          } else if (IMAGE_BLOCK_TYPES.has(innerBlock.type ?? '')) {
+            flushTextChunks(textChunks, parts);
+            parts.push({ ...innerBlock } as MessageContentComplex);
+          } else {
+            const innerText = innerBlock.text ?? innerBlock.input;
+            textChunks.push(
+              `${role}: [tool_result] ${
+                typeof innerText === 'string' && innerText
+                  ? innerText
+                  : JSON.stringify(innerBlock)
+              }`
+            );
+          }
+        }
+      } else if (inner != null) {
+        textChunks.push(`${role}: [tool_result] ${JSON.stringify(inner)}`);
+      }
       continue;
     }
 
@@ -2085,6 +2135,23 @@ function messageHasToolContent(msg: BaseMessage): boolean {
   return false;
 }
 
+/** Whether a message carries a tool RESULT: a ToolMessage, or a message whose
+ *  content includes a `tool_result` block (the shape when a call/result pair is
+ *  split as `AIMessage(tool_call)` + `HumanMessage(tool_result)`). Such a result
+ *  belongs with the preceding tool call, so it is absorbed into the same fold
+ *  and labelled as tool output. */
+function isToolResultMessage(msg: BaseMessage): boolean {
+  if (isToolMessage(msg)) {
+    return true;
+  }
+  if (Array.isArray(msg.content)) {
+    return (msg.content as ExtendedMessageContent[]).some(
+      (block) => typeof block === 'object' && block.type === 'tool_result'
+    );
+  }
+  return false;
+}
+
 /**
  * Folds tool_use / tool_result content into plain text for an agent that binds
  * no tools.
@@ -2098,46 +2165,46 @@ function messageHasToolContent(msg: BaseMessage): boolean {
  * is not an option: AWS requires at least one tool, and it would expose a
  * capability the destination was intentionally denied.
  *
- * Each AI tool-call turn plus its trailing ToolMessages is collapsed into a
- * single `[Previous tool interaction]` HumanMessage that preserves the tool
- * name, arguments and result as text (image blocks are kept as-is). Non-tool
- * messages pass through untouched, and the original array is returned unchanged
- * when it holds no tool content, so the common (fresh tool-less agent) case is
- * a single cheap scan.
+ * Each tool-call turn plus its trailing tool results (ToolMessages or
+ * `tool_result` content blocks) is collapsed into a single `[Previous tool
+ * interaction]` HumanMessage that preserves the tool name, arguments and result
+ * as text (image blocks are kept as-is). Runs in a single pass: non-tool
+ * messages pass through, `result` is allocated lazily on the first fold, and the
+ * original array is returned unchanged when it holds no tool content (the common
+ * fresh-tool-less-agent case).
  */
 export function foldToolBlocksForToollessAgent(
   messages: BaseMessage[],
   config?: RunnableConfig
 ): BaseMessage[] {
-  let firstToolIndex = -1;
-  for (let i = 0; i < messages.length; i++) {
-    if (messageHasToolContent(messages[i])) {
-      firstToolIndex = i;
-      break;
-    }
-  }
-  if (firstToolIndex === -1) {
-    return messages;
-  }
-
-  const result: BaseMessage[] = messages.slice(0, firstToolIndex);
+  let result: BaseMessage[] | null = null;
   let foldedCount = 0;
-  let i = firstToolIndex;
+  let i = 0;
   while (i < messages.length) {
     const msg = messages[i];
     if (!messageHasToolContent(msg)) {
-      result.push(msg);
+      result?.push(msg);
       i++;
       continue;
     }
 
+    /** First fold — copy the untouched prefix once, then append from here. */
+    if (result === null) {
+      result = messages.slice(0, i);
+    }
+
     const parts: MessageContentComplex[] = [];
     const textChunks: string[] = ['[Previous tool interaction]'];
-    appendMessageContent(msg, isToolMessage(msg) ? 'Tool' : 'AI', textChunks, parts);
+    appendMessageContent(
+      msg,
+      isToolResultMessage(msg) ? 'Tool' : 'AI',
+      textChunks,
+      parts
+    );
     foldedCount++;
 
     let j = i + 1;
-    while (j < messages.length && isToolMessage(messages[j])) {
+    while (j < messages.length && isToolResultMessage(messages[j])) {
       appendMessageContent(messages[j], 'Tool', textChunks, parts);
       foldedCount++;
       j++;
@@ -2151,6 +2218,10 @@ export function foldToolBlocksForToollessAgent(
       )
     );
     i = j;
+  }
+
+  if (result === null) {
+    return messages;
   }
 
   emitAgentLog(

--- a/src/specs/bedrock-toolless.live.test.ts
+++ b/src/specs/bedrock-toolless.live.test.ts
@@ -77,17 +77,22 @@ function toollessHistory(): BaseMessage[] {
 }
 
 describeIfLive('Bedrock tool-less destination (live)', () => {
-  let clientOptions: t.ClientOptions;
+  let clientOptions: t.BedrockConverseClientOptions;
 
   beforeAll(() => {
     // Force SigV4 with the explicit keys; the Bedrock API-key (bearer) auth
     // scheme otherwise takes precedence in the AWS SDK.
     delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    // `shouldRunLive` already guarantees both keys are set; `?? ''` only keeps
+    // the credential fields typed as strings.
     clientOptions = {
       region: REGION,
       model: MODEL,
-      credentials: { accessKeyId, secretAccessKey },
-    } as unknown as t.ClientOptions;
+      credentials: {
+        accessKeyId: accessKeyId ?? '',
+        secretAccessKey: secretAccessKey ?? '',
+      },
+    };
   });
 
   it('rejects inherited tool history when the agent binds no tools', async () => {

--- a/src/specs/bedrock-toolless.live.test.ts
+++ b/src/specs/bedrock-toolless.live.test.ts
@@ -1,0 +1,118 @@
+// src/specs/bedrock-toolless.live.test.ts
+/**
+ * Live Bedrock verification for the tool-less-destination toolConfig fix.
+ *
+ * A tool-less agent in a multi-agent graph inherits the prior agent's
+ * toolUse/toolResult history. Because it binds no tools, Bedrock's Converse API
+ * rejects the request ("The toolConfig field must be defined when using toolUse
+ * and toolResult content blocks"). `foldToolBlocksForToollessAgent` folds that
+ * history into text so the request becomes valid.
+ *
+ * Run with:
+ * RUN_BEDROCK_LIVE_TESTS=1 BEDROCK_AWS_ACCESS_KEY_ID=... BEDROCK_AWS_SECRET_ACCESS_KEY=... \
+ *   BEDROCK_AWS_DEFAULT_REGION=us-west-2 npm test -- bedrock-toolless.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { initializeModel } from '@/llm/init';
+import { foldToolBlocksForToollessAgent } from '@/messages';
+
+const accessKeyId =
+  process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID;
+const secretAccessKey =
+  process.env.BEDROCK_AWS_SECRET_ACCESS_KEY ??
+  process.env.AWS_SECRET_ACCESS_KEY;
+
+const shouldRunLive =
+  process.env.RUN_BEDROCK_LIVE_TESTS === '1' &&
+  accessKeyId != null &&
+  accessKeyId !== '' &&
+  secretAccessKey != null &&
+  secretAccessKey !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+
+const MODEL =
+  process.env.LIVE_BEDROCK_MODEL ??
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const REGION =
+  process.env.BEDROCK_AWS_DEFAULT_REGION ??
+  process.env.AWS_REGION ??
+  'us-west-2';
+
+/** History a tool-less destination inherits: a completed tool call, then a
+ *  follow-up user turn that itself invokes no tool. */
+function toollessHistory(): BaseMessage[] {
+  return [
+    new HumanMessage('Search my files for the roadmap.'),
+    new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'tt_live_1',
+          name: 'file_search',
+          args: { query: 'roadmap' },
+          type: 'tool_call',
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: 'Found: roadmap.md — Q3 goals and milestones.',
+      tool_call_id: 'tt_live_1',
+      name: 'file_search',
+    }),
+    new AIMessage('I found roadmap.md with your Q3 goals.'),
+    new HumanMessage('thanks!'),
+  ];
+}
+
+describeIfLive('Bedrock tool-less destination (live)', () => {
+  let clientOptions: t.ClientOptions;
+
+  beforeAll(() => {
+    // Force SigV4 with the explicit keys; the Bedrock API-key (bearer) auth
+    // scheme otherwise takes precedence in the AWS SDK.
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    clientOptions = {
+      region: REGION,
+      model: MODEL,
+      credentials: { accessKeyId, secretAccessKey },
+    } as unknown as t.ClientOptions;
+  });
+
+  it('rejects inherited tool history when the agent binds no tools', async () => {
+    const model = initializeModel({
+      provider: Providers.BEDROCK,
+      clientOptions,
+      tools: undefined,
+    });
+    await expect(model.invoke(toollessHistory())).rejects.toThrow(
+      /toolConfig field must be defined/i
+    );
+  }, 30000);
+
+  it('succeeds once inherited tool blocks are folded to text', async () => {
+    const model = initializeModel({
+      provider: Providers.BEDROCK,
+      clientOptions,
+      tools: undefined,
+    });
+    const folded = foldToolBlocksForToollessAgent(toollessHistory());
+    const res = await model.invoke(folded);
+    const text =
+      typeof res.content === 'string'
+        ? res.content
+        : JSON.stringify(res.content);
+    expect(text.length).toBeGreaterThan(0);
+  }, 30000);
+});

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -192,7 +192,7 @@ export interface ExtendedMessageContent {
   text?: string;
   input?: string;
   /** Tool-call arguments on a v1 standard-content `tool_call` block. */
-  args?: string | Record<string, unknown>;
+  args?: ToolCallPart['args'];
   index?: string | number;
   id?: string;
   name?: string;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -191,6 +191,8 @@ export interface ExtendedMessageContent {
   type?: string;
   text?: string;
   input?: string;
+  /** Tool-call arguments on a v1 standard-content `tool_call` block. */
+  args?: string | Record<string, unknown>;
   index?: string | number;
   id?: string;
   name?: string;


### PR DESCRIPTION
## Problem

In a multi-agent graph, a **tool-less destination agent** (e.g. a chained/handoff agent configured with no tools) still inherits the prior agent's conversation history, which can contain `toolUse`/`toolResult` blocks from a completed tool call. Because the destination binds no tools, the model is invoked with **no tool schema**, and Bedrock's Converse API rejects the request:

```
ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

The tool-triggering turn itself succeeds (that exchange is flattened into the downstream prompt), but on the **next** turn the tool call becomes pre-run history and is replayed structurally to the tool-less agent, so every follow-up fails — even a turn where the user just says "thanks" and no tool is invoked — until a new conversation.

Reported downstream: https://github.com/danny-avila/LibreChat/issues/14375

## Root cause

`initializeModel` returns an **unbound** model when the agent has zero tools (no `bindTools`, hence no `toolConfig`), while `@langchain/aws` still serializes the inherited `toolUse`/`toolResult` blocks. Bedrock requires a top-level `toolConfig` whenever such blocks are present.

## Fix

Fold inherited `tool_use` / `tool_result` content into a plain-text `HumanMessage` immediately before the model call in `StandardGraph.createCallModel`, **gated on the agent binding zero tools** (`toolsForBinding` empty). New helper `foldToolBlocksForToollessAgent` in `messages/format.ts`, reusing the existing `appendMessageContent` / `flushTextChunks` / `withMessageRole` serialization already used by `ensureThinkingBlockInMessages`.

- Each AI tool-call turn plus its trailing `ToolMessage`s collapses into one `[Previous tool interaction]` `HumanMessage`, **preserving the tool name, arguments and result** as text (image blocks kept as-is).
- **Provider-agnostic** and covers direct edges, handoffs, and legacy chains, since `createCallModel` is the single choke point every path flows through.
- **Handoff/routing tools count as bound tools**, so a tool-less router mid-handoff still sends a `toolConfig` and is not affected.
- Fast-paths to a single scan (returns the array unchanged) when there is no tool content, so the common fresh-tool-less-agent case is negligible cost.

### Why not a dummy `toolConfig`?

AWS requires **at least one** tool in `toolConfig` and Bedrock has no disabled/"none" tool choice ([ToolConfiguration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolConfiguration.html), [ToolChoice](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html)). A dummy or source-agent tool would also expose a capability the destination was intentionally denied.

## Testing

**Unit** (`src/messages/foldToollessToolBlocks.test.ts`, 7 tests): identity fast-path, single tool call + result, historical tool content before the last human turn (the reported bug), parallel tool calls, Anthropic-style `tool_use` content blocks, image-block preservation, and pass-through of non-tool conversations.

**Live Bedrock** (`src/specs/bedrock-toolless.live.test.ts`, gated by `RUN_BEDROCK_LIVE_TESTS=1`, skipped in CI). Verified against real Bedrock (`us.anthropic.claude-sonnet-4-5`, us-west-2):

| Case | Request | Result |
|---|---|---|
| A | tool-less model + raw tool history | ❌ `ValidationException: The toolConfig field must be defined...` (reproduces the bug) |
| B | tool-less model + **folded** history | ✅ 200 OK |
| C | **tooled** model + raw tool history | ✅ 200 OK (confirms the zero-tool gate is the right condition) |

Full existing suite green; typecheck and lint clean.
