### PR TITLE
🫧 fix: Classify ParentCommand Handoffs as Successful

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,4 +1,5 @@
 import { CallbackHandler } from '@langfuse/langchain';
+import { isParentCommand } from '@langchain/langgraph';
 import { context as otelContext } from '@opentelemetry/api';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import {
@@ -202,6 +203,20 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleChainStart']>
   ): ReturnType<CallbackHandler['handleChainStart']> {
     return this.withRuntimeContext(() => super.handleChainStart(...args));
+  }
+
+  override handleChainError(
+    ...args: Parameters<CallbackHandler['handleChainError']>
+  ): ReturnType<CallbackHandler['handleChainError']> {
+    const [error, runId, parentRunId] = args;
+    if (error != null && parentRunId != null && isParentCommand(error)) {
+      return super.handleChainEnd(
+        { controlFlow: 'ParentCommand' },
+        runId,
+        parentRunId
+      );
+    }
+    return super.handleChainError(...args);
   }
 
   override handleAgentAction(

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,11 +1,13 @@
 import { HumanMessage } from '@langchain/core/messages';
+import { Command, ParentCommand } from '@langchain/langgraph';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
-import { Providers } from '@/common';
+import { Constants, Providers } from '@/common';
 import { Run } from '@/run';
 
 const mockProcessorStarts: Array<{
@@ -387,6 +389,206 @@ describe('Langfuse callback composition', () => {
       'librechat.langfuse.tenant_export.enabled': 'true',
       'librechat.langfuse.destination': 'eu',
     });
+  });
+
+  it('ends nested ParentCommand control flow without reporting an error', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-parent-command';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['HandoffChain'] },
+      { input: 'handoff' },
+      runId,
+      'parent-run'
+    );
+    await handler?.handleChainError(
+      new ParentCommand(
+        new Command({ graph: 'source:graph', goto: 'destination' })
+      ),
+      runId,
+      'parent-run'
+    );
+
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          controlFlow: 'ParentCommand',
+        }),
+      })
+    );
+  });
+
+  it('reports a ParentCommand that escapes the root graph as an error', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-root-parent-command',
+      secretKey: 'sk-root-parent-command',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-root-parent-command';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['RootChain'] },
+      { input: 'root handoff' },
+      runId
+    );
+    await handler?.handleChainError(
+      new ParentCommand(
+        new Command({ graph: Command.PARENT, goto: 'destination' })
+      ),
+      runId
+    );
+
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+        [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]:
+          'ParentCommand',
+      })
+    );
+  });
+
+  it('continues reporting genuine nested chain failures as errors', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-genuine-error',
+      secretKey: 'sk-genuine-error',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-genuine-error';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['FailingChain'] },
+      { input: 'fail' },
+      runId,
+      'parent-run'
+    );
+    await handler?.handleChainError(new Error('boom'), runId, 'parent-run');
+
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+        [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]: 'Error: boom',
+      })
+    );
+  });
+
+  it('delegates null chain errors without throwing during classification', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-null-error',
+      secretKey: 'sk-null-error',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-null-error';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['NullErrorChain'] },
+      { input: 'fail' },
+      runId,
+      'parent-run'
+    );
+
+    await expect(
+      handler?.handleChainError(null, runId, 'parent-run')
+    ).resolves.toBeUndefined();
+  });
+
+  it('traces a completed two-agent handoff without false error spans', async () => {
+    const langfuse = {
+      publicKey: 'pk-handoff',
+      secretKey: 'sk-handoff',
+    };
+    const run = await Run.create<t.IState>({
+      runId: 'test-langfuse-completed-handoff',
+      graphConfig: {
+        type: 'multi-agent',
+        agents: [
+          {
+            agentId: 'agent_source',
+            name: 'Source Agent',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            instructions: 'Transfer to the destination agent.',
+            tools: [],
+          },
+          {
+            agentId: 'agent_destination',
+            name: 'Destination Agent',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            instructions: 'Complete the request.',
+            tools: [],
+          },
+        ],
+        edges: [
+          {
+            from: 'agent_source',
+            to: 'agent_destination',
+            edgeType: 'handoff',
+          },
+        ],
+      },
+      langfuse,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(
+      ['Transferring to destination', 'Destination complete'],
+      10,
+      [
+        {
+          id: 'handoff-call',
+          name: `${Constants.LC_TRANSFER_TO_}agent_destination`,
+          args: {},
+        } as ToolCall,
+      ]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('Please hand this off')] },
+      {
+        configurable: {
+          thread_id: 'test-langfuse-completed-handoff-thread',
+        },
+        version: 'v2',
+      }
+    );
+
+    expect(
+      run
+        .getRunMessages()
+        ?.some((message) => message.content === 'Destination complete')
+    ).toBe(true);
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          controlFlow: 'ParentCommand',
+        }),
+      })
+    );
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
   });
 
   it('exports Bedrock prompt-cache usage buckets to Langfuse', async () => {


### PR DESCRIPTION
## Summary

I fixed successful cross-graph agent handoffs being reported as errors in Langfuse while keeping actual chain failures visible.

- Classify nested LangGraph `ParentCommand` callbacks as successful control flow and close their observations through normal chain completion.
- Preserve error reporting for root-escaping `ParentCommand` values and ordinary exceptions.
- Guard malformed null chain errors before invoking LangGraph's type guard.
- Add callback-level regressions and a real two-agent handoff test that proves destination completion, `ParentCommand` control-flow closure, and zero false error spans.
- Avoid serializing the full handoff command and message state into the tracing output.

Related upstream discussion: https://github.com/orgs/langfuse/discussions/6060

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` in a dedicated worktree.
- Ran `npm test -- src/specs/langfuse-callbacks.test.ts --runInBand` (14/14 passing).
- Ran the Langfuse metadata, configuration, runtime-context, instrumentation, trace-shaping, tool-output-tracing, and ToolNode Langfuse suites in isolated processes (all passing).
- Ran `npm run build`.
- Ran targeted ESLint, Prettier, import-order, and diff checks for both changed files.

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2
- Langfuse/Otel transport mocked at the external boundary; LangGraph handoff execution and callback behavior remain real.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes