### PR TITLE
🏷️ feat: Session-Traced Activity Labels for Agent Tool Batches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.2.68",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.2.68",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.103.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.2.68",
+  "version": "3.3.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -31,9 +31,6 @@ export enum GraphEvents {
   ON_SUBAGENT_UPDATE = 'on_subagent_update',
   /** [Custom] Diagnostic logging event for context management observability */
   ON_AGENT_LOG = 'on_agent_log',
-  /** [Custom] Smart activity label for a completed tool batch (fast-model generated;
-   *  additive — consumers that don't know the event are unaffected) */
-  ON_ACTIVITY_LABEL = 'on_activity_label',
   /** [Custom] Per-model-call context window usage snapshot (post-prune token budget) */
   ON_CONTEXT_USAGE = 'on_context_usage',
 

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -31,6 +31,9 @@ export enum GraphEvents {
   ON_SUBAGENT_UPDATE = 'on_subagent_update',
   /** [Custom] Diagnostic logging event for context management observability */
   ON_AGENT_LOG = 'on_agent_log',
+  /** [Custom] Smart activity label for a completed tool batch (fast-model generated;
+   *  additive — consumers that don't know the event are unaffected) */
+  ON_ACTIVITY_LABEL = 'on_activity_label',
   /** [Custom] Per-model-call context window usage snapshot (post-prune token budget) */
   ON_CONTEXT_USAGE = 'on_context_usage',
 
@@ -142,6 +145,8 @@ export enum ContentTypes {
   REASONING_CONTENT = 'reasoning_content',
   /** Mid-run user steer persisted inline in an assistant message; replayed as a user turn */
   STEER = 'steer',
+  /** Fast-model activity label for a tool/reasoning block; UI-only, never model input */
+  ACTIVITY_LABEL = 'activity_label',
 }
 
 export enum ToolCallTypes {

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -84,7 +84,10 @@ function toolNameMatches(
   return config.redactedToolNames.has(normalizedToolName);
 }
 
-function shouldRedactTool(
+/** Whether a tool's outputs are excluded from tracing (global disable or
+ *  `redactedToolNames` match). Exported for the activity-label prompt
+ *  builder, whose prompt becomes Langfuse generation input. */
+export function shouldRedactTool(
   toolName: string | undefined,
   config: ResolvedLangfuseToolOutputTracingConfig
 ): boolean {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -931,6 +931,12 @@ function labelAllAgentContent(
       result.push(part);
       continue;
     }
+    if (part.type === ContentTypes.ACTIVITY_LABEL) {
+      /** UI-only progress headers: buffering one would attribute it to the
+       *  agent and fold its text into replayed provider content, which the
+       *  formatter's exclusions exist to prevent. */
+      continue;
+    }
     agentContentBuffer.push(part);
   }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -917,6 +917,14 @@ function labelAllAgentContent(
 
   for (let i = 0; i < contentParts.length; i++) {
     const part = contentParts[i];
+    /** UI-only progress headers are not agent content and must not disturb
+     *  agent state: a label with no `agentIdMap` entry would otherwise read
+     *  as an agent change and flush the buffer mid-agent, splitting one
+     *  agent's contiguous content into two labeled blocks. Skipped before
+     *  any state transition below (mirrors the transfer path). */
+    if (part.type === ContentTypes.ACTIVITY_LABEL) {
+      continue;
+    }
     const agentId = agentIdMap[i];
 
     // If agent changed, flush previous buffer
@@ -929,12 +937,6 @@ function labelAllAgentContent(
       /** User speech is never agent content — see the transfer path above. */
       flushAgentBuffer();
       result.push(part);
-      continue;
-    }
-    if (part.type === ContentTypes.ACTIVITY_LABEL) {
-      /** UI-only progress headers: buffering one would attribute it to the
-       *  agent and fold its text into replayed provider content, which the
-       *  formatter's exclusions exist to prevent. */
       continue;
     }
     agentContentBuffer.push(part);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -401,7 +401,8 @@ function hasMeaningfulAssistantContent(part: MessageContentComplex): boolean {
     part.type === ContentTypes.TOOL_CALL ||
     part.type === ContentTypes.ERROR ||
     part.type === ContentTypes.AGENT_UPDATE ||
-    part.type === ContentTypes.SUMMARY
+    part.type === ContentTypes.SUMMARY ||
+    part.type === ContentTypes.ACTIVITY_LABEL
   ) {
     return false;
   }
@@ -799,7 +800,8 @@ function formatAssistantMessage(
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||
-        part.type === ContentTypes.SUMMARY
+        part.type === ContentTypes.SUMMARY ||
+        part.type === ContentTypes.ACTIVITY_LABEL
       ) {
         continue;
       } else {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1088,6 +1088,12 @@ export const labelContentByAgent = (
       transferToolCallId = undefined;
       currentAgentId = undefined;
       result.push(part);
+    } else if (part.type === ContentTypes.ACTIVITY_LABEL) {
+      /** UI-only progress headers are not agent content. Buffering one
+       *  would open (or keep alive) a transfer capture whose formatter
+       *  emits only the `--- Transfer to X ---` frame with nothing inside,
+       *  and would attribute the label to the agent. */
+      continue;
     } else {
       agentContentBuffer.push(part);
     }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1046,6 +1046,14 @@ export const labelContentByAgent = (
 
   for (let i = 0; i < contentParts.length; i++) {
     const part = contentParts[i];
+    /** UI-only progress headers are not agent content and must not disturb
+     *  agent state: a label with no `agentIdMap` entry would otherwise look
+     *  like an agent change, flushing the buffer and resetting an open
+     *  transfer capture so the transferred agent's following chunks lose
+     *  their frame. Skipped before any state transition below. */
+    if (part.type === ContentTypes.ACTIVITY_LABEL) {
+      continue;
+    }
     const agentId = agentIdMap[i];
 
     // Check if this is a transfer tool call
@@ -1088,12 +1096,6 @@ export const labelContentByAgent = (
       transferToolCallId = undefined;
       currentAgentId = undefined;
       result.push(part);
-    } else if (part.type === ContentTypes.ACTIVITY_LABEL) {
-      /** UI-only progress headers are not agent content. Buffering one
-       *  would open (or keep alive) a transfer capture whose formatter
-       *  emits only the `--- Transfer to X ---` frame with nothing inside,
-       *  and would attribute the label to the agent. */
-      continue;
     } else {
       agentContentBuffer.push(part);
     }

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -1,0 +1,30 @@
+/**
+ * Default system prompt for fast-model activity labeling.
+ *
+ * Style synthesized from Claude Code's tool-use summary prompt (git-subject
+ * register, past tense, distinctive nouns) and claude.ai's observed group
+ * headers (5–9 words describing a mixed reasoning + tool block, e.g.
+ * "Synthesized version data and curated comparative framework").
+ */
+export const ACTIVITY_LABEL_PROMPT = `Write a short label describing what this block of agent activity accomplished. It appears as the header of a collapsed activity group in a chat UI.
+
+Rules:
+- 5 to 9 words, past-tense verb first
+- Name the most distinctive subject (file, API, topic); drop articles and filler
+- Describe outcomes, not mechanics; if something failed, say so plainly
+- Output only the label — no quotes, no punctuation at the end, no preamble
+
+Examples:
+- Searched Node.js release notes and changelogs
+- Compared runtime versions across official sources
+- Fixed failing auth middleware tests
+- Read project config and dependency manifests
+- Attempted database migration, hit permission errors`;
+
+/** Truncates a serialized value for the label prompt. */
+export function truncateForLabel(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, Math.max(0, maxLength - 1)) + '…';
+}

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -76,16 +76,22 @@ export function buildActivityLabelPrompt({
   redaction,
 }: BuildActivityLabelPromptParams): string {
   const clip = truncateForLabel;
-  /** Reasoning can quote tool output verbatim, so when the policy redacts
-   *  ANY entry in this batch (or tracing is globally disabled), the
-   *  excerpts are dropped wholesale — there is no reliable way to scrub a
-   *  quoted fragment out of free-form reasoning text. */
+  /** Reasoning and intent text can quote tool output verbatim, so when the
+   *  policy redacts ANY entry in this batch (or tracing is globally
+   *  disabled), both are dropped wholesale — there is no reliable way to
+   *  scrub a quoted fragment out of free-form model prose. */
   const excerptsRedacted =
     redaction != null &&
     (redaction.enabled === false ||
       entries.some((entry) => shouldRedactTool(entry.toolName, redaction)));
   const sections: string[] = [];
-  if (lastAssistantText != null && lastAssistantText.length > 0) {
+  /** Intent text is free-form assistant prose that can quote a redacted
+   *  tool result just as reasoning can, so it shares the excerpts' fate. */
+  if (
+    !excerptsRedacted &&
+    lastAssistantText != null &&
+    lastAssistantText.length > 0
+  ) {
     sections.push(
       `Intent (assistant's last message): ${clip(lastAssistantText, INPUT_CONTEXT_LIMIT)}`
     );

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -76,13 +76,25 @@ export function buildActivityLabelPrompt({
   redaction,
 }: BuildActivityLabelPromptParams): string {
   const clip = truncateForLabel;
+  /** Reasoning can quote tool output verbatim, so when the policy redacts
+   *  ANY entry in this batch (or tracing is globally disabled), the
+   *  excerpts are dropped wholesale — there is no reliable way to scrub a
+   *  quoted fragment out of free-form reasoning text. */
+  const excerptsRedacted =
+    redaction != null &&
+    (redaction.enabled === false ||
+      entries.some((entry) => shouldRedactTool(entry.toolName, redaction)));
   const sections: string[] = [];
   if (lastAssistantText != null && lastAssistantText.length > 0) {
     sections.push(
       `Intent (assistant's last message): ${clip(lastAssistantText, INPUT_CONTEXT_LIMIT)}`
     );
   }
-  if (thinkingExcerpts != null && thinkingExcerpts.length > 0) {
+  if (
+    !excerptsRedacted &&
+    thinkingExcerpts != null &&
+    thinkingExcerpts.length > 0
+  ) {
     sections.push(
       'Reasoning excerpts:\n' +
         thinkingExcerpts

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -1,3 +1,7 @@
+import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
+import type { ActivityLabelToolEntry } from '@/types/activityLabel';
+import { shouldRedactTool } from '@/langfuseToolOutputTracing';
+
 /**
  * Default system prompt for fast-model activity labeling.
  *
@@ -27,4 +31,87 @@ export function truncateForLabel(value: string, maxLength: number): string {
     return value;
   }
   return value.slice(0, Math.max(0, maxLength - 1)) + '…';
+}
+
+function serializeForLabel(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+const INPUT_CONTEXT_LIMIT = 200;
+const MAX_THINKING_EXCERPTS = 4;
+
+export type BuildActivityLabelPromptParams = {
+  entries: ActivityLabelToolEntry[];
+  charLimit: number;
+  thinkingExcerpts?: string[];
+  lastAssistantText?: string;
+  /**
+   * Resolved tool-output tracing policy. The label prompt becomes Langfuse
+   * generation input, so outputs/errors excluded from tracing (global
+   * disable or `redactedToolNames`) must never appear in it — the same
+   * redaction the span processor applies to structured tool observations.
+   */
+  redaction?: ResolvedLangfuseToolOutputTracingConfig;
+};
+
+/**
+ * Builds the user prompt for a fast-model activity label. Pure — exported
+ * for direct testing of redaction and truncation behavior.
+ */
+export function buildActivityLabelPrompt({
+  entries,
+  charLimit,
+  thinkingExcerpts,
+  lastAssistantText,
+  redaction,
+}: BuildActivityLabelPromptParams): string {
+  const clip = truncateForLabel;
+  const sections: string[] = [];
+  if (lastAssistantText != null && lastAssistantText.length > 0) {
+    sections.push(
+      `Intent (assistant's last message): ${clip(lastAssistantText, INPUT_CONTEXT_LIMIT)}`
+    );
+  }
+  if (thinkingExcerpts != null && thinkingExcerpts.length > 0) {
+    sections.push(
+      'Reasoning excerpts:\n' +
+        thinkingExcerpts
+          .slice(0, MAX_THINKING_EXCERPTS)
+          .map((excerpt) => `- ${clip(excerpt, charLimit)}`)
+          .join('\n')
+    );
+  }
+  if (entries.length > 0) {
+    sections.push(
+      'Tool calls:\n' +
+        entries
+          .map((entry) => {
+            const input = clip(serializeForLabel(entry.toolInput), charLimit);
+            const redacted =
+              redaction != null && shouldRedactTool(entry.toolName, redaction);
+            let outcome: string;
+            if (redacted) {
+              outcome = redaction.redactionText;
+            } else if (entry.status === 'error') {
+              outcome = `ERROR: ${clip(entry.error ?? 'unknown error', charLimit)}`;
+            } else {
+              outcome = clip(serializeForLabel(entry.toolOutput), charLimit);
+            }
+            return `- ${entry.toolName}(${input}) → ${outcome}`;
+          })
+          .join('\n')
+    );
+  }
+  sections.push('Label:');
+  return sections.join('\n\n');
 }

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -76,6 +76,10 @@ function serializeForLabel(value: unknown, limit: number): string {
 
 const INPUT_CONTEXT_LIMIT = 200;
 const MAX_THINKING_EXCERPTS = 4;
+/** A label is 5-9 words; no batch needs more than this many entries to
+ *  produce one, and the cap keeps a 200-call programmatic batch from
+ *  building an enormous prompt out of per-field-bounded pieces. */
+const MAX_PROMPT_ENTRIES = 12;
 
 export type BuildActivityLabelPromptParams = {
   entries: ActivityLabelToolEntry[];
@@ -137,9 +141,11 @@ export function buildActivityLabelPrompt({
     );
   }
   if (entries.length > 0) {
+    const shown = entries.slice(0, MAX_PROMPT_ENTRIES);
+    const omitted = entries.length - shown.length;
     sections.push(
       'Tool calls:\n' +
-        entries
+        shown
           .map((entry) => {
             const input = clip(
               serializeForLabel(entry.toolInput, charLimit),
@@ -160,7 +166,10 @@ export function buildActivityLabelPrompt({
             }
             return `- ${entry.toolName}(${input}) → ${outcome}`;
           })
-          .join('\n')
+          .join('\n') +
+        (omitted > 0
+          ? `\n- …and ${omitted} more tool ${omitted === 1 ? 'call' : 'calls'}`
+          : '')
     );
   }
   sections.push('Label:');

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -33,16 +33,43 @@ export function truncateForLabel(value: string, maxLength: number): string {
   return value.slice(0, Math.max(0, maxLength - 1)) + '…';
 }
 
-function serializeForLabel(value: unknown): string {
+const ABORT_SERIALIZATION = Symbol('abort-label-serialization');
+
+/**
+ * Serializes a tool value for the prompt WITHOUT materializing huge JSON:
+ * the output is clipped to a few hundred characters anyway, so a multi-
+ * megabyte tool result must not be stringified in full on the label path.
+ * Strings clip immediately; structured values serialize under a character
+ * budget and degrade to a shape summary once it is exhausted.
+ */
+function serializeForLabel(value: unknown, limit: number): string {
   if (value == null) {
     return '';
   }
   if (typeof value === 'string') {
-    return value;
+    return value.length > limit ? value.slice(0, limit + 1) : value;
   }
+  let budget = limit * 4;
   try {
-    return JSON.stringify(value);
-  } catch {
+    return (
+      JSON.stringify(value, (_key, nested: unknown) => {
+        if (budget <= 0) {
+          throw ABORT_SERIALIZATION;
+        }
+        if (typeof nested === 'string') {
+          const clipped =
+            nested.length > limit ? nested.slice(0, limit) : nested;
+          budget -= clipped.length;
+          return clipped;
+        }
+        budget -= 8;
+        return nested;
+      }) ?? ''
+    );
+  } catch (error) {
+    if (error === ABORT_SERIALIZATION) {
+      return Array.isArray(value) ? `[Array(${value.length})]` : '[Object]';
+    }
     return String(value);
   }
 }
@@ -76,14 +103,14 @@ export function buildActivityLabelPrompt({
   redaction,
 }: BuildActivityLabelPromptParams): string {
   const clip = truncateForLabel;
-  /** Reasoning and intent text can quote tool output verbatim, so when the
-   *  policy redacts ANY entry in this batch (or tracing is globally
-   *  disabled), both are dropped wholesale — there is no reliable way to
+  /** Reasoning and intent text can quote tool output verbatim — including
+   *  output from EARLIER calls to a redacted tool that this batch does not
+   *  contain — so any active policy (global disable or a configured
+   *  redacted-name list) drops both wholesale. There is no reliable way to
    *  scrub a quoted fragment out of free-form model prose. */
   const excerptsRedacted =
     redaction != null &&
-    (redaction.enabled === false ||
-      entries.some((entry) => shouldRedactTool(entry.toolName, redaction)));
+    (redaction.enabled === false || redaction.redactedToolNames.size > 0);
   const sections: string[] = [];
   /** Intent text is free-form assistant prose that can quote a redacted
    *  tool result just as reasoning can, so it shares the excerpts' fate. */
@@ -114,7 +141,10 @@ export function buildActivityLabelPrompt({
       'Tool calls:\n' +
         entries
           .map((entry) => {
-            const input = clip(serializeForLabel(entry.toolInput), charLimit);
+            const input = clip(
+              serializeForLabel(entry.toolInput, charLimit),
+              charLimit
+            );
             const redacted =
               redaction != null && shouldRedactTool(entry.toolName, redaction);
             let outcome: string;
@@ -123,7 +153,10 @@ export function buildActivityLabelPrompt({
             } else if (entry.status === 'error') {
               outcome = `ERROR: ${clip(entry.error ?? 'unknown error', charLimit)}`;
             } else {
-              outcome = clip(serializeForLabel(entry.toolOutput), charLimit);
+              outcome = clip(
+                serializeForLabel(entry.toolOutput, charLimit),
+                charLimit
+              );
             }
             return `- ${entry.toolName}(${input}) → ${outcome}`;
           })

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,6 +39,7 @@ import {
   createCompletionTitleRunnable,
   createTitleRunnable,
 } from '@/utils/title';
+import { ACTIVITY_LABEL_PROMPT } from '@/prompts/activityLabel';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
 import { GraphEvents, Callback, TitleMethod } from '@/common';
@@ -1476,6 +1477,223 @@ export class Run<_T extends t.BaseGraphState> {
       }
     } finally {
       await disposeLangfuseHandler(titleLangfuseHandler);
+    }
+  }
+
+  /**
+   * Generates a short activity label for a completed tool/reasoning block
+   * using a fast model. Mirrors `generateTitle`'s Langfuse wiring so the
+   * call is traced under the conversation's session (sessionId from
+   * `chainOptions.configurable.thread_id`) with its own tags — never as an
+   * orphan trace. The payload contains no human messages by design: intent
+   * comes from `lastAssistantText`, content from reasoning excerpts and
+   * tool entries.
+   */
+  async generateActivityLabel({
+    provider,
+    clientOptions,
+    entries,
+    thinkingExcerpts,
+    lastAssistantText,
+    prompt,
+    charLimit = 300,
+    chainOptions,
+    traceSeed,
+  }: t.RunActivityLabelOptions): Promise<{ label?: string }> {
+    if (entries.length === 0 && !(thinkingExcerpts && thinkingExcerpts.length > 0)) {
+      return {};
+    }
+
+    let labelLangfuseHandler: CallbackEntry | undefined;
+    let labelLangfuseConfig: t.LangfuseConfig | undefined;
+    let labelUserId: string | undefined;
+    let labelSessionId: string | undefined;
+    const labelContext =
+      this.Graph == null
+        ? undefined
+        : this.Graph.agentContexts.get(this.Graph.defaultAgentId);
+    const traceMetadata = createLangfuseTraceMetadata({
+      messageId: 'activity-label-' + this.id,
+      agentName: labelContext?.name,
+    });
+    const labelRunName = getLangfuseTraceName(
+      traceMetadata,
+      'LibreChat Activity Label'
+    );
+
+    const labelChainOptions = (chainOptions ?? {}) as Partial<RunnableConfig> & {
+      configurable?: Record<string, unknown>;
+    };
+    labelUserId =
+      typeof labelChainOptions.configurable?.user_id === 'string'
+        ? (labelChainOptions.configurable.user_id as string)
+        : undefined;
+    labelSessionId =
+      typeof labelChainOptions.configurable?.thread_id === 'string'
+        ? (labelChainOptions.configurable.thread_id as string)
+        : undefined;
+    labelLangfuseConfig = resolveLangfuseConfig(
+      this.langfuse,
+      labelContext?.langfuse
+    );
+    initializeLangfuseTracing(labelLangfuseConfig);
+    labelLangfuseHandler = createLangfuseHandler({
+      langfuse: labelLangfuseConfig,
+      userId: labelUserId,
+      sessionId: labelSessionId,
+      traceMetadata,
+      tags: ['librechat', 'activity-label'],
+      traceIdSeed:
+        labelLangfuseConfig?.deterministicTraceId === true
+          ? (traceSeed ?? 'activity-label-' + this.id)
+          : undefined,
+    });
+    if (labelLangfuseHandler != null) {
+      labelChainOptions.callbacks = appendCallbacks(labelChainOptions.callbacks, [
+        labelLangfuseHandler,
+      ]);
+    }
+
+    const serialize = (value: unknown): string => {
+      if (value == null) {
+        return '';
+      }
+      if (typeof value === 'string') {
+        return value;
+      }
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+    };
+    const clip = (value: string, max: number): string =>
+      value.length <= max ? value : value.slice(0, Math.max(0, max - 1)) + '…';
+
+    const sections: string[] = [];
+    if (lastAssistantText) {
+      sections.push(
+        `Intent (assistant's last message): ${clip(lastAssistantText, 200)}`
+      );
+    }
+    if (thinkingExcerpts && thinkingExcerpts.length > 0) {
+      sections.push(
+        'Reasoning excerpts:\n' +
+          thinkingExcerpts
+            .slice(0, 4)
+            .map((excerpt) => `- ${clip(excerpt, charLimit)}`)
+            .join('\n')
+      );
+    }
+    if (entries.length > 0) {
+      sections.push(
+        'Tool calls:\n' +
+          entries
+            .map((entry) => {
+              const input = clip(serialize(entry.toolInput), charLimit);
+              const outcome =
+                entry.status === 'error'
+                  ? `ERROR: ${clip(entry.error ?? 'unknown error', charLimit)}`
+                  : clip(serialize(entry.toolOutput), charLimit);
+              return `- ${entry.toolName}(${input}) → ${outcome}`;
+            })
+            .join('\n')
+      );
+    }
+    sections.push('Label:');
+    const userPrompt = sections.join('\n\n');
+
+    const model = initializeModel({
+      provider,
+      clientOptions: {
+        ...(clientOptions ?? {}),
+        streaming: false,
+      } as t.ClientOptions,
+    }) as t.ChatModelInstance;
+
+    const invokeConfig = Object.assign({}, labelChainOptions, {
+      run_id: this.id,
+      runId: this.id,
+      runName: labelChainOptions.runName ?? labelRunName,
+    }) as Partial<RunnableConfig>;
+
+    const invokeLabel = (
+      runtimeConfig: Partial<RunnableConfig>
+    ): Promise<unknown> =>
+      withLangfuseAttributes(
+        {
+          langfuse: labelLangfuseConfig,
+          userId: labelUserId,
+          sessionId: labelSessionId,
+          traceName: runtimeConfig.runName ?? labelRunName,
+          traceMetadata,
+          tags: ['librechat', 'activity-label'],
+        },
+        () =>
+          (
+            model as unknown as {
+              invoke: (
+                input: Array<[string, string]>,
+                config?: Partial<RunnableConfig>
+              ) => Promise<{ content?: unknown }>;
+            }
+          ).invoke(
+            [
+              ['system', prompt ?? ACTIVITY_LABEL_PROMPT],
+              ['human', userPrompt],
+            ],
+            runtimeConfig
+          )
+      );
+
+    const extractLabel = (response: unknown): string => {
+      const content = (response as { content?: unknown } | null)?.content;
+      let text = '';
+      if (typeof content === 'string') {
+        text = content;
+      } else if (Array.isArray(content)) {
+        text = content
+          .map((block) =>
+            typeof block === 'string'
+              ? block
+              : ((block as { text?: string })?.text ?? '')
+          )
+          .join('');
+      }
+      return text.trim().replace(/^["']|["']$/g, '');
+    };
+
+    try {
+      let response: unknown;
+      try {
+        response = await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: labelContext?.langfuse,
+          }),
+          () => invokeLabel(invokeConfig)
+        );
+      } catch (_e) {
+        const langfuseHandler = findCallback(
+          invokeConfig.callbacks,
+          isLangfuseCallbackHandler
+        );
+        const { callbacks: _cb, ...rest } = invokeConfig;
+        const safeConfig = Object.assign({}, rest, {
+          callbacks: langfuseHandler ? [langfuseHandler] : [],
+        });
+        response = await withLangfuseRuntimeScope(
+          resolveLangfuseRuntimeScope({
+            runLangfuse: this.langfuse,
+            langfuseOverlay: labelContext?.langfuse,
+          }),
+          () => invokeLabel(safeConfig as Partial<RunnableConfig>)
+        );
+      }
+      const label = extractLabel(response);
+      return label.length > 0 ? { label } : {};
+    } finally {
+      await disposeLangfuseHandler(labelLangfuseHandler);
     }
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -52,6 +52,7 @@ import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
 import { GraphEvents, Callback, TitleMethod } from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
+import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -1566,17 +1567,22 @@ export class Run<_T extends t.BaseGraphState> {
       labelContext?.langfuse
     );
     initializeLangfuseTracing(labelLangfuseConfig);
-    /** One seed for the handler AND the runtime scope: the scoped handler
-     *  prefers an inherited runtime seed, so passing the label seed only to
-     *  the handler would let the parent run's seed win and collapse label
-     *  generations into the main run trace.
-     *
-     *  Always computed — `runWithLangfuseRuntimeContext` spreads the
-     *  surrounding context, so an ABSENT seed INHERITS the parent's rather
-     *  than clearing it. A per-label seed is the only way to guarantee the
-     *  label never shares the parent's trace id; uniqueness comes from the
-     *  run id plus a per-run sequence. */
-    const labelTraceSeed = traceSeed ?? `activity-label-${this.id}-${labelSeq}`;
+    /** Seed policy, threading two constraints:
+     *  1. `runWithLangfuseRuntimeContext` SPREADS the surrounding context, so
+     *     an absent seed INHERITS the parent run's and collapses every label
+     *     into that trace. When a parent seed is active we must override it
+     *     with a per-label one.
+     *  2. Without deterministic tracing there is no parent seed, and forcing
+     *     one here would make label trace ids deterministic when neither
+     *     `processStream` nor `generateTitle` are — so leave it unset.
+     *  Seeded when determinism is opted into OR a parent seed is live;
+     *  otherwise unseeded, matching the other generation paths. */
+    const inheritedTraceSeed = getTraceIdSeed();
+    const labelTraceSeed =
+      labelLangfuseConfig?.deterministicTraceId === true ||
+      inheritedTraceSeed != null
+        ? (traceSeed ?? `activity-label-${this.id}-${labelSeq}`)
+        : undefined;
     const labelRuntimeScope = resolveLangfuseRuntimeScope({
       runLangfuse: this.langfuse,
       langfuseOverlay: labelContext?.langfuse,
@@ -1613,12 +1619,45 @@ export class Run<_T extends t.BaseGraphState> {
     /** The label prompt becomes Langfuse generation input, so the resolved
      *  tool-output redaction policy (global disable / redactedToolNames)
      *  applies to it exactly as to structured tool observations. */
-    const redaction = hasToolOutputTracingConfig(
+    let redaction = hasToolOutputTracingConfig(
       this.langfuse,
       labelContext?.langfuse
     )
       ? resolveToolOutputTracingConfig(this.langfuse, labelContext?.langfuse)
       : undefined;
+    /** Multi-agent graph with no `agentId`: the caller did not say WHICH
+     *  agent ran this batch, so resolving from the default agent could trace
+     *  raw output that a stricter sibling's policy forbids. Fold every
+     *  agent's policy into the strictest one instead of guessing. */
+    const agentContexts = this.Graph?.agentContexts;
+    if (agentId == null && agentContexts != null && agentContexts.size > 1) {
+      for (const context of agentContexts.values()) {
+        if (!hasToolOutputTracingConfig(this.langfuse, context.langfuse)) {
+          continue;
+        }
+        const candidate = resolveToolOutputTracingConfig(
+          this.langfuse,
+          context.langfuse
+        );
+        if (redaction == null) {
+          redaction = candidate;
+          continue;
+        }
+        redaction = {
+          enabled: redaction.enabled === false ? false : candidate.enabled,
+          redactedToolNames: new Set([
+            ...redaction.redactedToolNames,
+            ...candidate.redactedToolNames,
+          ]),
+          redactedToolNameMatchMode:
+            redaction.redactedToolNameMatchMode === 'partial' ||
+            candidate.redactedToolNameMatchMode === 'partial'
+              ? 'partial'
+              : 'exact',
+          redactionText: redaction.redactionText,
+        };
+      }
+    }
     /** An active redaction policy suppresses free-form reasoning/intent, so
      *  a reasoning-only block has nothing describable left — skip the model
      *  call rather than paying for a label built from the prompt alone. */

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,12 +39,19 @@ import {
   createCompletionTitleRunnable,
   createTitleRunnable,
 } from '@/utils/title';
-import { ACTIVITY_LABEL_PROMPT } from '@/prompts/activityLabel';
+import {
+  ACTIVITY_LABEL_PROMPT,
+  buildActivityLabelPrompt,
+} from '@/prompts/activityLabel';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
 import { GraphEvents, Callback, TitleMethod } from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
-import { resolveLangfuseConfig } from '@/langfuseConfig';
+import {
+  hasToolOutputTracingConfig,
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -78,7 +85,6 @@ const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_SUBAGENT_UPDATE,
   GraphEvents.ON_AGENT_LOG,
   GraphEvents.ON_CONTEXT_USAGE,
-  GraphEvents.ON_ACTIVITY_LABEL,
   GraphEvents.ON_CUSTOM_EVENT,
 ]);
 
@@ -1499,19 +1505,18 @@ export class Run<_T extends t.BaseGraphState> {
     thinkingExcerpts,
     lastAssistantText,
     prompt,
-    charLimit = 300,
+    charLimit = 600,
     chainOptions,
     traceSeed,
   }: t.RunActivityLabelOptions): Promise<{ label?: string }> {
-    if (entries.length === 0 && !(thinkingExcerpts && thinkingExcerpts.length > 0)) {
+    if (
+      entries.length === 0 &&
+      !(thinkingExcerpts && thinkingExcerpts.length > 0)
+    ) {
       return {};
     }
     const labelSeq = ++this.activityLabelSeq;
 
-    let labelLangfuseHandler: CallbackEntry | undefined;
-    let labelLangfuseConfig: t.LangfuseConfig | undefined;
-    let labelUserId: string | undefined;
-    let labelSessionId: string | undefined;
     const labelContext =
       this.Graph == null
         ? undefined
@@ -1528,87 +1533,68 @@ export class Run<_T extends t.BaseGraphState> {
     /** Shallow-cloned: activity labels run once per tool batch, and writing
      *  the Langfuse handler back onto a host-reused `chainOptions` would
      *  accumulate duplicate callbacks across batches. */
-    const labelChainOptions = { ...(chainOptions ?? {}) } as Partial<RunnableConfig> & {
+    const labelChainOptions = {
+      ...(chainOptions ?? {}),
+    } as Partial<RunnableConfig> & {
       configurable?: Record<string, unknown>;
     };
-    labelUserId =
+    const labelUserId =
       typeof labelChainOptions.configurable?.user_id === 'string'
         ? (labelChainOptions.configurable.user_id as string)
         : undefined;
-    labelSessionId =
+    const labelSessionId =
       typeof labelChainOptions.configurable?.thread_id === 'string'
         ? (labelChainOptions.configurable.thread_id as string)
         : undefined;
-    labelLangfuseConfig = resolveLangfuseConfig(
+    const labelLangfuseConfig = resolveLangfuseConfig(
       this.langfuse,
       labelContext?.langfuse
     );
     initializeLangfuseTracing(labelLangfuseConfig);
-    labelLangfuseHandler = createLangfuseHandler({
+    /** One seed for the handler AND both runtime scopes: the scoped handler
+     *  prefers an inherited runtime seed, so passing the label seed only to
+     *  the handler would let the parent run's seed win and collapse label
+     *  generations into the main run trace. */
+    const labelTraceSeed =
+      labelLangfuseConfig?.deterministicTraceId === true
+        ? (traceSeed ?? `activity-label-${this.id}-${labelSeq}`)
+        : undefined;
+    const labelRuntimeScope = resolveLangfuseRuntimeScope({
+      runLangfuse: this.langfuse,
+      langfuseOverlay: labelContext?.langfuse,
+      traceIdSeed: labelTraceSeed,
+    });
+    const labelLangfuseHandler = createLangfuseHandler({
       langfuse: labelLangfuseConfig,
       userId: labelUserId,
       sessionId: labelSessionId,
       traceMetadata,
       tags: ['librechat', 'activity-label'],
-      traceIdSeed:
-        labelLangfuseConfig?.deterministicTraceId === true
-          ? (traceSeed ?? `activity-label-${this.id}-${labelSeq}`)
-          : undefined,
+      traceIdSeed: labelTraceSeed,
     });
     if (labelLangfuseHandler != null) {
-      labelChainOptions.callbacks = appendCallbacks(labelChainOptions.callbacks, [
-        labelLangfuseHandler,
-      ]);
+      labelChainOptions.callbacks = appendCallbacks(
+        labelChainOptions.callbacks,
+        [labelLangfuseHandler]
+      );
     }
 
-    const serialize = (value: unknown): string => {
-      if (value == null) {
-        return '';
-      }
-      if (typeof value === 'string') {
-        return value;
-      }
-      try {
-        return JSON.stringify(value);
-      } catch {
-        return String(value);
-      }
-    };
-    const clip = (value: string, max: number): string =>
-      value.length <= max ? value : value.slice(0, Math.max(0, max - 1)) + '…';
-
-    const sections: string[] = [];
-    if (lastAssistantText) {
-      sections.push(
-        `Intent (assistant's last message): ${clip(lastAssistantText, 200)}`
-      );
-    }
-    if (thinkingExcerpts && thinkingExcerpts.length > 0) {
-      sections.push(
-        'Reasoning excerpts:\n' +
-          thinkingExcerpts
-            .slice(0, 4)
-            .map((excerpt) => `- ${clip(excerpt, charLimit)}`)
-            .join('\n')
-      );
-    }
-    if (entries.length > 0) {
-      sections.push(
-        'Tool calls:\n' +
-          entries
-            .map((entry) => {
-              const input = clip(serialize(entry.toolInput), charLimit);
-              const outcome =
-                entry.status === 'error'
-                  ? `ERROR: ${clip(entry.error ?? 'unknown error', charLimit)}`
-                  : clip(serialize(entry.toolOutput), charLimit);
-              return `- ${entry.toolName}(${input}) → ${outcome}`;
-            })
-            .join('\n')
-      );
-    }
-    sections.push('Label:');
-    const userPrompt = sections.join('\n\n');
+    /** The label prompt becomes Langfuse generation input, so the resolved
+     *  tool-output redaction policy (global disable / redactedToolNames)
+     *  applies to it exactly as to structured tool observations. */
+    const redaction = hasToolOutputTracingConfig(
+      this.langfuse,
+      labelContext?.langfuse
+    )
+      ? resolveToolOutputTracingConfig(this.langfuse, labelContext?.langfuse)
+      : undefined;
+    const userPrompt = buildActivityLabelPrompt({
+      entries,
+      charLimit,
+      thinkingExcerpts,
+      lastAssistantText,
+      redaction,
+    });
 
     const model = initializeModel({
       provider,
@@ -1663,7 +1649,7 @@ export class Run<_T extends t.BaseGraphState> {
           .map((block) =>
             typeof block === 'string'
               ? block
-              : ((block as { text?: string })?.text ?? '')
+              : ((block as { text?: string }).text ?? '')
           )
           .join('');
       }
@@ -1673,14 +1659,27 @@ export class Run<_T extends t.BaseGraphState> {
     try {
       let response: unknown;
       try {
-        response = await withLangfuseRuntimeScope(
-          resolveLangfuseRuntimeScope({
-            runLangfuse: this.langfuse,
-            langfuseOverlay: labelContext?.langfuse,
-          }),
-          () => invokeLabel(invokeConfig)
+        response = await withLangfuseRuntimeScope(labelRuntimeScope, () =>
+          invokeLabel(invokeConfig)
         );
-      } catch (_e) {
+      } catch (error) {
+        /** Retry ONLY recognized callback/tracer failures (the EventStream
+         *  tracer class of errors the stripped-callbacks fallback exists
+         *  for). Aborts and provider failures rethrow — retrying those
+         *  doubles traffic/cost and can restart cancelled requests. */
+        const aborted =
+          (labelChainOptions as { signal?: AbortSignal }).signal?.aborted ===
+            true || (error as Error | null)?.name === 'AbortError';
+        const callbackFailure = /callback|tracer|event.?stream/i.test(
+          String(
+            (error as Error | null)?.stack ??
+              (error as Error | null)?.message ??
+              ''
+          )
+        );
+        if (aborted || !callbackFailure) {
+          throw error;
+        }
         const langfuseHandler = findCallback(
           invokeConfig.callbacks,
           isLangfuseCallbackHandler
@@ -1689,12 +1688,8 @@ export class Run<_T extends t.BaseGraphState> {
         const safeConfig = Object.assign({}, rest, {
           callbacks: langfuseHandler ? [langfuseHandler] : [],
         });
-        response = await withLangfuseRuntimeScope(
-          resolveLangfuseRuntimeScope({
-            runLangfuse: this.langfuse,
-            langfuseOverlay: labelContext?.langfuse,
-          }),
-          () => invokeLabel(safeConfig as Partial<RunnableConfig>)
+        response = await withLangfuseRuntimeScope(labelRuntimeScope, () =>
+          invokeLabel(safeConfig as Partial<RunnableConfig>)
         );
       }
       const label = extractLabel(response);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1518,15 +1518,23 @@ export class Run<_T extends t.BaseGraphState> {
     }
     const labelSeq = ++this.activityLabelSeq;
 
-    /** Resolve the LABELED agent's context (falling back to the graph
-     *  default): its Langfuse overlay carries the trace metadata and the
-     *  tool-output redaction policy that must govern this label. */
+    /** Resolve the LABELED agent's context: its Langfuse overlay carries the
+     *  trace metadata and the tool-output redaction policy that must govern
+     *  this label. */
+    const requestedContext =
+      this.Graph == null || agentId == null
+        ? undefined
+        : this.Graph.agentContexts.get(agentId);
+    /** Fail closed: an explicit but unknown/stale `agentId` must NOT silently
+     *  fall back to the default agent, whose redaction policy may be weaker
+     *  than the labeled agent's. Skip generation entirely instead. */
+    if (agentId != null && requestedContext == null) {
+      return {};
+    }
     const labelContext =
       this.Graph == null
         ? undefined
-        : ((agentId != null
-          ? this.Graph.agentContexts.get(agentId)
-          : undefined) ??
+        : (requestedContext ??
           this.Graph.agentContexts.get(this.Graph.defaultAgentId));
     const traceMetadata = createLangfuseTraceMetadata({
       messageId: 'activity-label-' + this.id,
@@ -1618,9 +1626,13 @@ export class Run<_T extends t.BaseGraphState> {
       } as t.ClientOptions,
     }) as t.ChatModelInstance;
 
+    /** Distinct run id per label call: callback/tracing integrations key
+     *  in-flight runs by it, so reusing the parent run's id would collide
+     *  across successive (or concurrent) label batches. */
+    const labelRunId = `${this.id}-activity-${labelSeq}`;
     const invokeConfig = Object.assign({}, labelChainOptions, {
-      run_id: this.id,
-      runId: this.id,
+      run_id: labelRunId,
+      runId: labelRunId,
       runName: labelChainOptions.runName ?? labelRunName,
     }) as Partial<RunnableConfig>;
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1566,14 +1566,17 @@ export class Run<_T extends t.BaseGraphState> {
       labelContext?.langfuse
     );
     initializeLangfuseTracing(labelLangfuseConfig);
-    /** One seed for the handler AND both runtime scopes: the scoped handler
+    /** One seed for the handler AND the runtime scope: the scoped handler
      *  prefers an inherited runtime seed, so passing the label seed only to
      *  the handler would let the parent run's seed win and collapse label
-     *  generations into the main run trace. */
-    const labelTraceSeed =
-      labelLangfuseConfig?.deterministicTraceId === true
-        ? (traceSeed ?? `activity-label-${this.id}-${labelSeq}`)
-        : undefined;
+     *  generations into the main run trace.
+     *
+     *  Always computed — `runWithLangfuseRuntimeContext` spreads the
+     *  surrounding context, so an ABSENT seed INHERITS the parent's rather
+     *  than clearing it. A per-label seed is the only way to guarantee the
+     *  label never shares the parent's trace id; uniqueness comes from the
+     *  run id plus a per-run sequence. */
+    const labelTraceSeed = traceSeed ?? `activity-label-${this.id}-${labelSeq}`;
     const labelRuntimeScope = resolveLangfuseRuntimeScope({
       runLangfuse: this.langfuse,
       langfuseOverlay: labelContext?.langfuse,
@@ -1583,17 +1586,23 @@ export class Run<_T extends t.BaseGraphState> {
      *  `chainOptions.configurable.thread_id`: without it the label call has
      *  no conversation identity, and tracing it would create an orphan
      *  trace outside any session — worse than not tracing at all. */
-    const labelLangfuseHandler =
-      labelSessionId == null
-        ? undefined
-        : createLangfuseHandler({
-          langfuse: labelLangfuseConfig,
-          userId: labelUserId,
-          sessionId: labelSessionId,
-          traceMetadata,
-          tags: ['librechat', 'activity-label'],
-          traceIdSeed: labelTraceSeed,
-        });
+    /** Declared then conditionally assigned (title precedent): a ternary
+     *  around the object literal makes eslint's indent rule and prettier
+     *  disagree, and both gate CI. */
+    let labelLangfuseHandler: CallbackEntry | undefined;
+    if (labelSessionId != null) {
+      labelLangfuseHandler = createLangfuseHandler({
+        langfuse: labelLangfuseConfig,
+        userId: labelUserId,
+        sessionId: labelSessionId,
+        traceMetadata,
+        tags: ['librechat', 'activity-label'],
+        traceIdSeed:
+          labelLangfuseConfig?.deterministicTraceId === true
+            ? labelTraceSeed
+            : undefined,
+      });
+    }
     if (labelLangfuseHandler != null) {
       labelChainOptions.callbacks = appendCallbacks(
         labelChainOptions.callbacks,
@@ -1610,6 +1619,15 @@ export class Run<_T extends t.BaseGraphState> {
     )
       ? resolveToolOutputTracingConfig(this.langfuse, labelContext?.langfuse)
       : undefined;
+    /** An active redaction policy suppresses free-form reasoning/intent, so
+     *  a reasoning-only block has nothing describable left — skip the model
+     *  call rather than paying for a label built from the prompt alone. */
+    const freeFormSuppressed =
+      redaction != null &&
+      (redaction.enabled === false || redaction.redactedToolNames.size > 0);
+    if (entries.length === 0 && freeFormSuppressed) {
+      return {};
+    }
     const userPrompt = buildActivityLabelPrompt({
       entries,
       charLimit,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1564,14 +1564,20 @@ export class Run<_T extends t.BaseGraphState> {
       langfuseOverlay: labelContext?.langfuse,
       traceIdSeed: labelTraceSeed,
     });
-    const labelLangfuseHandler = createLangfuseHandler({
-      langfuse: labelLangfuseConfig,
-      userId: labelUserId,
-      sessionId: labelSessionId,
-      traceMetadata,
-      tags: ['librechat', 'activity-label'],
-      traceIdSeed: labelTraceSeed,
-    });
+    /** Handler only when the caller supplied `chainOptions` (title parity):
+     *  without it there is no thread/user identity, and tracing the call
+     *  would create an orphan label trace outside any session. */
+    const labelLangfuseHandler =
+      chainOptions == null
+        ? undefined
+        : createLangfuseHandler({
+            langfuse: labelLangfuseConfig,
+            userId: labelUserId,
+            sessionId: labelSessionId,
+            traceMetadata,
+            tags: ['librechat', 'activity-label'],
+            traceIdSeed: labelTraceSeed,
+          });
     if (labelLangfuseHandler != null) {
       labelChainOptions.callbacks = appendCallbacks(
         labelChainOptions.callbacks,

--- a/src/run.ts
+++ b/src/run.ts
@@ -78,6 +78,7 @@ const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_SUBAGENT_UPDATE,
   GraphEvents.ON_AGENT_LOG,
   GraphEvents.ON_CONTEXT_USAGE,
+  GraphEvents.ON_ACTIVITY_LABEL,
   GraphEvents.ON_CUSTOM_EVENT,
 ]);
 
@@ -154,6 +155,8 @@ export class Run<_T extends t.BaseGraphState> {
    * lets callers assert the type they expect.
    */
   private _interrupt: t.RunInterruptResult<unknown> | undefined;
+  /** Per-run sequence for batch-unique activity-label trace-seed fallbacks. */
+  private activityLabelSeq = 0;
   private _haltedReason: string | undefined;
 
   private constructor(config: Partial<t.RunConfig>) {
@@ -1503,6 +1506,7 @@ export class Run<_T extends t.BaseGraphState> {
     if (entries.length === 0 && !(thinkingExcerpts && thinkingExcerpts.length > 0)) {
       return {};
     }
+    const labelSeq = ++this.activityLabelSeq;
 
     let labelLangfuseHandler: CallbackEntry | undefined;
     let labelLangfuseConfig: t.LangfuseConfig | undefined;
@@ -1521,7 +1525,10 @@ export class Run<_T extends t.BaseGraphState> {
       'LibreChat Activity Label'
     );
 
-    const labelChainOptions = (chainOptions ?? {}) as Partial<RunnableConfig> & {
+    /** Shallow-cloned: activity labels run once per tool batch, and writing
+     *  the Langfuse handler back onto a host-reused `chainOptions` would
+     *  accumulate duplicate callbacks across batches. */
+    const labelChainOptions = { ...(chainOptions ?? {}) } as Partial<RunnableConfig> & {
       configurable?: Record<string, unknown>;
     };
     labelUserId =
@@ -1545,7 +1552,7 @@ export class Run<_T extends t.BaseGraphState> {
       tags: ['librechat', 'activity-label'],
       traceIdSeed:
         labelLangfuseConfig?.deterministicTraceId === true
-          ? (traceSeed ?? 'activity-label-' + this.id)
+          ? (traceSeed ?? `activity-label-${this.id}-${labelSeq}`)
           : undefined,
     });
     if (labelLangfuseHandler != null) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -27,9 +27,18 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
+  hasToolOutputTracingConfig,
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import {
+  ACTIVITY_LABEL_PROMPT,
+  buildActivityLabelPrompt,
+} from '@/prompts/activityLabel';
 import {
   appendCallbacks,
   findCallback,
@@ -39,19 +48,10 @@ import {
   createCompletionTitleRunnable,
   createTitleRunnable,
 } from '@/utils/title';
-import {
-  ACTIVITY_LABEL_PROMPT,
-  buildActivityLabelPrompt,
-} from '@/prompts/activityLabel';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
 import { GraphEvents, Callback, TitleMethod } from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
-import {
-  hasToolOutputTracingConfig,
-  resolveLangfuseConfig,
-  resolveToolOutputTracingConfig,
-} from '@/langfuseConfig';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -1508,6 +1508,7 @@ export class Run<_T extends t.BaseGraphState> {
     charLimit = 600,
     chainOptions,
     traceSeed,
+    agentId,
   }: t.RunActivityLabelOptions): Promise<{ label?: string }> {
     if (
       entries.length === 0 &&
@@ -1517,10 +1518,16 @@ export class Run<_T extends t.BaseGraphState> {
     }
     const labelSeq = ++this.activityLabelSeq;
 
+    /** Resolve the LABELED agent's context (falling back to the graph
+     *  default): its Langfuse overlay carries the trace metadata and the
+     *  tool-output redaction policy that must govern this label. */
     const labelContext =
       this.Graph == null
         ? undefined
-        : this.Graph.agentContexts.get(this.Graph.defaultAgentId);
+        : ((agentId != null
+          ? this.Graph.agentContexts.get(agentId)
+          : undefined) ??
+          this.Graph.agentContexts.get(this.Graph.defaultAgentId));
     const traceMetadata = createLangfuseTraceMetadata({
       messageId: 'activity-label-' + this.id,
       agentName: labelContext?.name,
@@ -1564,20 +1571,21 @@ export class Run<_T extends t.BaseGraphState> {
       langfuseOverlay: labelContext?.langfuse,
       traceIdSeed: labelTraceSeed,
     });
-    /** Handler only when the caller supplied `chainOptions` (title parity):
-     *  without it there is no thread/user identity, and tracing the call
-     *  would create an orphan label trace outside any session. */
+    /** Handler only when a session id resolved from
+     *  `chainOptions.configurable.thread_id`: without it the label call has
+     *  no conversation identity, and tracing it would create an orphan
+     *  trace outside any session — worse than not tracing at all. */
     const labelLangfuseHandler =
-      chainOptions == null
+      labelSessionId == null
         ? undefined
         : createLangfuseHandler({
-            langfuse: labelLangfuseConfig,
-            userId: labelUserId,
-            sessionId: labelSessionId,
-            traceMetadata,
-            tags: ['librechat', 'activity-label'],
-            traceIdSeed: labelTraceSeed,
-          });
+          langfuse: labelLangfuseConfig,
+          userId: labelUserId,
+          sessionId: labelSessionId,
+          traceMetadata,
+          tags: ['librechat', 'activity-label'],
+          traceIdSeed: labelTraceSeed,
+        });
     if (labelLangfuseHandler != null) {
       labelChainOptions.callbacks = appendCallbacks(
         labelChainOptions.callbacks,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,9 +1,9 @@
 // src/run.ts
-import { HumanMessage } from '@langchain/core/messages';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import {
   Command,
   INTERRUPT,
@@ -1667,17 +1667,10 @@ export class Run<_T extends t.BaseGraphState> {
           tags: ['librechat', 'activity-label'],
         },
         () =>
-          (
-            model as unknown as {
-              invoke: (
-                input: Array<[string, string]>,
-                config?: Partial<RunnableConfig>
-              ) => Promise<{ content?: unknown }>;
-            }
-          ).invoke(
+          model.invoke(
             [
-              ['system', prompt ?? ACTIVITY_LABEL_PROMPT],
-              ['human', userPrompt],
+              new SystemMessage(prompt ?? ACTIVITY_LABEL_PROMPT),
+              new HumanMessage(userPrompt),
             ],
             runtimeConfig
           )

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -59,7 +59,10 @@ describe('buildActivityLabelPrompt redaction', () => {
     expect(prompt).not.toContain('SECRET_CONNECTION_STRING_LEAK');
   });
 
-  it('keeps reasoning excerpts when no batch entry matches the policy', () => {
+  it('drops free-form context under ANY active policy, even with no matching entry', () => {
+    /** Reasoning/intent can quote output from an EARLIER call to the
+     *  redacted tool that this batch does not contain, so an active policy
+     *  suppresses free-form prose regardless of this batch's entries. */
     const redaction = resolveToolOutputTracingConfig({
       toolOutputTracing: { redactedToolNames: ['unrelated_tool'] },
     });
@@ -67,9 +70,46 @@ describe('buildActivityLabelPrompt redaction', () => {
       entries,
       charLimit: 600,
       thinkingExcerpts: ['Comparing versions across sources'],
+      lastAssistantText: 'Checking the unrelated_tool result from before',
       redaction,
     });
+    expect(prompt).not.toContain('Comparing versions across sources');
+    expect(prompt).not.toContain('Intent');
+    /** Non-matching entries keep their own outcomes. */
+    expect(prompt).toContain('PUBLIC_SEARCH_RESULTS');
+  });
+
+  it('keeps free-form context when no redaction policy is configured', () => {
+    const prompt = buildActivityLabelPrompt({
+      entries,
+      charLimit: 600,
+      thinkingExcerpts: ['Comparing versions across sources'],
+      lastAssistantText: 'Verifying each runtime',
+      redaction: undefined,
+    });
     expect(prompt).toContain('Comparing versions across sources');
+    expect(prompt).toContain('Verifying each runtime');
+  });
+
+  it('bounds serialization of oversized structured tool output', () => {
+    const huge = Array.from({ length: 50_000 }, (_, i) => ({
+      id: i,
+      blob: 'x'.repeat(200),
+    }));
+    const prompt = buildActivityLabelPrompt({
+      entries: [
+        {
+          toolName: 'db_rows',
+          toolInput: { sql: 'select *' },
+          toolOutput: huge,
+          status: 'success',
+        },
+      ],
+      charLimit: 600,
+    });
+    /** Degrades to a shape summary instead of materializing ~10MB of JSON. */
+    expect(prompt).toContain('[Array(50000)]');
+    expect(prompt.length).toBeLessThan(2000);
   });
 
   it('redacts only named tools, including their error text', () => {

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -1,0 +1,59 @@
+import { buildActivityLabelPrompt } from '@/prompts/activityLabel';
+import { resolveToolOutputTracingConfig } from '@/langfuseConfig';
+import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
+import type { ActivityLabelToolEntry } from '@/types/activityLabel';
+
+const entries: ActivityLabelToolEntry[] = [
+  {
+    toolName: 'web_search',
+    toolInput: { query: 'runtime versions' },
+    toolOutput: 'PUBLIC_SEARCH_RESULTS',
+    status: 'success',
+  },
+  {
+    toolName: 'db_query',
+    toolInput: { sql: 'select 1' },
+    error: 'SECRET_CONNECTION_STRING_LEAK',
+    status: 'error',
+  },
+];
+
+describe('buildActivityLabelPrompt redaction', () => {
+  it('embeds raw outputs and errors when no redaction policy resolves', () => {
+    const prompt = buildActivityLabelPrompt({ entries, charLimit: 600 });
+    expect(prompt).toContain('PUBLIC_SEARCH_RESULTS');
+    expect(prompt).toContain('SECRET_CONNECTION_STRING_LEAK');
+  });
+
+  it('redacts every outcome when tool-output tracing is globally disabled', () => {
+    const redaction = resolveToolOutputTracingConfig({
+      toolOutputTracing: { enabled: false },
+    });
+    const prompt = buildActivityLabelPrompt({
+      entries,
+      charLimit: 600,
+      redaction,
+    });
+    expect(prompt).not.toContain('PUBLIC_SEARCH_RESULTS');
+    expect(prompt).not.toContain('SECRET_CONNECTION_STRING_LEAK');
+    expect(prompt).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    /** Tool names and inputs stay — matching the span processor, which
+     *  redacts output fields only. */
+    expect(prompt).toContain('web_search');
+    expect(prompt).toContain('runtime versions');
+  });
+
+  it('redacts only named tools, including their error text', () => {
+    const redaction = resolveToolOutputTracingConfig({
+      toolOutputTracing: { redactedToolNames: ['db_query'] },
+    });
+    const prompt = buildActivityLabelPrompt({
+      entries,
+      charLimit: 600,
+      redaction,
+    });
+    expect(prompt).toContain('PUBLIC_SEARCH_RESULTS');
+    expect(prompt).not.toContain('SECRET_CONNECTION_STRING_LEAK');
+    expect(prompt).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+});

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -1,7 +1,7 @@
+import type { ActivityLabelToolEntry } from '@/types/activityLabel';
+import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
 import { buildActivityLabelPrompt } from '@/prompts/activityLabel';
 import { resolveToolOutputTracingConfig } from '@/langfuseConfig';
-import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
-import type { ActivityLabelToolEntry } from '@/types/activityLabel';
 
 const entries: ActivityLabelToolEntry[] = [
   {
@@ -41,6 +41,35 @@ describe('buildActivityLabelPrompt redaction', () => {
      *  redacts output fields only. */
     expect(prompt).toContain('web_search');
     expect(prompt).toContain('runtime versions');
+  });
+
+  it('drops reasoning excerpts when any batch entry is redacted', () => {
+    const redaction = resolveToolOutputTracingConfig({
+      toolOutputTracing: { redactedToolNames: ['db_query'] },
+    });
+    const prompt = buildActivityLabelPrompt({
+      entries,
+      charLimit: 600,
+      thinkingExcerpts: [
+        'The db_query returned SECRET_CONNECTION_STRING_LEAK earlier',
+      ],
+      redaction,
+    });
+    expect(prompt).not.toContain('Reasoning excerpts');
+    expect(prompt).not.toContain('SECRET_CONNECTION_STRING_LEAK');
+  });
+
+  it('keeps reasoning excerpts when no batch entry matches the policy', () => {
+    const redaction = resolveToolOutputTracingConfig({
+      toolOutputTracing: { redactedToolNames: ['unrelated_tool'] },
+    });
+    const prompt = buildActivityLabelPrompt({
+      entries,
+      charLimit: 600,
+      thinkingExcerpts: ['Comparing versions across sources'],
+      redaction,
+    });
+    expect(prompt).toContain('Comparing versions across sources');
   });
 
   it('redacts only named tools, including their error text', () => {

--- a/src/specs/activity-label-trace-seed.test.ts
+++ b/src/specs/activity-label-trace-seed.test.ts
@@ -1,8 +1,8 @@
-import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 
 /**
  * `generateActivityLabel` passes one label seed to both the Langfuse handler

--- a/src/specs/activity-label-trace-seed.test.ts
+++ b/src/specs/activity-label-trace-seed.test.ts
@@ -1,0 +1,47 @@
+import { getTraceIdSeed } from '@/langfuseRuntimeContext';
+import {
+  resolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
+
+/**
+ * `generateActivityLabel` passes one label seed to both the Langfuse handler
+ * and the runtime scope it invokes under. This proves the mechanism: a label
+ * scope's seed must override an inherited (parent run) seed for the duration
+ * of the label call, then restore — otherwise per-batch label generations
+ * collapse into the main run trace under deterministic tracing.
+ *
+ * Asserted through the ALS runtime-context channel (`getTraceIdSeed`), which
+ * the trace id generator consults alongside OTel context; tests run without
+ * a registered OTel context manager, so the OTel channel is a no-op here.
+ */
+describe('activity-label trace seed scoping', () => {
+  it('overrides an inherited run seed for the nested scope only', () => {
+    const runScope = resolveLangfuseRuntimeScope({ traceIdSeed: 'run-seed' });
+    withLangfuseRuntimeScope(runScope, () => {
+      expect(getTraceIdSeed()).toBe('run-seed');
+
+      const labelScope = resolveLangfuseRuntimeScope({
+        traceIdSeed: 'run-1-activity-3',
+      });
+      withLangfuseRuntimeScope(labelScope, () => {
+        expect(getTraceIdSeed()).toBe('run-1-activity-3');
+      });
+
+      expect(getTraceIdSeed()).toBe('run-seed');
+    });
+  });
+
+  it('keeps distinct seeds for successive label scopes', () => {
+    const seeds: Array<string | undefined> = [];
+    for (const seed of ['run-1-activity-0', 'run-1-activity-1']) {
+      withLangfuseRuntimeScope(
+        resolveLangfuseRuntimeScope({ traceIdSeed: seed }),
+        () => {
+          seeds.push(getTraceIdSeed());
+        }
+      );
+    }
+    expect(seeds).toEqual(['run-1-activity-0', 'run-1-activity-1']);
+  });
+});

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -1,37 +1,5 @@
 import type { Providers } from '@/common';
 
-/**
- * Deterministic classification of a completed tool batch, computed from tool
- * names with zero model calls. Rendered immediately as a fallback header
- * ("read 2 files · ran 1 command") until the fast-model label arrives.
- */
-export type ActivityCounts = {
-  searches: number;
-  reads: number;
-  writes: number;
-  commands: number;
-  other: number;
-};
-
-/**
- * Configuration for fast-model activity labeling. Fully configurable like
- * title generation: the label model never derives from the main loop model —
- * hosts resolve provider/model independently (e.g. titleModel-style
- * precedence) and pass the result here at run creation.
- */
-export type ActivityLabelConfig = {
-  enabled?: boolean;
-  provider?: Providers;
-  model?: string;
-  parameters?: Record<string, unknown>;
-  /** Override for the label system prompt. */
-  prompt?: string;
-  /** Per-tool input/output truncation for the label prompt. Default 300 chars. */
-  charLimit?: number;
-  /** Cost guard: maximum labels generated per run. Default 20. */
-  maxPerRun?: number;
-};
-
 /** One tool call's contribution to the label payload (host-assembled). */
 export type ActivityLabelToolEntry = {
   toolName: string;
@@ -46,6 +14,11 @@ export type ActivityLabelToolEntry = {
  * NO human messages: intent context comes from the assistant's own last text
  * (Claude Code's pattern) and the block's reasoning excerpts (claude.ai's
  * pattern) — user text stays out of this low-scrutiny pathway entirely.
+ *
+ * Event emission is intentionally host-owned: hosts claim content slots and
+ * stream label lifecycle events on their own transport (e.g. LibreChat's
+ * `on_activity_label` SSE event). The SDK's contract is limited to this
+ * method and the `activity_label` content type's formatter exclusions.
  */
 export type RunActivityLabelOptions = {
   provider: Providers;
@@ -57,34 +30,14 @@ export type RunActivityLabelOptions = {
   lastAssistantText?: string;
   /** Override for the default label system prompt. */
   prompt?: string;
-  /** Per-entry serialization cap for the prompt. Default 300. */
+  /** Per-entry serialization cap for the prompt. Default 600. */
   charLimit?: number;
   /** LangChain runnable config carrier (signal, callbacks, thread/user ids). */
   chainOptions?: Record<string, unknown>;
   /**
    * Seed for deterministic Langfuse trace ids (e.g. `${runId}-${slotIndex}`)
-   * so each batch's label gets a distinct, reproducible trace.
+   * so each batch's label gets a distinct, reproducible trace. When omitted,
+   * a per-run sequence keeps batches from collapsing into one trace.
    */
   traceSeed?: string;
-};
-
-/**
- * Payload of `GraphEvents.ON_ACTIVITY_LABEL`. Additive event: hosts and SDK
- * consumers that do not handle it are unaffected. Emitted once per tool
- * batch — first with `label` undefined at batch completion (deterministic
- * counts only), then again with the fast-model `label` when it resolves.
- */
-export type ActivityLabelEvent = {
-  runId: string;
-  /** Run step id of the tool batch this label describes. */
-  stepId?: string;
-  /** Tool call ids covered by this label — the trace/grouping anchor. */
-  toolCallIds: string[];
-  /** Fast-model generated label (~30 chars, git-commit-subject style). */
-  label?: string;
-  counts: ActivityCounts;
-  /** ok = all tools succeeded, failed = all failed, partial = mixed. */
-  status: 'ok' | 'partial' | 'failed';
-  /** Owning agent in multi-agent graphs, for lane grouping. */
-  agentId?: string;
 };

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -17,10 +17,11 @@ export type ActivityLabelToolEntry = {
  * (Claude Code's pattern) and the block's reasoning excerpts (claude.ai's
  * pattern) — user text stays out of this low-scrutiny pathway entirely.
  *
- * Event emission is intentionally host-owned: hosts claim content slots and
- * stream label lifecycle events on their own transport (e.g. LibreChat's
- * `on_activity_label` SSE event). The SDK's contract is limited to this
- * method and the `activity_label` content type's formatter exclusions.
+ * This SDK defines NO activity-label graph event and never dispatches one.
+ * Label lifecycle streaming is entirely host-owned: a host claims its own
+ * content slots and emits on its own transport, with a payload shape only
+ * it defines. The SDK surface here is exactly this method plus the
+ * `activity_label` content type's formatter exclusions.
  */
 export type RunActivityLabelOptions = {
   provider: Providers;

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -1,0 +1,90 @@
+import type { Providers } from '@/common';
+
+/**
+ * Deterministic classification of a completed tool batch, computed from tool
+ * names with zero model calls. Rendered immediately as a fallback header
+ * ("read 2 files · ran 1 command") until the fast-model label arrives.
+ */
+export type ActivityCounts = {
+  searches: number;
+  reads: number;
+  writes: number;
+  commands: number;
+  other: number;
+};
+
+/**
+ * Configuration for fast-model activity labeling. Fully configurable like
+ * title generation: the label model never derives from the main loop model —
+ * hosts resolve provider/model independently (e.g. titleModel-style
+ * precedence) and pass the result here at run creation.
+ */
+export type ActivityLabelConfig = {
+  enabled?: boolean;
+  provider?: Providers;
+  model?: string;
+  parameters?: Record<string, unknown>;
+  /** Override for the label system prompt. */
+  prompt?: string;
+  /** Per-tool input/output truncation for the label prompt. Default 300 chars. */
+  charLimit?: number;
+  /** Cost guard: maximum labels generated per run. Default 20. */
+  maxPerRun?: number;
+};
+
+/** One tool call's contribution to the label payload (host-assembled). */
+export type ActivityLabelToolEntry = {
+  toolName: string;
+  toolInput: unknown;
+  toolOutput?: unknown;
+  error?: string;
+  status: 'success' | 'error';
+};
+
+/**
+ * Options for `Run.generateActivityLabel`. The payload deliberately contains
+ * NO human messages: intent context comes from the assistant's own last text
+ * (Claude Code's pattern) and the block's reasoning excerpts (claude.ai's
+ * pattern) — user text stays out of this low-scrutiny pathway entirely.
+ */
+export type RunActivityLabelOptions = {
+  provider: Providers;
+  clientOptions?: Record<string, unknown>;
+  entries: ActivityLabelToolEntry[];
+  /** Truncated reasoning excerpts from the block being labeled. */
+  thinkingExcerpts?: string[];
+  /** Assistant's last text before the block (~200 chars), as intent context. */
+  lastAssistantText?: string;
+  /** Override for the default label system prompt. */
+  prompt?: string;
+  /** Per-entry serialization cap for the prompt. Default 300. */
+  charLimit?: number;
+  /** LangChain runnable config carrier (signal, callbacks, thread/user ids). */
+  chainOptions?: Record<string, unknown>;
+  /**
+   * Seed for deterministic Langfuse trace ids (e.g. `${runId}-${slotIndex}`)
+   * so each batch's label gets a distinct, reproducible trace.
+   */
+  traceSeed?: string;
+};
+
+/**
+ * Payload of `GraphEvents.ON_ACTIVITY_LABEL`. Additive event: hosts and SDK
+ * consumers that do not handle it are unaffected. Emitted once per tool
+ * batch — first with `label` undefined at batch completion (deterministic
+ * counts only), then again with the fast-model `label` when it resolves.
+ */
+export type ActivityLabelEvent = {
+  runId: string;
+  /** Run step id of the tool batch this label describes. */
+  stepId?: string;
+  /** Tool call ids covered by this label — the trace/grouping anchor. */
+  toolCallIds: string[];
+  /** Fast-model generated label (~30 chars, git-commit-subject style). */
+  label?: string;
+  counts: ActivityCounts;
+  /** ok = all tools succeeded, failed = all failed, partial = mixed. */
+  status: 'ok' | 'partial' | 'failed';
+  /** Owning agent in multi-agent graphs, for lane grouping. */
+  agentId?: string;
+};

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -1,3 +1,4 @@
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { Providers } from '@/common';
 
 /** One tool call's contribution to the label payload (host-assembled). */
@@ -33,7 +34,9 @@ export type RunActivityLabelOptions = {
   /** Per-entry serialization cap for the prompt. Default 600. */
   charLimit?: number;
   /** LangChain runnable config carrier (signal, callbacks, thread/user ids). */
-  chainOptions?: Record<string, unknown>;
+  chainOptions?: Partial<RunnableConfig> & {
+    configurable?: Record<string, unknown>;
+  };
   /**
    * Seed for deterministic Langfuse trace ids (e.g. `${runId}-${slotIndex}`)
    * so each batch's label gets a distinct, reproducible trace. When omitted,

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -1,4 +1,5 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ClientOptions } from '@/types/llm';
 import type { Providers } from '@/common';
 
 /** One tool call's contribution to the label payload (host-assembled). */
@@ -23,7 +24,14 @@ export type ActivityLabelToolEntry = {
  */
 export type RunActivityLabelOptions = {
   provider: Providers;
-  clientOptions?: Record<string, unknown>;
+  clientOptions?: ClientOptions;
+  /**
+   * Agent that executed the labeled batch. Selects that agent's Langfuse
+   * overlay (trace metadata AND tool-output redaction policy) instead of
+   * the graph default — a stricter per-agent policy must not be bypassed
+   * by labeling work the default agent never performed.
+   */
+  agentId?: string;
   entries: ActivityLabelToolEntry[];
   /** Truncated reasoning excerpts from the block being labeled. */
   thinkingExcerpts?: string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './skill';
 export * from './stream';
 export * from './tools';
 export * from './summarize';
+export * from './activityLabel';


### PR DESCRIPTION
## Summary

I added the SDK primitives for fast-model activity labeling: short generated headers for collapsed blocks of agent reasoning + tool calls (the claude.ai-style grouped hierarchy), consumed downstream by LibreChat. Everything is additive — consumers that do not know the event or content type are unaffected.

- Added `GraphEvents.ON_ACTIVITY_LABEL` as an additive custom event for tool-batch labels.
- Added `ContentTypes.ACTIVITY_LABEL` and skip branches in `formatAgentMessages` (content loop + `hasMeaningfulAssistantContent`) so persisted label parts can never replay into provider-facing content — same guarantee STEER received.
- Added `Run.generateActivityLabel()`, mirroring `generateTitle`'s Langfuse wiring: the label call traces under the conversation session (`thread_id`), tagged `['librechat', 'activity-label']`, with per-batch deterministic trace ids via a caller-supplied `traceSeed` — labels group to their sessions per the #316 trace shaping instead of orphaning.
- Structured the label payload to contain no human messages by design: intent context comes from `lastAssistantText` and truncated reasoning excerpts of the labeled block, plus per-tool name/input/output entries.
- Added `ACTIVITY_LABEL_PROMPT` (5–9 words, past-tense verb first, outcomes over mechanics) and the `ActivityLabelConfig`/`ActivityLabelEvent`/`RunActivityLabelOptions` types.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran the messages test suites covering `formatAgentMessages` with the new skip branches: 17 suites, 412 passed, 1 skipped.
- Typechecked the package (`tsc --noEmit`) clean.
- Exercised the consumer path end-to-end from the LibreChat companion branch (danny-avila/LibreChat feat/activity-labels), which probes `Run.prototype.generateActivityLabel` and bridges its hook generation through this method.
- `generateActivityLabel` has no isolated unit spec — `generateTitle` has none either; live-provider validation happens through the companion branch with `ACTIVITY_LABELS_POC=true`.

### **Test Configuration**:
- Node 24, jest via `npx jest src/messages`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
