### PR TITLE
🧯 fix: Compact Structured Tool Output Before Provider Calls

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2498,6 +2498,80 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ).toBe(true);
   });
 
+  it('serializes bigint output before eager completion dispatch', async () => {
+    const graph = createGraph();
+    const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completedEvents.push(data as { result: t.ToolEndEvent });
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: [{ rowsRead: BigInt(42) }],
+          },
+        ]);
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await graph.eagerEventToolExecutions.get('call_weather')?.promise;
+
+    expect(completedEvents).toHaveLength(1);
+    expect(
+      (
+        completedEvents[0].result as {
+          tool_call?: { output?: string };
+        }
+      ).tool_call?.output
+    ).toBe('[{"rowsRead":"42"}]');
+  });
+
   it('does not emit a stale eager completion after the active execution is invalidated', async () => {
     const graph = createGraph({
       getAgentContext: jest.fn(

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1638,6 +1638,7 @@ export class AgentContext {
       provider: this.provider,
       tokenCounter,
       maxTokens: this.maxContextTokens,
+      maxToolResultChars: this.maxToolResultChars,
       thinkingEnabled: isThinkingEnabled(this.provider, this.clientOptions),
       indexTokenCountMap,
       contextPruningConfig: this.contextPruningConfig,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -35,7 +35,7 @@ import {
   createPruneMessages,
   projectToolCallInputs,
   calculateMaxToolCallInputChars,
-  projectOpenAIToolMessageContent,
+  projectToolStreamContentForProvider,
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
@@ -59,6 +59,13 @@ import {
   sleep,
 } from '@/utils';
 import {
+  attemptInvoke,
+  tryFallbackProviders,
+  getFallbackErrorContext,
+  getFallbackOverflowCandidates,
+  projectMessagesForProvider,
+} from '@/llm/invoke';
+import {
   createLangfuseHandler,
   createLangfuseTraceMetadata,
   disposeLangfuseHandler,
@@ -69,12 +76,6 @@ import {
   planContextOverflowRecovery,
   translateRecoveryBudget,
 } from '@/llm/contextOverflowRecovery';
-import {
-  attemptInvoke,
-  tryFallbackProviders,
-  getFallbackErrorContext,
-  getFallbackOverflowCandidates,
-} from '@/llm/invoke';
 import {
   compactToolContent,
   getToolContentCharLength,
@@ -2038,13 +2039,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const maxProviderToolResultChars =
         agentContext.maxToolResultChars ??
         calculateMaxToolResultChars(agentContext.maxContextTokens);
-      if (isOpenAILike(agentContext.provider)) {
-        const before = finalMessages;
-        finalMessages = trackProviderMessageOrigins(
-          before,
-          projectOpenAIToolMessageContent(before, maxProviderToolResultChars)
-        );
-      }
+      const beforeToolStreamProjection = finalMessages;
+      finalMessages = trackProviderMessageOrigins(
+        beforeToolStreamProjection,
+        projectToolStreamContentForProvider(beforeToolStreamProjection)
+      );
       const beforeToolInputProjection = finalMessages;
       finalMessages = trackProviderMessageOrigins(
         beforeToolInputProjection,
@@ -2080,33 +2079,44 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       const measureProviderPayload = (
-        candidate: BaseMessage[]
+        candidate: BaseMessage[],
+        contextBudgetOverride?: number,
+        forceRawRecount = false
       ): {
         fits: boolean;
         projectedMessageTokens?: number;
         availableMessageTokens?: number;
       } => {
+        const contextBudget =
+          contextBudgetOverride ?? contextUsage?.contextBudget;
+        const effectiveInstructionTokens =
+          contextUsage?.effectiveInstructionTokens ??
+          (forceRawRecount ? agentContext.instructionTokens : undefined);
         if (
           agentContext.tokenCounter == null ||
-          contextUsage?.contextBudget == null ||
-          contextUsage.effectiveInstructionTokens == null
+          contextBudget == null ||
+          effectiveInstructionTokens == null
         ) {
           return { fits: true };
         }
         const availableMessageTokens = Math.max(
           0,
-          contextUsage.contextBudget - contextUsage.effectiveInstructionTokens
+          contextBudget - effectiveInstructionTokens
         );
         let usageRatio =
           agentContext.calibrationRatio > 0 ? agentContext.calibrationRatio : 1;
         if (
-          contextUsage.calibrationRatio != null &&
+          contextUsage?.calibrationRatio != null &&
           contextUsage.calibrationRatio > 0
         ) {
           usageRatio = contextUsage.calibrationRatio;
         }
-        const baselineRemaining = contextUsage.remainingContextTokens;
+        if (forceRawRecount) {
+          usageRatio = Math.max(1, usageRatio);
+        }
+        const baselineRemaining = contextUsage?.remainingContextTokens;
         const accountedMessageTokens =
+          !forceRawRecount &&
           providerMessageBaseline != null &&
           baselineRemaining != null &&
           Number.isFinite(baselineRemaining)
@@ -2516,6 +2526,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
+      const fallbackBaseMessages = finalMessages;
+      const beforeFinalProviderProjection = fallbackBaseMessages;
+      finalMessages = trackProviderMessageOrigins(
+        beforeFinalProviderProjection,
+        projectMessagesForProvider({
+          model: (this.overrideModel ?? model) as t.ChatModel,
+          messages: beforeFinalProviderProjection,
+          provider: agentContext.provider,
+          maxToolResultChars: maxProviderToolResultChars,
+          callOptions: config,
+        })
+      );
+
       /**
        * Prompt-cache placement and orphan sanitization are provider-wire
        * transforms too. Re-measure after both so no content added after the
@@ -2826,7 +2849,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               tryFallbackProviders({
                 fallbacks,
                 tools: agentContext.tools,
-                messages: finalMessages,
+                messages: fallbackBaseMessages,
                 config: invokeConfig,
                 primaryError,
                 context: this,
@@ -2839,6 +2862,56 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   provider: agentContext.provider,
                   estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
                   maxContextTokens: agentContext.maxContextTokens,
+                },
+                prepareProviderMessages: ({
+                  model: fallbackModel,
+                  messages: fallbackMessages,
+                  provider: fallbackProvider,
+                  maxContextTokens: fallbackMaxContextTokens,
+                  config: fallbackConfig,
+                }) => {
+                  const fallbackToolResultChars =
+                    agentContext.maxToolResultChars ??
+                    calculateMaxToolResultChars(
+                      fallbackMaxContextTokens ?? agentContext.maxContextTokens
+                    );
+                  const projectedFallbackMessages = trackProviderMessageOrigins(
+                    fallbackMessages,
+                    projectMessagesForProvider({
+                      model: fallbackModel,
+                      messages: fallbackMessages,
+                      provider: fallbackProvider,
+                      maxToolResultChars: fallbackToolResultChars,
+                      callOptions: fallbackConfig,
+                    })
+                  );
+                  const primaryContextBudget = contextUsage?.contextBudget;
+                  const fallbackContextBudget =
+                    fallbackMaxContextTokens == null
+                      ? primaryContextBudget
+                      : Math.min(
+                        primaryContextBudget ?? fallbackMaxContextTokens,
+                        fallbackMaxContextTokens
+                      );
+                  const projection = measureProviderPayload(
+                    projectedFallbackMessages,
+                    fallbackContextBudget,
+                    true
+                  );
+                  if (!projection.fits) {
+                    throw new ContextOverflowError(
+                      JSON.stringify({
+                        type: 'final_context_overflow',
+                        info: 'Fallback provider message formatting exceeded the context budget before invocation.',
+                        provider: fallbackProvider,
+                        projectedMessageTokens:
+                          projection.projectedMessageTokens,
+                        availableMessageTokens:
+                          projection.availableMessageTokens,
+                      })
+                    );
+                  }
+                  return projectedFallbackMessages;
                 },
               })
           );

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2002,6 +2002,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ) {
           return { fits: true };
         }
+        const availableMessageTokens = Math.max(
+          0,
+          contextUsage.contextBudget - contextUsage.effectiveInstructionTokens
+        );
+        // The dedicated empty-prompt guard below provides actionable
+        // instruction/tool-budget guidance; there is no provider payload yet.
+        if (candidate.length === 0) {
+          return {
+            fits: true,
+            projectedMessageTokens: 0,
+            availableMessageTokens,
+          };
+        }
         let rawTokens = 3; // reply-primer allowance
         for (const message of candidate) {
           rawTokens += agentContext.tokenCounter(message);
@@ -2012,10 +2025,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             ? contextUsage.calibrationRatio
             : agentContext.calibrationRatio;
         const projectedMessageTokens = Math.round(rawTokens * usageRatio);
-        const availableMessageTokens = Math.max(
-          0,
-          contextUsage.contextBudget - contextUsage.effectiveInstructionTokens
-        );
         return {
           fits: projectedMessageTokens <= availableMessageTokens,
           projectedMessageTokens,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3,8 +3,12 @@ import { nanoid } from 'nanoid';
 import { tool } from '@langchain/core/tools';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { Runnable, RunnableConfig } from '@langchain/core/runnables';
-import { ToolMessage, AIMessageChunk } from '@langchain/core/messages';
 import { START, END, StateGraph, Annotation } from '@langchain/langgraph';
+import {
+  ToolMessage,
+  HumanMessage,
+  AIMessageChunk,
+} from '@langchain/core/messages';
 import type {
   UsageMetadata,
   BaseMessage,
@@ -16,14 +20,14 @@ import type { FallbackErrorContext } from '@/llm/invoke';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
-  formatAnthropicArtifactContent,
+  projectAnthropicArtifactContent,
   ensureThinkingBlockInMessages,
   foldToolBlocksForToollessAgent,
   convertMessagesToContent,
   sanitizeOrphanToolBlocks,
   extractToolDiscoveries,
   addBedrockTailCacheControl,
-  formatArtifactPayload,
+  projectArtifactPayload,
   formatContentStrings,
   isLegacyConvertible,
   CALIBRATION_RATIO_MAX,
@@ -40,20 +44,21 @@ import {
   splitAtRecencyBoundary,
 } from '@/messages';
 import {
-  createLangfuseHandler,
-  createLangfuseTraceMetadata,
-  disposeLangfuseHandler,
-  isLangfuseCallbackHandler,
-} from '@/langfuse';
-import {
   resetIfNotEmpty,
   isAnthropicLike,
   isOpenAILike,
   isGoogleLike,
   apportionTokenCounts,
+  calculateMaxToolResultChars,
   joinKeys,
   sleep,
 } from '@/utils';
+import {
+  createLangfuseHandler,
+  createLangfuseTraceMetadata,
+  disposeLangfuseHandler,
+  isLangfuseCallbackHandler,
+} from '@/langfuse';
 import {
   getBlindRecoveryBudget,
   planContextOverflowRecovery,
@@ -82,6 +87,10 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
+import {
+  compactToolContent,
+  getToolContentCharLength,
+} from '@/utils/toolContent';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
@@ -1924,8 +1933,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       let finalMessages = messagesToUse;
       /** Tail snapshot for the dispatch-time usage delta: in-place
-       *  formatters (artifact appends, Bedrock content rewrites, legacy
-       *  string conversion) mutate without changing length or identity —
+       *  formatters (Bedrock content rewrites and legacy string conversion)
+       *  can mutate without changing length or identity —
        *  capture before they run. Legacy string conversion can also touch
        *  messages before the tail, so those convertible indices are
        *  tracked separately (none exist in the common case). */
@@ -1979,56 +1988,241 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           trimmed.length > 0 ? [{ type: 'text' as const, text: trimmed }] : '';
       }
 
+      const measureProviderPayload = (
+        candidate: BaseMessage[]
+      ): {
+        fits: boolean;
+        projectedMessageTokens?: number;
+        availableMessageTokens?: number;
+      } => {
+        if (
+          agentContext.tokenCounter == null ||
+          contextUsage?.contextBudget == null ||
+          contextUsage.effectiveInstructionTokens == null
+        ) {
+          return { fits: true };
+        }
+        let rawTokens = 3; // reply-primer allowance
+        for (const message of candidate) {
+          rawTokens += agentContext.tokenCounter(message);
+        }
+        const usageRatio =
+          contextUsage.calibrationRatio != null &&
+          contextUsage.calibrationRatio > 0
+            ? contextUsage.calibrationRatio
+            : agentContext.calibrationRatio;
+        const projectedMessageTokens = Math.round(rawTokens * usageRatio);
+        const availableMessageTokens = Math.max(
+          0,
+          contextUsage.contextBudget - contextUsage.effectiveInstructionTokens
+        );
+        return {
+          fits: projectedMessageTokens <= availableMessageTokens,
+          projectedMessageTokens,
+          availableMessageTokens,
+        };
+      };
+
+      const applyProviderMessageTransforms = (
+        candidate: BaseMessage[]
+      ): BaseMessage[] => {
+        let transformed = candidate;
+        if (
+          isThinkingEnabled(agentContext.provider, agentContext.clientOptions)
+        ) {
+          /**
+           * Current-run AI messages may validly omit a thinking block. The
+           * boundary prevents them from being mistaken for foreign history.
+           */
+          transformed = ensureThinkingBlockInMessages(
+            transformed,
+            agentContext.provider,
+            config,
+            this.startIndex
+          );
+        }
+
+        /**
+         * Tool-less destinations cannot send inherited tool blocks without a
+         * tool schema, so fold those interactions into provider-valid content.
+         */
+        if (toolsForBinding == null || toolsForBinding.length === 0) {
+          transformed = foldToolBlocksForToollessAgent(transformed, config);
+          if (agentContext.useLegacyContent) {
+            transformed = formatContentStrings(transformed);
+          }
+        }
+        return transformed;
+      };
+
+      const compactSyntheticProviderContext = (
+        candidate: BaseMessage[]
+      ): BaseMessage[] => {
+        const synthetic: Array<{
+          index: number;
+          message: HumanMessage;
+          chars: number;
+        }> = [];
+        for (let i = 0; i < candidate.length; i++) {
+          const message = candidate[i];
+          if (!(message instanceof HumanMessage)) {
+            continue;
+          }
+          const content = message.content;
+          let leadingText = '';
+          if (typeof content === 'string') {
+            leadingText = content;
+          } else if (
+            Array.isArray(content) &&
+            content[0]?.type === ContentTypes.TEXT &&
+            typeof content[0].text === 'string'
+          ) {
+            leadingText = content[0].text;
+          }
+          if (
+            !leadingText.startsWith('[Previous tool interaction]') &&
+            !leadingText.startsWith('[Previous agent context]')
+          ) {
+            continue;
+          }
+          synthetic.push({
+            index: i,
+            message,
+            chars: getToolContentCharLength(content),
+          });
+        }
+        if (synthetic.length === 0) {
+          return candidate;
+        }
+
+        const buildCandidate = (scale: number): BaseMessage[] => {
+          const compacted = [...candidate];
+          for (const { index, message, chars } of synthetic) {
+            const content = compactToolContent(
+              message.content,
+              Math.floor(chars * scale)
+            ).content;
+            compacted[index] = new HumanMessage({
+              content,
+              id: message.id,
+              name: message.name,
+              additional_kwargs: message.additional_kwargs,
+              response_metadata: message.response_metadata,
+            });
+          }
+          return compacted;
+        };
+
+        let best = buildCandidate(0);
+        if (!measureProviderPayload(best).fits) {
+          return candidate;
+        }
+        let low = 0;
+        let high = 1;
+        for (let i = 0; i < 12; i++) {
+          const scale = (low + high) / 2;
+          const attempt = buildCandidate(scale);
+          if (measureProviderPayload(attempt).fits) {
+            best = attempt;
+            low = scale;
+          } else {
+            high = scale;
+          }
+        }
+        return best;
+      };
+
+      let artifactBaseMessages: BaseMessage[] | undefined;
       if (lastMessageY instanceof ToolMessage) {
+        const maxArtifactPayloadChars = calculateMaxToolResultChars(
+          agentContext.maxContextTokens
+        );
+        let artifactCandidate = finalMessages;
         if (anthropicLike) {
-          formatAnthropicArtifactContent(finalMessages);
+          artifactCandidate = projectAnthropicArtifactContent(
+            finalMessages,
+            agentContext.maxToolResultChars ?? maxArtifactPayloadChars
+          );
         } else if (
           (isOpenAILike(agentContext.provider) &&
             agentContext.provider !== Providers.DEEPSEEK) ||
           isGoogleLike(agentContext.provider)
         ) {
-          formatArtifactPayload(finalMessages);
+          artifactCandidate = projectArtifactPayload(
+            finalMessages,
+            agentContext.maxToolResultChars ?? maxArtifactPayloadChars
+          );
+        }
+
+        if (artifactCandidate !== finalMessages) {
+          const projection = measureProviderPayload(artifactCandidate);
+          if (projection.fits) {
+            artifactBaseMessages = finalMessages;
+            finalMessages = artifactCandidate;
+          } else {
+            emitAgentLog(
+              config,
+              'warn',
+              'graph',
+              'Artifact payload omitted because it exceeds the remaining context budget',
+              {
+                projectedMessageTokens: projection.projectedMessageTokens,
+                availableMessageTokens: projection.availableMessageTokens,
+              },
+              { runId: this.runId, agentId }
+            );
+          }
         }
       }
 
-      if (
-        isThinkingEnabled(agentContext.provider, agentContext.clientOptions)
-      ) {
-        /**
-         * Pass `this.startIndex` so the function can distinguish CURRENT-run
-         * AI messages (the agent's own iterations — possibly without a
-         * leading thinking block, which Claude is allowed to skip) from
-         * historical context that genuinely needs the
-         * `[Previous agent context]` placeholder. Without this signal the
-         * function would convert the agent's own in-run tool_use messages,
-         * polluting the next iteration's prompt with a placeholder the
-         * model treats as suspicious injected content.
-         */
-        finalMessages = ensureThinkingBlockInMessages(
-          finalMessages,
-          agentContext.provider,
-          config,
-          this.startIndex
+      finalMessages = applyProviderMessageTransforms(finalMessages);
+      let finalProjection = measureProviderPayload(finalMessages);
+      if (artifactBaseMessages != null) {
+        if (!finalProjection.fits) {
+          finalMessages = applyProviderMessageTransforms(artifactBaseMessages);
+          finalProjection = measureProviderPayload(finalMessages);
+          emitAgentLog(
+            config,
+            'warn',
+            'graph',
+            'Artifact payload omitted after final provider formatting exceeded the remaining context budget',
+            {
+              projectedMessageTokens: finalProjection.projectedMessageTokens,
+              availableMessageTokens: finalProjection.availableMessageTokens,
+            },
+            { runId: this.runId, agentId }
+          );
+        }
+      }
+      if (!finalProjection.fits) {
+        const compacted = compactSyntheticProviderContext(finalMessages);
+        if (compacted !== finalMessages) {
+          finalMessages = compacted;
+          finalProjection = measureProviderPayload(finalMessages);
+          emitAgentLog(
+            config,
+            finalProjection.fits ? 'warn' : 'error',
+            'graph',
+            finalProjection.fits
+              ? 'Synthetic provider context compacted to fit the final payload budget'
+              : 'Final provider payload still exceeds budget after synthetic context compaction',
+            {
+              projectedMessageTokens: finalProjection.projectedMessageTokens,
+              availableMessageTokens: finalProjection.availableMessageTokens,
+            },
+            { runId: this.runId, agentId }
+          );
+        }
+      }
+      if (!finalProjection.fits) {
+        throw new Error(
+          JSON.stringify({
+            type: 'final_context_overflow',
+            info: 'Provider message formatting exceeded the context budget and no safe synthetic-context compaction could make it fit.',
+            projectedMessageTokens: finalProjection.projectedMessageTokens,
+            availableMessageTokens: finalProjection.availableMessageTokens,
+          })
         );
-      }
-
-      /**
-       * A destination that binds no tools is invoked without a tool schema, but
-       * in a multi-agent graph it can still inherit a prior agent's toolUse/
-       * toolResult history. Bedrock's Converse API (and other tool-schema-strict
-       * providers) reject such a request when no top-level toolConfig is sent.
-       * Fold that historical tool content into plain text so the tool-less agent
-       * receives valid, context-preserving messages. Handoff tools count as
-       * bound tools, so a tool-less router mid-handoff is not affected.
-       */
-      if (toolsForBinding == null || toolsForBinding.length === 0) {
-        finalMessages = foldToolBlocksForToollessAgent(finalMessages, config);
-        // The fold emits structured (array) content; re-flatten for agents that
-        // opted into string-only messages (`useLegacyContent`, run earlier at
-        // the top of this block) so the folded turn isn't the lone exception.
-        if (agentContext.useLegacyContent) {
-          finalMessages = formatContentStrings(finalMessages);
-        }
       }
 
       // Determine the prompt-cache strategy up front. Two distinct facts:

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2,6 +2,7 @@
 import { nanoid } from 'nanoid';
 import { tool } from '@langchain/core/tools';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
+import { ContextOverflowError } from '@langchain/core/errors';
 import { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import { START, END, StateGraph, Annotation } from '@langchain/langgraph';
 import {
@@ -32,11 +33,15 @@ import {
   isLegacyConvertible,
   CALIBRATION_RATIO_MAX,
   createPruneMessages,
+  projectToolCallInputs,
+  calculateMaxToolCallInputChars,
+  projectOpenAIToolMessageContent,
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
   resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
+  isSyntheticProviderContextMessage,
   getMessageId,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
@@ -71,6 +76,11 @@ import {
   getFallbackOverflowCandidates,
 } from '@/llm/invoke';
 import {
+  compactToolContent,
+  getToolContentCharLength,
+  serializeToolContentBounded,
+} from '@/utils/toolContent';
+import {
   Constants,
   GraphNodeKeys,
   ContentTypes,
@@ -78,6 +88,10 @@ import {
   Providers,
   StepTypes,
 } from '@/common';
+import {
+  annotateMessagesForLLM,
+  ToolOutputReferenceRegistry,
+} from '@/tools/toolOutputReferences';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
@@ -87,16 +101,11 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import {
-  compactToolContent,
-  getToolContentCharLength,
-} from '@/utils/toolContent';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
-import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
@@ -1756,6 +1765,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           provider: agentContext.provider,
           tokenCounter: agentContext.tokenCounter,
           maxTokens: agentContext.maxContextTokens,
+          maxToolResultChars: agentContext.maxToolResultChars,
           thinkingEnabled: isThinkingEnabled(
             agentContext.provider,
             agentContext.clientOptions
@@ -1963,6 +1973,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         finalMessages = formatContentStrings(finalMessages);
       }
 
+      const maxProviderToolResultChars =
+        agentContext.maxToolResultChars ??
+        calculateMaxToolResultChars(agentContext.maxContextTokens);
+      if (isOpenAILike(agentContext.provider)) {
+        finalMessages = projectOpenAIToolMessageContent(
+          finalMessages,
+          maxProviderToolResultChars
+        );
+      }
+      finalMessages = projectToolCallInputs(
+        finalMessages,
+        calculateMaxToolCallInputChars(agentContext.maxContextTokens)
+      );
+
       const lastMessageX =
         finalMessages.length >= 2
           ? finalMessages[finalMessages.length - 2]
@@ -2064,6 +2088,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         return transformed;
       };
 
+      const toolOutputRegistry = this.getOrCreateToolOutputRegistry();
+      const providerRunId = config.configurable?.run_id as string | undefined;
+      const projectProviderReferences = (
+        candidate: BaseMessage[]
+      ): BaseMessage[] =>
+        annotateMessagesForLLM(candidate, toolOutputRegistry, providerRunId);
+
       const compactSyntheticProviderContext = (
         candidate: BaseMessage[]
       ): BaseMessage[] => {
@@ -2074,26 +2105,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }> = [];
         for (let i = 0; i < candidate.length; i++) {
           const message = candidate[i];
-          if (!(message instanceof HumanMessage)) {
+          if (
+            !(message instanceof HumanMessage) ||
+            !isSyntheticProviderContextMessage(message)
+          ) {
             continue;
           }
           const content = message.content;
-          let leadingText = '';
-          if (typeof content === 'string') {
-            leadingText = content;
-          } else if (
-            Array.isArray(content) &&
-            content[0]?.type === ContentTypes.TEXT &&
-            typeof content[0].text === 'string'
-          ) {
-            leadingText = content[0].text;
-          }
-          if (
-            !leadingText.startsWith('[Previous tool interaction]') &&
-            !leadingText.startsWith('[Previous agent context]')
-          ) {
-            continue;
-          }
           synthetic.push({
             index: i,
             message,
@@ -2143,14 +2161,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       let artifactBaseMessages: BaseMessage[] | undefined;
       if (lastMessageY instanceof ToolMessage) {
-        const maxArtifactPayloadChars = calculateMaxToolResultChars(
-          agentContext.maxContextTokens
-        );
         let artifactCandidate = finalMessages;
         if (anthropicLike) {
           artifactCandidate = projectAnthropicArtifactContent(
             finalMessages,
-            agentContext.maxToolResultChars ?? maxArtifactPayloadChars
+            maxProviderToolResultChars
           );
         } else if (
           (isOpenAILike(agentContext.provider) &&
@@ -2159,7 +2174,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ) {
           artifactCandidate = projectArtifactPayload(
             finalMessages,
-            agentContext.maxToolResultChars ?? maxArtifactPayloadChars
+            maxProviderToolResultChars
           );
         }
 
@@ -2184,11 +2199,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
       }
 
-      finalMessages = applyProviderMessageTransforms(finalMessages);
+      finalMessages = projectProviderReferences(
+        applyProviderMessageTransforms(finalMessages)
+      );
       let finalProjection = measureProviderPayload(finalMessages);
       if (artifactBaseMessages != null) {
         if (!finalProjection.fits) {
-          finalMessages = applyProviderMessageTransforms(artifactBaseMessages);
+          finalMessages = projectProviderReferences(
+            applyProviderMessageTransforms(artifactBaseMessages)
+          );
           finalProjection = measureProviderPayload(finalMessages);
           emitAgentLog(
             config,
@@ -2223,17 +2242,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           );
         }
       }
-      if (!finalProjection.fits) {
-        throw new Error(
-          JSON.stringify({
-            type: 'final_context_overflow',
-            info: 'Provider message formatting exceeded the context budget and no safe synthetic-context compaction could make it fit.',
-            projectedMessageTokens: finalProjection.projectedMessageTokens,
-            availableMessageTokens: finalProjection.availableMessageTokens,
-          })
-        );
-      }
-
       // Determine the prompt-cache strategy up front. Two distinct facts:
       //
       //   `providerPromptCacheEnabled` — prompt caching is on for this provider
@@ -2347,6 +2355,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
+      /**
+       * Prompt-cache placement and orphan sanitization are provider-wire
+       * transforms too. Re-measure after both so no content added after the
+       * earlier artifact/synthetic compaction decision can bypass the guard.
+       */
+      finalProjection = measureProviderPayload(finalMessages);
+      const preInvokeContextOverflowError = !finalProjection.fits
+        ? new ContextOverflowError(
+          JSON.stringify({
+            type: 'final_context_overflow',
+            info: 'Provider message formatting exceeded the context budget and no safe synthetic-context compaction could make it fit.',
+            projectedMessageTokens: finalProjection.projectedMessageTokens,
+            availableMessageTokens: finalProjection.availableMessageTokens,
+          })
+        )
+        : undefined;
+
       if (
         agentContext.lastStreamCall != null &&
         agentContext.streamBuffer != null
@@ -2429,7 +2454,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             : 1;
         if (
           agentContext.tokenCounter != null &&
-          finalMessages.length !== messagesToUse.length
+          finalMessages !== messagesToUse
         ) {
           /** Post-prune formatting restructured the payload (e.g. thinking
            *  placeholder collapse, orphan drops) — recount so the gauge
@@ -2549,6 +2574,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const metadata = config.metadata as Record<string, unknown>;
 
       try {
+        if (preInvokeContextOverflowError != null) {
+          throw preInvokeContextOverflowError;
+        }
         result = await withLangfuseRuntimeScope(
           resolveLangfuseRuntimeScope({
             runLangfuse: this.langfuse,
@@ -2671,7 +2699,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             estimatedPromptTokens,
           });
         }
-
         /**
          * A fallback can reject the same prompt as too large even when the
          * primary failed for an unrelated reason — a fallback with a smaller
@@ -3368,6 +3395,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
 
     const { name, input: args, error } = data;
+    const eventValueLimit = calculateMaxToolResultChars();
+    const errorOutputPrefix = 'Error processing tool';
+    const errorDetail =
+      error?.message != null
+        ? `: ${serializeToolContentBounded(
+          error.message,
+          Math.max(0, eventValueLimit - errorOutputPrefix.length - 2)
+        )}`
+        : '';
 
     const runStep = graph.getRunStep(stepId);
     if (!runStep) {
@@ -3377,8 +3413,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const tool_call: t.ProcessedToolCall = {
       id: data.id,
       name: name || '',
-      args: typeof args === 'string' ? args : JSON.stringify(args),
-      output: `Error processing tool${error?.message != null ? `: ${error.message}` : ''}`,
+      args: serializeToolContentBounded(args, eventValueLimit),
+      output: `${errorOutputPrefix}${errorDetail}`,
       progress: 1,
     };
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -30,8 +30,8 @@ import {
   addBedrockTailCacheControl,
   projectArtifactPayload,
   formatContentStrings,
-  isLegacyConvertible,
   CALIBRATION_RATIO_MAX,
+  REPLY_PRIMER_TOKENS,
   createPruneMessages,
   projectToolCallInputs,
   calculateMaxToolCallInputChars,
@@ -140,26 +140,6 @@ function createToolHandlerRegistry(
   const registry = new HandlerRegistry();
   registry.register(GraphEvents.ON_TOOL_EXECUTE, toolHandler);
   return registry;
-}
-
-/**
- * Start index of the span post-prune formatters can mutate in place: the
- * trailing tool batch plus its owning AI message (artifact formatting touches
- * every tool result after the last AI tool call; Bedrock rewrites the AI
- * message before a trailing tool result). Capped so the usage-snapshot
- * recount stays constant-cost.
- */
-function trailingMutationStart(messages: BaseMessage[]): number {
-  const MAX_SPAN = 16;
-  let index = messages.length - 1;
-  while (
-    index >= 0 &&
-    messages[index]?.getType() === 'tool' &&
-    messages.length - index < MAX_SPAN
-  ) {
-    index--;
-  }
-  return Math.max(0, Math.min(index, messages.length - 2));
 }
 
 type ReasoningKey = 'reasoning_content' | 'reasoning';
@@ -1942,49 +1922,136 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       let finalMessages = messagesToUse;
-      /** Tail snapshot for the dispatch-time usage delta: in-place
-       *  formatters (Bedrock content rewrites and legacy string conversion)
-       *  can mutate without changing length or identity —
-       *  capture before they run. Legacy string conversion can also touch
-       *  messages before the tail, so those convertible indices are
-       *  tracked separately (none exist in the common case). */
-      const tailStart = trailingMutationStart(messagesToUse);
-      let preFormatTailTokens: number | null = null;
-      let legacyIndices: number[] | null = null;
-      let preFormatLegacyTokens = 0;
+      /**
+       * Keep the pruner's provider-grounded aggregate as the authoritative
+       * baseline, then attribute it across retained messages. Provider
+       * transforms can shrink one message while expanding or adding another;
+       * per-origin accounting prevents that unrelated shrink from canceling
+       * the expansion. Raw counts are frozen before in-place formatters run.
+       */
+      let providerMessageBaseline:
+        | Array<{ rawTokens: number; accountingWeight: number }>
+        | undefined;
+      const providerMessageOrigins = new WeakMap<BaseMessage, number>();
       if (contextUsage != null && agentContext.tokenCounter != null) {
-        preFormatTailTokens = 0;
-        for (const message of messagesToUse.slice(tailStart)) {
-          preFormatTailTokens += agentContext.tokenCounter(message);
+        const sourceIndices = new WeakMap<BaseMessage, number>();
+        for (let i = 0; i < messages.length; i++) {
+          sourceIndices.set(messages[i], i);
         }
-        if (agentContext.useLegacyContent) {
-          legacyIndices = [];
-          for (let i = 0; i < tailStart; i++) {
-            if (isLegacyConvertible(messagesToUse[i])) {
-              legacyIndices.push(i);
-              preFormatLegacyTokens += agentContext.tokenCounter(
-                messagesToUse[i]
-              );
+        providerMessageBaseline = messagesToUse.map((message, index) => {
+          const rawTokens = agentContext.tokenCounter!(message);
+          const sourceIndex = sourceIndices.get(message);
+          const indexedTokens =
+            sourceIndex != null
+              ? agentContext.indexTokenCountMap[sourceIndex]
+              : undefined;
+          const accountingWeight =
+            indexedTokens != null &&
+            Number.isFinite(indexedTokens) &&
+            indexedTokens >= 0
+              ? indexedTokens
+              : rawTokens;
+          if (!providerMessageOrigins.has(message)) {
+            providerMessageOrigins.set(message, index);
+          }
+          return { rawTokens, accountingWeight };
+        });
+      }
+
+      const getProviderMessageOriginKey = (
+        message: BaseMessage
+      ): string | undefined => {
+        const type = message.getType();
+        if (
+          message instanceof ToolMessage &&
+          typeof message.tool_call_id === 'string' &&
+          message.tool_call_id.length > 0
+        ) {
+          return `tool:call:${message.tool_call_id}`;
+        }
+        if (typeof message.id === 'string' && message.id.length > 0) {
+          return `${type}:id:${message.id}`;
+        }
+        return undefined;
+      };
+
+      /**
+       * Provider projections clone messages. Preserve their baseline origin
+       * without writing tracking metadata onto the wire. Synthetic fold
+       * messages intentionally remain unattributed and are charged in full.
+       */
+      const trackProviderMessageOrigins = (
+        before: BaseMessage[],
+        after: BaseMessage[]
+      ): BaseMessage[] => {
+        if (providerMessageBaseline == null || before === after) {
+          return after;
+        }
+        if (before.length === after.length) {
+          for (let i = 0; i < after.length; i++) {
+            const origin = providerMessageOrigins.get(before[i]);
+            if (
+              origin != null &&
+              !providerMessageOrigins.has(after[i]) &&
+              before[i].getType() === after[i].getType() &&
+              !isSyntheticProviderContextMessage(after[i])
+            ) {
+              providerMessageOrigins.set(after[i], origin);
             }
           }
+          return after;
         }
-      }
+
+        const keyedOrigins = new Map<string, number | null>();
+        for (const message of before) {
+          const origin = providerMessageOrigins.get(message);
+          const key = getProviderMessageOriginKey(message);
+          if (origin == null || key == null) {
+            continue;
+          }
+          keyedOrigins.set(key, keyedOrigins.has(key) ? null : origin);
+        }
+        for (const message of after) {
+          if (
+            providerMessageOrigins.has(message) ||
+            isSyntheticProviderContextMessage(message)
+          ) {
+            continue;
+          }
+          const key = getProviderMessageOriginKey(message);
+          const origin = key != null ? keyedOrigins.get(key) : undefined;
+          if (origin != null) {
+            providerMessageOrigins.set(message, origin);
+          }
+        }
+        return after;
+      };
+
       if (agentContext.useLegacyContent) {
-        finalMessages = formatContentStrings(finalMessages);
+        const before = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          before,
+          formatContentStrings(before)
+        );
       }
 
       const maxProviderToolResultChars =
         agentContext.maxToolResultChars ??
         calculateMaxToolResultChars(agentContext.maxContextTokens);
       if (isOpenAILike(agentContext.provider)) {
-        finalMessages = projectOpenAIToolMessageContent(
-          finalMessages,
-          maxProviderToolResultChars
+        const before = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          before,
+          projectOpenAIToolMessageContent(before, maxProviderToolResultChars)
         );
       }
-      finalMessages = projectToolCallInputs(
-        finalMessages,
-        calculateMaxToolCallInputChars(agentContext.maxContextTokens)
+      const beforeToolInputProjection = finalMessages;
+      finalMessages = trackProviderMessageOrigins(
+        beforeToolInputProjection,
+        projectToolCallInputs(
+          beforeToolInputProjection,
+          calculateMaxToolCallInputChars(agentContext.maxContextTokens)
+        )
       );
 
       const lastMessageX =
@@ -2030,25 +2097,84 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           0,
           contextUsage.contextBudget - contextUsage.effectiveInstructionTokens
         );
-        // The dedicated empty-prompt guard below provides actionable
-        // instruction/tool-budget guidance; there is no provider payload yet.
-        if (candidate.length === 0) {
-          return {
-            fits: true,
-            projectedMessageTokens: 0,
-            availableMessageTokens,
-          };
-        }
-        let rawTokens = 3; // reply-primer allowance
-        for (const message of candidate) {
-          rawTokens += agentContext.tokenCounter(message);
-        }
-        const usageRatio =
+        let usageRatio =
+          agentContext.calibrationRatio > 0 ? agentContext.calibrationRatio : 1;
+        if (
           contextUsage.calibrationRatio != null &&
           contextUsage.calibrationRatio > 0
-            ? contextUsage.calibrationRatio
-            : agentContext.calibrationRatio;
-        const projectedMessageTokens = Math.round(rawTokens * usageRatio);
+        ) {
+          usageRatio = contextUsage.calibrationRatio;
+        }
+        const baselineRemaining = contextUsage.remainingContextTokens;
+        const accountedMessageTokens =
+          providerMessageBaseline != null &&
+          baselineRemaining != null &&
+          Number.isFinite(baselineRemaining)
+            ? availableMessageTokens -
+              Math.min(availableMessageTokens, Math.max(0, baselineRemaining))
+            : undefined;
+
+        let projectedMessageTokens: number;
+        if (accountedMessageTokens != null && providerMessageBaseline != null) {
+          const replyPrimerTokens = Math.round(
+            REPLY_PRIMER_TOKENS * usageRatio
+          );
+          const rawWeights: Record<string, number> = {};
+          let totalWeight = 0;
+          for (let i = 0; i < providerMessageBaseline.length; i++) {
+            const weight = providerMessageBaseline[i].accountingWeight;
+            rawWeights[i] = weight;
+            totalWeight += weight;
+          }
+          const attributableTokens =
+            totalWeight > 0
+              ? Math.min(
+                Math.max(0, accountedMessageTokens - replyPrimerTokens),
+                Math.round(totalWeight * usageRatio)
+              )
+              : 0;
+          const apportionedTokens =
+            totalWeight > 0
+              ? apportionTokenCounts(
+                rawWeights,
+                attributableTokens / totalWeight,
+                attributableTokens
+              )
+              : {};
+          const attributedByOrigin = providerMessageBaseline.map(
+            (_, origin) => apportionedTokens[origin] || 0
+          );
+          projectedMessageTokens = Math.max(
+            replyPrimerTokens,
+            accountedMessageTokens - attributableTokens
+          );
+          let newRawTokens = 0;
+          const usedOrigins = new Set<number>();
+          for (const message of candidate) {
+            const rawTokens = agentContext.tokenCounter(message);
+            const origin = providerMessageOrigins.get(message);
+            if (origin == null || usedOrigins.has(origin)) {
+              newRawTokens += rawTokens;
+              continue;
+            }
+            usedOrigins.add(origin);
+            projectedMessageTokens += Math.max(
+              0,
+              attributedByOrigin[origin] +
+                Math.round(
+                  (rawTokens - providerMessageBaseline[origin].rawTokens) *
+                    usageRatio
+                )
+            );
+          }
+          projectedMessageTokens += Math.round(newRawTokens * usageRatio);
+        } else {
+          let rawTokens = REPLY_PRIMER_TOKENS;
+          for (const message of candidate) {
+            rawTokens += agentContext.tokenCounter(message);
+          }
+          projectedMessageTokens = Math.round(rawTokens * usageRatio);
+        }
         return {
           fits: projectedMessageTokens <= availableMessageTokens,
           projectedMessageTokens,
@@ -2067,11 +2193,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            * Current-run AI messages may validly omit a thinking block. The
            * boundary prevents them from being mistaken for foreign history.
            */
-          transformed = ensureThinkingBlockInMessages(
-            transformed,
-            agentContext.provider,
-            config,
-            this.startIndex
+          const before = transformed;
+          transformed = trackProviderMessageOrigins(
+            before,
+            ensureThinkingBlockInMessages(
+              before,
+              agentContext.provider,
+              config,
+              this.startIndex
+            )
           );
         }
 
@@ -2080,9 +2210,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * tool schema, so fold those interactions into provider-valid content.
          */
         if (toolsForBinding == null || toolsForBinding.length === 0) {
-          transformed = foldToolBlocksForToollessAgent(transformed, config);
+          const before = transformed;
+          transformed = trackProviderMessageOrigins(
+            before,
+            foldToolBlocksForToollessAgent(before, config)
+          );
           if (agentContext.useLegacyContent) {
-            transformed = formatContentStrings(transformed);
+            const beforeLegacyFormat = transformed;
+            transformed = trackProviderMessageOrigins(
+              beforeLegacyFormat,
+              formatContentStrings(beforeLegacyFormat)
+            );
           }
         }
         return transformed;
@@ -2093,7 +2231,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const projectProviderReferences = (
         candidate: BaseMessage[]
       ): BaseMessage[] =>
-        annotateMessagesForLLM(candidate, toolOutputRegistry, providerRunId);
+        trackProviderMessageOrigins(
+          candidate,
+          annotateMessagesForLLM(candidate, toolOutputRegistry, providerRunId)
+        );
 
       const compactSyntheticProviderContext = (
         candidate: BaseMessage[]
@@ -2163,18 +2304,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (lastMessageY instanceof ToolMessage) {
         let artifactCandidate = finalMessages;
         if (anthropicLike) {
-          artifactCandidate = projectAnthropicArtifactContent(
+          artifactCandidate = trackProviderMessageOrigins(
             finalMessages,
-            maxProviderToolResultChars
+            projectAnthropicArtifactContent(
+              finalMessages,
+              maxProviderToolResultChars
+            )
           );
         } else if (
           (isOpenAILike(agentContext.provider) &&
             agentContext.provider !== Providers.DEEPSEEK) ||
           isGoogleLike(agentContext.provider)
         ) {
-          artifactCandidate = projectArtifactPayload(
+          artifactCandidate = trackProviderMessageOrigins(
             finalMessages,
-            maxProviderToolResultChars
+            projectArtifactPayload(finalMessages, maxProviderToolResultChars)
           );
         }
 
@@ -2294,7 +2438,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           providerPromptCacheEnabled);
       if (needsOrphanSanitize) {
         const beforeSanitize = finalMessages.length;
-        finalMessages = sanitizeOrphanToolBlocks(finalMessages);
+        const beforeSanitizeMessages = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          beforeSanitizeMessages,
+          sanitizeOrphanToolBlocks(beforeSanitizeMessages, (source, clone) => {
+            const origin = providerMessageOrigins.get(source);
+            if (origin != null) {
+              providerMessageOrigins.set(clone, origin);
+            }
+          })
+        );
         if (finalMessages.length !== beforeSanitize) {
           emitAgentLog(
             config,
@@ -2324,20 +2477,24 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         (anthropicPromptCacheEnabled || openRouterPromptCacheEnabled) &&
         !agentContext.systemRunnable
       ) {
-        finalMessages = addTailCacheControl<BaseMessage>(
-          finalMessages,
-          resolvePromptCacheTtl(
-            anthropicPromptCacheEnabled
-              ? (
-                  agentContext.clientOptions as
-                    | t.AnthropicClientOptions
-                    | undefined
-              )?.promptCacheTtl
-              : (
-                  agentContext.clientOptions as
-                    | t.ProviderOptionsMap[Providers.OPENROUTER]
-                    | undefined
-              )?.promptCacheTtl
+        const beforeCacheControl = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          beforeCacheControl,
+          addTailCacheControl<BaseMessage>(
+            beforeCacheControl,
+            resolvePromptCacheTtl(
+              anthropicPromptCacheEnabled
+                ? (
+                    agentContext.clientOptions as
+                      | t.AnthropicClientOptions
+                      | undefined
+                )?.promptCacheTtl
+                : (
+                    agentContext.clientOptions as
+                      | t.ProviderOptionsMap[Providers.OPENROUTER]
+                      | undefined
+                )?.promptCacheTtl
+            )
           )
         );
       } else if (bedrockPromptCacheEnabled) {
@@ -2346,11 +2503,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           | undefined;
         // Non-Claude models (Nova) reject the extended 1h TTL, so resolve it
         // against the model — message/system caching stays on, clamped to 5m.
-        finalMessages = addBedrockTailCacheControl<BaseMessage>(
-          finalMessages,
-          resolveBedrockPromptCacheTtl(
-            bedrockOptions?.promptCacheTtl,
-            (bedrockOptions as { model?: string } | undefined)?.model
+        const beforeCacheControl = finalMessages;
+        finalMessages = trackProviderMessageOrigins(
+          beforeCacheControl,
+          addBedrockTailCacheControl<BaseMessage>(
+            beforeCacheControl,
+            resolveBedrockPromptCacheTtl(
+              bedrockOptions?.promptCacheTtl,
+              (bedrockOptions as { model?: string } | undefined)?.model
+            )
           )
         );
       }
@@ -2447,66 +2608,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       /** Past the empty-prompt guard — a model call is now guaranteed */
       if (contextUsage != null) {
-        const usageRatio =
-          contextUsage.calibrationRatio != null &&
-          contextUsage.calibrationRatio > 0
-            ? contextUsage.calibrationRatio
-            : 1;
         if (
-          agentContext.tokenCounter != null &&
-          finalMessages !== messagesToUse
+          finalProjection.projectedMessageTokens != null &&
+          finalProjection.availableMessageTokens != null
         ) {
-          /** Post-prune formatting restructured the payload (e.g. thinking
-           *  placeholder collapse, orphan drops) — recount so the gauge
-           *  reflects what is actually sent */
-          let rawTokens = 0;
-          for (const message of finalMessages) {
-            rawTokens += agentContext.tokenCounter(message);
-          }
           contextUsage.breakdown.messageCount = finalMessages.length;
-          if (
-            contextUsage.contextBudget != null &&
-            contextUsage.effectiveInstructionTokens != null
-          ) {
-            contextUsage.remainingContextTokens = Math.max(
-              0,
-              contextUsage.contextBudget -
-                contextUsage.effectiveInstructionTokens -
-                Math.round(rawTokens * usageRatio)
-            );
-          }
-        } else if (
-          preFormatTailTokens != null &&
-          agentContext.tokenCounter != null &&
-          contextUsage.remainingContextTokens != null
-        ) {
-          /** Same-length formatting can still mutate in place — the trailing
-           *  tool batch (artifacts, Bedrock rewrites) and any legacy-converted
-           *  messages before it — adjust remaining by the calibrated delta */
-          let postFormatTailTokens = 0;
-          for (const message of finalMessages.slice(tailStart)) {
-            postFormatTailTokens += agentContext.tokenCounter(message);
-          }
-          let formatDelta = postFormatTailTokens - preFormatTailTokens;
-          if (legacyIndices != null && legacyIndices.length > 0) {
-            let postFormatLegacyTokens = 0;
-            for (const index of legacyIndices) {
-              postFormatLegacyTokens += agentContext.tokenCounter(
-                finalMessages[index]
-              );
-            }
-            formatDelta += postFormatLegacyTokens - preFormatLegacyTokens;
-          }
-          if (formatDelta !== 0) {
-            contextUsage.remainingContextTokens = Math.max(
-              0,
-              Math.min(
-                contextUsage.contextBudget ?? Number.MAX_SAFE_INTEGER,
-                contextUsage.remainingContextTokens -
-                  Math.round(formatDelta * usageRatio)
-              )
-            );
-          }
+          contextUsage.remainingContextTokens = Math.max(
+            0,
+            finalProjection.availableMessageTokens -
+              finalProjection.projectedMessageTokens
+          );
         }
         syncBudgetDerivedFields(contextUsage);
         /** Awaited so async host handlers receive the pre-invoke snapshot

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2078,6 +2078,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           trimmed.length > 0 ? [{ type: 'text' as const, text: trimmed }] : '';
       }
 
+      const localProviderOverflowMeasurements = new WeakMap<
+        object,
+        {
+          contextBudget: number;
+          estimatedPromptTokens: number;
+        }
+      >();
       const measureProviderPayload = (
         candidate: BaseMessage[],
         contextBudgetOverride?: number,
@@ -2086,6 +2093,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         fits: boolean;
         projectedMessageTokens?: number;
         availableMessageTokens?: number;
+        contextBudget?: number;
+        effectiveInstructionTokens?: number;
       } => {
         const contextBudget =
           contextBudgetOverride ?? contextUsage?.contextBudget;
@@ -2189,7 +2198,42 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           fits: projectedMessageTokens <= availableMessageTokens,
           projectedMessageTokens,
           availableMessageTokens,
+          contextBudget,
+          effectiveInstructionTokens,
         };
+      };
+
+      const createProviderPayloadOverflowError = ({
+        projection,
+        provider,
+        info,
+      }: {
+        projection: ReturnType<typeof measureProviderPayload>;
+        provider?: Providers;
+        info: string;
+      }): ContextOverflowError => {
+        const error = new ContextOverflowError(
+          JSON.stringify({
+            type: 'final_context_overflow',
+            info,
+            provider,
+            projectedMessageTokens: projection.projectedMessageTokens,
+            availableMessageTokens: projection.availableMessageTokens,
+          })
+        );
+        if (
+          projection.projectedMessageTokens != null &&
+          projection.contextBudget != null &&
+          projection.effectiveInstructionTokens != null
+        ) {
+          localProviderOverflowMeasurements.set(error, {
+            contextBudget: projection.contextBudget,
+            estimatedPromptTokens:
+              projection.projectedMessageTokens +
+              projection.effectiveInstructionTokens,
+          });
+        }
+        return error;
       };
 
       const applyProviderMessageTransforms = (
@@ -2546,14 +2590,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        */
       finalProjection = measureProviderPayload(finalMessages);
       const preInvokeContextOverflowError = !finalProjection.fits
-        ? new ContextOverflowError(
-          JSON.stringify({
-            type: 'final_context_overflow',
-            info: 'Provider message formatting exceeded the context budget and no safe synthetic-context compaction could make it fit.',
-            projectedMessageTokens: finalProjection.projectedMessageTokens,
-            availableMessageTokens: finalProjection.availableMessageTokens,
-          })
-        )
+        ? createProviderPayloadOverflowError({
+          projection: finalProjection,
+          provider: agentContext.provider,
+          info: 'Provider message formatting exceeded the context budget and no safe synthetic-context compaction could make it fit.',
+        })
         : undefined;
 
       if (
@@ -2748,15 +2789,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          */
         const estimatedPromptTokens = getEstimatedPromptTokens(contextUsage);
 
-        /**
-         * A previous correction that left the prompt no smaller proves this
-         * state has nothing left to compact — an emptied message list whose
-         * content rides along in an injected summary, for instance. Measuring
-         * that beats trying to predict every such configuration.
-         */
-        const recoveryStalled = agentContext.overflowRecoveryStalled(
-          estimatedPromptTokens
-        );
         const canSummarizeOverflow =
           agentContext.summarizationEnabled === true &&
           splitAtRecencyBoundary(messages, {
@@ -2767,13 +2799,36 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             tokenCounter: agentContext.tokenCounter,
           }).head.length > 0;
 
+        const getLocalProviderOverflowMeasurement = (
+          error: unknown
+        ):
+          | {
+              contextBudget: number;
+              estimatedPromptTokens: number;
+            }
+          | undefined =>
+          typeof error === 'object' && error !== null
+            ? localProviderOverflowMeasurements.get(error)
+            : undefined;
+
+        const getRecoveryPromptEstimate = (
+          error: unknown,
+          fallbackContext?: FallbackErrorContext
+        ): number | undefined => {
+          const resolvedFallbackContext =
+            fallbackContext ?? getFallbackErrorContext(error);
+          return (
+            getLocalProviderOverflowMeasurement(error)?.estimatedPromptTokens ??
+            (resolvedFallbackContext == null
+              ? estimatedPromptTokens
+              : undefined)
+          );
+        };
+
         const planRecovery = (
           error: unknown,
           attributedFallbackContext?: FallbackErrorContext
         ): OverflowRecoveryPlan | null => {
-          if (recoveryStalled) {
-            return null;
-          }
           /**
            * When the rejection came from a fallback, plan against *that*
            * client: its window and output allowance are why it was configured
@@ -2781,13 +2836,28 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            */
           const fallbackContext =
             attributedFallbackContext ?? getFallbackErrorContext(error);
+          const localMeasurement = getLocalProviderOverflowMeasurement(error);
+          const recoveryPromptEstimate = getRecoveryPromptEstimate(
+            error,
+            fallbackContext
+          );
+          /**
+           * A previous correction that left the rejected prompt no smaller
+           * proves this state has nothing left to compact. Use the fallback
+           * projection when one exists so unlike provider formats are never
+           * compared through the primary's cheaper pre-projection estimate.
+           */
+          if (agentContext.overflowRecoveryStalled(recoveryPromptEstimate)) {
+            return null;
+          }
           const recovery = planContextOverflowRecovery({
             error,
             provider: fallbackContext?.provider ?? agentContext.provider,
             maxContextTokens:
+              localMeasurement?.contextBudget ??
               fallbackContext?.maxContextTokens ??
               agentContext.maxContextTokens,
-            estimatedPromptTokens,
+            estimatedPromptTokens: recoveryPromptEstimate,
             calibrationRatio: agentContext.calibrationRatio,
             instructionTokens: agentContext.instructionTokens,
             canSummarize: agentContext.summarizationEnabled === true,
@@ -2805,12 +2875,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 ...recovery,
                 budgetTokens: minDefined(
                   getBlindRecoveryBudget(agentContext.maxContextTokens),
-                  translateRecoveryBudget(
-                    recovery.budgetTokens,
-                    recovery.observedCalibrationRatio ??
-                        CALIBRATION_RATIO_MAX,
-                    agentContext.calibrationRatio
-                  )
+                  localMeasurement != null
+                    ? recovery.budgetTokens
+                    : translateRecoveryBudget(
+                      recovery.budgetTokens,
+                      recovery.observedCalibrationRatio ??
+                            CALIBRATION_RATIO_MAX,
+                      agentContext.calibrationRatio
+                    )
                 ),
                 observedCalibrationRatio: undefined,
               }
@@ -2824,13 +2896,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
         const recovery = planRecovery(primaryError);
         if (recovery != null) {
+          const recoveryPromptEstimate =
+            getRecoveryPromptEstimate(primaryError);
           return this.beginOverflowRecovery({
             recovery,
             agentContext,
             agentId,
             config,
             originalToolContent: prunedOriginalToolContent,
-            estimatedPromptTokens,
+            estimatedPromptTokens: recoveryPromptEstimate,
           });
         }
         /**
@@ -2899,17 +2973,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                     true
                   );
                   if (!projection.fits) {
-                    throw new ContextOverflowError(
-                      JSON.stringify({
-                        type: 'final_context_overflow',
-                        info: 'Fallback provider message formatting exceeded the context budget before invocation.',
-                        provider: fallbackProvider,
-                        projectedMessageTokens:
-                          projection.projectedMessageTokens,
-                        availableMessageTokens:
-                          projection.availableMessageTokens,
-                      })
-                    );
+                    throw createProviderPayloadOverflowError({
+                      projection,
+                      provider: fallbackProvider,
+                      info: 'Fallback provider message formatting exceeded the context budget before invocation.',
+                    });
                   }
                   return projectedFallbackMessages;
                 },
@@ -2919,14 +2987,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const overflowCandidates =
             getFallbackOverflowCandidates(fallbackError);
           let fallbackRecovery: OverflowRecoveryPlan | null = null;
+          let fallbackRecoveryPromptEstimate: number | undefined;
           for (const candidate of overflowCandidates) {
             fallbackRecovery = planRecovery(candidate.error, candidate.context);
             if (fallbackRecovery != null) {
+              fallbackRecoveryPromptEstimate = getRecoveryPromptEstimate(
+                candidate.error,
+                candidate.context
+              );
               break;
             }
           }
           if (overflowCandidates.length === 0) {
             fallbackRecovery = planRecovery(fallbackError);
+            fallbackRecoveryPromptEstimate =
+              getRecoveryPromptEstimate(fallbackError);
           }
           if (fallbackRecovery == null) {
             throw fallbackError;
@@ -2937,7 +3012,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             agentId,
             config,
             originalToolContent: prunedOriginalToolContent,
-            estimatedPromptTokens,
+            estimatedPromptTokens: fallbackRecoveryPromptEstimate,
           });
         }
       } finally {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -18,7 +18,8 @@ import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { ToolRuntime } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { serializeToolContent } from '@/utils/toolContent';
+import { serializeToolContentBounded } from '@/utils/toolContent';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { StandardGraph } from './Graph';
 import { Constants } from '@/common';
 
@@ -724,7 +725,10 @@ export class MultiAgentGraph extends StandardGraph {
     const contentStr =
       typeof toolMessage.content === 'string'
         ? toolMessage.content
-        : serializeToolContent(toolMessage.content);
+        : serializeToolContentBounded(
+          toolMessage.content,
+          HARD_MAX_TOOL_RESULT_CHARS
+        );
 
     const structuredInstructions =
       toolMessage.additional_kwargs[HANDOFF_INSTRUCTIONS_KEY];

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -18,6 +18,7 @@ import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { ToolRuntime } from '@langchain/core/tools';
 import type * as t from '@/types';
+import { serializeToolContent } from '@/utils/toolContent';
 import { StandardGraph } from './Graph';
 import { Constants } from '@/common';
 
@@ -723,7 +724,7 @@ export class MultiAgentGraph extends StandardGraph {
     const contentStr =
       typeof toolMessage.content === 'string'
         ? toolMessage.content
-        : JSON.stringify(toolMessage.content);
+        : serializeToolContent(toolMessage.content);
 
     const structuredInstructions =
       toolMessage.additional_kwargs[HANDOFF_INSTRUCTIONS_KEY];

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -117,6 +117,7 @@ async function createRun(options: {
   tools?: t.GraphTools;
   maxToolResultChars?: number;
   model?: string;
+  promptCache?: boolean;
   toolOutputReferences?: t.ToolOutputReferencesConfig;
 }): Promise<Run<t.IState>> {
   return Run.create<t.IState>({
@@ -126,6 +127,7 @@ async function createRun(options: {
       llmConfig: {
         provider: options.provider ?? Providers.ANTHROPIC,
         ...(options.model != null ? { model: options.model } : {}),
+        ...(options.promptCache === true ? { promptCache: true } : {}),
         disableStreaming: true,
         streamUsage: false,
       },
@@ -444,6 +446,243 @@ describe('context overflow recovery', () => {
     expect(
       run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
     ).toBe(0);
+  });
+
+  it('trusts the pruner baseline for an unchanged payload at high calibration', async () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('earlier question'),
+      new AIMessage('provider-counted answer'),
+      new HumanMessage('latest question'),
+    ];
+    const localCounter: t.TokenCounter = (message) =>
+      message.getType() === 'ai' ? 120 : 5;
+    const providerGroundedTokenMap = { 0: 5, 1: 10, 2: 5 };
+    const run = await createRun({
+      runId: 'provider-grounded-final-projection',
+      maxContextTokens: 200,
+      tokenCounter: localCounter,
+      indexTokenCountMap: providerGroundedTokenMap,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    agentContext.calibrationRatio = 5;
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream({ messages }, streamConfig);
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.calls).toHaveLength(1);
+    expect(model.calls[0]).toHaveLength(messages.length);
+    expect(agentContext.overflowRecoveryAttempts).toBe(0);
+  });
+
+  it('does not let an unrelated provider-format shrink hide artifact growth', async () => {
+    const toolCallId = 'tc-artifact-independent-growth';
+    const artifactSentinel = 'ARTIFACT_INDEPENDENT_GROWTH_SENTINEL';
+    const toolMessage = new ToolMessage({
+      content: 'rendered',
+      tool_call_id: toolCallId,
+      name: 'render_report',
+      artifact: {
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: artifactSentinel,
+          },
+        ],
+      },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('render the report'),
+      new AIMessageChunk({
+        content: 'calling render_report',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'render_report',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const transformCounter: t.TokenCounter = (message) => {
+      if (
+        message instanceof AIMessageChunk &&
+        typeof message.content === 'string'
+      ) {
+        return 100;
+      }
+      if (
+        message instanceof ToolMessage &&
+        JSON.stringify(message.content).includes(artifactSentinel)
+      ) {
+        return 50;
+      }
+      return 1;
+    };
+    const run = await createRun({
+      runId: 'artifact-independent-transform-growth',
+      maxContextTokens: 50,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: transformCounter,
+      indexTokenCountMap: { 0: 1, 1: 1, 2: 1 },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'render_report',
+          description: 'Renders a report',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      JSON.stringify(model.calls[0].map((message) => message.content))
+    ).not.toContain(artifactSentinel);
+    expect(toolMessage.artifact.content[0].text).toBe(artifactSentinel);
+  });
+
+  it('preserves provider attribution for an un-IDd AI clone during orphan sanitization', async () => {
+    const droppedCallId = 'tc-dropped-ai';
+    const missingCallId = 'tc-missing-result';
+    const unrelatedResultId = 'tc-unrelated-result';
+    const messages: BaseMessage[] = [
+      new HumanMessage('earlier question'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: droppedCallId,
+            name: 'declared_tool',
+            input: {},
+          },
+        ],
+        tool_calls: [
+          {
+            id: droppedCallId,
+            name: 'declared_tool',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new AIMessage({
+        content: 'provider-counted answer',
+        tool_calls: [
+          {
+            id: missingCallId,
+            name: 'declared_tool',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'orphaned result',
+        tool_call_id: unrelatedResultId,
+        name: 'declared_tool',
+      }),
+      new HumanMessage('latest question'),
+    ];
+    const skewedCounter: t.TokenCounter = (message) => {
+      if (message.getType() !== 'ai') {
+        return 5;
+      }
+      return Array.isArray(message.content) ? 1 : 120;
+    };
+    const run = await createRun({
+      runId: 'orphan-sanitize-provider-origin',
+      maxContextTokens: 1_000,
+      provider: Providers.ANTHROPIC,
+      promptCache: true,
+      tokenCounter: skewedCounter,
+      indexTokenCountMap: { 0: 5, 1: 80, 2: 10, 3: 5, 4: 5 },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'declared_tool',
+          description: 'Declared only to prevent tool-less folding',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const agentContext = run.Graph.agentContexts.get('default');
+    if (agentContext == null) {
+      throw new Error('Expected default agent context');
+    }
+    agentContext.calibrationRatio = 5;
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream({ messages }, streamConfig);
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.calls).toHaveLength(1);
+    expect(model.calls[0]).toHaveLength(3);
+    expect(model.calls[0].some((message) => message.getType() === 'tool')).toBe(
+      false
+    );
+    const sanitizedAI = model.calls[0].find(
+      (message) => message.getType() === 'ai'
+    ) as AIMessage | undefined;
+    expect(sanitizedAI?.content).toBe('provider-counted answer');
+    expect(sanitizedAI?.tool_calls ?? []).toHaveLength(0);
+    expect(agentContext.overflowRecoveryAttempts).toBe(0);
+  });
+
+  it('reserves the reply primer before accepting fast-path context', async () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('earlier question'),
+      new AIMessage('earlier answer'),
+      new HumanMessage('latest question'),
+    ];
+    const run = await createRun({
+      runId: 'fast-path-reply-primer',
+      maxContextTokens: 100,
+      tokenCounter: () => 31,
+      indexTokenCountMap: { 0: 31, 1: 31, 2: 31 },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    expect(model.calls[0].length).toBeLessThan(messages.length);
+    expect(3 + model.calls[0].length * 31).toBeLessThanOrEqual(95);
   });
 
   it('includes artifact expansion when it fits the post-prune budget', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
 import { MemorySaver } from '@langchain/langgraph';
 import { describe, expect, it } from '@jest/globals';
 import { Runnable } from '@langchain/core/runnables';
@@ -5,11 +7,12 @@ import {
   AIMessageChunk,
   HumanMessage,
   AIMessage,
+  ToolMessage,
 } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
-import { GraphEvents, Providers } from '@/common';
+import { ContentTypes, GraphEvents, Providers } from '@/common';
 import { Run } from '@/run';
 
 /**
@@ -64,6 +67,36 @@ class OverflowThenSucceedModel extends Runnable<BaseMessage[], AIMessageChunk> {
   }
 }
 
+class SizeBoundModel extends Runnable<BaseMessage[], AIMessageChunk> {
+  lc_namespace = ['tests'];
+  readonly toolContentChars: number[] = [];
+
+  constructor(
+    private readonly maxToolContentChars: number,
+    private readonly error: Record<string, unknown>
+  ) {
+    super();
+  }
+
+  async invoke(messages: BaseMessage[]): Promise<AIMessageChunk> {
+    let toolContentChars = 0;
+    for (const message of messages) {
+      if (message.getType() !== 'tool') {
+        continue;
+      }
+      toolContentChars +=
+        typeof message.content === 'string'
+          ? message.content.length
+          : JSON.stringify(message.content).length;
+    }
+    this.toolContentChars.push(toolContentChars);
+    if (toolContentChars > this.maxToolContentChars) {
+      throw throwable(this.error);
+    }
+    return new AIMessageChunk({ content: 'recovered' });
+  }
+}
+
 function buildConversation(turns: number): BaseMessage[] {
   const messages: BaseMessage[] = [];
   for (let i = 0; i < turns; i++) {
@@ -78,17 +111,26 @@ async function createRun(options: {
   runId: string;
   maxContextTokens: number;
   checkpointer?: boolean;
+  provider?: Providers;
+  tokenCounter?: t.TokenCounter;
+  indexTokenCountMap?: Record<string, number>;
+  tools?: t.GraphTools;
+  maxToolResultChars?: number;
+  model?: string;
 }): Promise<Run<t.IState>> {
   return Run.create<t.IState>({
     runId: options.runId,
     graphConfig: {
       type: 'standard',
       llmConfig: {
-        provider: Providers.ANTHROPIC,
+        provider: options.provider ?? Providers.ANTHROPIC,
+        ...(options.model != null ? { model: options.model } : {}),
         disableStreaming: true,
         streamUsage: false,
       },
       maxContextTokens: options.maxContextTokens,
+      maxToolResultChars: options.maxToolResultChars,
+      tools: options.tools,
       compileOptions:
         options.checkpointer === true
           ? { checkpointer: new MemorySaver() }
@@ -96,7 +138,8 @@ async function createRun(options: {
     },
     returnContent: true,
     skipCleanup: true,
-    tokenCounter,
+    tokenCounter: options.tokenCounter ?? tokenCounter,
+    indexTokenCountMap: options.indexTokenCountMap,
   });
 }
 
@@ -107,6 +150,459 @@ const streamConfig = {
 };
 
 describe('context overflow recovery', () => {
+  it('compacts cached structured tool output before the first provider call', async () => {
+    const toolCallId = 'tc-structured';
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'run_select_query',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: JSON.stringify(
+              Array.from({ length: 240 }, (_, index) => ({
+                id: index,
+                value: `${'x'.repeat(100)}-${index}`,
+              }))
+            ),
+          },
+        ],
+        tool_call_id: toolCallId,
+        name: 'run_select_query',
+      }),
+      new AIMessage('The query returned 240 rows.'),
+      new HumanMessage('compact context'),
+    ];
+    const structuredTokenCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      return Math.ceil(content.length / 4);
+    };
+    const indexTokenCountMap: Record<string, number> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = i === 2 ? 0 : structuredTokenCounter(messages[i]);
+    }
+    const run = await createRun({
+      runId: 'structured-output-preflight',
+      maxContextTokens: 5_000,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: structuredTokenCounter,
+      indexTokenCountMap,
+      tools: [
+        tool(async () => 'unused', {
+          name: 'run_select_query',
+          description: 'Queries ClickHouse',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new SizeBoundModel(
+      1_500,
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream({ messages }, streamConfig);
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.toolContentChars).toHaveLength(1);
+    expect(model.toolContentChars[0]).toBeGreaterThan(0);
+    expect(model.toolContentChars[0]).toBeLessThanOrEqual(1_500);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBe(0);
+  });
+
+  it('compacts an unconsumed structured tool result before its first provider call', async () => {
+    const toolCallId = 'tc-unconsumed-structured';
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'run_select_query',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: JSON.stringify(
+              Array.from({ length: 240 }, (_, index) => ({
+                id: index,
+                value: `${'x'.repeat(100)}-${index}`,
+              }))
+            ),
+          },
+        ],
+        tool_call_id: toolCallId,
+        name: 'run_select_query',
+      }),
+    ];
+    const structuredTokenCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      return Math.ceil(content.length / 4);
+    };
+    const run = await createRun({
+      runId: 'unconsumed-structured-output-preflight',
+      maxContextTokens: 5_000,
+      maxToolResultChars: 1_500,
+      provider: Providers.BEDROCK,
+      tokenCounter: structuredTokenCounter,
+      indexTokenCountMap: {
+        0: structuredTokenCounter(messages[0]),
+        1: structuredTokenCounter(messages[1]),
+        2: 0,
+      },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'run_select_query',
+          description: 'Queries ClickHouse',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new SizeBoundModel(
+      1_500,
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0')
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream({ messages }, streamConfig);
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.toolContentChars).toHaveLength(1);
+    expect(model.toolContentChars[0]).toBeGreaterThan(0);
+    expect(model.toolContentChars[0]).toBeLessThanOrEqual(1_500);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBe(0);
+  });
+
+  it('includes artifact expansion when it fits the post-prune budget', async () => {
+    const toolCallId = 'tc-artifact-fits';
+    const artifactSentinel = 'ARTIFACT_FITS_SENTINEL';
+    const toolMessage = new ToolMessage({
+      content: 'rendered',
+      tool_call_id: toolCallId,
+      name: 'render_report',
+      artifact: {
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: `${artifactSentinel}:complete`,
+          },
+        ],
+      },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('render the report'),
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'render_report',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const artifactTokenCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      return Math.ceil(content.length / 4);
+    };
+    const run = await createRun({
+      runId: 'artifact-budget-control',
+      maxContextTokens: 10_000,
+      maxToolResultChars: 2_000,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: artifactTokenCounter,
+      indexTokenCountMap: {
+        0: artifactTokenCounter(messages[0]),
+        1: artifactTokenCounter(messages[1]),
+        2: artifactTokenCounter(messages[2]),
+      },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'render_report',
+          description: 'Renders a report',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      JSON.stringify(model.calls[0].map((message) => message.content))
+    ).toContain(artifactSentinel);
+    expect(toolMessage.content).toBe('rendered');
+    expect(toolMessage.artifact.content[0].text).toContain(artifactSentinel);
+  });
+
+  it('rechecks artifact expansion after provider message transforms', async () => {
+    const toolCallId = 'tc-artifact-final-transform';
+    const artifactSentinel = 'ARTIFACT_FINAL_TRANSFORM_SENTINEL';
+    const toolMessage = new ToolMessage({
+      content: 'rendered',
+      tool_call_id: toolCallId,
+      name: 'render_report',
+      artifact: {
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: `${artifactSentinel}:complete`,
+          },
+        ],
+      },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('render the report'),
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'render_report',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const transformSensitiveCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      if (
+        message instanceof HumanMessage &&
+        content.includes(artifactSentinel)
+      ) {
+        return 10_000;
+      }
+      return Math.max(1, Math.ceil(content.length / 4));
+    };
+    const run = await createRun({
+      runId: 'artifact-final-transform-guard',
+      maxContextTokens: 5_000,
+      maxToolResultChars: 2_000,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: transformSensitiveCounter,
+      indexTokenCountMap: {
+        0: transformSensitiveCounter(messages[0]),
+        1: transformSensitiveCounter(messages[1]),
+        2: transformSensitiveCounter(messages[2]),
+      },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    const providerContent = JSON.stringify(
+      model.calls[0].map((message) => message.content)
+    );
+    expect(providerContent).toContain('[Previous tool interaction]');
+    expect(providerContent).not.toContain(artifactSentinel);
+    expect(toolMessage.artifact.content[0].text).toContain(artifactSentinel);
+  });
+
+  it('compacts expanded synthetic context without an artifact', async () => {
+    const toolCallId = 'tc-final-transform-without-artifact';
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'run_select_query',
+            args: { query: `SELECT '${'x'.repeat(5_000)}'` },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'query complete',
+        tool_call_id: toolCallId,
+        name: 'run_select_query',
+      }),
+    ];
+    const transformSensitiveCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      if (
+        message instanceof HumanMessage &&
+        content.includes('[Previous tool interaction]')
+      ) {
+        return content.length * 10;
+      }
+      return 1;
+    };
+    const run = await createRun({
+      runId: 'final-transform-without-artifact',
+      maxContextTokens: 500,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: transformSensitiveCounter,
+      indexTokenCountMap: { 0: 1, 1: 1, 2: 1 },
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    const humanMessages = model.calls[0].filter(
+      (message) => message instanceof HumanMessage
+    );
+    expect(humanMessages).toHaveLength(2);
+    expect(
+      JSON.stringify(humanMessages[humanMessages.length - 1].content).length
+    ).toBeLessThan(100);
+    expect(
+      JSON.stringify(humanMessages[humanMessages.length - 1].content)
+    ).not.toContain('x'.repeat(1_000));
+  });
+
+  it('omits artifact expansion that would exceed the post-prune budget', async () => {
+    const toolCallId = 'tc-artifact';
+    const artifactSentinel = 'ARTIFACT_SENTINEL';
+    const toolMessage = new ToolMessage({
+      content: 'result'.repeat(100),
+      tool_call_id: toolCallId,
+      name: 'render_report',
+      artifact: {
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: `${artifactSentinel}:${'a'.repeat(5_000)}`,
+          },
+        ],
+      },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('h'.repeat(2_400)),
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'render_report',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const artifactTokenCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      return Math.ceil(content.length / 4);
+    };
+    const indexTokenCountMap: Record<string, number> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = artifactTokenCounter(messages[i]);
+    }
+    const run = await createRun({
+      runId: 'artifact-budget-guard',
+      maxContextTokens: 1_000,
+      maxToolResultChars: 2_000,
+      provider: Providers.BEDROCK,
+      model: 'anthropic.claude-sonnet-4-5',
+      tokenCounter: artifactTokenCounter,
+      indexTokenCountMap,
+      tools: [
+        tool(async () => 'unused', {
+          name: 'render_report',
+          description: 'Renders a report',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    expect(
+      JSON.stringify(model.calls[0].map((message) => message.content))
+    ).not.toContain(artifactSentinel);
+    expect(toolMessage.content).toBe('result'.repeat(100));
+    expect(toolMessage.artifact.content[0].text).toContain(artifactSentinel);
+  });
+
   it('preserves masked tool originals while checkpointed messages survive', async () => {
     const run = await createRun({
       runId: 'overflow-originals-checkpoint',

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -117,6 +117,7 @@ async function createRun(options: {
   tools?: t.GraphTools;
   maxToolResultChars?: number;
   model?: string;
+  toolOutputReferences?: t.ToolOutputReferencesConfig;
 }): Promise<Run<t.IState>> {
   return Run.create<t.IState>({
     runId: options.runId,
@@ -140,6 +141,7 @@ async function createRun(options: {
     skipCleanup: true,
     tokenCounter: options.tokenCounter ?? tokenCounter,
     indexTokenCountMap: options.indexTokenCountMap,
+    toolOutputReferences: options.toolOutputReferences,
   });
 }
 
@@ -150,6 +152,144 @@ const streamConfig = {
 };
 
 describe('context overflow recovery', () => {
+  it('projects structured OpenAI tool content before the final payload check', async () => {
+    const toolCallId = 'tc-openai-structured';
+    const toolMessage = new ToolMessage({
+      content: [
+        { type: ContentTypes.TEXT, text: 'rendered chart' },
+        {
+          type: 'image_url',
+          image_url: {
+            url: `data:image/png;base64,${'A'.repeat(2_000)}`,
+          },
+        },
+      ],
+      tool_call_id: toolCallId,
+      name: 'render_chart',
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('render the chart'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'render_chart',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const measuredToolContents: string[] = [];
+    const projectionCounter: t.TokenCounter = (message) => {
+      if (message.getType() === 'tool' && typeof message.content === 'string') {
+        measuredToolContents.push(message.content);
+      }
+      return typeof message.content === 'string'
+        ? Math.max(1, Math.ceil(message.content.length / 4))
+        : 1;
+    };
+    const run = await createRun({
+      runId: 'openai-structured-final-projection',
+      maxContextTokens: 10_000,
+      maxToolResultChars: 200,
+      provider: Providers.OPENAI,
+      tokenCounter: projectionCounter,
+      indexTokenCountMap: {
+        0: projectionCounter(messages[0]),
+        1: projectionCounter(messages[1]),
+        2: projectionCounter(messages[2]),
+      },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'render_chart',
+          description: 'Renders a chart',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(signatureFor('gpt-4o-mini'), 0);
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    const projectedTool = model.calls[0].find(
+      (message) => message.getType() === 'tool'
+    ) as ToolMessage | undefined;
+    expect(typeof projectedTool?.content).toBe('string');
+    expect((projectedTool?.content as string).length).toBeLessThanOrEqual(200);
+    expect(measuredToolContents).toContain(projectedTool?.content);
+    expect(Array.isArray(toolMessage.content)).toBe(true);
+  });
+
+  it('projects unsafe tool-call args before measuring or invoking the provider', async () => {
+    let toJSONCalls = 0;
+    const toolCallId = 'tc-unsafe-input';
+    const unsafeArgs = {
+      query: 'safe',
+      toJSON() {
+        toJSONCalls++;
+        return { query: 'x'.repeat(100_000) };
+      },
+    };
+    const messages: BaseMessage[] = [
+      new HumanMessage('run the lookup'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'lookup_records',
+            args: unsafeArgs,
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'done',
+        tool_call_id: toolCallId,
+        name: 'lookup_records',
+      }),
+      new AIMessage('The lookup completed.'),
+      new HumanMessage('continue'),
+    ];
+    const run = await createRun({
+      runId: 'unsafe-tool-input-final-projection',
+      maxContextTokens: 10_000,
+      provider: Providers.OPENAI,
+      tokenCounter: () => 1,
+      indexTokenCountMap: { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1 },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'lookup_records',
+          description: 'Looks up records',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(signatureFor('gpt-4o-mini'), 0);
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    const projectedCall = (
+      model.calls[0].find((message) => message.getType() === 'ai') as AIMessage
+    ).tool_calls?.[0];
+    expect(projectedCall?.args).toEqual({ query: 'safe' });
+    expect(toJSONCalls).toBe(0);
+    expect(messages[1]).toBeInstanceOf(AIMessage);
+    expect((messages[1] as AIMessage).tool_calls?.[0].args).toBe(unsafeArgs);
+  });
+
   it('compacts cached structured tool output before the first provider call', async () => {
     const toolCallId = 'tc-structured';
     const messages: BaseMessage[] = [
@@ -524,6 +664,92 @@ describe('context overflow recovery', () => {
     expect(
       JSON.stringify(humanMessages[humanMessages.length - 1].content)
     ).not.toContain('x'.repeat(1_000));
+  });
+
+  it('counts unresolved-reference annotations before invoking the provider', async () => {
+    const toolCallId = 'tc-unresolved-projection';
+    const unresolvedRefs = Array.from(
+      { length: 1_200 },
+      (_, index) => `missing_tool_${index}_turn_${index}`
+    );
+    const messages: BaseMessage[] = [
+      new HumanMessage(`old question ${'q'.repeat(5_500)}`),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'lookup_records',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: `old result ${'r'.repeat(3_000)}`,
+        tool_call_id: toolCallId,
+        name: 'lookup_records',
+        additional_kwargs: { _unresolvedRefs: unresolvedRefs },
+      }),
+      new AIMessage(`old answer ${'a'.repeat(4_500)}`),
+      new HumanMessage(`latest question ${'n'.repeat(3_500)}`),
+    ];
+    const projectionCounter: t.TokenCounter = (message) => {
+      const content =
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+      return Math.max(1, content.length);
+    };
+    const indexTokenCountMap: Record<string, number> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = projectionCounter(messages[i]);
+    }
+    const run = await createRun({
+      runId: 'unresolved-reference-final-projection',
+      maxContextTokens: 20_000,
+      provider: Providers.ANTHROPIC,
+      tokenCounter: projectionCounter,
+      indexTokenCountMap,
+      toolOutputReferences: { enabled: true },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'lookup_records',
+          description: 'Looks up records',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(
+      signatureFor('claude-haiku-4-5-20251001'),
+      0
+    );
+    run.Graph.overrideModel = model;
+
+    const content = await run.processStream({ messages }, streamConfig);
+
+    expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+    expect(model.calls).toHaveLength(1);
+    expect(
+      run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+    ).toBeGreaterThan(0);
+    const providerPayload = JSON.stringify(
+      model.calls[0].map((message) => message.content)
+    );
+    expect(providerPayload).not.toContain(unresolvedRefs[0]);
+    expect(providerPayload).not.toContain(unresolvedRefs.at(-1));
+    const sentMessageTokens =
+      3 +
+      model.calls[0].reduce(
+        (total, message) => total + projectionCounter(message),
+        0
+      );
+    expect(sentMessageTokens).toBeLessThan(
+      run.Graph.agentContexts.get('default')?.maxContextTokens ?? 0
+    );
   });
 
   it('omits artifact expansion that would exceed the post-prune budget', async () => {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
 import { MemorySaver } from '@langchain/langgraph';
-import { describe, expect, it } from '@jest/globals';
 import { Runnable } from '@langchain/core/runnables';
+import { describe, expect, it, jest } from '@jest/globals';
 import {
   AIMessageChunk,
   HumanMessage,
@@ -13,6 +13,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
 import { ContentTypes, GraphEvents, Providers } from '@/common';
+import * as init from '@/llm/init';
 import { Run } from '@/run';
 
 /**
@@ -119,6 +120,7 @@ async function createRun(options: {
   model?: string;
   promptCache?: boolean;
   toolOutputReferences?: t.ToolOutputReferencesConfig;
+  fallbacks?: t.FallbackConfig[];
 }): Promise<Run<t.IState>> {
   return Run.create<t.IState>({
     runId: options.runId,
@@ -128,6 +130,7 @@ async function createRun(options: {
         provider: options.provider ?? Providers.ANTHROPIC,
         ...(options.model != null ? { model: options.model } : {}),
         ...(options.promptCache === true ? { promptCache: true } : {}),
+        ...(options.fallbacks != null ? { fallbacks: options.fallbacks } : {}),
         disableStreaming: true,
         streamUsage: false,
       },
@@ -228,6 +231,166 @@ describe('context overflow recovery', () => {
     expect((projectedTool?.content as string).length).toBeLessThanOrEqual(200);
     expect(measuredToolContents).toContain(projectedTool?.content);
     expect(Array.isArray(toolMessage.content)).toBe(true);
+  });
+
+  it('measures the bounded generic-provider tool payload that is invoked', async () => {
+    const toolCallId = 'tc-google-structured';
+    const structuredContent = Array.from({ length: 25_000 }, () => ({
+      type: ContentTypes.TEXT,
+      text: 'x',
+    }));
+    const toolMessage = new ToolMessage({
+      content: structuredContent,
+      tool_call_id: toolCallId,
+      name: 'dense_result',
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('return the dense result'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'dense_result',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+    const measuredToolContents: string[] = [];
+    const projectionCounter: t.TokenCounter = (message) => {
+      if (message.getType() === 'tool' && typeof message.content === 'string') {
+        measuredToolContents.push(message.content);
+      }
+      return typeof message.content === 'string'
+        ? Math.max(1, Math.ceil(message.content.length / 4))
+        : 1;
+    };
+    const run = await createRun({
+      runId: 'google-structured-final-projection',
+      maxContextTokens: 10_000,
+      maxToolResultChars: 2_000,
+      provider: Providers.GOOGLE,
+      tokenCounter: projectionCounter,
+      indexTokenCountMap: {
+        0: projectionCounter(messages[0]),
+        1: projectionCounter(messages[1]),
+        2: projectionCounter(messages[2]),
+      },
+      tools: [
+        tool(async () => 'unused', {
+          name: 'dense_result',
+          description: 'Returns a dense structured result',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const model = new OverflowThenSucceedModel(signatureFor('gpt-4o-mini'), 0);
+    run.Graph.overrideModel = model;
+
+    await run.processStream({ messages }, streamConfig);
+
+    expect(model.calls).toHaveLength(1);
+    const projectedTool = model.calls[0].find(
+      (message) => message.getType() === 'tool'
+    ) as ToolMessage | undefined;
+    expect(typeof projectedTool?.content).toBe('string');
+    expect((projectedTool?.content as string).length).toBeLessThanOrEqual(
+      2_000
+    );
+    expect(measuredToolContents).toContain(projectedTool?.content);
+    expect(toolMessage.content).toBe(structuredContent);
+  });
+
+  it('guards a fallback-specific projection before invoking the fallback', async () => {
+    const toolCallId = 'tc-fallback-structured';
+    const structuredContent = Array.from({ length: 25_000 }, () => ({
+      type: ContentTypes.TEXT,
+      text: '',
+    }));
+    const messages: BaseMessage[] = [
+      new HumanMessage('return the dense fallback result'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'dense_result',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: structuredContent,
+        tool_call_id: toolCallId,
+        name: 'dense_result',
+      }),
+    ];
+    const projectionCounter: t.TokenCounter = (message) =>
+      typeof message.content === 'string'
+        ? Math.max(1, message.content.length)
+        : 1;
+    const run = await createRun({
+      runId: 'fallback-structured-final-projection',
+      maxContextTokens: 1_000_000,
+      provider: Providers.ANTHROPIC,
+      tokenCounter: projectionCounter,
+      indexTokenCountMap: {
+        0: projectionCounter(messages[0]),
+        1: projectionCounter(messages[1]),
+        2: projectionCounter(messages[2]),
+      },
+      fallbacks: [
+        {
+          provider: Providers.GOOGLE,
+          maxContextTokens: 5_000,
+        },
+      ],
+      tools: [
+        tool(async () => 'unused', {
+          name: 'dense_result',
+          description: 'Returns a dense structured result',
+          schema: z.object({}),
+        }),
+      ],
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+    const primary = new OverflowThenSucceedModel(
+      { message: '503 primary unavailable' },
+      1
+    );
+    let fallbackInvocations = 0;
+    const fallback = {
+      invoke: async (): Promise<AIMessageChunk> => {
+        fallbackInvocations++;
+        return new AIMessageChunk({ content: 'fallback should not run' });
+      },
+    } as unknown as ReturnType<typeof init.initializeModel>;
+    const initializeSpy = jest
+      .spyOn(init, 'initializeModel')
+      .mockReturnValue(fallback);
+    run.Graph.overrideModel = primary;
+
+    try {
+      const content = await run.processStream({ messages }, streamConfig);
+
+      expect(content).toEqual([{ type: 'text', text: 'recovered' }]);
+      expect(primary.calls).toHaveLength(2);
+      expect(fallbackInvocations).toBe(0);
+      expect(
+        run.Graph.agentContexts.get('default')?.overflowRecoveryAttempts
+      ).toBe(1);
+    } finally {
+      initializeSpy.mockRestore();
+    }
   });
 
   it('projects unsafe tool-call args before measuring or invoking the provider', async () => {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -4,13 +4,14 @@
  * This util file contains functions for converting LangChain messages to Anthropic messages.
  */
 import { createHash } from 'node:crypto';
+import { isProxy } from 'node:util/types';
 import { ToolCall } from '@langchain/core/messages/tool';
 import {
   type BaseMessage,
   type SystemMessage,
   HumanMessage,
   type AIMessage,
-  type ToolMessage,
+  ToolMessage,
   isAIMessage,
   type Data,
   type StandardContentBlockConverter,
@@ -33,6 +34,11 @@ import {
   AnthropicCompactionBlockParam,
   AnthropicToolResponse,
 } from '../types';
+import {
+  cloneToolMessageWithContent,
+  serializeStructuredValueBounded,
+} from '@/utils/toolContent';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { Constants } from '@/common';
 
 type StandardTextBlock = Data.StandardTextBlock;
@@ -157,16 +163,139 @@ function hoistToolResultCacheControl(
   }
   let cacheControl: unknown;
   const stripped = content.map((block) => {
-    if ('cache_control' in block) {
-      cacheControl ??= (block as Record<string, unknown>).cache_control;
-      const clone = { ...(block as Record<string, unknown>) };
-      delete clone.cache_control;
-      return clone as MessageContentComplex;
+    if (typeof block !== 'object' || block == null || isProxy(block)) {
+      return block;
+    }
+    try {
+      const descriptors = Object.getOwnPropertyDescriptors(block);
+      const cacheControlDescriptor = descriptors.cache_control;
+      if (
+        cacheControlDescriptor.enumerable === true &&
+        'value' in cacheControlDescriptor
+      ) {
+        cacheControl ??= cacheControlDescriptor.value;
+        delete descriptors.cache_control;
+        return Object.create(
+          Object.getPrototypeOf(block),
+          descriptors
+        ) as MessageContentComplex;
+      }
+    } catch {
+      return block;
     }
     return block;
   });
   // `stripped` is element-equal to `content` when no marker was present.
   return { content: stripped, cacheControl };
+}
+
+/**
+ * A ToolMessage can already contain an Anthropic-native `tool_result` block
+ * (for example, when a tool returns provider-native structured content). The
+ * outer ToolMessage conversion supplies the one required result envelope, so
+ * unwrap an exact single nested envelope rather than sending an invalid
+ * `tool_result.content: [{ type: "tool_result", ... }]` payload.
+ */
+function unwrapToolMessageResultContent(content: ToolMessage['content']): {
+  content: string | MessageContentComplex[] | undefined;
+  cacheControl: unknown;
+  isError: boolean | undefined;
+} {
+  if (!Array.isArray(content) || content.length !== 1) {
+    return { content, cacheControl: undefined, isError: undefined };
+  }
+
+  const block = content[0];
+  if (typeof block !== 'object' || block == null || isProxy(block)) {
+    return { content, cacheControl: undefined, isError: undefined };
+  }
+
+  try {
+    const type = Object.getOwnPropertyDescriptor(block, 'type');
+    const nestedContent = Object.getOwnPropertyDescriptor(block, 'content');
+    if (
+      type?.enumerable !== true ||
+      !('value' in type) ||
+      type.value !== 'tool_result' ||
+      (nestedContent != null &&
+        (nestedContent.enumerable !== true || !('value' in nestedContent)))
+    ) {
+      return { content, cacheControl: undefined, isError: undefined };
+    }
+
+    const cacheControl = Object.getOwnPropertyDescriptor(
+      block,
+      'cache_control'
+    );
+    const isError = Object.getOwnPropertyDescriptor(block, 'is_error');
+    const nested =
+      nestedContent != null && 'value' in nestedContent
+        ? nestedContent.value
+        : undefined;
+    if (typeof nested === 'string') {
+      return {
+        content: nested,
+        cacheControl:
+          cacheControl?.enumerable === true && 'value' in cacheControl
+            ? cacheControl.value
+            : undefined,
+        isError:
+          isError?.enumerable === true &&
+          'value' in isError &&
+          typeof isError.value === 'boolean'
+            ? isError.value
+            : undefined,
+      };
+    }
+    if (Array.isArray(nested)) {
+      return {
+        content: nested as MessageContentComplex[],
+        cacheControl:
+          cacheControl?.enumerable === true && 'value' in cacheControl
+            ? cacheControl.value
+            : undefined,
+        isError:
+          isError?.enumerable === true &&
+          'value' in isError &&
+          typeof isError.value === 'boolean'
+            ? isError.value
+            : undefined,
+      };
+    }
+    if (nested == null) {
+      return {
+        content: undefined,
+        cacheControl:
+          cacheControl?.enumerable === true && 'value' in cacheControl
+            ? cacheControl.value
+            : undefined,
+        isError:
+          isError?.enumerable === true &&
+          'value' in isError &&
+          typeof isError.value === 'boolean'
+            ? isError.value
+            : undefined,
+      };
+    }
+    return {
+      content: serializeStructuredValueBounded(
+        nested,
+        HARD_MAX_TOOL_RESULT_CHARS
+      ).content,
+      cacheControl:
+        cacheControl?.enumerable === true && 'value' in cacheControl
+          ? cacheControl.value
+          : undefined,
+      isError:
+        isError?.enumerable === true &&
+        'value' in isError &&
+        typeof isError.value === 'boolean'
+          ? isError.value
+          : undefined,
+    };
+  } catch {
+    return { content, cacheControl: undefined, isError: undefined };
+  }
 }
 
 function _ensureMessageContents(
@@ -209,21 +338,38 @@ function _ensureMessageContents(
           );
         }
       } else {
-        const toolMessageContent = (
-          message as { content?: BaseMessage['content'] | null }
-        ).content;
+        const toolMessage = message as ToolMessage;
+        const toolMessageContent = toolMessage.content;
+        const unwrapped = unwrapToolMessageResultContent(toolMessageContent);
+        const formattedContent =
+          unwrapped.content == null
+            ? undefined
+            : _formatContent(
+              unwrapped.content === toolMessageContent
+                ? toolMessage
+                : cloneToolMessageWithContent(
+                  toolMessage,
+                      unwrapped.content as Parameters<
+                        typeof cloneToolMessageWithContent
+                      >[1]
+                )
+            );
         // Hoist a tail cache_control off the inner content onto the
         // tool_result block itself (the documented cacheable position).
-        const { content: hoistedContent, cacheControl } =
-          toolMessageContent != null
-            ? hoistToolResultCacheControl(_formatContent(message))
+        const { content: hoistedContent, cacheControl: innerCacheControl } =
+          formattedContent != null
+            ? hoistToolResultCacheControl(formattedContent)
             : { content: undefined, cacheControl: undefined };
+        const cacheControl = unwrapped.cacheControl ?? innerCacheControl;
         updatedMsgs.push(
           new HumanMessage({
             content: [
               {
                 type: 'tool_result',
                 ...(hoistedContent != null ? { content: hoistedContent } : {}),
+                ...(unwrapped.isError != null
+                  ? { is_error: unwrapped.isError }
+                  : {}),
                 ...(cacheControl != null
                   ? { cache_control: cacheControl as { type: 'ephemeral' } }
                   : {}),

--- a/src/llm/anthropic/utils/tool-id-normalization.test.ts
+++ b/src/llm/anthropic/utils/tool-id-normalization.test.ts
@@ -84,6 +84,115 @@ describe('normalizeAnthropicToolCallId', () => {
 });
 
 describe('_convertMessagesToAnthropicPayload — cross-provider ID normalization', () => {
+  it('flattens an Anthropic-native tool_result returned by a tool', () => {
+    const toolCallId = 'toolu_native_result';
+    const payload = _convertMessagesToAnthropicPayload([
+      new HumanMessage('run the native tool'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'native_tool',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: toolCallId,
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolCallId,
+            cache_control: { type: 'ephemeral', ttl: '1h' },
+            is_error: true,
+            content: [
+              {
+                type: 'text',
+                text: 'native result',
+                cache_control: { type: 'ephemeral' },
+              },
+              {
+                type: 'image_url',
+                image_url: 'data:image/png;base64,AA==',
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+
+    const result = (
+      payload.messages.find(
+        (message) =>
+          message.role === 'user' &&
+          Array.isArray(message.content) &&
+          message.content.some((block) => block.type === 'tool_result')
+      )!.content as unknown as Array<Record<string, unknown>>
+    ).find((block) => block.type === 'tool_result')!;
+
+    expect(result).toEqual({
+      type: 'tool_result',
+      tool_use_id: toolCallId,
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+      is_error: true,
+      content: [
+        { type: 'text', text: 'native result' },
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'AA==',
+          },
+        },
+      ],
+    });
+    expect(
+      (result.content as unknown as Array<Record<string, unknown>>).some(
+        (block) => block.type === 'tool_result'
+      )
+    ).toBe(false);
+  });
+
+  it('flattens a content-less native error tool_result', () => {
+    const toolCallId = 'toolu_empty_error';
+    const payload = _convertMessagesToAnthropicPayload([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'native_tool',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: toolCallId,
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolCallId,
+            is_error: true,
+          },
+        ],
+      }),
+    ]);
+
+    const result = (
+      payload.messages.find((message) => message.role === 'user')!
+        .content as unknown as Array<Record<string, unknown>>
+    )[0];
+    expect(result).toEqual({
+      type: 'tool_result',
+      tool_use_id: toolCallId,
+      is_error: true,
+    });
+  });
+
   it('normalizes Responses-style IDs on tool_use AND matching tool_result', () => {
     const responsesId = 'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs';
 

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -1,6 +1,7 @@
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { convertToConverseMessages } from './message_inputs';
+import { toLangChainContent } from '@/messages/langchain';
 
 /**
  * Native-Bedrock reasoning serialization. A `reasoning_content` block whose
@@ -30,6 +31,53 @@ const assistantContent = (result: ConverseResult): ConverseBlock[] => {
   const msg = result.converseMessages.find((m) => m.role === 'assistant');
   return (msg?.content ?? []) as ConverseBlock[];
 };
+
+describe('convertToConverseMessages — Anthropic tool replay', () => {
+  it('deduplicates raw tool_use blocks and unwraps tool_result content', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'Searching.' },
+          {
+            type: 'tool_use',
+            id: 'call_search',
+            name: 'search',
+            input: '',
+          },
+        ]),
+        tool_calls: [
+          {
+            id: 'call_search',
+            name: 'search',
+            args: { query: 'test' },
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: toLangChainContent([
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_search',
+            is_error: true,
+            content: 'result body',
+          },
+        ]),
+        tool_call_id: 'call_search',
+      }),
+    ];
+
+    const converted = convertToConverseMessages(messages);
+    const serialized = JSON.stringify(converted);
+
+    expect(serialized.match(/"toolUseId":"call_search"/g)).toHaveLength(2);
+    expect(serialized.match(/"toolUse":/g)).toHaveLength(1);
+    expect(serialized.match(/"toolResult":/g)).toHaveLength(1);
+    expect(serialized).toContain('"text":"result body"');
+    expect(serialized).toContain('"status":"error"');
+    expect(serialized).not.toContain('"type":"tool_result"');
+  });
+});
 
 describe('convertToConverseMessages — native Bedrock reasoning serialization', () => {
   it('drops a signature-only reasoning block, keeping text and tool calls', () => {

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -4,6 +4,7 @@
  */
 import {
   type BaseMessage,
+  type ToolMessage,
   isAIMessage,
   type Data,
   parseBase64DataUrl,
@@ -27,6 +28,8 @@ import type {
   BedrockContentBlock,
   MessageContentReasoningBlock,
 } from '../types';
+import { serializeStructuredValueBounded } from '@/utils/toolContent';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 
 /**
  * Reasoning blocks from other providers, relative to Bedrock. Bedrock's native
@@ -698,6 +701,13 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
   if (typeof msg.content === 'string' && msg.content !== '') {
     assistantMsg.content?.push({ text: msg.content });
   } else if (Array.isArray(msg.content)) {
+    const parsedToolCallIds = new Set(
+      isAIMessage(msg)
+        ? (msg.tool_calls ?? []).flatMap((toolCall) =>
+          toolCall.id != null ? [toolCall.id] : []
+        )
+        : []
+    );
     const concatenatedBlocks = concatenateLangchainReasoningBlocks(
       msg.content as Array<MessageContentComplex | MessageContentReasoningBlock>
     );
@@ -707,6 +717,33 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
       if (block.type === 'text') {
         const text = (block as { text?: string }).text ?? '';
         appendSerializableBedrockTextBlock(contentBlocks, text);
+      } else if (block.type === 'tool_use') {
+        const toolUse = block as {
+          id?: unknown;
+          name?: unknown;
+          input?: unknown;
+        };
+        if (
+          typeof toolUse.id === 'string' &&
+          parsedToolCallIds.has(toolUse.id)
+        ) {
+          return;
+        }
+        if (
+          typeof toolUse.id !== 'string' ||
+          typeof toolUse.name !== 'string' ||
+          toolUse.input == null ||
+          typeof toolUse.input !== 'object'
+        ) {
+          throw new Error('Invalid Anthropic tool_use content block');
+        }
+        contentBlocks.push({
+          toolUse: {
+            toolUseId: toolUse.id,
+            name: toolUse.name,
+            input: toolUse.input as Record<string, unknown>,
+          },
+        } as BedrockContentBlock);
       } else if (block.type === 'reasoning_content') {
         const reasoningBlock = block as MessageContentReasoningBlock;
         // Bedrock Converse rejects reasoningContent whose reasoningText.text is
@@ -756,13 +793,20 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
 
   // Important: this must be placed after any reasoning content blocks
   if (isAIMessage(msg) && msg.tool_calls != null && msg.tool_calls.length > 0) {
-    const toolUseBlocks = msg.tool_calls.map((tc) => ({
-      toolUse: {
-        toolUseId: tc.id,
-        name: tc.name,
-        input: tc.args as Record<string, unknown>,
-      },
-    }));
+    const existingToolUseIds = new Set(
+      (assistantMsg.content ?? [])
+        .filter((content) => 'toolUse' in content)
+        .map((content) => content.toolUse?.toolUseId)
+    );
+    const toolUseBlocks = msg.tool_calls
+      .filter((toolCall) => !existingToolUseIds.has(toolCall.id))
+      .map((toolCall) => ({
+        toolUse: {
+          toolUseId: toolCall.id,
+          name: toolCall.name,
+          input: toolCall.args as Record<string, unknown>,
+        },
+      }));
     assistantMsg.content = [
       ...(assistantMsg.content ?? []),
       ...toolUseBlocks,
@@ -917,17 +961,45 @@ function convertHumanMessageToConverseMessage(
  */
 function convertToolMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
   const toolCallId = (msg as { tool_call_id?: string }).tool_call_id;
+  let isError = (msg as ToolMessage).status === 'error';
 
   let content: BedrockContentBlock[];
   if (typeof msg.content === 'string') {
     content = [{ text: msg.content }];
   } else if (Array.isArray(msg.content)) {
-    content = msg.content.map((block) =>
-      convertLangChainContentBlockToConverseContentBlock({
-        block,
-        onUnknown: 'passthrough',
-      })
-    );
+    content = msg.content.flatMap((block) => {
+      if (typeof block === 'object' && block.type === 'tool_result') {
+        if ((block as { is_error?: unknown }).is_error === true) {
+          isError = true;
+        }
+        const toolResultContent = (block as { content?: unknown }).content;
+        if (typeof toolResultContent === 'string') {
+          return [{ text: toolResultContent }];
+        }
+        if (Array.isArray(toolResultContent)) {
+          return toolResultContent.map((nestedBlock) =>
+            convertLangChainContentBlockToConverseContentBlock({
+              block: nestedBlock,
+              onUnknown: 'passthrough',
+            })
+          );
+        }
+        return [
+          {
+            text: serializeStructuredValueBounded(
+              toolResultContent,
+              HARD_MAX_TOOL_RESULT_CHARS
+            ).content,
+          },
+        ];
+      }
+      return [
+        convertLangChainContentBlockToConverseContentBlock({
+          block,
+          onUnknown: 'passthrough',
+        }),
+      ];
+    });
   } else {
     content = [{ text: String(msg.content) }];
   }
@@ -958,6 +1030,7 @@ function convertToolMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
         toolResult: {
           toolUseId: toolCallId,
           content: toolResultContent as { text: string }[],
+          ...(isError ? { status: 'error' as const } : {}),
         },
       },
       ...trailingCachePoints,

--- a/src/llm/google/utils/common.test.ts
+++ b/src/llm/google/utils/common.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, describe } from '@jest/globals';
-import { AIMessageChunk } from '@langchain/core/messages';
-import type { Content, EnhancedGenerateContentResponse } from '@google/generative-ai';
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import type {
+  Content,
+  EnhancedGenerateContentResponse,
+} from '@google/generative-ai';
 import {
   STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
@@ -8,9 +11,53 @@ import {
 } from '@/tools/streamedToolCallSeals';
 import {
   convertResponseContentToChatGenerationChunk,
+  convertMessageContentToParts,
   dropUnsupportedModelTurnPrefill,
   rejectsModelTurnPrefill,
 } from './common';
+import { toLangChainContent } from '@/messages/langchain';
+
+describe('convertMessageContentToParts cross-provider tool calls', () => {
+  test('deduplicates Anthropic tool_use content mirrored in parsed tool_calls', () => {
+    const message = new AIMessage({
+      content: toLangChainContent([
+        { type: 'text', text: 'Checking.' },
+        {
+          type: 'tool_use',
+          id: 'call_weather',
+          name: 'weather',
+          input: '',
+        },
+        { type: 'text', index: 0, input: '{"city":"NYC"}' },
+      ]),
+      tool_calls: [
+        {
+          id: 'call_weather',
+          name: 'weather',
+          args: { city: 'NYC' },
+        },
+      ],
+    });
+
+    const parts = convertMessageContentToParts(
+      message,
+      false,
+      [],
+      'gemini-3.5-flash'
+    );
+    const functionCalls = parts.filter((part) => 'functionCall' in part);
+
+    expect(functionCalls).toHaveLength(1);
+    expect(parts).not.toContainEqual({});
+    expect(functionCalls[0]).toMatchObject({
+      functionCall: {
+        id: 'call_weather',
+        name: 'weather',
+        args: { city: 'NYC' },
+      },
+    });
+  });
+});
 
 function buildResponse(
   parts: Array<Record<string, unknown>>
@@ -72,7 +119,9 @@ describe('rejectsModelTurnPrefill', () => {
     expect(rejectsModelTurnPrefill('gemini-3.6-flash')).toBe(true);
     expect(rejectsModelTurnPrefill('gemini-3.5-flash-lite')).toBe(true);
     expect(rejectsModelTurnPrefill('models/gemini-3.6-flash')).toBe(true);
-    expect(rejectsModelTurnPrefill('google/gemini-3.5-flash-lite-latest')).toBe(true);
+    expect(rejectsModelTurnPrefill('google/gemini-3.5-flash-lite-latest')).toBe(
+      true
+    );
   });
 
   test('is false for models that still accept prefill and for empty input', () => {
@@ -86,34 +135,51 @@ describe('rejectsModelTurnPrefill', () => {
 
 describe('dropUnsupportedModelTurnPrefill', () => {
   const userTurn: Content = { role: 'user', parts: [{ text: 'Hi' }] };
-  const modelTurn: Content = { role: 'model', parts: [{ text: 'Hello, I am' }] };
+  const modelTurn: Content = {
+    role: 'model',
+    parts: [{ text: 'Hello, I am' }],
+  };
 
   test('drops a trailing model turn for no-prefill models', () => {
     const contents: Content[] = [userTurn, modelTurn];
-    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.6-flash');
+    const result = dropUnsupportedModelTurnPrefill(
+      contents,
+      'gemini-3.6-flash'
+    );
     expect(result).toEqual([userTurn]);
   });
 
   test('drops multiple consecutive trailing model turns but keeps one turn', () => {
     const contents: Content[] = [userTurn, modelTurn, modelTurn];
-    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.5-flash-lite');
+    const result = dropUnsupportedModelTurnPrefill(
+      contents,
+      'gemini-3.5-flash-lite'
+    );
     expect(result).toEqual([userTurn]);
   });
 
   test('leaves a trailing model turn for models that accept prefill', () => {
     const contents: Content[] = [userTurn, modelTurn];
-    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.5-flash');
+    const result = dropUnsupportedModelTurnPrefill(
+      contents,
+      'gemini-3.5-flash'
+    );
     expect(result).toBe(contents);
   });
 
   test('is a no-op when the request already ends with a user turn', () => {
     const contents: Content[] = [modelTurn, userTurn];
-    const result = dropUnsupportedModelTurnPrefill(contents, 'gemini-3.6-flash');
+    const result = dropUnsupportedModelTurnPrefill(
+      contents,
+      'gemini-3.6-flash'
+    );
     expect(result).toBe(contents);
   });
 
   test('is a no-op for empty or undefined contents', () => {
     expect(dropUnsupportedModelTurnPrefill([], 'gemini-3.6-flash')).toEqual([]);
-    expect(dropUnsupportedModelTurnPrefill(undefined, 'gemini-3.6-flash')).toBeUndefined();
+    expect(
+      dropUnsupportedModelTurnPrefill(undefined, 'gemini-3.6-flash')
+    ).toBeUndefined();
   });
 });

--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -390,7 +390,9 @@ function _convertLangChainContentToPart(
   }
 
   if (content.type === 'text') {
-    return { text: content.text };
+    return typeof content.text === 'string' && content.text !== ''
+      ? { text: content.text }
+      : undefined;
   } else if (content.type === 'executableCode') {
     return { executableCode: content.executableCode };
   } else if (content.type === 'codeExecutionResult') {
@@ -429,10 +431,14 @@ function _convertLangChainContentToPart(
   } else if (content.type === 'media') {
     return messageContentMedia(content);
   } else if (content.type === 'tool_use') {
+    const functionId = getGoogleFunctionId(
+      typeof content.id === 'string' ? content.id : undefined
+    );
     return {
       functionCall: {
         name: content.name,
         args: content.input,
+        ...(functionId != null ? { id: functionId } : {}),
       },
     };
   } else if (
@@ -553,7 +559,28 @@ export function convertMessageContentToParts(
     });
   }
 
-  return [...messageParts, ...functionCalls];
+  const parsedFunctionCallIds = new Set(
+    functionCalls.flatMap((part) => {
+      const functionCall = part.functionCall as GoogleFunctionCallWithId;
+      return functionCall.id != null ? [functionCall.id] : [];
+    })
+  );
+  const parsedFunctionCallNames = new Set(
+    functionCalls.map((part) => part.functionCall.name)
+  );
+  const contentWithoutParsedMirrors = messageParts.filter((part) => {
+    if (!('functionCall' in part) || part.functionCall == null) {
+      return true;
+    }
+    const functionCall = part.functionCall as GoogleFunctionCallWithId;
+    return !(
+      (functionCall.id != null && parsedFunctionCallIds.has(functionCall.id)) ||
+      (functionCall.id == null &&
+        parsedFunctionCallNames.has(functionCall.name))
+    );
+  });
+
+  return [...contentWithoutParsedMirrors, ...functionCalls];
 }
 
 export function convertBaseMessagesToContent(
@@ -665,7 +692,11 @@ export function dropUnsupportedModelTurnPrefill(
   contents: Content[] | undefined,
   model?: string
 ): Content[] | undefined {
-  if (contents == null || contents.length === 0 || !rejectsModelTurnPrefill(model)) {
+  if (
+    contents == null ||
+    contents.length === 0 ||
+    !rejectsModelTurnPrefill(model)
+  ) {
     return contents;
   }
   let end = contents.length;

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -7,13 +7,22 @@ import {
   HumanMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import {
+  convertMessagesToCompletionsMessageParams,
+  convertMessagesToResponsesInput,
+  tools as openAITools,
+} from '@langchain/openai';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import { convertMessageContentToParts } from '@/llm/google/utils/common';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { toLangChainContent } from '@/messages/langchain';
 import { Constants, Providers } from '@/common';
 import { ToolNode } from '@/tools/ToolNode';
+import { ChatOpenAI } from '@/llm/openai';
 
 /**
  * Minimal stub model shape `attemptInvoke` reads. Either `invoke` or
@@ -21,6 +30,9 @@ import { ToolNode } from '@/tools/ToolNode';
  * extending the real `BaseChatModel` would pull in too much surface.
  */
 type StubModel = {
+  _useResponsesApi?: (options?: unknown) => boolean;
+  defaultOptions?: unknown;
+  last?: unknown;
   invoke?: (messages: BaseMessage[], config?: unknown) => Promise<AIMessage>;
   stream?: (
     messages: BaseMessage[],
@@ -162,6 +174,482 @@ describe('attemptInvoke applies lazy ref annotation', () => {
 
     expect(invokeMessages).toHaveLength(1);
     expect(invokeMessages[0][0].content).toBe('output');
+  });
+
+  it('replaces native computer screenshots for non-Responses providers', async () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(100_000)}`;
+    const computerOutput = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'computer-output',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages: [computerOutput],
+      provider: Providers.ANTHROPIC,
+    });
+
+    expect(invokeMessages[0][0].content).toBe(
+      '[Computer screenshot omitted for this provider]'
+    );
+    expect(computerOutput.content).toBe(screenshot);
+  });
+
+  it('scopes cache blocks to providers that support them', async () => {
+    const cachedOutput = new ToolMessage({
+      content: [
+        {
+          type: 'text',
+          text: 'result body',
+          cache_control: { type: 'ephemeral' },
+        },
+      ] as ToolMessage['content'],
+      tool_call_id: 'call_cached_tool',
+    });
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_cached_tool', name: 'search', args: {} }],
+      }),
+      cachedOutput,
+    ];
+    const openRouter = buildCapturingModel();
+    const openAI = buildCapturingModel();
+    const anthropic = buildCapturingModel();
+    const google = buildCapturingModel();
+
+    await attemptInvoke({
+      model: openRouter.model as t.ChatModel,
+      messages,
+      provider: Providers.OPENROUTER,
+    });
+    await attemptInvoke({
+      model: openAI.model as t.ChatModel,
+      messages,
+      provider: Providers.OPENAI,
+    });
+    await attemptInvoke({
+      model: anthropic.model as t.ChatModel,
+      messages,
+      provider: Providers.ANTHROPIC,
+    });
+    await attemptInvoke({
+      model: google.model as t.ChatModel,
+      messages,
+      provider: Providers.GOOGLE,
+    });
+
+    expect(openRouter.invokeMessages[0][1].content).toEqual(
+      cachedOutput.content
+    );
+    expect(openAI.invokeMessages[0][1].content).toBe('result body');
+    expect(anthropic.invokeMessages[0][1].content).toEqual(
+      cachedOutput.content
+    );
+    expect(google.invokeMessages[0][1].content).toBe('result body');
+    expect(cachedOutput.content).toEqual([
+      {
+        type: 'text',
+        text: 'result body',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  it('removes foreign cache markers from official OpenAI Chat payloads', async () => {
+    const messages = [
+      new HumanMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'question',
+            cache_control: { type: 'ephemeral' },
+          },
+        ]),
+      }),
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'answer',
+            cache_control: { type: 'ephemeral' },
+          },
+        ]),
+      }),
+    ];
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.OPENAI,
+    });
+
+    const payload = convertMessagesToCompletionsMessageParams({
+      messages: invokeMessages[0],
+      model: 'gpt-4o',
+    });
+    expect(JSON.stringify(payload)).not.toContain('cache_control');
+    expect(JSON.stringify(messages)).toContain('cache_control');
+  });
+
+  it('removes Bedrock cache points before an Anthropic fallback', async () => {
+    const messages = [
+      new HumanMessage('search'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_bedrock_cache', name: 'search', args: {} }],
+      }),
+      new ToolMessage({
+        content: [
+          { type: 'text', text: 'result body' },
+          { cachePoint: { type: 'default' } },
+        ] as ToolMessage['content'],
+        tool_call_id: 'call_bedrock_cache',
+      }),
+    ];
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.ANTHROPIC,
+    });
+
+    expect((invokeMessages[0][2] as ToolMessage).content).toBe('result body');
+    expect(() =>
+      _convertMessagesToAnthropicPayload(invokeMessages[0])
+    ).not.toThrow();
+    expect(JSON.stringify(invokeMessages[0])).not.toContain('cachePoint');
+    expect(JSON.stringify(messages)).toContain('cachePoint');
+  });
+
+  it('preserves error tool metadata while stripping foreign cache markers', async () => {
+    const cachedError = new ToolMessage({
+      content: toLangChainContent([
+        {
+          type: 'text',
+          text: 'boom',
+          cache_control: { type: 'ephemeral' },
+        },
+      ]),
+      tool_call_id: 'call_error',
+      name: 'search',
+      status: 'error',
+      artifact: { source: 'test' },
+      metadata: { trace: 'trace-1' },
+    });
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_error', name: 'search', args: {} }],
+      }),
+      cachedError,
+    ];
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.GOOGLE,
+    });
+
+    const sent = invokeMessages[0][1] as ToolMessage;
+    expect(sent).toMatchObject({
+      content: 'boom',
+      status: 'error',
+      artifact: { source: 'test' },
+      metadata: { trace: 'trace-1' },
+    });
+    expect(convertMessageContentToParts(sent, false, messages)).toEqual([
+      expect.objectContaining({
+        functionResponse: expect.objectContaining({
+          response: { error: { details: 'boom' } },
+        }),
+      }),
+    ]);
+    expect(cachedError.content).not.toBe('boom');
+  });
+
+  it('removes per-block cache markers from OpenRouter Responses input', async () => {
+    const messages = [
+      new HumanMessage({
+        content: toLangChainContent([
+          {
+            type: 'text',
+            text: 'question',
+            cache_control: { type: 'ephemeral' },
+          },
+        ]),
+      }),
+    ];
+    const { invokeMessages, model } = buildCapturingModel();
+    model.last = { _useResponsesApi: () => true };
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.OPENROUTER,
+    });
+
+    const input = convertMessagesToResponsesInput({
+      messages: invokeMessages[0],
+      model: 'openai/gpt-5',
+      zdrEnabled: false,
+    });
+    expect(JSON.stringify(input)).not.toContain('cache_control');
+    expect(JSON.stringify(messages)).toContain('cache_control');
+  });
+
+  it.each([
+    [Providers.OPENAI, false],
+    [Providers.OPENAI, true],
+    [Providers.OPENROUTER, false],
+    [Providers.OPENROUTER, true],
+    [Providers.ANTHROPIC, false],
+    [Providers.BEDROCK, false],
+    [Providers.GOOGLE, false],
+  ])(
+    'drops incomplete streamed tool-input fragments for %s (Responses=%s)',
+    async (provider, responses) => {
+      let typeGetterCalls = 0;
+      const accessorBlock = {};
+      Object.defineProperty(accessorBlock, 'type', {
+        enumerable: true,
+        get() {
+          typeGetterCalls++;
+          throw new Error('type getter must not run');
+        },
+      });
+      const proxyBlock = new Proxy(
+        {},
+        {
+          getOwnPropertyDescriptor() {
+            throw new Error('proxy descriptor trap must not run');
+          },
+        }
+      );
+      const streamedToolCall = new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'calling' },
+          {
+            type: 'tool_use',
+            id: 'call_streamed',
+            name: 'search',
+            input: '',
+            index: 0,
+          },
+          {
+            type: 'text',
+            index: 0,
+            input: '{"query":"records"}',
+          },
+          accessorBlock,
+          proxyBlock,
+        ]),
+        tool_calls: [
+          {
+            id: 'call_streamed',
+            name: 'search',
+            args: { query: 'records' },
+            type: 'tool_call',
+          },
+        ],
+      });
+      const messages = [
+        new HumanMessage('run the search'),
+        streamedToolCall,
+        new ToolMessage({
+          content: 'result',
+          tool_call_id: 'call_streamed',
+          name: 'search',
+        }),
+      ];
+      const { invokeMessages, model } = buildCapturingModel();
+      if (responses) {
+        model.last = { _useResponsesApi: () => true };
+      }
+
+      await attemptInvoke({
+        model: model as t.ChatModel,
+        messages,
+        provider,
+      });
+
+      const sent = invokeMessages[0][1] as AIMessage;
+      expect(sent.content).toEqual([
+        { type: 'text', text: 'calling' },
+        {
+          type: 'tool_use',
+          id: 'call_streamed',
+          name: 'search',
+          input: '',
+          index: 0,
+        },
+      ]);
+      expect(sent.tool_calls).toEqual(streamedToolCall.tool_calls);
+      expect(typeGetterCalls).toBe(0);
+      expect(streamedToolCall.content).toHaveLength(5);
+    }
+  );
+
+  it.each([Providers.OPENAI, Providers.OPENROUTER])(
+    'canonicalizes computer screenshots for an actual %s Responses attempt',
+    async (provider) => {
+      const { invokeMessages, model } = buildCapturingModel();
+      model.last = { _useResponsesApi: () => true };
+      const computerCall = new AIMessage({
+        content: '',
+        response_metadata: {
+          output: [
+            {
+              type: 'computer_call',
+              call_id: 'computer-output',
+              action: { type: 'screenshot' },
+            },
+          ],
+        },
+      });
+      const computerOutput = new ToolMessage({
+        content: 'data:image/png;base64,AA==',
+        tool_call_id: 'computer-output',
+        additional_kwargs: { type: 'computer_call_output' },
+      });
+
+      await attemptInvoke({
+        model: model as t.ChatModel,
+        messages: [computerCall, computerOutput],
+        provider,
+      });
+
+      expect(invokeMessages[0][1].content).toEqual([
+        {
+          type: 'input_image',
+          image_url: 'data:image/png;base64,AA==',
+        },
+      ]);
+    }
+  );
+
+  it('merges per-call options when selecting Chat versus Responses', async () => {
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            call_id: 'call_per_call_computer',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_per_call_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const responses = buildCapturingModel();
+    responses.model.defaultOptions = { tools: [] };
+    responses.model._useResponsesApi = (options) =>
+      Array.isArray((options as { tools?: unknown[] } | undefined)?.tools) &&
+      ((options as { tools: unknown[] }).tools.length ?? 0) > 0;
+
+    await attemptInvoke(
+      {
+        model: responses.model as t.ChatModel,
+        messages: [computerCall, computerOutput],
+        provider: Providers.OPENAI,
+      },
+      {
+        tools: [{ type: 'computer_20251124' }],
+      } as unknown as Parameters<typeof attemptInvoke>[1]
+    );
+
+    expect(responses.invokeMessages[0][1].content).toEqual([
+      {
+        type: 'input_image',
+        image_url: 'data:image/png;base64,AA==',
+      },
+    ]);
+
+    const chat = buildCapturingModel();
+    chat.model.defaultOptions = {
+      tools: [{ type: 'computer_20251124' }],
+    };
+    chat.model._useResponsesApi = responses.model._useResponsesApi;
+
+    await attemptInvoke(
+      {
+        model: chat.model as t.ChatModel,
+        messages: [computerCall, computerOutput],
+        provider: Providers.OPENAI,
+      },
+      { tools: [] } as unknown as Parameters<typeof attemptInvoke>[1]
+    );
+
+    expect(chat.invokeMessages[0][1].content).toBe(
+      '[Computer screenshot omitted for this provider]'
+    );
+  });
+
+  it('detects Responses selected by a bound built-in computer tool', async () => {
+    const boundModel = new ChatOpenAI({
+      apiKey: 'test-key',
+      model: 'computer-use-preview',
+      useResponsesApi: false,
+    }).bindTools([
+      openAITools.computerUse({
+        displayWidth: 1024,
+        displayHeight: 768,
+        environment: 'browser',
+        execute: async () => 'data:image/png;base64,AA==',
+      }),
+    ]);
+    const invokeMessages: BaseMessage[][] = [];
+    Object.defineProperty(boundModel, 'stream', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(boundModel, 'invoke', {
+      configurable: true,
+      value: jest.fn(async (messages: BaseMessage[]) => {
+        invokeMessages.push(messages);
+        return new AIMessage({ content: 'ok' });
+      }),
+    });
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            call_id: 'bound-computer-output',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'bound-computer-output',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    await attemptInvoke({
+      model: boundModel as t.ChatModel,
+      messages: [computerCall, computerOutput],
+      provider: Providers.OPENAI,
+    });
+
+    expect(invokeMessages[0][1].content).toEqual([
+      {
+        type: 'input_image',
+        image_url: 'data:image/png;base64,AA==',
+      },
+    ]);
   });
 
   it('skips annotation for stale _refKey not present in current run registry (cross-run scenario)', async () => {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -6,6 +6,20 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type { ContextOverflowContext } from '@/utils/errors';
 import type * as t from '@/types';
+import {
+  projectCacheControlledToolOutputsToText,
+  projectComputerCallOutputsToText,
+  projectOpenAIChatToolMessageContent,
+  projectOpenAIResponsesToolMessageContent,
+  projectOpenRouterToolMessageContent,
+  projectSingleTextToolOutputsToText,
+  projectStructuredToolOutputsToText,
+  projectToolStreamContentForProvider,
+} from '@/messages/core';
+import {
+  stripAnthropicCacheControl,
+  stripBedrockCacheControl,
+} from '@/messages/cache';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { Constants, GraphEvents, Providers } from '@/common';
@@ -14,6 +28,7 @@ import { getContextOverflowInfo } from '@/utils/errors';
 import { modifyDeltaProperties } from '@/messages';
 import { ChatModelStreamHandler } from '@/stream';
 import { initializeModel } from '@/llm/init';
+import { isOpenAILike } from '@/utils/llm';
 
 /**
  * Context passed to `attemptInvoke`. Matches the subset of Graph that
@@ -53,6 +68,152 @@ export type InvokeContext = NonNullable<
  * When provided, replaces the default `ChatModelStreamHandler`.
  */
 export type OnChunk = (chunk: AIMessageChunk) => void | Promise<void>;
+
+export function usesNativeOpenAIResponses(
+  model: t.ChatModel,
+  provider: Providers,
+  callOptions?: unknown
+): boolean {
+  if (!isOpenAILike(provider)) {
+    return false;
+  }
+  let candidate: unknown = model;
+  let effectiveCallOptions = callOptions;
+  const seen = new Set<object>();
+  for (let depth = 0; depth < 20; depth++) {
+    if (candidate == null || typeof candidate !== 'object') {
+      return false;
+    }
+    if (seen.has(candidate)) {
+      return false;
+    }
+    seen.add(candidate);
+    const runnable = candidate as {
+      _useResponsesApi?: (options?: unknown) => boolean;
+      bound?: unknown;
+      defaultOptions?: unknown;
+      last?: unknown;
+      constructor?: { name?: unknown };
+    };
+    try {
+      if (
+        runnable.defaultOptions != null &&
+        typeof runnable.defaultOptions === 'object' &&
+        !Array.isArray(runnable.defaultOptions) &&
+        effectiveCallOptions != null &&
+        typeof effectiveCallOptions === 'object' &&
+        !Array.isArray(effectiveCallOptions)
+      ) {
+        effectiveCallOptions = {
+          ...(runnable.defaultOptions as Record<string, unknown>),
+          ...(effectiveCallOptions as Record<string, unknown>),
+        };
+      } else if (effectiveCallOptions == null) {
+        effectiveCallOptions = runnable.defaultOptions;
+      }
+      if (
+        runnable._useResponsesApi?.(effectiveCallOptions) === true ||
+        runnable._useResponsesApi?.(undefined) === true
+      ) {
+        return true;
+      }
+    } catch {
+      // Continue through RunnableSequence/RunnableBinding wrappers.
+    }
+    if (
+      typeof runnable.constructor?.name === 'string' &&
+      runnable.constructor.name.includes('Responses')
+    ) {
+      return true;
+    }
+    if (runnable.last != null && typeof runnable.last === 'object') {
+      candidate = runnable.last;
+      continue;
+    }
+    if (runnable.bound != null && typeof runnable.bound === 'object') {
+      candidate = runnable.bound;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Produces the exact provider-facing message representation before a model
+ * adapter serializes it. This is shared by invocation and Graph's final budget
+ * guard so structured tool output cannot grow after the payload was measured.
+ */
+export function projectMessagesForProvider({
+  model,
+  messages,
+  provider,
+  maxToolResultChars,
+  callOptions,
+}: {
+  model: t.ChatModel;
+  messages: BaseMessage[];
+  provider: Providers;
+  maxToolResultChars?: number;
+  callOptions?: unknown;
+}): BaseMessage[] {
+  const providerInputMessages = projectToolStreamContentForProvider(messages);
+  if (usesNativeOpenAIResponses(model, provider, callOptions)) {
+    return projectOpenAIResponsesToolMessageContent(
+      stripAnthropicCacheControl(
+        stripBedrockCacheControl(providerInputMessages)
+      ),
+      maxToolResultChars
+    );
+  }
+  if (provider === Providers.OPENROUTER) {
+    return projectComputerCallOutputsToText(
+      projectOpenRouterToolMessageContent(
+        stripBedrockCacheControl(providerInputMessages),
+        maxToolResultChars
+      )
+    );
+  }
+  if (isOpenAILike(provider)) {
+    return projectComputerCallOutputsToText(
+      projectOpenAIChatToolMessageContent(
+        stripAnthropicCacheControl(
+          stripBedrockCacheControl(providerInputMessages)
+        ),
+        maxToolResultChars
+      )
+    );
+  }
+  if (provider === Providers.ANTHROPIC) {
+    return projectComputerCallOutputsToText(
+      projectSingleTextToolOutputsToText(
+        stripBedrockCacheControl(providerInputMessages),
+        maxToolResultChars
+      )
+    );
+  }
+  if (provider === Providers.BEDROCK) {
+    return stripAnthropicCacheControl(
+      projectComputerCallOutputsToText(
+        projectCacheControlledToolOutputsToText(
+          providerInputMessages,
+          maxToolResultChars
+        )
+      )
+    );
+  }
+  return projectComputerCallOutputsToText(
+    projectStructuredToolOutputsToText(
+      projectSingleTextToolOutputsToText(
+        stripAnthropicCacheControl(
+          stripBedrockCacheControl(providerInputMessages)
+        ),
+        maxToolResultChars
+      ),
+      maxToolResultChars
+    )
+  );
+}
 
 function getRegisteredDefaultChatStreamHandler(
   context?: InvokeContext
@@ -207,9 +368,19 @@ export async function attemptInvoke(
    * untouched so the graph state never sees `[ref: …]` / `_ref`
    * payload.
    */
+  const invocationMessages = projectMessagesForProvider({
+    model,
+    messages,
+    provider,
+    callOptions: config,
+  });
   const registry = context?.getOrCreateToolOutputRegistry();
   const runId = config?.configurable?.run_id as string | undefined;
-  const messagesForProvider = annotateMessagesForLLM(messages, registry, runId);
+  const messagesForProvider = annotateMessagesForLLM(
+    invocationMessages,
+    registry,
+    runId
+  );
 
   /**
    * Stamp the provider that is ACTUALLY serving this invocation onto the
@@ -404,6 +575,7 @@ export async function tryFallbackProviders({
   context,
   onChunk,
   overflowContext,
+  prepareProviderMessages,
 }: {
   fallbacks: t.FallbackConfig[];
   tools?: t.GraphTools;
@@ -419,6 +591,19 @@ export async function tryFallbackProviders({
    * be dropped in favour of whichever failure came last.
    */
   overflowContext?: ContextOverflowContext;
+  /**
+   * Optional final payload guard used by Graph. It receives the initialized,
+   * tool-bound fallback model so Responses-vs-Chat projection is exact before
+   * the fallback request is measured and sent.
+   */
+  prepareProviderMessages?: (input: {
+    model: t.ChatModel;
+    messages: BaseMessage[];
+    provider: Providers;
+    clientOptions?: t.ClientOptions;
+    maxContextTokens?: number;
+    config?: RunnableConfig;
+  }) => BaseMessage[] | Promise<BaseMessage[]>;
 }): Promise<Partial<t.BaseGraphState> | undefined> {
   const isOverflow = (
     error: unknown,
@@ -460,10 +645,19 @@ export async function tryFallbackProviders({
               [Constants.INVOKED_MODEL]: fbModelName,
             },
           };
+      const fallbackMessages =
+        (await prepareProviderMessages?.({
+          model: fbModel as t.ChatModel,
+          messages,
+          provider: fb.provider,
+          clientOptions: fb.clientOptions,
+          maxContextTokens: fb.maxContextTokens,
+          config: fbConfig,
+        })) ?? messages;
       const result = await attemptInvoke(
         {
           model: fbModel as t.ChatModel,
-          messages,
+          messages: fallbackMessages,
           provider: fb.provider,
           context,
           onChunk,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -29,16 +29,28 @@ import type {
   BaseMessageChunk,
   UsageMetadata,
 } from '@langchain/core/messages';
+import type { ChatModelStreamEvent } from '@langchain/core/language_models/event';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
 import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
+import type { PromptCacheTtl } from '@/messages/cache';
+import {
+  buildAnthropicCacheControl,
+  resolvePromptCacheTtl,
+  stripAnthropicCacheControl,
+  stripBedrockCacheControl,
+} from '@/messages/cache';
 import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import {
+  projectOpenAIResponsesToolMessageContent,
+  projectToolStreamContentForProvider,
+} from '@/messages/core';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
@@ -102,6 +114,9 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
+  preserveToolCacheControl?: boolean;
+  responsesPromptCache?: boolean;
+  responsesPromptCacheTtl?: PromptCacheTtl;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
@@ -168,6 +183,40 @@ type OpenAIManagedRequestParams = {
   };
   safety_identifier?: string;
 };
+
+function stripResponsesToolCacheControl<T>(tools: T): T {
+  if (!Array.isArray(tools)) {
+    return tools;
+  }
+
+  return tools.map((tool) => {
+    if (tool == null || typeof tool !== 'object') {
+      return tool;
+    }
+    const clone = { ...(tool as Record<string, unknown>) };
+    delete clone.cache_control;
+    if (
+      clone.extras != null &&
+      typeof clone.extras === 'object' &&
+      !Array.isArray(clone.extras)
+    ) {
+      clone.extras = { ...(clone.extras as Record<string, unknown>) };
+      delete (clone.extras as Record<string, unknown>).cache_control;
+    }
+    return clone;
+  }) as T;
+}
+
+function projectOpenAIResponsesProviderMessages(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  return projectOpenAIResponsesToolMessageContent(
+    stripAnthropicCacheControl(
+      stripBedrockCacheControl(projectToolStreamContentForProvider(messages))
+    )
+  );
+}
+
 type ResponsesRequest =
   | OpenAIClient.Responses.ResponseCreateParamsStreaming
   | OpenAIClient.Responses.ResponseCreateParamsNonStreaming;
@@ -1116,6 +1165,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
   private convertReasoningDetailsToContent?: boolean;
+  private preserveToolCacheControl?: boolean;
   private promptCacheExplicit?: boolean;
   private safetyIdentifier?: string;
 
@@ -1125,6 +1175,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.includeReasoningDetails = fields?.includeReasoningDetails;
     this.convertReasoningDetailsToContent =
       fields?.convertReasoningDetailsToContent;
+    this.preserveToolCacheControl = fields?.preserveToolCacheControl;
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.safetyIdentifier = fields?.safety_identifier;
   }
@@ -1225,6 +1276,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
         includeReasoningContent: this.includeReasoningContent,
         includeReasoningDetails: this.includeReasoningDetails,
         convertReasoningDetailsToContent: this.convertReasoningDetailsToContent,
+        preserveToolCacheControl: this.preserveToolCacheControl,
       }
     );
 
@@ -1393,6 +1445,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
         includeReasoningContent: this.includeReasoningContent,
         includeReasoningDetails: this.includeReasoningDetails,
         convertReasoningDetailsToContent: this.convertReasoningDetailsToContent,
+        preserveToolCacheControl: this.preserveToolCacheControl,
       });
 
     const params = {
@@ -1533,21 +1586,52 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   private promptCacheExplicit?: boolean;
+  private responsesPromptCache?: boolean;
+  private responsesPromptCacheTtl?: PromptCacheTtl;
   private safetyIdentifier?: string;
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.responsesPromptCache = fields?.responsesPromptCache;
+    this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
   invocationParams(
     options?: this['ParsedCallOptions']
   ): ReturnType<OriginalChatOpenAIResponses['invocationParams']> {
-    const params = applyManagedRequestParams(super.invocationParams(options), {
-      promptCacheExplicit: this.promptCacheExplicit,
-      safetyIdentifier: this.safetyIdentifier,
-    });
+    const cacheOptions = options as
+      | {
+          promptCache?: boolean;
+          promptCacheTtl?: PromptCacheTtl;
+        }
+      | undefined;
+    const promptCache = cacheOptions?.promptCache ?? this.responsesPromptCache;
+    const cacheControl =
+      promptCache === true
+        ? buildAnthropicCacheControl(
+          resolvePromptCacheTtl(
+            cacheOptions?.promptCacheTtl ?? this.responsesPromptCacheTtl
+          )
+        )
+        : undefined;
+    const baseParams = applyManagedRequestParams(
+      super.invocationParams(options),
+      {
+        promptCacheExplicit: this.promptCacheExplicit,
+        safetyIdentifier: this.safetyIdentifier,
+      }
+    );
+    const params = {
+      ...baseParams,
+      ...(baseParams.tools != null && {
+        tools: stripResponsesToolCacheControl(baseParams.tools),
+      }),
+      ...(cacheControl != null && {
+        cache_control: cacheControl,
+      }),
+    };
     if (shouldIncludeEncryptedReasoning(this.model, params)) {
       params.include = [
         ...new Set([
@@ -1592,7 +1676,11 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
-    const result = await super._generate(messages, options, runManager);
+    const result = await super._generate(
+      projectOpenAIResponsesProviderMessages(messages),
+      options,
+      runManager
+    );
     for (const generation of result.generations) {
       attachCacheWriteUsage(generation.message);
     }
@@ -1605,13 +1693,25 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     for await (const chunk of super._streamResponseChunks(
-      messages,
+      projectOpenAIResponsesProviderMessages(messages),
       options,
       runManager
     )) {
       attachCacheWriteUsage(chunk.message);
       yield chunk;
     }
+  }
+
+  async *_streamChatModelEvents(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatModelStreamEvent> {
+    yield* super._streamChatModelEvents(
+      projectOpenAIResponsesProviderMessages(messages),
+      options,
+      runManager
+    );
   }
 
   protected _getReasoningParams(

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -42,6 +42,7 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import { serializeStructuredValue } from '@/utils/toolContent';
 import { toLangChainContent } from '@/messages/langchain';
 
 export type { OpenAICallOptions, OpenAIChatInput };
@@ -598,7 +599,7 @@ export function _convertMessagesToOpenAIResponsesParams(
           id: toolMessage.id?.startsWith('fc_') ? toolMessage.id : undefined,
           output:
             typeof toolMessage.content !== 'string'
-              ? JSON.stringify(toolMessage.content)
+              ? serializeStructuredValue(toolMessage.content)
               : toolMessage.content,
         };
       }

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -3,7 +3,6 @@
 import { type OpenAI as OpenAIClient } from 'openai';
 import { ChatGenerationChunk } from '@langchain/core/outputs';
 import {
-  convertLangChainToolCallToOpenAI,
   makeInvalidToolCall,
   parseToolCall,
 } from '@langchain/core/output_parsers/openai_tools';
@@ -42,7 +41,13 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { serializeStructuredValue } from '@/utils/toolContent';
+import {
+  calculateMaxToolCallInputChars,
+  projectToolCallInputs,
+  serializeToolCallInput,
+} from '@/messages/prune';
+import { serializeStructuredValueBounded } from '@/utils/toolContent';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from '@/messages/langchain';
 
 export type { OpenAICallOptions, OpenAIChatInput };
@@ -83,6 +88,32 @@ type OpenAIRoleEnum =
 
 type OpenAICompletionParam =
   OpenAIClient.Chat.Completions.ChatCompletionMessageParam;
+
+const MAX_PROVIDER_TOOL_CALL_INPUT_CHARS = calculateMaxToolCallInputChars();
+
+function convertLangChainToolCallToBoundedOpenAI(toolCall: ToolCall): {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+} {
+  if (toolCall.id == null) {
+    throw new Error('All OpenAI tool calls must have an "id" field.');
+  }
+  return {
+    id: toolCall.id,
+    type: 'function',
+    function: {
+      name: toolCall.name,
+      arguments: serializeToolCallInput(
+        toolCall.args,
+        MAX_PROVIDER_TOOL_CALL_INPUT_CHARS
+      ),
+    },
+  };
+}
 
 function extractGenericMessageCustomRole(message: ChatMessage) {
   if (
@@ -309,9 +340,13 @@ export function _convertMessagesToOpenAIParams(
   model?: string,
   options?: ConvertMessagesOptions
 ): OpenAICompletionParam[] {
+  const projectedMessages = projectToolCallInputs(
+    messages,
+    MAX_PROVIDER_TOOL_CALL_INPUT_CHARS
+  );
   let hasReasoningToolCallContext = false;
   // TODO: Function messages do not support array content, fix cast
-  return messages.flatMap((message) => {
+  return projectedMessages.flatMap((message) => {
     let role = messageToOpenAIRole(message);
     if (role === 'system' && isReasoningModel(model)) {
       role = 'developer';
@@ -319,22 +354,33 @@ export function _convertMessagesToOpenAIParams(
 
     let hasAnthropicThinkingBlock: boolean = false;
 
-    const content =
-      typeof message.content === 'string'
-        ? message.content
-        : message.content.map((m) => {
-          if ('type' in m && m.type === 'thinking') {
-            hasAnthropicThinkingBlock = true;
-            return m;
-          }
-          if (isDataContentBlock(m)) {
-            return convertToProviderContentBlock(
-              m,
-              completionsApiContentBlockConverter
-            );
-          }
+    let content: unknown;
+    if (
+      role === 'tool' &&
+      typeof message.content !== 'string' &&
+      message.additional_kwargs.type !== 'computer_call_output'
+    ) {
+      content = serializeStructuredValueBounded(
+        message.content,
+        HARD_MAX_TOOL_RESULT_CHARS
+      ).content;
+    } else if (typeof message.content === 'string') {
+      content = message.content;
+    } else {
+      content = message.content.map((m) => {
+        if ('type' in m && m.type === 'thinking') {
+          hasAnthropicThinkingBlock = true;
           return m;
-        });
+        }
+        if (isDataContentBlock(m)) {
+          return convertToProviderContentBlock(
+            m,
+            completionsApiContentBlockConverter
+          );
+        }
+        return m;
+      });
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const completionParam: Record<string, any> = {
       role,
@@ -352,7 +398,7 @@ export function _convertMessagesToOpenAIParams(
     if (isAIMessage(message) && !!message.tool_calls?.length) {
       messageHasToolCalls = true;
       completionParam.tool_calls = message.tool_calls.map(
-        convertLangChainToolCallToOpenAI
+        convertLangChainToolCallToBoundedOpenAI
       );
       completionParam.content = hasAnthropicThinkingBlock ? content : '';
       if (
@@ -528,7 +574,11 @@ export function _convertMessagesToOpenAIResponsesParams(
   model?: string,
   zdrEnabled?: boolean
 ): ResponsesInputItem[] {
-  return messages.flatMap(
+  const projectedMessages = projectToolCallInputs(
+    messages,
+    MAX_PROVIDER_TOOL_CALL_INPUT_CHARS
+  );
+  return projectedMessages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
       const additional_kwargs =
         lcMsg.additional_kwargs as BaseMessageFields['additional_kwargs'] & {
@@ -599,7 +649,10 @@ export function _convertMessagesToOpenAIResponsesParams(
           id: toolMessage.id?.startsWith('fc_') ? toolMessage.id : undefined,
           output:
             typeof toolMessage.content !== 'string'
-              ? serializeStructuredValue(toolMessage.content)
+              ? serializeStructuredValueBounded(
+                toolMessage.content,
+                HARD_MAX_TOOL_RESULT_CHARS
+              ).content
               : toolMessage.content,
         };
       }
@@ -683,7 +736,10 @@ export function _convertMessagesToOpenAIResponsesParams(
               (toolCall): ResponsesInputItem => ({
                 type: 'function_call',
                 name: toolCall.name,
-                arguments: JSON.stringify(toolCall.args),
+                arguments: serializeToolCallInput(
+                  toolCall.args,
+                  MAX_PROVIDER_TOOL_CALL_INPUT_CHARS
+                ),
                 call_id: toolCall.id!,
                 ...(zdrEnabled ? { id: functionCallIds?.[toolCall.id!] } : {}),
               })

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -37,6 +37,12 @@ import type {
 } from '@langchain/openai';
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import {
+  getBoundedCacheControlledTextToolContent,
+  getComputerCallOutputScreenshot,
+  isComputerCallOutputMessage,
+  serializeStructuredValueBounded,
+} from '@/utils/toolContent';
+import {
   STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
@@ -46,7 +52,6 @@ import {
   projectToolCallInputs,
   serializeToolCallInput,
 } from '@/messages/prune';
-import { serializeStructuredValueBounded } from '@/utils/toolContent';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from '@/messages/langchain';
 
@@ -332,6 +337,8 @@ export interface ConvertMessagesOptions {
   includeReasoningDetails?: boolean;
   /** Convert reasoning_details to content blocks for Claude (requires content array format) */
   convertReasoningDetailsToContent?: boolean;
+  /** Preserve OpenRouter's canonical cache-decorated tool text block. */
+  preserveToolCacheControl?: boolean;
 }
 
 // Used in LangSmith, export is important here
@@ -358,9 +365,16 @@ export function _convertMessagesToOpenAIParams(
     if (
       role === 'tool' &&
       typeof message.content !== 'string' &&
-      message.additional_kwargs.type !== 'computer_call_output'
+      !isComputerCallOutputMessage(message)
     ) {
-      content = serializeStructuredValueBounded(
+      content =
+        options?.preserveToolCacheControl === true
+          ? getBoundedCacheControlledTextToolContent(
+            message.content,
+            HARD_MAX_TOOL_RESULT_CHARS
+          )
+          : undefined;
+      content ??= serializeStructuredValueBounded(
         message.content,
         HARD_MAX_TOOL_RESULT_CHARS
       ).content;
@@ -603,44 +617,29 @@ export function _convertMessagesToOpenAIResponsesParams(
 
         // Handle computer call output
         if (additional_kwargs.type === 'computer_call_output') {
-          const output = (() => {
-            if (typeof toolMessage.content === 'string') {
-              return {
-                type: 'computer_screenshot' as const,
-                image_url: toolMessage.content,
-              };
-            }
-
-            if (Array.isArray(toolMessage.content)) {
-              const oaiScreenshot = toolMessage.content.find(
-                (i) => i.type === 'computer_screenshot'
-              ) as { type: 'computer_screenshot'; image_url: string };
-
-              if (oaiScreenshot) return oaiScreenshot;
-
-              const lcImage = toolMessage.content.find(
-                (i) => i.type === 'image_url'
-              ) as MessageContentImageUrl;
-
-              if (lcImage) {
-                return {
-                  type: 'computer_screenshot' as const,
-                  image_url:
-                    typeof lcImage.image_url === 'string'
-                      ? lcImage.image_url
-                      : lcImage.image_url.url,
-                };
-              }
-            }
-
+          const screenshot = getComputerCallOutputScreenshot(
+            toolMessage.content
+          );
+          if (screenshot == null) {
             throw new Error('Invalid computer call output');
-          })();
+          }
 
-          return {
+          const output: OpenAIClient.Responses.ResponseComputerToolCallOutputScreenshot =
+            'image_url' in screenshot
+              ? {
+                type: 'computer_screenshot',
+                image_url: screenshot.image_url,
+              }
+              : {
+                type: 'computer_screenshot',
+                file_id: screenshot.file_id,
+              };
+          const computerCallOutput: ResponsesInputItem = {
             type: 'computer_call_output',
             output,
             call_id: toolMessage.tool_call_id,
           };
+          return computerCallOutput;
         }
 
         return {

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -1,5 +1,10 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
-import { _convertMessagesToOpenAIParams } from './index';
+import {
+  _convertMessagesToOpenAIParams,
+  _convertMessagesToOpenAIResponsesParams,
+} from './index';
+import { calculateMaxToolCallInputChars } from '@/messages/prune';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 
 describe('_convertMessagesToOpenAIParams', () => {
   it('includes reasoning_content for assistant messages in tool-call context when requested', () => {
@@ -155,5 +160,224 @@ describe('_convertMessagesToOpenAIParams', () => {
         reasoning_content: 'The prior calculator result is available.',
       })
     );
+  });
+
+  it('bounds structured function-tool output for Chat and Responses adapters', () => {
+    let toJSONCalls = 0;
+    const toolMessage = new ToolMessage({
+      content: [
+        { type: 'text', text: 'rendered chart' },
+        {
+          type: 'image_url',
+          image_url: {
+            url: `data:image/png;base64,${'A'.repeat(
+              HARD_MAX_TOOL_RESULT_CHARS + 1_000
+            )}`,
+          },
+          toJSON() {
+            toJSONCalls++;
+            return { expanded: 'B'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2) };
+          },
+        },
+      ],
+      tool_call_id: 'call_structured',
+    });
+
+    const chat = _convertMessagesToOpenAIParams([toolMessage]);
+    const responses = _convertMessagesToOpenAIResponsesParams([toolMessage]);
+    const chatContent = chat[0].content;
+
+    expect(typeof chatContent).toBe('string');
+    expect((chatContent as string).length).toBeLessThanOrEqual(
+      HARD_MAX_TOOL_RESULT_CHARS
+    );
+    expect(responses[0]).toMatchObject({
+      type: 'function_call_output',
+      call_id: 'call_structured',
+      output: chatContent,
+    });
+    expect(toJSONCalls).toBe(0);
+    expect(Array.isArray(toolMessage.content)).toBe(true);
+  });
+
+  it('bounds direct structured tool-call args without invoking accessors or toJSON', () => {
+    const maxInputChars = calculateMaxToolCallInputChars();
+    let getterCalls = 0;
+    let toJSONCalls = 0;
+    const args: Record<string, unknown> = {
+      query: 'safe',
+      payload: 'x'.repeat(maxInputChars + 1_000),
+    };
+    Object.defineProperty(args, 'expanded', {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return 'y'.repeat(maxInputChars * 2);
+      },
+    });
+    args.self = args;
+    args.toJSON = (): Record<string, string> => {
+      toJSONCalls++;
+      return { payload: 'z'.repeat(maxInputChars * 2) };
+    };
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_adversarial',
+          name: 'lookup',
+          args,
+        },
+      ],
+    });
+
+    const chat = _convertMessagesToOpenAIParams([message]);
+    const responses = _convertMessagesToOpenAIResponsesParams([message]);
+    const chatArguments = (
+      chat[0] as {
+        tool_calls: Array<{ function: { arguments: string } }>;
+      }
+    ).tool_calls[0].function.arguments;
+    const responseArguments = (
+      responses.find((item) => item.type === 'function_call') as {
+        arguments: string;
+      }
+    ).arguments;
+
+    expect(chatArguments).toBe(responseArguments);
+    expect(chatArguments.length).toBeLessThanOrEqual(maxInputChars);
+    expect(() => JSON.parse(chatArguments)).not.toThrow();
+    expect(getterCalls).toBe(0);
+    expect(toJSONCalls).toBe(0);
+    expect(args.self).toBe(args);
+  });
+
+  it('bounds and synchronizes raw Chat and Responses function-call arguments', () => {
+    const maxInputChars = calculateMaxToolCallInputChars();
+    const rawArguments = `{"payload":"${'x'.repeat(maxInputChars + 1_000)}"}`;
+    const rawOnlyMessage = new AIMessage({
+      content: '',
+      additional_kwargs: {
+        tool_calls: [
+          {
+            id: 'call_raw',
+            type: 'function',
+            function: { name: 'lookup', arguments: rawArguments },
+          },
+        ],
+      },
+      response_metadata: {
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_raw',
+            call_id: 'call_raw',
+            name: 'lookup',
+            arguments: rawArguments,
+          },
+        ],
+      },
+    });
+
+    const chat = _convertMessagesToOpenAIParams([rawOnlyMessage]);
+    const responses = _convertMessagesToOpenAIResponsesParams([rawOnlyMessage]);
+    const chatArguments = (
+      chat[0] as {
+        tool_calls: Array<{ function: { arguments: string } }>;
+      }
+    ).tool_calls[0].function.arguments;
+    const responseArguments = (
+      responses.find((item) => item.type === 'function_call') as {
+        arguments: string;
+      }
+    ).arguments;
+
+    expect(chatArguments.length).toBeLessThanOrEqual(maxInputChars);
+    expect(responseArguments.length).toBeLessThanOrEqual(maxInputChars);
+    expect(() => JSON.parse(chatArguments)).not.toThrow();
+    expect(() => JSON.parse(responseArguments)).not.toThrow();
+    expect(
+      (
+        rawOnlyMessage.additional_kwargs.tool_calls as Array<{
+          function: { arguments: string };
+        }>
+      )[0].function.arguments
+    ).toBe(rawArguments);
+    expect(
+      (
+        rawOnlyMessage.response_metadata.output as Array<{
+          arguments: string;
+        }>
+      )[0].arguments
+    ).toBe(rawArguments);
+  });
+
+  it('makes Responses raw reuse match the projected LangChain tool-call args', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_synced',
+          name: 'lookup',
+          args: { query: 'canonical', payload: 'x'.repeat(500_000) },
+        },
+      ],
+      response_metadata: {
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_synced',
+            call_id: 'call_synced',
+            name: 'lookup',
+            arguments: '{"query":"stale"}',
+          },
+        ],
+      },
+    });
+
+    const chat = _convertMessagesToOpenAIParams([message]);
+    const responses = _convertMessagesToOpenAIResponsesParams([message]);
+    const chatArguments = (
+      chat[0] as {
+        tool_calls: Array<{ function: { arguments: string } }>;
+      }
+    ).tool_calls[0].function.arguments;
+    const responseArguments = (
+      responses.find((item) => item.type === 'function_call') as {
+        arguments: string;
+      }
+    ).arguments;
+
+    expect(responseArguments).toBe(chatArguments);
+    expect(() => JSON.parse(responseArguments)).not.toThrow();
+    expect(
+      (
+        message.response_metadata.output as Array<{
+          arguments: string;
+        }>
+      )[0].arguments
+    ).toBe('{"query":"stale"}');
+  });
+
+  it('preserves native Responses computer-call output handling', () => {
+    const toolMessage = new ToolMessage({
+      content: [
+        {
+          type: 'computer_screenshot',
+          image_url: 'data:image/png;base64,AA==',
+        },
+      ],
+      tool_call_id: 'call_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(_convertMessagesToOpenAIResponsesParams([toolMessage])[0]).toEqual({
+      type: 'computer_call_output',
+      call_id: 'call_computer',
+      output: {
+        type: 'computer_screenshot',
+        image_url: 'data:image/png;base64,AA==',
+      },
+    });
   });
 });

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -200,6 +200,30 @@ describe('_convertMessagesToOpenAIParams', () => {
     expect(Array.isArray(toolMessage.content)).toBe(true);
   });
 
+  it('preserves canonical OpenRouter cache blocks only when requested', () => {
+    const toolMessage = new ToolMessage({
+      content: [
+        {
+          type: 'text',
+          text: 'result body',
+          cache_control: { type: 'ephemeral', ttl: '1h' },
+        },
+      ],
+      tool_call_id: 'call_cached',
+    });
+
+    const defaultContent = _convertMessagesToOpenAIParams([toolMessage])[0]
+      .content;
+    const openRouterContent = _convertMessagesToOpenAIParams(
+      [toolMessage],
+      'anthropic/claude-sonnet-4',
+      { preserveToolCacheControl: true }
+    )[0].content;
+
+    expect(typeof defaultContent).toBe('string');
+    expect(openRouterContent).toEqual(toolMessage.content);
+  });
+
   it('bounds direct structured tool-call args without invoking accessors or toJSON', () => {
     const maxInputChars = calculateMaxToolCallInputChars();
     let getterCalls = 0;
@@ -312,6 +336,43 @@ describe('_convertMessagesToOpenAIParams', () => {
     ).toBe(rawArguments);
   });
 
+  it('normalizes legacy function calls before wire serialization', () => {
+    let toJSONCalls = 0;
+    const functionCall = {
+      name: 'legacy_lookup',
+      arguments: '{}',
+    };
+    const message = new AIMessage({
+      content: '',
+      additional_kwargs: {
+        function_call: functionCall,
+      },
+    });
+    Object.defineProperty(functionCall, 'toJSON', {
+      enumerable: true,
+      value: () => {
+        toJSONCalls++;
+        return {
+          name: 'legacy_lookup',
+          arguments: 'x'.repeat(500_000),
+        };
+      },
+    });
+
+    const [chat] = _convertMessagesToOpenAIParams([message]);
+    const serialized = JSON.stringify(chat);
+
+    expect(chat).toMatchObject({
+      role: 'assistant',
+      function_call: {
+        name: 'legacy_lookup',
+        arguments: '{}',
+      },
+    });
+    expect(serialized.length).toBeLessThanOrEqual(300);
+    expect(toJSONCalls).toBe(0);
+  });
+
   it('makes Responses raw reuse match the projected LangChain tool-call args', () => {
     const message = new AIMessage({
       content: '',
@@ -359,25 +420,69 @@ describe('_convertMessagesToOpenAIParams', () => {
     ).toBe('{"query":"stale"}');
   });
 
-  it('preserves native Responses computer-call output handling', () => {
-    const toolMessage = new ToolMessage({
-      content: [
-        {
+  it('normalizes native Responses computer-call output screenshots', () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const messages = [
+      new ToolMessage({
+        content: screenshot,
+        tool_call_id: 'call_computer_string',
+        additional_kwargs: { type: 'computer_call_output' },
+      }),
+      new ToolMessage({
+        content: [{ type: 'computer_screenshot', image_url: screenshot }],
+        tool_call_id: 'call_computer_structured',
+        additional_kwargs: { type: 'computer_call_output' },
+      }),
+      new ToolMessage({
+        content: [{ type: 'input_image', file_id: 'file_screenshot123' }],
+        tool_call_id: 'call_computer_file',
+        additional_kwargs: { type: 'computer_call_output' },
+      }),
+    ];
+
+    expect(_convertMessagesToOpenAIResponsesParams(messages)).toEqual([
+      {
+        type: 'computer_call_output',
+        call_id: 'call_computer_string',
+        output: { type: 'computer_screenshot', image_url: screenshot },
+      },
+      {
+        type: 'computer_call_output',
+        call_id: 'call_computer_structured',
+        output: { type: 'computer_screenshot', image_url: screenshot },
+      },
+      {
+        type: 'computer_call_output',
+        call_id: 'call_computer_file',
+        output: {
           type: 'computer_screenshot',
-          image_url: 'data:image/png;base64,AA==',
+          file_id: 'file_screenshot123',
         },
-      ],
-      tool_call_id: 'call_computer',
+      },
+    ]);
+  });
+
+  it('rejects malformed native Responses computer-call output', () => {
+    const message = new ToolMessage({
+      content: 'not a screenshot URL',
+      tool_call_id: 'call_computer_invalid',
       additional_kwargs: { type: 'computer_call_output' },
     });
 
-    expect(_convertMessagesToOpenAIResponsesParams([toolMessage])[0]).toEqual({
-      type: 'computer_call_output',
-      call_id: 'call_computer',
-      output: {
-        type: 'computer_screenshot',
-        image_url: 'data:image/png;base64,AA==',
-      },
+    expect(() => _convertMessagesToOpenAIResponsesParams([message])).toThrow(
+      'Invalid computer call output'
+    );
+  });
+
+  it('rejects a truncated data URI marked as a computer screenshot', () => {
+    const message = new ToolMessage({
+      content: 'data:image/png;base64,AAAA\n\n… [truncated: 1000 chars] …',
+      tool_call_id: 'call_computer_truncated',
+      additional_kwargs: { type: 'computer_call_output' },
     });
+
+    expect(() => _convertMessagesToOpenAIResponsesParams([message])).toThrow(
+      'Invalid computer call output'
+    );
   });
 });

--- a/src/llm/openrouter/index.ts
+++ b/src/llm/openrouter/index.ts
@@ -32,6 +32,7 @@ export interface ChatOpenRouterCallOptions
   include_reasoning?: boolean;
   reasoning?: OpenRouterReasoning;
   modelKwargs?: OpenAIChatInput['modelKwargs'];
+  useResponsesApi?: boolean;
   promptCache?: boolean;
   /**
    * Prompt-cache breakpoint TTL. Defaults to `'1h'` (extended cache) when
@@ -52,6 +53,7 @@ export type OpenRouterInvocationParams = Omit<
   'messages'
 > & {
   reasoning?: OpenRouterReasoning;
+  cache_control?: { type: 'ephemeral'; ttl?: '1h' };
 };
 
 type InvocationParamsExtra = {
@@ -150,6 +152,9 @@ export class ChatOpenRouter extends ChatOpenAI {
       modelKwargs: parentModelKwargs,
       includeReasoningDetails: true,
       convertReasoningDetailsToContent: true,
+      preserveToolCacheControl: true,
+      responsesPromptCache: _fields.promptCache,
+      responsesPromptCacheTtl: _fields.promptCacheTtl,
     });
 
     // Merge reasoning config: modelKwargs.reasoning < constructor reasoning
@@ -171,11 +176,16 @@ export class ChatOpenRouter extends ChatOpenAI {
     type MutableParams = Omit<
       OpenAIClient.Chat.ChatCompletionCreateParams,
       'messages'
-    > & { reasoning_effort?: string; reasoning?: OpenRouterReasoning };
+    > & {
+      reasoning_effort?: string;
+      reasoning?: OpenRouterReasoning;
+      cache_control?: { type: 'ephemeral'; ttl?: '1h' };
+    };
 
     const optionsWithDefaults = this._combineCallOptions(options);
+    const useResponsesApi = this._useResponsesApi(options);
     const params = (
-      this._useResponsesApi(options)
+      useResponsesApi
         ? this.responses.invocationParams(optionsWithDefaults)
         : this.completions.invocationParams(optionsWithDefaults, extra)
     ) as MutableParams;

--- a/src/llm/openrouter/reasoning.test.ts
+++ b/src/llm/openrouter/reasoning.test.ts
@@ -1,5 +1,10 @@
+import { tools as openAITools } from '@langchain/openai';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { OpenAIChatInput } from '@langchain/openai';
 import type { OpenRouterReasoning, ChatOpenRouterCallOptions } from './index';
+import type { GraphTools } from '@/types';
+import { partitionAndMarkOpenRouterToolCache } from './toolCache';
+import { addTailCacheControl } from '@/messages/cache';
 import { ChatOpenRouter } from './index';
 
 type CreateRouterOptions = Partial<
@@ -243,5 +248,314 @@ describe('ChatOpenRouter reasoning handling', () => {
       const params = router.invocationParams();
       expect(params.reasoning).toEqual({ exclude: true });
     });
+  });
+});
+
+describe('ChatOpenRouter Responses prompt caching', () => {
+  it('maps promptCache to the Responses top-level cache control', () => {
+    const router = new ChatOpenRouter({
+      model: 'anthropic/claude-sonnet-4',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: true,
+      promptCacheTtl: '1h',
+    });
+
+    expect(router.invocationParams().cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+  });
+
+  it('sends cache control on the actual Responses request', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: true,
+      promptCacheTtl: '1h',
+      streaming: false,
+    });
+    const sentinel = new Error('captured request');
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (request: unknown) => Promise<never>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      throw sentinel;
+    };
+
+    await expect(router.invoke([new HumanMessage('hello')])).rejects.toThrow(
+      sentinel
+    );
+    expect(capturedRequest).toMatchObject({
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+      input: [{ type: 'message', role: 'user', content: 'hello' }],
+    });
+  });
+
+  it('honors per-call Responses cache overrides', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: false,
+      streaming: false,
+    });
+    const sentinel = new Error('captured override');
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (request: unknown) => Promise<never>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      throw sentinel;
+    };
+
+    await expect(
+      router.invoke([new HumanMessage('hello')], {
+        promptCache: true,
+        promptCacheTtl: '5m',
+      } as unknown as Parameters<typeof router.invoke>[1])
+    ).rejects.toThrow(sentinel);
+    expect(capturedRequest).toMatchObject({
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(JSON.stringify(capturedRequest)).not.toContain('"ttl"');
+  });
+
+  it('removes tail block markers added after invocation normalization', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: true,
+      streaming: false,
+    });
+    const sentinel = new Error('captured tail cache');
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (request: unknown) => Promise<never>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      throw sentinel;
+    };
+    const messages = addTailCacheControl([
+      new HumanMessage('search'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_cached_result',
+            name: 'search',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'result body',
+        tool_call_id: 'call_cached_result',
+        name: 'search',
+      }),
+    ]);
+
+    await expect(router.invoke(messages)).rejects.toThrow(sentinel);
+
+    const request = capturedRequest as {
+      cache_control?: unknown;
+      input?: Array<{ type?: string; output?: unknown }>;
+    };
+    expect(
+      request.input?.find((item) => item.type === 'function_call_output')
+    ).toMatchObject({ output: 'result body' });
+    expect(request.cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+    expect(JSON.stringify(request.input)).not.toContain('cache_control');
+  });
+
+  it('normalizes cache markers for native Responses event streaming', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: true,
+      streaming: true,
+    });
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (
+            request: unknown
+          ) => Promise<AsyncIterable<never>>;
+          _streamChatModelEvents: (
+            messages: unknown[],
+            options: Record<string, unknown>
+          ) => AsyncIterable<unknown>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield* [];
+        },
+      };
+    };
+    const messages = addTailCacheControl([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_stream_cache',
+            name: 'search',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'stream result',
+        tool_call_id: 'call_stream_cache',
+        name: 'search',
+      }),
+    ]);
+
+    for await (const _event of responses._streamChatModelEvents(messages, {})) {
+      // The stubbed provider stream is empty; consuming it triggers request creation.
+    }
+
+    const request = capturedRequest as {
+      input?: Array<{ type?: string; output?: unknown }>;
+      cache_control?: unknown;
+    };
+    expect(
+      request.input?.find((item) => item.type === 'function_call_output')
+    ).toMatchObject({ output: 'stream result' });
+    expect(request.cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+    expect(JSON.stringify(request.input)).not.toContain('cache_control');
+  });
+
+  it('removes Chat-style tool cache markers from Responses tools', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+      promptCache: true,
+      streaming: false,
+    });
+    const sentinel = new Error('captured tool cache');
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (request: unknown) => Promise<never>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      throw sentinel;
+    };
+    const markedTools = partitionAndMarkOpenRouterToolCache(
+      [
+        {
+          type: 'function',
+          function: {
+            name: 'search',
+            description: 'Search records',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ] as GraphTools,
+      () => false,
+      '1h'
+    )!;
+    const bound = router.bindTools(markedTools);
+
+    await expect(bound.invoke([new HumanMessage('search')])).rejects.toThrow(
+      sentinel
+    );
+
+    const request = capturedRequest as {
+      cache_control?: unknown;
+      tools?: unknown[];
+    };
+    expect(request.cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+    expect(JSON.stringify(request.tools)).not.toContain('cache_control');
+  });
+
+  it('keeps top-level cache control when a computer tool auto-selects Responses', async () => {
+    const router = new ChatOpenRouter({
+      model: 'openai/gpt-4.1',
+      apiKey: 'test-key',
+      useResponsesApi: false,
+      promptCache: true,
+      streaming: false,
+    });
+    const sentinel = new Error('captured computer cache');
+    let capturedRequest: unknown;
+    const responses = (
+      router as unknown as {
+        responses: {
+          completionWithRetry: (request: unknown) => Promise<never>;
+        };
+      }
+    ).responses;
+    responses.completionWithRetry = async (request) => {
+      capturedRequest = request;
+      throw sentinel;
+    };
+    const bound = router.bindTools([
+      openAITools.computerUse({
+        displayWidth: 1024,
+        displayHeight: 768,
+        environment: 'browser',
+        execute: async () => 'data:image/png;base64,AA==',
+      }),
+    ]);
+
+    await expect(bound.invoke([new HumanMessage('inspect')])).rejects.toThrow(
+      sentinel
+    );
+
+    expect(capturedRequest).toMatchObject({
+      cache_control: { type: 'ephemeral', ttl: '1h' },
+    });
+  });
+
+  it('keeps Chat prompt caching on content blocks', () => {
+    const router = new ChatOpenRouter({
+      model: 'anthropic/claude-sonnet-4',
+      apiKey: 'test-key',
+      useResponsesApi: false,
+      promptCache: true,
+    });
+
+    expect(router.invocationParams().cache_control).toBeUndefined();
   });
 });

--- a/src/messages/__tests__/observationMasking.test.ts
+++ b/src/messages/__tests__/observationMasking.test.ts
@@ -1,7 +1,10 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { TokenCounter } from '@/types/run';
-import { maskConsumedToolResults } from '@/messages/prune';
+import {
+  maskConsumedToolResults,
+  ORIGINAL_CONTENT_MAX_CHARS,
+} from '@/messages/prune';
 
 const charCounter: TokenCounter = (msg) => {
   const raw = msg.content;
@@ -259,6 +262,42 @@ describe('maskConsumedToolResults', () => {
     expect(masked.artifact).toEqual({ source: 'clickhouse' });
     expect(map[2]).toBe(charCounter(masked));
     expect(originalContentStore.get(2)).toBe(originalContent);
+  });
+
+  it('bounds stored structured originals without invoking custom toJSON', () => {
+    const tcId = 'tc-large-structured';
+    const toJSON = jest.fn(() => ({ expanded: 'should not run' }));
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      aiToolCall(tcId, 'run_select_query'),
+      new ToolMessage({
+        content: [
+          {
+            type: 'json',
+            payload: 'x'.repeat(ORIGINAL_CONTENT_MAX_CHARS + 1_000),
+            toJSON,
+          },
+        ],
+        tool_call_id: tcId,
+        name: 'run_select_query',
+      }),
+      aiWithText('The query completed.'),
+    ];
+    const originalContentStore = new Map<number, string>();
+
+    const count = maskConsumedToolResults({
+      messages,
+      indexTokenCountMap: { 0: 1, 1: 1, 2: 1, 3: 1 },
+      tokenCounter: () => 1,
+      originalContentStore,
+    });
+
+    expect(count).toBe(1);
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(originalContentStore.get(2)?.length).toBeLessThanOrEqual(
+      ORIGINAL_CONTENT_MAX_CHARS
+    );
+    expect(originalContentStore.get(2)).toContain('truncated');
   });
 
   it('handles empty messages array', () => {

--- a/src/messages/__tests__/observationMasking.test.ts
+++ b/src/messages/__tests__/observationMasking.test.ts
@@ -6,7 +6,7 @@ import { maskConsumedToolResults } from '@/messages/prune';
 const charCounter: TokenCounter = (msg) => {
   const raw = msg.content;
   if (typeof raw === 'string') return raw.length;
-  return 0;
+  return JSON.stringify(raw).length;
 };
 
 function toolMsg(
@@ -207,6 +207,58 @@ describe('maskConsumedToolResults', () => {
     // Token count should be updated to match the masked content length
     expect(map[2]).toBeLessThan(2000);
     expect(map[2]).toBe((messages[2].content as string).length);
+  });
+
+  it('masks consumed structured tool results with a bounded text preview', () => {
+    const tcId = 'tc-structured';
+    const toolMessage = new ToolMessage({
+      content: [
+        {
+          type: 'json',
+          rows: Array.from({ length: 20 }, (_, index) => ({
+            id: index,
+            value: `${'x'.repeat(100)}-${index}`,
+          })),
+        },
+      ],
+      tool_call_id: tcId,
+      name: 'run_select_query',
+      status: 'success',
+      artifact: { source: 'clickhouse' },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      aiToolCall(tcId, 'run_select_query'),
+      toolMessage,
+      aiWithText('The query returned 20 rows.'),
+    ];
+    const map: Record<string, number | undefined> = {
+      0: 5,
+      1: 20,
+      2: 0,
+      3: 30,
+    };
+    const originalContentStore = new Map<number, string>();
+    const originalContent = JSON.stringify(toolMessage.content);
+
+    const count = maskConsumedToolResults({
+      messages,
+      indexTokenCountMap: map,
+      tokenCounter: charCounter,
+      originalContentStore,
+    });
+
+    expect(count).toBe(1);
+    expect(typeof messages[2].content).toBe('string');
+    expect(messages[2].content).toContain('truncated');
+    expect((messages[2].content as string).length).toBeLessThanOrEqual(300);
+    const masked = messages[2] as ToolMessage;
+    expect(masked.tool_call_id).toBe(tcId);
+    expect(masked.name).toBe('run_select_query');
+    expect(masked.status).toBe('success');
+    expect(masked.artifact).toEqual({ source: 'clickhouse' });
+    expect(map[2]).toBe(charCounter(masked));
+    expect(originalContentStore.get(2)).toBe(originalContent);
   });
 
   it('handles empty messages array', () => {

--- a/src/messages/cache.tail.test.ts
+++ b/src/messages/cache.tail.test.ts
@@ -1,3 +1,4 @@
+import { convertMessagesToCompletionsMessageParams } from '@langchain/openai';
 import {
   AIMessage,
   HumanMessage,
@@ -10,7 +11,15 @@ import type {
 } from '@langchain/core/messages';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicMessages } from '@/types/messages';
+import {
+  projectOpenAIChatToolMessageContent,
+  projectOpenAIToolMessageContent,
+  projectOpenAIResponsesToolMessageContent,
+  projectOpenRouterToolMessageContent,
+  projectComputerCallOutputsToText,
+} from './core';
 import { addTailCacheControl, addBedrockTailCacheControl } from './cache';
+import { convertToConverseMessages } from '@/llm/bedrock/utils';
 import { toLangChainContent } from './langchain';
 
 type CacheControlBlock = MessageContentComplex & {
@@ -84,6 +93,154 @@ describe('addTailCacheControl (single tail breakpoint)', () => {
 
     expect(countCacheMarkers(result)).toBe(1);
     expect(blocksOf(result[2])[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('skips native computer outputs and removes stale screenshot markers', () => {
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            call_id: 'call_computer_cache',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_computer_cache',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const canonical = projectOpenAIToolMessageContent([
+      new HumanMessage('Take a screenshot'),
+      computerCall,
+      computerOutput,
+    ]);
+
+    const cached = addTailCacheControl(canonical);
+
+    expect(countCacheMarkers(cached)).toBe(1);
+    expect(blocksOf(cached[0])[0].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+    expect(blocksOf(cached[2])[0]).not.toHaveProperty('cache_control');
+    expect(() =>
+      projectOpenAIResponsesToolMessageContent(cached)
+    ).not.toThrow();
+
+    const canonicalOutput = canonical[2] as ToolMessage;
+    const staleOutput = new ToolMessage({
+      content: toLangChainContent([
+        {
+          ...(canonicalOutput.content[0] as MessageContentComplex),
+          cache_control: { type: 'ephemeral' },
+        },
+      ]),
+      tool_call_id: canonicalOutput.tool_call_id,
+      additional_kwargs: canonicalOutput.additional_kwargs,
+    });
+    const cleaned = addTailCacheControl([
+      canonical[0],
+      canonical[1],
+      staleOutput,
+    ]);
+
+    expect(countCacheMarkers(cleaned)).toBe(1);
+    expect(blocksOf(cleaned[2])[0]).not.toHaveProperty('cache_control');
+    expect(blocksOf(staleOutput)[0]).toHaveProperty('cache_control');
+    expect(() =>
+      projectOpenAIResponsesToolMessageContent(cleaned)
+    ).not.toThrow();
+  });
+
+  test('keeps a cached tool result structured through Chat projection', () => {
+    const toolCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'call_cached_tool', name: 'search', args: {} }],
+    });
+    const toolOutput = new ToolMessage({
+      content: 'result body',
+      tool_call_id: 'call_cached_tool',
+    });
+    const graphProjected = projectOpenAIToolMessageContent([
+      new HumanMessage('Search'),
+      toolCall,
+      toolOutput,
+    ]);
+    const cached = addTailCacheControl(graphProjected);
+    const attemptProjected = projectOpenRouterToolMessageContent(cached);
+    const payload = convertMessagesToCompletionsMessageParams({
+      messages: attemptProjected,
+      model: 'gpt-4o',
+    });
+
+    expect(blocksOf(cached[2])[0]).toMatchObject({
+      type: 'text',
+      text: 'result body',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect((attemptProjected[2] as ToolMessage).content).toEqual(
+      (cached[2] as ToolMessage).content
+    );
+    expect(payload[2]).toMatchObject({
+      role: 'tool',
+      tool_call_id: 'call_cached_tool',
+      content: [
+        {
+          type: 'text',
+          text: 'result body',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    });
+
+    const fallbackProjected = projectOpenAIChatToolMessageContent(cached);
+    const fallbackPayload = convertMessagesToCompletionsMessageParams({
+      messages: fallbackProjected,
+      model: 'gpt-4o',
+    });
+
+    expect((fallbackProjected[2] as ToolMessage).content).toBe('result body');
+    expect(fallbackPayload[2]).toMatchObject({
+      role: 'tool',
+      tool_call_id: 'call_cached_tool',
+      content: 'result body',
+    });
+    expect(JSON.stringify(fallbackPayload[2])).not.toContain('cache_control');
+
+    expect(
+      typeof (projectOpenAIToolMessageContent(cached)[2] as ToolMessage).content
+    ).toBe('string');
+  });
+
+  test('does not stringify noncanonical cache metadata into tool output', () => {
+    const messages = addTailCacheControl<BaseMessage>([
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_nested_cache', name: 'search', args: {} }],
+      }),
+      new ToolMessage({
+        content: toLangChainContent([
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_nested_cache',
+            content: 'result body',
+          },
+        ] as MessageContentComplex[]),
+        tool_call_id: 'call_nested_cache',
+      }),
+    ]);
+
+    const projected = projectOpenRouterToolMessageContent(messages);
+    const content = (projected[2] as ToolMessage).content;
+
+    expect(typeof content).toBe('string');
+    expect(content).toContain('result body');
+    expect(content).not.toContain('cache_control');
+    expect(JSON.stringify(messages[2].content)).toContain('cache_control');
   });
 
   test('strips ALL stale markers and re-anchors a single one at the tail', () => {
@@ -336,5 +493,41 @@ describe('addBedrockTailCacheControl (single tail cachePoint)', () => {
       { type: 'text', text: 'result body' },
       { cachePoint: { type: 'default' } },
     ]);
+  });
+
+  test('keeps the cachePoint before an omitted computer screenshot', () => {
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_bedrock_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const cached = addBedrockTailCacheControl([
+      new HumanMessage('Take a screenshot'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_bedrock_computer',
+            name: 'computer',
+            args: { action: 'screenshot' },
+          },
+        ],
+      }),
+      computerOutput,
+    ]);
+
+    expect(countCachePoints(cached)).toBe(1);
+    expect(blocksOf(cached[0])[1]).toEqual({
+      cachePoint: { type: 'default' },
+    });
+    expect(cached[2].content).toBe(computerOutput.content);
+
+    const projected = projectComputerCallOutputsToText(cached);
+    const converse = convertToConverseMessages(projected);
+    expect((projected[2] as ToolMessage).content).toBe(
+      '[Computer screenshot omitted for this provider]'
+    );
+    expect(JSON.stringify(converse).match(/"cachePoint"/g)).toHaveLength(1);
+    expect(computerOutput.content).toBe('data:image/png;base64,AA==');
   });
 });

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -1029,6 +1029,87 @@ describe('stripAnthropicCacheControl', () => {
     expect(result[0].content).toBe('Hello');
   });
 
+  it('ignores primitive and proxy blocks without invoking proxy traps', () => {
+    const unsafe = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error('proxy keys must not be inspected');
+        },
+      }
+    );
+    const content = [
+      'primitive',
+      unsafe,
+      {
+        type: ContentTypes.TEXT,
+        text: 'cached',
+        cache_control: { type: 'ephemeral' },
+      },
+    ] as unknown as MessageContentComplex[];
+
+    const result = stripAnthropicCacheControl([{ role: 'user', content }]);
+    const stripped = result[0].content as unknown[];
+
+    expect(stripped[0]).toBe('primitive');
+    expect(stripped[1]).toBe(unsafe);
+    expect(stripped[2]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'cached',
+    });
+  });
+
+  it('removes a non-configurable cache_control from the clone only', () => {
+    const block = { type: ContentTypes.TEXT, text: 'cached' };
+    Object.defineProperty(block, 'cache_control', {
+      configurable: false,
+      enumerable: true,
+      value: { type: 'ephemeral' },
+      writable: false,
+    });
+    const messages = [
+      {
+        role: 'user',
+        content: [block as MessageContentComplex],
+      },
+    ];
+
+    const result = stripAnthropicCacheControl(messages);
+    const stripped = (result[0].content as MessageContentComplex[])[0];
+
+    expect('cache_control' in stripped).toBe(false);
+    expect(
+      (block as typeof block & { cache_control: unknown }).cache_control
+    ).toEqual({ type: 'ephemeral' });
+  });
+
+  it('removes an accessor cache_control without invoking it', () => {
+    let getterCalls = 0;
+    const block = { type: ContentTypes.TEXT, text: 'cached' };
+    Object.defineProperty(block, 'cache_control', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        getterCalls++;
+        throw new Error('cache getter must not run');
+      },
+    });
+
+    const result = stripAnthropicCacheControl([
+      {
+        role: 'user',
+        content: [block as MessageContentComplex],
+      },
+    ]);
+    const stripped = (result[0].content as MessageContentComplex[])[0];
+
+    expect(getterCalls).toBe(0);
+    expect('cache_control' in stripped).toBe(false);
+    expect(
+      Object.getOwnPropertyDescriptor(block, 'cache_control')
+    ).toBeDefined();
+  });
+
   it('returns non-array input unchanged', () => {
     const notArray = 'not an array';
     /** @ts-expect-error - Testing invalid input */
@@ -1072,6 +1153,38 @@ describe('stripBedrockCacheControl', () => {
       type: ContentTypes.TEXT,
       text: 'Hi there',
     });
+  });
+
+  it('ignores primitive and proxy blocks while removing cache points', () => {
+    let getterCalls = 0;
+    const unsafe = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error('proxy descriptors must not be inspected');
+        },
+      }
+    );
+    const accessorCachePoint = {};
+    Object.defineProperty(accessorCachePoint, 'cachePoint', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        getterCalls++;
+        throw new Error('cache point getter must not run');
+      },
+    });
+    const content = [
+      42,
+      unsafe,
+      accessorCachePoint,
+      { cachePoint: { type: 'default' } },
+    ] as unknown as MessageContentComplex[];
+
+    const result = stripBedrockCacheControl([{ role: 'user', content }]);
+
+    expect(result[0].content).toEqual([42, unsafe]);
+    expect(getterCalls).toBe(0);
   });
 
   it('handles messages without cachePoint blocks gracefully', () => {

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -1,16 +1,10 @@
-import {
-  AIMessage,
-  BaseMessage,
-  ToolMessage,
-  HumanMessage,
-  SystemMessage,
-  MessageContentComplex,
-} from '@langchain/core/messages';
+import { isProxy } from 'node:util/types';
+import { BaseMessage, MessageContentComplex } from '@langchain/core/messages';
 import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicMessage } from '@/types/messages';
+import { hasComputerCallOutputMarker } from '@/utils/toolContent';
 import { toLangChainContent } from './langchain';
 import { ContentTypes } from '@/common/enum';
-import { withMessageRole } from './format';
 
 type MessageWithContent = {
   content?: string | MessageContentComplex[];
@@ -134,13 +128,30 @@ export function resolveBedrockPromptCacheTtl(
  * Deep clones a message's content to prevent mutation of the original.
  */
 function deepCloneContent<T extends string | MessageContentComplex[]>(
-  content: T
+  content: T,
+  omittedProperty?: string
 ): T {
   if (typeof content === 'string') {
     return content;
   }
   if (Array.isArray(content)) {
-    return content.map((block) => ({ ...block })) as T;
+    return content.map((block) => {
+      if (typeof block !== 'object' || block == null || isProxy(block)) {
+        return block;
+      }
+      try {
+        const descriptors = Object.getOwnPropertyDescriptors(block);
+        if (omittedProperty != null) {
+          delete descriptors[omittedProperty];
+        }
+        return Object.create(
+          Object.getPrototypeOf(block),
+          descriptors
+        ) as MessageContentComplex;
+      } catch {
+        return block;
+      }
+    }) as T;
   }
   return content;
 }
@@ -156,45 +167,36 @@ export function cloneMessage<T extends MessageWithContent>(
   content: string | MessageContentComplex[]
 ): T {
   if (message instanceof BaseMessage) {
-    const baseParams = {
-      content: toLangChainContent(content),
-      additional_kwargs: { ...message.additional_kwargs },
-      response_metadata: { ...message.response_metadata },
-      id: message.id,
-      name: message.name,
+    const descriptors = Object.getOwnPropertyDescriptors(message) as Record<
+      PropertyKey,
+      PropertyDescriptor | undefined
+    >;
+    const contentDescriptor = descriptors.content;
+    descriptors.content = {
+      configurable: contentDescriptor?.configurable ?? true,
+      enumerable: contentDescriptor?.enumerable ?? true,
+      value: toLangChainContent(content),
+      writable: contentDescriptor?.writable ?? true,
     };
-
-    const msgType = message.getType();
-    switch (msgType) {
-    case 'ai':
-      return withMessageRole(
-        new AIMessage({
-          ...baseParams,
-          tool_calls: (message as unknown as AIMessage).tool_calls,
-        }),
-        'assistant'
-      ) as unknown as T;
-    case 'human':
-      return withMessageRole(
-        new HumanMessage(baseParams),
-        'user'
-      ) as unknown as T;
-    case 'system':
-      return withMessageRole(
-        new SystemMessage(baseParams),
-        'system'
-      ) as unknown as T;
-    case 'tool':
-      return withMessageRole(
-        new ToolMessage({
-          ...baseParams,
-          tool_call_id: (message as unknown as ToolMessage).tool_call_id,
-        }),
-        'tool'
-      ) as unknown as T;
-    default:
-      break;
+    const lcKwargs = descriptors.lc_kwargs;
+    if (
+      lcKwargs != null &&
+      'value' in lcKwargs &&
+      typeof lcKwargs.value === 'object' &&
+      lcKwargs.value != null
+    ) {
+      descriptors.lc_kwargs = {
+        ...lcKwargs,
+        value: {
+          ...(lcKwargs.value as Record<string, unknown>),
+          content: toLangChainContent(content),
+        },
+      };
     }
+    return Object.create(
+      Object.getPrototypeOf(message),
+      descriptors as PropertyDescriptorMap
+    ) as T;
   }
 
   const {
@@ -251,7 +253,11 @@ function sanitizeBedrockSystemMessage<T extends MessageWithContent>(
   let modified = false;
   for (const block of content) {
     if (isCachePoint(block)) {
-      const existing = (block as { cachePoint?: { ttl?: unknown } }).cachePoint;
+      const descriptor = Object.getOwnPropertyDescriptor(block, 'cachePoint');
+      const existing =
+        descriptor != null && 'value' in descriptor
+          ? (descriptor.value as { ttl?: unknown } | undefined)
+          : undefined;
       const desired = buildBedrockCachePoint(ttl);
       if (existing?.ttl !== desired.ttl) {
         modified = true;
@@ -378,8 +384,17 @@ export function addCacheControl<T extends AnthropicMessage | BaseMessage>(
 /**
  * Checks if a content block is a cache point
  */
-function isCachePoint(block: MessageContentComplex): boolean {
-  return 'cachePoint' in block && !('type' in block);
+function isCachePoint(block: unknown): boolean {
+  if (typeof block !== 'object' || block == null || isProxy(block)) {
+    return false;
+  }
+  try {
+    const cachePoint = Object.getOwnPropertyDescriptor(block, 'cachePoint');
+    const type = Object.getOwnPropertyDescriptor(block, 'type');
+    return cachePoint?.enumerable === true && type == null;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -460,8 +475,13 @@ export function addTailCacheControl<T extends AnthropicMessage | BaseMessage>(
     const originalMessage = updatedMessages[i];
     const content = originalMessage.content;
     const hasArrayContent = Array.isArray(content);
+    const isComputerOutput =
+      originalMessage instanceof BaseMessage &&
+      hasComputerCallOutputMarker(originalMessage);
     const canPlaceMarker =
-      !markerPlaced && !isSyntheticMetaMessage(originalMessage);
+      !markerPlaced &&
+      !isSyntheticMetaMessage(originalMessage) &&
+      !isComputerOutput;
 
     // Earlier string-content messages carry no markers to strip.
     if (!canPlaceMarker && !hasArrayContent) {
@@ -706,7 +726,21 @@ export function addCacheControlToStablePrefixMessages<
  */
 function hasAnthropicCacheControl(content: MessageContentComplex[]): boolean {
   for (let i = 0; i < content.length; i++) {
-    if ('cache_control' in content[i]) return true;
+    const block = content[i];
+    if (typeof block !== 'object' || block == null || isProxy(block)) {
+      continue;
+    }
+    try {
+      const cacheControl = Object.getOwnPropertyDescriptor(
+        block,
+        'cache_control'
+      );
+      if (cacheControl?.enumerable === true) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
   }
   return false;
 }
@@ -733,13 +767,7 @@ export function stripAnthropicCacheControl<T extends MessageWithContent>(
       continue;
     }
 
-    const clonedContent = deepCloneContent(content);
-    for (let j = 0; j < clonedContent.length; j++) {
-      const block = clonedContent[j] as Record<string, unknown>;
-      if ('cache_control' in block) {
-        delete block.cache_control;
-      }
-    }
+    const clonedContent = deepCloneContent(content, 'cache_control');
     updatedMessages[i] = cloneMessage(originalMessage, clonedContent);
   }
 
@@ -961,10 +989,14 @@ export function addBedrockTailCacheControl<
       'lc_namespace' in originalMessage;
     const hasArrayContent = Array.isArray(content);
     const isEmptyString = typeof content === 'string' && content === '';
+    const isComputerOutput =
+      originalMessage instanceof BaseMessage &&
+      hasComputerCallOutputMarker(originalMessage);
     const canPlaceCachePoint =
       !cachePointPlaced &&
       !isEmptyString &&
       !isSyntheticMetaMessage(originalMessage) &&
+      !isComputerOutput &&
       (typeof content === 'string' || hasArrayContent);
 
     if (!canPlaceCachePoint && !hasArrayContent && !hasSerializationProps) {

--- a/src/messages/contextPruning.test.ts
+++ b/src/messages/contextPruning.test.ts
@@ -130,4 +130,55 @@ describe('applyContextPruning', () => {
     expect(Array.isArray(messages[2].content)).toBe(true);
     expect(messages[2].content).toContain(document);
   });
+
+  it('does not hard-clear native computer screenshots', () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const computerOutput = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'tc-computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const messages: BaseMessage[] = [
+      new HumanMessage('take a screenshot'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'tc-computer',
+            name: 'computer',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      computerOutput,
+      new AIMessage('Done.'),
+      new HumanMessage('continue'),
+      new AIMessage('Ready.'),
+      new HumanMessage('next question'),
+    ];
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = charCounter(messages[i]);
+    }
+
+    const result = applyContextPruning({
+      messages,
+      indexTokenCountMap,
+      tokenCounter: charCounter,
+      config: {
+        enabled: true,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        minPrunableToolChars: 1,
+        softTrim: { maxChars: 80, headChars: 20, tailChars: 20 },
+        hardClear: { enabled: true },
+      },
+    });
+
+    expect(result.softTrimmed).toBe(0);
+    expect(result.hardCleared).toBe(0);
+    expect(messages[2]).toBe(computerOutput);
+    expect(messages[2].content).toBe(screenshot);
+  });
 });

--- a/src/messages/contextPruning.test.ts
+++ b/src/messages/contextPruning.test.ts
@@ -1,0 +1,133 @@
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  type BaseMessage,
+} from '@langchain/core/messages';
+import { applyContextPruning } from './contextPruning';
+
+function charCounter(message: BaseMessage): number {
+  return (
+    typeof message.content === 'string'
+      ? message.content
+      : JSON.stringify(message.content)
+  ).length;
+}
+
+describe('applyContextPruning', () => {
+  it('soft-trims old structured tool results and preserves metadata', () => {
+    const toolCallId = 'tc-old';
+    const messages: BaseMessage[] = [
+      new HumanMessage('query the table'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'run_select_query',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          {
+            type: 'json',
+            rows: Array.from({ length: 20 }, (_, index) => ({
+              id: index,
+              value: `${'x'.repeat(100)}-${index}`,
+            })),
+          },
+        ],
+        tool_call_id: toolCallId,
+        name: 'run_select_query',
+        status: 'success',
+        artifact: { source: 'clickhouse' },
+      }),
+      new AIMessage('The query returned 20 rows.'),
+      new HumanMessage('continue'),
+      new AIMessage('Ready.'),
+      new HumanMessage('next question'),
+    ];
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = charCounter(messages[i]);
+    }
+
+    const result = applyContextPruning({
+      messages,
+      indexTokenCountMap,
+      tokenCounter: charCounter,
+      config: {
+        enabled: true,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        minPrunableToolChars: 1,
+        softTrim: { maxChars: 200, headChars: 80, tailChars: 40 },
+        hardClear: { enabled: false },
+      },
+    });
+
+    expect(result.softTrimmed).toBe(1);
+    expect(typeof messages[2].content).toBe('string');
+    expect(messages[2].content).toContain('soft-trimmed');
+    const trimmed = messages[2] as ToolMessage;
+    expect(trimmed.tool_call_id).toBe(toolCallId);
+    expect(trimmed.name).toBe('run_select_query');
+    expect(trimmed.status).toBe('success');
+    expect(trimmed.artifact).toEqual({ source: 'clickhouse' });
+    expect(indexTokenCountMap[2]).toBe(charCounter(trimmed));
+  });
+
+  it('preserves small non-image media blocks while trimming adjacent text', () => {
+    const document = {
+      type: 'document',
+      source: { type: 'url', url: 'https://example.com/report.pdf' },
+    };
+    const messages: BaseMessage[] = [
+      new HumanMessage('read the report'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'tc-document',
+            name: 'read_document',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: [{ type: 'text', text: 'x'.repeat(2_000) }, document],
+        tool_call_id: 'tc-document',
+      }),
+      new AIMessage('I read the report.'),
+      new HumanMessage('continue'),
+      new AIMessage('Ready.'),
+      new HumanMessage('next question'),
+    ];
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = charCounter(messages[i]);
+    }
+
+    const result = applyContextPruning({
+      messages,
+      indexTokenCountMap,
+      tokenCounter: charCounter,
+      config: {
+        enabled: true,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        minPrunableToolChars: 1,
+        softTrim: { maxChars: 400, headChars: 80, tailChars: 40 },
+        hardClear: { enabled: false },
+      },
+    });
+
+    expect(result.softTrimmed).toBe(1);
+    expect(Array.isArray(messages[2].content)).toBe(true);
+    expect(messages[2].content).toContain(document);
+  });
+});

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -22,7 +22,7 @@ import {
   compactToolContent,
   getToolContentCharLength,
   isAtomicToolContentBlock,
-  serializeToolContent,
+  serializeToolContentBounded,
 } from '@/utils/toolContent';
 import { resolveContextPruningSettings } from './contextPruningSettings';
 
@@ -173,7 +173,15 @@ export function applyContextPruning(params: {
       if (contentLength > settings.softTrim.maxChars) {
         const cloned = cloneToolMessageWithContent(
           message as ToolMessage,
-          softTrimContent(serializeToolContent(content), settings.softTrim)
+          softTrimContent(
+            typeof content === 'string'
+              ? content
+              : serializeToolContentBounded(
+                content,
+                settings.softTrim.maxChars
+              ),
+            settings.softTrim
+          )
         );
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -22,6 +22,7 @@ import {
   compactToolContent,
   getToolContentCharLength,
   isAtomicToolContentBlock,
+  isComputerCallOutputMessage,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import { resolveContextPruningSettings } from './contextPruningSettings';
@@ -127,6 +128,9 @@ export function applyContextPruning(params: {
   for (let i = 0; i < totalMessages; i++) {
     const message = messages[i];
     if (message.getType() !== 'tool') {
+      continue;
+    }
+    if (isComputerCallOutputMessage(message)) {
       continue;
     }
     if (protectedIndices.has(i)) {

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -9,31 +9,22 @@
  * - Hard-clear: Replace entire content with a placeholder.
  *
  * Messages in the "protected zone" (recent assistant turns, system/pre-first-human
- * messages, and messages with image content) are never pruned.
+ * messages) are never pruned. Atomic media/resource blocks are preserved when
+ * they fit; oversized inline payloads are replaced with bounded placeholders.
  */
 
 import { ToolMessage, type BaseMessage } from '@langchain/core/messages';
 import type { ContextPruningSettings } from './contextPruningSettings';
 import type { ContextPruningConfig } from '@/types/graph';
 import type { TokenCounter } from '@/types/run';
+import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  getToolContentCharLength,
+  isAtomicToolContentBlock,
+  serializeToolContent,
+} from '@/utils/toolContent';
 import { resolveContextPruningSettings } from './contextPruningSettings';
-
-/**
- * Checks if a message contains image content blocks.
- * Messages with images are skipped by position-based content degradation
- * because images cannot be meaningfully soft-trimmed or replaced with placeholders.
- */
-function hasImageContent(message: BaseMessage): boolean {
-  if (!Array.isArray(message.content)) {
-    return false;
-  }
-  return message.content.some(
-    (block) =>
-      typeof block === 'object' &&
-      'type' in block &&
-      (block.type === 'image_url' || block.type === 'image')
-  );
-}
 
 /**
  * Applies head+tail soft-trim to tool result content.
@@ -141,45 +132,49 @@ export function applyContextPruning(params: {
     if (protectedIndices.has(i)) {
       continue;
     }
-    if (hasImageContent(message)) {
-      continue;
-    }
-
     const content = message.content;
-    if (typeof content !== 'string') {
-      continue;
-    }
-    if (content.length < settings.minPrunableToolChars) {
+    const contentLength = getToolContentCharLength(content);
+    if (contentLength < settings.minPrunableToolChars) {
       continue;
     }
 
     // Compute age ratio: how far back from the end (0 = latest, 1 = oldest)
     const ageRatio = (totalMessages - i) / totalMessages;
 
+    if (
+      Array.isArray(content) &&
+      content.some(isAtomicToolContentBlock) &&
+      ageRatio >= settings.softTrimRatio
+    ) {
+      const compacted = compactToolContent(content, settings.softTrim.maxChars);
+      if (compacted.changed) {
+        const cloned = cloneToolMessageWithContent(
+          message as ToolMessage,
+          compacted.content
+        );
+        messages[i] = cloned;
+        indexTokenCountMap[i] = tokenCounter(cloned);
+        softTrimmed++;
+      }
+      continue;
+    }
+
     if (ageRatio >= settings.hardClearRatio && settings.hardClear.enabled) {
       // Hard-clear: replace with placeholder
-      const cloned = new ToolMessage({
-        content: settings.hardClear.placeholder,
-        tool_call_id: (message as ToolMessage).tool_call_id,
-        name: message.name,
-        id: message.id,
-        additional_kwargs: message.additional_kwargs,
-        response_metadata: message.response_metadata,
-      });
+      const cloned = cloneToolMessageWithContent(
+        message as ToolMessage,
+        settings.hardClear.placeholder
+      );
       messages[i] = cloned;
       indexTokenCountMap[i] = tokenCounter(cloned);
       hardCleared++;
     } else if (ageRatio >= settings.softTrimRatio) {
       // Soft-trim: keep head + tail
-      if (content.length > settings.softTrim.maxChars) {
-        const cloned = new ToolMessage({
-          content: softTrimContent(content, settings.softTrim),
-          tool_call_id: (message as ToolMessage).tool_call_id,
-          name: message.name,
-          id: message.id,
-          additional_kwargs: message.additional_kwargs,
-          response_metadata: message.response_metadata,
-        });
+      if (contentLength > settings.softTrim.maxChars) {
+        const cloned = cloneToolMessageWithContent(
+          message as ToolMessage,
+          softTrimContent(serializeToolContent(content), settings.softTrim)
+        );
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);
         softTrimmed++;

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -11,7 +11,9 @@ import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
+  serializeStructuredValueBounded,
 } from '@/utils/toolContent';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
 
@@ -473,9 +475,75 @@ function stringifyToolMessageContent(
   return content == null ? '' : String(content);
 }
 
+function appendContentBlocks(
+  target: t.MessageContentComplex[],
+  content: BaseMessage['content']
+): void {
+  if (typeof content === 'string') {
+    target.push({ type: ContentTypes.TEXT, text: content });
+    return;
+  }
+  for (const block of content) {
+    target.push(block as t.MessageContentComplex);
+  }
+}
+
+/**
+ * Appends one artifact/tool-content segment without retaining an unbounded
+ * intermediate block array. Both operands are compacted before they are
+ * combined, and the combined result is compacted again under the aggregate
+ * cap.
+ */
+function appendBoundedContent(
+  current: BaseMessage['content'] | undefined,
+  next: unknown,
+  maxChars: number
+): BaseMessage['content'] {
+  const boundedNext = compactToolContent(next, maxChars).content;
+  if (current == null) {
+    return boundedNext;
+  }
+
+  const combined: t.MessageContentComplex[] = [];
+  appendContentBlocks(combined, current);
+  appendContentBlocks(combined, boundedNext);
+  return compactToolContent(toLangChainContent(combined), maxChars).content;
+}
+
+/**
+ * OpenAI Chat tool messages only accept strings or text-only parts, while the
+ * Responses API serializes any structured ToolMessage after graph accounting.
+ * Project every non-string tool result to one bounded string before the final
+ * provider payload is measured so both APIs receive the exact representation
+ * the budget guard counted. Native Responses computer screenshots stay
+ * structured because their dedicated converter sends the media block directly.
+ */
+export function projectOpenAIToolMessageContent(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (
+      !(message instanceof ToolMessage) ||
+      typeof message.content === 'string' ||
+      message.additional_kwargs.type === 'computer_call_output'
+    ) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneToolMessageWithContent(
+      message,
+      serializeStructuredValueBounded(message.content, maxChars).content
+    );
+  }
+  return projected ?? messages;
+}
+
 export function projectAnthropicArtifactContent(
   messages: BaseMessage[],
-  maxChars = Number.MAX_SAFE_INTEGER
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
 ): BaseMessage[] {
   const lastMessage = messages[messages.length - 1];
   if (!(lastMessage instanceof ToolMessage)) return messages;
@@ -515,14 +583,6 @@ export function projectAnthropicArtifactContent(
         (Array.isArray(msg.artifact?.content) &&
           msg.artifact.content.length > 0))
     ) {
-      const base = Array.isArray(msg.content)
-        ? msg.content
-        : [
-          {
-            type: ContentTypes.TEXT,
-            text: stringifyToolMessageContent(msg.content),
-          },
-        ];
       const artifactContent =
         typeof msg.artifact.content === 'string'
           ? [
@@ -532,10 +592,14 @@ export function projectAnthropicArtifactContent(
             },
           ]
           : msg.artifact.content;
-      const content = compactToolContent(
-        base.concat(artifactContent),
+      const baseContent = Array.isArray(msg.content)
+        ? msg.content
+        : stringifyToolMessageContent(msg.content);
+      const content = appendBoundedContent(
+        compactToolContent(baseContent, maxChars).content,
+        artifactContent,
         maxChars
-      ).content;
+      );
       formattedMessages ??= [...messages];
       formattedMessages[j] = cloneToolMessageWithContent(msg, content, {
         ...msg.artifact,
@@ -568,7 +632,7 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
 
 export function projectArtifactPayload(
   messages: BaseMessage[],
-  maxChars = Number.MAX_SAFE_INTEGER
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
 ): BaseMessage[] {
   const lastMessageY = messages[messages.length - 1];
   if (!(lastMessageY instanceof ToolMessage)) return messages;
@@ -586,7 +650,7 @@ export function projectArtifactPayload(
   if (latestAIParentIndex === -1) return messages;
 
   // Single pass: collect relevant tool messages with artifacts and aggregate
-  const aggregatedContent: t.MessageContentComplex[] = [];
+  let aggregatedContent: BaseMessage['content'] | undefined;
   let formattedMessages: BaseMessage[] | undefined;
 
   for (let i = latestAIParentIndex + 1; i < messages.length; i++) {
@@ -602,11 +666,11 @@ export function projectArtifactPayload(
     ) {
       continue;
     }
-    let currentContent = msg.content;
-    if (!Array.isArray(currentContent)) {
-      currentContent = [{ type: 'text', text: msg.content }];
-    }
-    aggregatedContent.push(...(currentContent as t.MessageContentComplex[]));
+    aggregatedContent = appendBoundedContent(
+      aggregatedContent,
+      msg.content,
+      maxChars
+    );
     formattedMessages ??= [...messages];
     formattedMessages[i] = cloneToolMessageWithContent(
       msg,
@@ -616,22 +680,15 @@ export function projectArtifactPayload(
         content: [],
       }
     );
-    if (typeof msg.artifact.content === 'string') {
-      aggregatedContent.push({
-        type: ContentTypes.TEXT,
-        text: msg.artifact.content,
-      });
-    } else {
-      aggregatedContent.push(...msg.artifact.content);
-    }
-  }
-
-  if (aggregatedContent.length > 0) {
-    const compacted = compactToolContent(
-      toLangChainContent(aggregatedContent),
+    aggregatedContent = appendBoundedContent(
+      aggregatedContent,
+      msg.artifact.content,
       maxChars
     );
-    formattedMessages?.push(new HumanMessage({ content: compacted.content }));
+  }
+
+  if (aggregatedContent != null) {
+    formattedMessages?.push(new HumanMessage({ content: aggregatedContent }));
   }
   return formattedMessages ?? messages;
 }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -1,4 +1,5 @@
 // src/messages.ts
+import { isProxy } from 'node:util/types';
 import {
   AIMessage,
   BaseMessage,
@@ -6,14 +7,20 @@ import {
   HumanMessage,
   AIMessageChunk,
 } from '@langchain/core/messages';
-import type { ToolCall } from '@langchain/core/messages/tool';
+import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
-  serializeStructuredValueBounded,
+  getBoundedCacheControlledTextToolContent,
+  getBoundedSingleTextToolContent,
+  getComputerCallOutputScreenshot,
+  hasComputerCallOutputMarker,
+  isComputerCallOutputMessage,
+  serializeToolContentBounded,
 } from '@/utils/toolContent';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import { stripAnthropicCacheControl } from './cache';
 import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
 
@@ -510,6 +517,165 @@ function appendBoundedContent(
   return compactToolContent(toLangChainContent(combined), maxChars).content;
 }
 
+function cloneAIMessageWithToolCalls(
+  message: AIMessage,
+  toolCalls: ToolCall[],
+  removedCallIds: ReadonlySet<string>
+): AIMessage {
+  const descriptors = Object.getOwnPropertyDescriptors(message) as Record<
+    string,
+    PropertyDescriptor | undefined
+  >;
+  let descriptor = descriptors.tool_calls;
+  descriptors.tool_calls = {
+    configurable: descriptor?.configurable ?? true,
+    enumerable: descriptor?.enumerable ?? true,
+    value: toolCalls,
+    writable: descriptor?.writable ?? true,
+  };
+  const toolCallChunks = descriptors.tool_call_chunks?.value as
+    | ToolCallChunk[]
+    | undefined;
+  if (Array.isArray(toolCallChunks)) {
+    descriptor = descriptors.tool_call_chunks;
+    descriptors.tool_call_chunks = {
+      configurable: descriptor?.configurable ?? true,
+      enumerable: descriptor?.enumerable ?? true,
+      value: toolCallChunks.filter(
+        (chunk) => typeof chunk.id !== 'string' || !removedCallIds.has(chunk.id)
+      ),
+      writable: descriptor?.writable ?? true,
+    };
+  }
+  return Object.create(
+    Object.getPrototypeOf(message),
+    descriptors as PropertyDescriptorMap
+  ) as AIMessage;
+}
+
+function cloneAIMessageWithContent(
+  message: AIMessage,
+  content: AIMessage['content']
+): AIMessage {
+  const descriptors = Object.getOwnPropertyDescriptors(message) as Record<
+    string,
+    PropertyDescriptor | undefined
+  >;
+  const descriptor = descriptors.content;
+  descriptors.content = {
+    configurable: descriptor?.configurable ?? true,
+    enumerable: descriptor?.enumerable ?? true,
+    value: content,
+    writable: descriptor?.writable ?? true,
+  };
+  const lcKwargs = descriptors.lc_kwargs;
+  if (
+    lcKwargs != null &&
+    'value' in lcKwargs &&
+    typeof lcKwargs.value === 'object' &&
+    lcKwargs.value != null
+  ) {
+    descriptors.lc_kwargs = {
+      ...lcKwargs,
+      value: {
+        ...(lcKwargs.value as Record<string, unknown>),
+        content,
+      },
+    };
+  }
+  return Object.create(
+    Object.getPrototypeOf(message),
+    descriptors as PropertyDescriptorMap
+  ) as AIMessage;
+}
+
+/**
+ * Drops incomplete streamed text-input fragments that some providers retain
+ * beside the assembled parsed tool call. They are neither user-visible text
+ * nor valid content blocks for a subsequent provider.
+ */
+export function projectToolStreamContentForProvider(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (message.getType() !== 'ai' || !Array.isArray(message.content)) {
+      continue;
+    }
+    const content = message.content.filter((block) => {
+      if (block == null || typeof block !== 'object') {
+        return true;
+      }
+      try {
+        if (isProxy(block)) {
+          return false;
+        }
+        const type = Object.getOwnPropertyDescriptor(block, 'type');
+        if (type == null) {
+          return true;
+        }
+        if (type.enumerable !== true || !('value' in type)) {
+          return false;
+        }
+        if (type.value !== 'text') {
+          return true;
+        }
+        const text = Object.getOwnPropertyDescriptor(block, 'text');
+        return (
+          text?.enumerable === true &&
+          'value' in text &&
+          typeof text.value === 'string' &&
+          text.value !== ''
+        );
+      } catch {
+        return false;
+      }
+    });
+    if (content.length === message.content.length) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneAIMessageWithContent(
+      message as AIMessage,
+      toLangChainContent(content)
+    );
+  }
+  return projected ?? messages;
+}
+
+type CacheControlledTextProjection = 'serialize' | 'preserve' | 'text';
+
+function projectStructuredOpenAIToolContent(
+  content: ToolMessage['content'],
+  maxChars: number,
+  cacheControlledTextProjection: CacheControlledTextProjection
+): ToolMessage['content'] {
+  if (cacheControlledTextProjection !== 'serialize') {
+    const cacheControlledContent = getBoundedCacheControlledTextToolContent(
+      content,
+      maxChars
+    );
+    if (cacheControlledContent != null) {
+      return cacheControlledTextProjection === 'preserve'
+        ? cacheControlledContent
+        : cacheControlledContent[0].text;
+    }
+    const singleTextContent = getBoundedSingleTextToolContent(
+      content,
+      maxChars
+    );
+    if (singleTextContent != null) {
+      return singleTextContent;
+    }
+  }
+  const serializableContent =
+    cacheControlledTextProjection === 'preserve'
+      ? stripAnthropicCacheControl([{ content }])[0].content
+      : content;
+  return serializeToolContentBounded(serializableContent, maxChars);
+}
+
 /**
  * OpenAI Chat tool messages only accept strings or text-only parts, while the
  * Responses API serializes any structured ToolMessage after graph accounting.
@@ -518,7 +684,274 @@ function appendBoundedContent(
  * the budget guard counted. Native Responses computer screenshots stay
  * structured because their dedicated converter sends the media block directly.
  */
+function projectOpenAIToolMessageContentInternal(
+  messages: BaseMessage[],
+  maxChars: number,
+  deduplicateResponsesComputerCalls: boolean,
+  cacheControlledTextProjection: CacheControlledTextProjection
+): BaseMessage[] {
+  const pendingComputerCallIds: string[] = [];
+  const seenComputerCallIds = new Set<string>();
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const messageRole = (message as BaseMessage & { role?: unknown }).role;
+    const isAssistant =
+      message.getType() === 'ai' || messageRole === 'assistant';
+    if (isAssistant) {
+      const parsedComputerCallIds = new Set<string>();
+      const toolCalls = (message as AIMessage).tool_calls;
+      if (Array.isArray(toolCalls)) {
+        for (const toolCall of toolCalls) {
+          const record = toolCall as ToolCall & {
+            isComputerTool?: unknown;
+          };
+          if (
+            record.type !== 'tool_call' ||
+            record.isComputerTool !== true ||
+            typeof record.id !== 'string' ||
+            record.id === ''
+          ) {
+            continue;
+          }
+          if (parsedComputerCallIds.has(record.id)) {
+            throw new Error(`Duplicate computer call id "${record.id}"`);
+          }
+          parsedComputerCallIds.add(record.id);
+          if (seenComputerCallIds.has(record.id)) {
+            throw new Error(`Duplicate computer call id "${record.id}"`);
+          }
+          seenComputerCallIds.add(record.id);
+          pendingComputerCallIds.push(record.id);
+        }
+      }
+
+      const rawOutput = (
+        message.response_metadata as {
+          output?: unknown;
+        }
+      ).output;
+      const fallbackOutput = (
+        message.additional_kwargs as {
+          tool_outputs?: unknown;
+        }
+      ).tool_outputs;
+      let actualToolOutputs: unknown[] = [];
+      if (Array.isArray(rawOutput) && rawOutput.length > 0) {
+        actualToolOutputs = rawOutput;
+      } else if (Array.isArray(fallbackOutput)) {
+        actualToolOutputs = fallbackOutput;
+      }
+      const rawComputerCallIds = new Set<string>();
+      for (const item of actualToolOutputs) {
+        if (item == null || typeof item !== 'object') {
+          continue;
+        }
+        const record = item as {
+          type?: unknown;
+          call_id?: unknown;
+        };
+        if (
+          record.type !== 'computer_call' ||
+          typeof record.call_id !== 'string' ||
+          record.call_id === ''
+        ) {
+          continue;
+        }
+        if (rawComputerCallIds.has(record.call_id)) {
+          throw new Error(`Duplicate computer call id "${record.call_id}"`);
+        }
+        rawComputerCallIds.add(record.call_id);
+        // LangChain can retain the same call in parsed and raw forms. It sends
+        // one logical call, so collapse that representation duplicate.
+        if (parsedComputerCallIds.has(record.call_id)) {
+          continue;
+        }
+        if (seenComputerCallIds.has(record.call_id)) {
+          throw new Error(`Duplicate computer call id "${record.call_id}"`);
+        }
+        seenComputerCallIds.add(record.call_id);
+        pendingComputerCallIds.push(record.call_id);
+      }
+
+      if (
+        deduplicateResponsesComputerCalls &&
+        Array.isArray(toolCalls) &&
+        rawComputerCallIds.size > 0
+      ) {
+        /**
+         * The non-streaming Responses converter marks parsed computer calls,
+         * but the streaming converter currently emits the same call as an
+         * ordinary parsed `computer_use` tool call. In both cases the raw
+         * `computer_call` item is authoritative and is replayed by LangChain,
+         * so remove every parsed representation with the same call id.
+         */
+        const projectedToolCalls = toolCalls.filter(
+          (toolCall) =>
+            typeof toolCall.id !== 'string' ||
+            !rawComputerCallIds.has(toolCall.id)
+        );
+        if (projectedToolCalls.length !== toolCalls.length) {
+          projected ??= [...messages];
+          projected[i] = cloneAIMessageWithToolCalls(
+            message as AIMessage,
+            projectedToolCalls,
+            rawComputerCallIds
+          );
+        }
+      }
+    }
+
+    if (
+      message instanceof ToolMessage &&
+      hasComputerCallOutputMarker(message)
+    ) {
+      const screenshot = getComputerCallOutputScreenshot(message.content);
+      if (screenshot == null) {
+        throw new Error('Invalid computer call output screenshot');
+      }
+      if (pendingComputerCallIds[0] !== message.tool_call_id) {
+        throw new Error(
+          `Invalid computer call output pairing for "${message.tool_call_id}"`
+        );
+      }
+      pendingComputerCallIds.shift();
+      projected ??= [...messages];
+      projected[i] = cloneToolMessageWithContent(message, [screenshot]);
+      continue;
+    }
+    if (
+      !(message instanceof ToolMessage) ||
+      typeof message.content === 'string'
+    ) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneToolMessageWithContent(
+      message,
+      projectStructuredOpenAIToolContent(
+        message.content,
+        maxChars,
+        cacheControlledTextProjection
+      )
+    );
+  }
+  if (pendingComputerCallIds.length > 0) {
+    throw new Error(
+      `Missing computer call output for "${pendingComputerCallIds[0]}"`
+    );
+  }
+  return projected ?? messages;
+}
+
+/** Projects OpenAI-compatible tool content without changing parsed call parents. */
 export function projectOpenAIToolMessageContent(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  return projectOpenAIToolMessageContentInternal(
+    messages,
+    maxChars,
+    false,
+    'serialize'
+  );
+}
+
+/** Projects an actual OpenAI-compatible Chat attempt and removes cache metadata. */
+export function projectOpenAIChatToolMessageContent(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  return projectOpenAIToolMessageContentInternal(
+    messages,
+    maxChars,
+    false,
+    'text'
+  );
+}
+
+/** Preserves OpenRouter's cache-decorated text blocks for a Chat attempt. */
+export function projectOpenRouterToolMessageContent(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  return projectOpenAIToolMessageContentInternal(
+    messages,
+    maxChars,
+    false,
+    'preserve'
+  );
+}
+
+/** Projects Responses tool content and collapses parsed/raw computer-call mirrors. */
+export function projectOpenAIResponsesToolMessageContent(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  return projectOpenAIToolMessageContentInternal(
+    messages,
+    maxChars,
+    true,
+    'text'
+  );
+}
+
+/** Removes Anthropic/OpenRouter cache metadata before unsupported providers run. */
+export function projectCacheControlledToolOutputsToText(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (
+      !(message instanceof ToolMessage) ||
+      typeof message.content === 'string'
+    ) {
+      continue;
+    }
+    const cacheControlledContent = getBoundedCacheControlledTextToolContent(
+      message.content,
+      maxChars
+    );
+    if (cacheControlledContent == null) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneToolMessageWithContent(
+      message,
+      cacheControlledContent[0].text
+    );
+  }
+  return projected ?? messages;
+}
+
+/** Unwraps a canonical single text block after provider cache markers are removed. */
+export function projectSingleTextToolOutputsToText(
+  messages: BaseMessage[],
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+): BaseMessage[] {
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (
+      !(message instanceof ToolMessage) ||
+      typeof message.content === 'string'
+    ) {
+      continue;
+    }
+    const text = getBoundedSingleTextToolContent(message.content, maxChars);
+    if (text == null) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneToolMessageWithContent(message, text);
+  }
+  return projected ?? messages;
+}
+
+/** Serializes provider-neutral structured tool outputs without media pairing. */
+export function projectStructuredToolOutputsToText(
   messages: BaseMessage[],
   maxChars = HARD_MAX_TOOL_RESULT_CHARS
 ): BaseMessage[] {
@@ -528,14 +961,40 @@ export function projectOpenAIToolMessageContent(
     if (
       !(message instanceof ToolMessage) ||
       typeof message.content === 'string' ||
-      message.additional_kwargs.type === 'computer_call_output'
+      hasComputerCallOutputMarker(message)
     ) {
       continue;
     }
     projected ??= [...messages];
     projected[i] = cloneToolMessageWithContent(
       message,
-      serializeStructuredValueBounded(message.content, maxChars).content
+      serializeToolContentBounded(message.content, maxChars)
+    );
+  }
+  return projected ?? messages;
+}
+
+/**
+ * Non-Responses providers cannot consume native computer screenshots. Keep
+ * the tool-call structure intact, but replace screenshot bytes with a bounded
+ * text marker at the actual invocation boundary.
+ */
+export function projectComputerCallOutputsToText(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  let projected: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (
+      !(message instanceof ToolMessage) ||
+      !hasComputerCallOutputMarker(message)
+    ) {
+      continue;
+    }
+    projected ??= [...messages];
+    projected[i] = cloneToolMessageWithContent(
+      message,
+      '[Computer screenshot omitted for this provider]'
     );
   }
   return projected ?? messages;
@@ -576,6 +1035,7 @@ export function projectAnthropicArtifactContent(
     const msg = messages[j];
     if (
       msg instanceof ToolMessage &&
+      !isComputerCallOutputMessage(msg) &&
       toolCallIdSet.has(msg.tool_call_id) &&
       msg.artifact != null &&
       ((typeof msg.artifact?.content === 'string' &&
@@ -657,6 +1117,7 @@ export function projectArtifactPayload(
     const msg = messages[i];
     if (
       !(msg instanceof ToolMessage) ||
+      isComputerCallOutputMessage(msg) ||
       !(
         (typeof msg.artifact?.content === 'string' &&
           msg.artifact.content.length > 0) ||

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -8,6 +8,10 @@ import {
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
+import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+} from '@/utils/toolContent';
 import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
 
@@ -181,15 +185,14 @@ function getReasoningDetailsText(
 function getAdditionalReasoningContent(
   message: BaseMessage
 ): string | undefined {
-  const additionalKwargs =
-    message.additional_kwargs as ReasoningAdditionalKwargs | undefined;
+  const additionalKwargs = message.additional_kwargs as
+    | ReasoningAdditionalKwargs
+    | undefined;
   if (additionalKwargs == null) {
     return undefined;
   }
 
-  const reasoningContent = getReasoningText(
-    additionalKwargs.reasoning_content
-  );
+  const reasoningContent = getReasoningText(additionalKwargs.reasoning_content);
   if (reasoningContent != null) {
     return reasoningContent;
   }
@@ -432,8 +435,7 @@ export function convertMessagesToContent(
         toolCallMap.set(tool_call.id, tool_call);
       }
 
-      currentAIMessageIndex =
-        addContentPart(message) ?? addToolCallBoundary();
+      currentAIMessageIndex = addContentPart(message) ?? addToolCallBoundary();
       continue;
     } else if (
       messageType === 'tool' &&
@@ -471,24 +473,27 @@ function stringifyToolMessageContent(
   return content == null ? '' : String(content);
 }
 
-export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
+export function projectAnthropicArtifactContent(
+  messages: BaseMessage[],
+  maxChars = Number.MAX_SAFE_INTEGER
+): BaseMessage[] {
   const lastMessage = messages[messages.length - 1];
-  if (!(lastMessage instanceof ToolMessage)) return;
+  if (!(lastMessage instanceof ToolMessage)) return messages;
 
   // Find the latest AIMessage with tool_calls that this tool message belongs to
   const latestAIParentIndex = findLastIndex(
     messages,
     (msg) =>
-      (msg instanceof AIMessageChunk &&
+      ((msg instanceof AIMessage || msg instanceof AIMessageChunk) &&
         (msg.tool_calls?.length ?? 0) > 0 &&
         msg.tool_calls?.some((tc) => tc.id === lastMessage.tool_call_id)) ??
       false
   );
 
-  if (latestAIParentIndex === -1) return;
+  if (latestAIParentIndex === -1) return messages;
 
   // Build tool call ID set and merge artifact content in a single forward pass.
-  const message = messages[latestAIParentIndex] as AIMessageChunk;
+  const message = messages[latestAIParentIndex] as AIMessage | AIMessageChunk;
   const toolCallIdSet = new Set<string>();
   if (message.tool_calls) {
     for (const tc of message.tool_calls) {
@@ -498,13 +503,17 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
     }
   }
 
+  let formattedMessages: BaseMessage[] | undefined;
   for (let j = latestAIParentIndex + 1; j < messages.length; j++) {
     const msg = messages[j];
     if (
       msg instanceof ToolMessage &&
       toolCallIdSet.has(msg.tool_call_id) &&
       msg.artifact != null &&
-      Array.isArray(msg.artifact?.content)
+      ((typeof msg.artifact?.content === 'string' &&
+        msg.artifact.content.length > 0) ||
+        (Array.isArray(msg.artifact?.content) &&
+          msg.artifact.content.length > 0))
     ) {
       const base = Array.isArray(msg.content)
         ? msg.content
@@ -514,35 +523,82 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
             text: stringifyToolMessageContent(msg.content),
           },
         ];
-      msg.content = base.concat(msg.artifact.content);
+      const artifactContent =
+        typeof msg.artifact.content === 'string'
+          ? [
+            {
+              type: ContentTypes.TEXT,
+              text: msg.artifact.content,
+            },
+          ]
+          : msg.artifact.content;
+      const content = compactToolContent(
+        base.concat(artifactContent),
+        maxChars
+      ).content;
+      formattedMessages ??= [...messages];
+      formattedMessages[j] = cloneToolMessageWithContent(msg, content, {
+        ...msg.artifact,
+        content: [],
+      });
+    }
+  }
+  return formattedMessages ?? messages;
+}
+
+/**
+ * Mutating compatibility wrapper retained for existing package consumers.
+ * New provider-call paths should use `projectAnthropicArtifactContent`.
+ */
+export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
+  const projected = projectAnthropicArtifactContent(messages);
+  if (projected === messages) {
+    return;
+  }
+  for (let i = 0; i < messages.length; i++) {
+    if (
+      messages[i] instanceof ToolMessage &&
+      projected[i] instanceof ToolMessage &&
+      projected[i] !== messages[i]
+    ) {
+      messages[i].content = projected[i].content;
     }
   }
 }
 
-export function formatArtifactPayload(messages: BaseMessage[]): void {
+export function projectArtifactPayload(
+  messages: BaseMessage[],
+  maxChars = Number.MAX_SAFE_INTEGER
+): BaseMessage[] {
   const lastMessageY = messages[messages.length - 1];
-  if (!(lastMessageY instanceof ToolMessage)) return;
+  if (!(lastMessageY instanceof ToolMessage)) return messages;
 
   // Find the latest AIMessage with tool_calls that this tool message belongs to
   const latestAIParentIndex = findLastIndex(
     messages,
     (msg) =>
-      (msg instanceof AIMessageChunk &&
+      ((msg instanceof AIMessage || msg instanceof AIMessageChunk) &&
         (msg.tool_calls?.length ?? 0) > 0 &&
         msg.tool_calls?.some((tc) => tc.id === lastMessageY.tool_call_id)) ??
       false
   );
 
-  if (latestAIParentIndex === -1) return;
+  if (latestAIParentIndex === -1) return messages;
 
   // Single pass: collect relevant tool messages with artifacts and aggregate
   const aggregatedContent: t.MessageContentComplex[] = [];
+  let formattedMessages: BaseMessage[] | undefined;
 
   for (let i = latestAIParentIndex + 1; i < messages.length; i++) {
     const msg = messages[i];
     if (
       !(msg instanceof ToolMessage) ||
-      !Array.isArray(msg.artifact?.content)
+      !(
+        (typeof msg.artifact?.content === 'string' &&
+          msg.artifact.content.length > 0) ||
+        (Array.isArray(msg.artifact?.content) &&
+          msg.artifact.content.length > 0)
+      )
     ) {
       continue;
     }
@@ -551,16 +607,55 @@ export function formatArtifactPayload(messages: BaseMessage[]): void {
       currentContent = [{ type: 'text', text: msg.content }];
     }
     aggregatedContent.push(...(currentContent as t.MessageContentComplex[]));
-    msg.content =
-      'Tool response is included in the next message as a Human message';
-    aggregatedContent.push(...msg.artifact.content);
+    formattedMessages ??= [...messages];
+    formattedMessages[i] = cloneToolMessageWithContent(
+      msg,
+      'Tool response is included in the next message as a Human message',
+      {
+        ...msg.artifact,
+        content: [],
+      }
+    );
+    if (typeof msg.artifact.content === 'string') {
+      aggregatedContent.push({
+        type: ContentTypes.TEXT,
+        text: msg.artifact.content,
+      });
+    } else {
+      aggregatedContent.push(...msg.artifact.content);
+    }
   }
 
   if (aggregatedContent.length > 0) {
-    messages.push(
-      new HumanMessage({ content: toLangChainContent(aggregatedContent) })
+    const compacted = compactToolContent(
+      toLangChainContent(aggregatedContent),
+      maxChars
     );
+    formattedMessages?.push(new HumanMessage({ content: compacted.content }));
   }
+  return formattedMessages ?? messages;
+}
+
+/**
+ * Mutating compatibility wrapper retained for existing package consumers.
+ * New provider-call paths should use `projectArtifactPayload`.
+ */
+export function formatArtifactPayload(messages: BaseMessage[]): void {
+  const originalLength = messages.length;
+  const projected = projectArtifactPayload(messages);
+  if (projected === messages) {
+    return;
+  }
+  for (let i = 0; i < originalLength; i++) {
+    if (
+      messages[i] instanceof ToolMessage &&
+      projected[i] instanceof ToolMessage &&
+      projected[i] !== messages[i]
+    ) {
+      messages[i].content = projected[i].content;
+    }
+  }
+  messages.push(...projected.slice(originalLength));
 }
 
 export function findLastIndex<T>(

--- a/src/messages/ensureThinkingBlock.test.ts
+++ b/src/messages/ensureThinkingBlock.test.ts
@@ -755,6 +755,54 @@ describe('ensureThinkingBlockInMessages', () => {
       expect(result[0]).toBeInstanceOf(HumanMessage);
       expect(result[1]).toBeInstanceOf(ToolMessage);
     });
+
+    test('should not emit an empty user message after the shared fold budget is exhausted', () => {
+      const messages = [
+        new HumanMessage({ content: 'Run both tools' }),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'first', name: 'query', args: {}, type: 'tool_call' },
+          ],
+        }),
+        new ToolMessage({
+          content: Array.from({ length: 60 }, () => ({
+            type: 'text',
+            text: 'x'.repeat(8_000),
+          })),
+          tool_call_id: 'first',
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'second', name: 'query', args: {}, type: 'tool_call' },
+          ],
+        }),
+        new ToolMessage({
+          content: 'second result',
+          tool_call_id: 'second',
+        }),
+      ];
+
+      const result = ensureThinkingBlockInMessages(
+        messages,
+        Providers.ANTHROPIC
+      );
+
+      expect(result).toHaveLength(2);
+      expect(getTextContent(result[1])).toContain(
+        'additional folded context omitted'
+      );
+      expect(
+        result
+          .filter((message) => message instanceof HumanMessage)
+          .every((message) =>
+            typeof message.content === 'string'
+              ? message.content.length > 0
+              : message.content.length > 0
+          )
+      ).toBe(true);
+    });
   });
 
   describe('image content preservation (token amplification fix)', () => {

--- a/src/messages/ensureThinkingBlock.test.ts
+++ b/src/messages/ensureThinkingBlock.test.ts
@@ -1117,7 +1117,7 @@ describe('ensureThinkingBlockInMessages', () => {
           content: [
             { type: 'text', text: 'Resource fetched' },
             {
-              type: 'resource',
+              type: 'custom_resource',
               resource: { uri: 'file:///data.csv', text: 'a,b,c' },
             },
           ],
@@ -1132,8 +1132,8 @@ describe('ensureThinkingBlockInMessages', () => {
 
       expect(result).toHaveLength(2);
       const allText = getTextContent(result[1]);
-      // The resource block should be serialized as text, not silently dropped
-      expect(allText).toContain('[resource]');
+      // Unknown blocks should be serialized as text, not silently dropped.
+      expect(allText).toContain('[custom_resource]');
       expect(allText).toContain('data.csv');
     });
 

--- a/src/messages/ensureThinkingBlock.test.ts
+++ b/src/messages/ensureThinkingBlock.test.ts
@@ -1117,7 +1117,7 @@ describe('ensureThinkingBlockInMessages', () => {
           content: [
             { type: 'text', text: 'Resource fetched' },
             {
-              type: 'custom_resource',
+              type: 'resource',
               resource: { uri: 'file:///data.csv', text: 'a,b,c' },
             },
           ],
@@ -1132,8 +1132,8 @@ describe('ensureThinkingBlockInMessages', () => {
 
       expect(result).toHaveLength(2);
       const allText = getTextContent(result[1]);
-      // Unknown blocks should be serialized as text, not silently dropped.
-      expect(allText).toContain('[custom_resource]');
+      // The resource block should be serialized as text, not silently dropped.
+      expect(allText).toContain('[resource]');
       expect(allText).toContain('data.csv');
     });
 

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -338,7 +338,11 @@ describe('foldToolBlocksForToollessAgent', () => {
       }),
       new HumanMessage({
         content: [
-          { type: 'tool_result', tool_use_id: 'c1', content: 'Found roadmap.md' },
+          {
+            type: 'tool_result',
+            tool_use_id: 'c1',
+            content: 'Found roadmap.md',
+          },
         ],
       }),
       new HumanMessage('thanks'),
@@ -393,9 +397,7 @@ describe('foldToolBlocksForToollessAgent', () => {
       new HumanMessage('Render a chart'),
       new AIMessage({
         content: '',
-        tool_calls: [
-          { id: 'c', name: 'chart', args: {}, type: 'tool_call' },
-        ],
+        tool_calls: [{ id: 'c', name: 'chart', args: {}, type: 'tool_call' }],
       }),
       new ToolMessage({
         content: [
@@ -420,6 +422,33 @@ describe('foldToolBlocksForToollessAgent', () => {
         (b) => b.type === 'image_url'
       )
     ).toBe(true);
+  });
+
+  test('preserves non-image media blocks instead of JSON-expanding them', () => {
+    const document = {
+      type: 'document',
+      source: { type: 'url', url: 'https://example.com/report.pdf' },
+    };
+    const messages = [
+      new HumanMessage('Read the report'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'doc', name: 'read_document', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: [{ type: 'text', text: 'report:' }, document],
+        tool_call_id: 'doc',
+        name: 'read_document',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const foldedContent = result[result.length - 1].content;
+
+    expect(Array.isArray(foldedContent)).toBe(true);
+    expect(foldedContent).toContainEqual(document);
   });
 
   test('leaves non-tool conversations untouched', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -6,7 +6,11 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import type { ExtendedMessageContent } from '@/types';
-import { foldToolBlocksForToollessAgent } from './format';
+import {
+  foldToolBlocksForToollessAgent,
+  isSyntheticProviderContextMessage,
+} from './format';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 
 /** Concatenated text across a message's content (string or structured array). */
 function getTextContent(msg: {
@@ -96,6 +100,12 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded).toContain('file_search');
     expect(folded).toContain('roadmap');
     expect(folded).toContain('Found roadmap.md');
+    expect(isSyntheticProviderContextMessage(result[1])).toBe(true);
+    expect(
+      isSyntheticProviderContextMessage(
+        new HumanMessage('[Previous tool interaction] user-authored text')
+      )
+    ).toBe(false);
   });
 
   test('folds historical tool content that precedes the last human turn (the reported bug)', () => {
@@ -459,6 +469,115 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(foldedText).toContain('report.bin');
     expect(foldedText.length).toBeLessThan(9_000);
     expect(foldedText).not.toContain(blob);
+  });
+
+  test('does not invoke toJSON while folding a small non-portable media block', () => {
+    let toJSONCalls = 0;
+    const resource = {
+      type: 'resource',
+      resource: { uri: 'file:///report.bin', blob: 'AAAA' },
+      toJSON() {
+        toJSONCalls++;
+        return { expanded: 'x'.repeat(100_000) };
+      },
+    };
+    const messages = [
+      new HumanMessage('Read the report'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'doc', name: 'read_document', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: [resource],
+        tool_call_id: 'doc',
+        name: 'read_document',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const foldedText = getTextContent(result[result.length - 1]);
+
+    expect(toJSONCalls).toBe(0);
+    expect(foldedText).toContain('report.bin');
+    expect(foldedText.length).toBeLessThan(9_000);
+    expect(foldedText).not.toContain('x'.repeat(1_000));
+  });
+
+  test('bounds the aggregate folded context across many large text blocks', () => {
+    const messages = [
+      new HumanMessage('Summarize the query'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'query', name: 'run_query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: Array.from({ length: 100 }, (_, index) => ({
+          type: 'text',
+          text: `${index}:${'x'.repeat(8_000)}`,
+        })),
+        tool_call_id: 'query',
+        name: 'run_query',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const foldedText = getTextContent(result[result.length - 1]);
+
+    expect(foldedText.length).toBeLessThanOrEqual(HARD_MAX_TOOL_RESULT_CHARS);
+    expect(foldedText).toContain('additional folded context omitted');
+  });
+
+  test('does not emit an empty user message when an earlier fold exhausts the shared budget', () => {
+    const messages = [
+      new HumanMessage('Run both queries'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'first', name: 'run_query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: Array.from({ length: 60 }, () => ({
+          type: 'text',
+          text: 'x'.repeat(8_000),
+        })),
+        tool_call_id: 'first',
+        name: 'run_query',
+      }),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'second', name: 'run_query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'second result',
+        tool_call_id: 'second',
+        name: 'run_query',
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const syntheticMessages = result.filter(isSyntheticProviderContextMessage);
+
+    expect(hasResidualToolContent(result)).toBe(false);
+    expect(syntheticMessages).toHaveLength(1);
+    expect(getTextContent(syntheticMessages[0])).toContain(
+      'additional folded context omitted'
+    );
+    expect(
+      result
+        .filter((message) => message instanceof HumanMessage)
+        .every((message) =>
+          typeof message.content === 'string'
+            ? message.content.length > 0
+            : message.content.length > 0
+        )
+    ).toBe(true);
   });
 
   test('leaves non-tool conversations untouched', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -424,10 +424,11 @@ describe('foldToolBlocksForToollessAgent', () => {
     ).toBe(true);
   });
 
-  test('preserves non-image media blocks instead of JSON-expanding them', () => {
-    const document = {
-      type: 'document',
-      source: { type: 'url', url: 'https://example.com/report.pdf' },
+  test('bounds non-portable media blocks instead of preserving or JSON-expanding them', () => {
+    const blob = 'A'.repeat(20_000);
+    const resource = {
+      type: 'resource',
+      resource: { uri: 'file:///report.bin', blob },
     };
     const messages = [
       new HumanMessage('Read the report'),
@@ -438,7 +439,7 @@ describe('foldToolBlocksForToollessAgent', () => {
         ],
       }),
       new ToolMessage({
-        content: [{ type: 'text', text: 'report:' }, document],
+        content: [{ type: 'text', text: 'report:' }, resource],
         tool_call_id: 'doc',
         name: 'read_document',
       }),
@@ -446,9 +447,18 @@ describe('foldToolBlocksForToollessAgent', () => {
 
     const result = foldToolBlocksForToollessAgent(messages);
     const foldedContent = result[result.length - 1].content;
+    const foldedText = getTextContent(result[result.length - 1]);
 
-    expect(Array.isArray(foldedContent)).toBe(true);
-    expect(foldedContent).toContainEqual(document);
+    expect(
+      Array.isArray(foldedContent) &&
+        foldedContent.some(
+          (block) => typeof block === 'object' && block.type === 'resource'
+        )
+    ).toBe(false);
+    expect(foldedText).toContain('[resource]');
+    expect(foldedText).toContain('report.bin');
+    expect(foldedText.length).toBeLessThan(9_000);
+    expect(foldedText).not.toContain(blob);
   });
 
   test('leaves non-tool conversations untouched', () => {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1778,6 +1778,16 @@ export function shiftIndexTokenCountMap(
 const isToolMessage = (m: BaseMessage): boolean =>
   m instanceof ToolMessage || ('role' in m && (m as any).role === 'tool');
 
+const PORTABLE_FOLDED_MEDIA_TYPES = new Set(['image', 'image_url']);
+const MAX_FOLDED_BLOCK_CHARS = 8_000;
+
+function serializeFoldedValue(value: unknown): string {
+  const compacted = compactToolContent(value, MAX_FOLDED_BLOCK_CHARS).content;
+  return typeof compacted === 'string'
+    ? compacted
+    : serializeStructuredValue(compacted);
+}
+
 /** Flushes accumulated text chunks into `parts` as a single text block. */
 function flushTextChunks(
   textChunks: string[],
@@ -1795,9 +1805,10 @@ function flushTextChunks(
 
 /**
  * Appends a single message's content to the running `textChunks` / `parts`
- * accumulators. Atomic media/resource blocks are shallow-copied into `parts`
- * so binary data never becomes text tokens. All other block types are
- * serialized to text rather than silently dropped.
+ * accumulators. Portable image blocks are shallow-copied into `parts` so
+ * binary data never becomes text tokens. Provider-specific media/resource
+ * blocks are retained as bounded text so a folded cross-provider history
+ * cannot contain an unsupported native block or JSON-expand without limit.
  *
  * When `content` is an array containing tool_use blocks, `tool_calls` is NOT
  * additionally serialized (avoiding double output).  `tool_calls` is used as
@@ -1828,15 +1839,21 @@ function appendMessageContent(
 
   for (const block of content as ExtendedMessageContent[]) {
     if (isAtomicToolContentBlock(block)) {
-      flushTextChunks(textChunks, parts);
-      parts.push({ ...block } as MessageContentComplex);
+      if (PORTABLE_FOLDED_MEDIA_TYPES.has(block.type ?? '')) {
+        flushTextChunks(textChunks, parts);
+        parts.push({ ...block } as MessageContentComplex);
+      } else {
+        textChunks.push(
+          `${role}: [${String(block.type ?? 'media')}] ${serializeFoldedValue(block)}`
+        );
+      }
       continue;
     }
 
     if (block.type === 'tool_use') {
       hasToolUseBlock = true;
       textChunks.push(
-        `${role}: [tool_use] ${String(block.name ?? '')} ${JSON.stringify(block.input ?? {})}`
+        `${role}: [tool_use] ${String(block.name ?? '')} ${serializeFoldedValue(block.input ?? {})}`
       );
       continue;
     }
@@ -1852,11 +1869,15 @@ function appendMessageContent(
       const name = String(nested?.name ?? block.name ?? '');
       const rawArgs = nested?.args ?? block.args ?? {};
       const argsText =
-        typeof rawArgs === 'string' ? rawArgs : JSON.stringify(rawArgs);
+        typeof rawArgs === 'string' ? rawArgs : serializeFoldedValue(rawArgs);
       textChunks.push(`${role}: [tool_use] ${name} ${argsText}`.trimEnd());
       const output = nested?.output;
       if (output != null && output !== '') {
-        textChunks.push(`Tool: ${String(output)}`);
+        textChunks.push(
+          `Tool: ${
+            typeof output === 'string' ? output : serializeFoldedValue(output)
+          }`
+        );
       }
       continue;
     }
@@ -1880,7 +1901,10 @@ function appendMessageContent(
             if (innerBlock) {
               textChunks.push(`${role}: [tool_result] ${innerBlock}`);
             }
-          } else if (isAtomicToolContentBlock(innerBlock)) {
+          } else if (
+            isAtomicToolContentBlock(innerBlock) &&
+            PORTABLE_FOLDED_MEDIA_TYPES.has(innerBlock.type ?? '')
+          ) {
             flushTextChunks(textChunks, parts);
             parts.push({ ...innerBlock } as MessageContentComplex);
           } else {
@@ -1889,13 +1913,15 @@ function appendMessageContent(
               `${role}: [tool_result] ${
                 typeof innerText === 'string' && innerText
                   ? innerText
-                  : JSON.stringify(innerBlock)
+                  : serializeFoldedValue(innerBlock)
               }`
             );
           }
         }
       } else if (inner != null) {
-        textChunks.push(`${role}: [tool_result] ${JSON.stringify(inner)}`);
+        textChunks.push(
+          `${role}: [tool_result] ${serializeFoldedValue(inner)}`
+        );
       }
       continue;
     }
@@ -1908,7 +1934,9 @@ function appendMessageContent(
 
     // Fallback: serialize unrecognized block types to preserve context
     if (block.type != null && block.type !== '') {
-      textChunks.push(`${role}: [${block.type}] ${JSON.stringify(block)}`);
+      textChunks.push(
+        `${role}: [${block.type}] ${serializeFoldedValue(block)}`
+      );
     }
   }
 
@@ -1930,7 +1958,9 @@ function appendToolCalls(
   const aiMsg = msg as AIMessage;
   if (aiMsg.tool_calls && aiMsg.tool_calls.length > 0) {
     for (const tc of aiMsg.tool_calls) {
-      textChunks.push(`AI: [tool_call] ${tc.name}(${JSON.stringify(tc.args)})`);
+      textChunks.push(
+        `AI: [tool_call] ${tc.name}(${serializeFoldedValue(tc.args)})`
+      );
     }
     return;
   }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -29,11 +29,13 @@ import type {
 } from '@/types';
 import {
   compactToolContent,
+  getToolContentCharLength,
   isAtomicToolContentBlock,
-  serializeStructuredValue,
+  serializeStructuredValueBounded,
 } from '@/utils/toolContent';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { Providers, ContentTypes, Constants } from '@/common';
 import { emitAgentLog } from '@/utils/events';
 
@@ -470,13 +472,7 @@ function formatToolCallOutput(
   if (output == null) {
     return '';
   }
-  if (typeof output === 'string') {
-    return output;
-  }
-  if (Array.isArray(output)) {
-    return compactToolContent(output, Number.MAX_SAFE_INTEGER).content;
-  }
-  return serializeStructuredValue(output);
+  return compactToolContent(output, HARD_MAX_TOOL_RESULT_CHARS).content;
 }
 
 /**
@@ -1270,7 +1266,11 @@ function contentPartCharLength(part: MessageContentComplex): number {
   if (typeof input === 'string') {
     len += input.length;
   } else if (input != null && typeof input === 'object') {
-    len += JSON.stringify(input).length;
+    const measured = serializeStructuredValueBounded(input, 0).originalChars;
+    len +=
+      measured === Number.MAX_SAFE_INTEGER
+        ? HARD_MAX_TOOL_RESULT_CHARS
+        : Math.min(measured, HARD_MAX_TOOL_RESULT_CHARS);
   }
   return len;
 }
@@ -1709,7 +1709,14 @@ export const formatAgentMessages = (
             if (typeof args === 'string') {
               len += args.length;
             } else if (args != null) {
-              len += JSON.stringify(args).length;
+              const measured = serializeStructuredValueBounded(
+                args,
+                0
+              ).originalChars;
+              len +=
+                measured === Number.MAX_SAFE_INTEGER
+                  ? HARD_MAX_TOOL_RESULT_CHARS
+                  : Math.min(measured, HARD_MAX_TOOL_RESULT_CHARS);
             }
           }
         }
@@ -1780,12 +1787,148 @@ const isToolMessage = (m: BaseMessage): boolean =>
 
 const PORTABLE_FOLDED_MEDIA_TYPES = new Set(['image', 'image_url']);
 const MAX_FOLDED_BLOCK_CHARS = 8_000;
+const MAX_FOLDED_CONTEXT_CHARS = HARD_MAX_TOOL_RESULT_CHARS;
+const MAX_FOLDED_CONTEXT_WORK = 100_000;
+const FOLDED_CONTEXT_TRUNCATION_NOTICE =
+  '… [additional folded context omitted]';
+const syntheticProviderContextMessages = new WeakSet<BaseMessage>();
+
+type FoldContextBudget = {
+  remainingChars: number;
+  remainingWork: number;
+  truncated: boolean;
+};
+
+function createFoldContextBudget(): FoldContextBudget {
+  return {
+    remainingChars: MAX_FOLDED_CONTEXT_CHARS,
+    remainingWork: MAX_FOLDED_CONTEXT_WORK,
+    truncated: false,
+  };
+}
+
+function readFoldedDataProperty(value: unknown, key: string): unknown {
+  if (value == null || typeof value !== 'object') {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor != null && 'value' in descriptor
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Adds one logical line without first concatenating caller-controlled strings.
+ * The shared budget covers every synthetic message emitted by one transform,
+ * so many individually bounded blocks cannot build an unbounded aggregate.
+ */
+function appendFoldedLine(
+  textChunks: string[],
+  budget: FoldContextBudget,
+  pieces: readonly string[]
+): boolean {
+  if (budget.remainingChars <= 0) {
+    budget.truncated = true;
+    return false;
+  }
+
+  const separatorChars = textChunks.length > 0 ? 1 : 0;
+  const available = budget.remainingChars - separatorChars;
+  if (available <= 0) {
+    budget.remainingChars = 0;
+    budget.truncated = true;
+    return false;
+  }
+
+  let totalChars = 0;
+  for (const piece of pieces) {
+    totalChars = Math.min(Number.MAX_SAFE_INTEGER, totalChars + piece.length);
+  }
+  if (totalChars <= available) {
+    const line = pieces.join('');
+    textChunks.push(line);
+    budget.remainingChars -= separatorChars + line.length;
+    return true;
+  }
+
+  const notice = FOLDED_CONTEXT_TRUNCATION_NOTICE.slice(0, available);
+  let remainingHeadChars = Math.max(0, available - notice.length);
+  const boundedPieces: string[] = [];
+  for (const piece of pieces) {
+    if (remainingHeadChars <= 0) {
+      break;
+    }
+    const retained = piece.slice(0, remainingHeadChars);
+    boundedPieces.push(retained);
+    remainingHeadChars -= retained.length;
+  }
+  boundedPieces.push(notice);
+  textChunks.push(boundedPieces.join(''));
+  budget.remainingChars = 0;
+  budget.truncated = true;
+  return false;
+}
+
+function consumeFoldedWork(
+  textChunks: string[],
+  budget: FoldContextBudget
+): boolean {
+  if (budget.remainingChars <= 0) {
+    return false;
+  }
+  if (budget.remainingWork-- > 0) {
+    return true;
+  }
+  appendFoldedLine(textChunks, budget, [FOLDED_CONTEXT_TRUNCATION_NOTICE]);
+  budget.remainingChars = 0;
+  budget.truncated = true;
+  return false;
+}
 
 function serializeFoldedValue(value: unknown): string {
   const compacted = compactToolContent(value, MAX_FOLDED_BLOCK_CHARS).content;
   return typeof compacted === 'string'
     ? compacted
-    : serializeStructuredValue(compacted);
+    : serializeStructuredValueBounded(compacted, MAX_FOLDED_BLOCK_CHARS)
+      .content;
+}
+
+function markSyntheticProviderContext<T extends BaseMessage>(message: T): T {
+  syntheticProviderContextMessages.add(message);
+  return message;
+}
+
+function appendSyntheticProviderContextMessage(
+  result: BaseMessage[],
+  parts: MessageContentComplex[]
+): boolean {
+  if (parts.length === 0) {
+    return false;
+  }
+  result.push(
+    markSyntheticProviderContext(
+      withMessageRole(
+        new HumanMessage({ content: toLangChainContent(parts) }),
+        'user'
+      )
+    )
+  );
+  return true;
+}
+
+/**
+ * Identifies provider-context placeholders created by this module without
+ * trusting user-controlled content prefixes or leaking marker metadata onto
+ * the provider wire.
+ */
+export function isSyntheticProviderContextMessage(
+  message: BaseMessage
+): boolean {
+  return syntheticProviderContextMessages.has(message);
 }
 
 /** Flushes accumulated text chunks into `parts` as a single text block. */
@@ -1818,43 +1961,69 @@ function appendMessageContent(
   msg: BaseMessage,
   role: string,
   textChunks: string[],
-  parts: MessageContentComplex[]
+  parts: MessageContentComplex[],
+  budget: FoldContextBudget
 ): void {
   const { content } = msg;
 
   if (typeof content === 'string') {
-    if (content) {
-      textChunks.push(`${role}: ${content}`);
+    if (content && consumeFoldedWork(textChunks, budget)) {
+      appendFoldedLine(textChunks, budget, [`${role}: `, content]);
     }
-    appendToolCalls(msg, role, textChunks);
+    appendToolCalls(msg, role, textChunks, budget);
     return;
   }
 
   if (!Array.isArray(content)) {
-    appendToolCalls(msg, role, textChunks);
+    appendToolCalls(msg, role, textChunks, budget);
     return;
   }
 
   let hasToolUseBlock = false;
 
   for (const block of content as ExtendedMessageContent[]) {
-    if (isAtomicToolContentBlock(block)) {
-      if (PORTABLE_FOLDED_MEDIA_TYPES.has(block.type ?? '')) {
+    if (!consumeFoldedWork(textChunks, budget)) {
+      hasToolUseBlock = true;
+      break;
+    }
+    const blockTypeValue = readFoldedDataProperty(block, 'type');
+    const blockType =
+      typeof blockTypeValue === 'string' ? blockTypeValue : undefined;
+
+    if (
+      blockType !== 'tool_use' &&
+      blockType !== 'tool_call' &&
+      blockType !== 'tool_result' &&
+      isAtomicToolContentBlock(block)
+    ) {
+      if (PORTABLE_FOLDED_MEDIA_TYPES.has(blockType ?? '')) {
+        const blockChars = getToolContentCharLength([block]);
+        if (blockChars > budget.remainingChars) {
+          appendFoldedLine(textChunks, budget, [
+            `${role}: [${blockType ?? 'media'} omitted: folded context limit]`,
+          ]);
+          continue;
+        }
         flushTextChunks(textChunks, parts);
         parts.push({ ...block } as MessageContentComplex);
+        budget.remainingChars -= blockChars;
       } else {
-        textChunks.push(
-          `${role}: [${String(block.type ?? 'media')}] ${serializeFoldedValue(block)}`
-        );
+        appendFoldedLine(textChunks, budget, [
+          `${role}: [${blockType ?? 'media'}] `,
+          serializeFoldedValue(block),
+        ]);
       }
       continue;
     }
 
-    if (block.type === 'tool_use') {
+    if (blockType === 'tool_use') {
       hasToolUseBlock = true;
-      textChunks.push(
-        `${role}: [tool_use] ${String(block.name ?? '')} ${serializeFoldedValue(block.input ?? {})}`
-      );
+      const name = readFoldedDataProperty(block, 'name');
+      const input = readFoldedDataProperty(block, 'input');
+      appendFoldedLine(textChunks, budget, [
+        `${role}: [tool_use] ${typeof name === 'string' ? name : ''} `,
+        serializeFoldedValue(input ?? {}),
+      ]);
       continue;
     }
 
@@ -1863,21 +2032,32 @@ function appendMessageContent(
     // toolUse) or this repo's `ToolCallContent` (`{ tool_call: { name, args,
     // output } }`, from `convertMessagesToContent` / persisted history). Handle
     // both, and emit any embedded output, so the name/args/result survive.
-    if (block.type === 'tool_call') {
+    if (blockType === 'tool_call') {
       hasToolUseBlock = true;
-      const nested = (block as { tool_call?: ToolCallPart }).tool_call;
-      const name = String(nested?.name ?? block.name ?? '');
-      const rawArgs = nested?.args ?? block.args ?? {};
+      const nested = readFoldedDataProperty(block, 'tool_call');
+      const nestedName = readFoldedDataProperty(nested, 'name');
+      const topLevelName = readFoldedDataProperty(block, 'name');
+      let name = '';
+      if (typeof nestedName === 'string') {
+        name = nestedName;
+      } else if (typeof topLevelName === 'string') {
+        name = topLevelName;
+      }
+      const nestedArgs = readFoldedDataProperty(nested, 'args');
+      const topLevelArgs = readFoldedDataProperty(block, 'args');
+      const rawArgs = nestedArgs ?? topLevelArgs ?? {};
       const argsText =
         typeof rawArgs === 'string' ? rawArgs : serializeFoldedValue(rawArgs);
-      textChunks.push(`${role}: [tool_use] ${name} ${argsText}`.trimEnd());
-      const output = nested?.output;
+      appendFoldedLine(textChunks, budget, [
+        `${role}: [tool_use] ${name}${argsText ? ' ' : ''}`,
+        argsText,
+      ]);
+      const output = readFoldedDataProperty(nested, 'output');
       if (output != null && output !== '') {
-        textChunks.push(
-          `Tool: ${
-            typeof output === 'string' ? output : serializeFoldedValue(output)
-          }`
-        );
+        appendFoldedLine(textChunks, budget, [
+          'Tool: ',
+          typeof output === 'string' ? output : serializeFoldedValue(output),
+        ]);
       }
       continue;
     }
@@ -1885,72 +2065,101 @@ function appendMessageContent(
     // A `tool_result` content block (e.g. an AIMessage(tool_call) followed by a
     // user message carrying the result). Preserve nested image blocks as-is
     // instead of JSON-stringifying them through the generic fallback.
-    if (block.type === 'tool_result') {
+    if (blockType === 'tool_result') {
       hasToolUseBlock = true;
-      const inner = (block as { content?: ToolResultContent['content'] })
-        .content;
+      const inner = readFoldedDataProperty(block, 'content') as
+        | ToolResultContent['content']
+        | undefined;
       if (typeof inner === 'string') {
         if (inner) {
-          textChunks.push(`${role}: [tool_result] ${inner}`);
+          appendFoldedLine(textChunks, budget, [
+            `${role}: [tool_result] `,
+            inner,
+          ]);
         }
       } else if (Array.isArray(inner)) {
         for (const innerBlock of inner as Array<
           string | ExtendedMessageContent
         >) {
+          if (!consumeFoldedWork(textChunks, budget)) {
+            break;
+          }
           if (typeof innerBlock === 'string') {
             if (innerBlock) {
-              textChunks.push(`${role}: [tool_result] ${innerBlock}`);
+              appendFoldedLine(textChunks, budget, [
+                `${role}: [tool_result] `,
+                innerBlock,
+              ]);
             }
-          } else if (
-            isAtomicToolContentBlock(innerBlock) &&
-            PORTABLE_FOLDED_MEDIA_TYPES.has(innerBlock.type ?? '')
-          ) {
-            flushTextChunks(textChunks, parts);
-            parts.push({ ...innerBlock } as MessageContentComplex);
           } else {
-            const innerText = innerBlock.text ?? innerBlock.input;
-            textChunks.push(
-              `${role}: [tool_result] ${
+            const innerTypeValue = readFoldedDataProperty(innerBlock, 'type');
+            const innerType =
+              typeof innerTypeValue === 'string' ? innerTypeValue : undefined;
+            if (
+              isAtomicToolContentBlock(innerBlock) &&
+              PORTABLE_FOLDED_MEDIA_TYPES.has(innerType ?? '')
+            ) {
+              const blockChars = getToolContentCharLength([innerBlock]);
+              if (blockChars <= budget.remainingChars) {
+                flushTextChunks(textChunks, parts);
+                parts.push({ ...innerBlock } as MessageContentComplex);
+                budget.remainingChars -= blockChars;
+              } else {
+                appendFoldedLine(textChunks, budget, [
+                  `${role}: [${innerType ?? 'media'} omitted: folded context limit]`,
+                ]);
+              }
+            } else {
+              const textValue = readFoldedDataProperty(innerBlock, 'text');
+              const inputValue = readFoldedDataProperty(innerBlock, 'input');
+              const innerText = textValue ?? inputValue;
+              appendFoldedLine(textChunks, budget, [
+                `${role}: [tool_result] `,
                 typeof innerText === 'string' && innerText
                   ? innerText
-                  : serializeFoldedValue(innerBlock)
-              }`
-            );
+                  : serializeFoldedValue(innerBlock),
+              ]);
+            }
           }
         }
       } else if (inner != null) {
-        textChunks.push(
-          `${role}: [tool_result] ${serializeFoldedValue(inner)}`
-        );
+        appendFoldedLine(textChunks, budget, [
+          `${role}: [tool_result] `,
+          serializeFoldedValue(inner),
+        ]);
       }
       continue;
     }
 
-    const text = block.text ?? block.input;
+    const text =
+      readFoldedDataProperty(block, 'text') ??
+      readFoldedDataProperty(block, 'input');
     if (typeof text === 'string' && text) {
-      textChunks.push(`${role}: ${text}`);
+      appendFoldedLine(textChunks, budget, [`${role}: `, text]);
       continue;
     }
 
     // Fallback: serialize unrecognized block types to preserve context
-    if (block.type != null && block.type !== '') {
-      textChunks.push(
-        `${role}: [${block.type}] ${serializeFoldedValue(block)}`
-      );
+    if (blockType != null && blockType !== '') {
+      appendFoldedLine(textChunks, budget, [
+        `${role}: [${blockType}] `,
+        serializeFoldedValue(block),
+      ]);
     }
   }
 
   // If content array had no tool_use blocks, fall back to tool_calls metadata
   // (handles edge case: empty content array with tool_calls populated)
   if (!hasToolUseBlock) {
-    appendToolCalls(msg, role, textChunks);
+    appendToolCalls(msg, role, textChunks, budget);
   }
 }
 
 function appendToolCalls(
   msg: BaseMessage,
   role: string,
-  textChunks: string[]
+  textChunks: string[],
+  budget: FoldContextBudget
 ): void {
   if (role !== 'AI') {
     return;
@@ -1958,9 +2167,16 @@ function appendToolCalls(
   const aiMsg = msg as AIMessage;
   if (aiMsg.tool_calls && aiMsg.tool_calls.length > 0) {
     for (const tc of aiMsg.tool_calls) {
-      textChunks.push(
-        `AI: [tool_call] ${tc.name}(${serializeFoldedValue(tc.args)})`
-      );
+      if (!consumeFoldedWork(textChunks, budget)) {
+        break;
+      }
+      const name = readFoldedDataProperty(tc, 'name');
+      const args = readFoldedDataProperty(tc, 'args');
+      appendFoldedLine(textChunks, budget, [
+        `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
+        serializeFoldedValue(args),
+        ')',
+      ]);
     }
     return;
   }
@@ -1970,14 +2186,20 @@ function appendToolCalls(
     return;
   }
   for (const tc of rawToolCalls) {
-    const fn = (tc as { function?: { name?: string; arguments?: string } })
-      .function;
+    if (!consumeFoldedWork(textChunks, budget)) {
+      break;
+    }
+    const fn = readFoldedDataProperty(tc, 'function');
     if (fn == null) {
       continue;
     }
-    textChunks.push(
-      `AI: [tool_call] ${String(fn.name ?? '')}(${String(fn.arguments ?? '')})`
-    );
+    const name = readFoldedDataProperty(fn, 'name');
+    const args = readFoldedDataProperty(fn, 'arguments');
+    appendFoldedLine(textChunks, budget, [
+      `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
+      typeof args === 'string' ? args : '',
+      ')',
+    ]);
   }
 }
 
@@ -2037,6 +2259,7 @@ export function ensureThinkingBlockInMessages(
 
   const result: BaseMessage[] =
     lastHumanIndex >= 0 ? messages.slice(0, lastHumanIndex + 1) : [];
+  const foldBudget = createFoldContextBudget();
   let i = lastHumanIndex + 1;
 
   while (i < messages.length) {
@@ -2067,13 +2290,14 @@ export function ensureThinkingBlockInMessages(
         if (typeof c !== 'object') {
           continue;
         }
-        if (c.type === 'tool_use') {
+        const type = readFoldedDataProperty(c, 'type');
+        if (type === 'tool_use') {
           hasToolUse = true;
         } else if (
-          c.type === ContentTypes.THINKING ||
-          c.type === ContentTypes.REASONING_CONTENT ||
-          c.type === ContentTypes.REASONING ||
-          c.type === 'redacted_thinking'
+          type === ContentTypes.THINKING ||
+          type === ContentTypes.REASONING_CONTENT ||
+          type === ContentTypes.REASONING ||
+          type === 'redacted_thinking'
         ) {
           hasThinkingBlock = true;
         }
@@ -2128,30 +2352,33 @@ export function ensureThinkingBlockInMessages(
       // ToolMessages — preserves image blocks as-is to avoid serializing
       // binary data as text (which caused 174× token amplification).
       const parts: MessageContentComplex[] = [];
-      const textChunks: string[] = ['[Previous agent context]'];
+      const textChunks: string[] = [];
+      appendFoldedLine(textChunks, foldBudget, ['[Previous agent context]']);
 
-      appendMessageContent(msg, 'AI', textChunks, parts);
+      appendMessageContent(msg, 'AI', textChunks, parts, foldBudget);
 
       let j = i + 1;
       while (j < messages.length && isToolMessage(messages[j])) {
-        appendMessageContent(messages[j], 'Tool', textChunks, parts);
+        appendMessageContent(
+          messages[j],
+          'Tool',
+          textChunks,
+          parts,
+          foldBudget
+        );
         j++;
       }
 
       flushTextChunks(textChunks, parts);
-      emitAgentLog(
-        config,
-        'warn',
-        'format',
-        'ensureThinkingBlockInMessages: injecting [Previous agent context] HumanMessage' +
-          ` (${parts.length} msgs at index ${i}, no thinking block in chain)`
-      );
-      result.push(
-        withMessageRole(
-          new HumanMessage({ content: toLangChainContent(parts) }),
-          'user'
-        )
-      );
+      if (appendSyntheticProviderContextMessage(result, parts)) {
+        emitAgentLog(
+          config,
+          'warn',
+          'format',
+          'ensureThinkingBlockInMessages: injecting [Previous agent context] HumanMessage' +
+            ` (${parts.length} msgs at index ${i}, no thinking block in chain)`
+        );
+      }
       i = j;
     } else {
       // Keep the message as is
@@ -2186,11 +2413,10 @@ function messageHasToolContent(msg: BaseMessage): boolean {
   }
   if (Array.isArray(msg.content)) {
     for (const block of msg.content as ExtendedMessageContent[]) {
+      const type = readFoldedDataProperty(block, 'type');
       if (
         typeof block === 'object' &&
-        (block.type === 'tool_use' ||
-          block.type === 'tool_call' ||
-          block.type === 'tool_result')
+        (type === 'tool_use' || type === 'tool_call' || type === 'tool_result')
       ) {
         return true;
       }
@@ -2210,7 +2436,9 @@ function isToolResultMessage(msg: BaseMessage): boolean {
   }
   if (Array.isArray(msg.content)) {
     return (msg.content as ExtendedMessageContent[]).some(
-      (block) => typeof block === 'object' && block.type === 'tool_result'
+      (block) =>
+        typeof block === 'object' &&
+        readFoldedDataProperty(block, 'type') === 'tool_result'
     );
   }
   return false;
@@ -2243,6 +2471,7 @@ export function foldToolBlocksForToollessAgent(
 ): BaseMessage[] {
   let result: BaseMessage[] | null = null;
   let foldedCount = 0;
+  const foldBudget = createFoldContextBudget();
   let i = 0;
   while (i < messages.length) {
     const msg = messages[i];
@@ -2258,29 +2487,26 @@ export function foldToolBlocksForToollessAgent(
     }
 
     const parts: MessageContentComplex[] = [];
-    const textChunks: string[] = ['[Previous tool interaction]'];
+    const textChunks: string[] = [];
+    appendFoldedLine(textChunks, foldBudget, ['[Previous tool interaction]']);
     appendMessageContent(
       msg,
       isToolResultMessage(msg) ? 'Tool' : 'AI',
       textChunks,
-      parts
+      parts,
+      foldBudget
     );
     foldedCount++;
 
     let j = i + 1;
     while (j < messages.length && isToolResultMessage(messages[j])) {
-      appendMessageContent(messages[j], 'Tool', textChunks, parts);
+      appendMessageContent(messages[j], 'Tool', textChunks, parts, foldBudget);
       foldedCount++;
       j++;
     }
 
     flushTextChunks(textChunks, parts);
-    result.push(
-      withMessageRole(
-        new HumanMessage({ content: toLangChainContent(parts) }),
-        'user'
-      )
-    );
+    appendSyntheticProviderContextMessage(result, parts);
     i = j;
   }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -27,6 +27,11 @@ import type {
   TPayload,
   TMessage,
 } from '@/types';
+import {
+  compactToolContent,
+  isAtomicToolContentBlock,
+  serializeStructuredValue,
+} from '@/utils/toolContent';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
 import { Providers, ContentTypes, Constants } from '@/common';
@@ -459,6 +464,21 @@ function hasToolCallOutput(part: MessageContentComplex): boolean {
   return output != null && output !== '';
 }
 
+function formatToolCallOutput(
+  output: ToolCallPart['output'] | undefined
+): MessageContent {
+  if (output == null) {
+    return '';
+  }
+  if (typeof output === 'string') {
+    return output;
+  }
+  if (Array.isArray(output)) {
+    return compactToolContent(output, Number.MAX_SAFE_INTEGER).content;
+  }
+  return serializeStructuredValue(output);
+}
+
 /**
  * Helper function to format an assistant message
  * @param message The message to format
@@ -718,7 +738,7 @@ function formatAssistantMessage(
             new ToolMessage({
               tool_call_id: tool_call.id ?? '',
               name: tool_call.name,
-              content: output != null ? output : '',
+              content: formatToolCallOutput(output),
             }),
             'tool'
           )
@@ -1754,9 +1774,6 @@ export function shiftIndexTokenCountMap(
   return shiftedMap;
 }
 
-/** Block types that contain binary image data and must be preserved structurally. */
-const IMAGE_BLOCK_TYPES = new Set(['image_url', 'image']);
-
 /** Checks whether a BaseMessage is a tool-role message. */
 const isToolMessage = (m: BaseMessage): boolean =>
   m instanceof ToolMessage || ('role' in m && (m as any).role === 'tool');
@@ -1778,10 +1795,9 @@ function flushTextChunks(
 
 /**
  * Appends a single message's content to the running `textChunks` / `parts`
- * accumulators.  Image blocks are shallow-copied into `parts` as-is so that
- * binary data (base64 images) never becomes text tokens.  All other block
- * types are serialized to text — unrecognized types are JSON-serialized
- * rather than silently dropped.
+ * accumulators. Atomic media/resource blocks are shallow-copied into `parts`
+ * so binary data never becomes text tokens. All other block types are
+ * serialized to text rather than silently dropped.
  *
  * When `content` is an array containing tool_use blocks, `tool_calls` is NOT
  * additionally serialized (avoiding double output).  `tool_calls` is used as
@@ -1811,7 +1827,7 @@ function appendMessageContent(
   let hasToolUseBlock = false;
 
   for (const block of content as ExtendedMessageContent[]) {
-    if (IMAGE_BLOCK_TYPES.has(block.type ?? '')) {
+    if (isAtomicToolContentBlock(block)) {
       flushTextChunks(textChunks, parts);
       parts.push({ ...block } as MessageContentComplex);
       continue;
@@ -1864,7 +1880,7 @@ function appendMessageContent(
             if (innerBlock) {
               textChunks.push(`${role}: [tool_result] ${innerBlock}`);
             }
-          } else if (IMAGE_BLOCK_TYPES.has(innerBlock.type ?? '')) {
+          } else if (isAtomicToolContentBlock(innerBlock)) {
             flushTextChunks(textChunks, parts);
             parts.push({ ...innerBlock } as MessageContentComplex);
           } else {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5,6 +5,12 @@ import {
   SystemMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import {
+  convertMessagesToCompletionsMessageParams,
+  convertResponsesDeltaToChatGenerationChunk,
+  convertMessagesToResponsesInput,
+  convertResponsesMessageToAIMessage,
+} from '@langchain/openai';
 import type { MessageContentComplex, TPayload } from '@/types';
 import {
   convertMessagesToContent,
@@ -12,7 +18,9 @@ import {
   formatArtifactPayload,
   projectAnthropicArtifactContent,
   projectArtifactPayload,
+  projectComputerCallOutputsToText,
   projectOpenAIToolMessageContent,
+  projectOpenAIResponsesToolMessageContent,
 } from './core';
 import {
   _convertMessagesToOpenAIParams,
@@ -1745,6 +1753,19 @@ describe('formatAgentMessages', () => {
   });
 
   it('preserves Responses computer outputs handled as provider-native media', () => {
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            id: 'computer-item',
+            call_id: 'call_computer',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
     const computerOutput = new ToolMessage({
       content: [
         {
@@ -1755,10 +1776,18 @@ describe('formatAgentMessages', () => {
       tool_call_id: 'call_computer',
       additional_kwargs: { type: 'computer_call_output' },
     });
-    const messages = [computerOutput];
+    const messages = [computerCall, computerOutput];
+    const projected = projectOpenAIToolMessageContent(messages, 10);
+    const responsesInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'computer-use-preview',
+    });
 
-    expect(projectOpenAIToolMessageContent(messages, 10)).toBe(messages);
-    expect(_convertMessagesToOpenAIResponsesParams(messages)[0]).toMatchObject({
+    expect(projected).not.toBe(messages);
+    expect(
+      responsesInput.find((item) => item.type === 'computer_call_output')
+    ).toMatchObject({
       type: 'computer_call_output',
       call_id: 'call_computer',
       output: {
@@ -1766,6 +1795,299 @@ describe('formatAgentMessages', () => {
         image_url: 'data:image/png;base64,AA==',
       },
     });
+  });
+
+  it('deduplicates parsed and raw Responses computer calls in ZDR mode', () => {
+    const response = {
+      id: 'resp_computer',
+      object: 'response',
+      created_at: 0,
+      model: 'computer-use-preview',
+      output: [
+        {
+          type: 'computer_call',
+          id: 'computer-item',
+          call_id: 'call_computer',
+          action: { type: 'screenshot' },
+          status: 'completed',
+        },
+      ],
+      status: 'completed',
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+      error: null,
+      incomplete_details: null,
+      metadata: {},
+      user: null,
+      service_tier: 'default',
+    } as unknown as Parameters<typeof convertResponsesMessageToAIMessage>[0];
+    const computerCall = convertResponsesMessageToAIMessage(response);
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([
+      computerCall,
+      computerOutput,
+    ]);
+    const zdrInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: true,
+      model: 'computer-use-preview',
+    });
+    const retainedInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'computer-use-preview',
+    });
+
+    expect(computerCall.tool_calls).toHaveLength(1);
+    expect((projected[0] as AIMessage).tool_calls).toHaveLength(0);
+    for (const input of [zdrInput, retainedInput]) {
+      expect(
+        input.filter(
+          (item) =>
+            item.type === 'computer_call' && item.call_id === 'call_computer'
+        )
+      ).toHaveLength(1);
+      expect(
+        input.filter(
+          (item) =>
+            item.type === 'computer_call_output' &&
+            item.call_id === 'call_computer'
+        )
+      ).toHaveLength(1);
+    }
+  });
+
+  it('deduplicates streaming Responses computer calls before replay', () => {
+    const event = {
+      type: 'response.output_item.done',
+      sequence_number: 1,
+      output_index: 0,
+      item: {
+        type: 'computer_call',
+        id: 'computer-stream-item',
+        call_id: 'call_computer_stream',
+        action: { type: 'screenshot' },
+        status: 'completed',
+      },
+    } as unknown as Parameters<
+      typeof convertResponsesDeltaToChatGenerationChunk
+    >[0];
+    const generation = convertResponsesDeltaToChatGenerationChunk(event);
+    const computerCall = generation?.message;
+    expect(computerCall).toBeDefined();
+
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_computer_stream',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const projected = projectOpenAIResponsesToolMessageContent([
+      computerCall!,
+      computerOutput,
+    ]);
+
+    expect((computerCall as AIMessage).tool_calls).toHaveLength(1);
+    expect((computerCall as AIMessageChunk).tool_call_chunks).toHaveLength(1);
+    expect((projected[0] as AIMessage).tool_calls).toHaveLength(0);
+    expect((projected[0] as AIMessageChunk).tool_call_chunks).toHaveLength(0);
+    expect(Object.getPrototypeOf(projected[0])).toBe(
+      Object.getPrototypeOf(computerCall)
+    );
+    expect(
+      new AIMessageChunk(projected[0] as AIMessageChunk).tool_calls
+    ).toHaveLength(0);
+    for (const zdrEnabled of [true, false]) {
+      const input = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled,
+        model: 'computer-use-preview',
+      });
+      expect(
+        input.filter(
+          (item) =>
+            item.type === 'computer_call' &&
+            item.call_id === 'call_computer_stream'
+        )
+      ).toHaveLength(1);
+      expect(
+        input.filter(
+          (item) =>
+            (item.type === 'function_call' || item.type === 'computer_call') &&
+            item.call_id === 'call_computer_stream'
+        )
+      ).toHaveLength(1);
+    }
+
+    const chatProjected = projectComputerCallOutputsToText(
+      projectOpenAIToolMessageContent([computerCall!, computerOutput])
+    );
+    const chatInput = convertMessagesToCompletionsMessageParams({
+      messages: chatProjected,
+      model: 'gpt-4o',
+    });
+
+    expect((chatProjected[0] as AIMessage).tool_calls).toHaveLength(1);
+    expect(chatInput).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        tool_calls: [
+          expect.objectContaining({
+            id: 'call_computer_stream',
+            type: 'function',
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        role: 'tool',
+        tool_call_id: 'call_computer_stream',
+        content: '[Computer screenshot omitted for this provider]',
+      }),
+    ]);
+  });
+
+  it('canonicalizes real OpenAI file-backed computer screenshots on the production converter path', () => {
+    const computerCall = new AIMessage({
+      content: '',
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            type: 'computer_call',
+            call_id: 'call_computer_file',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const computerOutput = new ToolMessage({
+      content: [
+        {
+          type: 'input_image',
+          file_id: 'file-abc123',
+          detail: 'low',
+        },
+      ],
+      tool_call_id: 'call_computer_file',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    const projected = projectOpenAIToolMessageContent(
+      [computerCall, computerOutput],
+      100
+    );
+    const responsesInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'computer-use-preview',
+    });
+
+    expect(responsesInput).toContainEqual({
+      type: 'computer_call_output',
+      call_id: 'call_computer_file',
+      output: {
+        type: 'input_image',
+        file_id: 'file-abc123',
+        detail: 'low',
+      },
+    });
+  });
+
+  it('rejects extra invalid screenshot fields instead of shipping the original block', () => {
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            call_id: 'call_computer_extra',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const malformed = new ToolMessage({
+      content: [
+        {
+          type: 'input_image',
+          image_url: 'data:image/png;base64,AA==',
+          file_id: 'not-a-file-id',
+        },
+      ],
+      tool_call_id: 'call_computer_extra',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(() =>
+      projectOpenAIToolMessageContent([computerCall, malformed], 100)
+    ).toThrow('Invalid computer call output screenshot');
+  });
+
+  it('rejects computer outputs that precede their call', () => {
+    const computerCall = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            call_id: 'call_computer_order',
+            action: { type: 'screenshot' },
+          },
+        ],
+      },
+    });
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_computer_order',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(() =>
+      projectOpenAIToolMessageContent([computerOutput, computerCall], 100)
+    ).toThrow('Invalid computer call output pairing');
+  });
+
+  it('rejects a malformed marked computer output before provider conversion', () => {
+    const malformed = new ToolMessage({
+      content: [{ type: 'text', text: 'A'.repeat(2_000) }],
+      tool_call_id: 'call_computer_malformed',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(() => projectOpenAIToolMessageContent([malformed], 100)).toThrow(
+      'Invalid computer call output screenshot'
+    );
+  });
+
+  it('rejects a marked screenshot paired with a normal function call', () => {
+    const functionCall = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_function',
+          name: 'render',
+          args: {},
+          type: 'tool_call',
+        },
+      ],
+    });
+    const malformedPair = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_function',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(() =>
+      projectOpenAIToolMessageContent([functionCall, malformedPair], 100)
+    ).toThrow('Invalid computer call output pairing');
   });
 
   it('keeps the mutating artifact formatter API backward compatible', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -12,7 +12,12 @@ import {
   formatArtifactPayload,
   projectAnthropicArtifactContent,
   projectArtifactPayload,
+  projectOpenAIToolMessageContent,
 } from './core';
+import {
+  _convertMessagesToOpenAIParams,
+  _convertMessagesToOpenAIResponsesParams,
+} from '@/llm/openai/utils';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
 import { serializeToolContent } from '@/utils/toolContent';
@@ -1649,6 +1654,118 @@ describe('formatAgentMessages', () => {
     expect(messages).toHaveLength(2);
     expect((messages[1] as ToolMessage).content).toBe('short result');
     expect(projectArtifactPayload(formatted, 200)).toBe(formatted);
+  });
+
+  it('bounds artifact block arrays without spreading them into call arguments', () => {
+    const repeatedBlock = {
+      type: ContentTypes.TEXT,
+      text: 'x',
+    } as MessageContentComplex;
+    const artifactContent = new Array<MessageContentComplex>(150_000).fill(
+      repeatedBlock
+    );
+    const toolMessage = new ToolMessage({
+      content: 'short result',
+      tool_call_id: 'call_artifact_many_blocks',
+      artifact: { content: artifactContent },
+    });
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_artifact_many_blocks',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+
+    const formatted = projectArtifactPayload(messages, 200);
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+
+    expect(payload).toBeInstanceOf(HumanMessage);
+    expect(serializeToolContent(payload.content).length).toBeLessThanOrEqual(
+      200
+    );
+    expect(toolMessage.content).toBe('short result');
+    expect(toolMessage.artifact.content).toBe(artifactContent);
+  });
+
+  it('projects structured tool content to the bounded string both OpenAI APIs send', () => {
+    let toJSONCalls = 0;
+    const toolMessage = new ToolMessage({
+      id: 'tool-message-id',
+      name: 'render',
+      status: 'success',
+      tool_call_id: 'call_openai_structured',
+      content: [
+        { type: ContentTypes.TEXT, text: 'rendered chart' },
+        {
+          type: 'image_url',
+          image_url: {
+            url: `data:image/png;base64,${'A'.repeat(2_000)}`,
+          },
+          toJSON() {
+            toJSONCalls++;
+            return { expanded: 'B'.repeat(20_000) };
+          },
+        },
+      ],
+      artifact: { retained: true },
+    });
+
+    const original = [toolMessage];
+    const projected = projectOpenAIToolMessageContent(original, 200);
+    const projectedTool = projected[0] as ToolMessage;
+    const chatPayload = _convertMessagesToOpenAIParams(projected);
+    const responsesPayload = _convertMessagesToOpenAIResponsesParams(projected);
+
+    expect(projected).not.toBe(original);
+    expect(typeof projectedTool.content).toBe('string');
+    expect((projectedTool.content as string).length).toBeLessThanOrEqual(200);
+    expect(projectedTool.tool_call_id).toBe(toolMessage.tool_call_id);
+    expect(projectedTool.status).toBe(toolMessage.status);
+    expect(projectedTool.artifact).toBe(toolMessage.artifact);
+    expect(Array.isArray(toolMessage.content)).toBe(true);
+    expect(toJSONCalls).toBe(0);
+    expect(chatPayload[0]).toMatchObject({
+      role: 'tool',
+      content: projectedTool.content,
+      tool_call_id: toolMessage.tool_call_id,
+    });
+    expect(responsesPayload[0]).toMatchObject({
+      type: 'function_call_output',
+      output: projectedTool.content,
+      call_id: toolMessage.tool_call_id,
+    });
+  });
+
+  it('preserves Responses computer outputs handled as provider-native media', () => {
+    const computerOutput = new ToolMessage({
+      content: [
+        {
+          type: 'computer_screenshot',
+          image_url: 'data:image/png;base64,AA==',
+        },
+      ],
+      tool_call_id: 'call_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const messages = [computerOutput];
+
+    expect(projectOpenAIToolMessageContent(messages, 10)).toBe(messages);
+    expect(_convertMessagesToOpenAIResponsesParams(messages)[0]).toMatchObject({
+      type: 'computer_call_output',
+      call_id: 'call_computer',
+      output: {
+        type: 'computer_screenshot',
+        image_url: 'data:image/png;base64,AA==',
+      },
+    });
   });
 
   it('keeps the mutating artifact formatter API backward compatible', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -6,12 +6,16 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import type { MessageContentComplex, TPayload } from '@/types';
-import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import {
   convertMessagesToContent,
   formatAnthropicArtifactContent,
+  formatArtifactPayload,
+  projectAnthropicArtifactContent,
+  projectArtifactPayload,
 } from './core';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
+import { serializeToolContent } from '@/utils/toolContent';
 import { formatAgentMessages } from './format';
 
 type AnthropicPayloadBlock = {
@@ -1551,7 +1555,7 @@ describe('formatAgentMessages', () => {
       configurable: true,
     });
 
-    formatAnthropicArtifactContent([
+    const originalMessages = [
       new AIMessageChunk({
         content: '',
         tool_calls: [
@@ -1564,12 +1568,149 @@ describe('formatAgentMessages', () => {
         ],
       }),
       toolMessage,
-    ]);
+    ];
+    const formattedMessages = projectAnthropicArtifactContent(originalMessages);
+    const formattedToolMessage = formattedMessages[1] as ToolMessage;
 
-    expect(toolMessage.content).toEqual([
+    expect(formattedToolMessage.content).toEqual([
       { type: ContentTypes.TEXT, text: '' },
       { type: ContentTypes.TEXT, text: 'artifact text' },
     ]);
+    expect(toolMessage.content).toBeUndefined();
+    expect(formattedMessages).not.toBe(originalMessages);
+  });
+
+  it('caps Anthropic artifact expansion after pruning', () => {
+    const toolMessage = new ToolMessage({
+      content: 'short result',
+      tool_call_id: 'call_artifact_capped',
+      artifact: {
+        content: 'artifact'.repeat(1_000),
+      },
+    });
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_artifact_capped',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+
+    const formatted = projectAnthropicArtifactContent(messages, 200);
+    const formattedTool = formatted[1] as ToolMessage;
+
+    expect(
+      serializeToolContent(formattedTool.content).length
+    ).toBeLessThanOrEqual(200);
+    expect(serializeToolContent(formattedTool.content)).toContain('truncated');
+    expect(toolMessage.content).toBe('short result');
+    expect(toolMessage.artifact.content).toContain('artifact');
+    expect(projectAnthropicArtifactContent(formatted, 200)).toBe(formatted);
+  });
+
+  it('caps the aggregate OpenAI/Google artifact payload', () => {
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_artifact_payload',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'short result',
+        tool_call_id: 'call_artifact_payload',
+        artifact: {
+          content: [
+            { type: ContentTypes.TEXT, text: 'artifact'.repeat(1_000) },
+          ],
+        },
+      }),
+    ];
+
+    const formatted = projectArtifactPayload(messages, 200);
+
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+    expect(payload).toBeInstanceOf(HumanMessage);
+    expect(serializeToolContent(payload.content).length).toBeLessThanOrEqual(
+      200
+    );
+    expect(messages).toHaveLength(2);
+    expect((messages[1] as ToolMessage).content).toBe('short result');
+    expect(projectArtifactPayload(formatted, 200)).toBe(formatted);
+  });
+
+  it('keeps the mutating artifact formatter API backward compatible', () => {
+    const anthropicToolMessage = new ToolMessage({
+      content: 'result',
+      tool_call_id: 'anthropic_legacy',
+      artifact: {
+        content: [{ type: ContentTypes.TEXT, text: 'anthropic artifact' }],
+      },
+    });
+    const anthropicMessages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'anthropic_legacy',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      anthropicToolMessage,
+    ];
+
+    expect(formatAnthropicArtifactContent(anthropicMessages)).toBeUndefined();
+    expect(anthropicToolMessage.content).toEqual([
+      { type: ContentTypes.TEXT, text: 'result' },
+      { type: ContentTypes.TEXT, text: 'anthropic artifact' },
+    ]);
+    expect(anthropicToolMessage.artifact.content).toHaveLength(1);
+
+    const payloadToolMessage = new ToolMessage({
+      content: 'result',
+      tool_call_id: 'payload_legacy',
+      artifact: {
+        content: [{ type: ContentTypes.TEXT, text: 'payload artifact' }],
+      },
+    });
+    const payloadMessages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'payload_legacy',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      payloadToolMessage,
+    ];
+
+    expect(formatArtifactPayload(payloadMessages)).toBeUndefined();
+    expect(payloadToolMessage.content).toContain(
+      'Tool response is included in the next message'
+    );
+    expect(payloadMessages[payloadMessages.length - 1]).toBeInstanceOf(
+      HumanMessage
+    );
+    expect(payloadToolMessage.artifact.content).toHaveLength(1);
   });
 
   it('should dynamically discover tools from tool_search output and keep their tool calls', () => {
@@ -2216,9 +2357,15 @@ describe('formatAgentMessages', () => {
       },
     ];
 
-    const result = formatAgentMessages(payload, undefined, undefined, undefined, {
-      preserveReasoningContent: true,
-    });
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      {
+        preserveReasoningContent: true,
+      }
+    );
 
     const toolCallMessage = result.messages[0] as AIMessage;
     expect(toolCallMessage.tool_calls).toHaveLength(1);
@@ -2254,15 +2401,19 @@ describe('formatAgentMessages', () => {
       },
     ];
 
-    const result = formatAgentMessages(payload, undefined, undefined, undefined, {
-      provider: Providers.DEEPSEEK,
-      preserveReasoningContent: false,
-    });
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      {
+        provider: Providers.DEEPSEEK,
+        preserveReasoningContent: false,
+      }
+    );
 
     const toolCallMessage = result.messages[0] as AIMessage;
-    expect(
-      toolCallMessage.additional_kwargs.reasoning_content
-    ).toBeUndefined();
+    expect(toolCallMessage.additional_kwargs.reasoning_content).toBeUndefined();
   });
 
   it('should preserve DeepSeek reasoning from supported hidden content blocks', () => {

--- a/src/messages/formatAgentMessages.tools.test.ts
+++ b/src/messages/formatAgentMessages.tools.test.ts
@@ -38,6 +38,69 @@ describe('formatAgentMessages with tools parameter', () => {
     expect((result.messages[2] as ToolMessage).tool_call_id).toBe('123');
   });
 
+  it('restores persisted structured tool output for harness accounting', () => {
+    const output = [
+      {
+        type: ContentTypes.TEXT,
+        text: JSON.stringify([
+          { id: 1, value: 'first' },
+          { id: 2, value: 'second' },
+        ]),
+      },
+    ];
+    const payload: TPayload = [
+      { role: 'user', content: 'Query the table' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'query-1',
+              name: 'run_select_query',
+              args: '{}',
+              output,
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload, { 0: 5, 1: 0 });
+
+    const toolMessage = result.messages[2] as ToolMessage;
+    expect(toolMessage).toBeInstanceOf(ToolMessage);
+    expect(toolMessage.content).toEqual(output);
+    expect(toolMessage.tool_call_id).toBe('query-1');
+  });
+
+  it('normalizes opaque persisted tool output before provider dispatch', () => {
+    const output = [{ type: 'json', rows: [{ id: 1, value: 'first' }] }];
+    const payload: TPayload = [
+      { role: 'user', content: 'Query the table' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'query-opaque',
+              name: 'run_select_query',
+              args: '{}',
+              output,
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload);
+    const toolMessage = result.messages[2] as ToolMessage;
+
+    expect(typeof toolMessage.content).toBe('string');
+    expect(toolMessage.content).toBe(JSON.stringify(output));
+  });
+
   it('should filter out all tool calls when tools set is empty', () => {
     const payload: TPayload = [
       { role: 'user', content: 'What\'s the weather?' },

--- a/src/messages/formatAgentMessages.tools.test.ts
+++ b/src/messages/formatAgentMessages.tools.test.ts
@@ -1,5 +1,6 @@
 import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
 import type { TPayload } from '@/types';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { formatAgentMessages } from './format';
 import { ContentTypes } from '@/common';
 
@@ -99,6 +100,45 @@ describe('formatAgentMessages with tools parameter', () => {
 
     expect(typeof toolMessage.content).toBe('string');
     expect(toolMessage.content).toBe(JSON.stringify(output));
+  });
+
+  it('hard-caps persisted structured output without invoking toJSON', () => {
+    let toJSONCalls = 0;
+    const output = {
+      rows: [{ value: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS + 1_000) }],
+      toJSON() {
+        toJSONCalls++;
+        return 'y'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2);
+      },
+    };
+    const payload: TPayload = [
+      { role: 'user', content: 'Query the table' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'query-bounded',
+              name: 'run_select_query',
+              args: '{}',
+              output,
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload);
+    const content = (result.messages[2] as ToolMessage).content;
+
+    expect(toJSONCalls).toBe(0);
+    expect(typeof content).toBe('string');
+    expect((content as string).length).toBeLessThanOrEqual(
+      HARD_MAX_TOOL_RESULT_CHARS
+    );
+    expect(content).toContain('truncated');
+    expect(content).not.toContain('y'.repeat(1_000));
   });
 
   it('should filter out all tool calls when tools set is empty', () => {

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -12,8 +12,13 @@ import type {
 import type { ContextPruningConfig } from '@/types/graph';
 import type { TokenCounter } from '@/types/run';
 import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  getToolContentCharLength,
+  serializeToolContent,
+} from '@/utils/toolContent';
+import {
   calculateMaxToolResultChars,
-  truncateToolResultContent,
   truncateToolInput,
 } from '@/utils/truncation';
 import { resolveContextPruningSettings } from './contextPruningSettings';
@@ -1065,9 +1070,6 @@ export function maskConsumedToolResults(params: {
     const i = consumedIndices[c];
     const message = messages[i];
     const content = message.content;
-    if (typeof content !== 'string') {
-      continue;
-    }
 
     let maxChars: number;
     if (totalBudgetChars > 0) {
@@ -1080,25 +1082,23 @@ export function maskConsumedToolResults(params: {
       maxChars = MASKED_RESULT_MAX_CHARS;
     }
 
-    if (content.length <= maxChars) {
+    const compacted = compactToolContent(content, maxChars);
+    if (!compacted.changed) {
       continue;
     }
 
     if (params.originalContentStore && !params.originalContentStore.has(i)) {
-      params.originalContentStore.set(i, content);
+      const original = serializeToolContent(content);
+      params.originalContentStore.set(i, original);
       if (params.onContentStored) {
-        params.onContentStored(i, content);
+        params.onContentStored(i, original);
       }
     }
 
-    const cloned = new ToolMessage({
-      content: truncateToolResultContent(content, maxChars),
-      tool_call_id: (message as ToolMessage).tool_call_id,
-      name: message.name,
-      id: message.id,
-      additional_kwargs: message.additional_kwargs,
-      response_metadata: message.response_metadata,
-    });
+    const cloned = cloneToolMessageWithContent(
+      message as ToolMessage,
+      compacted.content
+    );
     messages[i] = cloned;
     indexTokenCountMap[i] = tokenCounter(cloned);
     maskedCount++;
@@ -1140,27 +1140,19 @@ export function preFlightTruncateToolResults(params: {
     const i = toolIndices[t];
     const message = messages[i];
     const content = message.content;
-    if (typeof content !== 'string') {
-      continue;
-    }
 
     const position = toolIndices.length > 1 ? t / (toolIndices.length - 1) : 1;
     const recencyFactor = 0.2 + 0.8 * position;
     const maxChars = Math.max(200, Math.floor(baseMaxChars * recencyFactor));
 
-    if (content.length <= maxChars) {
+    const compacted = compactToolContent(content, maxChars);
+    if (!compacted.changed) {
       continue;
     }
-
-    const truncated = truncateToolResultContent(content, maxChars);
-    const cloned = new ToolMessage({
-      content: truncated,
-      tool_call_id: (message as ToolMessage).tool_call_id,
-      name: message.name,
-      id: message.id,
-      additional_kwargs: message.additional_kwargs,
-      response_metadata: message.response_metadata,
-    });
+    const cloned = cloneToolMessageWithContent(
+      message as ToolMessage,
+      compacted.content
+    );
     messages[i] = cloned;
     indexTokenCountMap[i] = tokenCounter(cloned);
     truncatedCount++;
@@ -1281,6 +1273,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
   for (const key in indexTokenCountMap) {
     totalTokens += indexTokenCountMap[key] ?? 0;
   }
+  const reconciledToolMessages = new WeakSet<BaseMessage>();
   let runThinkingStartIndex = -1;
   /** Cumulative raw tiktoken tokens we've sent to the provider (messages only,
    *  excludes instruction overhead and new outputs not yet seen by provider). */
@@ -1416,6 +1409,50 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     }
 
     const newOutputs = new Set<number>();
+
+    // Host token maps predate LangChain formatting and may omit tool output or
+    // assign it a zero/tiny count. Reconcile every ToolMessage once against the
+    // exact provider payload before making any budget decision.
+    for (let i = 0; i < params.messages.length; i++) {
+      let message = params.messages[i];
+      const cachedCount = indexTokenCountMap[i];
+      if (message.getType() !== 'tool' || reconciledToolMessages.has(message)) {
+        continue;
+      }
+      const normalized = compactToolContent(
+        message.content,
+        Number.MAX_SAFE_INTEGER
+      );
+      if (normalized.changed) {
+        message = cloneToolMessageWithContent(
+          message as ToolMessage,
+          normalized.content
+        );
+        params.messages[i] = message;
+      }
+      const reconciledCount = factoryParams.tokenCounter(message);
+      reconciledToolMessages.add(message);
+      if (cachedCount === undefined) {
+        indexTokenCountMap[i] = reconciledCount;
+        totalTokens += reconciledCount;
+        if (i >= lastTurnStartIndex) {
+          newOutputs.add(i);
+        }
+        continue;
+      }
+      // Preserve a larger host estimate: reconciliation is a safety floor,
+      // not permission to reduce an upstream count that may include provider
+      // serialization overhead unavailable to the local counter.
+      if (reconciledCount <= cachedCount) {
+        continue;
+      }
+      indexTokenCountMap[i] = reconciledCount;
+      totalTokens += reconciledCount - cachedCount;
+      if (i >= lastTurnStartIndex) {
+        newOutputs.add(i);
+      }
+    }
+
     let outputTokensAssigned = false;
     for (let i = lastTurnStartIndex; i < params.messages.length; i++) {
       const message = params.messages[i];
@@ -2024,18 +2061,15 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           const message = emergencyMessages[i];
           if (message.getType() === 'tool') {
             const content = message.content;
-            if (
-              typeof content === 'string' &&
-              content.length > emergencyMaxChars
-            ) {
-              const cloned = new ToolMessage({
-                content: truncateToolResultContent(content, emergencyMaxChars),
-                tool_call_id: (message as ToolMessage).tool_call_id,
-                name: message.name,
-                id: message.id,
-                additional_kwargs: message.additional_kwargs,
-                response_metadata: message.response_metadata,
-              });
+            if (getToolContentCharLength(content) > emergencyMaxChars) {
+              const compacted = compactToolContent(content, emergencyMaxChars);
+              if (!compacted.changed) {
+                continue;
+              }
+              const cloned = cloneToolMessageWithContent(
+                message as ToolMessage,
+                compacted.content
+              );
               emergencyMessages[i] = cloned;
               indexTokenCountMap[i] = factoryParams.tokenCounter(cloned);
               emergencyTruncatedCount++;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1,3 +1,4 @@
+import { isProxy } from 'node:util/types';
 import {
   AIMessage,
   BaseMessage,
@@ -16,12 +17,14 @@ import {
   cloneToolMessageWithContent,
   compactToolContent,
   getToolContentCharLength,
+  isComputerCallOutputMessage,
   serializeStructuredValueBounded,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
   HARD_MAX_TOOL_RESULT_CHARS,
   calculateMaxToolResultChars,
+  truncateToolResultContent,
 } from '@/utils/truncation';
 import { resolveContextPruningSettings } from './contextPruningSettings';
 import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
@@ -174,7 +177,8 @@ export type PruneMessagesParams = {
 };
 
 function getToolCallIds(message: BaseMessage): Set<string> {
-  if (message.getType() !== 'ai') {
+  const messageRole = (message as BaseMessage & { role?: unknown }).role;
+  if (message.getType() !== 'ai' && messageRole !== 'assistant') {
     return new Set<string>();
   }
 
@@ -202,7 +206,69 @@ function getToolCallIds(message: BaseMessage): Set<string> {
     }
   }
 
+  const toolOutputSource = getResponsesToolOutputSource(message);
+  if (toolOutputSource != null) {
+    for (const item of toolOutputSource.items) {
+      if (item == null || typeof item !== 'object') {
+        continue;
+      }
+      const record = item as {
+        type?: unknown;
+        call_id?: unknown;
+      };
+      if (
+        (record.type === 'function_call' ||
+          record.type === 'custom_tool_call' ||
+          record.type === 'computer_call') &&
+        typeof record.call_id === 'string' &&
+        record.call_id !== ''
+      ) {
+        ids.add(record.call_id);
+      }
+    }
+  }
+
   return ids;
+}
+
+type ResponsesToolOutputSource = {
+  source: 'response_metadata' | 'tool_outputs';
+  items: unknown[];
+};
+
+function getResponsesToolOutputSource(
+  message: BaseMessage
+): ResponsesToolOutputSource | undefined {
+  const responseOutput = readPropertyWithoutAccessors(
+    message.response_metadata,
+    'output'
+  );
+  if (
+    !responseOutput.accessor &&
+    Array.isArray(responseOutput.value) &&
+    !isProxy(responseOutput.value) &&
+    responseOutput.value.length > 0
+  ) {
+    return {
+      source: 'response_metadata',
+      items: responseOutput.value,
+    };
+  }
+  const fallbackOutput = readPropertyWithoutAccessors(
+    message.additional_kwargs,
+    'tool_outputs'
+  );
+  if (
+    !fallbackOutput.accessor &&
+    Array.isArray(fallbackOutput.value) &&
+    !isProxy(fallbackOutput.value)
+  ) {
+    return {
+      source: 'tool_outputs',
+      items: fallbackOutput.value,
+    };
+  }
+  return undefined;
 }
 
 function getToolResultId(message: BaseMessage): string | null {
@@ -305,7 +371,8 @@ export function repairOrphanedToolMessages({
       continue;
     }
 
-    if (message.getType() === 'ai' && message instanceof AIMessage) {
+    const messageRole = (message as BaseMessage & { role?: unknown }).role;
+    if (message.getType() === 'ai' || messageRole === 'assistant') {
       const toolCallIds = getToolCallIds(message);
       if (toolCallIds.size > 0) {
         let hasOrphanToolCalls = false;
@@ -357,16 +424,17 @@ export function repairOrphanedToolMessages({
  * Returns null if the message has no content left after stripping.
  */
 function stripOrphanToolUseBlocks(
-  message: AIMessage,
+  message: BaseMessage,
   presentToolResultIds: Set<string>
-): AIMessage | null {
-  const keptToolCalls = (message.tool_calls ?? []).filter(
+): BaseMessage | null {
+  const aiMessage = message as AIMessage;
+  const keptToolCalls = (aiMessage.tool_calls ?? []).filter(
     (tc) => typeof tc.id === 'string' && presentToolResultIds.has(tc.id)
   );
 
   let keptContent: MessageContentComplex[] | string;
-  if (Array.isArray(message.content)) {
-    const filtered = (message.content as MessageContentComplex[]).filter(
+  if (Array.isArray(aiMessage.content)) {
+    const filtered = (aiMessage.content as MessageContentComplex[]).filter(
       (block) => {
         if (typeof block !== 'object') {
           return true;
@@ -382,18 +450,60 @@ function stripOrphanToolUseBlocks(
       }
     );
 
-    if (filtered.length === 0) {
-      return null;
-    }
     keptContent = filtered;
   } else {
-    keptContent = message.content;
+    keptContent = aiMessage.content;
   }
 
-  return new AIMessage({
-    ...message,
+  const toolOutputSource = getResponsesToolOutputSource(message);
+  const keptToolOutputs =
+    toolOutputSource?.items.filter((item) => {
+      if (item == null || typeof item !== 'object') {
+        return true;
+      }
+      const record = item as {
+        type?: unknown;
+        call_id?: unknown;
+      };
+      if (
+        record.type !== 'function_call' &&
+        record.type !== 'custom_tool_call' &&
+        record.type !== 'computer_call'
+      ) {
+        return true;
+      }
+      return (
+        typeof record.call_id === 'string' &&
+        presentToolResultIds.has(record.call_id)
+      );
+    }) ?? [];
+
+  if (
+    keptToolCalls.length === 0 &&
+    Array.isArray(keptContent) &&
+    keptContent.length === 0 &&
+    keptToolOutputs.length === 0
+  ) {
+    return null;
+  }
+
+  let responseMetadata = message.response_metadata;
+  let additionalKwargs = message.additional_kwargs;
+  if (toolOutputSource?.source === 'response_metadata') {
+    responseMetadata = cloneWithProjectedProperties(responseMetadata, {
+      output: keptToolOutputs,
+    });
+  } else if (toolOutputSource?.source === 'tool_outputs') {
+    additionalKwargs = cloneWithProjectedProperties(additionalKwargs, {
+      tool_outputs: keptToolOutputs,
+    });
+  }
+
+  return cloneWithProjectedProperties(message, {
     content: toLangChainContent(keptContent),
     tool_calls: keptToolCalls.length > 0 ? keptToolCalls : undefined,
+    response_metadata: responseMetadata,
+    additional_kwargs: additionalKwargs,
   });
 }
 
@@ -421,6 +531,11 @@ export function sanitizeOrphanToolBlocks(
 
   for (const msg of messages) {
     const msgAny = msg as unknown as Record<string, unknown>;
+    if (typeof (msg as { getType?: unknown }).getType === 'function') {
+      for (const id of getToolCallIds(msg)) {
+        allToolCallIds.add(id);
+      }
+    }
     const toolCalls = msgAny.tool_calls as Array<{ id?: string }> | undefined;
     if (Array.isArray(toolCalls)) {
       for (const tc of toolCalls) {
@@ -1080,6 +1195,9 @@ export function maskConsumedToolResults(params: {
   for (let c = 0; c < count; c++) {
     const i = consumedIndices[c];
     const message = messages[i];
+    if (isComputerCallOutputMessage(message)) {
+      continue;
+    }
     const content = message.content;
 
     let maxChars: number;
@@ -1145,7 +1263,10 @@ export function preFlightTruncateToolResults(params: {
 
   const toolIndices: number[] = [];
   for (let i = 0; i < messages.length; i++) {
-    if (messages[i].getType() === 'tool') {
+    if (
+      messages[i].getType() === 'tool' &&
+      !isComputerCallOutputMessage(messages[i])
+    ) {
       toolIndices.push(i);
     }
   }
@@ -1217,6 +1338,9 @@ function readPropertyWithoutAccessors(
 ): PropertyRead {
   let current: object | null = value;
   for (let depth = 0; current != null && depth < 100; depth++) {
+    if (isProxy(current)) {
+      return { found: true, own: current === value, accessor: true };
+    }
     let descriptor: PropertyDescriptor | undefined;
     try {
       descriptor = Object.getOwnPropertyDescriptor(current, key);
@@ -1240,7 +1364,9 @@ function readPropertyWithoutAccessors(
       return { found: true, own: false, accessor: true };
     }
   }
-  return { found: false, own: false, accessor: false };
+  return current == null
+    ? { found: false, own: false, accessor: false }
+    : { found: true, own: false, accessor: true };
 }
 
 function cloneWithProjectedProperties<T extends object>(
@@ -1525,10 +1651,78 @@ function projectRawOpenAIToolCalls(
   };
 }
 
+function projectLegacyFunctionCall(
+  property: PropertyRead,
+  maxChars: number
+): { value: unknown; changed: boolean } {
+  if (!property.found) {
+    return { value: property.value, changed: false };
+  }
+  if (property.own && !property.accessor && property.value === undefined) {
+    return { value: undefined, changed: false };
+  }
+  if (
+    property.accessor ||
+    !property.own ||
+    property.value == null ||
+    typeof property.value !== 'object'
+  ) {
+    return { value: undefined, changed: true };
+  }
+
+  const nameProperty = readPropertyWithoutAccessors(property.value, 'name');
+  const argsProperty = readPropertyWithoutAccessors(
+    property.value,
+    'arguments'
+  );
+  if (
+    nameProperty.accessor ||
+    !nameProperty.own ||
+    typeof nameProperty.value !== 'string' ||
+    nameProperty.value === '' ||
+    nameProperty.value.length > normalizeToolInputLimit(maxChars) ||
+    !argsProperty.found ||
+    argsProperty.accessor ||
+    !argsProperty.own
+  ) {
+    return { value: undefined, changed: true };
+  }
+  try {
+    const prototype = Object.getPrototypeOf(property.value);
+    const enumerableKeys = Object.keys(property.value);
+    if (
+      (prototype === Object.prototype || prototype === null) &&
+      enumerableKeys.length === 2 &&
+      enumerableKeys.includes('name') &&
+      enumerableKeys.includes('arguments') &&
+      typeof argsProperty.value === 'string' &&
+      argsProperty.value.length <= normalizeToolInputLimit(maxChars) &&
+      !hasUnsafeStructuredSerialization(property.value)
+    ) {
+      return { value: property.value, changed: false };
+    }
+  } catch {
+    return { value: undefined, changed: true };
+  }
+  const projectedArgs = selectProjectedSerializedArguments(
+    argsProperty,
+    undefined,
+    maxChars
+  );
+  return {
+    value: {
+      name: nameProperty.value,
+      arguments: projectedArgs.value,
+    },
+    changed: true,
+  };
+}
+
 function projectResponsesOutput(
   output: unknown,
   maxChars: number,
-  canonicalArguments: ReadonlyMap<string, string>
+  canonicalArguments: ReadonlyMap<string, string>,
+  canonicalInputs: ReadonlyMap<string, unknown>
 ): { value: unknown; changed: boolean } {
   if (!Array.isArray(output)) {
     return { value: output, changed: false };
@@ -1540,28 +1734,87 @@ function projectResponsesOutput(
       return item;
     }
     const type = getStringProperty(item, 'type');
-    if (type !== 'function_call') {
+    if (
+      type !== 'function_call' &&
+      type !== 'custom_tool_call' &&
+      type !== 'computer_call'
+    ) {
       return item;
     }
-    const argsProperty = readPropertyWithoutAccessors(item, 'arguments');
-    if (!argsProperty.found) {
+    let inputKey = 'action';
+    if (type === 'function_call') {
+      inputKey = 'arguments';
+    } else if (type === 'custom_tool_call') {
+      inputKey = 'input';
+    }
+    const inputProperty = readPropertyWithoutAccessors(item, inputKey);
+    if (!inputProperty.found) {
       return item;
     }
     const callId =
       getStringProperty(item, 'call_id') ?? getStringProperty(item, 'id');
-    const canonical =
-      callId != null ? canonicalArguments.get(callId) : undefined;
-    const projectedArgs = selectProjectedSerializedArguments(
-      argsProperty,
-      canonical,
-      maxChars
-    );
-    if (!projectedArgs.changed && argsProperty.own) {
+    let projectedInput: ToolInputProjection;
+    if (type === 'function_call') {
+      const canonical =
+        callId != null ? canonicalArguments.get(callId) : undefined;
+      projectedInput = selectProjectedSerializedArguments(
+        inputProperty,
+        canonical,
+        maxChars
+      );
+    } else {
+      const canonicalArgs =
+        callId != null ? canonicalInputs.get(callId) : undefined;
+      const canonicalProperty =
+        canonicalArgs != null && typeof canonicalArgs === 'object'
+          ? readPropertyWithoutAccessors(canonicalArgs, inputKey)
+          : undefined;
+      let source = inputProperty.accessor
+        ? ACCESSOR_INPUT_PLACEHOLDER
+        : inputProperty.value;
+      if (canonicalProperty != null && canonicalProperty.found) {
+        source = canonicalProperty.accessor
+          ? ACCESSOR_INPUT_PLACEHOLDER
+          : canonicalProperty.value;
+      }
+      if (
+        type === 'custom_tool_call' &&
+        typeof source === 'string' &&
+        source.length <= normalizeToolInputLimit(maxChars)
+      ) {
+        projectedInput = {
+          value: source,
+          changed: !inputProperty.own || inputProperty.value !== source,
+        };
+      } else if (type === 'custom_tool_call') {
+        const value =
+          typeof source === 'string'
+            ? truncateToolResultContent(
+              source,
+              normalizeToolInputLimit(maxChars)
+            )
+            : serializeToolCallInput(source, maxChars);
+        projectedInput = {
+          value,
+          changed: !inputProperty.own || inputProperty.value !== value,
+        };
+      } else {
+        const projected = projectToolInputWithinLimit(source, maxChars);
+        projectedInput = {
+          value: projected.value,
+          changed:
+            projected.changed ||
+            !inputProperty.own ||
+            inputProperty.value !== projected.value,
+        };
+      }
+    }
+    if (!projectedInput.changed && inputProperty.own) {
       return item;
     }
     state.changed = true;
     return cloneWithProjectedProperties(item, {
-      arguments: projectedArgs.value,
+      [inputKey]: projectedInput.value,
     });
   });
   return {
@@ -1638,9 +1891,22 @@ export function projectToolCallInputs(
       (toolCall, toolCallIndex) => toolCall !== originalToolCalls[toolCallIndex]
     );
 
-    const rawAdditionalToolCalls = aiMessage.additional_kwargs.tool_calls;
-    const rawResponsesOutput = aiMessage.response_metadata.output;
+    const rawAdditionalToolCallsProperty = readPropertyWithoutAccessors(
+      aiMessage.additional_kwargs,
+      'tool_calls'
+    );
+    const rawAdditionalToolCalls = rawAdditionalToolCallsProperty.accessor
+      ? undefined
+      : rawAdditionalToolCallsProperty.value;
+    const rawResponsesOutputProperty = readPropertyWithoutAccessors(
+      aiMessage.response_metadata,
+      'output'
+    );
+    const rawResponsesOutput = rawResponsesOutputProperty.accessor
+      ? undefined
+      : rawResponsesOutputProperty.value;
     const canonicalArguments = new Map<string, string>();
+    const canonicalInputs = new Map<string, unknown>();
     if (
       Array.isArray(rawAdditionalToolCalls) ||
       Array.isArray(rawResponsesOutput)
@@ -1651,43 +1917,66 @@ export function projectToolCallInputs(
           continue;
         }
         const args = readPropertyWithoutAccessors(toolCall, 'args');
+        const canonicalInput = args.accessor
+          ? ACCESSOR_INPUT_PLACEHOLDER
+          : args.value;
+        canonicalInputs.set(id, canonicalInput);
         canonicalArguments.set(
           id,
-          serializeToolCallInput(
-            args.accessor ? ACCESSOR_INPUT_PLACEHOLDER : args.value,
-            normalizedMaxInputChars
-          )
+          serializeToolCallInput(canonicalInput, normalizedMaxInputChars)
         );
       }
     }
 
-    let projectedAdditionalKwargs = aiMessage.additional_kwargs;
-    let additionalKwargsChanged = false;
+    const additionalKwargsChanges: Record<string, unknown> =
+      rawAdditionalToolCallsProperty.accessor ? { tool_calls: undefined } : {};
     const rawToolCalls = projectRawOpenAIToolCalls(
       rawAdditionalToolCalls,
       normalizedMaxInputChars,
       canonicalArguments
     );
     if (rawToolCalls.changed) {
-      projectedAdditionalKwargs = cloneWithProjectedProperties(
+      additionalKwargsChanges.tool_calls = rawToolCalls.value;
+    }
+    const legacyFunctionCall = projectLegacyFunctionCall(
+      readPropertyWithoutAccessors(
         aiMessage.additional_kwargs,
-        { tool_calls: rawToolCalls.value }
-      );
-      additionalKwargsChanged = true;
+        'function_call'
+      ),
+      normalizedMaxInputChars
+    );
+    if (legacyFunctionCall.changed) {
+      additionalKwargsChanges.function_call = legacyFunctionCall.value;
+    }
+    const additionalKwargsChanged =
+      Object.keys(additionalKwargsChanges).length > 0;
+    let projectedAdditionalKwargs = aiMessage.additional_kwargs;
+    if (additionalKwargsChanged) {
+      projectedAdditionalKwargs = isProxy(aiMessage.additional_kwargs)
+        ? { ...additionalKwargsChanges }
+        : cloneWithProjectedProperties(
+          aiMessage.additional_kwargs,
+          additionalKwargsChanges
+        );
     }
 
     let projectedResponseMetadata = aiMessage.response_metadata;
-    let responseMetadataChanged = false;
+    let responseMetadataChanged = rawResponsesOutputProperty.accessor;
     const responsesOutput = projectResponsesOutput(
       rawResponsesOutput,
       normalizedMaxInputChars,
-      canonicalArguments
+      canonicalArguments,
+      canonicalInputs
     );
-    if (responsesOutput.changed) {
-      projectedResponseMetadata = cloneWithProjectedProperties(
-        aiMessage.response_metadata,
-        { output: responsesOutput.value }
-      );
+    if (responsesOutput.changed || rawResponsesOutputProperty.accessor) {
+      const output = rawResponsesOutputProperty.accessor
+        ? undefined
+        : responsesOutput.value;
+      projectedResponseMetadata = isProxy(aiMessage.response_metadata)
+        ? { output }
+        : cloneWithProjectedProperties(aiMessage.response_metadata, {
+          output,
+        });
       responseMetadataChanged = true;
     }
 
@@ -1770,6 +2059,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
   /** Best observed instruction overhead from a near-zero variance turn.
    *  Self-seeds from provider observations within the run. */
   let bestInstructionOverhead: number | undefined;
+  const reconciledLegacyAiMessages = new WeakSet<BaseMessage>();
   let bestVarianceAbs = Infinity;
   /** Local estimate at the time bestInstructionOverhead was observed.
    *  Used to invalidate the cached overhead when instructions change
@@ -1895,46 +2185,86 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     const newOutputs = new Set<number>();
 
     // Host token maps predate LangChain formatting and may omit tool output or
-    // assign it a zero/tiny count. Reconcile every ToolMessage once against the
-    // exact provider payload before making any budget decision.
-    for (let i = 0; i < params.messages.length; i++) {
-      let message = params.messages[i];
-      const cachedCount = indexTokenCountMap[i];
-      if (message.getType() !== 'tool' || reconciledToolMessages.has(message)) {
-        continue;
-      }
-      const normalized = compactToolContent(
-        message.content,
-        factoryParams.maxToolResultChars ?? HARD_MAX_TOOL_RESULT_CHARS
-      );
-      if (normalized.changed) {
-        message = cloneToolMessageWithContent(
-          message as ToolMessage,
-          normalized.content
-        );
-        params.messages[i] = message;
-      }
-      const reconciledCount = factoryParams.tokenCounter(message);
-      reconciledToolMessages.add(message);
+    // legacy function-call arguments. Reconcile those provider-bound shapes
+    // once before making any budget decision.
+    const applyReconciledCount = (
+      index: number,
+      cachedCount: number | undefined,
+      reconciledCount: number
+    ): void => {
       if (cachedCount === undefined) {
-        indexTokenCountMap[i] = reconciledCount;
+        indexTokenCountMap[index] = reconciledCount;
         totalTokens += reconciledCount;
-        if (i >= lastTurnStartIndex) {
-          newOutputs.add(i);
+        if (index >= lastTurnStartIndex) {
+          newOutputs.add(index);
         }
-        continue;
+        return;
       }
       // Preserve a larger host estimate: reconciliation is a safety floor,
       // not permission to reduce an upstream count that may include provider
       // serialization overhead unavailable to the local counter.
       if (reconciledCount <= cachedCount) {
+        return;
+      }
+      indexTokenCountMap[index] = reconciledCount;
+      totalTokens += reconciledCount - cachedCount;
+      if (index >= lastTurnStartIndex) {
+        newOutputs.add(index);
+      }
+    };
+    for (let i = 0; i < params.messages.length; i++) {
+      let message = params.messages[i];
+      const cachedCount = indexTokenCountMap[i];
+      const messageType = message.getType();
+      const messageRole = (message as BaseMessage & { role?: unknown }).role;
+      const isAssistant = messageType === 'ai' || messageRole === 'assistant';
+      const legacyFunctionCall = isAssistant
+        ? readPropertyWithoutAccessors(
+          message.additional_kwargs,
+          'function_call'
+        )
+        : undefined;
+      if (
+        legacyFunctionCall?.found === true &&
+        !reconciledLegacyAiMessages.has(message)
+      ) {
+        const [projected] = projectToolCallInputs(
+          [message],
+          calculateMaxToolCallInputChars(factoryParams.maxTokens)
+        );
+        if (projected !== message) {
+          message = projected;
+          params.messages[i] = message;
+        }
+        reconciledLegacyAiMessages.add(message);
+        if (cachedCount !== undefined || i < lastTurnStartIndex) {
+          applyReconciledCount(
+            i,
+            cachedCount,
+            factoryParams.tokenCounter(message)
+          );
+        }
         continue;
       }
-      indexTokenCountMap[i] = reconciledCount;
-      totalTokens += reconciledCount - cachedCount;
-      if (i >= lastTurnStartIndex) {
-        newOutputs.add(i);
+      if (messageType !== 'tool' || reconciledToolMessages.has(message)) {
+        continue;
       }
+      if (!isComputerCallOutputMessage(message)) {
+        const normalized = compactToolContent(
+          message.content,
+          factoryParams.maxToolResultChars ?? HARD_MAX_TOOL_RESULT_CHARS
+        );
+        if (normalized.changed) {
+          message = cloneToolMessageWithContent(
+            message as ToolMessage,
+            normalized.content
+          );
+          params.messages[i] = message;
+        }
+      }
+      const reconciledCount = factoryParams.tokenCounter(message);
+      reconciledToolMessages.add(message);
+      applyReconciledCount(i, cachedCount, reconciledCount);
     }
 
     let outputTokensAssigned = false;
@@ -2552,7 +2882,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         let emergencyTruncatedCount = 0;
         for (let i = 0; i < emergencyMessages.length; i++) {
           const message = emergencyMessages[i];
-          if (message.getType() === 'tool') {
+          if (
+            message.getType() === 'tool' &&
+            !isComputerCallOutputMessage(message)
+          ) {
             const content = message.content;
             if (getToolContentCharLength(content) > emergencyMaxChars) {
               const compacted = compactToolContent(content, emergencyMaxChars);

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -4,6 +4,7 @@ import {
   ToolMessage,
   UsageMetadata,
 } from '@langchain/core/messages';
+import type { AIMessageChunk } from '@langchain/core/messages';
 import type {
   ThinkingContentText,
   MessageContentComplex,
@@ -15,13 +16,15 @@ import {
   cloneToolMessageWithContent,
   compactToolContent,
   getToolContentCharLength,
-  serializeToolContent,
+  serializeStructuredValueBounded,
+  serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
+  HARD_MAX_TOOL_RESULT_CHARS,
   calculateMaxToolResultChars,
-  truncateToolInput,
 } from '@/utils/truncation';
 import { resolveContextPruningSettings } from './contextPruningSettings';
+import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
 import { ContentTypes, Providers, Constants } from '@/common';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
@@ -101,6 +104,8 @@ export function clampCalibrationRatio(ratio: number): number {
 export type PruneMessagesFactoryParams = {
   provider?: Providers;
   maxTokens: number;
+  /** Per-tool-result character cap applied while reconciling cached counts. */
+  maxToolResultChars?: number;
   startIndex: number;
   tokenCounter: TokenCounter;
   indexTokenCountMap: Record<string, number | undefined>;
@@ -1088,7 +1093,10 @@ export function maskConsumedToolResults(params: {
     }
 
     if (params.originalContentStore && !params.originalContentStore.has(i)) {
-      const original = serializeToolContent(content);
+      const original = serializeToolContentBounded(
+        content,
+        ORIGINAL_CONTENT_MAX_CHARS
+      );
       params.originalContentStore.set(i, original);
       if (params.onContentStored) {
         params.onContentStored(i, original);
@@ -1174,6 +1182,530 @@ export function preFlightTruncateToolResults(params: {
  *
  * @returns The number of AI messages that had tool_use inputs truncated.
  */
+const HARD_MAX_TOOL_CALL_INPUT_CHARS = 200_000;
+const MIN_JSON_VALUE_CHARS = 4;
+const ACCESSOR_INPUT_PLACEHOLDER = '[Property accessor omitted]';
+
+type ToolInputProjection = {
+  value: unknown;
+  changed: boolean;
+};
+
+type PropertyRead = {
+  found: boolean;
+  own: boolean;
+  accessor: boolean;
+  value?: unknown;
+};
+
+function normalizeToolInputLimit(maxChars: number): number {
+  if (!Number.isFinite(maxChars)) {
+    return HARD_MAX_TOOL_CALL_INPUT_CHARS;
+  }
+  return Math.max(MIN_JSON_VALUE_CHARS, Math.floor(maxChars));
+}
+
+function readPropertyWithoutAccessors(
+  value: object,
+  key: PropertyKey
+): PropertyRead {
+  let current: object | null = value;
+  for (let depth = 0; current != null && depth < 100; depth++) {
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(current, key);
+    } catch {
+      return { found: true, own: current === value, accessor: true };
+    }
+    if (descriptor != null) {
+      if (!('value' in descriptor)) {
+        return { found: true, own: current === value, accessor: true };
+      }
+      return {
+        found: true,
+        own: current === value,
+        accessor: false,
+        value: descriptor.value,
+      };
+    }
+    try {
+      current = Object.getPrototypeOf(current) as object | null;
+    } catch {
+      return { found: true, own: false, accessor: true };
+    }
+  }
+  return { found: false, own: false, accessor: false };
+}
+
+function cloneWithProjectedProperties<T extends object>(
+  value: T,
+  changes: Readonly<Record<string, unknown>>
+): T {
+  const descriptors = Object.getOwnPropertyDescriptors(value) as Record<
+    string,
+    PropertyDescriptor | undefined
+  >;
+  for (const [key, projectedValue] of Object.entries(changes)) {
+    const descriptor = descriptors[key];
+    descriptors[key] = {
+      configurable: descriptor?.configurable ?? true,
+      enumerable: descriptor?.enumerable ?? true,
+      value: projectedValue,
+      writable: descriptor?.writable ?? true,
+    };
+  }
+  return Object.create(
+    Object.getPrototypeOf(value),
+    descriptors as PropertyDescriptorMap
+  ) as T;
+}
+
+function createBoundedTruncationValue(
+  preview: string,
+  originalChars: number,
+  maxChars: number
+): unknown {
+  const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  const emptyEnvelope = {
+    _truncated: '',
+    _originalChars: originalChars,
+  };
+  if (JSON.stringify(emptyEnvelope).length > normalizedMaxChars) {
+    return null;
+  }
+
+  let low = 0;
+  let high = Math.min(preview.length, normalizedMaxChars);
+  while (low < high) {
+    const next = Math.ceil((low + high) / 2);
+    const candidate = {
+      _truncated: preview.slice(0, next),
+      _originalChars: originalChars,
+    };
+    if (JSON.stringify(candidate).length <= normalizedMaxChars) {
+      low = next;
+    } else {
+      high = next - 1;
+    }
+  }
+  const truncationMarker = '… [truncated]';
+  const boundedPreview =
+    low < preview.length && low >= truncationMarker.length
+      ? preview.slice(0, low - truncationMarker.length) + truncationMarker
+      : preview.slice(0, low);
+  return {
+    _truncated: boundedPreview,
+    _originalChars: originalChars,
+  };
+}
+
+function projectToolInputWithinLimit(
+  input: unknown,
+  maxChars: number
+): ToolInputProjection {
+  const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  const serialized = serializeStructuredValueBounded(input, normalizedMaxChars);
+  if (serialized.truncated) {
+    return {
+      value: createBoundedTruncationValue(
+        serialized.content,
+        serialized.originalChars,
+        normalizedMaxChars
+      ),
+      changed: true,
+    };
+  }
+  if (!hasUnsafeStructuredSerialization(input)) {
+    return { value: input, changed: false };
+  }
+
+  try {
+    return { value: JSON.parse(serialized.content), changed: true };
+  } catch {
+    return {
+      value: createBoundedTruncationValue(
+        serialized.content,
+        serialized.originalChars,
+        normalizedMaxChars
+      ),
+      changed: true,
+    };
+  }
+}
+
+/**
+ * Serializes one structured tool-call input as valid, bounded JSON without
+ * invoking user-defined accessors or `toJSON`.
+ */
+export function serializeToolCallInput(
+  input: unknown,
+  maxChars = HARD_MAX_TOOL_CALL_INPUT_CHARS
+): string {
+  const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  const projected = projectToolInputWithinLimit(input, normalizedMaxChars);
+  const serialized = serializeStructuredValueBounded(
+    projected.value,
+    normalizedMaxChars
+  );
+  if (!serialized.truncated) {
+    return serialized.content === 'undefined' ? 'null' : serialized.content;
+  }
+  const fallback = createBoundedTruncationValue(
+    serialized.content,
+    serialized.originalChars,
+    normalizedMaxChars
+  );
+  return JSON.stringify(fallback);
+}
+
+function projectKnownInputProperty(
+  value: object,
+  key: string,
+  maxChars: number,
+  changes: Record<string, unknown>
+): void {
+  const property = readPropertyWithoutAccessors(value, key);
+  if (!property.found) {
+    return;
+  }
+  const projected = property.accessor
+    ? { value: ACCESSOR_INPUT_PLACEHOLDER, changed: true }
+    : projectToolInputWithinLimit(property.value, maxChars);
+  if (projected.changed || !property.own) {
+    changes[key] = projected.value;
+  }
+}
+
+function getStringProperty(value: object, key: string): string | undefined {
+  const property = readPropertyWithoutAccessors(value, key);
+  return !property.accessor && typeof property.value === 'string'
+    ? property.value
+    : undefined;
+}
+
+function projectInlineToolInput(
+  block: MessageContentComplex,
+  maxChars: number
+): MessageContentComplex {
+  const type = getStringProperty(block, 'type');
+  if (type !== 'tool_use' && type !== 'tool_call') {
+    return block;
+  }
+
+  const changes: Record<string, unknown> = {};
+  projectKnownInputProperty(block, 'input', maxChars, changes);
+  projectKnownInputProperty(block, 'args', maxChars, changes);
+
+  const nestedProperty = readPropertyWithoutAccessors(block, 'tool_call');
+  if (
+    nestedProperty.found &&
+    !nestedProperty.accessor &&
+    nestedProperty.value != null &&
+    typeof nestedProperty.value === 'object'
+  ) {
+    const nestedChanges: Record<string, unknown> = {};
+    projectKnownInputProperty(
+      nestedProperty.value,
+      'args',
+      maxChars,
+      nestedChanges
+    );
+    if (Object.keys(nestedChanges).length > 0) {
+      changes.tool_call = cloneWithProjectedProperties(
+        nestedProperty.value,
+        nestedChanges
+      );
+    } else if (!nestedProperty.own) {
+      changes.tool_call = nestedProperty.value;
+    }
+  } else if (nestedProperty.accessor) {
+    changes.tool_call = { args: ACCESSOR_INPUT_PLACEHOLDER };
+  }
+
+  return Object.keys(changes).length > 0
+    ? cloneWithProjectedProperties(block, changes)
+    : block;
+}
+
+function projectSerializedArguments(
+  value: unknown,
+  maxChars: number
+): { value: string; changed: boolean } {
+  const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  if (typeof value === 'string' && value.length <= normalizedMaxChars) {
+    return { value, changed: false };
+  }
+  return {
+    value: serializeToolCallInput(value, normalizedMaxChars),
+    changed: true,
+  };
+}
+
+function selectProjectedSerializedArguments(
+  property: PropertyRead,
+  canonical: string | undefined,
+  maxChars: number
+): { value: string; changed: boolean } {
+  if (canonical != null) {
+    return { value: canonical, changed: property.value !== canonical };
+  }
+  if (property.accessor) {
+    return {
+      value: serializeToolCallInput(ACCESSOR_INPUT_PLACEHOLDER, maxChars),
+      changed: true,
+    };
+  }
+  return projectSerializedArguments(property.value, maxChars);
+}
+
+function projectRawOpenAIToolCalls(
+  rawToolCalls: unknown,
+  maxChars: number,
+  canonicalArguments: ReadonlyMap<string, string>
+): { value: unknown; changed: boolean } {
+  if (!Array.isArray(rawToolCalls)) {
+    return { value: rawToolCalls, changed: false };
+  }
+
+  const state = { changed: false };
+  const projected = rawToolCalls.map((rawToolCall) => {
+    if (rawToolCall == null || typeof rawToolCall !== 'object') {
+      return rawToolCall;
+    }
+    const functionProperty = readPropertyWithoutAccessors(
+      rawToolCall,
+      'function'
+    );
+    if (
+      !functionProperty.found ||
+      functionProperty.accessor ||
+      functionProperty.value == null ||
+      typeof functionProperty.value !== 'object'
+    ) {
+      return rawToolCall;
+    }
+
+    const argsProperty = readPropertyWithoutAccessors(
+      functionProperty.value,
+      'arguments'
+    );
+    if (!argsProperty.found) {
+      return rawToolCall;
+    }
+    const callId = getStringProperty(rawToolCall, 'id');
+    const canonical =
+      callId != null ? canonicalArguments.get(callId) : undefined;
+    const projectedArgs = selectProjectedSerializedArguments(
+      argsProperty,
+      canonical,
+      maxChars
+    );
+    if (!projectedArgs.changed && functionProperty.own && argsProperty.own) {
+      return rawToolCall;
+    }
+
+    state.changed = true;
+    const projectedFunction = cloneWithProjectedProperties(
+      functionProperty.value,
+      { arguments: projectedArgs.value }
+    );
+    return cloneWithProjectedProperties(rawToolCall, {
+      function: projectedFunction,
+    });
+  });
+  return {
+    value: state.changed ? projected : rawToolCalls,
+    changed: state.changed,
+  };
+}
+
+function projectResponsesOutput(
+  output: unknown,
+  maxChars: number,
+  canonicalArguments: ReadonlyMap<string, string>
+): { value: unknown; changed: boolean } {
+  if (!Array.isArray(output)) {
+    return { value: output, changed: false };
+  }
+
+  const state = { changed: false };
+  const projected = output.map((item) => {
+    if (item == null || typeof item !== 'object') {
+      return item;
+    }
+    const type = getStringProperty(item, 'type');
+    if (type !== 'function_call') {
+      return item;
+    }
+    const argsProperty = readPropertyWithoutAccessors(item, 'arguments');
+    if (!argsProperty.found) {
+      return item;
+    }
+    const callId =
+      getStringProperty(item, 'call_id') ?? getStringProperty(item, 'id');
+    const canonical =
+      callId != null ? canonicalArguments.get(callId) : undefined;
+    const projectedArgs = selectProjectedSerializedArguments(
+      argsProperty,
+      canonical,
+      maxChars
+    );
+    if (!projectedArgs.changed && argsProperty.own) {
+      return item;
+    }
+    state.changed = true;
+    return cloneWithProjectedProperties(item, {
+      arguments: projectedArgs.value,
+    });
+  });
+  return {
+    value: state.changed ? projected : output,
+    changed: state.changed,
+  };
+}
+
+/** Per-input cap: 15% of context at ~4 chars/token, never above 200K chars. */
+export function calculateMaxToolCallInputChars(
+  maxContextTokens?: number
+): number {
+  if (maxContextTokens == null || maxContextTokens <= 0) {
+    return HARD_MAX_TOOL_CALL_INPUT_CHARS;
+  }
+  return Math.max(
+    MIN_JSON_VALUE_CHARS,
+    Math.min(
+      Math.floor(maxContextTokens * 0.15) * 4,
+      HARD_MAX_TOOL_CALL_INPUT_CHARS
+    )
+  );
+}
+
+/**
+ * Projects historical tool-call inputs into a provider-safe bounded form.
+ * Returns the original array when no message changes and otherwise clones only
+ * the array and AI messages whose inline input or `tool_calls` args changed.
+ */
+export function projectToolCallInputs(
+  messages: BaseMessage[],
+  maxInputChars: number
+): BaseMessage[] {
+  const normalizedMaxInputChars = normalizeToolInputLimit(maxInputChars);
+  let projectedMessages: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const messageRole = (message as BaseMessage & { role?: unknown }).role;
+    if (message.getType() !== 'ai' && messageRole !== 'assistant') {
+      continue;
+    }
+
+    const aiMessage = message as AIMessage | AIMessageChunk;
+    let projectedContent = aiMessage.content;
+    let contentChanged = false;
+    if (Array.isArray(aiMessage.content)) {
+      const originalContent = aiMessage.content as MessageContentComplex[];
+      const mappedContent = originalContent.map((block) =>
+        projectInlineToolInput(block, normalizedMaxInputChars)
+      );
+      contentChanged = mappedContent.some(
+        (block, blockIndex) => block !== originalContent[blockIndex]
+      );
+      projectedContent = toLangChainContent(mappedContent);
+    }
+
+    const originalToolCalls = aiMessage.tool_calls ?? [];
+    const projectedToolCalls = originalToolCalls.map((toolCall) => {
+      const argsProperty = readPropertyWithoutAccessors(toolCall, 'args');
+      const projected = argsProperty.accessor
+        ? { value: ACCESSOR_INPUT_PLACEHOLDER, changed: true }
+        : projectToolInputWithinLimit(
+          argsProperty.value,
+          normalizedMaxInputChars
+        );
+      if (argsProperty.own && !projected.changed) {
+        return toolCall;
+      }
+      return cloneWithProjectedProperties(toolCall, {
+        args: projected.value as Record<string, unknown>,
+      });
+    });
+    const toolCallsChanged = projectedToolCalls.some(
+      (toolCall, toolCallIndex) => toolCall !== originalToolCalls[toolCallIndex]
+    );
+
+    const rawAdditionalToolCalls = aiMessage.additional_kwargs.tool_calls;
+    const rawResponsesOutput = aiMessage.response_metadata.output;
+    const canonicalArguments = new Map<string, string>();
+    if (
+      Array.isArray(rawAdditionalToolCalls) ||
+      Array.isArray(rawResponsesOutput)
+    ) {
+      for (const toolCall of projectedToolCalls) {
+        const id = getStringProperty(toolCall, 'id');
+        if (id == null) {
+          continue;
+        }
+        const args = readPropertyWithoutAccessors(toolCall, 'args');
+        canonicalArguments.set(
+          id,
+          serializeToolCallInput(
+            args.accessor ? ACCESSOR_INPUT_PLACEHOLDER : args.value,
+            normalizedMaxInputChars
+          )
+        );
+      }
+    }
+
+    let projectedAdditionalKwargs = aiMessage.additional_kwargs;
+    let additionalKwargsChanged = false;
+    const rawToolCalls = projectRawOpenAIToolCalls(
+      rawAdditionalToolCalls,
+      normalizedMaxInputChars,
+      canonicalArguments
+    );
+    if (rawToolCalls.changed) {
+      projectedAdditionalKwargs = cloneWithProjectedProperties(
+        aiMessage.additional_kwargs,
+        { tool_calls: rawToolCalls.value }
+      );
+      additionalKwargsChanged = true;
+    }
+
+    let projectedResponseMetadata = aiMessage.response_metadata;
+    let responseMetadataChanged = false;
+    const responsesOutput = projectResponsesOutput(
+      rawResponsesOutput,
+      normalizedMaxInputChars,
+      canonicalArguments
+    );
+    if (responsesOutput.changed) {
+      projectedResponseMetadata = cloneWithProjectedProperties(
+        aiMessage.response_metadata,
+        { output: responsesOutput.value }
+      );
+      responseMetadataChanged = true;
+    }
+
+    if (
+      !contentChanged &&
+      !toolCallsChanged &&
+      !additionalKwargsChanged &&
+      !responseMetadataChanged
+    ) {
+      continue;
+    }
+
+    const projectedMessage = cloneWithProjectedProperties(aiMessage, {
+      content: projectedContent,
+      tool_calls: projectedToolCalls.length > 0 ? projectedToolCalls : [],
+      additional_kwargs: projectedAdditionalKwargs,
+      response_metadata: projectedResponseMetadata,
+    });
+    projectedMessages ??= [...messages];
+    projectedMessages[i] = projectedMessage;
+  }
+  return projectedMessages ?? messages;
+}
+
 export function preFlightTruncateToolCallInputs(params: {
   messages: BaseMessage[];
   maxContextTokens: number;
@@ -1182,78 +1714,21 @@ export function preFlightTruncateToolCallInputs(params: {
 }): number {
   const { messages, maxContextTokens, indexTokenCountMap, tokenCounter } =
     params;
-  const maxInputChars = Math.min(
-    Math.floor(maxContextTokens * 0.15) * 4,
-    200_000
-  );
-  let truncatedCount = 0;
-
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
-    if (message.getType() !== 'ai') {
-      continue;
-    }
-    if (!Array.isArray(message.content)) {
-      continue;
-    }
-
-    const originalContent = message.content as MessageContentComplex[];
-    const state = { changed: false };
-    const newContent = originalContent.map((block) => {
-      if (typeof block !== 'object') {
-        return block;
-      }
-      const record = block as Record<string, unknown>;
-      if (record.type !== 'tool_use' && record.type !== 'tool_call') {
-        return block;
-      }
-
-      const input = record.input;
-      if (input == null) {
-        return block;
-      }
-      const serialized =
-        typeof input === 'string' ? input : JSON.stringify(input);
-      if (serialized.length <= maxInputChars) {
-        return block;
-      }
-
-      state.changed = true;
-      // Replaces original input with { _truncated, _originalChars } —
-      // safe because the tool call already executed in a prior turn.
-      return {
-        ...record,
-        input: truncateToolInput(serialized, maxInputChars),
-      };
-    });
-
-    if (!state.changed) {
-      continue;
-    }
-
-    const aiMsg = message as AIMessage;
-    const newToolCalls = (aiMsg.tool_calls ?? []).map((tc) => {
-      const serializedArgs = JSON.stringify(tc.args);
-      if (serializedArgs.length <= maxInputChars) {
-        return tc;
-      }
-      // Replaces original args with { _truncated, _originalChars } —
-      // safe because the tool call already executed in a prior turn.
-      return {
-        ...tc,
-        args: truncateToolInput(serializedArgs, maxInputChars),
-      };
-    });
-
-    messages[i] = new AIMessage({
-      ...aiMsg,
-      content: toLangChainContent(newContent),
-      tool_calls: newToolCalls.length > 0 ? newToolCalls : undefined,
-    });
-    indexTokenCountMap[i] = tokenCounter(messages[i]);
-    truncatedCount++;
+  const maxInputChars = calculateMaxToolCallInputChars(maxContextTokens);
+  const projected = projectToolCallInputs(messages, maxInputChars);
+  if (projected === messages) {
+    return 0;
   }
 
+  let truncatedCount = 0;
+  for (let i = 0; i < messages.length; i++) {
+    if (projected[i] === messages[i]) {
+      continue;
+    }
+    messages[i] = projected[i];
+    indexTokenCountMap[i] = tokenCounter(projected[i]);
+    truncatedCount++;
+  }
   return truncatedCount;
 }
 
@@ -1421,7 +1896,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       }
       const normalized = compactToolContent(
         message.content,
-        Number.MAX_SAFE_INTEGER
+        factoryParams.maxToolResultChars ?? HARD_MAX_TOOL_RESULT_CHARS
       );
       if (normalized.changed) {
         message = cloneToolMessageWithContent(
@@ -2075,69 +2550,22 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
               emergencyTruncatedCount++;
             }
           }
-          if (message.getType() === 'ai' && Array.isArray(message.content)) {
-            const aiMsg = message as AIMessage;
-            const contentBlocks = aiMsg.content as MessageContentComplex[];
-            const needsTruncation = contentBlocks.some((block) => {
-              if (typeof block !== 'object') return false;
-              const record = block as Record<string, unknown>;
-              if (
-                (record.type === 'tool_use' || record.type === 'tool_call') &&
-                record.input != null
-              ) {
-                const serialized =
-                  typeof record.input === 'string'
-                    ? record.input
-                    : JSON.stringify(record.input);
-                return serialized.length > emergencyMaxChars;
-              }
-              return false;
-            });
-            if (needsTruncation) {
-              const newContent = contentBlocks.map((block) => {
-                if (typeof block !== 'object') return block;
-                const record = block as Record<string, unknown>;
-                if (
-                  (record.type === 'tool_use' || record.type === 'tool_call') &&
-                  record.input != null
-                ) {
-                  const serialized =
-                    typeof record.input === 'string'
-                      ? record.input
-                      : JSON.stringify(record.input);
-                  if (serialized.length > emergencyMaxChars) {
-                    // Replaces original input with { _truncated, _originalChars } —
-                    // safe because the tool call already executed in a prior turn.
-                    return {
-                      ...record,
-                      input: truncateToolInput(serialized, emergencyMaxChars),
-                    };
-                  }
-                }
-                return block;
-              });
-              const newToolCalls = (aiMsg.tool_calls ?? []).map((tc) => {
-                const serializedArgs = JSON.stringify(tc.args);
-                if (serializedArgs.length > emergencyMaxChars) {
-                  // Replaces original args with { _truncated, _originalChars } —
-                  // safe because the tool call already executed in a prior turn.
-                  return {
-                    ...tc,
-                    args: truncateToolInput(serializedArgs, emergencyMaxChars),
-                  };
-                }
-                return tc;
-              });
-              emergencyMessages[i] = new AIMessage({
-                ...aiMsg,
-                content: toLangChainContent(newContent),
-                tool_calls: newToolCalls.length > 0 ? newToolCalls : undefined,
-              });
-              indexTokenCountMap[i] = factoryParams.tokenCounter(
-                emergencyMessages[i]
-              );
-              emergencyTruncatedCount++;
+        }
+
+        const projectedToolInputs = projectToolCallInputs(
+          emergencyMessages,
+          emergencyMaxChars
+        );
+        if (projectedToolInputs !== emergencyMessages) {
+          for (let i = 0; i < emergencyMessages.length; i++) {
+            if (projectedToolInputs[i] === emergencyMessages[i]) {
+              continue;
             }
+            emergencyMessages[i] = projectedToolInputs[i];
+            indexTokenCountMap[i] = factoryParams.tokenCounter(
+              projectedToolInputs[i]
+            );
+            emergencyTruncatedCount++;
           }
         }
 

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -43,6 +43,9 @@ function sumTokenCounts(
 /** Default fraction of the token budget reserved as headroom (5 %). */
 export const DEFAULT_RESERVE_RATIO = 0.05;
 
+/** Provider framing reserved for the assistant reply label. */
+export const REPLY_PRIMER_TOKENS = 3;
+
 /** Context pressure at which observation masking and context fading activate. */
 const PRESSURE_THRESHOLD_MASKING = 0.8;
 
@@ -410,7 +413,8 @@ function stripOrphanToolUseBlocks(
  * vice-versa, the original array is returned immediately with zero allocation.
  */
 export function sanitizeOrphanToolBlocks(
-  messages: BaseMessage[]
+  messages: BaseMessage[],
+  onMessageCloned?: (source: BaseMessage, clone: BaseMessage) => void
 ): BaseMessage[] {
   const allToolCallIds = new Set<string>();
   const allToolResultIds = new Set<string>();
@@ -502,6 +506,7 @@ export function sanitizeOrphanToolBlocks(
           const stripped = stripOrphanToolUseBlocks(msg, allToolResultIds);
           if (stripped != null) {
             strippedAiIndices.add(result.length);
+            onMessageCloned?.(msg, stripped);
             result.push(stripped);
           }
           continue;
@@ -537,6 +542,7 @@ export function sanitizeOrphanToolBlocks(
         );
         patched.tool_calls = keptToolCalls.length > 0 ? keptToolCalls : [];
         patched.content = keptContent;
+        onMessageCloned?.(msg, patched as BaseMessage);
         result.push(patched as BaseMessage);
         continue;
       }
@@ -690,7 +696,7 @@ export function getMessagesWithinTokenLimit({
 }): PruningResult {
   // Every reply is primed with <|start|>assistant<|message|>, so we
   // start with 3 tokens for the label after all messages have been counted.
-  let currentTokenCount = 3;
+  let currentTokenCount = REPLY_PRIMER_TOKENS;
   const instructions =
     _messages[0]?.getType() === 'system' ? _messages[0] : undefined;
   const instructionsTokenCount =
@@ -918,7 +924,7 @@ export function getMessagesWithinTokenLimit({
   const newThinkingMessageTokenCount =
     (indexTokenCountMap[thinkingStartIndex] ?? 0) + thinkingTokenCount;
   remainingContextTokens = initialContextTokens - newThinkingMessageTokenCount;
-  currentTokenCount = 3;
+  currentTokenCount = REPLY_PRIMER_TOKENS;
   let newContext: BaseMessage[] = [];
   const secondRoundMessages = [..._messages];
   let currentIndex = secondRoundMessages.length;
@@ -1808,6 +1814,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         (emptyReserveRatio > 0 && emptyReserveRatio < 1
           ? Math.round(factoryParams.maxTokens * emptyReserveRatio)
           : 0);
+      const emptyReplyPrimerTokens = Math.round(
+        REPLY_PRIMER_TOKENS * calibrationRatio
+      );
       return {
         context: [],
         indexTokenCountMap,
@@ -1815,7 +1824,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         prePruneContextTokens: 0,
         remainingContextTokens: Math.max(
           0,
-          emptyBudget - emptyInstructionTokens
+          emptyBudget - emptyInstructionTokens - emptyReplyPrimerTokens
         ),
         calibrationRatio,
         resolvedInstructionOverhead: bestInstructionOverhead,
@@ -2307,9 +2316,15 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     }
 
     lastTurnStartIndex = params.messages.length;
+    const calibratedReplyPrimerTokens = Math.round(
+      REPLY_PRIMER_TOKENS * calibrationRatio
+    );
     if (
       lastCutOffIndex === 0 &&
-      calibratedTotalTokens + currentInstructionTokens <= pruningBudget
+      calibratedTotalTokens +
+        calibratedReplyPrimerTokens +
+        currentInstructionTokens <=
+        pruningBudget
     ) {
       return {
         context: params.messages,
@@ -2317,7 +2332,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         messagesToRefine: [],
         prePruneContextTokens: calibratedTotalTokens,
         remainingContextTokens:
-          pruningBudget - calibratedTotalTokens - currentInstructionTokens,
+          pruningBudget -
+          calibratedTotalTokens -
+          calibratedReplyPrimerTokens -
+          currentInstructionTokens,
         contextPressure,
         originalToolContent:
           originalToolContent.size > 0 ? originalToolContent : undefined,

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -9,6 +9,7 @@ import {
   isBaseMessage,
   SystemMessage,
   AIMessageChunk,
+  ChatMessage,
 } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { UsageMetadata } from '@langchain/core/messages';
@@ -508,6 +509,77 @@ describe('Prune Messages Tests', () => {
       expect(result.indexTokenCountMap[2]).toBeGreaterThan(0);
     });
 
+    it('reconciles a stale cached legacy function-call count', () => {
+      const tokenCounter: t.TokenCounter = (message) => {
+        const functionCall = message.additional_kwargs.function_call;
+        return (
+          (typeof message.content === 'string' ? message.content.length : 0) +
+          (functionCall != null ? JSON.stringify(functionCall).length : 0) +
+          1
+        );
+      };
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: {
+            name: 'legacy_lookup',
+            arguments: `{"query":"${'x'.repeat(10_000)}"}`,
+          },
+        },
+      });
+      const messages: BaseMessage[] = [message];
+      const pruneMessages = createPruneMessages({
+        maxTokens: 2_000,
+        startIndex: messages.length,
+        tokenCounter,
+        indexTokenCountMap: { 0: 1 },
+        reserveRatio: 0,
+      });
+
+      const result = pruneMessages({ messages });
+      const projectedFunctionCall = result.context[0].additional_kwargs
+        .function_call as { arguments: string };
+
+      expect(result.context[0]).not.toBe(message);
+      expect(projectedFunctionCall.arguments.length).toBeLessThanOrEqual(
+        calculateMaxToolCallInputChars(2_000)
+      );
+      expect(result.indexTokenCountMap[0]).toBe(
+        tokenCounter(result.context[0])
+      );
+      expect(result.indexTokenCountMap[0]).toBeGreaterThan(1);
+    });
+
+    it('preserves provider output usage for an uncounted current legacy call', () => {
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: {
+            name: 'legacy_lookup',
+            arguments: '{}',
+          },
+        },
+      });
+      const pruneMessages = createPruneMessages({
+        maxTokens: 2_000,
+        startIndex: 0,
+        tokenCounter: () => 123,
+        indexTokenCountMap: {},
+        reserveRatio: 0,
+      });
+
+      const result = pruneMessages({
+        messages: [message],
+        usageMetadata: {
+          input_tokens: 10,
+          output_tokens: 7,
+          total_tokens: 17,
+        },
+      });
+
+      expect(result.indexTokenCountMap[0]).toBe(7);
+    });
+
     it('excludes a corrected tiny new tool count from calibration input', () => {
       const tokenCounter = createTestTokenCounter();
       const history: BaseMessage[] = [
@@ -910,6 +982,179 @@ describe('Prune Messages Tests', () => {
 
       // Token savings from stripping the large tool_use blocks
       expect(repaired.reclaimedTokens).toBeGreaterThan(0);
+    });
+
+    it('strips orphan raw Responses computer calls with parsed tool calls', () => {
+      const tokenCounter = createTestTokenCounter();
+      const computerCall = new AIMessage({
+        content: 'Taking a screenshot.',
+        tool_calls: [
+          {
+            id: 'computer-orphan',
+            name: 'computer_use',
+            args: { action: { type: 'screenshot' } },
+            type: 'tool_call',
+          },
+        ],
+        response_metadata: {
+          output: [
+            {
+              type: 'computer_call',
+              id: 'computer-item',
+              call_id: 'computer-orphan',
+              action: { type: 'screenshot' },
+            },
+          ],
+        },
+      });
+      const context: BaseMessage[] = [
+        new HumanMessage('take a screenshot'),
+        computerCall,
+      ];
+
+      const repaired = repairOrphanedToolMessages({
+        context,
+        allMessages: context,
+        tokenCounter,
+        indexTokenCountMap: {
+          0: tokenCounter(context[0]),
+          1: tokenCounter(context[1]),
+        },
+      });
+      const repairedAI = repaired.context[1] as AIMessage;
+
+      expect(repairedAI.tool_calls ?? []).toHaveLength(0);
+      expect(repairedAI.response_metadata.output).toEqual([]);
+    });
+
+    it('strips orphan computer calls from the LangChain tool_outputs fallback', () => {
+      const tokenCounter = createTestTokenCounter();
+      const computerCall = new AIMessage({
+        content: 'Taking a screenshot.',
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              type: 'computer_call',
+              call_id: 'computer-fallback-orphan',
+              action: { type: 'screenshot' },
+            },
+          ],
+        },
+      });
+      const context: BaseMessage[] = [
+        new HumanMessage('take a screenshot'),
+        computerCall,
+      ];
+
+      const repaired = repairOrphanedToolMessages({
+        context,
+        allMessages: context,
+        tokenCounter,
+        indexTokenCountMap: {
+          0: tokenCounter(context[0]),
+          1: tokenCounter(context[1]),
+        },
+      });
+      const repairedAI = repaired.context[1] as AIMessage;
+
+      expect(repairedAI.additional_kwargs.tool_outputs).toEqual([]);
+    });
+
+    it('retains an empty-content AI parent when one raw call remains paired', () => {
+      const tokenCounter = createTestTokenCounter();
+      const computerCall = new AIMessage({
+        content: [],
+        tool_calls: [
+          {
+            id: 'computer-keep',
+            name: 'computer_use',
+            args: { action: { type: 'screenshot' } },
+            type: 'tool_call',
+          },
+          {
+            id: 'computer-drop',
+            name: 'computer_use',
+            args: { action: { type: 'screenshot' } },
+            type: 'tool_call',
+          },
+        ],
+        response_metadata: {
+          output: [
+            {
+              type: 'computer_call',
+              call_id: 'computer-keep',
+              action: { type: 'screenshot' },
+            },
+            {
+              type: 'computer_call',
+              call_id: 'computer-drop',
+              action: { type: 'screenshot' },
+            },
+          ],
+        },
+      });
+      const computerOutput = new ToolMessage({
+        content: 'data:image/png;base64,AA==',
+        tool_call_id: 'computer-keep',
+        additional_kwargs: { type: 'computer_call_output' },
+      });
+      const context: BaseMessage[] = [computerCall, computerOutput];
+
+      const repaired = repairOrphanedToolMessages({
+        context,
+        allMessages: context,
+        tokenCounter,
+        indexTokenCountMap: {
+          0: tokenCounter(computerCall),
+          1: tokenCounter(computerOutput),
+        },
+      });
+
+      expect(repaired.context).toHaveLength(2);
+      const repairedAI = repaired.context[0] as AIMessage;
+      expect(repairedAI.tool_calls?.map((call) => call.id)).toEqual([
+        'computer-keep',
+      ]);
+      expect(repairedAI.response_metadata.output).toEqual([
+        expect.objectContaining({ call_id: 'computer-keep' }),
+      ]);
+      expect(repaired.context[1]).toBe(computerOutput);
+    });
+
+    it('recognizes raw computer calls on generic assistant messages', () => {
+      const tokenCounter = createTestTokenCounter();
+      const computerCall = new ChatMessage({
+        role: 'assistant',
+        content: '',
+        response_metadata: {
+          output: [
+            {
+              type: 'computer_call',
+              call_id: 'generic-computer',
+              action: { type: 'screenshot' },
+            },
+          ],
+        },
+      });
+      const computerOutput = new ToolMessage({
+        content: 'data:image/png;base64,AA==',
+        tool_call_id: 'generic-computer',
+        additional_kwargs: { type: 'computer_call_output' },
+      });
+      const context: BaseMessage[] = [computerCall, computerOutput];
+
+      const repaired = repairOrphanedToolMessages({
+        context,
+        allMessages: context,
+        tokenCounter,
+        indexTokenCountMap: {
+          0: tokenCounter(computerCall),
+          1: tokenCounter(computerOutput),
+        },
+      });
+
+      expect(repaired.context).toEqual(context);
+      expect(repaired.droppedOrphanCount).toBe(0);
     });
 
     it('should drop AI message entirely when it has only tool_use blocks with no text', () => {
@@ -1317,6 +1562,185 @@ describe('Prune Messages Tests', () => {
       expect(() => JSON.stringify(args)).not.toThrow();
     });
 
+    it('bounds legacy additional_kwargs.function_call arguments', () => {
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {
+          marker: 'preserved',
+          function_call: {
+            name: 'legacy_lookup',
+            arguments: `{"query":"${'x'.repeat(2_000)}"}`,
+          },
+        },
+      });
+      const messages: BaseMessage[] = [message];
+
+      const projected = projectToolCallInputs(messages, 200);
+
+      expect(projected).not.toBe(messages);
+      expect(projected[0]).not.toBe(message);
+      expect(projected[0].additional_kwargs.marker).toBe('preserved');
+      const projectedFunctionCall = projected[0].additional_kwargs
+        .function_call as {
+        name: string;
+        arguments: string;
+      };
+      expect(projectedFunctionCall.name).toBe('legacy_lookup');
+      expect(projectedFunctionCall.arguments.length).toBeLessThanOrEqual(200);
+      expect(() => JSON.parse(projectedFunctionCall.arguments)).not.toThrow();
+      expect(
+        (
+          message.additional_kwargs.function_call as {
+            arguments: string;
+          }
+        ).arguments.length
+      ).toBeGreaterThan(2_000);
+    });
+
+    it('normalizes legacy function calls without invoking serialization hooks', () => {
+      const toJSON = jest.fn(() => ({
+        name: 'legacy_lookup',
+        arguments: 'x'.repeat(500_000),
+      }));
+      const originalFunctionCall = {
+        name: 'legacy_lookup',
+        arguments: '{}',
+        toJSON,
+      };
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: originalFunctionCall,
+        },
+      });
+
+      const [projected] = projectToolCallInputs([message], 200);
+      const projectedFunctionCall = projected.additional_kwargs
+        .function_call as {
+        name: string;
+        arguments: string;
+      };
+      const serialized = JSON.stringify(projected.additional_kwargs);
+
+      expect(projected).not.toBe(message);
+      expect(projectedFunctionCall).toEqual({
+        name: 'legacy_lookup',
+        arguments: '{}',
+      });
+      expect(Object.getPrototypeOf(projectedFunctionCall)).toBe(
+        Object.prototype
+      );
+      expect(serialized.length).toBeLessThanOrEqual(300);
+      expect(toJSON).not.toHaveBeenCalled();
+      expect(projectToolCallInputs([projected], 200)[0]).toBe(projected);
+    });
+
+    it('omits a proxied legacy function call without propagating descriptor traps', () => {
+      let descriptorCalls = 0;
+      const legacyProxy = new Proxy(
+        {},
+        {
+          getOwnPropertyDescriptor() {
+            descriptorCalls++;
+            throw new Error('descriptor trap');
+          },
+        }
+      );
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {},
+      });
+      (message.additional_kwargs as Record<string, unknown>).function_call =
+        legacyProxy;
+
+      expect(() => projectToolCallInputs([message], 200)).not.toThrow();
+      const [projected] = projectToolCallInputs([message], 200);
+
+      expect(projected.additional_kwargs.function_call).toBeUndefined();
+      expect(descriptorCalls).toBe(0);
+      expect(projectToolCallInputs([projected], 200)[0]).toBe(projected);
+    });
+
+    it('shadows proxy-backed legacy metadata without invoking its get trap', () => {
+      let getCalls = 0;
+      const hugeFunctionCall = {
+        name: 'legacy_lookup',
+        arguments: 'x'.repeat(500_000),
+      };
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {},
+      });
+      message.additional_kwargs = new Proxy(
+        {},
+        {
+          get(_target, property) {
+            getCalls++;
+            return property === 'function_call' ? hugeFunctionCall : undefined;
+          },
+          getOwnPropertyDescriptor() {
+            return undefined;
+          },
+          getPrototypeOf() {
+            return null;
+          },
+        }
+      );
+
+      const [projected] = projectToolCallInputs([message], 200);
+
+      expect(getCalls).toBe(0);
+      expect(projected).not.toBe(message);
+      expect(projected.additional_kwargs.function_call).toBeUndefined();
+      expect(projectToolCallInputs([projected], 200)[0]).toBe(projected);
+    });
+
+    it('shadows legacy calls beyond the bounded prototype walk', () => {
+      const inherited = {
+        function_call: {
+          name: 'legacy_lookup',
+          arguments: 'x'.repeat(500_000),
+        },
+      };
+      let additionalKwargs = inherited;
+      for (let i = 0; i < 101; i++) {
+        additionalKwargs = Object.create(additionalKwargs) as typeof inherited;
+      }
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {},
+      });
+      message.additional_kwargs = additionalKwargs;
+
+      const [projected] = projectToolCallInputs([message], 200);
+
+      expect(projected).not.toBe(message);
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          projected.additional_kwargs,
+          'function_call'
+        )
+      ).toBe(true);
+      expect(projected.additional_kwargs.function_call).toBeUndefined();
+      expect(projectToolCallInputs([projected], 200)[0]).toBe(projected);
+    });
+
+    it('stabilizes an omitted invalid legacy function call', () => {
+      const message = new AIMessage({
+        content: '',
+        additional_kwargs: {},
+      });
+      (message.additional_kwargs as Record<string, unknown>).function_call =
+        null;
+
+      const [first] = projectToolCallInputs([message], 200);
+      const [second] = projectToolCallInputs([first], 200);
+
+      expect(first).not.toBe(message);
+      expect(first.additional_kwargs.function_call).toBeUndefined();
+      expect(second).toBe(first);
+    });
+
     it('projects every provider-consumed tool-call representation to the same bounded wire args', () => {
       let getterCalls = 0;
       let toJSONCalls = 0;
@@ -1364,6 +1788,16 @@ describe('Prune Messages Tests', () => {
             name: 'evaluate',
             args: adversarialArgs,
           },
+          {
+            id: 'custom-call',
+            name: 'shell',
+            args: { input: 'c'.repeat(2_000) },
+          },
+          {
+            id: 'computer-call',
+            name: 'computer_use',
+            args: { action: { type: 'type', text: 't'.repeat(2_000) } },
+          },
         ],
         additional_kwargs: {
           tool_calls: [
@@ -1400,6 +1834,19 @@ describe('Prune Messages Tests', () => {
               call_id: 'response-only',
               name: 'evaluate',
               arguments: `{"code":"${'q'.repeat(2_000)}"}`,
+            },
+            {
+              type: 'custom_tool_call',
+              id: 'ctc_shared',
+              call_id: 'custom-call',
+              name: 'shell',
+              input: 'c'.repeat(2_000),
+            },
+            {
+              type: 'computer_call',
+              id: 'cc_shared',
+              call_id: 'computer-call',
+              action: { type: 'type', text: 't'.repeat(2_000) },
             },
           ],
         },
@@ -1459,12 +1906,19 @@ describe('Prune Messages Tests', () => {
 
       const responseOutput = projectedMessage.response_metadata
         .output as Array<{
+        type: string;
         call_id: string;
-        arguments: string;
+        arguments?: string;
+        input?: string;
+        action?: unknown;
       }>;
       expect(responseOutput[0].arguments).toBe(canonicalArguments);
-      expect(responseOutput[1].arguments.length).toBeLessThanOrEqual(200);
-      expect(() => JSON.parse(responseOutput[1].arguments)).not.toThrow();
+      expect(responseOutput[1].arguments?.length).toBeLessThanOrEqual(200);
+      expect(() => JSON.parse(responseOutput[1].arguments ?? '')).not.toThrow();
+      expect(responseOutput[2].input?.length).toBeLessThanOrEqual(200);
+      expect(
+        serializeToolCallInput(responseOutput[3].action, 200).length
+      ).toBeLessThanOrEqual(200);
 
       expect(
         (

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -433,6 +433,190 @@ describe('Prune Messages Tests', () => {
       expect(result.remainingContextTokens).toBeGreaterThan(0);
     });
 
+    it('recounts and compacts omitted structured tool results before sending', () => {
+      const tokenCounter: t.TokenCounter = (message) => {
+        const content =
+          typeof message.content === 'string'
+            ? message.content
+            : JSON.stringify(message.content);
+        return content.length;
+      };
+      const toolCallId = 'tc-structured';
+      const messages: BaseMessage[] = [
+        new HumanMessage('query the table'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: toolCallId,
+              name: 'run_select_query',
+              args: {},
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              text: JSON.stringify(
+                Array.from({ length: 20 }, (_, index) => ({
+                  id: index,
+                  value: `${'x'.repeat(100)}-${index}`,
+                }))
+              ),
+            },
+          ],
+          tool_call_id: toolCallId,
+          name: 'run_select_query',
+        }),
+        new AIMessage('The query returned 20 rows.'),
+        new HumanMessage('compact context'),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = {
+        0: tokenCounter(messages[0]),
+        1: tokenCounter(messages[1]),
+        3: tokenCounter(messages[3]),
+        4: tokenCounter(messages[4]),
+      };
+      const pruneMessages = createPruneMessages({
+        maxTokens: 2_000,
+        startIndex: messages.length,
+        tokenCounter,
+        indexTokenCountMap,
+        reserveRatio: 0,
+      });
+
+      const result = pruneMessages({ messages });
+
+      const structuredResult = result.context.find(
+        (message) => message.getType() === 'tool'
+      );
+      expect(structuredResult).toBeDefined();
+      expect(typeof structuredResult?.content).toBe('string');
+      expect(structuredResult?.content).toContain('truncated');
+      expect(result.indexTokenCountMap[2]).toBeGreaterThan(0);
+    });
+
+    it('excludes a corrected tiny new tool count from calibration input', () => {
+      const tokenCounter = createTestTokenCounter();
+      const history: BaseMessage[] = [
+        new HumanMessage('h'.repeat(50)),
+        new AIMessage('a'.repeat(50)),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = {
+        0: 50,
+        1: 50,
+      };
+      const pruneMessages = createPruneMessages({
+        maxTokens: 10_000,
+        startIndex: history.length,
+        tokenCounter,
+        indexTokenCountMap,
+        reserveRatio: 0,
+      });
+
+      const first = pruneMessages({
+        messages: history,
+        usageMetadata: {
+          input_tokens: 100,
+          output_tokens: 10,
+          total_tokens: 110,
+        },
+      });
+      expect(first.calibrationRatio).toBe(1);
+
+      const toolCallId = 'new-output-with-tiny-count';
+      const secondMessages: BaseMessage[] = [
+        ...history,
+        new HumanMessage('q'.repeat(50)),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: toolCallId,
+              name: 'run_select_query',
+              args: {},
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: 'r'.repeat(50),
+          tool_call_id: toolCallId,
+        }),
+      ];
+      indexTokenCountMap[2] = 50;
+      indexTokenCountMap[4] = 1;
+
+      const second = pruneMessages({
+        messages: secondMessages,
+        usageMetadata: {
+          input_tokens: 100,
+          output_tokens: 10,
+          total_tokens: 110,
+        },
+      });
+
+      expect(second.indexTokenCountMap[4]).toBe(50);
+      expect(second.calibrationRatio).toBe(1);
+    });
+
+    it('preserves full structured output for summarization before masking', () => {
+      const tokenCounter: t.TokenCounter = (message) => {
+        const content =
+          typeof message.content === 'string'
+            ? message.content
+            : JSON.stringify(message.content);
+        return content.length;
+      };
+      const fullResult = JSON.stringify(
+        Array.from({ length: 50 }, (_, index) => ({
+          id: index,
+          value: `${'x'.repeat(100)}-${index}`,
+        }))
+      );
+      const messages: BaseMessage[] = [
+        new HumanMessage('query the table'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'tc-summary-structured',
+              name: 'run_select_query',
+              args: {},
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: [{ type: ContentTypes.TEXT, text: fullResult }],
+          tool_call_id: 'tc-summary-structured',
+        }),
+        new AIMessage('The query returned 50 rows.'),
+        new HumanMessage('summarize the context'),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = {};
+      for (let i = 0; i < messages.length; i++) {
+        indexTokenCountMap[i] = tokenCounter(messages[i]);
+      }
+      const pruneMessages = createPruneMessages({
+        maxTokens: 500,
+        startIndex: messages.length,
+        tokenCounter,
+        indexTokenCountMap,
+        reserveRatio: 0,
+        summarizationEnabled: true,
+      });
+
+      const result = pruneMessages({ messages });
+
+      expect(result.newOriginalToolContent?.get(2)).toBe(fullResult);
+      expect(messages[2].content).not.toEqual([
+        { type: ContentTypes.TEXT, text: fullResult },
+      ]);
+    });
+
     it('should prune messages when over token limit', () => {
       const tokenCounter = createTestTokenCounter();
       const messages = [

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -433,7 +433,14 @@ describe('Prune Messages Tests', () => {
       expect(result.context.length).toBe(3);
       expect(result.context).toEqual(messages);
       expect(result.messagesToRefine).toEqual([]);
-      expect(result.remainingContextTokens).toBeGreaterThan(0);
+      expect(result.remainingContextTokens).toBe(
+        95 -
+          Object.values(indexTokenCountMap).reduce(
+            (total, count) => total + count,
+            0
+          ) -
+          3
+      );
     });
 
     it('recounts and compacts omitted structured tool results before sending', () => {
@@ -1706,9 +1713,9 @@ describe('Prune Messages Tests', () => {
 
       // Total message tokens: 11 + 2 + 12 + 4 = 29
       // Instruction tokens: 20 (simulating system prompt overhead)
-      // Effective budget for messages: 50 - 20 = 30 → fits all 29 tokens
+      // Effective budget: 52 - 20 - 3 reply primer = 29 → exact fit
       const pruneMessages = createPruneMessages({
-        maxTokens: 50,
+        maxTokens: 52,
         startIndex: 0,
         tokenCounter,
         indexTokenCountMap,
@@ -1718,7 +1725,7 @@ describe('Prune Messages Tests', () => {
 
       const result = pruneMessages({ messages });
 
-      // All messages should fit: 29 message tokens + 20 instruction = 49 ≤ 50
+      // All messages fit exactly with instructions and reply framing.
       expect(result.context.length).toBe(4);
       expect(result.context).toEqual(messages);
       expect(result.messagesToRefine).toEqual([]);
@@ -2060,10 +2067,10 @@ describe('Prune Messages Tests', () => {
       expect(result.context).toEqual([]);
       expect(result.messagesToRefine).toEqual([]);
       expect(result.prePruneContextTokens).toBe(0);
-      /** Reserve-adjusted budget (8000 − 5%) minus instruction overhead */
+      /** Reserve-adjusted budget minus instructions and reply primer */
       expect(result.contextBudget).toBe(7600);
       expect(result.effectiveInstructionTokens).toBe(4000);
-      expect(result.remainingContextTokens).toBe(3600);
+      expect(result.remainingContextTokens).toBe(3597);
     });
   });
 

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -20,7 +20,10 @@ import {
   sanitizeOrphanToolBlocks,
   enforceOriginalContentCap,
   ORIGINAL_CONTENT_MAX_CHARS,
+  calculateMaxToolCallInputChars,
   createPruneMessages,
+  projectToolCallInputs,
+  serializeToolCallInput,
 } from '@/messages/prune';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { ensureThinkingBlockInMessages } from '@/messages/format';
@@ -1183,6 +1186,296 @@ describe('Prune Messages Tests', () => {
     });
   });
 
+  describe('projectToolCallInputs', () => {
+    it('uses the shared 15%-of-context cap with a 200K ceiling', () => {
+      expect(calculateMaxToolCallInputChars()).toBe(200_000);
+      expect(calculateMaxToolCallInputChars(0)).toBe(200_000);
+      expect(calculateMaxToolCallInputChars(1_000)).toBe(600);
+      expect(calculateMaxToolCallInputChars(1_000_000)).toBe(200_000);
+      expect(serializeToolCallInput(undefined, 4)).toBe('null');
+    });
+
+    it('returns the original array when every input is already safe and bounded', () => {
+      const messages: BaseMessage[] = [
+        new HumanMessage('Run it'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'safe-call', name: 'lookup', args: { query: 'safe' } },
+          ],
+        }),
+      ];
+
+      const projected = projectToolCallInputs(messages, 1_000);
+
+      expect(projected).toBe(messages);
+      expect(projected[1]).toBe(messages[1]);
+    });
+
+    it('copy-on-write projects inline input and tool_calls args on AIMessageChunk', () => {
+      let toJSONCalls = 0;
+      const chunk = new AIMessageChunk({
+        content: [
+          { type: 'text', text: 'Running.' },
+          {
+            type: 'tool_use',
+            id: 'chunk-call',
+            name: 'evaluate_script',
+            input: { code: 'x'.repeat(2_000) },
+          },
+        ],
+        id: 'chunk-id',
+        additional_kwargs: { marker: 'keep' },
+        response_metadata: { model: 'chunk-model' },
+        tool_calls: [
+          {
+            id: 'chunk-call',
+            name: 'evaluate_script',
+            args: {
+              query: 'safe',
+              toJSON() {
+                toJSONCalls++;
+                return { code: 'y'.repeat(2_000_000) };
+              },
+            },
+          },
+        ],
+      });
+      chunk.tool_call_chunks = [
+        {
+          id: 'chunk-call',
+          index: 0,
+          name: 'evaluate_script',
+          args: '',
+          type: 'tool_call_chunk',
+        },
+      ];
+      const messages: BaseMessage[] = [chunk];
+
+      const projected = projectToolCallInputs(messages, 200);
+
+      expect(projected).not.toBe(messages);
+      expect(projected[0]).not.toBe(chunk);
+      expect(projected[0]).toBeInstanceOf(AIMessageChunk);
+      expect(toJSONCalls).toBe(0);
+      const projectedChunk = projected[0] as AIMessageChunk;
+      expect(projectedChunk.id).toBe('chunk-id');
+      expect(projectedChunk.additional_kwargs).toEqual({ marker: 'keep' });
+      expect(projectedChunk.response_metadata).toEqual({
+        model: 'chunk-model',
+      });
+      expect(projectedChunk.tool_call_chunks).toEqual(chunk.tool_call_chunks);
+      const inlineToolUse = (
+        projectedChunk.content as Array<Record<string, unknown>>
+      ).find((block) => block.type === 'tool_use');
+      expect(inlineToolUse?.input).toMatchObject({
+        _truncated: expect.stringContaining('truncated'),
+        _originalChars: expect.any(Number),
+      });
+      expect(projectedChunk.tool_calls?.[0].args).toEqual({ query: 'safe' });
+      expect(
+        (
+          (chunk.content as Array<Record<string, unknown>>)[1].input as {
+            code: string;
+          }
+        ).code
+      ).toHaveLength(2_000);
+    });
+
+    it('normalizes cyclic and bigint args into provider-safe JSON values', () => {
+      const cyclic: Record<string, unknown> = { query: 'safe' };
+      cyclic.self = cyclic;
+      const messages: BaseMessage[] = [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'non-json-call',
+              name: 'lookup',
+              args: { cyclic, count: 7n },
+            },
+          ],
+        }),
+      ];
+
+      const projected = projectToolCallInputs(messages, 1_000);
+
+      expect(projected).not.toBe(messages);
+      const args = (projected[0] as AIMessage).tool_calls?.[0].args as {
+        cyclic: { self: string };
+        count: string;
+      };
+      expect(args.cyclic.self).toBe('[Circular]');
+      expect(args.count).toBe('7');
+      expect(() => JSON.stringify(args)).not.toThrow();
+    });
+
+    it('projects every provider-consumed tool-call representation to the same bounded wire args', () => {
+      let getterCalls = 0;
+      let toJSONCalls = 0;
+      const adversarialArgs: Record<string, unknown> = {
+        query: 'safe',
+        payload: 'x'.repeat(2_000),
+      };
+      Object.defineProperty(adversarialArgs, 'expanded', {
+        enumerable: true,
+        get() {
+          getterCalls++;
+          return 'y'.repeat(2_000_000);
+        },
+      });
+      adversarialArgs.self = adversarialArgs;
+      adversarialArgs.toJSON = (): Record<string, string> => {
+        toJSONCalls++;
+        return { payload: 'z'.repeat(2_000_000) };
+      };
+
+      const message = new AIMessageChunk({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'inline-use',
+            name: 'evaluate',
+            input: { code: 'i'.repeat(2_000) },
+          },
+          {
+            type: 'tool_call',
+            id: 'inline-call',
+            name: 'evaluate',
+            args: { code: 'a'.repeat(2_000) },
+            tool_call: {
+              type: 'tool_call',
+              id: 'nested-call',
+              name: 'evaluate',
+              args: { code: 'n'.repeat(2_000) },
+            },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'shared-call',
+            name: 'evaluate',
+            args: adversarialArgs,
+          },
+        ],
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'shared-call',
+              type: 'function',
+              function: {
+                name: 'evaluate',
+                arguments: `{"code":"${'r'.repeat(2_000)}"}`,
+              },
+            },
+            {
+              id: 'raw-only',
+              type: 'function',
+              function: {
+                name: 'evaluate',
+                arguments: `{"code":"${'o'.repeat(2_000)}"}`,
+              },
+            },
+          ],
+        },
+        response_metadata: {
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_shared',
+              call_id: 'shared-call',
+              name: 'evaluate',
+              arguments: `{"code":"${'w'.repeat(2_000)}"}`,
+            },
+            {
+              type: 'function_call',
+              id: 'fc_raw',
+              call_id: 'response-only',
+              name: 'evaluate',
+              arguments: `{"code":"${'q'.repeat(2_000)}"}`,
+            },
+          ],
+        },
+      });
+      Object.defineProperty(message, 'projectionMarker', {
+        configurable: false,
+        enumerable: false,
+        value: 'preserved',
+        writable: false,
+      });
+      const messages: BaseMessage[] = [message];
+
+      const projected = projectToolCallInputs(messages, 200);
+
+      expect(projected).not.toBe(messages);
+      expect(projected[0]).toBeInstanceOf(AIMessageChunk);
+      expect(getterCalls).toBe(0);
+      expect(toJSONCalls).toBe(0);
+      expect(
+        Object.getOwnPropertyDescriptor(projected[0], 'projectionMarker')
+      ).toEqual(Object.getOwnPropertyDescriptor(message, 'projectionMarker'));
+
+      const projectedMessage = projected[0] as AIMessageChunk;
+      const content = projectedMessage.content as Array<
+        Record<string, unknown>
+      >;
+      const inlineUse = content[0];
+      const inlineCall = content[1];
+      const nestedCall = inlineCall.tool_call as Record<string, unknown>;
+      for (const input of [
+        inlineUse.input,
+        inlineCall.args,
+        nestedCall.args,
+        projectedMessage.tool_calls?.[0].args,
+      ]) {
+        const serialized = serializeToolCallInput(input, 200);
+        expect(serialized.length).toBeLessThanOrEqual(200);
+        expect(() => JSON.parse(serialized)).not.toThrow();
+      }
+
+      const canonicalArguments = serializeToolCallInput(
+        projectedMessage.tool_calls?.[0].args,
+        200
+      );
+      const rawToolCalls = projectedMessage.additional_kwargs
+        .tool_calls as Array<{
+        id: string;
+        function: { arguments: string };
+      }>;
+      expect(rawToolCalls[0].function.arguments).toBe(canonicalArguments);
+      expect(rawToolCalls[1].function.arguments.length).toBeLessThanOrEqual(
+        200
+      );
+      expect(() =>
+        JSON.parse(rawToolCalls[1].function.arguments)
+      ).not.toThrow();
+
+      const responseOutput = projectedMessage.response_metadata
+        .output as Array<{
+        call_id: string;
+        arguments: string;
+      }>;
+      expect(responseOutput[0].arguments).toBe(canonicalArguments);
+      expect(responseOutput[1].arguments.length).toBeLessThanOrEqual(200);
+      expect(() => JSON.parse(responseOutput[1].arguments)).not.toThrow();
+
+      expect(
+        (
+          message.additional_kwargs.tool_calls as Array<{
+            function: { arguments: string };
+          }>
+        )[0].function.arguments.length
+      ).toBeGreaterThan(2_000);
+      expect(
+        (
+          message.response_metadata.output as Array<{
+            arguments: string;
+          }>
+        )[0].arguments.length
+      ).toBeGreaterThan(2_000);
+    });
+  });
+
   describe('preFlightTruncateToolCallInputs', () => {
     it('should truncate oversized tool_use input fields in AI messages', () => {
       const tokenCounter = createTestTokenCounter();
@@ -1248,6 +1541,88 @@ describe('Prune Messages Tests', () => {
       expect(aiMsg.tool_calls).toBeDefined();
       const tc = aiMsg.tool_calls![0];
       expect(tc.args).toHaveProperty('_truncated');
+    });
+
+    it('truncates tool_calls-only args and preserves AI message metadata', () => {
+      let recounts = 0;
+      const tokenCounter: t.TokenCounter = () => {
+        recounts++;
+        return 17;
+      };
+      const messages: BaseMessage[] = [
+        new AIMessage({
+          content: '',
+          id: 'ai-tool-call-only',
+          name: 'assistant',
+          additional_kwargs: { trace_marker: 'keep' },
+          response_metadata: { model: 'test-model' },
+          tool_calls: [
+            {
+              id: 'tool-exec',
+              name: 'evaluate_script',
+              args: { code: 'x'.repeat(5_000) },
+            },
+          ],
+        }),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = { 0: 1 };
+
+      const truncated = preFlightTruncateToolCallInputs({
+        messages,
+        maxContextTokens: 1_000,
+        indexTokenCountMap,
+        tokenCounter,
+      });
+
+      expect(truncated).toBe(1);
+      expect(recounts).toBe(1);
+      expect(indexTokenCountMap[0]).toBe(17);
+      const projected = messages[0] as AIMessage;
+      expect(projected.content).toBe('');
+      expect(projected.id).toBe('ai-tool-call-only');
+      expect(projected.name).toBe('assistant');
+      expect(projected.additional_kwargs).toEqual({ trace_marker: 'keep' });
+      expect(projected.response_metadata).toEqual({ model: 'test-model' });
+      expect(projected.tool_calls?.[0].args).toMatchObject({
+        _truncated: expect.stringContaining('truncated'),
+        _originalChars: expect.any(Number),
+      });
+    });
+
+    it('neutralizes adversarial tool-call args without invoking toJSON', () => {
+      let toJSONCalls = 0;
+      const messages: BaseMessage[] = [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'tool-adversarial',
+              name: 'lookup',
+              args: {
+                query: 'safe',
+                toJSON() {
+                  toJSONCalls++;
+                  return { query: 'x'.repeat(2_000_000) };
+                },
+              },
+            },
+          ],
+        }),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = { 0: 1 };
+
+      const changed = preFlightTruncateToolCallInputs({
+        messages,
+        maxContextTokens: 1_000,
+        indexTokenCountMap,
+        tokenCounter: () => 5,
+      });
+
+      expect(changed).toBe(1);
+      expect(toJSONCalls).toBe(0);
+      expect((messages[0] as AIMessage).tool_calls?.[0].args).toEqual({
+        query: 'safe',
+      });
     });
 
     it('should not truncate inputs that fit within the budget', () => {
@@ -1601,6 +1976,63 @@ describe('Prune Messages Tests', () => {
       // At minimum, the newest messages should be present
       const types = result.context.map((m) => m.getType());
       expect(types).toContain('human');
+    });
+
+    it('emergency-truncates tool_calls-only args when content is empty', () => {
+      const tokenCounter: t.TokenCounter = (message) => {
+        let chars =
+          typeof message.content === 'string' ? message.content.length : 0;
+        if (message.getType() === 'ai') {
+          for (const toolCall of (message as AIMessage).tool_calls ?? []) {
+            chars +=
+              toolCall.name.length + JSON.stringify(toolCall.args).length;
+          }
+        }
+        return Math.max(1, Math.ceil(chars / 4));
+      };
+      const messages: BaseMessage[] = [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'tool-call-only',
+              name: 'evaluate_script',
+              args: { code: 'x'.repeat(4_000) },
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: 'OK',
+          tool_call_id: 'tool-call-only',
+          name: 'evaluate_script',
+        }),
+      ];
+      const indexTokenCountMap: Record<string, number | undefined> = {
+        0: tokenCounter(messages[0]),
+        1: tokenCounter(messages[1]),
+      };
+      const pruneMessages = createPruneMessages({
+        maxTokens: 1_000,
+        startIndex: 0,
+        tokenCounter,
+        indexTokenCountMap,
+        getInstructionTokens: () => 900,
+        reserveRatio: 0,
+      });
+
+      const result = pruneMessages({ messages });
+
+      const projectedAI = result.context.find(
+        (message) => message.getType() === 'ai'
+      ) as AIMessage | undefined;
+      expect(projectedAI).toBeDefined();
+      expect(projectedAI?.content).toBe('');
+      const projectedArgs = projectedAI?.tool_calls?.[0].args as
+        | { _truncated?: string; _originalChars?: number }
+        | undefined;
+      expect(projectedArgs?._truncated).toContain('truncated');
+      expect(projectedArgs?._truncated?.length).toBeLessThanOrEqual(200);
+      expect(projectedArgs?._originalChars).toBeGreaterThan(200);
     });
   });
 

--- a/src/specs/summarization-unit.test.ts
+++ b/src/specs/summarization-unit.test.ts
@@ -188,6 +188,79 @@ describe('preFlightTruncateToolResults', () => {
     expect(indexTokenCountMap[2]).toBeLessThan(originalTokenCount);
   });
 
+  it('truncates structured tool results and preserves message metadata', () => {
+    const toolMsg = new ToolMessage({
+      content: [
+        {
+          type: 'json',
+          rows: Array.from({ length: 20 }, (_, index) => ({
+            id: index,
+            value: `${'x'.repeat(100)}-${index}`,
+          })),
+        },
+      ],
+      tool_call_id: 'tc-structured',
+      name: 'run_select_query',
+      status: 'success',
+      artifact: { source: 'clickhouse' },
+      metadata: { requestId: 'request-1' },
+      additional_kwargs: { traceId: 'trace-1' },
+    });
+    const messages: BaseMessage[] = [toolMsg];
+    const indexTokenCountMap: Record<string, number | undefined> = { 0: 0 };
+
+    const count = preFlightTruncateToolResults({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      tokenCounter,
+    });
+
+    expect(count).toBe(1);
+    expect(typeof messages[0].content).toBe('string');
+    expect(messages[0].content).toContain('truncated');
+    expect(messages[0].content).toContain('"id":0');
+    const truncated = messages[0] as ToolMessage;
+    expect(truncated.tool_call_id).toBe('tc-structured');
+    expect(truncated.name).toBe('run_select_query');
+    expect(truncated.status).toBe('success');
+    expect(truncated.artifact).toEqual({ source: 'clickhouse' });
+    expect(truncated.metadata).toEqual({ requestId: 'request-1' });
+    expect(truncated.additional_kwargs).toEqual({ traceId: 'trace-1' });
+    expect(indexTokenCountMap[0]).toBe(tokenCounter(truncated));
+  });
+
+  it('compacts text in multipart results without slicing media blocks', () => {
+    const imageBlock = {
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,AAAA' },
+    };
+    const toolMsg = new ToolMessage({
+      content: [{ type: 'text', text: 'x'.repeat(1_000) }, imageBlock],
+      tool_call_id: 'tc-multipart',
+      name: 'screenshot',
+    });
+    const messages: BaseMessage[] = [toolMsg];
+    const indexTokenCountMap: Record<string, number | undefined> = {
+      0: tokenCounter(toolMsg),
+    };
+
+    const count = preFlightTruncateToolResults({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      tokenCounter,
+    });
+
+    expect(count).toBe(1);
+    expect(Array.isArray(messages[0].content)).toBe(true);
+    const content = messages[0].content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(2);
+    expect(content[0].type).toBe('text');
+    expect(content[0].text).toContain('truncated');
+    expect(content[1]).toBe(imageBlock);
+  });
+
   it('does not truncate results that fit within budget', () => {
     const toolMsg = new ToolMessage({
       content: 'OK',

--- a/src/specs/summarization-unit.test.ts
+++ b/src/specs/summarization-unit.test.ts
@@ -230,6 +230,38 @@ describe('preFlightTruncateToolResults', () => {
     expect(indexTokenCountMap[0]).toBe(tokenCounter(truncated));
   });
 
+  it('does not truncate indivisible native computer screenshots', () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const stringOutput = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'computer-string',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const structuredOutput = new ToolMessage({
+      content: [{ type: 'computer_screenshot', image_url: screenshot }],
+      tool_call_id: 'computer-structured',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const messages: BaseMessage[] = [stringOutput, structuredOutput];
+    const indexTokenCountMap: Record<string, number | undefined> = {
+      0: tokenCounter(stringOutput),
+      1: tokenCounter(structuredOutput),
+    };
+
+    const count = preFlightTruncateToolResults({
+      messages,
+      maxContextTokens: 50,
+      indexTokenCountMap,
+      tokenCounter,
+    });
+
+    expect(count).toBe(0);
+    expect(messages[0]).toBe(stringOutput);
+    expect(messages[0].content).toBe(screenshot);
+    expect(messages[1]).toBe(structuredOutput);
+    expect(messages[1].content).toBe(structuredOutput.content);
+  });
+
   it('compacts text in multipart results without slicing media blocks', () => {
     const imageBlock = {
       type: 'image_url',

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -1,4 +1,9 @@
-import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  ChatMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import {
   encodingForModel,
   createTokenCounter,
@@ -116,6 +121,23 @@ describe('getTokenCountForMessage', () => {
 
     expect(Math.max(...callbackLengths)).toBe(200_000);
     expect(count).toBeGreaterThan(args.length);
+  });
+
+  test('counts legacy function_call arguments when parsed tool_calls are absent', () => {
+    const message = new AIMessage({
+      content: '',
+      additional_kwargs: {
+        function_call: {
+          name: 'legacy_lookup',
+          arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+        },
+      },
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(message.tool_calls).toHaveLength(0);
+    expect(count).toBeGreaterThan(5_000);
   });
 
   test('keeps nested dense strings on the bounded structured path', () => {
@@ -388,6 +410,82 @@ describe('getTokenCountForMessage', () => {
 
     // 3 message tokens + ceil((85 + 4 * 170) * 1.05)
     expect(count).toBe(807);
+  });
+
+  test('prices computer screenshots as images instead of base64 text', () => {
+    const screenshot = pngDataUri(1024, 768);
+    const structured = new ToolMessage({
+      content: [{ type: 'computer_screenshot', image_url: screenshot }],
+      tool_call_id: 'computer-structured',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const string = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'computer-string',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(
+      getTokenCountForMessage(structured, (text) => text.length, 'o200k_base')
+    ).toBe(807);
+    expect(
+      getTokenCountForMessage(string, (text) => text.length, 'o200k_base')
+    ).toBe(807);
+    const file = new ToolMessage({
+      content: [
+        { type: 'input_image', file_id: 'file-screenshot123', detail: 'low' },
+      ],
+      tool_call_id: 'computer-file',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    expect(
+      getTokenCountForMessage(file, (text) => text.length, 'o200k_base')
+    ).toBe(93);
+    const highDetailFile = new ToolMessage({
+      content: [
+        { type: 'input_image', file_id: 'file-screenshot456', detail: 'high' },
+      ],
+      tool_call_id: 'computer-file-high',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    expect(
+      getTokenCountForMessage(
+        highDetailFile,
+        (text) => text.length,
+        'o200k_base'
+      )
+    ).toBe(1079);
+  });
+
+  test('does not image-price malformed marked computer output', () => {
+    const content = 'not a screenshot URL';
+    const message = new ToolMessage({
+      content,
+      tool_call_id: 'computer-invalid',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+
+    expect(
+      getTokenCountForMessage(message, (text) => text.length, 'o200k_base')
+    ).toBe(3 + content.length);
+  });
+
+  test('counts legacy calls on generic assistant messages', () => {
+    const argumentsValue = `{"query":"${'x'.repeat(5_000)}"}`;
+    const message = new ChatMessage({
+      role: 'assistant',
+      content: '',
+      additional_kwargs: {
+        function_call: {
+          name: 'legacy_lookup',
+          arguments: argumentsValue,
+        },
+      },
+    });
+
+    expect(
+      getTokenCountForMessage(message, (text) => text.length, 'o200k_base')
+    ).toBeGreaterThan(argumentsValue.length);
   });
 
   test('prices Google PDF media blocks per estimated page', () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -1,8 +1,9 @@
-import { HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import {
   encodingForModel,
   createTokenCounter,
   getTokenCountForMessage,
+  hasUnsafeStructuredSerialization,
   TokenEncoderManager,
   estimateImageBlockTokens,
   estimateDocumentBlockTokens,
@@ -84,6 +85,254 @@ describe('createTokenCounter with different encodings', () => {
 });
 
 describe('getTokenCountForMessage', () => {
+  const messageWithToolArgs = (args: unknown): AIMessage =>
+    ({
+      content: '',
+      tool_calls: [{ id: 'adversarial-call', name: 'stress', args }],
+      getType: () => 'ai',
+    }) as unknown as AIMessage;
+
+  test('bounds direct message strings before tokenization and charges omitted characters', () => {
+    const callbackLengths: number[] = [];
+    const content = 'x'.repeat(300_000);
+
+    const count = getTokenCountForMessage(new HumanMessage(content), (text) => {
+      callbackLengths.push(text.length);
+      return text.length;
+    });
+
+    expect(Math.max(...callbackLengths)).toBe(200_000);
+    expect(count).toBe(600_003);
+  });
+
+  test('bounds direct string tool args before tokenization and charges omitted characters', () => {
+    const callbackLengths: number[] = [];
+    const args = 'x'.repeat(300_000);
+
+    const count = getTokenCountForMessage(messageWithToolArgs(args), (text) => {
+      callbackLengths.push(text.length);
+      return text.length;
+    });
+
+    expect(Math.max(...callbackLengths)).toBe(200_000);
+    expect(count).toBeGreaterThan(args.length);
+  });
+
+  test('keeps nested dense strings on the bounded structured path', () => {
+    const callbackLengths: number[] = [];
+    const payload = 'x'.repeat(4 * 1024 * 1024);
+
+    const count = getTokenCountForMessage(
+      messageWithToolArgs({ payload }),
+      (text) => {
+        callbackLengths.push(text.length);
+        return text.length;
+      }
+    );
+
+    expect(Math.max(...callbackLengths)).toBeLessThanOrEqual(200_000);
+    expect(count).toBeGreaterThan(payload.length);
+  });
+
+  test('fails closed when prototype traps throw', () => {
+    let prototypeCalls = 0;
+    const args = new Proxy(
+      { safe: true },
+      {
+        getPrototypeOf() {
+          prototypeCalls++;
+          throw new Error('prototype denied');
+        },
+      }
+    );
+
+    expect(hasUnsafeStructuredSerialization(args)).toBe(true);
+    expect(
+      getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
+    ).toBe(Number.MAX_SAFE_INTEGER);
+    expect(prototypeCalls).toBeLessThanOrEqual(2);
+  });
+
+  test('fails closed without recursing through self-referential prototype proxies', () => {
+    let prototypeCalls = 0;
+    const args: Record<string, unknown> = new Proxy<Record<string, unknown>>(
+      {},
+      {
+        getPrototypeOf(): object | null {
+          prototypeCalls++;
+          return args;
+        },
+      }
+    );
+
+    expect(hasUnsafeStructuredSerialization(args)).toBe(true);
+    expect(
+      getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
+    ).toBe(Number.MAX_SAFE_INTEGER);
+    expect(prototypeCalls).toBeLessThanOrEqual(2);
+  });
+
+  test('fails closed when descriptor and own-key proxy traps throw', () => {
+    const descriptorProxy = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error('descriptor denied');
+        },
+      }
+    );
+    const ownKeysProxy = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error('keys denied');
+        },
+      }
+    );
+
+    for (const args of [descriptorProxy, ownKeysProxy]) {
+      expect(hasUnsafeStructuredSerialization(args)).toBe(true);
+      expect(
+        getTokenCountForMessage(
+          messageWithToolArgs(args),
+          (text) => text.length
+        )
+      ).toBe(Number.MAX_SAFE_INTEGER);
+    }
+  });
+
+  test('fails closed on get traps and revoked proxies without invoking them', () => {
+    let getCalls = 0;
+    const getProxy = new Proxy(
+      {},
+      {
+        get() {
+          getCalls++;
+          return { payload: 'x'.repeat(1_000_000) };
+        },
+      }
+    );
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    const inheritedProxy = Object.create(getProxy);
+
+    for (const args of [
+      getProxy,
+      { nested: getProxy },
+      inheritedProxy,
+      revoked.proxy,
+    ]) {
+      expect(hasUnsafeStructuredSerialization(args)).toBe(true);
+      expect(
+        getTokenCountForMessage(
+          messageWithToolArgs(args),
+          (text) => text.length
+        )
+      ).toBe(Number.MAX_SAFE_INTEGER);
+    }
+    expect(getCalls).toBe(0);
+  });
+
+  test('fails closed on proxied content blocks without invoking their traps', () => {
+    let getCalls = 0;
+    const contentBlock = new Proxy(
+      { type: 'text', text: 'safe' },
+      {
+        get() {
+          getCalls++;
+          throw new Error('content read denied');
+        },
+      }
+    );
+    const message = {
+      content: [contentBlock],
+      getType: () => 'tool',
+    } as unknown as ToolMessage;
+
+    expect(getTokenCountForMessage(message, (text) => text.length)).toBe(
+      Number.MAX_SAFE_INTEGER
+    );
+    expect(getCalls).toBe(0);
+  });
+
+  test('detects inherited accessors without invoking them', () => {
+    let accessorCalls = 0;
+    const prototype = {};
+    Object.defineProperty(prototype, 'danger', {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return 'x'.repeat(1_000_000);
+      },
+    });
+    const args = Object.assign(Object.create(prototype), { safe: true });
+
+    expect(hasUnsafeStructuredSerialization(args)).toBe(true);
+    expect(
+      getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
+    ).toBe(Number.MAX_SAFE_INTEGER);
+    expect(accessorCalls).toBe(0);
+  });
+
+  test('counts tool_calls-only names and arguments', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'tool-call-only',
+          name: 'evaluate_script',
+          args: { code: 'x'.repeat(5_000) },
+        },
+      ],
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(count).toBeGreaterThan(5_000);
+  });
+
+  test('counts adversarial structured tool-call args without invoking toJSON', () => {
+    let toJSONCalls = 0;
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'adversarial-tool-call',
+          name: 'evaluate_script',
+          args: {
+            query: 'safe',
+            toJSON() {
+              toJSONCalls++;
+              return { code: 'y'.repeat(2_000_000) };
+            },
+          },
+        },
+      ],
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(count).toBeGreaterThanOrEqual(Number.MAX_SAFE_INTEGER);
+    expect(toJSONCalls).toBe(0);
+  });
+
+  test('retains conservative pressure when structured args exceed the preview', () => {
+    const message = new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'large-structured-tool-call',
+          name: 'evaluate_script',
+          args: { code: 'x'.repeat(300_000) },
+        },
+      ],
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(count).toBeGreaterThan(300_000);
+  });
+
   test('counts opaque structured tool-result blocks as serialized content', () => {
     const message = new ToolMessage({
       content: [
@@ -118,6 +367,114 @@ describe('getTokenCountForMessage', () => {
 
     expect(count).toBeGreaterThan(5_000);
   });
+
+  test('prices Google image media blocks with the image estimator', () => {
+    const message = new ToolMessage({
+      content: [
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: pngDataUri(1024, 768),
+        },
+      ],
+      tool_call_id: 'google-image-media',
+    });
+
+    const count = getTokenCountForMessage(
+      message,
+      (text) => text.length,
+      'o200k_base'
+    );
+
+    // 3 message tokens + ceil((85 + 4 * 170) * 1.05)
+    expect(count).toBe(807);
+  });
+
+  test('prices Google PDF media blocks per estimated page', () => {
+    const message = new ToolMessage({
+      content: [
+        {
+          type: 'media',
+          mime_type: 'application/pdf',
+          data: 'A'.repeat(150_000),
+        },
+      ],
+      tool_call_id: 'google-pdf-media',
+    });
+
+    const count = getTokenCountForMessage(
+      message,
+      (text) => text.length,
+      'o200k_base'
+    );
+
+    // 3 message tokens + ceil((2 pages * 1500) * 1.05)
+    expect(count).toBe(3153);
+  });
+
+  test('continues pricing Google audio and video media as timed content', () => {
+    const audio = new ToolMessage({
+      content: [
+        {
+          type: 'media',
+          mime_type: '  Audio/MP3 ; codecs=mp3 ',
+          data: 'A'.repeat(320_000),
+        },
+      ],
+      tool_call_id: 'google-audio-media',
+    });
+    const video = new ToolMessage({
+      content: [
+        {
+          type: 'media',
+          mimeType: 'video/mp4',
+          data: 'A'.repeat(1_000_000),
+        },
+      ],
+      tool_call_id: 'google-video-media',
+    });
+
+    expect(
+      getTokenCountForMessage(audio, (text) => text.length, 'o200k_base')
+    ).toBe(507);
+    expect(
+      getTokenCountForMessage(video, (text) => text.length, 'o200k_base')
+    ).toBe(948);
+  });
+
+  test.each([
+    ['mimeType', 'text/plain'],
+    ['mime_type', 'application/json'],
+  ])(
+    'conservatively prices unknown Google media MIME via %s',
+    (mimeKey, mimeType) => {
+      let toJSONCalls = 0;
+      const data = 'A'.repeat(100_000);
+      const message = new ToolMessage({
+        content: [
+          {
+            type: 'media',
+            [mimeKey]: mimeType,
+            data,
+            toJSON() {
+              toJSONCalls++;
+              return { expanded: 'x'.repeat(1_000_000) };
+            },
+          },
+        ],
+        tool_call_id: 'google-unknown-media',
+      });
+
+      const count = getTokenCountForMessage(
+        message,
+        (text) => text.length,
+        'o200k_base'
+      );
+
+      expect(count).toBeGreaterThan(data.length);
+      expect(toJSONCalls).toBe(0);
+    }
+  );
 });
 
 describe('estimateImageBlockTokens', () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -1,7 +1,8 @@
-import { HumanMessage } from '@langchain/core/messages';
+import { HumanMessage, ToolMessage } from '@langchain/core/messages';
 import {
   encodingForModel,
   createTokenCounter,
+  getTokenCountForMessage,
   TokenEncoderManager,
   estimateImageBlockTokens,
   estimateDocumentBlockTokens,
@@ -82,15 +83,58 @@ describe('createTokenCounter with different encodings', () => {
   });
 });
 
+describe('getTokenCountForMessage', () => {
+  test('counts opaque structured tool-result blocks as serialized content', () => {
+    const message = new ToolMessage({
+      content: [
+        {
+          type: 'json',
+          rows: Array.from({ length: 20 }, (_, index) => ({
+            id: index,
+            value: `row-${index}-${'x'.repeat(100)}`,
+          })),
+        },
+      ],
+      tool_call_id: 'select-query',
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(count).toBeGreaterThan(2_000);
+  });
+
+  test('counts spoofed media types as serialized structured output', () => {
+    const message = new ToolMessage({
+      content: [
+        {
+          type: 'image_url',
+          rows: [{ value: 'x'.repeat(5_000) }],
+        },
+      ],
+      tool_call_id: 'spoofed-image',
+    });
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(count).toBeGreaterThan(5_000);
+  });
+});
+
 describe('estimateImageBlockTokens', () => {
   test('claude: tokens = ceil(w*h/750), floored at 1024', () => {
-    const block = { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } };
+    const block = {
+      type: 'image_url',
+      image_url: { url: pngDataUri(1024, 768) },
+    };
     // 1024*768/750 = 1048.58 -> ceil 1049 (> 1024 floor)
     expect(estimateImageBlockTokens(block, 'claude')).toBe(1049);
   });
 
   test('openai: tokens = 85 + tiles*170 (512px tiles)', () => {
-    const block = { type: 'image_url', image_url: { url: pngDataUri(1024, 768) } };
+    const block = {
+      type: 'image_url',
+      image_url: { url: pngDataUri(1024, 768) },
+    };
     // ceil(1024/512)*ceil(768/512) = 2*2 = 4 tiles -> 85 + 680 = 765
     expect(estimateImageBlockTokens(block, 'o200k_base')).toBe(765);
   });
@@ -110,7 +154,9 @@ describe('estimateDocumentBlockTokens', () => {
 
   test('text document is tokenized directly via getTokenCount', () => {
     const block = { type: 'file', source_type: 'text', text: 'hello world' };
-    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(11);
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(
+      11
+    );
   });
 
   test('base64 PDF is priced per estimated page', () => {
@@ -122,12 +168,16 @@ describe('estimateDocumentBlockTokens', () => {
     };
     // ceil(150000/75000) = 2 pages
     expect(estimateDocumentBlockTokens(block, 'claude', countChars)).toBe(4000); // 2 * 2000
-    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(3000); // 2 * 1500
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(
+      3000
+    ); // 2 * 1500
   });
 
   test('url-referenced document uses the conservative fallback', () => {
     const block = { type: 'file', source_type: 'url', url: 'https://x/y.pdf' };
-    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(2000);
+    expect(estimateDocumentBlockTokens(block, 'o200k_base', countChars)).toBe(
+      2000
+    );
   });
 });
 
@@ -137,49 +187,79 @@ describe('estimateTimedMediaBlockTokens', () => {
   test('Google video (type=media, video/*): duration from size at ~300 tok/s', () => {
     // 1,000,000 b64 -> 750,000 bytes / 250,000 Bps = 3s * 300 = 900
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'video/mp4', data: B64(1_000_000) }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'video/mp4',
+        data: B64(1_000_000),
+      })
     ).toBe(900);
   });
 
   test('Google audio (type=media, audio/*): 32 tok/s at ~16KB/s', () => {
     // 320,000 b64 -> 240,000 bytes / 16,000 Bps = 15s * 32 = 480
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'audio/mp3', data: B64(320_000) }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'audio/mp3',
+        data: B64(320_000),
+      })
     ).toBe(480);
   });
 
   test('OpenRouter input_audio: estimates from base64 data', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'input_audio', input_audio: { data: B64(320_000) } }),
+      estimateTimedMediaBlockTokens({
+        type: 'input_audio',
+        input_audio: { data: B64(320_000) },
+      })
     ).toBe(480);
   });
 
   test('OpenRouter video_url with a data: URL estimates from size', () => {
     const url = `data:video/mp4;base64,${B64(1_000_000)}`;
-    expect(estimateTimedMediaBlockTokens({ type: 'video_url', video_url: { url } })).toBe(900);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'video_url', video_url: { url } })
+    ).toBe(900);
   });
 
   test('bare remote URL falls back to the flat ~30s estimate', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video_url', video_url: { url: 'https://x/v.mp4' } }),
+      estimateTimedMediaBlockTokens({
+        type: 'video_url',
+        video_url: { url: 'https://x/v.mp4' },
+      })
     ).toBe(9000);
-    expect(estimateTimedMediaBlockTokens({ type: 'input_audio', input_audio: {} })).toBe(960);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'input_audio', input_audio: {} })
+    ).toBe(960);
   });
 
   test('clamps to at least one second of tokens for tiny payloads', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'audio/wav', data: 'AAAA' }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'audio/wav',
+        data: 'AAAA',
+      })
     ).toBe(32);
   });
 
   test('standard type=video / type=audio blocks (Bedrock converter shape)', () => {
     // 750,000 bytes video / 250,000 = 3s * 300 = 900
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video', mimeType: 'video/mp4', data: B64(1_000_000) }),
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        mimeType: 'video/mp4',
+        data: B64(1_000_000),
+      })
     ).toBe(900);
     // 240,000 bytes audio / 16,000 = 15s * 32 = 480
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mpeg', data: B64(320_000) }),
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        mimeType: 'audio/mpeg',
+        data: B64(320_000),
+      })
     ).toBe(480);
   });
 
@@ -190,7 +270,7 @@ describe('estimateTimedMediaBlockTokens', () => {
         type: 'audio',
         mimeType: 'audio/wav',
         data: new Uint8Array(240_000),
-      }),
+      })
     ).toBe(480);
     // base64 data url on a bare video block
     expect(
@@ -198,37 +278,63 @@ describe('estimateTimedMediaBlockTokens', () => {
         type: 'video',
         mimeType: 'video/mp4',
         url: `data:video/mp4;base64,${B64(1_000_000)}`,
-      }),
+      })
     ).toBe(900);
   });
 
   test('non-video/audio media (image/document MIME) is NOT priced as video', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'image/png', fileUri: 's3://x' }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'image/png',
+        fileUri: 's3://x',
+      })
     ).toBe(0);
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'image/png', data: B64(400_000) }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'image/png',
+        data: B64(400_000),
+      })
     ).toBe(0);
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'application/pdf', data: B64(400) }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'application/pdf',
+        data: B64(400),
+      })
     ).toBe(0);
   });
 
   test('fileId / bare URL with no size falls back to the ~30s estimate', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video', mimeType: 'video/mp4', fileId: 's3://v' }),
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        mimeType: 'video/mp4',
+        fileId: 's3://v',
+      })
     ).toBe(9000);
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mp3', fileId: 's3://a' }),
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        mimeType: 'audio/mp3',
+        fileId: 's3://a',
+      })
     ).toBe(960);
   });
 
   test('reads native Bedrock nested source.bytes (video/audio)', () => {
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video', video: { source: { bytes: new Uint8Array(750_000) } } }),
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        video: { source: { bytes: new Uint8Array(750_000) } },
+      })
     ).toBe(900); // 750,000 / 250,000 = 3s * 300
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio', audio: { source: { bytes: new Uint8Array(240_000) } } }),
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        audio: { source: { bytes: new Uint8Array(240_000) } },
+      })
     ).toBe(480); // 240,000 / 16,000 = 15s * 32
   });
 
@@ -238,41 +344,57 @@ describe('estimateTimedMediaBlockTokens', () => {
       estimateTimedMediaBlockTokens({
         type: 'video',
         video: { url: `data:video/mp4;base64,${B64(1_000_000)}` },
-      }),
+      })
     ).toBe(900);
     // nested base64 data (240,000 -> 15s * 32)
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio', audio: { data: B64(320_000) } }),
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        audio: { data: B64(320_000) },
+      })
     ).toBe(480);
     // nested REMOTE url has no size -> ~30s fallback
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video', video: { url: 'https://x/v.mp4' } }),
+      estimateTimedMediaBlockTokens({
+        type: 'video',
+        video: { url: 'https://x/v.mp4' },
+      })
     ).toBe(9000);
   });
 
   test('non-data URI schemes (gs://, s3://) are treated as remote, not base64', () => {
     // gs:// audio must hit the ~30s remote fallback, not clamp to 32
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio', mimeType: 'audio/mp3', url: 'gs://bucket/a.mp3' }),
+      estimateTimedMediaBlockTokens({
+        type: 'audio',
+        mimeType: 'audio/mp3',
+        url: 'gs://bucket/a.mp3',
+      })
     ).toBe(960);
     expect(
-      estimateTimedMediaBlockTokens({ type: 'media', mimeType: 'video/mp4', data: 's3://bucket/v.mp4' }),
+      estimateTimedMediaBlockTokens({
+        type: 'media',
+        mimeType: 'video/mp4',
+        data: 's3://bucket/v.mp4',
+      })
     ).toBe(9000);
   });
 
   test('classifies Google MIME-as-type blocks (type is the mime string)', () => {
     // { type: 'audio/wav', data } -> 240,000 bytes / 16,000 = 15s * 32 = 480
     expect(
-      estimateTimedMediaBlockTokens({ type: 'audio/wav', data: B64(320_000) }),
+      estimateTimedMediaBlockTokens({ type: 'audio/wav', data: B64(320_000) })
     ).toBe(480);
     // { type: 'video/mp4', data } -> 750,000 / 250,000 = 3s * 300 = 900
     expect(
-      estimateTimedMediaBlockTokens({ type: 'video/mp4', data: B64(1_000_000) }),
+      estimateTimedMediaBlockTokens({ type: 'video/mp4', data: B64(1_000_000) })
     ).toBe(900);
   });
 
   test('returns 0 for non-timed-media blocks', () => {
     expect(estimateTimedMediaBlockTokens({ type: 'text' })).toBe(0);
-    expect(estimateTimedMediaBlockTokens({ type: 'image/png', data: B64(400) })).toBe(0);
+    expect(
+      estimateTimedMediaBlockTokens({ type: 'image/png', data: B64(400) })
+    ).toBe(0);
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -36,6 +36,7 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
+import { serializeStructuredValue } from '@/utils/toolContent';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
@@ -843,11 +844,14 @@ async function dispatchEagerToolCompletions(args: {
     }
     const output =
       result.status === 'error'
-        ? `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`
+        ? truncateToolResultContent(
+          `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
+          maxToolResultChars
+        )
         : truncateToolResultContent(
           typeof result.content === 'string'
             ? result.content
-            : JSON.stringify(result.content),
+            : serializeStructuredValue(result.content),
           maxToolResultChars
         );
 
@@ -2248,11 +2252,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
             const contentIndex =
               toolCallIndices[toolCallIndex] ?? runStep.index;
             const toolCallId = toolCall.id ?? '';
-            registerToolContentIndex(
-              toolStepContent,
-              contentIndex,
-              toolCallId
-            );
+            registerToolContentIndex(toolStepContent, contentIndex, toolCallId);
             const contentPart: t.MessageContentComplex = {
               type: ContentTypes.TOOL_CALL,
               tool_call: {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -27,6 +27,10 @@ import {
   normalizeError,
 } from '@/tools/eagerEventExecution';
 import {
+  serializeStructuredValueBounded,
+  serializeToolContentBounded,
+} from '@/utils/toolContent';
+import {
   handleServerToolResult,
   handleToolCallChunks,
   handleToolCalls,
@@ -36,7 +40,6 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
-import { serializeStructuredValue } from '@/utils/toolContent';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
@@ -842,18 +845,20 @@ async function dispatchEagerToolCompletions(args: {
     if (stepId === '') {
       continue;
     }
-    const output =
-      result.status === 'error'
-        ? truncateToolResultContent(
-          `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
-          maxToolResultChars
-        )
-        : truncateToolResultContent(
-          typeof result.content === 'string'
-            ? result.content
-            : serializeStructuredValue(result.content),
-          maxToolResultChars
-        );
+    let output: string;
+    if (result.status === 'error') {
+      output = truncateToolResultContent(
+        `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
+        maxToolResultChars
+      );
+    } else if (typeof result.content === 'string') {
+      output = truncateToolResultContent(result.content, maxToolResultChars);
+    } else {
+      output = serializeStructuredValueBounded(
+        result.content,
+        maxToolResultChars
+      ).content;
+    }
 
     try {
       const dispatched = await safeDispatchCustomEvent(
@@ -865,7 +870,10 @@ async function dispatchEagerToolCompletions(args: {
             type: 'tool_call' as const,
             eager: true,
             tool_call: {
-              args: JSON.stringify(record.request.args),
+              args: serializeToolContentBounded(
+                record.request.args,
+                maxToolResultChars
+              ),
               name: record.toolName,
               id: result.toolCallId,
               output,

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1045,6 +1045,83 @@ describe('recency window — first-turn protection', () => {
     expect(tailToolMsg!.content).not.toContain('FULL_ORIGINAL_OUTPUT');
   });
 
+  it('bounds restored tool originals and preserves ToolMessage metadata', async () => {
+    captureEvents();
+
+    let restoredToolMessage: ToolMessage | undefined;
+    const invokeMock = jest.fn().mockImplementation((messages: unknown) => {
+      restoredToolMessage = (messages as Array<unknown>).find(
+        (message) => message instanceof ToolMessage
+      ) as ToolMessage | undefined;
+      return Promise.resolve({ content: 'summary' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const artifact = { source: 'clickhouse', rows: 1_000 };
+    const originalToolMessage = new ToolMessage({
+      content: 'masked-stub',
+      tool_call_id: 'bounded',
+      name: 'run_select_query',
+      status: 'success',
+      artifact,
+      metadata: { traceId: 'trace-1' },
+      additional_kwargs: { retained: true },
+      response_metadata: { requestId: 'request-1' },
+    });
+    const agentContext = createAgentContext({
+      maxContextTokens: 2_000,
+      summarizationConfig: { retainRecent: { turns: 0 } },
+      setSummary: jest.fn(),
+    });
+    agentContext.pendingOriginalToolContent = new Map([
+      [2, `[{"rows":"${'x'.repeat(20_000)}"}]`],
+    ]);
+
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('query the table'),
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'bounded', name: 'run_select_query', args: {} }],
+          }),
+          originalToolMessage,
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(restoredToolMessage).toBeDefined();
+    expect(typeof restoredToolMessage!.content).toBe('string');
+    expect(String(restoredToolMessage!.content).length).toBeLessThanOrEqual(
+      2_400
+    );
+    expect(restoredToolMessage!.content).toContain('[truncated:');
+    expect(restoredToolMessage!.status).toBe('success');
+    expect(restoredToolMessage!.artifact).toBe(artifact);
+    expect(restoredToolMessage!.metadata).toEqual({ traceId: 'trace-1' });
+    expect(restoredToolMessage!.additional_kwargs).toEqual({ retained: true });
+    expect(restoredToolMessage!.response_metadata).toEqual({
+      requestId: 'request-1',
+    });
+    expect(originalToolMessage.content).toBe('masked-stub');
+  });
+
   it('preserves tail-relevant pendingOriginalToolContent entries (reindexed) for future summaries', async () => {
     captureEvents();
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -11,6 +11,11 @@ import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
 import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  serializeToolContent,
+} from '@/utils/toolContent';
+import {
   addTailCacheControl,
   resolvePromptCacheTtl,
   type PromptCacheTtl,
@@ -28,6 +33,7 @@ import {
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
@@ -206,10 +212,7 @@ function extractToolFailuresSection(messages: BaseMessage[]): string {
     }
 
     const toolName = toolMsg.name ?? 'tool';
-    const content =
-      typeof toolMsg.content === 'string'
-        ? toolMsg.content
-        : JSON.stringify(toolMsg.content);
+    const content = serializeToolContent(toolMsg.content);
     const normalized = content.replace(/\s+/g, ' ').trim();
     const summary =
       normalized.length > MAX_TOOL_FAILURE_CHARS
@@ -250,24 +253,41 @@ function enrichSummary(summaryText: string, messages: BaseMessage[]): string {
  */
 function restoreOriginalToolContent(
   messages: BaseMessage[],
-  originalToolContent: Map<number, string> | undefined
+  originalToolContent: Map<number, string> | undefined,
+  maxContextTokens?: number
 ): BaseMessage[] {
   if (originalToolContent == null || originalToolContent.size === 0) {
     return messages;
   }
-  const restored = [...messages];
-  for (const [idx, content] of originalToolContent) {
-    const msg = restored[idx];
-    if (msg instanceof ToolMessage) {
-      restored[idx] = new ToolMessage({
-        content,
-        tool_call_id: msg.tool_call_id,
-        name: msg.name,
-        id: msg.id,
-        additional_kwargs: msg.additional_kwargs,
-        response_metadata: msg.response_metadata,
-      });
+
+  const restorable: Array<{
+    index: number;
+    message: ToolMessage;
+    content: string;
+  }> = [];
+  for (const [index, content] of originalToolContent) {
+    const message = messages[index];
+    if (message instanceof ToolMessage) {
+      restorable.push({ index, message, content });
     }
+  }
+  if (restorable.length === 0) {
+    return messages;
+  }
+
+  /**
+   * Restored originals improve checkpoint quality, but they still feed a
+   * provider call. Share one tool-result budget across every restoration so
+   * several previously masked results cannot overflow the summarizer.
+   */
+  let remainingChars = calculateMaxToolResultChars(maxContextTokens);
+  const restored = [...messages];
+  for (let i = 0; i < restorable.length; i++) {
+    const { index, message, content } = restorable[i];
+    const maxChars = Math.floor(remainingChars / (restorable.length - i));
+    const compacted = compactToolContent(content, maxChars).content;
+    restored[index] = cloneToolMessageWithContent(message, compacted);
+    remainingChars -= serializeToolContent(compacted).length;
   }
   return restored;
 }
@@ -845,7 +865,8 @@ export function createSummarizeNode({
 
     const restoredMessages = restoreOriginalToolContent(
       state.messages,
-      originalPending
+      originalPending,
+      agentContext.maxContextTokens
     );
 
     const runnableConfig = config ?? graph.config;

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -13,6 +13,7 @@ import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
+  isComputerCallOutputMessage,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
@@ -270,7 +271,10 @@ function restoreOriginalToolContent(
   }> = [];
   for (const [index, content] of originalToolContent) {
     const message = messages[index];
-    if (message instanceof ToolMessage) {
+    if (
+      message instanceof ToolMessage &&
+      !isComputerCallOutputMessage(message)
+    ) {
       restorable.push({ index, message, content });
     }
   }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -13,7 +13,7 @@ import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
-  serializeToolContent,
+  serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
   addTailCacheControl,
@@ -212,7 +212,10 @@ function extractToolFailuresSection(messages: BaseMessage[]): string {
     }
 
     const toolName = toolMsg.name ?? 'tool';
-    const content = serializeToolContent(toolMsg.content);
+    const content = serializeToolContentBounded(
+      toolMsg.content,
+      MAX_TOOL_FAILURE_CHARS * 4
+    );
     const normalized = content.replace(/\s+/g, ' ').trim();
     const summary =
       normalized.length > MAX_TOOL_FAILURE_CHARS
@@ -287,7 +290,7 @@ function restoreOriginalToolContent(
     const maxChars = Math.floor(remainingChars / (restorable.length - i));
     const compacted = compactToolContent(content, maxChars).content;
     restored[index] = cloneToolMessageWithContent(message, compacted);
-    remainingChars -= serializeToolContent(compacted).length;
+    remainingChars -= serializeToolContentBounded(compacted, maxChars).length;
   }
   return restored;
 }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -39,15 +39,16 @@ import type {
 } from '@/hooks';
 import type * as t from '@/types';
 import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  serializeStructuredValueBounded,
+  serializeToolContentBounded,
+} from '@/utils/toolContent';
+import {
   buildToolExecutionRequestPlan,
   resolveRuntimeSessionHint,
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
-import {
-  cloneToolMessageWithContent,
-  compactToolContent,
-  serializeStructuredValue,
-} from '@/utils/toolContent';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
@@ -123,6 +124,40 @@ type RunToolBatchContext<T = unknown> = {
    */
   runInput?: T;
 };
+
+type BoundedToolOutput = {
+  content: string;
+  registryContent: string;
+};
+
+/**
+ * Produces the provider preview and, when requested, the exact registry prefix
+ * in one bounded traversal. String outputs already exist in memory when a tool
+ * returns them; structured outputs must never be fully JSON-materialized before
+ * either limit applies.
+ */
+function serializeToolOutputWithinLimits(
+  output: unknown,
+  maxToolResultChars: number,
+  registryPrefixChars = 0
+): BoundedToolOutput {
+  if (typeof output === 'string') {
+    return {
+      content: truncateToolResultContent(output, maxToolResultChars),
+      registryContent: registryPrefixChars > 0 ? output : '',
+    };
+  }
+
+  const serialized = serializeStructuredValueBounded(
+    output,
+    maxToolResultChars,
+    registryPrefixChars
+  );
+  return {
+    content: serialized.content,
+    registryContent: serialized.prefix,
+  };
+}
 
 const TOOL_NODE_RUN_NAME = 'tool_batch';
 const NANOID_URL_ALPHABET =
@@ -1184,22 +1219,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
         return toolMsg;
       }
-      const rawContent =
-        typeof output === 'string' ? output : serializeStructuredValue(output);
-      const truncated = truncateToolResultContent(
-        rawContent,
-        this.maxToolResultChars
+      const serialized = serializeToolOutputWithinLimits(
+        output,
+        this.maxToolResultChars,
+        this.toolOutputRegistry != null && refKey != null
+          ? this.toolOutputRegistry.perOutputLimit
+          : 0
       );
       const refMeta = this.recordOutputReference(
         runId,
-        stripCodeSessionFileSummary(rawContent),
+        stripCodeSessionFileSummary(serialized.registryContent),
         refKey,
         unresolvedRefs
       );
       return new ToolMessage({
         status: 'success',
         name: tool.name,
-        content: truncated,
+        content: serialized.content,
         tool_call_id: call.id!,
         ...(refMeta != null && {
           additional_kwargs: refMeta as Record<string, unknown>,
@@ -1641,7 +1677,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           error:
             typeof output.content === 'string'
               ? output.content
-              : serializeStructuredValue(output.content),
+              : serializeStructuredValueBounded(
+                output.content,
+                this.maxToolResultChars
+              ).content,
           stepId,
           turn,
         },
@@ -1693,10 +1732,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       if (postResult?.updatedOutput != null) {
-        const replaced =
-          typeof postResult.updatedOutput === 'string'
-            ? postResult.updatedOutput
-            : serializeStructuredValue(postResult.updatedOutput);
         // Keep the tool-output registry in sync with what the model
         // actually sees. Without this, `runTool` already registered
         // the PRE-hook content under `_refKey`, and a later
@@ -1711,13 +1746,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           | undefined;
         const refKey = refMeta?._refKey;
         const refScope = refMeta?._refScope;
-        if (this.toolOutputRegistry != null && refKey != null) {
-          this.toolOutputRegistry.set(refScope, refKey, replaced);
-        }
-        return cloneToolMessageWithContent(
-          output,
-          compactToolContent(replaced, this.maxToolResultChars).content
+        const replaced = serializeToolOutputWithinLimits(
+          postResult.updatedOutput,
+          this.maxToolResultChars,
+          this.toolOutputRegistry != null && refKey != null
+            ? this.toolOutputRegistry.perOutputLimit
+            : 0
         );
+        if (this.toolOutputRegistry != null && refKey != null) {
+          this.toolOutputRegistry.set(
+            refScope,
+            refKey,
+            replaced.registryContent
+          );
+        }
+        return cloneToolMessageWithContent(output, replaced.content);
       }
     }
 
@@ -2003,7 +2046,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const contentString =
         typeof toolMessage.content === 'string'
           ? toolMessage.content
-          : serializeStructuredValue(toolMessage.content);
+          : serializeStructuredValueBounded(
+            toolMessage.content,
+            this.maxToolResultChars
+          ).content;
 
       /**
        * Prefer the post-substitution args when a `{{…}}` placeholder
@@ -2013,10 +2059,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        */
       const effectiveArgs = resolvedArgsByCallId?.get(toolCallId) ?? call.args;
       const tool_call: t.ProcessedToolCall = {
-        args:
-          typeof effectiveArgs === 'string'
-            ? (effectiveArgs as string)
-            : JSON.stringify((effectiveArgs as unknown) ?? {}),
+        args: serializeToolContentBounded(
+          (effectiveArgs as unknown) ?? {},
+          this.maxToolResultChars
+        ),
         name: call.name,
         id: toolCallId,
         output: contentString,
@@ -2959,14 +3005,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             }
           }
         } else {
-          let registryRaw =
-            typeof result.content === 'string'
-              ? result.content
-              : serializeStructuredValue(result.content);
-          contentString = truncateToolResultContent(
-            registryRaw,
-            this.maxToolResultChars
+          const batchIndex = batchIndexByCallId.get(result.toolCallId);
+          const refKey =
+            this.toolOutputRegistry != null &&
+            batchIndex != null &&
+            turn != null
+              ? buildReferenceKey(batchIndex, turn)
+              : undefined;
+          let serialized = serializeToolOutputWithinLimits(
+            result.content,
+            this.maxToolResultChars,
+            this.toolOutputRegistry != null && refKey != null
+              ? this.toolOutputRegistry.perOutputLimit
+              : 0
           );
+          let registryRaw = serialized.registryContent;
+          contentString = serialized.content;
 
           if (hasPostHook) {
             const hookResult = await executeHooks({
@@ -2993,15 +3047,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               }
             }
             if (hookResult?.updatedOutput != null) {
-              const replaced =
-                typeof hookResult.updatedOutput === 'string'
-                  ? hookResult.updatedOutput
-                  : serializeStructuredValue(hookResult.updatedOutput);
-              registryRaw = replaced;
-              contentString = truncateToolResultContent(
-                replaced,
-                this.maxToolResultChars
+              serialized = serializeToolOutputWithinLimits(
+                hookResult.updatedOutput,
+                this.maxToolResultChars,
+                this.toolOutputRegistry != null && refKey != null
+                  ? this.toolOutputRegistry.perOutputLimit
+                  : 0
               );
+              registryRaw = serialized.registryContent;
+              contentString = serialized.content;
               finalToolOutput = hookResult.updatedOutput;
               /**
                * The hook ACTUALLY rewrote this output: any completion the
@@ -3015,14 +3069,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             }
           }
 
-          const batchIndex = batchIndexByCallId.get(result.toolCallId);
           const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
-          const refKey =
-            this.toolOutputRegistry != null &&
-            batchIndex != null &&
-            turn != null
-              ? buildReferenceKey(batchIndex, turn)
-              : undefined;
           const successRefMeta = this.recordOutputReference(
             registryRunId,
             stripCodeSessionFileSummary(registryRaw),
@@ -3313,7 +3360,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           index: turn ?? this.toolUsageCount.get(toolName) ?? 0,
           type: 'tool_call' as const,
           tool_call: {
-            args: JSON.stringify(args),
+            args: serializeToolContentBounded(args, this.maxToolResultChars),
             name: toolName,
             id: toolCallId,
             output,
@@ -3344,12 +3391,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
           this.maxToolResultChars
         )
-        : truncateToolResultContent(
-          typeof result.content === 'string'
-            ? result.content
-            : serializeStructuredValue(result.content),
+        : serializeToolOutputWithinLimits(
+          result.content,
           this.maxToolResultChars
-        );
+        ).content;
     return this.dispatchStepCompleted(
       result.toolCallId,
       request.name,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -41,6 +41,9 @@ import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
+  hasComputerCallOutputMarker,
+  isComputerCallOutputContent,
+  isComputerCallOutputMessage,
   serializeStructuredValueBounded,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
@@ -1147,6 +1150,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       if (isBaseMessage(output) && output._getType() === 'tool') {
         const toolMsg = output as ToolMessage;
+        if (isComputerCallOutputMessage(toolMsg)) {
+          return toolMsg;
+        }
         const originalContent = toolMsg.content;
         const compacted = compactToolContent(
           originalContent,
@@ -1732,6 +1738,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       if (postResult?.updatedOutput != null) {
+        if (hasComputerCallOutputMarker(output)) {
+          if (!isComputerCallOutputContent(postResult.updatedOutput)) {
+            throw new Error(
+              'PostToolUse updatedOutput for a computer call must be a valid screenshot URL or screenshot content block.'
+            );
+          }
+          return cloneToolMessageWithContent(output, postResult.updatedOutput);
+        }
         // Keep the tool-output registry in sync with what the model
         // actually sees. Without this, `runTool` already registered
         // the PRE-hook content under `_refKey`, and a later
@@ -2043,13 +2057,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      const contentString =
-        typeof toolMessage.content === 'string'
-          ? toolMessage.content
-          : serializeStructuredValueBounded(
-            toolMessage.content,
-            this.maxToolResultChars
-          ).content;
+      let contentString: string;
+      if (isComputerCallOutputMessage(toolMessage)) {
+        contentString = truncateToolResultContent(
+          '[Computer screenshot omitted from completion event]',
+          this.maxToolResultChars
+        );
+      } else if (typeof toolMessage.content === 'string') {
+        contentString = toolMessage.content;
+      } else {
+        contentString = serializeStructuredValueBounded(
+          toolMessage.content,
+          this.maxToolResultChars
+        ).content;
+      }
 
       /**
        * Prefer the post-substitution args when a `{{…}}` placeholder

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -44,6 +44,11 @@ import {
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  serializeStructuredValue,
+} from '@/utils/toolContent';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -1107,6 +1112,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       if (isBaseMessage(output) && output._getType() === 'tool') {
         const toolMsg = output as ToolMessage;
+        const originalContent = toolMsg.content;
+        const compacted = compactToolContent(
+          originalContent,
+          this.maxToolResultChars
+        );
+        if (compacted.changed) {
+          toolMsg.content = compacted.content;
+        }
         const isError = toolMsg.status === 'error';
         if (isError) {
           /**
@@ -1125,14 +1138,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           return toolMsg;
         }
         if (this.toolOutputRegistry != null || unresolvedRefs.length > 0) {
-          if (typeof toolMsg.content === 'string') {
-            const rawContent = toolMsg.content;
+          if (typeof originalContent === 'string') {
+            const rawContent = originalContent;
             const registryContent = stripCodeSessionFileSummary(rawContent);
-            const llmContent = truncateToolResultContent(
-              rawContent,
-              this.maxToolResultChars
-            );
-            toolMsg.content = llmContent;
             const refMeta = this.recordOutputReference(
               runId,
               registryContent,
@@ -1148,7 +1156,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           } else {
             /**
              * Non-string content (multi-part content blocks — text +
-             * image). Known limitation: we cannot register under a
+             * image). It is now bounded for the LLM, but cannot register under a
              * reference key because there's no canonical serialized
              * form. Warn once per tool per run when the caller
              * intended to register. The unresolved-refs hint is still
@@ -1177,7 +1185,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         return toolMsg;
       }
       const rawContent =
-        typeof output === 'string' ? output : JSON.stringify(output);
+        typeof output === 'string' ? output : serializeStructuredValue(output);
       const truncated = truncateToolResultContent(
         rawContent,
         this.maxToolResultChars
@@ -1258,7 +1266,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
       }
-      const errorContent = `Error: ${e.message}\n Please fix your mistakes.`;
+      const errorContent = truncateToolResultContent(
+        `Error: ${e.message}\n Please fix your mistakes.`,
+        this.maxToolResultChars
+      );
       const refMeta =
         unresolvedRefs.length > 0
           ? this.recordOutputReference(
@@ -1630,7 +1641,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           error:
             typeof output.content === 'string'
               ? output.content
-              : JSON.stringify(output.content),
+              : serializeStructuredValue(output.content),
           stepId,
           turn,
         },
@@ -1685,7 +1696,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const replaced =
           typeof postResult.updatedOutput === 'string'
             ? postResult.updatedOutput
-            : JSON.stringify(postResult.updatedOutput);
+            : serializeStructuredValue(postResult.updatedOutput);
         // Keep the tool-output registry in sync with what the model
         // actually sees. Without this, `runTool` already registered
         // the PRE-hook content under `_refKey`, and a later
@@ -1703,14 +1714,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (this.toolOutputRegistry != null && refKey != null) {
           this.toolOutputRegistry.set(refScope, refKey, replaced);
         }
-        return new ToolMessage({
-          status: output.status,
-          name: output.name,
-          content: replaced,
-          artifact: output.artifact,
-          tool_call_id: output.tool_call_id,
-          additional_kwargs: output.additional_kwargs,
-        });
+        return cloneToolMessageWithContent(
+          output,
+          compactToolContent(replaced, this.maxToolResultChars).content
+        );
       }
     }
 
@@ -1996,7 +2003,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const contentString =
         typeof toolMessage.content === 'string'
           ? toolMessage.content
-          : JSON.stringify(toolMessage.content);
+          : serializeStructuredValue(toolMessage.content);
 
       /**
        * Prefer the post-substitution args when a `{{…}}` placeholder
@@ -2886,7 +2893,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         let finalToolOutput: unknown = result.content;
 
         if (result.status === 'error') {
-          contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
+          contentString = truncateToolResultContent(
+            `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
+            this.maxToolResultChars
+          );
           /**
            * Error results bypass registration but stamp the
            * unresolved-refs hint into `additional_kwargs` so the lazy
@@ -2952,7 +2962,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           let registryRaw =
             typeof result.content === 'string'
               ? result.content
-              : JSON.stringify(result.content);
+              : serializeStructuredValue(result.content);
           contentString = truncateToolResultContent(
             registryRaw,
             this.maxToolResultChars
@@ -2986,7 +2996,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               const replaced =
                 typeof hookResult.updatedOutput === 'string'
                   ? hookResult.updatedOutput
-                  : JSON.stringify(hookResult.updatedOutput);
+                  : serializeStructuredValue(hookResult.updatedOutput);
               registryRaw = replaced;
               contentString = truncateToolResultContent(
                 replaced,
@@ -3330,11 +3340,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   ): Promise<boolean> {
     const output =
       result.status === 'error'
-        ? `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`
+        ? truncateToolResultContent(
+          `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`,
+          this.maxToolResultChars
+        )
         : truncateToolResultContent(
           typeof result.content === 'string'
             ? result.content
-            : JSON.stringify(result.content),
+            : serializeStructuredValue(result.content),
           this.maxToolResultChars
         );
     return this.dispatchStepCompleted(

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -29,7 +29,7 @@ function createAIMessageWithToolCalls(
 type CompletionEvent = {
   result: {
     id: string;
-    tool_call: { id: string; output: string };
+    tool_call: { id: string; output: string; args?: string };
   };
 };
 
@@ -171,6 +171,56 @@ describe('ToolNode per-call onResult completion emission', () => {
     expect(completions).toHaveLength(1);
     expect(completions[0].result.tool_call.output).toBe(serialized);
     expect(result.messages[0].content).toBe(serialized);
+  });
+
+  it('bounds cyclic tool args without losing the completion event', async () => {
+    const completions: CompletionEvent[] = [];
+    const cyclicArgs: Record<string, unknown> = { city: 'NYC' };
+    cyclicArgs.self = cyclicArgs;
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as CompletionEvent);
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'success',
+          content: 'sunny',
+        });
+        await flushAsync();
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: cyclicArgs },
+        ]),
+      ],
+    });
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].result.tool_call.args).toContain('[Circular]');
+    expect(completions[0].result.tool_call.output).toBe('sunny');
   });
 
   it('ignores duplicate and unknown onResult reports', async () => {

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -173,6 +173,54 @@ describe('ToolNode per-call onResult completion emission', () => {
     expect(result.messages[0].content).toBe(serialized);
   });
 
+  it('omits native computer screenshots from completion events', async () => {
+    const completions: CompletionEvent[] = [];
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const computerOutput = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'call_computer',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const computer = createDummyTool('computer_use');
+    (
+      computer as unknown as {
+        invoke: () => Promise<ToolMessage>;
+      }
+    ).invoke = async () => computerOutput;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as CompletionEvent);
+        }
+      });
+    const toolNode = new ToolNode({
+      tools: [computer],
+      eventDrivenMode: true,
+      directToolNames: new Set(['computer_use']),
+      toolCallStepIds: new Map([['call_computer', 'step_computer']]),
+      maxToolResultChars: 80,
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_computer', name: 'computer_use', args: {} },
+        ]),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    expect(result.messages[0]).toBe(computerOutput);
+    expect(result.messages[0].content).toBe(screenshot);
+    expect(completions).toHaveLength(1);
+    expect(completions[0].result.tool_call.output).toContain(
+      'Computer screenshot omitted'
+    );
+    expect(completions[0].result.tool_call.output.length).toBeLessThanOrEqual(
+      80
+    );
+  });
+
   it('bounds cyclic tool args without losing the completion event', async () => {
     const completions: CompletionEvent[] = [];
     const cyclicArgs: Record<string, unknown> = { city: 'NYC' };

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -124,6 +124,55 @@ describe('ToolNode per-call onResult completion emission', () => {
     expect(result.messages.map((m) => m.content)).toEqual(['sunny', '42']);
   });
 
+  it('serializes bigint output before early and batch completion paths', async () => {
+    const completions: CompletionEvent[] = [];
+    const structuredOutput = [{ rowsRead: BigInt(42), status: 'complete' }];
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as CompletionEvent);
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.onResult?.({
+          toolCallId: 'call_query',
+          status: 'success',
+          content: structuredOutput,
+        });
+        await flushAsync();
+        batch.resolve([
+          {
+            toolCallId: 'call_query',
+            status: 'success',
+            content: structuredOutput,
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('query')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_query', 'step_query']]),
+    });
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_query', name: 'query', args: {} },
+        ]),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    const serialized = '[{"rowsRead":"42","status":"complete"}]';
+    expect(completions).toHaveLength(1);
+    expect(completions[0].result.tool_call.output).toBe(serialized);
+    expect(result.messages[0].content).toBe(serialized);
+  });
+
   it('ignores duplicate and unknown onResult reports', async () => {
     const completions: CompletionEvent[] = [];
 

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -113,6 +113,54 @@ describe('ToolNode tool output references', () => {
 
       expect(capturedArgs).toEqual(['raw {{tool0turn0}}']);
     });
+
+    it('bounds structured ToolMessage output before its first model call', async () => {
+      const structuredTool = tool(
+        async () =>
+          new ToolMessage({
+            status: 'success',
+            content: [
+              {
+                type: 'json',
+                rows: Array.from({ length: 20 }, (_, index) => ({
+                  id: index,
+                  value: `${'x'.repeat(100)}-${index}`,
+                })),
+              },
+            ],
+            artifact: { source: 'clickhouse' },
+            metadata: { requestId: 'request-1' },
+            name: 'run_select_query',
+            tool_call_id: 'c1',
+          }),
+        {
+          name: 'run_select_query',
+          description: 'returns structured rows',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+      const node = new ToolNode({
+        tools: [structuredTool],
+        maxToolResultChars: 200,
+      });
+
+      const [msg] = await invokeBatch(node, [
+        {
+          id: 'c1',
+          name: 'run_select_query',
+          command: 'SELECT * FROM events',
+        },
+      ]);
+
+      expect(typeof msg.content).toBe('string');
+      expect(msg.content).toContain('truncated');
+      expect((msg.content as string).length).toBeLessThanOrEqual(200);
+      expect(msg.tool_call_id).toBe('c1');
+      expect(msg.name).toBe('run_select_query');
+      expect(msg.status).toBe('success');
+      expect(msg.artifact).toEqual({ source: 'clickhouse' });
+      expect(msg.metadata).toEqual({ requestId: 'request-1' });
+    });
   });
 
   describe('enabled', () => {
@@ -823,7 +871,7 @@ describe('ToolNode tool output references', () => {
       expect(JSON.parse(stepCompletedArgs[1]).command).toBe('echo STORED');
     });
 
-    it('records unresolved refs as metadata on non-string ToolMessage content (content untouched)', async () => {
+    it('records unresolved refs on multipart ToolMessage content within the cap', async () => {
       const complexTool = tool(
         async () =>
           new ToolMessage({
@@ -855,8 +903,8 @@ describe('ToolNode tool output references', () => {
 
       expect(Array.isArray(msg.content)).toBe(true);
       const blocks = msg.content as Array<{ type: string; text?: string }>;
-      // Multi-part content is untouched at storage time — the lazy
-      // transform handles the unresolved-refs warning at request time.
+      // In-budget multi-part content stays intact; the lazy transform handles
+      // the unresolved-refs warning at request time.
       expect(blocks).toHaveLength(2);
       expect(blocks[0].type).toBe('text');
       expect(blocks[0].text).toBe('data');

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -412,6 +412,67 @@ describe('ToolNode tool output references', () => {
       ).toBe(raw);
     });
 
+    it('preserves structured output exactly up to the registry limit', async () => {
+      const structured = {
+        rows: Array.from({ length: 10 }, (_, index) => ({
+          id: index,
+          value: `row-${index}-${'x'.repeat(100)}`,
+        })),
+      };
+      const exact = JSON.stringify(structured);
+      const capturedArgs: string[] = [];
+      let callCount = 0;
+      const structuredTool = createEchoTool({
+        capturedArgs: [],
+        outputs: ['unused'],
+        name: 'structured',
+      });
+      (
+        structuredTool as unknown as {
+          invoke: (input: {
+            args: { command: string };
+          }) => Promise<typeof structured | string>;
+        }
+      ).invoke = async (input) => {
+        capturedArgs.push(input.args.command);
+        return callCount++ === 0 ? structured : 'done';
+      };
+      const node = new ToolNode({
+        tools: [structuredTool],
+        maxToolResultChars: 100,
+        toolOutputReferences: {
+          enabled: true,
+          maxOutputSize: exact.length,
+        },
+      });
+
+      const [first] = await invokeBatch(
+        node,
+        [{ id: 'c1', name: 'structured', command: 'first' }],
+        'structured-raw-preservation'
+      );
+      await invokeBatch(
+        node,
+        [
+          {
+            id: 'c2',
+            name: 'structured',
+            command: '{{tool0turn0}}',
+          },
+        ],
+        'structured-raw-preservation'
+      );
+
+      expect((first.content as string).length).toBeLessThanOrEqual(100);
+      expect(first.content).toContain('truncated');
+      expect(capturedArgs[1]).toBe(exact);
+      expect(
+        node
+          ._unsafeGetToolOutputRegistry()!
+          .get('structured-raw-preservation', 'tool0turn0')
+      ).toBe(exact);
+    });
+
     it('uses each batch\'s own turn when ToolNode is invoked concurrently within a run', async () => {
       const gates: Record<string, () => void> = {};
       const slowTool = tool(

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -90,6 +90,38 @@ describe('annotateMessagesForLLM', () => {
     expect(out[0]).not.toBe(tm);
   });
 
+  it('does not annotate native computer screenshot strings', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'stored-raw');
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const tm = makeToolMessage({
+      content: screenshot,
+      additional_kwargs: {
+        type: 'computer_call_output',
+        _refKey: 'tool0turn0',
+      },
+    });
+
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+
+    expect(out[0].content).toBe(screenshot);
+    expect((out[0] as ToolMessage).additional_kwargs.type).toBe(
+      'computer_call_output'
+    );
+    expect((out[0] as ToolMessage).additional_kwargs._refKey).toBeUndefined();
+  });
+
+  it('leaves native computer screenshots reference-equal without ref metadata', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'data:image/png;base64,AAAA',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const messages = [tm];
+
+    expect(annotateMessagesForLLM(messages, registry, 'r1')).toBe(messages);
+  });
+
   it('leaves content untouched but strips framework metadata when _refKey is stale', () => {
     /**
      * Stale `_refKey` (not in registry) doesn't trigger annotation,

--- a/src/tools/__tests__/directToolHooks.test.ts
+++ b/src/tools/__tests__/directToolHooks.test.ts
@@ -202,6 +202,123 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
     expect(message.content).toContain('truncated');
   });
 
+  it('keeps native computer screenshots intact despite the generic result cap', async () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const contents: ToolMessage['content'][] = [
+      screenshot,
+      [{ type: 'computer_screenshot', image_url: screenshot }],
+    ];
+
+    for (let i = 0; i < contents.length; i++) {
+      const name = `computer_output_${i}`;
+      const computerOutput = new ToolMessage({
+        content: contents[i],
+        tool_call_id: `computer-call-${i}`,
+        additional_kwargs: { type: 'computer_call_output' },
+      });
+      const computer = createDirectTool(name, () => 'unused');
+      (
+        computer as unknown as {
+          invoke: () => Promise<ToolMessage>;
+        }
+      ).invoke = async () => computerOutput;
+      const node = new ToolNode({
+        tools: [computer],
+        eventDrivenMode: true,
+        directToolNames: new Set([name]),
+        maxToolResultChars: 80,
+      });
+
+      const result = await node.invoke({
+        messages: [aiCall(`computer-call-${i}`, name, {})],
+      });
+      const [message] = toolMessages(result);
+
+      expect(message).toBe(computerOutput);
+      expect(message.content).toBe(contents[i]);
+      expect(message.additional_kwargs.type).toBe('computer_call_output');
+    }
+  });
+
+  it('preserves a valid PostToolUse computer screenshot replacement', async () => {
+    const original = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const replacement = `data:image/png;base64,${'B'.repeat(2_000)}`;
+    const computerOutput = new ToolMessage({
+      content: original,
+      tool_call_id: 'computer-hook-valid',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const computer = createDirectTool('computer_hook_valid', () => 'unused');
+    (
+      computer as unknown as {
+        invoke: () => Promise<ToolMessage>;
+      }
+    ).invoke = async () => computerOutput;
+    const registry = new HookRegistry();
+    registry.register('PostToolUse', {
+      hooks: [
+        async (): Promise<PostToolUseHookOutput> => ({
+          updatedOutput: replacement,
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [computer],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['computer_hook_valid']),
+      maxToolResultChars: 80,
+    });
+
+    const result = await node.invoke({
+      messages: [aiCall('computer-hook-valid', 'computer_hook_valid', {})],
+    });
+    const [message] = toolMessages(result);
+
+    expect(message.content).toBe(replacement);
+    expect(message.additional_kwargs.type).toBe('computer_call_output');
+  });
+
+  it('rejects an invalid PostToolUse computer output replacement', async () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(2_000)}`;
+    const computerOutput = new ToolMessage({
+      content: screenshot,
+      tool_call_id: 'computer-hook-invalid',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    const computer = createDirectTool('computer_hook_invalid', () => 'unused');
+    (
+      computer as unknown as {
+        invoke: () => Promise<ToolMessage>;
+      }
+    ).invoke = async () => computerOutput;
+    const registry = new HookRegistry();
+    registry.register('PostToolUse', {
+      hooks: [
+        async (): Promise<PostToolUseHookOutput> => ({
+          updatedOutput: 'redacted screenshot',
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [computer],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['computer_hook_invalid']),
+      maxToolResultChars: 80,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [
+          aiCall('computer-hook-invalid', 'computer_hook_invalid', {}),
+        ],
+      })
+    ).rejects.toThrow(
+      'PostToolUse updatedOutput for a computer call must be a valid screenshot'
+    );
+  });
+
   it('caps returned and thrown direct-tool errors before storing them', async () => {
     const returnedError = createDirectTool(
       'returned_error',

--- a/src/tools/__tests__/directToolHooks.test.ts
+++ b/src/tools/__tests__/directToolHooks.test.ts
@@ -169,6 +169,39 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
     expect(message.content).toBe('[{"rowsRead":"42","status":"complete"}]');
   });
 
+  it('bounds a large structured result without invoking toJSON', async () => {
+    let toJSONCalls = 0;
+    const structuredOutput = {
+      rows: [{ value: 'x'.repeat(20_000) }],
+      toJSON() {
+        toJSONCalls++;
+        return 'y'.repeat(100_000);
+      },
+    };
+    const query = createDirectTool('large_query', () => 'unused');
+    (
+      query as unknown as {
+        invoke: () => Promise<typeof structuredOutput>;
+      }
+    ).invoke = async () => structuredOutput;
+    const node = new ToolNode({
+      tools: [query],
+      eventDrivenMode: true,
+      directToolNames: new Set(['large_query']),
+      maxToolResultChars: 200,
+    });
+
+    const result = await node.invoke({
+      messages: [aiCall('call_large', 'large_query', {})],
+    });
+    const [message] = toolMessages(result);
+
+    expect(toJSONCalls).toBe(0);
+    expect(typeof message.content).toBe('string');
+    expect((message.content as string).length).toBeLessThanOrEqual(200);
+    expect(message.content).toContain('truncated');
+  });
+
   it('caps returned and thrown direct-tool errors before storing them', async () => {
     const returnedError = createDirectTool(
       'returned_error',

--- a/src/tools/__tests__/directToolHooks.test.ts
+++ b/src/tools/__tests__/directToolHooks.test.ts
@@ -20,7 +20,7 @@ import { ToolNode } from '../ToolNode';
  */
 function createDirectTool(
   name: string,
-  impl: (args: Record<string, unknown>) => string | Promise<string>
+  impl: (args: Record<string, unknown>) => unknown | Promise<unknown>
 ): StructuredToolInterface {
   return tool(async (args: Record<string, unknown>) => impl(args), {
     name,
@@ -147,6 +147,67 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
     expect(String(message.content)).toBe('ran:ls');
   });
 
+  it('serializes bigint values in direct structured tool output', async () => {
+    const query = createDirectTool('query', () => 'unused');
+    (
+      query as unknown as {
+        invoke: () => Promise<Array<Record<string, unknown>>>;
+      }
+    ).invoke = async () => [{ rowsRead: BigInt(42), status: 'complete' }];
+    const node = new ToolNode({
+      tools: [query],
+      eventDrivenMode: true,
+      directToolNames: new Set(['query']),
+    });
+
+    const result = await node.invoke({
+      messages: [aiCall('call_bigint', 'query', {})],
+    });
+    const [message] = toolMessages(result);
+
+    expect(message.status).toBe('success');
+    expect(message.content).toBe('[{"rowsRead":"42","status":"complete"}]');
+  });
+
+  it('caps returned and thrown direct-tool errors before storing them', async () => {
+    const returnedError = createDirectTool(
+      'returned_error',
+      () =>
+        new ToolMessage({
+          status: 'error',
+          content: `returned:${'x'.repeat(2_000)}`,
+          tool_call_id: 'returned',
+        })
+    );
+    const thrownError = createDirectTool('thrown_error', () => {
+      throw new Error(`thrown:${'y'.repeat(2_000)}`);
+    });
+    const node = new ToolNode({
+      tools: [returnedError, thrownError],
+      eventDrivenMode: true,
+      directToolNames: new Set(['returned_error', 'thrown_error']),
+      maxToolResultChars: 200,
+    });
+
+    const returned = toolMessages(
+      await node.invoke({
+        messages: [aiCall('returned', 'returned_error', {})],
+      })
+    )[0];
+    const thrown = toolMessages(
+      await node.invoke({
+        messages: [aiCall('thrown', 'thrown_error', {})],
+      })
+    )[0];
+
+    expect(returned.status).toBe('error');
+    expect(String(returned.content).length).toBeLessThanOrEqual(200);
+    expect(returned.content).toContain('[truncated:');
+    expect(thrown.status).toBe('error');
+    expect(String(thrown.content).length).toBeLessThanOrEqual(200);
+    expect(thrown.content).toContain('[truncated:');
+  });
+
   it('executingAgentId defaults to agentId for direct callers, and an explicit value wins', async () => {
     const echo = createDirectTool('echo', (args) => `ran:${args.command}`);
     const captured: Array<string | undefined> = [];
@@ -245,6 +306,37 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
     const [message] = toolMessages(result);
     expect(String(message.content)).toBe('REPLACED');
     expect(message.status).toBe('success');
+  });
+
+  it('caps PostToolUse updatedOutput after the hook rewrite', async () => {
+    const echo = createDirectTool('echo', () => 'ORIGINAL');
+    const replacement = 'R'.repeat(500);
+
+    const registry = new HookRegistry();
+    registry.register('PostToolUse', {
+      hooks: [
+        async (): Promise<PostToolUseHookOutput> => ({
+          updatedOutput: replacement,
+        }),
+      ],
+    });
+
+    const node = new ToolNode({
+      tools: [echo],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      maxToolResultChars: 50,
+    });
+
+    const result = await node.invoke({
+      messages: [aiCall('call_5_capped', 'echo', { command: 'x' })],
+    });
+    const [message] = toolMessages(result);
+
+    expect(typeof message.content).toBe('string');
+    expect((message.content as string).length).toBeLessThanOrEqual(50);
+    expect(message.content).not.toBe(replacement);
   });
 
   it('PostToolUseFailure observes errors thrown by the tool', async () => {
@@ -376,11 +468,16 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
 
     // Patch the tool's `func` to record the turn the body sees via the
     // standard LangChain config.toolCall.turn channel.
-    const originalFunc = (echo as unknown as { func: (input: unknown, config: unknown) => Promise<string> }).func;
-    (echo as unknown as { func: (input: unknown, config: unknown) => Promise<string> }).func = async (
-      input,
-      config
-    ): Promise<string> => {
+    const originalFunc = (
+      echo as unknown as {
+        func: (input: unknown, config: unknown) => Promise<string>;
+      }
+    ).func;
+    (
+      echo as unknown as {
+        func: (input: unknown, config: unknown) => Promise<string>;
+      }
+    ).func = async (input, config): Promise<string> => {
       const t = (config as { toolCall?: { turn?: number } } | undefined)
         ?.toolCall?.turn;
       if (typeof t === 'number') bodyTurns.push(t);
@@ -424,7 +521,8 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
       hooks: [
         async (): Promise<PreToolUseHookOutput> => ({
           decision: 'allow',
-          additionalContext: 'POLICY-NOTE: writes here require approval next time',
+          additionalContext:
+            'POLICY-NOTE: writes here require approval next time',
         }),
       ],
     });

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -29,6 +29,7 @@ import {
   HARD_MAX_TOOL_RESULT_CHARS,
   HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
 } from '@/utils/truncation';
+import { isComputerCallOutputMessage } from '@/utils/toolContent';
 
 /**
  * Non-global matcher for a single `{{tool<i>turn<n>}}` placeholder.
@@ -656,6 +657,11 @@ export function annotateMessagesForLLM(
     const hasRefScope = '_refScope' in meta;
     const hasUnresolvedField = '_unresolvedRefs' in meta;
     if (!hasRefKey && !hasRefScope && !hasUnresolvedField) continue;
+    if (isComputerCallOutputMessage(m)) {
+      out ??= messages.slice();
+      out[i] = cloneToolMessageWithContent(m as ToolMessage, m.content);
+      continue;
+    }
 
     const refKey = readRefKey(meta);
     const unresolved = readUnresolvedRefs(meta);

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -336,7 +336,7 @@ export type ToolCallPart = {
   /** If provided, an identifier associated with the tool call */
   id?: string;
   /** If provided, the output of the tool call */
-  output?: string;
+  output?: ToolResultContent['content'];
   /** Auth URL */
   auth?: string;
   /** Expiration time */

--- a/src/utils/llm.test.ts
+++ b/src/utils/llm.test.ts
@@ -1,0 +1,18 @@
+import { isAnthropicLike } from './llm';
+import { Providers } from '@/common';
+
+describe('isAnthropicLike', () => {
+  it('treats the default Bedrock model as Claude', () => {
+    expect(isAnthropicLike(Providers.BEDROCK)).toBe(true);
+    expect(
+      isAnthropicLike(Providers.BEDROCK, {
+        model: 'anthropic.claude-sonnet-4-5',
+      })
+    ).toBe(true);
+    expect(
+      isAnthropicLike(Providers.BEDROCK, {
+        model: 'amazon.nova-pro-v1:0',
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -32,7 +32,10 @@ export function isAnthropicLike(
 ): boolean {
   if (provider === Providers.ANTHROPIC) return true;
   if (provider === Providers.BEDROCK) {
-    return /claude/i.test(String(clientOptions?.model ?? ''));
+    return (
+      clientOptions?.model == null ||
+      /claude/i.test(String(clientOptions.model))
+    );
   }
   return false;
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,8 +1,9 @@
 import { Tokenizer } from 'ai-tokenizer';
-import type { BaseMessage } from '@langchain/core/messages';
+import { isProxy } from 'node:util/types';
+import type { AIMessage, BaseMessage } from '@langchain/core/messages';
 import {
   isAtomicToolContentBlock,
-  serializeStructuredValue,
+  serializeStructuredValueBounded,
 } from './toolContent';
 import { ContentTypes } from '@/common/enum';
 
@@ -63,6 +64,15 @@ const TIMED_MEDIA_TYPES = new Set([
   'video_url',
   'input_audio',
 ]);
+/**
+ * Structured content is tokenized exactly up to this size. Larger values are
+ * traversed by the bounded serializer and priced conservatively for the omitted
+ * suffix, avoiding a full JSON string allocation in the context guard.
+ */
+const MAX_STRUCTURED_TOKENIZATION_CHARS = 200_000;
+/** One UTF-16 character can encode to several tokenizer pieces. */
+const MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR = 4;
+const MAX_STRUCTURED_SAFETY_INSPECTION_WORK = 10_000;
 
 /**
  * Extracts image dimensions from the first bytes of a base64-encoded
@@ -389,17 +399,16 @@ function mediaBlockByteLength(block: Record<string, unknown>): number {
 function timedMediaKind(
   block: Record<string, unknown>
 ): 'video' | 'audio' | null {
-  const type = typeof block.type === 'string' ? block.type : '';
+  const type =
+    typeof block.type === 'string' ? normalizeMediaMimeType(block.type) : '';
   if (type === 'input_audio' || type === 'audio') {
     return 'audio';
   }
   if (type === 'video_url' || type === 'video') {
     return 'video';
   }
-  const mime =
-    type === 'media' && typeof block.mimeType === 'string'
-      ? block.mimeType
-      : type;
+  const mediaMime = getMediaMimeType(block);
+  const mime = type === 'media' && mediaMime != null ? mediaMime : type;
   if (mime.startsWith('audio/')) {
     return 'audio';
   }
@@ -409,15 +418,143 @@ function timedMediaKind(
   return null;
 }
 
+function getMediaMimeType(block: Record<string, unknown>): string | undefined {
+  if (typeof block.mimeType === 'string') {
+    return normalizeMediaMimeType(block.mimeType);
+  }
+  if (typeof block.mime_type === 'string') {
+    return normalizeMediaMimeType(block.mime_type);
+  }
+  return undefined;
+}
+
+function normalizeMediaMimeType(mimeType: string): string {
+  return mimeType.split(';')[0].trim().toLowerCase();
+}
+
 /** Whether a content-block `type` can carry timed media — the fixed set plus the
  *  Google MIME-as-type shape (`audio/*` / `video/*`). Gates callers before they
  *  hand the block to {@link estimateTimedMediaBlockTokens}. */
 function isTimedMediaType(type: string): boolean {
+  const normalizedType = normalizeMediaMimeType(type);
   return (
-    TIMED_MEDIA_TYPES.has(type) ||
-    type.startsWith('audio/') ||
-    type.startsWith('video/')
+    TIMED_MEDIA_TYPES.has(normalizedType) ||
+    normalizedType.startsWith('audio/') ||
+    normalizedType.startsWith('video/')
   );
+}
+
+/** Conservatively prices unknown inline media without materializing JSON. */
+function estimateUnknownMediaBlockTokens(data: unknown): number {
+  if (typeof data === 'string') {
+    if (base64ByteLength(data) <= 0) {
+      return URL_DOCUMENT_FALLBACK_TOKENS;
+    }
+    return Math.max(URL_DOCUMENT_FALLBACK_TOKENS, data.length);
+  }
+  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+    return Math.max(
+      URL_DOCUMENT_FALLBACK_TOKENS,
+      Math.ceil((data.byteLength * 4) / 3)
+    );
+  }
+  return URL_DOCUMENT_FALLBACK_TOKENS;
+}
+
+/**
+ * Estimates Google `type: "media"` blocks whose MIME describes static content.
+ * Timed audio/video continues through {@link estimateTimedMediaBlockTokens}.
+ */
+function estimateStaticMediaBlockTokens(
+  block: Record<string, unknown>,
+  encoding: EncodingName,
+  getTokenCount: (text: string) => number
+): number | undefined {
+  const mediaMime = getMediaMimeType(block);
+  if (block.type !== 'media' || mediaMime == null) {
+    return undefined;
+  }
+
+  const mimeType = mediaMime;
+  const nestedMedia =
+    block.media != null && typeof block.media === 'object'
+      ? (block.media as Record<string, unknown>)
+      : undefined;
+  const data =
+    block.data ?? block.bytes ?? nestedMedia?.data ?? nestedMedia?.bytes;
+  const reference =
+    block.url ??
+    block.fileUri ??
+    block.fileId ??
+    nestedMedia?.url ??
+    nestedMedia?.fileUri ??
+    nestedMedia?.fileId;
+
+  if (mimeType.startsWith('image/')) {
+    let encodedImage: string | undefined;
+    if (typeof data === 'string') {
+      encodedImage = data;
+    } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      const view =
+        data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+      encodedImage = Buffer.from(view.subarray(0, 80)).toString('base64');
+    }
+
+    if (encodedImage != null && encodedImage.length > 0) {
+      return estimateImageBlockTokens(
+        {
+          type: 'image',
+          source: { type: 'base64', data: encodedImage },
+        },
+        encoding
+      );
+    }
+    return estimateImageBlockTokens(
+      {
+        type: 'image_url',
+        image_url: { url: typeof reference === 'string' ? reference : '' },
+      },
+      encoding
+    );
+  }
+
+  if (mimeType === 'application/pdf') {
+    if (typeof data === 'string' && data.length > 0) {
+      const comma = data.startsWith('data:') ? data.indexOf(',') : -1;
+      const base64Data = comma >= 0 ? data.slice(comma + 1) : data;
+      return estimateDocumentBlockTokens(
+        {
+          type: 'file',
+          source_type: 'base64',
+          mime_type: mimeType,
+          data: base64Data,
+        },
+        encoding,
+        getTokenCount
+      );
+    }
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      const estimatedBase64Chars = Math.ceil((data.byteLength * 4) / 3);
+      const pdfTokensPerPage =
+        encoding === 'claude'
+          ? ANTHROPIC_PDF_TOKENS_PER_PAGE
+          : OPENAI_PDF_TOKENS_PER_PAGE;
+      return (
+        Math.max(
+          1,
+          Math.ceil(estimatedBase64Chars / BASE64_BYTES_PER_PDF_PAGE)
+        ) * pdfTokensPerPage
+      );
+    }
+    return URL_DOCUMENT_FALLBACK_TOKENS;
+  }
+
+  if (mimeType.startsWith('audio/') || mimeType.startsWith('video/')) {
+    return undefined;
+  }
+  return estimateUnknownMediaBlockTokens(data);
 }
 
 /**
@@ -489,19 +626,282 @@ export function encodingForModel(model: string): EncodingName {
   return 'o200k_base';
 }
 
+type StructuredSafetyInspection = {
+  remaining: number;
+};
+
+function consumeStructuredSafetyWork(
+  inspection: StructuredSafetyInspection
+): boolean {
+  if (inspection.remaining <= 0) {
+    return false;
+  }
+  inspection.remaining--;
+  return true;
+}
+
+function hasUnsafeToJSON(
+  value: object,
+  inspection: StructuredSafetyInspection
+): boolean {
+  let current: object | null = value;
+  const seen = new Set<object>();
+  try {
+    while (current != null) {
+      if (isProxy(current)) {
+        return true;
+      }
+      if (seen.has(current) || !consumeStructuredSafetyWork(inspection)) {
+        return true;
+      }
+      seen.add(current);
+      const descriptor = Object.getOwnPropertyDescriptor(current, 'toJSON');
+      if (descriptor != null) {
+        return (
+          ('value' in descriptor && typeof descriptor.value === 'function') ||
+          !('value' in descriptor)
+        );
+      }
+      current = Object.getPrototypeOf(current) as object | null;
+    }
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+const arrayBufferByteLengthGetter = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype,
+  'byteLength'
+)?.get;
+
+/**
+ * Tests native binary values without `instanceof`, whose prototype walk can
+ * recurse or throw for adversarial proxies.
+ */
+function isNativeBinaryValue(value: object): boolean {
+  try {
+    if (ArrayBuffer.isView(value)) {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+  if (arrayBufferByteLengthGetter == null) {
+    return false;
+  }
+  try {
+    arrayBufferByteLengthGetter.call(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detects an inherited accessor without reading it. Any proxy/prototype trap or
+ * cyclic prototype chain is unsafe rather than observable to the caller.
+ */
+function hasUnsafeInheritedProperty(
+  value: object,
+  key: string,
+  inspection: StructuredSafetyInspection
+): boolean {
+  const seen = new Set<object>([value]);
+  let current: object | null;
+  try {
+    current = Object.getPrototypeOf(value) as object | null;
+  } catch {
+    return true;
+  }
+
+  while (current != null) {
+    if (isProxy(current)) {
+      return true;
+    }
+    if (seen.has(current) || !consumeStructuredSafetyWork(inspection)) {
+      return true;
+    }
+    seen.add(current);
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(current, key);
+    } catch {
+      return true;
+    }
+    if (descriptor != null) {
+      return !('value' in descriptor);
+    }
+    try {
+      current = Object.getPrototypeOf(current) as object | null;
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Detects values whose native JSON representation can differ after local
+ * measurement. Accessor properties and `toJSON` hooks are deliberately not
+ * invoked; values too large to inspect within bounded work are treated as
+ * unsafe so the caller can normalize or reject them conservatively.
+ */
+export function hasUnsafeStructuredSerialization(value: unknown): boolean {
+  if (typeof value === 'bigint') {
+    return true;
+  }
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  if (isProxy(value)) {
+    return true;
+  }
+  if (isNativeBinaryValue(value)) {
+    return true;
+  }
+
+  const stack: object[] = [value];
+  const seen = new Set<object>();
+  const inspection: StructuredSafetyInspection = {
+    remaining: MAX_STRUCTURED_SAFETY_INSPECTION_WORK,
+  };
+  while (stack.length > 0) {
+    const current = stack.pop() as object;
+    if (isProxy(current)) {
+      return true;
+    }
+    if (seen.has(current)) {
+      return true;
+    }
+    seen.add(current);
+    if (!consumeStructuredSafetyWork(inspection)) {
+      return true;
+    }
+
+    try {
+      if (hasUnsafeToJSON(current, inspection)) {
+        return true;
+      }
+      for (const key in current) {
+        if (!consumeStructuredSafetyWork(inspection)) {
+          return true;
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(current, key);
+        if (descriptor == null) {
+          if (hasUnsafeInheritedProperty(current, key, inspection)) {
+            return true;
+          }
+          continue;
+        }
+        if (descriptor.enumerable !== true) {
+          continue;
+        }
+        if (!('value' in descriptor)) {
+          return true;
+        }
+        if ('value' in descriptor) {
+          if (typeof descriptor.value === 'bigint') {
+            return true;
+          }
+          if (
+            descriptor.value != null &&
+            typeof descriptor.value === 'object' &&
+            isNativeBinaryValue(descriptor.value)
+          ) {
+            return true;
+          }
+          if (
+            descriptor.value != null &&
+            typeof descriptor.value === 'object'
+          ) {
+            stack.push(descriptor.value);
+          }
+        }
+      }
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getBoundedTextTokenCount(
+  value: string,
+  getTokenCount: (text: string) => number
+): number {
+  const preview =
+    value.length > MAX_STRUCTURED_TOKENIZATION_CHARS
+      ? value.slice(0, MAX_STRUCTURED_TOKENIZATION_CHARS)
+      : value;
+  const previewTokens = getTokenCount(preview);
+  const omittedChars = value.length - preview.length;
+  if (omittedChars <= 0) {
+    return previewTokens;
+  }
+  return Math.min(
+    Number.MAX_SAFE_INTEGER,
+    previewTokens + omittedChars * MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR
+  );
+}
+
+function getBoundedStructuredTokenCount(
+  value: unknown,
+  getTokenCount: (text: string) => number
+): number {
+  if (hasUnsafeStructuredSerialization(value)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  const serialized = serializeStructuredValueBounded(
+    value,
+    MAX_STRUCTURED_TOKENIZATION_CHARS
+  );
+  const previewTokens = getTokenCount(serialized.content);
+  if (!serialized.truncated) {
+    return previewTokens;
+  }
+  if (!Number.isSafeInteger(serialized.originalChars)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  const omittedChars = Math.max(
+    0,
+    serialized.originalChars - serialized.content.length
+  );
+  return Math.min(
+    Number.MAX_SAFE_INTEGER,
+    previewTokens + omittedChars * MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR
+  );
+}
+
 export function getTokenCountForMessage(
   message: BaseMessage,
   getTokenCount: (text: string) => number,
   encoding: EncodingName = 'o200k_base'
 ): number {
   const tokensPerMessage = 3;
+  const countText = (text: string): number =>
+    getBoundedTextTokenCount(text, getTokenCount);
+  if (isProxy(message)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
 
   type ContentBlock = Record<string, unknown> & {
     type?: string;
-    tool_call?: { name?: string; args?: unknown; output?: unknown };
+    tool_call?: {
+      id?: string;
+      name?: string;
+      args?: unknown;
+      output?: unknown;
+    };
   };
+  const representedToolCallIds = new Set<string>();
 
   const processValue = (value: unknown): void => {
+    if (value != null && typeof value === 'object' && isProxy(value)) {
+      numTokens = Number.MAX_SAFE_INTEGER;
+      return;
+    }
     if (Array.isArray(value)) {
       for (const raw of value) {
         if (
@@ -516,9 +916,20 @@ export function getTokenCountForMessage(
         if (item == null || typeof item !== 'object') {
           continue;
         }
+        if (isProxy(item)) {
+          numTokens = Number.MAX_SAFE_INTEGER;
+          return;
+        }
         if (typeof item.type !== 'string') {
-          numTokens += getTokenCount(serializeStructuredValue(item));
+          numTokens += getBoundedStructuredTokenCount(item, countText);
           continue;
+        }
+        if (item.type === ContentTypes.TOOL_CALL || item.type === 'tool_use') {
+          const inlineId =
+            typeof item.id === 'string' ? item.id : item.tool_call?.id;
+          if (typeof inlineId === 'string' && inlineId.length > 0) {
+            representedToolCallIds.add(inlineId);
+          }
         }
         if (item.type === ContentTypes.ERROR) {
           continue;
@@ -543,29 +954,47 @@ export function getTokenCountForMessage(
             item.type === ContentTypes.IMAGE_FILE)
         ) {
           numTokens += Math.ceil(
-            estimateDocumentBlockTokens(item, encoding, getTokenCount) *
+            estimateDocumentBlockTokens(item, encoding, countText) *
               IMAGE_TOKEN_SAFETY_MARGIN
           );
           continue;
         }
 
-        if (isAtomicToolContentBlock(item) && isTimedMediaType(item.type)) {
-          numTokens += Math.ceil(
-            estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
+        if (isAtomicToolContentBlock(item) && item.type === 'media') {
+          const staticMediaTokens = estimateStaticMediaBlockTokens(
+            item,
+            encoding,
+            countText
           );
-          continue;
+          if (staticMediaTokens != null) {
+            numTokens += Math.ceil(
+              staticMediaTokens * IMAGE_TOKEN_SAFETY_MARGIN
+            );
+            continue;
+          }
+        }
+
+        if (isAtomicToolContentBlock(item) && isTimedMediaType(item.type)) {
+          const timedMediaTokens = estimateTimedMediaBlockTokens(item);
+          if (timedMediaTokens > 0) {
+            numTokens += Math.ceil(
+              timedMediaTokens * IMAGE_TOKEN_SAFETY_MARGIN
+            );
+            continue;
+          }
         }
 
         if (item.type === ContentTypes.TOOL_CALL && item.tool_call != null) {
           const toolName = item.tool_call.name;
           if (typeof toolName === 'string' && toolName.length > 0) {
-            numTokens += getTokenCount(toolName);
+            numTokens += countText(toolName);
           }
           const args = item.tool_call.args;
           if (args != null) {
-            numTokens += getTokenCount(
-              typeof args === 'string' ? args : serializeStructuredValue(args)
-            );
+            numTokens +=
+              typeof args === 'string'
+                ? countText(args)
+                : getBoundedStructuredTokenCount(args, countText);
           }
           const output = item.tool_call.output;
           if (output != null) {
@@ -576,26 +1005,56 @@ export function getTokenCountForMessage(
 
         const nestedValue = item[item.type];
         if (nestedValue == null) {
-          numTokens += getTokenCount(serializeStructuredValue(item));
+          numTokens += getBoundedStructuredTokenCount(item, countText);
           continue;
         }
 
         processValue(nestedValue);
       }
     } else if (typeof value === 'string') {
-      numTokens += getTokenCount(value);
+      numTokens += countText(value);
     } else if (typeof value === 'number') {
-      numTokens += getTokenCount(value.toString());
+      numTokens += countText(value.toString());
     } else if (typeof value === 'boolean') {
-      numTokens += getTokenCount(value.toString());
+      numTokens += countText(value.toString());
     } else if (value != null && typeof value === 'object') {
-      numTokens += getTokenCount(serializeStructuredValue(value));
+      numTokens += getBoundedStructuredTokenCount(value, countText);
     }
   };
 
   let numTokens = tokensPerMessage;
   processValue(message.content);
-  return numTokens;
+  if (numTokens >= Number.MAX_SAFE_INTEGER) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (message.getType() === 'ai') {
+    const toolCalls = (message as AIMessage).tool_calls ?? [];
+    if (isProxy(toolCalls)) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    for (const toolCall of toolCalls) {
+      if (isProxy(toolCall)) {
+        return Number.MAX_SAFE_INTEGER;
+      }
+      if (
+        typeof toolCall.id === 'string' &&
+        representedToolCallIds.has(toolCall.id)
+      ) {
+        continue;
+      }
+      if (typeof toolCall.name === 'string' && toolCall.name.length > 0) {
+        numTokens += countText(toolCall.name);
+      }
+      const args: unknown = toolCall.args;
+      if (args != null) {
+        numTokens +=
+          typeof args === 'string'
+            ? countText(args)
+            : getBoundedStructuredTokenCount(args, countText);
+      }
+    }
+  }
+  return Math.min(Number.MAX_SAFE_INTEGER, numTokens);
 }
 
 /**

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,5 +1,9 @@
 import { Tokenizer } from 'ai-tokenizer';
 import type { BaseMessage } from '@langchain/core/messages';
+import {
+  isAtomicToolContentBlock,
+  serializeStructuredValue,
+} from './toolContent';
 import { ContentTypes } from '@/common/enum';
 
 export type EncodingName = 'o200k_base' | 'claude';
@@ -393,7 +397,9 @@ function timedMediaKind(
     return 'video';
   }
   const mime =
-    type === 'media' && typeof block.mimeType === 'string' ? block.mimeType : type;
+    type === 'media' && typeof block.mimeType === 'string'
+      ? block.mimeType
+      : type;
   if (mime.startsWith('audio/')) {
     return 'audio';
   }
@@ -492,14 +498,26 @@ export function getTokenCountForMessage(
 
   type ContentBlock = Record<string, unknown> & {
     type?: string;
-    tool_call?: { name?: string; args?: string; output?: string };
+    tool_call?: { name?: string; args?: unknown; output?: unknown };
   };
 
   const processValue = (value: unknown): void => {
     if (Array.isArray(value)) {
       for (const raw of value) {
+        if (
+          typeof raw === 'string' ||
+          typeof raw === 'number' ||
+          typeof raw === 'boolean'
+        ) {
+          processValue(raw);
+          continue;
+        }
         const item = raw as ContentBlock | null | undefined;
-        if (item == null || typeof item.type !== 'string') {
+        if (item == null || typeof item !== 'object') {
+          continue;
+        }
+        if (typeof item.type !== 'string') {
+          numTokens += getTokenCount(serializeStructuredValue(item));
           continue;
         }
         if (item.type === ContentTypes.ERROR) {
@@ -507,9 +525,10 @@ export function getTokenCountForMessage(
         }
 
         if (
-          item.type === ContentTypes.IMAGE_URL ||
-          item.type === 'image_url' ||
-          item.type === 'image'
+          isAtomicToolContentBlock(item) &&
+          (item.type === ContentTypes.IMAGE_URL ||
+            item.type === 'image_url' ||
+            item.type === 'image')
         ) {
           numTokens += Math.ceil(
             estimateImageBlockTokens(item, encoding) * IMAGE_TOKEN_SAFETY_MARGIN
@@ -518,9 +537,10 @@ export function getTokenCountForMessage(
         }
 
         if (
-          item.type === 'document' ||
-          item.type === 'file' ||
-          item.type === ContentTypes.IMAGE_FILE
+          isAtomicToolContentBlock(item) &&
+          (item.type === 'document' ||
+            item.type === 'file' ||
+            item.type === ContentTypes.IMAGE_FILE)
         ) {
           numTokens += Math.ceil(
             estimateDocumentBlockTokens(item, encoding, getTokenCount) *
@@ -529,7 +549,7 @@ export function getTokenCountForMessage(
           continue;
         }
 
-        if (isTimedMediaType(item.type)) {
+        if (isAtomicToolContentBlock(item) && isTimedMediaType(item.type)) {
           numTokens += Math.ceil(
             estimateTimedMediaBlockTokens(item) * IMAGE_TOKEN_SAFETY_MARGIN
           );
@@ -542,18 +562,21 @@ export function getTokenCountForMessage(
             numTokens += getTokenCount(toolName);
           }
           const args = item.tool_call.args;
-          if (typeof args === 'string' && args.length > 0) {
-            numTokens += getTokenCount(args);
+          if (args != null) {
+            numTokens += getTokenCount(
+              typeof args === 'string' ? args : serializeStructuredValue(args)
+            );
           }
           const output = item.tool_call.output;
-          if (typeof output === 'string' && output.length > 0) {
-            numTokens += getTokenCount(output);
+          if (output != null) {
+            processValue(output);
           }
           continue;
         }
 
         const nestedValue = item[item.type];
         if (nestedValue == null) {
+          numTokens += getTokenCount(serializeStructuredValue(item));
           continue;
         }
 
@@ -565,6 +588,8 @@ export function getTokenCountForMessage(
       numTokens += getTokenCount(value.toString());
     } else if (typeof value === 'boolean') {
       numTokens += getTokenCount(value.toString());
+    } else if (value != null && typeof value === 'object') {
+      numTokens += getTokenCount(serializeStructuredValue(value));
     }
   };
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -2,6 +2,7 @@ import { Tokenizer } from 'ai-tokenizer';
 import { isProxy } from 'node:util/types';
 import type { AIMessage, BaseMessage } from '@langchain/core/messages';
 import {
+  isComputerCallOutputContent,
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from './toolContent';
@@ -182,11 +183,20 @@ export function estimateImageBlockTokens(
 ): number {
   let base64Data: string | undefined;
 
-  if (block.type === ContentTypes.IMAGE_URL || block.type === 'image_url') {
+  if (
+    block.type === ContentTypes.IMAGE_URL ||
+    block.type === 'image_url' ||
+    block.type === 'computer_screenshot' ||
+    block.type === 'input_image'
+  ) {
     const imageUrl = block.image_url as string | { url?: string } | undefined;
     const url = typeof imageUrl === 'string' ? imageUrl : imageUrl?.url;
     if (typeof url === 'string' && url.startsWith('data:')) {
       base64Data = url;
+    } else if (typeof block.file_id === 'string' && block.file_id !== '') {
+      return block.detail === 'low'
+        ? OPENAI_IMAGE_LOW_TOKENS
+        : ANTHROPIC_IMAGE_MIN_TOKENS;
     } else {
       return ANTHROPIC_IMAGE_MIN_TOKENS;
     }
@@ -939,7 +949,9 @@ export function getTokenCountForMessage(
           isAtomicToolContentBlock(item) &&
           (item.type === ContentTypes.IMAGE_URL ||
             item.type === 'image_url' ||
-            item.type === 'image')
+            item.type === 'image' ||
+            item.type === 'computer_screenshot' ||
+            item.type === 'input_image')
         ) {
           numTokens += Math.ceil(
             estimateImageBlockTokens(item, encoding) * IMAGE_TOKEN_SAFETY_MARGIN
@@ -1022,12 +1034,51 @@ export function getTokenCountForMessage(
     }
   };
 
+  const rawAdditionalKwargs = message.additional_kwargs as unknown;
+  const additionalKwargs =
+    rawAdditionalKwargs != null && typeof rawAdditionalKwargs === 'object'
+      ? rawAdditionalKwargs
+      : undefined;
+  if (additionalKwargs != null && isProxy(additionalKwargs)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  let additionalType: PropertyDescriptor | undefined;
+  try {
+    additionalType =
+      additionalKwargs != null
+        ? Object.getOwnPropertyDescriptor(additionalKwargs, 'type')
+        : undefined;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  if (additionalType != null && !('value' in additionalType)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
   let numTokens = tokensPerMessage;
-  processValue(message.content);
+  const messageType = message.getType();
+  const isComputerCallOutput =
+    messageType === 'tool' &&
+    additionalType?.value === 'computer_call_output' &&
+    isComputerCallOutputContent(message.content);
+  if (isComputerCallOutput && typeof message.content === 'string') {
+    numTokens += Math.ceil(
+      estimateImageBlockTokens(
+        {
+          type: 'computer_screenshot',
+          image_url: message.content,
+        },
+        encoding
+      ) * IMAGE_TOKEN_SAFETY_MARGIN
+    );
+  } else {
+    processValue(message.content);
+  }
   if (numTokens >= Number.MAX_SAFE_INTEGER) {
     return Number.MAX_SAFE_INTEGER;
   }
-  if (message.getType() === 'ai') {
+  const messageRole = (message as BaseMessage & { role?: unknown }).role;
+  if (messageType === 'ai' || messageRole === 'assistant') {
     const toolCalls = (message as AIMessage).tool_calls ?? [];
     if (isProxy(toolCalls)) {
       return Number.MAX_SAFE_INTEGER;
@@ -1051,6 +1102,26 @@ export function getTokenCountForMessage(
           typeof args === 'string'
             ? countText(args)
             : getBoundedStructuredTokenCount(args, countText);
+      }
+    }
+    let legacyFunctionCall: PropertyDescriptor | undefined;
+    try {
+      legacyFunctionCall =
+        additionalKwargs != null
+          ? Object.getOwnPropertyDescriptor(additionalKwargs, 'function_call')
+          : undefined;
+    } catch {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    if (legacyFunctionCall != null) {
+      if (!('value' in legacyFunctionCall)) {
+        return Number.MAX_SAFE_INTEGER;
+      }
+      if (legacyFunctionCall.value != null) {
+        numTokens += getBoundedStructuredTokenCount(
+          legacyFunctionCall.value,
+          countText
+        );
       }
     }
   }

--- a/src/utils/toolContent.test.ts
+++ b/src/utils/toolContent.test.ts
@@ -2,6 +2,10 @@ import { spawnSync } from 'child_process';
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   compactToolContent,
+  getBoundedCacheControlledTextToolContent,
+  getBoundedSingleTextToolContent,
+  getComputerCallOutputScreenshot,
+  getToolContentCharLength,
   isAtomicToolContentBlock,
   serializeStructuredValue,
   serializeStructuredValueBounded,
@@ -121,6 +125,375 @@ describe('toolContent', () => {
 
     expect(result.changed).toBe(false);
     expect(result.content).toBe(content);
+  });
+
+  it('classifies each mixed content block once during compaction', () => {
+    const blocks: Array<Record<string, unknown>> = [];
+    const tracked = new Set<object>();
+    for (let i = 0; i < 100; i++) {
+      const text = { type: 'text', text: `row-${i}-${'x'.repeat(20)}` };
+      const image = {
+        type: 'image_url',
+        image_url: { url: `https://example.com/chart-${i}.png` },
+      };
+      const opaque = { type: 'json', row: { id: i } };
+      blocks.push(text, image, opaque);
+      tracked.add(text);
+      tracked.add(image);
+      tracked.add(opaque);
+    }
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    let topLevelSafetyWalks = 0;
+    const descriptorSpy = jest
+      .spyOn(Object, 'getOwnPropertyDescriptor')
+      .mockImplementation((target, property) => {
+        if (property === 'toJSON' && tracked.has(target as object)) {
+          topLevelSafetyWalks++;
+        }
+        return getOwnPropertyDescriptor(target, property);
+      });
+
+    const compacted = (() => {
+      try {
+        return compactToolContent(blocks as ToolContent, 1_000);
+      } finally {
+        descriptorSpy.mockRestore();
+      }
+    })();
+
+    expect(topLevelSafetyWalks).toBe(blocks.length);
+    expect(compacted.changed).toBe(true);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      1_000
+    );
+  });
+
+  it('does not reclassify oversized text blocks while serializing', () => {
+    const blocks: Array<Record<string, unknown>> = [];
+    const tracked = new Set<object>();
+    for (let i = 0; i < 300; i++) {
+      const block = {
+        type: 'text',
+        text: `row-${i}-${'x'.repeat(20)}`,
+      };
+      blocks.push(block);
+      tracked.add(block);
+    }
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    let topLevelSafetyWalks = 0;
+    const descriptorSpy = jest
+      .spyOn(Object, 'getOwnPropertyDescriptor')
+      .mockImplementation((target, property) => {
+        if (property === 'toJSON' && tracked.has(target as object)) {
+          topLevelSafetyWalks++;
+        }
+        return getOwnPropertyDescriptor(target, property);
+      });
+
+    const compacted = (() => {
+      try {
+        return compactToolContent(blocks as ToolContent, 1_000);
+      } finally {
+        descriptorSpy.mockRestore();
+      }
+    })();
+
+    expect(topLevelSafetyWalks).toBe(blocks.length);
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(1_000);
+  });
+
+  it('includes forwarded text-block metadata in the compaction bound', () => {
+    const citations = 'A'.repeat(1_000_000);
+    const content = [
+      {
+        type: 'text',
+        text: 'x',
+        citations,
+      },
+    ] as ToolContent;
+
+    const compacted = compactToolContent(content, 2_000);
+    const serialized = serializeToolContent(compacted.content);
+
+    expect(compacted.changed).toBe(true);
+    expect(compacted.content).not.toBe(content);
+    expect(serialized.length).toBeLessThanOrEqual(2_000);
+    expect(serialized).not.toContain(citations);
+    expect(compacted.originalChars).toBeGreaterThan(1_000_000);
+  });
+
+  it('does not trust callable serialization hooks on the content array', () => {
+    const toJSON = jest.fn(() => ({
+      expanded: 'x'.repeat(100_000),
+    }));
+    const content = [{ type: 'text', text: 'safe' }] as ToolContent;
+    Object.defineProperty(content, 'toJSON', {
+      enumerable: true,
+      value: toJSON,
+    });
+
+    const compacted = compactToolContent(content, 100);
+
+    expect(toJSON).not.toHaveBeenCalled();
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(100);
+  });
+
+  it('uses one bounded fallback when nested opaque validation is exhausted', () => {
+    const opaque = Array.from({ length: 10_001 }, (_, index) => index);
+    const image = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+    };
+    const content: unknown[] = [];
+    for (let i = 0; i < 25; i++) {
+      content.push(image, opaque);
+    }
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    let descriptorReads = 0;
+    const descriptorSpy = jest
+      .spyOn(Object, 'getOwnPropertyDescriptor')
+      .mockImplementation((target, property) => {
+        if (target === opaque && property !== 'toJSON') {
+          descriptorReads++;
+        }
+        return getOwnPropertyDescriptor(target, property);
+      });
+
+    const compacted = (() => {
+      try {
+        return compactToolContent(content as ToolContent, 1_000);
+      } finally {
+        descriptorSpy.mockRestore();
+      }
+    })();
+
+    expect(descriptorReads).toBeLessThan(400_000);
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(1_000);
+  });
+
+  it('preserves only the atomic occurrence that fits the budget', () => {
+    const image = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+    };
+    const imageChars = JSON.stringify(image).length;
+    const content = [
+      image,
+      image,
+      { type: 'text', text: 'x'.repeat(1_000) },
+    ] as ToolContent;
+
+    const compacted = compactToolContent(content, imageChars * 2 + 20);
+
+    expect(Array.isArray(compacted.content)).toBe(true);
+    expect(
+      (compacted.content as Exclude<ToolContent, string>).filter(
+        (block) => block === image
+      )
+    ).toHaveLength(1);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      imageChars * 2 + 20
+    );
+  });
+
+  it('accounts for non-finite numbers using their JSON null length', () => {
+    const content = [
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/chart.png' },
+        metadata: [NaN, NaN, NaN, NaN, NaN],
+      },
+    ] as ToolContent;
+    const maxChars = JSON.stringify(content).length - 1;
+
+    const compacted = compactToolContent(content, maxChars);
+
+    expect(compacted.changed).toBe(true);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      maxChars
+    );
+  });
+
+  it('fails closed without invoking traps on an array proxy prototype', () => {
+    let trapCalls = 0;
+    const proxyPrototype = new Proxy(Array.prototype, {
+      getOwnPropertyDescriptor() {
+        trapCalls++;
+        return undefined;
+      },
+      getPrototypeOf(target) {
+        trapCalls++;
+        return Reflect.getPrototypeOf(target);
+      },
+    });
+    const nested = ['safe'];
+    Object.setPrototypeOf(nested, proxyPrototype);
+
+    const compacted = compactToolContent(
+      [nested] as unknown as ToolContent,
+      100
+    );
+
+    expect(trapCalls).toBe(0);
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(100);
+  });
+
+  it('does not invoke overridden byteLength accessors on typed views', () => {
+    let byteLengthCalls = 0;
+    const bytes = new Uint8Array([1]);
+    Object.defineProperty(bytes, 'byteLength', {
+      get() {
+        byteLengthCalls++;
+        return 10_000_000;
+      },
+    });
+
+    const compacted = compactToolContent(
+      [{ type: 'video', data: bytes }] as ToolContent,
+      100
+    );
+
+    expect(byteLengthCalls).toBe(0);
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(100);
+  });
+
+  it('uses fixed native view names for exact cap accounting', () => {
+    const bytes = new Uint8Array([1]);
+    Object.defineProperty(bytes, 'constructor', {
+      value: { name: 'X'.repeat(1_000) },
+    });
+    const content = [{ type: 'video', data: bytes }] as ToolContent;
+
+    const compacted = compactToolContent(content, 60);
+    const serialized = serializeToolContent(compacted.content);
+
+    expect(compacted.changed).toBe(true);
+    expect(serialized.length).toBeLessThanOrEqual(60);
+    expect(serialized).not.toContain('X'.repeat(100));
+  });
+
+  it('caps aggregate character traversal across repeated opaque runs', () => {
+    const payload = 'x'.repeat(100_000);
+    const opaque = { type: 'json', payload };
+    const image = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+    };
+    const content = Array.from({ length: 20 }, (_, index) =>
+      index % 2 === 0 ? opaque : image
+    ) as ToolContent;
+    const charCodeAt = String.prototype.charCodeAt;
+    let characterReads = 0;
+    const charSpy = jest
+      .spyOn(String.prototype, 'charCodeAt')
+      .mockImplementation(function (this: string, index: number) {
+        characterReads++;
+        return charCodeAt.call(this, index);
+      });
+
+    const compacted = (() => {
+      try {
+        return compactToolContent(content, 200);
+      } finally {
+        charSpy.mockRestore();
+      }
+    })();
+
+    expect(characterReads).toBeLessThanOrEqual(1_010_000);
+    expect(compacted.changed).toBe(true);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      200
+    );
+    expect(compacted.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('bounds structured traversal across repeated block references', () => {
+    const metadata = Array.from({ length: 1_000 }, (_, index) => index);
+    const block = { type: 'text', text: 'safe', metadata };
+    const content = new Array(100).fill(block) as ToolContent;
+    const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    let descriptorReads = 0;
+    const descriptorSpy = jest
+      .spyOn(Object, 'getOwnPropertyDescriptor')
+      .mockImplementation((target, property) => {
+        if (target === metadata && property !== 'toJSON') {
+          descriptorReads++;
+        }
+        return getOwnPropertyDescriptor(target, property);
+      });
+
+    try {
+      expect(serializeToolContent(content)).toContain('safe');
+      expect(getToolContentCharLength(content)).toBeGreaterThan(0);
+      expect(
+        serializeToolContentBounded(content, 100).length
+      ).toBeLessThanOrEqual(100);
+    } finally {
+      descriptorSpy.mockRestore();
+    }
+
+    expect(descriptorReads).toBeLessThan(10_000);
+  });
+
+  it('rejects oversized MIME-like types before scanning each distinct block', () => {
+    const hugeType = `${'a'.repeat(100_000)}/b`;
+    const content = Array.from({ length: 50 }, () => ({
+      type: hugeType,
+      data: 'x',
+    })) as ToolContent;
+    const indexOf = String.prototype.indexOf;
+    let hugeTypeScans = 0;
+    const indexOfSpy = jest
+      .spyOn(String.prototype, 'indexOf')
+      .mockImplementation(function (
+        this: string,
+        searchString: string,
+        position?: number
+      ) {
+        if (String(this) === hugeType) {
+          hugeTypeScans++;
+        }
+        return indexOf.call(this, searchString, position);
+      });
+
+    const compacted = (() => {
+      try {
+        return compactToolContent(content, 200);
+      } finally {
+        indexOfSpy.mockRestore();
+      }
+    })();
+    const serialized = serializeToolContent(compacted.content);
+
+    expect(hugeTypeScans).toBe(0);
+    expect(compacted.changed).toBe(true);
+    expect(serialized.length).toBeLessThanOrEqual(200);
+    expect(serialized).not.toContain('a'.repeat(1_000));
+  });
+
+  it('bounds omitted atomic type labels before building the notice', () => {
+    const boundedType = `${'a'.repeat(250)}/b`;
+    const content = Array.from({ length: 50 }, () => ({
+      type: boundedType,
+      data: 'x',
+    })) as ToolContent;
+
+    const compacted = compactToolContent(content, 200);
+    const serialized = serializeToolContent(compacted.content);
+
+    expect(compacted.changed).toBe(true);
+    expect(serialized.length).toBeLessThanOrEqual(200);
+    expect(serialized).not.toContain(boundedType);
   });
 
   it('preserves safe provider-native tool-result blocks atomically', () => {
@@ -596,7 +969,7 @@ describe('toolContent', () => {
     const serialized = serializeStructuredValueBounded(value, 200);
 
     expect(getterCalls).toBe(0);
-    expect(serialized.content).toBe('[null]');
+    expect(serialized.content).toBe('"[Unsafe array omitted]"');
   });
 
   it('fails closed when a proxy blocks own property descriptors', () => {
@@ -835,16 +1208,14 @@ describe('toolContent', () => {
         await import('./src/utils/toolContent.ts');
       const payload = 'A'.repeat(32 * 1024 * 1024);
       const result = serializeStructuredValueBounded({ payload }, 4096);
-      const expectedLength = payload.length + '{"payload":""}'.length;
       if (
         result.content.length !== 4096 ||
-        result.originalChars !== expectedLength ||
+        result.originalChars !== Number.MAX_SAFE_INTEGER ||
         result.truncated !== true
       ) {
         throw new Error(JSON.stringify({
           contentLength: result.content.length,
           originalChars: result.originalChars,
-          expectedLength,
           truncated: result.truncated,
         }));
       }
@@ -930,6 +1301,114 @@ describe('toolContent', () => {
     expect(typeof compacted.content).toBe('string');
     expect((compacted.content as string).length).toBeLessThanOrEqual(200);
     expect(compacted.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('bounds canonical cache-controlled text without enumerating malformed arrays', () => {
+    const canonical = getBoundedCacheControlledTextToolContent(
+      [
+        {
+          type: 'text',
+          text: 'result body',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      6
+    );
+    const ownKeys = jest.spyOn(Reflect, 'ownKeys');
+    const malformed: unknown[] = [];
+    malformed.length = 100_000;
+
+    expect(canonical).toEqual([
+      {
+        type: 'text',
+        text: 'result',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    expect(
+      getBoundedCacheControlledTextToolContent(malformed, 100)
+    ).toBeUndefined();
+    expect(ownKeys).not.toHaveBeenCalled();
+    ownKeys.mockRestore();
+  });
+
+  it('rejects an accessor-backed cache ttl without invoking it', () => {
+    let ttlReads = 0;
+    const cacheControl = { type: 'ephemeral' };
+    Object.defineProperty(cacheControl, 'ttl', {
+      enumerable: true,
+      get() {
+        ttlReads++;
+        return '1h';
+      },
+    });
+
+    expect(
+      getBoundedCacheControlledTextToolContent(
+        [{ type: 'text', text: 'result', cache_control: cacheControl }],
+        100
+      )
+    ).toBeUndefined();
+    expect(ttlReads).toBe(0);
+
+    const nonEnumerableTtl = { type: 'ephemeral' };
+    Object.defineProperty(nonEnumerableTtl, 'ttl', { value: '1h' });
+    expect(
+      getBoundedCacheControlledTextToolContent(
+        [{ type: 'text', text: 'result', cache_control: nonEnumerableTtl }],
+        100
+      )
+    ).toBeUndefined();
+  });
+
+  it('only unwraps canonical text cache wrappers', () => {
+    expect(
+      getBoundedSingleTextToolContent(
+        [{ type: 'text', text: 'result', extra: true }],
+        100
+      )
+    ).toBeUndefined();
+    expect(
+      getBoundedCacheControlledTextToolContent(
+        [
+          {
+            type: 'text',
+            text: 'result',
+            cache_control: { type: 'ephemeral', extra: true },
+          },
+        ],
+        100
+      )
+    ).toBeUndefined();
+  });
+
+  it('rejects oversized screenshot URLs and file ids before scanning them', () => {
+    const oversizedUrl = `https://example.com/${'a'.repeat(20_000)}`;
+    const charCodeAt = jest.spyOn(String.prototype, 'charCodeAt');
+
+    const urlResult = getComputerCallOutputScreenshot(oversizedUrl);
+    const urlCharacterReads = charCodeAt.mock.calls.length;
+    charCodeAt.mockRestore();
+
+    expect(urlResult).toBeUndefined();
+    expect(urlCharacterReads).toBe(0);
+    expect(
+      getComputerCallOutputScreenshot([
+        {
+          type: 'input_image',
+          file_id: `file_${'a'.repeat(5_000)}`,
+        },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('preserves bounded native computer screenshots', () => {
+    const screenshot = `data:image/png;base64,${'A'.repeat(100_000)}`;
+
+    expect(getComputerCallOutputScreenshot(screenshot)).toEqual({
+      type: 'input_image',
+      image_url: screenshot,
+    });
   });
 
   it('keeps large bounded head-tail collection linear', () => {

--- a/src/utils/toolContent.test.ts
+++ b/src/utils/toolContent.test.ts
@@ -1,0 +1,186 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import {
+  compactToolContent,
+  isAtomicToolContentBlock,
+  serializeStructuredValue,
+  serializeToolContent,
+} from './toolContent';
+
+type ToolContent = BaseMessage['content'];
+
+describe('toolContent', () => {
+  it('normalizes a small opaque array to provider-neutral text', () => {
+    const content = [{ type: 'json', rows: [{ id: 1 }] }] as ToolContent;
+
+    const result = compactToolContent(content, 10_000);
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toBe(JSON.stringify(content));
+  });
+
+  it('does not trust a media-looking type without a valid media payload', () => {
+    const invalidBlocks = [
+      {
+        type: 'image_url',
+        rows: [{ id: 1, value: 'not an image' }],
+      },
+      { type: 'image', text: 'ordinary row' },
+      { type: 'file', content: [{ id: 1 }] },
+      { type: 'media', uri: 'not-a-supported-media-payload' },
+      { type: 'image_url', image_url: [{ id: 1 }] },
+      {
+        type: 'media',
+        mimeType: 'application/octet-stream',
+        data: [{ id: 1 }],
+      },
+    ];
+
+    for (const block of invalidBlocks) {
+      const content = [block] as ToolContent;
+      const result = compactToolContent(content, 10_000);
+
+      expect(result.changed).toBe(true);
+      expect(result.content).toBe(JSON.stringify(content));
+    }
+  });
+
+  it('recognizes native byte and resource payload shapes as atomic', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    expect(
+      isAtomicToolContentBlock({
+        type: 'video',
+        video: { source: { bytes } },
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        type: 'document',
+        document: {
+          source: { content: [{ type: 'text', text: 'page' }] },
+        },
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        type: 'resource',
+        resource: { uri: 'file:///result.bin', blob: bytes },
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        type: 'file',
+        source_type: 'id',
+        id: 'file_123',
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        type: 'computer_screenshot',
+        image_url: 'data:image/png;base64,AAAA',
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        type: 'application/pdf',
+        data: 'JVBERi0xLjQ=',
+      })
+    ).toBe(true);
+  });
+
+  it('normalizes a direct object result to provider-neutral text', () => {
+    const content = { rows: [{ id: 1 }], count: 1 };
+
+    const result = compactToolContent(content, 10_000);
+
+    expect(result.changed).toBe(true);
+    expect(result.content).toBe(JSON.stringify(content));
+  });
+
+  it('keeps valid text and small media blocks intact', () => {
+    const image = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+    };
+    const content = [
+      { type: 'text', text: 'Query result chart' },
+      image,
+    ] as ToolContent;
+
+    const result = compactToolContent(content, 10_000);
+
+    expect(result.changed).toBe(false);
+    expect(result.content).toBe(content);
+  });
+
+  it('omits an oversized inline media block instead of leaking past the cap', () => {
+    const base64 = 'A'.repeat(10_000);
+    const content = [
+      {
+        type: 'image_url',
+        image_url: { url: `data:image/png;base64,${base64}` },
+      },
+    ] as ToolContent;
+
+    const result = compactToolContent(content, 200);
+
+    expect(result.changed).toBe(true);
+    expect(serializeToolContent(result.content).length).toBeLessThanOrEqual(
+      200
+    );
+    expect(serializeToolContent(result.content)).toContain('omitted');
+    expect(serializeToolContent(result.content)).not.toContain(base64);
+  });
+
+  it('sizes large native byte payloads without JSON-expanding them', () => {
+    const bytes = new Uint8Array(1_000_000);
+    const content = [
+      {
+        type: 'video',
+        video: { source: { bytes } },
+      },
+    ] as ToolContent;
+
+    const uncapped = compactToolContent(content, Number.MAX_SAFE_INTEGER);
+    const compacted = compactToolContent(content, 200);
+
+    expect(uncapped.content).toBe(content);
+    expect(compacted.changed).toBe(true);
+    expect(compacted.originalChars).toBeGreaterThan(1_000_000);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      200
+    );
+    expect(serializeToolContent(compacted.content)).toContain('omitted');
+  });
+
+  it('preserves small document blocks while compacting adjacent text', () => {
+    const document = {
+      type: 'document',
+      source: { type: 'url', url: 'https://example.com/report.pdf' },
+    };
+    const content = [
+      { type: 'text', text: 'x'.repeat(2_000) },
+      document,
+    ] as ToolContent;
+
+    const result = compactToolContent(content, 400);
+
+    expect(result.changed).toBe(true);
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content).toContain(document);
+    expect(serializeToolContent(result.content).length).toBeLessThanOrEqual(
+      400
+    );
+  });
+
+  it('repeats shared non-cyclic values and marks only true cycles', () => {
+    const shared = { value: 'repeated' };
+    expect(serializeStructuredValue([shared, shared])).toBe(
+      '[{"value":"repeated"},{"value":"repeated"}]'
+    );
+
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    expect(serializeStructuredValue(cyclic)).toBe('{"self":"[Circular]"}');
+  });
+});

--- a/src/utils/toolContent.test.ts
+++ b/src/utils/toolContent.test.ts
@@ -1,9 +1,12 @@
+import { spawnSync } from 'child_process';
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   compactToolContent,
   isAtomicToolContentBlock,
   serializeStructuredValue,
+  serializeStructuredValueBounded,
   serializeToolContent,
+  serializeToolContentBounded,
 } from './toolContent';
 
 type ToolContent = BaseMessage['content'];
@@ -69,6 +72,13 @@ describe('toolContent', () => {
     ).toBe(true);
     expect(
       isAtomicToolContentBlock({
+        type: 'media',
+        mimeType: 'application/octet-stream',
+        data: new ArrayBuffer(8),
+      })
+    ).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
         type: 'file',
         source_type: 'id',
         id: 'file_123',
@@ -111,6 +121,84 @@ describe('toolContent', () => {
 
     expect(result.changed).toBe(false);
     expect(result.content).toBe(content);
+  });
+
+  it('preserves safe provider-native tool-result blocks atomically', () => {
+    const webSearchResult = {
+      type: 'web_search_result',
+      url: 'https://example.com/result',
+      title: 'Example result',
+      encrypted_content: 'encrypted',
+    };
+    const content = [
+      {
+        type: 'search_result',
+        title: 'Knowledge base result',
+        source: 'https://example.com/source',
+        citations: { enabled: true },
+        content: [{ type: 'text', text: 'Citation-preserving content' }],
+      },
+      {
+        type: 'web_search_tool_result',
+        tool_use_id: 'srvtoolu_search',
+        content: [webSearchResult],
+      },
+      webSearchResult,
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_custom',
+        content: 'done',
+      },
+      {
+        type: 'server_tool_call_result',
+        toolCallId: 'server_call',
+        status: 'success',
+        output: { stdout: 'done' },
+      },
+      {
+        type: 'toolResponse',
+        toolResponse: {
+          id: 'google_search',
+          name: 'google_search',
+          response: { results: [] },
+        },
+      },
+    ] as ToolContent;
+
+    expect(
+      (content as Exclude<ToolContent, string>).every(isAtomicToolContentBlock)
+    ).toBe(true);
+    const result = compactToolContent(content, 10_000);
+
+    expect(result.changed).toBe(false);
+    expect(result.content).toBe(content);
+  });
+
+  it('omits an oversized provider-native result as one atomic block', () => {
+    const sentinel = 'OVERSIZED_NATIVE_RESULT';
+    const content = [
+      {
+        type: 'search_result',
+        title: 'Large result',
+        source: 'https://example.com/large',
+        citations: { enabled: true },
+        content: [
+          {
+            type: 'text',
+            text: `${sentinel}:${'x'.repeat(20_000)}`,
+          },
+        ],
+      },
+    ] as ToolContent;
+
+    const result = compactToolContent(content, 200);
+    const serialized = serializeToolContent(result.content);
+
+    expect(result.changed).toBe(true);
+    expect(serialized.length).toBeLessThanOrEqual(200);
+    expect(serialized).toContain('omitted');
+    expect(serialized).toContain('search_result');
+    expect(serialized).not.toContain(sentinel);
   });
 
   it('omits an oversized inline media block instead of leaking past the cap', () => {
@@ -182,5 +270,684 @@ describe('toolContent', () => {
     const cyclic: { self?: unknown } = {};
     cyclic.self = cyclic;
     expect(serializeStructuredValue(cyclic)).toBe('{"self":"[Circular]"}');
+  });
+
+  it('normalizes cyclic atomic and text blocks instead of returning them unchanged', () => {
+    const cyclicPayload: {
+      url: string;
+      self?: unknown;
+    } = {
+      url: 'https://example.com/chart.png',
+    };
+    cyclicPayload.self = cyclicPayload;
+    const atomicBlock = {
+      type: 'image_url',
+      image_url: cyclicPayload,
+    };
+    const textBlock: {
+      type: 'text';
+      text: string;
+      metadata?: unknown;
+    } = {
+      type: 'text',
+      text: 'done',
+    };
+    textBlock.metadata = textBlock;
+
+    const atomicResult = compactToolContent(
+      [atomicBlock] as ToolContent,
+      1_000
+    );
+    const textResult = compactToolContent([textBlock] as ToolContent, 1_000);
+
+    expect(isAtomicToolContentBlock(atomicBlock)).toBe(false);
+    for (const result of [atomicResult, textResult]) {
+      expect(result.changed).toBe(true);
+      expect(typeof result.content).toBe('string');
+      expect((result.content as string).length).toBeLessThanOrEqual(1_000);
+      expect(result.content).toContain('[Circular]');
+      expect(() => JSON.parse(result.content as string)).not.toThrow();
+    }
+  });
+
+  it('still preserves atomic blocks with shared non-cyclic values', () => {
+    const shared = { source: 'tool' };
+    const block = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+      first: shared,
+      second: shared,
+    };
+    const content = [block] as ToolContent;
+
+    expect(isAtomicToolContentBlock(block)).toBe(true);
+    const compacted = compactToolContent(content, 1_000);
+
+    expect(compacted.changed).toBe(false);
+    expect(compacted.content).toBe(content);
+  });
+
+  it('bounds structured values without invoking custom toJSON', () => {
+    let toJSONCalls = 0;
+    const value = {
+      safe: 'ok',
+      toJSON() {
+        toJSONCalls++;
+        return 'x'.repeat(10_000);
+      },
+    };
+
+    const serialized = serializeStructuredValueBounded(value, 10);
+    const compacted = compactToolContent(value, 10);
+
+    expect(toJSONCalls).toBe(0);
+    expect(serialized.content.length).toBeLessThanOrEqual(10);
+    expect(String(compacted.content).length).toBeLessThanOrEqual(10);
+    expect(serialized.originalChars).toBe(
+      JSON.stringify({ safe: 'ok' }).length
+    );
+  });
+
+  it('does not preserve atomic blocks with callable toJSON methods', () => {
+    let toJSONCalls = 0;
+    const block = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+      toJSON() {
+        toJSONCalls++;
+        return {
+          type: 'image_url',
+          image_url: { url: 'x'.repeat(10_000) },
+        };
+      },
+    };
+
+    const compacted = compactToolContent([block] as ToolContent, 200);
+
+    expect(toJSONCalls).toBe(0);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+    expect(compacted.changed).toBe(true);
+  });
+
+  it('does not invoke toJSON accessors while validating atomic blocks', () => {
+    let getterCalls = 0;
+    const source = { url: 'https://example.com/chart.png' };
+    Object.defineProperty(source, 'toJSON', {
+      enumerable: false,
+      get() {
+        getterCalls++;
+        return (): string => 'unsafe';
+      },
+    });
+    const block = { type: 'image_url', image_url: source };
+
+    const compacted = compactToolContent([block] as ToolContent, 200);
+
+    expect(getterCalls).toBe(0);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+  });
+
+  it('does not preserve ArrayBuffer payloads with custom toJSON methods', () => {
+    let toJSONCalls = 0;
+    const data = new ArrayBuffer(8) as ArrayBuffer & {
+      toJSON: () => string;
+    };
+    data.toJSON = () => {
+      toJSONCalls++;
+      return 'x'.repeat(10_000);
+    };
+    const block = {
+      type: 'media',
+      mimeType: 'application/octet-stream',
+      data,
+    };
+
+    const compacted = compactToolContent([block] as ToolContent, 200);
+
+    expect(isAtomicToolContentBlock(block)).toBe(false);
+    expect(toJSONCalls).toBe(0);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+  });
+
+  it('preserves only native Dates inside atomic blocks', () => {
+    let toJSONCalls = 0;
+    let toISOStringCalls = 0;
+    const nativeBlock = {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+      capturedAt: new Date('2026-07-27T12:00:00.000Z'),
+    };
+    const dateWithToJSON = new Date('2026-07-27T12:00:00.000Z');
+    Object.defineProperty(dateWithToJSON, 'toJSON', {
+      value() {
+        toJSONCalls++;
+        return 'x'.repeat(10_000);
+      },
+    });
+    const dateWithToISOString = new Date('2026-07-27T12:00:00.000Z');
+    Object.defineProperty(dateWithToISOString, 'toISOString', {
+      value() {
+        toISOStringCalls++;
+        return 'x'.repeat(10_000);
+      },
+    });
+    class ExpandingDate extends Date {
+      override toJSON(): string {
+        toJSONCalls++;
+        return 'x'.repeat(10_000);
+      }
+    }
+
+    expect(isAtomicToolContentBlock(nativeBlock)).toBe(true);
+    expect(
+      isAtomicToolContentBlock({
+        ...nativeBlock,
+        capturedAt: dateWithToJSON,
+      })
+    ).toBe(false);
+    expect(
+      isAtomicToolContentBlock({
+        ...nativeBlock,
+        capturedAt: dateWithToISOString,
+      })
+    ).toBe(false);
+    expect(
+      isAtomicToolContentBlock({
+        ...nativeBlock,
+        capturedAt: new ExpandingDate('2026-07-27T12:00:00.000Z'),
+      })
+    ).toBe(false);
+    expect(toJSONCalls).toBe(0);
+    expect(toISOStringCalls).toBe(0);
+  });
+
+  it('rejects atomic blocks with enumerable accessors without invoking them', () => {
+    let getterCalls = 0;
+    const imageUrl = {};
+    Object.defineProperty(imageUrl, 'url', {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return getterCalls === 1
+          ? 'https://example.com/chart.png'
+          : 'x'.repeat(10_000);
+      },
+    });
+
+    expect(
+      isAtomicToolContentBlock({
+        type: 'image_url',
+        image_url: imageUrl,
+      })
+    ).toBe(false);
+    expect(getterCalls).toBe(0);
+  });
+
+  it('rejects inherited discriminators without invoking accessors', () => {
+    for (const enumerable of [true, false]) {
+      let getterCalls = 0;
+      const prototype = {};
+      Object.defineProperty(prototype, 'type', {
+        enumerable,
+        get() {
+          getterCalls++;
+          return 'image_url';
+        },
+      });
+      const block = Object.create(prototype) as Record<string, unknown>;
+      block.image_url = { url: 'https://example.com/chart.png' };
+
+      expect(isAtomicToolContentBlock(block)).toBe(false);
+      const compacted = compactToolContent([block] as ToolContent, 200);
+      expect(getterCalls).toBe(0);
+      expect(typeof compacted.content).toBe('string');
+    }
+
+    const inheritedDataBlock = Object.create({
+      type: 'image_url',
+      image_url: { url: 'https://example.com/chart.png' },
+    }) as Record<string, unknown>;
+    expect(isAtomicToolContentBlock(inheritedDataBlock)).toBe(false);
+  });
+
+  it('rejects inherited payloads without invoking accessors', () => {
+    let getterCalls = 0;
+    const imageUrlPrototype = {};
+    Object.defineProperty(imageUrlPrototype, 'url', {
+      enumerable: false,
+      get() {
+        getterCalls++;
+        return `data:image/png;base64,${'A'.repeat(100_000)}`;
+      },
+    });
+    const block = {
+      type: 'image_url',
+      image_url: Object.create(imageUrlPrototype) as Record<string, unknown>,
+    };
+
+    expect(isAtomicToolContentBlock(block)).toBe(false);
+    const compacted = compactToolContent([block] as ToolContent, 200);
+
+    expect(getterCalls).toBe(0);
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+  });
+
+  it('compacts accessor-backed atomic shapes without invoking accessors', () => {
+    let getterCalls = 0;
+    const imageUrl = {};
+    Object.defineProperty(imageUrl, 'url', {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return getterCalls === 1
+          ? 'https://example.com/chart.png'
+          : 'x'.repeat(10_000);
+      },
+    });
+
+    const compacted = compactToolContent(
+      [{ type: 'image_url', image_url: imageUrl }] as ToolContent,
+      200
+    );
+
+    expect(getterCalls).toBe(0);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+    expect(compacted.content).toContain('[Property accessor omitted]');
+  });
+
+  it('bounds generic accessor properties without invoking them', () => {
+    let getterCalls = 0;
+    const value = {};
+    Object.defineProperty(value, 'payload', {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return 'x'.repeat(10_000);
+      },
+    });
+
+    const serialized = serializeStructuredValueBounded(value, 200);
+
+    expect(getterCalls).toBe(0);
+    expect(serialized.content).toBe(
+      '{"payload":"[Property accessor omitted]"}'
+    );
+  });
+
+  it('serializes array holes without invoking inherited accessors', () => {
+    let getterCalls = 0;
+    const prototype = Object.create(Array.prototype) as unknown[];
+    Object.defineProperty(prototype, '0', {
+      get() {
+        getterCalls++;
+        return 'x'.repeat(10_000);
+      },
+    });
+    const value: unknown[] = [];
+    value.length = 1;
+    Object.setPrototypeOf(value, prototype);
+
+    const serialized = serializeStructuredValueBounded(value, 200);
+
+    expect(getterCalls).toBe(0);
+    expect(serialized.content).toBe('[null]');
+  });
+
+  it('fails closed when a proxy blocks own property descriptors', () => {
+    let propertyReads = 0;
+    const value = new Proxy<unknown[]>(['safe'], {
+      get(target, property, receiver) {
+        propertyReads++;
+        return Reflect.get(target, property, receiver);
+      },
+      getOwnPropertyDescriptor(target, property) {
+        if (property === '0') {
+          throw new Error('blocked descriptor');
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    const serialized = serializeStructuredValueBounded(value, 200);
+
+    expect(propertyReads).toBe(0);
+    expect(serialized.content).toBe('"[Proxy value omitted]"');
+    expect(serialized.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(serialized.truncated).toBe(true);
+  });
+
+  it('never returns stateful proxy blocks through structured fast paths', () => {
+    const hugeValue = 'x'.repeat(1_000_000);
+    let descriptorReads = 0;
+    let propertyReads = 0;
+    function statefulProxy<T extends object>(
+      target: T,
+      unstableKey: PropertyKey,
+      expandedValue: unknown
+    ): T {
+      return new Proxy(target, {
+        get(innerTarget, property, receiver) {
+          propertyReads++;
+          if (property === unstableKey && propertyReads > 2) {
+            return expandedValue;
+          }
+          return Reflect.get(innerTarget, property, receiver);
+        },
+        getOwnPropertyDescriptor(innerTarget, property) {
+          descriptorReads++;
+          const descriptor = Reflect.getOwnPropertyDescriptor(
+            innerTarget,
+            property
+          );
+          if (
+            descriptor != null &&
+            property === unstableKey &&
+            descriptorReads > 2
+          ) {
+            return { ...descriptor, value: expandedValue };
+          }
+          return descriptor;
+        },
+      });
+    }
+    const textBlock = statefulProxy(
+      { type: 'text', text: 'ok' },
+      'text',
+      hugeValue
+    );
+    const atomicBlock = statefulProxy(
+      {
+        type: 'image_url',
+        image_url: { url: 'https://example.com/chart.png' },
+      },
+      'image_url',
+      { url: `data:image/png;base64,${hugeValue}` }
+    );
+    const content = [textBlock, atomicBlock] as ToolContent;
+
+    const compacted = compactToolContent(content, 1_000);
+
+    expect(descriptorReads).toBe(0);
+    expect(propertyReads).toBe(0);
+    expect(compacted.changed).toBe(true);
+    expect(compacted.content).not.toBe(content);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(1_000);
+    expect(compacted.content).toContain('[Proxy value omitted]');
+    expect(() => JSON.parse(compacted.content as string)).not.toThrow();
+  });
+
+  it('does not traverse proxy arrays or proxy payloads while compacting', () => {
+    const hugeValue = 'x'.repeat(1_000_000);
+    let proxyTrapCalls = 0;
+    let accessorCalls = 0;
+    const payloadTarget = {};
+    Object.defineProperty(payloadTarget, 'url', {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return `data:image/png;base64,${hugeValue}`;
+      },
+    });
+    const payload = new Proxy(payloadTarget, {
+      get() {
+        proxyTrapCalls++;
+        return hugeValue;
+      },
+      getOwnPropertyDescriptor(target, property) {
+        proxyTrapCalls++;
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+    const proxiedArray = new Proxy(
+      [
+        {
+          type: 'image_url',
+          image_url: payload,
+        },
+      ],
+      {
+        get(target, property, receiver) {
+          proxyTrapCalls++;
+          return Reflect.get(target, property, receiver);
+        },
+        getOwnPropertyDescriptor(target, property) {
+          proxyTrapCalls++;
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      }
+    ) as ToolContent;
+    const callableProxy = new Proxy(() => 'safe', {
+      get() {
+        proxyTrapCalls++;
+        return hugeValue;
+      },
+    });
+
+    const arrayResult = compactToolContent(proxiedArray, 1_000);
+    const callableResult = compactToolContent(callableProxy, 1_000);
+    const nestedResult = compactToolContent(
+      [
+        {
+          type: 'image_url',
+          image_url: payload,
+        },
+      ] as ToolContent,
+      1_000
+    );
+
+    expect(proxyTrapCalls).toBe(0);
+    expect(accessorCalls).toBe(0);
+    expect(arrayResult.changed).toBe(true);
+    expect(callableResult.changed).toBe(true);
+    expect(nestedResult.changed).toBe(true);
+    expect(arrayResult.content).toBe('"[Proxy value omitted]"');
+    expect(callableResult.content).toBe('"[Proxy value omitted]"');
+    expect(typeof nestedResult.content).toBe('string');
+    expect((nestedResult.content as string).length).toBeLessThanOrEqual(1_000);
+    expect(nestedResult.content).toContain('[Proxy value omitted]');
+    expect(() => JSON.parse(nestedResult.content as string)).not.toThrow();
+  });
+
+  it('counts lone surrogates before preserving atomic content', () => {
+    const content = [
+      {
+        type: 'image_url',
+        image_url: { url: '\ud800'.repeat(30) },
+      },
+    ] as ToolContent;
+
+    const compacted = compactToolContent(content, 200);
+
+    expect(compacted.changed).toBe(true);
+    expect(serializeToolContent(compacted.content).length).toBeLessThanOrEqual(
+      200
+    );
+  });
+
+  it('serializes Buffer values as bounded byte placeholders', () => {
+    const value = Buffer.alloc(10_000, 1);
+
+    const serialized = serializeStructuredValueBounded(value, 15_000);
+    const compacted = compactToolContent(value, 15_000);
+
+    expect(serialized.content).toBe('"[Buffer: 10000 bytes]"');
+    expect(serialized.content.length).toBeLessThanOrEqual(15_000);
+    expect(compacted.content).toBe(serialized.content);
+  });
+
+  it('does not preserve Buffer toJSON expansion inside atomic blocks', () => {
+    const content = [
+      {
+        type: 'image',
+        data: Buffer.alloc(100, 255),
+      },
+    ] as ToolContent;
+
+    const compacted = compactToolContent(content, 200);
+
+    expect(compacted.changed).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+    expect(compacted.content).toContain('[Buffer: 100 bytes]');
+  });
+
+  it('retains an exact registry prefix independently of the provider preview', () => {
+    const value = { payload: 'x'.repeat(1_000), tail: 'done' };
+    const exact = JSON.stringify(value);
+
+    const serialized = serializeStructuredValueBounded(
+      value,
+      100,
+      exact.length
+    );
+
+    expect(serialized.content.length).toBeLessThanOrEqual(100);
+    expect(serialized.content).toContain('truncated');
+    expect(serialized.prefix).toBe(exact);
+  });
+
+  it('emits JSON-exact strings across escape and surrogate chunk boundaries', () => {
+    const value = {
+      payload:
+        `${'x'.repeat(4_095)}😀` +
+        `\ud800${'y'.repeat(4_095)}\udc00` +
+        '\b\t\n\f\r"\\',
+    };
+    const exact = JSON.stringify(value);
+
+    const serialized = serializeStructuredValueBounded(value, exact.length);
+
+    expect(serialized.content).toBe(exact);
+    expect(serialized.originalChars).toBe(exact.length);
+    expect(serialized.truncated).toBe(false);
+  });
+
+  it('bounds a 32 MiB primitive string within a 128 MiB heap', () => {
+    const script = `
+      const { serializeStructuredValueBounded } =
+        await import('./src/utils/toolContent.ts');
+      const payload = 'A'.repeat(32 * 1024 * 1024);
+      const result = serializeStructuredValueBounded({ payload }, 4096);
+      const expectedLength = payload.length + '{"payload":""}'.length;
+      if (
+        result.content.length !== 4096 ||
+        result.originalChars !== expectedLength ||
+        result.truncated !== true
+      ) {
+        throw new Error(JSON.stringify({
+          contentLength: result.content.length,
+          originalChars: result.originalChars,
+          expectedLength,
+          truncated: result.truncated,
+        }));
+      }
+      process.stdout.write('ok');
+    `;
+    const benchmark = spawnSync(
+      process.execPath,
+      [
+        '--max-old-space-size=128',
+        '--loader',
+        'ts-node/esm/transpile-only',
+        '--experimental-specifier-resolution=node',
+        '--input-type=module',
+        '--eval',
+        script,
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: { ...process.env, NODE_NO_WARNINGS: '1' },
+        timeout: 30_000,
+      }
+    );
+
+    if (benchmark.status !== 0) {
+      throw new Error(
+        `Constrained-heap serializer benchmark failed: ${benchmark.stderr}`
+      );
+    }
+    expect(benchmark.stdout).toBe('ok');
+  });
+
+  it('bounds arrays with many small values using an exact segmented prefix', () => {
+    const value = Array.from({ length: 25_000 }, (_, index) => index);
+    const exact = JSON.stringify(value);
+
+    const serialized = serializeStructuredValueBounded(value, 1_000, 2_000);
+
+    expect(serialized.content.length).toBeLessThanOrEqual(1_000);
+    expect(serialized.content).toContain('truncated');
+    expect(serialized.prefix).toBe(exact.slice(0, 2_000));
+    expect(serialized.originalChars).toBe(exact.length);
+  });
+
+  it('routes sparse text-looking arrays through bounded serialization', () => {
+    const sparse: unknown[] = [];
+    sparse.length = 100;
+
+    const compacted = compactToolContent(sparse, 20);
+
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(20);
+    expect(compacted.changed).toBe(true);
+  });
+
+  it('fails closed without reading a hostile array proxy length', () => {
+    const hostile = new Proxy<unknown[]>([], {
+      get(target, property, receiver) {
+        if (property === 'length') {
+          throw new Error('blocked length');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const compacted = compactToolContent(hostile, 20);
+
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(20);
+    expect(compacted.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('caps traversal work for enormous sparse arrays', () => {
+    const sparse: unknown[] = [];
+    sparse.length = 0xffffffff;
+
+    const serialized = serializeStructuredValueBounded(sparse, 200);
+    const compacted = compactToolContent(sparse, 200);
+
+    expect(serialized.content.length).toBeLessThanOrEqual(200);
+    expect(serialized.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(serialized.truncated).toBe(true);
+    expect(typeof compacted.content).toBe('string');
+    expect((compacted.content as string).length).toBeLessThanOrEqual(200);
+    expect(compacted.originalChars).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('keeps large bounded head-tail collection linear', () => {
+    const values = new Array<number>(500_000).fill(0);
+    const serialized = serializeStructuredValueBounded(values, 400_000);
+
+    expect(serialized.content).toHaveLength(400_000);
+    expect(serialized.originalChars).toBe(1_000_001);
+    expect(serialized.truncated).toBe(true);
+  });
+
+  it('bounds provider-facing tool content directly', () => {
+    const serialized = serializeToolContentBounded(
+      { payload: 'x'.repeat(1_000) },
+      80
+    );
+
+    expect(serialized.length).toBeLessThanOrEqual(80);
+    expect(serialized).toContain('truncated');
   });
 });

--- a/src/utils/toolContent.ts
+++ b/src/utils/toolContent.ts
@@ -1,8 +1,10 @@
+import { isProxy } from 'node:util/types';
 import { ToolMessage, type BaseMessage } from '@langchain/core/messages';
 import { truncateToolResultContent } from './truncation';
 
 type ToolContent = BaseMessage['content'];
 type ToolContentBlock = Exclude<ToolContent, string>[number];
+type TextToolContentBlock = ToolContentBlock & { type: 'text'; text: string };
 
 const ATOMIC_CONTENT_TYPES = new Set([
   'audio',
@@ -18,6 +20,15 @@ const ATOMIC_CONTENT_TYPES = new Set([
   'resource_link',
   'video',
   'video_url',
+]);
+
+const PROVIDER_NATIVE_TOOL_RESULT_TYPES = new Set([
+  'search_result',
+  'server_tool_call_result',
+  'tool_result',
+  'toolResponse',
+  'web_search_result',
+  'web_search_tool_result',
 ]);
 
 /**
@@ -60,17 +71,69 @@ export function serializeStructuredValue(value: unknown): string {
     );
     return typeof serialized === 'string' ? serialized : String(value);
   } catch {
-    return String(value);
+    try {
+      return String(value);
+    } catch {
+      return '[Unserializable structured value]';
+    }
   }
+}
+
+const SERIALIZATION_CHUNK_SIZE = 4_096;
+const MAX_STRUCTURED_SERIALIZATION_DEPTH = 200;
+const MAX_STRUCTURED_SERIALIZATION_WORK = 1_000_000;
+const PROXY_VALUE_PLACEHOLDER = '[Proxy value omitted]';
+
+type StructuredWorkState = {
+  remaining: number;
+  exceeded: boolean;
+};
+
+function createStructuredWorkState(): StructuredWorkState {
+  return {
+    remaining: MAX_STRUCTURED_SERIALIZATION_WORK,
+    exceeded: false,
+  };
+}
+
+function consumeStructuredWork(state: StructuredWorkState): boolean {
+  if (state.remaining <= 0) {
+    state.exceeded = true;
+    return false;
+  }
+  state.remaining--;
+  return true;
+}
+
+function conservativeStructuredLength(limit: number): number {
+  return limit >= Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : limit + 1;
 }
 
 function jsonStringLength(value: string): number {
   let length = 2;
   for (let i = 0; i < value.length; i++) {
     const code = value.charCodeAt(i);
-    if (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x0c) {
+    if (
+      code === 0x08 ||
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0c ||
+      code === 0x0d ||
+      code === 0x22 ||
+      code === 0x5c
+    ) {
       length += 2;
     } else if (code < 0x20) {
+      length += 6;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        length += 2;
+        i++;
+      } else {
+        length += 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
       length += 6;
     } else {
       length++;
@@ -82,7 +145,9 @@ function jsonStringLength(value: string): number {
 function estimateStructuredChars(
   value: unknown,
   limit = Number.MAX_SAFE_INTEGER,
-  ancestors: object[] = []
+  ancestors: object[] = [],
+  work = createStructuredWorkState(),
+  depth = 0
 ): number {
   if (typeof value === 'string') {
     return jsonStringLength(value);
@@ -97,14 +162,39 @@ function estimateStructuredChars(
   ) {
     return String(value).length;
   }
+  if (isProxy(value)) {
+    work.exceeded = true;
+    return conservativeStructuredLength(limit);
+  }
   if (typeof value === 'undefined' || typeof value === 'function') {
     return 4;
   }
   if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
     return Math.min(limit + 1, Math.ceil((value.byteLength * 4) / 3) + 32);
   }
+  if (value instanceof Date) {
+    const time = Date.prototype.getTime.call(value);
+    return Number.isFinite(time)
+      ? jsonStringLength(Date.prototype.toISOString.call(value))
+      : 4;
+  }
+  if (value instanceof String) {
+    return jsonStringLength(String.prototype.valueOf.call(value));
+  }
+  if (value instanceof Number) {
+    const number = Number.prototype.valueOf.call(value);
+    return Number.isFinite(number)
+      ? String(number === 0 ? 0 : number).length
+      : 4;
+  }
+  if (value instanceof Boolean) {
+    return String(Boolean.prototype.valueOf.call(value)).length;
+  }
   if (typeof value !== 'object') {
     return jsonStringLength(String(value));
+  }
+  if (depth >= MAX_STRUCTURED_SERIALIZATION_DEPTH) {
+    return jsonStringLength('[Max serialization depth]');
   }
   if (ancestors.includes(value)) {
     return 12;
@@ -112,24 +202,513 @@ function estimateStructuredChars(
 
   ancestors.push(value);
   let length = 2;
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length && length <= limit; i++) {
-      if (i > 0) {
-        length++;
+  try {
+    if (Array.isArray(value)) {
+      const arrayLength = readStructuredArrayLength(value, work);
+      if (arrayLength == null) {
+        return conservativeStructuredLength(limit);
       }
-      length += estimateStructuredChars(
-        value[i],
-        Math.max(0, limit - length),
-        ancestors
+      for (let i = 0; i < arrayLength && length <= limit; i++) {
+        if (!consumeStructuredWork(work)) {
+          return conservativeStructuredLength(limit);
+        }
+        if (i > 0) {
+          length++;
+        }
+        length += estimateStructuredChars(
+          readStructuredProperty(value, i, work),
+          Math.max(0, limit - length),
+          ancestors,
+          work,
+          depth + 1
+        );
+      }
+    } else {
+      let emitted = 0;
+      for (const key in value) {
+        if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
+          continue;
+        }
+        if (!consumeStructuredWork(work)) {
+          return conservativeStructuredLength(limit);
+        }
+        if (length > limit) {
+          break;
+        }
+        const nested = readStructuredProperty(
+          value as Record<string, unknown>,
+          key,
+          work
+        );
+        if (
+          typeof nested === 'undefined' ||
+          typeof nested === 'function' ||
+          typeof nested === 'symbol'
+        ) {
+          continue;
+        }
+        if (emitted > 0) {
+          length++;
+        }
+        length += jsonStringLength(key) + 1;
+        length += estimateStructuredChars(
+          nested,
+          Math.max(0, limit - length),
+          ancestors,
+          work,
+          depth + 1
+        );
+        emitted++;
+      }
+    }
+  } catch {
+    work.exceeded = true;
+    return conservativeStructuredLength(limit);
+  } finally {
+    ancestors.pop();
+  }
+  if (work.exceeded) {
+    return conservativeStructuredLength(limit);
+  }
+  return Math.min(limit + 1, length);
+}
+
+type StructuredSerializationCollector = {
+  totalChars: number;
+  prefix: SegmentedStringBuffer;
+  suffix: SegmentedStringBuffer;
+  prefixLimit: number;
+  suffixLimit: number;
+  work: StructuredWorkState;
+};
+
+type SegmentedStringBuffer = {
+  segments: string[];
+  head: number;
+  pending: string[];
+  pendingChars: number;
+  length: number;
+};
+
+export type BoundedStructuredSerialization = {
+  /** Provider-facing head/tail preview, bounded by `maxChars`. */
+  content: string;
+  /** Exact serialized prefix up to the defensive traversal-work ceiling. */
+  prefix: string;
+  /** Exact length, or `Number.MAX_SAFE_INTEGER` when traversal was capped. */
+  originalChars: number;
+  truncated: boolean;
+};
+
+function normalizeCharLimit(limit: number): number {
+  return Number.isFinite(limit)
+    ? Math.max(0, Math.floor(limit))
+    : Number.MAX_SAFE_INTEGER;
+}
+
+function createSegmentedStringBuffer(): SegmentedStringBuffer {
+  return {
+    segments: [],
+    head: 0,
+    pending: [],
+    pendingChars: 0,
+    length: 0,
+  };
+}
+
+function flushSegmentedStringBuffer(buffer: SegmentedStringBuffer): void {
+  if (buffer.pendingChars === 0) {
+    return;
+  }
+  buffer.segments.push(buffer.pending.join(''));
+  buffer.pending = [];
+  buffer.pendingChars = 0;
+}
+
+function appendToSegmentedStringBuffer(
+  buffer: SegmentedStringBuffer,
+  chunk: string
+): void {
+  if (chunk.length === 0) {
+    return;
+  }
+  buffer.pending.push(chunk);
+  buffer.pendingChars += chunk.length;
+  buffer.length += chunk.length;
+  if (buffer.pendingChars >= SERIALIZATION_CHUNK_SIZE) {
+    flushSegmentedStringBuffer(buffer);
+  }
+}
+
+function trimSegmentedStringBufferStart(
+  buffer: SegmentedStringBuffer,
+  chars: number
+): void {
+  let remaining = Math.min(chars, buffer.length);
+  if (remaining <= 0) {
+    return;
+  }
+  flushSegmentedStringBuffer(buffer);
+  while (remaining > 0 && buffer.head < buffer.segments.length) {
+    const segment = buffer.segments[buffer.head];
+    if (segment.length <= remaining) {
+      remaining -= segment.length;
+      buffer.length -= segment.length;
+      buffer.head++;
+    } else {
+      buffer.segments[buffer.head] = segment.slice(remaining);
+      buffer.length -= remaining;
+      remaining = 0;
+    }
+  }
+  if (buffer.head >= 1_024 && buffer.head * 2 >= buffer.segments.length) {
+    buffer.segments = buffer.segments.slice(buffer.head);
+    buffer.head = 0;
+  }
+}
+
+function materializeSegmentedStringBuffer(
+  buffer: SegmentedStringBuffer
+): string {
+  const segments = buffer.segments.slice(buffer.head);
+  if (buffer.pendingChars > 0) {
+    segments.push(buffer.pending.join(''));
+  }
+  return segments.join('');
+}
+
+function appendSerializedChunk(
+  collector: StructuredSerializationCollector,
+  chunk: string
+): void {
+  if (chunk.length === 0) {
+    return;
+  }
+
+  collector.totalChars += chunk.length;
+
+  const prefixRemaining = collector.prefixLimit - collector.prefix.length;
+  if (prefixRemaining > 0) {
+    appendToSegmentedStringBuffer(
+      collector.prefix,
+      chunk.slice(0, prefixRemaining)
+    );
+  }
+
+  if (collector.suffixLimit <= 0) {
+    return;
+  }
+  appendToSegmentedStringBuffer(collector.suffix, chunk);
+  if (
+    collector.suffix.length >=
+    collector.suffixLimit + SERIALIZATION_CHUNK_SIZE
+  ) {
+    trimSegmentedStringBufferStart(
+      collector.suffix,
+      collector.suffix.length - collector.suffixLimit
+    );
+  }
+}
+
+function appendJsonSafeRange(
+  collector: StructuredSerializationCollector,
+  value: string,
+  start: number,
+  end: number
+): void {
+  let offset = start;
+  while (offset < end) {
+    let chunkEnd = Math.min(end, offset + SERIALIZATION_CHUNK_SIZE);
+    if (
+      chunkEnd < end &&
+      chunkEnd > offset &&
+      value.charCodeAt(chunkEnd - 1) >= 0xd800 &&
+      value.charCodeAt(chunkEnd - 1) <= 0xdbff &&
+      value.charCodeAt(chunkEnd) >= 0xdc00 &&
+      value.charCodeAt(chunkEnd) <= 0xdfff
+    ) {
+      chunkEnd--;
+    }
+    appendSerializedChunk(collector, value.slice(offset, chunkEnd));
+    offset = chunkEnd;
+  }
+}
+
+/**
+ * Emits one JSON string incrementally. Calling JSON.stringify on the complete
+ * string would allocate an escaped copy before the output cap could apply.
+ */
+function appendJsonString(
+  collector: StructuredSerializationCollector,
+  value: string
+): void {
+  appendSerializedChunk(collector, '"');
+  let safeStart = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    let escaped: string | undefined;
+    switch (code) {
+    case 0x08:
+      escaped = '\\b';
+      break;
+    case 0x09:
+      escaped = '\\t';
+      break;
+    case 0x0a:
+      escaped = '\\n';
+      break;
+    case 0x0c:
+      escaped = '\\f';
+      break;
+    case 0x0d:
+      escaped = '\\r';
+      break;
+    case 0x22:
+      escaped = '\\"';
+      break;
+    case 0x5c:
+      escaped = '\\\\';
+      break;
+    default:
+      if (code < 0x20) {
+        escaped = `\\u${code.toString(16).padStart(4, '0')}`;
+      } else if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(i + 1);
+        if (next >= 0xdc00 && next <= 0xdfff) {
+          i++;
+        } else {
+          escaped = `\\u${code.toString(16).padStart(4, '0')}`;
+        }
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        escaped = `\\u${code.toString(16).padStart(4, '0')}`;
+      }
+    }
+
+    if (escaped != null) {
+      appendJsonSafeRange(collector, value, safeStart, i);
+      appendSerializedChunk(collector, escaped);
+      safeStart = i + 1;
+    }
+  }
+  appendJsonSafeRange(collector, value, safeStart, value.length);
+  appendSerializedChunk(collector, '"');
+}
+
+function getArrayBufferViewName(value: ArrayBufferView): string {
+  try {
+    const prototype = Object.getPrototypeOf(value) as {
+      constructor?: { name?: unknown };
+    } | null;
+    const name = prototype?.constructor?.name;
+    return typeof name === 'string' && name !== '' ? name : 'ArrayBufferView';
+  } catch {
+    return 'ArrayBufferView';
+  }
+}
+
+function readStructuredProperty(
+  value: Record<string, unknown> | unknown[],
+  key: string | number,
+  work: StructuredWorkState
+): unknown {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(key));
+    if (descriptor == null) {
+      return undefined;
+    }
+    if ('value' in descriptor) {
+      return descriptor.value;
+    }
+    return '[Property accessor omitted]';
+  } catch {
+    work.exceeded = true;
+    work.remaining = 0;
+    return '[Unreadable property omitted]';
+  }
+}
+
+function readStructuredArrayLength(
+  value: unknown[],
+  work: StructuredWorkState
+): number | undefined {
+  const length = readStructuredProperty(value, 'length', work);
+  if (
+    typeof length === 'number' &&
+    Number.isSafeInteger(length) &&
+    length >= 0
+  ) {
+    return length;
+  }
+  work.exceeded = true;
+  work.remaining = 0;
+  return undefined;
+}
+
+/**
+ * Provider-neutral JSON writer which deliberately does not invoke `toJSON` or
+ * property accessors. Native `JSON.stringify` can invoke both before a replacer
+ * can bound their output.
+ */
+function appendStructuredValue(
+  collector: StructuredSerializationCollector,
+  value: unknown,
+  ancestors: Set<object>,
+  depth: number,
+  position: 'top' | 'array' | 'object'
+): boolean {
+  if (typeof value === 'string') {
+    appendJsonString(collector, value);
+    return true;
+  }
+  if (typeof value === 'bigint') {
+    appendJsonString(collector, value.toString());
+    return true;
+  }
+  if (typeof value === 'number') {
+    appendSerializedChunk(
+      collector,
+      Number.isFinite(value) ? String(value === 0 ? 0 : value) : 'null'
+    );
+    return true;
+  }
+  if (typeof value === 'boolean' || value === null) {
+    appendSerializedChunk(collector, String(value));
+    return true;
+  }
+  if (isProxy(value)) {
+    collector.work.exceeded = true;
+    appendJsonString(collector, PROXY_VALUE_PLACEHOLDER);
+    return true;
+  }
+  if (
+    typeof value === 'undefined' ||
+    typeof value === 'function' ||
+    typeof value === 'symbol'
+  ) {
+    if (position === 'object') {
+      return false;
+    }
+    if (position === 'array') {
+      appendSerializedChunk(collector, 'null');
+    } else if (typeof value === 'undefined') {
+      appendSerializedChunk(collector, 'undefined');
+    } else {
+      appendJsonString(
+        collector,
+        typeof value === 'function'
+          ? `[Function${value.name ? `: ${value.name}` : ''}]`
+          : String(value)
       );
     }
-  } else {
+    return true;
+  }
+  if (value instanceof ArrayBuffer) {
+    appendJsonString(collector, `[ArrayBuffer: ${value.byteLength} bytes]`);
+    return true;
+  }
+  if (ArrayBuffer.isView(value)) {
+    appendJsonString(
+      collector,
+      `[${getArrayBufferViewName(value)}: ${value.byteLength} bytes]`
+    );
+    return true;
+  }
+  if (value instanceof Date) {
+    const time = Date.prototype.getTime.call(value);
+    if (!Number.isFinite(time)) {
+      appendSerializedChunk(collector, 'null');
+    } else {
+      appendJsonString(collector, Date.prototype.toISOString.call(value));
+    }
+    return true;
+  }
+  if (value instanceof String) {
+    appendJsonString(collector, String.prototype.valueOf.call(value));
+    return true;
+  }
+  if (value instanceof Number) {
+    const number = Number.prototype.valueOf.call(value);
+    appendSerializedChunk(
+      collector,
+      Number.isFinite(number) ? String(number === 0 ? 0 : number) : 'null'
+    );
+    return true;
+  }
+  if (value instanceof Boolean) {
+    appendSerializedChunk(
+      collector,
+      String(Boolean.prototype.valueOf.call(value))
+    );
+    return true;
+  }
+  if (depth >= MAX_STRUCTURED_SERIALIZATION_DEPTH) {
+    appendJsonString(collector, '[Max serialization depth]');
+    return true;
+  }
+  if (ancestors.has(value)) {
+    appendJsonString(collector, '[Circular]');
+    return true;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const arrayLength = readStructuredArrayLength(value, collector.work);
+      if (arrayLength == null) {
+        appendJsonString(collector, '[Unreadable array omitted]');
+        return true;
+      }
+      appendSerializedChunk(collector, '[');
+      for (let i = 0; i < arrayLength; i++) {
+        if (!consumeStructuredWork(collector.work)) {
+          if (i > 0) {
+            appendSerializedChunk(collector, ',');
+          }
+          appendJsonString(
+            collector,
+            `[Traversal limit exceeded: ${arrayLength - i} array entries omitted]`
+          );
+          break;
+        }
+        if (i > 0) {
+          appendSerializedChunk(collector, ',');
+        }
+        appendStructuredValue(
+          collector,
+          readStructuredProperty(value, i, collector.work),
+          ancestors,
+          depth + 1,
+          'array'
+        );
+      }
+      appendSerializedChunk(collector, ']');
+      return true;
+    }
+
+    appendSerializedChunk(collector, '{');
     let emitted = 0;
-    for (const key of Object.keys(value)) {
-      if (length > limit) {
+    // `Object.keys()` allocates an array proportional to the complete object
+    // before either output limit applies. Filter a streaming `for…in` walk to
+    // retain JSON's own-enumerable-key semantics without that extra array.
+    for (const key in value) {
+      if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
+        continue;
+      }
+      if (!consumeStructuredWork(collector.work)) {
+        if (emitted > 0) {
+          appendSerializedChunk(collector, ',');
+        }
+        appendJsonString(collector, '_truncated');
+        appendSerializedChunk(collector, ':');
+        appendJsonString(collector, '[Traversal limit exceeded]');
         break;
       }
-      const nested = (value as Record<string, unknown>)[key];
+      const nested = readStructuredProperty(
+        value as Record<string, unknown>,
+        key,
+        collector.work
+      );
       if (
         typeof nested === 'undefined' ||
         typeof nested === 'function' ||
@@ -138,117 +717,222 @@ function estimateStructuredChars(
         continue;
       }
       if (emitted > 0) {
-        length++;
+        appendSerializedChunk(collector, ',');
       }
-      length += jsonStringLength(key) + 1;
-      length += estimateStructuredChars(
-        nested,
-        Math.max(0, limit - length),
-        ancestors
-      );
+      appendJsonString(collector, key);
+      appendSerializedChunk(collector, ':');
+      appendStructuredValue(collector, nested, ancestors, depth + 1, 'object');
       emitted++;
     }
+    appendSerializedChunk(collector, '}');
+    return true;
+  } finally {
+    ancestors.delete(value);
   }
-  ancestors.pop();
-  return Math.min(limit + 1, length);
 }
 
-type PreviewState = {
-  remaining: number;
-  ancestors: object[];
-};
-
-function createStructuredPreview(value: unknown, state: PreviewState): unknown {
-  if (typeof value === 'string') {
-    const available = Math.max(0, state.remaining - 24);
-    const preview =
-      value.length > available
-        ? `${value.slice(0, available)}…[truncated]`
-        : value;
-    state.remaining = Math.max(0, state.remaining - preview.length);
-    return preview;
-  }
-  if (typeof value === 'bigint') {
-    return value.toString();
-  }
-  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
-    const name =
-      value instanceof ArrayBuffer ? 'ArrayBuffer' : value.constructor.name;
-    return `[${name}: ${value.byteLength} bytes]`;
-  }
-  if (value == null || typeof value !== 'object') {
-    return value;
-  }
-  if (state.ancestors.includes(value)) {
-    return '[Circular]';
+function formatBoundedStructuredContent(
+  collector: StructuredSerializationCollector,
+  maxChars: number,
+  prefix: string,
+  suffix: string
+): string {
+  if (collector.totalChars <= maxChars) {
+    return prefix.slice(0, collector.totalChars);
   }
 
-  state.ancestors.push(value);
-  if (Array.isArray(value)) {
-    const preview: unknown[] = [];
-    let i = 0;
-    for (; i < value.length && state.remaining > 48; i++) {
-      state.remaining -= 2;
-      preview.push(createStructuredPreview(value[i], state));
-    }
-    if (i < value.length) {
-      preview.push(`[truncated ${value.length - i} item(s)]`);
-    }
-    state.ancestors.pop();
-    return preview;
+  const indicator =
+    `\n\n… [truncated: ${collector.totalChars} chars exceeded ` +
+    `${maxChars} limit] …\n\n`;
+  const available = maxChars - indicator.length;
+  if (available <= 0) {
+    return prefix.slice(0, maxChars);
+  }
+  if (available < 200) {
+    return prefix.slice(0, available) + indicator.trimEnd();
   }
 
-  const preview: Record<string, unknown> = {};
-  const entries = Object.entries(value);
-  let i = 0;
-  for (; i < entries.length && state.remaining > 48; i++) {
-    const [key, nested] = entries[i];
-    state.remaining -= key.length + 4;
-    preview[key] = createStructuredPreview(nested, state);
+  const headSize = Math.ceil(available * 0.7);
+  const tailSize = available - headSize;
+  let headEnd = headSize;
+  const headNewline = prefix.lastIndexOf('\n', headSize);
+  if (headNewline > headSize - 200 && headNewline > 0) {
+    headEnd = headNewline;
   }
-  if (i < entries.length) {
-    preview._truncated = `${entries.length - i} field(s)`;
+
+  let tailStart = Math.max(0, suffix.length - tailSize);
+  const tailNewline = suffix.indexOf('\n', tailStart);
+  if (tailNewline > 0 && tailNewline < tailStart + 200) {
+    tailStart = tailNewline + 1;
   }
-  state.ancestors.pop();
-  return preview;
+
+  return prefix.slice(0, headEnd) + indicator + suffix.slice(tailStart);
+}
+
+/**
+ * Serializes structured output while retaining at most the requested provider
+ * preview and registry prefix. The traversal never calls `toJSON` and never
+ * materializes the complete serialized string when it exceeds those limits.
+ *
+ * `prefixChars` is useful for the tool-output registry: it receives the exact
+ * serialized prefix up to `registry.perOutputLimit`, while `content` retains
+ * the provider-facing head/tail truncation behavior at `maxChars`. Property
+ * accessors are represented by a fixed placeholder instead of being invoked.
+ */
+export function serializeStructuredValueBounded(
+  value: unknown,
+  maxChars: number,
+  prefixChars = 0
+): BoundedStructuredSerialization {
+  const normalizedMaxChars = normalizeCharLimit(maxChars);
+  const normalizedPrefixChars = normalizeCharLimit(prefixChars);
+  const prefixLimit = Math.max(normalizedMaxChars, normalizedPrefixChars);
+  const collector: StructuredSerializationCollector = {
+    totalChars: 0,
+    prefix: createSegmentedStringBuffer(),
+    suffix: createSegmentedStringBuffer(),
+    prefixLimit,
+    suffixLimit:
+      normalizedMaxChars === Number.MAX_SAFE_INTEGER ? 0 : normalizedMaxChars,
+    work: createStructuredWorkState(),
+  };
+
+  try {
+    appendStructuredValue(collector, value, new Set<object>(), 0, 'top');
+  } catch {
+    collector.totalChars = 0;
+    collector.prefix = createSegmentedStringBuffer();
+    collector.suffix = createSegmentedStringBuffer();
+    collector.work = createStructuredWorkState();
+    collector.work.exceeded = true;
+    appendJsonString(collector, '[Unserializable structured value]');
+  }
+
+  const prefix = materializeSegmentedStringBuffer(collector.prefix);
+  const suffix = materializeSegmentedStringBuffer(collector.suffix);
+  const originalChars = collector.work.exceeded
+    ? Number.MAX_SAFE_INTEGER
+    : collector.totalChars;
+  return {
+    content: formatBoundedStructuredContent(
+      collector,
+      normalizedMaxChars,
+      prefix,
+      suffix
+    ),
+    prefix: prefix.slice(0, normalizedPrefixChars),
+    originalChars,
+    truncated:
+      collector.work.exceeded || collector.totalChars > normalizedMaxChars,
+  };
 }
 
 function serializeStructuredValueWithinLimit(
   value: unknown,
   maxChars: number
 ): string {
-  const normalizedMaxChars = Math.max(0, Math.floor(maxChars));
-  if (
-    estimateStructuredChars(value, normalizedMaxChars) <= normalizedMaxChars
-  ) {
-    return serializeStructuredValue(value);
+  return serializeStructuredValueBounded(value, maxChars).content;
+}
+
+function isTextBlock(value: unknown): value is TextToolContentBlock {
+  if (!isRecord(value) || hasUnsafeCallableToJSON(value)) {
+    return false;
   }
-  const preview = createStructuredPreview(value, {
-    remaining: normalizedMaxChars,
-    ancestors: [],
-  });
-  return truncateToolResultContent(
-    serializeStructuredValue(preview),
-    normalizedMaxChars
+  const type = readOwnEnumerableDataProperty(value, 'type');
+  const text = readOwnEnumerableDataProperty(value, 'text');
+  return (
+    type.found &&
+    type.value === 'text' &&
+    text.found &&
+    typeof text.value === 'string'
   );
 }
 
-function isTextBlock(
-  value: unknown
-): value is ToolContentBlock & { type: 'text'; text: string } {
-  if (typeof value !== 'object' || value == null) {
+function isArray(value: unknown): value is unknown[] {
+  try {
+    return Array.isArray(value);
+  } catch {
     return false;
   }
-  const record = value as Record<string, unknown>;
-  return record.type === 'text' && typeof record.text === 'string';
+}
+
+function getDenseTextBlockArrayLength(content: unknown[]): number | undefined {
+  if (isProxy(content)) {
+    return undefined;
+  }
+  let contentLength: number;
+  try {
+    contentLength = content.length;
+  } catch {
+    return undefined;
+  }
+  if (
+    contentLength === 0 ||
+    contentLength > MAX_STRUCTURED_SERIALIZATION_WORK
+  ) {
+    return undefined;
+  }
+
+  let length = contentLength - 1;
+  try {
+    for (let i = 0; i < contentLength; i++) {
+      if (!Object.prototype.hasOwnProperty.call(content, i)) {
+        return undefined;
+      }
+      const block = content[i];
+      if (!isTextBlock(block)) {
+        return undefined;
+      }
+      length += block.text.length;
+      if (length >= Number.MAX_SAFE_INTEGER) {
+        return Number.MAX_SAFE_INTEGER;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return length;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value != null;
 }
 
+type OwnDataProperty =
+  | { found: true; value: unknown }
+  | { found: false; value?: never };
+
+function readOwnEnumerableDataProperty(
+  record: Record<string, unknown>,
+  key: string
+): OwnDataProperty {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (
+      descriptor == null ||
+      descriptor.enumerable !== true ||
+      !('value' in descriptor)
+    ) {
+      return { found: false };
+    }
+    return { found: true, value: descriptor.value };
+  } catch {
+    return { found: false };
+  }
+}
+
 function hasString(record: Record<string, unknown>, key: string): boolean {
-  return typeof record[key] === 'string' && record[key] !== '';
+  const property = readOwnEnumerableDataProperty(record, key);
+  return (
+    property.found &&
+    typeof property.value === 'string' &&
+    property.value !== ''
+  );
+}
+
+function hasValue(record: Record<string, unknown>, key: string): boolean {
+  const property = readOwnEnumerableDataProperty(record, key);
+  return property.found && property.value !== undefined;
 }
 
 function isStringPayload(value: unknown): boolean {
@@ -266,7 +950,7 @@ function isBinaryPayload(value: unknown): boolean {
 }
 
 function isContentPayload(value: unknown): boolean {
-  return Array.isArray(value) && value.length > 0;
+  return isArray(value) && value.length > 0;
 }
 
 function hasPayloadPath(
@@ -279,7 +963,11 @@ function hasPayloadPath(
     if (!isRecord(value)) {
       return false;
     }
-    value = value[key];
+    const property = readOwnEnumerableDataProperty(value, key);
+    if (!property.found) {
+      return false;
+    }
+    value = property.value;
   }
   return validator(value);
 }
@@ -292,21 +980,282 @@ function hasAnyPayloadPath(
   return paths.some((path) => hasPayloadPath(record, path, validator));
 }
 
+function isProviderNativeToolResultBlock(
+  record: Record<string, unknown>,
+  type: string
+): boolean {
+  if (type === 'search_result') {
+    return (
+      hasString(record, 'title') &&
+      hasString(record, 'source') &&
+      hasPayloadPath(record, ['content'], isArray)
+    );
+  }
+  if (type === 'web_search_result') {
+    return hasString(record, 'url');
+  }
+  if (type === 'web_search_tool_result') {
+    const content = readOwnEnumerableDataProperty(record, 'content');
+    return (
+      hasString(record, 'tool_use_id') &&
+      content.found &&
+      (isArray(content.value) || isRecord(content.value))
+    );
+  }
+  if (type === 'tool_result') {
+    return hasString(record, 'tool_use_id');
+  }
+  if (type === 'server_tool_call_result') {
+    const status = readOwnEnumerableDataProperty(record, 'status');
+    return (
+      hasString(record, 'toolCallId') &&
+      status.found &&
+      (status.value === 'success' || status.value === 'error') &&
+      hasValue(record, 'output')
+    );
+  }
+  if (type === 'toolResponse') {
+    const response = readOwnEnumerableDataProperty(record, 'toolResponse');
+    return response.found && isRecord(response.value);
+  }
+  return false;
+}
+
+const MAX_ATOMIC_VALIDATION_WORK = 10_000;
+const MAX_ATOMIC_VALIDATION_DEPTH = 50;
+const NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype,
+  'byteLength'
+)?.get;
+const NATIVE_DATE_GET_TIME = Date.prototype.getTime;
+const NATIVE_DATE_TO_JSON = Date.prototype.toJSON;
+const NATIVE_DATE_TO_ISO_STRING = Date.prototype.toISOString;
+const NATIVE_DATE_VALUE_OF = Date.prototype.valueOf;
+const NATIVE_DATE_TO_STRING = Date.prototype.toString;
+const NATIVE_DATE_TO_PRIMITIVE = Date.prototype[Symbol.toPrimitive];
+const NATIVE_DATE_PROTOTYPE_METHODS: ReadonlyArray<
+  readonly [PropertyKey, unknown]
+> = [
+  ['getTime', NATIVE_DATE_GET_TIME],
+  ['toJSON', NATIVE_DATE_TO_JSON],
+  ['toISOString', NATIVE_DATE_TO_ISO_STRING],
+  ['valueOf', NATIVE_DATE_VALUE_OF],
+  ['toString', NATIVE_DATE_TO_STRING],
+  [Symbol.toPrimitive, NATIVE_DATE_TO_PRIMITIVE],
+];
+
+function hasPotentiallyCallableToJSON(value: object): boolean {
+  let current: object | null = value;
+  const seen = new Set<object>();
+  for (let depth = 0; current != null && depth < 100; depth++) {
+    if (seen.has(current)) {
+      return true;
+    }
+    seen.add(current);
+    const descriptor = Object.getOwnPropertyDescriptor(current, 'toJSON');
+    if (descriptor != null) {
+      return (
+        typeof descriptor.value === 'function' ||
+        typeof descriptor.get === 'function'
+      );
+    }
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return current != null;
+}
+
+function isSafeNativeArrayBuffer(value: ArrayBuffer): boolean {
+  try {
+    if (
+      Object.getPrototypeOf(value) !== ArrayBuffer.prototype ||
+      NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER == null ||
+      Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength')
+        ?.get !== NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER ||
+      hasPotentiallyCallableToJSON(value)
+    ) {
+      return false;
+    }
+    NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER.call(value);
+    for (const key in value) {
+      if (Object.prototype.propertyIsEnumerable.call(value, key)) {
+        return false;
+      }
+    }
+    return Object.getOwnPropertyDescriptor(value, 'byteLength') == null;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeNativeDate(value: Date): boolean {
+  try {
+    if (Object.getPrototypeOf(value) !== Date.prototype) {
+      return false;
+    }
+    NATIVE_DATE_GET_TIME.call(value);
+    for (const [key, nativeMethod] of NATIVE_DATE_PROTOTYPE_METHODS) {
+      if (
+        Object.getOwnPropertyDescriptor(value, key) != null ||
+        Object.getOwnPropertyDescriptor(Date.prototype, key)?.value !==
+          nativeMethod
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasUnsafeCallableToJSON(
+  value: unknown,
+  seen = new Set<object>(),
+  remaining = { value: MAX_ATOMIC_VALIDATION_WORK },
+  depth = 0
+): boolean {
+  if (isProxy(value)) {
+    return true;
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  try {
+    if (value instanceof ArrayBuffer) {
+      return !isSafeNativeArrayBuffer(value);
+    }
+    if (value instanceof Date) {
+      return !isSafeNativeDate(value);
+    }
+    if (ArrayBuffer.isView(value)) {
+      return hasPotentiallyCallableToJSON(value);
+    }
+  } catch {
+    return true;
+  }
+  if (seen.has(value)) {
+    return true;
+  }
+  if (depth >= MAX_ATOMIC_VALIDATION_DEPTH || remaining.value <= 0) {
+    return true;
+  }
+
+  remaining.value--;
+  seen.add(value);
+  try {
+    if (hasPotentiallyCallableToJSON(value)) {
+      return true;
+    }
+    if (isArray(value)) {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Array.prototype && prototype !== null) {
+        return true;
+      }
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+      const length = lengthDescriptor?.value;
+      if (
+        typeof length !== 'number' ||
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        length > remaining.value
+      ) {
+        return true;
+      }
+      remaining.value -= length;
+      for (let i = 0; i < length; i++) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(i));
+        if (
+          descriptor == null ||
+          typeof descriptor.get === 'function' ||
+          typeof descriptor.set === 'function'
+        ) {
+          return true;
+        }
+        if (
+          hasUnsafeCallableToJSON(descriptor.value, seen, remaining, depth + 1)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return true;
+    }
+    for (const key in value) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor == null) {
+        return true;
+      }
+      if (descriptor.enumerable !== true) {
+        continue;
+      }
+      if (
+        remaining.value <= 0 ||
+        typeof descriptor.get === 'function' ||
+        typeof descriptor.set === 'function'
+      ) {
+        return true;
+      }
+      remaining.value--;
+      if (
+        hasUnsafeCallableToJSON(descriptor.value, seen, remaining, depth + 1)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return true;
+  } finally {
+    seen.delete(value);
+  }
+}
+
 export function isAtomicToolContentBlock(value: unknown): boolean {
+  try {
+    return (
+      !hasUnsafeCallableToJSON(value) &&
+      isAtomicToolContentBlockUnchecked(value)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isAtomicToolContentBlockUnchecked(value: unknown): boolean {
   if (!isRecord(value)) {
     return false;
   }
   const record = value;
-  if (!('type' in record)) {
-    const cachePoint = record.cachePoint;
-    return isRecord(cachePoint) && cachePoint.type === 'default';
+  const typeProperty = readOwnEnumerableDataProperty(record, 'type');
+  if (!typeProperty.found) {
+    const cachePointProperty = readOwnEnumerableDataProperty(
+      record,
+      'cachePoint'
+    );
+    if (!cachePointProperty.found || !isRecord(cachePointProperty.value)) {
+      return false;
+    }
+    const cachePointType = readOwnEnumerableDataProperty(
+      cachePointProperty.value,
+      'type'
+    );
+    return cachePointType.found && cachePointType.value === 'default';
   }
-  const type = typeof record.type === 'string' ? record.type : '';
+  const type = typeof typeProperty.value === 'string' ? typeProperty.value : '';
   if (
     !ATOMIC_CONTENT_TYPES.has(type) &&
+    !PROVIDER_NATIVE_TOOL_RESULT_TYPES.has(type) &&
     !(type.includes('/') && type.split('/').length === 2)
   ) {
     return false;
+  }
+
+  if (PROVIDER_NATIVE_TOOL_RESULT_TYPES.has(type)) {
+    return isProviderNativeToolResultBlock(record, type);
   }
 
   if (type === 'computer_screenshot') {
@@ -429,8 +1378,10 @@ export function isAtomicToolContentBlock(value: unknown): boolean {
         [nestedType, 'source', 'content'],
         isContentPayload
       ) ||
-      (record.source_type === 'text' && hasString(record, 'text')) ||
-      (record.source_type === 'id' && hasString(record, 'id'))
+      (readOwnEnumerableDataProperty(record, 'source_type').value === 'text' &&
+        hasString(record, 'text')) ||
+      (readOwnEnumerableDataProperty(record, 'source_type').value === 'id' &&
+        hasString(record, 'id'))
     );
   }
 
@@ -445,11 +1396,13 @@ export function serializeToolContent(content: unknown): string {
   if (typeof content === 'string') {
     return content;
   }
-  if (!Array.isArray(content)) {
+  if (!isArray(content)) {
     return serializeStructuredValue(content);
   }
-  if (content.length > 0 && content.every(isTextBlock)) {
-    return content.map((block) => block.text).join('\n');
+  if (getDenseTextBlockArrayLength(content) != null) {
+    return (content as TextToolContentBlock[])
+      .map((block) => block.text)
+      .join('\n');
   }
   return serializeStructuredValue(content);
 }
@@ -458,50 +1411,54 @@ export function getToolContentCharLength(content: unknown): number {
   if (typeof content === 'string') {
     return content.length;
   }
-  if (
-    Array.isArray(content) &&
-    content.length > 0 &&
-    content.every(isTextBlock)
-  ) {
-    let length = content.length - 1;
-    for (const block of content) {
-      length += block.text.length;
+  if (isArray(content)) {
+    const denseTextLength = getDenseTextBlockArrayLength(content);
+    if (denseTextLength != null) {
+      return denseTextLength;
     }
-    return length;
   }
-  return estimateStructuredChars(content);
+  try {
+    return estimateStructuredChars(content);
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
 }
 
-function serializeToolContentWithinLimit(
+/**
+ * Produces provider-facing tool-result text without ever exceeding `maxChars`.
+ */
+export function serializeToolContentBounded(
   content: unknown,
   maxChars: number
 ): string {
-  const normalizedMaxChars = Math.max(0, Math.floor(maxChars));
+  const normalizedMaxChars = normalizeCharLimit(maxChars);
   if (typeof content === 'string') {
     return truncateToolResultContent(content, normalizedMaxChars);
   }
-  if (
-    !Array.isArray(content) ||
-    content.length === 0 ||
-    !content.every(isTextBlock)
-  ) {
+  if (!isArray(content)) {
     return serializeStructuredValueWithinLimit(content, normalizedMaxChars);
   }
 
-  const originalChars = getToolContentCharLength(content);
+  const originalChars = getDenseTextBlockArrayLength(content);
+  if (originalChars == null) {
+    return serializeStructuredValueWithinLimit(content, normalizedMaxChars);
+  }
   if (originalChars <= normalizedMaxChars) {
-    return content.map((block) => block.text).join('\n');
+    return (content as TextToolContentBlock[])
+      .map((block) => block.text)
+      .join('\n');
   }
   const indicator =
     `\n\n… [truncated: ${originalChars} chars exceeded ` +
     `${normalizedMaxChars} limit] …`;
   const available = Math.max(0, normalizedMaxChars - indicator.length);
   let preview = '';
+  const textBlocks = content as TextToolContentBlock[];
   for (let i = 0; i < content.length && preview.length < available; i++) {
     if (i > 0) {
       preview += '\n';
     }
-    preview += content[i].text.slice(0, available - preview.length);
+    preview += textBlocks[i].text.slice(0, available - preview.length);
   }
   return (preview + indicator).slice(0, normalizedMaxChars);
 }
@@ -532,168 +1489,221 @@ export function compactToolContent(
       originalChars: content.length,
     };
   }
-  if (!Array.isArray(content)) {
-    const originalChars = estimateStructuredChars(content);
-    const serialized = serializeStructuredValueWithinLimit(
+  if (!isArray(content)) {
+    const serialized = serializeStructuredValueBounded(
       content,
       normalizedMaxChars
     );
     return {
-      content: serialized,
+      content: serialized.content,
       changed: true,
-      originalChars,
+      originalChars: serialized.originalChars,
+    };
+  }
+  if (isProxy(content)) {
+    const serialized = serializeStructuredValueBounded(
+      content,
+      normalizedMaxChars
+    );
+    return {
+      content: serialized.content,
+      changed: true,
+      originalChars: serialized.originalChars,
+    };
+  }
+  const contentBlocks = content as ToolContentBlock[];
+
+  let contentLength: number;
+  try {
+    contentLength = contentBlocks.length;
+  } catch {
+    const serialized = serializeStructuredValueBounded(
+      contentBlocks,
+      normalizedMaxChars
+    );
+    return {
+      content: serialized.content,
+      changed: true,
+      originalChars: Number.MAX_SAFE_INTEGER,
+    };
+  }
+  if (contentLength > MAX_STRUCTURED_SERIALIZATION_WORK) {
+    const serialized = serializeStructuredValueBounded(
+      contentBlocks,
+      normalizedMaxChars
+    );
+    return {
+      content: serialized.content,
+      changed: true,
+      originalChars: serialized.originalChars,
     };
   }
 
-  const originalChars = getToolContentCharLength(content);
-  const atomicBlocks = content.filter(isAtomicToolContentBlock);
-  if (atomicBlocks.length === 0) {
-    if (
-      content.length > 0 &&
-      content.every(isTextBlock) &&
-      originalChars <= normalizedMaxChars
-    ) {
+  try {
+    const originalChars = getToolContentCharLength(contentBlocks);
+    const denseTextLength = getDenseTextBlockArrayLength(contentBlocks);
+    const atomicBlocks = contentBlocks.filter(isAtomicToolContentBlock);
+    if (atomicBlocks.length === 0) {
+      if (denseTextLength != null && originalChars <= normalizedMaxChars) {
+        return {
+          content: contentBlocks,
+          changed: false,
+          originalChars,
+        };
+      }
+      const serialized = serializeToolContentBounded(
+        contentBlocks,
+        normalizedMaxChars
+      );
       return {
-        content,
-        changed: false,
+        content: truncateToolResultContent(serialized, normalizedMaxChars),
+        // Opaque arrays are normalized even when they are small so every
+        // provider receives a universally valid tool-result string.
+        changed: true,
         originalChars,
       };
     }
-    const serialized = serializeToolContentWithinLimit(
-      content,
+
+    const hasOpaqueBlocks = contentBlocks.some(
+      (block) => !isAtomicToolContentBlock(block) && !isTextBlock(block)
+    );
+    const normalizedBlocks: ToolContentBlock[] = [];
+    let opaqueRun: unknown[] = [];
+    const flushOpaqueRun = (): void => {
+      if (opaqueRun.length === 0) {
+        return;
+      }
+      normalizedBlocks.push({
+        type: 'text',
+        text: serializeStructuredValueWithinLimit(
+          opaqueRun,
+          normalizedMaxChars
+        ),
+      });
+      opaqueRun = [];
+    };
+    for (const block of contentBlocks) {
+      if (isAtomicToolContentBlock(block) || isTextBlock(block)) {
+        flushOpaqueRun();
+        normalizedBlocks.push(block);
+      } else {
+        opaqueRun.push(block);
+      }
+    }
+    flushOpaqueRun();
+
+    const normalizedLength = getToolContentCharLength(normalizedBlocks);
+    if (normalizedLength <= normalizedMaxChars) {
+      return {
+        content: hasOpaqueBlocks ? normalizedBlocks : contentBlocks,
+        changed: hasOpaqueBlocks,
+        originalChars,
+      };
+    }
+
+    // Keep small media/resource blocks intact, but never let a single inline
+    // base64/blob block defeat the cap. Half of the budget is reserved for
+    // compactable text so the model still receives an explanation.
+    const atomicBudget = Math.floor(normalizedMaxChars / 2);
+    let atomicChars = 0;
+    const preservedAtomicBlocks = new Set<ToolContentBlock>();
+    const omittedAtomicTypes: string[] = [];
+    for (const block of normalizedBlocks) {
+      if (!isAtomicToolContentBlock(block)) {
+        continue;
+      }
+      const blockChars = estimateStructuredChars(
+        block,
+        atomicBudget - atomicChars
+      );
+      if (atomicChars + blockChars <= atomicBudget) {
+        preservedAtomicBlocks.add(block);
+        atomicChars += blockChars;
+      } else {
+        const typeProperty = isRecord(block)
+          ? readOwnEnumerableDataProperty(block, 'type')
+          : { found: false as const };
+        omittedAtomicTypes.push(
+          typeProperty.found && typeof typeProperty.value === 'string'
+            ? typeProperty.value
+            : 'media'
+        );
+      }
+    }
+
+    const compactableBlocks = normalizedBlocks.filter(
+      (block) => !isAtomicToolContentBlock(block)
+    );
+    let previewSource = serializeToolContentBounded(
+      compactableBlocks,
+      normalizedMaxChars
+    );
+    if (omittedAtomicTypes.length > 0) {
+      const omittedNotice =
+        `[omitted ${omittedAtomicTypes.length} oversized atomic tool-content ` +
+        `block${omittedAtomicTypes.length === 1 ? '' : 's'}: ` +
+        `${omittedAtomicTypes.join(', ')}]`;
+      previewSource =
+        previewSource.length > 0
+          ? `${previewSource}\n${omittedNotice}`
+          : omittedNotice;
+    }
+
+    const structuralAllowance =
+      preservedAtomicBlocks.size * 4 + (previewSource.length > 0 ? 32 : 2);
+    const previewBudget = Math.max(
+      0,
+      normalizedMaxChars - atomicChars - structuralAllowance
+    );
+    const preview = truncateToolResultContent(previewSource, previewBudget);
+    const compacted: ToolContentBlock[] = [];
+    let previewInserted = false;
+    for (const block of normalizedBlocks) {
+      if (isAtomicToolContentBlock(block)) {
+        if (preservedAtomicBlocks.has(block)) {
+          compacted.push(block);
+        }
+      } else if (!previewInserted) {
+        if (preview.length > 0) {
+          compacted.push({ type: 'text', text: preview });
+        }
+        previewInserted = true;
+      }
+    }
+    if (!previewInserted && preview.length > 0) {
+      compacted.push({ type: 'text', text: preview });
+    }
+
+    // JSON framing can make the block array a few bytes larger than the
+    // character budget. Fall back to bounded provider-neutral text rather than
+    // leaking an oversized media payload.
+    if (getToolContentCharLength(compacted) > normalizedMaxChars) {
+      return {
+        content: serializeToolContentBounded(
+          normalizedBlocks,
+          normalizedMaxChars
+        ),
+        changed: true,
+        originalChars,
+      };
+    }
+
+    return {
+      content: compacted,
+      changed: true,
+      originalChars,
+    };
+  } catch {
+    const serialized = serializeStructuredValueBounded(
+      contentBlocks,
       normalizedMaxChars
     );
     return {
-      content: truncateToolResultContent(serialized, normalizedMaxChars),
-      // Opaque arrays are normalized even when they are small so every
-      // provider receives a universally valid tool-result string.
+      content: serialized.content,
       changed: true,
-      originalChars,
+      originalChars: serialized.originalChars,
     };
   }
-
-  const hasOpaqueBlocks = content.some(
-    (block) => !isAtomicToolContentBlock(block) && !isTextBlock(block)
-  );
-  const normalizedBlocks: ToolContentBlock[] = [];
-  let opaqueRun: unknown[] = [];
-  const flushOpaqueRun = (): void => {
-    if (opaqueRun.length === 0) {
-      return;
-    }
-    normalizedBlocks.push({
-      type: 'text',
-      text: serializeStructuredValueWithinLimit(opaqueRun, normalizedMaxChars),
-    });
-    opaqueRun = [];
-  };
-  for (const block of content) {
-    if (isAtomicToolContentBlock(block) || isTextBlock(block)) {
-      flushOpaqueRun();
-      normalizedBlocks.push(block);
-    } else {
-      opaqueRun.push(block);
-    }
-  }
-  flushOpaqueRun();
-
-  const normalizedLength = getToolContentCharLength(normalizedBlocks);
-  if (normalizedLength <= normalizedMaxChars) {
-    return {
-      content: hasOpaqueBlocks ? normalizedBlocks : content,
-      changed: hasOpaqueBlocks,
-      originalChars,
-    };
-  }
-
-  // Keep small media/resource blocks intact, but never let a single inline
-  // base64/blob block defeat the cap. Half of the budget is reserved for
-  // compactable text so the model still receives an explanation.
-  const atomicBudget = Math.floor(normalizedMaxChars / 2);
-  let atomicChars = 0;
-  const preservedAtomicBlocks = new Set<ToolContentBlock>();
-  const omittedAtomicTypes: string[] = [];
-  for (const block of normalizedBlocks) {
-    if (!isAtomicToolContentBlock(block)) {
-      continue;
-    }
-    const blockChars = estimateStructuredChars(
-      block,
-      atomicBudget - atomicChars
-    );
-    if (atomicChars + blockChars <= atomicBudget) {
-      preservedAtomicBlocks.add(block);
-      atomicChars += blockChars;
-    } else {
-      const record = block as Record<string, unknown>;
-      omittedAtomicTypes.push(
-        typeof record.type === 'string' ? record.type : 'media'
-      );
-    }
-  }
-
-  const compactableBlocks = normalizedBlocks.filter(
-    (block) => !isAtomicToolContentBlock(block)
-  );
-  let previewSource = serializeToolContentWithinLimit(
-    compactableBlocks,
-    normalizedMaxChars
-  );
-  if (omittedAtomicTypes.length > 0) {
-    const omittedNotice =
-      `[omitted ${omittedAtomicTypes.length} oversized media/resource ` +
-      `block${omittedAtomicTypes.length === 1 ? '' : 's'}: ` +
-      `${omittedAtomicTypes.join(', ')}]`;
-    previewSource =
-      previewSource.length > 0
-        ? `${previewSource}\n${omittedNotice}`
-        : omittedNotice;
-  }
-
-  const structuralAllowance =
-    preservedAtomicBlocks.size * 4 + (previewSource.length > 0 ? 32 : 2);
-  const previewBudget = Math.max(
-    0,
-    normalizedMaxChars - atomicChars - structuralAllowance
-  );
-  const preview = truncateToolResultContent(previewSource, previewBudget);
-  const compacted: ToolContentBlock[] = [];
-  let previewInserted = false;
-  for (const block of normalizedBlocks) {
-    if (isAtomicToolContentBlock(block)) {
-      if (preservedAtomicBlocks.has(block)) {
-        compacted.push(block);
-      }
-    } else if (!previewInserted) {
-      if (preview.length > 0) {
-        compacted.push({ type: 'text', text: preview });
-      }
-      previewInserted = true;
-    }
-  }
-  if (!previewInserted && preview.length > 0) {
-    compacted.push({ type: 'text', text: preview });
-  }
-
-  // JSON framing can make the block array a few bytes larger than the
-  // character budget. Fall back to bounded provider-neutral text rather than
-  // leaking an oversized media payload.
-  if (getToolContentCharLength(compacted) > normalizedMaxChars) {
-    return {
-      content: serializeToolContentWithinLimit(
-        normalizedBlocks,
-        normalizedMaxChars
-      ),
-      changed: true,
-      originalChars,
-    };
-  }
-
-  return {
-    content: compacted,
-    changed: true,
-    originalChars,
-  };
 }
 
 /** Clones a ToolMessage while retaining fields omitted by ad-hoc clones. */

--- a/src/utils/toolContent.ts
+++ b/src/utils/toolContent.ts
@@ -1,6 +1,9 @@
 import { isProxy } from 'node:util/types';
 import { ToolMessage, type BaseMessage } from '@langchain/core/messages';
-import { truncateToolResultContent } from './truncation';
+import {
+  HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
+  truncateToolResultContent,
+} from './truncation';
 
 type ToolContent = BaseMessage['content'];
 type ToolContentBlock = Exclude<ToolContent, string>[number];
@@ -15,12 +18,16 @@ const ATOMIC_CONTENT_TYPES = new Set([
   'image_file',
   'image_url',
   'input_audio',
+  'input_image',
   'media',
   'resource',
   'resource_link',
   'video',
   'video_url',
 ]);
+const MAX_TOOL_CONTENT_TYPE_CHARS = 256;
+const MAX_PROVIDER_IMAGE_URL_CHARS = 16_384;
+const MAX_PROVIDER_FILE_ID_CHARS = 4_096;
 
 const PROVIDER_NATIVE_TOOL_RESULT_TYPES = new Set([
   'search_result',
@@ -36,82 +43,76 @@ const PROVIDER_NATIVE_TOOL_RESULT_TYPES = new Set([
  * such as bigint or circular diagnostic metadata.
  */
 export function serializeStructuredValue(value: unknown): string {
-  const ancestors: object[] = [];
-  try {
-    const serialized: unknown = JSON.stringify(
-      value,
-      function (_key, nestedValue: unknown) {
-        if (typeof nestedValue === 'bigint') {
-          return nestedValue.toString();
-        }
-        if (
-          nestedValue instanceof ArrayBuffer ||
-          ArrayBuffer.isView(nestedValue)
-        ) {
-          const name =
-            nestedValue instanceof ArrayBuffer
-              ? 'ArrayBuffer'
-              : nestedValue.constructor.name;
-          return `[${name}: ${nestedValue.byteLength} bytes]`;
-        }
-        if (nestedValue != null && typeof nestedValue === 'object') {
-          while (
-            ancestors.length > 0 &&
-            ancestors[ancestors.length - 1] !== this
-          ) {
-            ancestors.pop();
-          }
-          if (ancestors.includes(nestedValue)) {
-            return '[Circular]';
-          }
-          ancestors.push(nestedValue);
-        }
-        return nestedValue;
-      }
-    );
-    return typeof serialized === 'string' ? serialized : String(value);
-  } catch {
-    try {
-      return String(value);
-    } catch {
-      return '[Unserializable structured value]';
-    }
-  }
+  return serializeStructuredValueBounded(value, Number.MAX_SAFE_INTEGER)
+    .content;
 }
 
 const SERIALIZATION_CHUNK_SIZE = 4_096;
 const MAX_STRUCTURED_SERIALIZATION_DEPTH = 200;
 const MAX_STRUCTURED_SERIALIZATION_WORK = 1_000_000;
+const MAX_STRUCTURED_CHARACTER_WORK = 1_000_000;
+const MAX_STRUCTURED_PROPERTY_CACHE_ENTRIES = 10_000;
 const PROXY_VALUE_PLACEHOLDER = '[Proxy value omitted]';
+const CHARACTER_WORK_PLACEHOLDER =
+  '[truncated: character traversal limit exceeded]';
 
 type StructuredWorkState = {
   remaining: number;
+  characterRemaining: number;
   exceeded: boolean;
+  failurePlaceholder?: string;
+  propertyCache: WeakMap<object, Map<string, unknown>>;
+  propertyCacheEntries: number;
 };
 
 function createStructuredWorkState(): StructuredWorkState {
   return {
     remaining: MAX_STRUCTURED_SERIALIZATION_WORK,
+    characterRemaining: MAX_STRUCTURED_CHARACTER_WORK,
     exceeded: false,
+    propertyCache: new WeakMap<object, Map<string, unknown>>(),
+    propertyCacheEntries: 0,
   };
 }
 
 function consumeStructuredWork(state: StructuredWorkState): boolean {
   if (state.remaining <= 0) {
     state.exceeded = true;
+    state.failurePlaceholder ??= '[Traversal limit exceeded]';
     return false;
   }
   state.remaining--;
   return true;
 }
 
+function consumeStructuredCharacterWork(state: StructuredWorkState): boolean {
+  if (state.characterRemaining <= 0) {
+    state.exceeded = true;
+    state.failurePlaceholder ??= CHARACTER_WORK_PLACEHOLDER;
+    return false;
+  }
+  state.characterRemaining--;
+  return true;
+}
+
+function hasExceededStructuredWork(state: StructuredWorkState): boolean {
+  return state.exceeded;
+}
+
 function conservativeStructuredLength(limit: number): number {
   return limit >= Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : limit + 1;
 }
 
-function jsonStringLength(value: string): number {
+function jsonStringLength(
+  value: string,
+  limit: number,
+  work: StructuredWorkState
+): number {
   let length = 2;
   for (let i = 0; i < value.length; i++) {
+    if (!consumeStructuredCharacterWork(work)) {
+      return conservativeStructuredLength(limit);
+    }
     const code = value.charCodeAt(i);
     if (
       code === 0x08 ||
@@ -126,6 +127,9 @@ function jsonStringLength(value: string): number {
     } else if (code < 0x20) {
       length += 6;
     } else if (code >= 0xd800 && code <= 0xdbff) {
+      if (!consumeStructuredCharacterWork(work)) {
+        return conservativeStructuredLength(limit);
+      }
       const next = value.charCodeAt(i + 1);
       if (next >= 0xdc00 && next <= 0xdfff) {
         length += 2;
@@ -138,8 +142,63 @@ function jsonStringLength(value: string): number {
     } else {
       length++;
     }
+    if (length > limit) {
+      return conservativeStructuredLength(limit);
+    }
   }
   return length;
+}
+
+type NativeDateRead = { matched: true; time: number } | { matched: false };
+
+function readNativeArrayBufferByteLength(value: unknown): number | undefined {
+  if (
+    value == null ||
+    typeof value !== 'object' ||
+    NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER == null
+  ) {
+    return undefined;
+  }
+  try {
+    return NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER.call(value) as number;
+  } catch {
+    return undefined;
+  }
+}
+
+function readNativeDate(value: unknown): NativeDateRead {
+  if (value == null || typeof value !== 'object') {
+    return { matched: false };
+  }
+  try {
+    return { matched: true, time: NATIVE_DATE_GET_TIME.call(value) };
+  } catch {
+    return { matched: false };
+  }
+}
+
+function readNativeBoxedString(value: object): string | undefined {
+  try {
+    return String.prototype.valueOf.call(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readNativeBoxedNumber(value: object): number | undefined {
+  try {
+    return Number.prototype.valueOf.call(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function readNativeBoxedBoolean(value: object): boolean | undefined {
+  try {
+    return Boolean.prototype.valueOf.call(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function estimateStructuredChars(
@@ -149,52 +208,115 @@ function estimateStructuredChars(
   work = createStructuredWorkState(),
   depth = 0
 ): number {
+  if (hasExceededStructuredWork(work)) {
+    return conservativeStructuredLength(limit);
+  }
   if (typeof value === 'string') {
-    return jsonStringLength(value);
+    return jsonStringLength(value, limit, work);
   }
   if (typeof value === 'bigint') {
-    return jsonStringLength(value.toString());
+    return jsonStringLength(value.toString(), limit, work);
   }
-  if (
-    typeof value === 'number' ||
-    typeof value === 'boolean' ||
-    value == null
-  ) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value === 0 ? 0 : value).length : 4;
+  }
+  if (typeof value === 'boolean' || value == null) {
     return String(value).length;
   }
   if (isProxy(value)) {
     work.exceeded = true;
+    work.failurePlaceholder = PROXY_VALUE_PLACEHOLDER;
     return conservativeStructuredLength(limit);
   }
   if (typeof value === 'undefined' || typeof value === 'function') {
     return 4;
   }
-  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
-    return Math.min(limit + 1, Math.ceil((value.byteLength * 4) / 3) + 32);
-  }
-  if (value instanceof Date) {
-    const time = Date.prototype.getTime.call(value);
-    return Number.isFinite(time)
-      ? jsonStringLength(Date.prototype.toISOString.call(value))
-      : 4;
-  }
-  if (value instanceof String) {
-    return jsonStringLength(String.prototype.valueOf.call(value));
-  }
-  if (value instanceof Number) {
-    const number = Number.prototype.valueOf.call(value);
-    return Number.isFinite(number)
-      ? String(number === 0 ? 0 : number).length
-      : 4;
-  }
-  if (value instanceof Boolean) {
-    return String(Boolean.prototype.valueOf.call(value)).length;
-  }
   if (typeof value !== 'object') {
-    return jsonStringLength(String(value));
+    return jsonStringLength(String(value), limit, work);
+  }
+
+  const valueIsArray = isArray(value);
+  if (!valueIsArray) {
+    const arrayBufferByteLength = readNativeArrayBufferByteLength(value);
+    if (arrayBufferByteLength != null) {
+      if (!isSafeNativeArrayBuffer(value as ArrayBuffer)) {
+        work.exceeded = true;
+        return conservativeStructuredLength(limit);
+      }
+      return Math.min(
+        limit + 1,
+        Math.ceil((arrayBufferByteLength * 4) / 3) + 32
+      );
+    }
+    if (ArrayBuffer.isView(value)) {
+      const view = readSafeNativeArrayBufferView(
+        value,
+        undefined,
+        undefined,
+        false
+      );
+      if (view == null) {
+        work.exceeded = true;
+        return conservativeStructuredLength(limit);
+      }
+      return Math.min(limit + 1, Math.ceil((view.byteLength * 4) / 3) + 32);
+    }
+    const date = readNativeDate(value);
+    if (date.matched) {
+      if (!isSafeNativeDate(value as Date)) {
+        work.exceeded = true;
+        return conservativeStructuredLength(limit);
+      }
+      return Number.isFinite(date.time)
+        ? jsonStringLength(Date.prototype.toISOString.call(value), limit, work)
+        : 4;
+    }
+    const boxedString = readNativeBoxedString(value);
+    if (boxedString != null) {
+      return jsonStringLength(boxedString, limit, work);
+    }
+    const boxedNumber = readNativeBoxedNumber(value);
+    if (boxedNumber != null) {
+      return Number.isFinite(boxedNumber)
+        ? String(boxedNumber === 0 ? 0 : boxedNumber).length
+        : 4;
+    }
+    const boxedBoolean = readNativeBoxedBoolean(value);
+    if (boxedBoolean != null) {
+      return String(boxedBoolean).length;
+    }
+    let prototype: object | null;
+    try {
+      prototype = Object.getPrototypeOf(value) as object | null;
+    } catch {
+      work.exceeded = true;
+      return conservativeStructuredLength(limit);
+    }
+    if (
+      isProxy(prototype) ||
+      (prototype !== Object.prototype && prototype !== null)
+    ) {
+      work.exceeded = true;
+      return conservativeStructuredLength(limit);
+    }
+  } else {
+    let prototype: object | null;
+    try {
+      prototype = Object.getPrototypeOf(value) as object | null;
+    } catch {
+      work.exceeded = true;
+      return conservativeStructuredLength(limit);
+    }
+    if (
+      isProxy(prototype) ||
+      (prototype !== Array.prototype && prototype !== null)
+    ) {
+      work.exceeded = true;
+      return conservativeStructuredLength(limit);
+    }
   }
   if (depth >= MAX_STRUCTURED_SERIALIZATION_DEPTH) {
-    return jsonStringLength('[Max serialization depth]');
+    return jsonStringLength('[Max serialization depth]', limit, work);
   }
   if (ancestors.includes(value)) {
     return 12;
@@ -203,7 +325,7 @@ function estimateStructuredChars(
   ancestors.push(value);
   let length = 2;
   try {
-    if (Array.isArray(value)) {
+    if (valueIsArray) {
       const arrayLength = readStructuredArrayLength(value, work);
       if (arrayLength == null) {
         return conservativeStructuredLength(limit);
@@ -226,11 +348,11 @@ function estimateStructuredChars(
     } else {
       let emitted = 0;
       for (const key in value) {
-        if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
-          continue;
-        }
         if (!consumeStructuredWork(work)) {
           return conservativeStructuredLength(limit);
+        }
+        if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
+          continue;
         }
         if (length > limit) {
           break;
@@ -250,7 +372,7 @@ function estimateStructuredChars(
         if (emitted > 0) {
           length++;
         }
-        length += jsonStringLength(key) + 1;
+        length += jsonStringLength(key, Math.max(0, limit - length), work) + 1;
         length += estimateStructuredChars(
           nested,
           Math.max(0, limit - length),
@@ -267,7 +389,7 @@ function estimateStructuredChars(
   } finally {
     ancestors.pop();
   }
-  if (work.exceeded) {
+  if (hasExceededStructuredWork(work)) {
     return conservativeStructuredLength(limit);
   }
   return Math.min(limit + 1, length);
@@ -442,10 +564,22 @@ function appendJsonString(
   collector: StructuredSerializationCollector,
   value: string
 ): void {
+  if (collector.work.exceeded) {
+    appendSerializedChunk(
+      collector,
+      `"${collector.work.failurePlaceholder ?? CHARACTER_WORK_PLACEHOLDER}"`
+    );
+    return;
+  }
   appendSerializedChunk(collector, '"');
   let safeStart = 0;
 
   for (let i = 0; i < value.length; i++) {
+    if (!consumeStructuredCharacterWork(collector.work)) {
+      appendJsonSafeRange(collector, value, safeStart, i);
+      appendSerializedChunk(collector, `${CHARACTER_WORK_PLACEHOLDER}"`);
+      return;
+    }
     const code = value.charCodeAt(i);
     let escaped: string | undefined;
     switch (code) {
@@ -474,6 +608,11 @@ function appendJsonString(
       if (code < 0x20) {
         escaped = `\\u${code.toString(16).padStart(4, '0')}`;
       } else if (code >= 0xd800 && code <= 0xdbff) {
+        if (!consumeStructuredCharacterWork(collector.work)) {
+          appendJsonSafeRange(collector, value, safeStart, i);
+          appendSerializedChunk(collector, `${CHARACTER_WORK_PLACEHOLDER}"`);
+          return;
+        }
         const next = value.charCodeAt(i + 1);
         if (next >= 0xdc00 && next <= 0xdfff) {
           i++;
@@ -495,32 +634,38 @@ function appendJsonString(
   appendSerializedChunk(collector, '"');
 }
 
-function getArrayBufferViewName(value: ArrayBufferView): string {
-  try {
-    const prototype = Object.getPrototypeOf(value) as {
-      constructor?: { name?: unknown };
-    } | null;
-    const name = prototype?.constructor?.name;
-    return typeof name === 'string' && name !== '' ? name : 'ArrayBufferView';
-  } catch {
-    return 'ArrayBufferView';
-  }
-}
-
 function readStructuredProperty(
   value: Record<string, unknown> | unknown[],
   key: string | number,
   work: StructuredWorkState
 ): unknown {
+  const normalizedKey = String(key);
+  // Callers still consume traversal work for every occurrence. This bounded
+  // cache only avoids re-reading the same descriptor through shared references.
+  const cachedProperties = work.propertyCache.get(value);
+  if (cachedProperties != null && cachedProperties.has(normalizedKey)) {
+    return cachedProperties.get(normalizedKey);
+  }
+
   try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, String(key));
+    const descriptor = Object.getOwnPropertyDescriptor(value, normalizedKey);
+    let propertyValue: unknown;
     if (descriptor == null) {
-      return undefined;
+      propertyValue = undefined;
+    } else if ('value' in descriptor) {
+      propertyValue = descriptor.value;
+    } else {
+      propertyValue = '[Property accessor omitted]';
     }
-    if ('value' in descriptor) {
-      return descriptor.value;
+    if (work.propertyCacheEntries < MAX_STRUCTURED_PROPERTY_CACHE_ENTRIES) {
+      const properties = cachedProperties ?? new Map<string, unknown>();
+      if (cachedProperties == null) {
+        work.propertyCache.set(value, properties);
+      }
+      properties.set(normalizedKey, propertyValue);
+      work.propertyCacheEntries++;
     }
-    return '[Property accessor omitted]';
+    return propertyValue;
   } catch {
     work.exceeded = true;
     work.remaining = 0;
@@ -557,6 +702,13 @@ function appendStructuredValue(
   depth: number,
   position: 'top' | 'array' | 'object'
 ): boolean {
+  if (collector.work.exceeded) {
+    appendSerializedChunk(
+      collector,
+      `"${collector.work.failurePlaceholder ?? CHARACTER_WORK_PLACEHOLDER}"`
+    );
+    return true;
+  }
   if (typeof value === 'string') {
     appendJsonString(collector, value);
     return true;
@@ -577,8 +729,9 @@ function appendStructuredValue(
     return true;
   }
   if (isProxy(value)) {
+    appendSerializedChunk(collector, `"${PROXY_VALUE_PLACEHOLDER}"`);
     collector.work.exceeded = true;
-    appendJsonString(collector, PROXY_VALUE_PLACEHOLDER);
+    collector.work.failurePlaceholder = PROXY_VALUE_PLACEHOLDER;
     return true;
   }
   if (
@@ -596,51 +749,106 @@ function appendStructuredValue(
     } else {
       appendJsonString(
         collector,
-        typeof value === 'function'
-          ? `[Function${value.name ? `: ${value.name}` : ''}]`
-          : String(value)
+        typeof value === 'function' ? '[Function]' : String(value)
       );
     }
     return true;
   }
-  if (value instanceof ArrayBuffer) {
-    appendJsonString(collector, `[ArrayBuffer: ${value.byteLength} bytes]`);
-    return true;
-  }
-  if (ArrayBuffer.isView(value)) {
-    appendJsonString(
-      collector,
-      `[${getArrayBufferViewName(value)}: ${value.byteLength} bytes]`
-    );
-    return true;
-  }
-  if (value instanceof Date) {
-    const time = Date.prototype.getTime.call(value);
-    if (!Number.isFinite(time)) {
-      appendSerializedChunk(collector, 'null');
-    } else {
-      appendJsonString(collector, Date.prototype.toISOString.call(value));
+  const valueIsArray = isArray(value);
+  if (!valueIsArray) {
+    const arrayBufferByteLength = readNativeArrayBufferByteLength(value);
+    if (arrayBufferByteLength != null) {
+      if (!isSafeNativeArrayBuffer(value as ArrayBuffer)) {
+        appendSerializedChunk(collector, '"[Unsafe ArrayBuffer omitted]"');
+        collector.work.exceeded = true;
+        return true;
+      }
+      appendJsonString(
+        collector,
+        `[ArrayBuffer: ${arrayBufferByteLength} bytes]`
+      );
+      return true;
     }
-    return true;
-  }
-  if (value instanceof String) {
-    appendJsonString(collector, String.prototype.valueOf.call(value));
-    return true;
-  }
-  if (value instanceof Number) {
-    const number = Number.prototype.valueOf.call(value);
-    appendSerializedChunk(
-      collector,
-      Number.isFinite(number) ? String(number === 0 ? 0 : number) : 'null'
-    );
-    return true;
-  }
-  if (value instanceof Boolean) {
-    appendSerializedChunk(
-      collector,
-      String(Boolean.prototype.valueOf.call(value))
-    );
-    return true;
+    if (ArrayBuffer.isView(value)) {
+      const view = readSafeNativeArrayBufferView(
+        value,
+        undefined,
+        undefined,
+        false
+      );
+      if (view == null) {
+        appendSerializedChunk(collector, '"[Unsafe ArrayBufferView omitted]"');
+        collector.work.exceeded = true;
+        return true;
+      }
+      appendJsonString(collector, `[${view.name}: ${view.byteLength} bytes]`);
+      return true;
+    }
+    const date = readNativeDate(value);
+    if (date.matched) {
+      if (!isSafeNativeDate(value as Date)) {
+        appendSerializedChunk(collector, '"[Unsafe Date omitted]"');
+        collector.work.exceeded = true;
+      } else if (!Number.isFinite(date.time)) {
+        appendSerializedChunk(collector, 'null');
+      } else {
+        appendJsonString(collector, Date.prototype.toISOString.call(value));
+      }
+      return true;
+    }
+    const boxedString = readNativeBoxedString(value);
+    if (boxedString != null) {
+      appendJsonString(collector, boxedString);
+      return true;
+    }
+    const boxedNumber = readNativeBoxedNumber(value);
+    if (boxedNumber != null) {
+      appendSerializedChunk(
+        collector,
+        Number.isFinite(boxedNumber)
+          ? String(boxedNumber === 0 ? 0 : boxedNumber)
+          : 'null'
+      );
+      return true;
+    }
+    const boxedBoolean = readNativeBoxedBoolean(value);
+    if (boxedBoolean != null) {
+      appendSerializedChunk(collector, String(boxedBoolean));
+      return true;
+    }
+    let prototype: object | null;
+    try {
+      prototype = Object.getPrototypeOf(value) as object | null;
+    } catch {
+      appendSerializedChunk(collector, '"[Unreadable object omitted]"');
+      collector.work.exceeded = true;
+      return true;
+    }
+    if (
+      isProxy(prototype) ||
+      (prototype !== Object.prototype && prototype !== null)
+    ) {
+      appendSerializedChunk(collector, '"[Unsupported object omitted]"');
+      collector.work.exceeded = true;
+      return true;
+    }
+  } else {
+    let prototype: object | null;
+    try {
+      prototype = Object.getPrototypeOf(value) as object | null;
+    } catch {
+      appendSerializedChunk(collector, '"[Unreadable array omitted]"');
+      collector.work.exceeded = true;
+      return true;
+    }
+    if (
+      isProxy(prototype) ||
+      (prototype !== Array.prototype && prototype !== null)
+    ) {
+      appendSerializedChunk(collector, '"[Unsafe array omitted]"');
+      collector.work.exceeded = true;
+      return true;
+    }
   }
   if (depth >= MAX_STRUCTURED_SERIALIZATION_DEPTH) {
     appendJsonString(collector, '[Max serialization depth]');
@@ -653,7 +861,7 @@ function appendStructuredValue(
 
   ancestors.add(value);
   try {
-    if (Array.isArray(value)) {
+    if (valueIsArray) {
       const arrayLength = readStructuredArrayLength(value, collector.work);
       if (arrayLength == null) {
         appendJsonString(collector, '[Unreadable array omitted]');
@@ -692,17 +900,18 @@ function appendStructuredValue(
     // before either output limit applies. Filter a streaming `for…in` walk to
     // retain JSON's own-enumerable-key semantics without that extra array.
     for (const key in value) {
-      if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
-        continue;
-      }
       if (!consumeStructuredWork(collector.work)) {
         if (emitted > 0) {
           appendSerializedChunk(collector, ',');
         }
-        appendJsonString(collector, '_truncated');
-        appendSerializedChunk(collector, ':');
-        appendJsonString(collector, '[Traversal limit exceeded]');
+        appendSerializedChunk(
+          collector,
+          '"_truncated":"[Traversal limit exceeded]"'
+        );
         break;
+      }
+      if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
+        continue;
       }
       const nested = readStructuredProperty(
         value as Record<string, unknown>,
@@ -741,9 +950,10 @@ function formatBoundedStructuredContent(
     return prefix.slice(0, collector.totalChars);
   }
 
-  const indicator =
-    `\n\n… [truncated: ${collector.totalChars} chars exceeded ` +
-    `${maxChars} limit] …\n\n`;
+  const indicator = collector.work.exceeded
+    ? '\n\n… [truncated: safe traversal limit exceeded] …\n\n'
+    : `\n\n… [truncated: ${collector.totalChars} chars exceeded ` +
+      `${maxChars} limit] …\n\n`;
   const available = maxChars - indicator.length;
   if (available <= 0) {
     return prefix.slice(0, maxChars);
@@ -782,7 +992,8 @@ function formatBoundedStructuredContent(
 export function serializeStructuredValueBounded(
   value: unknown,
   maxChars: number,
-  prefixChars = 0
+  prefixChars = 0,
+  work = createStructuredWorkState()
 ): BoundedStructuredSerialization {
   const normalizedMaxChars = normalizeCharLimit(maxChars);
   const normalizedPrefixChars = normalizeCharLimit(prefixChars);
@@ -794,7 +1005,7 @@ export function serializeStructuredValueBounded(
     prefixLimit,
     suffixLimit:
       normalizedMaxChars === Number.MAX_SAFE_INTEGER ? 0 : normalizedMaxChars,
-    work: createStructuredWorkState(),
+    work,
   };
 
   try {
@@ -803,9 +1014,8 @@ export function serializeStructuredValueBounded(
     collector.totalChars = 0;
     collector.prefix = createSegmentedStringBuffer();
     collector.suffix = createSegmentedStringBuffer();
-    collector.work = createStructuredWorkState();
     collector.work.exceeded = true;
-    appendJsonString(collector, '[Unserializable structured value]');
+    appendSerializedChunk(collector, '"[Unserializable structured value]"');
   }
 
   const prefix = materializeSegmentedStringBuffer(collector.prefix);
@@ -829,23 +1039,36 @@ export function serializeStructuredValueBounded(
 
 function serializeStructuredValueWithinLimit(
   value: unknown,
-  maxChars: number
+  maxChars: number,
+  work = createStructuredWorkState()
 ): string {
-  return serializeStructuredValueBounded(value, maxChars).content;
+  return serializeStructuredValueBounded(value, maxChars, 0, work).content;
 }
 
-function isTextBlock(value: unknown): value is TextToolContentBlock {
-  if (!isRecord(value) || hasUnsafeCallableToJSON(value)) {
+function isTextBlockUnchecked(value: unknown): value is TextToolContentBlock {
+  if (!isRecord(value) || isProxy(value)) {
     return false;
   }
-  const type = readOwnEnumerableDataProperty(value, 'type');
-  const text = readOwnEnumerableDataProperty(value, 'text');
-  return (
-    type.found &&
-    type.value === 'text' &&
-    text.found &&
-    typeof text.value === 'string'
-  );
+  try {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return false;
+    }
+    const keys = Object.keys(value);
+    if (keys.length !== 2 || !keys.includes('type') || !keys.includes('text')) {
+      return false;
+    }
+    const type = readOwnEnumerableDataProperty(value, 'type');
+    const text = readOwnEnumerableDataProperty(value, 'text');
+    return (
+      type.found &&
+      type.value === 'text' &&
+      text.found &&
+      typeof text.value === 'string'
+    );
+  } catch {
+    return false;
+  }
 }
 
 function isArray(value: unknown): value is unknown[] {
@@ -860,8 +1083,21 @@ function getDenseTextBlockArrayLength(content: unknown[]): number | undefined {
   if (isProxy(content)) {
     return undefined;
   }
+  const validation = createToolBlockClassificationContext();
+  const containerWork = { value: MAX_ATOMIC_VALIDATION_WORK };
   let contentLength: number;
   try {
+    const prototype = Object.getPrototypeOf(content);
+    if (
+      (prototype !== Array.prototype && prototype !== null) ||
+      hasPotentiallyCallableToJSON(
+        content,
+        containerWork,
+        validation.totalRemaining
+      )
+    ) {
+      return undefined;
+    }
     contentLength = content.length;
   } catch {
     return undefined;
@@ -876,14 +1112,19 @@ function getDenseTextBlockArrayLength(content: unknown[]): number | undefined {
   let length = contentLength - 1;
   try {
     for (let i = 0; i < contentLength; i++) {
-      if (!Object.prototype.hasOwnProperty.call(content, i)) {
+      const descriptor = Object.getOwnPropertyDescriptor(content, String(i));
+      if (descriptor == null || !('value' in descriptor)) {
         return undefined;
       }
-      const block = content[i];
-      if (!isTextBlock(block)) {
+      const block = descriptor.value;
+      if (
+        classifyToolContentBlock(block, validation) !== TOOL_BLOCK_TEXT ||
+        validation.totalRemaining.value <= 0
+      ) {
         return undefined;
       }
-      length += block.text.length;
+      const text = readOwnEnumerableDataProperty(block, 'text');
+      length += typeof text.value === 'string' ? text.value.length : 0;
       if (length >= Number.MAX_SAFE_INTEGER) {
         return Number.MAX_SAFE_INTEGER;
       }
@@ -943,8 +1184,18 @@ function isBinaryPayload(value: unknown): boolean {
   if (typeof value === 'string') {
     return value.length > 0;
   }
-  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
-    return value.byteLength > 0;
+  if (isArray(value)) {
+    return false;
+  }
+  const arrayBufferByteLength = readNativeArrayBufferByteLength(value);
+  if (arrayBufferByteLength != null) {
+    return (
+      isSafeNativeArrayBuffer(value as ArrayBuffer) && arrayBufferByteLength > 0
+    );
+  }
+  if (ArrayBuffer.isView(value)) {
+    const view = readSafeNativeArrayBufferView(value);
+    return view != null && view.byteLength > 0;
   }
   return false;
 }
@@ -1023,10 +1274,37 @@ function isProviderNativeToolResultBlock(
 
 const MAX_ATOMIC_VALIDATION_WORK = 10_000;
 const MAX_ATOMIC_VALIDATION_DEPTH = 50;
+type AtomicValidationWork = { value: number };
 const NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
   ArrayBuffer.prototype,
   'byteLength'
 )?.get;
+const NATIVE_TYPED_ARRAY_PROTOTYPE = Object.getPrototypeOf(
+  Uint8Array.prototype
+) as object;
+const NATIVE_TYPED_ARRAY_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  NATIVE_TYPED_ARRAY_PROTOTYPE,
+  'byteLength'
+)?.get;
+const NATIVE_DATA_VIEW_BYTE_LENGTH_GETTER = Object.getOwnPropertyDescriptor(
+  DataView.prototype,
+  'byteLength'
+)?.get;
+const NATIVE_ARRAY_BUFFER_VIEW_NAMES = new Map<object, string>([
+  [Buffer.prototype, 'Buffer'],
+  [DataView.prototype, 'DataView'],
+  [Int8Array.prototype, 'Int8Array'],
+  [Uint8Array.prototype, 'Uint8Array'],
+  [Uint8ClampedArray.prototype, 'Uint8ClampedArray'],
+  [Int16Array.prototype, 'Int16Array'],
+  [Uint16Array.prototype, 'Uint16Array'],
+  [Int32Array.prototype, 'Int32Array'],
+  [Uint32Array.prototype, 'Uint32Array'],
+  [Float32Array.prototype, 'Float32Array'],
+  [Float64Array.prototype, 'Float64Array'],
+  [BigInt64Array.prototype, 'BigInt64Array'],
+  [BigUint64Array.prototype, 'BigUint64Array'],
+]);
 const NATIVE_DATE_GET_TIME = Date.prototype.getTime;
 const NATIVE_DATE_TO_JSON = Date.prototype.toJSON;
 const NATIVE_DATE_TO_ISO_STRING = Date.prototype.toISOString;
@@ -1044,10 +1322,45 @@ const NATIVE_DATE_PROTOTYPE_METHODS: ReadonlyArray<
   [Symbol.toPrimitive, NATIVE_DATE_TO_PRIMITIVE],
 ];
 
-function hasPotentiallyCallableToJSON(value: object): boolean {
+function consumeAtomicValidationWork(
+  remaining: AtomicValidationWork,
+  totalRemaining: AtomicValidationWork | undefined,
+  amount = 1
+): boolean {
+  if (
+    amount > remaining.value ||
+    (totalRemaining != null && amount > totalRemaining.value)
+  ) {
+    remaining.value = 0;
+    if (totalRemaining != null) {
+      totalRemaining.value = 0;
+    }
+    return false;
+  }
+  remaining.value -= amount;
+  if (totalRemaining != null) {
+    totalRemaining.value -= amount;
+  }
+  return true;
+}
+
+function hasPotentiallyCallableToJSON(
+  value: object,
+  remaining?: AtomicValidationWork,
+  totalRemaining?: AtomicValidationWork
+): boolean {
   let current: object | null = value;
   const seen = new Set<object>();
   for (let depth = 0; current != null && depth < 100; depth++) {
+    if (isProxy(current)) {
+      return true;
+    }
+    if (
+      remaining != null &&
+      !consumeAtomicValidationWork(remaining, totalRemaining)
+    ) {
+      return true;
+    }
     if (seen.has(current)) {
       return true;
     }
@@ -1064,19 +1377,72 @@ function hasPotentiallyCallableToJSON(value: object): boolean {
   return current != null;
 }
 
-function isSafeNativeArrayBuffer(value: ArrayBuffer): boolean {
+type NativeArrayBufferViewRead = {
+  byteLength: number;
+  name: string;
+};
+
+function readSafeNativeArrayBufferView(
+  value: ArrayBufferView,
+  remaining?: AtomicValidationWork,
+  totalRemaining?: AtomicValidationWork,
+  rejectCallableToJSON = true
+): NativeArrayBufferViewRead | undefined {
+  try {
+    const prototype = Object.getPrototypeOf(value) as object | null;
+    if (prototype == null || isProxy(prototype)) {
+      return undefined;
+    }
+    const name = NATIVE_ARRAY_BUFFER_VIEW_NAMES.get(prototype);
+    if (
+      name == null ||
+      Object.getOwnPropertyDescriptor(value, 'byteLength') != null ||
+      Object.getOwnPropertyDescriptor(value, 'constructor') != null ||
+      Object.getOwnPropertyDescriptor(value, 'toJSON') != null ||
+      (rejectCallableToJSON &&
+        hasPotentiallyCallableToJSON(value, remaining, totalRemaining))
+    ) {
+      return undefined;
+    }
+    const getter =
+      prototype === DataView.prototype
+        ? NATIVE_DATA_VIEW_BYTE_LENGTH_GETTER
+        : NATIVE_TYPED_ARRAY_BYTE_LENGTH_GETTER;
+    if (getter == null) {
+      return undefined;
+    }
+    const byteLength = getter.call(value) as number;
+    return Number.isSafeInteger(byteLength) && byteLength >= 0
+      ? { byteLength, name }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafeNativeArrayBuffer(
+  value: ArrayBuffer,
+  remaining?: AtomicValidationWork,
+  totalRemaining?: AtomicValidationWork
+): boolean {
   try {
     if (
       Object.getPrototypeOf(value) !== ArrayBuffer.prototype ||
       NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER == null ||
       Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength')
         ?.get !== NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER ||
-      hasPotentiallyCallableToJSON(value)
+      hasPotentiallyCallableToJSON(value, remaining, totalRemaining)
     ) {
       return false;
     }
     NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER.call(value);
     for (const key in value) {
+      if (
+        remaining != null &&
+        !consumeAtomicValidationWork(remaining, totalRemaining)
+      ) {
+        return false;
+      }
       if (Object.prototype.propertyIsEnumerable.call(value, key)) {
         return false;
       }
@@ -1112,7 +1478,8 @@ function hasUnsafeCallableToJSON(
   value: unknown,
   seen = new Set<object>(),
   remaining = { value: MAX_ATOMIC_VALIDATION_WORK },
-  depth = 0
+  depth = 0,
+  totalRemaining?: AtomicValidationWork
 ): boolean {
   if (isProxy(value)) {
     return true;
@@ -1120,33 +1487,40 @@ function hasUnsafeCallableToJSON(
   if (!isRecord(value)) {
     return false;
   }
-  try {
-    if (value instanceof ArrayBuffer) {
-      return !isSafeNativeArrayBuffer(value);
+  if (
+    seen.has(value) ||
+    depth >= MAX_ATOMIC_VALIDATION_DEPTH ||
+    !consumeAtomicValidationWork(remaining, totalRemaining)
+  ) {
+    return true;
+  }
+  const valueIsArray = isArray(value);
+  if (!valueIsArray) {
+    const arrayBufferByteLength = readNativeArrayBufferByteLength(value);
+    if (arrayBufferByteLength != null) {
+      return !isSafeNativeArrayBuffer(
+        value as unknown as ArrayBuffer,
+        remaining,
+        totalRemaining
+      );
     }
-    if (value instanceof Date) {
-      return !isSafeNativeDate(value);
+    const date = readNativeDate(value);
+    if (date.matched) {
+      return !isSafeNativeDate(value as unknown as Date);
     }
     if (ArrayBuffer.isView(value)) {
-      return hasPotentiallyCallableToJSON(value);
+      return (
+        readSafeNativeArrayBufferView(value, remaining, totalRemaining) == null
+      );
     }
-  } catch {
-    return true;
-  }
-  if (seen.has(value)) {
-    return true;
-  }
-  if (depth >= MAX_ATOMIC_VALIDATION_DEPTH || remaining.value <= 0) {
-    return true;
   }
 
-  remaining.value--;
   seen.add(value);
   try {
-    if (hasPotentiallyCallableToJSON(value)) {
+    if (hasPotentiallyCallableToJSON(value, remaining, totalRemaining)) {
       return true;
     }
-    if (isArray(value)) {
+    if (valueIsArray) {
       const prototype = Object.getPrototypeOf(value);
       if (prototype !== Array.prototype && prototype !== null) {
         return true;
@@ -1157,11 +1531,10 @@ function hasUnsafeCallableToJSON(
         typeof length !== 'number' ||
         !Number.isSafeInteger(length) ||
         length < 0 ||
-        length > remaining.value
+        !consumeAtomicValidationWork(remaining, totalRemaining, length)
       ) {
         return true;
       }
-      remaining.value -= length;
       for (let i = 0; i < length; i++) {
         const descriptor = Object.getOwnPropertyDescriptor(value, String(i));
         if (
@@ -1172,7 +1545,13 @@ function hasUnsafeCallableToJSON(
           return true;
         }
         if (
-          hasUnsafeCallableToJSON(descriptor.value, seen, remaining, depth + 1)
+          hasUnsafeCallableToJSON(
+            descriptor.value,
+            seen,
+            remaining,
+            depth + 1,
+            totalRemaining
+          )
         ) {
           return true;
         }
@@ -1193,15 +1572,20 @@ function hasUnsafeCallableToJSON(
         continue;
       }
       if (
-        remaining.value <= 0 ||
         typeof descriptor.get === 'function' ||
-        typeof descriptor.set === 'function'
+        typeof descriptor.set === 'function' ||
+        !consumeAtomicValidationWork(remaining, totalRemaining)
       ) {
         return true;
       }
-      remaining.value--;
       if (
-        hasUnsafeCallableToJSON(descriptor.value, seen, remaining, depth + 1)
+        hasUnsafeCallableToJSON(
+          descriptor.value,
+          seen,
+          remaining,
+          depth + 1,
+          totalRemaining
+        )
       ) {
         return true;
       }
@@ -1246,10 +1630,18 @@ function isAtomicToolContentBlockUnchecked(value: unknown): boolean {
     return cachePointType.found && cachePointType.value === 'default';
   }
   const type = typeof typeProperty.value === 'string' ? typeProperty.value : '';
+  if (type.length > MAX_TOOL_CONTENT_TYPE_CHARS) {
+    return false;
+  }
+  const slashIndex = type.indexOf('/');
+  const isMimeType =
+    slashIndex > 0 &&
+    slashIndex < type.length - 1 &&
+    slashIndex === type.lastIndexOf('/');
   if (
     !ATOMIC_CONTENT_TYPES.has(type) &&
     !PROVIDER_NATIVE_TOOL_RESULT_TYPES.has(type) &&
-    !(type.includes('/') && type.split('/').length === 2)
+    !isMimeType
   ) {
     return false;
   }
@@ -1259,7 +1651,18 @@ function isAtomicToolContentBlockUnchecked(value: unknown): boolean {
   }
 
   if (type === 'computer_screenshot') {
-    return hasPayloadPath(record, ['image_url'], isStringPayload);
+    return hasAnyPayloadPath(
+      record,
+      [['image_url'], ['file_id']],
+      isStringPayload
+    );
+  }
+  if (type === 'input_image') {
+    return hasAnyPayloadPath(
+      record,
+      [['image_url'], ['file_id']],
+      isStringPayload
+    );
   }
   if (type === 'image_url') {
     return hasAnyPayloadPath(
@@ -1305,7 +1708,7 @@ function isAtomicToolContentBlockUnchecked(value: unknown): boolean {
     );
   }
 
-  if (type.includes('/') && type.split('/').length === 2) {
+  if (isMimeType) {
     return hasPayloadPath(record, ['data'], isStringPayload);
   }
 
@@ -1388,6 +1791,59 @@ function isAtomicToolContentBlockUnchecked(value: unknown): boolean {
   return false;
 }
 
+const TOOL_BLOCK_OPAQUE = 0;
+const TOOL_BLOCK_TEXT = 1;
+const TOOL_BLOCK_ATOMIC = 2;
+
+type ToolBlockClassificationContext = {
+  totalRemaining: AtomicValidationWork;
+  cache: WeakMap<object, number>;
+};
+
+function createToolBlockClassificationContext(): ToolBlockClassificationContext {
+  return {
+    totalRemaining: { value: MAX_STRUCTURED_SERIALIZATION_WORK },
+    cache: new WeakMap<object, number>(),
+  };
+}
+
+function classifyToolContentBlock(
+  value: unknown,
+  context: ToolBlockClassificationContext
+): number {
+  if (isRecord(value)) {
+    const cached = context.cache.get(value);
+    if (cached != null) {
+      return cached;
+    }
+  }
+  const remaining = { value: MAX_ATOMIC_VALIDATION_WORK };
+  let kind = TOOL_BLOCK_OPAQUE;
+  try {
+    if (
+      hasUnsafeCallableToJSON(
+        value,
+        new Set<object>(),
+        remaining,
+        0,
+        context.totalRemaining
+      )
+    ) {
+      kind = TOOL_BLOCK_OPAQUE;
+    } else if (isAtomicToolContentBlockUnchecked(value)) {
+      kind = TOOL_BLOCK_ATOMIC;
+    } else {
+      kind = isTextBlockUnchecked(value) ? TOOL_BLOCK_TEXT : TOOL_BLOCK_OPAQUE;
+    }
+  } catch {
+    kind = TOOL_BLOCK_OPAQUE;
+  }
+  if (isRecord(value) && context.totalRemaining.value > 0) {
+    context.cache.set(value, kind);
+  }
+  return kind;
+}
+
 /**
  * Produces the text representation providers use for structured tool results.
  * Text-only block arrays stay readable; opaque blocks use canonical JSON.
@@ -1443,18 +1899,27 @@ export function serializeToolContentBounded(
   if (originalChars == null) {
     return serializeStructuredValueWithinLimit(content, normalizedMaxChars);
   }
+  return serializeDenseTextBlocksWithinLimit(
+    content as TextToolContentBlock[],
+    originalChars,
+    normalizedMaxChars
+  );
+}
+
+function serializeDenseTextBlocksWithinLimit(
+  textBlocks: readonly TextToolContentBlock[],
+  originalChars: number,
+  normalizedMaxChars: number
+): string {
   if (originalChars <= normalizedMaxChars) {
-    return (content as TextToolContentBlock[])
-      .map((block) => block.text)
-      .join('\n');
+    return textBlocks.map((block) => block.text).join('\n');
   }
   const indicator =
     `\n\n… [truncated: ${originalChars} chars exceeded ` +
     `${normalizedMaxChars} limit] …`;
   const available = Math.max(0, normalizedMaxChars - indicator.length);
   let preview = '';
-  const textBlocks = content as TextToolContentBlock[];
-  for (let i = 0; i < content.length && preview.length < available; i++) {
+  for (let i = 0; i < textBlocks.length && preview.length < available; i++) {
     if (i > 0) {
       preview += '\n';
     }
@@ -1468,6 +1933,395 @@ export type CompactToolContentResult = {
   changed: boolean;
   originalChars: number;
 };
+
+function isProviderImageUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || value === '') {
+    return false;
+  }
+  const isDataImage = value.startsWith('data:image/');
+  if (
+    value.length >
+    (isDataImage
+      ? HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      : MAX_PROVIDER_IMAGE_URL_CHARS)
+  ) {
+    return false;
+  }
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x20 || code === 0x7f) {
+      return false;
+    }
+  }
+  if (isDataImage) {
+    const separator = value.indexOf(',');
+    if (
+      separator < 0 ||
+      !value.slice(0, separator).toLowerCase().endsWith(';base64')
+    ) {
+      return false;
+    }
+    const payload = value.slice(separator + 1);
+    return (
+      payload.length > 0 &&
+      payload.length % 4 === 0 &&
+      /^[a-z0-9+/]+={0,2}$/i.test(payload)
+    );
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isProviderFileId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= MAX_PROVIDER_FILE_ID_CHARS &&
+    /^file[-_][a-z0-9_-]+$/i.test(value)
+  );
+}
+
+function hasOnlyEnumerableKeys(
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>
+): boolean {
+  try {
+    const keys = Object.keys(record);
+    return keys.every((key) => allowed.has(key));
+  } catch {
+    return false;
+  }
+}
+
+export type CacheControlledTextToolContent = [
+  {
+    type: 'text';
+    text: string;
+    cache_control: { type: 'ephemeral'; ttl?: '1h' };
+  },
+];
+
+const SINGLE_TEXT_TOOL_CONTENT_KEYS = new Set(['type', 'text']);
+const CACHE_CONTROLLED_TEXT_TOOL_CONTENT_KEYS = new Set([
+  'type',
+  'text',
+  'cache_control',
+]);
+const CACHE_CONTROL_KEYS = new Set(['type', 'ttl']);
+
+function hasSafePlainPrototype(value: object): boolean {
+  try {
+    const prototype = Object.getPrototypeOf(value) as object | null;
+    return (
+      (prototype === Object.prototype || prototype === null) &&
+      !hasPotentiallyCallableToJSON(value)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readSafeArrayItem(
+  content: unknown,
+  expectedLength: number,
+  index: number
+): OwnDataProperty {
+  if (!isArray(content) || isProxy(content)) {
+    return { found: false };
+  }
+  try {
+    const length = Object.getOwnPropertyDescriptor(content, 'length');
+    if (length?.value !== expectedLength) {
+      return { found: false };
+    }
+    const prototype = Object.getPrototypeOf(content) as object | null;
+    if (
+      (prototype !== Array.prototype && prototype !== null) ||
+      hasPotentiallyCallableToJSON(content)
+    ) {
+      return { found: false };
+    }
+    const item = Object.getOwnPropertyDescriptor(content, String(index));
+    if (item?.enumerable !== true || !('value' in item)) {
+      return { found: false };
+    }
+    return { found: true, value: item.value };
+  } catch {
+    return { found: false };
+  }
+}
+
+/** Reads one safe text block and returns its bounded text payload. */
+export function getBoundedSingleTextToolContent(
+  content: unknown,
+  maxChars: number
+): string | undefined {
+  const block = readSafeArrayItem(content, 1, 0);
+  if (
+    !block.found ||
+    !isRecord(block.value) ||
+    isProxy(block.value) ||
+    !hasSafePlainPrototype(block.value) ||
+    !hasOnlyEnumerableKeys(block.value, SINGLE_TEXT_TOOL_CONTENT_KEYS)
+  ) {
+    return undefined;
+  }
+  const type = readOwnEnumerableDataProperty(block.value, 'type');
+  const text = readOwnEnumerableDataProperty(block.value, 'text');
+  if (
+    !type.found ||
+    type.value !== 'text' ||
+    !text.found ||
+    typeof text.value !== 'string'
+  ) {
+    return undefined;
+  }
+  const normalizedMaxChars = Number.isFinite(maxChars)
+    ? Math.max(0, Math.floor(maxChars))
+    : Number.MAX_SAFE_INTEGER;
+  return truncateToolResultContent(text.value, normalizedMaxChars);
+}
+
+/**
+ * Canonicalizes the single cache-decorated text block produced by tail prompt
+ * caching without invoking accessors or custom serialization hooks.
+ */
+export function getBoundedCacheControlledTextToolContent(
+  content: unknown,
+  maxChars: number
+): CacheControlledTextToolContent | undefined {
+  const block = readSafeArrayItem(content, 1, 0);
+  if (
+    !block.found ||
+    !isRecord(block.value) ||
+    isProxy(block.value) ||
+    !hasSafePlainPrototype(block.value) ||
+    !hasOnlyEnumerableKeys(block.value, CACHE_CONTROLLED_TEXT_TOOL_CONTENT_KEYS)
+  ) {
+    return undefined;
+  }
+  const type = readOwnEnumerableDataProperty(block.value, 'type');
+  const text = readOwnEnumerableDataProperty(block.value, 'text');
+  const cacheControl = readOwnEnumerableDataProperty(
+    block.value,
+    'cache_control'
+  );
+  if (
+    !type.found ||
+    type.value !== 'text' ||
+    !text.found ||
+    typeof text.value !== 'string' ||
+    !cacheControl.found ||
+    !isRecord(cacheControl.value) ||
+    isProxy(cacheControl.value) ||
+    !hasSafePlainPrototype(cacheControl.value) ||
+    !hasOnlyEnumerableKeys(cacheControl.value, CACHE_CONTROL_KEYS)
+  ) {
+    return undefined;
+  }
+
+  const cacheType = readOwnEnumerableDataProperty(cacheControl.value, 'type');
+  const ttl = readOwnEnumerableDataProperty(cacheControl.value, 'ttl');
+  let hasOwnTtl: boolean;
+  try {
+    hasOwnTtl =
+      Object.getOwnPropertyDescriptor(cacheControl.value, 'ttl') != null;
+  } catch {
+    return undefined;
+  }
+  if (
+    !cacheType.found ||
+    cacheType.value !== 'ephemeral' ||
+    (hasOwnTtl && (!ttl.found || ttl.value !== '1h'))
+  ) {
+    return undefined;
+  }
+
+  const normalizedMaxChars = Number.isFinite(maxChars)
+    ? Math.max(0, Math.floor(maxChars))
+    : Number.MAX_SAFE_INTEGER;
+  return [
+    {
+      type: 'text',
+      text: truncateToolResultContent(text.value, normalizedMaxChars),
+      cache_control: {
+        type: 'ephemeral',
+        ...(ttl.found ? { ttl: '1h' as const } : {}),
+      },
+    },
+  ];
+}
+
+export type ComputerCallOutputScreenshot =
+  | { type: 'input_image'; image_url: string; detail?: InputImageDetail }
+  | { type: 'input_image'; file_id: string; detail?: InputImageDetail }
+  | { type: 'computer_screenshot'; image_url: string }
+  | { type: 'computer_screenshot'; file_id: string };
+
+type InputImageDetail = 'low' | 'high' | 'auto' | 'original';
+
+const INPUT_IMAGE_KEYS = new Set(['type', 'image_url', 'file_id', 'detail']);
+const COMPUTER_SCREENSHOT_KEYS = new Set(['type', 'image_url', 'file_id']);
+const IMAGE_URL_KEYS = new Set(['type', 'image_url', 'detail']);
+const NESTED_IMAGE_URL_KEYS = new Set(['url', 'detail']);
+const INPUT_IMAGE_DETAILS = new Set(['low', 'high', 'auto', 'original']);
+
+/**
+ * Selects the exact screenshot shape accepted by LangChain's Responses
+ * converter without invoking accessors or user-defined serialization hooks.
+ */
+export function getComputerCallOutputScreenshot(
+  content: unknown
+): ComputerCallOutputScreenshot | undefined {
+  if (isProviderImageUrl(content)) {
+    return { type: 'input_image', image_url: content };
+  }
+  if (
+    !isArray(content) ||
+    hasUnsafeCallableToJSON(content) ||
+    content.length !== 1
+  ) {
+    return undefined;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(content, '0');
+  if (descriptor == null || !('value' in descriptor)) {
+    return undefined;
+  }
+  const block = descriptor.value;
+  if (!isRecord(block)) {
+    return undefined;
+  }
+  const type = readOwnEnumerableDataProperty(block, 'type');
+  if (!type.found) {
+    return undefined;
+  }
+  const imageUrl = readOwnEnumerableDataProperty(block, 'image_url');
+  const fileId = readOwnEnumerableDataProperty(block, 'file_id');
+  const validImageUrl =
+    imageUrl.found && isProviderImageUrl(imageUrl.value)
+      ? imageUrl.value
+      : undefined;
+  const validFileId =
+    fileId.found && isProviderFileId(fileId.value) ? fileId.value : undefined;
+  const hasImageUrl = validImageUrl != null;
+  const hasFileId = validFileId != null;
+
+  if (
+    type.value === 'input_image' &&
+    hasOnlyEnumerableKeys(block, INPUT_IMAGE_KEYS)
+  ) {
+    if (
+      (imageUrl.found && !hasImageUrl) ||
+      (fileId.found && !hasFileId) ||
+      hasImageUrl === hasFileId
+    ) {
+      return undefined;
+    }
+    const detail = readOwnEnumerableDataProperty(block, 'detail');
+    if (
+      detail.found &&
+      (typeof detail.value !== 'string' ||
+        !INPUT_IMAGE_DETAILS.has(detail.value))
+    ) {
+      return undefined;
+    }
+    return hasImageUrl
+      ? {
+        type: 'input_image',
+        image_url: validImageUrl,
+        ...(detail.found ? { detail: detail.value as InputImageDetail } : {}),
+      }
+      : {
+        type: 'input_image',
+        file_id: validFileId as string,
+        ...(detail.found ? { detail: detail.value as InputImageDetail } : {}),
+      };
+  }
+  if (
+    type.value === 'computer_screenshot' &&
+    hasOnlyEnumerableKeys(block, COMPUTER_SCREENSHOT_KEYS)
+  ) {
+    if (
+      (imageUrl.found && !hasImageUrl) ||
+      (fileId.found && !hasFileId) ||
+      hasImageUrl === hasFileId
+    ) {
+      return undefined;
+    }
+    return hasImageUrl
+      ? { type: 'computer_screenshot', image_url: validImageUrl }
+      : {
+        type: 'computer_screenshot',
+        file_id: validFileId as string,
+      };
+  }
+  if (
+    type.value === 'image_url' &&
+    !fileId.found &&
+    hasOnlyEnumerableKeys(block, IMAGE_URL_KEYS)
+  ) {
+    if (hasImageUrl) {
+      return { type: 'input_image', image_url: validImageUrl };
+    }
+    if (
+      imageUrl.found &&
+      isRecord(imageUrl.value) &&
+      hasOnlyEnumerableKeys(imageUrl.value, NESTED_IMAGE_URL_KEYS)
+    ) {
+      const url = readOwnEnumerableDataProperty(imageUrl.value, 'url');
+      if (url.found && isProviderImageUrl(url.value)) {
+        return { type: 'input_image', image_url: url.value };
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Returns the provider image URL when a screenshot is URL-backed. */
+export function getComputerCallOutputImageUrl(
+  content: unknown
+): string | undefined {
+  const screenshot = getComputerCallOutputScreenshot(content);
+  return screenshot != null && 'image_url' in screenshot
+    ? screenshot.image_url
+    : undefined;
+}
+
+/** Returns whether content can be sent as a native computer screenshot. */
+export function isComputerCallOutputContent(
+  content: unknown
+): content is ToolContent {
+  return getComputerCallOutputScreenshot(content) != null;
+}
+
+/** Returns whether a ToolMessage carries the native computer-output marker. */
+export function hasComputerCallOutputMarker(message: BaseMessage): boolean {
+  try {
+    if (message.getType() !== 'tool') {
+      return false;
+    }
+    const metadata = message.additional_kwargs as unknown;
+    if (!isRecord(metadata)) {
+      return false;
+    }
+    const type = readOwnEnumerableDataProperty(metadata, 'type');
+    return type.found && type.value === 'computer_call_output';
+  } catch {
+    return false;
+  }
+}
+
+/** Native Responses computer screenshots are indivisible provider payloads. */
+export function isComputerCallOutputMessage(message: BaseMessage): boolean {
+  return (
+    hasComputerCallOutputMarker(message) &&
+    isComputerCallOutputContent(message.content)
+  );
+}
 
 /**
  * Bounds structured tool output without slicing binary/media payloads.
@@ -1540,10 +2394,92 @@ export function compactToolContent(
   }
 
   try {
-    const originalChars = getToolContentCharLength(contentBlocks);
-    const denseTextLength = getDenseTextBlockArrayLength(contentBlocks);
-    const atomicBlocks = contentBlocks.filter(isAtomicToolContentBlock);
-    if (atomicBlocks.length === 0) {
+    const blockKinds = new Uint8Array(contentLength);
+    const validation = createToolBlockClassificationContext();
+    const structuredWork = createStructuredWorkState();
+    const containerValidationWork = {
+      value: MAX_ATOMIC_VALIDATION_WORK,
+    };
+    const containerPrototype = Object.getPrototypeOf(contentBlocks);
+    if (
+      (containerPrototype !== Array.prototype && containerPrototype !== null) ||
+      hasPotentiallyCallableToJSON(
+        contentBlocks,
+        containerValidationWork,
+        validation.totalRemaining
+      )
+    ) {
+      const serialized = serializeStructuredValueBounded(
+        contentBlocks,
+        normalizedMaxChars
+      );
+      return {
+        content: serialized.content,
+        changed: true,
+        originalChars: serialized.originalChars,
+      };
+    }
+    let atomicBlockCount = 0;
+    let denseTextLength = contentLength > 0 ? contentLength - 1 : undefined;
+    for (let i = 0; i < contentLength; i++) {
+      const descriptor = Object.getOwnPropertyDescriptor(
+        contentBlocks,
+        String(i)
+      );
+      if (
+        descriptor == null ||
+        typeof descriptor.get === 'function' ||
+        typeof descriptor.set === 'function'
+      ) {
+        const serialized = serializeStructuredValueBounded(
+          contentBlocks,
+          normalizedMaxChars
+        );
+        return {
+          content: serialized.content,
+          changed: true,
+          originalChars: serialized.originalChars,
+        };
+      }
+      const block = descriptor.value as ToolContentBlock;
+      const kind = classifyToolContentBlock(block, validation);
+      if (validation.totalRemaining.value <= 0) {
+        const serialized = serializeStructuredValueBounded(
+          contentBlocks,
+          normalizedMaxChars
+        );
+        return {
+          content: serialized.content,
+          changed: true,
+          originalChars: serialized.originalChars,
+        };
+      }
+      blockKinds[i] = kind;
+      if (kind === TOOL_BLOCK_ATOMIC) {
+        atomicBlockCount++;
+      }
+      if (denseTextLength == null) {
+        continue;
+      }
+      if (kind !== TOOL_BLOCK_TEXT) {
+        denseTextLength = undefined;
+        continue;
+      }
+      const text = readOwnEnumerableDataProperty(block, 'text').value;
+      denseTextLength += typeof text === 'string' ? text.length : 0;
+      if (denseTextLength >= Number.MAX_SAFE_INTEGER) {
+        denseTextLength = Number.MAX_SAFE_INTEGER;
+      }
+    }
+    const originalChars =
+      denseTextLength ??
+      estimateStructuredChars(
+        contentBlocks,
+        Number.MAX_SAFE_INTEGER,
+        [],
+        structuredWork
+      );
+    if (atomicBlockCount === 0) {
       if (denseTextLength != null && originalChars <= normalizedMaxChars) {
         return {
           content: contentBlocks,
@@ -1551,10 +2487,18 @@ export function compactToolContent(
           originalChars,
         };
       }
-      const serialized = serializeToolContentBounded(
-        contentBlocks,
-        normalizedMaxChars
-      );
+      const serialized =
+        denseTextLength != null
+          ? serializeDenseTextBlocksWithinLimit(
+              contentBlocks as TextToolContentBlock[],
+              denseTextLength,
+              normalizedMaxChars
+          )
+          : serializeStructuredValueWithinLimit(
+            contentBlocks,
+            normalizedMaxChars,
+            structuredWork
+          );
       return {
         content: truncateToolResultContent(serialized, normalizedMaxChars),
         // Opaque arrays are normalized even when they are small so every
@@ -1564,10 +2508,9 @@ export function compactToolContent(
       };
     }
 
-    const hasOpaqueBlocks = contentBlocks.some(
-      (block) => !isAtomicToolContentBlock(block) && !isTextBlock(block)
-    );
+    let hasOpaqueBlocks = false;
     const normalizedBlocks: ToolContentBlock[] = [];
+    const normalizedKinds: number[] = [];
     let opaqueRun: unknown[] = [];
     const flushOpaqueRun = (): void => {
       if (opaqueRun.length === 0) {
@@ -1577,22 +2520,33 @@ export function compactToolContent(
         type: 'text',
         text: serializeStructuredValueWithinLimit(
           opaqueRun,
-          normalizedMaxChars
+          normalizedMaxChars,
+          structuredWork
         ),
       });
+      normalizedKinds.push(TOOL_BLOCK_TEXT);
       opaqueRun = [];
     };
-    for (const block of contentBlocks) {
-      if (isAtomicToolContentBlock(block) || isTextBlock(block)) {
+    for (let i = 0; i < contentLength; i++) {
+      const block = contentBlocks[i];
+      const kind = blockKinds[i];
+      if (kind !== TOOL_BLOCK_OPAQUE) {
         flushOpaqueRun();
         normalizedBlocks.push(block);
+        normalizedKinds.push(kind);
       } else {
+        hasOpaqueBlocks = true;
         opaqueRun.push(block);
       }
     }
     flushOpaqueRun();
 
-    const normalizedLength = getToolContentCharLength(normalizedBlocks);
+    const normalizedLength = estimateStructuredChars(
+      normalizedBlocks,
+      Number.MAX_SAFE_INTEGER,
+      [],
+      structuredWork
+    );
     if (normalizedLength <= normalizedMaxChars) {
       return {
         content: hasOpaqueBlocks ? normalizedBlocks : contentBlocks,
@@ -1606,43 +2560,59 @@ export function compactToolContent(
     // compactable text so the model still receives an explanation.
     const atomicBudget = Math.floor(normalizedMaxChars / 2);
     let atomicChars = 0;
-    const preservedAtomicBlocks = new Set<ToolContentBlock>();
+    let preservedAtomicCount = 0;
+    const preservedAtomicFlags = new Uint8Array(normalizedBlocks.length);
+    let omittedAtomicCount = 0;
     const omittedAtomicTypes: string[] = [];
-    for (const block of normalizedBlocks) {
-      if (!isAtomicToolContentBlock(block)) {
+    const compactableBlocks: ToolContentBlock[] = [];
+    let compactableChars = 0;
+    for (let i = 0; i < normalizedBlocks.length; i++) {
+      const block = normalizedBlocks[i];
+      if (normalizedKinds[i] !== TOOL_BLOCK_ATOMIC) {
+        if (compactableBlocks.length > 0) {
+          compactableChars++;
+        }
+        compactableBlocks.push(block);
+        compactableChars += (block as TextToolContentBlock).text.length;
         continue;
       }
       const blockChars = estimateStructuredChars(
         block,
-        atomicBudget - atomicChars
+        atomicBudget - atomicChars,
+        [],
+        structuredWork
       );
       if (atomicChars + blockChars <= atomicBudget) {
-        preservedAtomicBlocks.add(block);
+        preservedAtomicFlags[i] = 1;
+        preservedAtomicCount++;
         atomicChars += blockChars;
       } else {
+        omittedAtomicCount++;
         const typeProperty = isRecord(block)
           ? readOwnEnumerableDataProperty(block, 'type')
           : { found: false as const };
-        omittedAtomicTypes.push(
-          typeProperty.found && typeof typeProperty.value === 'string'
-            ? typeProperty.value
-            : 'media'
-        );
+        if (omittedAtomicTypes.length < 8) {
+          const rawType =
+            typeProperty.found && typeof typeProperty.value === 'string'
+              ? typeProperty.value
+              : 'media';
+          omittedAtomicTypes.push(truncateToolResultContent(rawType, 80));
+        }
       }
     }
 
-    const compactableBlocks = normalizedBlocks.filter(
-      (block) => !isAtomicToolContentBlock(block)
-    );
-    let previewSource = serializeToolContentBounded(
-      compactableBlocks,
+    let previewSource = serializeDenseTextBlocksWithinLimit(
+      compactableBlocks as TextToolContentBlock[],
+      compactableChars,
       normalizedMaxChars
     );
-    if (omittedAtomicTypes.length > 0) {
+    if (omittedAtomicCount > 0) {
+      const undisplayedCount = omittedAtomicCount - omittedAtomicTypes.length;
       const omittedNotice =
-        `[omitted ${omittedAtomicTypes.length} oversized atomic tool-content ` +
-        `block${omittedAtomicTypes.length === 1 ? '' : 's'}: ` +
-        `${omittedAtomicTypes.join(', ')}]`;
+        `[omitted ${omittedAtomicCount} oversized atomic tool-content ` +
+        `block${omittedAtomicCount === 1 ? '' : 's'}: ` +
+        `${omittedAtomicTypes.join(', ')}` +
+        `${undisplayedCount > 0 ? `, +${undisplayedCount} more` : ''}]`;
       previewSource =
         previewSource.length > 0
           ? `${previewSource}\n${omittedNotice}`
@@ -1650,7 +2620,7 @@ export function compactToolContent(
     }
 
     const structuralAllowance =
-      preservedAtomicBlocks.size * 4 + (previewSource.length > 0 ? 32 : 2);
+      preservedAtomicCount * 4 + (previewSource.length > 0 ? 32 : 2);
     const previewBudget = Math.max(
       0,
       normalizedMaxChars - atomicChars - structuralAllowance
@@ -1658,9 +2628,10 @@ export function compactToolContent(
     const preview = truncateToolResultContent(previewSource, previewBudget);
     const compacted: ToolContentBlock[] = [];
     let previewInserted = false;
-    for (const block of normalizedBlocks) {
-      if (isAtomicToolContentBlock(block)) {
-        if (preservedAtomicBlocks.has(block)) {
+    for (let i = 0; i < normalizedBlocks.length; i++) {
+      const block = normalizedBlocks[i];
+      if (normalizedKinds[i] === TOOL_BLOCK_ATOMIC) {
+        if (preservedAtomicFlags[i] === 1) {
           compacted.push(block);
         }
       } else if (!previewInserted) {
@@ -1677,11 +2648,21 @@ export function compactToolContent(
     // JSON framing can make the block array a few bytes larger than the
     // character budget. Fall back to bounded provider-neutral text rather than
     // leaking an oversized media payload.
-    if (getToolContentCharLength(compacted) > normalizedMaxChars) {
+    const compactedChars =
+      preservedAtomicCount > 0 || compacted.length === 0
+        ? estimateStructuredChars(
+          compacted,
+          Number.MAX_SAFE_INTEGER,
+          [],
+          structuredWork
+        )
+        : preview.length;
+    if (compactedChars > normalizedMaxChars) {
       return {
-        content: serializeToolContentBounded(
+        content: serializeStructuredValueWithinLimit(
           normalizedBlocks,
-          normalizedMaxChars
+          normalizedMaxChars,
+          structuredWork
         ),
         changed: true,
         originalChars,

--- a/src/utils/toolContent.ts
+++ b/src/utils/toolContent.ts
@@ -1,0 +1,716 @@
+import { ToolMessage, type BaseMessage } from '@langchain/core/messages';
+import { truncateToolResultContent } from './truncation';
+
+type ToolContent = BaseMessage['content'];
+type ToolContentBlock = Exclude<ToolContent, string>[number];
+
+const ATOMIC_CONTENT_TYPES = new Set([
+  'audio',
+  'computer_screenshot',
+  'document',
+  'file',
+  'image',
+  'image_file',
+  'image_url',
+  'input_audio',
+  'media',
+  'resource',
+  'resource_link',
+  'video',
+  'video_url',
+]);
+
+/**
+ * Serializes values that providers render as JSON without throwing on values
+ * such as bigint or circular diagnostic metadata.
+ */
+export function serializeStructuredValue(value: unknown): string {
+  const ancestors: object[] = [];
+  try {
+    const serialized: unknown = JSON.stringify(
+      value,
+      function (_key, nestedValue: unknown) {
+        if (typeof nestedValue === 'bigint') {
+          return nestedValue.toString();
+        }
+        if (
+          nestedValue instanceof ArrayBuffer ||
+          ArrayBuffer.isView(nestedValue)
+        ) {
+          const name =
+            nestedValue instanceof ArrayBuffer
+              ? 'ArrayBuffer'
+              : nestedValue.constructor.name;
+          return `[${name}: ${nestedValue.byteLength} bytes]`;
+        }
+        if (nestedValue != null && typeof nestedValue === 'object') {
+          while (
+            ancestors.length > 0 &&
+            ancestors[ancestors.length - 1] !== this
+          ) {
+            ancestors.pop();
+          }
+          if (ancestors.includes(nestedValue)) {
+            return '[Circular]';
+          }
+          ancestors.push(nestedValue);
+        }
+        return nestedValue;
+      }
+    );
+    return typeof serialized === 'string' ? serialized : String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function jsonStringLength(value: string): number {
+  let length = 2;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x0c) {
+      length += 2;
+    } else if (code < 0x20) {
+      length += 6;
+    } else {
+      length++;
+    }
+  }
+  return length;
+}
+
+function estimateStructuredChars(
+  value: unknown,
+  limit = Number.MAX_SAFE_INTEGER,
+  ancestors: object[] = []
+): number {
+  if (typeof value === 'string') {
+    return jsonStringLength(value);
+  }
+  if (typeof value === 'bigint') {
+    return jsonStringLength(value.toString());
+  }
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value == null
+  ) {
+    return String(value).length;
+  }
+  if (typeof value === 'undefined' || typeof value === 'function') {
+    return 4;
+  }
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    return Math.min(limit + 1, Math.ceil((value.byteLength * 4) / 3) + 32);
+  }
+  if (typeof value !== 'object') {
+    return jsonStringLength(String(value));
+  }
+  if (ancestors.includes(value)) {
+    return 12;
+  }
+
+  ancestors.push(value);
+  let length = 2;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length && length <= limit; i++) {
+      if (i > 0) {
+        length++;
+      }
+      length += estimateStructuredChars(
+        value[i],
+        Math.max(0, limit - length),
+        ancestors
+      );
+    }
+  } else {
+    let emitted = 0;
+    for (const key of Object.keys(value)) {
+      if (length > limit) {
+        break;
+      }
+      const nested = (value as Record<string, unknown>)[key];
+      if (
+        typeof nested === 'undefined' ||
+        typeof nested === 'function' ||
+        typeof nested === 'symbol'
+      ) {
+        continue;
+      }
+      if (emitted > 0) {
+        length++;
+      }
+      length += jsonStringLength(key) + 1;
+      length += estimateStructuredChars(
+        nested,
+        Math.max(0, limit - length),
+        ancestors
+      );
+      emitted++;
+    }
+  }
+  ancestors.pop();
+  return Math.min(limit + 1, length);
+}
+
+type PreviewState = {
+  remaining: number;
+  ancestors: object[];
+};
+
+function createStructuredPreview(value: unknown, state: PreviewState): unknown {
+  if (typeof value === 'string') {
+    const available = Math.max(0, state.remaining - 24);
+    const preview =
+      value.length > available
+        ? `${value.slice(0, available)}…[truncated]`
+        : value;
+    state.remaining = Math.max(0, state.remaining - preview.length);
+    return preview;
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    const name =
+      value instanceof ArrayBuffer ? 'ArrayBuffer' : value.constructor.name;
+    return `[${name}: ${value.byteLength} bytes]`;
+  }
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+  if (state.ancestors.includes(value)) {
+    return '[Circular]';
+  }
+
+  state.ancestors.push(value);
+  if (Array.isArray(value)) {
+    const preview: unknown[] = [];
+    let i = 0;
+    for (; i < value.length && state.remaining > 48; i++) {
+      state.remaining -= 2;
+      preview.push(createStructuredPreview(value[i], state));
+    }
+    if (i < value.length) {
+      preview.push(`[truncated ${value.length - i} item(s)]`);
+    }
+    state.ancestors.pop();
+    return preview;
+  }
+
+  const preview: Record<string, unknown> = {};
+  const entries = Object.entries(value);
+  let i = 0;
+  for (; i < entries.length && state.remaining > 48; i++) {
+    const [key, nested] = entries[i];
+    state.remaining -= key.length + 4;
+    preview[key] = createStructuredPreview(nested, state);
+  }
+  if (i < entries.length) {
+    preview._truncated = `${entries.length - i} field(s)`;
+  }
+  state.ancestors.pop();
+  return preview;
+}
+
+function serializeStructuredValueWithinLimit(
+  value: unknown,
+  maxChars: number
+): string {
+  const normalizedMaxChars = Math.max(0, Math.floor(maxChars));
+  if (
+    estimateStructuredChars(value, normalizedMaxChars) <= normalizedMaxChars
+  ) {
+    return serializeStructuredValue(value);
+  }
+  const preview = createStructuredPreview(value, {
+    remaining: normalizedMaxChars,
+    ancestors: [],
+  });
+  return truncateToolResultContent(
+    serializeStructuredValue(preview),
+    normalizedMaxChars
+  );
+}
+
+function isTextBlock(
+  value: unknown
+): value is ToolContentBlock & { type: 'text'; text: string } {
+  if (typeof value !== 'object' || value == null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return record.type === 'text' && typeof record.text === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null;
+}
+
+function hasString(record: Record<string, unknown>, key: string): boolean {
+  return typeof record[key] === 'string' && record[key] !== '';
+}
+
+function isStringPayload(value: unknown): boolean {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isBinaryPayload(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    return value.byteLength > 0;
+  }
+  return false;
+}
+
+function isContentPayload(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function hasPayloadPath(
+  record: Record<string, unknown>,
+  path: string[],
+  validator: (value: unknown) => boolean = isBinaryPayload
+): boolean {
+  let value: unknown = record;
+  for (const key of path) {
+    if (!isRecord(value)) {
+      return false;
+    }
+    value = value[key];
+  }
+  return validator(value);
+}
+
+function hasAnyPayloadPath(
+  record: Record<string, unknown>,
+  paths: string[][],
+  validator: (value: unknown) => boolean = isBinaryPayload
+): boolean {
+  return paths.some((path) => hasPayloadPath(record, path, validator));
+}
+
+export function isAtomicToolContentBlock(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const record = value;
+  if (!('type' in record)) {
+    const cachePoint = record.cachePoint;
+    return isRecord(cachePoint) && cachePoint.type === 'default';
+  }
+  const type = typeof record.type === 'string' ? record.type : '';
+  if (
+    !ATOMIC_CONTENT_TYPES.has(type) &&
+    !(type.includes('/') && type.split('/').length === 2)
+  ) {
+    return false;
+  }
+
+  if (type === 'computer_screenshot') {
+    return hasPayloadPath(record, ['image_url'], isStringPayload);
+  }
+  if (type === 'image_url') {
+    return hasAnyPayloadPath(
+      record,
+      [['image_url'], ['image_url', 'url']],
+      isStringPayload
+    );
+  }
+  if (type === 'image_file') {
+    return hasAnyPayloadPath(
+      record,
+      [
+        ['image_file', 'file_id'],
+        ['image_file', 'fileId'],
+      ],
+      isStringPayload
+    );
+  }
+  if (type === 'input_audio') {
+    return hasAnyPayloadPath(record, [
+      ['input_audio', 'data'],
+      ['input_audio', 'bytes'],
+    ]);
+  }
+  if (type === 'resource_link') {
+    return hasString(record, 'uri');
+  }
+  if (type === 'video_url') {
+    return hasAnyPayloadPath(
+      record,
+      [['video_url'], ['video_url', 'url']],
+      isStringPayload
+    );
+  }
+  if (type === 'resource') {
+    return (
+      hasAnyPayloadPath(record, [
+        ['resource', 'blob'],
+        ['resource', 'bytes'],
+        ['resource', 'data'],
+        ['resource', 'text'],
+      ]) || hasPayloadPath(record, ['resource', 'content'], isContentPayload)
+    );
+  }
+
+  if (type.includes('/') && type.split('/').length === 2) {
+    return hasPayloadPath(record, ['data'], isStringPayload);
+  }
+
+  if (type === 'image' || type === 'audio' || type === 'video') {
+    return hasAnyPayloadPath(record, [
+      ['data'],
+      ['bytes'],
+      ['url'],
+      ['source', 'data'],
+      ['source', 'bytes'],
+      ['source', 'url'],
+      [type, 'data'],
+      [type, 'bytes'],
+      [type, 'url'],
+      [type, 'source', 'data'],
+      [type, 'source', 'bytes'],
+      [type, 'source', 'url'],
+    ]);
+  }
+
+  if (type === 'media') {
+    const hasMimeType =
+      hasString(record, 'mimeType') || hasString(record, 'mime_type');
+    return (
+      hasMimeType &&
+      hasAnyPayloadPath(record, [
+        ['data'],
+        ['bytes'],
+        ['fileUri'],
+        ['media', 'data'],
+        ['media', 'bytes'],
+        ['media', 'fileUri'],
+        ['media', 'source', 'bytes'],
+      ])
+    );
+  }
+
+  if (type === 'document' || type === 'file') {
+    const nestedType = type;
+    return (
+      hasAnyPayloadPath(record, [
+        ['data'],
+        ['bytes'],
+        ['url'],
+        ['file_data'],
+        ['file_id'],
+        ['fileId'],
+        ['fileUri'],
+        ['source', 'data'],
+        ['source', 'bytes'],
+        ['source', 'url'],
+        ['source', 'file_data'],
+        ['source', 'file_id'],
+        ['source', 'fileId'],
+        ['source', 'fileUri'],
+        [nestedType, 'data'],
+        [nestedType, 'bytes'],
+        [nestedType, 'url'],
+        [nestedType, 'file_data'],
+        [nestedType, 'file_id'],
+        [nestedType, 'fileId'],
+        [nestedType, 'fileUri'],
+        [nestedType, 'source', 'data'],
+        [nestedType, 'source', 'bytes'],
+        [nestedType, 'source', 'url'],
+      ]) ||
+      hasPayloadPath(record, ['source', 'content'], isContentPayload) ||
+      hasPayloadPath(
+        record,
+        [nestedType, 'source', 'content'],
+        isContentPayload
+      ) ||
+      (record.source_type === 'text' && hasString(record, 'text')) ||
+      (record.source_type === 'id' && hasString(record, 'id'))
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Produces the text representation providers use for structured tool results.
+ * Text-only block arrays stay readable; opaque blocks use canonical JSON.
+ */
+export function serializeToolContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return serializeStructuredValue(content);
+  }
+  if (content.length > 0 && content.every(isTextBlock)) {
+    return content.map((block) => block.text).join('\n');
+  }
+  return serializeStructuredValue(content);
+}
+
+export function getToolContentCharLength(content: unknown): number {
+  if (typeof content === 'string') {
+    return content.length;
+  }
+  if (
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content.every(isTextBlock)
+  ) {
+    let length = content.length - 1;
+    for (const block of content) {
+      length += block.text.length;
+    }
+    return length;
+  }
+  return estimateStructuredChars(content);
+}
+
+function serializeToolContentWithinLimit(
+  content: unknown,
+  maxChars: number
+): string {
+  const normalizedMaxChars = Math.max(0, Math.floor(maxChars));
+  if (typeof content === 'string') {
+    return truncateToolResultContent(content, normalizedMaxChars);
+  }
+  if (
+    !Array.isArray(content) ||
+    content.length === 0 ||
+    !content.every(isTextBlock)
+  ) {
+    return serializeStructuredValueWithinLimit(content, normalizedMaxChars);
+  }
+
+  const originalChars = getToolContentCharLength(content);
+  if (originalChars <= normalizedMaxChars) {
+    return content.map((block) => block.text).join('\n');
+  }
+  const indicator =
+    `\n\n… [truncated: ${originalChars} chars exceeded ` +
+    `${normalizedMaxChars} limit] …`;
+  const available = Math.max(0, normalizedMaxChars - indicator.length);
+  let preview = '';
+  for (let i = 0; i < content.length && preview.length < available; i++) {
+    if (i > 0) {
+      preview += '\n';
+    }
+    preview += content[i].text.slice(0, available - preview.length);
+  }
+  return (preview + indicator).slice(0, normalizedMaxChars);
+}
+
+export type CompactToolContentResult = {
+  content: ToolContent;
+  changed: boolean;
+  originalChars: number;
+};
+
+/**
+ * Bounds structured tool output without slicing binary/media payloads.
+ * Purely textual/structured arrays become a universally valid string tool
+ * result. For mixed-media arrays, compactable blocks become one text preview
+ * while atomic blocks remain intact.
+ */
+export function compactToolContent(
+  content: unknown,
+  maxChars: number
+): CompactToolContentResult {
+  const normalizedMaxChars = Number.isFinite(maxChars)
+    ? Math.max(0, Math.floor(maxChars))
+    : Number.MAX_SAFE_INTEGER;
+  if (typeof content === 'string') {
+    return {
+      content: truncateToolResultContent(content, normalizedMaxChars),
+      changed: content.length > normalizedMaxChars,
+      originalChars: content.length,
+    };
+  }
+  if (!Array.isArray(content)) {
+    const originalChars = estimateStructuredChars(content);
+    const serialized = serializeStructuredValueWithinLimit(
+      content,
+      normalizedMaxChars
+    );
+    return {
+      content: serialized,
+      changed: true,
+      originalChars,
+    };
+  }
+
+  const originalChars = getToolContentCharLength(content);
+  const atomicBlocks = content.filter(isAtomicToolContentBlock);
+  if (atomicBlocks.length === 0) {
+    if (
+      content.length > 0 &&
+      content.every(isTextBlock) &&
+      originalChars <= normalizedMaxChars
+    ) {
+      return {
+        content,
+        changed: false,
+        originalChars,
+      };
+    }
+    const serialized = serializeToolContentWithinLimit(
+      content,
+      normalizedMaxChars
+    );
+    return {
+      content: truncateToolResultContent(serialized, normalizedMaxChars),
+      // Opaque arrays are normalized even when they are small so every
+      // provider receives a universally valid tool-result string.
+      changed: true,
+      originalChars,
+    };
+  }
+
+  const hasOpaqueBlocks = content.some(
+    (block) => !isAtomicToolContentBlock(block) && !isTextBlock(block)
+  );
+  const normalizedBlocks: ToolContentBlock[] = [];
+  let opaqueRun: unknown[] = [];
+  const flushOpaqueRun = (): void => {
+    if (opaqueRun.length === 0) {
+      return;
+    }
+    normalizedBlocks.push({
+      type: 'text',
+      text: serializeStructuredValueWithinLimit(opaqueRun, normalizedMaxChars),
+    });
+    opaqueRun = [];
+  };
+  for (const block of content) {
+    if (isAtomicToolContentBlock(block) || isTextBlock(block)) {
+      flushOpaqueRun();
+      normalizedBlocks.push(block);
+    } else {
+      opaqueRun.push(block);
+    }
+  }
+  flushOpaqueRun();
+
+  const normalizedLength = getToolContentCharLength(normalizedBlocks);
+  if (normalizedLength <= normalizedMaxChars) {
+    return {
+      content: hasOpaqueBlocks ? normalizedBlocks : content,
+      changed: hasOpaqueBlocks,
+      originalChars,
+    };
+  }
+
+  // Keep small media/resource blocks intact, but never let a single inline
+  // base64/blob block defeat the cap. Half of the budget is reserved for
+  // compactable text so the model still receives an explanation.
+  const atomicBudget = Math.floor(normalizedMaxChars / 2);
+  let atomicChars = 0;
+  const preservedAtomicBlocks = new Set<ToolContentBlock>();
+  const omittedAtomicTypes: string[] = [];
+  for (const block of normalizedBlocks) {
+    if (!isAtomicToolContentBlock(block)) {
+      continue;
+    }
+    const blockChars = estimateStructuredChars(
+      block,
+      atomicBudget - atomicChars
+    );
+    if (atomicChars + blockChars <= atomicBudget) {
+      preservedAtomicBlocks.add(block);
+      atomicChars += blockChars;
+    } else {
+      const record = block as Record<string, unknown>;
+      omittedAtomicTypes.push(
+        typeof record.type === 'string' ? record.type : 'media'
+      );
+    }
+  }
+
+  const compactableBlocks = normalizedBlocks.filter(
+    (block) => !isAtomicToolContentBlock(block)
+  );
+  let previewSource = serializeToolContentWithinLimit(
+    compactableBlocks,
+    normalizedMaxChars
+  );
+  if (omittedAtomicTypes.length > 0) {
+    const omittedNotice =
+      `[omitted ${omittedAtomicTypes.length} oversized media/resource ` +
+      `block${omittedAtomicTypes.length === 1 ? '' : 's'}: ` +
+      `${omittedAtomicTypes.join(', ')}]`;
+    previewSource =
+      previewSource.length > 0
+        ? `${previewSource}\n${omittedNotice}`
+        : omittedNotice;
+  }
+
+  const structuralAllowance =
+    preservedAtomicBlocks.size * 4 + (previewSource.length > 0 ? 32 : 2);
+  const previewBudget = Math.max(
+    0,
+    normalizedMaxChars - atomicChars - structuralAllowance
+  );
+  const preview = truncateToolResultContent(previewSource, previewBudget);
+  const compacted: ToolContentBlock[] = [];
+  let previewInserted = false;
+  for (const block of normalizedBlocks) {
+    if (isAtomicToolContentBlock(block)) {
+      if (preservedAtomicBlocks.has(block)) {
+        compacted.push(block);
+      }
+    } else if (!previewInserted) {
+      if (preview.length > 0) {
+        compacted.push({ type: 'text', text: preview });
+      }
+      previewInserted = true;
+    }
+  }
+  if (!previewInserted && preview.length > 0) {
+    compacted.push({ type: 'text', text: preview });
+  }
+
+  // JSON framing can make the block array a few bytes larger than the
+  // character budget. Fall back to bounded provider-neutral text rather than
+  // leaking an oversized media payload.
+  if (getToolContentCharLength(compacted) > normalizedMaxChars) {
+    return {
+      content: serializeToolContentWithinLimit(
+        normalizedBlocks,
+        normalizedMaxChars
+      ),
+      changed: true,
+      originalChars,
+    };
+  }
+
+  return {
+    content: compacted,
+    changed: true,
+    originalChars,
+  };
+}
+
+/** Clones a ToolMessage while retaining fields omitted by ad-hoc clones. */
+export function cloneToolMessageWithContent(
+  message: ToolMessage,
+  content: ToolContent,
+  artifact: unknown = message.artifact
+): ToolMessage {
+  return new ToolMessage({
+    content,
+    tool_call_id: message.tool_call_id,
+    name: message.name,
+    id: message.id,
+    status: message.status,
+    artifact,
+    metadata: message.metadata,
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+  });
+}


### PR DESCRIPTION
## Summary

I implemented provider-safe context accounting and compaction for structured tool results and tool-call inputs, so every provider-bound payload is bounded before invocation and final formatting overflow re-enters the existing recovery path.

- Bound structured serialization without invoking custom `toJSON`, accessors, or proxy traps, including bigint, cycles, typed arrays, sparse arrays, and very large primitive strings.
- Project tool-call arguments across parsed, raw, Responses, and provider-adapter representations before token measurement and dispatch.
- Preserve stable native media, resource, and provider search/result blocks only when they fit; normalize unsafe or oversized values to bounded provider-valid text.
- Reconcile provider-grounded pruner usage per message origin after formatting, artifact expansion, cache placement, and orphan sanitization, so one message shrinking cannot conceal independent payload growth.
- Preserve exact provenance through provider and sanitizer clones without adding wire metadata, including dropped and retained un-ID'd AI messages.
- Reserve calibrated reply-primer tokens in every pruning path and route final provider-payload overflow through compaction, summarization, retry, and fallback handling.
- Bound persisted history, summaries, event payloads, eager/direct hook output, tool-output references, and tool-less folded context under shared limits.
- Add adversarial regressions for huge payloads, custom serialization hooks, stateful and revoked proxies, cycles, provider transformations, attribution skew, reply framing, and overflow recovery.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build`.
- Ran `npx tsc --noEmit`.
- Ran all four CI-equivalent Jest shards from the final source state: 3,028 tests passed and 58 skipped.
- Ran the focused context-overflow, pruning, context-usage, and token-accounting suites: 115 tests passed.
- Ran local summarization coverage without provider keys: 15 tests passed and 10 skipped.
- Ran import sorting and the staged Prettier/ESLint hooks with no errors.
- Re-ran the sole contention-sensitive parallel timing test in isolation after it exceeded its 80 ms threshold while all four shards shared one local machine; it passed in isolation.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
