### PR TITLE
🧵 fix: Break the Predecessor Prefill for Bare Direct-Edge Successors on Claude

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -50,7 +50,6 @@ import {
   convertInjectedMessages,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
-  appendPredecessorHandoffCue,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -1465,6 +1464,24 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return this.messages.slice(this.startIndex);
   }
 
+  /**
+   * The run's most recent message without materializing the whole tail —
+   * `getRunMessages()` slices O(n) per call, which is too much for per-model-
+   * invocation reads that only need the last entry (the handoff-cue gate).
+   * Mirrors `getRunMessages`' disposed-graph fallbacks.
+   */
+  getLastRunMessage(): BaseMessage | undefined {
+    /** Typed honestly: disposed-but-cached graphs really do carry null here. */
+    const live = this.messages as BaseMessage[] | null | undefined;
+    if (live == null || live.length === 0) {
+      return this.cachedRunMessages?.at(-1);
+    }
+    if (live.length <= this.startIndex) {
+      return undefined;
+    }
+    return live.at(-1);
+  }
+
   getContentParts(): t.MessageContentComplex[] | undefined {
     // `messages` can be null/undefined on a graph that has been disposed
     // (clearHeavyState) but is still reachable via a cache (e.g. RedisJobStore's
@@ -2517,27 +2534,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               formatContentStrings(beforeLegacyFormat)
             );
           }
-        }
-        /**
-         * Prefill-semantics providers CONTINUE a trailing assistant turn. A
-         * bare direct-edge successor in a multi-agent run receives exactly
-         * that shape — the predecessor's fresh output last — so without a
-         * user-turn cue it answers in the predecessor's voice, or returns
-         * empty content when that turn reads complete (#345). Scoped to
-         * Claude surfaces and to run-produced tails (host-supplied trailing
-         * assistant turns are deliberate prefill and never match by id).
-         */
-        if (
-          isAnthropicLike(
-            agentContext.provider,
-            agentContext.clientOptions as { model?: string }
-          )
-        ) {
-          const before = transformed;
-          transformed = trackProviderMessageOrigins(
-            before,
-            appendPredecessorHandoffCue(before, this.getRunMessages())
-          );
         }
         return transformed;
       };

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -51,6 +51,7 @@ import {
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
   appendPredecessorHandoffCue,
+  removePredecessorHandoffCue,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -68,7 +69,9 @@ import {
   getFallbackErrorContext,
   getFallbackOverflowCandidates,
   projectMessagesForProvider,
+  resolveServingModelId,
 } from '@/llm/invoke';
+import { v4 } from 'uuid';
 import {
   createLangfuseHandler,
   createLangfuseTraceMetadata,
@@ -3279,11 +3282,31 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                     calculateMaxToolResultChars(
                       fallbackMaxContextTokens ?? agentContext.maxContextTokens
                     );
-                  const projectedFallbackMessages = trackProviderMessageOrigins(
+                  /**
+                   * Serving-provider cue shaping BEFORE the fallback payload
+                   * is measured: a Claude fallback behind a tolerant primary
+                   * gains the cue inside the guarded projection (a prompt
+                   * within the cue's cost of the fallback budget must take
+                   * the recovery path, not ship oversized), and a tolerant
+                   * fallback behind an Anthropic primary sheds the baked cue
+                   * before it is measured against the tighter budget. The
+                   * attemptInvoke funnel pass then finds nothing to change.
+                   */
+                  const cueShapedFallbackMessages = trackProviderMessageOrigins(
                     fallbackMessages,
+                    isAnthropicLike(fallbackProvider, {
+                      model: resolveServingModelId(fallbackModel),
+                    })
+                      ? appendPredecessorHandoffCue(fallbackMessages, (m) =>
+                        this.isRunProducedMessage(m)
+                      )
+                      : removePredecessorHandoffCue(fallbackMessages)
+                  );
+                  const projectedFallbackMessages = trackProviderMessageOrigins(
+                    cueShapedFallbackMessages,
                     projectMessagesForProvider({
                       model: fallbackModel,
-                      messages: fallbackMessages,
+                      messages: cueShapedFallbackMessages,
                       provider: fallbackProvider,
                       maxToolResultChars: fallbackToolResultChars,
                       callOptions: fallbackConfig,
@@ -3371,15 +3394,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const responseMessage = result.messages?.[0];
       /**
        * Provenance for the handoff-cue gate: recorded at the node, where the
-       * produced turn is unambiguous. A null id (rare; the reducer would
-       * assign one later) simply leaves the cue off for that turn —
-       * fail-safe in the direction of provider-default behavior.
+       * produced turn is unambiguous. The public ChatModel contract does not
+       * require implementations to set message ids — the reducer would
+       * assign one AFTER this node returns, which is too late for the set —
+       * so an id is assigned here first, the same way the reducer does it
+       * (`v4()`, mirrored into `lc_kwargs`), and the reducer's
+       * keep-existing-id rule makes the state message match.
        */
-      if (
-        responseMessage?.getType() === 'ai' &&
-        typeof responseMessage.id === 'string' &&
-        responseMessage.id !== ''
-      ) {
+      if (responseMessage?.getType() === 'ai') {
+        if (
+          typeof responseMessage.id !== 'string' ||
+          responseMessage.id === ''
+        ) {
+          responseMessage.id = v4();
+          responseMessage.lc_kwargs.id = responseMessage.id;
+        }
         this.runProducedAiMessageIds.add(responseMessage.id);
       }
       const toolCalls = (responseMessage as AIMessageChunk | undefined)

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -50,6 +50,7 @@ import {
   convertInjectedMessages,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
+  appendPredecessorHandoffCue,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -988,6 +989,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   messages: BaseMessage[] = [];
   /** Cached run messages preserved before clearHeavyState() so getRunMessages() works after cleanup. */
   private cachedRunMessages?: BaseMessage[];
+  /** Ids of AI turns the agent node returned THIS run; see isRunProducedMessage. */
+  protected runProducedAiMessageIds = new Set<string>();
   /** Checkpoint scope whose messages match index-keyed tool snapshots. */
   private originalToolContentCheckpointScope?: string;
   runId: string | undefined;
@@ -1119,6 +1122,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * a stale reference on 2nd+ processStream calls.
      */
     this.toolCallStepIds.clear();
+    this.runProducedAiMessageIds.clear();
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
@@ -1465,21 +1469,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   }
 
   /**
-   * The run's most recent message without materializing the whole tail —
-   * `getRunMessages()` slices O(n) per call, which is too much for per-model-
-   * invocation reads that only need the last entry (the handoff-cue gate).
-   * Mirrors `getRunMessages`' disposed-graph fallbacks.
+   * True when THIS RUN produced `message` — the provenance the handoff cue
+   * gate needs. Tracked as an id set rather than inferred from `startIndex`
+   * arithmetic: summarization's remove-all compaction rewrites the live
+   * array and leaves `startIndex` stale, so index-based run/host
+   * discrimination silently breaks right after a mid-run summarize. Ids
+   * survive compaction (retained messages keep theirs), host-supplied
+   * prefill messages are never in the set, and membership is O(1) per
+   * model call.
    */
-  getLastRunMessage(): BaseMessage | undefined {
-    /** Typed honestly: disposed-but-cached graphs really do carry null here. */
-    const live = this.messages as BaseMessage[] | null | undefined;
-    if (live == null || live.length === 0) {
-      return this.cachedRunMessages?.at(-1);
-    }
-    if (live.length <= this.startIndex) {
-      return undefined;
-    }
-    return live.at(-1);
+  isRunProducedMessage(message: BaseMessage): boolean {
+    const id = message.id;
+    return (
+      typeof id === 'string' &&
+      id !== '' &&
+      this.runProducedAiMessageIds.has(id)
+    );
   }
 
   getContentParts(): t.MessageContentComplex[] | undefined {
@@ -2535,6 +2540,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             );
           }
         }
+        /**
+         * Applied HERE for the primary so the cue is part of the MEASURED
+         * payload — the pre-invoke projection and overflow guard run on this
+         * stage's output, and a post-measure append could push a just-fits
+         * prompt over budget unreported (#346 round 2). The attemptInvoke
+         * funnel re-keys per SERVING provider: it strips this cue for a
+         * tolerant fallback and adds it for a Claude fallback behind a
+         * tolerant primary.
+         */
+        if (
+          isAnthropicLike(
+            agentContext.provider,
+            agentContext.clientOptions as { model?: string }
+          )
+        ) {
+          const before = transformed;
+          transformed = trackProviderMessageOrigins(
+            before,
+            appendPredecessorHandoffCue(before, (message) =>
+              this.isRunProducedMessage(message)
+            )
+          );
+        }
         return transformed;
       };
 
@@ -3341,6 +3369,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * handled everything — both paths become no-ops.
        */
       const responseMessage = result.messages?.[0];
+      /**
+       * Provenance for the handoff-cue gate: recorded at the node, where the
+       * produced turn is unambiguous. A null id (rare; the reducer would
+       * assign one later) simply leaves the cue off for that turn —
+       * fail-safe in the direction of provider-default behavior.
+       */
+      if (
+        responseMessage?.getType() === 'ai' &&
+        typeof responseMessage.id === 'string' &&
+        responseMessage.id !== ''
+      ) {
+        this.runProducedAiMessageIds.add(responseMessage.id);
+      }
       const toolCalls = (responseMessage as AIMessageChunk | undefined)
         ?.tool_calls;
       const hasToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -50,6 +50,7 @@ import {
   convertInjectedMessages,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
+  appendPredecessorHandoffCue,
 } from '@/messages';
 import {
   resetIfNotEmpty,
@@ -2516,6 +2517,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               formatContentStrings(beforeLegacyFormat)
             );
           }
+        }
+        /**
+         * Prefill-semantics providers CONTINUE a trailing assistant turn. A
+         * bare direct-edge successor in a multi-agent run receives exactly
+         * that shape — the predecessor's fresh output last — so without a
+         * user-turn cue it answers in the predecessor's voice, or returns
+         * empty content when that turn reads complete (#345). Scoped to
+         * Claude surfaces and to run-produced tails (host-supplied trailing
+         * assistant turns are deliberate prefill and never match by id).
+         */
+        if (
+          isAnthropicLike(
+            agentContext.provider,
+            agentContext.clientOptions as { model?: string }
+          )
+        ) {
+          const before = transformed;
+          transformed = trackProviderMessageOrigins(
+            before,
+            appendPredecessorHandoffCue(before, this.getRunMessages())
+          );
         }
         return transformed;
       };

--- a/src/llm/invoke.handoffCue.test.ts
+++ b/src/llm/invoke.handoffCue.test.ts
@@ -1,14 +1,17 @@
 // src/llm/invoke.handoffCue.test.ts
 /**
- * The handoff cue is keyed on the provider ACTUALLY serving the call, at the
- * `attemptInvoke` funnel — the seam every fallback and summarization send
- * passes through. An OpenAI primary falling back to a Claude surface must
- * gain the cue; an Anthropic primary falling back to OpenAI must not ship it.
+ * The handoff cue is re-keyed on the provider ACTUALLY serving the call at
+ * the `attemptInvoke` funnel — the seam every fallback send passes through.
+ * A tolerant primary falling back to a Claude surface must gain the cue; an
+ * Anthropic primary falling back to a tolerant provider must have the baked
+ * cue stripped; and the serving model id must be read through the wrapper
+ * stack, or a wrapped Bedrock-Nova model would default to Claude.
  */
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { RunnableBinding } from '@langchain/core/runnables';
 import { Providers } from '@/common';
 import { PREDECESSOR_HANDOFF_CUE } from '@/messages/handoffCue';
 import { FakeChatModel } from '@/llm/fake';
@@ -35,20 +38,30 @@ class CapturingChatModel extends FakeChatModel {
 }
 
 const runTail = new AIMessage({ content: 'predecessor output', id: 'run-1' });
-const payload = (): BaseMessage[] => [new HumanMessage('go'), runTail];
 const context = {
-  getLastRunMessage: (): BaseMessage => runTail,
+  isRunProducedMessage: (message: BaseMessage): boolean =>
+    message.id === 'run-1',
   getOrCreateToolOutputRegistry: (): undefined => undefined,
 } as unknown as InvokeContext;
 
+const bakedCue = (): HumanMessage =>
+  new HumanMessage({
+    content: PREDECESSOR_HANDOFF_CUE,
+    additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
+  });
+
 async function sentBy(
   provider: Providers,
-  modelId?: string
+  options?: { modelId?: string; wrap?: boolean; messages?: BaseMessage[] }
 ): Promise<BaseMessage[]> {
-  const model = new CapturingChatModel(modelId);
+  const model = new CapturingChatModel(options?.modelId);
+  const served =
+    options?.wrap === true
+      ? new RunnableBinding({ bound: model, kwargs: {}, config: {} })
+      : model;
   await attemptInvoke({
-    model: model as never,
-    messages: payload(),
+    model: served as never,
+    messages: options?.messages ?? [new HumanMessage('go'), runTail],
     provider,
     context,
     onChunk: async () => undefined,
@@ -62,24 +75,38 @@ describe('attemptInvoke handoff-cue funnel', () => {
     expect(sent.at(-1)?.content).toBe(PREDECESSOR_HANDOFF_CUE);
   });
 
-  it('applies the cue for Bedrock serving a Claude model', async () => {
-    const sent = await sentBy(
-      Providers.BEDROCK,
-      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
-    );
+  it('applies the cue for Bedrock serving a WRAPPED Claude model', async () => {
+    const sent = await sentBy(Providers.BEDROCK, {
+      modelId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      wrap: true,
+    });
     expect(sent.at(-1)?.content).toBe(PREDECESSOR_HANDOFF_CUE);
   });
 
-  it('does not apply the cue for Bedrock serving a non-Claude model', async () => {
-    const sent = await sentBy(Providers.BEDROCK, 'us.amazon.nova-pro-v1:0');
+  it('does not apply the cue for Bedrock serving a WRAPPED Nova model', async () => {
+    const sent = await sentBy(Providers.BEDROCK, {
+      modelId: 'us.amazon.nova-pro-v1:0',
+      wrap: true,
+    });
     expect(sent.at(-1)?.getType()).toBe('ai');
   });
 
-  it('does not ship the Claude-only turn to a tolerant serving provider', async () => {
-    const sent = await sentBy(Providers.OPENAI);
+  it('strips a baked cue for a tolerant serving provider', async () => {
+    const sent = await sentBy(Providers.OPENAI, {
+      messages: [new HumanMessage('go'), runTail, bakedCue()],
+    });
     expect(sent.at(-1)?.getType()).toBe('ai');
     expect(sent.some((m) => m.content === PREDECESSOR_HANDOFF_CUE)).toBe(
       false
     );
+  });
+
+  it('is idempotent when the primary already baked the cue', async () => {
+    const sent = await sentBy(Providers.ANTHROPIC, {
+      messages: [new HumanMessage('go'), runTail, bakedCue()],
+    });
+    expect(
+      sent.filter((m) => m.content === PREDECESSOR_HANDOFF_CUE)
+    ).toHaveLength(1);
   });
 });

--- a/src/llm/invoke.handoffCue.test.ts
+++ b/src/llm/invoke.handoffCue.test.ts
@@ -1,0 +1,85 @@
+// src/llm/invoke.handoffCue.test.ts
+/**
+ * The handoff cue is keyed on the provider ACTUALLY serving the call, at the
+ * `attemptInvoke` funnel — the seam every fallback and summarization send
+ * passes through. An OpenAI primary falling back to a Claude surface must
+ * gain the cue; an Anthropic primary falling back to OpenAI must not ship it.
+ */
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { Providers } from '@/common';
+import { PREDECESSOR_HANDOFF_CUE } from '@/messages/handoffCue';
+import { FakeChatModel } from '@/llm/fake';
+import { attemptInvoke, type InvokeContext } from './invoke';
+
+class CapturingChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+  /** Serving model id, as a real provider client would expose it. */
+  model?: string;
+
+  constructor(modelId?: string) {
+    super({ responses: ['ok'] });
+    this.model = modelId;
+  }
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.invocations.push(messages);
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+const runTail = new AIMessage({ content: 'predecessor output', id: 'run-1' });
+const payload = (): BaseMessage[] => [new HumanMessage('go'), runTail];
+const context = {
+  getLastRunMessage: (): BaseMessage => runTail,
+  getOrCreateToolOutputRegistry: (): undefined => undefined,
+} as unknown as InvokeContext;
+
+async function sentBy(
+  provider: Providers,
+  modelId?: string
+): Promise<BaseMessage[]> {
+  const model = new CapturingChatModel(modelId);
+  await attemptInvoke({
+    model: model as never,
+    messages: payload(),
+    provider,
+    context,
+    onChunk: async () => undefined,
+  });
+  return model.invocations[0];
+}
+
+describe('attemptInvoke handoff-cue funnel', () => {
+  it('applies the cue when the serving provider is Anthropic', async () => {
+    const sent = await sentBy(Providers.ANTHROPIC);
+    expect(sent.at(-1)?.content).toBe(PREDECESSOR_HANDOFF_CUE);
+  });
+
+  it('applies the cue for Bedrock serving a Claude model', async () => {
+    const sent = await sentBy(
+      Providers.BEDROCK,
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    expect(sent.at(-1)?.content).toBe(PREDECESSOR_HANDOFF_CUE);
+  });
+
+  it('does not apply the cue for Bedrock serving a non-Claude model', async () => {
+    const sent = await sentBy(Providers.BEDROCK, 'us.amazon.nova-pro-v1:0');
+    expect(sent.at(-1)?.getType()).toBe('ai');
+  });
+
+  it('does not ship the Claude-only turn to a tolerant serving provider', async () => {
+    const sent = await sentBy(Providers.OPENAI);
+    expect(sent.at(-1)?.getType()).toBe('ai');
+    expect(sent.some((m) => m.content === PREDECESSOR_HANDOFF_CUE)).toBe(
+      false
+    );
+  });
+});

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -673,10 +673,20 @@ export async function attemptInvoke(
    * elsewhere. No-op identity when the payload does not end on a
    * run-produced assistant turn.
    */
+  /**
+   * Widened deliberately: the type says every context is a full Graph, but
+   * summarization passes none and long-standing tests pass partial stubs —
+   * the accessor genuinely may be absent at runtime.
+   */
+  const getRunTail = (
+    context as
+      | { getLastRunMessage?: () => BaseMessage | undefined }
+      | undefined
+  )?.getLastRunMessage;
   const cued = isAnthropicLike(provider, {
     model: (model as { model?: string }).model,
   })
-    ? appendPredecessorHandoffCue(annotated, context?.getLastRunMessage())
+    ? appendPredecessorHandoffCue(annotated, getRunTail?.call(context))
     : annotated;
   const messagesForProvider = strictAlternationProviders.has(provider)
     ? coalesceAdjacentUserTurns(cued)

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -40,6 +40,7 @@ import {
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
   appendPredecessorHandoffCue,
+  removePredecessorHandoffCue,
 } from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
@@ -519,6 +520,36 @@ function collectModelCallbackSources(model: unknown): Callbacks[] {
   return sources;
 }
 
+/**
+ * The serving model's id, read through the same wrapper stack
+ * `collectModelCallbackSources` walks — `bindTools` returns a
+ * `RunnableBinding` and a system runnable pipes a `RunnableSequence`, and
+ * neither exposes the chat model's `model` at the top level.
+ */
+function resolveServingModelId(model: unknown): string | undefined {
+  const seen = new Set<unknown>();
+  let current: unknown = model;
+  while (current != null && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const wrapper = current as {
+      model?: unknown;
+      bound?: unknown;
+      last?: unknown;
+      steps?: unknown[];
+    };
+    if (typeof wrapper.model === 'string' && wrapper.model !== '') {
+      return wrapper.model;
+    }
+    current =
+      wrapper.bound ??
+      wrapper.last ??
+      (Array.isArray(wrapper.steps)
+        ? wrapper.steps[wrapper.steps.length - 1]
+        : undefined);
+  }
+  return undefined;
+}
+
 async function endSealedModelRun(
   context: InvokeContext | undefined,
   chunk: AIMessageChunk,
@@ -664,30 +695,37 @@ export async function attemptInvoke(
    * the primary simply re-runs a no-op over already-coalesced messages.
    */
   /**
-   * Same serving-provider rule for the predecessor handoff cue (#345): an
-   * OpenAI primary falling back to a Claude surface needs the cue applied
-   * for the fallback, and an Anthropic primary falling back to OpenAI must
-   * NOT ship the Claude-only synthetic turn. The Bedrock model id is read
-   * off the serving model instance; when absent, `isAnthropicLike` defaults
-   * Bedrock to Claude — the safe direction for a cue that is inert
-   * elsewhere. No-op identity when the payload does not end on a
-   * run-produced assistant turn.
+   * Serving-provider re-keying for the predecessor handoff cue (#345). The
+   * PRIMARY's cue is baked in createCallModel's measured transform stage —
+   * appending after measurement could push a just-fits prompt over budget —
+   * so this funnel only corrects for fallbacks crossing provider families:
+   * a tolerant primary falling back to a Claude surface gains the cue here,
+   * and an Anthropic primary falling back to OpenAI/Mistral/Nova has the
+   * Claude-only synthetic turn stripped. Both helpers are identity on their
+   * no-op paths, so the primary's own pass re-runs for free.
+   *
+   * The serving model id is read through the wrapper stack (`bindTools`'
+   * binding, a system runnable's sequence) — a wrapper's top-level `.model`
+   * is undefined, and `isAnthropicLike` would otherwise default a wrapped
+   * Bedrock-Nova model to Claude. The context cast is widened deliberately:
+   * the type says every context is a full Graph, but summarization passes
+   * none and long-standing tests pass partial stubs.
    */
-  /**
-   * Widened deliberately: the type says every context is a full Graph, but
-   * summarization passes none and long-standing tests pass partial stubs —
-   * the accessor genuinely may be absent at runtime.
-   */
-  const getRunTail = (
+  const isRunProduced = (
     context as
-      | { getLastRunMessage?: () => BaseMessage | undefined }
+      | { isRunProducedMessage?: (message: BaseMessage) => boolean }
       | undefined
-  )?.getLastRunMessage;
+  )?.isRunProducedMessage;
   const cued = isAnthropicLike(provider, {
-    model: (model as { model?: string }).model,
+    model: resolveServingModelId(model),
   })
-    ? appendPredecessorHandoffCue(annotated, getRunTail?.call(context))
-    : annotated;
+    ? appendPredecessorHandoffCue(
+      annotated,
+      isRunProduced == null
+        ? undefined
+        : (message): boolean => isRunProduced.call(context, message)
+    )
+    : removePredecessorHandoffCue(annotated);
   const messagesForProvider = strictAlternationProviders.has(provider)
     ? coalesceAdjacentUserTurns(cued)
     : cued;

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -39,11 +39,12 @@ import {
   modifyDeltaProperties,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
+  appendPredecessorHandoffCue,
 } from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { initializeModel } from '@/llm/init';
-import { isOpenAILike } from '@/utils/llm';
+import { isAnthropicLike, isOpenAILike } from '@/utils/llm';
 
 /**
  * Context passed to `attemptInvoke`. Matches the subset of Graph that
@@ -662,9 +663,24 @@ export async function attemptInvoke(
    * summarization calls, so applying it here covers all three. Idempotent, so
    * the primary simply re-runs a no-op over already-coalesced messages.
    */
-  const messagesForProvider = strictAlternationProviders.has(provider)
-    ? coalesceAdjacentUserTurns(annotated)
+  /**
+   * Same serving-provider rule for the predecessor handoff cue (#345): an
+   * OpenAI primary falling back to a Claude surface needs the cue applied
+   * for the fallback, and an Anthropic primary falling back to OpenAI must
+   * NOT ship the Claude-only synthetic turn. The Bedrock model id is read
+   * off the serving model instance; when absent, `isAnthropicLike` defaults
+   * Bedrock to Claude — the safe direction for a cue that is inert
+   * elsewhere. No-op identity when the payload does not end on a
+   * run-produced assistant turn.
+   */
+  const cued = isAnthropicLike(provider, {
+    model: (model as { model?: string }).model,
+  })
+    ? appendPredecessorHandoffCue(annotated, context?.getLastRunMessage())
     : annotated;
+  const messagesForProvider = strictAlternationProviders.has(provider)
+    ? coalesceAdjacentUserTurns(cued)
+    : cued;
 
   /**
    * Stamp the provider that is ACTUALLY serving this invocation onto the

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -526,7 +526,7 @@ function collectModelCallbackSources(model: unknown): Callbacks[] {
  * `RunnableBinding` and a system runnable pipes a `RunnableSequence`, and
  * neither exposes the chat model's `model` at the top level.
  */
-function resolveServingModelId(model: unknown): string | undefined {
+export function resolveServingModelId(model: unknown): string | undefined {
   const seen = new Set<unknown>();
   let current: unknown = model;
   while (current != null && typeof current === 'object' && !seen.has(current)) {

--- a/src/messages/handoffCue.test.ts
+++ b/src/messages/handoffCue.test.ts
@@ -1,15 +1,20 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
 import {
   appendPredecessorHandoffCue,
+  removePredecessorHandoffCue,
   PREDECESSOR_HANDOFF_CUE,
 } from './handoffCue';
 
-describe('appendPredecessorHandoffCue', () => {
-  const runAi = new AIMessage({ content: 'predecessor output', id: 'run-ai-1' });
+const runAi = new AIMessage({ content: 'predecessor output', id: 'run-ai-1' });
+const producedIds = new Set(['run-ai-1']);
+const isRunProduced = (message: BaseMessage): boolean =>
+  message.id != null && producedIds.has(message.id);
 
-  it('appends the cue when the payload ends with the run-produced assistant turn', () => {
+describe('appendPredecessorHandoffCue', () => {
+  it('appends the cue when the payload ends with a run-produced assistant turn', () => {
     const payload = [new HumanMessage('ask'), runAi];
-    const result = appendPredecessorHandoffCue(payload, runAi);
+    const result = appendPredecessorHandoffCue(payload, isRunProduced);
     expect(result).toHaveLength(3);
     expect(result[2].content).toBe(PREDECESSOR_HANDOFF_CUE);
     expect(result[2].additional_kwargs).toEqual({
@@ -23,40 +28,69 @@ describe('appendPredecessorHandoffCue', () => {
 
   it('matches a transformed clone of the run tail by id', () => {
     const clone = new AIMessage({ content: 'projected copy', id: 'run-ai-1' });
-    const result = appendPredecessorHandoffCue([clone], runAi);
-    expect(result).toHaveLength(2);
+    expect(appendPredecessorHandoffCue([clone], isRunProduced)).toHaveLength(2);
   });
 
   /**
    * Host-supplied trailing assistant turns are deliberate prefill (continue
-   * generation flows). The run has not produced them, so the id never
+   * generation flows). The run has not produced them, so provenance never
    * matches and the cue must stay off.
    */
   it('leaves host-history prefill payloads alone', () => {
     const hostAi = new AIMessage({ content: 'host prefill', id: 'host-ai-9' });
-    expect(appendPredecessorHandoffCue([hostAi], runAi)).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([hostAi], isRunProduced)).toHaveLength(
+      1
+    );
     expect(appendPredecessorHandoffCue([hostAi], undefined)).toHaveLength(1);
   });
 
   it('is off when the payload does not end on an assistant turn', () => {
     const tool = new ToolMessage({ content: 'r', tool_call_id: 't1' });
     expect(
-      appendPredecessorHandoffCue([runAi, tool], tool)
+      appendPredecessorHandoffCue([runAi, tool], isRunProduced)
     ).toHaveLength(2);
     expect(
-      appendPredecessorHandoffCue([new HumanMessage('hi')], runAi)
+      appendPredecessorHandoffCue([new HumanMessage('hi')], isRunProduced)
     ).toHaveLength(1);
-    expect(appendPredecessorHandoffCue([], runAi)).toHaveLength(0);
+    expect(appendPredecessorHandoffCue([], isRunProduced)).toHaveLength(0);
   });
 
-  it('fails safe when ids are missing on either side', () => {
+  it('fails safe when the tail carries no id', () => {
     const noId = new AIMessage({ content: 'no id' });
-    expect(appendPredecessorHandoffCue([noId], noId)).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([noId], isRunProduced)).toHaveLength(1);
+  });
+});
+
+describe('removePredecessorHandoffCue', () => {
+  const cue = new HumanMessage({
+    content: PREDECESSOR_HANDOFF_CUE,
+    additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
   });
 
-  it('is off when the run tail is not an assistant turn', () => {
-    const runTail = new HumanMessage({ content: 'steer', id: 'h1' });
-    const ai = new AIMessage({ content: 'x', id: 'h1' });
-    expect(appendPredecessorHandoffCue([ai], runTail)).toHaveLength(1);
+  it('strips a trailing cue and only a trailing cue', () => {
+    const stripped = removePredecessorHandoffCue([runAi, cue]);
+    expect(stripped).toHaveLength(1);
+    expect(stripped[0]).toBe(runAi);
+  });
+
+  it('is identity when no cue trails', () => {
+    const messages = [runAi];
+    expect(removePredecessorHandoffCue(messages)).toBe(messages);
+    const userTail = [runAi, new HumanMessage('real user turn')];
+    expect(removePredecessorHandoffCue(userTail)).toBe(userTail);
+    const empty: BaseMessage[] = [];
+    expect(removePredecessorHandoffCue(empty)).toBe(empty);
+  });
+
+  it('does not strip a user turn that merely repeats the cue text', () => {
+    const impostor = new HumanMessage({ content: PREDECESSOR_HANDOFF_CUE });
+    const messages = [runAi, impostor];
+    expect(removePredecessorHandoffCue(messages)).toBe(messages);
+  });
+
+  it('round-trips with append', () => {
+    const payload = [new HumanMessage('ask'), runAi];
+    const appended = appendPredecessorHandoffCue(payload, isRunProduced);
+    expect(removePredecessorHandoffCue(appended)).toEqual(payload);
   });
 });

--- a/src/messages/handoffCue.test.ts
+++ b/src/messages/handoffCue.test.ts
@@ -1,0 +1,63 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  appendPredecessorHandoffCue,
+  PREDECESSOR_HANDOFF_CUE,
+} from './handoffCue';
+
+describe('appendPredecessorHandoffCue', () => {
+  const runAi = new AIMessage({ content: 'predecessor output', id: 'run-ai-1' });
+
+  it('appends the cue when the payload ends with the run-produced assistant turn', () => {
+    const payload = [new HumanMessage('ask'), runAi];
+    const result = appendPredecessorHandoffCue(payload, [runAi]);
+    expect(result).toHaveLength(3);
+    expect(result[2].content).toBe(PREDECESSOR_HANDOFF_CUE);
+    expect(result[2].additional_kwargs).toEqual({
+      role: 'user',
+      isMeta: true,
+      source: 'handoff',
+    });
+    /** Non-mutating: the input array is untouched. */
+    expect(payload).toHaveLength(2);
+  });
+
+  it('matches a transformed clone of the run tail by id', () => {
+    const clone = new AIMessage({ content: 'projected copy', id: 'run-ai-1' });
+    const result = appendPredecessorHandoffCue([clone], [runAi]);
+    expect(result).toHaveLength(2);
+  });
+
+  /**
+   * Host-supplied trailing assistant turns are deliberate prefill (continue
+   * generation flows). The run has not produced them, so the id never
+   * matches and the cue must stay off.
+   */
+  it('leaves host-history prefill payloads alone', () => {
+    const hostAi = new AIMessage({ content: 'host prefill', id: 'host-ai-9' });
+    expect(appendPredecessorHandoffCue([hostAi], [runAi])).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([hostAi], [])).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([hostAi], undefined)).toHaveLength(1);
+  });
+
+  it('is off when the payload does not end on an assistant turn', () => {
+    const tool = new ToolMessage({ content: 'r', tool_call_id: 't1' });
+    expect(
+      appendPredecessorHandoffCue([runAi, tool], [runAi, tool])
+    ).toHaveLength(2);
+    expect(
+      appendPredecessorHandoffCue([new HumanMessage('hi')], [runAi])
+    ).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([], [runAi])).toHaveLength(0);
+  });
+
+  it('fails safe when ids are missing on either side', () => {
+    const noId = new AIMessage({ content: 'no id' });
+    expect(appendPredecessorHandoffCue([noId], [noId])).toHaveLength(1);
+  });
+
+  it('is off when the run tail is not an assistant turn', () => {
+    const runTail = new HumanMessage({ content: 'steer', id: 'h1' });
+    const ai = new AIMessage({ content: 'x', id: 'h1' });
+    expect(appendPredecessorHandoffCue([ai], [runTail])).toHaveLength(1);
+  });
+});

--- a/src/messages/handoffCue.test.ts
+++ b/src/messages/handoffCue.test.ts
@@ -9,7 +9,7 @@ describe('appendPredecessorHandoffCue', () => {
 
   it('appends the cue when the payload ends with the run-produced assistant turn', () => {
     const payload = [new HumanMessage('ask'), runAi];
-    const result = appendPredecessorHandoffCue(payload, [runAi]);
+    const result = appendPredecessorHandoffCue(payload, runAi);
     expect(result).toHaveLength(3);
     expect(result[2].content).toBe(PREDECESSOR_HANDOFF_CUE);
     expect(result[2].additional_kwargs).toEqual({
@@ -23,7 +23,7 @@ describe('appendPredecessorHandoffCue', () => {
 
   it('matches a transformed clone of the run tail by id', () => {
     const clone = new AIMessage({ content: 'projected copy', id: 'run-ai-1' });
-    const result = appendPredecessorHandoffCue([clone], [runAi]);
+    const result = appendPredecessorHandoffCue([clone], runAi);
     expect(result).toHaveLength(2);
   });
 
@@ -34,30 +34,29 @@ describe('appendPredecessorHandoffCue', () => {
    */
   it('leaves host-history prefill payloads alone', () => {
     const hostAi = new AIMessage({ content: 'host prefill', id: 'host-ai-9' });
-    expect(appendPredecessorHandoffCue([hostAi], [runAi])).toHaveLength(1);
-    expect(appendPredecessorHandoffCue([hostAi], [])).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([hostAi], runAi)).toHaveLength(1);
     expect(appendPredecessorHandoffCue([hostAi], undefined)).toHaveLength(1);
   });
 
   it('is off when the payload does not end on an assistant turn', () => {
     const tool = new ToolMessage({ content: 'r', tool_call_id: 't1' });
     expect(
-      appendPredecessorHandoffCue([runAi, tool], [runAi, tool])
+      appendPredecessorHandoffCue([runAi, tool], tool)
     ).toHaveLength(2);
     expect(
-      appendPredecessorHandoffCue([new HumanMessage('hi')], [runAi])
+      appendPredecessorHandoffCue([new HumanMessage('hi')], runAi)
     ).toHaveLength(1);
-    expect(appendPredecessorHandoffCue([], [runAi])).toHaveLength(0);
+    expect(appendPredecessorHandoffCue([], runAi)).toHaveLength(0);
   });
 
   it('fails safe when ids are missing on either side', () => {
     const noId = new AIMessage({ content: 'no id' });
-    expect(appendPredecessorHandoffCue([noId], [noId])).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([noId], noId)).toHaveLength(1);
   });
 
   it('is off when the run tail is not an assistant turn', () => {
     const runTail = new HumanMessage({ content: 'steer', id: 'h1' });
     const ai = new AIMessage({ content: 'x', id: 'h1' });
-    expect(appendPredecessorHandoffCue([ai], [runTail])).toHaveLength(1);
+    expect(appendPredecessorHandoffCue([ai], runTail)).toHaveLength(1);
   });
 });

--- a/src/messages/handoffCue.ts
+++ b/src/messages/handoffCue.ts
@@ -1,0 +1,58 @@
+// src/messages/handoffCue.ts
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Bracketed-meta convention, like the handoff path's
+ * `[Processed tool result and transferring to …]` bridge. The wording makes
+ * two things unambiguous to the model: the assistant turn above is FINISHED,
+ * and it belongs to a previous stage — so the successor answers as itself
+ * instead of continuing someone else's sentence.
+ */
+export const PREDECESSOR_HANDOFF_CUE =
+  '[The assistant message above is the completed output of a previous ' +
+  'agent. Respond now according to your own role and instructions.]';
+
+/**
+ * Appends a user-turn handoff cue when a payload ends with an assistant turn
+ * that THIS RUN produced — which only happens when a different agent in a
+ * multi-agent workflow produced it (an agent's own self-loops always re-enter
+ * on a tool result or an injected user turn).
+ *
+ * Why: providers with prefill semantics (Anthropic, Bedrock-Claude) treat a
+ * trailing assistant message as a prefill and CONTINUE it. A bare direct-edge
+ * successor therefore speaks in its predecessor's voice — or, when the
+ * trailing turn reads complete (a preemption steer's short resume, say),
+ * returns empty content (danny-avila/agents#345, reproduced live 3/3).
+ * Handoff edges with instructions and prompt-instruction edges already break
+ * the prefill with a user turn; this closes the same gap for bare edges.
+ *
+ * Fail-safe OFF by identity: the trailing payload message must carry the same
+ * id as the run's last recorded message. Host-supplied trailing assistant
+ * turns (deliberate prefill flows) never match — the run has not produced
+ * them — so single-agent prefill behavior is untouched. Wire-only: the cue is
+ * appended to the provider projection, never to graph state or host history.
+ */
+export function appendPredecessorHandoffCue(
+  messages: BaseMessage[],
+  runMessages: BaseMessage[] | undefined
+): BaseMessage[] {
+  const last = messages.at(-1);
+  if (last == null || last.getType() !== 'ai') {
+    return messages;
+  }
+  const lastRun = runMessages?.at(-1);
+  if (lastRun == null || lastRun.getType() !== 'ai') {
+    return messages;
+  }
+  if (last.id == null || lastRun.id == null || last.id !== lastRun.id) {
+    return messages;
+  }
+  return [
+    ...messages,
+    new HumanMessage({
+      content: PREDECESSOR_HANDOFF_CUE,
+      additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
+    }),
+  ];
+}

--- a/src/messages/handoffCue.ts
+++ b/src/messages/handoffCue.ts
@@ -28,20 +28,21 @@ export const PREDECESSOR_HANDOFF_CUE =
  * the prefill with a user turn; this closes the same gap for bare edges.
  *
  * Fail-safe OFF by identity: the trailing payload message must carry the same
- * id as the run's last recorded message. Host-supplied trailing assistant
+ * id as the run's last recorded message (`runTail`, from the graph's
+ * non-allocating `getLastRunMessage()`). Host-supplied trailing assistant
  * turns (deliberate prefill flows) never match — the run has not produced
  * them — so single-agent prefill behavior is untouched. Wire-only: the cue is
  * appended to the provider projection, never to graph state or host history.
  */
 export function appendPredecessorHandoffCue(
   messages: BaseMessage[],
-  runMessages: BaseMessage[] | undefined
+  runTail: BaseMessage | undefined
 ): BaseMessage[] {
   const last = messages.at(-1);
   if (last == null || last.getType() !== 'ai') {
     return messages;
   }
-  const lastRun = runMessages?.at(-1);
+  const lastRun = runTail;
   if (lastRun == null || lastRun.getType() !== 'ai') {
     return messages;
   }

--- a/src/messages/handoffCue.ts
+++ b/src/messages/handoffCue.ts
@@ -27,26 +27,23 @@ export const PREDECESSOR_HANDOFF_CUE =
  * Handoff edges with instructions and prompt-instruction edges already break
  * the prefill with a user turn; this closes the same gap for bare edges.
  *
- * Fail-safe OFF by identity: the trailing payload message must carry the same
- * id as the run's last recorded message (`runTail`, from the graph's
- * non-allocating `getLastRunMessage()`). Host-supplied trailing assistant
+ * Fail-safe OFF by provenance: the trailing payload message must be one the
+ * run itself produced (`isRunProduced`, backed by the graph's run-produced id
+ * set — immune to summarization compaction, which rewrites the live array
+ * and stales index-based boundaries). Host-supplied trailing assistant
  * turns (deliberate prefill flows) never match — the run has not produced
  * them — so single-agent prefill behavior is untouched. Wire-only: the cue is
  * appended to the provider projection, never to graph state or host history.
  */
 export function appendPredecessorHandoffCue(
   messages: BaseMessage[],
-  runTail: BaseMessage | undefined
+  isRunProduced: ((message: BaseMessage) => boolean) | undefined
 ): BaseMessage[] {
   const last = messages.at(-1);
   if (last == null || last.getType() !== 'ai') {
     return messages;
   }
-  const lastRun = runTail;
-  if (lastRun == null || lastRun.getType() !== 'ai') {
-    return messages;
-  }
-  if (last.id == null || lastRun.id == null || last.id !== lastRun.id) {
+  if (isRunProduced == null || !isRunProduced(last)) {
     return messages;
   }
   return [
@@ -56,4 +53,26 @@ export function appendPredecessorHandoffCue(
       additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
     }),
   ];
+}
+
+/**
+ * Strips a trailing handoff cue. The counterpart for the serving-provider
+ * funnel: an Anthropic-like PRIMARY bakes the cue into its measured payload,
+ * and a tolerant fallback (OpenAI, Mistral, Bedrock-Nova) re-sending that
+ * payload must not ship the Claude-only synthetic turn. Identity on the
+ * no-op path.
+ */
+export function removePredecessorHandoffCue(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const last = messages.at(-1);
+  if (
+    last == null ||
+    last.getType() !== 'human' ||
+    last.additional_kwargs.source !== 'handoff' ||
+    last.content !== PREDECESSOR_HANDOFF_CUE
+  ) {
+    return messages;
+  }
+  return messages.slice(0, -1);
 }

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -9,6 +9,7 @@ export * from './content';
 export * from './tools';
 export * from './injected';
 export * from './alternation';
+export * from './handoffCue';
 export * from './contextPruning';
 export * from './contextPruningSettings';
 export * from './reducer';

--- a/src/specs/handoffCue.test.ts
+++ b/src/specs/handoffCue.test.ts
@@ -4,7 +4,7 @@
  * provider must receive a user-turn handoff cue after the predecessor's
  * trailing assistant output — and tolerant providers must not.
  */
-import { HumanMessage } from '@langchain/core/messages';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
@@ -27,6 +27,32 @@ class CapturingChatModel extends FakeChatModel {
   }
 }
 
+/**
+ * A ChatModel whose streamed chunks never carry ids. Overrides
+ * `_streamIterator` — the seam BELOW LangChain's run-id stamping (which
+ * happens in `_generateUncached`, downstream of `_streamResponseChunks`, so
+ * a subclass override there cannot produce this shape) but still a Runnable,
+ * so `systemRunnable.pipe(model)` works. The public ChatModel contract
+ * requires no ids; custom implementations really do ship this.
+ */
+class IdlessChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+  private turn = 0;
+
+  constructor(private texts: string[]) {
+    super({ responses: texts });
+  }
+
+  override async *_streamIterator(
+    input: BaseMessage[]
+  ): AsyncGenerator<AIMessageChunk> {
+    this.invocations.push(input);
+    const text = this.texts[Math.min(this.turn, this.texts.length - 1)];
+    this.turn += 1;
+    yield new AIMessageChunk({ content: text });
+  }
+}
+
 const streamConfig = {
   configurable: { thread_id: 'handoff-cue-e2e' },
   streamMode: 'values' as const,
@@ -35,7 +61,8 @@ const streamConfig = {
 
 async function runTwoAgents(
   provider: Providers,
-  modelId = 'test-model'
+  modelId = 'test-model',
+  idlessModel = false
 ): Promise<{ criticPayload: BaseMessage[]; messages: BaseMessage[] }> {
   const run = await Run.create<t.IState>({
     runId: `handoff-cue-${provider}`,
@@ -63,10 +90,12 @@ async function runTwoAgents(
   if (!run.Graph) {
     throw new Error('Expected graph to be initialized');
   }
-  const model = new CapturingChatModel({
-    responses: ['The essay text.', 'The critique text.'],
-  });
-  run.Graph.overrideModel = model;
+  const model = idlessModel
+    ? new IdlessChatModel(['The essay text.', 'The critique text.'])
+    : new CapturingChatModel({
+      responses: ['The essay text.', 'The critique text.'],
+    });
+  run.Graph.overrideModel = model as never;
 
   await run.processStream(
     { messages: [new HumanMessage('write the essay')] },
@@ -105,6 +134,21 @@ describe('bare direct-edge handoff cue (#345)', () => {
     const { criticPayload } = await runTwoAgents(
       Providers.BEDROCK,
       'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    const last = criticPayload[criticPayload.length - 1];
+    expect(last.content).toBe(PREDECESSOR_HANDOFF_CUE);
+  });
+
+  /**
+   * The public ChatModel contract does not require ids. Provenance must not
+   * depend on the model setting one — the node assigns a reducer-style id
+   * before recording, so the successor still gets the cue.
+   */
+  it('applies the cue even when the model never sets message ids', async () => {
+    const { criticPayload } = await runTwoAgents(
+      Providers.ANTHROPIC,
+      'test-model',
+      true
     );
     const last = criticPayload[criticPayload.length - 1];
     expect(last.content).toBe(PREDECESSOR_HANDOFF_CUE);

--- a/src/specs/handoffCue.test.ts
+++ b/src/specs/handoffCue.test.ts
@@ -1,0 +1,121 @@
+// src/specs/handoffCue.test.ts
+/**
+ * End-to-end #345: a bare direct-edge successor on a prefill-semantics
+ * provider must receive a user-turn handoff cue after the predecessor's
+ * trailing assistant output — and tolerant providers must not.
+ */
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { PREDECESSOR_HANDOFF_CUE } from '@/messages/handoffCue';
+import { FakeChatModel } from '@/llm/fake';
+import { Run } from '@/run';
+
+class CapturingChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.invocations.push(messages);
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+const streamConfig = {
+  configurable: { thread_id: 'handoff-cue-e2e' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+async function runTwoAgents(
+  provider: Providers,
+  modelId = 'test-model'
+): Promise<{ criticPayload: BaseMessage[]; messages: BaseMessage[] }> {
+  const run = await Run.create<t.IState>({
+    runId: `handoff-cue-${provider}`,
+    graphConfig: {
+      type: 'multi-agent',
+      agents: [
+        {
+          agentId: 'writer',
+          provider,
+          clientOptions: { model: modelId, apiKey: 'test-key' },
+          instructions: 'You are the writer.',
+        },
+        {
+          agentId: 'critic',
+          provider,
+          clientOptions: { model: modelId, apiKey: 'test-key' },
+          instructions: 'You are the critic.',
+        },
+      ],
+      edges: [{ from: 'writer', to: 'critic', edgeType: 'direct' }],
+    },
+    returnContent: true,
+    skipCleanup: true,
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph to be initialized');
+  }
+  const model = new CapturingChatModel({
+    responses: ['The essay text.', 'The critique text.'],
+  });
+  run.Graph.overrideModel = model;
+
+  await run.processStream(
+    { messages: [new HumanMessage('write the essay')] },
+    streamConfig
+  );
+
+  expect(model.invocations).toHaveLength(2);
+  return {
+    criticPayload: model.invocations[1],
+    messages: run.getRunMessages() ?? [],
+  };
+}
+
+describe('bare direct-edge handoff cue (#345)', () => {
+  jest.setTimeout(15000);
+
+  it('anthropic successor payload ends with the cue, not the predecessor prefill', async () => {
+    const { criticPayload, messages } = await runTwoAgents(
+      Providers.ANTHROPIC
+    );
+    const last = criticPayload[criticPayload.length - 1];
+    expect(last.getType()).toBe('human');
+    expect(last.content).toBe(PREDECESSOR_HANDOFF_CUE);
+    expect(criticPayload[criticPayload.length - 2].getType()).toBe('ai');
+    /**
+     * Wire-only: the cue exists in the provider payload, never in run
+     * state or host-visible messages.
+     */
+    expect(
+      messages.some((m) => m.content === PREDECESSOR_HANDOFF_CUE)
+    ).toBe(false);
+  });
+
+  it('bedrock successor payload also gets the cue', async () => {
+    /** Bedrock anthropic-likeness is model-dependent — needs a Claude id. */
+    const { criticPayload } = await runTwoAgents(
+      Providers.BEDROCK,
+      'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    );
+    const last = criticPayload[criticPayload.length - 1];
+    expect(last.content).toBe(PREDECESSOR_HANDOFF_CUE);
+  });
+
+  it('openAI successor payload is untouched', async () => {
+    const { criticPayload } = await runTwoAgents(Providers.OPENAI);
+    const last = criticPayload[criticPayload.length - 1];
+    expect(last.getType()).toBe('ai');
+    expect(
+      criticPayload.some((m) => m.content === PREDECESSOR_HANDOFF_CUE)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #345.

## Why

In a multi-agent direct-edge flow, the successor's payload ends with the predecessor's assistant turn. Claude surfaces (Anthropic, Bedrock-Claude) treat a trailing assistant message as a **prefill** and *continue* it — so a bare-edge successor speaks in its predecessor's voice, or returns **empty content** when that turn reads complete (e.g. a preemption steer's short resume; reproduced live 3/3 in #335's scenario runner). Handoff edges with instructions and prompt-instruction edges already break the prefill with a user turn; bare edges were the gap.

## What

`appendPredecessorHandoffCue` (new, `src/messages/handoffCue.ts`) runs as the last provider message transform for `isAnthropicLike` targets and appends a bracketed user-turn cue when the payload's trailing assistant turn is **run-produced**:

- **Detection needs no message tagging**: the trailing message is matched by id against `getRunMessages()`'s tail. An agent's own self-loops never present this shape (they re-enter on tool results or injected user turns), so a run-produced trailing assistant turn can only be another agent's output.
- **Deliberate single-agent prefill flows are untouched**: host-supplied trailing assistant turns are not run-produced and never match. Fail-safe off when ids are missing.
- **Wire-only**: the cue exists in the provider projection only — graph state and host-visible messages stay clean (asserted in the e2e spec). Marked `isMeta` so the Bedrock tail cache anchor does not pin it.
- **Scoped**: chosen over the broader "cue every bare edge on every provider" option (#345 option 1 vs 2) — OpenAI/Gemini have no prefill semantics and existing flows there keep their exact payloads.

## Verification

Live, before → after (scenario runner from #335):
- `ma-continue --provider anthropic`: **empty critic (3/3)** → real critique in the critic's own voice
- `ma-baseline --provider anthropic`: continuation-shaped appendage (`\n\n**Critique:**…`) → proper critic voice
- `ma-continue --provider bedrock`: critique that even correctly notes the writer was interrupted

Tests: unit truth-table on the identity gate (run-produced vs host prefill vs missing ids vs non-assistant tails, non-mutation), e2e two-agent spec asserting the cue in anthropic + bedrock successor payloads, its absence for openAI, and clean run state. `tsc` clean, no new lint warnings.

@codex review