### PR TITLE
🔀 fix: Preserve Handoff Context and Parallel Groups

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -186,6 +186,8 @@ export enum Constants {
   WEB_SEARCH = 'web_search',
   CONTENT_AND_ARTIFACT = 'content_and_artifact',
   LC_TRANSFER_TO_ = 'lc_transfer_to_',
+  HANDOFF_PARALLEL_BATCH = '__handoff_parallel_batch',
+  HANDOFF_GROUP_ID = '__handoff_group_id',
   /** Delimiter for MCP tools: toolName_mcp_serverName */
   MCP_DELIMITER = '_mcp_',
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -51,16 +51,17 @@ import {
   sleep,
 } from '@/utils';
 import {
-  resolveLangfuseRuntimeScope,
-  withLangfuseRuntimeScope,
-} from '@/langfuseRuntimeScope';
-import {
+  Constants,
   GraphNodeKeys,
   ContentTypes,
   GraphEvents,
   Providers,
   StepTypes,
 } from '@/common';
+import {
+  resolveLangfuseRuntimeScope,
+  withLangfuseRuntimeScope,
+} from '@/langfuseRuntimeScope';
 import {
   appendCallbacks,
   findCallback,
@@ -2593,10 +2594,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             isMultiAgent: this.isMultiAgentGraph(),
             hookRegistry: this.hookRegistry,
             dispatchRunStep: async (runStep, nodeConfig) => {
+              const resolvedConfig = nodeConfig ?? this.config;
+              if (runStep.agentId != null) {
+                const groupId = this.resolveParallelGroupId(
+                  runStep.agentId,
+                  resolvedConfig?.metadata
+                );
+                if (groupId != null) {
+                  runStep.groupId = groupId;
+                }
+              }
               this.contentData.push(runStep);
               this.contentIndexMap.set(runStep.id, runStep.index);
 
-              const resolvedConfig = nodeConfig ?? this.config;
               const handler = this.handlerRegistry?.getHandler(
                 GraphEvents.ON_RUN_STEP
               );
@@ -2716,6 +2726,33 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return undefined;
   }
 
+  protected resolveParallelGroupId(
+    agentId: string,
+    metadata?: Record<string, unknown>
+  ): number | undefined {
+    if (
+      metadata == null ||
+      !Object.prototype.hasOwnProperty.call(
+        metadata,
+        Constants.HANDOFF_GROUP_ID
+      )
+    ) {
+      return this.getParallelGroupIdForAgent(agentId);
+    }
+    const runtimeGroupId = metadata[Constants.HANDOFF_GROUP_ID];
+    if (runtimeGroupId === null) {
+      return undefined;
+    }
+    if (
+      typeof runtimeGroupId === 'number' &&
+      Number.isSafeInteger(runtimeGroupId) &&
+      runtimeGroupId > 0
+    ) {
+      return runtimeGroupId;
+    }
+    return this.getParallelGroupIdForAgent(agentId);
+  }
+
   /* Dispatchers */
 
   /**
@@ -2760,7 +2797,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const agentContext = this.getAgentContext(metadata);
         if (this.isMultiAgentGraph() && agentContext.agentId) {
           runStep.agentId = agentContext.agentId;
-          const groupId = this.getParallelGroupIdForAgent(agentContext.agentId);
+          const groupId = this.resolveParallelGroupId(
+            agentContext.agentId,
+            metadata
+          );
           if (groupId != null) {
             runStep.groupId = groupId;
           }

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -934,28 +934,26 @@ export class MultiAgentGraph extends StandardGraph {
           state.messages,
           agentId
         );
+        const agentContext = this.agentContexts.get(agentId);
+
+        if (
+          handoffContext?.sourceAgentName != null &&
+          handoffContext.sourceAgentName !== ''
+        ) {
+          agentContext?.setHandoffContext(
+            handoffContext.sourceAgentName,
+            handoffContext.parallelSiblings
+          );
+        } else {
+          agentContext?.clearHandoffContext();
+        }
 
         if (handoffContext !== null) {
           const {
             filteredMessages,
             instructions,
-            sourceAgentName,
-            parallelSiblings,
             parallelGroupId,
           } = handoffContext;
-
-          /**
-           * Set handoff context on the receiving agent.
-           * Uses pre-computed graph position for depth and parallel info.
-           */
-          const agentContext = this.agentContexts.get(agentId);
-          if (
-            agentContext &&
-            sourceAgentName != null &&
-            sourceAgentName !== ''
-          ) {
-            agentContext.setHandoffContext(sourceAgentName, parallelSiblings);
-          }
 
           /** Build messages for the receiving agent */
           let messagesForAgent = filteredMessages;
@@ -1039,7 +1037,6 @@ export class MultiAgentGraph extends StandardGraph {
            * When using agentMessages (excludeResults=true), we need to update
            * the token map to account for the new prompt message
            */
-          const agentContext = this.agentContexts.get(agentId);
           if (agentContext && agentContext.tokenCounter) {
             /** The agentMessages contains:
              * 1. Filtered messages (0 to startIndex) - already have token counts

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -23,6 +23,63 @@ import { Constants } from '@/common';
 
 /** Pattern to extract instructions from transfer ToolMessage content */
 const HANDOFF_INSTRUCTIONS_PATTERN = /(?:Instructions?|Context):\s*(.+)/is;
+const HANDOFF_INSTRUCTIONS_KEY = 'handoff_instructions';
+
+function getHandoffInstructions(
+  input: Record<string, unknown>,
+  promptKey: string,
+  hasHandoffInput: boolean
+): string | null {
+  if (
+    !hasHandoffInput ||
+    !Object.prototype.hasOwnProperty.call(input, promptKey)
+  ) {
+    return null;
+  }
+  const value = input[promptKey];
+  return typeof value === 'string' ? value : null;
+}
+
+function formatHandoffPromptLabel(promptKey: string): string {
+  return promptKey.charAt(0).toUpperCase() + promptKey.slice(1);
+}
+
+function extractLegacyHandoffInstructions(
+  content: string,
+  promptLabels: Set<string> | undefined
+): string | null {
+  let markerIndex = -1;
+  let markerLength = 0;
+  for (const label of promptLabels ?? []) {
+    const marker = `\n\n${label}:`;
+    const index = content.indexOf(marker);
+    if (index >= 0 && (markerIndex < 0 || index < markerIndex)) {
+      markerIndex = index;
+      markerLength = marker.length;
+    }
+  }
+  if (markerIndex >= 0) {
+    return content.slice(markerIndex + markerLength).trim();
+  }
+  return content.match(HANDOFF_INSTRUCTIONS_PATTERN)?.[1]?.trim() ?? null;
+}
+
+function isValidHandoffGroupId(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function withHandoffGroupMetadata(
+  config: LangGraphRunnableConfig | undefined,
+  groupId: number | undefined
+): LangGraphRunnableConfig {
+  return {
+    ...config,
+    metadata: {
+      ...config?.metadata,
+      [Constants.HANDOFF_GROUP_ID]: groupId ?? null,
+    },
+  };
+}
 
 /**
  * MultiAgentGraph extends StandardGraph to support dynamic multi-agent workflows
@@ -43,6 +100,7 @@ export class MultiAgentGraph extends StandardGraph {
   private startingNodes: Set<string> = new Set();
   private directEdges: t.GraphEdge[] = [];
   private handoffEdges: t.GraphEdge[] = [];
+  private handoffPromptLabels: Map<string, Set<string>> = new Map();
   /**
    * Map of agentId to parallel group info.
    * Contains groupId (incrementing number reflecting execution order) for agents in parallel groups.
@@ -271,6 +329,18 @@ export class MultiAgentGraph extends StandardGraph {
 
     // Only process handoff edges for tool creation
     for (const edge of this.handoffEdges) {
+      if (typeof edge.prompt === 'string') {
+        const label = formatHandoffPromptLabel(
+          edge.promptKey ?? 'instructions'
+        );
+        const destinations = Array.isArray(edge.to) ? edge.to : [edge.to];
+        for (const destination of destinations) {
+          const labels =
+            this.handoffPromptLabels.get(destination) ?? new Set<string>();
+          labels.add(label);
+          this.handoffPromptLabels.set(destination, labels);
+        }
+      }
       const sources = Array.isArray(edge.from) ? edge.from : [edge.from];
       sources.forEach((source) => {
         if (!handoffsByAgent.has(source)) {
@@ -349,13 +419,14 @@ export class MultiAgentGraph extends StandardGraph {
               destination = Array.isArray(result) ? result[0] : destinations[0];
             }
 
+            const handoffInstructions = getHandoffInstructions(
+              input,
+              promptKey,
+              hasHandoffInput
+            );
             let content = `Conditionally transferred to ${destination}`;
-            if (
-              hasHandoffInput &&
-              promptKey in input &&
-              input[promptKey] != null
-            ) {
-              content += `\n\n${promptKey.charAt(0).toUpperCase() + promptKey.slice(1)}: ${input[promptKey]}`;
+            if (handoffInstructions !== null) {
+              content += `\n\n${formatHandoffPromptLabel(promptKey)}: ${handoffInstructions}`;
             }
 
             const toolMessage = new ToolMessage({
@@ -367,6 +438,9 @@ export class MultiAgentGraph extends StandardGraph {
                 handoff_destination: destination,
                 /** Store source agent name for receiving agent to know who handed off */
                 handoff_source_name: sourceAgentName,
+                ...(handoffInstructions !== null && {
+                  [HANDOFF_INSTRUCTIONS_KEY]: handoffInstructions,
+                }),
               },
             });
 
@@ -415,13 +489,14 @@ export class MultiAgentGraph extends StandardGraph {
               const input = rawInput as Record<string, unknown>;
               const toolCallId = runtime.toolCall?.id ?? 'unknown';
 
+              const handoffInstructions = getHandoffInstructions(
+                input,
+                promptKey,
+                hasHandoffInput
+              );
               let content = `Successfully transferred to ${destination}`;
-              if (
-                hasHandoffInput &&
-                promptKey in input &&
-                input[promptKey] != null
-              ) {
-                content += `\n\n${promptKey.charAt(0).toUpperCase() + promptKey.slice(1)}: ${input[promptKey]}`;
+              if (handoffInstructions !== null) {
+                content += `\n\n${formatHandoffPromptLabel(promptKey)}: ${handoffInstructions}`;
               }
 
               const toolMessage = new ToolMessage({
@@ -431,6 +506,9 @@ export class MultiAgentGraph extends StandardGraph {
                 additional_kwargs: {
                   /** Store source agent name for receiving agent to know who handed off */
                   handoff_source_name: sourceAgentName,
+                  ...(handoffInstructions !== null && {
+                    [HANDOFF_INSTRUCTIONS_KEY]: handoffInstructions,
+                  }),
                 },
               });
 
@@ -558,8 +636,39 @@ export class MultiAgentGraph extends StandardGraph {
     instructions: string | null;
     sourceAgentName: string | null;
     parallelSiblings: string[];
+    parallelGroupId?: number;
   } | null {
     if (messages.length === 0) return null;
+
+    /**
+     * A handoff is active only while resolving the most recent assistant
+     * tool-call round. Older transfer results remain in conversation history,
+     * but must not be reused when this agent is reached later through a direct
+     * edge or cycle.
+     */
+    const activeTransferToolCallIds = new Set<string>();
+    let activeToolMessageStartIndex = messages.length;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.getType() === 'tool') continue;
+
+      if (msg.getType() === 'ai') {
+        const aiMsg = msg as AIMessage | AIMessageChunk;
+        for (const toolCall of aiMsg.tool_calls ?? []) {
+          if (
+            toolCall.id != null &&
+            (toolCall.name.startsWith(Constants.LC_TRANSFER_TO_) ||
+              toolCall.name === 'conditional_transfer')
+          ) {
+            activeTransferToolCallIds.add(toolCall.id);
+          }
+        }
+        activeToolMessageStartIndex = i + 1;
+      }
+      break;
+    }
+
+    if (activeTransferToolCallIds.size === 0) return null;
 
     /**
      * Search for a transfer ToolMessage targeting this agent.
@@ -569,14 +678,19 @@ export class MultiAgentGraph extends StandardGraph {
     let toolMessage: ToolMessage | null = null;
     let toolMessageIndex = -1;
 
-    for (let i = messages.length - 1; i >= 0; i--) {
+    for (let i = messages.length - 1; i >= activeToolMessageStartIndex; i--) {
       const msg = messages[i];
       if (msg.getType() !== 'tool') continue;
 
       const candidateMsg = msg as ToolMessage;
       const toolName = candidateMsg.name;
 
-      if (typeof toolName !== 'string') continue;
+      if (
+        typeof toolName !== 'string' ||
+        !activeTransferToolCallIds.has(candidateMsg.tool_call_id)
+      ) {
+        continue;
+      }
 
       /** Check for standard transfer pattern */
       const isTransferMessage = toolName.startsWith(Constants.LC_TRANSFER_TO_);
@@ -611,8 +725,15 @@ export class MultiAgentGraph extends StandardGraph {
         ? toolMessage.content
         : JSON.stringify(toolMessage.content);
 
-    const instructionsMatch = contentStr.match(HANDOFF_INSTRUCTIONS_PATTERN);
-    const instructions = instructionsMatch?.[1]?.trim() ?? null;
+    const structuredInstructions =
+      toolMessage.additional_kwargs[HANDOFF_INSTRUCTIONS_KEY];
+    const instructions =
+      typeof structuredInstructions === 'string'
+        ? structuredInstructions.trim()
+        : extractLegacyHandoffInstructions(
+          contentStr,
+          this.handoffPromptLabels.get(agentId)
+        );
 
     /** Extract source agent name from additional_kwargs */
     const handoffSourceName = toolMessage.additional_kwargs.handoff_source_name;
@@ -629,6 +750,11 @@ export class MultiAgentGraph extends StandardGraph {
       const ctx = this.agentContexts.get(id);
       return ctx?.name ?? id;
     });
+    const storedParallelGroupId =
+      toolMessage.additional_kwargs[Constants.HANDOFF_GROUP_ID];
+    const parallelGroupId = isValidHandoffGroupId(storedParallelGroupId)
+      ? storedParallelGroupId
+      : undefined;
 
     /** Get the tool_call_id to find and filter the AI message's tool call */
     const toolCallId = toolMessage.tool_call_id;
@@ -640,15 +766,27 @@ export class MultiAgentGraph extends StandardGraph {
      */
     const transferToolCallIds = new Set<string>([toolCallId]);
     for (const msg of messages) {
-      if (msg.getType() !== 'tool') continue;
-      const tm = msg as ToolMessage;
-      const tName = tm.name;
-      if (typeof tName !== 'string') continue;
-      if (
-        tName.startsWith(Constants.LC_TRANSFER_TO_) ||
-        tName === 'conditional_transfer'
-      ) {
-        transferToolCallIds.add(tm.tool_call_id);
+      if (msg.getType() === 'tool') {
+        const tm = msg as ToolMessage;
+        const tName = tm.name;
+        if (
+          typeof tName === 'string' &&
+          (tName.startsWith(Constants.LC_TRANSFER_TO_) ||
+            tName === 'conditional_transfer')
+        ) {
+          transferToolCallIds.add(tm.tool_call_id);
+        }
+      } else if (msg.getType() === 'ai') {
+        const aiMsg = msg as AIMessage | AIMessageChunk;
+        for (const toolCall of aiMsg.tool_calls ?? []) {
+          if (
+            toolCall.id != null &&
+            (toolCall.name.startsWith(Constants.LC_TRANSFER_TO_) ||
+              toolCall.name === 'conditional_transfer')
+          ) {
+            transferToolCallIds.add(toolCall.id);
+          }
+        }
       }
     }
 
@@ -708,6 +846,7 @@ export class MultiAgentGraph extends StandardGraph {
       instructions,
       sourceAgentName,
       parallelSiblings,
+      parallelGroupId,
     };
   }
 
@@ -802,6 +941,7 @@ export class MultiAgentGraph extends StandardGraph {
             instructions,
             sourceAgentName,
             parallelSiblings,
+            parallelGroupId,
           } = handoffContext;
 
           /**
@@ -883,7 +1023,10 @@ export class MultiAgentGraph extends StandardGraph {
             ...state,
             messages: messagesForAgent,
           };
-          result = await agentSubgraph.invoke(transformedState, config);
+          result = await agentSubgraph.invoke(
+            transformedState,
+            withHandoffGroupMetadata(config, parallelGroupId)
+          );
           result = {
             ...result,
             agentMessages: [],

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -953,6 +953,128 @@ describe('Agent Handoffs Tests', () => {
       expect(directPassMessages).toHaveLength(2);
     });
 
+    it('should clear the handoff identity before a direct re-entry', async () => {
+      const agents: t.AgentInputs[] = [
+        {
+          ...createBasicAgent('router', 'stale-context-router-marker'),
+          name: 'Router',
+        },
+        {
+          ...createBasicAgent('recipient', 'stale-context-recipient-marker'),
+          name: 'Recipient',
+        },
+        {
+          ...createBasicAgent('sibling', 'stale-context-sibling-marker'),
+          name: 'Sibling',
+        },
+        {
+          ...createBasicAgent('relay', 'stale-context-relay-marker'),
+          name: 'Relay',
+        },
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'recipient',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the recipient',
+        },
+        {
+          from: 'router',
+          to: 'sibling',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the sibling',
+        },
+        {
+          from: 'recipient',
+          to: 'relay',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the relay',
+        },
+        { from: 'relay', to: 'recipient', edgeType: 'direct' },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      const model = new ScriptedHandoffModel([
+        {
+          promptMarker: 'stale-context-router-marker',
+          response: 'Routing in parallel',
+          toolCalls: [
+            {
+              id: 'tool_call_stale_context_recipient',
+              name: `${Constants.LC_TRANSFER_TO_}recipient`,
+              args: { instructions: 'recipient-first-handoff-marker' },
+            },
+            {
+              id: 'tool_call_stale_context_sibling',
+              name: `${Constants.LC_TRANSFER_TO_}sibling`,
+              args: { instructions: 'sibling-first-handoff-marker' },
+            },
+          ],
+        },
+        {
+          promptMarker: 'recipient-first-handoff-marker',
+          response: 'Sending through relay',
+          toolCalls: [
+            {
+              id: 'tool_call_stale_context_relay',
+              name: `${Constants.LC_TRANSFER_TO_}relay`,
+              args: { instructions: 'relay-handoff-marker' },
+            },
+          ],
+        },
+        {
+          promptMarker: 'sibling-first-handoff-marker',
+          response: 'Sibling complete',
+        },
+        {
+          promptMarker: 'relay-handoff-marker',
+          response: 'relay-direct-reentry-marker',
+        },
+        {
+          promptMarker: 'relay-direct-reentry-marker',
+          response: 'Recipient direct complete',
+        },
+      ]);
+      run.Graph.overrideModel = model;
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: {
+          thread_id: 'test-clear-handoff-context-direct-reentry-thread',
+        },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('stale-context-router-marker')] },
+        config
+      );
+
+      const recipientContext = run.Graph.agentContexts.get('recipient');
+      const recipientSystemRunnable = recipientContext?.systemRunnable;
+      if (recipientSystemRunnable == null) {
+        throw new Error('Expected recipient system instructions');
+      }
+      const recipientSystemPrompt = getBufferString(
+        await recipientSystemRunnable.invoke([])
+      );
+      expect(recipientSystemPrompt).toContain(
+        'stale-context-recipient-marker'
+      );
+      expect(recipientSystemPrompt).not.toContain('## Multi-Agent Workflow');
+      expect(recipientSystemPrompt).not.toContain(
+        'transferred from "Router"'
+      );
+      expect(recipientSystemPrompt).not.toContain(
+        'Running in parallel with:'
+      );
+    });
+
     it('should clear the runtime group after a parallel target hands off sequentially', async () => {
       const agents: t.AgentInputs[] = [
         createBasicAgent('router', 'router-script-marker'),

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -1,12 +1,22 @@
 // src/specs/agent-handoffs.test.ts
+import { MemorySaver } from '@langchain/langgraph';
 import { DynamicStructuredTool } from '@langchain/core/tools';
-import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  getBufferString,
+} from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { Providers, GraphEvents, Constants } from '@/common';
+import { createHandlers } from '@/utils/handlers';
 import { StandardGraph } from '@/graphs/Graph';
 import { ToolNode } from '@/tools/ToolNode';
+import { FakeChatModel } from '@/llm/fake';
 import * as events from '@/utils/events';
 import { Run } from '@/run';
 
@@ -39,6 +49,100 @@ const findToolByName = (
   name: string
 ): t.GraphTools[0] | undefined => {
   return tools?.find((tool) => getToolName(tool) === name);
+};
+
+type HandoffModelScript = {
+  promptMarker: string;
+  response: string;
+  toolCalls?: ToolCall[];
+};
+
+function validateToolHistory(messages: t.BaseGraphState['messages']): void {
+  const toolCallIds = new Set<string>();
+  const toolResultIds = new Set<string>();
+  for (const message of messages) {
+    if (message.getType() === 'ai') {
+      for (const toolCall of (message as AIMessage).tool_calls ?? []) {
+        if (toolCall.id != null) {
+          toolCallIds.add(toolCall.id);
+        }
+      }
+    } else if (message.getType() === 'tool') {
+      toolResultIds.add((message as ToolMessage).tool_call_id);
+    }
+  }
+  for (const toolCallId of toolCallIds) {
+    if (!toolResultIds.has(toolCallId)) {
+      throw new Error(`Tool call ${toolCallId} has no matching result`);
+    }
+  }
+  for (const toolResultId of toolResultIds) {
+    if (!toolCallIds.has(toolResultId)) {
+      throw new Error(`Tool result ${toolResultId} has no matching call`);
+    }
+  }
+}
+
+class ScriptedHandoffModel extends FakeChatModel {
+  private scripts: HandoffModelScript[];
+
+  constructor(scripts: HandoffModelScript[]) {
+    super({ responses: [''] });
+    this.scripts = scripts;
+  }
+
+  override async *_streamResponseChunks(
+    messages: t.BaseGraphState['messages'],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    validateToolHistory(messages);
+    const prompt = getBufferString(messages);
+    let script: HandoffModelScript | undefined;
+    let latestMarkerIndex = -1;
+    for (const candidate of this.scripts) {
+      const markerIndex = prompt.lastIndexOf(candidate.promptMarker);
+      if (markerIndex > latestMarkerIndex) {
+        script = candidate;
+        latestMarkerIndex = markerIndex;
+      }
+    }
+    if (script == null) {
+      throw new Error(`No handoff model script matched prompt: ${prompt}`);
+    }
+    const model = new FakeChatModel({
+      responses: [script.response],
+      toolCalls: script.toolCalls,
+    });
+    yield* model._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+type HandoffReceptionProbe = {
+  processHandoffReception(
+    messages: t.BaseGraphState['messages'],
+    agentId: string
+  ): {
+    instructions: string | null;
+    parallelGroupId?: number;
+  } | null;
+};
+
+type PendingSend = {
+  node: string;
+  args: { messages?: t.BaseGraphState['messages'] };
+};
+
+const isPendingSend = (value: unknown): value is PendingSend => {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as { node?: unknown; args?: unknown };
+  return (
+    typeof candidate.node === 'string' &&
+    candidate.args != null &&
+    typeof candidate.args === 'object'
+  );
 };
 
 /**
@@ -510,6 +614,516 @@ describe('Agent Handoffs Tests', () => {
     });
   });
 
+  describe('Parallel Handoffs', () => {
+    it('should expose one runtime group on simultaneous destination content', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('left', 'You are the left specialist'),
+        createBasicAgent('right', 'You are the right specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        { from: 'router', to: 'left', edgeType: 'handoff' },
+        { from: 'router', to: 'right', edgeType: 'handoff' },
+      ];
+      const { contentParts, handlers } = createHandlers();
+      const runConfig = createTestConfig(agents, edges);
+      runConfig.customHandlers = handlers;
+      const run = await Run.create(runConfig);
+
+      run.Graph?.overrideTestModel(
+        ['Routing', 'Left complete', 'Right complete'],
+        10,
+        [
+          {
+            id: 'tool_call_left',
+            name: `${Constants.LC_TRANSFER_TO_}left`,
+            args: {},
+          } as ToolCall,
+          {
+            id: 'tool_call_right',
+            name: `${Constants.LC_TRANSFER_TO_}right`,
+            args: {},
+          } as ToolCall,
+        ]
+      );
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-parallel-handoff-group-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('Run both specialists')] },
+        config
+      );
+
+      const definedParts = contentParts.filter(
+        (part): part is t.MessageContentComplex => part != null
+      );
+      const routerParts = definedParts.filter(
+        (part) => part.agentId === 'router'
+      );
+      const leftParts = definedParts.filter((part) => part.agentId === 'left');
+      const rightParts = definedParts.filter(
+        (part) => part.agentId === 'right'
+      );
+      const leftGroupId = leftParts[0]?.groupId;
+
+      expect(routerParts.length).toBeGreaterThan(0);
+      expect(routerParts.every((part) => part.groupId == null)).toBe(true);
+      expect(leftParts.length).toBeGreaterThan(0);
+      expect(rightParts.length).toBeGreaterThan(0);
+      expect(leftGroupId).toEqual(expect.any(Number));
+      expect(leftParts.every((part) => part.groupId === leftGroupId)).toBe(
+        true
+      );
+      expect(rightParts.every((part) => part.groupId === leftGroupId)).toBe(
+        true
+      );
+    });
+
+    it('should checkpoint one durable group ID before parallel recipients run', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('left', 'You are the left specialist'),
+        createBasicAgent('right', 'You are the right specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        { from: 'router', to: 'left', edgeType: 'handoff' },
+        { from: 'router', to: 'right', edgeType: 'handoff' },
+      ];
+      const checkpointer = new MemorySaver();
+      const runConfig = createTestConfig(agents, edges);
+      runConfig.graphConfig.compileOptions = { checkpointer };
+      const run = await Run.create(runConfig);
+
+      run.Graph?.overrideTestModel(
+        ['Routing', 'Left complete', 'Right complete'],
+        10,
+        [
+          {
+            id: 'tool_call_checkpoint_left',
+            name: `${Constants.LC_TRANSFER_TO_}left`,
+            args: {},
+          } as ToolCall,
+          {
+            id: 'tool_call_checkpoint_right',
+            name: `${Constants.LC_TRANSFER_TO_}right`,
+            args: {},
+          } as ToolCall,
+        ]
+      );
+
+      const threadId = 'test-parallel-handoff-checkpoint-thread';
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+        durability: 'sync';
+      } = {
+        configurable: { thread_id: threadId },
+        streamMode: 'values',
+        version: 'v2',
+        durability: 'sync',
+      };
+      const historicalToolCall = {
+        id: 'tool_call_before_parallel_handoff',
+        name: 'historical_lookup',
+        args: {},
+      };
+      await run.processStream(
+        {
+          messages: [
+            new HumanMessage('Look this up first'),
+            new AIMessage({ content: '', tool_calls: [historicalToolCall] }),
+            new ToolMessage({
+              content: 'Historical result',
+              name: historicalToolCall.name,
+              tool_call_id: historicalToolCall.id,
+            }),
+            new HumanMessage('Run both specialists'),
+          ],
+        },
+        config
+      );
+
+      let persistedHandoffs: ToolMessage[] = [];
+      let persistedSends: PendingSend[] = [];
+      for await (const tuple of checkpointer.list({
+        configurable: { thread_id: threadId },
+      })) {
+        const sends = (tuple.pendingWrites ?? [])
+          .filter(([, channel]) => channel === '__pregel_tasks')
+          .map(([, , value]) => value)
+          .filter(isPendingSend)
+          .filter(({ node }) => node === 'left' || node === 'right');
+        const handoffs = sends.flatMap((send) =>
+          (send.args.messages ?? []).filter(
+            (message): message is ToolMessage =>
+              message.getType() === 'tool' &&
+              message.name === `${Constants.LC_TRANSFER_TO_}${send.node}`
+          )
+        );
+        if (handoffs.length === 2) {
+          persistedHandoffs = handoffs;
+          persistedSends = sends;
+          break;
+        }
+      }
+
+      expect(persistedHandoffs).toHaveLength(2);
+      const persistedGroupIds = persistedHandoffs.map(
+        (message) => message.additional_kwargs[Constants.HANDOFF_GROUP_ID]
+      );
+      const persistedBatchIds = persistedHandoffs.map(
+        (message) => message.additional_kwargs[Constants.HANDOFF_PARALLEL_BATCH]
+      );
+      const persistedGroupId = persistedGroupIds[0];
+      if (typeof persistedGroupId !== 'number') {
+        throw new Error('Expected a persisted numeric handoff group ID');
+      }
+
+      expect(Number.isSafeInteger(persistedGroupId)).toBe(true);
+      expect(persistedGroupId).toBeGreaterThanOrEqual(2 ** 48);
+      expect(persistedGroupIds[1]).toBe(persistedGroupId);
+      expect(persistedBatchIds[0]).toEqual(expect.any(String));
+      expect(persistedBatchIds[1]).toBe(persistedBatchIds[0]);
+
+      const historicalResults = persistedSends.flatMap((send) =>
+        (send.args.messages ?? []).filter(
+          (message): message is ToolMessage =>
+            message.getType() === 'tool' &&
+            (message as ToolMessage).tool_call_id === historicalToolCall.id
+        )
+      );
+      expect(historicalResults).toHaveLength(2);
+      for (const result of historicalResults) {
+        expect(
+          result.additional_kwargs[Constants.HANDOFF_PARALLEL_BATCH]
+        ).toBeUndefined();
+        expect(
+          result.additional_kwargs[Constants.HANDOFF_GROUP_ID]
+        ).toBeUndefined();
+        expect(
+          result.additional_kwargs.handoff_parallel_siblings
+        ).toBeUndefined();
+      }
+    });
+
+    it('should suppress a static group when a hybrid router selects one handoff', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('left', 'You are the left specialist'),
+        createBasicAgent('right', 'You are the right specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: ['left', 'right'],
+          edgeType: 'direct',
+        },
+        { from: 'router', to: 'left', edgeType: 'handoff' },
+        { from: 'router', to: 'right', edgeType: 'handoff' },
+      ];
+      const { contentParts, handlers } = createHandlers();
+      const runConfig = createTestConfig(agents, edges);
+      runConfig.customHandlers = handlers;
+      const run = await Run.create(runConfig);
+
+      run.Graph?.overrideTestModel(['Routing', 'Left complete'], 10, [
+        {
+          id: 'tool_call_left_only',
+          name: `${Constants.LC_TRANSFER_TO_}left`,
+          args: {},
+        } as ToolCall,
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-hybrid-handoff-group-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('Run only the left specialist')] },
+        config
+      );
+
+      const definedParts = contentParts.filter(
+        (part): part is t.MessageContentComplex => part != null
+      );
+      const leftParts = definedParts.filter((part) => part.agentId === 'left');
+      const rightParts = definedParts.filter(
+        (part) => part.agentId === 'right'
+      );
+
+      expect(leftParts.length).toBeGreaterThan(0);
+      expect(leftParts.every((part) => part.groupId == null)).toBe(true);
+      expect(rightParts).toHaveLength(0);
+    });
+
+    it('should not reuse a historical handoff when a target is later reached directly', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'historical-router-marker'),
+        createBasicAgent('recipient', 'historical-recipient-agent-marker'),
+        createBasicAgent('sibling', 'historical-sibling-agent-marker'),
+      ];
+      const edges: t.GraphEdge[] = [
+        { from: 'router', to: 'recipient', edgeType: 'direct' },
+        {
+          from: 'router',
+          to: 'recipient',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the recipient',
+        },
+        {
+          from: 'router',
+          to: 'sibling',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the sibling',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      run.Graph.overrideModel = new ScriptedHandoffModel([
+        {
+          promptMarker: 'stale-recipient-instructions-marker',
+          response: 'Historical recipient complete',
+        },
+        {
+          promptMarker: 'second-direct-request-marker',
+          response: 'Direct pass complete',
+        },
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: {
+          thread_id: 'test-historical-handoff-direct-thread',
+        },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      const historicalToolCall = {
+        id: 'tool_call_historical_recipient',
+        name: `${Constants.LC_TRANSFER_TO_}recipient`,
+        args: { instructions: 'stale-recipient-instructions-marker' },
+      };
+      await run.processStream(
+        {
+          messages: [
+            new HumanMessage('first-historical-request-marker'),
+            new AIMessage({ content: '', tool_calls: [historicalToolCall] }),
+            new ToolMessage({
+              content:
+                'Successfully transferred to recipient\n\nInstructions: stale-recipient-instructions-marker',
+              name: historicalToolCall.name,
+              tool_call_id: historicalToolCall.id,
+              additional_kwargs: {
+                handoff_source_name: 'Router',
+                handoff_instructions: 'stale-recipient-instructions-marker',
+                handoff_parallel_siblings: ['sibling'],
+                [Constants.HANDOFF_GROUP_ID]: 2 ** 48 + 1,
+              },
+            }),
+            new HumanMessage('second-direct-request-marker'),
+          ],
+        },
+        config
+      );
+
+      const recipientSteps = run.Graph.getRunSteps('recipient');
+      expect(recipientSteps.length).toBeGreaterThan(0);
+      expect(recipientSteps.every((step) => step.groupId == null)).toBe(true);
+      const directPassMessages = run
+        .getRunMessages()
+        ?.filter(
+          (message) =>
+            message.getType() === 'ai' &&
+            message.content === 'Direct pass complete'
+        );
+      expect(directPassMessages).toHaveLength(2);
+    });
+
+    it('should clear the runtime group after a parallel target hands off sequentially', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'router-script-marker'),
+        createBasicAgent('left', 'left-script-marker'),
+        createBasicAgent('right', 'right-script-marker'),
+        createBasicAgent('final', 'final-script-marker'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'left',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the left specialist',
+        },
+        {
+          from: 'router',
+          to: 'right',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the right specialist',
+        },
+        {
+          from: 'left',
+          to: 'final',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the final specialist',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      run.Graph.overrideModel = new ScriptedHandoffModel([
+        {
+          promptMarker: 'router-script-marker',
+          response: 'Routing',
+          toolCalls: [
+            {
+              id: 'tool_call_nested_left',
+              name: `${Constants.LC_TRANSFER_TO_}left`,
+              args: { instructions: 'left-script-marker' },
+            },
+            {
+              id: 'tool_call_nested_right',
+              name: `${Constants.LC_TRANSFER_TO_}right`,
+              args: { instructions: 'right-script-marker' },
+            },
+          ],
+        },
+        {
+          promptMarker: 'left-script-marker',
+          response: 'Forwarding',
+          toolCalls: [
+            {
+              id: 'tool_call_nested_final',
+              name: `${Constants.LC_TRANSFER_TO_}final`,
+              args: { instructions: 'final-script-marker' },
+            },
+          ],
+        },
+        {
+          promptMarker: 'right-script-marker',
+          response: 'Right complete',
+        },
+        {
+          promptMarker: 'final-script-marker',
+          response: 'Final complete',
+        },
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-nested-handoff-group-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('router-script-marker')] },
+        config
+      );
+
+      const leftSteps = run.Graph.getRunSteps('left');
+      const rightSteps = run.Graph.getRunSteps('right');
+      const finalSteps = run.Graph.getRunSteps('final');
+      const parallelGroupId = leftSteps[0]?.groupId;
+
+      expect(parallelGroupId).toEqual(expect.any(Number));
+      expect(rightSteps.length).toBeGreaterThan(0);
+      expect(rightSteps.every((step) => step.groupId === parallelGroupId)).toBe(
+        true
+      );
+      expect(finalSteps.length).toBeGreaterThan(0);
+      expect(finalSteps.every((step) => step.groupId == null)).toBe(true);
+    });
+
+    it('should remove every transfer call from mixed conditional recipient history', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'mixed-router-marker'),
+        createBasicAgent('left', 'mixed-left-marker'),
+        createBasicAgent('right', 'mixed-right-marker'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'left',
+          edgeType: 'handoff',
+          prompt: 'Instructions for the left specialist',
+        },
+        {
+          from: 'router',
+          to: 'right',
+          condition: () => 'right',
+          prompt: 'Instructions for the right specialist',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      run.Graph.overrideModel = new ScriptedHandoffModel([
+        {
+          promptMarker: 'mixed-router-marker',
+          response: 'Routing',
+          toolCalls: [
+            {
+              id: 'tool_call_mixed_left',
+              name: `${Constants.LC_TRANSFER_TO_}left`,
+              args: { instructions: 'mixed-left-marker' },
+            },
+            {
+              id: 'tool_call_mixed_right',
+              name: 'conditional_transfer',
+              args: { instructions: 'mixed-right-marker' },
+            },
+          ],
+        },
+        {
+          promptMarker: 'mixed-left-marker',
+          response: 'Left complete',
+        },
+        {
+          promptMarker: 'mixed-right-marker',
+          response: 'Right complete',
+        },
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-mixed-parallel-handoff-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await expect(
+        run.processStream(
+          { messages: [new HumanMessage('mixed-router-marker')] },
+          config
+        )
+      ).resolves.toBeDefined();
+
+      const leftSteps = run.Graph.getRunSteps('left');
+      const rightSteps = run.Graph.getRunSteps('right');
+      const groupId = leftSteps[0]?.groupId;
+      expect(groupId).toEqual(expect.any(Number));
+      expect(rightSteps.length).toBeGreaterThan(0);
+      expect(rightSteps.every((step) => step.groupId === groupId)).toBe(true);
+    });
+  });
+
   describe('Handoffs with Prompts', () => {
     it('should create handoff tool with prompt parameter when prompt is specified', async () => {
       const agents: t.AgentInputs[] = [
@@ -627,6 +1241,178 @@ describe('Agent Handoffs Tests', () => {
       expect(handoffMessage).toBeDefined();
       // Tool message should contain the prompt key and value
       expect(handoffMessage?.content).toContain('Context:');
+    });
+
+    it('should deliver custom prompt key content to the receiving agent', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('agent_a', 'You are agent A'),
+        createBasicAgent('agent_b', 'You are agent B'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'agent_a',
+          to: 'agent_b',
+          edgeType: 'handoff',
+          prompt: 'Brief for agent B',
+          promptKey: 'brief',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      const brief = 'Investigate the cache invalidation path';
+      const rawBrief = `  ${brief}\n`;
+
+      run.Graph?.overrideTestModel(
+        ['Transferring', 'Investigation complete'],
+        10,
+        [
+          {
+            id: 'tool_call_custom_prompt',
+            name: `${Constants.LC_TRANSFER_TO_}agent_b`,
+            args: { brief: rawBrief },
+          } as ToolCall,
+        ]
+      );
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-custom-prompt-key-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('Delegate this investigation')] },
+        config
+      );
+
+      const receivedBrief = run
+        .getRunMessages()
+        ?.some(
+          (message) =>
+            message.getType() === 'human' && message.content === brief
+        );
+      expect(receivedBrief).toBe(true);
+      expect(
+        run
+          .getRunMessages()
+          ?.some(
+            (message) =>
+              message.getType() === 'human' && message.content === rawBrief
+          )
+      ).toBe(false);
+    });
+
+    it('should deliver custom prompt key content through a conditional handoff', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('agent_a', 'You are agent A'),
+        createBasicAgent('agent_b', 'You are agent B'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'agent_a',
+          to: 'agent_b',
+          condition: () => 'agent_b',
+          prompt: 'Brief for agent B',
+          promptKey: 'brief',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      const brief = 'Review the conditional routing result';
+
+      run.Graph?.overrideTestModel(['Transferring', 'Review complete'], 10, [
+        {
+          id: 'tool_call_conditional_prompt',
+          name: 'conditional_transfer',
+          args: { brief },
+        } as ToolCall,
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: {
+          thread_id: 'test-conditional-custom-prompt-key-thread',
+        },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('Delegate conditionally')] },
+        config
+      );
+
+      const receivedBrief = run
+        .getRunMessages()
+        ?.some(
+          (message) =>
+            message.getType() === 'human' && message.content === brief
+        );
+      expect(receivedBrief).toBe(true);
+    });
+
+    it('should recover a complete custom-key payload from a legacy checkpoint', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('agent_a', 'You are agent A'),
+        createBasicAgent('agent_b', 'You are agent B'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'agent_a',
+          to: 'agent_b',
+          edgeType: 'handoff',
+          prompt: 'Brief for agent B',
+          promptKey: 'brief',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      const graph = run.Graph as unknown as HandoffReceptionProbe;
+      const toolCall = {
+        id: 'tool_call_legacy_prompt',
+        name: `${Constants.LC_TRANSFER_TO_}agent_b`,
+        args: {},
+      };
+      const payload =
+        'Inspect the routing decision.\nContext: retain this entire line.';
+      const context = graph.processHandoffReception(
+        [
+          new AIMessage({ content: '', tool_calls: [toolCall] }),
+          new ToolMessage({
+            content: `Successfully transferred to agent_b\n\nBrief: ${payload}`,
+            name: toolCall.name,
+            tool_call_id: toolCall.id,
+          }),
+        ],
+        'agent_b'
+      );
+
+      expect(context?.instructions).toBe(payload);
+
+      const whitespaceContext = graph.processHandoffReception(
+        [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'tool_call_whitespace_prompt',
+                name: `${Constants.LC_TRANSFER_TO_}agent_b`,
+                args: {},
+              },
+            ],
+          }),
+          new ToolMessage({
+            content: 'Successfully transferred to agent_b\n\nBrief:   ',
+            name: `${Constants.LC_TRANSFER_TO_}agent_b`,
+            tool_call_id: 'tool_call_whitespace_prompt',
+            additional_kwargs: {
+              handoff_instructions: '  \n ',
+            },
+          }),
+        ],
+        'agent_b'
+      );
+      expect(whitespaceContext?.instructions).toBe('');
     });
   });
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1829,6 +1829,19 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     }
     return Array.isArray(content) ? content[0] : content;
   };
+  const applyContentMetadata = (index: number): void => {
+    const contentPart = contentParts[index];
+    if (contentPart == null) {
+      return;
+    }
+    const meta = contentMetaMap.get(index);
+    if (meta?.agentId != null) {
+      contentPart.agentId = meta.agentId;
+    }
+    if (meta?.groupId != null) {
+      contentPart.groupId = meta.groupId;
+    }
+  };
 
   const updateContent = (
     index: number,
@@ -1996,13 +2009,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     // Apply agentId (for MultiAgentGraph) and groupId (for parallel execution) to content parts
     // - agentId present → MultiAgentGraph (show agent labels)
     // - groupId present → parallel execution (render columns)
-    const meta = contentMetaMap.get(index);
-    if (meta?.agentId != null) {
-      (contentParts[index] as t.MessageContentComplex).agentId = meta.agentId;
-    }
-    if (meta?.groupId != null) {
-      (contentParts[index] as t.MessageContentComplex).groupId = meta.groupId;
-    }
+    applyContentMetadata(index);
   };
 
   const aggregateContent = ({
@@ -2046,6 +2053,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       // concatenate in updateContent.  This event carries only the correct
       // final text from the last stage.
       contentParts[runStep.index] = summary;
+      applyContentMetadata(runStep.index);
       return;
     }
 
@@ -2173,6 +2181,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
 
       if (result.type === ContentTypes.SUMMARY && 'summary' in result) {
         contentParts[runStep.index] = result.summary as t.MessageContentComplex;
+        applyContentMetadata(runStep.index);
       } else if ('tool_call' in result) {
         const contentPart: t.MessageContentComplex = {
           type: ContentTypes.TOOL_CALL,

--- a/src/summarization/__tests__/aggregator.test.ts
+++ b/src/summarization/__tests__/aggregator.test.ts
@@ -125,6 +125,89 @@ describe('createContentAggregator – SUMMARY accumulation', () => {
     expect(part.model).toBe('claude-sonnet-4-5');
   });
 
+  it('preserves agent and parallel-group metadata on summary completion', () => {
+    const { aggregateContent, contentParts } = createContentAggregator();
+
+    const runStep: t.RunStep = {
+      stepIndex: 0,
+      id: 'step_sum_3',
+      type: StepTypes.MESSAGE_CREATION,
+      index: 0,
+      agentId: 'researcher',
+      groupId: 7,
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'step_sum_3' },
+      },
+      summary: {
+        type: ContentTypes.SUMMARY,
+        content: [],
+        tokenCount: 0,
+        provider: 'openai',
+      },
+      usage: null,
+    };
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: runStep,
+    });
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP_COMPLETED,
+      data: {
+        result: {
+          id: 'step_sum_3',
+          index: 0,
+          type: ContentTypes.SUMMARY,
+          summary: {
+            type: ContentTypes.SUMMARY,
+            content: [{ type: ContentTypes.TEXT, text: 'Step summary' }],
+            tokenCount: 4,
+            provider: 'openai',
+          },
+        },
+      } as unknown as { result: t.ToolEndEvent },
+    });
+
+    expect(contentParts[0]).toEqual(
+      expect.objectContaining({
+        type: ContentTypes.SUMMARY,
+        content: [{ type: ContentTypes.TEXT, text: 'Step summary' }],
+        agentId: 'researcher',
+        groupId: 7,
+      })
+    );
+
+    aggregateContent({
+      event: GraphEvents.ON_SUMMARIZE_COMPLETE,
+      data: {
+        id: 'step_sum_3',
+        agentId: 'researcher',
+        summary: {
+          type: ContentTypes.SUMMARY,
+          content: [{ type: ContentTypes.TEXT, text: 'Final summary' }],
+          tokenCount: 5,
+          provider: 'openai',
+          boundary: {
+            messageId: 'step_sum_3',
+            contentIndex: 0,
+          },
+        },
+      } as t.SummarizeCompleteEvent,
+    });
+
+    expect(contentParts[0]).toEqual(
+      expect.objectContaining({
+        type: ContentTypes.SUMMARY,
+        content: [{ type: ContentTypes.TEXT, text: 'Final summary' }],
+        tokenCount: 5,
+        agentId: 'researcher',
+        groupId: 7,
+      })
+    );
+  });
+
   it('handles delta when no run step exists', () => {
     const { aggregateContent, contentParts } = createContentAggregator();
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { ToolCall } from '@langchain/core/messages/tool';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import {
@@ -119,6 +120,9 @@ type RunToolBatchContext<T = unknown> = {
 };
 
 const TOOL_NODE_RUN_NAME = 'tool_batch';
+const NANOID_URL_ALPHABET =
+  '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const RUNTIME_HANDOFF_GROUP_OFFSET = 2 ** 48;
 
 /**
  * Per-batch context for `dispatchToolEvents` / `executeViaEvent`.
@@ -156,6 +160,41 @@ function isSend(value: unknown): value is Send {
 
 function isHandoffToolName(name: string): boolean {
   return name.startsWith(Constants.LC_TRANSFER_TO_);
+}
+
+/**
+ * Encodes 48 random bits from the persisted batch key into a safe integer.
+ * The high offset keeps runtime groups disjoint from low, structural group IDs.
+ */
+function getRuntimeHandoffGroupId(batch: string): number {
+  let value = 0;
+  for (const char of batch.slice(0, 8)) {
+    const digit = NANOID_URL_ALPHABET.indexOf(char);
+    value = value * 64 + Math.max(digit, 0);
+  }
+  return RUNTIME_HANDOFF_GROUP_OFFSET + value;
+}
+
+function findHandoffMessage(
+  messages: BaseMessage[],
+  destination: string
+): ToolMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.getType() !== 'tool') {
+      continue;
+    }
+    const toolMessage = message as ToolMessage;
+    const isStandardHandoff =
+      toolMessage.name === `${Constants.LC_TRANSFER_TO_}${destination}`;
+    const isConditionalHandoff =
+      toolMessage.name === 'conditional_transfer' &&
+      toolMessage.additional_kwargs.handoff_destination === destination;
+    if (isStandardHandoff || isConditionalHandoff) {
+      return toolMessage;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -3854,21 +3893,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const goto = cmd.goto;
         return typeof goto === 'string' ? goto : (goto as string[])[0];
       });
+      const parallelBatch = nanoid();
+      const parallelGroupId = getRuntimeHandoffGroupId(parallelBatch);
 
       const sends = handoffCommands.map((cmd, idx) => {
         const destination = allDestinations[idx];
         /** Get siblings (other destinations, not this one) */
         const siblings = allDestinations.filter((d) => d !== destination);
 
-        /** Add siblings to ToolMessage additional_kwargs */
         const update = cmd.update as { messages?: BaseMessage[] } | undefined;
-        if (update && update.messages) {
-          for (const msg of update.messages) {
-            if (msg.getType() === 'tool') {
-              (msg as ToolMessage).additional_kwargs.handoff_parallel_siblings =
-                siblings;
-            }
-          }
+        const handoffMessage = update?.messages
+          ? findHandoffMessage(update.messages, destination)
+          : undefined;
+        if (handoffMessage) {
+          handoffMessage.additional_kwargs.handoff_parallel_siblings = siblings;
+          handoffMessage.additional_kwargs[Constants.HANDOFF_PARALLEL_BATCH] =
+            parallelBatch;
+          handoffMessage.additional_kwargs[Constants.HANDOFF_GROUP_ID] =
+            parallelGroupId;
         }
 
         return new Send(destination, cmd.update);

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -68,13 +68,14 @@ export type RunStep = {
   runId?: string; // #new
   agentId?: string; // #new - tracks which agent this step belongs to
   /**
-   * Group ID - incrementing number (1, 2, 3...) reflecting execution order.
-   * Agents with the same groupId run in parallel and should be rendered together.
-   * undefined means the agent runs sequentially (not part of any parallel group).
+   * Opaque positive safe-integer identifier for parallel execution.
+   * Agents with the same groupId should be rendered together.
+   * Consumers must use content indexes, not groupId ordering, for execution order.
+   * undefined means the agent runs sequentially (not part of a parallel group).
    *
    * Example for: researcher -> [analyst1, analyst2, analyst3] -> summarizer
    * - researcher: undefined (sequential)
-   * - analyst1, analyst2, analyst3: 1 (first parallel group)
+   * - analyst1, analyst2, analyst3: the same groupId (parallel group)
    * - summarizer: undefined (sequential)
    */
   groupId?: number; // #new


### PR DESCRIPTION
## Summary

I fixed handoff payload preservation, runtime parallel grouping, stale reception, and summary metadata in the agents SDK, with regression coverage for the host failures surfaced by LibreChat's handoff E2E suite.

- Preserve arbitrary handoff `promptKey` values through structured metadata while retaining exact-label compatibility for legacy checkpoints.
- Persist one shared, safe numeric `groupId` on simultaneous standard and conditional handoff siblings before checkpointing or `Send` execution.
- Treat runtime `groupId` values as opaque equality tokens while keeping static graph groups and sequential branches distinct.
- Prevent hybrid and nested routes from inheriting structural or prior runtime groups by carrying an explicit ungrouped sentinel.
- Prevent historical transfer messages from re-injecting stale instructions or grouping later direct executions into an earlier batch.
- Remove every transfer call/result from mixed standard and conditional handoff prompts so receiving models never see orphaned tool calls.
- Preserve `agentId` and `groupId` when summarization replaces streamed content or run-step output.
- Add public-stream, MemorySaver checkpoint, hybrid routing, nested routing, custom-key, mixed-transfer, stale-history, and summarization regressions.

This supplies the SDK-side fixes needed by [LibreChat #14428](https://github.com/danny-avila/LibreChat/pull/14428). LibreChat should keep its 3.2.68 compatibility adapter until this change is released and the dependency is bumped.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm test -- --runInBand src/specs/agent-handoffs.test.ts src/graphs/__tests__/MultiAgentGraph.test.ts src/graphs/__tests__/composition.smoke.test.ts src/summarization/__tests__/aggregator.test.ts src/specs/multi-agent-summarization.test.ts` — 57 passed
- `npx tsc --noEmit`
- `npm run build`
- `npx lint-staged --no-stash`
- `node scripts/sort-imports.ts --check <8 changed files>`
- `git diff --check`
- Attempted the complete Jest suite. It could not finish in this environment because live Anthropic/Google suites lacked API keys, local execution and session-store suites were denied sandbox bind/home-directory access, and the process eventually exhausted its 4 GiB heap. The two isolated Langfuse routing failures reproduced identically on untouched `c23bc081`, so they are pre-existing and unrelated to this diff.

### **Test Configuration**:

- macOS
- Node.js 24.16.0
- Jest with `--experimental-vm-modules`
- LangGraph `MemorySaver` for durable parallel-handoff assertions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes