### PR TITLE
🧭 fix: Recover Tool Completions Across HITL Resume

### DIFF
--- a/src/splitStream.test.ts
+++ b/src/splitStream.test.ts
@@ -225,6 +225,163 @@ describe('ContentAggregator empty deltas', () => {
   });
 });
 
+describe('ContentAggregator resumed tool completions', () => {
+  it('matches a completion to seeded content when a rebuilt run has no step id', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    contentParts.push(
+      { type: ContentTypes.TEXT, text: 'Before approval' },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_approval',
+          name: 'approval_probe',
+          args: { value: 'original' },
+        },
+      }
+    );
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP_COMPLETED,
+      data: {
+        result: {
+          id: '',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_approval',
+            name: 'approval_probe',
+            args: '{"value":"original"}',
+            output: 'approved',
+            progress: 1,
+          } as t.ProcessedToolCall,
+        },
+      } as { result: t.ToolEndEvent },
+    });
+
+    expect(contentParts[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Before approval',
+    });
+    expect(contentParts[1]).toEqual({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_approval',
+        name: 'approval_probe',
+        args: '{"value":"original"}',
+        type: 'tool_call',
+        output: 'approved',
+        progress: 1,
+      },
+    });
+  });
+
+  it('rebinds a replacement run step to seeded content by tool call id', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { contentParts, aggregateContent, stepMap } =
+      createContentAggregator();
+    contentParts.push(
+      { type: ContentTypes.TEXT, text: 'Before approval' },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_approval',
+          name: 'approval_probe',
+          args: { value: 'original' },
+        },
+      }
+    );
+
+    try {
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP,
+        data: {
+          id: 'step_rebuilt',
+          stepIndex: 0,
+          type: StepTypes.TOOL_CALLS,
+          index: 0,
+          stepDetails: {
+            type: StepTypes.TOOL_CALLS,
+            tool_calls: [
+              {
+                id: 'call_approval',
+                name: 'approval_probe',
+                args: { value: 'original' },
+              },
+            ],
+          },
+          usage: null,
+        },
+      });
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: {
+          result: {
+            id: 'step_rebuilt',
+            index: 0,
+            type: 'tool_call',
+            tool_call: {
+              id: 'call_approval',
+              name: 'approval_probe',
+              args: '{"value":"original"}',
+              output: 'approved',
+              progress: 1,
+            } as t.ProcessedToolCall,
+          },
+        } as { result: t.ToolEndEvent },
+      });
+
+      expect(stepMap.get('step_rebuilt')?.index).toBe(1);
+      expect(contentParts[0]).toEqual({
+        type: ContentTypes.TEXT,
+        text: 'Before approval',
+      });
+      expect(contentParts[1]).toMatchObject({
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_approval',
+          output: 'approved',
+          progress: 1,
+        },
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('drops a completion that matches neither a step nor seeded tool call', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { contentParts, aggregateContent } = createContentAggregator();
+
+    try {
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: {
+          result: {
+            id: '',
+            index: 0,
+            type: 'tool_call',
+            tool_call: {
+              id: 'call_unknown',
+              name: 'unknown',
+              args: '{}',
+              output: 'untrusted',
+              progress: 1,
+            } as t.ProcessedToolCall,
+          },
+        } as { result: t.ToolEndEvent },
+      });
+
+      expect(contentParts).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'No run step or tool call found for completed step event'
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
 describe('ContentAggregator provider-specific parts', () => {
   it('should preserve Gemini server-side tool content blocks', () => {
     const { contentParts, aggregateContent } = createContentAggregator();

--- a/src/splitStream.test.ts
+++ b/src/splitStream.test.ts
@@ -273,6 +273,30 @@ describe('ContentAggregator resumed tool completions', () => {
         progress: 1,
       },
     });
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: { ...createRunStep('step_continuation'), index: 1 },
+    });
+    aggregateContent({
+      event: GraphEvents.ON_MESSAGE_DELTA,
+      data: {
+        id: 'step_continuation',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              text: 'After approval',
+            },
+          ],
+        },
+      } as t.MessageDeltaEvent,
+    });
+
+    expect(contentParts[2]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'After approval',
+    });
   });
 
   it('rebinds a replacement run step to seeded content by tool call id', () => {
@@ -343,10 +367,145 @@ describe('ContentAggregator resumed tool completions', () => {
           progress: 1,
         },
       });
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP,
+        data: { ...createRunStep('step_continuation'), index: 1 },
+      });
+      aggregateContent({
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: {
+          id: 'step_continuation',
+          delta: {
+            content: [
+              {
+                type: ContentTypes.TEXT,
+                text: 'After approval',
+              },
+            ],
+          },
+        } as t.MessageDeltaEvent,
+      });
+      expect(stepMap.get('step_continuation')?.index).toBe(2);
+      expect(contentParts[2]).toEqual({
+        type: ContentTypes.TEXT,
+        text: 'After approval',
+      });
       expect(warnSpy).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it('matches parallel completions to their own seeded tool cards', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    contentParts.push(
+      { type: ContentTypes.TEXT, text: 'Before approval' },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_first',
+          name: 'approval_probe',
+          args: { value: 'first' },
+        },
+      },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'call_second',
+          name: 'approval_probe',
+          args: { value: 'second' },
+        },
+      }
+    );
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: {
+        id: 'step_parallel',
+        stepIndex: 0,
+        type: StepTypes.TOOL_CALLS,
+        index: 0,
+        stepDetails: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'call_first',
+              name: 'approval_probe',
+              args: { value: 'first' },
+            },
+            {
+              id: 'call_second',
+              name: 'approval_probe',
+              args: { value: 'second' },
+            },
+          ],
+        },
+        usage: null,
+      },
+    });
+
+    for (const [id, value] of [
+      ['call_first', 'first'],
+      ['call_second', 'second'],
+    ]) {
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: {
+          result: {
+            id: 'step_parallel',
+            index: 0,
+            type: 'tool_call',
+            tool_call: {
+              id,
+              name: 'approval_probe',
+              args: JSON.stringify({ value }),
+              output: `${value} approved`,
+              progress: 1,
+            } as t.ProcessedToolCall,
+          },
+        } as { result: t.ToolEndEvent },
+      });
+    }
+
+    expect(contentParts[1]).toMatchObject({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_first',
+        output: 'first approved',
+        progress: 1,
+      },
+    });
+    expect(contentParts[2]).toMatchObject({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_second',
+        output: 'second approved',
+        progress: 1,
+      },
+    });
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: { ...createRunStep('step_after_parallel'), index: 1 },
+    });
+    aggregateContent({
+      event: GraphEvents.ON_MESSAGE_DELTA,
+      data: {
+        id: 'step_after_parallel',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              text: 'Parallel tools complete',
+            },
+          ],
+        },
+      } as t.MessageDeltaEvent,
+    });
+    expect(contentParts[3]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Parallel tools complete',
+    });
   });
 
   it('drops a completion that matches neither a step nor seeded tool call', () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1829,6 +1829,23 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     }
     return Array.isArray(content) ? content[0] : content;
   };
