### PR TITLE
🔪 feat: Cooperative Mid-Generation Stream Preemption

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -12,3 +12,24 @@ export const ANTHROPIC_TOOL_TOKEN_MULTIPLIER = 2.6;
  * Empirically calibrated at ~1.4× the raw JSON token count.
  */
 export const DEFAULT_TOOL_TOKEN_MULTIPLIER = 1.4;
+
+/**
+ * Default ceiling on cooperative stream seals per run. Each seal costs one
+ * extra superstep, so this also sizes the recursion-limit headroom a
+ * preemption-enabled run reserves.
+ */
+export const DEFAULT_MAX_SEALS = 8;
+
+/**
+ * Per-hook timeout for `PreemptBoundary`, deliberately far above
+ * `DEFAULT_HOOK_TIMEOUT_MS`. A host drain has already popped its queue and
+ * persisted content by the time this fires, so a timeout does not cancel the
+ * work — it only loses the messages the run was about to inject.
+ */
+export const PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS = 120_000;
+
+/**
+ * Default LangGraph recursion limit for a run. Callers may override it via
+ * the stream config; a preemption-enabled run adds its seal budget on top.
+ */
+export const DEFAULT_RECURSION_LIMIT = 50;

--- a/src/events.ts
+++ b/src/events.ts
@@ -7,6 +7,7 @@ import type {
 import type { Logger } from 'winston';
 import type { MultiAgentGraph, StandardGraph } from '@/graphs';
 import type * as t from '@/types';
+import { dispatchesChatModelStream, SDK_STREAM_DISPATCH } from '@/stream';
 import { Constants } from '@/common';
 
 export class HandlerRegistry {
@@ -36,7 +37,7 @@ export function composeEventHandlers(
         composed[eventType] = handler;
         continue;
       }
-      composed[eventType] = {
+      const wrapper: t.EventHandler = {
         handle: async (
           ...args: Parameters<t.EventHandler['handle']>
         ): Promise<void> => {
@@ -44,6 +45,19 @@ export function composeEventHandlers(
           await handler.handle(...args);
         },
       };
+      /**
+       * Carry the stream-dispatch brand across the wrapper. Without this a
+       * composed handler fails every capability check made about it — notably
+       * the one deciding whether a run may seal — even though it still drives
+       * the SDK's content-part dispatch.
+       */
+      if (
+        dispatchesChatModelStream(previous) ||
+        dispatchesChatModelStream(handler)
+      ) {
+        Object.defineProperty(wrapper, SDK_STREAM_DISPATCH, { value: true });
+      }
+      composed[eventType] = wrapper;
     }
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2685,7 +2685,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * last shaping step before the cache breakpoint is chosen.
        */
       if (strictAlternationProviders.has(agentContext.provider)) {
-        finalMessages = coalesceAdjacentUserTurns(finalMessages);
+        /**
+         * Wrapped like every other provider transform: the merged message is
+         * a NEW object, and without re-attachment the final pre-invoke
+         * measurement would drop both source turns' calibrated shares and
+         * recharge the merge at full raw estimate — enough to flip a
+         * just-fits payload (the synthetic-context compaction above binary
+         * searches to exactly that) into a spurious pre-invoke overflow. The
+         * merge keeps the first source's id, so the keyed branch re-attaches
+         * that origin; the absorbed turn's tokens are charged as new raw
+         * growth, which only ever under-estimates by less than the old
+         * behavior over-estimated.
+         */
+        const beforeCoalesce = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          beforeCoalesce,
+          coalesceAdjacentUserTurns(beforeCoalesce)
+        );
       }
 
       // Determine the prompt-cache strategy up front. Two distinct facts:

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1184,11 +1184,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   /** Internal seal preconditions only — no host callback, no side effects. */
   private canClaimPreemptSeal(): boolean {
+    /**
+     * Resolved and required here with the same rule `dispatchPreemptBoundary`
+     * uses. Without it a direct `StandardGraph` consumer that supplies no
+     * `runId` could claim a seal on the strength of a global matcher, then hit
+     * the boundary's own null-runId guard and get nothing back — truncating
+     * the answer for a drain that provably could not run.
+     */
+    const runId =
+      (this.config?.configurable?.run_id as string | undefined) ?? this.runId;
     return (
       !this.subagentScope &&
       this.preemption != null &&
       !this.preemptSealInFlight &&
       this.preemptSealBudgetUsed < resolveMaxSeals(this.preemption.maxSeals) &&
+      runId != null &&
       /**
        * A seal only buys room for an injection. With no `PreemptBoundary`
        * matcher live — never registered, or a `once` matcher already
@@ -1200,10 +1210,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * Same session resolution as `dispatchPreemptBoundary`, or a
        * session-scoped matcher would be visible at one site and not the other.
        */
-      this.hookRegistry?.hasDispatchableHookFor(
-        'PreemptBoundary',
-        (this.config?.configurable?.run_id as string | undefined) ?? this.runId
-      ) === true
+      this.hookRegistry?.hasDispatchableHookFor('PreemptBoundary', runId) ===
+        true
     );
   }
 
@@ -3449,9 +3457,42 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       },
       sessionId: runId,
       timeoutMs: PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
+      /**
+       * The host's own abort signal, deliberately NOT `config.signal` — inside
+       * a node the latter is LangGraph's composed signal, which also fires
+       * when an unrelated sibling in the same superstep throws. Cancellation
+       * already returns control in milliseconds without this; what it buys is
+       * that a drain does not keep running after the run it belongs to died.
+       */
+      signal: this.signal,
     }).catch((): undefined => undefined);
     if (result == null) {
       return EMPTY_PREEMPT_BOUNDARY;
+    }
+    /**
+     * `executeHooks` raises a registry halt whenever a hook returns
+     * `preventContinuation`. That halt has exactly one consumer — the poll in
+     * `Run.processStream` — and its `break` cancels the stream iterator, which
+     * aborts Pregel. The abort lands BEFORE the outer reducer commits
+     * `StandardGraph.messages`, so honoring the halt here would destroy the
+     * sealed assistant turn: the run returns empty content and the host
+     * persists nothing. Measured deterministically — the commit is several
+     * stream events downstream of the point the halt becomes observable.
+     *
+     * The `preventContinuation` branch in `createCallModel` already enforces
+     * the contract locally by declining to self-loop, and a sealed chunk
+     * provably carries no tool calls, so the turn routes to END after exactly
+     * one model call either way. Clearing the halt therefore costs nothing it
+     * was buying and saves the content the seal exists to preserve.
+     *
+     * Scoped to a halt this event raised, so a halt from an earlier hook in
+     * the same run — `haltRun` is first-write-wins — is left alone.
+     */
+    if (
+      result.preventContinuation === true &&
+      this.hookRegistry.getHaltSignal(runId)?.source === 'PreemptBoundary'
+    ) {
+      this.hookRegistry.clearHaltSignal(runId);
     }
     const injected: BaseMessage[] = [];
     /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -146,6 +146,25 @@ const EMPTY_PREEMPT_BOUNDARY: PreemptBoundaryResult = {
   preventContinuation: false,
 };
 
+/**
+ * One signal that fires when either input fires. `AbortSignal.any` is skipped
+ * when the inputs collapse to a single signal — the composite is a fresh
+ * object per call, and the common cases (one channel, or the host reusing the
+ * same controller for both) don't need one.
+ */
+function composeAbortSignals(
+  a: AbortSignal | undefined,
+  b: AbortSignal | undefined
+): AbortSignal | undefined {
+  if (a == null || a === b) {
+    return b;
+  }
+  if (b == null) {
+    return a;
+  }
+  return AbortSignal.any([a, b]);
+}
+
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
@@ -673,6 +692,20 @@ export abstract class Graph<
   reasoningStepHasDeltas: Set<string> = new Set();
   protected handlerDispatchedEventCounts: Map<string, number> = new Map();
   signal?: AbortSignal;
+  /**
+   * The abort signal the CALLER handed to the current `processStream` call,
+   * assigned unconditionally — including back to `undefined` — on every call.
+   *
+   * Kept separate from {@link signal} on purpose. That field is construction
+   * state with its own consumers (model-call config, subagent parentSignal),
+   * so adopting a per-call signal into it would leak one call's controller
+   * into the next — `clearHeavyState()` is skipped on HITL interrupts, so a
+   * host that aborts a finished request's controller would poison the resumed
+   * run's model calls and boundary drains with an already-aborted signal.
+   * Boundary dispatch composes the two instead; see
+   * `StandardGraph.dispatchPreemptBoundary`.
+   */
+  callerSignal?: AbortSignal;
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
   handlerRegistry: HandlerRegistry | undefined;
@@ -752,6 +785,7 @@ export abstract class Graph<
   clearHeavyState(): void {
     this.config = undefined;
     this.signal = undefined;
+    this.callerSignal = undefined;
     this.contentData = [];
     this.contentIndexMap = new Map();
     this.stepKeyIds = new Map();
@@ -3468,13 +3502,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessionId: runId,
       timeoutMs: PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
       /**
-       * The host's own abort signal, deliberately NOT `config.signal` — inside
-       * a node the latter is LangGraph's composed signal, which also fires
-       * when an unrelated sibling in the same superstep throws. Cancellation
-       * already returns control in milliseconds without this; what it buys is
-       * that a drain does not keep running after the run it belongs to died.
+       * The host's own abort signal(s), deliberately NOT `config.signal` —
+       * inside a node the latter is LangGraph's composed signal, which also
+       * fires when an unrelated sibling in the same superstep throws.
+       * Cancellation already returns control in milliseconds without this;
+       * what it buys is that a drain does not keep running after the run it
+       * belongs to died.
+       *
+       * Composed because the host can cancel through either channel: the
+       * construction signal, or the per-call `callerConfig.signal` — the only
+       * one a multi-agent run has, since `MultiAgentGraphConfig` exposes no
+       * construction signal. When both exist they may be different
+       * controllers, and a drain must stop when EITHER fires.
        */
-      signal: this.signal,
+      signal: composeAbortSignals(this.signal, this.callerSignal),
     }).catch((): undefined => undefined);
     if (result == null) {
       return EMPTY_PREEMPT_BOUNDARY;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1844,6 +1844,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         throw new Error('No config provided');
       }
 
+      /**
+       * A `PreemptBoundary` hook halted this run and the sealed commit is
+       * already in state. Enforced at every model node's ENTRY because that
+       * is the only site that covers all of `MultiAgentGraph`'s onward
+       * routing at once — static direct edges, Command fan-out, fan-in
+       * wrappers, and parallel siblings' subsequent inner-loop turns — none
+       * of which consult the halt (the registry signal was deliberately
+       * cleared to keep the stream-cancel from destroying the sealed turn).
+       * Declining the model call turns every routed-to successor into a
+       * no-op, so the outer workflow drains to END without new turns or tool
+       * side effects. Reset per turn in `resetPreemptTotals`, so the next
+       * `processStream` call starts clean.
+       */
+      if (this.preemptHaltReason != null) {
+        return { messages: [] };
+      }
+
       const { messages } = state;
 
       const discoveredNames = extractToolDiscoveries(messages);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1168,28 +1168,39 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * Subagent scopes never seal: a steer targets the top-level conversation,
    * and a child run must finish so its parent sees a complete result.
    */
-  shouldPreemptStream(): boolean {
+  /** Internal seal preconditions only — no host callback, no side effects. */
+  private canClaimPreemptSeal(): boolean {
     return (
       !this.subagentScope &&
       this.preemption != null &&
       !this.preemptSealInFlight &&
       this.preemptSealBudgetUsed <
-        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
-      this.preemption.shouldPreempt() === true
+        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS)
+    );
+  }
+
+  shouldPreemptStream(): boolean {
+    return (
+      this.canClaimPreemptSeal() && this.preemption?.shouldPreempt() === true
     );
   }
 
   /**
    * Takes the seal slot, or returns false if another stream already holds it.
    *
-   * Every check and both mutations sit in one synchronous body, so no `await`
-   * can split them — which is the point. `shouldPreemptStream()` is polled
-   * from an async chunk loop, so two parallel agents can both observe it as
-   * true; only one can win here. The loser keeps streaming normally instead of
-   * sealing for a message it would never receive.
+   * Assumes the caller already polled `shouldPreemptStream()` for THIS chunk,
+   * and deliberately does not poll the host again — `StreamPreemption`
+   * documents `shouldPreempt` as once per chunk, and a host that consumes a
+   * pending flag on read would lose the request to a second call.
+   *
+   * The guard and both mutations remain one synchronous body, which is what
+   * makes this safe under a parallel `MultiAgentGraph`: several agents share
+   * one graph and can each see the poll as true, but no `await` can split the
+   * claim, so only one takes the slot. The loser keeps streaming normally
+   * rather than sealing for a message it would never receive.
    */
   claimPreemptSeal(): boolean {
-    if (!this.shouldPreemptStream()) {
+    if (!this.canClaimPreemptSeal()) {
       return false;
     }
     this.preemptSealInFlight = true;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -134,6 +134,18 @@ import { executeHooks } from '@/hooks';
 
 const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 
+/** What a `PreemptBoundary` drain resolved to. */
+type PreemptBoundaryResult = {
+  messages: BaseMessage[];
+  /** A hook asked for no further model turn; the seal must not self-loop. */
+  preventContinuation: boolean;
+};
+
+const EMPTY_PREEMPT_BOUNDARY: PreemptBoundaryResult = {
+  messages: [],
+  preventContinuation: false,
+};
+
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
@@ -1189,7 +1201,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * Same session resolution as `dispatchPreemptBoundary`, or a
        * session-scoped matcher would be visible at one site and not the other.
        */
-      this.hookRegistry?.hasHookFor(
+      this.hookRegistry?.hasDispatchableHookFor(
         'PreemptBoundary',
         (this.config?.configurable?.run_id as string | undefined) ?? this.runId
       ) === true
@@ -3358,12 +3370,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         (responseMessage as AIMessageChunk | undefined)?.response_metadata
           .preempted === true
       ) {
-        const injected = await this.dispatchPreemptBoundary(agentId, config);
+        const { messages: injected, preventContinuation } =
+          await this.dispatchPreemptBoundary(agentId, config);
         /**
          * Release before branching: the slot is held only for the duration of
          * the drain, and an early return below must not strand it.
          */
         this.releasePreemptSeal();
+        if (preventContinuation) {
+          /**
+           * A hook halted at the boundary. Commit the sealed turn and anything
+           * it injected, but do NOT self-loop: `preventContinuation` promises
+           * no further model turn, and the run-loop poll in `processStream`
+           * only sees the halt AFTER the next call would already have started
+           * — direct graph consumers never poll it at all. A trailing injected
+           * HumanMessage carries no tool calls, so `toolsCondition` routes it
+           * to END.
+           */
+          this.preemptIncomplete = true;
+          this.cleanupSignalListener();
+          return injected.length > 0
+            ? { messages: [...(result.messages ?? []), ...injected] }
+            : result;
+        }
         if (injected.length > 0) {
           this.pendingPreemptReturn.add(agentId);
           this.cleanupSignalListener();
@@ -3391,18 +3420,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    *
    * Never throws: a drain that fails or times out costs the injection, not the
    * run. The caller treats an empty result as "nothing to resume with".
+   *
+   * `preventContinuation` is surfaced alongside the messages rather than left
+   * to the registry halt signal, which `processStream` only polls between
+   * stream events — by then the self-loop it was meant to prevent has already
+   * issued another model call, and a direct graph consumer never polls it.
    */
   private async dispatchPreemptBoundary(
     agentId: string,
     config: RunnableConfig | undefined
-  ): Promise<BaseMessage[]> {
+  ): Promise<PreemptBoundaryResult> {
     if (this.hookRegistry == null) {
-      return [];
+      return EMPTY_PREEMPT_BOUNDARY;
     }
     const configurable = config?.configurable;
     const runId = (configurable?.run_id as string | undefined) ?? this.runId;
     if (runId == null) {
-      return [];
+      return EMPTY_PREEMPT_BOUNDARY;
     }
     const result = await executeHooks({
       registry: this.hookRegistry,
@@ -3418,7 +3452,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       timeoutMs: PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
     }).catch((): undefined => undefined);
     if (result == null) {
-      return [];
+      return EMPTY_PREEMPT_BOUNDARY;
     }
     const injected: BaseMessage[] = [];
     /**
@@ -3447,7 +3481,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
     }
-    return injected;
+    return {
+      messages: injected,
+      preventContinuation: result.preventContinuation === true,
+    };
   }
 
   createAgentNode(agentId: string): t.CompiledAgentWorfklow {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -48,6 +48,8 @@ import {
   DEFAULT_RETAIN_RECENT_TURNS,
   splitAtRecencyBoundary,
   convertInjectedMessages,
+  coalesceAdjacentUserTurns,
+  strictAlternationProviders,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -1175,7 +1177,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       this.preemption != null &&
       !this.preemptSealInFlight &&
       this.preemptSealBudgetUsed <
-        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS)
+        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
+      /**
+       * A seal only buys room for an injection. With no `PreemptBoundary`
+       * matcher live — never registered, or a `once` matcher already
+       * consumed — the boundary provably returns nothing and the answer is
+       * cut short for no gain, so refuse the seal instead. Failing closed
+       * lands on the documented no-preemption behavior: the model finishes
+       * and the message waits for the next tool boundary.
+       *
+       * Same session resolution as `dispatchPreemptBoundary`, or a
+       * session-scoped matcher would be visible at one site and not the other.
+       */
+      this.hookRegistry?.hasHookFor(
+        'PreemptBoundary',
+        (this.config?.configurable?.run_id as string | undefined) ?? this.runId
+      ) === true
     );
   }
 
@@ -2583,6 +2600,31 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           );
         }
       }
+
+      /**
+       * Bedrock Converse and Mistral require strict user/assistant
+       * alternation and reject consecutive user turns outright. Four sites
+       * can emit them — the `PostToolBatch` and `PreemptBoundary` hook
+       * boundaries (a consolidated context message followed by one
+       * `HumanMessage` per injected entry), a queue drain carrying more than
+       * one steer, and `run.ts`'s pre-stream context push onto a payload that
+       * already ends on a user turn.
+       *
+       * Normalized here, at the last provider-facing hop, rather than at any
+       * one boundary: the boundaries must keep per-message identity, because
+       * `additional_kwargs.source`/`skillName` drive steer rendering and the
+       * trailing-steer anchor downstream. Graph state and the host's
+       * persisted messages are untouched — this shapes only what goes on the
+       * wire, for the providers that actually care.
+       *
+       * Runs AFTER synthetic-context compaction: that pass can rewrite or
+       * drop messages, so coalescing has to see its output, and it is the
+       * last shaping step before the cache breakpoint is chosen.
+       */
+      if (strictAlternationProviders.has(agentContext.provider)) {
+        finalMessages = coalesceAdjacentUserTurns(finalMessages);
+      }
+
       // Determine the prompt-cache strategy up front. Two distinct facts:
       //
       //   `providerPromptCacheEnabled` — prompt caching is on for this provider
@@ -3269,8 +3311,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       const invokeElapsed = ((Date.now() - invokeStart) / 1000).toFixed(2);
       agentContext.currentUsage = this.getUsageMetadata(result.messages?.[0]);
