### PR TITLE
fix: sanitize CodeAPI execution errors

### DIFF
--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -11,7 +11,9 @@ import {
   appendCodeSessionFileSummary,
   emptyOutputMessage,
   buildCodeApiHttpErrorMessage,
+  CodeApiRequestError,
   getCodeBaseURL,
+  normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
 } from './CodeExecutor';
 import { Constants } from '@/common';
@@ -250,7 +252,7 @@ function createBashExecutionTool(
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {
-          throw new Error(
+          throw new CodeApiRequestError(
             await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
           );
         }
@@ -291,7 +293,7 @@ function createBashExecutionTool(
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(
-          (error as Error | undefined)?.message ?? '',
+          normalizeCodeApiRequestError(error).message,
           command
         );
         throw new Error(`Execution error:\n\n${messageWithReminder}`);

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -7,7 +7,7 @@ import {
   BASH_SHELL_GUIDANCE,
   CODE_ARTIFACT_PATH_GUIDANCE,
   appendFailedExecutionFileReminder,
-  CODE_API_EXECUTION_FAILED_ERROR_MESSAGE,
+  buildCodeApiExecutionErrorMessage,
   CodeApiRequestError,
   getCodeBaseURL,
 } from './CodeExecutor';
@@ -436,12 +436,7 @@ export function createBashProgrammaticToolCallingTool(
         }
 
         if (response.status === 'error') {
-          throw new Error(
-            CODE_API_EXECUTION_FAILED_ERROR_MESSAGE +
-              (response.stderr != null && response.stderr !== ''
-                ? `\n\nStderr:\n${response.stderr}`
-                : '')
-          );
+          throw new Error(buildCodeApiExecutionErrorMessage(response));
         }
 
         throw new CodeApiRequestError();

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -7,6 +7,8 @@ import {
   BASH_SHELL_GUIDANCE,
   CODE_ARTIFACT_PATH_GUIDANCE,
   appendFailedExecutionFileReminder,
+  CODE_API_EXECUTION_FAILED_ERROR_MESSAGE,
+  CodeApiRequestError,
   getCodeBaseURL,
 } from './CodeExecutor';
 import {
@@ -435,14 +437,14 @@ export function createBashProgrammaticToolCallingTool(
 
         if (response.status === 'error') {
           throw new Error(
-            `Execution error: ${response.error}` +
+            CODE_API_EXECUTION_FAILED_ERROR_MESSAGE +
               (response.stderr != null && response.stderr !== ''
                 ? `\n\nStderr:\n${response.stderr}`
                 : '')
           );
         }
 
-        throw new Error(`Unexpected response status: ${response.status}`);
+        throw new CodeApiRequestError();
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(
           (error as Error).message,

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -115,11 +115,25 @@ const MAX_RETRY_AFTER_SECONDS = 3600;
 
 export const CODE_API_UNAVAILABLE_ERROR_MESSAGE =
   'Code execution is temporarily unavailable. Please retry.';
+export const CODE_API_AUTHORIZATION_ERROR_MESSAGE =
+  'Code execution is not authorized. Verify access before trying again.';
 export const CODE_API_EXECUTION_FAILED_ERROR_MESSAGE = 'Code execution failed.';
 export const CODE_API_INVALID_REQUEST_ERROR_MESSAGE =
   'The code execution request was rejected. Please check the tool input and try again.';
 export const CODE_API_RATE_LIMITED_ERROR_MESSAGE =
   'Code execution is temporarily rate-limited. Please retry shortly.';
+
+const SAFE_CODE_API_EXECUTION_ERROR_DETAILS: Readonly<
+  Partial<Record<string, string>>
+> = {
+  'Execution failed or timed out': 'Execution failed or timed out.',
+  'Out of memory': 'Execution exceeded the memory limit.',
+  'Time limit exceeded': 'Execution exceeded the time limit.',
+  'sandbox emitted an empty pending tool call block; aborting to avoid a tight retry loop':
+    'Generated code emitted an invalid empty tool request.',
+  'stderr length exceeded': 'Execution error output exceeded the size limit.',
+  'stdout length exceeded': 'Execution output exceeded the size limit.',
+};
 
 export class CodeApiRequestError extends Error {
   constructor(message = CODE_API_UNAVAILABLE_ERROR_MESSAGE) {
@@ -159,6 +173,38 @@ export function normalizeCodeApiRequestError(
     : new CodeApiRequestError();
 }
 
+function getSafeCodeApiExecutionErrorDetail(
+  error: unknown
+): string | undefined {
+  if (typeof error !== 'string') {
+    return undefined;
+  }
+  const exactMatch = SAFE_CODE_API_EXECUTION_ERROR_DETAILS[error];
+  if (exactMatch != null) {
+    return exactMatch;
+  }
+  if (/^Sandbox exited with code (?:-?\d{1,4}|unknown)$/.test(error)) {
+    return error.replace(/^Sandbox/, 'Execution');
+  }
+  if (/^Sandbox requested an unregistered tool: .+$/.test(error)) {
+    return 'Generated code requested a tool that is not available.';
+  }
+  return undefined;
+}
+
+export function buildCodeApiExecutionErrorMessage(response: {
+  error?: unknown;
+  stderr?: unknown;
+}): string {
+  if (typeof response.stderr === 'string' && response.stderr !== '') {
+    return `${CODE_API_EXECUTION_FAILED_ERROR_MESSAGE}\n\nStderr:\n${response.stderr}`;
+  }
+  const safeDetail = getSafeCodeApiExecutionErrorDetail(response.error);
+  return safeDetail != null
+    ? `${CODE_API_EXECUTION_FAILED_ERROR_MESSAGE} ${safeDetail}`
+    : CODE_API_EXECUTION_FAILED_ERROR_MESSAGE;
+}
+
 export async function resolveCodeApiAuthHeaders(
   authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeApiAuthHeaderMap> {
@@ -187,6 +233,9 @@ export async function buildCodeApiHttpErrorMessage(
     return retryAfterSeconds != null
       ? `Code execution is temporarily rate-limited. Retry after ${retryAfterSeconds} seconds.`
       : CODE_API_RATE_LIMITED_ERROR_MESSAGE;
+  }
+  if (response.status === 401 || response.status === 403) {
+    return CODE_API_AUTHORIZATION_ERROR_MESSAGE;
   }
   if (response.status === 400 || response.status === 422) {
     return CODE_API_INVALID_REQUEST_ERROR_MESSAGE;

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -196,13 +196,15 @@ export function buildCodeApiExecutionErrorMessage(response: {
   error?: unknown;
   stderr?: unknown;
 }): string {
-  if (typeof response.stderr === 'string' && response.stderr !== '') {
-    return `${CODE_API_EXECUTION_FAILED_ERROR_MESSAGE}\n\nStderr:\n${response.stderr}`;
-  }
   const safeDetail = getSafeCodeApiExecutionErrorDetail(response.error);
-  return safeDetail != null
-    ? `${CODE_API_EXECUTION_FAILED_ERROR_MESSAGE} ${safeDetail}`
-    : CODE_API_EXECUTION_FAILED_ERROR_MESSAGE;
+  const message =
+    safeDetail != null
+      ? `${CODE_API_EXECUTION_FAILED_ERROR_MESSAGE} ${safeDetail}`
+      : CODE_API_EXECUTION_FAILED_ERROR_MESSAGE;
+  if (typeof response.stderr === 'string' && response.stderr !== '') {
+    return `${message}\n\nStderr:\n${response.stderr}`;
+  }
+  return message;
 }
 
 export async function resolveCodeApiAuthHeaders(

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -214,7 +214,12 @@ export async function resolveCodeApiAuthHeaders(
     return {};
   }
   if (typeof authHeaders === 'function') {
-    return authHeaders();
+    try {
+      const resolvedHeaders = await authHeaders();
+      return resolvedHeaders;
+    } catch {
+      throw new CodeApiRequestError(CODE_API_AUTHORIZATION_ERROR_MESSAGE);
+    }
   }
   return authHeaders;
 }

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -111,6 +111,54 @@ const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
 
 type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
+const MAX_RETRY_AFTER_SECONDS = 3600;
+
+export const CODE_API_UNAVAILABLE_ERROR_MESSAGE =
+  'Code execution is temporarily unavailable. Please retry.';
+export const CODE_API_EXECUTION_FAILED_ERROR_MESSAGE = 'Code execution failed.';
+export const CODE_API_INVALID_REQUEST_ERROR_MESSAGE =
+  'The code execution request was rejected. Please check the tool input and try again.';
+export const CODE_API_RATE_LIMITED_ERROR_MESSAGE =
+  'Code execution is temporarily rate-limited. Please retry shortly.';
+
+export class CodeApiRequestError extends Error {
+  constructor(message = CODE_API_UNAVAILABLE_ERROR_MESSAGE) {
+    super(message);
+    this.name = 'CodeApiRequestError';
+  }
+}
+
+function getRetryAfterSeconds(responseBody: string): number | undefined {
+  try {
+    const parsed = JSON.parse(responseBody) as {
+      error?: unknown;
+      retry_after_seconds?: unknown;
+    };
+    if (
+      parsed.error !== 'rate_limited' ||
+      typeof parsed.retry_after_seconds !== 'number' ||
+      !Number.isFinite(parsed.retry_after_seconds) ||
+      parsed.retry_after_seconds <= 0
+    ) {
+      return undefined;
+    }
+    return Math.min(
+      Math.ceil(parsed.retry_after_seconds),
+      MAX_RETRY_AFTER_SECONDS
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeCodeApiRequestError(
+  error: unknown
+): CodeApiRequestError {
+  return error instanceof CodeApiRequestError
+    ? error
+    : new CodeApiRequestError();
+}
+
 export async function resolveCodeApiAuthHeaders(
   authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeApiAuthHeaderMap> {
@@ -124,8 +172,8 @@ export async function resolveCodeApiAuthHeaders(
 }
 
 export async function buildCodeApiHttpErrorMessage(
-  method: string,
-  endpoint: string,
+  _method: string,
+  _endpoint: string,
   response: { status: number; text: () => Promise<string> }
 ): Promise<string> {
   let responseBody = '';
@@ -134,9 +182,16 @@ export async function buildCodeApiHttpErrorMessage(
   } catch {
     responseBody = '';
   }
-  const body = responseBody.trim();
-  const bodySuffix = body === '' ? '' : `, body: ${body.slice(0, 1000)}`;
-  return `CodeAPI request failed: ${method} ${endpoint} returned ${response.status}${bodySuffix}`;
+  if (response.status === 429) {
+    const retryAfterSeconds = getRetryAfterSeconds(responseBody);
+    return retryAfterSeconds != null
+      ? `Code execution is temporarily rate-limited. Retry after ${retryAfterSeconds} seconds.`
+      : CODE_API_RATE_LIMITED_ERROR_MESSAGE;
+  }
+  if (response.status === 400 || response.status === 422) {
+    return CODE_API_INVALID_REQUEST_ERROR_MESSAGE;
+  }
+  return CODE_API_UNAVAILABLE_ERROR_MESSAGE;
 }
 
 export const CodeExecutionToolDescription = `
@@ -314,7 +369,7 @@ function createCodeExecutionTool(
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {
-          throw new Error(
+          throw new CodeApiRequestError(
             await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
           );
         }
@@ -358,7 +413,7 @@ function createCodeExecutionTool(
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(
-          (error as Error | undefined)?.message ?? '',
+          normalizeCodeApiRequestError(error).message,
           code
         );
         throw new Error(`Execution error:\n\n${messageWithReminder}`);

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -10,8 +10,8 @@ import {
   CODE_ARTIFACT_PATH_GUIDANCE,
   appendCodeSessionFileSummary,
   appendFailedExecutionFileReminder,
+  buildCodeApiExecutionErrorMessage,
   buildCodeApiHttpErrorMessage,
-  CODE_API_EXECUTION_FAILED_ERROR_MESSAGE,
   CodeApiRequestError,
   emptyOutputMessage,
   getCodeBaseURL,
@@ -1021,12 +1021,7 @@ export function createProgrammaticToolCallingTool(
         }
 
         if (response.status === 'error') {
-          throw new Error(
-            CODE_API_EXECUTION_FAILED_ERROR_MESSAGE +
-              (response.stderr != null && response.stderr !== ''
-                ? `\n\nStderr:\n${response.stderr}`
-                : '')
-          );
+          throw new Error(buildCodeApiExecutionErrorMessage(response));
         }
 
         throw new CodeApiRequestError();

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -11,9 +11,12 @@ import {
   appendCodeSessionFileSummary,
   appendFailedExecutionFileReminder,
   buildCodeApiHttpErrorMessage,
+  CODE_API_EXECUTION_FAILED_ERROR_MESSAGE,
+  CodeApiRequestError,
   emptyOutputMessage,
   getCodeBaseURL,
   appendTmpScratchReminder,
+  normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
 } from './CodeExecutor';
 import {
@@ -474,30 +477,34 @@ export async function makeRequest(
   proxy?: string,
   authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.ProgrammaticExecutionResponse> {
-  const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
-  const fetchOptions: RequestInit = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'User-Agent': 'LibreChat/1.0',
-      ...resolvedAuthHeaders,
-    },
-    body: JSON.stringify(body),
-  };
+  try {
+    const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
+    const fetchOptions: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'LibreChat/1.0',
+        ...resolvedAuthHeaders,
+      },
+      body: JSON.stringify(body),
+    };
 
-  if (proxy != null && proxy !== '') {
-    fetchOptions.agent = new HttpsProxyAgent(proxy);
+    if (proxy != null && proxy !== '') {
+      fetchOptions.agent = new HttpsProxyAgent(proxy);
+    }
+
+    const response = await fetch(endpoint, fetchOptions);
+
+    if (!response.ok) {
+      throw new CodeApiRequestError(
+        await buildCodeApiHttpErrorMessage('POST', endpoint, response)
+      );
+    }
+
+    return (await response.json()) as t.ProgrammaticExecutionResponse;
+  } catch (error) {
+    throw normalizeCodeApiRequestError(error);
   }
-
-  const response = await fetch(endpoint, fetchOptions);
-
-  if (!response.ok) {
-    throw new Error(
-      await buildCodeApiHttpErrorMessage('POST', endpoint, response)
-    );
-  }
-
-  return (await response.json()) as t.ProgrammaticExecutionResponse;
 }
 
 /**
@@ -1015,14 +1022,14 @@ export function createProgrammaticToolCallingTool(
 
         if (response.status === 'error') {
           throw new Error(
-            `Execution error: ${response.error}` +
+            CODE_API_EXECUTION_FAILED_ERROR_MESSAGE +
               (response.stderr != null && response.stderr !== ''
                 ? `\n\nStderr:\n${response.stderr}`
                 : '')
           );
         }
 
-        throw new Error(`Unexpected response status: ${response.status}`);
+        throw new CodeApiRequestError();
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(
           (error as Error).message,

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -145,6 +145,38 @@ describe('CodeAPI auth header injection', () => {
     );
   });
 
+  it('maps dynamic auth-header failures to the safe authorization error', async () => {
+    const authHeaders = jest.fn(async () => {
+      throw new Error(
+        'credential helper failed for secret codeapi-signing-key in namespace internal-auth'
+      );
+    });
+    const tool = createProgrammaticToolCallingTool({ authHeaders });
+
+    const error = await tool
+      .invoke(
+        { code: 'print("hello")' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution is not authorized. Verify access before trying again.'
+    );
+    expect((error as Error).message).not.toContain('Please retry');
+    expect((error as Error).message).not.toContain('codeapi-signing-key');
+    expect((error as Error).message).not.toContain('internal-auth');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('forwards Authorization for direct code execution', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({ session_id: 'session_123', stdout: '1\n' })

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -381,6 +381,39 @@ describe('CodeAPI auth header injection', () => {
     );
   });
 
+  it('preserves an allowlisted execution error alongside stderr', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'error',
+        error: 'Time limit exceeded',
+        stderr: 'processed 42 records before termination',
+      })
+    );
+    const tool = createProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'while True: process_next_record()' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution failed. Execution exceeded the time limit.'
+    );
+    expect((error as Error).message).toContain(
+      'Stderr:\nprocessed 42 records before termination'
+    );
+  });
+
   it('keeps arbitrary programmatic execution errors redacted when stderr is absent', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -202,13 +202,129 @@ describe('CodeAPI auth header injection', () => {
     ).not.toHaveProperty('authHeaders');
   });
 
-  it('includes the CodeAPI endpoint and response body on direct execution failures', async () => {
+  it('redacts the CodeAPI endpoint and response body on direct execution failures', async () => {
     fetchMock.mockResolvedValueOnce(errorResponse(404, 'Cannot POST /exec'));
     const tool = createBashExecutionTool();
 
-    await expect(tool.invoke({ command: 'echo 1' })).rejects.toThrow(
-      /CodeAPI request failed: POST .*\/exec returned 404, body: Cannot POST \/exec/
+    const error = await tool
+      .invoke({ command: 'echo 1' })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution is temporarily unavailable. Please retry.'
     );
+    expect((error as Error).message).not.toContain('/exec');
+    expect((error as Error).message).not.toContain('Cannot POST');
+  });
+
+  it('preserves only a bounded retry delay from CodeAPI rate-limit failures', async () => {
+    fetchMock.mockResolvedValueOnce(
+      errorResponse(
+        429,
+        JSON.stringify({
+          error: 'rate_limited',
+          message:
+            'Too many CodeAPI execution requests from internal deployment details.',
+          retry_after_seconds: 8.2,
+        })
+      )
+    );
+    const tool = createBashExecutionTool();
+
+    const error = await tool
+      .invoke({ command: 'echo 1' })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution is temporarily rate-limited. Retry after 9 seconds.'
+    );
+    expect((error as Error).message).not.toContain('CodeAPI');
+    expect((error as Error).message).not.toContain('internal deployment');
+  });
+
+  it('redacts network details from direct execution failures', async () => {
+    fetchMock.mockRejectedValueOnce(
+      new Error(
+        'request to http://codeapi.internal.svc.cluster.local/exec failed: getaddrinfo ENOTFOUND'
+      )
+    );
+    const tool = createBashExecutionTool();
+
+    const error = await tool
+      .invoke({ command: 'echo 1' })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution is temporarily unavailable. Please retry.'
+    );
+    expect((error as Error).message).not.toContain('svc.cluster.local');
+    expect((error as Error).message).not.toContain('ENOTFOUND');
+  });
+
+  it('redacts network details from programmatic execution failures', async () => {
+    fetchMock.mockRejectedValueOnce(
+      new Error(
+        'request to http://codeapi.internal.svc.cluster.local/exec/programmatic failed'
+      )
+    );
+    const tool = createProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'print("hello")' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution is temporarily unavailable. Please retry.'
+    );
+    expect((error as Error).message).not.toContain('svc.cluster.local');
+  });
+
+  it('redacts CodeAPI programmatic errors while preserving execution stderr', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'error',
+        error:
+          'sandbox worker codeapi-runtime-7f9d failed in internal namespace',
+        stderr: 'NameError: tenant_variable is not defined',
+      })
+    );
+    const tool = createProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'print(tenant_variable)' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Code execution failed.');
+    expect((error as Error).message).toContain(
+      'NameError: tenant_variable is not defined'
+    );
+    expect((error as Error).message).not.toContain('codeapi-runtime');
+    expect((error as Error).message).not.toContain('internal namespace');
   });
 
   it('forwards Authorization on programmatic initial and continuation requests', async () => {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -218,6 +218,31 @@ describe('CodeAPI auth header injection', () => {
     expect((error as Error).message).not.toContain('Cannot POST');
   });
 
+  it.each([401, 403])(
+    'reports CodeAPI HTTP %s authorization failures as non-retryable',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(
+        errorResponse(
+          status,
+          'Invalid bearer token for codeapi.internal.svc.cluster.local'
+        )
+      );
+      const tool = createBashExecutionTool();
+
+      const error = await tool
+        .invoke({ command: 'echo 1' })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        'Code execution is not authorized. Verify access before trying again.'
+      );
+      expect((error as Error).message).not.toContain('Please retry');
+      expect((error as Error).message).not.toContain('svc.cluster.local');
+      expect((error as Error).message).not.toContain('Invalid bearer token');
+    }
+  );
+
   it('preserves only a bounded retry delay from CodeAPI rate-limit failures', async () => {
     fetchMock.mockResolvedValueOnce(
       errorResponse(
@@ -325,6 +350,94 @@ describe('CodeAPI auth header injection', () => {
     );
     expect((error as Error).message).not.toContain('codeapi-runtime');
     expect((error as Error).message).not.toContain('internal namespace');
+  });
+
+  it('preserves an allowlisted programmatic execution error when stderr is absent', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'error',
+        error: 'Time limit exceeded',
+      })
+    );
+    const tool = createProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'while True: pass' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution failed. Execution exceeded the time limit.'
+    );
+  });
+
+  it('keeps arbitrary programmatic execution errors redacted when stderr is absent', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'error',
+        error:
+          'sandbox worker codeapi-runtime-7f9d failed in internal namespace',
+      })
+    );
+    const tool = createProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'print("hello")' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Code execution failed.');
+    expect((error as Error).message).not.toContain('codeapi-runtime');
+    expect((error as Error).message).not.toContain('internal namespace');
+  });
+
+  it('preserves an allowlisted bash execution error when stderr is absent', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'error',
+        error: 'Out of memory',
+      })
+    );
+    const tool = createBashProgrammaticToolCallingTool();
+
+    const error = await tool
+      .invoke(
+        { code: 'lookup_user "{}"' },
+        {
+          toolCall: {
+            name: 'bash_programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+          },
+        }
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Code execution failed. Execution exceeded the memory limit.'
+    );
   });
 
   it('forwards Authorization on programmatic initial and continuation requests', async () => {


### PR DESCRIPTION
## Summary

- Normalize CodeAPI transport and platform failures before they become tool output.
- Preserve only safe recovery signals, including bounded rate-limit delays and tenant execution stderr.
- Cover direct, bash, and programmatic execution paths.

## Why

CodeAPI failures currently include raw internal endpoints and response bodies in agent tool errors, which can expose deployment details in conversations and langfuse traces. Since we will expose langfuse traces to tenants, we need to clean it up.

## Validation

- `npm test -- --runInBand src/tools/__tests__/CodeApiAuthHeaders.test.ts`
- `npx tsc --noEmit`
- `npm run build`