### PR TITLE
feat(search): add Keenable as a keyless content scraper

### DIFF
--- a/src/tools/search/keenable-scraper.test.ts
+++ b/src/tools/search/keenable-scraper.test.ts
@@ -1,0 +1,153 @@
+import axios from 'axios';
+import { createKeenableScraper } from './keenable-scraper';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const sampleResponse = {
+  data: {
+    url: 'https://example.com/',
+    title: 'Example Domain',
+    content:
+      '# Example Domain\n\nThis domain is for use in documentation examples.',
+    description: 'An example page.',
+  },
+};
+
+describe('Keenable scraper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.KEENABLE_API_KEY;
+    delete process.env.KEENABLE_FETCH_URL;
+  });
+
+  it('returns an error for empty URLs without calling the API', async () => {
+    const scraper = createKeenableScraper();
+    const [url, response] = await scraper.scrapeUrl('   ');
+
+    expect(url).toBe('   ');
+    expect(response.success).toBe(false);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('hits the public endpoint and omits the API key header when keyless', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const scraper = createKeenableScraper();
+    const [, response] = await scraper.scrapeUrl('https://example.com');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://api.keenable.ai/v1/fetch/public',
+      expect.objectContaining({
+        params: { url: 'https://example.com' },
+        headers: expect.objectContaining({ 'X-Keenable-Title': 'LibreChat' }),
+      })
+    );
+    const headers = mockedAxios.get.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers['X-API-Key']).toBeUndefined();
+    expect(response.success).toBe(true);
+    expect(response.data?.content).toContain('# Example Domain');
+  });
+
+  it('hits the keyed endpoint and sends the API key header when a key is set', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const scraper = createKeenableScraper({ apiKey: 'secret-key' });
+    await scraper.scrapeUrl('https://example.com');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://api.keenable.ai/v1/fetch',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'secret-key' }),
+      })
+    );
+  });
+
+  it('honors a custom attribution title and fetch URL override', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const scraper = createKeenableScraper({
+      apiUrl: 'https://keenable.internal/v1/fetch/public',
+      attributionTitle: 'MyApp',
+    });
+    await scraper.scrapeUrl('https://example.com');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://keenable.internal/v1/fetch/public',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Keenable-Title': 'MyApp' }),
+      })
+    );
+  });
+
+  it('reports failure when the API returns no content', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { url: 'https://x.test', content: '' },
+    });
+
+    const scraper = createKeenableScraper();
+    const [, response] = await scraper.scrapeUrl('https://x.test');
+
+    expect(response.success).toBe(false);
+    expect(response.error).toMatch(/no content/i);
+  });
+
+  it('reports failure with a message when the request throws', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('network down'));
+
+    const scraper = createKeenableScraper();
+    const [, response] = await scraper.scrapeUrl('https://x.test');
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('network down');
+  });
+
+  it('scrapes multiple URLs concurrently', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: { content: 'a', url: 'https://a.test' } })
+      .mockResolvedValueOnce({ data: { content: 'b', url: 'https://b.test' } });
+
+    const scraper = createKeenableScraper();
+    const results = await scraper.scrapeUrls([
+      'https://a.test',
+      'https://b.test',
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0][1].data?.content).toBe('a');
+    expect(results[1][1].data?.content).toBe('b');
+  });
+
+  it('extractContent returns the markdown with no structured references', () => {
+    const scraper = createKeenableScraper();
+    const [content, references] = scraper.extractContent({
+      success: true,
+      data: { content: '# Title\n\nBody' },
+    });
+
+    expect(content).toBe('# Title\n\nBody');
+    expect(references).toBeUndefined();
+  });
+
+  it('extractMetadata surfaces title, description and url', () => {
+    const scraper = createKeenableScraper();
+    const metadata = scraper.extractMetadata({
+      success: true,
+      data: {
+        content: 'x',
+        title: 'Example Domain',
+        description: 'An example page.',
+        url: 'https://example.com/',
+      },
+    });
+
+    expect(metadata).toEqual({
+      title: 'Example Domain',
+      description: 'An example page.',
+      url: 'https://example.com/',
+    });
+  });
+});