+  const findToolCallIndex = (
+    toolCallId: string | undefined
+  ): number | undefined => {
+    if (toolCallId == null || toolCallId === '') {
+      return undefined;
+    }
+    for (let index = contentParts.length - 1; index >= 0; index--) {
+      const contentPart = contentParts[index];
+      if (
+        contentPart?.type === ContentTypes.TOOL_CALL &&
+        contentPart.tool_call.id === toolCallId
+      ) {
+        return index;
+      }
+    }
+    return undefined;
+  };
 
   const updateContent = (
     index: number,
@@ -2050,7 +2067,18 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     }
 
     if (event === GraphEvents.ON_RUN_STEP) {
-      const runStep = data as t.RunStep;
+      const incomingRunStep = data as t.RunStep;
+      const seededToolCallIndex =
+        incomingRunStep.stepDetails.type === StepTypes.TOOL_CALLS
+          ? incomingRunStep.stepDetails.tool_calls
+            ?.map((toolCall) => findToolCallIndex(toolCall.id))
+            .find((index) => index != null)
+          : undefined;
+      const runStep =
+        seededToolCallIndex != null &&
+        seededToolCallIndex !== incomingRunStep.index
+          ? { ...incomingRunStep, index: seededToolCallIndex }
+          : incomingRunStep;
       stepMap.set(runStep.id, runStep);
 
       // Track agentId (MultiAgentGraph) and groupId (parallel execution) separately
@@ -2166,19 +2194,27 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       const { id: stepId } = result;
 
       const runStep = stepMap.get(stepId);
-      if (!runStep) {
-        console.warn('No run step or runId found for completed step event');
-        return;
-      }
 
       if (result.type === ContentTypes.SUMMARY && 'summary' in result) {
+        if (!runStep) {
+          console.warn('No run step or runId found for completed step event');
+          return;
+        }
         contentParts[runStep.index] = result.summary as t.MessageContentComplex;
       } else if ('tool_call' in result) {
+        const contentIndex =
+          runStep?.index ?? findToolCallIndex(result.tool_call.id);
+        if (contentIndex == null) {
+          console.warn(
+            'No run step or tool call found for completed step event'
+          );
+          return;
+        }
         const contentPart: t.MessageContentComplex = {
           type: ContentTypes.TOOL_CALL,
           tool_call: (result as t.ToolEndEvent).tool_call,
         };
-        updateContent(runStep.index, contentPart, true);
+        updateContent(contentIndex, contentPart, true);
       }
     }
   };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1815,7 +1815,11 @@ hasToolCallChunks: ${hasToolCallChunks}
 export function createContentAggregator(): t.ContentAggregatorResult {
   const contentParts: Array<t.MessageContentComplex | undefined> = [];
   const stepMap = new Map<string, t.RunStep>();
-  const toolCallIdMap = new Map<string, string>();
+  const toolCallIdsByStep = new Map<string, string[]>();
+  const toolCallContentIndexMap = new Map<string, number>();
+  const sourceStepIndexMap = new Map<string, number>();
+  let indexedContentLength = 0;
+  let contentIndexOffset = 0;
   // Track agentId and groupId for each content index (applied to content parts)
   const contentMetaMap = new Map<
     number,
@@ -1829,22 +1833,60 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     }
     return Array.isArray(content) ? content[0] : content;
   };
