### PR TITLE
🛟 feat: Provider Context-Overflow Detection with Forced Summarization Recovery

### DIFF
--- a/docs/context-overflow-signatures.md
+++ b/docs/context-overflow-signatures.md
@@ -1,0 +1,150 @@
+# Provider context-overflow signatures
+
+What each provider actually does when the input exceeds what it can accept,
+and how the SDK turns that into a forced compaction instead of an error the
+caller sees.
+
+Everything in the tables below was captured by sending a real over-limit
+prompt to a live endpoint with
+[`src/scripts/context-overflow-probe.ts`](../src/scripts/context-overflow-probe.ts).
+The same payloads are frozen as test fixtures in
+[`contextOverflowSignatures.ts`](../src/utils/__tests__/fixtures/contextOverflowSignatures.ts),
+so a matcher can never drift away from what a provider really sends.
+
+## Why this is not a one-line check
+
+The obvious implementation — look for "context length" in the message — fails
+on most of the providers this SDK supports:
+
+- **OpenAI usually reports overflow as a `429`, not a `400`.** When a prompt is
+  large enough to overrun the account's tokens-per-minute allowance, it is
+  rejected on the rate-limit path before context validation runs. The error
+  says `rate_limit_exceeded`, and any matcher that excludes rate limits
+  discards the single most common OpenAI symptom.
+- **Bedrock can report overflow inside an HTTP `200`.** For Nova and Llama, the
+  failure arrives mid-stream, so `$metadata.httpStatusCode` is `200` and the
+  thrown value is a bare `Error`.
+- **Bedrock's wording changes per upstream model** — three different sentences
+  across four models, only one of which reports token counts.
+- **Vertex AI discards the reason entirely.** Its gaxios path throws
+  `Google request failed with status code 400` with no body, indistinguishable
+  from any other 400.
+- **xAI says "maximum prompt length"**, not "context length", so LangChain's own
+  `ContextOverflowError` wrapper does not catch it.
+- **OpenRouter rejects on an inflated estimate.** It counted 56,827 tokens for a
+  prompt the underlying tokenizer scores at ~42,600 — about 1.33× — so a budget
+  set to its stated ceiling still overflows.
+- **DeepSeek accepted a 227k-token prompt** that was assumed over-limit;
+  `deepseek-v4-flash` actually reports a 1,048,565-token window. Configured
+  limits are not reliable; the provider's own number is.
+
+## Captured signatures
+
+| Provider     | Model probed                                                                           | Thrown as                          | HTTP    | Message                                                                                                    |
+| ------------ | -------------------------------------------------------------------------------------- | ---------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `anthropic`  | `claude-haiku-4-5`                                                                     | `ContextOverflowError` (LangChain) | 400     | `prompt is too long: 274468 tokens > 200000 maximum`                                                       |
+| `openAI`     | `gpt-4o-mini`                                                                          | `ContextOverflowError` (LangChain) | 400     | `This model's maximum context length is 128000 tokens. However, your messages resulted in 149767 tokens.`  |
+| `openAI`     | `gpt-5-nano`, `gpt-4`, `gpt-4o`, `gpt-4.1-nano`                                        | `RateLimitError`                   | **429** | `Request too large … on tokens per min (TPM): Limit 200000, Requested 480002`                              |
+| `bedrock`    | `us.anthropic.claude-haiku-4-5`                                                        | `ValidationException`              | 400     | `The model returned the following errors: prompt is too long: 207848 tokens > 200000 maximum`              |
+| `bedrock`    | `us.anthropic.claude-sonnet-4-5`                                                       | `ValidationException`              | 400     | `The model returned the following errors: Input is too long for requested model.`                          |
+| `bedrock`    | `us.amazon.nova-lite`                                                                  | `Error`                            | **200** | `… Input Tokens Exceeded: Number of input tokens exceeds maximum length.`                                  |
+| `bedrock`    | `us.meta.llama3-1-70b`                                                                 | `Error`                            | **200** | `… This model's maximum context length is 131072 tokens.`                                                  |
+| `google`     | `gemini-3.1-flash-image`, `gemini-omni-flash-preview`                                  | `GoogleGenerativeAIFetchError`     | 400     | `[400 Bad Request] The input token count exceeds the maximum number of tokens allowed (65536).`            |
+| `vertexai`   | `gemini-2.5-flash-lite`                                                                | `Error`                            | 400     | `Google request failed with status code 400` — **no reason text**                                          |
+| `openrouter` | 9 upstreams (qwen, mistral, meta, openai, anthropic, deepseek, moonshot, google, x-ai) | `ContextOverflowError` (LangChain) | 400     | `This endpoint's maximum context length is 32768 tokens. However, you requested about 56827 tokens …`      |
+| `deepseek`   | `deepseek-v4-flash`                                                                    | `ContextOverflowError` (LangChain) | 400     | `This model's maximum context length is 1048565 tokens. However, you requested 1179668 tokens …`           |
+| `xai`        | `grok-build-0.1`                                                                       | `BadRequestError`                  | 400     | `This model's maximum prompt length is 256000 but the request contains 332986 tokens.`                     |
+| `mistral`    | `mistral-tiny-latest`                                                                  | `SDKError`                         | 400     | `Prompt contains 170397 tokens and 0 draft tokens, too large for model with 131072 maximum context length` |
+
+`azureOpenAI`, `moonshot`, and `mistralai` are not probed separately: they
+reuse the OpenAI and Mistral clients verbatim, so the captured signatures for
+those clients apply unchanged.
+
+### Not reproduced
+
+- **`vertexai` with a reason** — the native-fetch path in
+  `@langchain/google-common` does include the response body
+  (`Google request failed with status code 400: {…}`), but the service-account
+  (gaxios) path used here does not. The matcher handles both.
+- **`moonshot` direct** — no `MOONSHOT_API_KEY` was available. `ChatMoonshot`
+  extends `ChatOpenAI`, and the OpenRouter probe of `moonshotai/kimi-k2`
+  behaved like every other OpenAI-compatible endpoint.
+
+## What the SDK does with this
+
+Detection lives in [`src/utils/errors.ts`](../src/utils/errors.ts):
+`getContextOverflowInfo(error, context)` returns the kind of overflow plus
+whatever numbers the provider disclosed, or `null` for anything compaction
+cannot fix.
+
+Two kinds are distinguished:
+
+- `context_window` — the input exceeded the model's window.
+- `request_too_large` — a single request exceeded a per-minute token
+  allowance. Waiting cannot help, because the request can never fit the
+  bucket; only a smaller prompt can. This is separated from ordinary
+  throttling numerically: it counts only when `Requested >= Limit`. When
+  `Requested < Limit`, the account was merely busy and a retry is correct.
+
+Deliberately excluded, with fixtures pinning each: genuine RPM/TPM throttling,
+quota and billing failures, authentication failures, output-token-cap errors
+(`max_tokens` too large), and Bedrock's invalid-model and legacy-model errors.
+
+Vertex AI's reasonless 400 is classified only when the caller can corroborate
+it — the SDK passes its own estimate of the prompt it just sent, and the
+signature counts as overflow only when that estimate had reached 80% of the
+budget. Without corroboration the error propagates untouched.
+
+## Recovery
+
+[`src/llm/contextOverflowRecovery.ts`](../src/llm/contextOverflowRecovery.ts)
+turns a detection into a budget for the retry:
+
+1. **Believe the provider over the config.** If the error names a ceiling, that
+   becomes the new budget — this is how a `maxContextTokens` that was simply
+   wrong gets corrected mid-run.
+2. **Convert units.** If the error also names the size it attributed to the
+   prompt we just sent, the ratio against our own estimate is the conversion
+   factor between the two tokenizers. Targeting a raw ceiling from a provider
+   that counts 1.33× our tokens would just overflow again.
+3. **Shrink blindly when nothing was disclosed** — 70% of the prompt that was
+   rejected.
+4. **Bound it.** Two forced compactions per agent per run. After that the error
+   propagates, so a model that rejects everything cannot make a run compact
+   forever.
+
+In [`Graph.ts`](../src/graphs/Graph.ts), a failed model call that classifies as
+overflow applies the corrected budget and returns a summarization request
+instead of throwing. The graph routes to the summarize node, compacts, and
+comes back to the agent node, which re-prunes against the corrected budget and
+retries — the caller sees a slightly longer turn, not an error.
+
+Fallback providers still run for every other failure, and for an overflow whose
+recovery budget is spent. They are skipped on the first overflow on purpose:
+an overflow is caused by the payload, not by the provider being unavailable, so
+re-sending the same oversized prompt elsewhere is unlikely to help.
+
+When `summarizationEnabled` is `false`, the summarize node performs no model
+call — the corrected budget plus a re-prune is the entire fix, and the caller
+never pays for a summarization they opted out of.
+
+## Re-running the probe
+
+```bash
+DOTENV_CONFIG_PATH=./.env node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts --list
+```
+
+Drop `--list` to execute. Useful flags: `--only <provider,…>`, `--model
+<substring>`, `--tier full|confirm`, `--mode stream|invoke|both`, `--factor <n>`,
+`--out <path>`.
+
+Over-limit requests are rejected at validation, so providers do not bill the
+prompt. Two cautions:
+
+- A payload that lands _under_ the limit **is** billed in full. The probe sizes
+  payloads in single-token words so the word count is a guaranteed lower bound
+  on tokens, and the `confirm` tier overshoots 2× so a stale context-window
+  figure cannot cause an accidental accept.
+- `--factor` bypasses the safety floor. It exists because on accounts whose TPM
+  ceiling sits below the context window, the only way to observe the true
+  context rejection is to land the payload between the two.

--- a/docs/context-overflow-signatures.md
+++ b/docs/context-overflow-signatures.md
@@ -103,15 +103,27 @@ turns a detection into a budget for the retry:
 1. **Believe the provider over the config.** If the error names a ceiling, that
    becomes the new budget — this is how a `maxContextTokens` that was simply
    wrong gets corrected mid-run.