--- a/src/tools/search/keenable-scraper.ts
+++ b/src/tools/search/keenable-scraper.ts
@@ -1,0 +1,137 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+
+const DEFAULT_KEENABLE_SCRAPE_TIMEOUT = 15000;
+
+/** Keyed and keyless fetch endpoints. Keenable reads any URL as clean markdown
+ * without a key via the public endpoint; a key only lifts rate limits. */
+const KEENABLE_FETCH_API_URL = 'https://api.keenable.ai/v1/fetch';
+const KEENABLE_FETCH_PUBLIC_URL = 'https://api.keenable.ai/v1/fetch/public';
+
+export class KeenableScraper implements t.BaseScraper {
+  private apiKey: string | undefined;
+  private apiUrl: string;
+  private timeout: number;
+  private attributionTitle: string;
+  private logger: t.Logger;
+
+  constructor(config: t.KeenableScraperConfig = {}) {
+    const resolvedKey = config.apiKey ?? process.env.KEENABLE_API_KEY;
+    this.apiKey =
+      resolvedKey != null && resolvedKey !== '' ? resolvedKey : undefined;
+    this.apiUrl =
+      config.apiUrl ??
+      process.env.KEENABLE_FETCH_URL ??
+      (this.apiKey != null
+        ? KEENABLE_FETCH_API_URL
+        : KEENABLE_FETCH_PUBLIC_URL);
+    this.timeout = config.timeout ?? DEFAULT_KEENABLE_SCRAPE_TIMEOUT;
+    this.attributionTitle = config.attributionTitle ?? 'LibreChat';
+    this.logger = config.logger || createDefaultLogger();
+  }
+
+  private buildHeaders(): Record<string, string> {
+    /** X-Keenable-Title is used for traffic attribution and required on the
+     * keyless endpoint; the key only lifts rate limits, so it is sent only when
+     * present. */
+    const headers: Record<string, string> = {
+      'X-Keenable-Title': this.attributionTitle,
+    };
+    if (this.apiKey != null) {
+      headers['X-API-Key'] = this.apiKey;
+    }
+    return headers;
+  }
+
+  async scrapeUrl(
+    url: string,
+    options: t.KeenableScrapeOptions = {}
+  ): Promise<[string, t.KeenableScrapeResponse]> {
+    if (!url || !url.trim()) {
+      return [url, { success: false, error: 'URL cannot be empty' }];
+    }
+
+    try {
+      const response = await axios.get<t.KeenableFetchResult>(this.apiUrl, {
+        params: { url },
+        headers: this.buildHeaders(),
+        timeout: options.timeout ?? this.timeout,
+      });
+
+      const data = response.data;
+      const content = data.content ?? '';
+      if (!content) {
+        return [
+          url,
+          { success: false, error: 'Keenable Fetch returned no content' },
+        ];
+      }
+
+      return [
+        url,
+        {
+          success: true,
+          data: {
+            content,
+            title: data.title,
+            description: data.description,
+            url: data.url ?? url,
+          },
+        },
+      ];
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return [
+        url,
+        {
+          success: false,
+          error: `Keenable Fetch API request failed: ${errorMessage}`,
+        },
+      ];
+    }
+  }
+
+  async scrapeUrls(
+    urls: string[],
+    options: t.KeenableScrapeOptions = {}
+  ): Promise<Array<[string, t.KeenableScrapeResponse]>> {
+    /** Keenable fetch is single-URL; run the batch concurrently. */
+    return Promise.all(urls.map((url) => this.scrapeUrl(url, options)));
+  }
+
+  extractContent(
+    response: t.KeenableScrapeResponse
+  ): [string, undefined | t.References] {
+    if (!response.success || !response.data) {
+      return ['', undefined];
+    }
+    /** Keenable returns clean markdown with no separate media arrays, so there
+     * are no structured references to surface. */
+    return [response.data.content, undefined];
+  }
+
+  extractMetadata(response: t.KeenableScrapeResponse): t.GenericScrapeMetadata {
+    if (!response.success || !response.data) {
+      return {};
+    }
+    const metadata: t.GenericScrapeMetadata = {};
+    if (response.data.title != null) {
+      metadata.title = response.data.title;
+    }
+    if (response.data.description != null && response.data.description !== '') {
+      metadata.description = response.data.description;
+    }
+    if (response.data.url != null) {
+      metadata.url = response.data.url;
+    }
+    return metadata;
+  }
+}
+
+export const createKeenableScraper = (
+  config: t.KeenableScraperConfig = {}
+): KeenableScraper => {
+  return new KeenableScraper(config);
+};

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -13,6 +13,7 @@ import {
   DATE_RANGE,
 } from './schema';
 import { createSearchAPI, createSourceProcessor } from './search';
+import { createKeenableScraper } from './keenable-scraper';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
@@ -378,6 +379,7 @@ export const createSearchTool = (
     keenableApiKey,
     keenableApiUrl,
     keenableSearchOptions,
+    keenableScraperOptions,
     rerankerType = 'cohere',
     rerankerTimeout,
     topResults = 5,
@@ -476,11 +478,20 @@ export const createSearchTool = (
   } else if (scraperProvider === 'crw') {
     scraperInstance = createCrwScraper({
       ...crwScraperOptions,
-      apiKey:
-        crwScraperOptions?.apiKey ?? crwApiKey ?? process.env.CRW_API_KEY,
+      apiKey: crwScraperOptions?.apiKey ?? crwApiKey ?? process.env.CRW_API_KEY,
       apiUrl: crwScraperOptions?.apiUrl ?? crwApiUrl,
       timeout: scraperTimeout ?? crwScraperOptions?.timeout,
       formats: crwScraperOptions?.formats ?? ['markdown', 'rawHtml'],
+      logger,
+    });
+  } else if (scraperProvider === 'keenable') {
+    scraperInstance = createKeenableScraper({
+      ...keenableScraperOptions,
+      apiKey: keenableScraperOptions?.apiKey ?? keenableApiKey,
+      timeout: scraperTimeout ?? keenableScraperOptions?.timeout,
+      attributionTitle:
+        keenableScraperOptions?.attributionTitle ??
+        keenableSearchOptions?.attributionTitle,
       logger,
     });
   } else {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,8 +3,18 @@ import type { Logger as WinstonLogger } from 'winston';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'keenable' | 'crw';
-export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily' | 'crw';
+export type SearchProvider =
+  | 'serper'
+  | 'searxng'
+  | 'tavily'
+  | 'keenable'
+  | 'crw';
+export type ScraperProvider =
+  | 'firecrawl'
+  | 'serper'
+  | 'tavily'
+  | 'crw'
+  | 'keenable';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -198,6 +208,41 @@ export interface KeenableSearchResponse {
   results?: KeenableSearchResult[];
 }
 
+export interface KeenableScraperConfig {
+  apiKey?: string;
+  /** Override the fetch endpoint base (default: public keyless, keyed when a
+   * key is set). Env fallback: KEENABLE_FETCH_URL. */
+  apiUrl?: string;
+  timeout?: number;
+  logger?: Logger;
+  /** Sent as the X-Keenable-Title attribution header. Defaults to "LibreChat". */
+  attributionTitle?: string;
+}
+
+export type KeenableScrapeOptions = Omit<
+  KeenableScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
+>;
+
+/** Raw JSON shape returned by GET /v1/fetch{,/public}?url=... */
+export interface KeenableFetchResult {
+  url?: string;
+  title?: string;
+  content?: string;
+  description?: string;
+}
+
+export interface KeenableScrapeResponse {
+  success: boolean;
+  data?: {
+    content: string;
+    title?: string;
+    description?: string;
+    url?: string;
+  };
+  error?: string;
+}
+
 export type References = {
   links: MediaReference[];
   images: MediaReference[];
@@ -311,6 +356,7 @@ export interface SearchToolConfig
     FirecrawlConfig {
   tavilyScraperOptions?: TavilyScraperConfig;
   crwScraperOptions?: CrwScraperConfig;
+  keenableScraperOptions?: KeenableScraperConfig;
   /** Max chars of highlight content this tool feeds the MODEL per search (the
    * dominant, otherwise-unbounded part of the output). Distinct from
    * `maxContentLength`, which caps scraped/reranked content per source — full
@@ -351,7 +397,8 @@ export type AnyScraperResponse =
   | FirecrawlScrapeResponse
   | SerperScrapeResponse
   | TavilyScrapeResponse
-  | CrwScrapeResponse;
+  | CrwScrapeResponse
+  | KeenableScrapeResponse;
 
 /** Base Scraper Interface */
 export interface BaseScraper {


### PR DESCRIPTION
## Summary

Keenable already ships as a search provider (#285). This adds it as a **scraper** so a Keenable-only web-search stack (provider + scraper) needs **no third-party key** — Keenable reads any URL as clean markdown via its own fetch endpoint, keyless by default.

Together with `searchProvider: keenable`, this lets a deployment run web search fully keyless (`scraperProvider: keenable`, `rerankerType: none`) instead of requiring a firecrawl/serper/tavily scraper key.

## Endpoint

- `GET /v1/fetch/public?url=…` (keyless) or `GET /v1/fetch?url=…` with `X-API-Key` (rate limit lifted)
- `X-Keenable-Title` attribution header; public keyless endpoint used by default
- Response: `{ url, title, content (markdown), description }`

## Changes

- `keenable-scraper.ts`: `KeenableScraper implements BaseScraper` — `scrapeUrl` / `scrapeUrls` (concurrent), `extractContent`, `extractMetadata`, `createKeenableScraper` factory.
- `tool.ts`: wired into the scraper factory under `scraperProvider: 'keenable'`. The fetch endpoint is resolved independently of the search endpoint (`keenableApiUrl` is search-only).
- `types.ts`: `ScraperProvider` union, `keenableScraperOptions`, and the scraper types; added `KeenableScrapeResponse` to `AnyScraperResponse`.
- 9 unit tests (keyless/keyed endpoint selection, headers, URL override, no-content, error, batch, extract*).

Verified: `tsc -p tsconfig.build.json` clean, eslint clean, all tests pass. Mirrors the existing `tavily-scraper` shape.

The LibreChat glue (registering `keenable` as a scraper option in the web-search auth surface) will follow in danny-avila/LibreChat#14194 once a release includes this.