+      /**
+       * Synthetic usage from a sealed turn is an estimate derived from the
+       * host's own counter, so feeding it to calibration would teach a ratio
+       * of exactly 1.0 — self-consistent by construction, and wrong for any
+       * provider whose real ratio differs. It still flows to `currentUsage`
+       * for host billing; it just does not get to move the EMA.
+       */
+      const estimatedUsage =
+        (result.messages?.[0] as AIMessageChunk | undefined)?.response_metadata
+          .estimated_usage === true;
       if (agentContext.currentUsage) {
-        agentContext.updateLastCallUsage(agentContext.currentUsage);
+        if (!estimatedUsage) {
+          agentContext.updateLastCallUsage(agentContext.currentUsage);
+        }
         emitAgentLog(
           config,
           'debug',

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1011,6 +1011,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   preemptIncomplete = false;
   /**
+   * `stopReason` from a `PreemptBoundary` hook that halted the turn.
+   *
+   * Clearing the registry halt is what keeps the sealed turn alive, but the
+   * registry held the only copy of the reason — so it is captured here first.
+   * Without it `getHaltReason()` returns undefined and a host records a
+   * hook-halted turn as an ordinary completion.
+   */
+  preemptHaltReason: string | undefined;
+  /**
    * Agent IDs whose next superstep must return to the agent node. Keyed by
    * agent because `MultiAgentGraph` routes every parallel agent through this
    * same instance, and a single field would let one agent's boundary resume
@@ -1168,6 +1177,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.preemptSealCount = 0;
     this.preemptEmptyBoundaries = 0;
     this.preemptIncomplete = false;
+    this.preemptHaltReason = undefined;
   }
 
   /**
@@ -3488,10 +3498,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * Scoped to a halt this event raised, so a halt from an earlier hook in
      * the same run — `haltRun` is first-write-wins — is left alone.
      */
-    if (
-      result.preventContinuation === true &&
-      this.hookRegistry.getHaltSignal(runId)?.source === 'PreemptBoundary'
-    ) {
+    const halt = this.hookRegistry.getHaltSignal(runId);
+    if (result.preventContinuation === true && halt?.source === 'PreemptBoundary') {
+      this.preemptHaltReason = halt.reason;
       this.hookRegistry.clearHaltSignal(runId);
     }
     const injected: BaseMessage[] = [];
@@ -3503,10 +3512,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * short. Same system-flavored `HumanMessage` convention `ToolNode` uses —
      * Anthropic and Google reject a mid-conversation `SystemMessage`.
      */
-    if (result.additionalContexts.length > 0) {
+    /**
+     * Whitespace-only entries are dropped for the same reason empty
+     * `injectedMessages` are: `executeHooks` keeps them because their raw
+     * length is nonzero, but a blank turn is not something to resume from —
+     * it costs a model call and strict providers reject it outright.
+     */
+    const contexts = result.additionalContexts.filter(
+      (context) => context.trim() !== ''
+    );
+    if (contexts.length > 0) {
       injected.push(
         new HumanMessage({
-          content: result.additionalContexts.join('\n\n'),
+          content: contexts.join('\n\n'),
           additional_kwargs: { role: 'system', isMeta: true, source: 'hook' },
         })
       );

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -967,10 +967,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   subagentScope: boolean;
   /** See {@link t.StandardGraphInput.preemption}. */
   preemption?: t.StreamPreemption;
-  /** Seals honored so far in this run; bounded by `preemption.maxSeals`. */
+  /**
+   * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
+   * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
+   * which skips `resetValues` — keeps what it had left.
+   */
+  private preemptSealBudgetUsed = 0;
+  /**
+   * Seals honored over the graph's lifetime. Reported by
+   * {@link getPreemptStats}, so it deliberately SURVIVES `clearHeavyState()`
+   * — a host reads it after `processStream` returns, which is strictly after
+   * cleanup runs.
+   */
   preemptSealCount = 0;
   /** Boundaries that produced nothing to inject, so the turn stopped early. */
   preemptEmptyBoundaries = 0;
+  /**
+   * Set between claiming a seal and resolving its boundary. `MultiAgentGraph`
+   * fans parallel agents through this one instance against a single host
+   * request, so without a one-at-a-time gate several streams would each seal
+   * for the same queued message and every loser would take the
+   * nothing-to-inject path and cut its answer short.
+   */
+  private preemptSealInFlight = false;
   /**
    * True when a seal ended the turn without a resume. The assistant turn is
    * real and kept, but it is not the answer the model intended to finish —
@@ -1075,7 +1094,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       new Map()
     );
     this.invokedToolIds = resetIfNotEmpty(this.invokedToolIds, undefined);
-    this.resetPreemptState();
+    this.resetPreemptTurnState();
+    this.resetPreemptTotals();
     const hasScopedCheckpoint =
       this.hasCompiledCheckpointer &&
       checkpointScope != null &&
@@ -1096,7 +1116,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
-    this.resetPreemptState();
+    /**
+     * Turn state only. The reported totals must outlive cleanup — this runs
+     * in `processStream`'s `finally`, and the host reads `getPreemptStats()`
+     * after that returns.
+     */
+    this.resetPreemptTurnState();
     const preserveOriginalToolContent =
       this.hasCompiledCheckpointer &&
       this.originalToolContentCheckpointScope != null;
@@ -1106,21 +1131,39 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   }
 
   /**
-   * Seal budget and pending-resume markers are per-run, not per-graph. Kept
-   * as one helper because `resetValues` is skipped on resume while
-   * `clearHeavyState` is not, and the two must not be able to drift.
+   * Per-turn seal budget and routing markers. Cleared by both reset paths so
+   * a new turn starts with a full budget and no stale resume marker.
+   *
+   * The REPORTED counters are deliberately not touched here — see
+   * {@link resetPreemptTotals}.
    */
-  private resetPreemptState(): void {
+  private resetPreemptTurnState(): void {
+    this.preemptSealBudgetUsed = 0;
+    this.preemptSealInFlight = false;
+    this.pendingPreemptReturn.clear();
+  }
+
+  /**
+   * Lifetime seal totals, cleared only when a genuinely new run starts.
+   * `clearHeavyState()` must NOT call this: it runs in `processStream`'s
+   * `finally`, so zeroing here would make {@link getPreemptStats} and
+   * `preemptIncomplete` unreadable for every caller of the method that just
+   * produced them.
+   */
+  private resetPreemptTotals(): void {
     this.preemptSealCount = 0;
     this.preemptEmptyBoundaries = 0;
     this.preemptIncomplete = false;
-    this.pendingPreemptReturn.clear();
   }
 
   /**
    * True when the host has requested a cooperative seal AND this graph may
    * honor it. Read once per streamed chunk, so it stays property reads plus
    * one host callback — no I/O, no allocation.
+   *
+   * Non-mutating: a true result only means a seal is worth evaluating. The
+   * budget is taken by {@link claimPreemptSeal} once the accumulated chunk is
+   * known to be safe, so a chunk that cannot seal never spends budget.
    *
    * Subagent scopes never seal: a steer targets the top-level conversation,
    * and a child run must finish so its parent sees a complete result.
@@ -1129,13 +1172,35 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return (
       !this.subagentScope &&
       this.preemption != null &&
-      this.preemptSealCount < (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
+      !this.preemptSealInFlight &&
+      this.preemptSealBudgetUsed <
+        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
       this.preemption.shouldPreempt() === true
     );
   }
 
-  notePreemptSeal(): void {
+  /**
+   * Takes the seal slot, or returns false if another stream already holds it.
+   *
+   * Every check and both mutations sit in one synchronous body, so no `await`
+   * can split them — which is the point. `shouldPreemptStream()` is polled
+   * from an async chunk loop, so two parallel agents can both observe it as
+   * true; only one can win here. The loser keeps streaming normally instead of
+   * sealing for a message it would never receive.
+   */
+  claimPreemptSeal(): boolean {
+    if (!this.shouldPreemptStream()) {
+      return false;
+    }
+    this.preemptSealInFlight = true;
+    this.preemptSealBudgetUsed += 1;
     this.preemptSealCount += 1;
+    return true;
+  }
+
+  /** Releases the seal slot once its boundary has resolved, win or lose. */
+  releasePreemptSeal(): void {
+    this.preemptSealInFlight = false;
   }
 
   getPreemptStats(): t.PreemptStats {
@@ -3229,6 +3294,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           .preempted === true
       ) {
         const injected = await this.dispatchPreemptBoundary(agentId, config);
+        /**
+         * Release before branching: the slot is held only for the duration of
+         * the drain, and an early return below must not strand it.
+         */
+        this.releasePreemptSeal();
         if (injected.length > 0) {
           this.pendingPreemptReturn.add(agentId);
           this.cleanupSignalListener();
@@ -3282,18 +3352,37 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessionId: runId,
       timeoutMs: PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
     }).catch((): undefined => undefined);
-    if (result == null || result.injectedMessages.length === 0) {
+    if (result == null) {
       return [];
     }
-    try {
-      return convertInjectedMessages(result.injectedMessages);
-    } catch (e) {
-      console.warn(
-        '[StandardGraph] Failed to convert PreemptBoundary injectedMessages:',
-        e instanceof Error ? e.message : e
+    const injected: BaseMessage[] = [];
+    /**
+     * `PreemptBoundaryHookOutput` is `BaseHookOutput`, so `additionalContext`
+     * is part of the contract here just as it is at the tool boundary. It has
+     * to be materialized BEFORE the emptiness test, or a hook that returns
+     * context alone would read as "nothing to resume with" and cut the answer
+     * short. Same system-flavored `HumanMessage` convention `ToolNode` uses —
+     * Anthropic and Google reject a mid-conversation `SystemMessage`.
+     */
+    if (result.additionalContexts.length > 0) {
+      injected.push(
+        new HumanMessage({
+          content: result.additionalContexts.join('\n\n'),
+          additional_kwargs: { role: 'system', isMeta: true, source: 'hook' },
+        })
       );
-      return [];
     }
+    if (result.injectedMessages.length > 0) {
+      try {
+        injected.push(...convertInjectedMessages(result.injectedMessages));
+      } catch (e) {
+        console.warn(
+          '[StandardGraph] Failed to convert PreemptBoundary injectedMessages:',
+          e instanceof Error ? e.message : e
+        );
+      }
+    }
+    return injected;
   }
 
   createAgentNode(agentId: string): t.CompiledAgentWorfklow {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2665,9 +2665,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       /**
-       * Bedrock Converse and Mistral require strict user/assistant
-       * alternation and reject consecutive user turns outright. Four sites
-       * can emit them — the `PostToolBatch` and `PreemptBoundary` hook
+       * Mistral rejects consecutive user turns outright; Bedrock's Converse
+       * API documents strict user/assistant alternation across its model
+       * families, with enforcement varying by family (Claude on Converse
+       * currently tolerates the shape — verified live — but the payload is
+       * normalized for all of them rather than betting on leniency). Four
+       * sites can emit them — the `PostToolBatch` and `PreemptBoundary` hook
        * boundaries (a consolidated context message followed by one
        * `HumanMessage` per injected entry), a queue drain carrying more than
        * one steer, and `run.ts`'s pre-stream context push onto a payload that
@@ -3455,6 +3458,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            * to END.
            */
           this.preemptIncomplete = true;
+          /**
+           * A halting boundary that ALSO injected nothing is still an empty
+           * boundary by the `getPreemptStats().emptyBoundaries` contract —
+           * hosts use the counter for truncated-seal telemetry, and both
+           * paths end the turn with nothing to resume from.
+           */
+          if (injected.length === 0) {
+            this.preemptEmptyBoundaries += 1;
+          }
           this.cleanupSignalListener();
           return injected.length > 0
             ? { messages: [...(result.messages ?? []), ...injected] }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -84,6 +84,7 @@ import {
   getToolContentCharLength,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
+import { resolveMaxSeals } from '@/llm/preempt';
 import {
   Constants,
   GraphNodeKeys,
@@ -91,7 +92,6 @@ import {
   GraphEvents,
   Providers,
   StepTypes,
-  DEFAULT_MAX_SEALS,
   PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
 } from '@/common';
 import {
@@ -1188,8 +1188,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       !this.subagentScope &&
       this.preemption != null &&
       !this.preemptSealInFlight &&
-      this.preemptSealBudgetUsed <
-        (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
+      this.preemptSealBudgetUsed < resolveMaxSeals(this.preemption.maxSeals) &&
       /**
        * A seal only buys room for an injection. With no `PreemptBoundary`
        * matcher live — never registered, or a `once` matcher already

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -47,6 +47,7 @@ import {
   partitionAndMarkAnthropicToolCache,
   DEFAULT_RETAIN_RECENT_TURNS,
   splitAtRecencyBoundary,
+  convertInjectedMessages,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -88,6 +89,8 @@ import {
   GraphEvents,
   Providers,
   StepTypes,
+  DEFAULT_MAX_SEALS,
+  PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
 } from '@/common';
 import {
   annotateMessagesForLLM,
@@ -125,6 +128,7 @@ import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
 import { ChatOpenAI } from '@/llm/openai';
+import { executeHooks } from '@/hooks';
 
 const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 
@@ -961,6 +965,25 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   subagentUsageSink?: t.SubagentUsageSink;
   /** See {@link t.StandardGraphInput.subagentScope}. */
   subagentScope: boolean;
+  /** See {@link t.StandardGraphInput.preemption}. */
+  preemption?: t.StreamPreemption;
+  /** Seals honored so far in this run; bounded by `preemption.maxSeals`. */
+  preemptSealCount = 0;
+  /** Boundaries that produced nothing to inject, so the turn stopped early. */
+  preemptEmptyBoundaries = 0;
+  /**
+   * True when a seal ended the turn without a resume. The assistant turn is
+   * real and kept, but it is not the answer the model intended to finish —
+   * hosts persist it as unfinished rather than complete.
+   */
+  preemptIncomplete = false;
+  /**
+   * Agent IDs whose next superstep must return to the agent node. Keyed by
+   * agent because `MultiAgentGraph` routes every parallel agent through this
+   * same instance, and a single field would let one agent's boundary resume
+   * another's turn.
+   */
+  pendingPreemptReturn = new Set<string>();
 
   constructor({
     runId,
@@ -972,6 +995,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     calibrationRatio,
     subagentUsageSink,
     subagentScope,
+    preemption,
   }: t.StandardGraphInput) {
     super();
     this.runId = runId;
@@ -979,6 +1003,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.langfuse = langfuse;
     this.subagentUsageSink = subagentUsageSink;
     this.subagentScope = subagentScope === true;
+    this.preemption = preemption;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -1050,6 +1075,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       new Map()
     );
     this.invokedToolIds = resetIfNotEmpty(this.invokedToolIds, undefined);
+    this.resetPreemptState();
     const hasScopedCheckpoint =
       this.hasCompiledCheckpointer &&
       checkpointScope != null &&
@@ -1070,12 +1096,53 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
+    this.resetPreemptState();
     const preserveOriginalToolContent =
       this.hasCompiledCheckpointer &&
       this.originalToolContentCheckpointScope != null;
     for (const context of this.agentContexts.values()) {
       context.reset({ preserveOriginalToolContent });
     }
+  }
+
+  /**
+   * Seal budget and pending-resume markers are per-run, not per-graph. Kept
+   * as one helper because `resetValues` is skipped on resume while
+   * `clearHeavyState` is not, and the two must not be able to drift.
+   */
+  private resetPreemptState(): void {
+    this.preemptSealCount = 0;
+    this.preemptEmptyBoundaries = 0;
+    this.preemptIncomplete = false;
+    this.pendingPreemptReturn.clear();
+  }
+
+  /**
+   * True when the host has requested a cooperative seal AND this graph may
+   * honor it. Read once per streamed chunk, so it stays property reads plus
+   * one host callback — no I/O, no allocation.
+   *
+   * Subagent scopes never seal: a steer targets the top-level conversation,
+   * and a child run must finish so its parent sees a complete result.
+   */
+  shouldPreemptStream(): boolean {
+    return (
+      !this.subagentScope &&
+      this.preemption != null &&
+      this.preemptSealCount < (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS) &&
+      this.preemption.shouldPreempt() === true
+    );
+  }
+
+  notePreemptSeal(): void {
+    this.preemptSealCount += 1;
+  }
+
+  getPreemptStats(): t.PreemptStats {
+    return {
+      seals: this.preemptSealCount,
+      emptyBoundaries: this.preemptEmptyBoundaries,
+    };
   }
 
   /* Run Step Processing */
@@ -3157,9 +3224,76 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           { force: true }
         );
       }
+      if (
+        (responseMessage as AIMessageChunk | undefined)?.response_metadata
+          .preempted === true
+      ) {
+        const injected = await this.dispatchPreemptBoundary(agentId, config);
+        if (injected.length > 0) {
+          this.pendingPreemptReturn.add(agentId);
+          this.cleanupSignalListener();
+          return { messages: [...(result.messages ?? []), ...injected] };
+        }
+        /**
+         * Nothing to inject — the host cancelled or already drained. Do NOT
+         * self-loop: a trailing model turn with no new input is dropped by
+         * some Gemini models and read as prefill by Anthropic. Do NOT pretend
+         * the turn completed either; the answer really was cut short.
+         */
+        this.preemptEmptyBoundaries += 1;
+        this.preemptIncomplete = true;
+      }
+
       this.cleanupSignalListener();
       return result;
     };
+  }
+
+  /**
+   * Fires `PreemptBoundary` after a sealed turn and returns whatever the
+   * hooks asked to inject, converted through the same `convertInjectedMessages`
+   * the tool boundary uses so the two sites cannot emit different shapes.
+   *
+   * Never throws: a drain that fails or times out costs the injection, not the
+   * run. The caller treats an empty result as "nothing to resume with".
+   */
+  private async dispatchPreemptBoundary(
+    agentId: string,
+    config: RunnableConfig | undefined
+  ): Promise<BaseMessage[]> {
+    if (this.hookRegistry == null) {
+      return [];
+    }
+    const configurable = config?.configurable;
+    const runId = (configurable?.run_id as string | undefined) ?? this.runId;
+    if (runId == null) {
+      return [];
+    }
+    const result = await executeHooks({
+      registry: this.hookRegistry,
+      input: {
+        hook_event_name: 'PreemptBoundary',
+        runId,
+        threadId: configurable?.thread_id as string | undefined,
+        agentId: this.subagentScope ? agentId : undefined,
+        executingAgentId: agentId,
+        sealCount: this.preemptSealCount,
+      },
+      sessionId: runId,
+      timeoutMs: PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
+    }).catch((): undefined => undefined);
+    if (result == null || result.injectedMessages.length === 0) {
+      return [];
+    }
+    try {
+      return convertInjectedMessages(result.injectedMessages);
+    } catch (e) {
+      console.warn(
+        '[StandardGraph] Failed to convert PreemptBoundary injectedMessages:',
+        e instanceof Error ? e.message : e
+      );
+      return [];
+    }
   }
 
   createAgentNode(agentId: string): t.CompiledAgentWorfklow {
@@ -3325,6 +3459,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       config?: RunnableConfig
     ): string => {
       this.config = config;
+      /**
+       * A sealed turn that injected messages resumes in the SAME pregel run:
+       * back to the agent node as a new superstep, so the model continues in
+       * one assistant message instead of restarting the graph.
+       */
+      if (this.pendingPreemptReturn.delete(agentId)) {
+        return agentNode;
+      }
       if (state.summarizationRequest != null) {
         return summarizeNode;
       }

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1059,13 +1059,24 @@ describe('context overflow recovery', () => {
     const humanMessages = model.calls[0].filter(
       (message) => message instanceof HumanMessage
     );
-    expect(humanMessages).toHaveLength(2);
-    expect(
-      JSON.stringify(humanMessages[humanMessages.length - 1].content).length
-    ).toBeLessThan(100);
-    expect(
-      JSON.stringify(humanMessages[humanMessages.length - 1].content)
-    ).not.toContain('x'.repeat(1_000));
+    /**
+     * Bedrock is a strict-alternation provider: after compaction shrinks the
+     * synthetic context, `coalesceAdjacentUserTurns` merges it into the
+     * adjacent user query — Converse rejects consecutive user turns, and the
+     * `@langchain/aws` converter only merges toolResult-bearing ones. So one
+     * user turn reaches the provider, carrying both the query and the
+     * compacted note, and it must still be small.
+     */
+    expect(humanMessages).toHaveLength(1);
+    const coalescedContent = JSON.stringify(humanMessages[0].content);
+    expect(coalescedContent).toContain('query the table');
+    /**
+     * No closing bracket: compaction truncates at a character budget, and the
+     * cut can land inside the `[Previous tool interaction]` header itself.
+     */
+    expect(coalescedContent).toContain('[Previous tool interaction');
+    expect(coalescedContent.length).toBeLessThan(150);
+    expect(coalescedContent).not.toContain('x'.repeat(1_000));
   });
 
   it('counts unresolved-reference annotations before invoking the provider', async () => {

--- a/src/graphs/__tests__/Graph.preemptSignal.test.ts
+++ b/src/graphs/__tests__/Graph.preemptSignal.test.ts
@@ -1,0 +1,126 @@
+// src/graphs/__tests__/Graph.preemptSignal.test.ts
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { StandardGraph } from '../Graph';
+
+const makeAgent = (agentId: string): t.AgentInputs => ({
+  agentId,
+  provider: Providers.OPENAI,
+  instructions: `You are ${agentId}.`,
+});
+
+type DispatchResult = { messages: unknown[]; preventContinuation: boolean };
+
+const dispatchBoundary = (
+  graph: StandardGraph,
+  agentId = 'agent'
+): Promise<DispatchResult> =>
+  (
+    graph as unknown as {
+      dispatchPreemptBoundary: (
+        agentId: string,
+        config: { configurable: { run_id: string } } | undefined
+      ) => Promise<DispatchResult>;
+    }
+  ).dispatchPreemptBoundary(agentId, {
+    configurable: { run_id: 'run_1' },
+  });
+
+/**
+ * Registers a PreemptBoundary hook that aborts `controller` from inside its
+ * own body, then reports whether the signal `executeHooks` handed it observed
+ * that abort. Racing against a short timer keeps a broken composition from
+ * stalling the suite for the 120-second boundary hook timeout.
+ */
+function registerAbortProbe(
+  registry: HookRegistry,
+  controller: AbortController
+): { outcome: () => string | undefined } {
+  let outcome: string | undefined;
+  registry.register('PreemptBoundary', {
+    hooks: [
+      async (_input, signal): Promise<Record<string, never>> => {
+        const aborted = new Promise<string>((resolve) => {
+          if (signal.aborted) {
+            resolve('aborted');
+            return;
+          }
+          signal.addEventListener('abort', () => resolve('aborted'), {
+            once: true,
+          });
+        });
+        const timer = new Promise<string>((resolve) =>
+          setTimeout(() => resolve('not-observed'), 200)
+        );
+        controller.abort();
+        outcome = await Promise.race([aborted, timer]);
+        return {};
+      },
+    ],
+  });
+  return { outcome: () => outcome };
+}
+
+describe('PreemptBoundary abort-signal composition', () => {
+  it('observes a per-call caller abort even when a construction signal exists', async () => {
+    const constructionController = new AbortController();
+    const callerController = new AbortController();
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      signal: constructionController.signal,
+      agents: [makeAgent('agent')],
+    });
+    const registry = new HookRegistry();
+    const probe = registerAbortProbe(registry, callerController);
+    graph.hookRegistry = registry;
+    graph.callerSignal = callerController.signal;
+
+    await dispatchBoundary(graph);
+
+    expect(probe.outcome()).toBe('aborted');
+    expect(constructionController.signal.aborted).toBe(false);
+  });
+
+  it('observes the caller abort when no construction signal exists (multi-agent shape)', async () => {
+    const callerController = new AbortController();
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    const registry = new HookRegistry();
+    const probe = registerAbortProbe(registry, callerController);
+    graph.hookRegistry = registry;
+    graph.callerSignal = callerController.signal;
+
+    await dispatchBoundary(graph);
+
+    expect(probe.outcome()).toBe('aborted');
+  });
+
+  it('still observes the construction signal when no caller signal was supplied', async () => {
+    const constructionController = new AbortController();
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      signal: constructionController.signal,
+      agents: [makeAgent('agent')],
+    });
+    const registry = new HookRegistry();
+    const probe = registerAbortProbe(registry, constructionController);
+    graph.hookRegistry = registry;
+
+    await dispatchBoundary(graph);
+
+    expect(probe.outcome()).toBe('aborted');
+  });
+
+  it('drops the caller signal reference on clearHeavyState', () => {
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    graph.callerSignal = new AbortController().signal;
+    graph.clearHeavyState();
+    expect(graph.callerSignal).toBeUndefined();
+  });
+});

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -247,6 +247,34 @@ export class HookRegistry {
     return readList(bucket, event).length > 0;
   }
 
+  /**
+   * True when at least one matcher for `event` would actually DISPATCH on a
+   * query-less call — a wildcard pattern with a non-empty `hooks` array.
+   *
+   * `hasHookFor` answers "is one registered", which is not the same question:
+   * a matcher carrying a pattern is inert for events that supply no
+   * `matchQuery`, so a caller using registration as a proxy for "something
+   * will run" can act on a hook that never fires. Mirrors the two skips in
+   * `executeHooks` (pattern mismatch, empty `hooks`).
+   *
+   * Non-allocating on purpose — `StandardGraph.canClaimPreemptSeal` reads it
+   * once per streamed chunk, where `getMatchers`' defensive `slice()` would
+   * allocate on every delta.
+   */
+  hasDispatchableHookFor(event: HookEvent, sessionId?: string): boolean {
+    if (hasDispatchableInList(readList(this.global, event))) {
+      return true;
+    }
+    if (sessionId === undefined) {
+      return false;
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return false;
+    }
+    return hasDispatchableInList(readList(bucket, event));
+  }
+
   private ensureSessionBucket(sessionId: string): MatcherBucket {
     const existing = this.sessions.get(sessionId);
     if (existing !== undefined) {
@@ -276,6 +304,18 @@ function readList(
   event: HookEvent
 ): HookMatcher<HookEvent>[] {
   return bucket[event] ?? [];
+}
+
+function hasDispatchableInList(list: HookMatcher<HookEvent>[]): boolean {
+  for (const matcher of list) {
+    if (
+      (matcher.pattern === undefined || matcher.pattern === '') &&
+      matcher.hooks.length > 0
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hasResultAlteringInBucket(bucket: MatcherBucket): boolean {

--- a/src/hooks/__tests__/preemptBoundary.test.ts
+++ b/src/hooks/__tests__/preemptBoundary.test.ts
@@ -46,6 +46,47 @@ describe('PreemptBoundary hook event', () => {
     expect(registry.hasResultAlteringHooks()).toBe(true);
   });
 
+  /**
+   * `hasHookFor` answers "is one registered"; the seal gate needs "will one
+   * fire". A pattern-scoped matcher is inert for a query-less dispatch, so
+   * treating registration as a proxy would seal into a boundary that injects
+   * nothing and cut the answer short.
+   */
+  describe('hasDispatchableHookFor', () => {
+    it('is true for a wildcard matcher with a callback', () => {
+      const registry = new HookRegistry();
+      registry.register('PreemptBoundary', makeMatcher());
+      expect(registry.hasDispatchableHookFor('PreemptBoundary')).toBe(true);
+    });
+
+    it('is false for a pattern-scoped matcher that can never match', () => {
+      const registry = new HookRegistry();
+      registry.register('PreemptBoundary', { pattern: 'Bash', hooks: [noop] });
+      expect(registry.hasHookFor('PreemptBoundary')).toBe(true);
+      expect(registry.hasDispatchableHookFor('PreemptBoundary')).toBe(false);
+    });
+
+    it('is false for a matcher carrying no callbacks', () => {
+      const registry = new HookRegistry();
+      registry.register('PreemptBoundary', { hooks: [] });
+      expect(registry.hasDispatchableHookFor('PreemptBoundary')).toBe(false);
+    });
+
+    it('is false when nothing is registered at all', () => {
+      const registry = new HookRegistry();
+      expect(registry.hasDispatchableHookFor('PreemptBoundary')).toBe(false);
+    });
+
+    it('finds a session-scoped dispatchable matcher', () => {
+      const registry = new HookRegistry();
+      registry.registerSession('run_1', 'PreemptBoundary', makeMatcher());
+      expect(registry.hasDispatchableHookFor('PreemptBoundary')).toBe(false);
+      expect(registry.hasDispatchableHookFor('PreemptBoundary', 'run_1')).toBe(
+        true
+      );
+    });
+  });
+
   it('keeps registration isolated from the tool boundary event', () => {
     const registry = new HookRegistry();
     const matcher = makeMatcher();

--- a/src/hooks/__tests__/preemptBoundary.test.ts
+++ b/src/hooks/__tests__/preemptBoundary.test.ts
@@ -1,0 +1,111 @@
+// src/hooks/__tests__/preemptBoundary.test.ts
+import type { HookMatcher, HookCallback, HookOutput } from '../types';
+import { HOOK_EVENTS } from '../types';
+import { HookRegistry } from '../HookRegistry';
+import { executeHooks } from '../executeHooks';
+import {
+  HOOK_PREEMPT_BOUNDARY_CAPABLE,
+  HOOK_INJECTED_MESSAGES_CAPABLE,
+} from '../index';
+
+const noop: HookCallback<
+  'PreemptBoundary'
+> = async (): Promise<HookOutput> => ({});
+
+function makeMatcher(
+  hook: HookCallback<'PreemptBoundary'> = noop
+): HookMatcher<'PreemptBoundary'> {
+  return { hooks: [hook] };
+}
+
+describe('PreemptBoundary hook event', () => {
+  it('is part of the closed event set', () => {
+    expect(HOOK_EVENTS).toContain('PreemptBoundary');
+  });
+
+  it('advertises its own capability flag, separate from injectedMessages', () => {
+    expect(HOOK_PREEMPT_BOUNDARY_CAPABLE).toBe(true);
+    expect(HOOK_INJECTED_MESSAGES_CAPABLE).toBe(true);
+  });
+
+  /**
+   * Load-bearing: `hasResultAlteringHooks` gates eager tool execution. If
+   * `PreemptBoundary` ever counted as result-altering, registering a steering
+   * drain would silently disable eager dispatch for every steering run.
+   */
+  it('is not result-altering, so eager tool execution stays enabled', () => {
+    const registry = new HookRegistry();
+    registry.register('PreemptBoundary', makeMatcher());
+    expect(registry.hasResultAlteringHooks()).toBe(false);
+  });
+
+  it('still reports result-altering when a tool hook is also registered', () => {
+    const registry = new HookRegistry();
+    registry.register('PreemptBoundary', makeMatcher());
+    registry.register('PreToolUse', { hooks: [async () => ({})] });
+    expect(registry.hasResultAlteringHooks()).toBe(true);
+  });
+
+  it('keeps registration isolated from the tool boundary event', () => {
+    const registry = new HookRegistry();
+    const matcher = makeMatcher();
+    registry.register('PreemptBoundary', matcher);
+    expect(registry.getMatchers('PreemptBoundary')).toEqual([matcher]);
+    expect(registry.getMatchers('PostToolBatch')).toEqual([]);
+  });
+
+  it('aggregates injectedMessages from the boundary dispatch', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'PreemptBoundary',
+      makeMatcher(async () => ({
+        injectedMessages: [
+          { role: 'user', content: 'Skip phase two.', source: 'steer' },
+        ],
+      }))
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: {
+        hook_event_name: 'PreemptBoundary',
+        runId: 'run_1',
+        executingAgentId: 'agent_1',
+        sealCount: 1,
+      },
+      sessionId: 'run_1',
+    });
+
+    expect(result.injectedMessages).toEqual([
+      { role: 'user', content: 'Skip phase two.', source: 'steer' },
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports the 1-based seal index to the hook', async () => {
+    const registry = new HookRegistry();
+    const seen: number[] = [];
+    registry.register(
+      'PreemptBoundary',
+      makeMatcher(async (input) => {
+        seen.push(input.sealCount);
+        return {};
+      })
+    );
+
+    for (const sealCount of [1, 2]) {
+      await executeHooks({
+        registry,
+        input: {
+          hook_event_name: 'PreemptBoundary',
+          runId: 'run_1',
+          executingAgentId: 'agent_1',
+          sealCount,
+        },
+        sessionId: 'run_1',
+      });
+    }
+
+    expect(seen).toEqual([1, 2]);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,8 +4,9 @@
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
 // UserPromptSubmit, Stop, StopFailure), `ToolNode.dispatchToolEvents`
 // (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied),
-// `createSummarizeNode` (PreCompact, PostCompact), and
-// `SubagentExecutor.execute` (SubagentStart, SubagentStop).
+// `createSummarizeNode` (PreCompact, PostCompact),
+// `SubagentExecutor.execute` (SubagentStart, SubagentStop), and
+// `StandardGraph.createCallModel` (PreemptBoundary).
 export { HookRegistry } from './HookRegistry';
 export type { HookHaltSignal } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
@@ -16,6 +17,17 @@ export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
  * be consumed by an SDK version that would silently drop it.
  */
 export const HOOK_INJECTED_MESSAGES_CAPABLE = true;
+/**
+ * Feature probe for hosts: this SDK dispatches `PreemptBoundary`, so a
+ * cooperative mid-generation seal can drain into the run.
+ *
+ * Deliberately separate from {@link HOOK_INJECTED_MESSAGES_CAPABLE} — an SDK
+ * version can support `injectedMessages` at the tool boundary and know
+ * nothing about preemption. A host that probed the wrong flag would arm an
+ * interrupt control whose seal request is silently ignored, which reads to
+ * the user as a dead button rather than as an unsupported feature.
+ */
+export const HOOK_PREEMPT_BOUNDARY_CAPABLE = true;
 export {
   matchesQuery,
   hasNestedQuantifier,
@@ -52,6 +64,7 @@ export type {
   PostToolUseFailureHookInput,
   PostToolBatchHookInput,
   PostToolBatchEntry,
+  PreemptBoundaryHookInput,
   PermissionDeniedHookInput,
   SubagentStartHookInput,
   SubagentStopHookInput,
@@ -65,6 +78,7 @@ export type {
   PostToolUseHookOutput,
   PostToolUseFailureHookOutput,
   PostToolBatchHookOutput,
+  PreemptBoundaryHookOutput,
   PermissionDeniedHookOutput,
   SubagentStartHookOutput,
   SubagentStopHookOutput,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -151,11 +151,24 @@ export interface PostToolBatchHookInput extends BaseHookInput {
  * — the second injection boundary, and the only one that exists during a
  * long text answer with no tool calls in it.
  *
- * Order: fires AFTER the sealed assistant turn is committed to graph state,
- * BEFORE the next model call. The `injectedMessages` a hook returns here are
- * appended verbatim and the agent node self-loops. Returning nothing is a
- * valid outcome (the host's queue was cancelled or already drained): the run
- * stops honestly rather than self-looping into an empty turn.
+ * Order: fires after the model stream is sealed and BEFORE the next model
+ * call. The `injectedMessages` a hook returns here are appended verbatim and
+ * the agent node self-loops. Returning nothing is a valid outcome (the host's
+ * queue was cancelled or already drained): the run stops honestly rather than
+ * self-looping into an empty turn.
+ *
+ * The sealed turn is NOT yet observable from graph state when this fires.
+ * Dispatch happens inside the agent node, and only the outer graph's reducer
+ * writes `StandardGraph.messages` — which cannot run until the node returns.
+ * A hook calling `Run.getRunMessages()` here sees the state as of the last
+ * completed superstep, so the sealed text is absent. `PostToolBatch` behaves
+ * the same way: a tool-boundary hook cannot see the assistant turn that
+ * requested the tool. This is a property of the single-node outer graph, not
+ * of preemption, and committing first would mean returning from the node and
+ * re-entering — precisely what the self-loop exists to avoid.
+ *
+ * A hook that needs the sealed text should therefore not go looking for it in
+ * graph state. Decide from the host's own queue, or read it after the run.
  *
  * Requires `RunConfig.preemption`. This event is deliberately NOT
  * result-altering, so registering it never disables eager tool execution.

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -17,6 +17,7 @@ export const HOOK_EVENTS = [
   'PostToolUse',
   'PostToolUseFailure',
   'PostToolBatch',
+  'PreemptBoundary',
   'PermissionDenied',
   'SubagentStart',
   'SubagentStop',
@@ -145,6 +146,26 @@ export interface PostToolBatchHookInput extends BaseHookInput {
   entries: PostToolBatchEntry[];
 }
 
+/**
+ * Fires when a cooperative preemption seals the model stream mid-generation
+ * — the second injection boundary, and the only one that exists during a
+ * long text answer with no tool calls in it.
+ *
+ * Order: fires AFTER the sealed assistant turn is committed to graph state,
+ * BEFORE the next model call. The `injectedMessages` a hook returns here are
+ * appended verbatim and the agent node self-loops. Returning nothing is a
+ * valid outcome (the host's queue was cancelled or already drained): the run
+ * stops honestly rather than self-looping into an empty turn.
+ *
+ * Requires `RunConfig.preemption`. This event is deliberately NOT
+ * result-altering, so registering it never disables eager tool execution.
+ */
+export interface PreemptBoundaryHookInput extends BaseHookInput {
+  hook_event_name: 'PreemptBoundary';
+  /** 1-based index of this seal within the run. */
+  sealCount: number;
+}
+
 export interface PermissionDeniedHookInput extends BaseHookInput {
   hook_event_name: 'PermissionDenied';
   toolName: string;
@@ -217,6 +238,7 @@ export type HookInput =
   | PostToolUseHookInput
   | PostToolUseFailureHookInput
   | PostToolBatchHookInput
+  | PreemptBoundaryHookInput
   | PermissionDeniedHookInput
   | SubagentStartHookInput
   | SubagentStopHookInput
@@ -233,6 +255,7 @@ export type HookInputByEvent = {
   PostToolUse: PostToolUseHookInput;
   PostToolUseFailure: PostToolUseFailureHookInput;
   PostToolBatch: PostToolBatchHookInput;
+  PreemptBoundary: PreemptBoundaryHookInput;
   PermissionDenied: PermissionDeniedHookInput;
   SubagentStart: SubagentStartHookInput;
   SubagentStop: SubagentStopHookInput;
@@ -251,14 +274,18 @@ export interface BaseHookOutput {
   additionalContext?: string;
   /**
    * Messages to inject into graph state, one `HumanMessage` per entry
-   * (converted via `ToolNode.convertInjectedMessages`, which preserves
+   * (converted via `convertInjectedMessages`, which preserves
    * `role`/`source`/`isMeta` in `additional_kwargs`). Unlike
    * `additionalContext` — which is consolidated across hooks into a single
    * system-flavored message — each entry keeps its own identity and role,
    * making this the channel for injecting verbatim user speech (e.g. a
    * mid-run steering message). Accumulated across hooks in registration
-   * order. Currently consumed only at the `PostToolBatch` dispatch site;
-   * other events ignore the field.
+   * order.
+   *
+   * Consumed at exactly two dispatch sites, both of which run the same
+   * converter so the emitted shapes cannot drift: `PostToolBatch` (the tool
+   * boundary) and `PreemptBoundary` (a cooperative mid-generation seal).
+   * Every other event ignores the field.
    */
   injectedMessages?: InjectedMessage[];
   /** True to prevent the next model turn. Any hook can set this. */
@@ -367,6 +394,8 @@ export type PostToolUseFailureHookOutput = BaseHookOutput;
 
 export type PostToolBatchHookOutput = BaseHookOutput;
 
+export type PreemptBoundaryHookOutput = BaseHookOutput;
+
 export type PermissionDeniedHookOutput = BaseHookOutput;
 
 export interface SubagentStartHookOutput extends BaseHookOutput {
@@ -395,6 +424,7 @@ export type HookOutputByEvent = {
   PostToolUse: PostToolUseHookOutput;
   PostToolUseFailure: PostToolUseFailureHookOutput;
   PostToolBatch: PostToolBatchHookOutput;
+  PreemptBoundary: PreemptBoundaryHookOutput;
   PermissionDenied: PermissionDeniedHookOutput;
   SubagentStart: SubagentStartHookOutput;
   SubagentStop: SubagentStopHookOutput;
@@ -412,6 +442,7 @@ export type HookOutput =
   | PostToolUseHookOutput
   | PostToolUseFailureHookOutput
   | PostToolBatchHookOutput
+  | PreemptBoundaryHookOutput
   | PermissionDeniedHookOutput
   | SubagentStartHookOutput
   | SubagentStopHookOutput

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,4 +80,5 @@ export { getChatModelClass } from './llm/providers';
 export { FakeChatModel, createFakeStreamingLLM } from './llm/fake';
 export { initializeModel } from './llm/init';
 export { attemptInvoke, tryFallbackProviders } from './llm/invoke';
+export { canSealPreempt } from './llm/preempt';
 export { isThinkingEnabled, getMaxOutputTokensKey } from './llm/request';

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -450,3 +450,85 @@ describe('convertToConverseMessages — v1 reasoning serialization', () => {
     expect(content.some((b) => b.text === 'answer')).toBe(true);
   });
 });
+
+/**
+ * Converse rejects consecutive same-role messages categorically, and both
+ * `ToolMessage` and `HumanMessage` convert to `role: 'user'` — so a hook
+ * injection landing a text turn directly after tool results (`PostToolBatch`
+ * / `PreemptBoundary` drains) must merge into one user message here, with
+ * block order preserved so the toolUse/toolResult pairing stays intact.
+ */
+describe('convertToConverseMessages — user-role run merging', () => {
+  it('merges a tool result followed by an injected text turn into one user message', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('run the search'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call_1', name: 'search', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'search output',
+        tool_call_id: 'call_1',
+        name: 'search',
+      }),
+      new HumanMessage({
+        content: 'Actually, focus on the second result.',
+        additional_kwargs: { source: 'steer' },
+      }),
+    ];
+
+    const { converseMessages } = convertToConverseMessages(messages);
+
+    expect(converseMessages.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+    ]);
+    const merged = converseMessages[2];
+    const blockKinds = (merged.content ?? []).map((block) =>
+      'toolResult' in block ? 'toolResult' : 'text'
+    );
+    expect(blockKinds).toEqual(['toolResult', 'text']);
+    expect(
+      (merged.content ?? []).find((block) => 'text' in block)?.text
+    ).toBe('Actually, focus on the second result.');
+  });
+
+  it('still merges adjacent tool-result-only turns', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call_1', name: 'a', args: {}, type: 'tool_call' },
+          { id: 'call_2', name: 'b', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({ content: 'one', tool_call_id: 'call_1', name: 'a' }),
+      new ToolMessage({ content: 'two', tool_call_id: 'call_2', name: 'b' }),
+    ];
+
+    const { converseMessages } = convertToConverseMessages(messages);
+
+    expect(converseMessages.map((m) => m.role)).toEqual(['assistant', 'user']);
+    const toolResultIds = (converseMessages[1].content ?? [])
+      .map((block) => ('toolResult' in block ? block.toolResult?.toolUseId : undefined))
+      .filter(Boolean);
+    expect(toolResultIds).toEqual(['call_1', 'call_2']);
+  });
+
+  it('does not merge across an assistant turn', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('first'),
+      new AIMessage('answer'),
+      new HumanMessage('second'),
+    ];
+    const { converseMessages } = convertToConverseMessages(messages);
+    expect(converseMessages.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+    ]);
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -1063,7 +1063,19 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
       }
     });
 
-  // Combine consecutive user tool result messages into a single message
+  /**
+   * Combine ALL consecutive user messages into one, not just tool-result
+   * pairs. The Converse API documents strict role alternation; enforcement
+   * varies by model family (Claude on Converse currently tolerates adjacent
+   * user messages — verified live, 2026-07-28 — but the docs promise nothing
+   * for the others), so the converter never emits the shape. The case that
+   * matters: a `PostToolBatch`/`PreemptBoundary` hook injection lands a text
+   * turn directly after tool results, and `ToolMessage` and `HumanMessage`
+   * both convert to `role: 'user'` above. Block order is preserved
+   * (toolResult blocks, then text) — verified live that Converse accepts the
+   * mixed user message and answers both halves — and the toolUse/toolResult
+   * pairing stays intact.
+   */
   const combinedConverseMessages = converseMessages.reduce<BedrockMessage[]>(
     (acc, curr) => {
       if (acc.length === 0) {
@@ -1071,16 +1083,7 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
         return acc;
       }
       const lastMessage = acc[acc.length - 1];
-      const lastHasToolResult =
-        lastMessage.content?.some((c) => 'toolResult' in c) === true;
-      const currHasToolResult =
-        curr.content?.some((c) => 'toolResult' in c) === true;
-      if (
-        lastMessage.role === 'user' &&
-        lastHasToolResult &&
-        curr.role === 'user' &&
-        currHasToolResult
-      ) {
+      if (lastMessage.role === 'user' && curr.role === 'user') {
         lastMessage.content = lastMessage.content?.concat(curr.content ?? []);
       } else {
         acc.push(curr);

--- a/src/llm/bedrock/utils/toolResultCachePoint.test.ts
+++ b/src/llm/bedrock/utils/toolResultCachePoint.test.ts
@@ -47,6 +47,10 @@ describe('convertToConverseMessages — tool-result cachePoint hoisting', () => 
 
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('go'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 't1', name: 'calc', args: {}, type: 'tool_call' }],
+      }),
       toolMsg,
     ]);
 
@@ -66,6 +70,17 @@ describe('convertToConverseMessages — tool-result cachePoint hoisting', () => 
   it('leaves tool results without a cachePoint untouched', () => {
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('go'),
+      /**
+       * The calling assistant turn matters: without it the human turn and
+       * the tool result are adjacent user-role messages, which the converter
+       * now merges (Converse rejects consecutive user messages), and this
+       * test would assert against the merged artifact instead of the
+       * tool-result body it is about.
+       */
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 't1', name: 'calc', args: {}, type: 'tool_call' }],
+      }),
       new ToolMessage({ tool_call_id: 't1', content: 'plain result' }),
     ]);
 

--- a/src/llm/invoke.alternation.test.ts
+++ b/src/llm/invoke.alternation.test.ts
@@ -1,0 +1,87 @@
+// src/llm/invoke.alternation.test.ts
+/**
+ * `attemptInvoke` is the single funnel for primary, fallback and
+ * summarization model calls, and it keys the alternation pass on the provider
+ * ACTUALLY serving the call. This is the seam that protects a fallback: an
+ * OpenAI primary that failed after a boundary injected two human turns hands
+ * the same array to a Bedrock fallback, which rejects consecutive user turns.
+ */
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { Providers } from '@/common';
+import { FakeChatModel } from '@/llm/fake';
+import { attemptInvoke } from './invoke';
+import type * as t from '@/types';
+
+class CapturingChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+
+  constructor() {
+    super({ responses: ['ok'] });
+  }
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.invocations.push(messages);
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+const adjacentUserPayload = (): BaseMessage[] => [
+  new HumanMessage({ content: 'question' }),
+  new AIMessage({ content: 'partial answer' }),
+  new HumanMessage({ content: 'hook context' }),
+  new HumanMessage({ content: 'steer' }),
+];
+
+async function invokeAs(provider: Providers): Promise<BaseMessage[]> {
+  const model = new CapturingChatModel();
+  await attemptInvoke({
+    model: model as unknown as t.ChatModel,
+    messages: adjacentUserPayload(),
+    provider,
+    onChunk: async () => undefined,
+  });
+  expect(model.invocations).toHaveLength(1);
+  return model.invocations[0];
+}
+
+describe('attemptInvoke alternation funnel', () => {
+  it('coalesces adjacent user turns when the serving provider is strict', async () => {
+    const sent = await invokeAs(Providers.BEDROCK);
+    expect(sent.map((m) => m.getType())).toEqual(['human', 'ai', 'human']);
+    expect(sent[2].content).toBe('hook context\n\nsteer');
+  });
+
+  it('leaves the payload alone for a tolerant provider', async () => {
+    const sent = await invokeAs(Providers.OPENAI);
+    expect(sent.map((m) => m.getType())).toEqual([
+      'human',
+      'ai',
+      'human',
+      'human',
+    ]);
+  });
+
+  it('is idempotent when the graph already coalesced for the primary', async () => {
+    const model = new CapturingChatModel();
+    const once = await invokeAs(Providers.BEDROCK);
+    await attemptInvoke({
+      model: model as unknown as t.ChatModel,
+      messages: once,
+      provider: Providers.BEDROCK,
+      onChunk: async () => undefined,
+    });
+    expect(model.invocations[0].map((m) => m.getType())).toEqual([
+      'human',
+      'ai',
+      'human',
+    ]);
+    expect(model.invocations[0][2].content).toBe('hook context\n\nsteer');
+  });
+});

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1,5 +1,9 @@
 import { concat } from '@langchain/core/utils/stream';
 import { AIMessageChunk } from '@langchain/core/messages';
+import { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import { getCallbackManagerForConfig } from '@langchain/core/runnables';
+import type { Serialized } from '@langchain/core/load/serializable';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
@@ -22,8 +26,9 @@ import {
 } from '@/messages/cache';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
+import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import { manualToolStreamProviders } from '@/llm/providers';
-import { Constants, GraphEvents, Providers } from '@/common';
+import { appendCallbacks } from '@/utils/callbacks';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { modifyDeltaProperties } from '@/messages';
@@ -375,36 +380,88 @@ function synthesizeSealedUsage(
   };
 }
 
+function getMessageText(chunk: AIMessageChunk): string {
+  if (typeof chunk.content === 'string') {
+    return chunk.content;
+  }
+  let text = '';
+  for (const block of chunk.content) {
+    if (block.type === ContentTypes.TEXT) {
+      const value = block[ContentTypes.TEXT];
+      if (typeof value === 'string') {
+        text += value;
+      }
+    }
+  }
+  return text;
+}
+
 /**
- * Emits `CHAT_MODEL_END` for a turn that was sealed mid-stream.
+ * Ends the real model run for a turn that was sealed mid-stream.
  *
  * Mandatory, not cosmetic. `@langchain/core`'s `_streamIterator` calls
  * `handleLLMEnd` after its try/catch with no `finally`, so breaking out of the
  * consumer's `for await` produces a *return* completion that fires neither
- * `handleLLMError` nor `handleLLMEnd` — the model-end event the host uses to
- * record token usage would never arrive. Since every seal re-sends the whole
- * prompt on resume, a user who preempts N times would otherwise spend N
- * unrecorded full prompts.
+ * `handleLLMError` nor `handleLLMEnd`. The run would stay open in every
+ * callback handler: the host records no usage — and since each seal re-sends
+ * the whole prompt, N preemptions cost N unrecorded prompts — while LangSmith
+ * and Langfuse hold a span that never closes.
  *
- * KNOWN LIMITATION. This is a custom event, so it reaches the host's handler
- * registry but NOT the model run manager: external tracers (LangSmith,
- * Langfuse) are left holding a model run that never closes. Ending the real
- * run is not reachable from here — `model` is a bound runnable, so the
- * binding consumes `config.runId` for its own run and `patchConfig` hands the
- * chat model a fresh id, leaving no way to name the run we need to end.
- * Reconstructing a manager against a pinned id was tried and fails live with
- * "No LLM run to end", and it also suppresses the host's model-end event,
- * which is strictly worse than an unclosed trace span. Closing this properly
- * needs a seam in `@langchain/core`.
+ * `runId` cannot be dictated from here (the bound runnable consumes
+ * `config.runId` for its own run and hands the chat model a fresh one), but it
+ * can be OBSERVED: the capture handler installed at the `model.stream` call
+ * records it from `handleChatModelStart`, which fires before the first chunk.
+ * Rebuilding the manager against that id closes the real run, and the host's
+ * `on_chat_model_end` then arrives through the ordinary `streamEvents` path.
+ *
+ * Falls back to a custom-event dispatch if the id was never observed, so the
+ * host still records usage even when the native close is unavailable.
  */
-async function dispatchSealedModelEnd(
+async function endSealedModelRun(
   context: InvokeContext | undefined,
   chunk: AIMessageChunk,
   prompt: BaseMessage[],
+  llmRunId: string | undefined,
   config?: RunnableConfig
 ): Promise<void> {
   const metadata = config?.metadata as Record<string, unknown> | undefined;
   synthesizeSealedUsage(context, chunk, prompt, metadata);
+  if (llmRunId != null) {
+    try {
+      const callbackManager = await getCallbackManagerForConfig(config);
+      if (callbackManager != null) {
+        const runManager = new CallbackManagerForLLMRun(
+          llmRunId,
+          callbackManager.handlers,
+          callbackManager.inheritableHandlers,
+          callbackManager.tags,
+          callbackManager.inheritableTags,
+          callbackManager.metadata,
+          callbackManager.inheritableMetadata,
+          callbackManager.getParentRunId()
+        );
+        const generation: ChatGeneration = {
+          text: getMessageText(chunk),
+          message: chunk,
+        };
+        await runManager.handleLLMEnd({
+          generations: [[generation]],
+          llmOutput: {},
+        });
+        return;
+      }
+    } catch (e) {
+      /**
+       * A sealed answer that reaches the user is worth more than a tidy
+       * trace. Fall through to the custom event rather than failing the run.
+       */
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[attemptInvoke] Native close of the sealed model run failed; falling back to a custom event:',
+        e instanceof Error ? e.message : e
+      );
+    }
+  }
   await safeDispatchCustomEvent(
     GraphEvents.CHAT_MODEL_END,
     { output: chunk },
@@ -494,7 +551,32 @@ export async function attemptInvoke(
   };
 
   if (model.stream) {
-    const stream = await model.stream(messagesForProvider, config);
+    /**
+     * Observed, not dictated. `handleChatModelStart` fires with the chat
+     * model's real run id before the first chunk, which is the only way to
+     * name the run a seal has to close — pinning `config.runId` does not
+     * survive the bound runnable. Installed only when preemption is
+     * configured, so a run that cannot seal carries no extra handler.
+     */
+    let sealedRunId: string | undefined;
+    const streamConfig =
+      context?.preemption == null
+        ? config
+        : {
+          ...config,
+          callbacks: appendCallbacks(config.callbacks, [
+            {
+              handleChatModelStart: (
+                _llm: Serialized,
+                _messages: BaseMessage[][],
+                runId: string
+              ): void => {
+                sealedRunId ??= runId;
+              },
+            },
+          ]),
+        };
+    const stream = await model.stream(messagesForProvider, streamConfig);
     let finalChunk: AIMessageChunk | undefined;
     let preempted = false;
     const registeredStreamHandler =
@@ -585,10 +667,11 @@ export async function attemptInvoke(
         ...finalChunk.response_metadata,
         preempted: true,
       };
-      await dispatchSealedModelEnd(
+      await endSealedModelRun(
         context,
         finalChunk,
         messagesForProvider,
+        sealedRunId,
         config
       );
     }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -31,7 +31,11 @@ import { manualToolStreamProviders } from '@/llm/providers';
 import { appendCallbacks } from '@/utils/callbacks';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
-import { modifyDeltaProperties } from '@/messages';
+import {
+  modifyDeltaProperties,
+  coalesceAdjacentUserTurns,
+  strictAlternationProviders,
+} from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { initializeModel } from '@/llm/init';
@@ -581,11 +585,26 @@ export async function attemptInvoke(
   });
   const registry = context?.getOrCreateToolOutputRegistry();
   const runId = config?.configurable?.run_id as string | undefined;
-  const messagesForProvider = annotateMessagesForLLM(
+  const annotated = annotateMessagesForLLM(
     invocationMessages,
     registry,
     runId
   );
+  /**
+   * Keyed on the provider ACTUALLY serving this call, not the agent's primary.
+   * `createCallModel` normalizes for the primary, but `tryFallbackProviders`
+   * re-sends the same array — so an OpenAI primary that fails after a boundary
+   * injected two human turns would hand a Bedrock or Mistral fallback the
+   * consecutive user turns those APIs reject, and the recovery request would
+   * fail for a reason unrelated to the original failure.
+   *
+   * `attemptInvoke` is the single funnel for primary, fallback and
+   * summarization calls, so applying it here covers all three. Idempotent, so
+   * the primary simply re-runs a no-op over already-coalesced messages.
+   */
+  const messagesForProvider = strictAlternationProviders.has(provider)
+    ? coalesceAdjacentUserTurns(annotated)
+    : annotated;
 
   /**
    * Stamp the provider that is ACTUALLY serving this invocation onto the

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -33,7 +33,7 @@ import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { modifyDeltaProperties } from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
-import { ChatModelStreamHandler } from '@/stream';
+import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { initializeModel } from '@/llm/init';
 import { isOpenAILike } from '@/utils/llm';
 
@@ -222,13 +222,23 @@ export function projectMessagesForProvider({
   );
 }
 
+/**
+ * The registered handler that owns content-part dispatch, if any.
+ *
+ * Detected by brand rather than by `instanceof`: a host that registers
+ * `new ChatModelStreamHandler()` to opt out of sealing gets wrapped by
+ * `createRunHandlers` on every `AgentSession` run, and by
+ * `composeEventHandlers` on a key collision. Both wrappers forward to the same
+ * dispatcher while failing an identity check, so an identity test would
+ * silently revoke the opt-out documented on `StreamPreemption`.
+ */
 function getRegisteredDefaultChatStreamHandler(
   context?: InvokeContext
-): ChatModelStreamHandler | undefined {
+): t.EventHandler | undefined {
   const handler = context?.handlerRegistry?.getHandler(
     GraphEvents.CHAT_MODEL_STREAM
   );
-  return handler instanceof ChatModelStreamHandler ? handler : undefined;
+  return dispatchesChatModelStream(handler) ? handler : undefined;
 }
 
 function hasReasoningDetails(chunk: AIMessageChunk): boolean {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -324,16 +324,55 @@ function getStreamHandlingChunk({
  * Best-effort output-token count for a sealed turn, used only when the
  * provider never got to send its usage chunk.
  */
-function countSealedOutputTokens(
+function countSealedTokens(
   context: InvokeContext | undefined,
-  chunk: AIMessageChunk,
-  metadata: Record<string, unknown> | undefined
+  metadata: Record<string, unknown> | undefined,
+  messages: BaseMessage[]
 ): number | undefined {
   try {
-    return context?.getAgentContext(metadata).tokenCounter?.(chunk);
+    const counter = context?.getAgentContext(metadata).tokenCounter;
+    if (counter == null) {
+      return undefined;
+    }
+    let total = 0;
+    for (const message of messages) {
+      total += counter(message);
+    }
+    return total;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Best-effort usage for a turn the provider never got to bill us for.
+ *
+ * The prompt matters as much as the completion here: the provider processed
+ * the ENTIRE prompt before we sealed, and every resume re-sends it, so
+ * reporting `input_tokens: 0` would under-count the most expensive half of a
+ * preempted run. Both sides come from the host's own counter, so they are
+ * estimates — but estimates in the right order of magnitude beat a fabricated
+ * zero. When no counter is configured we report nothing rather than guess.
+ */
+function synthesizeSealedUsage(
+  context: InvokeContext | undefined,
+  chunk: AIMessageChunk,
+  prompt: BaseMessage[],
+  metadata: Record<string, unknown> | undefined
+): void {
+  if (chunk.usage_metadata != null) {
+    return;
+  }
+  const outputTokens = countSealedTokens(context, metadata, [chunk]);
+  if (outputTokens == null) {
+    return;
+  }
+  const inputTokens = countSealedTokens(context, metadata, prompt) ?? 0;
+  chunk.usage_metadata = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: inputTokens + outputTokens,
+  };
 }
 
 /**
@@ -346,23 +385,26 @@ function countSealedOutputTokens(
  * record token usage would never arrive. Since every seal re-sends the whole
  * prompt on resume, a user who preempts N times would otherwise spend N
  * unrecorded full prompts.
+ *
+ * KNOWN LIMITATION. This is a custom event, so it reaches the host's handler
+ * registry but NOT the model run manager: external tracers (LangSmith,
+ * Langfuse) are left holding a model run that never closes. Ending the real
+ * run is not reachable from here — `model` is a bound runnable, so the
+ * binding consumes `config.runId` for its own run and `patchConfig` hands the
+ * chat model a fresh id, leaving no way to name the run we need to end.
+ * Reconstructing a manager against a pinned id was tried and fails live with
+ * "No LLM run to end", and it also suppresses the host's model-end event,
+ * which is strictly worse than an unclosed trace span. Closing this properly
+ * needs a seam in `@langchain/core`.
  */
 async function dispatchSealedModelEnd(
   context: InvokeContext | undefined,
   chunk: AIMessageChunk,
+  prompt: BaseMessage[],
   config?: RunnableConfig
 ): Promise<void> {
   const metadata = config?.metadata as Record<string, unknown> | undefined;
-  if (chunk.usage_metadata == null) {
-    const outputTokens = countSealedOutputTokens(context, chunk, metadata);
-    if (outputTokens != null) {
-      chunk.usage_metadata = {
-        input_tokens: 0,
-        output_tokens: outputTokens,
-        total_tokens: outputTokens,
-      };
-    }
-  }
+  synthesizeSealedUsage(context, chunk, prompt, metadata);
   await safeDispatchCustomEvent(
     GraphEvents.CHAT_MODEL_END,
     { output: chunk },
@@ -495,9 +537,16 @@ export async function attemptInvoke(
          * which can lag the accumulated chunk — sealing there would let the
          * host index a content part the user has not been shown yet.
          */
+        /**
+         * Cheap poll first, shape check second, budget claim last. The claim
+         * is what makes this safe under a parallel `MultiAgentGraph`: several
+         * agents share one graph and can each see the poll as true, but only
+         * one can take the slot, and a chunk that cannot seal never spends it.
+         */
         if (
           context?.shouldPreemptStream() === true &&
-          canSealPreempt(finalChunk)
+          canSealPreempt(finalChunk) &&
+          context.claimPreemptSeal()
         ) {
           preempted = true;
           break;
@@ -536,8 +585,12 @@ export async function attemptInvoke(
         ...finalChunk.response_metadata,
         preempted: true,
       };
-      context?.notePreemptSeal();
-      await dispatchSealedModelEnd(context, finalChunk, config);
+      await dispatchSealedModelEnd(
+        context,
+        finalChunk,
+        messagesForProvider,
+        config
+      );
     }
 
     if ((finalChunk?.tool_calls?.length ?? 0) > 0) {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -479,6 +479,45 @@ function getMessageText(chunk: AIMessageChunk): string {
  * Falls back to a custom-event dispatch if the id was never observed, so the
  * host still records usage even when the native close is unavailable.
  */
+/**
+ * Every callbacks source the real model run would compose beyond the per-call
+ * config. `model` here is whatever `createCallModel` produced — with tools
+ * that is `bindTools(...)`'s `RunnableBinding`, and a system runnable pipes a
+ * `RunnableSequence` on top — while `clientOptions.callbacks` lives on the
+ * chat model at the BOTTOM of that stack. Walks `bound` (bindings) and
+ * `last`/`steps` (sequences), collecting each wrapper's own `callbacks` and
+ * any binding-config callbacks along the way, since the binding merges its
+ * config into the call before the chat model composes.
+ */
+function collectModelCallbackSources(model: unknown): Callbacks[] {
+  const sources: Callbacks[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = model;
+  while (current != null && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const wrapper = current as {
+      callbacks?: Callbacks;
+      config?: { callbacks?: Callbacks };
+      bound?: unknown;
+      last?: unknown;
+      steps?: unknown[];
+    };
+    if (wrapper.callbacks != null) {
+      sources.push(wrapper.callbacks);
+    }
+    if (wrapper.config?.callbacks != null) {
+      sources.push(wrapper.config.callbacks);
+    }
+    current =
+      wrapper.bound ??
+      wrapper.last ??
+      (Array.isArray(wrapper.steps)
+        ? wrapper.steps[wrapper.steps.length - 1]
+        : undefined);
+  }
+  return sources;
+}
+
 async function endSealedModelRun(
   context: InvokeContext | undefined,
   chunk: AIMessageChunk,
@@ -503,14 +542,10 @@ async function endSealedModelRun(
        * model callbacks appended non-inheritable, parent run id preserved by
        * `copy`, tracers deduped by `configure`.
        */
-      const modelCallbacks = (model as { callbacks?: Callbacks } | undefined)
-        ?.callbacks;
-      if (modelCallbacks != null) {
+      for (const source of collectModelCallbackSources(model)) {
         callbackManager =
-          CallbackManager.configure(
-            callbackManager ?? undefined,
-            modelCallbacks
-          ) ?? callbackManager;
+          CallbackManager.configure(callbackManager ?? undefined, source) ??
+          callbackManager;
       }
       if (callbackManager != null) {
         const runManager = new CallbackManagerForLLMRun(

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -350,14 +350,52 @@ function countSealedTokens(
 }
 
 /**
+ * Instruction overhead the provider processed but that never appears in the
+ * message array: `createCallModel` pipes the model through
+ * `agentContext.systemRunnable` and binds tool schemas AFTER `messages` is
+ * formed, so the system prompt, dynamic instructions, summary and tool
+ * schemas are all billed yet invisible here.
+ *
+ * Read per-node via `getAgentContext(metadata)` rather than the graph-level
+ * accessor, which is hardcoded to `defaultAgentId` and would report the wrong
+ * agent's overhead in a `MultiAgentGraph`.
+ */
+function sealedInstructionOverhead(
+  context: InvokeContext | undefined,
+  metadata: Record<string, unknown> | undefined
+): number {
+  try {
+    const agentContext = context?.getAgentContext(metadata);
+    return (
+      agentContext?.resolvedInstructionOverhead ??
+      agentContext?.instructionTokens ??
+      0
+    );
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * Best-effort usage for a turn the provider never got to bill us for.
  *
- * The prompt matters as much as the completion here: the provider processed
- * the ENTIRE prompt before we sealed, and every resume re-sends it, so
- * reporting `input_tokens: 0` would under-count the most expensive half of a
- * preempted run. Both sides come from the host's own counter, so they are
- * estimates — but estimates in the right order of magnitude beat a fabricated
- * zero. When no counter is configured we report nothing rather than guess.
+ * The prompt matters as much as the completion: the provider processed the
+ * ENTIRE prompt — messages plus instruction overhead — before we sealed, and
+ * every resume re-sends it, so under-counting input hides the expensive half
+ * of a preempted run.
+ *
+ * ESTIMATE, NOT MEASUREMENT. Messages are counted with the host's tokenizer
+ * rather than the provider's, and `toolSchemaTokens` applies a heuristic
+ * multiplier. It is also an over-count on the fallback path, where
+ * `tryFallbackProviders` builds a bare model with no `systemRunnable` pipe so
+ * the system prompt genuinely is not sent. Accepted rather than threaded
+ * through a flag: only the fallback-plus-seal combination is affected, and an
+ * over-count is safer than the previous fabricated `input_tokens: 0`.
+ *
+ * Marked `estimated_usage` so calibration can refuse to learn from it — a
+ * ratio derived from the same counter that produced the estimate is
+ * self-consistent by construction and would drag a provider's real
+ * calibration toward 1.0.
  */
 function synthesizeSealedUsage(
   context: InvokeContext | undefined,
@@ -372,11 +410,17 @@ function synthesizeSealedUsage(
   if (outputTokens == null) {
     return;
   }
-  const inputTokens = countSealedTokens(context, metadata, prompt) ?? 0;
+  const inputTokens =
+    (countSealedTokens(context, metadata, prompt) ?? 0) +
+    sealedInstructionOverhead(context, metadata);
   chunk.usage_metadata = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
     total_tokens: inputTokens + outputTokens,
+  };
+  chunk.response_metadata = {
+    ...chunk.response_metadata,
+    estimated_usage: true,
   };
 }
 

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -22,10 +22,12 @@ import {
 } from '@/messages/cache';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
-import { Constants, GraphEvents, Providers } from '@/common';
 import { manualToolStreamProviders } from '@/llm/providers';
+import { Constants, GraphEvents, Providers } from '@/common';
+import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { modifyDeltaProperties } from '@/messages';
+import { canSealPreempt } from '@/llm/preempt';
 import { ChatModelStreamHandler } from '@/stream';
 import { initializeModel } from '@/llm/init';
 import { isOpenAILike } from '@/utils/llm';
@@ -318,6 +320,56 @@ function getStreamHandlingChunk({
   );
 }
 
+/**
+ * Best-effort output-token count for a sealed turn, used only when the
+ * provider never got to send its usage chunk.
+ */
+function countSealedOutputTokens(
+  context: InvokeContext | undefined,
+  chunk: AIMessageChunk,
+  metadata: Record<string, unknown> | undefined
+): number | undefined {
+  try {
+    return context?.getAgentContext(metadata).tokenCounter?.(chunk);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Emits `CHAT_MODEL_END` for a turn that was sealed mid-stream.
+ *
+ * Mandatory, not cosmetic. `@langchain/core`'s `_streamIterator` calls
+ * `handleLLMEnd` after its try/catch with no `finally`, so breaking out of the
+ * consumer's `for await` produces a *return* completion that fires neither
+ * `handleLLMError` nor `handleLLMEnd` — the model-end event the host uses to
+ * record token usage would never arrive. Since every seal re-sends the whole
+ * prompt on resume, a user who preempts N times would otherwise spend N
+ * unrecorded full prompts.
+ */
+async function dispatchSealedModelEnd(
+  context: InvokeContext | undefined,
+  chunk: AIMessageChunk,
+  config?: RunnableConfig
+): Promise<void> {
+  const metadata = config?.metadata as Record<string, unknown> | undefined;
+  if (chunk.usage_metadata == null) {
+    const outputTokens = countSealedOutputTokens(context, chunk, metadata);
+    if (outputTokens != null) {
+      chunk.usage_metadata = {
+        input_tokens: 0,
+        output_tokens: outputTokens,
+        total_tokens: outputTokens,
+      };
+    }
+  }
+  await safeDispatchCustomEvent(
+    GraphEvents.CHAT_MODEL_END,
+    { output: chunk },
+    config
+  );
+}
+
 function appendStreamChunk({
   current,
   next,
@@ -402,6 +454,7 @@ export async function attemptInvoke(
   if (model.stream) {
     const stream = await model.stream(messagesForProvider, config);
     let finalChunk: AIMessageChunk | undefined;
+    let preempted = false;
     const registeredStreamHandler =
       getRegisteredDefaultChatStreamHandler(context);
 
@@ -436,6 +489,19 @@ export async function attemptInvoke(
           next: chunk,
           provider,
         });
+        /**
+         * Only this loop may seal. The registered-handler branch below
+         * dispatches through `run.ts`'s decoupled `streamEvents` consumer,
+         * which can lag the accumulated chunk — sealing there would let the
+         * host index a content part the user has not been shown yet.
+         */
+        if (
+          context?.shouldPreemptStream() === true &&
+          canSealPreempt(finalChunk)
+        ) {
+          preempted = true;
+          break;
+        }
       }
     } else {
       const metadata = config.metadata as Record<string, unknown> | undefined;
@@ -463,6 +529,15 @@ export async function attemptInvoke(
 
     if (manualToolStreamProviders.has(provider)) {
       finalChunk = modifyDeltaProperties(provider, finalChunk);
+    }
+
+    if (preempted && finalChunk != null) {
+      finalChunk.response_metadata = {
+        ...finalChunk.response_metadata,
+        preempted: true,
+      };
+      context?.notePreemptSeal();
+      await dispatchSealedModelEnd(context, finalChunk, config);
     }
 
     if ((finalChunk?.tool_calls?.length ?? 0) > 0) {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1,6 +1,10 @@
 import { concat } from '@langchain/core/utils/stream';
 import { AIMessageChunk } from '@langchain/core/messages';
-import { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import {
+  CallbackManager,
+  CallbackManagerForLLMRun,
+  type Callbacks,
+} from '@langchain/core/callbacks/manager';
 import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import type { Serialized } from '@langchain/core/load/serializable';
 import type { ChatGeneration } from '@langchain/core/outputs';
@@ -480,13 +484,34 @@ async function endSealedModelRun(
   chunk: AIMessageChunk,
   prompt: BaseMessage[],
   llmRunId: string | undefined,
-  config?: RunnableConfig
+  config?: RunnableConfig,
+  model?: t.ChatModel
 ): Promise<void> {
   const metadata = config?.metadata as Record<string, unknown> | undefined;
   synthesizeSealedUsage(context, chunk, prompt, metadata);
   if (llmRunId != null) {
     try {
-      const callbackManager = await getCallbackManagerForConfig(config);
+      let callbackManager = await getCallbackManagerForConfig(config);
+      /**
+       * The real model run composes the per-call config's callbacks WITH the
+       * model's own (`CallbackManager.configure(config.callbacks,
+       * this.callbacks, …)` in `@langchain/core`'s base chat model), so a
+       * handler supplied via `clientOptions.callbacks` received
+       * `handleChatModelStart` for this run. Rebuilding from the config alone
+       * would close the run for every handler EXCEPT those — leaving their
+       * span open forever. Composed the same way the real run composes:
+       * model callbacks appended non-inheritable, parent run id preserved by
+       * `copy`, tracers deduped by `configure`.
+       */
+      const modelCallbacks = (model as { callbacks?: Callbacks } | undefined)
+        ?.callbacks;
+      if (modelCallbacks != null) {
+        callbackManager =
+          CallbackManager.configure(
+            callbackManager ?? undefined,
+            modelCallbacks
+          ) ?? callbackManager;
+      }
       if (callbackManager != null) {
         const runManager = new CallbackManagerForLLMRun(
           llmRunId,
@@ -745,7 +770,8 @@ export async function attemptInvoke(
         finalChunk,
         messagesForProvider,
         sealedRunId,
-        config
+        config,
+        model
       );
     }
 

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -100,7 +100,14 @@ describe('canSealPreempt', () => {
       expect(canSealPreempt(c)).toBe(false);
     });
 
-    it('with an unpaired Anthropic server_tool_use block', () => {
+    /**
+     * Anthropic emits a `tool_call_chunk` alongside every `server_tool_use`
+     * content block, and `concat` keeps it on the accumulated message for the
+     * rest of the turn. So a web-search turn is refused by the tool-call gate,
+     * both while the search is in flight and after its result has landed —
+     * this pins that invariant rather than a content-block check.
+     */
+    it('while an Anthropic server tool is in flight', () => {
       expect(
         canSealPreempt(
           chunk({
@@ -112,6 +119,35 @@ describe('canSealPreempt', () => {
                 name: 'web_search',
                 input: { query: 'x' },
               },
+            ],
+            tool_call_chunks: [
+              { id: 'srvtoolu_1', name: 'web_search', args: '', index: 0 },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('after an Anthropic server tool result has landed', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Here is what I found.' },
+              {
+                type: 'server_tool_use',
+                id: 'srvtoolu_1',
+                name: 'web_search',
+                input: { query: 'x' },
+              },
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtoolu_1',
+                content: [],
+              },
+            ],
+            tool_call_chunks: [
+              { id: 'srvtoolu_1', name: 'web_search', args: '', index: 0 },
             ],
           })
         )
@@ -164,17 +200,13 @@ describe('canSealPreempt', () => {
       ).toBe(true);
     });
 
-    it('once a paired server tool result has landed', () => {
+    it('on a non-text block that carries no tool call', () => {
       expect(
         canSealPreempt(
           chunk({
             content: [
-              { type: 'text', text: 'Here is what I found.' },
-              {
-                type: 'web_search_tool_result',
-                tool_use_id: 'srvtoolu_1',
-                content: [],
-              },
+              { type: 'text', text: 'Here is the diagram.' },
+              { type: 'image_url', image_url: { url: 'https://x/y.png' } },
             ],
           })
         )

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -128,6 +128,39 @@ describe('canSealPreempt', () => {
       ).toBe(false);
     });
 
+    /**
+     * Gemini server-side tools land as `toolCall` / `toolResponse` content
+     * blocks and never populate `tool_calls` or `tool_call_chunks`, so the
+     * tool-call gates above cannot see them.
+     */
+    it('while a Google server tool call is unanswered', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Let me look that up.' },
+              { type: 'toolCall', id: 'gcall_1', name: 'google_search' },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('with more Google server tool calls than responses', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Checking two things.' },
+              { type: 'toolCall', id: 'gcall_1', name: 'google_search' },
+              { type: 'toolResponse', id: 'gcall_1', response: {} },
+              { type: 'toolCall', id: 'gcall_2', name: 'google_search' },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
     it('after an Anthropic server tool result has landed', () => {
       expect(
         canSealPreempt(
@@ -195,6 +228,20 @@ describe('canSealPreempt', () => {
             tool_calls: [],
             tool_call_chunks: [],
             invalid_tool_calls: [],
+          })
+        )
+      ).toBe(true);
+    });
+
+    it('once every Google server tool call has been answered', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Here is what I found.' },
+              { type: 'toolCall', id: 'gcall_1', name: 'google_search' },
+              { type: 'toolResponse', id: 'gcall_1', response: {} },
+            ],
           })
         )
       ).toBe(true);

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -194,18 +194,12 @@ describe('canSealPreempt', () => {
       ).toBe(false);
     });
 
-    it('after an Anthropic server tool result has landed', () => {
+    it('while one of several server tool calls is still unanswered', () => {
       expect(
         canSealPreempt(
           chunk({
             content: [
-              { type: 'text', text: 'Here is what I found.' },
-              {
-                type: 'server_tool_use',
-                id: 'srvtoolu_1',
-                name: 'web_search',
-                input: { query: 'x' },
-              },
+              { type: 'text', text: 'Checking two sources.' },
               {
                 type: 'web_search_tool_result',
                 tool_use_id: 'srvtoolu_1',
@@ -214,6 +208,7 @@ describe('canSealPreempt', () => {
             ],
             tool_call_chunks: [
               { id: 'srvtoolu_1', name: 'web_search', args: '', index: 0 },
+              { id: 'srvtoolu_2', name: 'web_search', args: '', index: 1 },
             ],
           })
         )
@@ -274,6 +269,38 @@ describe('canSealPreempt', () => {
               { type: 'text', text: 'Here is what I found.' },
               { type: 'toolCall', id: 'gcall_1', name: 'google_search' },
               { type: 'toolResponse', id: 'gcall_1', response: {} },
+            ],
+          })
+        )
+      ).toBe(true);
+    });
+
+    /**
+     * Provider-side tools never reach `ToolNode`, so no `PostToolBatch`
+     * boundary exists to drain into. Refusing forever after a search would
+     * defer a queued message to the end of the turn rather than to the next
+     * tool step, so a call whose result has landed counts as settled.
+     */
+    it('once an Anthropic server tool result has landed', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Here is what I found.' },
+              {
+                type: 'server_tool_use',
+                id: 'srvtoolu_1',
+                name: 'web_search',
+                input: { query: 'x' },
+              },
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtoolu_1',
+                content: [],
+              },
+            ],
+            tool_call_chunks: [
+              { id: 'srvtoolu_1', name: 'web_search', args: '', index: 0 },
             ],
           })
         )

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -1,0 +1,184 @@
+import { AIMessageChunk } from '@langchain/core/messages';
+import { canSealPreempt } from './preempt';
+
+function chunk(fields: Partial<AIMessageChunk>): AIMessageChunk {
+  return new AIMessageChunk({
+    content: '',
+    ...fields,
+  } as ConstructorParameters<typeof AIMessageChunk>[0]);
+}
+
+describe('canSealPreempt', () => {
+  describe('refuses to seal', () => {
+    it('on a missing chunk', () => {
+      expect(canSealPreempt(undefined)).toBe(false);
+    });
+
+    it('on empty string content', () => {
+      expect(canSealPreempt(chunk({ content: '' }))).toBe(false);
+    });
+
+    it('on whitespace-only string content', () => {
+      expect(canSealPreempt(chunk({ content: '  \n\t ' }))).toBe(false);
+    });
+
+    it('on an empty content array', () => {
+      expect(canSealPreempt(chunk({ content: [] }))).toBe(false);
+    });
+
+    it('on whitespace-only text blocks', () => {
+      expect(
+        canSealPreempt(chunk({ content: [{ type: 'text', text: '   ' }] }))
+      ).toBe(false);
+    });
+
+    it('when the only content is thinking', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'thinking', thinking: 'Let me work through this.' },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('when the only content is reasoning', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [{ type: 'reasoning', reasoning: 'Considering.' }],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('when the only content is redacted_thinking', () => {
+      expect(
+        canSealPreempt(
+          chunk({ content: [{ type: 'redacted_thinking', data: 'xxx' }] })
+        )
+      ).toBe(false);
+    });
+
+    it('with a resolved tool call present', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: 'Looking that up.',
+            tool_calls: [{ id: 'c1', name: 'search', args: {} }],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('with a partial tool call still streaming', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: 'Looking that up.',
+            tool_call_chunks: [
+              { id: 'c1', name: 'search', args: '{"q"', index: 0 },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    /**
+     * Assigned after construction on purpose: `AIMessageChunk` derives
+     * `invalid_tool_calls` from `tool_call_chunks` and drops a directly
+     * supplied array, so this is the only way to exercise the guard on its
+     * own rather than through the `tool_call_chunks` check above it.
+     */
+    it('with an invalid tool call present', () => {
+      const c = chunk({ content: 'Looking that up.' });
+      c.invalid_tool_calls = [
+        { id: 'c1', name: 'search', args: '{oops', error: 'bad json' },
+      ];
+      expect(canSealPreempt(c)).toBe(false);
+    });
+
+    it('with an unpaired Anthropic server_tool_use block', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Searching the web for that.' },
+              {
+                type: 'server_tool_use',
+                id: 'srvtoolu_1',
+                name: 'web_search',
+                input: { query: 'x' },
+              },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('seals', () => {
+    it('on non-empty string content', () => {
+      expect(canSealPreempt(chunk({ content: 'The migration has' }))).toBe(
+        true
+      );
+    });
+
+    it('on a non-empty text block', () => {
+      expect(
+        canSealPreempt(
+          chunk({ content: [{ type: 'text', text: 'The migration has' }] })
+        )
+      ).toBe(true);
+    });
+
+    it('on text that follows signed thinking', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              {
+                type: 'thinking',
+                thinking: 'Working it out.',
+                signature: 'sig',
+              },
+              { type: 'text', text: 'The migration has' },
+            ],
+          })
+        )
+      ).toBe(true);
+    });
+
+    it('with empty tool-call arrays present', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: 'The migration has',
+            tool_calls: [],
+            tool_call_chunks: [],
+            invalid_tool_calls: [],
+          })
+        )
+      ).toBe(true);
+    });
+
+    it('once a paired server tool result has landed', () => {
+      expect(
+        canSealPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: 'Here is what I found.' },
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtoolu_1',
+                content: [],
+              },
+            ],
+          })
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -1,5 +1,38 @@
 import { AIMessageChunk } from '@langchain/core/messages';
-import { canSealPreempt } from './preempt';
+import { canSealPreempt, resolveMaxSeals } from './preempt';
+
+/**
+ * The budget is read by two consumers that interpret it differently — a
+ * numeric comparison in the seal gate, and an addition into the graph's
+ * recursion limit. Normalizing once keeps them in agreement.
+ */
+describe('resolveMaxSeals', () => {
+  it('defaults when unset', () => {
+    expect(resolveMaxSeals(undefined)).toBe(8);
+  });
+
+  it('passes a sane whole number through', () => {
+    expect(resolveMaxSeals(3)).toBe(3);
+  });
+
+  it('floors a fractional budget so both readers agree', () => {
+    expect(resolveMaxSeals(1.5)).toBe(1);
+  });
+
+  it('honors zero as a deliberate never-seal', () => {
+    expect(resolveMaxSeals(0)).toBe(0);
+  });
+
+  it('clamps a negative budget to never-seal', () => {
+    expect(resolveMaxSeals(-4)).toBe(0);
+  });
+
+  it('falls back rather than poisoning the recursion limit', () => {
+    expect(resolveMaxSeals(NaN)).toBe(8);
+    expect(resolveMaxSeals(Infinity)).toBe(8);
+    expect(resolveMaxSeals(-Infinity)).toBe(8);
+  });
+});
 
 function chunk(fields: Partial<AIMessageChunk>): AIMessageChunk {
   return new AIMessageChunk({

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -58,8 +58,12 @@ function hasOpenGoogleServerToolCall(
 /**
  * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
  * yields a message sequence valid on EVERY supported provider:
- *  - non-whitespace TEXT content, so the injected user turn is preceded by a
- *    NON-EMPTY assistant turn (no empty-content 400s, no adjacent user turns);
+ *  - non-whitespace TEXT content, so the FIRST injected user turn is preceded
+ *    by a non-empty assistant turn — no empty-content 400s. Note this says
+ *    nothing about adjacency AMONG several injected turns: a boundary that
+ *    drains two steers emits two consecutive user messages, which strict
+ *    providers reject. That is normalized at the provider-facing hop by
+ *    `coalesceAdjacentUserTurns`, not here;
  *  - no tool call in flight, so no `tool_use` can be orphaned AND no eagerly
  *    prestarted execution can be stripped out from under the model.
  *

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -76,6 +76,50 @@ function hasOpenGoogleServerToolCall(
 }
 
 /**
+ * Ids of Anthropic server-side tool calls whose paired result block is already
+ * on the accumulated content. Those calls are answered and cannot be orphaned
+ * by a seal.
+ */
+function settledServerToolCallIds(
+  content: AIMessageChunk['content']
+): Set<string> {
+  const settled = new Set<string>();
+  if (typeof content === 'string') {
+    return settled;
+  }
+  for (const block of content) {
+    if (block.type !== 'web_search_tool_result') {
+      continue;
+    }
+    const id = block.tool_use_id;
+    if (typeof id === 'string') {
+      settled.add(id);
+    }
+  }
+  return settled;
+}
+
+/** Tool calls still awaiting an answer, ignoring ones already settled. */
+function countOpenToolCalls(
+  calls: ReadonlyArray<{ id?: string }> | undefined,
+  settled: Set<string>
+): number {
+  if (calls == null || calls.length === 0) {
+    return 0;
+  }
+  if (settled.size === 0) {
+    return calls.length;
+  }
+  let open = 0;
+  for (const call of calls) {
+    if (call.id == null || !settled.has(call.id)) {
+      open += 1;
+    }
+  }
+  return open;
+}
+
+/**
  * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
  * yields a message sequence valid on EVERY supported provider:
  *  - non-whitespace TEXT content, so the FIRST injected user turn is preceded
@@ -104,10 +148,24 @@ export function canSealPreempt(chunk: AIMessageChunk | undefined): boolean {
   if (chunk == null) {
     return false;
   }
-  if ((chunk.tool_calls?.length ?? 0) > 0) {
+  /**
+   * Anthropic's server-side tools run inside the provider, so unlike a client
+   * tool they never reach `ToolNode` and never produce a `PostToolBatch`
+   * boundary. `concat` also keeps their `server_tool_use` chunk on the
+   * accumulated message for the rest of the turn. Together that means a naive
+   * tool-call gate makes a turn permanently unsealable the moment a web
+   * search starts, with no later boundary to drain into — the queued message
+   * waits for the whole turn to finish rather than for the next tool step.
+   *
+   * So calls whose paired result block has already landed are treated as
+   * settled: they cannot be orphaned, because the provider has already
+   * answered them.
+   */
+  const settled = settledServerToolCallIds(chunk.content);
+  if (countOpenToolCalls(chunk.tool_calls, settled) > 0) {
     return false;
   }
-  if ((chunk.tool_call_chunks?.length ?? 0) > 0) {
+  if (countOpenToolCalls(chunk.tool_call_chunks, settled) > 0) {
     return false;
   }
   if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -1,6 +1,26 @@
 // src/llm/preempt.ts
 import type { AIMessageChunk } from '@langchain/core/messages';
-import { ContentTypes } from '@/common';
+import { ContentTypes, DEFAULT_MAX_SEALS } from '@/common';
+
+/**
+ * Normalizes a host-supplied seal budget.
+ *
+ * Read in two places that interpret it differently — a numeric comparison in
+ * the seal gate and an addition into the recursion limit — so a value like
+ * `1.5` would permit two seals while reserving fractional headroom, `NaN`
+ * would poison the recursion limit outright, and `Infinity` would remove both
+ * bounds at once. Normalizing once keeps the two readings in agreement.
+ *
+ * `0` is honored as a deliberate "never seal"; anything not finite falls back
+ * to the default rather than silently disabling the feature.
+ */
+export function resolveMaxSeals(maxSeals: number | undefined): number {
+  if (maxSeals == null || !Number.isFinite(maxSeals)) {
+    return DEFAULT_MAX_SEALS;
+  }
+  const whole = Math.floor(maxSeals);
+  return whole > 0 ? whole : 0;
+}
 
 /**
  * True when the accumulated content carries at least one non-whitespace text

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -1,0 +1,76 @@
+// src/llm/preempt.ts
+import type { AIMessageChunk } from '@langchain/core/messages';
+import { ContentTypes } from '@/common';
+
+/**
+ * True when the accumulated content carries at least one non-whitespace text
+ * block. `thinking` / `reasoning` blocks deliberately do not count: they are
+ * stripped or signed on several providers and cannot stand in for the visible
+ * assistant turn a sealed sequence needs.
+ */
+function hasNonEmptyTextContent(content: AIMessageChunk['content']): boolean {
+  if (typeof content === 'string') {
+    return content.trim() !== '';
+  }
+  for (const block of content) {
+    if (block.type !== ContentTypes.TEXT) {
+      continue;
+    }
+    const text = block[ContentTypes.TEXT];
+    if (typeof text === 'string' && text.trim() !== '') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when the accumulated content carries an Anthropic `server_tool_use`
+ * block (web search). These pair with a `web_search_tool_result` that arrives
+ * later in the stream, and an unpaired one is repaired by neither
+ * `sanitizeOrphanToolBlocks` nor `preserveUnpairedServerToolUses`.
+ */
+function hasServerToolUseBlock(content: AIMessageChunk['content']): boolean {
+  if (typeof content === 'string') {
+    return false;
+  }
+  for (const block of content) {
+    if (block.type === 'server_tool_use') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
+ * yields a message sequence valid on EVERY supported provider:
+ *  - non-whitespace TEXT content, so the injected user turn is preceded by a
+ *    NON-EMPTY assistant turn (no empty-content 400s, no adjacent user turns);
+ *  - no tool call in flight, so no `tool_use` can be orphaned AND no eagerly
+ *    prestarted execution can be stripped out from under the model;
+ *  - no unpaired Anthropic `server_tool_use`.
+ *
+ * Nothing is stripped and nothing is repaired: when the accumulated shape is
+ * not already safe the stream simply runs on, and whatever the host queued
+ * lands at the next tool boundary instead. Chunks accumulate monotonically
+ * through `concat`, so an unsafe shape can never be observed at a seal point.
+ */
+export function canSealPreempt(chunk: AIMessageChunk | undefined): boolean {
+  if (chunk == null) {
+    return false;
+  }
+  if ((chunk.tool_calls?.length ?? 0) > 0) {
+    return false;
+  }
+  if ((chunk.tool_call_chunks?.length ?? 0) > 0) {
+    return false;
+  }
+  if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {
+    return false;
+  }
+  if (hasServerToolUseBlock(chunk.content)) {
+    return false;
+  }
+  return hasNonEmptyTextContent(chunk.content);
+}

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -25,6 +25,37 @@ function hasNonEmptyTextContent(content: AIMessageChunk['content']): boolean {
 }
 
 /**
+ * True while a Gemini server-side tool call is still awaiting its response.
+ *
+ * Google's server-side tools (Search, URL context) never populate
+ * `tool_calls` or `tool_call_chunks` — those are derived from `functionCall`
+ * parts only, while a server-side invocation arrives as a `toolCall` CONTENT
+ * block and its result as a later `toolResponse` block. The tool-call gates
+ * cannot see it, so sealing between the two would replay a model turn holding
+ * an unanswered server-side call.
+ *
+ * Counted rather than id-matched: Google answers calls in order, and counting
+ * stays correct when a part omits its id.
+ */
+function hasOpenGoogleServerToolCall(
+  content: AIMessageChunk['content']
+): boolean {
+  if (typeof content === 'string') {
+    return false;
+  }
+  let calls = 0;
+  let responses = 0;
+  for (const block of content) {
+    if (block.type === 'toolCall') {
+      calls += 1;
+    } else if (block.type === 'toolResponse') {
+      responses += 1;
+    }
+  }
+  return calls > responses;
+}
+
+/**
  * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
  * yields a message sequence valid on EVERY supported provider:
  *  - non-whitespace TEXT content, so the injected user turn is preceded by a
@@ -56,6 +87,9 @@ export function canSealPreempt(chunk: AIMessageChunk | undefined): boolean {
     return false;
   }
   if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {
+    return false;
+  }
+  if (hasOpenGoogleServerToolCall(chunk.content)) {
     return false;
   }
   return hasNonEmptyTextContent(chunk.content);

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -25,31 +25,20 @@ function hasNonEmptyTextContent(content: AIMessageChunk['content']): boolean {
 }
 
 /**
- * True when the accumulated content carries an Anthropic `server_tool_use`
- * block (web search). These pair with a `web_search_tool_result` that arrives
- * later in the stream, and an unpaired one is repaired by neither
- * `sanitizeOrphanToolBlocks` nor `preserveUnpairedServerToolUses`.
- */
-function hasServerToolUseBlock(content: AIMessageChunk['content']): boolean {
-  if (typeof content === 'string') {
-    return false;
-  }
-  for (const block of content) {
-    if (block.type === 'server_tool_use') {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
  * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
  * yields a message sequence valid on EVERY supported provider:
  *  - non-whitespace TEXT content, so the injected user turn is preceded by a
  *    NON-EMPTY assistant turn (no empty-content 400s, no adjacent user turns);
  *  - no tool call in flight, so no `tool_use` can be orphaned AND no eagerly
- *    prestarted execution can be stripped out from under the model;
- *  - no unpaired Anthropic `server_tool_use`.
+ *    prestarted execution can be stripped out from under the model.
+ *
+ * Anthropic's server-side tools need no check of their own. Every
+ * `server_tool_use` content block also emits a `tool_call_chunk`
+ * (`_makeMessageChunkFromAnthropicEvent`), and `concat` keeps that chunk on
+ * the accumulated message for the remainder of the turn, so the tool-call
+ * gates below already cover it. The practical consequence is worth stating
+ * plainly: once a turn starts a web search it is no longer preemptible, and
+ * a queued message waits for the ordinary tool boundary instead.
  *
  * Nothing is stripped and nothing is repaired: when the accumulated shape is
  * not already safe the stream simply runs on, and whatever the host queued
@@ -67,9 +56,6 @@ export function canSealPreempt(chunk: AIMessageChunk | undefined): boolean {
     return false;
   }
   if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {
-    return false;
-  }
-  if (hasServerToolUseBlock(chunk.content)) {
     return false;
   }
   return hasNonEmptyTextContent(chunk.content);

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -1,0 +1,123 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { Providers } from '@/common';
+import {
+  coalesceAdjacentUserTurns,
+  strictAlternationProviders,
+} from './alternation';
+
+describe('strictAlternationProviders', () => {
+  it('covers the providers that reject consecutive user turns', () => {
+    expect(strictAlternationProviders.has(Providers.BEDROCK)).toBe(true);
+    expect(strictAlternationProviders.has(Providers.MISTRAL)).toBe(true);
+    expect(strictAlternationProviders.has(Providers.MISTRALAI)).toBe(true);
+  });
+
+  it('leaves providers that accept them alone', () => {
+    expect(strictAlternationProviders.has(Providers.ANTHROPIC)).toBe(false);
+    expect(strictAlternationProviders.has(Providers.OPENAI)).toBe(false);
+    expect(strictAlternationProviders.has(Providers.GOOGLE)).toBe(false);
+  });
+});
+
+describe('coalesceAdjacentUserTurns', () => {
+  it('leaves an already-alternating run untouched', () => {
+    const messages = [
+      new HumanMessage({ content: 'question' }),
+      new AIMessage({ content: 'answer' }),
+      new HumanMessage({ content: 'follow-up' }),
+    ];
+    const result = coalesceAdjacentUserTurns(messages);
+    expect(result.map((m) => m.getType())).toEqual(['human', 'ai', 'human']);
+    expect(result[0]).toBe(messages[0]);
+  });
+
+  /** A boundary that drains two steers, which is the ordinary queue case. */
+  it('merges a run of consecutive human turns', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({ content: 'question' }),
+      new AIMessage({ content: 'partial' }),
+      new HumanMessage({ content: 'steer 1' }),
+      new HumanMessage({ content: 'steer 2' }),
+    ]);
+    expect(result.map((m) => m.getType())).toEqual(['human', 'ai', 'human']);
+    expect(result[2].content).toBe('steer 1\n\nsteer 2');
+  });
+
+  it('merges context plus injected messages into one turn', () => {
+    const result = coalesceAdjacentUserTurns([
+      new AIMessage({ content: 'partial' }),
+      new HumanMessage({
+        content: 'hook context',
+        additional_kwargs: { role: 'system', source: 'hook' },
+      }),
+      new HumanMessage({
+        content: 'steer',
+        additional_kwargs: { role: 'user', source: 'steer' },
+      }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[1].content).toBe('hook context\n\nsteer');
+  });
+
+  it('concatenates block content rather than stringifying it', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({ content: [{ type: 'text', text: 'look' }] }),
+      new HumanMessage({
+        content: [{ type: 'image_url', image_url: { url: 'data:,' } }],
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'look' },
+      { type: 'image_url', image_url: { url: 'data:,' } },
+    ]);
+  });
+
+  it('normalizes a mixed string and block pair', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({ content: 'plain' }),
+      new HumanMessage({ content: [{ type: 'text', text: 'blocks' }] }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'plain' },
+      { type: 'text', text: 'blocks' },
+    ]);
+  });
+
+  /**
+   * Both vendored converters merge adjacent tool-result runs themselves, and
+   * folding one into a text turn would orphan the pairing.
+   */
+  it('never merges tool-result turns', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
+      }),
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 't2', content: 'ok' }],
+      }),
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('never merges a tool-result turn into a text turn', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
+      }),
+      new HumanMessage({ content: 'steer' }),
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not mutate the input array or its messages', () => {
+    const first = new HumanMessage({ content: 'a' });
+    const second = new HumanMessage({ content: 'b' });
+    const messages = [first, second];
+    coalesceAdjacentUserTurns(messages);
+    expect(messages).toHaveLength(2);
+    expect(first.content).toBe('a');
+    expect(second.content).toBe('b');
+  });
+});

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -20,15 +20,29 @@ describe('strictAlternationProviders', () => {
 });
 
 describe('coalesceAdjacentUserTurns', () => {
-  it('leaves an already-alternating run untouched', () => {
+  it('leaves an already-alternating run untouched, returning the SAME array', () => {
     const messages = [
       new HumanMessage({ content: 'question' }),
       new AIMessage({ content: 'answer' }),
       new HumanMessage({ content: 'follow-up' }),
     ];
     const result = coalesceAdjacentUserTurns(messages);
-    expect(result.map((m) => m.getType())).toEqual(['human', 'ai', 'human']);
-    expect(result[0]).toBe(messages[0]);
+    /**
+     * Identity, not just equality: the pass runs twice for a primary
+     * Bedrock/Mistral call (createCallModel, then the attemptInvoke funnel),
+     * so the normalized second pass must not reallocate a context-sized
+     * array — and origin tracking early-exits on `before === after`.
+     */
+    expect(result).toBe(messages);
+  });
+
+  it('is idempotent by identity: re-coalescing merged output is a no-op', () => {
+    const once = coalesceAdjacentUserTurns([
+      new HumanMessage({ content: 'steer 1' }),
+      new HumanMessage({ content: 'steer 2' }),
+    ]);
+    expect(once).toHaveLength(1);
+    expect(coalesceAdjacentUserTurns(once)).toBe(once);
   });
 
   /** A boundary that drains two steers, which is the ordinary queue case. */

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -111,6 +111,81 @@ describe('coalesceAdjacentUserTurns', () => {
     expect(result).toHaveLength(2);
   });
 
+  /**
+   * The prompt-cache tail anchor reasons positionally — it inserts the
+   * breakpoint after the merged message's LAST text block — so the last
+   * part's provenance flags must survive the merge. A skill body absorbed
+   * into a real user turn stays anchorable; a real turn absorbed into a
+   * trailing skill body must not let the anchor pin the volatile body.
+   */
+  it('keeps the last turn\'s additional_kwargs and the first turn\'s id', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'skill body',
+        id: 'first-id',
+        additional_kwargs: { isMeta: true, source: 'skill' },
+      }),
+      new HumanMessage({
+        content: 'real user turn',
+        id: 'second-id',
+        additional_kwargs: { role: 'user' },
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs).toEqual({ role: 'user' });
+    expect(result[0].id).toBe('first-id');
+  });
+
+  it('marks the merge meta when the trailing part is the volatile one', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'real steer',
+        additional_kwargs: { source: 'steer' },
+      }),
+      new HumanMessage({
+        content: 'skill body',
+        additional_kwargs: { isMeta: true, source: 'skill', skillName: 'x' },
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs.source).toBe('skill');
+    expect(result[0].additional_kwargs.isMeta).toBe(true);
+  });
+
+  /**
+   * Only ALL-tool-result turns are excluded. A mixed turn is an ordinary
+   * user turn that happens to carry a result block — merging preserves block
+   * order, so the pairing survives, and excluding it would leave adjacent
+   * user turns on the wire for exactly the shape Bedrock rejects.
+   */
+  it('merges a mixed text plus tool-result turn', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'ok' },
+          { type: 'text', text: 'and my comment' },
+        ],
+      }),
+      new HumanMessage({ content: 'next turn' }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: 'tool_result', tool_use_id: 't1', content: 'ok' },
+      { type: 'text', text: 'and my comment' },
+      { type: 'text', text: 'next turn' },
+    ]);
+  });
+
+  it('excludes the camelCase toolResult variant too', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [{ type: 'toolResult', toolResult: { content: 'ok' } }],
+      }),
+      new HumanMessage({ content: 'steer' }),
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
   it('does not mutate the input array or its messages', () => {
     const first = new HumanMessage({ content: 'a' });
     const second = new HumanMessage({ content: 'b' });

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -4,9 +4,14 @@ import type { BaseMessage, MessageContent } from '@langchain/core/messages';
 import { Providers } from '@/common';
 
 /**
- * Providers whose APIs require strict user/assistant alternation and reject
- * consecutive user turns. Anthropic's Messages API, OpenAI and Gemini all
- * accept them, so they are deliberately absent.
+ * Providers whose APIs specify strict user/assistant alternation. Mistral
+ * rejects consecutive user turns outright. Bedrock's Converse API documents
+ * the alternation requirement across many model families; enforcement varies
+ * by family — Claude on Converse currently tolerates adjacent user turns
+ * (verified live, 2026-07-28) — so the payload is normalized for all of them
+ * rather than betting on per-family leniency. Anthropic's own Messages API,
+ * OpenAI and Gemini all accept consecutive user turns, so they are
+ * deliberately absent.
  */
 export const strictAlternationProviders: ReadonlySet<Providers> = new Set([
   Providers.BEDROCK,

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -67,6 +67,7 @@ export function coalesceAdjacentUserTurns(
   messages: BaseMessage[]
 ): BaseMessage[] {
   const result: BaseMessage[] = [];
+  let mergedAny = false;
   for (const message of messages) {
     const previous = result[result.length - 1];
     const mergeable =
@@ -80,6 +81,7 @@ export function coalesceAdjacentUserTurns(
       result.push(message);
       continue;
     }
+    mergedAny = true;
 
     result[result.length - 1] = new HumanMessage({
       content: joinContent(previous.content, message.content),
@@ -98,5 +100,13 @@ export function coalesceAdjacentUserTurns(
       ...(previous.id != null && { id: previous.id }),
     });
   }
-  return result;
+  /**
+   * Identity on the no-merge path. The pass runs twice for a primary
+   * Bedrock/Mistral call — once in `createCallModel` (must precede the cache
+   * breakpoint) and once in the `attemptInvoke` funnel (must cover fallback
+   * and summarization sends) — so the already-normalized second pass returns
+   * the SAME array rather than reallocating a context-sized copy, and
+   * callers can cheaply detect "nothing changed" by identity.
+   */
+  return mergedAny ? result : messages;
 }

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -1,0 +1,86 @@
+// src/messages/alternation.ts
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage, MessageContent } from '@langchain/core/messages';
+import { Providers } from '@/common';
+
+/**
+ * Providers whose APIs require strict user/assistant alternation and reject
+ * consecutive user turns. Anthropic's Messages API, OpenAI and Gemini all
+ * accept them, so they are deliberately absent.
+ */
+export const strictAlternationProviders: ReadonlySet<Providers> = new Set([
+  Providers.BEDROCK,
+  Providers.MISTRAL,
+  Providers.MISTRALAI,
+]);
+
+const TOOL_RESULT_TYPES = new Set(['tool_result', 'toolResult']);
+
+/**
+ * True when every block is a tool result. Both vendored converters already
+ * merge adjacent runs of these, and folding one into a text turn would break
+ * the tool pairing they depend on — so they are left alone here.
+ */
+function isToolResultMessage(message: BaseMessage): boolean {
+  const { content } = message;
+  if (typeof content === 'string' || content.length === 0) {
+    return false;
+  }
+  return content.every(
+    (block) =>
+      typeof block.type === 'string' && TOOL_RESULT_TYPES.has(block.type)
+  );
+}
+
+function toBlocks(content: MessageContent): Exclude<MessageContent, string> {
+  if (typeof content === 'string') {
+    return content === '' ? [] : [{ type: 'text', text: content }];
+  }
+  return content;
+}
+
+function joinContent(
+  left: MessageContent,
+  right: MessageContent
+): MessageContent {
+  if (typeof left === 'string' && typeof right === 'string') {
+    return left === '' ? right : `${left}\n\n${right}`;
+  }
+  return [...toBlocks(left), ...toBlocks(right)];
+}
+
+/**
+ * Merges runs of consecutive human turns into one, for providers that reject
+ * them. Purely a wire-shaping pass: it returns a new array of new messages,
+ * so graph state and the host's persisted messages keep the per-message
+ * identity that steer rendering and the trailing-steer anchor rely on.
+ *
+ * Tool-result turns are excluded — the converters merge those themselves, and
+ * combining one with a text turn would orphan the pairing.
+ */
+export function coalesceAdjacentUserTurns(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const result: BaseMessage[] = [];
+  for (const message of messages) {
+    const previous = result[result.length - 1];
+    const mergeable =
+      result.length > 0 &&
+      previous.getType() === 'human' &&
+      message.getType() === 'human' &&
+      !isToolResultMessage(previous) &&
+      !isToolResultMessage(message);
+
+    if (!mergeable) {
+      result.push(message);
+      continue;
+    }
+
+    result[result.length - 1] = new HumanMessage({
+      content: joinContent(previous.content, message.content),
+      additional_kwargs: previous.additional_kwargs,
+      ...(previous.id != null && { id: previous.id }),
+    });
+  }
+  return result;
+}

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -78,7 +78,18 @@ export function coalesceAdjacentUserTurns(
 
     result[result.length - 1] = new HumanMessage({
       content: joinContent(previous.content, message.content),
-      additional_kwargs: previous.additional_kwargs,
+      /**
+       * The LATER turn's kwargs, deliberately. The one provider-path consumer
+       * of these flags is the prompt-cache tail anchor, and it reasons
+       * positionally: `isSyntheticMetaMessage` decides whether a breakpoint
+       * may be inserted after the message's LAST text block. Merging keeps
+       * the last block's provenance only if the last part's kwargs survive —
+       * a skill body absorbed into a real user turn must stay anchorable
+       * (the real turn ends it), while a real steer absorbed into a trailing
+       * skill body must not pin the cache to the volatile body. The first
+       * turn's id is kept so origin tracking can re-attach by key.
+       */
+      additional_kwargs: message.additional_kwargs,
       ...(previous.id != null && { id: previous.id }),
     });
   }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1588,6 +1588,11 @@ export const formatAgentMessages = (
         options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
     });
+    if (sourceMessageId != null && sourceMessageId !== '') {
+      for (const formattedMessage of formattedMessages) {
+        formattedMessage.id = sourceMessageId;
+      }
+    }
     /**
      * A steer that ends an assistant message leaves the replay on a
      * `HumanMessage`. The next payload message is itself a user turn, so the
@@ -1597,16 +1602,18 @@ export const formatAgentMessages = (
      * Guarded on not-being-last: when the steer IS the final message, the
      * user turn belongs at the end, which is exactly what the model is about
      * to answer. Reachable today through abort, not only through preemption.
+     *
+     * Pushed AFTER the id stamping above, deliberately. `messagesStateReducer`
+     * treats a repeated id as replace-in-place, so an anchor carrying the
+     * shared `sourceMessageId` would overwrite the steer it exists to protect.
+     * Left unstamped, it reaches the reducer with a null id and is assigned a
+     * fresh one. `endsWithSteerMessage` reads only `additional_kwargs.source`,
+     * so the reorder cannot change which messages get anchored.
      */
     if (i < payload.length - 1 && endsWithSteerMessage(formattedMessages)) {
       formattedMessages.push(
         withMessageRole(new AIMessage({ content: '' }), 'assistant')
       );
-    }
-    if (sourceMessageId != null && sourceMessageId !== '') {
-      for (const formattedMessage of formattedMessages) {
-        formattedMessage.id = sourceMessageId;
-      }
     }
     messages.push(...formattedMessages);
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1367,7 +1367,7 @@ export const formatAgentMessages = (
    * pushed. When that message is itself an assistant turn, it already IS the
    * separation the anchor exists to synthesize, so the intent is simply
    * discharged: emitting the placeholder anyway would put two assistant turns
-   * back to back, which Bedrock and Mistral reject and nothing downstream
+   * back to back, which strict-alternation providers can reject and nothing downstream
    * repairs (`coalesceAdjacentUserTurns` merges user turns only).
    */
   const flushSteerAnchor = (next: { role?: LangChainMessageRole }): void => {
@@ -1634,7 +1634,7 @@ export const formatAgentMessages = (
      * A steer that ends an assistant message leaves the replay on a
      * `HumanMessage`. The next payload message is itself a user turn, so the
      * sequence would reach the provider as two adjacent user turns — rejected
-     * outright by Bedrock and Mistral. Anchor it with a placeholder assistant
+     * by strict-alternation providers. Anchor it with a placeholder assistant
      * turn.
      *
      * The placeholder must be NON-EMPTY. A string-content assistant message

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -476,6 +476,12 @@ function formatToolCallOutput(
 }
 
 /**
+ * Content for the synthetic assistant turn that separates a trailing steer
+ * from the next user turn. Non-empty by necessity — see the push site.
+ */
+const STEER_ANCHOR_PLACEHOLDER = '_';
+
+/**
  * True when an assistant message replayed as a steer and nothing followed it,
  * so the emitted run ends on the steer's `HumanMessage`.
  */
@@ -1597,7 +1603,16 @@ export const formatAgentMessages = (
      * A steer that ends an assistant message leaves the replay on a
      * `HumanMessage`. The next payload message is itself a user turn, so the
      * sequence would reach the provider as two adjacent user turns — rejected
-     * outright by Bedrock and Mistral. Anchor it with an empty assistant turn.
+     * outright by Bedrock and Mistral. Anchor it with a placeholder assistant
+     * turn.
+     *
+     * The placeholder must be NON-EMPTY. A string-content assistant message
+     * with no tool calls passes through `_convertMessagesToAnthropicPayload`
+     * verbatim — the empty-text repair there only covers array content and
+     * tool-call turns — so an empty anchor would reach Anthropic as
+     * `{role: 'assistant', content: ''}` and trade one invalid sequence for
+     * another. Same single-underscore convention the Anthropic converter
+     * already uses when it has to synthesize a non-empty block.
      *
      * Guarded on not-being-last: when the steer IS the final message, the
      * user turn belongs at the end, which is exactly what the model is about
@@ -1612,7 +1627,10 @@ export const formatAgentMessages = (
      */
     if (i < payload.length - 1 && endsWithSteerMessage(formattedMessages)) {
       formattedMessages.push(
-        withMessageRole(new AIMessage({ content: '' }), 'assistant')
+        withMessageRole(
+          new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
+          'assistant'
+        )
       );
     }
     messages.push(...formattedMessages);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1362,11 +1362,22 @@ export const formatAgentMessages = (
    * nothing cannot leave the anchor stranded as the final turn.
    */
   let pendingSteerAnchor = false;
-  const flushSteerAnchor = (): void => {
+  /**
+   * Emits the deferred anchor ahead of `next` — the message about to be
+   * pushed. When that message is itself an assistant turn, it already IS the
+   * separation the anchor exists to synthesize, so the intent is simply
+   * discharged: emitting the placeholder anyway would put two assistant turns
+   * back to back, which Bedrock and Mistral reject and nothing downstream
+   * repairs (`coalesceAdjacentUserTurns` merges user turns only).
+   */
+  const flushSteerAnchor = (next: { role?: LangChainMessageRole }): void => {
     if (!pendingSteerAnchor) {
       return;
     }
     pendingSteerAnchor = false;
+    if (next.role === 'assistant') {
+      return;
+    }
     messages.push(
       withMessageRole(
         new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
@@ -1435,7 +1446,7 @@ export const formatAgentMessages = (
       if (sourceMessageId != null && sourceMessageId !== '') {
         formattedMessage.id = sourceMessageId;
       }
-      flushSteerAnchor();
+      flushSteerAnchor(formattedMessage);
       messages.push(formattedMessage);
 
       // Update the index mapping for this message
@@ -1649,7 +1660,14 @@ export const formatAgentMessages = (
      * fresh one. `endsWithSteerMessage` reads only `additional_kwargs.source`,
      * so the deferral cannot change which messages get anchored.
      */
-    flushSteerAnchor();
+    /**
+     * Guarded on emission: an assistant entry whose blocks all filtered away
+     * emits nothing, and flushing for it would strand the anchor as the final
+     * turn — the pending flag stays set for whichever entry emits next.
+     */
+    if (formattedMessages.length > 0) {
+      flushSteerAnchor(formattedMessages[0]);
+    }
     messages.push(...formattedMessages);
     if (endsWithSteerMessage(formattedMessages)) {
       pendingSteerAnchor = true;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -476,6 +476,19 @@ function formatToolCallOutput(
 }
 
 /**
+ * True when an assistant message replayed as a steer and nothing followed it,
+ * so the emitted run ends on the steer's `HumanMessage`.
+ */
+function endsWithSteerMessage(
+  formatted: Array<RoleBearingMessage<BaseMessage>>
+): boolean {
+  if (formatted.length === 0) {
+    return false;
+  }
+  return formatted[formatted.length - 1].additional_kwargs.source === 'steer';
+}
+
+/**
  * Helper function to format an assistant message
  * @param message The message to format
  * @param options Optional formatting options
@@ -1575,6 +1588,21 @@ export const formatAgentMessages = (
         options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
     });
+    /**
+     * A steer that ends an assistant message leaves the replay on a
+     * `HumanMessage`. The next payload message is itself a user turn, so the
+     * sequence would reach the provider as two adjacent user turns — rejected
+     * outright by Bedrock and Mistral. Anchor it with an empty assistant turn.
+     *
+     * Guarded on not-being-last: when the steer IS the final message, the
+     * user turn belongs at the end, which is exactly what the model is about
+     * to answer. Reachable today through abort, not only through preemption.
+     */
+    if (i < payload.length - 1 && endsWithSteerMessage(formattedMessages)) {
+      formattedMessages.push(
+        withMessageRole(new AIMessage({ content: '' }), 'assistant')
+      );
+    }
     if (sourceMessageId != null && sourceMessageId !== '') {
       for (const formattedMessage of formattedMessages) {
         formattedMessage.id = sourceMessageId;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1355,6 +1355,25 @@ export const formatAgentMessages = (
     | RoleBearingMessage<SystemMessage>
     | RoleBearingMessage<ToolMessage>
   > = [];
+  /**
+   * A steer ended the previous payload entry, so the next message emitted —
+   * whichever entry finally produces one — must be separated from it by an
+   * assistant turn. Held rather than emitted so an entry that produces
+   * nothing cannot leave the anchor stranded as the final turn.
+   */
+  let pendingSteerAnchor = false;
+  const flushSteerAnchor = (): void => {
+    if (!pendingSteerAnchor) {
+      return;
+    }
+    pendingSteerAnchor = false;
+    messages.push(
+      withMessageRole(
+        new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
+        'assistant'
+      )
+    );
+  };
   // If indexTokenCountMap is provided, create a new map to track the updated indices
   const updatedIndexTokenCountMap: Record<number, number> = {};
   let boundaryTokenAdjustment:
@@ -1416,6 +1435,7 @@ export const formatAgentMessages = (
       if (sourceMessageId != null && sourceMessageId !== '') {
         formattedMessage.id = sourceMessageId;
       }
+      flushSteerAnchor();
       messages.push(formattedMessage);
 
       // Update the index mapping for this message
@@ -1614,26 +1634,26 @@ export const formatAgentMessages = (
      * another. Same single-underscore convention the Anthropic converter
      * already uses when it has to synthesize a non-empty block.
      *
-     * Guarded on not-being-last: when the steer IS the final message, the
-     * user turn belongs at the end, which is exactly what the model is about
-     * to answer. Reachable today through abort, not only through preemption.
+     * Deferred rather than decided by lookahead. `i < payload.length - 1` only
+     * proves a later ENTRY exists, not that it EMITS: entries with empty
+     * content, and entries dropped by `applySummaryBoundary`, are skipped
+     * silently. A trailing steer followed only by those would get the anchor
+     * as the FINAL turn — an assistant prefill with no request after it, which
+     * the model may simply never answer. So the intent is recorded and flushed
+     * only when a message actually follows.
      *
      * Pushed AFTER the id stamping above, deliberately. `messagesStateReducer`
      * treats a repeated id as replace-in-place, so an anchor carrying the
      * shared `sourceMessageId` would overwrite the steer it exists to protect.
      * Left unstamped, it reaches the reducer with a null id and is assigned a
      * fresh one. `endsWithSteerMessage` reads only `additional_kwargs.source`,
-     * so the reorder cannot change which messages get anchored.
+     * so the deferral cannot change which messages get anchored.
      */
-    if (i < payload.length - 1 && endsWithSteerMessage(formattedMessages)) {
-      formattedMessages.push(
-        withMessageRole(
-          new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
-          'assistant'
-        )
-      );
-    }
+    flushSteerAnchor();
     messages.push(...formattedMessages);
+    if (endsWithSteerMessage(formattedMessages)) {
+      pendingSteerAnchor = true;
+    }
 
     // Capture index range BEFORE skill body injection so injected
     // HumanMessages are excluded from the assistant's token distribution.

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -324,3 +324,120 @@ describe('formatAgentMessages steer replay', () => {
     ]);
   });
 });
+
+describe('formatAgentMessages trailing-steer anchor', () => {
+  const steerPart = (text: string): Record<string, unknown> =>
+    ({
+      type: ContentTypes.STEER,
+      [ContentTypes.STEER]: text,
+    }) as unknown as Record<string, unknown>;
+
+  /**
+   * A steer that ends an assistant message leaves the replay on a
+   * HumanMessage. Followed by the next turn's user message, that reaches the
+   * provider as two adjacent user turns — a hard error on Bedrock and
+   * Mistral. Reachable today through abort, not only through preemption.
+   */
+  it('anchors a trailing steer when another turn follows', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Working on it.' },
+          steerPart('Actually, stop and do the other thing.'),
+        ],
+      },
+      { role: 'user', content: 'Next turn' },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    const steerIndex = messages.findIndex(
+      (message) =>
+        message instanceof HumanMessage &&
+        message.additional_kwargs.source === 'steer'
+    );
+    expect(steerIndex).toBeGreaterThan(0);
+
+    const anchor = messages[steerIndex + 1];
+    expect(anchor).toBeInstanceOf(AIMessage);
+    expect(anchor.content).toBe('');
+
+    const following = messages[steerIndex + 2];
+    expect(following).toBeInstanceOf(HumanMessage);
+    expect(following.content).toEqual([{ type: 'text', text: 'Next turn' }]);
+  });
+
+  it('leaves the user turn last when the steer ends the payload', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Working on it.' },
+          steerPart('Actually, stop and do the other thing.'),
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    const last = messages[messages.length - 1];
+    expect(last).toBeInstanceOf(HumanMessage);
+    expect(last.additional_kwargs.source).toBe('steer');
+  });
+
+  it('does not anchor when assistant content follows the steer', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Working on it.' },
+          steerPart('Focus on item two.'),
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Focusing.' },
+        ],
+      },
+      { role: 'user', content: 'Next turn' },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    const emptyAssistants = messages.filter(
+      (message) => message instanceof AIMessage && message.content === ''
+    );
+    expect(emptyAssistants).toHaveLength(0);
+  });
+
+  it('never emits two adjacent user turns around a trailing steer', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Partial answer.' },
+          steerPart('Change of plan.'),
+        ],
+      },
+      { role: 'user', content: 'Next turn' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Second answer.' },
+          steerPart('Change again.'),
+        ],
+      },
+      { role: 'user', content: 'Third turn' },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    for (let i = 1; i < messages.length; i++) {
+      const adjacentHumans =
+        messages[i] instanceof HumanMessage &&
+        messages[i - 1] instanceof HumanMessage;
+      expect(adjacentHumans).toBe(false);
+    }
+  });
+});

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -369,6 +369,40 @@ describe('formatAgentMessages trailing-steer anchor', () => {
     expect(following.content).toEqual([{ type: 'text', text: 'Next turn' }]);
   });
 
+  /**
+   * `messagesStateReducer` treats a repeated id as replace-in-place, so an
+   * anchor stamped with the shared `sourceMessageId` would overwrite the very
+   * steer it exists to protect. It must reach the reducer unstamped.
+   */
+  it('does not stamp the anchor with the shared source message id', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        messageId: 'assistant_1',
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Partial answer.' },
+          steerPart('Change of plan.'),
+        ],
+      } as unknown as TPayload[number],
+      { role: 'user', content: 'Next turn' },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    const steerIndex = messages.findIndex(
+      (message) => message.additional_kwargs.source === 'steer'
+    );
+    expect(steerIndex).toBeGreaterThan(0);
+    expect(messages[steerIndex].id).toBe('assistant_1');
+    expect(messages[steerIndex - 1].id).toBe('assistant_1');
+
+    const anchor = messages[steerIndex + 1];
+    expect(anchor).toBeInstanceOf(AIMessage);
+    expect(anchor.content).toBe('');
+    expect(anchor.id).not.toBe('assistant_1');
+  });
+
   it('leaves the user turn last when the steer ends the payload', () => {
     const payload: TPayload = [
       { role: 'user', content: 'Original request' },

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -520,7 +520,7 @@ describe('formatAgentMessages trailing-steer anchor', () => {
    * A trailing steer followed by another assistant ENTRY needs no anchor —
    * that entry's own assistant turn IS the separation. Emitting the
    * placeholder anyway would put two assistant turns back to back, which
-   * Bedrock and Mistral reject and nothing downstream merges
+   * strict-alternation providers can reject and nothing downstream merges
    * (`coalesceAdjacentUserTurns` merges user turns only).
    */
   it('suppresses the anchor when the next payload entry is an assistant turn', () => {

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -1,5 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { TPayload } from '@/types';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { ContentTypes, Constants, Providers } from '@/common';
 import { formatAgentMessages } from './format';
 
@@ -362,7 +363,7 @@ describe('formatAgentMessages trailing-steer anchor', () => {
 
     const anchor = messages[steerIndex + 1];
     expect(anchor).toBeInstanceOf(AIMessage);
-    expect(anchor.content).toBe('');
+    expect(anchor.content).not.toBe('');
 
     const following = messages[steerIndex + 2];
     expect(following).toBeInstanceOf(HumanMessage);
@@ -399,8 +400,50 @@ describe('formatAgentMessages trailing-steer anchor', () => {
 
     const anchor = messages[steerIndex + 1];
     expect(anchor).toBeInstanceOf(AIMessage);
-    expect(anchor.content).toBe('');
+    expect(anchor.content).not.toBe('');
     expect(anchor.id).not.toBe('assistant_1');
+  });
+
+  /**
+   * The anchor exists to keep the sequence provider-valid, so the assertion
+   * that matters is what a provider actually receives. An empty-string
+   * assistant turn with no tool calls survives the Anthropic converter
+   * verbatim — the empty-text repair covers only array content and tool-call
+   * turns — so an empty anchor would trade adjacent user turns for an
+   * empty-content 400.
+   */
+  it('survives the Anthropic converter with non-empty assistant content', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Partial answer.' },
+          steerPart('Change of plan.'),
+        ],
+      },
+      { role: 'user', content: 'Next turn' },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+    const { messages: anthropicMessages } =
+      _convertMessagesToAnthropicPayload(messages);
+
+    for (const message of anthropicMessages) {
+      if (message.role !== 'assistant') {
+        continue;
+      }
+      if (typeof message.content === 'string') {
+        expect(message.content.trim()).not.toBe('');
+        continue;
+      }
+      expect(message.content.length).toBeGreaterThan(0);
+    }
+
+    const roles = anthropicMessages.map((message) => message.role);
+    for (let i = 1; i < roles.length; i++) {
+      expect(roles[i] === 'user' && roles[i - 1] === 'user').toBe(false);
+    }
   });
 
   it('leaves the user turn last when the steer ends the payload', () => {

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -516,6 +516,50 @@ describe('formatAgentMessages trailing-steer anchor', () => {
     expect(emptyAssistants).toHaveLength(0);
   });
 
+  /**
+   * A trailing steer followed by another assistant ENTRY needs no anchor —
+   * that entry's own assistant turn IS the separation. Emitting the
+   * placeholder anyway would put two assistant turns back to back, which
+   * Bedrock and Mistral reject and nothing downstream merges
+   * (`coalesceAdjacentUserTurns` merges user turns only).
+   */
+  it('suppresses the anchor when the next payload entry is an assistant turn', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Working on it.' },
+          steerPart('Actually, do the other thing.'),
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Doing the other thing.' },
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+
+    expect(messages.map((message) => message.constructor.name)).toEqual([
+      'HumanMessage',
+      'AIMessage',
+      'HumanMessage',
+      'AIMessage',
+    ]);
+    expect(messages[2].additional_kwargs.source).toBe('steer');
+    expect(messages[3].content).toEqual([
+      { type: 'text', text: 'Doing the other thing.' },
+    ]);
+    expect(
+      messages.some(
+        (message) => message instanceof AIMessage && message.content === '_'
+      )
+    ).toBe(false);
+  });
+
   it('never emits two adjacent user turns around a trailing steer', () => {
     const payload: TPayload = [
       { role: 'user', content: 'Original request' },

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -446,6 +446,35 @@ describe('formatAgentMessages trailing-steer anchor', () => {
     }
   });
 
+  /**
+   * The old lookahead only proved a later ENTRY existed, not that it emitted.
+   * An entry with empty content is skipped silently, so a trailing steer
+   * followed only by such entries would leave the anchor as the final turn —
+   * an assistant prefill with no request after it.
+   */
+  it('omits the anchor when no later payload entry emits a message', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Original request' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Partial answer.' },
+          steerPart('Change of plan.'),
+        ],
+      },
+      { role: 'user', content: [] } as unknown as TPayload[number],
+    ];
+
+    const { messages } = formatAgentMessages(payload);
+    const last = messages[messages.length - 1];
+    expect(last.additional_kwargs.source).toBe('steer');
+    expect(
+      messages.some(
+        (m) => m instanceof AIMessage && m.content === '_'
+      )
+    ).toBe(false);
+  });
+
   it('leaves the user turn last when the steer ends the payload', () => {
     const payload: TPayload = [
       { role: 'user', content: 'Original request' },

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -8,6 +8,7 @@ export * from './anthropicToolCache';
 export * from './content';
 export * from './tools';
 export * from './injected';
+export * from './alternation';
 export * from './contextPruning';
 export * from './contextPruningSettings';
 export * from './reducer';

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -7,6 +7,7 @@ export * from './cache';
 export * from './anthropicToolCache';
 export * from './content';
 export * from './tools';
+export * from './injected';
 export * from './contextPruning';
 export * from './contextPruningSettings';
 export * from './reducer';

--- a/src/messages/injected.test.ts
+++ b/src/messages/injected.test.ts
@@ -1,0 +1,90 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type { InjectedMessage } from '@/types/tools';
+import { convertInjectedMessages } from './injected';
+
+describe('convertInjectedMessages', () => {
+  it('returns an empty array for no entries', () => {
+    expect(convertInjectedMessages([])).toEqual([]);
+  });
+
+  it('emits one HumanMessage per entry, in order', () => {
+    const messages: InjectedMessage[] = [
+      { role: 'user', content: 'first' },
+      { role: 'user', content: 'second' },
+    ];
+    const converted = convertInjectedMessages(messages);
+    expect(converted).toHaveLength(2);
+    expect(converted[0]).toBeInstanceOf(HumanMessage);
+    expect(converted[0].content).toBe('first');
+    expect(converted[1].content).toBe('second');
+  });
+
+  /**
+   * Both 'user' and 'system' become `HumanMessage` — Anthropic and Google
+   * reject a non-leading SystemMessage — with the original role preserved for
+   * downstream consumers.
+   */
+  it('converts a system role to a HumanMessage carrying the original role', () => {
+    const [converted] = convertInjectedMessages([
+      { role: 'system', content: 'convention reminder' },
+    ]);
+    expect(converted).toBeInstanceOf(HumanMessage);
+    expect(converted.additional_kwargs.role).toBe('system');
+  });
+
+  it('carries isMeta, source and skillName only when set', () => {
+    const [bare] = convertInjectedMessages([{ role: 'user', content: 'x' }]);
+    expect(bare.additional_kwargs).toEqual({ role: 'user' });
+
+    const [full] = convertInjectedMessages([
+      {
+        role: 'user',
+        content: 'x',
+        isMeta: true,
+        source: 'steer',
+        skillName: 'writing',
+      },
+    ]);
+    expect(full.additional_kwargs).toEqual({
+      role: 'user',
+      isMeta: true,
+      source: 'steer',
+      skillName: 'writing',
+    });
+  });
+
+  it('passes multimodal content through as a content array', () => {
+    const [converted] = convertInjectedMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look at this' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AA' } },
+        ],
+      },
+    ]);
+    expect(Array.isArray(converted.content)).toBe(true);
+    expect(converted.content).toHaveLength(2);
+  });
+
+  /**
+   * The provider-safety argument for sealing a stream mid-generation rests on
+   * the preempt boundary emitting exactly what the already-shipped tool
+   * boundary emits. Both call this function, so shape parity is structural —
+   * this pins it against a future divergence.
+   */
+  it('produces identical shapes for the same entry across calls', () => {
+    const entry: InjectedMessage = {
+      role: 'user',
+      content: 'Skip phase two.',
+      source: 'steer',
+    };
+    const [atToolBoundary] = convertInjectedMessages([entry]);
+    const [atPreemptBoundary] = convertInjectedMessages([entry]);
+    expect(atPreemptBoundary.content).toEqual(atToolBoundary.content);
+    expect(atPreemptBoundary.additional_kwargs).toEqual(
+      atToolBoundary.additional_kwargs
+    );
+    expect(atPreemptBoundary.getType()).toBe(atToolBoundary.getType());
+  });
+});

--- a/src/messages/injected.ts
+++ b/src/messages/injected.ts
@@ -1,0 +1,40 @@
+// src/messages/injected.ts
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { InjectedMessage } from '@/types/tools';
+import { toLangChainContent } from './langchain';
+
+/**
+ * Converts `InjectedMessage` instances to LangChain `HumanMessage` objects.
+ * Both 'user' and 'system' roles become `HumanMessage` to avoid provider
+ * rejections (Anthropic/Google reject non-leading SystemMessages). The
+ * original role is preserved in `additional_kwargs` for downstream consumers.
+ *
+ * Shared by both injection boundaries — `ToolNode`'s tool-batch dispatch and
+ * `StandardGraph`'s preempt-boundary dispatch. Keeping one implementation is
+ * load-bearing rather than tidy: the provider-safety argument for sealing a
+ * stream mid-generation rests on the injected turn having byte-identical
+ * shape to the one the already-shipped tool boundary emits, so the two sites
+ * must not be able to drift.
+ */
+export function convertInjectedMessages(
+  messages: InjectedMessage[]
+): BaseMessage[] {
+  const converted: BaseMessage[] = [];
+  for (const msg of messages) {
+    const additional_kwargs: Record<string, unknown> = {
+      role: msg.role,
+    };
+    if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
+    if (msg.source != null) additional_kwargs.source = msg.source;
+    if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
+
+    converted.push(
+      new HumanMessage({
+        content: toLangChainContent(msg.content),
+        additional_kwargs,
+      })
+    );
+  }
+  return converted;
+}

--- a/src/messages/injected.ts
+++ b/src/messages/injected.ts
@@ -2,6 +2,7 @@
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { InjectedMessage } from '@/types/tools';
+import { ContentTypes } from '@/common';
 import { toLangChainContent } from './langchain';
 
 /**
@@ -17,11 +18,44 @@ import { toLangChainContent } from './langchain';
  * shape to the one the already-shipped tool boundary emits, so the two sites
  * must not be able to drift.
  */
+/**
+ * True when an entry carries nothing a provider will accept as a turn.
+ *
+ * The public `InjectedMessage` type admits `content: ''` and `content: []`,
+ * and a host hook is free to return one. Converting it anyway produces a
+ * `HumanMessage` that passes the caller's `length > 0` test, so the graph
+ * resumes and sends a trailing EMPTY user turn — which Anthropic and other
+ * strict providers reject outright, turning a cooperative seal into a failed
+ * run. Permissive providers merely burn a model call.
+ *
+ * Whitespace counts as empty, matching the standard `canSealPreempt` applies
+ * to the assistant side of the same pair. Non-text blocks count as content: a
+ * media-only steer is a real turn and must survive.
+ */
+function isEmptyInjectedContent(content: InjectedMessage['content']): boolean {
+  if (typeof content === 'string') {
+    return content.trim() === '';
+  }
+  if (content.length === 0) {
+    return true;
+  }
+  return content.every((block) => {
+    if (block.type !== ContentTypes.TEXT) {
+      return false;
+    }
+    const text = block[ContentTypes.TEXT];
+    return typeof text !== 'string' || text.trim() === '';
+  });
+}
+
 export function convertInjectedMessages(
   messages: InjectedMessage[]
 ): BaseMessage[] {
   const converted: BaseMessage[] = [];
   for (const msg of messages) {
+    if (isEmptyInjectedContent(msg.content)) {
+      continue;
+    }
     const additional_kwargs: Record<string, unknown> = {
       role: msg.role,
     };

--- a/src/run.ts
+++ b/src/run.ts
@@ -999,6 +999,16 @@ export class Run<_T extends t.BaseGraphState> {
             threadId,
             agentId: graph.defaultAgentId,
             messages: graph.getRunMessages() ?? stateInputs?.messages ?? [],
+            /**
+             * A seal whose boundary had nothing to inject ends the turn where
+             * it stands. The run really did stop, so `Stop` must still fire —
+             * but it did not stop because the model was finished, and a host
+             * that persists or notifies on completion needs to tell those
+             * apart.
+             */
+            stopReason: graph.preemptIncomplete
+              ? 'preempt_incomplete'
+              : undefined,
             stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
           },
           sessionId: this.id,

--- a/src/run.ts
+++ b/src/run.ts
@@ -744,13 +744,15 @@ export class Run<_T extends t.BaseGraphState> {
      * Cancellation can arrive either at graph construction or per-call through
      * `callerConfig.signal`, and boundary hooks need to observe both — for a
      * multi-agent run the construction signal does not exist at all, since
-     * `MultiAgentGraphConfig` exposes none. The graph keeps whichever it was
-     * given and adopts the caller's when that is the only one, so a drain
-     * cannot keep running against a host queue after the caller aborted.
+     * `MultiAgentGraphConfig` exposes none. Carried on its own field, assigned
+     * unconditionally: writing into `graph.signal` would leak this call's
+     * controller into later calls (model-call config and subagent
+     * parentSignal read that field, and `clearHeavyState()` is skipped on
+     * HITL interrupts), while a conditional write would keep observing a
+     * stale controller the host has since aborted. The boundary dispatch
+     * composes both channels; see `dispatchPreemptBoundary`.
      */
-    if (callerConfig.signal != null && graph.signal == null) {
-      graph.signal = callerConfig.signal;
-    }
+    graph.callerSignal = callerConfig.signal;
 
     /**
      * Skip `resetValues` on resume — we're continuing an in-flight

--- a/src/run.ts
+++ b/src/run.ts
@@ -50,7 +50,13 @@ import {
 } from '@/utils/title';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
-import { GraphEvents, Callback, TitleMethod } from '@/common';
+import {
+  Callback,
+  GraphEvents,
+  TitleMethod,
+  DEFAULT_MAX_SEALS,
+  DEFAULT_RECURSION_LIMIT,
+} from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import { StandardGraph } from '@/graphs/Graph';
@@ -140,6 +146,7 @@ export class Run<_T extends t.BaseGraphState> {
   private interruptingToolNames?: string[];
   private toolExecution?: t.ToolExecutionConfig;
   private subagentUsageSink?: t.SubagentUsageSink;
+  private preemption?: t.StreamPreemption;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -201,6 +208,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.interruptingToolNames = config.interruptingToolNames;
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
+    this.preemption = config.preemption;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -275,6 +283,7 @@ export class Run<_T extends t.BaseGraphState> {
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
       subagentUsageSink: this.subagentUsageSink,
+      preemption: this.preemption,
     });
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = this.applyHITLCheckpointerFallback(
@@ -306,6 +315,7 @@ export class Run<_T extends t.BaseGraphState> {
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
       subagentUsageSink: this.subagentUsageSink,
+      preemption: this.preemption,
     });
 
     multiAgentGraph.compileOptions =
@@ -541,6 +551,15 @@ export class Run<_T extends t.BaseGraphState> {
     return this.Graph?.getResolvedInstructionOverhead();
   }
 
+  /**
+   * Cooperative-seal counters for this run. `emptyBoundaries` is the one to
+   * watch: it counts seals whose `PreemptBoundary` produced nothing to
+   * inject, which ends the turn early and leaves the answer unfinished.
+   */
+  getPreemptStats(): t.PreemptStats {
+    return this.Graph?.getPreemptStats() ?? { seals: 0, emptyBoundaries: 0 };
+  }
+
   getToolCount(): number {
     return this.Graph?.getToolCount() ?? 0;
   }
@@ -703,9 +722,23 @@ export class Run<_T extends t.BaseGraphState> {
     const isResume = inputs instanceof Command;
     const stateInputs = isResume ? undefined : (inputs as t.IState);
 
+    /**
+     * Every honored seal costs one extra superstep, so a preemption-enabled
+     * run reserves headroom for its whole seal budget. Without it, a
+     * tool-heavy agent that gets preempted could hit `GraphRecursionError` —
+     * which surfaces as a thrown stream, setting `streamThrew`, firing
+     * `StopFailure`, and wiping via `clearHeavyState()` exactly the partial
+     * content the seal existed to preserve.
+     */
+    const recursionLimit =
+      (callerConfig.recursionLimit ?? DEFAULT_RECURSION_LIMIT) +
+      (this.preemption != null
+        ? (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS)
+        : 0);
+
     const config: t.RunStreamConfig = {
-      recursionLimit: 50,
       ...callerConfig,
+      recursionLimit,
       configurable: { ...callerConfig.configurable },
     };
 
@@ -923,10 +956,17 @@ export class Run<_T extends t.BaseGraphState> {
          * graph doesn't take another model turn after the halting
          * operation completes.
          *
-         * Limitation: the current step (in-flight model call, ongoing
-         * tool batch) is not aborted — only the next step is skipped.
-         * This matches Claude Code's `continue: false` semantic where
-         * the active operation finishes before halting takes effect.
+         * This `break` is NOT graceful, despite what a `continue: false`
+         * reading suggests. Leaving the `for await` calls the iterator's
+         * `return()`, which cancels the reader
+         * (`@langchain/core/utils/stream`), and langgraph's stream wrapper
+         * turns that cancel into `_abortController.abort()`
+         * (`pregel/stream.js`). The in-flight model call or tool batch is
+         * torn down where it stands — it does not finish first.
+         *
+         * A halt is therefore the wrong tool for "stop generating but keep
+         * what you have". That is what `RunConfig.preemption` is for: it
+         * seals the stream at a provider-safe boundary and keeps the run.
          */
         const haltSignal = this.hookRegistry?.getHaltSignal(this.id);
         if (haltSignal != null) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -49,12 +49,12 @@ import {
   createTitleRunnable,
 } from '@/utils/title';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
+import { resolveMaxSeals } from '@/llm/preempt';
 import { initializeLangfuseTracing } from './instrumentation';
 import {
   Callback,
   GraphEvents,
   TitleMethod,
-  DEFAULT_MAX_SEALS,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
@@ -732,9 +732,7 @@ export class Run<_T extends t.BaseGraphState> {
      */
     const recursionLimit =
       (callerConfig.recursionLimit ?? DEFAULT_RECURSION_LIMIT) +
-      (this.preemption != null
-        ? (this.preemption.maxSeals ?? DEFAULT_MAX_SEALS)
-        : 0);
+      (this.preemption != null ? resolveMaxSeals(this.preemption.maxSeals) : 0);
 
     const config: t.RunStreamConfig = {
       ...callerConfig,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1037,9 +1037,19 @@ export class Run<_T extends t.BaseGraphState> {
        * `Stop` dispatch above, so the host still receives a completion signal
        * to persist the partial answer with while `getHaltReason()` correctly
        * reports that a hook stopped the run rather than the model finishing.
+       *
+       * An empty boundary — sealed, but nothing to inject because the host's
+       * queue was drained or cancelled in the meantime — cut the answer short
+       * just as surely, only without a hook-supplied reason. It surfaces
+       * through the same channel under the same name the `Stop` dispatch
+       * already used for its `stopReason`, so terminal consumers
+       * (`AgentSession` emits `run.halted`, not `run.completed`) cannot
+       * finalize a truncated answer as a natural finish.
        */
       if (this._haltedReason == null && graph.preemptHaltReason != null) {
         this._haltedReason = graph.preemptHaltReason;
+      } else if (this._haltedReason == null && graph.preemptIncomplete) {
+        this._haltedReason = 'preempt_incomplete';
       }
     };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1012,15 +1012,15 @@ export class Run<_T extends t.BaseGraphState> {
             agentId: graph.defaultAgentId,
             messages: graph.getRunMessages() ?? stateInputs?.messages ?? [],
             /**
-             * A seal whose boundary had nothing to inject ends the turn where
-             * it stands. The run really did stop, so `Stop` must still fire —
-             * but it did not stop because the model was finished, and a host
-             * that persists or notifies on completion needs to tell those
-             * apart.
+             * A seal whose boundary ended the turn early must say so. The
+             * hook-supplied reason wins when a `PreemptBoundary` hook halted
+             * with one — a persistence/audit `Stop` hook should record the
+             * actual cause, not the generic label — and `preempt_incomplete`
+             * is reserved for the boundary that simply had nothing to inject.
              */
-            stopReason: graph.preemptIncomplete
-              ? 'preempt_incomplete'
-              : undefined,
+            stopReason:
+              graph.preemptHaltReason ??
+              (graph.preemptIncomplete ? 'preempt_incomplete' : undefined),
             stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
           },
           sessionId: this.id,

--- a/src/run.ts
+++ b/src/run.ts
@@ -741,6 +741,18 @@ export class Run<_T extends t.BaseGraphState> {
     };
 
     /**
+     * Cancellation can arrive either at graph construction or per-call through
+     * `callerConfig.signal`, and boundary hooks need to observe both — for a
+     * multi-agent run the construction signal does not exist at all, since
+     * `MultiAgentGraphConfig` exposes none. The graph keeps whichever it was
+     * given and adopts the caller's when that is the only one, so a drain
+     * cannot keep running against a host queue after the caller aborted.
+     */
+    if (callerConfig.signal != null && graph.signal == null) {
+      graph.signal = callerConfig.signal;
+    }
+
+    /**
      * Skip `resetValues` on resume — we're continuing an in-flight
      * run, not starting a fresh one. Resetting would wipe the
      * sidecars (`toolCallStepIds`, `stepKeyIds`, accumulated
@@ -1013,6 +1025,19 @@ export class Run<_T extends t.BaseGraphState> {
         }).catch(() => {
           /* Stop hook errors must not masquerade as stream failures */
         });
+      }
+
+      /**
+       * A `PreemptBoundary` hook that returned `preventContinuation` has its
+       * registry halt cleared by the graph — that is what stops the halt from
+       * cancelling the stream before the sealed turn commits — so the reason
+       * is carried across on the graph instead. Surfaced here, AFTER the
+       * `Stop` dispatch above, so the host still receives a completion signal
+       * to persist the partial answer with while `getHaltReason()` correctly
+       * reports that a hook stopped the run rather than the model finishing.
+       */
+      if (this._haltedReason == null && graph.preemptHaltReason != null) {
+        this._haltedReason = graph.preemptHaltReason;
       }
     };
 

--- a/src/scripts/preempt-probe.ts
+++ b/src/scripts/preempt-probe.ts
@@ -46,6 +46,10 @@ type Verdict = {
   boundarySealCount: number | null;
   modelEndEvents: number;
   usageEventsWithTokens: number;
+  chatModelStarts: number;
+  llmEnds: number;
+  llmErrors: number;
+  runsLeftOpen: number;
   sealedTextChars: number;
   resumedTextChars: number;
   sequence: string[];
@@ -112,6 +116,9 @@ async function probe(): Promise<Verdict> {
   let deltaCount = 0;
   let modelEndEvents = 0;
   let usageEventsWithTokens = 0;
+  let chatModelStarts = 0;
+  let llmEnds = 0;
+  let llmErrors = 0;
   let boundaryFired = false;
   let boundarySealCount: number | null = null;
   let injectedOnce = false;
@@ -205,11 +212,29 @@ async function probe(): Promise<Verdict> {
     skipCleanup: true,
   });
 
+  /**
+   * Counts the RAW LangChain model-run lifecycle, which is what a tracer
+   * (LangSmith, Langfuse) sees. A seal that fails to close its run shows up
+   * here as starts > ends — an span that would hang open forever.
+   */
   const streamConfig = {
     runId: uuidv4(),
     configurable: { user_id: 'probe-user', thread_id: 'preempt-probe' },
     streamMode: 'values',
     version: 'v2' as const,
+    callbacks: [
+      {
+        handleChatModelStart: (): void => {
+          chatModelStarts += 1;
+        },
+        handleLLMEnd: (): void => {
+          llmEnds += 1;
+        },
+        handleLLMError: (): void => {
+          llmErrors += 1;
+        },
+      },
+    ],
   };
 
   await run.processStream(
@@ -239,7 +264,8 @@ async function probe(): Promise<Verdict> {
     sealedText.trim().length > 0 &&
     resumedText.trim().length > 0 &&
     modelEndEvents >= 2 &&
-    usageEventsWithTokens >= 2;
+    usageEventsWithTokens >= 2 &&
+    chatModelStarts === llmEnds;
 
   return {
     provider: providerKey,
@@ -252,6 +278,10 @@ async function probe(): Promise<Verdict> {
     boundarySealCount,
     modelEndEvents,
     usageEventsWithTokens,
+    chatModelStarts,
+    llmEnds,
+    llmErrors,
+    runsLeftOpen: chatModelStarts - llmEnds,
     sealedTextChars: sealedText.length,
     resumedTextChars: resumedText.length,
     sequence,

--- a/src/scripts/preempt-probe.ts
+++ b/src/scripts/preempt-probe.ts
@@ -1,0 +1,280 @@
+// src/scripts/preempt-probe.ts
+//
+// Live-provider probe for cooperative mid-generation preemption.
+//
+//   npm run probe:preempt -- --provider anthropic
+//
+// Asks for a long, tool-free answer, arms `shouldPreempt` once text has
+// started streaming, and asserts the full seal -> PreemptBoundary -> inject ->
+// self-loop path against a real provider: the stream stops mid-answer, the
+// injected user turn lands between two assistant turns, generation resumes in
+// the same run, and CHAT_MODEL_END fires for the sealed turn so usage is still
+// recorded. Prints a JSON verdict block as its last line.
+import { config } from 'dotenv';
+config();
+import { v4 as uuidv4 } from 'uuid';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import { createTokenCounter } from '@/utils/tokens';
+import { getLLMConfig } from '@/utils/llmConfig';
+import { HookRegistry } from '@/hooks';
+import { Run } from '@/run';
+
+/** Deltas to let through before arming the seal. */
+const ARM_AFTER_DELTAS = 15;
+
+const PROMPT =
+  'Write a detailed history of the Byzantine Empire from Constantine to ' +
+  '1453. Cover the major emperors, the religious schisms, and the military ' +
+  'campaigns. Aim for at least 800 words of flowing prose. Do not use ' +
+  'headings or bullet points.';
+
+const STEER =
+  'Stop. Forget the essay. Answer only this, in one short sentence: what ' +
+  'year did Constantinople fall?';
+
+type Verdict = {
+  provider: string;
+  model: string;
+  ok: boolean;
+  sealed: boolean;
+  seals: number;
+  emptyBoundaries: number;
+  boundaryFired: boolean;
+  boundarySealCount: number | null;
+  modelEndEvents: number;
+  usageEventsWithTokens: number;
+  sealedTextChars: number;
+  resumedTextChars: number;
+  sequence: string[];
+  injectedFound: boolean;
+  resumeAnswersSteer: boolean;
+  error: string | null;
+};
+
+/**
+ * Streamed assistant turns arrive as `AIMessageChunk`, which extends
+ * `BaseMessageChunk` rather than `AIMessage` — `instanceof AIMessage` is
+ * false for them. Type discrimination has to go through `getType()`.
+ */
+function isAssistant(message: BaseMessage | undefined): boolean {
+  return message?.getType() === 'ai';
+}
+
+function messageKind(message: BaseMessage): string {
+  if (message.getType() === 'human') {
+    const source = message.additional_kwargs.source;
+    return typeof source === 'string' ? `human(${source})` : 'human';
+  }
+  return message.getType();
+}
+
+function textOf(message: BaseMessage | undefined): string {
+  if (message == null) {
+    return '';
+  }
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  let text = '';
+  for (const block of message.content) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      text += block.text;
+    }
+  }
+  return text;
+}
+
+function parseProvider(): string {
+  const index = process.argv.indexOf('--provider');
+  if (index !== -1 && process.argv[index + 1] != null) {
+    return process.argv[index + 1];
+  }
+  return Providers.ANTHROPIC;
+}
+
+/** Control mode: identical run with no `preemption` config at all. */
+function isControl(): boolean {
+  return process.argv.includes('--control');
+}
+
+async function probe(): Promise<Verdict> {
+  const providerKey = parseProvider();
+  const llmConfig = getLLMConfig(providerKey);
+  if (llmConfig == null) {
+    throw new Error(`No llmConfig entry for provider "${providerKey}"`);
+  }
+
+  let armed = false;
+  let armedOnce = false;
+  let deltaCount = 0;
+  let modelEndEvents = 0;
+  let usageEventsWithTokens = 0;
+  let boundaryFired = false;
+  let boundarySealCount: number | null = null;
+  let injectedOnce = false;
+  const collectedUsage: UsageMetadata[] = [];
+
+  /**
+   * Deliberately NOT a `ChatModelStreamHandler` instance: that would make
+   * `getRegisteredDefaultChatStreamHandler` return a handler and route the run
+   * down the registered-handler loop, which never seals. Plain-object handlers
+   * mirror how LibreChat registers, which is the sealable path.
+   */
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (): void => {
+        deltaCount += 1;
+        if (!armedOnce && deltaCount >= ARM_AFTER_DELTAS) {
+          armed = true;
+          armedOnce = true;
+        }
+      },
+    },
+    [GraphEvents.CHAT_MODEL_END]: {
+      handle: (_event: string, data: t.ModelEndData): void => {
+        modelEndEvents += 1;
+        const usage = data?.output?.usage_metadata;
+        if (usage != null) {
+          collectedUsage.push(usage);
+          if ((usage.output_tokens ?? 0) > 0) {
+            usageEventsWithTokens += 1;
+          }
+        }
+      },
+    },
+  };
+
+  const hooks = new HookRegistry();
+  hooks.register('PreemptBoundary', {
+    hooks: [
+      async (input) => {
+        boundaryFired = true;
+        boundarySealCount = input.sealCount;
+        /**
+         * Disarm on drain. The SDK polls `shouldPreempt` on every chunk and
+         * does not clear it for you — a host that leaves the request set
+         * armed re-seals the resumed turn immediately. LibreChat's real drain
+         * does this via `noteSteersRemoved`.
+         */
+        armed = false;
+        if (injectedOnce) {
+          return {};
+        }
+        injectedOnce = true;
+        return {
+          injectedMessages: [
+            { role: 'user', content: STEER, source: 'steer' },
+          ],
+        };
+      },
+    ],
+  });
+
+  /**
+   * A real host configures this. It is what `dispatchSealedModelEnd` falls
+   * back to when the provider never got to send its usage chunk, so running
+   * without one hides whether sealed-turn usage is recoverable. Pass
+   * `--no-token-counter` to probe the unconfigured case deliberately.
+   */
+  const tokenCounter = process.argv.includes('--no-token-counter')
+    ? undefined
+    : await createTokenCounter();
+
+  const run = await Run.create<t.IState>({
+    runId: uuidv4(),
+    graphConfig: {
+      type: 'standard',
+      llmConfig,
+      instructions: 'You are a knowledgeable history assistant.',
+    },
+    tokenCounter,
+    customHandlers,
+    hooks,
+    ...(isControl()
+      ? {}
+      : {
+        preemption: {
+          shouldPreempt: (): boolean => armed,
+          maxSeals: 2,
+        },
+      }),
+    returnContent: true,
+    skipCleanup: true,
+  });
+
+  const streamConfig = {
+    runId: uuidv4(),
+    configurable: { user_id: 'probe-user', thread_id: 'preempt-probe' },
+    streamMode: 'values',
+    version: 'v2' as const,
+  };
+
+  await run.processStream(
+    { messages: [new HumanMessage(PROMPT)] },
+    streamConfig
+  );
+
+  const messages = run.getRunMessages() ?? [];
+  const sequence = messages.map(messageKind);
+  const injectedIndex = messages.findIndex(
+    (message) =>
+      message instanceof HumanMessage &&
+      message.additional_kwargs.source === 'steer'
+  );
+  const stats = run.getPreemptStats();
+  const sealedText = textOf(messages[injectedIndex - 1]);
+  const resumedText = textOf(messages[injectedIndex + 1]);
+  const resumeAnswersSteer = /1453/.test(resumedText);
+
+  const ok =
+    stats.seals === 1 &&
+    stats.emptyBoundaries === 0 &&
+    boundaryFired &&
+    injectedIndex > 0 &&
+    isAssistant(messages[injectedIndex - 1]) &&
+    isAssistant(messages[injectedIndex + 1]) &&
+    sealedText.trim().length > 0 &&
+    resumedText.trim().length > 0 &&
+    modelEndEvents >= 2 &&
+    usageEventsWithTokens >= 2;
+
+  return {
+    provider: providerKey,
+    model: String((llmConfig as { model?: unknown }).model ?? 'unknown'),
+    ok,
+    sealed: stats.seals > 0,
+    seals: stats.seals,
+    emptyBoundaries: stats.emptyBoundaries,
+    boundaryFired,
+    boundarySealCount,
+    modelEndEvents,
+    usageEventsWithTokens,
+    sealedTextChars: sealedText.length,
+    resumedTextChars: resumedText.length,
+    sequence,
+    injectedFound: injectedIndex >= 0,
+    resumeAnswersSteer,
+    error: null,
+  };
+}
+
+probe()
+  .then((verdict) => {
+    console.log('\n===== SEALED TAIL / RESUMED HEAD =====');
+    console.log(JSON.stringify(verdict, null, 2));
+    console.log(`\nVERDICT_JSON ${JSON.stringify(verdict)}`);
+    process.exit(verdict.ok ? 0 : 1);
+  })
+  .catch((error: unknown) => {
+    const verdict: Partial<Verdict> = {
+      provider: parseProvider(),
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+    console.error(error);
+    console.log(`\nVERDICT_JSON ${JSON.stringify(verdict)}`);
+    process.exit(1);
+  });

--- a/src/scripts/preempt-probe.ts
+++ b/src/scripts/preempt-probe.ts
@@ -2,7 +2,12 @@
 //
 // Live-provider probe for cooperative mid-generation preemption.
 //
-//   npm run probe:preempt -- --provider anthropic
+//   npx tsx --env-file=.env src/scripts/preempt-probe.ts --provider anthropic
+//
+// (tsx rather than the repo's node-loader `script` runner: the import chain
+// reaches @mistralai/mistralai, which ships ESM-only and defeats the loader.
+// Keep live credentials OUT of the worktree's .env — jest loads it — and
+// point --env-file at wherever they actually live.)
 //
 // Asks for a long, tool-free answer, arms `shouldPreempt` once text has
 // started streaming, and asserts the full seal -> PreemptBoundary -> inject ->
@@ -254,18 +259,33 @@ async function probe(): Promise<Verdict> {
   const resumedText = textOf(messages[injectedIndex + 1]);
   const resumeAnswersSteer = /1453/.test(resumedText);
 
-  const ok =
-    stats.seals === 1 &&
-    stats.emptyBoundaries === 0 &&
-    boundaryFired &&
-    injectedIndex > 0 &&
-    isAssistant(messages[injectedIndex - 1]) &&
-    isAssistant(messages[injectedIndex + 1]) &&
-    sealedText.trim().length > 0 &&
-    resumedText.trim().length > 0 &&
-    modelEndEvents >= 2 &&
-    usageEventsWithTokens >= 2 &&
-    chatModelStarts === llmEnds;
+  /**
+   * Control mode is the no-preemption baseline: one uninterrupted model run,
+   * nothing sealed, nothing injected. Its value is the contrast — the same
+   * lifecycle counters must balance WITHOUT the seal machinery — so it gets
+   * its own criteria instead of failing the seal-path ones by construction.
+   */
+  const ok = isControl()
+    ? stats.seals === 0 &&
+      !boundaryFired &&
+      injectedIndex === -1 &&
+      messages.length > 0 &&
+      textOf(messages[messages.length - 1]).trim().length > 0 &&
+      modelEndEvents >= 1 &&
+      usageEventsWithTokens >= 1 &&
+      llmErrors === 0 &&
+      chatModelStarts === llmEnds
+    : stats.seals === 1 &&
+      stats.emptyBoundaries === 0 &&
+      boundaryFired &&
+      injectedIndex > 0 &&
+      isAssistant(messages[injectedIndex - 1]) &&
+      isAssistant(messages[injectedIndex + 1]) &&
+      sealedText.trim().length > 0 &&
+      resumedText.trim().length > 0 &&
+      modelEndEvents >= 2 &&
+      usageEventsWithTokens >= 2 &&
+      chatModelStarts === llmEnds;
 
   return {
     provider: providerKey,

--- a/src/scripts/preempt-scenarios.ts
+++ b/src/scripts/preempt-scenarios.ts
@@ -1,0 +1,388 @@
+// src/scripts/preempt-scenarios.ts
+//
+// Live scenario matrix for the seal paths the basic probe does not exercise:
+//
+//   npx tsx --env-file=/path/to/.env src/scripts/preempt-scenarios.ts \
+//     --scenario multiseal|toolturn|budget|cache|ma-halt|ma-continue|websearch \
+//     --provider anthropic|bedrock|...
+//
+// One scenario per invocation; prints SCENARIO_VERDICT as the last line.
+import { config } from 'dotenv';
+config();
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { GraphEvents } from '@/common';
+import { createTokenCounter } from '@/utils/tokens';
+import { getLLMConfig } from '@/utils/llmConfig';
+import { HookRegistry } from '@/hooks';
+import { Run } from '@/run';
+
+const LONG_PROMPT =
+  'Write a detailed history of the Byzantine Empire from Constantine to ' +
+  '1453 in at least 800 words of flowing prose. No headings or bullets.';
+
+function argOf(flag: string, fallback: string): string {
+  const index = process.argv.indexOf(flag);
+  return index !== -1 && process.argv[index + 1] != null
+    ? process.argv[index + 1]
+    : fallback;
+}
+
+function textOf(message: BaseMessage | undefined): string {
+  if (message == null) return '';
+  if (typeof message.content === 'string') return message.content;
+  let text = '';
+  for (const block of message.content) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      text += block.text;
+    }
+  }
+  return text;
+}
+
+function kindOf(message: BaseMessage): string {
+  if (message.getType() === 'human') {
+    const source = message.additional_kwargs.source;
+    return typeof source === 'string' ? `human(${source})` : 'human';
+  }
+  if (message.getType() === 'tool') return 'tool';
+  return message.getType();
+}
+
+type Outcome = {
+  scenario: string;
+  provider: string;
+  ok: boolean;
+  detail: Record<string, unknown>;
+  error: string | null;
+};
+
+async function main(): Promise<Outcome> {
+  const scenario = argOf('--scenario', 'multiseal');
+  const providerKey = argOf('--provider', 'anthropic');
+  const llmConfig = getLLMConfig(providerKey);
+  if (llmConfig == null) {
+    throw new Error(`No llmConfig entry for provider "${providerKey}"`);
+  }
+  const tokenCounter = await createTokenCounter();
+
+  let armed = false;
+  let deltas = 0;
+  let armAt = 15;
+  let injections = 0;
+  let maxInjections = 1;
+  let chatModelStarts = 0;
+  let llmEnds = 0;
+  let toolExecutions = 0;
+  let haltOnBoundary = false;
+
+  const hooks = new HookRegistry();
+  hooks.register('PreemptBoundary', {
+    hooks: [
+      async () => {
+        armed = false;
+        if (haltOnBoundary) {
+          return { preventContinuation: true, stopReason: 'scenario_halt' };
+        }
+        if (injections >= maxInjections) return {};
+        injections += 1;
+        if (scenario === 'multiseal' && injections < maxInjections + 1) {
+          /** Re-arm after the resumed stream produces more deltas. */
+          armAt = deltas + 12;
+        }
+        return {
+          injectedMessages: [
+            {
+              role: 'user' as const,
+              content:
+                injections === 1 && maxInjections > 1
+                  ? 'Change of plan: write 300 words about the fall of Constantinople specifically.'
+                  : 'Stop. In one short sentence: what year did Constantinople fall?',
+              source: 'steer',
+            },
+          ],
+        };
+      },
+    ],
+  });
+
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (): void => {
+        deltas += 1;
+        /** Never re-arm past the scenario's injection budget: a real host
+         *  disarms when its queue drains; this models that. */
+        if (deltas >= armAt && injections < maxInjections) armed = true;
+      },
+    },
+  };
+
+  const calculator = tool(
+    async () => {
+      toolExecutions += 1;
+      return '345';
+    },
+    {
+      name: 'calculator',
+      description: 'Evaluates a basic arithmetic expression.',
+      schema: z.object({ expression: z.string() }),
+    }
+  );
+
+  const streamConfig = {
+    runId: uuidv4(),
+    configurable: { user_id: 'probe-user', thread_id: `scenario-${scenario}` },
+    streamMode: 'values',
+    version: 'v2' as const,
+    callbacks: [
+      {
+        handleChatModelStart: (): void => {
+          chatModelStarts += 1;
+        },
+        handleLLMEnd: (): void => {
+          llmEnds += 1;
+        },
+      },
+    ],
+  };
+
+  const base = {
+    runId: uuidv4(),
+    tokenCounter,
+    customHandlers,
+    hooks,
+    returnContent: true,
+    skipCleanup: true,
+  };
+
+  let run: Run<t.IState>;
+  let prompt = LONG_PROMPT;
+
+  switch (scenario) {
+    case 'multiseal':
+      maxInjections = 2;
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: { type: 'standard', llmConfig, instructions: 'You are a history assistant.' },
+        preemption: { shouldPreempt: () => armed, maxSeals: 3 },
+      });
+      break;
+    case 'toolturn':
+      armAt = 0;
+      armed = true;
+      prompt =
+        'Use the calculator tool to compute 15 * 23, then explain the historical significance of the number 345 in Roman history in at least 300 words.';
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          tools: [calculator],
+          instructions:
+            'Call the calculator immediately, before writing ANY text. After the tool result, write the explanation.',
+        },
+        preemption: { shouldPreempt: () => armed, maxSeals: 2 },
+      });
+      break;
+    case 'budget':
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: { type: 'standard', llmConfig, instructions: 'You are a history assistant.' },
+        preemption: {
+          shouldPreempt: () => {
+            /** Deliberately NEVER disarmed by the host: level-triggered forever. */
+            return deltas >= 15;
+          },
+          maxSeals: 1,
+        },
+      });
+      break;
+    case 'cache':
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: {
+          type: 'standard',
+          llmConfig: { ...llmConfig, promptCache: true } as typeof llmConfig,
+          instructions:
+            'You are a history assistant. '.repeat(80) +
+            'Answer at length in flowing prose.',
+        },
+        preemption: { shouldPreempt: () => armed, maxSeals: 2 },
+      });
+      break;
+    case 'ma-halt':
+    case 'ma-continue':
+    case 'ma-baseline':
+      haltOnBoundary = scenario === 'ma-halt';
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: {
+          type: 'multi-agent',
+          agents: (() => {
+            const { provider, ...clientOptions } = llmConfig as {
+              provider: t.AgentInputs['provider'];
+            } & Record<string, unknown>;
+            return [
+              {
+                agentId: 'writer',
+                provider,
+                clientOptions,
+                instructions: 'You are the writer. Write the requested essay.',
+              },
+              {
+                agentId: 'critic',
+                provider,
+                clientOptions,
+                instructions:
+                  'You are the critic. In two sentences, critique what the writer produced.',
+              },
+            ] as t.AgentInputs[];
+          })(),
+          edges: [{ from: 'writer', to: 'critic', edgeType: 'direct' }],
+        },
+        ...(scenario === 'ma-baseline'
+          ? {}
+          : { preemption: { shouldPreempt: () => armed, maxSeals: 1 } }),
+      });
+      break;
+    case 'websearch':
+      armAt = Number(argOf('--arm-at', '1'));
+      prompt =
+        'Search the web for the current population of Istanbul, then write a 300-word reflection on the city\'s growth.';
+      run = await Run.create<t.IState>({
+        ...base,
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          tools: [
+            { type: 'web_search_20250305', name: 'web_search', max_uses: 1 },
+          ] as unknown as t.GraphTools,
+          instructions: 'Use web search before answering.',
+        },
+        preemption: { shouldPreempt: () => armed, maxSeals: 2 },
+      });
+      break;
+    default:
+      throw new Error(`Unknown scenario: ${scenario}`);
+  }
+
+  await run.processStream({ messages: [new HumanMessage(prompt)] }, streamConfig);
+
+  const messages = run.getRunMessages() ?? [];
+  const sequence = messages.map(kindOf);
+  const stats = run.getPreemptStats();
+  const steerCount = sequence.filter((k) => k === 'human(steer)').length;
+  const finalText = textOf(messages[messages.length - 1]);
+  const detail: Record<string, unknown> = {
+    sequence,
+    seals: stats.seals,
+    emptyBoundaries: stats.emptyBoundaries,
+    steerCount,
+    chatModelStarts,
+    llmEnds,
+    runsLeftOpen: chatModelStarts - llmEnds,
+    toolExecutions,
+    haltReason: run.getHaltReason() ?? null,
+    finalChars: finalText.length,
+    sealedBlockTypes: Array.isArray(messages[0]?.content)
+      ? (messages[0].content as Array<{ type?: string }>).map((b) => b.type)
+      : ['string'],
+    lastTexts: messages.slice(-3).map((m) => ({
+      kind: kindOf(m),
+      agent: (m as { name?: string }).name ?? m.additional_kwargs.agentId ?? null,
+      chars: textOf(m).length,
+      head: textOf(m).slice(0, 80),
+    })),
+  };
+
+  let ok = false;
+  switch (scenario) {
+    case 'multiseal':
+      ok =
+        stats.seals === 2 &&
+        steerCount === 2 &&
+        chatModelStarts === 3 &&
+        llmEnds === 3 &&
+        /1453/.test(finalText);
+      break;
+    case 'toolturn': {
+      const toolIdx = sequence.indexOf('tool');
+      const steerIdx = sequence.indexOf('human(steer)');
+      ok =
+        stats.seals === 1 &&
+        toolExecutions === 1 &&
+        toolIdx !== -1 &&
+        steerIdx > toolIdx &&
+        chatModelStarts === llmEnds &&
+        finalText.trim().length > 0;
+      break;
+    }
+    case 'budget':
+      ok =
+        stats.seals === 1 &&
+        steerCount === 1 &&
+        chatModelStarts === 2 &&
+        llmEnds === 2 &&
+        /1453/.test(finalText);
+      break;
+    case 'cache':
+      ok =
+        stats.seals === 1 &&
+        steerCount === 1 &&
+        chatModelStarts === llmEnds &&
+        finalText.trim().length > 0;
+      break;
+    case 'ma-halt':
+      ok =
+        stats.seals === 1 &&
+        run.getHaltReason() === 'scenario_halt' &&
+        chatModelStarts === 1 &&
+        llmEnds === 1;
+      break;
+    case 'ma-baseline':
+      ok = chatModelStarts === 2 && llmEnds === 2;
+      break;
+    case 'ma-continue':
+      ok =
+        stats.seals === 1 &&
+        steerCount === 1 &&
+        chatModelStarts === 3 &&
+        llmEnds === 3 &&
+        finalText.trim().length > 0;
+      break;
+    case 'websearch':
+      /**
+       * Best-effort: the load-bearing claims are (a) no seal orphans an
+       * unanswered server-tool call — the provider would 400 the resume —
+       * and (b) the run completes with balanced lifecycle counters.
+       */
+      ok =
+        chatModelStarts === llmEnds &&
+        finalText.trim().length > 0 &&
+        stats.seals <= 2;
+      break;
+  }
+
+  return { scenario, provider: providerKey, ok, detail, error: null };
+}
+
+main()
+  .then((outcome) => {
+    console.log(`SCENARIO_VERDICT ${JSON.stringify(outcome)}`);
+    process.exit(outcome.ok ? 0 : 1);
+  })
+  .catch((error: unknown) => {
+    console.log(
+      `SCENARIO_VERDICT ${JSON.stringify({
+        scenario: argOf('--scenario', '?'),
+        provider: argOf('--provider', '?'),
+        ok: false,
+        error: error instanceof Error ? error.message.slice(0, 400) : String(error),
+      })}`
+    );
+    process.exit(1);
+  });

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -7,7 +7,11 @@ import type {
 import type * as t from '@/types';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
 import { toJsonValue } from './messageSerialization';
-import { createContentAggregator } from '@/stream';
+import {
+  createContentAggregator,
+  dispatchesChatModelStream,
+  SDK_STREAM_DISPATCH,
+} from '@/stream';
 import { createTimestamp } from './ids';
 import { GraphEvents } from '@/common';
 
@@ -107,18 +111,34 @@ export function createRunHandlers(params: {
 
   emitEvent(createEvent('run.started'));
 
-  const handlers: Record<string, t.EventHandler> = {
-    [GraphEvents.CHAT_MODEL_STREAM]: {
-      handle: async (event, data, metadata, graph): Promise<void> => {
-        await callUserHandler({
-          userHandlers: params.userHandlers,
-          event,
-          data,
-          metadata,
-          graph,
-        });
-      },
+  /**
+   * Forwards to the host's own handler, so it inherits that handler's
+   * capability. Branding matters because this wrapper is installed on EVERY
+   * session run and merged last: without it, a host that registered
+   * `new ChatModelStreamHandler()` would silently lose the sealing opt-out
+   * that registration is supposed to buy.
+   */
+  const streamWrapper: t.EventHandler = {
+    handle: async (event, data, metadata, graph): Promise<void> => {
+      await callUserHandler({
+        userHandlers: params.userHandlers,
+        event,
+        data,
+        metadata,
+        graph,
+      });
     },
+  };
+  if (
+    dispatchesChatModelStream(
+      params.userHandlers?.[GraphEvents.CHAT_MODEL_STREAM]
+    )
+  ) {
+    Object.defineProperty(streamWrapper, SDK_STREAM_DISPATCH, { value: true });
+  }
+
+  const handlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: streamWrapper,
     [GraphEvents.CHAT_MODEL_END]: {
       handle: async (event, data, metadata, graph): Promise<void> => {
         await modelEndHandler.handle(

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -29,6 +29,7 @@ async function createSealRun(options: {
   hook: HookCallback<'PreemptBoundary'>;
   responses: string[];
   stopHook?: HookCallback<'Stop'>;
+  modelCallbacks?: FakeChatModel['callbacks'];
 }): Promise<Run<t.IState>> {
   const registry = new HookRegistry();
   registry.register('PreemptBoundary', { hooks: [options.hook] });
@@ -54,9 +55,13 @@ async function createSealRun(options: {
   if (!run.Graph) {
     throw new Error('Expected graph to be initialized');
   }
-  run.Graph.overrideModel = new FakeChatModel({
+  const model = new FakeChatModel({
     responses: options.responses,
   });
+  if (options.modelCallbacks != null) {
+    model.callbacks = options.modelCallbacks;
+  }
+  run.Graph.overrideModel = model;
   return run;
 }
 
@@ -133,6 +138,46 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(run.getHaltReason()).toBe('host_policy_stop');
     expect(run.Graph?.preemptIncomplete).toBe(true);
     expect(run.Graph?.preemptEmptyBoundaries).toBe(1);
+  });
+
+  it('closes model-level callbacks for the sealed run, not just config-level ones', async () => {
+    let starts = 0;
+    let ends = 0;
+    const run = await createSealRun({
+      runId: 'seal-model-callbacks',
+      hook: async () => ({
+        injectedMessages: [
+          { role: 'user' as const, content: 'Shorter.', source: 'steer' },
+        ],
+      }),
+      responses: [FULL_RESPONSE, RESUMED_RESPONSE],
+      /**
+       * A handler supplied on the MODEL (clientOptions.callbacks) gets
+       * handleChatModelStart from the real run, so the sealed turn's
+       * synthetic close must reach it too — otherwise its span for the
+       * sealed run never closes. Two runs (sealed + resumed): both must
+       * balance.
+       */
+      modelCallbacks: [
+        {
+          handleChatModelStart: (): void => {
+            starts += 1;
+          },
+          handleLLMEnd: (): void => {
+            ends += 1;
+          },
+        },
+      ],
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    expect(run.Graph?.preemptSealCount).toBe(1);
+    expect(starts).toBe(2);
+    expect(ends).toBe(2);
   });
 
   it('resumes after an injecting boundary and completes without a halt reason', async () => {

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -28,9 +28,13 @@ async function createSealRun(options: {
   runId: string;
   hook: HookCallback<'PreemptBoundary'>;
   responses: string[];
+  stopHook?: HookCallback<'Stop'>;
 }): Promise<Run<t.IState>> {
   const registry = new HookRegistry();
   registry.register('PreemptBoundary', { hooks: [options.hook] });
+  if (options.stopHook) {
+    registry.register('Stop', { hooks: [options.stopHook] });
+  }
   const run = await Run.create<t.IState>({
     runId: options.runId,
     graphConfig: {
@@ -96,6 +100,39 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(contents[0].length).toBeGreaterThan(0);
     expect(contents[0].length).toBeLessThan(FULL_RESPONSE.length);
     expect(FULL_RESPONSE.startsWith(contents[0])).toBe(true);
+  });
+
+  it('forwards a halting hook\'s own stopReason to Stop hooks and getHaltReason', async () => {
+    let stopReasonSeen: string | undefined;
+    const run = await createSealRun({
+      runId: 'seal-halt-reason',
+      hook: async () => ({
+        preventContinuation: true,
+        stopReason: 'host_policy_stop',
+      }),
+      responses: [FULL_RESPONSE],
+      stopHook: async (input) => {
+        stopReasonSeen = input.stopReason;
+        return {};
+      },
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    /**
+     * The hook-supplied reason must win end to end: a persistence/audit Stop
+     * hook records the actual cause, not the generic preempt_incomplete
+     * label, and getHaltReason() reports the same string afterward. A
+     * halting boundary that injected nothing also counts as an empty
+     * boundary in the truncated-seal telemetry.
+     */
+    expect(stopReasonSeen).toBe('host_policy_stop');
+    expect(run.getHaltReason()).toBe('host_policy_stop');
+    expect(run.Graph?.preemptIncomplete).toBe(true);
+    expect(run.Graph?.preemptEmptyBoundaries).toBe(1);
   });
 
   it('resumes after an injecting boundary and completes without a halt reason', async () => {

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -1,0 +1,140 @@
+// src/specs/preemptSeal.test.ts
+/**
+ * End-to-end cooperative seal flow through a real `Run`: fake model streams,
+ * the host requests a preempt, the stream seals at a safe chunk, the
+ * `PreemptBoundary` drain decides what happens next. Everything below runs
+ * the dispatch-synchronous loop in `attemptInvoke` (no registered
+ * CHAT_MODEL_STREAM handler), which is the only loop allowed to seal.
+ */
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import type { HookCallback } from '@/hooks/types';
+import { FakeChatModel } from '@/llm/fake';
+import { Run } from '@/run';
+
+const FULL_RESPONSE = 'Alpha beta gamma delta epsilon zeta';
+const RESUMED_RESPONSE = 'Continuing after the steer.';
+
+const streamConfig = {
+  configurable: { thread_id: 'preempt-seal-e2e' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+async function createSealRun(options: {
+  runId: string;
+  hook: HookCallback<'PreemptBoundary'>;
+  responses: string[];
+}): Promise<Run<t.IState>> {
+  const registry = new HookRegistry();
+  registry.register('PreemptBoundary', { hooks: [options.hook] });
+  const run = await Run.create<t.IState>({
+    runId: options.runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-4o-mini',
+        apiKey: 'test-key',
+      },
+      instructions: 'Answer plainly.',
+    },
+    hooks: registry,
+    preemption: { shouldPreempt: () => true, maxSeals: 1 },
+    returnContent: true,
+    skipCleanup: true,
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph to be initialized');
+  }
+  run.Graph.overrideModel = new FakeChatModel({
+    responses: options.responses,
+  });
+  return run;
+}
+
+const aiContents = (messages: BaseMessage[]): string[] =>
+  messages
+    .filter((message) => message.getType() === 'ai')
+    .map((message) =>
+      typeof message.content === 'string'
+        ? message.content
+        : JSON.stringify(message.content)
+    );
+
+describe('cooperative seal (end-to-end via Run)', () => {
+  jest.setTimeout(15000);
+
+  it('surfaces an empty boundary as preempt_incomplete instead of a natural finish', async () => {
+    const run = await createSealRun({
+      runId: 'seal-empty-boundary',
+      hook: async () => ({}),
+      responses: [FULL_RESPONSE],
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    /**
+     * The answer really was cut short: the host asked to preempt, the seal
+     * took the budget, and the drain had nothing to resume with. A terminal
+     * consumer reading only completion events would persist a truncated
+     * answer as finished — `getHaltReason()` is the channel that prevents
+     * that (AgentSession emits `run.halted` off it).
+     */
+    expect(run.getHaltReason()).toBe('preempt_incomplete');
+    expect(run.Graph?.preemptIncomplete).toBe(true);
+    expect(run.Graph?.preemptEmptyBoundaries).toBe(1);
+
+    const contents = aiContents(run.getRunMessages() ?? []);
+    expect(contents).toHaveLength(1);
+    expect(contents[0].length).toBeGreaterThan(0);
+    expect(contents[0].length).toBeLessThan(FULL_RESPONSE.length);
+    expect(FULL_RESPONSE.startsWith(contents[0])).toBe(true);
+  });
+
+  it('resumes after an injecting boundary and completes without a halt reason', async () => {
+    const run = await createSealRun({
+      runId: 'seal-inject-resume',
+      hook: async () => ({
+        injectedMessages: [
+          { role: 'user' as const, content: 'Make it shorter.', source: 'steer' },
+        ],
+      }),
+      responses: [FULL_RESPONSE, RESUMED_RESPONSE],
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    expect(run.getHaltReason()).toBeUndefined();
+    expect(run.Graph?.preemptIncomplete).toBe(false);
+    expect(run.Graph?.preemptSealCount).toBe(1);
+
+    const messages = run.getRunMessages() ?? [];
+    const steer = messages.find(
+      (message) => message.additional_kwargs.source === 'steer'
+    );
+    expect(steer).toBeDefined();
+    expect(steer?.content).toBe('Make it shorter.');
+
+    /**
+     * Two assistant turns: the sealed partial and the post-steer
+     * continuation, which must have run to completion — the seal budget was
+     * spent, so the second stream cannot seal again even though
+     * `shouldPreempt` still answers true.
+     */
+    const contents = aiContents(messages);
+    expect(contents).toHaveLength(2);
+    expect(FULL_RESPONSE.startsWith(contents[0])).toBe(true);
+    expect(contents[0].length).toBeLessThan(FULL_RESPONSE.length);
+    expect(contents[1]).toBe(RESUMED_RESPONSE);
+  });
+});

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -78,6 +78,17 @@ async function createSealRun(options: {
   return run;
 }
 
+class CountingChatModel extends FakeChatModel {
+  invocations = 0;
+
+  override async *_streamResponseChunks(
+    ...args: Parameters<FakeChatModel['_streamResponseChunks']>
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    this.invocations += 1;
+    yield* super._streamResponseChunks(...args);
+  }
+}
+
 const aiContents = (messages: BaseMessage[]): string[] =>
   messages
     .filter((message) => message.getType() === 'ai')
@@ -191,6 +202,69 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(run.Graph?.preemptSealCount).toBe(1);
     expect(starts).toBe(2);
     expect(ends).toBe(2);
+  });
+
+  it('a halting boundary stops multi-agent successors, not just the sealed subgraph', async () => {
+    const registry = new HookRegistry();
+    registry.register('PreemptBoundary', {
+      hooks: [
+        async () => ({
+          preventContinuation: true,
+          stopReason: 'stop_everything',
+        }),
+      ],
+    });
+    const run = await Run.create<t.IState>({
+      runId: 'seal-halt-multiagent',
+      graphConfig: {
+        type: 'multi-agent',
+        agents: [
+          {
+            agentId: 'agent_a',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'You are agent A.',
+          },
+          {
+            agentId: 'agent_b',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'You are agent B.',
+          },
+        ],
+        edges: [{ from: 'agent_a', to: 'agent_b', edgeType: 'direct' }],
+      },
+      hooks: registry,
+      preemption: { shouldPreempt: () => true, maxSeals: 1 },
+      returnContent: true,
+      skipCleanup: true,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new CountingChatModel({
+      responses: [FULL_RESPONSE, 'agent B should never say this'],
+    });
+    run.Graph.overrideModel = model;
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    /**
+     * The registry halt is cleared to protect the sealed commit, so nothing
+     * in processStream's poll stops the outer workflow — the createCallModel
+     * entry guard is what keeps the direct-edge successor from taking a
+     * model turn after the halting boundary.
+     */
+    expect(model.invocations).toBe(1);
+    expect(run.getHaltReason()).toBe('stop_everything');
+    expect(run.Graph.preemptIncomplete).toBe(true);
+    const contents = aiContents(run.getRunMessages() ?? []);
+    expect(contents.some((c) => c.includes('agent B should never'))).toBe(
+      false
+    );
   });
 
   it('resumes after an injecting boundary and completes without a halt reason', async () => {

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -8,6 +8,7 @@
  */
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import { RunnableBinding } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { Providers } from '@/common';
 import { HookRegistry } from '@/hooks/HookRegistry';
@@ -61,7 +62,19 @@ async function createSealRun(options: {
   if (options.modelCallbacks != null) {
     model.callbacks = options.modelCallbacks;
   }
-  run.Graph.overrideModel = model;
+  /**
+   * Wrapped, not bare, when the test watches model-level callbacks: with
+   * tools bound, production hands `attemptInvoke` a `RunnableBinding` (and a
+   * system runnable pipes a sequence on top), while `clientOptions.callbacks`
+   * lives on the chat model at the bottom. A bare override would let a
+   * naive `model.callbacks` property read pass the detector while missing
+   * every real tool-enabled run.
+   */
+  run.Graph.overrideModel = (
+    options.modelCallbacks != null
+      ? new RunnableBinding({ bound: model, kwargs: {}, config: {} })
+      : model
+  ) as typeof model;
   return run;
 }
 

--- a/src/stream.dispatch.test.ts
+++ b/src/stream.dispatch.test.ts
@@ -1,0 +1,63 @@
+import type * as t from '@/types';
+import {
+  ChatModelStreamHandler,
+  dispatchesChatModelStream,
+  SDK_STREAM_DISPATCH,
+} from '@/stream';
+import { composeEventHandlers } from '@/events';
+import { GraphEvents } from '@/common';
+
+const inert: t.EventHandler = {
+  handle: (): void => {
+    /* renders nothing */
+  },
+};
+
+describe('dispatchesChatModelStream', () => {
+  it('recognizes the dispatcher itself', () => {
+    expect(dispatchesChatModelStream(new ChatModelStreamHandler())).toBe(true);
+  });
+
+  it('is false for a handler that owns no content-part dispatch', () => {
+    expect(dispatchesChatModelStream(inert)).toBe(false);
+  });
+
+  it('is false for nothing registered', () => {
+    expect(dispatchesChatModelStream(undefined)).toBe(false);
+  });
+
+  /**
+   * The reason identity is not a usable test: hosts wrap handlers, and every
+   * wrapper fails `instanceof` while still driving the same dispatch. A run
+   * that seals on that basis would be sealing against its own contract.
+   */
+  it('sees through a composed wrapper in either position', () => {
+    const first = composeEventHandlers(
+      { [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler() },
+      { [GraphEvents.CHAT_MODEL_STREAM]: inert }
+    )[GraphEvents.CHAT_MODEL_STREAM];
+    const second = composeEventHandlers(
+      { [GraphEvents.CHAT_MODEL_STREAM]: inert },
+      { [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler() }
+    )[GraphEvents.CHAT_MODEL_STREAM];
+
+    expect(first).not.toBeInstanceOf(ChatModelStreamHandler);
+    expect(second).not.toBeInstanceOf(ChatModelStreamHandler);
+    expect(dispatchesChatModelStream(first)).toBe(true);
+    expect(dispatchesChatModelStream(second)).toBe(true);
+  });
+
+  it('does not brand a composition of inert handlers', () => {
+    const composed = composeEventHandlers(
+      { [GraphEvents.CHAT_MODEL_STREAM]: inert },
+      { [GraphEvents.CHAT_MODEL_STREAM]: inert }
+    )[GraphEvents.CHAT_MODEL_STREAM];
+    expect(dispatchesChatModelStream(composed)).toBe(false);
+  });
+
+  it('exposes the brand as a cross-realm-safe registered symbol', () => {
+    expect(SDK_STREAM_DISPATCH).toBe(
+      Symbol.for('@librechat/agents:chatModelStreamDispatch')
+    );
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1422,10 +1422,7 @@ export function dispatchesChatModelStream(handler?: t.EventHandler): boolean {
   if (handler instanceof ChatModelStreamHandler) {
     return true;
   }
-  return (
-    (handler as unknown as Record<symbol, unknown>)[SDK_STREAM_DISPATCH] ===
-    true
-  );
+  return Reflect.get(handler, SDK_STREAM_DISPATCH) === true;
 }
 
 export class ChatModelStreamHandler implements t.EventHandler {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1400,7 +1400,37 @@ function shouldSkipLateOpenRouterReasoningChunk({
   );
 }
 
+/**
+ * Brands a handler as one that dispatches content parts for the SDK — either
+ * `ChatModelStreamHandler` itself or a wrapper forwarding to one.
+ *
+ * Identity alone is not a usable contract here. Hosts compose and wrap
+ * handlers (`composeEventHandlers`, `createRunHandlers`), and every wrapper
+ * fails `instanceof` while still driving the same dispatch. A brand survives
+ * wrapping, so "does this handler own content-part dispatch" can be answered
+ * about a value the SDK did not construct.
+ */
+export const SDK_STREAM_DISPATCH = Symbol.for(
+  '@librechat/agents:chatModelStreamDispatch'
+);
+
+/** True when `handler` is, or forwards to, the SDK's stream dispatcher. */
+export function dispatchesChatModelStream(handler?: t.EventHandler): boolean {
+  if (handler == null) {
+    return false;
+  }
+  if (handler instanceof ChatModelStreamHandler) {
+    return true;
+  }
+  return (
+    (handler as unknown as Record<symbol, unknown>)[SDK_STREAM_DISPATCH] ===
+    true
+  );
+}
+
 export class ChatModelStreamHandler implements t.EventHandler {
+  readonly [SDK_STREAM_DISPATCH] = true;
+
   async handle(
     event: string,
     data: t.StreamEventData,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -70,7 +70,7 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
-import { toLangChainContent } from '@/messages/langchain';
+import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { RunnableCallable } from '@/utils';
 import { executeHooks } from '@/hooks';
@@ -2934,7 +2934,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (result.injectedMessages && result.injectedMessages.length > 0) {
           try {
             injected.push(
-              ...this.convertInjectedMessages(result.injectedMessages)
+              ...convertInjectedMessages(result.injectedMessages)
             );
           } catch (e) {
             // eslint-disable-next-line no-console
@@ -3344,7 +3344,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      */
     if (hookInjectedMessages.length > 0) {
       try {
-        injected.push(...this.convertInjectedMessages(hookInjectedMessages));
+        injected.push(...convertInjectedMessages(hookInjectedMessages));
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(
@@ -3424,34 +3424,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       config,
       request.turn
     );
-  }
-
-  /**
-   * Converts InjectedMessage instances to LangChain HumanMessage objects.
-   * Both 'user' and 'system' roles become HumanMessage to avoid provider
-   * rejections (Anthropic/Google reject non-leading SystemMessages).
-   * The original role is preserved in additional_kwargs for downstream consumers.
-   */
-  private convertInjectedMessages(
-    messages: t.InjectedMessage[]
-  ): BaseMessage[] {
-    const converted: BaseMessage[] = [];
-    for (const msg of messages) {
-      const additional_kwargs: Record<string, unknown> = {
-        role: msg.role,
-      };
-      if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
-      if (msg.source != null) additional_kwargs.source = msg.source;
-      if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
-
-      converted.push(
-        new HumanMessage({
-          content: toLangChainContent(msg.content),
-          additional_kwargs,
-        })
-      );
-    }
-    return converted;
   }
 
   /**

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -30,7 +30,11 @@ import type {
   MessageDeltaEvent,
   ReasoningDeltaEvent,
 } from '@/types/stream';
-import type { TokenCounter, TokenBudgetBreakdown } from '@/types/run';
+import type {
+  TokenCounter,
+  StreamPreemption,
+  TokenBudgetBreakdown,
+} from '@/types/run';
 import type { Providers, Callback, GraphNodeKeys } from '@/common';
 import type { StandardGraph, MultiAgentGraph } from '@/graphs';
 import type { ClientOptions } from '@/types/llm';
@@ -346,6 +350,13 @@ export type StandardGraphInput = {
    * hook inputs carry only `executingAgentId`.
    */
   subagentScope?: boolean;
+  /**
+   * Cooperative preemption, forwarded from `RunConfig.preemption`. Only ever
+   * set on the top-level graph: a steer targets the conversation, so subagent
+   * children must run to completion and `buildChildInputs` does not propagate
+   * this field.
+   */
+  preemption?: StreamPreemption;
 };
 
 export type GraphEdge = {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -115,6 +115,37 @@ export type StandardGraphConfig = Omit<
   'edges' | 'type'
 > & { type?: 'standard'; signal?: AbortSignal };
 
+/**
+ * Cooperative mid-generation preemption. Lets a host seal the live model
+ * stream at the next provider-safe token boundary — the run is never
+ * aborted, the partial assistant turn is kept, and the graph self-loops
+ * into a fresh model call once the `PreemptBoundary` hook has injected
+ * whatever the host queued.
+ *
+ * Preconditions the host MUST satisfy:
+ *   - `shouldPreempt` is polled once per streamed chunk on the top-level
+ *     graph. It must be synchronous, allocation-free and O(1) — never I/O.
+ *   - Sealing is only honored on the SDK's own dispatch loop. A host that
+ *     registers its own `CHAT_MODEL_STREAM` handler consumes chunks through
+ *     a decoupled `streamEvents` reader that can lag the accumulated chunk,
+ *     which would invert content-part indices; those runs never seal.
+ */
+export interface StreamPreemption {
+  /** Polled once per streamed chunk. Synchronous, allocation-free, O(1). */
+  shouldPreempt: () => boolean;
+  /**
+   * Max cooperative seals per run. Each seal costs one extra superstep, so
+   * this also bounds the recursion-limit headroom the run reserves.
+   */
+  maxSeals?: number;
+}
+
+/** Seals honored and boundaries that had nothing to inject, per run. */
+export type PreemptStats = {
+  seals: number;
+  emptyBoundaries: number;
+};
+
 export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
@@ -146,6 +177,14 @@ export type RunConfig = {
    * block to prevent leaks.
    */
   hooks?: HookRegistry;
+  /**
+   * Opt-in cooperative preemption for this run. Requires a `hooks` registry
+   * with a `PreemptBoundary` matcher — the seal only stops the stream, the
+   * hook is what supplies the messages to resume with. Omit to keep the
+   * pre-preemption behavior, where a mid-run injection can only land at a
+   * tool boundary.
+   */
+  preemption?: StreamPreemption;
   returnContent?: boolean;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -125,6 +125,14 @@ export type StandardGraphConfig = Omit<
  * Preconditions the host MUST satisfy:
  *   - `shouldPreempt` is polled once per streamed chunk on the top-level
  *     graph. It must be synchronous, allocation-free and O(1) — never I/O.
+ *     It must also be LEVEL-TRIGGERED (non-consuming): the SDK never clears
+ *     the host's request, and a true result is only honored once the
+ *     accumulated chunk is provider-safe, so the predicate may be polled
+ *     many times before a seal. A one-shot read that clears its own pending
+ *     flag would silently lose the request on an unsafe chunk (leading
+ *     whitespace/reasoning, an in-flight tool call) — keep returning true
+ *     until the `PreemptBoundary` drain hands over the queued injection,
+ *     then disarm there.
  *   - Sealing is only honored on the SDK's own dispatch loop. A run whose
  *     registered `CHAT_MODEL_STREAM` handler IS the SDK dispatcher — or wraps
  *     it, which `composeEventHandlers` and `createRunHandlers` both do —
@@ -147,7 +155,11 @@ export type StandardGraphConfig = Omit<
  *     and reports it either way.
  */
 export interface StreamPreemption {
-  /** Polled once per streamed chunk. Synchronous, allocation-free, O(1). */
+  /**
+   * Polled once per streamed chunk. Synchronous, allocation-free, O(1), and
+   * level-triggered — keep returning true until the `PreemptBoundary` drain
+   * consumes the request; a self-clearing read loses it on an unsafe chunk.
+   */
   shouldPreempt: () => boolean;
   /**
    * Max cooperative seals per run. Each seal costs one extra superstep, so

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -125,10 +125,19 @@ export type StandardGraphConfig = Omit<
  * Preconditions the host MUST satisfy:
  *   - `shouldPreempt` is polled once per streamed chunk on the top-level
  *     graph. It must be synchronous, allocation-free and O(1) — never I/O.
- *   - Sealing is only honored on the SDK's own dispatch loop. A host that
- *     registers its own `CHAT_MODEL_STREAM` handler consumes chunks through
- *     a decoupled `streamEvents` reader that can lag the accumulated chunk,
- *     which would invert content-part indices; those runs never seal.
+ *   - Sealing is only honored on the SDK's own dispatch loop. A run whose
+ *     registered `CHAT_MODEL_STREAM` handler IS the SDK dispatcher — or wraps
+ *     it, which `composeEventHandlers` and `createRunHandlers` both do —
+ *     consumes chunks through a decoupled `streamEvents` reader that can lag
+ *     the accumulated chunk, so those runs never seal.
+ *
+ *     Detection is by capability, not identity: the dispatcher carries
+ *     `SDK_STREAM_DISPATCH` and the SDK's wrappers propagate it. A handler
+ *     that merely OBSERVES the raw chunk echo — LibreChat's no-op
+ *     `OpenAIChatModelStreamHandler`, say — is unbranded and does NOT disable
+ *     sealing, because it assigns no content-part indices and so cannot be
+ *     inverted. A host that renders from the raw feed and wants the opt-out
+ *     should brand its handler with `SDK_STREAM_DISPATCH`.
  *   - `RunConfig.tokenCounter` should be set. A sealed turn ends before most
  *     providers send their usage chunk, so the synthetic `CHAT_MODEL_END`
  *     falls back to the counter to report `output_tokens`. Without one that

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -129,6 +129,13 @@ export type StandardGraphConfig = Omit<
  *     registers its own `CHAT_MODEL_STREAM` handler consumes chunks through
  *     a decoupled `streamEvents` reader that can lag the accumulated chunk,
  *     which would invert content-part indices; those runs never seal.
+ *   - `RunConfig.tokenCounter` should be set. A sealed turn ends before most
+ *     providers send their usage chunk, so the synthetic `CHAT_MODEL_END`
+ *     falls back to the counter to report `output_tokens`. Without one that
+ *     fallback silently no-ops and the sealed turn's usage is lost — verified
+ *     live: OpenAI, Azure OpenAI and DeepSeek report no usage for the sealed
+ *     segment without a counter, while Anthropic streams usage incrementally
+ *     and reports it either way.
  */
 export interface StreamPreemption {
   /** Polled once per streamed chunk. Synchronous, allocation-free, O(1). */


### PR DESCRIPTION
## Why

The only mid-run injection seam today is `PostToolBatch`, and it fires only when a batch produced tool entries (`ToolNode.ts`, guarded on `orderedBatchEntries.length > 0`). During a long text answer there is **no boundary at all**. A host that wants to redirect the model mid-answer has exactly two options right now: wait for a tool step that may never come, or abort the run and throw away everything it wrote.

This adds the missing third option — a cooperative seal.

## What it does

Seal the live model stream at a provably-safe chunk boundary, dispatch a new `PreemptBoundary` hook, and self-loop the agent node **inside the same pregel run**. No abort, no job-status change, no checkpointer, no second `processStream` pass. The partial assistant turn is kept and the model continues in the same message.

| | halts the run? | waits for | keeps partial output? | new turn? |
|---|---|---|---|---|
| `PostToolBatch` injection | no | next tool batch | yes | no |
| abort + resend | **yes** | nothing | only as an unfinished record | yes |
| **preemption (new)** | generation only, cooperatively | next **safe chunk boundary** | **yes, in place** | no |

## The safety argument

`canSealPreempt` (`src/llm/preempt.ts`) refuses to seal unless the **accumulated** chunk already satisfies all of:

1. non-whitespace **text** content — `thinking` / `reasoning` / `redacted_thinking` do not count
2. no open entries in `tool_calls` / `tool_call_chunks`, and `invalid_tool_calls` empty — with one refinement: an Anthropic **server-side** call whose paired `web_search_tool_result` block has already landed counts as *settled* (provider-side tools never produce a `PostToolBatch` boundary, so without this a turn would become permanently unsealable the moment a web search starts)
3. no unanswered **Google server-side** tool call — Gemini's server tools never surface in `tool_calls`; their `toolCall`/`toolResponse` content blocks are counted pairwise

Chunks accumulate monotonically through `concat`, so an unsafe shape can never be observed at a seal point. **Nothing is stripped and nothing is repaired** — if the shape is not already safe the stream simply runs on and the injection falls through to today's tool boundary.

Only the SDK's own dispatch-synchronous loop may seal. The registered-stream-handler loop is excluded by construction (brand check `SDK_STREAM_DISPATCH`, robust to `composeEventHandlers`/`createRunHandlers` wrappers): it dispatches through a decoupled `streamEvents` consumer that can lag the accumulated chunk, which would let a host index a content part the user has not been shown.

## Native close of the sealed model run

`@langchain/core`'s `_streamIterator` calls `handleLLMEnd` **after** its try/catch with no `finally`, so breaking the consumer's `for await` fires neither `handleLLMError` nor `handleLLMEnd` — the run would stay open in every callback handler and each seal would cost one unrecorded full prompt. The seal therefore closes the real run natively: the chat model's actual runId is *observed* via a `handleChatModelStart` capture handler (it cannot be dictated — bound runnables consume `config.runId`), and the close composes the per-call config callbacks **with the model's own** (`clientOptions.callbacks`) — unwrapping the production wrapper stack (`bindTools`' `RunnableBinding`, a system runnable's `RunnableSequence`) to find them, the same composition the real run uses — so no handler class is left with an open span. Usage for the sealed turn is synthesized from the agent's token counter when the provider never got to send its usage chunk.

## Wire shaping for strict-alternation providers

Boundary injection can put two user turns next to each other (context + steer, a two-steer drain, or a steer landing right after tool results). Three layers keep the wire valid without touching graph state or host persistence:

- **`coalesceAdjacentUserTurns`** (`src/messages/alternation.ts`) merges consecutive plain user turns at the last provider-facing hop, keyed on the provider actually serving the call (`attemptInvoke` is the single funnel, so fallbacks are covered — an OpenAI primary failing over to Bedrock gets the same shaping). The merged turn keeps the **first** turn's id (origin tracking re-attaches by key) and the **last** turn's `additional_kwargs` (the prompt-cache tail anchor reasons positionally). Tool-result-only turns are excluded; mixed turns merge with block order preserved. The no-merge path returns the input array by identity, so the funnel's second pass over an already-normalized payload is a walk with zero allocation.
- **The vendored Bedrock converter** now merges *all* consecutive user-role messages, not just toolResult pairs — `ToolMessage` and `HumanMessage` both convert to `role: 'user'`, so a hook injection after tool results otherwise reaches Converse as adjacent user messages.
- **The trailing-steer anchor** in `formatAgentMessages` marks a replayed steer as answered with a placeholder assistant turn — deferred until a later entry actually emits (never stranded as a final prefill), and *suppressed* when the next emitted message is itself an assistant turn (which is its own separation; emitting anyway would create adjacent assistant turns).

Enforcement nuance, live-verified (2026-07-28): Mistral rejects consecutive user turns outright; Bedrock Converse *documents* strict alternation but claude-sonnet-4-5 on Converse currently **accepts** both the unmerged and merged shapes. The shaping is contract-safety across Converse model families (Nova, Llama, …), not a bet on per-family leniency.

## Halt semantics and telemetry

- A `PreemptBoundary` hook returning `preventContinuation: true` halts **without destroying the sealed turn**: the registry halt (whose stream-cancel would abort pregel before the outer reducer commits) is cleared at the boundary, the reason is carried on the graph, and `processStream` transfers it into `getHaltReason()` *after* the `Stop` dispatch — hosts keep their persistence signal, `AgentSession` emits `run.halted`, and the hook's own `stopReason` reaches `Stop` hooks verbatim.
- **The halt reaches the whole workflow, not just the sealed agent.** In a `MultiAgentGraph`, clearing the registry halt removed the only signal the outer routing consulted — so every model node now carries an entry guard: when the halt reason is set, `createCallModel` declines the turn and the workflow (static direct edges, Command fan-out, fan-in wrappers, parallel siblings' next turns) drains to END with the sealed commit intact. One chokepoint covers every routing mode; a `Command({goto: END})` cannot suppress statically compiled edges.
- An **empty boundary** (sealed, but the host's queue was drained or cancelled in the meantime) surfaces as `getHaltReason() === 'preempt_incomplete'` — a truncated answer can never be finalized as a natural completion — and counts toward `getPreemptStats().emptyBoundaries` whether or not the hook also halted.
- Cancellation reaches boundary drains through **both** channels: the construction signal and the per-call `callerConfig.signal` (`Graph.callerSignal`, assigned unconditionally per call; composed with `AbortSignal.any` when both exist and differ). `graph.signal` stays pure construction state — its other consumers (model-call config, subagent parentSignal) are unaffected.

## Scope

- `shouldPreempt` is contractually **level-triggered** (non-consuming): the SDK never clears the host's request, and a true result is honored only once the accumulated chunk is provider-safe. The seal condition's poll-first order is load-bearing — evaluating the shape check before the poll would walk the accumulated content on every chunk.
- `PreemptBoundary` is **not** result-altering — registering a drain hook never silently disables eager tool execution. Pinned by a test.
- `ToolNode.convertInjectedMessages` is lifted to `@/messages/injected` and shared by both injection sites — the provider-safety argument rests on the two sites emitting identical `HumanMessage` shapes.
- Subagents never seal, guarded twice: `buildChildInputs` does not propagate `preemption`, and `shouldPreemptStream()` returns false for `subagentScope`.
- Seal budget (`maxSeals`, default 8) is per-turn; a HITL resume keeps its remaining budget. Preemption-enabled runs reserve recursion-limit headroom equal to the budget so a preempted tool-heavy agent cannot hit `GraphRecursionError`.
- `MultiAgentGraph` routes parallel agents through one `StandardGraph`: the seal claim is a synchronous one-in-flight slot, so concurrent streams cannot double-spend a queued message.
- Coalescing is wrapped in `trackProviderMessageOrigins` like every other provider transform, so merged turns keep calibrated token attribution (a bare merge could flip a just-fits payload into a spurious pre-invoke overflow).
- **One provider-specific file changed**: the vendored Bedrock converter's user-run merging (above). The abort path, `RunControl`, `keepContent`, `prune.ts`, ToolNode execution paths, and all other converters are untouched.

## Tests

95 tests across 9 PR-owned suites (plus additions to the Bedrock converter suite), all passing:

- `src/llm/preempt.test.ts` — truth table over every seal condition
- `src/specs/preemptSeal.test.ts` — **fake-model end-to-end**: seal → empty boundary → `preempt_incomplete` with partial content kept; seal → inject → self-loop resume → completion with budget spent; halting hook's `stopReason` through `Stop` and `getHaltReason()`; a two-agent run where a halting boundary stops the direct-edge successor (agent B takes a model turn without the guard, none with it); model-level callbacks balanced through a real `RunnableBinding` wrapper (each detector counterfactually verified — fails without its fix)
- `src/graphs/__tests__/Graph.preemptSignal.test.ts` — abort-signal composition (both channels, either alone, clearHeavyState)
- `src/messages/alternation.test.ts` + `src/llm/invoke.alternation.test.ts` — merge semantics (kwargs/id survivorship, mixed tool_result, camelCase variant) and the fallback funnel (strict vs tolerant provider, idempotency)
- `src/messages/formatAgentMessages.steer.test.ts` — anchor deferral, assistant-turn suppression, no-adjacent-user-turns invariant, Anthropic converter round-trip
- `src/hooks/__tests__/preemptBoundary.test.ts`, `src/messages/injected.test.ts`, `src/stream.dispatch.test.ts` — event registration/capabilities, injected-message shape parity, dispatch brand

The former "known gap" (no integration test for the seal → boundary → self-loop path) is closed: #343 unblocked jest for the `providers` import chain, and `preemptSeal.test.ts` runs the full path on a fake streaming model.

## Live verification

Seal → boundary → inject → resume verified against real providers **on the final head**: **anthropic, bedrock, vertexai (gemini-2.5-flash), openAI, azureOpenAI, openrouter, deepseek (deepseek-reasoner), xai (grok-3-fast)** — all `ok`, lifecycle counters balanced, no orphaned spans. `--control` mode (no preemption) verified as the baseline. Bedrock wire probes verified the merged `[toolResult, text]` user message is accepted end-to-end.

A live **scenario matrix** (`src/scripts/preempt-scenarios.ts`, anthropic + bedrock) additionally verified: two seals in one turn (three balanced model runs); the gate holding through a tool-call turn with the tool executed exactly once and the steer landing after the result; budget exhaustion with a never-disarming predicate (second seal refused, turn completes); promptCache + seal + steer with no rejections; the multi-agent halt guard live (successor never starts, halt reason surfaces); and a seal landing after an Anthropic server-side web search settles — the sealed `[server_tool_use, web_search_tool_result, text…]` content replays and is accepted.

**Known interaction (pre-existing mechanism, documented not fixed):** in a multi-agent direct-edge flow on Anthropic, the successor receives the previous agent's trailing assistant turn as a *prefill continuation*. A steer's short, complete-reading resume can leave the continuation nothing to add, yielding an empty successor turn (reproduced 3/3 live; the no-preemption baseline's successor output is itself continuation-shaped, and OpenAI is unaffected). Preemption raises the likelihood of the trigger shape but the prefill framing predates it — tracked as #345, out of scope here. Untested for lack of working credentials: mistral (401 — note Mistral is a strict-alternation provider whose converter path is unit-tested but not live-verified) and google direct (no `GOOGLE_API_KEY`); Gemini itself is covered via Vertex. (`src/utils/llmConfig.ts` pins xai to `grok-2-latest`, which this team can no longer access — probe ran with `grok-3-fast`.)

## Review provenance

17 requested Codex review rounds, 42 findings — every finding either fixed with a regression test (most counterfactually verified against the pre-fix code) or refuted with executed evidence, plus a 20-agent adversarial self-review of the rebase surface. All review threads carry written dispositions.

## Follow-ups

This is PR 1 of 3. LibreChat server (fenced preempt request set, `emitPreempt`/`onPreempt` transport pair) and client (composer control, `steerInterruptsByDefault` preference) build on this and land after it.