-2. **Convert units.** If the error also names the size it attributed to the
-   prompt we just sent, the ratio against our own estimate is the conversion
-   factor between the two tokenizers. Targeting a raw ceiling from a provider
-   that counts 1.33× our tokens would just overflow again.
-3. **Shrink blindly when nothing was disclosed** — 70% of the prompt that was
+2. **Reserve what the completion will cost.** Several providers count the
+   requested `max_tokens` against the same ceiling and quote a combined total —
+   OpenRouter's `you requested about 56827 tokens (56811 of text input, 16 in
+the output)`, DeepSeek's `(1179652 in the messages, 16 in the completion)`,
+   and OpenAI's 429 `Requested 480002`. The retry budget governs the prompt
+   only, so a known completion allowance comes off the ceiling first;
+   otherwise a large `max_tokens` keeps the request over the limit no matter
+   how far the prompt is compacted.
+3. **Convert units.** If the error names the size it attributed to _the prompt_,
+   the ratio against our own estimate is the conversion factor between the two
+   tokenizers. Targeting a raw ceiling from a provider that counts 1.33× our
+   tokens would just overflow again. This uses `promptTokens`, never
+   `requestedTokens` — calibrating on a completion-inclusive total would invent
+   a ratio and shrink the prompt far past what the overflow calls for, so
+   providers that quote only a total (OpenAI's 429, xAI) contribute no ratio.
+4. **Shrink blindly when nothing was disclosed** — 70% of the prompt that was
    rejected.
-4. **Bound it.** Two forced compactions per agent per run. After that the error
-   propagates, so a model that rejects everything cannot make a run compact
-   forever.
+5. **Bound it.** Two forced compactions per agent per run, reset at the start of
+   each turn. After that the error propagates, so a model that rejects
+   everything cannot make a run compact forever — and a single overflow cannot
+   permanently shrink the budget for every later turn.
 
 In [`Graph.ts`](../src/graphs/Graph.ts), a failed model call that classifies as
 overflow applies the corrected budget and returns a summarization request

--- a/docs/context-overflow-signatures.md
+++ b/docs/context-overflow-signatures.md
@@ -100,9 +100,20 @@ budget. Without corroboration the error propagates untouched.
 [`src/llm/contextOverflowRecovery.ts`](../src/llm/contextOverflowRecovery.ts)
 turns a detection into a budget for the retry:
 
-1. **Believe the provider over the config.** If the error names a ceiling, that
-   becomes the new budget — this is how a `maxContextTokens` that was simply
-   wrong gets corrected mid-run.
+1. **Shrink by the measured overage.** When the error names both its ceiling
+   and the size it attributed to our prompt, `ceiling / promptTokens` is a
+   pure ratio — applying it to our own estimate needs no conversion between
+   tokenizers, and targets the prompt that was actually rejected rather than a
+   budget it may have been sitting well under. When only a ceiling is named,
+   that ceiling becomes the budget directly; `maxContextTokens` is
+   provider-space, which is how a `maxContextTokens` that was simply wrong
+   gets corrected mid-run.
+
+   Note what must _not_ happen here: the pruner already divides the budget by
+   the `calibrationRatio` it learns from reported usage. Converting the
+   ceiling into "our" units as well applies the same correction twice and
+   prunes toward roughly `limit / ratio²`.
+
 2. **Reserve what the completion will cost.** Several providers count the
    requested `max_tokens` against the same ceiling and quote a combined total —
    OpenRouter's `you requested about 56827 tokens (56811 of text input, 16 in
@@ -130,6 +141,23 @@ overflow applies the corrected budget and returns a summarization request
 instead of throwing. The graph routes to the summarize node, compacts, and
 comes back to the agent node, which re-prunes against the corrected budget and
 retries — the caller sees a slightly longer turn, not an error.
+
+Compaction is staged, and the first stage costs nothing:
+
+1. **Compress.** The first recovery spends no summarization call. Re-pruning
+   under the corrected budget raises context pressure, which is what drives
+   the pruner's existing tool-output truncation and observation masking. Tool
+   output is usually where the bulk of an overflowing context sits, and
+   squeezing it loses no message content.
+2. **Summarize.** Only if the provider rejects the prompt again — and only
+   when summarization is enabled — does the next attempt spend a model call.
+
+A summarization that fails falls back to a metadata stub describing the
+history rather than summarizing it. Committing that stub means removing the
+head and keeping none of what it said, so on the overflow path it is refused:
+history is left intact and the provider error surfaces. Recovering by
+destroying the conversation the recovery exists to preserve is not a trade
+worth making. The configured-trigger path keeps its previous stub behavior.
 
 Fallback providers still run for every other failure, and for an overflow whose
 recovery budget is spent. They are skipped on the first overflow on purpose:

--- a/docs/context-overflow-signatures.md
+++ b/docs/context-overflow-signatures.md
@@ -134,7 +134,17 @@ retries — the caller sees a slightly longer turn, not an error.
 Fallback providers still run for every other failure, and for an overflow whose
 recovery budget is spent. They are skipped on the first overflow on purpose:
 an overflow is caused by the payload, not by the provider being unavailable, so
-re-sending the same oversized prompt elsewhere is unlikely to help.
+re-sending the same oversized prompt elsewhere is unlikely to help. A fallback
+that overflows is recovered on the same path, and when several fallbacks fail
+`tryFallbackProviders` surfaces the overflow in preference to whichever failure
+came last — an overflow is the one the caller can act on.
+
+Recovery is skipped entirely when nothing could shrink the prompt: with no
+token counter there is no pruner, and with summarization disabled the summarize
+node no-ops, so the retry would resend a byte-identical payload. It is also
+declined when the corrected budget would not clear the instructions with room
+to spare, since the summarize node refuses to run in that state and the detour
+would bounce between nodes without compacting anything.
 
 When `summarizationEnabled` is `false`, the summarize node performs no model
 call — the corrected budget plus a re-prune is the entire fix, and the caller

--- a/docs/context-overflow-signatures.md
+++ b/docs/context-overflow-signatures.md
@@ -83,8 +83,10 @@ Two kinds are distinguished:
 - `request_too_large` — a single request exceeded a per-minute token
   allowance. Waiting cannot help, because the request can never fit the
   bucket; only a smaller prompt can. This is separated from ordinary
-  throttling numerically: it counts only when `Requested >= Limit`. When
-  `Requested < Limit`, the account was merely busy and a retry is correct.
+  throttling numerically: it counts only when `Requested > Limit`. At
+  `Requested <= Limit` the request fits an empty bucket, so the account was
+  merely busy and a retry is correct — losing conversation history to a
+  temporarily busy account would be the worse failure.
 
 Deliberately excluded, with fixtures pinning each: genuine RPM/TPM throttling,
 quota and billing failures, authentication failures, output-token-cap errors

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/search.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
+    "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",
     "subagent:tools": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-tools-debug.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -335,6 +335,13 @@ export class AgentContext {
    */
   private _preOverflowMaxContextTokens?: number;
   /**
+   * Prompt size, by our own estimate, at the last overflow correction. A
+   * later overflow whose prompt is no smaller proves the correction changed
+   * nothing, which is the only reliable way to detect the configurations
+   * where neither pruning nor summarization has anything left to remove.
+   */
+  private _lastOverflowPromptTokens?: number;
+  /**
    * Handoff context when this agent receives control via handoff.
    * Contains source and parallel execution info for system message context.
    */
@@ -1335,14 +1342,36 @@ export class AgentContext {
    * here the history has not changed and compaction is exactly what is
    * needed.
    */
-  applyContextBudgetCorrection(budgetTokens: number): void {
+  applyContextBudgetCorrection(
+    budgetTokens: number,
+    promptTokens?: number
+  ): void {
     if (this._overflowRecoveryAttempts === 0) {
       this._preOverflowMaxContextTokens = this.maxContextTokens;
     }
     this.maxContextTokens = budgetTokens;
     this.pruneMessages = undefined;
     this._lastSummarizationMsgCount = 0;
+    this._lastOverflowPromptTokens = promptTokens;
     this._overflowRecoveryAttempts += 1;
+  }
+
+  /**
+   * True when a previous correction failed to make the prompt any smaller —
+   * the signature of a state nothing can compact further (an emptied message
+   * list carrying its content in an injected summary, for example). Retrying
+   * from there resends a byte-identical prompt, so the caller should stop.
+   */
+  overflowRecoveryStalled(currentPromptTokens?: number): boolean {
+    const previous = this._lastOverflowPromptTokens;
+    if (
+      previous == null ||
+      currentPromptTokens == null ||
+      !Number.isFinite(currentPromptTokens)
+    ) {
+      return false;
+    }
+    return currentPromptTokens >= previous;
   }
 
   /**
@@ -1359,6 +1388,7 @@ export class AgentContext {
     }
     this.maxContextTokens = this._preOverflowMaxContextTokens;
     this._preOverflowMaxContextTokens = undefined;
+    this._lastOverflowPromptTokens = undefined;
     this._overflowRecoveryAttempts = 0;
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -329,6 +329,12 @@ export class AgentContext {
    */
   private _overflowRecoveryAttempts: number = 0;
   /**
+   * Budget in force before the first overflow correction of the current run.
+   * Recorded so `reset()` can undo the correction for the next run without
+   * disturbing a `maxContextTokens` that no correction ever touched.
+   */
+  private _preOverflowMaxContextTokens?: number;
+  /**
    * Handoff context when this agent receives control via handoff.
    * Contains source and parallel execution info for system message context.
    */
@@ -994,6 +1000,7 @@ export class AgentContext {
     this._lastSummarizationMsgCount = 0;
     this.lastCallUsage = undefined;
     this.totalTokensFresh = false;
+    this.restoreContextBudgetAfterOverflow();
 
     if (this.tokenCounter) {
       this.initializeSystemRunnable();
@@ -1329,10 +1336,30 @@ export class AgentContext {
    * needed.
    */
   applyContextBudgetCorrection(budgetTokens: number): void {
+    if (this._overflowRecoveryAttempts === 0) {
+      this._preOverflowMaxContextTokens = this.maxContextTokens;
+    }
     this.maxContextTokens = budgetTokens;
     this.pruneMessages = undefined;
     this._lastSummarizationMsgCount = 0;
     this._overflowRecoveryAttempts += 1;
+  }
+
+  /**
+   * Undoes overflow corrections so a reused context starts the next run with
+   * the budget it was configured with and a fresh recovery allowance.
+   *
+   * Without this, a single overflow would permanently shrink the budget for
+   * every later turn, and two would exhaust the per-run allowance for the
+   * lifetime of the context.
+   */
+  private restoreContextBudgetAfterOverflow(): void {
+    if (this._overflowRecoveryAttempts === 0) {
+      return;
+    }
+    this.maxContextTokens = this._preOverflowMaxContextTokens;
+    this._preOverflowMaxContextTokens = undefined;
+    this._overflowRecoveryAttempts = 0;
   }
 
   clearSummary(): void {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -992,7 +992,7 @@ export class AgentContext {
   /**
    * Reset context for a new run
    */
-  reset(): void {
+  reset(options?: { preserveOriginalToolContent?: boolean }): void {
     this.systemMessageTokens = 0;
     this.dynamicInstructionTokens = 0;
     this.toolSchemaTokens = 0;
@@ -1010,7 +1010,9 @@ export class AgentContext {
     this.currentTokenType = ContentTypes.TEXT;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;
-    this.pendingOriginalToolContent = undefined;
+    if (options?.preserveOriginalToolContent !== true) {
+      this.pendingOriginalToolContent = undefined;
+    }
 
     this.summaryText = this._durableSummaryText;
     this.summaryTokenCount = this._durableSummaryTokenCount;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1340,7 +1340,9 @@ export class AgentContext {
   shouldSummarizeOverflow(): boolean {
     return (
       this.summarizationEnabled === true &&
-      (this.tokenCounter == null || this._overflowRecoveryAttempts > 0)
+      (this.tokenCounter == null ||
+        this.maxContextTokens == null ||
+        this._overflowRecoveryAttempts > 0)
     );
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -20,9 +20,9 @@ import {
 } from '@/messages/cache';
 import {
   DEFAULT_RESERVE_RATIO,
+  ORIGINAL_CONTENT_MAX_CHARS,
   clampCalibrationRatio,
   createPruneMessages,
-  enforceOriginalContentCap,
   syncBudgetDerivedFields,
 } from '@/messages';
 import {
@@ -222,8 +222,22 @@ export class AgentContext {
   calibrationRatio: number = 1;
   /** Provider-observed instruction overhead from the pruner's best-variance turn. */
   resolvedInstructionOverhead?: number;
+  private _pendingOriginalToolContent?: Map<number, string>;
+  private pendingOriginalToolContentChars = 0;
   /** Pre-masking tool content keyed by message index, consumed by the summarize node. */
-  pendingOriginalToolContent?: Map<number, string>;
+  get pendingOriginalToolContent(): Map<number, string> | undefined {
+    return this._pendingOriginalToolContent;
+  }
+  set pendingOriginalToolContent(value: Map<number, string> | undefined) {
+    this._pendingOriginalToolContent = value;
+    this.pendingOriginalToolContentChars = 0;
+    if (value != null) {
+      for (const content of value.values()) {
+        this.pendingOriginalToolContentChars += content.length;
+      }
+      this.enforcePendingOriginalContentCap();
+    }
+  }
 
   /** Total instruction overhead: system message + tool schemas + pending summary. */
   get instructionTokens(): number {
@@ -1354,16 +1368,36 @@ export class AgentContext {
       return;
     }
     if (this.pendingOriginalToolContent == null) {
-      this.pendingOriginalToolContent = new Map(originalToolContent);
-      enforceOriginalContentCap(this.pendingOriginalToolContent);
-      return;
+      this.pendingOriginalToolContent = new Map();
     }
     for (const [index, content] of originalToolContent) {
       if (!this.pendingOriginalToolContent.has(index)) {
         this.pendingOriginalToolContent.set(index, content);
+        this.pendingOriginalToolContentChars += content.length;
       }
     }
-    enforceOriginalContentCap(this.pendingOriginalToolContent);
+    this.enforcePendingOriginalContentCap();
+  }
+
+  private enforcePendingOriginalContentCap(): void {
+    const pending = this._pendingOriginalToolContent;
+    if (pending == null) {
+      return;
+    }
+    while (
+      this.pendingOriginalToolContentChars > ORIGINAL_CONTENT_MAX_CHARS &&
+      pending.size > 0
+    ) {
+      const oldest = pending.keys().next();
+      if (oldest.done === true) {
+        break;
+      }
+      const removed = pending.get(oldest.value);
+      if (removed != null) {
+        this.pendingOriginalToolContentChars -= removed.length;
+      }
+      pending.delete(oldest.value);
+    }
   }
 
   /**
@@ -1389,8 +1423,8 @@ export class AgentContext {
     this.pruneMessages = undefined;
     this._lastSummarizationMsgCount = 0;
     this._lastOverflowPromptTokens =
-      promptTokens != null && this.calibrationRatio > 0
-        ? promptTokens / this.calibrationRatio
+      promptTokens != null
+        ? this.normalizePromptTokens(promptTokens)
         : promptTokens;
     this._overflowRecoveryAttempts += 1;
   }
@@ -1425,11 +1459,16 @@ export class AgentContext {
     ) {
       return false;
     }
-    const rawCurrent =
-      this.calibrationRatio > 0
-        ? currentPromptTokens / this.calibrationRatio
-        : currentPromptTokens;
+    const rawCurrent = this.normalizePromptTokens(currentPromptTokens);
     return rawCurrent >= previous;
+  }
+
+  private normalizePromptTokens(promptTokens: number): number {
+    if (this.calibrationRatio <= 0) {
+      return promptTokens;
+    }
+    const messageTokens = Math.max(0, promptTokens - this.instructionTokens);
+    return this.instructionTokens + messageTokens / this.calibrationRatio;
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -323,6 +323,12 @@ export class AgentContext {
    */
   private _lastSummarizationMsgCount: number = 0;
   /**
+   * Forced compactions performed after a provider rejected a prompt as too
+   * large. Bounds the recovery loop so a model that keeps refusing cannot
+   * make the run compact indefinitely.
+   */
+  private _overflowRecoveryAttempts: number = 0;
+  /**
    * Handoff context when this agent receives control via handoff.
    * Contains source and parallel execution info for system message context.
    */
@@ -1306,6 +1312,27 @@ export class AgentContext {
    */
   markSummarizationTriggered(msgCount: number): void {
     this._lastSummarizationMsgCount = msgCount;
+  }
+
+  get overflowRecoveryAttempts(): number {
+    return this._overflowRecoveryAttempts;
+  }
+
+  /**
+   * Retargets the context budget after a provider rejected the prompt as too
+   * large, and clears the memoized pruner so the next call is planned against
+   * the corrected budget rather than the one that was evidently wrong.
+   *
+   * Also clears the "already summarized at this message count" guard: that
+   * guard exists to stop redundant summarization of an unchanged history, but
+   * here the history has not changed and compaction is exactly what is
+   * needed.
+   */
+  applyContextBudgetCorrection(budgetTokens: number): void {
+    this.maxContextTokens = budgetTokens;
+    this.pruneMessages = undefined;
+    this._lastSummarizationMsgCount = 0;
+    this._overflowRecoveryAttempts += 1;
   }
 
   clearSummary(): void {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -28,6 +28,7 @@ import {
 import {
   DEFAULT_RESERVE_RATIO,
   createPruneMessages,
+  enforceOriginalContentCap,
   syncBudgetDerivedFields,
 } from '@/messages';
 import { createSchemaOnlyTools } from '@/tools/schema';
@@ -1009,6 +1010,7 @@ export class AgentContext {
     this.currentTokenType = ContentTypes.TEXT;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;
+    this.pendingOriginalToolContent = undefined;
 
     this.summaryText = this._durableSummaryText;
     this.summaryTokenCount = this._durableSummaryTokenCount;
@@ -1338,6 +1340,33 @@ export class AgentContext {
 
   get overflowRecoveryAttempts(): number {
     return this._overflowRecoveryAttempts;
+  }
+
+  shouldSummarizeOverflow(): boolean {
+    return (
+      this.summarizationEnabled === true &&
+      (this.tokenCounter == null || this._overflowRecoveryAttempts > 0)
+    );
+  }
+
+  /** Preserves the earliest full tool output recorded for each message index. */
+  preserveOriginalToolContent(
+    originalToolContent: Map<number, string> | undefined
+  ): void {
+    if (originalToolContent == null || originalToolContent.size === 0) {
+      return;
+    }
+    if (this.pendingOriginalToolContent == null) {
+      this.pendingOriginalToolContent = new Map(originalToolContent);
+      enforceOriginalContentCap(this.pendingOriginalToolContent);
+      return;
+    }
+    for (const [index, content] of originalToolContent) {
+      if (!this.pendingOriginalToolContent.has(index)) {
+        this.pendingOriginalToolContent.set(index, content);
+      }
+    }
+    enforceOriginalContentCap(this.pendingOriginalToolContent);
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -343,14 +343,6 @@ export class AgentContext {
    */
   private _lastOverflowPromptTokens?: number;
   /**
-   * Set while a compression-only overflow retry is in flight. Suppressing the
-   * *configured* summarization trigger for that one pass is what makes the
-   * staging real: without it the summarize node's skip just hands control
-   * back to the agent node, where the ordinary trigger fires on the very
-   * messages the re-prune produced and spends the model call anyway.
-   */
-  private _compressionRetryPending: boolean = false;
-  /**
    * Handoff context when this agent receives control via handoff.
    * Contains source and parallel execution info for system message context.
    */
@@ -1383,8 +1375,7 @@ export class AgentContext {
    */
   applyContextBudgetCorrection(
     budgetTokens: number | undefined,
-    promptTokens?: number,
-    compressionOnly = false
+    promptTokens?: number
   ): void {
     if (this._overflowRecoveryAttempts === 0) {
       this._preOverflowMaxContextTokens = this.maxContextTokens;
@@ -1398,7 +1389,6 @@ export class AgentContext {
       promptTokens != null && this.calibrationRatio > 0
         ? promptTokens / this.calibrationRatio
         : promptTokens;
-    this._compressionRetryPending = compressionOnly;
     this._overflowRecoveryAttempts += 1;
   }
 
@@ -1415,17 +1405,6 @@ export class AgentContext {
       return;
     }
     this.calibrationRatio = observedCalibrationRatio;
-  }
-
-  /**
-   * Reads and clears the compression-only marker. Consumed once per pass
-   * through the agent node so the suppression covers exactly the retry it was
-   * issued for and cannot leak into a later turn's legitimate trigger.
-   */
-  consumeCompressionRetry(): boolean {
-    const pending = this._compressionRetryPending;
-    this._compressionRetryPending = false;
-    return pending;
   }
 
   /**
@@ -1465,7 +1444,6 @@ export class AgentContext {
     this.maxContextTokens = this._preOverflowMaxContextTokens;
     this._preOverflowMaxContextTokens = undefined;
     this._lastOverflowPromptTokens = undefined;
-    this._compressionRetryPending = false;
     this._overflowRecoveryAttempts = 0;
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -342,6 +342,14 @@ export class AgentContext {
    */
   private _lastOverflowPromptTokens?: number;
   /**
+   * Set while a compression-only overflow retry is in flight. Suppressing the
+   * *configured* summarization trigger for that one pass is what makes the
+   * staging real: without it the summarize node's skip just hands control
+   * back to the agent node, where the ordinary trigger fires on the very
+   * messages the re-prune produced and spends the model call anyway.
+   */
+  private _compressionRetryPending: boolean = false;
+  /**
    * Handoff context when this agent receives control via handoff.
    * Contains source and parallel execution info for system message context.
    */
@@ -1344,7 +1352,8 @@ export class AgentContext {
    */
   applyContextBudgetCorrection(
     budgetTokens: number,
-    promptTokens?: number
+    promptTokens?: number,
+    compressionOnly = false
   ): void {
     if (this._overflowRecoveryAttempts === 0) {
       this._preOverflowMaxContextTokens = this.maxContextTokens;
@@ -1353,7 +1362,19 @@ export class AgentContext {
     this.pruneMessages = undefined;
     this._lastSummarizationMsgCount = 0;
     this._lastOverflowPromptTokens = promptTokens;
+    this._compressionRetryPending = compressionOnly;
     this._overflowRecoveryAttempts += 1;
+  }
+
+  /**
+   * Reads and clears the compression-only marker. Consumed once per pass
+   * through the agent node so the suppression covers exactly the retry it was
+   * issued for and cannot leak into a later turn's legitimate trigger.
+   */
+  consumeCompressionRetry(): boolean {
+    const pending = this._compressionRetryPending;
+    this._compressionRetryPending = false;
+    return pending;
   }
 
   /**
@@ -1389,6 +1410,7 @@ export class AgentContext {
     this.maxContextTokens = this._preOverflowMaxContextTokens;
     this._preOverflowMaxContextTokens = undefined;
     this._lastOverflowPromptTokens = undefined;
+    this._compressionRetryPending = false;
     this._overflowRecoveryAttempts = 0;
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -19,18 +19,19 @@ import {
   type PromptCacheTtl,
 } from '@/messages/cache';
 import {
+  DEFAULT_RESERVE_RATIO,
+  clampCalibrationRatio,
+  createPruneMessages,
+  enforceOriginalContentCap,
+  syncBudgetDerivedFields,
+} from '@/messages';
+import {
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
   ContentTypes,
   Constants,
   Providers,
 } from '@/common';
-import {
-  DEFAULT_RESERVE_RATIO,
-  createPruneMessages,
-  enforceOriginalContentCap,
-  syncBudgetDerivedFields,
-} from '@/messages';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
@@ -1404,7 +1405,7 @@ export class AgentContext {
     ) {
       return;
     }
-    this.calibrationRatio = observedCalibrationRatio;
+    this.calibrationRatio = clampCalibrationRatio(observedCalibrationRatio);
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -336,10 +336,10 @@ export class AgentContext {
    */
   private _preOverflowMaxContextTokens?: number;
   /**
-   * Prompt size, by our own estimate, at the last overflow correction. A
-   * later overflow whose prompt is no smaller proves the correction changed
-   * nothing, which is the only reliable way to detect the configurations
-   * where neither pruning nor summarization has anything left to remove.
+   * Prompt size, normalized into the local counter's uncalibrated units, at
+   * the last overflow correction. Keeping both measurements in the same units
+   * lets a later overflow prove whether compaction changed anything even when
+   * the provider observation updated calibration between attempts.
    */
   private _lastOverflowPromptTokens?: number;
   /**
@@ -1382,19 +1382,39 @@ export class AgentContext {
    * needed.
    */
   applyContextBudgetCorrection(
-    budgetTokens: number,
+    budgetTokens: number | undefined,
     promptTokens?: number,
     compressionOnly = false
   ): void {
     if (this._overflowRecoveryAttempts === 0) {
       this._preOverflowMaxContextTokens = this.maxContextTokens;
     }
-    this.maxContextTokens = budgetTokens;
+    if (budgetTokens != null) {
+      this.maxContextTokens = budgetTokens;
+    }
     this.pruneMessages = undefined;
     this._lastSummarizationMsgCount = 0;
-    this._lastOverflowPromptTokens = promptTokens;
+    this._lastOverflowPromptTokens =
+      promptTokens != null && this.calibrationRatio > 0
+        ? promptTokens / this.calibrationRatio
+        : promptTokens;
     this._compressionRetryPending = compressionOnly;
     this._overflowRecoveryAttempts += 1;
+  }
+
+  /** Applies token calibration only when the observation came from this provider. */
+  applyObservedOverflowCalibration(
+    provider: Providers | undefined,
+    observedCalibrationRatio: number | undefined
+  ): void {
+    if (
+      provider !== this.provider ||
+      observedCalibrationRatio == null ||
+      observedCalibrationRatio <= 0
+    ) {
+      return;
+    }
+    this.calibrationRatio = observedCalibrationRatio;
   }
 
   /**
@@ -1423,7 +1443,11 @@ export class AgentContext {
     ) {
       return false;
     }
-    return currentPromptTokens >= previous;
+    const rawCurrent =
+      this.calibrationRatio > 0
+        ? currentPromptTokens / this.calibrationRatio
+        : currentPromptTokens;
+    return rawCurrent >= previous;
   }
 
   /**

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -129,6 +129,25 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.consumeCompressionRetry()).toBe(false);
   });
 
+  it('keeps fallback calibration out of the primary agent context', () => {
+    const context = createContext(1_000_000);
+    context.calibrationRatio = 1.5;
+
+    context.applyObservedOverflowCalibration(Providers.VERTEXAI, 2);
+    expect(context.calibrationRatio).toBe(1.5);
+
+    context.applyObservedOverflowCalibration(Providers.ANTHROPIC, 2);
+    expect(context.calibrationRatio).toBe(2);
+  });
+
+  it('records a summary-only recovery without inventing a token budget', () => {
+    const context = createContext();
+    context.applyContextBudgetCorrection(undefined, undefined, false);
+
+    expect(context.maxContextTokens).toBeUndefined();
+    expect(context.overflowRecoveryAttempts).toBe(1);
+  });
+
   it('clears the compression marker on reset', () => {
     const context = createContext(1_000_000);
     context.applyContextBudgetCorrection(190_000, 274_468, true);
@@ -150,6 +169,15 @@ describe('AgentContext overflow recovery state', () => {
     context.applyContextBudgetCorrection(190_000, 250_000);
 
     expect(context.overflowRecoveryStalled(180_000)).toBe(false);
+  });
+
+  it('compares stall measurements in uncalibrated token units', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 250_000);
+    context.calibrationRatio = 2;
+
+    expect(context.overflowRecoveryStalled(360_000)).toBe(false);
+    expect(context.overflowRecoveryStalled(500_000)).toBe(true);
   });
 
   it('reports no stall before any correction, or without a measurement', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -82,6 +82,16 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.pendingOriginalToolContent).toBeUndefined();
   });
 
+  it('preserves tool output snapshots when checkpointed messages survive reset', () => {
+    const context = createContext(1_000_000);
+    context.preserveOriginalToolContent(new Map([[2, 'full output']]));
+    context.reset({ preserveOriginalToolContent: true });
+
+    expect(context.pendingOriginalToolContent).toEqual(
+      new Map([[2, 'full output']])
+    );
+  });
+
   it('restores the pre-correction budget on reset', () => {
     const context = createContext(1_000_000);
     context.applyContextBudgetCorrection(190_000, 274_468);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -1,0 +1,77 @@
+import type * as t from '@/types';
+import { AgentContext } from '@/agents/AgentContext';
+import { Providers } from '@/common';
+
+/**
+ * The overflow-recovery bookkeeping on AgentContext: the budget correction,
+ * its restoration between runs, and the stall detector that stops a recovery
+ * loop when a correction demonstrably changed nothing.
+ */
+describe('AgentContext overflow recovery state', () => {
+  const createContext = (maxContextTokens?: number): AgentContext =>
+    AgentContext.fromConfig({
+      agentId: 'overflow-agent',
+      provider: Providers.ANTHROPIC,
+      instructions: 'Test instructions',
+      maxContextTokens,
+    } as Partial<t.AgentInputs> as t.AgentInputs);
+
+  it('records the correction and counts the attempt', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 274_468);
+
+    expect(context.maxContextTokens).toBe(190_000);
+    expect(context.overflowRecoveryAttempts).toBe(1);
+    /** Forces the pruner to be rebuilt against the corrected budget. */
+    expect(context.pruneMessages).toBeUndefined();
+  });
+
+  it('restores the pre-correction budget on reset', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 274_468);
+    context.applyContextBudgetCorrection(133_000, 180_000);
+    context.reset();
+
+    expect(context.maxContextTokens).toBe(1_000_000);
+    expect(context.overflowRecoveryAttempts).toBe(0);
+  });
+
+  it('leaves an untouched budget alone on reset', () => {
+    const context = createContext(1_000_000);
+    context.maxContextTokens = 500_000;
+    context.reset();
+
+    expect(context.maxContextTokens).toBe(500_000);
+  });
+
+  it('reports a stall when the prompt did not shrink', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 250_000);
+
+    expect(context.overflowRecoveryStalled(250_000)).toBe(true);
+    expect(context.overflowRecoveryStalled(260_000)).toBe(true);
+  });
+
+  it('reports no stall while the prompt is still shrinking', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 250_000);
+
+    expect(context.overflowRecoveryStalled(180_000)).toBe(false);
+  });
+
+  it('reports no stall before any correction, or without a measurement', () => {
+    const context = createContext(1_000_000);
+    expect(context.overflowRecoveryStalled(250_000)).toBe(false);
+
+    context.applyContextBudgetCorrection(190_000, 250_000);
+    expect(context.overflowRecoveryStalled(undefined)).toBe(false);
+  });
+
+  it('clears the stall measurement on reset', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 250_000);
+    context.reset();
+
+    expect(context.overflowRecoveryStalled(250_000)).toBe(false);
+  });
+});

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -44,6 +44,33 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.maxContextTokens).toBe(500_000);
   });
 
+  it('marks a compression-only retry so the configured trigger is suppressed', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 274_468, true);
+
+    /**
+     * Consumed once, by the single agent-node pass the suppression covers.
+     * Leaving it set would silence a later turn's legitimate trigger.
+     */
+    expect(context.consumeCompressionRetry()).toBe(true);
+    expect(context.consumeCompressionRetry()).toBe(false);
+  });
+
+  it('does not mark an escalated recovery as compression-only', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 274_468, false);
+
+    expect(context.consumeCompressionRetry()).toBe(false);
+  });
+
+  it('clears the compression marker on reset', () => {
+    const context = createContext(1_000_000);
+    context.applyContextBudgetCorrection(190_000, 274_468, true);
+    context.reset();
+
+    expect(context.consumeCompressionRetry()).toBe(false);
+  });
+
   it('reports a stall when the prompt did not shrink', () => {
     const context = createContext(1_000_000);
     context.applyContextBudgetCorrection(190_000, 250_000);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -46,7 +46,7 @@ describe('AgentContext overflow recovery state', () => {
     );
 
     expect(context.shouldSummarizeOverflow()).toBe(false);
-    context.applyContextBudgetCorrection(190_000, 274_468, true);
+    context.applyContextBudgetCorrection(190_000, 274_468);
     expect(context.shouldSummarizeOverflow()).toBe(true);
   });
 
@@ -110,25 +110,6 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.maxContextTokens).toBe(500_000);
   });
 
-  it('marks a compression-only retry so the configured trigger is suppressed', () => {
-    const context = createContext(1_000_000);
-    context.applyContextBudgetCorrection(190_000, 274_468, true);
-
-    /**
-     * Consumed once, by the single agent-node pass the suppression covers.
-     * Leaving it set would silence a later turn's legitimate trigger.
-     */
-    expect(context.consumeCompressionRetry()).toBe(true);
-    expect(context.consumeCompressionRetry()).toBe(false);
-  });
-
-  it('does not mark an escalated recovery as compression-only', () => {
-    const context = createContext(1_000_000);
-    context.applyContextBudgetCorrection(190_000, 274_468, false);
-
-    expect(context.consumeCompressionRetry()).toBe(false);
-  });
-
   it('keeps fallback calibration out of the primary agent context', () => {
     const context = createContext(1_000_000);
     context.calibrationRatio = 1.5;
@@ -142,18 +123,10 @@ describe('AgentContext overflow recovery state', () => {
 
   it('records a summary-only recovery without inventing a token budget', () => {
     const context = createContext();
-    context.applyContextBudgetCorrection(undefined, undefined, false);
+    context.applyContextBudgetCorrection(undefined, undefined);
 
     expect(context.maxContextTokens).toBeUndefined();
     expect(context.overflowRecoveryAttempts).toBe(1);
-  });
-
-  it('clears the compression marker on reset', () => {
-    const context = createContext(1_000_000);
-    context.applyContextBudgetCorrection(190_000, 274_468, true);
-    context.reset();
-
-    expect(context.consumeCompressionRetry()).toBe(false);
   });
 
   it('reports a stall when the prompt did not shrink', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -26,6 +26,62 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.pruneMessages).toBeUndefined();
   });
 
+  it('summarizes the first overflow when deterministic pruning is unavailable', () => {
+    const context = createContext(1_000_000);
+    context.summarizationEnabled = true;
+
+    expect(context.shouldSummarizeOverflow()).toBe(true);
+  });
+
+  it('stages deterministic pruning before summarization when a counter exists', () => {
+    const context = AgentContext.fromConfig(
+      {
+        agentId: 'overflow-agent',
+        provider: Providers.ANTHROPIC,
+        instructions: 'Test instructions',
+        maxContextTokens: 1_000_000,
+        summarizationEnabled: true,
+      } as Partial<t.AgentInputs> as t.AgentInputs,
+      () => 1
+    );
+
+    expect(context.shouldSummarizeOverflow()).toBe(false);
+    context.applyContextBudgetCorrection(190_000, 274_468, true);
+    expect(context.shouldSummarizeOverflow()).toBe(true);
+  });
+
+  it('preserves the earliest full tool output when masking records collide', () => {
+    const context = createContext(1_000_000);
+    context.preserveOriginalToolContent(
+      new Map([
+        [2, 'full output'],
+        [4, 'another output'],
+      ])
+    );
+    context.preserveOriginalToolContent(
+      new Map([
+        [2, 'truncated placeholder'],
+        [6, 'new output'],
+      ])
+    );
+
+    expect(context.pendingOriginalToolContent).toEqual(
+      new Map([
+        [2, 'full output'],
+        [4, 'another output'],
+        [6, 'new output'],
+      ])
+    );
+  });
+
+  it('releases index-keyed tool output snapshots on reset', () => {
+    const context = createContext(1_000_000);
+    context.preserveOriginalToolContent(new Map([[2, 'full output']]));
+    context.reset();
+
+    expect(context.pendingOriginalToolContent).toBeUndefined();
+  });
+
   it('restores the pre-correction budget on reset', () => {
     const context = createContext(1_000_000);
     context.applyContextBudgetCorrection(190_000, 274_468);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -177,6 +177,16 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.overflowRecoveryStalled(500_000)).toBe(true);
   });
 
+  it('leaves fixed instruction overhead out of calibration normalization', () => {
+    const context = createContext(1_000_000);
+    context.systemMessageTokens = 100_000;
+    context.applyContextBudgetCorrection(190_000, 250_000);
+    context.calibrationRatio = 0.5;
+
+    expect(context.overflowRecoveryStalled(160_000)).toBe(false);
+    expect(context.overflowRecoveryStalled(175_000)).toBe(true);
+  });
+
   it('reports no stall before any correction, or without a measurement', () => {
     const context = createContext(1_000_000);
     expect(context.overflowRecoveryStalled(250_000)).toBe(false);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -121,6 +121,16 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.calibrationRatio).toBe(2);
   });
 
+  it('clamps provider-observed calibration to the shared safe range', () => {
+    const context = createContext(1_000_000);
+
+    context.applyObservedOverflowCalibration(Providers.ANTHROPIC, 10);
+    expect(context.calibrationRatio).toBe(5);
+
+    context.applyObservedOverflowCalibration(Providers.ANTHROPIC, 0.1);
+    expect(context.calibrationRatio).toBe(0.5);
+  });
+
   it('records a summary-only recovery without inventing a token budget', () => {
     const context = createContext();
     context.applyContextBudgetCorrection(undefined, undefined);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -33,6 +33,20 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.shouldSummarizeOverflow()).toBe(true);
   });
 
+  it('summarizes immediately when no pruning budget is configured', () => {
+    const context = AgentContext.fromConfig(
+      {
+        agentId: 'overflow-agent',
+        provider: Providers.ANTHROPIC,
+        instructions: 'Test instructions',
+        summarizationEnabled: true,
+      } as Partial<t.AgentInputs> as t.AgentInputs,
+      () => 1
+    );
+
+    expect(context.shouldSummarizeOverflow()).toBe(true);
+  });
+
   it('stages deterministic pruning before summarization when a counter exists', () => {
     const context = AgentContext.fromConfig(
       {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -59,6 +59,10 @@ import {
   StepTypes,
 } from '@/common';
 import {
+  planContextOverflowRecovery,
+  translateRecoveryBudget,
+} from '@/llm/contextOverflowRecovery';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -77,7 +81,6 @@ import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
-import { planContextOverflowRecovery } from '@/llm/contextOverflowRecovery';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
@@ -1546,8 +1549,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     agentContext.preserveOriginalToolContent(originalToolContent);
     agentContext.applyContextBudgetCorrection(
       recovery.budgetTokens,
-      estimatedPromptTokens,
-      !allowSummarization
+      estimatedPromptTokens
     );
     agentContext.applyObservedOverflowCalibration(
       recovery.info.provider,
@@ -1770,13 +1772,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * AgentContext bounds what accumulates.
          */
         agentContext.preserveOriginalToolContent(originalToolContent);
-        /**
-         * Consumed once per pass so a compression-only retry suppresses the
-         * configured trigger exactly here — the summarize node's skip would
-         * otherwise hand control straight back and the ordinary trigger would
-         * spend the summarization call the staging exists to avoid.
-         */
-        const compressionRetryPending = agentContext.consumeCompressionRetry();
         agentContext.indexTokenCountMap = indexTokenCountMap;
         if (calibrationRatio != null && calibrationRatio > 0) {
           agentContext.calibrationRatio = calibrationRatio;
@@ -1845,7 +1840,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           );
           const triggerResult =
             !shouldSkip &&
-            !compressionRetryPending &&
             shouldTriggerSummarization({
               trigger: agentContext.summarizationConfig?.trigger,
               maxContextTokens: agentContext.maxContextTokens,
@@ -2392,7 +2386,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            * as an alternative in the first place.
            */
           const fallbackContext = getFallbackErrorContext(error);
-          return planContextOverflowRecovery({
+          const recovery = planContextOverflowRecovery({
             error,
             provider: fallbackContext?.provider ?? agentContext.provider,
             maxContextTokens:
@@ -2406,6 +2400,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             ),
             attemptsSoFar: agentContext.overflowRecoveryAttempts,
           });
+          if (
+            recovery == null ||
+            fallbackContext == null ||
+            fallbackContext.provider === agentContext.provider
+          ) {
+            return recovery;
+          }
+          return {
+            ...recovery,
+            budgetTokens: translateRecoveryBudget(
+              recovery.budgetTokens,
+              recovery.observedCalibrationRatio,
+              agentContext.calibrationRatio
+            ),
+          };
         };
 
         const recovery = planRecovery(primaryError);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1025,8 +1025,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       new Map()
     );
     this.invokedToolIds = resetIfNotEmpty(this.invokedToolIds, undefined);
+    const preserveOriginalToolContent =
+      this.compileOptions?.checkpointer != null;
     for (const context of this.agentContexts.values()) {
-      context.reset();
+      context.reset({ preserveOriginalToolContent });
     }
   }
 
@@ -1035,8 +1037,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
+    const preserveOriginalToolContent =
+      this.compileOptions?.checkpointer != null;
     for (const context of this.agentContexts.values()) {
-      context.reset();
+      context.reset({ preserveOriginalToolContent });
     }
   }
 
@@ -2382,8 +2386,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           return planContextOverflowRecovery({
             error,
             provider: fallbackContext?.provider ?? agentContext.provider,
-            maxContextTokens: agentContext.maxContextTokens,
+            maxContextTokens:
+              fallbackContext?.maxContextTokens ??
+              agentContext.maxContextTokens,
             estimatedPromptTokens,
+            calibrationRatio: agentContext.calibrationRatio,
             instructionTokens: agentContext.instructionTokens,
             configuredCompletionTokens: getConfiguredCompletionTokens(
               fallbackContext?.clientOptions ?? agentContext.clientOptions

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1560,6 +1560,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   }): Partial<t.AgentSubgraphState> {
     const previousBudget = agentContext.maxContextTokens;
     /**
+     * Deterministic compaction first. Re-pruning against the corrected budget
+     * raises context pressure, which is what drives the pruner's tool-output
+     * truncation and observation masking — no model call, no cost, and no
+     * message content lost. A summarization call is held back until that has
+     * been tried and the provider rejected the prompt again.
+     */
+    const allowSummarization =
+      agentContext.summarizationEnabled === true &&
+      agentContext.overflowRecoveryAttempts > 0;
+
+    /**
      * Preserved before the detour for the same reason the configured trigger
      * preserves it: the summarize node restores full tool output from this
      * map, and without it a forced summary is written from truncated stubs.
@@ -1569,7 +1580,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * clears it, so storing megabytes of tool output there would be a leak
      * for a detour that never reads it.
      */
-    if (agentContext.summarizationEnabled === true) {
+    if (allowSummarization) {
       preserveOriginalToolContent(agentContext, originalToolContent);
     }
     agentContext.applyContextBudgetCorrection(
@@ -1588,9 +1599,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         recoveredBudget: recovery.budgetTokens,
         providerReportedLimit: recovery.info.limitTokens,
         providerReportedTokens: recovery.info.requestedTokens,
+        providerReportedPromptTokens: recovery.info.promptTokens,
         observedCalibrationRatio: recovery.observedCalibrationRatio,
         detectedBy: recovery.info.source,
         attempt: agentContext.overflowRecoveryAttempts,
+        compaction: allowSummarization ? 'summarize' : 'compress',
       },
       { runId: this.runId, agentId },
       { force: true }
@@ -1601,6 +1614,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         remainingContextTokens: 0,
         agentId: agentId || agentContext.agentId,
         reason: 'overflow',
+        allowSummarization,
       },
     };
   }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -11,6 +11,7 @@ import type {
   MessageContent,
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
@@ -71,6 +72,7 @@ import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
+import { planContextOverflowRecovery } from '@/llm/contextOverflowRecovery';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
@@ -368,6 +370,28 @@ function clearCurrentDeltaStepMarkers({
     graph.messageStepHasTextDeltas.delete(stepId);
     graph.reasoningStepHasDeltas.delete(stepId);
   }
+}
+
+/**
+ * Our own estimate of the prompt that was actually sent, derived from the
+ * pre-invoke usage snapshot. Used to corroborate ambiguous provider errors
+ * and to measure how far our token accounting sits from the provider's.
+ */
+function getEstimatedPromptTokens(
+  contextUsage: t.ContextUsageEvent | null
+): number | undefined {
+  const budget = contextUsage?.contextBudget;
+  const remaining = contextUsage?.remainingContextTokens;
+  if (
+    budget == null ||
+    remaining == null ||
+    !Number.isFinite(budget) ||
+    !Number.isFinite(remaining)
+  ) {
+    return undefined;
+  }
+  const used = budget - remaining;
+  return used > 0 ? used : undefined;
 }
 
 async function dispatchMessageCreationStep({
@@ -1445,6 +1469,56 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     client.abortHandler = undefined;
   }
 
+  /**
+   * Applies a context-overflow recovery plan and hands control to the
+   * summarize node, which compacts and then routes straight back here for a
+   * retry against the corrected budget.
+   *
+   * Returning the detour rather than rethrowing is the whole point: the
+   * caller never sees the provider's rejection, only a slightly longer turn.
+   */
+  private beginOverflowRecovery({
+    recovery,
+    agentContext,
+    agentId,
+    config,
+  }: {
+    recovery: OverflowRecoveryPlan;
+    agentContext: AgentContext;
+    agentId: string;
+    config?: RunnableConfig;
+  }): Partial<t.AgentSubgraphState> {
+    const previousBudget = agentContext.maxContextTokens;
+    agentContext.applyContextBudgetCorrection(recovery.budgetTokens);
+
+    emitAgentLog(
+      config,
+      'warn',
+      'graph',
+      'Provider rejected the prompt as too large — compacting and retrying',
+      {
+        kind: recovery.info.kind,
+        previousBudget,
+        recoveredBudget: recovery.budgetTokens,
+        providerReportedLimit: recovery.info.limitTokens,
+        providerReportedTokens: recovery.info.requestedTokens,
+        observedCalibrationRatio: recovery.observedCalibrationRatio,
+        detectedBy: recovery.info.source,
+        attempt: agentContext.overflowRecoveryAttempts,
+      },
+      { runId: this.runId, agentId },
+      { force: true }
+    );
+
+    return {
+      summarizationRequest: {
+        remainingContextTokens: 0,
+        agentId: agentId || agentContext.agentId,
+        reason: 'overflow',
+      },
+    };
+  }
+
   createCallModel(agentId = 'default') {
     return async (
       state: t.AgentSubgraphState,
@@ -2220,6 +2294,28 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           graph: this,
           metadata,
         });
+        /**
+         * A context overflow is a deterministic consequence of the payload,
+         * not a provider being unavailable — so it is answered by compacting
+         * and retrying rather than by re-sending the same oversized prompt
+         * down the fallback chain. Fallbacks still run for every other
+         * failure, and for an overflow whose recovery budget is spent.
+         */
+        const recovery = planContextOverflowRecovery({
+          error: primaryError,
+          provider: agentContext.provider,
+          maxContextTokens: agentContext.maxContextTokens,
+          estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
+          attemptsSoFar: agentContext.overflowRecoveryAttempts,
+        });
+        if (recovery != null) {
+          return this.beginOverflowRecovery({
+            recovery,
+            agentContext,
+            agentId,
+            config,
+          });
+        }
         result = await withLangfuseRuntimeScope(
           resolveLangfuseRuntimeScope({
             runLangfuse: this.langfuse,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -413,6 +413,26 @@ function preserveOriginalToolContent(
 }
 
 /**
+ * The completion allowance the caller configured, under whichever key the
+ * provider's client uses. Providers count it against the same ceiling as the
+ * prompt, so overflow recovery has to reserve it when the error did not
+ * itemize the total.
+ */
+function getConfiguredCompletionTokens(
+  clientOptions: t.ClientOptions | undefined
+): number | undefined {
+  const options = clientOptions as
+    | { maxTokens?: unknown; maxOutputTokens?: unknown }
+    | undefined;
+  for (const value of [options?.maxTokens, options?.maxOutputTokens]) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Our own estimate of the prompt that was actually sent, derived from the
  * pre-invoke usage snapshot. Used to corroborate ambiguous provider errors
  * and to measure how far our token accounting sits from the provider's.
@@ -2327,14 +2347,31 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * down the fallback chain. Fallbacks still run for every other
          * failure, and for an overflow whose recovery budget is spent.
          */
+        /**
+         * Compaction has to have something to work with. Without a token
+         * counter there is no pruner, and with summarization disabled the
+         * summarize node deliberately no-ops — so in that combination the
+         * retry would resend a byte-identical prompt. Skipping the detour
+         * keeps the original error and one round trip instead of three.
+         */
+        const canReduceContext =
+          agentContext.tokenCounter != null ||
+          agentContext.summarizationEnabled === true;
+
         const planRecovery = (error: unknown): OverflowRecoveryPlan | null =>
-          planContextOverflowRecovery({
-            error,
-            provider: agentContext.provider,
-            maxContextTokens: agentContext.maxContextTokens,
-            estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
-            attemptsSoFar: agentContext.overflowRecoveryAttempts,
-          });
+          canReduceContext
+            ? planContextOverflowRecovery({
+              error,
+              provider: agentContext.provider,
+              maxContextTokens: agentContext.maxContextTokens,
+              estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
+              instructionTokens: agentContext.instructionTokens,
+              configuredCompletionTokens: getConfiguredCompletionTokens(
+                agentContext.clientOptions
+              ),
+              attemptsSoFar: agentContext.overflowRecoveryAttempts,
+            })
+            : null;
 
         const recovery = planRecovery(primaryError);
         if (recovery != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -23,7 +23,6 @@ import {
   extractToolDiscoveries,
   addBedrockTailCacheControl,
   formatArtifactPayload,
-  enforceOriginalContentCap,
   formatContentStrings,
   isLegacyConvertible,
   createPruneMessages,
@@ -375,46 +374,6 @@ function clearCurrentDeltaStepMarkers({
     graph.messageStepHasTextDeltas.delete(stepId);
     graph.reasoningStepHasDeltas.delete(stepId);
   }
-}
-
-/**
- * Merge — never overwrite — the pruner's masking record into
- * `pendingOriginalToolContent`, which the summarize node reads to restore
- * full tool output before writing a summary. Skipping this leaves the
- * summarizer working from truncated placeholders.
- *
- * Carry-over entries from a prior summarize (preserved by the recency window
- * for masked tool messages still in the tail) and the current pruner's new
- * entries are both keyed by indices in the current `state.messages`, so a
- * key-wise union is correct. Overwriting would discard the carry-over and
- * reduce summary fidelity when those masked tail messages eventually move
- * into the head.
- *
- * Called from both paths that reach the summarize node: the configured
- * trigger, and overflow recovery.
- */
-function preserveOriginalToolContent(
-  agentContext: AgentContext,
-  originalToolContent: Map<number, string> | undefined
-): void {
-  if (originalToolContent == null || originalToolContent.size === 0) {
-    return;
-  }
-  if (agentContext.pendingOriginalToolContent == null) {
-    agentContext.pendingOriginalToolContent = originalToolContent;
-    return;
-  }
-  for (const [index, content] of originalToolContent) {
-    agentContext.pendingOriginalToolContent.set(index, content);
-  }
-  /**
-   * Re-apply the per-store char cap after the union. The pruner enforces
-   * ORIGINAL_CONTENT_MAX_CHARS inside its own map via the onContentStored
-   * callback, but a key-wise merge with recency carry-over bypasses that
-   * accounting and could let the merged map grow without bound across long
-   * sessions.
-   */
-  enforceOriginalContentCap(agentContext.pendingOriginalToolContent);
 }
 
 /**
@@ -1567,11 +1526,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * message content lost. A summarization call is held back until that has
      * been tried and the provider rejected the prompt again.
      */
-    const allowSummarization =
-      agentContext.summarizationEnabled === true &&
-      agentContext.overflowRecoveryAttempts > 0;
+    const allowSummarization = agentContext.shouldSummarizeOverflow();
 
-    preserveOriginalToolContent(agentContext, originalToolContent);
+    agentContext.preserveOriginalToolContent(originalToolContent);
+    if (
+      recovery.observedCalibrationRatio != null &&
+      recovery.observedCalibrationRatio > 0
+    ) {
+      agentContext.calibrationRatio = recovery.observedCalibrationRatio;
+    }
     agentContext.applyContextBudgetCorrection(
       recovery.budgetTokens,
       estimatedPromptTokens,
@@ -1791,9 +1754,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * every prune, not just when a summary is about to be written — the
          * pruner closure that produced it is discarded on the next reset, and
          * with it any chance of a later summary restoring the real content.
-         * `enforceOriginalContentCap` bounds what accumulates.
+         * AgentContext bounds what accumulates.
          */
-        preserveOriginalToolContent(agentContext, originalToolContent);
+        agentContext.preserveOriginalToolContent(originalToolContent);
         /**
          * Consumed once per pass so a compression-only retry suppresses the
          * configured trigger exactly here — the summarize node's skip would

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1570,22 +1570,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       agentContext.summarizationEnabled === true &&
       agentContext.overflowRecoveryAttempts > 0;
 
-    /**
-     * Preserved before the detour for the same reason the configured trigger
-     * preserves it: the summarize node restores full tool output from this
-     * map, and without it a forced summary is written from truncated stubs.
-     *
-     * Only when a summary will actually be written, though. On the re-prune
-     * -only path the node no-ops without consuming the map, and nothing else
-     * clears it, so storing megabytes of tool output there would be a leak
-     * for a detour that never reads it.
-     */
-    if (allowSummarization) {
-      preserveOriginalToolContent(agentContext, originalToolContent);
-    }
+    preserveOriginalToolContent(agentContext, originalToolContent);
     agentContext.applyContextBudgetCorrection(
       recovery.budgetTokens,
-      estimatedPromptTokens
+      estimatedPromptTokens,
+      !allowSummarization
     );
 
     emitAgentLog(
@@ -1795,6 +1784,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           totalTokensFresh: agentContext.totalTokensFresh,
         });
         prunedOriginalToolContent = originalToolContent;
+        /**
+         * Masking rewrites tool content in `state.messages` in place, so this
+         * map is the only surviving copy of the full output. Persist it on
+         * every prune, not just when a summary is about to be written — the
+         * pruner closure that produced it is discarded on the next reset, and
+         * with it any chance of a later summary restoring the real content.
+         * `enforceOriginalContentCap` bounds what accumulates.
+         */
+        preserveOriginalToolContent(agentContext, originalToolContent);
+        /**
+         * Consumed once per pass so a compression-only retry suppresses the
+         * configured trigger exactly here — the summarize node's skip would
+         * otherwise hand control straight back and the ordinary trigger would
+         * spend the summarization call the staging exists to avoid.
+         */
+        const compressionRetryPending = agentContext.consumeCompressionRetry();
         agentContext.indexTokenCountMap = indexTokenCountMap;
         if (calibrationRatio != null && calibrationRatio > 0) {
           agentContext.calibrationRatio = calibrationRatio;
@@ -1863,6 +1868,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           );
           const triggerResult =
             !shouldSkip &&
+            !compressionRetryPending &&
             shouldTriggerSummarization({
               trigger: agentContext.summarizationConfig?.trigger,
               maxContextTokens: agentContext.maxContextTokens,
@@ -1875,8 +1881,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             });
 
           if (triggerResult) {
-            preserveOriginalToolContent(agentContext, originalToolContent);
-
             emitAgentLog(
               config,
               'info',

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1563,8 +1563,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * Preserved before the detour for the same reason the configured trigger
      * preserves it: the summarize node restores full tool output from this
      * map, and without it a forced summary is written from truncated stubs.
+     *
+     * Only when a summary will actually be written, though. On the re-prune
+     * -only path the node no-ops without consuming the map, and nothing else
+     * clears it, so storing megabytes of tool output there would be a leak
+     * for a detour that never reads it.
      */
-    preserveOriginalToolContent(agentContext, originalToolContent);
+    if (agentContext.summarizationEnabled === true) {
+      preserveOriginalToolContent(agentContext, originalToolContent);
+    }
     agentContext.applyContextBudgetCorrection(
       recovery.budgetTokens,
       estimatedPromptTokens

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -36,6 +36,8 @@ import {
   getMessageId,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
+  DEFAULT_RETAIN_RECENT_TURNS,
+  splitAtRecencyBoundary,
 } from '@/messages';
 import {
   createLangfuseHandler,
@@ -1770,7 +1772,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           messagesToRefine,
           prePruneContextTokens,
           remainingContextTokens,
-          originalToolContent,
+          newOriginalToolContent,
           calibrationRatio,
           resolvedInstructionOverhead,
           contextBudget,
@@ -1781,7 +1783,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           lastCallUsage: agentContext.lastCallUsage,
           totalTokensFresh: agentContext.totalTokensFresh,
         });
-        prunedOriginalToolContent = originalToolContent;
+        prunedOriginalToolContent = newOriginalToolContent;
         /**
          * Masking rewrites tool content in `state.messages` in place, so this
          * map is the only surviving copy of the full output. Persist it on
@@ -1790,7 +1792,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * with it any chance of a later summary restoring the real content.
          * AgentContext bounds what accumulates.
          */
-        agentContext.preserveOriginalToolContent(originalToolContent);
+        agentContext.preserveOriginalToolContent(newOriginalToolContent);
         agentContext.indexTokenCountMap = indexTokenCountMap;
         if (calibrationRatio != null && calibrationRatio > 0) {
           agentContext.calibrationRatio = calibrationRatio;
@@ -2390,6 +2392,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const recoveryStalled = agentContext.overflowRecoveryStalled(
           estimatedPromptTokens
         );
+        const canSummarizeOverflow =
+          agentContext.summarizationEnabled === true &&
+          splitAtRecencyBoundary(messages, {
+            turns:
+              agentContext.summarizationConfig?.retainRecent?.turns ??
+              DEFAULT_RETAIN_RECENT_TURNS,
+            tokens: agentContext.summarizationConfig?.retainRecent?.tokens,
+            tokenCounter: agentContext.tokenCounter,
+          }).head.length > 0;
 
         const planRecovery = (
           error: unknown,
@@ -2440,7 +2451,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               }
               : recovery;
           const canReduceContext =
-            agentContext.summarizationEnabled === true ||
+            canSummarizeOverflow ||
             (agentContext.tokenCounter != null &&
               translatedRecovery.budgetTokens != null);
           return canReduceContext ? translatedRecovery : null;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -373,6 +373,46 @@ function clearCurrentDeltaStepMarkers({
 }
 
 /**
+ * Merge — never overwrite — the pruner's masking record into
+ * `pendingOriginalToolContent`, which the summarize node reads to restore
+ * full tool output before writing a summary. Skipping this leaves the
+ * summarizer working from truncated placeholders.
+ *
+ * Carry-over entries from a prior summarize (preserved by the recency window
+ * for masked tool messages still in the tail) and the current pruner's new
+ * entries are both keyed by indices in the current `state.messages`, so a
+ * key-wise union is correct. Overwriting would discard the carry-over and
+ * reduce summary fidelity when those masked tail messages eventually move
+ * into the head.
+ *
+ * Called from both paths that reach the summarize node: the configured
+ * trigger, and overflow recovery.
+ */
+function preserveOriginalToolContent(
+  agentContext: AgentContext,
+  originalToolContent: Map<number, string> | undefined
+): void {
+  if (originalToolContent == null || originalToolContent.size === 0) {
+    return;
+  }
+  if (agentContext.pendingOriginalToolContent == null) {
+    agentContext.pendingOriginalToolContent = originalToolContent;
+    return;
+  }
+  for (const [index, content] of originalToolContent) {
+    agentContext.pendingOriginalToolContent.set(index, content);
+  }
+  /**
+   * Re-apply the per-store char cap after the union. The pruner enforces
+   * ORIGINAL_CONTENT_MAX_CHARS inside its own map via the onContentStored
+   * callback, but a key-wise merge with recency carry-over bypasses that
+   * accounting and could let the merged map grow without bound across long
+   * sessions.
+   */
+  enforceOriginalContentCap(agentContext.pendingOriginalToolContent);
+}
+
+/**
  * Our own estimate of the prompt that was actually sent, derived from the
  * pre-invoke usage snapshot. Used to corroborate ambiguous provider errors
  * and to measure how far our token accounting sits from the provider's.
@@ -1482,13 +1522,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     agentContext,
     agentId,
     config,
+    originalToolContent,
   }: {
     recovery: OverflowRecoveryPlan;
     agentContext: AgentContext;
     agentId: string;
     config?: RunnableConfig;
+    /** Masking record from the prune pass that built the rejected prompt. */
+    originalToolContent?: Map<number, string>;
   }): Partial<t.AgentSubgraphState> {
     const previousBudget = agentContext.maxContextTokens;
+    /**
+     * Preserved before the detour for the same reason the configured trigger
+     * preserves it: the summarize node restores full tool output from this
+     * map, and without it a forced summary is written from truncated stubs.
+     */
+    preserveOriginalToolContent(agentContext, originalToolContent);
     agentContext.applyContextBudgetCorrection(recovery.budgetTokens);
 
     emitAgentLog(
@@ -1641,6 +1690,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       let messagesToUse = messages;
       let contextUsage: t.ContextUsageEvent | null = null;
+      /**
+       * Held outside the prune block so overflow recovery — which detours to
+       * the summarize node from the invoke catch below — can preserve the
+       * same masking record the configured trigger preserves.
+       */
+      let prunedOriginalToolContent: Map<number, string> | undefined;
       if (
         !agentContext.pruneMessages &&
         agentContext.tokenCounter &&
@@ -1688,6 +1743,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           lastCallUsage: agentContext.lastCallUsage,
           totalTokensFresh: agentContext.totalTokensFresh,
         });
+        prunedOriginalToolContent = originalToolContent;
         agentContext.indexTokenCountMap = indexTokenCountMap;
         if (calibrationRatio != null && calibrationRatio > 0) {
           agentContext.calibrationRatio = calibrationRatio;
@@ -1768,37 +1824,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             });
 
           if (triggerResult) {
-            if (originalToolContent != null && originalToolContent.size > 0) {
-              /**
-               * Merge — never overwrite — the pruner's masking record
-               * into pendingOriginalToolContent.  Carry-over entries
-               * from a prior summarize (preserved by the recency
-               * window for masked tool messages still in the tail) and
-               * the current pruner's new entries are both keyed by
-               * indices in the current `state.messages`, so a key-wise
-               * union is correct.  Overwriting would discard the
-               * carry-over and reduce summary fidelity when those
-               * masked tail messages eventually move into the head.
-               */
-              if (agentContext.pendingOriginalToolContent == null) {
-                agentContext.pendingOriginalToolContent = originalToolContent;
-              } else {
-                for (const [idx, content] of originalToolContent) {
-                  agentContext.pendingOriginalToolContent.set(idx, content);
-                }
-                /**
-                 * Re-apply the per-store char cap after the union.  The
-                 * pruner enforces ORIGINAL_CONTENT_MAX_CHARS inside its
-                 * own map via the onContentStored callback, but a
-                 * key-wise merge with recency carry-over bypasses that
-                 * accounting and could let the merged map grow without
-                 * bound across long sessions.
-                 */
-                enforceOriginalContentCap(
-                  agentContext.pendingOriginalToolContent
-                );
-              }
-            }
+            preserveOriginalToolContent(agentContext, originalToolContent);
 
             emitAgentLog(
               config,
@@ -2301,36 +2327,61 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * down the fallback chain. Fallbacks still run for every other
          * failure, and for an overflow whose recovery budget is spent.
          */
-        const recovery = planContextOverflowRecovery({
-          error: primaryError,
-          provider: agentContext.provider,
-          maxContextTokens: agentContext.maxContextTokens,
-          estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
-          attemptsSoFar: agentContext.overflowRecoveryAttempts,
-        });
+        const planRecovery = (error: unknown): OverflowRecoveryPlan | null =>
+          planContextOverflowRecovery({
+            error,
+            provider: agentContext.provider,
+            maxContextTokens: agentContext.maxContextTokens,
+            estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
+            attemptsSoFar: agentContext.overflowRecoveryAttempts,
+          });
+
+        const recovery = planRecovery(primaryError);
         if (recovery != null) {
           return this.beginOverflowRecovery({
             recovery,
             agentContext,
             agentId,
             config,
+            originalToolContent: prunedOriginalToolContent,
           });
         }
-        result = await withLangfuseRuntimeScope(
-          resolveLangfuseRuntimeScope({
-            runLangfuse: this.langfuse,
-            langfuseOverlay: agentContext.langfuse,
-          }),
-          () =>
-            tryFallbackProviders({
-              fallbacks,
-              tools: agentContext.tools,
-              messages: finalMessages,
-              config: invokeConfig,
-              primaryError,
-              context: this,
-            })
-        );
+
+        /**
+         * A fallback can reject the same prompt as too large even when the
+         * primary failed for an unrelated reason — a fallback with a smaller
+         * window is the obvious case. Planning against the exhausted-chain
+         * error keeps that path recoverable instead of surfacing it.
+         */
+        try {
+          result = await withLangfuseRuntimeScope(
+            resolveLangfuseRuntimeScope({
+              runLangfuse: this.langfuse,
+              langfuseOverlay: agentContext.langfuse,
+            }),
+            () =>
+              tryFallbackProviders({
+                fallbacks,
+                tools: agentContext.tools,
+                messages: finalMessages,
+                config: invokeConfig,
+                primaryError,
+                context: this,
+              })
+          );
+        } catch (fallbackError) {
+          const fallbackRecovery = planRecovery(fallbackError);
+          if (fallbackRecovery == null) {
+            throw fallbackError;
+          }
+          return this.beginOverflowRecovery({
+            recovery: fallbackRecovery,
+            agentContext,
+            agentId,
+            config,
+            originalToolContent: prunedOriginalToolContent,
+          });
+        }
       } finally {
         await disposeLangfuseHandler(langfuseHandler);
       }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -12,6 +12,7 @@ import type {
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
+import type { FallbackErrorContext } from '@/llm/invoke';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
@@ -57,6 +58,12 @@ import {
   translateRecoveryBudget,
 } from '@/llm/contextOverflowRecovery';
 import {
+  attemptInvoke,
+  tryFallbackProviders,
+  getFallbackErrorContext,
+  getFallbackOverflowCandidates,
+} from '@/llm/invoke';
+import {
   Constants,
   GraphNodeKeys,
   ContentTypes,
@@ -68,11 +75,6 @@ import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
-import {
-  attemptInvoke,
-  tryFallbackProviders,
-  getFallbackErrorContext,
-} from '@/llm/invoke';
 import {
   appendCallbacks,
   findCallback,
@@ -2389,7 +2391,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           estimatedPromptTokens
         );
 
-        const planRecovery = (error: unknown): OverflowRecoveryPlan | null => {
+        const planRecovery = (
+          error: unknown,
+          attributedFallbackContext?: FallbackErrorContext
+        ): OverflowRecoveryPlan | null => {
           if (recoveryStalled) {
             return null;
           }
@@ -2398,7 +2403,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            * client: its window and output allowance are why it was configured
            * as an alternative in the first place.
            */
-          const fallbackContext = getFallbackErrorContext(error);
+          const fallbackContext =
+            attributedFallbackContext ?? getFallbackErrorContext(error);
           const recovery = planContextOverflowRecovery({
             error,
             provider: fallbackContext?.provider ?? agentContext.provider,
@@ -2418,8 +2424,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             return null;
           }
           const translatedRecovery =
-            fallbackContext != null &&
-            fallbackContext.provider !== agentContext.provider
+            fallbackContext != null
               ? {
                 ...recovery,
                 budgetTokens: minDefined(
@@ -2431,6 +2436,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                     agentContext.calibrationRatio
                   )
                 ),
+                observedCalibrationRatio: undefined,
               }
               : recovery;
           const canReduceContext =
@@ -2478,13 +2484,25 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                  * surface it rather than a later unrelated failure.
                  */
                 overflowContext: {
+                  provider: agentContext.provider,
                   estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
                   maxContextTokens: agentContext.maxContextTokens,
                 },
               })
           );
         } catch (fallbackError) {
-          const fallbackRecovery = planRecovery(fallbackError);
+          const overflowCandidates =
+            getFallbackOverflowCandidates(fallbackError);
+          let fallbackRecovery: OverflowRecoveryPlan | null = null;
+          for (const candidate of overflowCandidates) {
+            fallbackRecovery = planRecovery(candidate.error, candidate.context);
+            if (fallbackRecovery != null) {
+              break;
+            }
+          }
+          if (overflowCandidates.length === 0) {
+            fallbackRecovery = planRecovery(fallbackError);
+          }
           if (fallbackRecovery == null) {
             throw fallbackError;
           }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -56,6 +56,11 @@ import {
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
 import {
+  attemptInvoke,
+  tryFallbackProviders,
+  getFallbackErrorContext,
+} from '@/llm/invoke';
+import {
   GraphNodeKeys,
   ContentTypes,
   GraphEvents,
@@ -77,7 +82,6 @@ import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
-import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
 import { shouldTriggerSummarization } from '@/summarization';
@@ -1543,6 +1547,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     agentId,
     config,
     originalToolContent,
+    estimatedPromptTokens,
   }: {
     recovery: OverflowRecoveryPlan;
     agentContext: AgentContext;
@@ -1550,6 +1555,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     config?: RunnableConfig;
     /** Masking record from the prune pass that built the rejected prompt. */
     originalToolContent?: Map<number, string>;
+    /** Size of the rejected prompt, recorded to detect a correction that changed nothing. */
+    estimatedPromptTokens?: number;
   }): Partial<t.AgentSubgraphState> {
     const previousBudget = agentContext.maxContextTokens;
     /**
@@ -1558,7 +1565,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * map, and without it a forced summary is written from truncated stubs.
      */
     preserveOriginalToolContent(agentContext, originalToolContent);
-    agentContext.applyContextBudgetCorrection(recovery.budgetTokens);
+    agentContext.applyContextBudgetCorrection(
+      recovery.budgetTokens,
+      estimatedPromptTokens
+    );
 
     emitAgentLog(
       config,
@@ -2358,20 +2368,40 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.tokenCounter != null ||
           agentContext.summarizationEnabled === true;
 
-        const planRecovery = (error: unknown): OverflowRecoveryPlan | null =>
-          canReduceContext
-            ? planContextOverflowRecovery({
-              error,
-              provider: agentContext.provider,
-              maxContextTokens: agentContext.maxContextTokens,
-              estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
-              instructionTokens: agentContext.instructionTokens,
-              configuredCompletionTokens: getConfiguredCompletionTokens(
-                agentContext.clientOptions
-              ),
-              attemptsSoFar: agentContext.overflowRecoveryAttempts,
-            })
-            : null;
+        const estimatedPromptTokens = getEstimatedPromptTokens(contextUsage);
+
+        /**
+         * A previous correction that left the prompt no smaller proves this
+         * state has nothing left to compact — an emptied message list whose
+         * content rides along in an injected summary, for instance. Measuring
+         * that beats trying to predict every such configuration.
+         */
+        const recoveryStalled = agentContext.overflowRecoveryStalled(
+          estimatedPromptTokens
+        );
+
+        const planRecovery = (error: unknown): OverflowRecoveryPlan | null => {
+          if (!canReduceContext || recoveryStalled) {
+            return null;
+          }
+          /**
+           * When the rejection came from a fallback, plan against *that*
+           * client: its window and output allowance are why it was configured
+           * as an alternative in the first place.
+           */
+          const fallbackContext = getFallbackErrorContext(error);
+          return planContextOverflowRecovery({
+            error,
+            provider: fallbackContext?.provider ?? agentContext.provider,
+            maxContextTokens: agentContext.maxContextTokens,
+            estimatedPromptTokens,
+            instructionTokens: agentContext.instructionTokens,
+            configuredCompletionTokens: getConfiguredCompletionTokens(
+              fallbackContext?.clientOptions ?? agentContext.clientOptions
+            ),
+            attemptsSoFar: agentContext.overflowRecoveryAttempts,
+          });
+        };
 
         const recovery = planRecovery(primaryError);
         if (recovery != null) {
@@ -2381,6 +2411,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             agentId,
             config,
             originalToolContent: prunedOriginalToolContent,
+            estimatedPromptTokens,
           });
         }
 
@@ -2426,6 +2457,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             agentId,
             config,
             originalToolContent: prunedOriginalToolContent,
+            estimatedPromptTokens,
           });
         }
       } finally {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -25,6 +25,7 @@ import {
   formatArtifactPayload,
   formatContentStrings,
   isLegacyConvertible,
+  CALIBRATION_RATIO_MAX,
   createPruneMessages,
   syncBudgetDerivedFields,
   addTailCacheControl,
@@ -420,6 +421,19 @@ function getEstimatedPromptTokens(
   }
   const used = budget - remaining;
   return used > 0 ? used : undefined;
+}
+
+function minDefined(
+  left: number | undefined,
+  right: number | undefined
+): number | undefined {
+  if (left == null) {
+    return right;
+  }
+  if (right == null) {
+    return left;
+  }
+  return Math.min(left, right);
 }
 
 async function dispatchMessageCreationStep({
@@ -914,6 +928,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   overrideModel?: t.ChatModel;
   /** Optional compile options passed into workflow.compile() */
   compileOptions?: t.CompileOptions | undefined;
+  /** Whether the workflow was actually compiled with a checkpointer. */
+  hasCompiledCheckpointer: boolean = false;
   messages: BaseMessage[] = [];
   /** Cached run messages preserved before clearHeavyState() so getRunMessages() works after cleanup. */
   private cachedRunMessages?: BaseMessage[];
@@ -1032,7 +1048,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     );
     this.invokedToolIds = resetIfNotEmpty(this.invokedToolIds, undefined);
     const hasScopedCheckpoint =
-      this.compileOptions?.checkpointer != null &&
+      this.hasCompiledCheckpointer &&
       checkpointScope != null &&
       checkpointScope !== '';
     const preserveOriginalToolContent =
@@ -1052,7 +1068,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.messages = [];
     this.overrideModel = undefined;
     const preserveOriginalToolContent =
-      this.compileOptions?.checkpointer != null &&
+      this.hasCompiledCheckpointer &&
       this.originalToolContentCheckpointScope != null;
     for (const context of this.agentContexts.values()) {
       context.reset({ preserveOriginalToolContent });
@@ -2406,14 +2422,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             fallbackContext.provider !== agentContext.provider
               ? {
                 ...recovery,
-                budgetTokens:
-                    recovery.observedCalibrationRatio == null
-                      ? getBlindRecoveryBudget(agentContext.maxContextTokens)
-                      : translateRecoveryBudget(
-                        recovery.budgetTokens,
-                        recovery.observedCalibrationRatio,
-                        agentContext.calibrationRatio
-                      ),
+                budgetTokens: minDefined(
+                  getBlindRecoveryBudget(agentContext.maxContextTokens),
+                  translateRecoveryBudget(
+                    recovery.budgetTokens,
+                    recovery.observedCalibrationRatio ??
+                        CALIBRATION_RATIO_MAX,
+                    agentContext.calibrationRatio
+                  )
+                ),
               }
               : recovery;
           const canReduceContext =
@@ -2920,6 +2937,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   }
 
   createWorkflow(): t.CompiledStateWorkflow {
+    this.hasCompiledCheckpointer = this.compileOptions?.checkpointer != null;
     const agentNode = this.createAgentNode(this.defaultAgentId);
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2404,6 +2404,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 config: invokeConfig,
                 primaryError,
                 context: this,
+                /**
+                 * Lets the chain recognise a fallback overflow whose signature
+                 * carries no reason of its own (Vertex AI's bare 400) and
+                 * surface it rather than a later unrelated failure.
+                 */
+                overflowContext: {
+                  estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
+                  maxContextTokens: agentContext.maxContextTokens,
+                },
               })
           );
         } catch (fallbackError) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -568,7 +568,7 @@ export abstract class Graph<
   T extends t.BaseGraphState = t.BaseGraphState,
   _TNodeName extends string = string,
 > {
-  abstract resetValues(): void;
+  abstract resetValues(keepContent?: boolean, checkpointScope?: string): void;
   abstract initializeTools({
     currentTools,
     currentToolMap,
@@ -913,6 +913,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   messages: BaseMessage[] = [];
   /** Cached run messages preserved before clearHeavyState() so getRunMessages() works after cleanup. */
   private cachedRunMessages?: BaseMessage[];
+  /** Checkpoint scope whose messages match index-keyed tool snapshots. */
+  private originalToolContentCheckpointScope?: string;
   runId: string | undefined;
   /**
    * Boundary between historical messages (loaded from conversation state)
@@ -977,7 +979,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /* Init */
 
-  resetValues(keepContent?: boolean): void {
+  resetValues(keepContent?: boolean, checkpointScope?: string): void {
     this.messages = [];
     this.cachedRunMessages = undefined;
     this.config = resetIfNotEmpty(this.config, undefined);
@@ -1025,11 +1027,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       new Map()
     );
     this.invokedToolIds = resetIfNotEmpty(this.invokedToolIds, undefined);
+    const hasScopedCheckpoint =
+      this.compileOptions?.checkpointer != null &&
+      checkpointScope != null &&
+      checkpointScope !== '';
     const preserveOriginalToolContent =
-      this.compileOptions?.checkpointer != null;
+      hasScopedCheckpoint &&
+      this.originalToolContentCheckpointScope === checkpointScope;
     for (const context of this.agentContexts.values()) {
       context.reset({ preserveOriginalToolContent });
     }
+    this.originalToolContentCheckpointScope = hasScopedCheckpoint
+      ? checkpointScope
+      : undefined;
   }
 
   override clearHeavyState(): void {
@@ -1038,7 +1048,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.messages = [];
     this.overrideModel = undefined;
     const preserveOriginalToolContent =
-      this.compileOptions?.checkpointer != null;
+      this.compileOptions?.checkpointer != null &&
+      this.originalToolContentCheckpointScope != null;
     for (const context of this.agentContexts.values()) {
       context.reset({ preserveOriginalToolContent });
     }
@@ -1533,16 +1544,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const allowSummarization = agentContext.shouldSummarizeOverflow();
 
     agentContext.preserveOriginalToolContent(originalToolContent);
-    if (
-      recovery.observedCalibrationRatio != null &&
-      recovery.observedCalibrationRatio > 0
-    ) {
-      agentContext.calibrationRatio = recovery.observedCalibrationRatio;
-    }
     agentContext.applyContextBudgetCorrection(
       recovery.budgetTokens,
       estimatedPromptTokens,
       !allowSummarization
+    );
+    agentContext.applyObservedOverflowCalibration(
+      recovery.info.provider,
+      recovery.observedCalibrationRatio
     );
 
     emitAgentLog(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -51,6 +51,11 @@ import {
   sleep,
 } from '@/utils';
 import {
+  getBlindRecoveryBudget,
+  planContextOverflowRecovery,
+  translateRecoveryBudget,
+} from '@/llm/contextOverflowRecovery';
+import {
   Constants,
   GraphNodeKeys,
   ContentTypes,
@@ -58,10 +63,6 @@ import {
   Providers,
   StepTypes,
 } from '@/common';
-import {
-  planContextOverflowRecovery,
-  translateRecoveryBudget,
-} from '@/llm/contextOverflowRecovery';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
@@ -2360,10 +2361,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * retry would resend a byte-identical prompt. Skipping the detour
          * keeps the original error and one round trip instead of three.
          */
-        const canReduceContext =
-          agentContext.tokenCounter != null ||
-          agentContext.summarizationEnabled === true;
-
         const estimatedPromptTokens = getEstimatedPromptTokens(contextUsage);
 
         /**
@@ -2377,7 +2374,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
 
         const planRecovery = (error: unknown): OverflowRecoveryPlan | null => {
-          if (!canReduceContext || recoveryStalled) {
+          if (recoveryStalled) {
             return null;
           }
           /**
@@ -2395,26 +2392,35 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             estimatedPromptTokens,
             calibrationRatio: agentContext.calibrationRatio,
             instructionTokens: agentContext.instructionTokens,
+            canSummarize: agentContext.summarizationEnabled === true,
             configuredCompletionTokens: getConfiguredCompletionTokens(
               fallbackContext?.clientOptions ?? agentContext.clientOptions
             ),
             attemptsSoFar: agentContext.overflowRecoveryAttempts,
           });
-          if (
-            recovery == null ||
-            fallbackContext == null ||
-            fallbackContext.provider === agentContext.provider
-          ) {
-            return recovery;
+          if (recovery == null) {
+            return null;
           }
-          return {
-            ...recovery,
-            budgetTokens: translateRecoveryBudget(
-              recovery.budgetTokens,
-              recovery.observedCalibrationRatio,
-              agentContext.calibrationRatio
-            ),
-          };
+          const translatedRecovery =
+            fallbackContext != null &&
+            fallbackContext.provider !== agentContext.provider
+              ? {
+                ...recovery,
+                budgetTokens:
+                    recovery.observedCalibrationRatio == null
+                      ? getBlindRecoveryBudget(agentContext.maxContextTokens)
+                      : translateRecoveryBudget(
+                        recovery.budgetTokens,
+                        recovery.observedCalibrationRatio,
+                        agentContext.calibrationRatio
+                      ),
+              }
+              : recovery;
+          const canReduceContext =
+            agentContext.summarizationEnabled === true ||
+            (agentContext.tokenCounter != null &&
+              translatedRecovery.budgetTokens != null);
+          return canReduceContext ? translatedRecovery : null;
         };
 
         const recovery = planRecovery(primaryError);

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -854,6 +854,7 @@ export class MultiAgentGraph extends StandardGraph {
    * Create the multi-agent workflow with dynamic handoffs
    */
   override createWorkflow(): t.CompiledMultiAgentWorkflow {
+    this.hasCompiledCheckpointer = this.compileOptions?.checkpointer != null;
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -151,7 +151,7 @@ describe('context overflow recovery', () => {
     expect(agentContext.pendingOriginalToolContent).toBeUndefined();
   });
 
-  it('does not share masked tool originals across checkpoint branches', async () => {
+  it('does not share masked tool originals across sibling checkpoint forks', async () => {
     const run = await createRun({
       runId: 'overflow-originals-branch-isolated',
       maxContextTokens: 1_000_000,
@@ -166,13 +166,13 @@ describe('context overflow recovery', () => {
     }
     run.Graph.resetValues(
       undefined,
-      JSON.stringify(['thread-a', 'namespace', 'checkpoint-a'])
+      JSON.stringify(['thread-a', 'namespace', 'checkpoint-a', 1])
     );
     agentContext.preserveOriginalToolContent(new Map([[2, 'branch A']]));
 
     run.Graph.resetValues(
       undefined,
-      JSON.stringify(['thread-a', 'namespace', 'checkpoint-b'])
+      JSON.stringify(['thread-a', 'namespace', 'checkpoint-a', 2])
     );
 
     expect(agentContext.pendingOriginalToolContent).toBeUndefined();
@@ -375,6 +375,40 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
+  it('does not retry without a configured pruning budget', async () => {
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-recovery-no-pruning-budget',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      tokenCounter,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      Number.MAX_SAFE_INTEGER
+    );
+    run.Graph.overrideModel = model;
+
+    await expect(
+      run.processStream({ messages: buildConversation(8) }, streamConfig)
+    ).rejects.toThrow(/too long/i);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBe(0);
+  });
+
   it('summarizes conversation messages pruned on the first recovery', async () => {
     /**
      * The initial overflow detour avoids an unconditional summarization call,
@@ -452,9 +486,8 @@ describe('context overflow recovery', () => {
 
     const uncalibratedPrompt = model.calls[0].length * TOKENS_PER_MESSAGE;
     expect(agentContext.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
-    expect(agentContext.calibrationRatio).toBeCloseTo(
-      274_468 / uncalibratedPrompt
-    );
+    expect(274_468 / uncalibratedPrompt).toBeLessThan(0.5);
+    expect(agentContext.calibrationRatio).toBe(0.5);
   });
 
   it('does not intercept errors compaction cannot fix', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1,3 +1,4 @@
+import { MemorySaver } from '@langchain/langgraph';
 import { describe, expect, it } from '@jest/globals';
 import {
   AIMessageChunk,
@@ -83,6 +84,7 @@ function buildConversation(turns: number): BaseMessage[] {
 async function createRun(options: {
   runId: string;
   maxContextTokens: number;
+  checkpointer?: boolean;
 }): Promise<Run<t.IState>> {
   return Run.create<t.IState>({
     runId: options.runId,
@@ -94,6 +96,10 @@ async function createRun(options: {
         streamUsage: false,
       },
       maxContextTokens: options.maxContextTokens,
+      compileOptions:
+        options.checkpointer === true
+          ? { checkpointer: new MemorySaver() }
+          : undefined,
     },
     returnContent: true,
     skipCleanup: true,
@@ -108,6 +114,28 @@ const streamConfig = {
 };
 
 describe('context overflow recovery', () => {
+  it('preserves masked tool originals while checkpointed messages survive', async () => {
+    const run = await createRun({
+      runId: 'overflow-originals-checkpoint',
+      maxContextTokens: 1_000_000,
+      checkpointer: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    agentContext.preserveOriginalToolContent(new Map([[2, 'full output']]));
+
+    run.Graph.resetValues();
+
+    expect(agentContext.pendingOriginalToolContent).toEqual(
+      new Map([[2, 'full output']])
+    );
+  });
+
   it('compacts and retries instead of surfacing the provider error', async () => {
     const run = await createRun({
       runId: 'overflow-recovery-numbers',
@@ -370,18 +398,23 @@ describe('context overflow recovery', () => {
     if (!run.Graph) {
       throw new Error('Expected graph to be initialized');
     }
-    run.Graph.overrideModel = new OverflowThenSucceedModel(
+    const model = new OverflowThenSucceedModel(
       signatureFor('claude-haiku-4-5-20251001')
     );
+    run.Graph.overrideModel = model;
 
     const messages = buildConversation(8);
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    agentContext.calibrationRatio = 1.5;
     await run.processStream({ messages }, streamConfig);
 
-    const estimatedPrompt = messages.length * TOKENS_PER_MESSAGE;
-    const agentContext = run.Graph.agentContexts.get('default');
-    expect(agentContext?.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
-    expect(agentContext?.calibrationRatio).toBeCloseTo(
-      274_468 / estimatedPrompt
+    const uncalibratedPrompt = model.calls[0].length * TOKENS_PER_MESSAGE;
+    expect(agentContext.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
+    expect(agentContext.calibrationRatio).toBeCloseTo(
+      274_468 / uncalibratedPrompt
     );
   });
 

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -446,6 +446,47 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
+  it('summarizes the first numberless overflow without a pruning budget', async () => {
+    const summarizeStarts: unknown[] = [];
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-recovery-summary-without-budget',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        summarizationEnabled: true,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      tokenCounter,
+      customHandlers: {
+        [GraphEvents.ON_SUMMARIZE_START]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            summarizeStarts.push(data);
+          },
+        },
+      },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream(
+      { messages: buildConversation(8) },
+      streamConfig
+    );
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(summarizeStarts).toHaveLength(1);
+  });
+
   it('summarizes conversation messages pruned on the first recovery', async () => {
     /**
      * The initial overflow detour avoids an unconditional summarization call,

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -266,6 +266,45 @@ describe('context overflow recovery', () => {
     expect(agentContext?.overflowRecoveryAttempts).toBe(1);
   });
 
+  it('does not retry when neither pruning nor summarization can shrink the prompt', async () => {
+    /**
+     * No token counter means no pruner, and summarization is off, so the
+     * summarize node deliberately no-ops — a retry would resend a
+     * byte-identical prompt.
+     */
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-recovery-nothing-to-shrink',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        maxContextTokens: 1_000_000,
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      Number.MAX_SAFE_INTEGER
+    );
+    run.Graph.overrideModel = model;
+
+    await expect(
+      run.processStream({ messages: buildConversation(8) }, streamConfig)
+    ).rejects.toThrow(/too long/i);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBe(0);
+  });
+
   it('does not intercept errors compaction cannot fix', async () => {
     const run = await createRun({
       runId: 'overflow-recovery-unrelated',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -412,6 +412,43 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
+  it('does not retry when recency preserves the entire first turn', async () => {
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-recovery-recent-first-turn',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        summarizationEnabled: true,
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      Number.MAX_SAFE_INTEGER
+    );
+    run.Graph.overrideModel = model;
+
+    await expect(
+      run.processStream(
+        { messages: [new HumanMessage('oversized first turn')] },
+        streamConfig
+      )
+    ).rejects.toThrow(/too long/i);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBe(0);
+  });
+
   it('does not retry without a configured pruning budget', async () => {
     const run = await Run.create<t.IState>({
       runId: 'overflow-recovery-no-pruning-budget',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -212,6 +212,60 @@ describe('context overflow recovery', () => {
     expect(model.calls.length).toBeLessThanOrEqual(4);
   });
 
+  it('restores the configured budget and allowance for the next run', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-reset',
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    run.Graph.overrideModel = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001')
+    );
+
+    await run.processStream({ messages: buildConversation(8) }, streamConfig);
+
+    const agentContext = run.Graph.agentContexts.get('default');
+    expect(agentContext?.maxContextTokens).toBeLessThanOrEqual(200_000);
+    expect(agentContext?.overflowRecoveryAttempts).toBe(1);
+
+    /** What `processStream` runs at the start of every turn. */
+    run.Graph.resetValues();
+
+    expect(agentContext?.maxContextTokens).toBe(1_000_000);
+    expect(agentContext?.overflowRecoveryAttempts).toBe(0);
+  });
+
+  it('recovers again on a later turn of the same run', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-second-turn',
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const signature = signatureFor('claude-haiku-4-5-20251001');
+
+    for (const turn of [1, 2, 3]) {
+      run.Graph.overrideModel = new OverflowThenSucceedModel(signature);
+      await run.processStream(
+        { messages: buildConversation(8) },
+        {
+          ...streamConfig,
+          configurable: { thread_id: `context-overflow-recovery-${turn}` },
+        }
+      );
+    }
+
+    const agentContext = run.Graph.agentContexts.get('default');
+    /**
+     * One recovery per turn, not three accumulated — an allowance that
+     * carried across turns would have stopped recovering by turn three.
+     */
+    expect(agentContext?.overflowRecoveryAttempts).toBe(1);
+  });
+
   it('does not intercept errors compaction cannot fix', async () => {
     const run = await createRun({
       runId: 'overflow-recovery-unrelated',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -305,29 +305,30 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
-  it('reports actionable guidance when a corrected budget fits nothing', async () => {
+  it('does not scale the corrected budget by the tokenizer divergence', async () => {
     /**
-     * One message larger than the corrected budget. Rather than looping, the
-     * run surfaces the empty-prompt guidance with the token breakdown.
+     * `maxContextTokens` is a provider-space budget that the pruner already
+     * divides by its learned calibrationRatio. Applying the observed
+     * divergence here as well would target `limit / ratio²` — with this
+     * fixture's 274,468-vs-estimate divergence that meant a 27,689 budget
+     * against a 200,000 ceiling, discarding roughly seven times more history
+     * than the overflow called for.
      */
     const run = await createRun({
-      runId: 'overflow-recovery-nothing-fits',
+      runId: 'overflow-recovery-no-double-calibration',
       maxContextTokens: 1_000_000,
     });
     if (!run.Graph) {
       throw new Error('Expected graph to be initialized');
     }
     run.Graph.overrideModel = new OverflowThenSucceedModel(
-      signatureFor('claude-haiku-4-5-20251001'),
-      Number.MAX_SAFE_INTEGER
+      signatureFor('claude-haiku-4-5-20251001')
     );
 
-    await expect(
-      run.processStream(
-        { messages: [new HumanMessage('one oversized turn')] },
-        streamConfig
-      )
-    ).rejects.toThrow(/empty_messages/);
+    await run.processStream({ messages: buildConversation(8) }, streamConfig);
+
+    const agentContext = run.Graph.agentContexts.get('default');
+    expect(agentContext?.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
   });
 
   it('does not intercept errors compaction cannot fix', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1,11 +1,11 @@
 import { MemorySaver } from '@langchain/langgraph';
 import { describe, expect, it } from '@jest/globals';
+import { Runnable } from '@langchain/core/runnables';
 import {
   AIMessageChunk,
   HumanMessage,
   AIMessage,
 } from '@langchain/core/messages';
-import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
@@ -40,13 +40,16 @@ function throwable(fields: Record<string, unknown>): Error {
  * answers normally — the shape of a run that overflows and then fits after
  * compaction.
  */
-class OverflowThenSucceedModel implements t.ChatModel {
+class OverflowThenSucceedModel extends Runnable<BaseMessage[], AIMessageChunk> {
+  lc_namespace = ['tests'];
   readonly calls: BaseMessage[][] = [];
 
   constructor(
     private readonly error: Record<string, unknown>,
     private readonly failures = 1
-  ) {}
+  ) {
+    super();
+  }
 
   private record(messages: BaseMessage[]): void {
     this.calls.push(messages);
@@ -58,16 +61,6 @@ class OverflowThenSucceedModel implements t.ChatModel {
   async invoke(messages: BaseMessage[]): Promise<AIMessageChunk> {
     this.record(messages);
     return new AIMessageChunk({ content: 'recovered' });
-  }
-
-  async stream(
-    messages: BaseMessage[],
-    _config?: RunnableConfig
-  ): Promise<AsyncIterable<AIMessageChunk>> {
-    this.record(messages);
-    return (async function* chunks(): AsyncGenerator<AIMessageChunk> {
-      yield new AIMessageChunk({ content: 'recovered' });
-    })();
   }
 }
 
@@ -154,6 +147,33 @@ describe('context overflow recovery', () => {
     agentContext.preserveOriginalToolContent(new Map([[2, 'thread A']]));
 
     run.Graph.resetValues(undefined, '8:thread-b:branch');
+
+    expect(agentContext.pendingOriginalToolContent).toBeUndefined();
+  });
+
+  it('does not share masked tool originals across checkpoint branches', async () => {
+    const run = await createRun({
+      runId: 'overflow-originals-branch-isolated',
+      maxContextTokens: 1_000_000,
+      checkpointer: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    run.Graph.resetValues(
+      undefined,
+      JSON.stringify(['thread-a', 'namespace', 'checkpoint-a'])
+    );
+    agentContext.preserveOriginalToolContent(new Map([[2, 'branch A']]));
+
+    run.Graph.resetValues(
+      undefined,
+      JSON.stringify(['thread-a', 'namespace', 'checkpoint-b'])
+    );
 
     expect(agentContext.pendingOriginalToolContent).toBeUndefined();
   });
@@ -355,13 +375,11 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
-  it('spends no summarization call on the first recovery', async () => {
+  it('summarizes conversation messages pruned on the first recovery', async () => {
     /**
-     * The regression this guards: suppressing the summarize node alone is not
-     * enough, because it hands control straight back to the agent node, where
-     * the *configured* trigger fires by default on the very messages the
-     * re-prune produced — spending the model call the staging exists to
-     * avoid.
+     * The initial overflow detour avoids an unconditional summarization call,
+     * but the corrected prune must still summarize any conversation messages
+     * it moves out of the retained tail.
      */
     const summarizeStarts: unknown[] = [];
     const run = await Run.create<t.IState>({
@@ -402,8 +420,7 @@ describe('context overflow recovery', () => {
 
     expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
     expect(model.calls).toHaveLength(2);
-    /** Recovered on tool-output compression alone. */
-    expect(summarizeStarts).toHaveLength(0);
+    expect(summarizeStarts).toHaveLength(1);
   });
 
   it('keeps the corrected budget in provider units and seeds calibration', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -8,7 +8,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
-import { Providers } from '@/common';
+import { GraphEvents, Providers } from '@/common';
 import { Run } from '@/run';
 
 /**
@@ -303,6 +303,57 @@ describe('context overflow recovery', () => {
     expect(
       run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
     ).toBe(0);
+  });
+
+  it('spends no summarization call on the first recovery', async () => {
+    /**
+     * The regression this guards: suppressing the summarize node alone is not
+     * enough, because it hands control straight back to the agent node, where
+     * the *configured* trigger fires by default on the very messages the
+     * re-prune produced — spending the model call the staging exists to
+     * avoid.
+     */
+    const summarizeStarts: unknown[] = [];
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-recovery-compress-first',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        maxContextTokens: 1_000_000,
+        summarizationEnabled: true,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      tokenCounter,
+      customHandlers: {
+        [GraphEvents.ON_SUMMARIZE_START]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            summarizeStarts.push(data);
+          },
+        },
+      },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream(
+      { messages: buildConversation(8) },
+      streamConfig
+    );
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.calls).toHaveLength(2);
+    /** Recovered on tool-output compression alone. */
+    expect(summarizeStarts).toHaveLength(0);
   });
 
   it('shrinks the budget in proportion to the measured overage', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -178,6 +178,43 @@ describe('context overflow recovery', () => {
     expect(agentContext.pendingOriginalToolContent).toBeUndefined();
   });
 
+  it('preserves snapshots with the auto-installed HITL checkpointer', async () => {
+    const run = await Run.create<t.IState>({
+      runId: 'overflow-originals-hitl-checkpointer',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        maxContextTokens: 1_000_000,
+        compileOptions: { interruptAfter: [] },
+      },
+      humanInTheLoop: { enabled: true },
+      returnContent: true,
+      skipCleanup: true,
+      tokenCounter,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    expect(run.Graph.compileOptions?.checkpointer).toBeUndefined();
+    expect(run.Graph.hasCompiledCheckpointer).toBe(true);
+    run.Graph.resetValues(undefined, 'checkpoint-scope');
+    agentContext.preserveOriginalToolContent(new Map([[2, 'full output']]));
+
+    run.Graph.resetValues(undefined, 'checkpoint-scope');
+
+    expect(agentContext.pendingOriginalToolContent).toEqual(
+      new Map([[2, 'full output']])
+    );
+  });
+
   it('compacts and retries instead of surfacing the provider error', async () => {
     const run = await createRun({
       runId: 'overflow-recovery-numbers',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -356,13 +356,12 @@ describe('context overflow recovery', () => {
     expect(summarizeStarts).toHaveLength(0);
   });
 
-  it('shrinks the budget in proportion to the measured overage', async () => {
+  it('keeps the corrected budget in provider units and seeds calibration', async () => {
     /**
      * The provider counted 274,468 for a prompt it caps at 200,000 — 1.37×
-     * over. Applying that ratio to our own estimate is unit-free, so it needs
-     * no tokenizer conversion; converting instead would double-count against
-     * the pruner's own calibration and discard far more than the overflow
-     * called for.
+     * over the provider ceiling. The corrected budget stays in provider units,
+     * and the provider/local ratio is installed on the pruner so it is applied
+     * exactly once on this retry and later tool-call turns.
      */
     const run = await createRun({
       runId: 'overflow-recovery-proportional',
@@ -379,9 +378,10 @@ describe('context overflow recovery', () => {
     await run.processStream({ messages }, streamConfig);
 
     const estimatedPrompt = messages.length * TOKENS_PER_MESSAGE;
-    const expected = Math.floor(estimatedPrompt * (200_000 / 274_468) * 0.95);
-    expect(run.Graph.agentContexts.get('default')?.maxContextTokens).toBe(
-      expected
+    const agentContext = run.Graph.agentContexts.get('default');
+    expect(agentContext?.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
+    expect(agentContext?.calibrationRatio).toBeCloseTo(
+      274_468 / estimatedPrompt
     );
   });
 

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -127,13 +127,35 @@ describe('context overflow recovery', () => {
     if (agentContext == null) {
       throw new Error('Expected default agent context');
     }
+    run.Graph.resetValues(undefined, '8:thread-a:');
     agentContext.preserveOriginalToolContent(new Map([[2, 'full output']]));
 
-    run.Graph.resetValues();
+    run.Graph.resetValues(undefined, '8:thread-a:');
 
     expect(agentContext.pendingOriginalToolContent).toEqual(
       new Map([[2, 'full output']])
     );
+  });
+
+  it('does not share masked tool originals across checkpoint scopes', async () => {
+    const run = await createRun({
+      runId: 'overflow-originals-isolated',
+      maxContextTokens: 1_000_000,
+      checkpointer: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    run.Graph.resetValues(undefined, '8:thread-a:branch');
+    agentContext.preserveOriginalToolContent(new Map([[2, 'thread A']]));
+
+    run.Graph.resetValues(undefined, '8:thread-b:branch');
+
+    expect(agentContext.pendingOriginalToolContent).toBeUndefined();
   });
 
   it('compacts and retries instead of surfacing the provider error', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  AIMessageChunk,
+  HumanMessage,
+  AIMessage,
+} from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Every message is claimed to cost the same, so the budget the recovery
+ * settles on maps directly onto a message count and the assertions can be
+ * about behavior rather than arithmetic.
+ */
+const TOKENS_PER_MESSAGE = 40_000;
+
+const tokenCounter: t.TokenCounter = () => TOKENS_PER_MESSAGE;
+
+function signatureFor(model: string): Record<string, unknown> {
+  const signature = OVERFLOW_SIGNATURES.find((s) => s.model === model);
+  if (signature == null) {
+    throw new Error(`missing fixture for ${model}`);
+  }
+  return signature.error;
+}
+
+/** Rebuilds a thrown provider error from a captured signature. */
+function throwable(fields: Record<string, unknown>): Error {
+  const error = new Error(String(fields.message));
+  return Object.assign(error, fields);
+}
+
+/**
+ * Fails the first N calls with a real captured provider rejection, then
+ * answers normally — the shape of a run that overflows and then fits after
+ * compaction.
+ */
+class OverflowThenSucceedModel implements t.ChatModel {
+  readonly calls: BaseMessage[][] = [];
+
+  constructor(
+    private readonly error: Record<string, unknown>,
+    private readonly failures = 1
+  ) {}
+
+  private record(messages: BaseMessage[]): void {
+    this.calls.push(messages);
+    if (this.calls.length <= this.failures) {
+      throw throwable(this.error);
+    }
+  }
+
+  async invoke(messages: BaseMessage[]): Promise<AIMessageChunk> {
+    this.record(messages);
+    return new AIMessageChunk({ content: 'recovered' });
+  }
+
+  async stream(
+    messages: BaseMessage[],
+    _config?: RunnableConfig
+  ): Promise<AsyncIterable<AIMessageChunk>> {
+    this.record(messages);
+    return (async function* chunks(): AsyncGenerator<AIMessageChunk> {
+      yield new AIMessageChunk({ content: 'recovered' });
+    })();
+  }
+}
+
+function buildConversation(turns: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let i = 0; i < turns; i++) {
+    messages.push(new HumanMessage(`question ${i}`));
+    messages.push(new AIMessage(`answer ${i}`));
+  }
+  messages.push(new HumanMessage('final question'));
+  return messages;
+}
+
+async function createRun(options: {
+  runId: string;
+  maxContextTokens: number;
+}): Promise<Run<t.IState>> {
+  return Run.create<t.IState>({
+    runId: options.runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.ANTHROPIC,
+        disableStreaming: true,
+        streamUsage: false,
+      },
+      maxContextTokens: options.maxContextTokens,
+    },
+    returnContent: true,
+    skipCleanup: true,
+    tokenCounter,
+  });
+}
+
+const streamConfig = {
+  configurable: { thread_id: 'context-overflow-recovery' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+describe('context overflow recovery', () => {
+  it('compacts and retries instead of surfacing the provider error', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-numbers',
+      /** Deliberately wrong: far above the model's real 200k window. */
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream(
+      { messages: buildConversation(8) },
+      streamConfig
+    );
+
+    expect(model.calls).toHaveLength(2);
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+  });
+
+  it('retargets the budget to the ceiling the provider reported', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-budget',
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    run.Graph.overrideModel = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001')
+    );
+
+    await run.processStream({ messages: buildConversation(8) }, streamConfig);
+
+    const agentContext = run.Graph.agentContexts.get('default');
+    expect(agentContext?.maxContextTokens).toBeLessThanOrEqual(200_000);
+    expect(agentContext?.overflowRecoveryAttempts).toBe(1);
+  });
+
+  it('sends strictly less on the retry', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-shrinks',
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001')
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages: buildConversation(8) }, streamConfig);
+
+    expect(model.calls[1].length).toBeLessThan(model.calls[0].length);
+  });
+
+  it('recovers from a rejection that reported no numbers', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-blind',
+      maxContextTokens: 600_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream(
+      { messages: buildConversation(8) },
+      streamConfig
+    );
+
+    expect(model.calls).toHaveLength(2);
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+  });
+
+  it('gives up after the bounded number of recoveries rather than looping', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-bounded',
+      maxContextTokens: 600_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      Number.MAX_SAFE_INTEGER
+    );
+    run.Graph.overrideModel = model;
+
+    await expect(
+      run.processStream({ messages: buildConversation(8) }, streamConfig)
+    ).rejects.toThrow(/too long/i);
+
+    /** Initial call plus one retry per allowed recovery. */
+    expect(model.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it('does not intercept errors compaction cannot fix', async () => {
+    const run = await createRun({
+      runId: 'overflow-recovery-unrelated',
+      maxContextTokens: 600_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      {
+        name: 'AuthenticationError',
+        status: 401,
+        message: '401 Incorrect API key provided.',
+      },
+      Number.MAX_SAFE_INTEGER
+    );
+    run.Graph.overrideModel = model;
+
+    await expect(
+      run.processStream({ messages: buildConversation(2) }, streamConfig)
+    ).rejects.toThrow(/Incorrect API key/);
+    expect(model.calls).toHaveLength(1);
+  });
+});

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -305,6 +305,31 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
+  it('reports actionable guidance when a corrected budget fits nothing', async () => {
+    /**
+     * One message larger than the corrected budget. Rather than looping, the
+     * run surfaces the empty-prompt guidance with the token breakdown.
+     */
+    const run = await createRun({
+      runId: 'overflow-recovery-nothing-fits',
+      maxContextTokens: 1_000_000,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    run.Graph.overrideModel = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      Number.MAX_SAFE_INTEGER
+    );
+
+    await expect(
+      run.processStream(
+        { messages: [new HumanMessage('one oversized turn')] },
+        streamConfig
+      )
+    ).rejects.toThrow(/empty_messages/);
+  });
+
   it('does not intercept errors compaction cannot fix', async () => {
     const run = await createRun({
       runId: 'overflow-recovery-unrelated',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -146,7 +146,7 @@ describe('context overflow recovery', () => {
     await run.processStream({ messages: buildConversation(8) }, streamConfig);
 
     const agentContext = run.Graph.agentContexts.get('default');
-    expect(agentContext?.maxContextTokens).toBeLessThanOrEqual(200_000);
+    expect(agentContext?.maxContextTokens).toBeLessThan(1_000_000);
     expect(agentContext?.overflowRecoveryAttempts).toBe(1);
   });
 
@@ -227,7 +227,7 @@ describe('context overflow recovery', () => {
     await run.processStream({ messages: buildConversation(8) }, streamConfig);
 
     const agentContext = run.Graph.agentContexts.get('default');
-    expect(agentContext?.maxContextTokens).toBeLessThanOrEqual(200_000);
+    expect(agentContext?.maxContextTokens).toBeLessThan(1_000_000);
     expect(agentContext?.overflowRecoveryAttempts).toBe(1);
 
     /** What `processStream` runs at the start of every turn. */
@@ -305,17 +305,16 @@ describe('context overflow recovery', () => {
     ).toBe(0);
   });
 
-  it('does not scale the corrected budget by the tokenizer divergence', async () => {
+  it('shrinks the budget in proportion to the measured overage', async () => {
     /**
-     * `maxContextTokens` is a provider-space budget that the pruner already
-     * divides by its learned calibrationRatio. Applying the observed
-     * divergence here as well would target `limit / ratio²` — with this
-     * fixture's 274,468-vs-estimate divergence that meant a 27,689 budget
-     * against a 200,000 ceiling, discarding roughly seven times more history
-     * than the overflow called for.
+     * The provider counted 274,468 for a prompt it caps at 200,000 — 1.37×
+     * over. Applying that ratio to our own estimate is unit-free, so it needs
+     * no tokenizer conversion; converting instead would double-count against
+     * the pruner's own calibration and discard far more than the overflow
+     * called for.
      */
     const run = await createRun({
-      runId: 'overflow-recovery-no-double-calibration',
+      runId: 'overflow-recovery-proportional',
       maxContextTokens: 1_000_000,
     });
     if (!run.Graph) {
@@ -325,10 +324,14 @@ describe('context overflow recovery', () => {
       signatureFor('claude-haiku-4-5-20251001')
     );
 
-    await run.processStream({ messages: buildConversation(8) }, streamConfig);
+    const messages = buildConversation(8);
+    await run.processStream({ messages }, streamConfig);
 
-    const agentContext = run.Graph.agentContexts.get('default');
-    expect(agentContext?.maxContextTokens).toBe(Math.floor(200_000 * 0.95));
+    const estimatedPrompt = messages.length * TOKENS_PER_MESSAGE;
+    const expected = Math.floor(estimatedPrompt * (200_000 / 274_468) * 0.95);
+    expect(run.Graph.agentContexts.get('default')?.maxContextTokens).toBe(
+      expected
+    );
   });
 
   it('does not intercept errors compaction cannot fix', async () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  planContextOverflowRecovery,
+  DEFAULT_MAX_OVERFLOW_RECOVERIES,
+} from '@/llm/contextOverflowRecovery';
+import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
+import { Providers } from '@/common';
+
+function signatureFor(model: string) {
+  const signature = OVERFLOW_SIGNATURES.find((s) => s.model === model);
+  if (signature == null) {
+    throw new Error(`missing fixture for ${model}`);
+  }
+  return signature;
+}
+
+describe('planContextOverflowRecovery', () => {
+  it('targets the ceiling the provider reported, with headroom', () => {
+    const anthropic = signatureFor('claude-haiku-4-5-20251001');
+    const plan = planContextOverflowRecovery({
+      error: anthropic.error,
+      provider: Providers.ANTHROPIC,
+      /** Misconfigured: caller believed the window was far larger. */
+      maxContextTokens: 1_000_000,
+      estimatedPromptTokens: 274_468,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.budgetTokens).toBeLessThan(200_000);
+    expect(plan?.budgetTokens).toBeGreaterThan(180_000);
+    expect(plan?.info.limitTokens).toBe(200_000);
+  });
+
+  it('converts the reported ceiling into our units when we under-count', () => {
+    const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
+    /**
+     * OpenRouter counted 56,827 tokens for a prompt we estimated at 42,599 —
+     * it bills roughly 1.33 of our tokens per token, so a budget set to its
+     * raw 32,768 ceiling would still overflow.
+     */
+    const plan = planContextOverflowRecovery({
+      error: openrouter.error,
+      provider: Providers.OPENROUTER,
+      maxContextTokens: 32_768,
+      estimatedPromptTokens: 42_599,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.observedCalibrationRatio).toBeCloseTo(1.334, 2);
+    expect(plan?.budgetTokens).toBeLessThan(32_768 / 1.3);
+  });
+
+  it('shrinks blindly when the provider named no numbers', () => {
+    const bedrock = signatureFor(
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    const plan = planContextOverflowRecovery({
+      error: bedrock.error,
+      provider: Providers.BEDROCK,
+      maxContextTokens: 200_000,
+      estimatedPromptTokens: 190_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.info.limitTokens).toBeUndefined();
+    expect(plan?.budgetTokens).toBe(Math.floor(190_000 * 0.7));
+  });
+
+  it('recovers the mid-stream Bedrock overflow that arrives as HTTP 200', () => {
+    const nova = signatureFor('us.amazon.nova-lite-v1:0');
+    const plan = planContextOverflowRecovery({
+      error: nova.error,
+      provider: Providers.BEDROCK,
+      maxContextTokens: 300_000,
+      estimatedPromptTokens: 290_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.budgetTokens).toBeLessThan(300_000);
+  });
+
+  it('recovers an OpenAI token-bucket rejection', () => {
+    const openai = signatureFor('gpt-5-nano');
+    const plan = planContextOverflowRecovery({
+      error: openai.error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 400_000,
+      estimatedPromptTokens: 480_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.info.kind).toBe('request_too_large');
+    /** The bucket, not the context window, is the binding constraint. */
+    expect(plan?.budgetTokens).toBeLessThan(200_000);
+  });
+
+  it('stops once the per-run recovery budget is spent', () => {
+    const anthropic = signatureFor('claude-haiku-4-5-20251001');
+    const params = {
+      error: anthropic.error,
+      provider: Providers.ANTHROPIC,
+      maxContextTokens: 1_000_000,
+      estimatedPromptTokens: 274_468,
+    };
+
+    expect(
+      planContextOverflowRecovery({
+        ...params,
+        attemptsSoFar: DEFAULT_MAX_OVERFLOW_RECOVERIES - 1,
+      })
+    ).not.toBeNull();
+    expect(
+      planContextOverflowRecovery({
+        ...params,
+        attemptsSoFar: DEFAULT_MAX_OVERFLOW_RECOVERIES,
+      })
+    ).toBeNull();
+  });
+
+  it('declines when the budget cannot meaningfully shrink further', () => {
+    const anthropic = signatureFor('claude-haiku-4-5-20251001');
+    const plan = planContextOverflowRecovery({
+      error: anthropic.error,
+      provider: Providers.ANTHROPIC,
+      maxContextTokens: 3_000,
+      estimatedPromptTokens: 2_900,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it('declines for failures compaction cannot fix', () => {
+    const plan = planContextOverflowRecovery({
+      error: {
+        status: 429,
+        message: '429 Rate limit reached. Try again in 4ms.',
+      },
+      provider: Providers.OPENAI,
+      maxContextTokens: 128_000,
+      estimatedPromptTokens: 100_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it('successive recoveries keep shrinking', () => {
+    const bedrock = signatureFor(
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    const first = planContextOverflowRecovery({
+      error: bedrock.error,
+      provider: Providers.BEDROCK,
+      maxContextTokens: 200_000,
+      estimatedPromptTokens: 190_000,
+      attemptsSoFar: 0,
+    });
+    const second = planContextOverflowRecovery({
+      error: bedrock.error,
+      provider: Providers.BEDROCK,
+      maxContextTokens: first?.budgetTokens,
+      estimatedPromptTokens: first?.budgetTokens,
+      attemptsSoFar: 1,
+    });
+
+    expect(second?.budgetTokens).toBeLessThan(first?.budgetTokens ?? 0);
+  });
+});

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -137,6 +137,80 @@ describe('planContextOverflowRecovery', () => {
     expect(plan?.budgetTokens).toBeLessThan(200_000);
   });
 
+  it('reserves the configured completion allowance on a total-only error', () => {
+    const openai = signatureFor('gpt-5-nano');
+    /**
+     * The 429 quotes a 200k bucket and no breakdown. With a 32k completion
+     * allowance configured, a retry aimed at the whole bucket would still be
+     * `prompt + 32k` and over the limit.
+     */
+    const plan = planContextOverflowRecovery({
+      error: openai.error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 400_000,
+      estimatedPromptTokens: 240_000,
+      configuredCompletionTokens: 32_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.budgetTokens).toBe(Math.floor((200_000 - 32_000) * 0.95));
+  });
+
+  it('prefers the provider breakdown over the configured allowance', () => {
+    const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
+    /** The error itemized 16 output tokens; that beats a stale config value. */
+    const withConfig = planContextOverflowRecovery({
+      error: openrouter.error,
+      provider: Providers.OPENROUTER,
+      maxContextTokens: 32_768,
+      estimatedPromptTokens: 42_599,
+      configuredCompletionTokens: 8_000,
+      attemptsSoFar: 0,
+    });
+    const withoutConfig = planContextOverflowRecovery({
+      error: openrouter.error,
+      provider: Providers.OPENROUTER,
+      maxContextTokens: 32_768,
+      estimatedPromptTokens: 42_599,
+      attemptsSoFar: 0,
+    });
+
+    expect(withConfig?.budgetTokens).toBe(withoutConfig?.budgetTokens);
+  });
+
+  it('declines when the corrected budget would not clear the instructions', () => {
+    const anthropic = signatureFor('claude-haiku-4-5-20251001');
+    /**
+     * Tool schemas alone fill the provider's real window, so compaction has
+     * nowhere to put the messages and the summarize node would refuse to run —
+     * the detour would bounce between nodes without shrinking anything.
+     */
+    const plan = planContextOverflowRecovery({
+      error: anthropic.error,
+      provider: Providers.ANTHROPIC,
+      maxContextTokens: 1_000_000,
+      estimatedPromptTokens: 274_468,
+      instructionTokens: 199_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it('still recovers when the instructions leave room for messages', () => {
+    const anthropic = signatureFor('claude-haiku-4-5-20251001');
+    const plan = planContextOverflowRecovery({
+      error: anthropic.error,
+      provider: Providers.ANTHROPIC,
+      maxContextTokens: 1_000_000,
+      estimatedPromptTokens: 274_468,
+      instructionTokens: 20_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.budgetTokens).toBeGreaterThan(180_000);
+  });
+
   it('stops once the per-run recovery budget is spent', () => {
     const anthropic = signatureFor('claude-haiku-4-5-20251001');
     const params = {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -32,14 +32,15 @@ describe('planContextOverflowRecovery', () => {
     expect(plan?.info.limitTokens).toBe(200_000);
   });
 
-  it('applies the reported ceiling verbatim, leaving calibration to the pruner', () => {
+  it('scales our own estimate by the measured overage, needing no unit conversion', () => {
     const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
     /**
      * OpenRouter counted 56,811 input tokens for a prompt we estimated at
-     * 42,599 — a ~1.33 divergence. `maxContextTokens` is a provider-space
-     * budget that the pruner already divides by its own learned
-     * calibrationRatio, so converting here too would prune toward
-     * `limit / ratio²`. The ratio is reported but not applied.
+     * 42,599 — a ~1.33 divergence. The ratio `promptCeiling / promptTokens`
+     * is unit-free, so applying it to our estimate lands on a correct target
+     * without converting between tokenizers. Converting instead would
+     * double-count against the pruner's own calibration, which already
+     * divides the budget by its learned ratio.
      */
     const plan = planContextOverflowRecovery({
       error: openrouter.error,
@@ -50,7 +51,8 @@ describe('planContextOverflowRecovery', () => {
     });
 
     expect(plan?.observedCalibrationRatio).toBeCloseTo(1.333, 2);
-    expect(plan?.budgetTokens).toBe(Math.floor((32_768 - 16) * 0.95));
+    const overageScale = (32_768 - 16) / 56_811;
+    expect(plan?.budgetTokens).toBe(Math.floor(42_599 * overageScale * 0.95));
   });
 
   it('recovers on a small-window model despite the absolute floor', () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   planContextOverflowRecovery,
   DEFAULT_MAX_OVERFLOW_RECOVERIES,
+  translateRecoveryBudget,
 } from '@/llm/contextOverflowRecovery';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
 import { Providers } from '@/common';
@@ -50,6 +51,28 @@ describe('planContextOverflowRecovery', () => {
 
     expect(plan?.observedCalibrationRatio).toBeCloseTo(1.333, 2);
     expect(plan?.budgetTokens).toBe(Math.floor((32_768 - 16) * 0.95));
+  });
+
+  it('calibrates message tokens without scaling fixed instruction overhead', () => {
+    const error = {
+      message:
+        'This model\'s maximum context length is 4096 tokens. However, your messages resulted in 1400 tokens.',
+    };
+    const plan = planContextOverflowRecovery({
+      error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 4_096,
+      estimatedPromptTokens: 1_000,
+      calibrationRatio: 2,
+      instructionTokens: 600,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.observedCalibrationRatio).toBe(4);
+  });
+
+  it('translates fallback budgets into the primary pruner calibration', () => {
+    expect(translateRecoveryBudget(80_000, 2, 1.5)).toBe(60_000);
   });
 
   it('recovers on a small-window model despite the absolute floor', () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -6,6 +6,7 @@ import {
   translateRecoveryBudget,
 } from '@/llm/contextOverflowRecovery';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
+import { clampCalibrationRatio } from '@/messages';
 import { Providers } from '@/common';
 
 function signatureFor(model: string) {
@@ -78,6 +79,22 @@ describe('planContextOverflowRecovery', () => {
 
   it('uses a primary-space blind shrink when fallback units cannot be translated', () => {
     expect(getBlindRecoveryBudget(100_000)).toBe(70_000);
+  });
+
+  it('conservatively translates an uncalibrated fallback ceiling', () => {
+    const primaryBlindBudget = getBlindRecoveryBudget(1_000_000);
+    const fallbackBound = translateRecoveryBudget(
+      32_000,
+      clampCalibrationRatio(Number.POSITIVE_INFINITY),
+      1
+    );
+
+    expect(
+      Math.min(
+        primaryBlindBudget ?? Number.POSITIVE_INFINITY,
+        fallbackBound ?? Number.POSITIVE_INFINITY
+      )
+    ).toBe(6_400);
   });
 
   it('recovers on a small-window model despite the absolute floor', () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  getBlindRecoveryBudget,
   planContextOverflowRecovery,
   DEFAULT_MAX_OVERFLOW_RECOVERIES,
   translateRecoveryBudget,
@@ -75,6 +76,10 @@ describe('planContextOverflowRecovery', () => {
     expect(translateRecoveryBudget(80_000, 2, 1.5)).toBe(60_000);
   });
 
+  it('uses a primary-space blind shrink when fallback units cannot be translated', () => {
+    expect(getBlindRecoveryBudget(100_000)).toBe(70_000);
+  });
+
   it('recovers on a small-window model despite the absolute floor', () => {
     /** 4,096-token window: 95% of the ceiling lands under MIN_RECOVERY_BUDGET. */
     const error = {
@@ -88,6 +93,23 @@ describe('planContextOverflowRecovery', () => {
       maxContextTokens: 8_192,
       estimatedPromptTokens: 6_000,
       instructionTokens: 200,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.budgetTokens).toBe(Math.floor(4_096 * 0.95));
+  });
+
+  it('permits small-window summary-only recovery below the pruning floor', () => {
+    const error = {
+      message:
+        '400 This model\'s maximum context length is 4096 tokens. However, your messages resulted in 6000 tokens.',
+    };
+    const plan = planContextOverflowRecovery({
+      error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 8_192,
+      instructionTokens: 0,
+      canSummarize: true,
       attemptsSoFar: 0,
     });
 

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -32,15 +32,13 @@ describe('planContextOverflowRecovery', () => {
     expect(plan?.info.limitTokens).toBe(200_000);
   });
 
-  it('scales our own estimate by the measured overage, needing no unit conversion', () => {
+  it('keeps the corrected budget in provider token units', () => {
     const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
     /**
      * OpenRouter counted 56,811 input tokens for a prompt we estimated at
-     * 42,599 — a ~1.33 divergence. The ratio `promptCeiling / promptTokens`
-     * is unit-free, so applying it to our estimate lands on a correct target
-     * without converting between tokenizers. Converting instead would
-     * double-count against the pruner's own calibration, which already
-     * divides the budget by its learned ratio.
+     * 42,599 — a ~1.33 divergence. `maxContextTokens` remains in provider
+     * units, while the observed ratio seeds the pruner's conversion into its
+     * local counter units.
      */
     const plan = planContextOverflowRecovery({
       error: openrouter.error,
@@ -51,8 +49,7 @@ describe('planContextOverflowRecovery', () => {
     });
 
     expect(plan?.observedCalibrationRatio).toBeCloseTo(1.333, 2);
-    const overageScale = (32_768 - 16) / 56_811;
-    expect(plan?.budgetTokens).toBe(Math.floor(42_599 * overageScale * 0.95));
+    expect(plan?.budgetTokens).toBe(Math.floor((32_768 - 16) * 0.95));
   });
 
   it('recovers on a small-window model despite the absolute floor', () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -178,6 +178,25 @@ describe('planContextOverflowRecovery', () => {
     expect(withConfig?.budgetTokens).toBe(withoutConfig?.budgetTokens);
   });
 
+  it('declines when the completion allowance alone exceeds the ceiling', () => {
+    const openai = signatureFor('gpt-5-nano');
+    /**
+     * A 240k output allowance against a 200k bucket: no prompt, however
+     * small, makes this request fit. Spending recovery attempts on it would
+     * bury the real problem.
+     */
+    const plan = planContextOverflowRecovery({
+      error: openai.error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 400_000,
+      estimatedPromptTokens: 240_000,
+      configuredCompletionTokens: 240_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).toBeNull();
+  });
+
   it('declines when the corrected budget would not clear the instructions', () => {
     const anthropic = signatureFor('claude-haiku-4-5-20251001');
     /**

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -322,4 +322,18 @@ describe('planContextOverflowRecovery', () => {
 
     expect(second?.budgetTokens).toBeLessThan(first?.budgetTokens ?? 0);
   });
+
+  it('plans summary-only recovery when no token budget is configured', () => {
+    const bedrock = signatureFor(
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    const plan = planContextOverflowRecovery({
+      error: bedrock.error,
+      provider: Providers.BEDROCK,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.budgetTokens).toBeUndefined();
+  });
 });

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -32,23 +32,44 @@ describe('planContextOverflowRecovery', () => {
     expect(plan?.info.limitTokens).toBe(200_000);
   });
 
-  it('converts the reported ceiling into our units when we under-count', () => {
+  it('applies the reported ceiling verbatim, leaving calibration to the pruner', () => {
     const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
     /**
      * OpenRouter counted 56,811 input tokens for a prompt we estimated at
-     * 42,599 — it bills roughly 1.33 of our tokens per token, so a budget set
-     * to its raw 32,768 ceiling would still overflow.
+     * 42,599 — a ~1.33 divergence. `maxContextTokens` is a provider-space
+     * budget that the pruner already divides by its own learned
+     * calibrationRatio, so converting here too would prune toward
+     * `limit / ratio²`. The ratio is reported but not applied.
      */
     const plan = planContextOverflowRecovery({
       error: openrouter.error,
       provider: Providers.OPENROUTER,
-      maxContextTokens: 32_768,
+      maxContextTokens: 40_000,
       estimatedPromptTokens: 42_599,
       attemptsSoFar: 0,
     });
 
     expect(plan?.observedCalibrationRatio).toBeCloseTo(1.333, 2);
-    expect(plan?.budgetTokens).toBeLessThan(32_768 / 1.3);
+    expect(plan?.budgetTokens).toBe(Math.floor((32_768 - 16) * 0.95));
+  });
+
+  it('recovers on a small-window model despite the absolute floor', () => {
+    /** 4,096-token window: 95% of the ceiling lands under MIN_RECOVERY_BUDGET. */
+    const error = {
+      name: 'ContextOverflowError',
+      message:
+        '400 This model\'s maximum context length is 4096 tokens. However, your messages resulted in 6000 tokens. Please reduce the length of the messages.',
+    };
+    const plan = planContextOverflowRecovery({
+      error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 8_192,
+      estimatedPromptTokens: 6_000,
+      instructionTokens: 200,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.budgetTokens).toBe(Math.floor(4_096 * 0.95));
   });
 
   it('calibrates on the prompt, never on a completion-inclusive total', () => {

--- a/src/llm/__tests__/contextOverflowRecovery.test.ts
+++ b/src/llm/__tests__/contextOverflowRecovery.test.ts
@@ -35,9 +35,9 @@ describe('planContextOverflowRecovery', () => {
   it('converts the reported ceiling into our units when we under-count', () => {
     const openrouter = signatureFor('qwen/qwen-2.5-7b-instruct');
     /**
-     * OpenRouter counted 56,827 tokens for a prompt we estimated at 42,599 —
-     * it bills roughly 1.33 of our tokens per token, so a budget set to its
-     * raw 32,768 ceiling would still overflow.
+     * OpenRouter counted 56,811 input tokens for a prompt we estimated at
+     * 42,599 — it bills roughly 1.33 of our tokens per token, so a budget set
+     * to its raw 32,768 ceiling would still overflow.
      */
     const plan = planContextOverflowRecovery({
       error: openrouter.error,
@@ -47,8 +47,49 @@ describe('planContextOverflowRecovery', () => {
       attemptsSoFar: 0,
     });
 
-    expect(plan?.observedCalibrationRatio).toBeCloseTo(1.334, 2);
+    expect(plan?.observedCalibrationRatio).toBeCloseTo(1.333, 2);
     expect(plan?.budgetTokens).toBeLessThan(32_768 / 1.3);
+  });
+
+  it('calibrates on the prompt, never on a completion-inclusive total', () => {
+    const openai = signatureFor('gpt-5-nano');
+    /**
+     * The 429 quotes "Requested 480002", which includes the output
+     * allowance. Reading that as the prompt size would invent a ratio and
+     * shrink the budget far past what the overflow calls for.
+     */
+    const plan = planContextOverflowRecovery({
+      error: openai.error,
+      provider: Providers.OPENAI,
+      maxContextTokens: 400_000,
+      estimatedPromptTokens: 240_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.observedCalibrationRatio).toBeUndefined();
+    expect(plan?.budgetTokens).toBe(Math.floor(200_000 * 0.95));
+  });
+
+  it('reserves the completion allowance the provider counted against the ceiling', () => {
+    /**
+     * A 64k completion allowance inside a 128k ceiling leaves 64k for the
+     * prompt; targeting the full ceiling would overflow again no matter how
+     * far the prompt is compacted.
+     */
+    const error = {
+      name: 'ContextOverflowError',
+      message:
+        '400 This model\'s maximum context length is 128000 tokens. However, you requested 190000 tokens (126000 in the messages, 64000 in the completion). Please reduce the length of the messages or completion.',
+    };
+    const plan = planContextOverflowRecovery({
+      error,
+      provider: Providers.DEEPSEEK,
+      maxContextTokens: 128_000,
+      estimatedPromptTokens: 126_000,
+      attemptsSoFar: 0,
+    });
+
+    expect(plan?.budgetTokens).toBe(Math.floor((128_000 - 64_000) * 0.95));
   });
 
   it('shrinks blindly when the provider named no numbers', () => {

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -94,26 +94,60 @@ describe('tryFallbackProviders surfacing', () => {
 
     await expect(
       tryFallbackProviders({
-        fallbacks,
+        fallbacks: [
+          { provider: Providers.VERTEXAI, maxContextTokens: 200_000 },
+          { provider: Providers.OPENAI },
+        ],
+        messages,
+        primaryError: new Error('primary boom'),
+        overflowContext: {
+          estimatedPromptTokens: 190_000,
+        },
+      })
+    ).rejects.toThrow(/Google request failed/);
+  });
+
+  it('uses the fallback context window to corroborate a Vertex overflow', async () => {
+    const vertex = signatureError('gemini-2.5-flash-lite');
+    stubModels([vertex, new Error('503 upstream unavailable')]);
+
+    const error = await tryFallbackProviders({
+      fallbacks: [
+        { provider: Providers.VERTEXAI, maxContextTokens: 32_000 },
+        { provider: Providers.OPENAI },
+      ],
+      messages,
+      primaryError: new Error('primary boom'),
+      overflowContext: {
+        estimatedPromptTokens: 50_000,
+        maxContextTokens: 200_000,
+      },
+    }).catch((fallbackError: Error) => fallbackError);
+
+    expect(error).toBe(vertex);
+    expect(getFallbackErrorContext(error)).toEqual({
+      provider: Providers.VERTEXAI,
+      clientOptions: undefined,
+      maxContextTokens: 32_000,
+    });
+  });
+
+  it('does not corroborate Vertex against the primary context window', async () => {
+    const vertex = signatureError('gemini-2.5-flash-lite');
+    stubModels([vertex, new Error('503 upstream unavailable')]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks: [
+          { provider: Providers.VERTEXAI },
+          { provider: Providers.OPENAI },
+        ],
         messages,
         primaryError: new Error('primary boom'),
         overflowContext: {
           estimatedPromptTokens: 190_000,
           maxContextTokens: 200_000,
         },
-      })
-    ).rejects.toThrow(/Google request failed/);
-  });
-
-  it('leaves a bare Vertex 400 alone without corroboration', async () => {
-    const vertex = signatureError('gemini-2.5-flash-lite');
-    stubModels([vertex, new Error('503 upstream unavailable')]);
-
-    await expect(
-      tryFallbackProviders({
-        fallbacks,
-        messages,
-        primaryError: new Error('primary boom'),
       })
     ).rejects.toThrow(/upstream unavailable/);
   });

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -1,8 +1,12 @@
 import { AIMessageChunk } from '@langchain/core/messages';
 import { describe, expect, it, jest } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
+import {
+  tryFallbackProviders,
+  getFallbackErrorContext,
+  getFallbackOverflowCandidates,
+} from '@/llm/invoke';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
-import { tryFallbackProviders, getFallbackErrorContext } from '@/llm/invoke';
 import { Providers } from '@/common';
 import * as init from '@/llm/init';
 
@@ -101,6 +105,7 @@ describe('tryFallbackProviders surfacing', () => {
         messages,
         primaryError: new Error('primary boom'),
         overflowContext: {
+          provider: Providers.VERTEXAI,
           estimatedPromptTokens: 190_000,
         },
       })
@@ -119,6 +124,7 @@ describe('tryFallbackProviders surfacing', () => {
       messages,
       primaryError: new Error('primary boom'),
       overflowContext: {
+        provider: Providers.VERTEXAI,
         estimatedPromptTokens: 50_000,
         maxContextTokens: 200_000,
       },
@@ -145,6 +151,7 @@ describe('tryFallbackProviders surfacing', () => {
         messages,
         primaryError: new Error('primary boom'),
         overflowContext: {
+          provider: Providers.OPENAI,
           estimatedPromptTokens: 190_000,
           maxContextTokens: 200_000,
         },
@@ -179,6 +186,60 @@ describe('tryFallbackProviders surfacing', () => {
 
     const attribution = getFallbackErrorContext(thrown);
     expect(attribution?.provider).toBe(Providers.ANTHROPIC);
+  });
+
+  it('retains every fallback overflow candidate', async () => {
+    const first = new Error(
+      'This model\'s maximum context length is 4096 tokens. However, your messages resulted in 6000 tokens.'
+    );
+    const second = signatureError('claude-haiku-4-5-20251001');
+    stubModels([first, second]);
+
+    const thrown = await tryFallbackProviders({
+      fallbacks,
+      messages,
+      primaryError: new Error('primary boom'),
+    }).catch((error: unknown) => error);
+
+    expect(getFallbackOverflowCandidates(thrown)).toEqual([
+      {
+        error: first,
+        context: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: undefined,
+          maxContextTokens: undefined,
+        },
+      },
+      {
+        error: second,
+        context: {
+          provider: Providers.OPENAI,
+          clientOptions: undefined,
+          maxContextTokens: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('declines ambiguous pressure from another provider token space', async () => {
+    const vertex = signatureError('gemini-2.5-flash-lite');
+    stubModels([vertex, new Error('503 upstream unavailable')]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks: [
+          { provider: Providers.VERTEXAI, maxContextTokens: 32_000 },
+          { provider: Providers.OPENAI },
+        ],
+        messages,
+        primaryError: new Error('primary boom'),
+        overflowContext: {
+          provider: Providers.OPENAI,
+          estimatedPromptTokens: 50_000,
+          maxContextTokens: 200_000,
+        },
+      })
+    ).rejects.toThrow(/upstream unavailable/);
   });
 
   it('continues past a frozen fallback error', async () => {

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -2,7 +2,7 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import { describe, expect, it, jest } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
-import { tryFallbackProviders } from '@/llm/invoke';
+import { tryFallbackProviders, getFallbackErrorContext } from '@/llm/invoke';
 import { Providers } from '@/common';
 import * as init from '@/llm/init';
 
@@ -116,6 +116,47 @@ describe('tryFallbackProviders surfacing', () => {
         primaryError: new Error('primary boom'),
       })
     ).rejects.toThrow(/upstream unavailable/);
+  });
+
+  it('prefers a fallback overflow over the primary one', async () => {
+    /**
+     * Reaching this function with an overflowing primary means the caller
+     * already failed to recover from it, so the fallback's — which sits
+     * against a different window — is the more useful of the two.
+     */
+    const primary = signatureError('gpt-5-nano');
+    const fallbackOverflow = signatureError('claude-haiku-4-5-20251001');
+    stubModels([fallbackOverflow, new Error('503 upstream unavailable')]);
+
+    await expect(
+      tryFallbackProviders({ fallbacks, messages, primaryError: primary })
+    ).rejects.toThrow(/prompt is too long/i);
+  });
+
+  it('attributes a fallback overflow to the client that produced it', async () => {
+    const fallbackOverflow = signatureError('claude-haiku-4-5-20251001');
+    stubModels([fallbackOverflow, new Error('503 upstream unavailable')]);
+
+    const thrown = await tryFallbackProviders({
+      fallbacks,
+      messages,
+      primaryError: new Error('primary boom'),
+    }).catch((error: unknown) => error);
+
+    const attribution = getFallbackErrorContext(thrown);
+    expect(attribution?.provider).toBe(Providers.ANTHROPIC);
+  });
+
+  it('leaves a primary overflow unattributed', async () => {
+    stubModels([new Error('first failed'), new Error('second failed')]);
+
+    const thrown = await tryFallbackProviders({
+      fallbacks,
+      messages,
+      primaryError: signatureError('us.amazon.nova-lite-v1:0'),
+    }).catch((error: unknown) => error);
+
+    expect(getFallbackErrorContext(thrown)).toBeUndefined();
   });
 
   it('returns the first success without consulting later fallbacks', async () => {

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -181,6 +181,23 @@ describe('tryFallbackProviders surfacing', () => {
     expect(attribution?.provider).toBe(Providers.ANTHROPIC);
   });
 
+  it('continues past a frozen fallback error', async () => {
+    const fallbackOverflow = Object.freeze(
+      signatureError('claude-haiku-4-5-20251001')
+    );
+    stubModels([fallbackOverflow, 'ok']);
+
+    const result = await tryFallbackProviders({
+      fallbacks,
+      messages,
+      primaryError: new Error('primary boom'),
+    });
+
+    expect((result?.messages?.[0] as AIMessageChunk | undefined)?.content).toBe(
+      'ok'
+    );
+  });
+
   it('leaves a primary overflow unattributed', async () => {
     stubModels([new Error('first failed'), new Error('second failed')]);
 

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -1,0 +1,104 @@
+import { AIMessageChunk } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
+import { tryFallbackProviders } from '@/llm/invoke';
+import { Providers } from '@/common';
+import * as init from '@/llm/init';
+
+function signatureError(model: string): Error {
+  const signature = OVERFLOW_SIGNATURES.find((s) => s.model === model);
+  if (signature == null) {
+    throw new Error(`missing fixture for ${model}`);
+  }
+  const error = new Error(String(signature.error.message));
+  return Object.assign(error, signature.error);
+}
+
+/**
+ * `tryFallbackProviders` builds its own clients through `initializeModel`, so
+ * the only seam for driving per-fallback outcomes is that factory.
+ */
+function stubModels(
+  outcomes: Array<Error | 'ok'>
+): jest.SpiedFunction<typeof init.initializeModel> {
+  let call = 0;
+  return jest.spyOn(init, 'initializeModel').mockImplementation(() => {
+    const outcome = outcomes[call++];
+    return {
+      invoke: async (): Promise<AIMessageChunk> => {
+        if (outcome instanceof Error) {
+          throw outcome;
+        }
+        return new AIMessageChunk({ content: 'ok' });
+      },
+    } as unknown as ReturnType<typeof init.initializeModel>;
+  });
+}
+
+const messages: BaseMessage[] = [];
+const fallbacks: Array<{ provider: Providers }> = [
+  { provider: Providers.ANTHROPIC },
+  { provider: Providers.OPENAI },
+];
+
+describe('tryFallbackProviders surfacing', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws the overflow even when a later fallback failed for another reason', async () => {
+    const overflow = signatureError('claude-haiku-4-5-20251001');
+    const unrelated = new Error('503 upstream unavailable');
+    stubModels([overflow, unrelated]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks,
+        messages,
+        primaryError: new Error('primary boom'),
+      })
+    ).rejects.toThrow(/prompt is too long/i);
+  });
+
+  it('keeps last-error-wins when no fallback overflowed', async () => {
+    stubModels([
+      new Error('first failed'),
+      new Error('503 upstream unavailable'),
+    ]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks,
+        messages,
+        primaryError: new Error('primary boom'),
+      })
+    ).rejects.toThrow(/upstream unavailable/);
+  });
+
+  it('surfaces a primary overflow when every fallback also fails', async () => {
+    stubModels([new Error('first failed'), new Error('second failed')]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks,
+        messages,
+        primaryError: signatureError('us.amazon.nova-lite-v1:0'),
+      })
+    ).rejects.toThrow(/Input Tokens Exceeded/i);
+  });
+
+  it('returns the first success without consulting later fallbacks', async () => {
+    stubModels([signatureError('claude-haiku-4-5-20251001'), 'ok']);
+
+    const result = await tryFallbackProviders({
+      fallbacks,
+      messages,
+      primaryError: new Error('primary boom'),
+    });
+
+    expect((result?.messages?.[0] as AIMessageChunk | undefined)?.content).toBe(
+      'ok'
+    );
+  });
+});

--- a/src/llm/__tests__/fallbackOverflow.test.ts
+++ b/src/llm/__tests__/fallbackOverflow.test.ts
@@ -88,6 +88,36 @@ describe('tryFallbackProviders surfacing', () => {
     ).rejects.toThrow(/Input Tokens Exceeded/i);
   });
 
+  it('recognises a reasonless Vertex overflow when given corroboration', async () => {
+    const vertex = signatureError('gemini-2.5-flash-lite');
+    stubModels([vertex, new Error('503 upstream unavailable')]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks,
+        messages,
+        primaryError: new Error('primary boom'),
+        overflowContext: {
+          estimatedPromptTokens: 190_000,
+          maxContextTokens: 200_000,
+        },
+      })
+    ).rejects.toThrow(/Google request failed/);
+  });
+
+  it('leaves a bare Vertex 400 alone without corroboration', async () => {
+    const vertex = signatureError('gemini-2.5-flash-lite');
+    stubModels([vertex, new Error('503 upstream unavailable')]);
+
+    await expect(
+      tryFallbackProviders({
+        fallbacks,
+        messages,
+        primaryError: new Error('primary boom'),
+      })
+    ).rejects.toThrow(/upstream unavailable/);
+  });
+
   it('returns the first success without consulting later fallbacks', async () => {
     stubModels([signatureError('claude-haiku-4-5-20251001'), 'ok']);
 

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -51,13 +51,15 @@ export interface OverflowRecoveryPlan {
   /** What the provider disclosed. Carried through for logging. */
   info: ContextOverflowInfo;
   /**
-   * Provider-reported prompt size divided by our own estimate, when both are
-   * known. Greater than 1 means we under-count relative to this provider.
+   * Provider-reported message tokens divided by our own message estimate,
+   * when both are known. Greater than 1 means we under-count relative to this
+   * provider.
    *
    * Returned separately so the graph can seed the pruner's calibration;
-   * applying it to this plan's budget as well would double-count. Derived
-   * from `info.promptTokens`, never `info.requestedTokens`, since several
-   * providers fold the completion allowance into the latter.
+   * applying it to this plan's budget as well would double-count. Fixed
+   * instruction overhead is removed before deriving it from
+   * `info.promptTokens`, never `info.requestedTokens`, since several providers
+   * fold the completion allowance into the latter.
    */
   observedCalibrationRatio?: number;
 }
@@ -91,6 +93,27 @@ export interface OverflowRecoveryParams {
 
 function isUsable(value: number | undefined): value is number {
   return value != null && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Converts a provider-space retry budget into the units consumed by a pruner
+ * calibrated for another provider while preserving the same raw-token limit.
+ */
+export function translateRecoveryBudget(
+  budgetTokens: number | undefined,
+  sourceCalibrationRatio: number | undefined,
+  targetCalibrationRatio: number | undefined
+): number | undefined {
+  if (
+    !isUsable(budgetTokens) ||
+    !isUsable(sourceCalibrationRatio) ||
+    !isUsable(targetCalibrationRatio)
+  ) {
+    return budgetTokens;
+  }
+  return Math.floor(
+    (budgetTokens * targetCalibrationRatio) / sourceCalibrationRatio
+  );
 }
 
 /**
@@ -182,10 +205,21 @@ export function planContextOverflowRecovery({
     return null;
   }
 
+  const currentCalibrationRatio = isUsable(calibrationRatio)
+    ? calibrationRatio
+    : 1;
+  const estimatedMessageTokens =
+    isUsable(estimatedPromptTokens) && isUsable(instructionTokens)
+      ? estimatedPromptTokens - instructionTokens
+      : estimatedPromptTokens;
+  const observedMessageTokens =
+    isUsable(info.promptTokens) && isUsable(instructionTokens)
+      ? info.promptTokens - instructionTokens
+      : info.promptTokens;
   const observedCalibrationRatio =
-    isUsable(info.promptTokens) && isUsable(estimatedPromptTokens)
-      ? (info.promptTokens / estimatedPromptTokens) *
-        (isUsable(calibrationRatio) ? calibrationRatio : 1)
+    isUsable(observedMessageTokens) && isUsable(estimatedMessageTokens)
+      ? (observedMessageTokens / estimatedMessageTokens) *
+        currentCalibrationRatio
       : undefined;
 
   const target = resolveTargetBudget(

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -30,6 +30,13 @@ const CEILING_HEADROOM_RATIO = 0.95;
  */
 const MIN_RECOVERY_BUDGET_TOKENS = 4_000;
 
+/**
+ * Room a corrected budget must leave above the instructions for the messages
+ * themselves. Without it, a budget that merely clears the system prompt and
+ * tool schemas is not a budget anything can be compacted into.
+ */
+const MIN_MESSAGE_HEADROOM_TOKENS = 2_000;
+
 /** Bound on forced-compaction retries per agent, per run. */
 export const DEFAULT_MAX_OVERFLOW_RECOVERIES = 2;
 
@@ -58,6 +65,19 @@ export interface OverflowRecoveryParams {
   maxContextTokens?: number;
   /** Our own estimate of the prompt we actually sent. */
   estimatedPromptTokens?: number;
+  /**
+   * System prompt plus tool schemas — the part of the budget compaction
+   * cannot touch. A corrected budget at or below this leaves no room for
+   * messages, and the summarize node refuses to run, so recovery is declined
+   * rather than entered.
+   */
+  instructionTokens?: number;
+  /**
+   * Completion allowance the caller configured. Providers count it against
+   * the same ceiling, so it has to come off the top when the error itself did
+   * not break the total down.
+   */
+  configuredCompletionTokens?: number;
   /** Recoveries already attempted for this agent in this run. */
   attemptsSoFar: number;
   maxAttempts?: number;
@@ -87,23 +107,37 @@ function toLocalUnits(limitTokens: number, ratio: number | undefined): number {
  * otherwise a large `maxTokens` keeps the request over the limit no matter
  * how far the prompt is compacted.
  */
-function reservedForCompletion(info: ContextOverflowInfo): number {
-  if (!isUsable(info.requestedTokens) || !isUsable(info.promptTokens)) {
-    return 0;
+function reservedForCompletion(
+  info: ContextOverflowInfo,
+  configuredCompletionTokens: number | undefined
+): number {
+  if (isUsable(info.requestedTokens) && isUsable(info.promptTokens)) {
+    const difference = info.requestedTokens - info.promptTokens;
+    if (difference > 0) {
+      return difference;
+    }
   }
-  const difference = info.requestedTokens - info.promptTokens;
-  return difference > 0 ? difference : 0;
+  /**
+   * No breakdown on offer. Fall back to what the caller configured, because
+   * the provider still counts it: targeting the whole ceiling would leave the
+   * retry at `prompt + maxTokens` and over the limit however far the prompt
+   * is compacted.
+   */
+  return isUsable(configuredCompletionTokens) ? configuredCompletionTokens : 0;
 }
 
 function resolveTargetBudget(
   info: ContextOverflowInfo,
   ratio: number | undefined,
   maxContextTokens: number | undefined,
-  estimatedPromptTokens: number | undefined
+  estimatedPromptTokens: number | undefined,
+  configuredCompletionTokens: number | undefined
 ): number | null {
   if (isUsable(info.limitTokens)) {
     /** Subtract in provider units, then convert the remainder to ours. */
-    const promptCeiling = info.limitTokens - reservedForCompletion(info);
+    const promptCeiling =
+      info.limitTokens -
+      reservedForCompletion(info, configuredCompletionTokens);
     if (promptCeiling > 0) {
       return toLocalUnits(promptCeiling, ratio) * CEILING_HEADROOM_RATIO;
     }
@@ -130,6 +164,8 @@ export function planContextOverflowRecovery({
   provider,
   maxContextTokens,
   estimatedPromptTokens,
+  instructionTokens,
+  configuredCompletionTokens,
   attemptsSoFar,
   maxAttempts = DEFAULT_MAX_OVERFLOW_RECOVERIES,
 }: OverflowRecoveryParams): OverflowRecoveryPlan | null {
@@ -155,7 +191,8 @@ export function planContextOverflowRecovery({
     info,
     observedCalibrationRatio,
     maxContextTokens,
-    estimatedPromptTokens
+    estimatedPromptTokens,
+    configuredCompletionTokens
   );
   if (target == null) {
     return null;
@@ -171,14 +208,29 @@ export function planContextOverflowRecovery({
       ? maxContextTokens * BLIND_SHRINK_RATIO
       : target;
 
-  const budgetTokens = Math.max(
-    MIN_RECOVERY_BUDGET_TOKENS,
-    Math.floor(bounded)
-  );
+  const budgetTokens = Math.floor(bounded);
 
   /**
-   * Refuse to report a "recovery" that changes nothing: when the floor is
-   * already at or above the budget in force, re-pruning cannot free space.
+   * Below the floor there is no usable budget left: either nothing survives
+   * pruning, or the instructions alone fill the window, in which case the
+   * summarize node refuses to run and the detour would bounce between the
+   * agent and summarize nodes without ever shrinking the prompt. Declining
+   * lets the existing "instructions exceed context budget" guidance surface
+   * instead.
+   */
+  const floorTokens = Math.max(
+    MIN_RECOVERY_BUDGET_TOKENS,
+    isUsable(instructionTokens)
+      ? instructionTokens + MIN_MESSAGE_HEADROOM_TOKENS
+      : 0
+  );
+  if (budgetTokens < floorTokens) {
+    return null;
+  }
+
+  /**
+   * Refuse to report a "recovery" that changes nothing: when the budget in
+   * force is already at or below the target, re-pruning cannot free space.
    */
   if (isUsable(maxContextTokens) && budgetTokens >= maxContextTokens) {
     return null;

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -13,9 +13,9 @@
  * apply the same correction twice and prune toward roughly `limit / ratio²`,
  * silently discarding far more history than the overflow called for.
  *
- * `observedCalibrationRatio` is still reported, because a large divergence
- * between the provider's count and ours is worth surfacing, but it is
- * deliberately not applied to the budget.
+ * `observedCalibrationRatio` is returned separately so the caller can seed
+ * the pruner's conversion without folding the same correction into the
+ * provider-space budget.
  */
 import type { ContextOverflowInfo } from '@/utils/errors';
 import type { Providers } from '@/common';
@@ -46,7 +46,7 @@ const MIN_MESSAGE_HEADROOM_TOKENS = 2_000;
 export const DEFAULT_MAX_OVERFLOW_RECOVERIES = 2;
 
 export interface OverflowRecoveryPlan {
-  /** Budget the retry should target, in the SDK's own token units. */
+  /** Budget the retry should target, in provider token units. */
   budgetTokens: number;
   /** What the provider disclosed. Carried through for logging. */
   info: ContextOverflowInfo;
@@ -54,10 +54,10 @@ export interface OverflowRecoveryPlan {
    * Provider-reported prompt size divided by our own estimate, when both are
    * known. Greater than 1 means we under-count relative to this provider.
    *
-   * Reported for observability only — the pruner applies its own learned
-   * calibration to the budget, so applying this as well would double-count.
-   * Derived from `info.promptTokens`, never `info.requestedTokens`, since
-   * several providers fold the completion allowance into the latter.
+   * Returned separately so the graph can seed the pruner's calibration;
+   * applying it to this plan's budget as well would double-count. Derived
+   * from `info.promptTokens`, never `info.requestedTokens`, since several
+   * providers fold the completion allowance into the latter.
    */
   observedCalibrationRatio?: number;
 }
@@ -135,20 +135,6 @@ function resolveTargetBudget(
      */
     if (promptCeiling <= 0) {
       return null;
-    }
-
-    /**
-     * Preferred path: scale by how far over the prompt actually was.
-     *
-     * `promptCeiling / promptTokens` is a pure ratio in the provider's units,
-     * so applying it to our own estimate needs no unit conversion — which is
-     * what makes this immune to the tokenizer divergence that the absolute
-     * ceiling below has to be careful about. It also targets the prompt that
-     * was rejected rather than a budget it may have been sitting well under.
-     */
-    if (isUsable(info.promptTokens) && isUsable(estimatedPromptTokens)) {
-      const overageScale = promptCeiling / info.promptTokens;
-      return estimatedPromptTokens * overageScale * CEILING_HEADROOM_RATIO;
     }
 
     return promptCeiling * CEILING_HEADROOM_RATIO;

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -42,6 +42,11 @@ export interface OverflowRecoveryPlan {
    * Provider-reported prompt size divided by our own estimate, when both are
    * known. Greater than 1 means we systematically under-count for this
    * provider.
+   *
+   * Derived from `info.promptTokens`, never from `info.requestedTokens`:
+   * several providers fold the requested completion allowance into the
+   * latter, which would inflate the ratio and shrink the prompt far more than
+   * the overflow actually calls for.
    */
   observedCalibrationRatio?: number;
 }
@@ -75,6 +80,21 @@ function toLocalUnits(limitTokens: number, ratio: number | undefined): number {
   return limitTokens / ratio;
 }
 
+/**
+ * The completion allowance the provider counted against the same ceiling,
+ * when it reported both the total and the prompt portion. The retry budget
+ * governs the prompt only, so this has to come off the ceiling first —
+ * otherwise a large `maxTokens` keeps the request over the limit no matter
+ * how far the prompt is compacted.
+ */
+function reservedForCompletion(info: ContextOverflowInfo): number {
+  if (!isUsable(info.requestedTokens) || !isUsable(info.promptTokens)) {
+    return 0;
+  }
+  const difference = info.requestedTokens - info.promptTokens;
+  return difference > 0 ? difference : 0;
+}
+
 function resolveTargetBudget(
   info: ContextOverflowInfo,
   ratio: number | undefined,
@@ -82,7 +102,11 @@ function resolveTargetBudget(
   estimatedPromptTokens: number | undefined
 ): number | null {
   if (isUsable(info.limitTokens)) {
-    return toLocalUnits(info.limitTokens, ratio) * CEILING_HEADROOM_RATIO;
+    /** Subtract in provider units, then convert the remainder to ours. */
+    const promptCeiling = info.limitTokens - reservedForCompletion(info);
+    if (promptCeiling > 0) {
+      return toLocalUnits(promptCeiling, ratio) * CEILING_HEADROOM_RATIO;
+    }
   }
   if (isUsable(estimatedPromptTokens)) {
     return estimatedPromptTokens * BLIND_SHRINK_RATIO;
@@ -123,8 +147,8 @@ export function planContextOverflowRecovery({
   }
 
   const observedCalibrationRatio =
-    isUsable(info.requestedTokens) && isUsable(estimatedPromptTokens)
-      ? info.requestedTokens / estimatedPromptTokens
+    isUsable(info.promptTokens) && isUsable(estimatedPromptTokens)
+      ? info.promptTokens / estimatedPromptTokens
       : undefined;
 
   const target = resolveTargetBudget(

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -69,6 +69,8 @@ export interface OverflowRecoveryParams {
   maxContextTokens?: number;
   /** Our own estimate of the prompt we actually sent. */
   estimatedPromptTokens?: number;
+  /** Provider/local calibration already applied to the prompt estimate. */
+  calibrationRatio?: number;
   /**
    * System prompt plus tool schemas — the part of the budget compaction
    * cannot touch. A corrected budget at or below this leaves no room for
@@ -161,6 +163,7 @@ export function planContextOverflowRecovery({
   provider,
   maxContextTokens,
   estimatedPromptTokens,
+  calibrationRatio,
   instructionTokens,
   configuredCompletionTokens,
   attemptsSoFar,
@@ -181,7 +184,8 @@ export function planContextOverflowRecovery({
 
   const observedCalibrationRatio =
     isUsable(info.promptTokens) && isUsable(estimatedPromptTokens)
-      ? info.promptTokens / estimatedPromptTokens
+      ? (info.promptTokens / estimatedPromptTokens) *
+        (isUsable(calibrationRatio) ? calibrationRatio : 1)
       : undefined;
 
   const target = resolveTargetBudget(

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -133,7 +133,25 @@ function resolveTargetBudget(
      * Compaction cannot fix that, so declining surfaces the real problem
      * instead of burning the recovery budget on retries that must fail.
      */
-    return promptCeiling > 0 ? promptCeiling * CEILING_HEADROOM_RATIO : null;
+    if (promptCeiling <= 0) {
+      return null;
+    }
+
+    /**
+     * Preferred path: scale by how far over the prompt actually was.
+     *
+     * `promptCeiling / promptTokens` is a pure ratio in the provider's units,
+     * so applying it to our own estimate needs no unit conversion — which is
+     * what makes this immune to the tokenizer divergence that the absolute
+     * ceiling below has to be careful about. It also targets the prompt that
+     * was rejected rather than a budget it may have been sitting well under.
+     */
+    if (isUsable(info.promptTokens) && isUsable(estimatedPromptTokens)) {
+      const overageScale = promptCeiling / info.promptTokens;
+      return estimatedPromptTokens * overageScale * CEILING_HEADROOM_RATIO;
+    }
+
+    return promptCeiling * CEILING_HEADROOM_RATIO;
   }
   if (isUsable(estimatedPromptTokens)) {
     return estimatedPromptTokens * BLIND_SHRINK_RATIO;

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -6,12 +6,16 @@
  * should the retry target?" — deliberately kept as pure functions so the
  * policy can be reasoned about and tested without a graph.
  *
- * The interesting case is unit mismatch. A provider reports its ceiling in
- * *its* tokenizer's units, while our budget is expressed in ours. When the
- * error also names the size it attributed to the prompt we just sent, the
- * two numbers give us the conversion factor for free, so the retry targets a
- * budget that is genuinely under the limit instead of one that merely looks
- * smaller.
+ * On units: `maxContextTokens` is a **provider-space** budget. The pruner
+ * converts it into its own raw estimate space by dividing by the
+ * `calibrationRatio` it learns from reported usage. A provider-reported
+ * ceiling is therefore applied verbatim — converting it here as well would
+ * apply the same correction twice and prune toward roughly `limit / ratio²`,
+ * silently discarding far more history than the overflow called for.
+ *
+ * `observedCalibrationRatio` is still reported, because a large divergence
+ * between the provider's count and ours is worth surfacing, but it is
+ * deliberately not applied to the budget.
  */
 import type { ContextOverflowInfo } from '@/utils/errors';
 import type { Providers } from '@/common';
@@ -24,9 +28,10 @@ const BLIND_SHRINK_RATIO = 0.7;
 const CEILING_HEADROOM_RATIO = 0.95;
 
 /**
- * Floor for a recovered budget. Below this the prompt could not hold a system
- * prompt plus one turn, so shrinking further trades an overflow error for an
- * empty-context error.
+ * Fallback floor, used only when the instruction size is unknown. When it is
+ * known the floor is derived from it instead, so a genuinely small model — a
+ * 4k window, where a 95%-of-ceiling budget lands below this constant — can
+ * still recover.
  */
 const MIN_RECOVERY_BUDGET_TOKENS = 4_000;
 
@@ -47,13 +52,12 @@ export interface OverflowRecoveryPlan {
   info: ContextOverflowInfo;
   /**
    * Provider-reported prompt size divided by our own estimate, when both are
-   * known. Greater than 1 means we systematically under-count for this
-   * provider.
+   * known. Greater than 1 means we under-count relative to this provider.
    *
-   * Derived from `info.promptTokens`, never from `info.requestedTokens`:
-   * several providers fold the requested completion allowance into the
-   * latter, which would inflate the ratio and shrink the prompt far more than
-   * the overflow actually calls for.
+   * Reported for observability only — the pruner applies its own learned
+   * calibration to the budget, so applying this as well would double-count.
+   * Derived from `info.promptTokens`, never `info.requestedTokens`, since
+   * several providers fold the completion allowance into the latter.
    */
   observedCalibrationRatio?: number;
 }
@@ -88,19 +92,6 @@ function isUsable(value: number | undefined): value is number {
 }
 
 /**
- * Converts the provider's reported ceiling into our token units using the
- * ratio between what it said the prompt cost and what we estimated.
- * Only ratios above 1 are applied: if we over-count relative to the provider,
- * our budget is already conservative and scaling it up would undo that.
- */
-function toLocalUnits(limitTokens: number, ratio: number | undefined): number {
-  if (ratio == null || ratio <= 1) {
-    return limitTokens;
-  }
-  return limitTokens / ratio;
-}
-
-/**
  * The completion allowance the provider counted against the same ceiling,
  * when it reported both the total and the prompt portion. The retry budget
  * governs the prompt only, so this has to come off the ceiling first —
@@ -128,13 +119,11 @@ function reservedForCompletion(
 
 function resolveTargetBudget(
   info: ContextOverflowInfo,
-  ratio: number | undefined,
   maxContextTokens: number | undefined,
   estimatedPromptTokens: number | undefined,
   configuredCompletionTokens: number | undefined
 ): number | null {
   if (isUsable(info.limitTokens)) {
-    /** Subtract in provider units, then convert the remainder to ours. */
     const promptCeiling =
       info.limitTokens -
       reservedForCompletion(info, configuredCompletionTokens);
@@ -144,9 +133,7 @@ function resolveTargetBudget(
      * Compaction cannot fix that, so declining surfaces the real problem
      * instead of burning the recovery budget on retries that must fail.
      */
-    return promptCeiling > 0
-      ? toLocalUnits(promptCeiling, ratio) * CEILING_HEADROOM_RATIO
-      : null;
+    return promptCeiling > 0 ? promptCeiling * CEILING_HEADROOM_RATIO : null;
   }
   if (isUsable(estimatedPromptTokens)) {
     return estimatedPromptTokens * BLIND_SHRINK_RATIO;
@@ -195,7 +182,6 @@ export function planContextOverflowRecovery({
 
   const target = resolveTargetBudget(
     info,
-    observedCalibrationRatio,
     maxContextTokens,
     estimatedPromptTokens,
     configuredCompletionTokens
@@ -224,12 +210,9 @@ export function planContextOverflowRecovery({
    * lets the existing "instructions exceed context budget" guidance surface
    * instead.
    */
-  const floorTokens = Math.max(
-    MIN_RECOVERY_BUDGET_TOKENS,
-    isUsable(instructionTokens)
-      ? instructionTokens + MIN_MESSAGE_HEADROOM_TOKENS
-      : 0
-  );
+  const floorTokens = isUsable(instructionTokens)
+    ? instructionTokens + MIN_MESSAGE_HEADROOM_TOKENS
+    : MIN_RECOVERY_BUDGET_TOKENS;
   if (budgetTokens < floorTokens) {
     return null;
   }

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -80,6 +80,8 @@ export interface OverflowRecoveryParams {
    * rather than entered.
    */
   instructionTokens?: number;
+  /** Whether a model-backed summary can compact messages without a pruner. */
+  canSummarize?: boolean;
   /**
    * Completion allowance the caller configured. Providers count it against
    * the same ceiling, so it has to come off the top when the error itself did
@@ -114,6 +116,15 @@ export function translateRecoveryBudget(
   return Math.floor(
     (budgetTokens * targetCalibrationRatio) / sourceCalibrationRatio
   );
+}
+
+/** Applies the conservative shrink used when no provider-space ceiling is usable. */
+export function getBlindRecoveryBudget(
+  maxContextTokens: number | undefined
+): number | undefined {
+  return isUsable(maxContextTokens)
+    ? Math.floor(maxContextTokens * BLIND_SHRINK_RATIO)
+    : undefined;
 }
 
 /**
@@ -188,6 +199,7 @@ export function planContextOverflowRecovery({
   estimatedPromptTokens,
   calibrationRatio,
   instructionTokens,
+  canSummarize = false,
   configuredCompletionTokens,
   attemptsSoFar,
   maxAttempts = DEFAULT_MAX_OVERFLOW_RECOVERIES,
@@ -245,7 +257,7 @@ export function planContextOverflowRecovery({
    */
   const bounded =
     isUsable(maxContextTokens) && target >= maxContextTokens
-      ? maxContextTokens * BLIND_SHRINK_RATIO
+      ? (getBlindRecoveryBudget(maxContextTokens) ?? target)
       : target;
 
   const budgetTokens = Math.floor(bounded);
@@ -258,9 +270,12 @@ export function planContextOverflowRecovery({
    * lets the existing "instructions exceed context budget" guidance surface
    * instead.
    */
-  const floorTokens = isUsable(instructionTokens)
-    ? instructionTokens + MIN_MESSAGE_HEADROOM_TOKENS
-    : MIN_RECOVERY_BUDGET_TOKENS;
+  let floorTokens = MIN_RECOVERY_BUDGET_TOKENS;
+  if (isUsable(instructionTokens)) {
+    floorTokens = instructionTokens + MIN_MESSAGE_HEADROOM_TOKENS;
+  } else if (canSummarize) {
+    floorTokens = 1;
+  }
   if (budgetTokens < floorTokens) {
     return null;
   }

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -1,0 +1,164 @@
+/**
+ * Recovery policy for provider context-overflow rejections.
+ *
+ * Detection (`@/utils/errors`) answers "was this an overflow, and what did
+ * the provider disclose?". This module answers the follow-up: "what budget
+ * should the retry target?" — deliberately kept as pure functions so the
+ * policy can be reasoned about and tested without a graph.
+ *
+ * The interesting case is unit mismatch. A provider reports its ceiling in
+ * *its* tokenizer's units, while our budget is expressed in ours. When the
+ * error also names the size it attributed to the prompt we just sent, the
+ * two numbers give us the conversion factor for free, so the retry targets a
+ * budget that is genuinely under the limit instead of one that merely looks
+ * smaller.
+ */
+import type { ContextOverflowInfo } from '@/utils/errors';
+import type { Providers } from '@/common';
+import { getContextOverflowInfo } from '@/utils/errors';
+
+/** Fraction of the previous budget used when the provider named no ceiling. */
+const BLIND_SHRINK_RATIO = 0.7;
+
+/** Slack left below a known ceiling so the retry is not sized to the edge. */
+const CEILING_HEADROOM_RATIO = 0.95;
+
+/**
+ * Floor for a recovered budget. Below this the prompt could not hold a system
+ * prompt plus one turn, so shrinking further trades an overflow error for an
+ * empty-context error.
+ */
+const MIN_RECOVERY_BUDGET_TOKENS = 4_000;
+
+/** Bound on forced-compaction retries per agent, per run. */
+export const DEFAULT_MAX_OVERFLOW_RECOVERIES = 2;
+
+export interface OverflowRecoveryPlan {
+  /** Budget the retry should target, in the SDK's own token units. */
+  budgetTokens: number;
+  /** What the provider disclosed. Carried through for logging. */
+  info: ContextOverflowInfo;
+  /**
+   * Provider-reported prompt size divided by our own estimate, when both are
+   * known. Greater than 1 means we systematically under-count for this
+   * provider.
+   */
+  observedCalibrationRatio?: number;
+}
+
+export interface OverflowRecoveryParams {
+  error: unknown;
+  provider: Providers;
+  /** Budget in force when the rejected prompt was built. */
+  maxContextTokens?: number;
+  /** Our own estimate of the prompt we actually sent. */
+  estimatedPromptTokens?: number;
+  /** Recoveries already attempted for this agent in this run. */
+  attemptsSoFar: number;
+  maxAttempts?: number;
+}
+
+function isUsable(value: number | undefined): value is number {
+  return value != null && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Converts the provider's reported ceiling into our token units using the
+ * ratio between what it said the prompt cost and what we estimated.
+ * Only ratios above 1 are applied: if we over-count relative to the provider,
+ * our budget is already conservative and scaling it up would undo that.
+ */
+function toLocalUnits(limitTokens: number, ratio: number | undefined): number {
+  if (ratio == null || ratio <= 1) {
+    return limitTokens;
+  }
+  return limitTokens / ratio;
+}
+
+function resolveTargetBudget(
+  info: ContextOverflowInfo,
+  ratio: number | undefined,
+  maxContextTokens: number | undefined,
+  estimatedPromptTokens: number | undefined
+): number | null {
+  if (isUsable(info.limitTokens)) {
+    return toLocalUnits(info.limitTokens, ratio) * CEILING_HEADROOM_RATIO;
+  }
+  if (isUsable(estimatedPromptTokens)) {
+    return estimatedPromptTokens * BLIND_SHRINK_RATIO;
+  }
+  if (isUsable(maxContextTokens)) {
+    return maxContextTokens * BLIND_SHRINK_RATIO;
+  }
+  return null;
+}
+
+/**
+ * Decides whether a failed model call is a recoverable context overflow and,
+ * if so, what budget the retry should be re-pruned against.
+ *
+ * Returns `null` when the error is something compaction cannot fix, or when
+ * the per-run recovery budget is spent — in both cases the caller should let
+ * its normal failure handling proceed.
+ */
+export function planContextOverflowRecovery({
+  error,
+  provider,
+  maxContextTokens,
+  estimatedPromptTokens,
+  attemptsSoFar,
+  maxAttempts = DEFAULT_MAX_OVERFLOW_RECOVERIES,
+}: OverflowRecoveryParams): OverflowRecoveryPlan | null {
+  if (attemptsSoFar >= maxAttempts) {
+    return null;
+  }
+
+  const info = getContextOverflowInfo(error, {
+    provider,
+    estimatedPromptTokens,
+    maxContextTokens,
+  });
+  if (info == null) {
+    return null;
+  }
+
+  const observedCalibrationRatio =
+    isUsable(info.requestedTokens) && isUsable(estimatedPromptTokens)
+      ? info.requestedTokens / estimatedPromptTokens
+      : undefined;
+
+  const target = resolveTargetBudget(
+    info,
+    observedCalibrationRatio,
+    maxContextTokens,
+    estimatedPromptTokens
+  );
+  if (target == null) {
+    return null;
+  }
+
+  /**
+   * A retry that does not actually shrink the prompt would just reproduce the
+   * same rejection, so a ceiling that lands at or above the budget we already
+   * had is replaced by a blind shrink.
+   */
+  const bounded =
+    isUsable(maxContextTokens) && target >= maxContextTokens
+      ? maxContextTokens * BLIND_SHRINK_RATIO
+      : target;
+
+  const budgetTokens = Math.max(
+    MIN_RECOVERY_BUDGET_TOKENS,
+    Math.floor(bounded)
+  );
+
+  /**
+   * Refuse to report a "recovery" that changes nothing: when the floor is
+   * already at or above the budget in force, re-pruning cannot free space.
+   */
+  if (isUsable(maxContextTokens) && budgetTokens >= maxContextTokens) {
+    return null;
+  }
+
+  return { budgetTokens, info, observedCalibrationRatio };
+}

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -46,8 +46,8 @@ const MIN_MESSAGE_HEADROOM_TOKENS = 2_000;
 export const DEFAULT_MAX_OVERFLOW_RECOVERIES = 2;
 
 export interface OverflowRecoveryPlan {
-  /** Budget the retry should target, in provider token units. */
-  budgetTokens: number;
+  /** Budget the retry should target, in provider token units when known. */
+  budgetTokens?: number;
   /** What the provider disclosed. Carried through for logging. */
   info: ContextOverflowInfo;
   /**
@@ -195,7 +195,13 @@ export function planContextOverflowRecovery({
     configuredCompletionTokens
   );
   if (target == null) {
-    return null;
+    const hasNumericBasis =
+      isUsable(info.limitTokens) ||
+      isUsable(maxContextTokens) ||
+      isUsable(estimatedPromptTokens);
+    return hasNumericBasis
+      ? null
+      : { info, observedCalibrationRatio, budgetTokens: undefined };
   }
 
   /**

--- a/src/llm/contextOverflowRecovery.ts
+++ b/src/llm/contextOverflowRecovery.ts
@@ -138,9 +138,15 @@ function resolveTargetBudget(
     const promptCeiling =
       info.limitTokens -
       reservedForCompletion(info, configuredCompletionTokens);
-    if (promptCeiling > 0) {
-      return toLocalUnits(promptCeiling, ratio) * CEILING_HEADROOM_RATIO;
-    }
+    /**
+     * A completion allowance at or above the ceiling leaves nothing for the
+     * prompt: even an empty one plus the requested output overruns the limit.
+     * Compaction cannot fix that, so declining surfaces the real problem
+     * instead of burning the recovery budget on retries that must fail.
+     */
+    return promptCeiling > 0
+      ? toLocalUnits(promptCeiling, ratio) * CEILING_HEADROOM_RATIO
+      : null;
   }
   if (isUsable(estimatedPromptTokens)) {
     return estimatedPromptTokens * BLIND_SHRINK_RATIO;

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -315,6 +315,52 @@ export async function attemptInvoke(
 }
 
 /**
+ * Identifies which fallback produced an error, so a caller planning a
+ * recovery can reason about the client that actually failed rather than the
+ * primary's configuration — their context windows and output allowances
+ * differ, which is the whole reason a fallback exists.
+ */
+export interface FallbackErrorContext {
+  provider: Providers;
+  clientOptions?: t.ClientOptions;
+}
+
+/**
+ * Symbol-keyed so it never appears in `Object.keys`, `JSON.stringify`, or the
+ * error-message flattening the overflow classifier performs.
+ */
+const FALLBACK_ERROR_CONTEXT = Symbol.for(
+  '@librechat/agents.fallbackErrorContext'
+);
+
+function attachFallbackErrorContext(
+  error: unknown,
+  fallbackContext: FallbackErrorContext
+): void {
+  if (typeof error !== 'object' || error === null) {
+    return;
+  }
+  Object.defineProperty(error, FALLBACK_ERROR_CONTEXT, {
+    value: fallbackContext,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** Reads back the fallback attribution attached by `tryFallbackProviders`. */
+export function getFallbackErrorContext(
+  error: unknown
+): FallbackErrorContext | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+  return (error as Record<symbol, FallbackErrorContext | undefined>)[
+    FALLBACK_ERROR_CONTEXT
+  ];
+}
+
+/**
  * Best-effort read of the configured model name from client options.
  * Providers disagree on the key (`model` vs `modelName`).
  */
@@ -370,7 +416,14 @@ export async function tryFallbackProviders({
   const isOverflow = (error: unknown): boolean =>
     getContextOverflowInfo(error, overflowContext) != null;
   let lastError: unknown = primaryError;
-  let overflowError: unknown = isOverflow(primaryError)
+  /**
+   * Tracked apart from the primary's overflow. A caller reaching this
+   * function with an overflowing primary has already failed to recover from
+   * it, so a fallback overflow — which may sit against a different window and
+   * output allowance — is the more useful of the two to surface.
+   */
+  let fallbackOverflowError: unknown;
+  const primaryOverflowError: unknown = isOverflow(primaryError)
     ? primaryError
     : undefined;
   for (const fb of fallbacks) {
@@ -411,17 +464,25 @@ export async function tryFallbackProviders({
       return result;
     } catch (e) {
       lastError = e;
-      if (overflowError === undefined && isOverflow(e)) {
-        overflowError = e;
+      if (fallbackOverflowError === undefined && isOverflow(e)) {
+        attachFallbackErrorContext(e, {
+          provider: fb.provider,
+          clientOptions: fb.clientOptions,
+        });
+        fallbackOverflowError = e;
       }
       continue;
     }
   }
-  if (overflowError !== undefined) {
-    throw overflowError;
-  }
-  if (lastError !== undefined) {
-    throw lastError;
+  /**
+   * Preference order: a fallback overflow, then the primary's overflow, then
+   * whichever failure came last. An overflow is the only one of the three a
+   * caller can act on, and the fallback's carries the client attribution that
+   * makes a correct retry budget possible.
+   */
+  const preferred = fallbackOverflowError ?? primaryOverflowError ?? lastError;
+  if (preferred !== undefined) {
+    throw preferred;
   }
   return undefined;
 }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -323,6 +323,7 @@ export async function attemptInvoke(
 export interface FallbackErrorContext {
   provider: Providers;
   clientOptions?: t.ClientOptions;
+  maxContextTokens?: number;
 }
 
 /**
@@ -398,7 +399,7 @@ export async function tryFallbackProviders({
   onChunk,
   overflowContext,
 }: {
-  fallbacks: Array<{ provider: Providers; clientOptions?: t.ClientOptions }>;
+  fallbacks: t.FallbackConfig[];
   tools?: t.GraphTools;
   messages: BaseMessage[];
   config?: RunnableConfig;
@@ -413,8 +414,10 @@ export async function tryFallbackProviders({
    */
   overflowContext?: ContextOverflowContext;
 }): Promise<Partial<t.BaseGraphState> | undefined> {
-  const isOverflow = (error: unknown): boolean =>
-    getContextOverflowInfo(error, overflowContext) != null;
+  const isOverflow = (
+    error: unknown,
+    contextOverride = overflowContext
+  ): boolean => getContextOverflowInfo(error, contextOverride) != null;
   let lastError: unknown = primaryError;
   /**
    * Tracked apart from the primary's overflow. A caller reaching this
@@ -464,10 +467,19 @@ export async function tryFallbackProviders({
       return result;
     } catch (e) {
       lastError = e;
-      if (fallbackOverflowError === undefined && isOverflow(e)) {
+      const fallbackOverflowContext: ContextOverflowContext = {
+        ...overflowContext,
+        provider: fb.provider,
+        maxContextTokens: fb.maxContextTokens,
+      };
+      if (
+        fallbackOverflowError === undefined &&
+        isOverflow(e, fallbackOverflowContext)
+      ) {
         attachFallbackErrorContext(e, {
           provider: fb.provider,
           clientOptions: fb.clientOptions,
+          maxContextTokens: fb.maxContextTokens,
         });
         fallbackOverflowError = e;
       }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -326,7 +326,16 @@ export interface FallbackErrorContext {
   maxContextTokens?: number;
 }
 
+export interface FallbackOverflowCandidate {
+  error: unknown;
+  context: FallbackErrorContext;
+}
+
 const fallbackErrorContexts = new WeakMap<object, FallbackErrorContext>();
+const fallbackOverflowCandidates = new WeakMap<
+  object,
+  FallbackOverflowCandidate[]
+>();
 
 function attachFallbackErrorContext(
   error: unknown,
@@ -346,6 +355,16 @@ export function getFallbackErrorContext(
     return undefined;
   }
   return fallbackErrorContexts.get(error);
+}
+
+/** Returns every fallback overflow retained from an exhausted provider chain. */
+export function getFallbackOverflowCandidates(
+  error: unknown
+): FallbackOverflowCandidate[] {
+  if (typeof error !== 'object' || error === null) {
+    return [];
+  }
+  return [...(fallbackOverflowCandidates.get(error) ?? [])];
 }
 
 /**
@@ -412,7 +431,7 @@ export async function tryFallbackProviders({
    * it, so a fallback overflow — which may sit against a different window and
    * output allowance — is the more useful of the two to surface.
    */
-  let fallbackOverflowError: unknown;
+  const overflowCandidates: FallbackOverflowCandidate[] = [];
   const primaryOverflowError: unknown = isOverflow(primaryError)
     ? primaryError
     : undefined;
@@ -455,20 +474,22 @@ export async function tryFallbackProviders({
     } catch (e) {
       lastError = e;
       const fallbackOverflowContext: ContextOverflowContext = {
-        ...overflowContext,
         provider: fb.provider,
         maxContextTokens: fb.maxContextTokens,
+        ...(overflowContext?.provider === fb.provider
+          ? {
+            estimatedPromptTokens: overflowContext.estimatedPromptTokens,
+          }
+          : {}),
       };
-      if (
-        fallbackOverflowError === undefined &&
-        isOverflow(e, fallbackOverflowContext)
-      ) {
-        attachFallbackErrorContext(e, {
+      if (isOverflow(e, fallbackOverflowContext)) {
+        const errorContext: FallbackErrorContext = {
           provider: fb.provider,
           clientOptions: fb.clientOptions,
           maxContextTokens: fb.maxContextTokens,
-        });
-        fallbackOverflowError = e;
+        };
+        attachFallbackErrorContext(e, errorContext);
+        overflowCandidates.push({ error: e, context: errorContext });
       }
       continue;
     }
@@ -479,7 +500,15 @@ export async function tryFallbackProviders({
    * caller can act on, and the fallback's carries the client attribution that
    * makes a correct retry budget possible.
    */
-  const preferred = fallbackOverflowError ?? primaryOverflowError ?? lastError;
+  const preferred =
+    overflowCandidates[0]?.error ?? primaryOverflowError ?? lastError;
+  if (
+    overflowCandidates.length > 0 &&
+    typeof preferred === 'object' &&
+    preferred !== null
+  ) {
+    fallbackOverflowCandidates.set(preferred, overflowCandidates);
+  }
   if (preferred !== undefined) {
     throw preferred;
   }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -4,6 +4,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { ContextOverflowContext } from '@/utils/errors';
 import type * as t from '@/types';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
@@ -349,6 +350,7 @@ export async function tryFallbackProviders({
   primaryError,
   context,
   onChunk,
+  overflowContext,
 }: {
   fallbacks: Array<{ provider: Providers; clientOptions?: t.ClientOptions }>;
   tools?: t.GraphTools;
@@ -357,10 +359,20 @@ export async function tryFallbackProviders({
   primaryError: unknown;
   context?: InvokeContext;
   onChunk?: OnChunk;
+  /**
+   * Prompt-size corroboration for signatures that are not self-describing.
+   * Vertex AI's overflow is a bare `400` with no reason, so without this a
+   * fallback that overflows is indistinguishable from any other 400 and would
+   * be dropped in favour of whichever failure came last.
+   */
+  overflowContext?: ContextOverflowContext;
 }): Promise<Partial<t.BaseGraphState> | undefined> {
+  const isOverflow = (error: unknown): boolean =>
+    getContextOverflowInfo(error, overflowContext) != null;
   let lastError: unknown = primaryError;
-  let overflowError: unknown =
-    getContextOverflowInfo(primaryError) != null ? primaryError : undefined;
+  let overflowError: unknown = isOverflow(primaryError)
+    ? primaryError
+    : undefined;
   for (const fb of fallbacks) {
     try {
       const fbModel = initializeModel({
@@ -399,7 +411,7 @@ export async function tryFallbackProviders({
       return result;
     } catch (e) {
       lastError = e;
-      if (overflowError === undefined && getContextOverflowInfo(e) != null) {
+      if (overflowError === undefined && isOverflow(e)) {
         overflowError = e;
       }
       continue;

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -9,6 +9,7 @@ import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { manualToolStreamProviders } from '@/llm/providers';
+import { getContextOverflowInfo } from '@/utils/errors';
 import { modifyDeltaProperties } from '@/messages';
 import { ChatModelStreamHandler } from '@/stream';
 import { initializeModel } from '@/llm/init';
@@ -333,7 +334,12 @@ function extractClientOptionsModel(
 
 /**
  * Attempts each fallback provider in order until one succeeds.
- * Throws the last error if all fallbacks fail.
+ *
+ * When every fallback fails, a context overflow among them is thrown in
+ * preference to whichever failure happened to come last. An overflow is the
+ * one failure the caller can act on — it compacts and retries — and losing it
+ * behind a later unrelated error would surface a dead end instead. Ordinary
+ * failures still throw last-error-wins.
  */
 export async function tryFallbackProviders({
   fallbacks,
@@ -353,6 +359,8 @@ export async function tryFallbackProviders({
   onChunk?: OnChunk;
 }): Promise<Partial<t.BaseGraphState> | undefined> {
   let lastError: unknown = primaryError;
+  let overflowError: unknown =
+    getContextOverflowInfo(primaryError) != null ? primaryError : undefined;
   for (const fb of fallbacks) {
     try {
       const fbModel = initializeModel({
@@ -391,8 +399,14 @@ export async function tryFallbackProviders({
       return result;
     } catch (e) {
       lastError = e;
+      if (overflowError === undefined && getContextOverflowInfo(e) != null) {
+        overflowError = e;
+      }
       continue;
     }
+  }
+  if (overflowError !== undefined) {
+    throw overflowError;
   }
   if (lastError !== undefined) {
     throw lastError;

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -326,13 +326,7 @@ export interface FallbackErrorContext {
   maxContextTokens?: number;
 }
 
-/**
- * Symbol-keyed so it never appears in `Object.keys`, `JSON.stringify`, or the
- * error-message flattening the overflow classifier performs.
- */
-const FALLBACK_ERROR_CONTEXT = Symbol.for(
-  '@librechat/agents.fallbackErrorContext'
-);
+const fallbackErrorContexts = new WeakMap<object, FallbackErrorContext>();
 
 function attachFallbackErrorContext(
   error: unknown,
@@ -341,12 +335,7 @@ function attachFallbackErrorContext(
   if (typeof error !== 'object' || error === null) {
     return;
   }
-  Object.defineProperty(error, FALLBACK_ERROR_CONTEXT, {
-    value: fallbackContext,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
+  fallbackErrorContexts.set(error, fallbackContext);
 }
 
 /** Reads back the fallback attribution attached by `tryFallbackProviders`. */
@@ -356,9 +345,7 @@ export function getFallbackErrorContext(
   if (typeof error !== 'object' || error === null) {
     return undefined;
   }
-  return (error as Record<symbol, FallbackErrorContext | undefined>)[
-    FALLBACK_ERROR_CONTEXT
-  ];
+  return fallbackErrorContexts.get(error);
 }
 
 /**

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -85,6 +85,14 @@ const CALIBRATION_RATIO_MIN = 0.5;
 /** Maximum cumulative calibration ratio — sanity cap for the running ratio. */
 const CALIBRATION_RATIO_MAX = 5;
 
+/** Keeps provider/local token calibration within the shared safe range. */
+export function clampCalibrationRatio(ratio: number): number {
+  return Math.max(
+    CALIBRATION_RATIO_MIN,
+    Math.min(CALIBRATION_RATIO_MAX, ratio)
+  );
+}
+
 export type PruneMessagesFactoryParams = {
   provider?: Providers;
   maxTokens: number;
@@ -1479,10 +1487,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         cumulativeRawSent += rawSentThisTurn;
         cumulativeProviderReported += providerMessageTokens;
         const newRatio = cumulativeProviderReported / cumulativeRawSent;
-        calibrationRatio = Math.max(
-          CALIBRATION_RATIO_MIN,
-          Math.min(CALIBRATION_RATIO_MAX, newRatio)
-        );
+        calibrationRatio = clampCalibrationRatio(newRatio);
 
         const calibratedOurTotal =
           instructionOverhead + rawSentThisTurn * calibrationRatio;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -80,10 +80,10 @@ export function enforceOriginalContentCap(map: Map<number, string>): void {
 
 /** Minimum cumulative calibration ratio — provider can't count fewer tokens
  *  than our raw estimate (within reason). Prevents divide-by-zero edge cases. */
-const CALIBRATION_RATIO_MIN = 0.5;
+export const CALIBRATION_RATIO_MIN = 0.5;
 
 /** Maximum cumulative calibration ratio — sanity cap for the running ratio. */
-const CALIBRATION_RATIO_MAX = 5;
+export const CALIBRATION_RATIO_MAX = 5;
 
 /** Keeps provider/local token calibration within the shared safe range. */
 export function clampCalibrationRatio(ratio: number): number {

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1010,8 +1010,8 @@ export function maskConsumedToolResults(params: {
   /** When provided, original (pre-masking) content is stored here keyed by
    *  message index — only for entries that actually get truncated. */
   originalContentStore?: Map<number, string>;
-  /** Called after storing content with the char length of the stored entry. */
-  onContentStored?: (charLength: number) => void;
+  /** Called after storing a newly captured entry. */
+  onContentStored?: (index: number, content: string) => void;
 }): number {
   const { messages, indexTokenCountMap, tokenCounter } = params;
   let maskedCount = 0;
@@ -1087,7 +1087,7 @@ export function maskConsumedToolResults(params: {
     if (params.originalContentStore && !params.originalContentStore.has(i)) {
       params.originalContentStore.set(i, content);
       if (params.onContentStored) {
-        params.onContentStored(content.length);
+        params.onContentStored(i, content);
       }
     }
 
@@ -1319,6 +1319,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     remainingContextTokens?: number;
     contextPressure?: number;
     originalToolContent?: Map<number, string>;
+    newOriginalToolContent?: Map<number, string>;
     calibrationRatio?: number;
     resolvedInstructionOverhead?: number;
     /** Usable budget this call: maxTokens minus output reserve */
@@ -1326,6 +1327,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     /** Calibrated instruction overhead actually applied this call */
     effectiveInstructionTokens?: number;
   } {
+    let newOriginalToolContent: Map<number, string> | undefined;
     if (params.messages.length === 0) {
       /** Post-compaction calls still invoke the model — report the same
        *  reserve-adjusted budget fields as the populated paths */
@@ -1666,8 +1668,12 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             : undefined,
         onContentStored:
           factoryParams.summarizationEnabled === true
-            ? (charLen: number): void => {
-              originalToolContentSize += charLen;
+            ? (index: number, content: string): void => {
+              originalToolContentSize += content.length;
+              if (newOriginalToolContent == null) {
+                newOriginalToolContent = new Map();
+              }
+              newOriginalToolContent.set(index, content);
               while (
                 originalToolContentSize > ORIGINAL_CONTENT_MAX_CHARS &&
                   originalToolContent.size > 0
@@ -1803,6 +1809,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         contextPressure,
         originalToolContent:
           originalToolContent.size > 0 ? originalToolContent : undefined,
+        newOriginalToolContent,
         calibrationRatio,
         resolvedInstructionOverhead: bestInstructionOverhead,
         contextBudget: pruningBudget,
@@ -2187,6 +2194,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       contextPressure,
       originalToolContent:
         originalToolContent.size > 0 ? originalToolContent : undefined,
+      newOriginalToolContent,
       calibrationRatio,
       resolvedInstructionOverhead: bestInstructionOverhead,
       contextBudget: pruningBudget,

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -1,5 +1,7 @@
 import type { BaseMessage } from '@langchain/core/messages';
 
+export const DEFAULT_RETAIN_RECENT_TURNS = 2;
+
 /**
  * Configuration for splitting a message list into a head (to be summarized)
  * and a tail (to be preserved verbatim).
@@ -68,7 +70,7 @@ export function splitAtRecencyBoundary(
   messages: BaseMessage[],
   options: RecencyWindowOptions = {}
 ): RecencySplit {
-  const turnsCap = options.turns ?? 2;
+  const turnsCap = options.turns ?? DEFAULT_RETAIN_RECENT_TURNS;
 
   if (messages.length === 0 || turnsCap <= 0) {
     return {

--- a/src/run.ts
+++ b/src/run.ts
@@ -164,6 +164,8 @@ export class Run<_T extends t.BaseGraphState> {
   private _interrupt: t.RunInterruptResult<unknown> | undefined;
   /** Per-run sequence for batch-unique activity-label trace-seed fallbacks. */
   private activityLabelSeq = 0;
+  /** Distinguishes sibling forks started from the same explicit checkpoint. */
+  private checkpointForkSeq = 0;
   private _haltedReason: string | undefined;
 
   private constructor(config: Partial<t.RunConfig>) {
@@ -738,6 +740,7 @@ export class Run<_T extends t.BaseGraphState> {
             checkpointThreadId,
             checkpointNamespace,
             checkpointId,
+            checkpointId === '' ? 0 : ++this.checkpointForkSeq,
           ]);
       graph.resetValues(streamOptions?.keepContent, checkpointScope);
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -727,10 +727,18 @@ export class Run<_T extends t.BaseGraphState> {
         typeof config.configurable?.checkpoint_ns === 'string'
           ? config.configurable.checkpoint_ns
           : '';
+      const checkpointId =
+        typeof config.configurable?.checkpoint_id === 'string'
+          ? config.configurable.checkpoint_id
+          : '';
       const checkpointScope =
         checkpointThreadId == null
           ? undefined
-          : `${checkpointThreadId.length}:${checkpointThreadId}:${checkpointNamespace}`;
+          : JSON.stringify([
+            checkpointThreadId,
+            checkpointNamespace,
+            checkpointId,
+          ]);
       graph.resetValues(streamOptions?.keepContent, checkpointScope);
     }
     this._interrupt = undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -719,7 +719,19 @@ export class Run<_T extends t.BaseGraphState> {
      * boundary.
      */
     if (!isResume) {
-      graph.resetValues(streamOptions?.keepContent);
+      const checkpointThreadId =
+        typeof config.configurable?.thread_id === 'string'
+          ? config.configurable.thread_id
+          : undefined;
+      const checkpointNamespace =
+        typeof config.configurable?.checkpoint_ns === 'string'
+          ? config.configurable.checkpoint_ns
+          : '';
+      const checkpointScope =
+        checkpointThreadId == null
+          ? undefined
+          : `${checkpointThreadId.length}:${checkpointThreadId}:${checkpointNamespace}`;
+      graph.resetValues(streamOptions?.keepContent, checkpointScope);
     }
     this._interrupt = undefined;
     this._haltedReason = undefined;

--- a/src/scripts/context-overflow-probe.ts
+++ b/src/scripts/context-overflow-probe.ts
@@ -1,0 +1,994 @@
+/**
+ * Context-overflow signature probe.
+ *
+ * Deliberately sends an over-limit prompt to every provider the SDK
+ * supports and records the raw error each one throws, so the overflow
+ * classifier is grounded in observed provider behavior rather than
+ * guessed phrases.
+ *
+ * Run:
+ *   DOTENV_CONFIG_PATH=/path/to/.env node --loader ./tsconfig-paths-bootstrap.mjs \
+ *     --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts
+ *
+ * Flags:
+ *   --only <provider[,provider]>  restrict to given providers
+ *   --model <substring>           restrict to matching model ids
+ *   --tier <full|confirm>         restrict to a load tier
+ *   --mode <stream|invoke|both>   which invocation path to probe (default: stream)
+ *   --out <path>                  output JSON path
+ *   --list                        print the resolved matrix and exit
+ *
+ * Cost note: an over-limit request is rejected at request validation, so
+ * providers do not bill the prompt. The `confirm` tier still overshoots by a
+ * wide margin so an expensive model can never accidentally accept the prompt.
+ */
+import { writeFileSync } from 'fs';
+import { config as loadEnv } from 'dotenv';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { initializeModel } from '@/llm/init';
+import { Providers } from '@/common';
+
+loadEnv({ path: process.env.DOTENV_CONFIG_PATH ?? '.env' });
+
+/**
+ * `full` targets are cheap enough to probe at a modest overshoot.
+ * `confirm` targets are expensive or huge-context; they get a single
+ * wide-margin attempt purely to confirm the API surface's signature.
+ */
+type ProbeTier = 'full' | 'confirm';
+
+type ProbeMode = 'stream' | 'invoke';
+
+interface ProbeTarget {
+  provider: Providers;
+  /** Model id as the provider expects it. */
+  model: string;
+  /** Documented input context window, in tokens. */
+  contextWindow: number;
+  tier: ProbeTier;
+  /** Upstream API actually serving the request (OpenRouter routes to many). */
+  upstream?: string;
+}
+
+interface SerializedError {
+  constructorName: string;
+  name?: string;
+  message: string;
+  status?: number;
+  code?: string;
+  type?: string;
+  errorType?: string;
+  errorCode?: string;
+  errorStatus?: string;
+  httpStatusCode?: number;
+  awsErrorType?: string;
+  requestId?: string;
+  lcErrorCode?: string;
+  /** gaxios-style clients (Vertex AI) hide the API error document here. */
+  responseData?: string;
+  /** Enumerable own properties, minus noisy/secret-bearing ones. */
+  ownProperties: Record<string, string>;
+  /** Best-effort raw JSON body if the SDK attached one. */
+  rawBody?: string;
+}
+
+interface ProbeResult {
+  provider: Providers;
+  model: string;
+  upstream?: string;
+  tier: ProbeTier;
+  mode: ProbeMode;
+  contextWindow: number;
+  approxTokensSent: number;
+  outcome: 'rejected' | 'accepted' | 'skipped' | 'unavailable';
+  skipReason?: string;
+  durationMs: number;
+  error?: SerializedError;
+}
+
+const OVERSHOOT_BY_TIER: Record<ProbeTier, number> = {
+  full: 1.3,
+  confirm: 2,
+};
+
+/** Absolute floor so tiny-context models still clear the window decisively. */
+const MIN_OVERSHOOT_TOKENS = 4_000;
+
+/**
+ * Payload ceiling (~12MB of text). Beyond this the request stops testing the
+ * token limit and starts testing the provider's body-size limit, which is a
+ * different failure mode. Targets that would need more are skipped rather
+ * than probed with a smaller payload, since an under-limit payload could be
+ * *accepted* and billed.
+ */
+const MAX_PROBE_TOKENS = 2_400_000;
+
+/**
+ * Words chosen to be single tokens under BPE vocabularies, so an N-word
+ * payload is guaranteed to be at least N tokens for every provider. Under-
+ * counting would risk a request being *accepted* and billed; over-counting
+ * only costs bandwidth.
+ */
+const FILLER_WORDS = [
+  'the',
+  'quick',
+  'brown',
+  'fox',
+  'jumps',
+  'over',
+  'lazy',
+  'dog',
+  'and',
+  'then',
+  'runs',
+  'past',
+  'green',
+  'river',
+  'under',
+  'bright',
+  'morning',
+  'sky',
+];
+
+function buildOverflowText(wordCount: number): string {
+  const parts: string[] = new Array(wordCount);
+  for (let i = 0; i < wordCount; i++) {
+    parts[i] = FILLER_WORDS[i % FILLER_WORDS.length];
+  }
+  return parts.join(' ');
+}
+
+function overflowTokenTarget(
+  target: ProbeTarget,
+  factorOverride?: number
+): number {
+  const factor = factorOverride ?? OVERSHOOT_BY_TIER[target.tier];
+  const scaled = Math.ceil(target.contextWindow * factor);
+  if (factorOverride != null) {
+    return scaled;
+  }
+  return Math.max(scaled, target.contextWindow + MIN_OVERSHOOT_TOKENS);
+}
+
+const SECRET_KEY_RE = /key|token|secret|credential|authorization|password/i;
+
+function readString(
+  source: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = source[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function readNumber(
+  source: Record<string, unknown>,
+  key: string
+): number | undefined {
+  const value = source[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringifySafe(value: unknown, limit = 4_000): string {
+  if (typeof value === 'string') {
+    return value.slice(0, limit);
+  }
+  try {
+    return JSON.stringify(value)?.slice(0, limit) ?? String(value);
+  } catch {
+    return String(value).slice(0, limit);
+  }
+}
+
+function collectOwnProperties(error: object): Record<string, string> {
+  const collected: Record<string, string> = {};
+  for (const key of Object.keys(error)) {
+    if (SECRET_KEY_RE.test(key)) {
+      continue;
+    }
+    if (key === 'stack' || key === 'message') {
+      continue;
+    }
+    collected[key] = stringifySafe(
+      (error as Record<string, unknown>)[key],
+      800
+    );
+  }
+  return collected;
+}
+
+/**
+ * Flattens a provider error into the fields a classifier could realistically
+ * key on. Deliberately shallow-but-wide: the point of the probe is to learn
+ * which of these fields providers actually populate.
+ */
+function serializeError(error: unknown): SerializedError {
+  const record = asRecord(error) ?? {};
+  const nestedError = asRecord(record.error);
+  const metadata = asRecord(record.$metadata);
+  const responseBody = asRecord(record.response);
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : (readString(record, 'message') ?? stringifySafe(error));
+
+  return {
+    constructorName:
+      typeof error === 'object' && error !== null
+        ? error.constructor.name
+        : typeof error,
+    name: readString(record, 'name'),
+    message: message.slice(0, 4_000),
+    status: readNumber(record, 'status') ?? readNumber(record, 'statusCode'),
+    code: readString(record, 'code'),
+    type: readString(record, 'type'),
+    errorType: nestedError ? readString(nestedError, 'type') : undefined,
+    errorCode: nestedError ? readString(nestedError, 'code') : undefined,
+    errorStatus: nestedError ? readString(nestedError, 'status') : undefined,
+    httpStatusCode: metadata
+      ? readNumber(metadata, 'httpStatusCode')
+      : undefined,
+    awsErrorType: readString(record, '__type'),
+    requestId:
+      readString(record, 'request_id') ?? readString(record, 'requestId'),
+    lcErrorCode: readString(record, 'lc_error_code'),
+    responseData:
+      responseBody?.data != null
+        ? stringifySafe(responseBody.data, 2_000)
+        : undefined,
+    ownProperties:
+      typeof error === 'object' && error !== null
+        ? collectOwnProperties(error)
+        : {},
+    rawBody: nestedError
+      ? stringifySafe(nestedError)
+      : responseBody
+        ? stringifySafe(responseBody)
+        : undefined,
+  };
+}
+
+function envValue(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value != null && value !== ''
+    ? value.replace(/^["']|["']$/g, '')
+    : undefined;
+}
+
+interface CredentialCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+function checkCredentials(provider: Providers): CredentialCheck {
+  switch (provider) {
+    case Providers.OPENAI:
+      return envValue('OPENAI_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'OPENAI_API_KEY not set' };
+    case Providers.AZURE:
+      return envValue('AZURE_OPENAI_API_KEY') &&
+        envValue('AZURE_OPENAI_API_INSTANCE')
+        ? { ok: true }
+        : { ok: false, reason: 'AZURE_OPENAI_API_* not set' };
+    case Providers.ANTHROPIC:
+      return envValue('ANTHROPIC_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'ANTHROPIC_API_KEY not set' };
+    case Providers.BEDROCK:
+      return (envValue('BEDROCK_AWS_ACCESS_KEY_ID') ??
+        envValue('AWS_ACCESS_KEY_ID'))
+        ? { ok: true }
+        : { ok: false, reason: 'BEDROCK_AWS_* credentials not set' };
+    case Providers.GOOGLE:
+      return (envValue('GOOGLE_API_KEY') ?? envValue('GEMINI_API_KEY'))
+        ? { ok: true }
+        : { ok: false, reason: 'GOOGLE_API_KEY / GEMINI_API_KEY not set' };
+    case Providers.VERTEXAI:
+      return (envValue('GOOGLE_APPLICATION_CREDENTIALS') ??
+        envValue('VERTEXAI_KEY_FILE'))
+        ? { ok: true }
+        : { ok: false, reason: 'Vertex credentials not set' };
+    case Providers.OPENROUTER:
+      return envValue('OPENROUTER_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'OPENROUTER_API_KEY not set' };
+    case Providers.DEEPSEEK:
+      return envValue('DEEPSEEK_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'DEEPSEEK_API_KEY not set' };
+    case Providers.XAI:
+      return envValue('XAI_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'XAI_API_KEY not set' };
+    case Providers.MISTRAL:
+    case Providers.MISTRALAI:
+      return envValue('MISTRAL_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'MISTRAL_API_KEY not set' };
+    case Providers.MOONSHOT:
+      return envValue('MOONSHOT_API_KEY')
+        ? { ok: true }
+        : { ok: false, reason: 'MOONSHOT_API_KEY not set' };
+    default:
+      return { ok: false, reason: `no credential rule for ${provider}` };
+  }
+}
+
+/** Output cap kept minimal — a probe never wants generated tokens. */
+const MAX_OUTPUT_TOKENS = 16;
+
+function buildClientOptions(target: ProbeTarget): t.ClientOptions {
+  const { provider, model } = target;
+
+  if (provider === Providers.ANTHROPIC) {
+    return {
+      model,
+      apiKey: envValue('ANTHROPIC_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+      streaming: true,
+    } as t.AnthropicClientOptions;
+  }
+
+  if (provider === Providers.BEDROCK) {
+    const accessKeyId =
+      envValue('BEDROCK_AWS_ACCESS_KEY_ID') ?? envValue('AWS_ACCESS_KEY_ID');
+    const secretAccessKey =
+      envValue('BEDROCK_AWS_SECRET_ACCESS_KEY') ??
+      envValue('AWS_SECRET_ACCESS_KEY');
+    const sessionToken =
+      envValue('BEDROCK_AWS_SESSION_TOKEN') ?? envValue('AWS_SESSION_TOKEN');
+    return {
+      model,
+      region:
+        envValue('BEDROCK_AWS_REGION') ??
+        envValue('AWS_REGION') ??
+        envValue('AWS_DEFAULT_REGION') ??
+        'us-east-1',
+      maxTokens: MAX_OUTPUT_TOKENS,
+      credentials:
+        accessKeyId != null && secretAccessKey != null
+          ? {
+              accessKeyId,
+              secretAccessKey,
+              ...(sessionToken != null ? { sessionToken } : {}),
+            }
+          : undefined,
+    } as t.BedrockConverseClientOptions;
+  }
+
+  if (provider === Providers.GOOGLE) {
+    return {
+      model,
+      apiKey: envValue('GOOGLE_API_KEY') ?? envValue('GEMINI_API_KEY'),
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+    } as t.GoogleClientOptions;
+  }
+
+  if (provider === Providers.VERTEXAI) {
+    return {
+      model,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+      location:
+        envValue('GOOGLE_CLOUD_LOCATION') ??
+        envValue('GOOGLE_LOC') ??
+        'us-central1',
+    } as t.VertexAIClientOptions;
+  }
+
+  if (provider === Providers.OPENROUTER) {
+    return {
+      model,
+      apiKey: envValue('OPENROUTER_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+      configuration: {
+        baseURL:
+          envValue('OPENROUTER_BASE_URL') ?? 'https://openrouter.ai/api/v1',
+      },
+    } as t.OpenAIClientOptions;
+  }
+
+  if (provider === Providers.DEEPSEEK) {
+    return {
+      model,
+      apiKey: envValue('DEEPSEEK_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+    } as t.DeepSeekClientOptions;
+  }
+
+  if (provider === Providers.XAI) {
+    return {
+      model,
+      apiKey: envValue('XAI_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+    } as t.XAIClientOptions;
+  }
+
+  if (provider === Providers.MISTRAL || provider === Providers.MISTRALAI) {
+    return {
+      model,
+      apiKey: envValue('MISTRAL_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+    } as t.MistralAIClientOptions;
+  }
+
+  if (provider === Providers.MOONSHOT) {
+    return {
+      model,
+      apiKey: envValue('MOONSHOT_API_KEY'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+    } as t.OpenAIClientOptions;
+  }
+
+  if (provider === Providers.AZURE) {
+    return {
+      model,
+      azureOpenAIApiKey: envValue('AZURE_OPENAI_API_KEY'),
+      azureOpenAIApiInstanceName: envValue('AZURE_OPENAI_API_INSTANCE'),
+      azureOpenAIApiDeploymentName: envValue('AZURE_OPENAI_API_DEPLOYMENT'),
+      azureOpenAIApiVersion: envValue('AZURE_OPENAI_API_VERSION'),
+      maxTokens: MAX_OUTPUT_TOKENS,
+    } as t.AzureClientOptions;
+  }
+
+  return {
+    model,
+    apiKey: envValue('OPENAI_API_KEY'),
+    maxTokens: MAX_OUTPUT_TOKENS,
+  } as t.OpenAIClientOptions;
+}
+
+/**
+ * The probe matrix. Context windows are the documented input limits; the
+ * probe only needs them to be right enough to overshoot.
+ */
+const PROBE_MATRIX: ProbeTarget[] = [
+  /* ---------------- OpenAI ---------------- */
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-4',
+    contextWindow: 8_192,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-3.5-turbo',
+    contextWindow: 16_385,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-4o-mini',
+    contextWindow: 128_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-4o',
+    contextWindow: 128_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-4.1-nano',
+    contextWindow: 1_047_576,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5-nano',
+    contextWindow: 400_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5-mini',
+    contextWindow: 400_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.4-nano',
+    contextWindow: 400_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.4-mini',
+    contextWindow: 400_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.4',
+    contextWindow: 400_000,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.5',
+    contextWindow: 400_000,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'o4-mini',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'o3',
+    contextWindow: 200_000,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Azure OpenAI ---------------- */
+  {
+    provider: Providers.AZURE,
+    model: envValue('AZURE_MODEL_NAME') ?? 'gpt-4o-mini',
+    contextWindow: 128_000,
+    tier: 'full',
+  },
+
+  /* ---------------- Anthropic ---------------- */
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-haiku-4-5-20251001',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-sonnet-4-5-20250929',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-sonnet-4-6',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-fable-5',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-sonnet-5',
+    contextWindow: 200_000,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-opus-4-5-20251101',
+    contextWindow: 200_000,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-opus-5',
+    contextWindow: 200_000,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Bedrock ---------------- */
+  {
+    provider: Providers.BEDROCK,
+    model: 'anthropic.claude-3-haiku-20240307-v1:0',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    contextWindow: 200_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.amazon.nova-lite-v1:0',
+    contextWindow: 300_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.meta.llama3-1-70b-instruct-v1:0',
+    contextWindow: 128_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'mistral.mistral-large-2407-v1:0',
+    contextWindow: 128_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-opus-4-5-20251101-v1:0',
+    contextWindow: 200_000,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Google (Gemini API) ---------------- */
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-3.1-flash-image',
+    contextWindow: 65_536,
+    tier: 'full',
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-omni-flash-preview',
+    contextWindow: 131_072,
+    tier: 'full',
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-2.5-flash-lite',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-2.5-flash',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-3.5-flash',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-2.5-pro',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Vertex AI ---------------- */
+  {
+    provider: Providers.VERTEXAI,
+    model: 'gemini-2.5-flash-lite',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.VERTEXAI,
+    model: 'gemini-2.5-flash',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+  },
+
+  /* ---------------- OpenRouter (many upstreams) ---------------- */
+  {
+    provider: Providers.OPENROUTER,
+    model: 'qwen/qwen-2.5-7b-instruct',
+    contextWindow: 32_768,
+    tier: 'full',
+    upstream: 'qwen',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'mistralai/mistral-nemo',
+    contextWindow: 131_072,
+    tier: 'full',
+    upstream: 'mistral',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'meta-llama/llama-3.1-8b-instruct',
+    contextWindow: 131_072,
+    tier: 'full',
+    upstream: 'meta',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'openai/gpt-4o-mini',
+    contextWindow: 128_000,
+    tier: 'full',
+    upstream: 'openai',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'anthropic/claude-haiku-4.5',
+    contextWindow: 200_000,
+    tier: 'full',
+    upstream: 'anthropic',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'deepseek/deepseek-chat',
+    contextWindow: 163_840,
+    tier: 'full',
+    upstream: 'deepseek',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'moonshotai/kimi-k2',
+    contextWindow: 131_072,
+    tier: 'full',
+    upstream: 'moonshot',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'google/gemini-3.1-flash-lite-image',
+    contextWindow: 65_536,
+    tier: 'full',
+    upstream: 'google',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'google/gemini-3.5-flash-lite',
+    contextWindow: 1_048_576,
+    tier: 'confirm',
+    upstream: 'google',
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'x-ai/grok-build-0.1',
+    contextWindow: 256_000,
+    tier: 'full',
+    upstream: 'xai',
+  },
+
+  /* ---------------- DeepSeek ---------------- */
+  {
+    provider: Providers.DEEPSEEK,
+    model: 'deepseek-v4-flash',
+    contextWindow: 131_072,
+    tier: 'full',
+  },
+  {
+    provider: Providers.DEEPSEEK,
+    model: 'deepseek-v4-pro',
+    contextWindow: 131_072,
+    tier: 'confirm',
+  },
+
+  /* ---------------- xAI ---------------- */
+  {
+    provider: Providers.XAI,
+    model: 'grok-build-0.1',
+    contextWindow: 256_000,
+    tier: 'full',
+  },
+  {
+    provider: Providers.XAI,
+    model: 'grok-4.5',
+    contextWindow: 500_000,
+    tier: 'confirm',
+  },
+  {
+    provider: Providers.XAI,
+    model: 'grok-4.3',
+    contextWindow: 1_000_000,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Mistral ---------------- */
+  {
+    provider: Providers.MISTRAL,
+    model: 'mistral-tiny-latest',
+    contextWindow: 131_072,
+    tier: 'full',
+  },
+  {
+    provider: Providers.MISTRAL,
+    model: 'mistral-medium-2508',
+    contextWindow: 131_072,
+    tier: 'confirm',
+  },
+
+  /* ---------------- Moonshot ---------------- */
+  {
+    provider: Providers.MOONSHOT,
+    model: 'moonshot-v1-8k',
+    contextWindow: 8_192,
+    tier: 'full',
+  },
+];
+
+interface CliOptions {
+  only?: Set<string>;
+  modelFilter?: string;
+  tier?: ProbeTier;
+  modes: ProbeMode[];
+  out: string;
+  list: boolean;
+  /**
+   * Overrides the tier overshoot. Useful for landing a payload *between* the
+   * model's context window and the account's per-minute token allowance, which
+   * is the only way to observe a provider's true context-window rejection on
+   * accounts whose TPM ceiling sits below the window.
+   */
+  factor?: number;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    modes: ['stream'],
+    out: 'context-overflow-signatures.json',
+    list: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--only') {
+      options.only = new Set(
+        argv[++i]?.split(',').map((value) => value.trim())
+      );
+    } else if (arg === '--model') {
+      options.modelFilter = argv[++i];
+    } else if (arg === '--tier') {
+      options.tier = argv[++i] as ProbeTier;
+    } else if (arg === '--mode') {
+      const mode = argv[++i];
+      options.modes =
+        mode === 'both' ? ['stream', 'invoke'] : [mode as ProbeMode];
+    } else if (arg === '--out') {
+      options.out = argv[++i];
+    } else if (arg === '--factor') {
+      options.factor = Number(argv[++i]);
+    } else if (arg === '--list') {
+      options.list = true;
+    }
+  }
+  return options;
+}
+
+function selectTargets(options: CliOptions): ProbeTarget[] {
+  return PROBE_MATRIX.filter((target) => {
+    if (options.only && !options.only.has(target.provider)) {
+      return false;
+    }
+    if (options.modelFilter && !target.model.includes(options.modelFilter)) {
+      return false;
+    }
+    if (options.tier && target.tier !== options.tier) {
+      return false;
+    }
+    return true;
+  });
+}
+
+async function runProbe(
+  target: ProbeTarget,
+  mode: ProbeMode,
+  factor?: number
+): Promise<ProbeResult> {
+  const tokenTarget = overflowTokenTarget(target, factor);
+  const base: Omit<ProbeResult, 'outcome' | 'durationMs'> = {
+    provider: target.provider,
+    model: target.model,
+    upstream: target.upstream,
+    tier: target.tier,
+    mode,
+    contextWindow: target.contextWindow,
+    approxTokensSent: tokenTarget,
+  };
+
+  const credentials = checkCredentials(target.provider);
+  if (!credentials.ok) {
+    return {
+      ...base,
+      outcome: 'skipped',
+      skipReason: credentials.reason,
+      durationMs: 0,
+    };
+  }
+
+  if (tokenTarget > MAX_PROBE_TOKENS) {
+    return {
+      ...base,
+      outcome: 'skipped',
+      skipReason: `payload would exceed ${MAX_PROBE_TOKENS} tokens`,
+      durationMs: 0,
+    };
+  }
+
+  const messages: BaseMessage[] = [
+    new HumanMessage(buildOverflowText(tokenTarget)),
+  ];
+  const started = Date.now();
+
+  try {
+    const model = initializeModel({
+      provider: target.provider,
+      clientOptions: buildClientOptions(target),
+    }) as t.ChatModel;
+
+    if (mode === 'invoke' || model.stream == null) {
+      await model.invoke(messages);
+    } else {
+      const stream = await model.stream(messages);
+      for await (const _chunk of stream) {
+        void _chunk;
+      }
+    }
+
+    return { ...base, outcome: 'accepted', durationMs: Date.now() - started };
+  } catch (error) {
+    const serialized = serializeError(error);
+    const unavailable =
+      /not found|does not exist|access|not authorized|no such model|invalid model/i.test(
+        serialized.message
+      );
+    return {
+      ...base,
+      outcome: unavailable ? 'unavailable' : 'rejected',
+      durationMs: Date.now() - started,
+      error: serialized,
+    };
+  }
+}
+
+function summarize(result: ProbeResult): string {
+  const head = `${result.provider}/${result.model}${result.mode === 'invoke' ? ' [invoke]' : ''}`;
+  if (result.outcome === 'skipped') {
+    return `SKIP  ${head} — ${result.skipReason}`;
+  }
+  if (result.outcome === 'accepted') {
+    return `ACCEPT ${head} — request was NOT rejected (${result.approxTokensSent} tokens)`;
+  }
+  const error = result.error;
+  const status = error?.status ?? error?.httpStatusCode ?? '?';
+  const code =
+    error?.code ?? error?.errorType ?? error?.awsErrorType ?? error?.name ?? '';
+  const label = result.outcome === 'unavailable' ? 'N/A  ' : 'HIT  ';
+  return `${label} ${head} — ${status} ${code}: ${error?.message.slice(0, 160) ?? ''}`;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const targets = selectTargets(options);
+
+  if (options.list) {
+    for (const target of targets) {
+      console.log(
+        `${target.provider}\t${target.model}\tctx=${target.contextWindow}\ttier=${target.tier}\tprobe≈${overflowTokenTarget(target, options.factor)} tokens`
+      );
+    }
+    return;
+  }
+
+  const results: ProbeResult[] = [];
+  for (const target of targets) {
+    for (const mode of options.modes) {
+      const result = await runProbe(target, mode, options.factor);
+      results.push(result);
+      console.log(summarize(result));
+    }
+  }
+
+  writeFileSync(
+    options.out,
+    JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2)
+  );
+  console.log(`\nWrote ${results.length} probe results to ${options.out}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/scripts/context-overflow-probe.ts
+++ b/src/scripts/context-overflow-probe.ts
@@ -383,6 +383,12 @@ function buildClientOptions(target: ProbeTarget): t.ClientOptions {
         envValue('GOOGLE_CLOUD_LOCATION') ??
         envValue('GOOGLE_LOC') ??
         'us-central1',
+      /**
+       * Matches `utils/llmConfig`. Without it, an environment that supplies
+       * only `VERTEXAI_KEY_FILE` passes the credential check and then records
+       * auth failures instead of overflow signatures.
+       */
+      keyFile: envValue('VERTEXAI_KEY_FILE'),
     } as t.VertexAIClientOptions;
   }
 

--- a/src/scripts/context-overflow-probe.ts
+++ b/src/scripts/context-overflow-probe.ts
@@ -27,6 +27,7 @@ import { config as loadEnv } from 'dotenv';
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import { isSecretKey, redactSecrets } from '@/utils/redactSecrets';
 import { initializeModel } from '@/llm/init';
 import { Providers } from '@/common';
 
@@ -152,8 +153,6 @@ function overflowTokenTarget(
   return Math.max(scaled, target.contextWindow + MIN_OVERSHOOT_TOKENS);
 }
 
-const SECRET_KEY_RE = /key|token|secret|credential|authorization|password/i;
-
 function readString(
   source: Record<string, unknown>,
   key: string
@@ -183,7 +182,9 @@ function stringifySafe(value: unknown, limit = 4_000): string {
     return value.slice(0, limit);
   }
   try {
-    return JSON.stringify(value)?.slice(0, limit) ?? String(value);
+    return (
+      JSON.stringify(redactSecrets(value))?.slice(0, limit) ?? String(value)
+    );
   } catch {
     return String(value).slice(0, limit);
   }
@@ -192,16 +193,12 @@ function stringifySafe(value: unknown, limit = 4_000): string {
 function collectOwnProperties(error: object): Record<string, string> {
   const collected: Record<string, string> = {};
   for (const key of Object.keys(error)) {
-    if (SECRET_KEY_RE.test(key)) {
-      continue;
-    }
     if (key === 'stack' || key === 'message') {
       continue;
     }
-    collected[key] = stringifySafe(
-      (error as Record<string, unknown>)[key],
-      800
-    );
+    collected[key] = isSecretKey(key)
+      ? '[REDACTED]'
+      : stringifySafe((error as Record<string, unknown>)[key], 800);
   }
   return collected;
 }

--- a/src/specs/context-overflow-recovery.live.test.ts
+++ b/src/specs/context-overflow-recovery.live.test.ts
@@ -153,6 +153,12 @@ describeIfLive('context overflow recovery (live)', () => {
             },
           },
           returnContent: true,
+          /**
+           * The assertions below read post-run `AgentContext` state, and the
+           * default cleanup path calls `clearHeavyState()` → `reset()`, which
+           * deliberately undoes the overflow correction for the next turn.
+           */
+          skipCleanup: true,
           tokenCounter,
           customHandlers: {
             [GraphEvents.ON_SUMMARIZE_COMPLETE]: {

--- a/src/specs/context-overflow-recovery.live.test.ts
+++ b/src/specs/context-overflow-recovery.live.test.ts
@@ -191,7 +191,15 @@ describeIfLive('context overflow recovery (live)', () => {
         expect(agentContext?.maxContextTokens).toBeLessThan(
           testCase.contextWindow * 2
         );
-        expect(summarizeEvents.length).toBeGreaterThan(0);
+        /**
+         * No summarization assertion: the first recovery compacts by
+         * compressing tool output, so a run that fits after compression alone
+         * never spends a summarization call. Any summary event that does
+         * arrive must at least carry no error.
+         */
+        for (const event of summarizeEvents) {
+          expect(event.error).toBeUndefined();
+        }
       }
     );
   }

--- a/src/specs/context-overflow-recovery.live.test.ts
+++ b/src/specs/context-overflow-recovery.live.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Live end-to-end verification that a real provider rejection for an
+ * over-limit prompt is absorbed by forced compaction instead of surfacing.
+ *
+ * Each case deliberately configures `maxContextTokens` far above the model's
+ * real window, so the proactive pruner does not prevent the overflow and the
+ * reactive recovery path is what gets exercised.
+ *
+ * Run with:
+ * RUN_CONTEXT_OVERFLOW_LIVE_TESTS=1 OPENROUTER_API_KEY=... npm test -- context-overflow-recovery.live.test.ts --runInBand
+ *
+ * Cases self-skip when their provider credentials are absent. Models are the
+ * smallest-window, cheapest option per provider — the prompt has to exceed
+ * the window for the test to mean anything, so a large window is a large bill.
+ *
+ * The Bedrock case needs `NODE_OPTIONS='--experimental-vm-modules'`; the AWS
+ * SDK uses a dynamic import that jest otherwise refuses.
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { createTokenCounter } from '@/utils/tokens';
+import { hasAnyEnv, hasEnv } from '@/specs/spec.utils';
+import { GraphEvents, Providers } from '@/common';
+import { Run } from '@/run';
+
+jest.setTimeout(300_000);
+
+const liveEnabled = process.env.RUN_CONTEXT_OVERFLOW_LIVE_TESTS === '1';
+
+interface LiveCase {
+  label: string;
+  provider: Providers;
+  model: string;
+  /** The model's real input window. */
+  contextWindow: number;
+  envKeys: readonly string[];
+  clientOptions: Record<string, unknown>;
+}
+
+const LIVE_CASES: readonly LiveCase[] = [
+  {
+    label: 'openrouter / qwen-2.5-7b (32k window)',
+    provider: Providers.OPENROUTER,
+    model: 'qwen/qwen-2.5-7b-instruct',
+    contextWindow: 32_768,
+    envKeys: ['OPENROUTER_API_KEY'],
+    clientOptions: {
+      apiKey: process.env.OPENROUTER_API_KEY,
+      configuration: {
+        baseURL:
+          process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
+      },
+    },
+  },
+  {
+    /**
+     * Google's text models all carry a ~1M window, which would make this the
+     * most expensive case in the file by an order of magnitude. This model
+     * accepts ordinary text and caps its input at 64k, so it exercises the
+     * same Gemini API rejection for a fraction of the tokens.
+     */
+    label: 'google / gemini-3.1-flash-image (64k window)',
+    provider: Providers.GOOGLE,
+    model: 'gemini-3.1-flash-image',
+    contextWindow: 65_536,
+    envKeys: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
+    clientOptions: {
+      apiKey: process.env.GOOGLE_API_KEY ?? process.env.GEMINI_API_KEY,
+    },
+  },
+  {
+    label: 'anthropic / haiku (200k window)',
+    provider: Providers.ANTHROPIC,
+    model: 'claude-haiku-4-5-20251001',
+    contextWindow: 200_000,
+    envKeys: ['ANTHROPIC_API_KEY'],
+    clientOptions: { apiKey: process.env.ANTHROPIC_API_KEY },
+  },
+  {
+    label: 'bedrock / haiku (200k window)',
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    contextWindow: 200_000,
+    envKeys: ['BEDROCK_AWS_ACCESS_KEY_ID', 'AWS_ACCESS_KEY_ID'],
+    clientOptions: {
+      region:
+        process.env.BEDROCK_AWS_REGION ?? process.env.AWS_REGION ?? 'us-east-1',
+    },
+  },
+];
+
+/**
+ * Single-token words, so an N-word message is at least N tokens under every
+ * provider's tokenizer — the prompt must clear the window with certainty,
+ * since a request that squeaks under it is billed in full and proves nothing.
+ */
+const FILLER =
+  'the quick brown fox jumps over lazy dog and then runs past'.split(' ');
+
+function buildOversizedHistory(totalWords: number): BaseMessage[] {
+  const perMessage = Math.ceil(totalWords / 4);
+  const messages: BaseMessage[] = [];
+  for (let turn = 0; turn < 4; turn++) {
+    const words: string[] = new Array(perMessage);
+    for (let i = 0; i < perMessage; i++) {
+      words[i] = FILLER[(i + turn) % FILLER.length];
+    }
+    messages.push(new HumanMessage(`Notes part ${turn}: ${words.join(' ')}`));
+  }
+  messages.push(
+    new HumanMessage('In one short sentence, what were those notes about?')
+  );
+  return messages;
+}
+
+const describeIfLive = liveEnabled ? describe : describe.skip;
+
+describeIfLive('context overflow recovery (live)', () => {
+  for (const testCase of LIVE_CASES) {
+    const runnable = hasAnyEnv(testCase.envKeys);
+    const maybeIt = runnable ? it : it.skip;
+
+    maybeIt(
+      `recovers without surfacing an error — ${testCase.label}`,
+      async () => {
+        const summarizeEvents: t.SummarizeCompleteEvent[] = [];
+        const tokenCounter = await createTokenCounter();
+
+        const run = await Run.create<t.IState>({
+          runId: `overflow-live-${testCase.provider}-${Date.now()}`,
+          graphConfig: {
+            type: 'standard',
+            llmConfig: {
+              provider: testCase.provider,
+              ...testCase.clientOptions,
+              model: testCase.model,
+            } as t.LLMConfig,
+            /**
+             * Deliberately wrong, by a wide margin: the pruner will happily
+             * build a prompt the provider cannot accept, which is exactly the
+             * situation the recovery path exists for.
+             */
+            maxContextTokens: testCase.contextWindow * 2,
+            summarizationEnabled: true,
+            summarizationConfig: {
+              provider: testCase.provider,
+              model: testCase.model,
+            },
+          },
+          returnContent: true,
+          tokenCounter,
+          customHandlers: {
+            [GraphEvents.ON_SUMMARIZE_COMPLETE]: {
+              handle: (_event: string, data: t.StreamEventData): void => {
+                summarizeEvents.push(
+                  data as unknown as t.SummarizeCompleteEvent
+                );
+              },
+            },
+          },
+        });
+
+        const messages = buildOversizedHistory(
+          Math.ceil(testCase.contextWindow * 1.3)
+        );
+
+        const content = await run.processStream({ messages }, {
+          configurable: { thread_id: `overflow-live-${testCase.provider}` },
+          streamMode: 'values',
+          version: 'v2',
+        } as never);
+
+        expect(content).toBeDefined();
+        expect(Array.isArray(content)).toBe(true);
+        expect((content ?? []).length).toBeGreaterThan(0);
+
+        const agentContext = run.Graph?.agentContexts.get('default');
+        expect(agentContext?.overflowRecoveryAttempts).toBeGreaterThan(0);
+        /** The corrected budget must be below the fiction we started with. */
+        expect(agentContext?.maxContextTokens).toBeLessThan(
+          testCase.contextWindow * 2
+        );
+        expect(summarizeEvents.length).toBeGreaterThan(0);
+      }
+    );
+  }
+
+  it('has at least one runnable provider configured', () => {
+    const anyRunnable = LIVE_CASES.some((testCase) =>
+      testCase.envKeys.some(hasEnv)
+    );
+    expect(anyRunnable).toBe(true);
+  });
+});

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1303,3 +1303,142 @@ describe('emoji-heavy content does not break summarization', () => {
     expect(result.messages!.length).toBeGreaterThan(0);
   });
 });
+
+describe('createSummarizeNode — overflow recovery', () => {
+  /**
+   * The first recovery compacts deterministically: re-pruning under the
+   * corrected budget drives the pruner's tool-output compression. Spending a
+   * summarization call there would cost money and risk replacing message
+   * content that compression alone can shrink.
+   */
+  it('skips the model call when summarization is not yet escalated', async () => {
+    const modelFactory = jest.spyOn(providers, 'getChatModelClass');
+    const agentContext = createAgentContext();
+    const graph = mockGraph(() => {});
+    const node = createSummarizeNode({ agentContext, graph, generateStepId });
+
+    const result = await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+          reason: 'overflow',
+          allowSummarization: false,
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(modelFactory).not.toHaveBeenCalled();
+    expect(result.summarizationRequest).toBeUndefined();
+    /** State untouched, so the agent node re-prunes and retries. */
+    expect(result.messages).toBeUndefined();
+  });
+
+  it('runs the model call once the recovery escalates', async () => {
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel('Escalated summary');
+        }
+      } as never
+    );
+    const agentContext = createAgentContext();
+    const graph = mockGraph(() => {});
+    const node = createSummarizeNode({ agentContext, graph, generateStepId });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+          reason: 'overflow',
+          allowSummarization: true,
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(agentContext.getSummaryText()).toContain('Escalated summary');
+  });
+
+  /**
+   * The metadata stub describes the history instead of summarizing it, so
+   * committing it removes the head and keeps nothing of what it said. That is
+   * never an acceptable way to paper over an overflow.
+   */
+  it('keeps history when the escalated summarizer falls back to a stub', async () => {
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: (): never => {
+              throw new Error(
+                '400 prompt is too long: 900 tokens > 500 maximum'
+              );
+            },
+            stream: (): never => {
+              throw new Error(
+                '400 prompt is too long: 900 tokens > 500 maximum'
+              );
+            },
+          };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext();
+    const graph = mockGraph(() => {});
+    const node = createSummarizeNode({ agentContext, graph, generateStepId });
+
+    const result = await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+          reason: 'overflow',
+          allowSummarization: true,
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(agentContext.hasSummary()).toBe(false);
+    expect(result.messages).toBeUndefined();
+  });
+
+  it('still commits a stub for a configured trigger, preserving prior behavior', async () => {
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: (): never => {
+              throw new Error('upstream unavailable');
+            },
+            stream: (): never => {
+              throw new Error('upstream unavailable');
+            },
+          };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext();
+    const graph = mockGraph(() => {});
+    const node = createSummarizeNode({ agentContext, graph, generateStepId });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(agentContext.hasSummary()).toBe(true);
+  });
+});

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -774,6 +774,28 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
+    /**
+     * Overflow recovery routes through this node purely to get back to the
+     * agent node with a corrected budget. When summarization was never
+     * enabled, making a model call here would be an unrequested cost the
+     * caller opted out of — the re-prune against the lower budget is the
+     * whole fix.
+     */
+    if (
+      request.reason === 'overflow' &&
+      agentContext.summarizationEnabled !== true
+    ) {
+      emitAgentLog(
+        config,
+        'debug',
+        'summarize',
+        'Overflow recovery re-prune — summarization not enabled, no summary generated',
+        { maxContextTokens: agentContext.maxContextTokens },
+        { runId: graph.runId, agentId: request.agentId }
+      );
+      return { summarizationRequest: undefined };
+    }
+
     const maxCtx = agentContext.maxContextTokens ?? 0;
     if (maxCtx > 0 && agentContext.instructionTokens >= maxCtx) {
       emitAgentLog(

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -16,6 +16,10 @@ import {
   type PromptCacheTtl,
 } from '@/messages/cache';
 import {
+  DEFAULT_RETAIN_RECENT_TURNS,
+  splitAtRecencyBoundary,
+} from '@/messages/recency';
+import {
   Constants,
   ContentTypes,
   GraphEvents,
@@ -25,7 +29,6 @@ import {
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
-import { splitAtRecencyBoundary } from '@/messages/recency';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
@@ -43,8 +46,6 @@ const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
  * `retainRecent.turns` to `0` reverts to the legacy "summarize every
  * message" behavior.
  */
-const DEFAULT_RETAIN_RECENT_TURNS = 2;
-
 /**
  * Token overhead of the XML wrapper + instruction text added around the
  * summary at injection time in AgentContext.buildSystemRunnable:

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -517,7 +517,16 @@ async function executeSummarizationWithFallback(params: {
   stepId: string;
   usePromptCache: boolean;
   log: LogFn;
-}): Promise<{ text: string; usage?: Partial<UsageMetadata> }> {
+}): Promise<{
+  text: string;
+  usage?: Partial<UsageMetadata>;
+  /**
+   * True when every model call failed and `text` is the generated metadata
+   * stub rather than a real summary. Callers that would replace history with
+   * this need to know it carries none of the original content.
+   */
+  usedMetadataStub?: boolean;
+}> {
   const {
     agentContext,
     messages,
@@ -532,6 +541,7 @@ async function executeSummarizationWithFallback(params: {
 
   let summaryText = '';
   let summaryUsage: Partial<UsageMetadata> | undefined;
+  let usedMetadataStub = false;
 
   try {
     /**
@@ -634,10 +644,11 @@ async function executeSummarizationWithFallback(params: {
         }
       );
       summaryText = generateMetadataStub(messages);
+      usedMetadataStub = true;
     }
   }
 
-  return { text: summaryText, usage: summaryUsage };
+  return { text: summaryText, usage: summaryUsage, usedMetadataStub };
 }
 
 /** Dispatches run step completion, ON_SUMMARIZE_COMPLETE, and rebuilds token map. */
@@ -776,21 +787,27 @@ export function createSummarizeNode({
 
     /**
      * Overflow recovery routes through this node purely to get back to the
-     * agent node with a corrected budget. When summarization was never
-     * enabled, making a model call here would be an unrequested cost the
-     * caller opted out of — the re-prune against the lower budget is the
-     * whole fix.
+     * agent node with a corrected budget, and deliberately spends no model
+     * call on its first attempt: re-pruning under the raised context pressure
+     * drives the pruner's tool-output compression and masking, which is
+     * cheaper than a summary and cannot lose message content. Summarization
+     * is also skipped outright when the caller never enabled it.
      */
     if (
       request.reason === 'overflow' &&
-      agentContext.summarizationEnabled !== true
+      (request.allowSummarization !== true ||
+        agentContext.summarizationEnabled !== true)
     ) {
       emitAgentLog(
         config,
         'debug',
         'summarize',
-        'Overflow recovery re-prune — summarization not enabled, no summary generated',
-        { maxContextTokens: agentContext.maxContextTokens },
+        'Overflow recovery re-prune — compressing tool output without a summarization call',
+        {
+          maxContextTokens: agentContext.maxContextTokens,
+          summarizationEnabled: agentContext.summarizationEnabled === true,
+          allowSummarization: request.allowSummarization === true,
+        },
         { runId: graph.runId, agentId: request.agentId }
       );
       return { summarizationRequest: undefined };
@@ -998,16 +1015,48 @@ export function createSummarizeNode({
       }
       : undefined;
 
-    const { text: rawText, usage: summaryUsage } =
-      await executeSummarizationWithFallback({
-        agentContext,
-        messages: messagesToRefine,
-        clientConfig,
-        summarizeConfig,
-        stepId,
-        usePromptCache: isSelfSummarizeModel && hasPromptCache,
-        log,
-      });
+    const {
+      text: rawText,
+      usage: summaryUsage,
+      usedMetadataStub,
+    } = await executeSummarizationWithFallback({
+      agentContext,
+      messages: messagesToRefine,
+      clientConfig,
+      summarizeConfig,
+      stepId,
+      usePromptCache: isSelfSummarizeModel && hasPromptCache,
+      log,
+    });
+
+    /**
+     * The metadata stub describes the history rather than summarizing it, so
+     * committing it means removing the head and keeping nothing of what it
+     * said. That trade is never worth making to paper over an overflow: the
+     * recovery would "succeed" only by destroying the conversation it was
+     * supposed to preserve. Leave state untouched and let the provider error
+     * surface instead.
+     */
+    if (usedMetadataStub === true && request.reason === 'overflow') {
+      log(
+        'warn',
+        'Overflow summarization failed; keeping history rather than replacing it with a metadata stub'
+      );
+      agentContext.markSummarizationTriggered(state.messages.length);
+      if (runnableConfig) {
+        await safeDispatchCustomEvent(
+          GraphEvents.ON_SUMMARIZE_COMPLETE,
+          {
+            id: stepId,
+            agentId: request.agentId,
+            error:
+              'Summarization failed during overflow recovery; conversation history was preserved',
+          } satisfies t.SummarizeCompleteEvent,
+          runnableConfig
+        );
+      }
+      return { summarizationRequest: undefined };
+    }
 
     if (!rawText) {
       agentContext.markSummarizationTriggered(0);

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1043,6 +1043,19 @@ export function createSummarizeNode({
         'Overflow summarization failed; keeping history rather than replacing it with a metadata stub'
       );
       agentContext.markSummarizationTriggered(state.messages.length);
+      /**
+       * The run step was already dispatched, so it has to be resolved here or
+       * consumers tracking step lifecycle keep an unfinished placeholder for
+       * the rest of the run.
+       */
+      await graph.dispatchRunStepCompleted(
+        stepId,
+        {
+          type: 'summary',
+          summary: placeholderSummary,
+        } satisfies t.SummaryCompleted,
+        runnableConfig
+      );
       if (runnableConfig) {
         await safeDispatchCustomEvent(
           GraphEvents.ON_SUMMARIZE_COMPLETE,

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -137,10 +137,17 @@ export type SharedLLMConfig = {
   _lc_stream_delay?: number;
 };
 
+export interface FallbackConfig {
+  provider: Providers;
+  clientOptions?: ClientOptions;
+  /** Context window used to corroborate ambiguous fallback overflow errors. */
+  maxContextTokens?: number;
+}
+
 export type LLMConfig = SharedLLMConfig &
   ClientOptions & {
     /** Optional provider fallbacks in order of attempt */
-    fallbacks?: Array<{ provider: Providers; clientOptions?: ClientOptions }>;
+    fallbacks?: FallbackConfig[];
   };
 
 export type ProviderOptionsMap = {

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -63,6 +63,17 @@ export interface SummarizeResult {
 export interface SummarizationNodeInput {
   remainingContextTokens: number;
   agentId: string;
+  /**
+   * Why the detour was requested.
+   *
+   * - `trigger` (default): the configured summarization trigger fired during
+   *   the pre-call budget check.
+   * - `overflow`: the provider rejected the prompt as too large and the run
+   *   is compacting to recover. When summarization is not enabled, this
+   *   variant performs no model call — the corrected budget alone is what the
+   *   retry needs.
+   */
+  reason?: 'trigger' | 'overflow';
 }
 
 export interface SummarizeStartEvent {

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -74,6 +74,17 @@ export interface SummarizationNodeInput {
    *   retry needs.
    */
   reason?: 'trigger' | 'overflow';
+  /**
+   * Whether an overflow recovery may spend a summarization model call.
+   *
+   * The first recovery deliberately does not: re-pruning against the
+   * corrected budget raises context pressure, which drives the pruner's
+   * existing tool-output compression and masking. That is cheaper, needs no
+   * model call, and cannot lose message content the way a summary can. Only
+   * when deterministic compression proves insufficient does the next attempt
+   * allow the summarizer to run.
+   */
+  allowSummarization?: boolean;
 }
 
 export interface SummarizeStartEvent {

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  getContextOverflowInfo,
+  isLikelyContextOverflowError,
+  isContextOverflowError,
+  extractErrorMessage,
+} from '@/utils/errors';
+import {
+  OVERFLOW_SIGNATURES,
+  NON_OVERFLOW_SIGNATURES,
+} from './fixtures/contextOverflowSignatures';
+import { Providers } from '@/common';
+
+/** Enough pressure to satisfy the corroboration gate for ambiguous errors. */
+const UNDER_PRESSURE = {
+  estimatedPromptTokens: 190_000,
+  maxContextTokens: 200_000,
+};
+
+describe('getContextOverflowInfo — captured provider signatures', () => {
+  for (const signature of OVERFLOW_SIGNATURES) {
+    const label = `${signature.provider}/${signature.model} (${signature.thrownAs})`;
+
+    it(`classifies ${label}`, () => {
+      const info = getContextOverflowInfo(signature.error, {
+        provider: signature.provider,
+        ...(signature.requiresContextPressure === true ? UNDER_PRESSURE : {}),
+      });
+
+      expect(info).not.toBeNull();
+      expect(info?.kind).toBe(signature.expected.kind);
+      expect(info?.provider).toBe(signature.provider);
+      expect(info?.limitTokens).toBe(signature.expected.limitTokens);
+      expect(info?.requestedTokens).toBe(signature.expected.requestedTokens);
+    });
+  }
+
+  it('covers every provider the SDK ships a client for, or records why not', () => {
+    const covered = new Set(OVERFLOW_SIGNATURES.map((s) => s.provider));
+    /**
+     * Azure and Moonshot reuse the OpenAI client verbatim, and MistralAI is
+     * the same client as Mistral, so the captured OpenAI/Mistral signatures
+     * apply unchanged. Every other provider has its own captured entry.
+     */
+    const byOpenAIClient = new Set([
+      Providers.AZURE,
+      Providers.MOONSHOT,
+      Providers.MISTRALAI,
+    ]);
+    for (const provider of Object.values(Providers)) {
+      expect(covered.has(provider) || byOpenAIClient.has(provider)).toBe(true);
+    }
+  });
+});
+
+describe('getContextOverflowInfo — errors compaction cannot fix', () => {
+  for (const signature of NON_OVERFLOW_SIGNATURES) {
+    it(`ignores ${signature.label}`, () => {
+      expect(getContextOverflowInfo(signature.error)).toBeNull();
+      expect(isContextOverflowError(signature.error)).toBe(false);
+    });
+  }
+
+  it('ignores an unrelated error entirely', () => {
+    expect(getContextOverflowInfo(new Error('socket hang up'))).toBeNull();
+    expect(getContextOverflowInfo(undefined)).toBeNull();
+    expect(getContextOverflowInfo(null)).toBeNull();
+  });
+});
+
+describe('token-bucket rejections', () => {
+  const requestTooLarge = OVERFLOW_SIGNATURES.find(
+    (s) => s.expected.kind === 'request_too_large'
+  );
+
+  it('treats a request that alone overruns the bucket as recoverable', () => {
+    const info = getContextOverflowInfo(requestTooLarge?.error);
+    expect(info?.kind).toBe('request_too_large');
+    expect(info?.requestedTokens).toBeGreaterThan(info?.limitTokens ?? 0);
+  });
+
+  it('leaves ordinary throttling alone even when phrased with the same fields', () => {
+    const throttled = {
+      name: 'Error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+      type: 'tokens',
+      message:
+        '429 Request too large for gpt-4o on tokens per min (TPM): Limit 30000, Requested 900.',
+    };
+    expect(getContextOverflowInfo(throttled)).toBeNull();
+  });
+});
+
+describe('ambiguous signatures require corroboration', () => {
+  const vertex = OVERFLOW_SIGNATURES.find(
+    (s) => s.requiresContextPressure === true
+  );
+
+  it('does not fire without a caller-side pressure signal', () => {
+    expect(
+      getContextOverflowInfo(vertex?.error, { provider: Providers.VERTEXAI })
+    ).toBeNull();
+  });
+
+  it('does not fire when the prompt was comfortably inside the budget', () => {
+    expect(
+      getContextOverflowInfo(vertex?.error, {
+        provider: Providers.VERTEXAI,
+        estimatedPromptTokens: 20_000,
+        maxContextTokens: 200_000,
+      })
+    ).toBeNull();
+  });
+
+  it('fires once the prompt is near the budget', () => {
+    expect(
+      getContextOverflowInfo(vertex?.error, {
+        provider: Providers.VERTEXAI,
+        ...UNDER_PRESSURE,
+      })
+    ).not.toBeNull();
+  });
+
+  it('still reports a Vertex error that did carry a reason', () => {
+    const withBody = {
+      name: 'Error',
+      message:
+        'Google request failed with status code 400: {"error":{"code":400,"message":"The input token count exceeds the maximum number of tokens allowed (1048576).","status":"INVALID_ARGUMENT"}}',
+    };
+    const info = getContextOverflowInfo(withBody, {
+      provider: Providers.VERTEXAI,
+    });
+    expect(info?.limitTokens).toBe(1_048_576);
+  });
+});
+
+describe('reported numbers are usable for recalibration', () => {
+  it('reads the true ceiling even when it differs from what we configured', () => {
+    const deepseek = OVERFLOW_SIGNATURES.find(
+      (s) => s.provider === Providers.DEEPSEEK
+    );
+    const info = getContextOverflowInfo(deepseek?.error);
+    expect(info?.limitTokens).toBe(1_048_565);
+  });
+
+  it('reads the provider-side count of the prompt we sent', () => {
+    const bedrock = OVERFLOW_SIGNATURES.find(
+      (s) => s.model === 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+    );
+    const info = getContextOverflowInfo(bedrock?.error);
+    expect(info?.requestedTokens).toBe(207_848);
+    expect(info?.limitTokens).toBe(200_000);
+  });
+});
+
+describe('back-compatible helpers', () => {
+  it('accepts a bare message string', () => {
+    expect(
+      isContextOverflowError(
+        'prompt is too long: 274468 tokens > 200000 maximum'
+      )
+    ).toBe(true);
+    expect(isContextOverflowError('connection reset')).toBe(false);
+  });
+
+  it('treats body-size rejections as likely overflow only in the loose check', () => {
+    const payload = { status: 413, message: 'request entity too large' };
+    expect(isContextOverflowError(payload)).toBe(false);
+    expect(isLikelyContextOverflowError(payload)).toBe(true);
+  });
+
+  it('keeps the loose check away from throttling and auth', () => {
+    for (const signature of NON_OVERFLOW_SIGNATURES) {
+      expect(isLikelyContextOverflowError(signature.error)).toBe(false);
+    }
+  });
+
+  it('extracts messages from nested provider shapes', () => {
+    expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+    expect(extractErrorMessage({ error: { message: 'nested' } })).toBe(
+      'nested'
+    );
+    expect(extractErrorMessage('raw')).toBe('raw');
+    expect(extractErrorMessage(null)).toBe('');
+  });
+});

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -223,6 +223,10 @@ describe('back-compatible helpers', () => {
     expect(isContextOverflowError('connection reset')).toBe(false);
   });
 
+  it('retains the legacy space-separated context overflow signature', () => {
+    expect(isContextOverflowError('context length exceeded')).toBe(true);
+  });
+
   it('treats body-size rejections as likely overflow only in the loose check', () => {
     const payload = { status: 413, message: 'request entity too large' };
     expect(isContextOverflowError(payload)).toBe(false);

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -135,6 +135,52 @@ describe('ambiguous signatures require corroboration', () => {
   });
 });
 
+describe('prompt size is separated from completion-inclusive totals', () => {
+  it('reads the input-only figure out of OpenRouter’s breakdown', () => {
+    const openrouter = OVERFLOW_SIGNATURES.find(
+      (s) => s.provider === Providers.OPENROUTER
+    );
+    const info = getContextOverflowInfo(openrouter?.error);
+    expect(info?.requestedTokens).toBe(56_827);
+    /** 56,811 of text input; the remaining 16 were the output allowance. */
+    expect(info?.promptTokens).toBe(56_811);
+  });
+
+  it('reads the input-only figure out of DeepSeek’s breakdown', () => {
+    const deepseek = OVERFLOW_SIGNATURES.find(
+      (s) => s.provider === Providers.DEEPSEEK
+    );
+    const info = getContextOverflowInfo(deepseek?.error);
+    expect(info?.requestedTokens).toBe(1_179_668);
+    expect(info?.promptTokens).toBe(1_179_652);
+  });
+
+  it('treats an unqualified input-only count as the prompt', () => {
+    const anthropic = OVERFLOW_SIGNATURES.find(
+      (s) => s.provider === Providers.ANTHROPIC
+    );
+    const info = getContextOverflowInfo(anthropic?.error);
+    expect(info?.promptTokens).toBe(info?.requestedTokens);
+  });
+
+  it('refuses to read a token-bucket total as a prompt measurement', () => {
+    const openai = OVERFLOW_SIGNATURES.find(
+      (s) => s.expected.kind === 'request_too_large'
+    );
+    const info = getContextOverflowInfo(openai?.error);
+    /** "Requested 480002" folds in the completion allowance. */
+    expect(info?.requestedTokens).toBe(480_002);
+    expect(info?.promptTokens).toBeUndefined();
+  });
+
+  it('refuses to read xAI’s request total as a prompt measurement', () => {
+    const xai = OVERFLOW_SIGNATURES.find((s) => s.provider === Providers.XAI);
+    const info = getContextOverflowInfo(xai?.error);
+    expect(info?.requestedTokens).toBe(332_986);
+    expect(info?.promptTokens).toBeUndefined();
+  });
+});
+
 describe('reported numbers are usable for recalibration', () => {
   it('reads the true ceiling even when it differs from what we configured', () => {
     const deepseek = OVERFLOW_SIGNATURES.find(

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -79,6 +79,19 @@ describe('token-bucket rejections', () => {
     expect(info?.requestedTokens).toBeGreaterThan(info?.limitTokens ?? 0);
   });
 
+  it('treats an exactly-filling request as throttling, not overflow', () => {
+    /** It fits an empty bucket, so waiting can succeed — compaction would lose context needlessly. */
+    const exactFit = {
+      name: 'Error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+      type: 'tokens',
+      message:
+        '429 Request too large for gpt-4o on tokens per min (TPM): Limit 30000, Requested 30000.',
+    };
+    expect(getContextOverflowInfo(exactFit)).toBeNull();
+  });
+
   it('leaves ordinary throttling alone even when phrased with the same fields', () => {
     const throttled = {
       name: 'Error',

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -227,6 +227,21 @@ describe('back-compatible helpers', () => {
     expect(isContextOverflowError('context length exceeded')).toBe(true);
   });
 
+  it('reads structured overflow reason fields alongside generic messages', () => {
+    expect(
+      isContextOverflowError({
+        message: 'Bad Request',
+        code: 'context_length_exceeded',
+      })
+    ).toBe(true);
+    expect(
+      isContextOverflowError({
+        message: 'Bad Request',
+        error: { type: 'context_length_exceeded' },
+      })
+    ).toBe(true);
+  });
+
   it('treats body-size rejections as likely overflow only in the loose check', () => {
     const payload = { status: 413, message: 'request entity too large' };
     expect(isContextOverflowError(payload)).toBe(false);

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -227,6 +227,11 @@ describe('back-compatible helpers', () => {
     expect(isContextOverflowError('context length exceeded')).toBe(true);
   });
 
+  it('retains the legacy input-too-long signature', () => {
+    expect(getContextOverflowInfo(new Error('Input too long'))).not.toBeNull();
+    expect(isContextOverflowError('Input too long')).toBe(true);
+  });
+
   it('reads structured overflow reason fields alongside generic messages', () => {
     expect(
       isContextOverflowError({

--- a/src/utils/__tests__/fixtures/contextOverflowSignatures.ts
+++ b/src/utils/__tests__/fixtures/contextOverflowSignatures.ts
@@ -1,0 +1,336 @@
+/**
+ * Provider error signatures captured from live over-limit requests.
+ *
+ * Every entry below was produced by `src/scripts/context-overflow-probe.ts`
+ * sending a prompt past the model's context window and recording what came
+ * back. Account identifiers and request ids have been replaced with
+ * placeholders; the wording, status codes, and nesting are verbatim.
+ *
+ * Treat these as evidence, not examples: if a provider changes its wording,
+ * re-run the probe and update the fixture rather than loosening the matcher.
+ */
+import { Providers } from '@/common';
+
+export interface OverflowSignature {
+  provider: Providers;
+  model: string;
+  /** Class the SDK actually threw, for reference in review. */
+  thrownAs: string;
+  /**
+   * Stand-in for the thrown error carrying exactly the fields the classifier
+   * reads. Nested bodies are kept as the strings the SDKs attach.
+   */
+  error: Record<string, unknown>;
+  expected: {
+    kind: 'context_window' | 'request_too_large';
+    limitTokens?: number;
+    requestedTokens?: number;
+  };
+  /** Set when the signature is only decidable with caller-side corroboration. */
+  requiresContextPressure?: boolean;
+}
+
+export const OVERFLOW_SIGNATURES: readonly OverflowSignature[] = [
+  {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-haiku-4-5-20251001',
+    thrownAs: 'ContextOverflowError',
+    error: {
+      name: 'ContextOverflowError',
+      lc_error_code: 'CONTEXT_OVERFLOW',
+      message:
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 274468 tokens > 200000 maximum"},"request_id":"req_test"}\n\nTroubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/CONTEXT_OVERFLOW/\n',
+      cause:
+        '{"status":400,"headers":{},"requestID":"req_test","error":{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 274468 tokens > 200000 maximum"},"request_id":"req_test"},"type":"invalid_request_error"}',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 200_000,
+      requestedTokens: 274_468,
+    },
+  },
+  {
+    provider: Providers.OPENAI,
+    model: 'gpt-4o-mini',
+    thrownAs: 'ContextOverflowError',
+    error: {
+      name: 'ContextOverflowError',
+      message:
+        '400 This model\'s maximum context length is 128000 tokens. However, your messages resulted in 149767 tokens. Please reduce the length of the messages.',
+      cause:
+        '{"status":400,"headers":{},"requestID":"req_test","error":{"message":"This model\'s maximum context length is 128000 tokens. However, your messages resulted in 149767 tokens. Please reduce the length of the messages.","type":"invalid_request_error","param":"messages","code":"context_length_exceeded"},"code":"context_length_exceeded","param":"messages","type":"invalid_request_error"}',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 128_000,
+      requestedTokens: 149_767,
+    },
+  },
+  {
+    /**
+     * The common OpenAI symptom in practice: the request is large enough to
+     * overrun the per-minute token bucket, so it is rejected as a 429 before
+     * context validation ever runs. LangChain labels it MODEL_RATE_LIMIT.
+     */
+    provider: Providers.OPENAI,
+    model: 'gpt-5-nano',
+    thrownAs: 'RateLimitError',
+    error: {
+      name: 'Error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+      type: 'tokens',
+      lc_error_code: 'MODEL_RATE_LIMIT',
+      message:
+        '429 Request too large for gpt-5-nano in organization org-test on tokens per min (TPM): Limit 200000, Requested 480002. The input or output tokens must be reduced in order to run successfully. Visit https://platform.openai.com/account/rate-limits to learn more.\n\nTroubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/MODEL_RATE_LIMIT/\n',
+      error:
+        '{"message":"Request too large for gpt-5-nano in organization org-test on tokens per min (TPM): Limit 200000, Requested 480002. The input or output tokens must be reduced in order to run successfully.","type":"tokens","param":null,"code":"rate_limit_exceeded"}',
+    },
+    expected: {
+      kind: 'request_too_large',
+      limitTokens: 200_000,
+      requestedTokens: 480_002,
+    },
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    thrownAs: 'ValidationException',
+    error: {
+      name: 'ValidationException',
+      message:
+        'The model returned the following errors: prompt is too long: 207848 tokens > 200000 maximum',
+      $metadata: { httpStatusCode: 400 },
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 200_000,
+      requestedTokens: 207_848,
+    },
+  },
+  {
+    /** Same provider, same model family, no numbers reported. */
+    provider: Providers.BEDROCK,
+    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    thrownAs: 'ValidationException',
+    error: {
+      name: 'ValidationException',
+      message:
+        'The model returned the following errors: Input is too long for requested model.',
+      $metadata: { httpStatusCode: 400 },
+    },
+    expected: { kind: 'context_window' },
+  },
+  {
+    /**
+     * Bedrock's most dangerous shape: the overflow arrives inside a
+     * successful HTTP 200 stream, so status-code-based detection is useless.
+     */
+    provider: Providers.BEDROCK,
+    model: 'us.amazon.nova-lite-v1:0',
+    thrownAs: 'Error',
+    error: {
+      name: 'Error',
+      message:
+        'The model returned the following errors: Input Tokens Exceeded: Number of input tokens exceeds maximum length. Please update the input to try again.\n  Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.',
+      $metadata: { httpStatusCode: 200 },
+    },
+    expected: { kind: 'context_window' },
+  },
+  {
+    provider: Providers.BEDROCK,
+    model: 'us.meta.llama3-1-70b-instruct-v1:0',
+    thrownAs: 'Error',
+    error: {
+      name: 'Error',
+      message:
+        'The model returned the following errors: This model\'s maximum context length is 131072 tokens. Please reduce the length of the prompt\n  Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.',
+      $metadata: { httpStatusCode: 200 },
+    },
+    expected: { kind: 'context_window', limitTokens: 131_072 },
+  },
+  {
+    provider: Providers.GOOGLE,
+    model: 'gemini-3.1-flash-image',
+    thrownAs: 'GoogleGenerativeAIFetchError',
+    error: {
+      name: 'Error',
+      status: 400,
+      message:
+        '[GoogleGenerativeAI Error]: Error fetching from https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:streamGenerateContent?alt=sse: [400 Bad Request] The input token count exceeds the maximum number of tokens allowed (65536).',
+    },
+    expected: { kind: 'context_window', limitTokens: 65_536 },
+  },
+  {
+    /**
+     * Vertex AI's gaxios path discards the API error document, leaving a bare
+     * status line indistinguishable from any other 400 — the only signature
+     * in this set that needs caller-side corroboration.
+     */
+    provider: Providers.VERTEXAI,
+    model: 'gemini-2.5-flash-lite',
+    thrownAs: 'Error',
+    error: {
+      name: 'Error',
+      message: 'Google request failed with status code 400',
+    },
+    expected: { kind: 'context_window' },
+    requiresContextPressure: true,
+  },
+  {
+    provider: Providers.OPENROUTER,
+    model: 'qwen/qwen-2.5-7b-instruct',
+    thrownAs: 'ContextOverflowError',
+    error: {
+      name: 'ContextOverflowError',
+      message:
+        '400 This endpoint\'s maximum context length is 32768 tokens. However, you requested about 56827 tokens (56811 of text input, 16 in the output). Please reduce the length of either one, or use the context-compression plugin to compress your prompt automatically.',
+      cause:
+        '{"status":400,"headers":{},"requestID":null,"error":{"message":"This endpoint\'s maximum context length is 32768 tokens. However, you requested about 56827 tokens (56811 of text input, 16 in the output).","code":400,"metadata":{"provider_name":null}},"code":400}',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 32_768,
+      requestedTokens: 56_827,
+    },
+  },
+  {
+    provider: Providers.DEEPSEEK,
+    model: 'deepseek-v4-flash',
+    thrownAs: 'ContextOverflowError',
+    error: {
+      name: 'ContextOverflowError',
+      message:
+        '400 This model\'s maximum context length is 1048565 tokens. However, you requested 1179668 tokens (1179652 in the messages, 16 in the completion). Please reduce the length of the messages or completion.',
+      cause:
+        '{"status":400,"headers":{},"requestID":null,"error":{"message":"This model\'s maximum context length is 1048565 tokens. However, you requested 1179668 tokens (1179652 in the messages, 16 in the completion).","type":"invalid_request_error","param":null,"code":"invalid_request_error"},"code":"invalid_request_error"}',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 1_048_565,
+      requestedTokens: 1_179_668,
+    },
+  },
+  {
+    /** xAI says "prompt length", which LangChain's own matcher does not catch. */
+    provider: Providers.XAI,
+    model: 'grok-build-0.1',
+    thrownAs: 'BadRequestError',
+    error: {
+      name: 'Error',
+      status: 400,
+      message:
+        '400 "This model\'s maximum prompt length is 256000 but the request contains 332986 tokens."',
+      error:
+        'This model\'s maximum prompt length is 256000 but the request contains 332986 tokens.',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 256_000,
+      requestedTokens: 332_986,
+    },
+  },
+  {
+    provider: Providers.MISTRAL,
+    model: 'mistral-tiny-latest',
+    thrownAs: 'SDKError',
+    error: {
+      name: 'SDKError',
+      status: 400,
+      message:
+        'API error occurred: Status 400 Content-Type application/json Body \n{"object":"error","message":"Prompt contains 170397 tokens and 0 draft tokens, too large for model with 131072 maximum context length","type":"invalid_request_invalid_args","param":null,"code":"3051","raw_status_code":400}',
+      body: '{"object":"error","message":"Prompt contains 170397 tokens and 0 draft tokens, too large for model with 131072 maximum context length","type":"invalid_request_invalid_args","param":null,"code":"3051","raw_status_code":400}',
+    },
+    expected: {
+      kind: 'context_window',
+      limitTokens: 131_072,
+      requestedTokens: 170_397,
+    },
+  },
+] as const;
+
+/**
+ * Errors that mention limits, sizes, or tokens but are NOT fixed by
+ * compaction. The first two were captured live alongside the signatures
+ * above; the rest are the adjacent failures a loose matcher would swallow.
+ */
+export const NON_OVERFLOW_SIGNATURES: readonly {
+  label: string;
+  error: Record<string, unknown>;
+}[] = [
+  {
+    label: 'bedrock invalid model identifier (captured live)',
+    error: {
+      name: 'ValidationException',
+      message: 'The provided model identifier is invalid.',
+      $metadata: { httpStatusCode: 400 },
+    },
+  },
+  {
+    label: 'bedrock legacy model access denied (captured live)',
+    error: {
+      name: 'ResourceNotFoundException',
+      message:
+        'Access denied. This Model is marked by provider as Legacy and you have not been actively using the model in the last 30 days. Please upgrade to an active model.',
+      $metadata: { httpStatusCode: 404 },
+    },
+  },
+  {
+    label: 'openai genuine token throttling — request alone fits the bucket',
+    error: {
+      name: 'Error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+      type: 'tokens',
+      message:
+        '429 Rate limit reached for gpt-4o in organization org-test on tokens per min (TPM): Limit 30000, Used 28000, Requested 4000. Please try again in 4ms.',
+    },
+  },
+  {
+    label: 'openai request-per-minute throttling',
+    error: {
+      name: 'Error',
+      status: 429,
+      code: 'rate_limit_exceeded',
+      type: 'requests',
+      message:
+        '429 Rate limit reached for gpt-4o in organization org-test on requests per min (RPM): Limit 500, Used 500, Requested 1. Please try again in 120ms.',
+    },
+  },
+  {
+    label: 'output token cap, not input',
+    error: {
+      name: 'BadRequestError',
+      status: 400,
+      message:
+        '400 max_tokens is too large: 200000. This model supports at most 64000 completion tokens, whereas you provided 200000.',
+    },
+  },
+  {
+    label: 'anthropic max_tokens above model output limit',
+    error: {
+      name: 'BadRequestError',
+      status: 400,
+      message:
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: 100000 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-5"}}',
+    },
+  },
+  {
+    label: 'quota exhausted',
+    error: {
+      name: 'Error',
+      status: 429,
+      code: 'insufficient_quota',
+      message:
+        '429 You exceeded your current quota, please check your plan and billing details.',
+    },
+  },
+  {
+    label: 'authentication failure',
+    error: {
+      name: 'AuthenticationError',
+      status: 401,
+      message: '401 Incorrect API key provided.',
+    },
+  },
+];

--- a/src/utils/__tests__/redactSecrets.test.ts
+++ b/src/utils/__tests__/redactSecrets.test.ts
@@ -37,4 +37,20 @@ describe('redactSecrets', () => {
       request: '[CIRCULAR]',
     });
   });
+
+  it('redacts credentials embedded in diagnostic URLs', () => {
+    const value = {
+      request: {
+        url: 'https://user:pass@example.com/path?api_key=live-key&X-Amz-Signature=live-signature&version=1',
+      },
+    };
+
+    const serialized = JSON.stringify(redactSecrets(value));
+
+    expect(serialized).toContain('version=1');
+    expect(serialized).not.toContain('live-key');
+    expect(serialized).not.toContain('live-signature');
+    expect(serialized).not.toContain('user');
+    expect(serialized).not.toContain('pass');
+  });
 });

--- a/src/utils/__tests__/redactSecrets.test.ts
+++ b/src/utils/__tests__/redactSecrets.test.ts
@@ -1,0 +1,40 @@
+import { redactSecrets } from '@/utils/redactSecrets';
+
+describe('redactSecrets', () => {
+  it('redacts secret-bearing keys at every nesting depth', () => {
+    const value = {
+      message: 'Bad Request',
+      config: {
+        headers: {
+          Authorization: 'Bearer live-secret',
+          'x-api-key': 'live-key',
+          Accept: 'application/json',
+        },
+      },
+      response: {
+        data: [{ password: 'hunter2', detail: 'overflow' }],
+      },
+    };
+
+    const serialized = JSON.stringify(redactSecrets(value));
+
+    expect(serialized).toContain('Bad Request');
+    expect(serialized).toContain('application/json');
+    expect(serialized).toContain('overflow');
+    expect(serialized).not.toContain('live-secret');
+    expect(serialized).not.toContain('live-key');
+    expect(serialized).not.toContain('hunter2');
+  });
+
+  it('handles circular diagnostic payloads without exposing nested secrets', () => {
+    const value: { request?: object; token?: string } = {
+      token: 'live-token',
+    };
+    value.request = value;
+
+    expect(redactSecrets(value)).toEqual({
+      token: '[REDACTED]',
+      request: '[CIRCULAR]',
+    });
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -33,8 +33,20 @@ export interface ContextOverflowInfo {
   kind: ContextOverflowKind;
   /** Ceiling the provider reported, when it named one. */
   limitTokens?: number;
-  /** Token count the provider attributed to the request, when reported. */
+  /**
+   * Token count the provider attributed to the whole request. Several
+   * providers fold the requested completion allowance into this number, so it
+   * is not interchangeable with the prompt size.
+   */
   requestedTokens?: number;
+  /**
+   * The prompt alone, counted by the provider — set only when the provider
+   * distinguished input from output, either by reporting an input-only figure
+   * or by breaking the total down. Callers comparing provider counts against
+   * their own prompt estimate must use this and not `requestedTokens`, whose
+   * completion component would inflate the comparison.
+   */
+  promptTokens?: number;
   /** Which layer produced the verdict. Surfaced in logs and asserted in tests. */
   source: 'langchain' | 'pattern';
   provider?: Providers;
@@ -45,6 +57,12 @@ interface OverflowPattern {
   readonly re: RegExp;
   readonly limitGroup?: number;
   readonly requestedGroup?: number;
+  /**
+   * Whether `requestedGroup` counts the prompt alone. Providers that report a
+   * combined input+completion total leave this false, and their number is
+   * never used as a prompt measurement.
+   */
+  readonly requestedIsPromptOnly?: boolean;
   /**
    * Marks a signature that is consistent with overflow but not exclusive to
    * it, so it only counts when the caller can corroborate that the prompt was
@@ -82,18 +100,36 @@ const OVERFLOW_PATTERNS: readonly OverflowPattern[] = [
     re: /prompt is too long:\s*(\d+)\s*tokens\s*>\s*(\d+)\s*maximum/i,
     requestedGroup: 1,
     limitGroup: 2,
+    requestedIsPromptOnly: true,
   },
   /**
-   * OpenAI (`your messages resulted in`), OpenRouter (`you requested about`)
-   * and DeepSeek (`you requested`) share one sentence with three verbs.
+   * OpenAI's own wording, which measures the messages and nothing else.
+   * Ordered ahead of the shared sentence below so the prompt-only reading is
+   * preferred when OpenAI is the one answering.
    */
   {
     kind: 'context_window',
-    re: /maximum context length is\s*(\d+)\s*tokens\.\s*however,\s*(?:your messages resulted in|you requested(?:\s*about)?)\s*(\d+)/i,
+    re: /maximum context length is\s*(\d+)\s*tokens\.\s*however,\s*your messages resulted in\s*(\d+)/i,
+    limitGroup: 1,
+    requestedGroup: 2,
+    requestedIsPromptOnly: true,
+  },
+  /**
+   * OpenRouter (`you requested about`) and DeepSeek (`you requested`). Their
+   * total folds in the completion allowance — both then break it down in
+   * parentheses, which `PROMPT_ONLY_BREAKDOWN_RE` recovers.
+   */
+  {
+    kind: 'context_window',
+    re: /maximum context length is\s*(\d+)\s*tokens\.\s*however,\s*you requested(?:\s*about)?\s*(\d+)/i,
     limitGroup: 1,
     requestedGroup: 2,
   },
-  /** xAI. Says "prompt length" rather than "context length". */
+  /**
+   * xAI. Says "prompt length" rather than "context length", and does not say
+   * whether the count it quotes includes the completion allowance — so it is
+   * not trusted as a prompt measurement.
+   */
   {
     kind: 'context_window',
     re: /maximum prompt length is\s*(\d+)\s*(?:tokens\s*)?but the request contains\s*(\d+)\s*tokens/i,
@@ -106,6 +142,7 @@ const OVERFLOW_PATTERNS: readonly OverflowPattern[] = [
     re: /prompt contains\s*(\d+)\s*tokens[^.]*?too large for model with\s*(\d+)\s*maximum context length/i,
     requestedGroup: 1,
     limitGroup: 2,
+    requestedIsPromptOnly: true,
   },
   /** Google Gemini / Vertex. Reports the ceiling only. */
   {
@@ -181,6 +218,14 @@ const NON_RECOVERABLE_RE =
  */
 const OUTPUT_LIMIT_RE =
   /max_?(?:completion_?)?tokens\s*(?:must be|is too|cannot|exceeds|too large|greater than)|maximum number of output tokens|max_tokens.*less than or equal/i;
+
+/**
+ * Recovers the input-only figure from providers that quote a combined total
+ * and then break it down — OpenRouter's "(56811 of text input, 16 in the
+ * output)" and DeepSeek's "(1179652 in the messages, 16 in the completion)".
+ */
+const PROMPT_ONLY_BREAKDOWN_RE =
+  /\(\s*(\d+)\s*(?:of\s+text\s+input|in\s+the\s+messages|of\s+input|input\s+tokens)\b/i;
 
 /** Broader hints for the deliberately fuzzy `isLikelyContextOverflowError`. */
 const CONTEXT_OVERFLOW_HINT_RE =
@@ -267,6 +312,28 @@ function readNumber(
   }
   const parsed = Number(match[group]);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * The provider's count of the prompt alone: its own breakdown when it gave
+ * one, otherwise the quoted total but only for providers that quote the
+ * prompt rather than the whole request. Returns undefined when the number on
+ * offer includes the completion allowance, since treating that as a prompt
+ * measurement would overstate how much the prompt has to shrink.
+ */
+function resolvePromptTokens(
+  haystack: string,
+  pattern: OverflowPattern,
+  requestedTokens: number | undefined
+): number | undefined {
+  const breakdown = haystack.match(PROMPT_ONLY_BREAKDOWN_RE);
+  if (breakdown != null) {
+    const parsed = Number(breakdown[1]);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return pattern.requestedIsPromptOnly === true ? requestedTokens : undefined;
 }
 
 /**
@@ -400,6 +467,7 @@ export function getContextOverflowInfo(
       kind: pattern.kind,
       limitTokens,
       requestedTokens,
+      promptTokens: resolvePromptTokens(haystack, pattern, requestedTokens),
       source: 'pattern',
       provider,
     };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -174,7 +174,7 @@ const OVERFLOW_PATTERNS: readonly OverflowPattern[] = [
   /** Bedrock (Claude Sonnet upstream). */
   {
     kind: 'context_window',
-    re: /input is too long for requested model/i,
+    re: /\binput (?:is )?too long(?: for requested model)?\b/i,
   },
   /** OpenAI-compatible error code, and the phrases LangChain itself keys on. */
   {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -451,14 +451,16 @@ export function getContextOverflowInfo(
 
     /**
      * A token-bucket rejection is only unrecoverable-by-waiting when the
-     * request alone overruns the bucket. When it does not, the account was
-     * merely busy and the correct response is a retry, not compaction.
+     * request alone overruns the bucket. When it merely fills it, the account
+     * was busy and the request will fit once the window drains — so equality
+     * belongs on the retry side, not the compaction side. Losing conversation
+     * history to a temporarily busy account is the worse error.
      */
     if (
       pattern.kind === 'request_too_large' &&
       limitTokens != null &&
       requestedTokens != null &&
-      requestedTokens < limitTokens
+      requestedTokens <= limitTokens
     ) {
       return null;
     }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,45 +1,307 @@
 /**
- * Context overflow error detection utilities.
+ * Context overflow error detection.
  *
- * Identifies provider-specific error messages that indicate the request
- * exceeded the model's context window. Used by the overflow recovery loop
- * to decide whether to retry with truncation/compaction vs. propagating
- * the error.
+ * Providers disagree on how they report "your input is bigger than I can
+ * take" — the class thrown, the HTTP status, whether numbers are reported,
+ * and even whether it arrives as an HTTP error at all. Every pattern below
+ * was captured from a live over-limit request (see
+ * `src/scripts/context-overflow-probe.ts` and
+ * `docs/context-overflow-signatures.md`); nothing here is guessed.
+ *
+ * Consumed by the graph's overflow recovery loop, which converts a detection
+ * into a forced summarization pass instead of surfacing the error.
  */
+import { ContextOverflowError } from '@langchain/core/errors';
+import type { Providers } from '@/common';
 
 /**
- * Exact phrases that definitively indicate a context overflow error.
- * These are returned by various LLM providers when the prompt is too large.
+ * Why the request was rejected. Both kinds are fixed by shrinking the
+ * prompt, which is what makes them recoverable; they are distinguished
+ * because only `context_window` tells us the model's true window.
  */
-const CONTEXT_OVERFLOW_PHRASES = [
-  'request_too_large',
-  'context length exceeded',
-  'maximum context length',
-  'prompt is too long',
-  'exceeds model context window',
-  'exceeds the model',
-  'too large for model',
-  'context_length_exceeded',
-  'max_tokens',
-  'token limit',
-  'input too long',
-  'payload too large',
-  'content_too_large',
+export type ContextOverflowKind =
+  /** Input exceeded the model's context window. */
+  | 'context_window'
+  /**
+   * A single request exceeded a per-minute token allowance. Waiting cannot
+   * help — the request can never fit the bucket — so this is a payload
+   * problem wearing a 429, not throttling.
+   */
+  | 'request_too_large';
+
+export interface ContextOverflowInfo {
+  kind: ContextOverflowKind;
+  /** Ceiling the provider reported, when it named one. */
+  limitTokens?: number;
+  /** Token count the provider attributed to the request, when reported. */
+  requestedTokens?: number;
+  /** Which layer produced the verdict. Surfaced in logs and asserted in tests. */
+  source: 'langchain' | 'pattern';
+  provider?: Providers;
+}
+
+interface OverflowPattern {
+  readonly kind: ContextOverflowKind;
+  readonly re: RegExp;
+  readonly limitGroup?: number;
+  readonly requestedGroup?: number;
+  /**
+   * Marks a signature that is consistent with overflow but not exclusive to
+   * it, so it only counts when the caller can corroborate that the prompt was
+   * actually near the budget. Without corroboration the error propagates
+   * untouched rather than triggering a needless compaction.
+   */
+  readonly requiresContextPressure?: boolean;
+}
+
+/**
+ * Fraction of the believed budget the prompt must reach before an ambiguous
+ * provider error is read as overflow. Well above normal traffic, low enough to
+ * catch the case the budget itself was miscalibrated.
+ */
+const CONTEXT_PRESSURE_RATIO = 0.8;
+
+export interface ContextOverflowContext {
+  provider?: Providers;
+  /** Our own estimate of the prompt size for the call that failed. */
+  estimatedPromptTokens?: number;
+  /** The budget we believed applied when we built that prompt. */
+  maxContextTokens?: number;
+}
+
+/**
+ * Ordered most-specific first; the first match wins. Patterns that capture
+ * both numbers come before the bare-phrase fallbacks for the same provider so
+ * a recoverable error still yields the numbers when the provider reported
+ * them.
+ */
+const OVERFLOW_PATTERNS: readonly OverflowPattern[] = [
+  /** Anthropic, and Bedrock's passthrough of the same upstream. */
+  {
+    kind: 'context_window',
+    re: /prompt is too long:\s*(\d+)\s*tokens\s*>\s*(\d+)\s*maximum/i,
+    requestedGroup: 1,
+    limitGroup: 2,
+  },
+  /**
+   * OpenAI (`your messages resulted in`), OpenRouter (`you requested about`)
+   * and DeepSeek (`you requested`) share one sentence with three verbs.
+   */
+  {
+    kind: 'context_window',
+    re: /maximum context length is\s*(\d+)\s*tokens\.\s*however,\s*(?:your messages resulted in|you requested(?:\s*about)?)\s*(\d+)/i,
+    limitGroup: 1,
+    requestedGroup: 2,
+  },
+  /** xAI. Says "prompt length" rather than "context length". */
+  {
+    kind: 'context_window',
+    re: /maximum prompt length is\s*(\d+)\s*(?:tokens\s*)?but the request contains\s*(\d+)\s*tokens/i,
+    limitGroup: 1,
+    requestedGroup: 2,
+  },
+  /** Mistral. */
+  {
+    kind: 'context_window',
+    re: /prompt contains\s*(\d+)\s*tokens[^.]*?too large for model with\s*(\d+)\s*maximum context length/i,
+    requestedGroup: 1,
+    limitGroup: 2,
+  },
+  /** Google Gemini / Vertex. Reports the ceiling only. */
+  {
+    kind: 'context_window',
+    re: /input token count exceeds the maximum number of tokens allowed\s*\((\d+)\)/i,
+    limitGroup: 1,
+  },
+  /**
+   * OpenAI's token-bucket rejection. Numbers are validated by the caller:
+   * `Requested >= Limit` means no retry can ever succeed.
+   */
+  {
+    kind: 'request_too_large',
+    re: /request too large[\s\S]*?limit\s*(\d+),\s*requested\s*(\d+)/i,
+    limitGroup: 1,
+    requestedGroup: 2,
+  },
+  /** Bedrock (Llama upstream) and any provider naming the ceiling alone. */
+  {
+    kind: 'context_window',
+    re: /(?:maximum context length|maximum prompt length) is\s*(\d+)\s*tokens/i,
+    limitGroup: 1,
+  },
+  /** Bedrock (Nova upstream). */
+  {
+    kind: 'context_window',
+    re: /number of input tokens exceeds maximum length|input tokens exceeded/i,
+  },
+  /** Bedrock (Claude Sonnet upstream). */
+  {
+    kind: 'context_window',
+    re: /input is too long for requested model/i,
+  },
+  /** OpenAI-compatible error code, and the phrases LangChain itself keys on. */
+  {
+    kind: 'context_window',
+    re: /context_length_exceeded|input tokens exceed the configured limit|exceeds the context window|exceeds model context window/i,
+  },
+  /** Generic long-tail phrasings observed across OpenAI-compatible gateways. */
+  {
+    kind: 'context_window',
+    re: /prompt is too long|too large for model|reduce the length of (?:the |your )?(?:messages|prompt)/i,
+  },
+  /**
+   * Vertex AI. Its gaxios path discards the API error document, so an
+   * over-limit prompt arrives as a bare status line with no reason —
+   * identical to every other 400 from the same endpoint. Only a corroborated
+   * near-budget prompt makes this readable as overflow.
+   */
+  {
+    kind: 'context_window',
+    re: /google request failed with status code 400(?!\s*:)/i,
+    requiresContextPressure: true,
+  },
 ] as const;
 
 /**
- * HTTP status codes and broader hints that suggest context overflow.
- * Used by the less-strict `isLikelyContextOverflowError`.
+ * Errors that mention size or limits but are NOT recoverable by compaction.
+ * Checked before the positive patterns.
+ *
+ * Note the deliberate precision: OpenAI's *recoverable* "Request too large"
+ * body links to `platform.openai.com/account/rate-limits`, so a loose
+ * /rate.?limit/ test would discard the very case this module exists to catch.
+ * URLs are stripped from the haystack before matching, and genuine throttling
+ * is matched on its own distinct phrasing.
  */
-const CONTEXT_OVERFLOW_HINT_RE =
-  /413|too large|too long|context.*exceed|exceed.*context|token.*limit|limit.*token|prompt.*size|size.*limit|maximum.*length|length.*maximum/i;
+const NON_RECOVERABLE_RE =
+  /rate limit reached|requests per (?:min|day)|\brpm\b|too many requests|insufficient[_ ]quota|quota exceeded|billing|payment required|invalid[_ ]api[_ ]key|authentication|unauthorized|permission denied|forbidden/i;
 
 /**
- * Patterns that should NOT be treated as context overflow even if they
- * contain words like "limit" or "too large".
+ * Output-cap complaints. `max_tokens` appears in both families, so these are
+ * matched on the surrounding grammar rather than the bare parameter name.
  */
-const FALSE_POSITIVE_RE =
-  /rate.?limit|too many requests|quota|billing|auth|permission|forbidden/i;
+const OUTPUT_LIMIT_RE =
+  /max_?(?:completion_?)?tokens\s*(?:must be|is too|cannot|exceeds|too large|greater than)|maximum number of output tokens|max_tokens.*less than or equal/i;
+
+/** Broader hints for the deliberately fuzzy `isLikelyContextOverflowError`. */
+const CONTEXT_OVERFLOW_HINT_RE =
+  /413|payload too large|content_too_large|request entity too large|too many tokens|token count.*exceed|exceed.*token count/i;
+
+const MAX_CAUSE_DEPTH = 4;
+
+interface NestedErrorShape {
+  message?: unknown;
+  error?: unknown;
+  cause?: unknown;
+  body?: unknown;
+  response?: unknown;
+  /** gaxios-style clients (Vertex AI) put the API error document here. */
+  data?: unknown;
+}
+
+function asRecord(value: unknown): NestedErrorShape | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as NestedErrorShape)
+    : undefined;
+}
+
+/**
+ * Flattens an error into a single searchable string.
+ *
+ * Necessary because providers bury the useful sentence at different depths:
+ * Anthropic puts a JSON document in `message`, Mistral puts one in `body`,
+ * LangChain's `ContextOverflowError` keeps the original API error under
+ * `cause`, and the OpenAI SDK nests the body under `error`.
+ */
+function collectErrorText(error: unknown, depth = 0): string {
+  if (error == null || depth > MAX_CAUSE_DEPTH) {
+    return '';
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  const record = asRecord(error);
+  if (record == null) {
+    return String(error);
+  }
+
+  const parts: string[] = [];
+  if (typeof record.message === 'string') {
+    parts.push(record.message);
+  }
+  for (const nested of [
+    record.error,
+    record.cause,
+    record.body,
+    record.data,
+    record.response,
+  ]) {
+    if (nested == null) {
+      continue;
+    }
+    parts.push(
+      typeof nested === 'string' ? nested : collectErrorText(nested, depth + 1)
+    );
+  }
+  if (parts.length === 0) {
+    try {
+      /** Non-objects returned above, so this always yields a string. */
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return parts.join(' ');
+}
+
+/** Strips URLs so their path segments cannot trip the negative matchers. */
+function stripUrls(text: string): string {
+  return text.replace(/https?:\/\/\S+/gi, ' ');
+}
+
+function readNumber(
+  match: RegExpMatchArray,
+  group?: number
+): number | undefined {
+  if (group == null) {
+    return undefined;
+  }
+  const parsed = Number(match[group]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * True when the caller's own accounting says the failed prompt was close
+ * enough to the budget that an otherwise ambiguous provider error is best
+ * explained by overflow.
+ */
+function hasContextPressure(context?: ContextOverflowContext): boolean {
+  const estimated = context?.estimatedPromptTokens;
+  const budget = context?.maxContextTokens;
+  if (
+    estimated == null ||
+    budget == null ||
+    !Number.isFinite(estimated) ||
+    !Number.isFinite(budget) ||
+    budget <= 0
+  ) {
+    return false;
+  }
+  return estimated / budget >= CONTEXT_PRESSURE_RATIO;
+}
+
+function isLangChainOverflowError(error: unknown): boolean {
+  if (ContextOverflowError.isInstance(error)) {
+    return true;
+  }
+  /** Duplicate `@langchain/core` copies break branding; the name survives. */
+  const record = asRecord(error) as
+    | { name?: unknown; lc_error_code?: unknown }
+    | undefined;
+  return (
+    record?.name === 'ContextOverflowError' ||
+    record?.lc_error_code === 'CONTEXT_OVERFLOW'
+  );
+}
 
 /**
  * Extracts a human-readable error message from an unknown error value.
@@ -54,21 +316,20 @@ export function extractErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
-  if (typeof error === 'object') {
-    const record = error as Record<string, unknown>;
-    if (typeof record.message === 'string') {
-      return record.message;
-    }
-    if (typeof record.error === 'string') {
-      return record.error;
-    }
-    if (
-      typeof record.error === 'object' &&
-      record.error != null &&
-      typeof (record.error as Record<string, unknown>).message === 'string'
-    ) {
-      return (record.error as Record<string, unknown>).message as string;
-    }
+  const record = asRecord(error);
+  if (record == null) {
+    /** Functions and symbols serialize to nothing; describe them instead. */
+    return String(error);
+  }
+  if (typeof record.message === 'string') {
+    return record.message;
+  }
+  if (typeof record.error === 'string') {
+    return record.error;
+  }
+  const nested = asRecord(record.error);
+  if (typeof nested?.message === 'string') {
+    return nested.message;
   }
   try {
     return JSON.stringify(error);
@@ -78,40 +339,113 @@ export function extractErrorMessage(error: unknown): string {
 }
 
 /**
- * Returns true if the error message definitively indicates a context
- * overflow / prompt-too-large error from the provider.
+ * Classifies a provider error as a recoverable context overflow, returning
+ * whatever the provider disclosed about the limit and the request size.
  *
- * This is the strict check: only matches known, unambiguous phrases.
- * Use this when you want high confidence before taking recovery action.
+ * Returns `null` for anything that compaction cannot fix — genuine
+ * throttling, auth, quota, and output-token-cap errors all mention limits
+ * and must not be mistaken for overflow.
+ *
+ * The reported numbers are the point of the return value: they let the
+ * caller retarget the token budget to the provider's real ceiling instead of
+ * retrying blindly against a configured value that was evidently wrong.
  */
-export function isContextOverflowError(errorMessage?: string): boolean {
-  if (!errorMessage) {
-    return false;
+export function getContextOverflowInfo(
+  error: unknown,
+  context?: ContextOverflowContext
+): ContextOverflowInfo | null {
+  const provider = context?.provider;
+  const haystack = stripUrls(collectErrorText(error));
+  if (haystack === '') {
+    return null;
   }
-  const lower = errorMessage.toLowerCase();
-  if (FALSE_POSITIVE_RE.test(lower)) {
-    return false;
+
+  if (OUTPUT_LIMIT_RE.test(haystack)) {
+    return null;
   }
-  return CONTEXT_OVERFLOW_PHRASES.some((phrase) => lower.includes(phrase));
+
+  const langChainFlagged = isLangChainOverflowError(error);
+  if (!langChainFlagged && NON_RECOVERABLE_RE.test(haystack)) {
+    return null;
+  }
+
+  const underContextPressure = hasContextPressure(context);
+
+  for (const pattern of OVERFLOW_PATTERNS) {
+    const match = haystack.match(pattern.re);
+    if (match == null) {
+      continue;
+    }
+    if (pattern.requiresContextPressure === true && !underContextPressure) {
+      continue;
+    }
+    const limitTokens = readNumber(match, pattern.limitGroup);
+    const requestedTokens = readNumber(match, pattern.requestedGroup);
+
+    /**
+     * A token-bucket rejection is only unrecoverable-by-waiting when the
+     * request alone overruns the bucket. When it does not, the account was
+     * merely busy and the correct response is a retry, not compaction.
+     */
+    if (
+      pattern.kind === 'request_too_large' &&
+      limitTokens != null &&
+      requestedTokens != null &&
+      requestedTokens < limitTokens
+    ) {
+      return null;
+    }
+
+    return {
+      kind: pattern.kind,
+      limitTokens,
+      requestedTokens,
+      source: 'pattern',
+      provider,
+    };
+  }
+
+  if (langChainFlagged) {
+    return { kind: 'context_window', source: 'langchain', provider };
+  }
+
+  return null;
 }
 
 /**
- * Returns true if the error message likely indicates a context overflow.
- * Uses broader heuristic matching (regex) in addition to exact phrases.
+ * Returns true if the error definitively indicates a context overflow.
  *
- * May produce false positives for unusual error messages. Use this when
- * the cost of a false positive (one extra retry) is acceptable.
+ * Accepts either a raw error or a pre-extracted message; passing the error
+ * itself is preferred, since several providers report the decisive detail in
+ * a nested body rather than in `message`.
  */
-export function isLikelyContextOverflowError(errorMessage?: string): boolean {
-  if (!errorMessage) {
-    return false;
-  }
-  if (isContextOverflowError(errorMessage)) {
+export function isContextOverflowError(
+  error?: unknown,
+  context?: ContextOverflowContext
+): boolean {
+  return getContextOverflowInfo(error, context) != null;
+}
+
+/**
+ * Returns true if the error likely indicates a context overflow, adding
+ * body-size and token-count heuristics on top of the definitive patterns.
+ *
+ * May produce false positives on unusual messages. Use when the cost of
+ * being wrong is one extra compaction pass.
+ */
+export function isLikelyContextOverflowError(
+  error?: unknown,
+  context?: ContextOverflowContext
+): boolean {
+  if (isContextOverflowError(error, context)) {
     return true;
   }
-  const lower = errorMessage.toLowerCase();
-  if (FALSE_POSITIVE_RE.test(lower)) {
+  const haystack = stripUrls(collectErrorText(error));
+  if (haystack === '' || OUTPUT_LIMIT_RE.test(haystack)) {
     return false;
   }
-  return CONTEXT_OVERFLOW_HINT_RE.test(lower);
+  if (NON_RECOVERABLE_RE.test(haystack)) {
+    return false;
+  }
+  return CONTEXT_OVERFLOW_HINT_RE.test(haystack);
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -179,7 +179,7 @@ const OVERFLOW_PATTERNS: readonly OverflowPattern[] = [
   /** OpenAI-compatible error code, and the phrases LangChain itself keys on. */
   {
     kind: 'context_window',
-    re: /context_length_exceeded|input tokens exceed the configured limit|exceeds the context window|exceeds model context window/i,
+    re: /context[_ ]length[_ ]exceeded|input tokens exceed the configured limit|exceeds the context window|exceeds model context window/i,
   },
   /** Generic long-tail phrasings observed across OpenAI-compatible gateways. */
   {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -235,6 +235,10 @@ const MAX_CAUSE_DEPTH = 4;
 
 interface NestedErrorShape {
   message?: unknown;
+  code?: unknown;
+  type?: unknown;
+  status?: unknown;
+  reason?: unknown;
   error?: unknown;
   cause?: unknown;
   body?: unknown;
@@ -272,6 +276,16 @@ function collectErrorText(error: unknown, depth = 0): string {
   const parts: string[] = [];
   if (typeof record.message === 'string') {
     parts.push(record.message);
+  }
+  for (const reason of [
+    record.code,
+    record.type,
+    record.status,
+    record.reason,
+  ]) {
+    if (typeof reason === 'string') {
+      parts.push(reason);
+    }
   }
   for (const nested of [
     record.error,

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -1,5 +1,5 @@
 const SECRET_KEY_RE =
-  /key|token|secret|credential|authorization|password|cookie/i;
+  /key|token|secret|credential|authorization|password|cookie|signature|(?:^|[_-])sig(?:$|[_-])/i;
 
 const REDACTED_VALUE = '[REDACTED]';
 const CIRCULAR_VALUE = '[CIRCULAR]';
@@ -8,11 +8,37 @@ export function isSecretKey(key: string): boolean {
   return SECRET_KEY_RE.test(key);
 }
 
+function redactUrlCredentials(value: string): string {
+  if (!/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  try {
+    const url = new URL(value);
+    if (url.username !== '') {
+      url.username = REDACTED_VALUE;
+    }
+    if (url.password !== '') {
+      url.password = REDACTED_VALUE;
+    }
+    for (const key of url.searchParams.keys()) {
+      if (isSecretKey(key)) {
+        url.searchParams.set(key, REDACTED_VALUE);
+      }
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
 /** Recursively removes credentials from structured diagnostic payloads. */
 export function redactSecrets(
   value: unknown,
   seen: WeakSet<object> = new WeakSet()
 ): unknown {
+  if (typeof value === 'string') {
+    return redactUrlCredentials(value);
+  }
   if (value == null || typeof value !== 'object') {
     return value;
   }

--- a/src/utils/redactSecrets.ts
+++ b/src/utils/redactSecrets.ts
@@ -1,0 +1,35 @@
+const SECRET_KEY_RE =
+  /key|token|secret|credential|authorization|password|cookie/i;
+
+const REDACTED_VALUE = '[REDACTED]';
+const CIRCULAR_VALUE = '[CIRCULAR]';
+
+export function isSecretKey(key: string): boolean {
+  return SECRET_KEY_RE.test(key);
+}
+
+/** Recursively removes credentials from structured diagnostic payloads. */
+export function redactSecrets(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet()
+): unknown {
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    return CIRCULAR_VALUE;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSecrets(entry, seen));
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = isSecretKey(key)
+      ? REDACTED_VALUE
+      : redactSecrets(entry, seen);
+  }
+  return redacted;
+}


### PR DESCRIPTION
## Summary

I made context overflow a recoverable condition instead of an error the caller sees. When a provider rejects a prompt as too large, the run now retargets its token budget to the limit the provider itself reported, forces a summarization pass, and retries — so the user gets a slightly longer turn rather than a failure.

The detection is grounded in observation, not guesswork. I wrote a probe script and sent deliberately over-limit prompts to ~30 model/provider combinations across 11 providers, then built the matchers from what actually came back. The captured payloads are frozen as test fixtures, so a matcher can never drift from what a provider really sends. Findings are documented in `docs/context-overflow-signatures.md`.

The naive check — look for "context length" in the message — misses most of them:

- **OpenAI usually reports overflow as a `429`, not a `400`.** A large enough prompt overruns the per-minute token bucket before context validation runs, surfacing as `rate_limit_exceeded`. Any matcher that excludes rate limits discards the single most common OpenAI symptom.
- **Bedrock can report overflow inside an HTTP `200`.** For Nova and Llama the failure arrives mid-stream, so `$metadata.httpStatusCode` is `200` and the thrown value is a bare `Error`. Bedrock also uses three different sentences across four upstream model families.
- **Vertex AI discards the reason entirely** on its gaxios path — a bare `Google request failed with status code 400`, indistinguishable from any other 400.
- **xAI says "maximum prompt length"**, so LangChain's own `ContextOverflowError` wrapper never catches it.
- **OpenRouter rejects on an inflated estimate** — it counted 56,827 tokens for a prompt the real tokenizer scores at ~42,600, so targeting its stated ceiling still overflows.
- **DeepSeek's `deepseek-v4-flash` window is 1,048,565**, not the documented figure I started from. Configured limits are not trustworthy; the provider's own number is.

Changes:

- Added `getContextOverflowInfo` in `src/utils/errors.ts`, which classifies a provider error and returns the limit and request size it disclosed. Replaced the previous unused phrase list, whose entries (`max_tokens`, `token limit`) matched output-cap errors and whose `rate.?limit` guard rejected the OpenAI case outright.
- Split the verdict into `context_window` and `request_too_large`, separating the latter from ordinary throttling numerically rather than by wording: it counts only when `Requested >= Limit`, since a request that fits the bucket just needs a retry.
- Gated Vertex AI's reasonless 400 behind caller-side corroboration — it classifies as overflow only when the SDK's own estimate of the prompt had reached 80% of budget, so an unrelated 400 still propagates.
- Added `planContextOverflowRecovery` in `src/llm/contextOverflowRecovery.ts`, which converts a detection into a retry budget: believe the provider's ceiling over the configured value, and convert that ceiling into local token units using the ratio between the provider's count of our prompt and our own estimate. Falls back to a 70% shrink when nothing was disclosed.
- Wired the recovery into `Graph.ts`: a failed call that classifies as overflow applies the corrected budget and returns a summarization request instead of throwing, routing through the summarize node and back for a retry. Bounded at two recoveries per agent per run.
- Skipped fallback providers on the first overflow, since an overflow is caused by the payload rather than by the provider being unavailable. Fallbacks still run for every other failure and once the recovery budget is spent.
- Taught the summarize node an `overflow` reason so that when `summarizationEnabled` is `false` it makes no model call — the corrected budget plus a re-prune is the entire fix, and the caller never pays for a summarization they opted out of.
- Added `applyContextBudgetCorrection` to `AgentContext`, which retargets the budget, clears the memoized pruner, and clears the already-summarized guard.
- Added `src/scripts/context-overflow-probe.ts` (`npm run probe:overflow`) so the catalog can be regenerated when providers change their wording.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

50 unit tests run the captured provider payloads through the classifier, covering every provider the SDK ships a client for, plus negative fixtures pinning the failures compaction must not touch: genuine RPM/TPM throttling, quota, billing, auth, output-token-cap errors, and Bedrock's invalid-model and legacy-model rejections.

Six graph tests drive the full loop against a model that throws a real captured rejection and then succeeds, asserting the error never surfaces, the budget is retargeted, the retry sends strictly less, the loop is bounded, and unrelated errors pass through untouched. 351 tests pass across the affected suites with no regressions.

I also verified the recovery end-to-end against live providers with a real over-limit prompt:

- `openrouter` / `qwen-2.5-7b-instruct` — passed
- `anthropic` / `claude-haiku-4-5` — passed
- `bedrock` / `us.anthropic.claude-haiku-4-5` — passed
- `google` / `gemini-3.1-flash-image` — passed

To reproduce the live cases:

```bash
RUN_CONTEXT_OVERFLOW_LIVE_TESTS=1 npx jest src/specs/context-overflow-recovery.live.test.ts --runInBand
```

Each case self-skips without its provider credentials. The Bedrock case needs `NODE_OPTIONS='--experimental-vm-modules'`.

### **Test Configuration**:

Node 24, live keys for OpenRouter, Anthropic, Bedrock, Google Gemini, DeepSeek, xAI, Mistral, and Vertex AI. Models were chosen as the smallest-window, cheapest option per provider, since the prompt has to exceed the window for the test to mean anything.

One environment note for reviewers: the graph and live suites cannot compile under the repo's own jest config with a stale `node_modules` — `@langchain/core` resolves to 1.1.44 against a required `^1.2.2`, and `@langfuse/tracing` to 4.3.0 against `^5.4.1`. This is pre-existing on `main` (`Graph.reasoning.test.ts` fails identically) and unrelated to these changes; `npm install` resolves it. My files are clean under `npx tsc --noEmit` and `npx eslint`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