-  const findToolCallIndex = (
+  const indexToolCall = (
+    index: number,
+    contentPart?: t.MessageContentComplex
+  ): void => {
+    if (contentPart?.type !== ContentTypes.TOOL_CALL) {
+      return;
+    }
+    const toolCallId = contentPart.tool_call.id;
+    if (toolCallId != null && toolCallId !== '') {
+      toolCallContentIndexMap.set(toolCallId, index);
+    }
+  };
+  const indexSeededToolCalls = (): void => {
+    for (
+      let index = indexedContentLength;
+      index < contentParts.length;
+      index++
+    ) {
+      indexToolCall(index, contentParts[index]);
+    }
+    indexedContentLength = contentParts.length;
+  };
+  const getToolCallContentIndex = (
     toolCallId: string | undefined
   ): number | undefined => {
     if (toolCallId == null || toolCallId === '') {
       return undefined;
     }
-    for (let index = contentParts.length - 1; index >= 0; index--) {
-      const contentPart = contentParts[index];
-      if (
-        contentPart?.type === ContentTypes.TOOL_CALL &&
-        contentPart.tool_call.id === toolCallId
-      ) {
-        return index;
-      }
+    indexSeededToolCalls();
+    return toolCallContentIndexMap.get(toolCallId);
+  };
+  const expandContentIndexOffset = (
+    sourceIndex: number,
+    contentIndex: number
+  ): void => {
+    contentIndexOffset = Math.max(
+      contentIndexOffset,
+      contentIndex - sourceIndex
+    );
+  };
+  const setContentMeta = (index: number, runStep: t.RunStep): void => {
+    const hasAgentId = runStep.agentId != null && runStep.agentId !== '';
+    const hasGroupId = runStep.groupId != null;
+    if (!hasAgentId && !hasGroupId) {
+      return;
     }
-    return undefined;
+    const existingMeta = contentMetaMap.get(index) ?? {};
+    if (hasAgentId) {
+      existingMeta.agentId = runStep.agentId;
+    }
+    if (hasGroupId) {
+      existingMeta.groupId = runStep.groupId;
+    }
+    contentMetaMap.set(index, existingMeta);
   };
 
   const updateContent = (
@@ -1981,6 +2023,15 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       const name =
         getNonEmptyValue([incomingName, existingContent?.tool_call?.name]) ??
         '';
+      const existingToolCallId = existingContent?.tool_call?.id;
+      if (
+        existingToolCallId != null &&
+        existingToolCallId !== '' &&
+        existingToolCallId !== id &&
+        toolCallContentIndexMap.get(existingToolCallId) === index
+      ) {
+        toolCallContentIndexMap.delete(existingToolCallId);
+      }
 
       const newToolCall: ToolCall & t.PartMetadata = {
         id,
@@ -2008,6 +2059,8 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         type: ContentTypes.TOOL_CALL,
         tool_call: newToolCall,
       };
+      indexToolCall(index, contentParts[index]);
+      indexedContentLength = Math.max(indexedContentLength, index + 1);
     }
 
     // Apply agentId (for MultiAgentGraph) and groupId (for parallel execution) to content parts
@@ -2068,34 +2121,46 @@ export function createContentAggregator(): t.ContentAggregatorResult {
 
     if (event === GraphEvents.ON_RUN_STEP) {
       const incomingRunStep = data as t.RunStep;
-      const seededToolCallIndex =
+      const toolCalls =
         incomingRunStep.stepDetails.type === StepTypes.TOOL_CALLS
-          ? incomingRunStep.stepDetails.tool_calls
-            ?.map((toolCall) => findToolCallIndex(toolCall.id))
-            .find((index) => index != null)
+          ? (incomingRunStep.stepDetails.tool_calls as ToolCall[] | undefined)
           : undefined;
+      let runStepIndex = incomingRunStep.index + contentIndexOffset;
+      let toolCallIndices: number[] | undefined;
+      if (toolCalls && toolCalls.length > 0) {
+        indexSeededToolCalls();
+        let seededBaseIndex: number | undefined;
+        for (let index = 0; index < toolCalls.length; index++) {
+          const seededIndex = toolCallContentIndexMap.get(
+            toolCalls[index].id ?? ''
+          );
+          if (seededIndex != null) {
+            seededBaseIndex = seededIndex - index;
+            break;
+          }
+        }
+        if (seededBaseIndex != null) {
+          expandContentIndexOffset(incomingRunStep.index, seededBaseIndex);
+        }
+        const baseIndex = incomingRunStep.index + contentIndexOffset;
+        toolCallIndices = toolCalls.map(
+          (toolCall, index) =>
+            toolCallContentIndexMap.get(toolCall.id ?? '') ?? baseIndex + index
+        );
+        runStepIndex = toolCallIndices[0] ?? baseIndex;
+        expandContentIndexOffset(
+          incomingRunStep.index,
+          Math.max(...toolCallIndices)
+        );
+      }
       const runStep =
-        seededToolCallIndex != null &&
-        seededToolCallIndex !== incomingRunStep.index
-          ? { ...incomingRunStep, index: seededToolCallIndex }
+        runStepIndex !== incomingRunStep.index
+          ? { ...incomingRunStep, index: runStepIndex }
           : incomingRunStep;
+      sourceStepIndexMap.set(runStep.id, incomingRunStep.index);
       stepMap.set(runStep.id, runStep);
 
-      // Track agentId (MultiAgentGraph) and groupId (parallel execution) separately
-      // - agentId: present for all MultiAgentGraph runs (enables agent labels in UI)
-      // - groupId: present only for parallel execution (enables column rendering)
-      const hasAgentId = runStep.agentId != null && runStep.agentId !== '';
-      const hasGroupId = runStep.groupId != null;
-      if (hasAgentId || hasGroupId) {
-        const existingMeta = contentMetaMap.get(runStep.index) ?? {};
-        if (hasAgentId) {
-          existingMeta.agentId = runStep.agentId;
-        }
-        if (hasGroupId) {
-          existingMeta.groupId = runStep.groupId;
-        }
-        contentMetaMap.set(runStep.index, existingMeta);
-      }
+      setContentMeta(runStep.index, runStep);
 
       if (runStep.summary != null) {
         updateContent(runStep.index, runStep.summary);
@@ -2105,22 +2170,29 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         runStep.stepDetails.type === StepTypes.TOOL_CALLS &&
         runStep.stepDetails.tool_calls
       ) {
-        (runStep.stepDetails.tool_calls as ToolCall[]).forEach((toolCall) => {
-          const toolCallId = toolCall.id ?? '';
-          if ('id' in toolCall && toolCallId) {
-            toolCallIdMap.set(runStep.id, toolCallId);
-          }
-          const contentPart: t.MessageContentComplex = {
-            type: ContentTypes.TOOL_CALL,
-            tool_call: {
-              args: toolCall.args,
-              name: toolCall.name,
-              id: toolCallId,
-            },
-          };
+        const toolCallIds = toolCallIdsByStep.get(runStep.id) ?? [];
+        (runStep.stepDetails.tool_calls as ToolCall[]).forEach(
+          (toolCall, toolCallIndex) => {
+            const contentIndex =
+              toolCallIndices?.[toolCallIndex] ?? runStep.index + toolCallIndex;
+            const toolCallId = toolCall.id ?? '';
+            if ('id' in toolCall && toolCallId) {
+              toolCallIds[toolCallIndex] = toolCallId;
+            }
+            const contentPart: t.MessageContentComplex = {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                args: toolCall.args,
+                name: toolCall.name,
+                id: toolCallId,
+              },
+            };
 
-          updateContent(runStep.index, contentPart);
-        });
+            setContentMeta(contentIndex, runStep);
+            updateContent(contentIndex, contentPart);
+          }
+        );
+        toolCallIdsByStep.set(runStep.id, toolCallIds);
       }
     } else if (event === GraphEvents.ON_MESSAGE_DELTA) {
       const messageDelta = data as t.MessageDeltaEvent;
@@ -2167,8 +2239,21 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         runStepDelta.delta.type === StepTypes.TOOL_CALLS &&
         runStepDelta.delta.tool_calls
       ) {
-        runStepDelta.delta.tool_calls.forEach((toolCallDelta) => {
-          const toolCallId = toolCallIdMap.get(runStepDelta.id);
+        const toolCallIds = toolCallIdsByStep.get(runStepDelta.id) ?? [];
+        runStepDelta.delta.tool_calls.forEach((toolCallDelta, deltaIndex) => {
+          const toolCallIndex = toolCallDelta.index ?? deltaIndex;
+          const explicitToolCallId =
+            toolCallDelta.id != null && toolCallDelta.id !== ''
+              ? toolCallDelta.id
+              : undefined;
+          const toolCallId =
+            explicitToolCallId ?? toolCallIds.at(toolCallIndex);
+          if (toolCallId !== undefined) {
+            toolCallIds[toolCallIndex] = toolCallId;
+          }
+          const contentIndex =
+            getToolCallContentIndex(toolCallId) ??
+            runStep.index + toolCallIndex;
 
           const contentPart: t.MessageContentComplex = {
             type: ContentTypes.TOOL_CALL,
@@ -2181,8 +2266,14 @@ export function createContentAggregator(): t.ContentAggregatorResult {
             },
           };
 
-          updateContent(runStep.index, contentPart);
+          setContentMeta(contentIndex, runStep);
+          updateContent(contentIndex, contentPart);
+          expandContentIndexOffset(
+            sourceStepIndexMap.get(runStep.id) ?? runStep.index,
+            contentIndex
+          );
         });
+        toolCallIdsByStep.set(runStepDelta.id, toolCallIds);
       }
     } else if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
       const { result } = data as unknown as {
@@ -2203,13 +2294,14 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         contentParts[runStep.index] = result.summary as t.MessageContentComplex;
       } else if ('tool_call' in result) {
         const contentIndex =
-          runStep?.index ?? findToolCallIndex(result.tool_call.id);
+          getToolCallContentIndex(result.tool_call.id) ?? runStep?.index;
         if (contentIndex == null) {
           console.warn(
             'No run step or tool call found for completed step event'
           );
           return;
         }
+        expandContentIndexOffset(result.index, contentIndex);
         const contentPart: t.MessageContentComplex = {
           type: ContentTypes.TOOL_CALL,
           tool_call: (result as t.ToolEndEvent).tool_call,


### PR DESCRIPTION
## Summary

I made resumed HITL tool completions resilient when a rebuilt run emits a blank or replacement step ID.

- Match completed tool calls to seeded message content by stable tool-call ID when the run-step lookup is unavailable.
- Rebind replacement run steps to the existing seeded tool card instead of trusting a stale content index.
- Preserve the existing strict behavior for summaries and drop unknown completions with a warning instead of writing to an unrelated content slot.
- Add regressions for blank step IDs, replacement step IDs, shifted seeded content, and unmatched completions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused aggregator and resume contract suites, the package build, and lint:

- `npm test -- --runInBand src/splitStream.test.ts src/specs/tool-error-resume.test.ts` (22 tests passed)
- `npm run build`
- `npx eslint src/stream.ts src/splitStream.test.ts`

### **Test Configuration**:

- Node.js package workspace with the repository's installed dependencies
- Jest run serially for deterministic stream-event aggregation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes