### PR TITLE
🎯 feat: Tool Intent & Outcome Label Core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './tools/ReadFile';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';
+export * from './tools/intentArg';
 export * from './tools/schema';
 export * from './tools/handlers';
 export * from './tools/local';

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1702,7 +1702,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
         ]),
       ];
     }
-    return params;
+    return stripIntentFromStrictTools(params);
   }
 
   async completionWithRetry(
@@ -1952,7 +1952,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
         ]),
       ];
     }
-    return params;
+    return stripIntentFromStrictTools(params);
   }
 
   async completionWithRetry(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -51,6 +51,7 @@ import {
   projectOpenAIResponsesToolMessageContent,
   projectToolStreamContentForProvider,
 } from '@/messages/core';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
@@ -1003,6 +1004,65 @@ function createAbortHandler(controller: AbortController): () => void {
  * @param {Object} [fields] Additional fields to add to the OpenAI tool.
  * @returns {ToolDefinition} The inputted tool in OpenAI tool format.
  */
+/**
+ * OpenAI strict function schemas require every property to appear in
+ * `required`. The optional `intent` label (see `tools/intentArg.ts`) is
+ * deliberately NOT required — the same schema is callable from programmatic
+ * tool calling — so a tool auto-marked `strict: true` (the non-streaming
+ * `json_schema` structured-output path) would be rejected as invalid before
+ * execution. That path never streams a live label anyway, so the
+ * marker-identified property is dropped there; every other path keeps it.
+ */
+function stripIntentFromStrictTools<T extends object>(params: T): T {
+  const record = params as { tools?: unknown[] };
+  const tools = record.tools;
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return params;
+  }
+  const nextTools = tools.map((tool) => {
+    const candidate = tool as {
+      strict?: boolean;
+      parameters?: { properties?: Record<string, unknown>; required?: unknown };
+      function?: {
+        strict?: boolean;
+        parameters?: {
+          properties?: Record<string, unknown>;
+          required?: unknown;
+        };
+      };
+    };
+    /** Chat-completions tools nest under `function`; responses-API tools are flat. */
+    const holder = candidate.function ?? candidate;
+    if (holder.strict !== true) {
+      return tool;
+    }
+    const parameters = holder.parameters;
+    const properties = parameters?.properties;
+    if (properties == null || !isIntentLabelProperty(properties[INTENT_ARG])) {
+      return tool;
+    }
+    const required = Array.isArray(parameters?.required)
+      ? (parameters.required as unknown[])
+      : [];
+    if (required.includes(INTENT_ARG)) {
+      return tool;
+    }
+    const { [INTENT_ARG]: _omit, ...restProps } = properties;
+    const nextParams = { ...parameters, properties: restProps };
+    if (candidate.function != null) {
+      return {
+        ...candidate,
+        function: { ...candidate.function, parameters: nextParams },
+      };
+    }
+    return { ...candidate, parameters: nextParams };
+  });
+  if (nextTools.every((tool, index) => tool === tools[index])) {
+    return params;
+  }
+  return { ...params, tools: nextTools } as T;
+}
+
 export function _convertToOpenAITool(
   tool: BindToolsInput,
   fields?: {
@@ -1184,10 +1244,12 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options?: this['ParsedCallOptions'],
     extra?: { streaming?: boolean }
   ): ReturnType<OriginalChatOpenAICompletions['invocationParams']> {
-    return applyManagedRequestParams(super.invocationParams(options, extra), {
-      promptCacheExplicit: this.promptCacheExplicit,
-      safetyIdentifier: this.safetyIdentifier,
-    });
+    return stripIntentFromStrictTools(
+      applyManagedRequestParams(super.invocationParams(options, extra), {
+        promptCacheExplicit: this.promptCacheExplicit,
+        safetyIdentifier: this.safetyIdentifier,
+      })
+    );
   }
 
   protected _getReasoningParams(
@@ -1741,10 +1803,12 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     options?: this['ParsedCallOptions'],
     extra?: { streaming?: boolean }
   ): ReturnType<OriginalAzureChatOpenAICompletions['invocationParams']> {
-    return applyManagedRequestParams(super.invocationParams(options, extra), {
-      promptCacheExplicit: this.promptCacheExplicit,
-      safetyIdentifier: this.safetyIdentifier,
-    });
+    return stripIntentFromStrictTools(
+      applyManagedRequestParams(super.invocationParams(options, extra), {
+        promptCacheExplicit: this.promptCacheExplicit,
+        safetyIdentifier: this.safetyIdentifier,
+      })
+    );
   }
 
   protected _getReasoningParams(

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -1248,6 +1248,40 @@ describe('ChatOpenAICompletions strict tools for structured output', () => {
       expect(toolProperties({})).toEqual(['intent', 'query']);
     });
 
+    /**
+     * The Responses API flattens tools to `{type, name, parameters, strict}`
+     * and does NOT infer strict from a `json_schema` response_format the way
+     * Completions does — an explicit `strict` (per-call option or on the tool)
+     * is what turns it on there.
+     */
+    function responsesToolProperties(
+      options: Record<string, unknown>
+    ): string[] {
+      const model = new ChatOpenAI({ model: 'gpt-4', apiKey: 'test-key' });
+      const responses = (
+        model as unknown as {
+          responses: {
+            invocationParams: (o: Record<string, unknown>) => {
+              tools?: { parameters?: { properties?: object } }[];
+            };
+          };
+        }
+      ).responses;
+      const params = responses.invocationParams({
+        tools: [intentTool],
+        ...options,
+      });
+      return Object.keys(params.tools?.[0]?.parameters?.properties ?? {});
+    }
+
+    it('drops the label on the RESPONSES delegate under strict too', () => {
+      expect(responsesToolProperties({ strict: true })).toEqual(['query']);
+    });
+
+    it('keeps the label on a non-strict RESPONSES request', () => {
+      expect(responsesToolProperties({})).toEqual(['intent', 'query']);
+    });
+
     it('spares a business `intent` param even under strict', () => {
       const businessTool = {
         type: 'function' as const,

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -1206,6 +1206,77 @@ describe('ChatOpenAICompletions strict tools for structured output', () => {
       toolStrict({ response_format: { type: 'json_object' } })
     ).toBeUndefined();
   });
+
+  describe('optional intent labels under strict mode', () => {
+    const intentTool = {
+      type: 'function' as const,
+      function: {
+        name: 'search_mcp_docs',
+        description: 'Search docs',
+        parameters: {
+          type: 'object',
+          properties: {
+            intent: {
+              type: 'string',
+              description:
+                'ALWAYS write this field FIRST, before any other argument. One short sentence…',
+            },
+            query: { type: 'string' },
+          },
+          required: ['query'],
+        },
+      },
+    };
+
+    function toolProperties(options: Record<string, unknown>): string[] {
+      const model = new ChatOpenAI({ model: 'gpt-4', apiKey: 'test-key' });
+      const completions = completionsOf<InvocationParamsDelegate>(model);
+      const params = completions.invocationParams({
+        tools: [intentTool],
+        ...options,
+      }) as unknown as {
+        tools?: { function: { parameters: { properties: object } } }[];
+      };
+      return Object.keys(params.tools?.[0]?.function.parameters.properties ?? {});
+    }
+
+    it('drops the optional label when strict is auto-enabled (invalid otherwise)', () => {
+      expect(toolProperties({ response_format: jsonSchemaResponseFormat })).toEqual(['query']);
+    });
+
+    it('keeps the label on non-strict requests', () => {
+      expect(toolProperties({})).toEqual(['intent', 'query']);
+    });
+
+    it('spares a business `intent` param even under strict', () => {
+      const businessTool = {
+        type: 'function' as const,
+        function: {
+          name: 'create_record',
+          parameters: {
+            type: 'object',
+            properties: {
+              intent: { type: 'string', description: 'CRM intent category' },
+              title: { type: 'string' },
+            },
+            required: ['intent', 'title'],
+          },
+        },
+      };
+      const model = new ChatOpenAI({ model: 'gpt-4', apiKey: 'test-key' });
+      const completions = completionsOf<InvocationParamsDelegate>(model);
+      const params = completions.invocationParams({
+        tools: [businessTool],
+        response_format: jsonSchemaResponseFormat,
+      }) as unknown as {
+        tools?: { function: { parameters: { properties: object } } }[];
+      };
+      expect(Object.keys(params.tools?.[0]?.function.parameters.properties ?? {})).toEqual([
+        'intent',
+        'title',
+      ]);
+    });
+  });
 });
 
 describe('ChatOpenAI._streamChatModelEvents (native, fork)', () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -860,7 +860,9 @@ async function dispatchEagerToolCompletions(args: {
         maxToolResultChars
       ).content;
     }
-    const outcome = resolveToolOutcome(record.request.args, result);
+    const outcome = resolveToolOutcome(record.request.args, result, {
+      isError: result.status === 'error',
+    });
 
     try {
       const dispatched = await safeDispatchCustomEvent(

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -860,10 +860,7 @@ async function dispatchEagerToolCompletions(args: {
         maxToolResultChars
       ).content;
     }
-    const outcome =
-      result.status === 'error'
-        ? undefined
-        : resolveToolOutcome(record.request.args, result);
+    const outcome = resolveToolOutcome(record.request.args, result);
 
     try {
       const dispatched = await safeDispatchCustomEvent(
@@ -2163,7 +2160,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         toolCallContentIndexMap.delete(existingToolCallId);
       }
 
-      const newToolCall: ToolCall & t.PartMetadata = {
+      const newToolCall: ToolCall & t.PartMetadata & { outcome?: string } = {
         id,
         name,
         args,
@@ -2183,6 +2180,10 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       if (finalUpdate) {
         newToolCall.progress = 1;
         newToolCall.output = contentPart.tool_call.output;
+        const outcome = (contentPart.tool_call as t.ToolCallPart).outcome;
+        if (outcome != null) {
+          newToolCall.outcome = outcome;
+        }
       }
 
       contentParts[index] = {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -41,6 +41,7 @@ import {
 } from '@/utils/truncation';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
+import { resolveToolOutcome } from '@/tools/intentArg';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
 
@@ -859,6 +860,10 @@ async function dispatchEagerToolCompletions(args: {
         maxToolResultChars
       ).content;
     }
+    const outcome =
+      result.status === 'error'
+        ? undefined
+        : resolveToolOutcome(record.request.args, result);
 
     try {
       const dispatched = await safeDispatchCustomEvent(
@@ -878,6 +883,7 @@ async function dispatchEagerToolCompletions(args: {
               id: result.toolCallId,
               output,
               progress: 1,
+              ...(outcome != null && { outcome }),
             } as t.ProcessedToolCall,
           },
         },

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -69,6 +69,10 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
+import {
+  readOutcomeFields,
+  resolveToolOutcome,
+} from '@/tools/intentArg';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
@@ -2079,6 +2083,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * the tool actually received rather than leaking the template.
        */
       const effectiveArgs = resolvedArgsByCallId?.get(toolCallId) ?? call.args;
+      const outcome =
+        toolMessage.status === 'error'
+          ? undefined
+          : resolveToolOutcome(
+            effectiveArgs,
+            readOutcomeFields(toolMessage.artifact)
+          );
       const tool_call: t.ProcessedToolCall = {
         args: serializeToolContentBounded(
           (effectiveArgs as unknown) ?? {},
@@ -2088,6 +2099,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         id: toolCallId,
         output: contentString,
         progress: 1,
+        ...(outcome != null && { outcome }),
       };
 
       await safeDispatchCustomEvent(
@@ -3120,7 +3132,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             request?.args ?? {},
             contentString,
             config,
-            request?.turn
+            request?.turn,
+            result.status === 'error'
+              ? undefined
+              : resolveToolOutcome(request?.args, result)
           );
         }
 
@@ -3361,7 +3376,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     args: Record<string, unknown>,
     output: string,
     config: RunnableConfig,
-    turn?: number
+    turn?: number,
+    outcome?: string
   ): Promise<boolean> {
     const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
     if (!stepId) {
@@ -3386,6 +3402,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             id: toolCallId,
             output,
             progress: 1,
+            ...(outcome != null && { outcome }),
           } as t.ProcessedToolCall,
         },
       },
@@ -3422,7 +3439,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       request.args,
       output,
       config,
-      request.turn
+      request.turn,
+      result.status === 'error'
+        ? undefined
+        : resolveToolOutcome(request.args, result)
     );
   }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -54,6 +54,12 @@ import {
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
+  INTENT_ARG,
+  readOutcomeFields,
+  resolveToolOutcome,
+  isIntentLabelProperty,
+} from '@/tools/intentArg';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -70,12 +76,6 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
-import {
-  INTENT_ARG,
-  readOutcomeFields,
-  resolveToolOutcome,
-  isIntentLabelProperty,
-} from '@/tools/intentArg';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
@@ -133,7 +133,36 @@ type RunToolBatchContext<T = unknown> = {
    * which relies on `node:async_hooks` and is browser-incompatible).
    */
   runInput?: T;
+  /** Batch-local error-completion ownership (see {@link ToolErrorOwnership}). */
+  errorOwnership?: ToolErrorOwnership;
 };
+
+/**
+ * Batch-local record of who owns each failed call's completion event.
+ *
+ * Kept per invocation rather than on the instance: tool-call ids are
+ * provider-scoped (and synthetic ids can repeat), so concurrent `run()`s on
+ * one ToolNode would otherwise share and cross-consume these markers — one
+ * invocation's thrown-error marker suppressing another's only completion,
+ * or leaving a stale marker behind when an interrupt aborts a batch before
+ * the output loop reads it.
+ *
+ * - `handlerOwned`: the errorHandler ran and dispatched (or threw — a throw
+ *   is not proof it didn't dispatch). The output loop must skip these.
+ * - `undispatched`: the handler explicitly reported it could NOT dispatch,
+ *   so the output loop owns the completion instead.
+ *
+ * A call in NEITHER set returned an error `ToolMessage` without ever
+ * entering the catch path, so the output loop owns it too.
+ */
+export type ToolErrorOwnership = {
+  handlerOwned: Set<string>;
+  undispatched: Set<string>;
+};
+
+export function createToolErrorOwnership(): ToolErrorOwnership {
+  return { handlerOwned: new Set(), undispatched: new Set() };
+}
 
 type BoundedToolOutput = {
   content: string;
@@ -506,22 +535,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   toolCallStepIds?: Map<string, string>;
   errorHandler?: t.ToolNodeConstructorParams['errorHandler'];
   /**
-   * Tool call ids whose `errorHandler` did NOT dispatch the error completion
-   * event (it returned `false` or threw). The output loop must dispatch the
-   * completion for these itself — skipping them there would strand the
-   * client's tool-call part without a terminal event.
+   * Fallback error-completion ownership for calls that reach `runTool`
+   * outside a batch context (direct `runTool` use in tests / embedders).
+   * Batch-scoped ownership is threaded via `RunToolBatchContext` instead —
+   * see {@link ToolErrorOwnership} for why per-invocation scoping matters.
    */
-  private undispatchedToolErrors: Set<string> = new Set();
-  /**
-   * Tool call ids whose `errorHandler` OWNS the error completion event —
-   * it ran and either dispatched or threw (a throw is not proof it didn't
-   * dispatch; the built-in session handler emits `tool.completed` before
-   * invoking user callbacks). Only these may be skipped by the output
-   * loop. A tool that RETURNS an error `ToolMessage` never enters the
-   * catch path at all, so it appears in neither set and the output loop
-   * dispatches its completion — and therefore its authored failure label.
-   */
-  private handlerOwnedToolErrors: Set<string> = new Set();
+  private looseErrorOwnership: ToolErrorOwnership =
+    createToolErrorOwnership();
   private toolUsageCount: Map<string, number>;
   /** Maps toolCallId → turn captured in runTool, used by handleRunToolCompletions */
   private toolCallTurns: Map<string, number> = new Map();
@@ -1286,6 +1306,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             config.metadata
           );
+          const ownership =
+            batchContext.errorOwnership ?? this.looseErrorOwnership;
           if (call.id != null && call.id !== '') {
             if (dispatched === false) {
               /**
@@ -1295,9 +1317,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                * output loop dispatches the completion itself instead of
                * assuming the handler covered it.
                */
-              this.undispatchedToolErrors.add(call.id);
+              ownership.undispatched.add(call.id);
             } else {
-              this.handlerOwnedToolErrors.add(call.id);
+              ownership.handlerOwned.add(call.id);
             }
           }
         } catch (handlerError) {
@@ -1309,7 +1331,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // `false` return (handled above) means "nothing dispatched"; a throw
           // is just logged.
           if (call.id != null && call.id !== '') {
-            this.handlerOwnedToolErrors.add(call.id);
+            (
+              batchContext.errorOwnership ?? this.looseErrorOwnership
+            ).handlerOwned.add(call.id);
           }
           // eslint-disable-next-line no-console
           console.error('Error in errorHandler:', {
@@ -2063,8 +2087,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     calls: ToolCall[],
     outputs: (BaseMessage | Command)[],
     config: RunnableConfig,
-    resolvedArgsByCallId?: ResolvedArgsByCallId
+    resolvedArgsByCallId?: ResolvedArgsByCallId,
+    errorOwnership?: ToolErrorOwnership
   ): Promise<void> {
+    const ownership = errorOwnership ?? this.looseErrorOwnership;
     for (let i = 0; i < calls.length; i++) {
       const call = calls[i];
       const output = outputs[i];
@@ -2090,11 +2116,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // ToolNode re-executing the batch) take the wrong branch, and the sets
       // would grow unbounded across a long-lived graph's failing calls.
       if (toolMessage.status === 'error' && this.errorHandler != null) {
-        if (this.handlerOwnedToolErrors.has(toolCallId)) {
-          this.handlerOwnedToolErrors.delete(toolCallId);
+        if (ownership.handlerOwned.has(toolCallId)) {
+          ownership.handlerOwned.delete(toolCallId);
           continue;
         }
-        this.undispatchedToolErrors.delete(toolCallId);
+        ownership.undispatched.delete(toolCallId);
       }
 
       if (this.sessions && this.participatesInCodeSession(call.name)) {
@@ -3657,6 +3683,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * ToolNode cannot read or wipe each other's entries.
      */
     const resolvedArgsByCallId = new Map<string, Record<string, unknown>>();
+    /** Per-invocation error-completion ownership — see `ToolErrorOwnership`. */
+    const errorOwnership = createToolErrorOwnership();
     /**
      * Claim this batch's turn synchronously from the registry (or
      * fall back to 0 when the feature is disabled). The registry is
@@ -3702,6 +3730,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           turn,
           batchScopeId,
           resolvedArgsByCallId,
+          errorOwnership,
           additionalContextsSink: directAdditionalContexts,
           runInput: sendState as T,
         }
@@ -3725,7 +3754,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // HumanMessage isn't a tool result.
         [sendOutput],
         config,
-        resolvedArgsByCallId
+        resolvedArgsByCallId,
+        errorOwnership
       );
     } else {
       let messages: BaseMessage[];
@@ -3850,7 +3880,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           for (const entry of eventEntries) {
             if (entry.call.id != null) {
               const { resolved, unresolved } = preBatchSnapshot.resolve(
-                entry.call.args as Record<string, unknown>
+                entry.call.args as Record<string, unknown>,
+                {
+                  substituteIntentKey: this.toolDeclaresBusinessIntent(
+                    entry.call.name
+                  ),
+                }
               );
               preResolvedEventArgs.set(entry.call.id, {
                 resolved: resolved as Record<string, unknown>,
@@ -3875,6 +3910,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 turn,
                 batchScopeId,
                 resolvedArgsByCallId,
+                errorOwnership,
                 preBatchSnapshot,
                 additionalContextsSink: directAdditionalContexts,
                 runInput: input as T,
@@ -3887,7 +3923,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             directCalls,
             directOutputs,
             config,
-            resolvedArgsByCallId
+            resolvedArgsByCallId,
+            errorOwnership
           );
         }
 
@@ -3940,6 +3977,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             turn,
             batchScopeId,
             resolvedArgsByCallId,
+            errorOwnership,
             preBatchSnapshot,
             additionalContextsSink: directAdditionalContexts,
             runInput: input as T,
@@ -3949,7 +3987,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           filteredCalls,
           toolOutputs,
           config,
-          resolvedArgsByCallId
+          resolvedArgsByCallId,
+          errorOwnership
         );
         // Append accumulated additionalContexts as a single
         // HumanMessage so the next model turn sees them. Codex P2 #39.

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2108,7 +2108,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        *  without one, an error call simply stays unlabeled. */
       const outcome = resolveToolOutcome(
         effectiveArgs,
-        readOutcomeFields(toolMessage.artifact)
+        readOutcomeFields(toolMessage.artifact),
+        { isError: toolMessage.status === 'error' }
       );
       const tool_call: t.ProcessedToolCall = {
         args: serializeToolContentBounded(
@@ -3153,7 +3154,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             contentString,
             config,
             request?.turn,
-            resolveToolOutcome(request?.args, result)
+            resolveToolOutcome(request?.args, result, {
+              isError: result.status === 'error',
+            })
           );
         }
 
@@ -3458,7 +3461,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       output,
       config,
       request.turn,
-      resolveToolOutcome(request.args, result)
+      resolveToolOutcome(request.args, result, {
+        isError: result.status === 'error',
+      })
     );
   }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -31,6 +31,7 @@ import type {
   PreResolvedArgsMap,
   ResolvedArgsByCallId,
   ResolveResult,
+  ResolveOptions,
 } from '@/tools/toolOutputReferences';
 import type {
   HookRegistry,
@@ -70,8 +71,10 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import {
+  INTENT_ARG,
   readOutcomeFields,
   resolveToolOutcome,
+  isIntentLabelProperty,
 } from '@/tools/intentArg';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { convertInjectedMessages } from '@/messages/injected';
@@ -509,6 +512,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * client's tool-call part without a terminal event.
    */
   private undispatchedToolErrors: Set<string> = new Set();
+  /**
+   * Tool call ids whose `errorHandler` OWNS the error completion event —
+   * it ran and either dispatched or threw (a throw is not proof it didn't
+   * dispatch; the built-in session handler emits `tool.completed` before
+   * invoking user callbacks). Only these may be skipped by the output
+   * loop. A tool that RETURNS an error `ToolMessage` never enters the
+   * catch path at all, so it appears in neither set and the output loop
+   * dispatches its completion — and therefore its authored failure label.
+   */
+  private handlerOwnedToolErrors: Set<string> = new Set();
   private toolUsageCount: Map<string, number>;
   /** Maps toolCallId → turn captured in runTool, used by handleRunToolCompletions */
   private toolCallTurns: Map<string, number> = new Map();
@@ -956,14 +969,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       args: T
     ) => ResolveResult<T>;
     let resolveFn: ResolveFn | undefined;
+    const resolveOptions = {
+      substituteIntentKey: this.toolDeclaresBusinessIntent(call.name),
+    };
     if (preBatchSnapshot != null) {
       resolveFn = <T>(_runId: string | undefined, args: T): ResolveResult<T> =>
-        preBatchSnapshot.resolve(args);
+        preBatchSnapshot.resolve(args, resolveOptions);
     } else if (registry != null) {
       resolveFn = <T>(
         runIdArg: string | undefined,
         args: T
-      ): ResolveResult<T> => registry.resolve(runIdArg, args);
+      ): ResolveResult<T> => registry.resolve(runIdArg, args, resolveOptions);
     }
     /**
      * Precompute the reference key once per call — captured locally
@@ -1270,15 +1286,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             config.metadata
           );
-          if (dispatched === false && call.id != null && call.id !== '') {
-            /**
-             * The handler could not dispatch the error completion (typically
-             * a resume pass, where a fast-failing tool errors before the
-             * step replay registers its run step). Remember the call so the
-             * output loop dispatches the completion itself instead of
-             * assuming the handler covered it.
-             */
-            this.undispatchedToolErrors.add(call.id);
+          if (call.id != null && call.id !== '') {
+            if (dispatched === false) {
+              /**
+               * The handler could not dispatch the error completion (typically
+               * a resume pass, where a fast-failing tool errors before the
+               * step replay registers its run step). Remember the call so the
+               * output loop dispatches the completion itself instead of
+               * assuming the handler covered it.
+               */
+              this.undispatchedToolErrors.add(call.id);
+            } else {
+              this.handlerOwnedToolErrors.add(call.id);
+            }
           }
         } catch (handlerError) {
           // A THROWN handler is not proof the completion wasn't dispatched: the
@@ -1288,6 +1308,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // fallback loop re-emit a duplicate completion — only an explicit
           // `false` return (handled above) means "nothing dispatched"; a throw
           // is just logged.
+          if (call.id != null && call.id !== '') {
+            this.handlerOwnedToolErrors.add(call.id);
+          }
           // eslint-disable-next-line no-console
           console.error('Error in errorHandler:', {
             toolName: call.name,
@@ -1452,13 +1475,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // (later-awaited) `runTool` will actually run with — both are
     // anchored to the pre-batch registry state.
     let resolvedArgs = call.args as Record<string, unknown>;
+    const hookResolveOptions = {
+      substituteIntentKey: this.toolDeclaresBusinessIntent(call.name),
+    };
     if (batchContext.preBatchSnapshot != null) {
-      const { resolved } = batchContext.preBatchSnapshot.resolve(call.args);
+      const { resolved } = batchContext.preBatchSnapshot.resolve(
+        call.args,
+        hookResolveOptions
+      );
       resolvedArgs = resolved as Record<string, unknown>;
     } else if (this.toolOutputRegistry != null) {
       const { resolved } = this.toolOutputRegistry.resolve(
         registryRunId,
-        call.args
+        call.args,
+        hookResolveOptions
       );
       resolvedArgs = resolved as Record<string, unknown>;
     }
@@ -2047,23 +2077,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const toolMessage = output as ToolMessage;
       const toolCallId = call.id ?? '';
 
-      // Skip error ToolMessages when errorHandler already dispatched ON_RUN_STEP_COMPLETED
-      // via handleToolCallErrorStatic — dispatching again here would double-dispatch.
-      // When the handler reported it could NOT dispatch (no run step registered yet at
-      // error time, e.g. a fast-failing tool on a resume pass), fall through: by now the
-      // step replay has usually registered the id, so this loop's dispatch is the only
-      // terminal event the client's tool-call part will ever get.
+      // Skip error ToolMessages only when the errorHandler OWNS the completion —
+      // it ran and dispatched (or threw) via handleToolCallErrorStatic, so
+      // dispatching again here would double-dispatch. Two cases fall through:
+      //  - the handler reported it could NOT dispatch (no run step registered yet
+      //    at error time, e.g. a fast-failing tool on a resume pass); by now the
+      //    step replay has usually registered the id, so this loop's dispatch is
+      //    the only terminal event the client's tool-call part will ever get.
+      //  - the tool RETURNED an error ToolMessage rather than throwing, so the
+      //    catch path (and the handler with it) never ran at all.
+      // Markers are CONSUMED: leaving one set would let a later re-entry (same
+      // ToolNode re-executing the batch) take the wrong branch, and the sets
+      // would grow unbounded across a long-lived graph's failing calls.
       if (toolMessage.status === 'error' && this.errorHandler != null) {
-        if (this.undispatchedToolErrors.has(toolCallId)) {
-          // CONSUME the marker: this loop now owns the dispatch for this id.
-          // Leaving it set would let a later re-entry (same ToolNode instance
-          // re-executing the batch, where the handler CAN dispatch) fall
-          // through here too and double-dispatch — and the set would grow
-          // unbounded across a long-lived graph's fast-failing calls.
-          this.undispatchedToolErrors.delete(toolCallId);
-        } else {
+        if (this.handlerOwnedToolErrors.has(toolCallId)) {
+          this.handlerOwnedToolErrors.delete(toolCallId);
           continue;
         }
+        this.undispatchedToolErrors.delete(toolCallId);
       }
 
       if (this.sessions && this.participatesInCodeSession(call.name)) {
@@ -2198,7 +2229,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       } else if (registry != null) {
         const { resolved, unresolved } = registry.resolve(
           registryRunId,
-          originalArgs
+          originalArgs,
+          { substituteIntentKey: this.toolDeclaresBusinessIntent(call.name) }
         );
         resolvedArgs = resolved as Record<string, unknown>;
         if (unresolved.length > 0 && call.id != null) {
@@ -2419,9 +2451,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       ): void => {
         if (registry != null) {
           const view: ToolOutputResolveView = preBatchSnapshot ?? {
-            resolve: <T>(args: T) => registry.resolve(registryRunId, args),
+            resolve: <T>(args: T, options?: ResolveOptions) =>
+              registry.resolve(registryRunId, args, options),
           };
-          const { resolved, unresolved } = view.resolve(nextArgs);
+          const { resolved, unresolved } = view.resolve(nextArgs, {
+            substituteIntentKey: this.toolDeclaresBusinessIntent(
+              entry.call.name
+            ),
+          });
           entry.args = resolved as Record<string, unknown>;
           if (entry.call.id != null) {
             if (unresolved.length > 0) {
@@ -3389,6 +3426,35 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
       }
     }
+  }
+
+  /**
+   * Whether `name`'s own schema declares a BUSINESS parameter called
+   * `intent` (declared, and not the injected label contract — see
+   * `isIntentLabelProperty`). Such a parameter must keep participating in
+   * `{{tool…}}` placeholder substitution; only the display label is exempt.
+   */
+  private toolDeclaresBusinessIntent(name: string): boolean {
+    const instance = this.toolMap.get(name) as
+      | {
+          schema?: {
+            shape?: Record<string, unknown>;
+            properties?: Record<string, unknown>;
+          };
+        }
+      | undefined;
+    const instanceProp =
+      instance?.schema?.properties?.[INTENT_ARG] ??
+      instance?.schema?.shape?.[INTENT_ARG];
+    if (instanceProp != null) {
+      return !isIntentLabelProperty(instanceProp);
+    }
+    const defProp =
+      this.toolRegistry?.get(name)?.parameters?.properties?.[INTENT_ARG];
+    if (defProp != null) {
+      return !isIntentLabelProperty(defProp);
+    }
+    return false;
   }
 
   private async dispatchStepCompleted(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1659,6 +1659,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
 
+    /**
+     * A hook (`PreToolUse.updatedInput`) or HITL `edit` decision rewrote the
+     * args: expose the EFFECTIVE args to downstream completion handling
+     * (`handleRunToolCompletions` reads this sink), so the emitted
+     * `tool_call.args` — and any intent/outcome label resolved from them —
+     * reflect what the tool actually ran with. `runTool`'s own placeholder
+     * substitution may overwrite this entry with the post-substitution args,
+     * which is strictly more accurate.
+     */
+    if (
+      effectiveCall !== call &&
+      batchContext.resolvedArgsByCallId != null &&
+      call.id != null &&
+      call.id !== ''
+    ) {
+      batchContext.resolvedArgsByCallId.set(
+        call.id,
+        effectiveCall.args as Record<string, unknown>
+      );
+    }
+
     const output = await this.runTool(effectiveCall, config, {
       ...batchContext,
       usageCount,
@@ -2083,13 +2104,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * the tool actually received rather than leaking the template.
        */
       const effectiveArgs = resolvedArgsByCallId?.get(toolCallId) ?? call.args;
-      const outcome =
-        toolMessage.status === 'error'
-          ? undefined
-          : resolveToolOutcome(
-            effectiveArgs,
-            readOutcomeFields(toolMessage.artifact)
-          );
+      /** Authored outcomes apply to failed calls too (“Search failed for…”);
+       *  without one, an error call simply stays unlabeled. */
+      const outcome = resolveToolOutcome(
+        effectiveArgs,
+        readOutcomeFields(toolMessage.artifact)
+      );
       const tool_call: t.ProcessedToolCall = {
         args: serializeToolContentBounded(
           (effectiveArgs as unknown) ?? {},
@@ -3133,9 +3153,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             contentString,
             config,
             request?.turn,
-            result.status === 'error'
-              ? undefined
-              : resolveToolOutcome(request?.args, result)
+            resolveToolOutcome(request?.args, result)
           );
         }
 
@@ -3440,9 +3458,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       output,
       config,
       request.turn,
-      result.status === 'error'
-        ? undefined
-        : resolveToolOutcome(request.args, result)
+      resolveToolOutcome(request.args, result)
     );
   }
 

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -560,3 +560,72 @@ describe('ToolNode per-call onResult completion emission', () => {
     );
   });
 });
+
+describe('ToolNode returned-error completions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * A tool that RETURNS an error ToolMessage never enters the catch path, so
+   * the errorHandler never runs and cannot have dispatched. The output loop
+   * must therefore emit the completion — and with it the tool's authored
+   * failure label — instead of assuming the handler owned it.
+   */
+  it('emits a completion (and authored outcome) for a RETURNED error ToolMessage', async () => {
+    const completions: Array<{
+      result: { tool_call: { id: string; outcome?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(
+            data as { result: { tool_call: { id: string; outcome?: string } } }
+          );
+        }
+      });
+
+    const returnsError = tool(
+      async () =>
+        new ToolMessage({
+          content: 'boom',
+          tool_call_id: 'call_fail',
+          status: 'error',
+          artifact: { outcome: 'Search failed for OAuth' },
+        }),
+      {
+        name: 'failing',
+        description: 'returns an error message',
+        schema: z.object({}).passthrough(),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const errorHandler = jest.fn(async () => true);
+    const toolNode = new ToolNode({
+      tools: [returnsError],
+      toolCallStepIds: new Map([['call_fail', 'step_fail']]),
+      errorHandler: errorHandler as unknown as t.ToolNodeConstructorParams['errorHandler'],
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          {
+            id: 'call_fail',
+            name: 'failing',
+            args: { intent: 'Searching for OAuth handling' },
+          },
+        ]),
+      ],
+    });
+    await flushAsync();
+
+    expect(errorHandler).not.toHaveBeenCalled();
+    const completion = completions.find(
+      (c) => c.result.tool_call.id === 'call_fail'
+    );
+    expect(completion).toBeDefined();
+    expect(completion?.result.tool_call.outcome).toBe('Search failed for OAuth');
+  });
+});

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -629,3 +629,108 @@ describe('ToolNode returned-error completions', () => {
     expect(completion?.result.tool_call.outcome).toBe('Search failed for OAuth');
   });
 });
+
+describe('ToolNode error-ownership scoping', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Tool-call ids are provider-scoped and synthetic ids can repeat, so
+   * ownership markers kept on the INSTANCE cross-consume between that
+   * instance's concurrent invocations.
+   *
+   * Interleaving that exposes it: invocation 1 batches a throwing call
+   * (whose handler claims ownership) alongside a slow call that keeps the
+   * batch — and therefore its output loop — pending. While it is parked,
+   * invocation 2 reuses the same id and RETURNS an error message. With
+   * instance-scoped markers, invocation 2's output loop consumes the
+   * marker invocation 1 set and drops its only completion.
+   */
+  it('does not let a pending invocation\'s marker suppress a concurrent call reusing the id', async () => {
+    const completions: string[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(
+            (data as { result: { tool_call: { id: string } } }).result.tool_call
+              .id
+          );
+        }
+      });
+
+    const shared = 'call_shared';
+    let releaseSlow: (() => void) | undefined;
+    const slowGate = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+
+    const thrower = tool(
+      async () => {
+        throw new Error('boom');
+      },
+      { name: 'thrower', description: 'throws', schema: z.object({}).passthrough() }
+    ) as unknown as StructuredToolInterface;
+    const slow = tool(
+      async () => {
+        await slowGate;
+        return 'done';
+      },
+      { name: 'slow', description: 'parks the batch', schema: z.object({}).passthrough() }
+    ) as unknown as StructuredToolInterface;
+    const returner = tool(
+      async () =>
+        new ToolMessage({
+          content: 'failed',
+          tool_call_id: shared,
+          status: 'error',
+        }),
+      {
+        name: 'returner',
+        description: 'returns an error message',
+        schema: z.object({}).passthrough(),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    /** ONE instance — the shared state the finding is about. */
+    const node = new ToolNode({
+      tools: [thrower, slow, returner],
+      toolCallStepIds: new Map([
+        [shared, 'step_shared'],
+        ['call_slow', 'step_slow'],
+      ]),
+      errorHandler: (async () =>
+        true) as unknown as t.ToolNodeConstructorParams['errorHandler'],
+    });
+
+    // Invocation 1: throws (claiming ownership of `shared`) and parks.
+    const pending = node.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: shared, name: 'thrower', args: {} },
+          { id: 'call_slow', name: 'slow', args: {} },
+        ]),
+      ],
+    }) as Promise<unknown>;
+    await flushAsync();
+
+    // Invocation 2, while invocation 1 is still parked.
+    const before = completions.length;
+    await node.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: shared, name: 'returner', args: {} },
+        ]),
+      ],
+    });
+    await flushAsync();
+    const emittedBySecond = completions.slice(before);
+
+    releaseSlow?.();
+    await pending;
+    await flushAsync();
+
+    expect(emittedBySecond).toContain(shared);
+  });
+});

--- a/src/tools/__tests__/intentArg.test.ts
+++ b/src/tools/__tests__/intentArg.test.ts
@@ -218,6 +218,44 @@ describe('resolveToolOutcome', () => {
       'Searched for OAuth handling'
     );
   });
+
+  it('keeps $-token replacement text literal', () => {
+    expect(
+      resolveToolOutcome(args, {
+        outcome_patch: { from: 'Searching', to: 'Found $& via $\' and $$' },
+      })
+    ).toBe('Found $& via $\' and $$ for OAuth handling');
+  });
+
+  it('labels failed calls only with tool-authored text', () => {
+    expect(resolveToolOutcome(args, { outcome: 'Search failed for OAuth' }, { isError: true })).toBe(
+      'Search failed for OAuth'
+    );
+    expect(
+      resolveToolOutcome(
+        args,
+        { outcome_patch: { from: 'Searching', to: 'Search failed' } },
+        { isError: true }
+      )
+    ).toBe('Search failed for OAuth handling');
+  });
+
+  it('never falls back to the mechanical transform on a failed call', () => {
+    expect(
+      resolveToolOutcome(
+        args,
+        { outcome_patch: { from: 'searching', to: 'searched' } },
+        { isError: true }
+      )
+    ).toBeUndefined();
+    expect(
+      resolveToolOutcome(
+        { query: 'oauth' },
+        { outcome_patch: { from: 'Searching', to: 'Searched' } },
+        { isError: true }
+      )
+    ).toBeUndefined();
+  });
 });
 
 describe('readOutcomeFields', () => {

--- a/src/tools/__tests__/intentArg.test.ts
+++ b/src/tools/__tests__/intentArg.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from '@jest/globals';
+import type { JsonSchemaType } from '@/types';
+import {
+  INTENT_ARG,
+  INTENT_PROPERTY,
+  INTENT_DESCRIPTION,
+  withIntent,
+  readIntent,
+  stripIntent,
+  applyOutcome,
+  readOutcomeFields,
+  resolveToolOutcome,
+} from '../intentArg';
+
+describe('withIntent', () => {
+  const base: JsonSchemaType = {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Search query' },
+      limit: { type: 'number' },
+    },
+    required: ['query'],
+  };
+
+  it('prepends intent as the FIRST property key', () => {
+    const next = withIntent(base);
+    expect(Object.keys(next.properties ?? {})).toEqual(['intent', 'query', 'limit']);
+    expect(next.properties?.[INTENT_ARG]).toBe(INTENT_PROPERTY);
+  });
+
+  it('never mutates the input schema', () => {
+    const frozen = Object.freeze<JsonSchemaType>({
+      type: 'object',
+      properties: Object.freeze({ query: { type: 'string' } }),
+    }) as JsonSchemaType;
+    const next = withIntent(frozen);
+    expect(next).not.toBe(frozen);
+    expect(Object.keys(frozen.properties ?? {})).toEqual(['query']);
+    expect(Object.keys(next.properties ?? {})).toEqual(['intent', 'query']);
+  });
+
+  it('does not add intent to required', () => {
+    const next = withIntent(base);
+    expect(next.required).toEqual(['query']);
+  });
+
+  it('is idempotent when intent already exists (position preserved)', () => {
+    const once = withIntent(base);
+    const twice = withIntent(once);
+    expect(twice).toBe(once);
+    expect(Object.keys(twice.properties ?? {})[0]).toBe('intent');
+  });
+
+  it('handles a schema with no properties', () => {
+    const next = withIntent({ type: 'object', properties: {} });
+    expect(Object.keys(next.properties ?? {})).toEqual(['intent']);
+  });
+
+  it('handles an undefined schema', () => {
+    const next = withIntent(undefined);
+    expect(next.type).toBe('object');
+    expect(Object.keys(next.properties ?? {})).toEqual(['intent']);
+  });
+
+  it('carries the model-facing instruction', () => {
+    expect(INTENT_PROPERTY.description).toBe(INTENT_DESCRIPTION);
+    expect(INTENT_DESCRIPTION).toContain('FIRST');
+    expect(INTENT_DESCRIPTION).toContain('distinguish that call from its siblings');
+  });
+});
+
+describe('readIntent', () => {
+  it('reads from object args', () => {
+    expect(readIntent({ intent: 'Searching for OAuth handling' })).toBe(
+      'Searching for OAuth handling'
+    );
+  });
+
+  it('reads from stringified JSON args', () => {
+    expect(readIntent('{"intent":"Searching for OAuth handling","query":"oauth"}')).toBe(
+      'Searching for OAuth handling'
+    );
+  });
+
+  it('returns undefined for absent, empty, or non-string intents', () => {
+    expect(readIntent({ query: 'oauth' })).toBeUndefined();
+    expect(readIntent({ intent: '' })).toBeUndefined();
+    expect(readIntent({ intent: '   ' })).toBeUndefined();
+    expect(readIntent({ intent: 42 })).toBeUndefined();
+    expect(readIntent(undefined)).toBeUndefined();
+    expect(readIntent('not json')).toBeUndefined();
+    expect(readIntent('{"intent": broken')).toBeUndefined();
+  });
+});
+
+describe('stripIntent', () => {
+  it('removes the key from object args', () => {
+    expect(stripIntent({ intent: 'Searching', query: 'oauth' })).toEqual({ query: 'oauth' });
+  });
+
+  it('parses and strips stringified args', () => {
+    expect(stripIntent('{"intent":"Searching","query":"oauth"}')).toEqual({ query: 'oauth' });
+  });
+
+  it('returns args unchanged when the key is absent', () => {
+    const args = { query: 'oauth' };
+    expect(stripIntent(args)).toBe(args);
+    expect(stripIntent('plain string')).toBe('plain string');
+    expect(stripIntent(undefined)).toBeUndefined();
+  });
+});
+
+describe('applyOutcome', () => {
+  const intent = 'Searching for OAuth handling';
+
+  it('prefers a tool-supplied outcome (full replacement)', () => {
+    expect(
+      applyOutcome(intent, {
+        outcome: 'Found 12 results for OAuth handling',
+        outcome_patch: { from: 'Searching', to: 'Searched' },
+      })
+    ).toBe('Found 12 results for OAuth handling');
+  });
+
+  it('ignores a blank outcome', () => {
+    expect(applyOutcome(intent, { outcome: '  ' })).toBe('Searched for OAuth handling');
+  });
+
+  it('applies outcome_patch to the first occurrence only, case-sensitive', () => {
+    expect(
+      applyOutcome('Searching for Searching patterns', {
+        outcome_patch: { from: 'Searching', to: 'Searched' },
+      })
+    ).toBe('Searched for Searching patterns');
+    expect(
+      applyOutcome(intent, { outcome_patch: { from: 'searching', to: 'searched' } })
+    ).toBe('Searched for OAuth handling');
+  });
+
+  it('ignores a patch whose from is empty or absent from the intent', () => {
+    expect(applyOutcome(intent, { outcome_patch: { from: '', to: 'x' } })).toBe(
+      'Searched for OAuth handling'
+    );
+    expect(applyOutcome(intent, { outcome_patch: { from: 'Grepping', to: 'Grepped' } })).toBe(
+      'Searched for OAuth handling'
+    );
+  });
+
+  it('mechanically transforms the leading verb', () => {
+    expect(applyOutcome('Reading the callback router')).toBe('Read the callback router');
+    expect(applyOutcome('Writing the zod schema')).toBe('Wrote the zod schema');
+    expect(applyOutcome('Delegating the OAuth audit')).toBe('Delegated the OAuth audit');
+  });
+
+  it('preserves a lowercase leading verb', () => {
+    expect(applyOutcome('searching for OAuth handling')).toBe('searched for OAuth handling');
+  });
+
+  it('leaves an unknown leading word unchanged', () => {
+    expect(applyOutcome('Refactoring the zod schema')).toBe('Refactoring the zod schema');
+  });
+
+  it('handles a single-word intent', () => {
+    expect(applyOutcome('Searching')).toBe('Searched');
+  });
+
+  it('returns undefined with neither intent nor outcome', () => {
+    expect(applyOutcome(undefined)).toBeUndefined();
+    expect(applyOutcome('')).toBeUndefined();
+    expect(applyOutcome(undefined, { outcome_patch: { from: 'a', to: 'b' } })).toBeUndefined();
+  });
+
+  it('returns the outcome even without an intent', () => {
+    expect(applyOutcome(undefined, { outcome: 'Found 12 results' })).toBe('Found 12 results');
+  });
+});
+
+describe('resolveToolOutcome', () => {
+  const args = { intent: 'Searching for OAuth handling', query: 'oauth' };
+
+  it('returns undefined when the tool authored no outcome fields', () => {
+    expect(resolveToolOutcome(args)).toBeUndefined();
+    expect(resolveToolOutcome(args, {})).toBeUndefined();
+    expect(resolveToolOutcome(args, null)).toBeUndefined();
+  });
+
+  it('resolves a tool-supplied outcome', () => {
+    expect(resolveToolOutcome(args, { outcome: 'Found 12 results' })).toBe('Found 12 results');
+  });
+
+  it('resolves a patch against the intent read from args', () => {
+    expect(
+      resolveToolOutcome(args, { outcome_patch: { from: 'Searching', to: 'Searched' } })
+    ).toBe('Searched for OAuth handling');
+  });
+
+  it('returns undefined for a patch with no intent in the args', () => {
+    expect(
+      resolveToolOutcome({ query: 'oauth' }, { outcome_patch: { from: 'a', to: 'b' } })
+    ).toBeUndefined();
+  });
+});
+
+describe('readOutcomeFields', () => {
+  it('reads valid fields from an artifact-shaped object', () => {
+    expect(readOutcomeFields({ outcome: 'Found 12 results', other: 1 })).toEqual({
+      outcome: 'Found 12 results',
+      outcome_patch: undefined,
+    });
+    expect(readOutcomeFields({ outcome_patch: { from: 'a', to: 'b' } })).toEqual({
+      outcome: undefined,
+      outcome_patch: { from: 'a', to: 'b' },
+    });
+  });
+
+  it('rejects malformed fields', () => {
+    expect(readOutcomeFields(undefined)).toBeUndefined();
+    expect(readOutcomeFields('outcome')).toBeUndefined();
+    expect(readOutcomeFields({ outcome: 42 })).toBeUndefined();
+    expect(readOutcomeFields({ outcome: '  ' })).toBeUndefined();
+    expect(readOutcomeFields({ outcome_patch: { from: 'a' } })).toBeUndefined();
+    expect(readOutcomeFields({ outcome_patch: 'Searched' })).toBeUndefined();
+  });
+});

--- a/src/tools/__tests__/intentArg.test.ts
+++ b/src/tools/__tests__/intentArg.test.ts
@@ -206,6 +206,18 @@ describe('resolveToolOutcome', () => {
       resolveToolOutcome({ query: 'oauth' }, { outcome_patch: { from: 'a', to: 'b' } })
     ).toBeUndefined();
   });
+
+  it('collapses the label to a bounded single line', () => {
+    expect(
+      resolveToolOutcome(args, { outcome: 'Found 12 results\n  for   "OAuth handling"' })
+    ).toBe('Found 12 results for "OAuth handling"');
+    const oversized = resolveToolOutcome(args, { outcome: `Found ${'x'.repeat(500)}` });
+    expect(oversized?.length).toBe(256);
+    expect(oversized?.endsWith('…')).toBe(true);
+    expect(resolveToolOutcome(args, { outcome: ' \n \t ' })).toBe(
+      'Searched for OAuth handling'
+    );
+  });
 });
 
 describe('readOutcomeFields', () => {

--- a/src/tools/__tests__/intentArg.test.ts
+++ b/src/tools/__tests__/intentArg.test.ts
@@ -25,7 +25,14 @@ describe('withIntent', () => {
   it('prepends intent as the FIRST property key', () => {
     const next = withIntent(base);
     expect(Object.keys(next.properties ?? {})).toEqual(['intent', 'query', 'limit']);
-    expect(next.properties?.[INTENT_ARG]).toBe(INTENT_PROPERTY);
+    expect(next.properties?.[INTENT_ARG]).toEqual(INTENT_PROPERTY);
+    /**
+     * Must be a copy, not the frozen canonical instance: LangChain's
+     * JSON-schema validator stamps `__absolute_uri__` onto subschemas,
+     * which throws on a frozen object.
+     */
+    expect(next.properties?.[INTENT_ARG]).not.toBe(INTENT_PROPERTY);
+    expect(Object.isFrozen(next.properties?.[INTENT_ARG])).toBe(false);
   });
 
   it('never mutates the input schema', () => {

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -202,6 +202,26 @@ describe('ToolOutputReferenceRegistry', () => {
       });
     });
 
+    it('preserves the intent key inside STRINGIFIED object args too', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'HUGE-STORED-OUTPUT');
+      const { resolved } = reg.resolve(
+        'r',
+        '{"intent":"Reusing {{tool0turn0}}","command":"cat {{tool0turn0}}"}'
+      );
+      expect(JSON.parse(resolved as string)).toEqual({
+        intent: 'Reusing {{tool0turn0}}',
+        command: 'cat HUGE-STORED-OUTPUT',
+      });
+    });
+
+    it('keeps plain (non-object) string args on the raw substitution path', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'DATA');
+      const { resolved } = reg.resolve('r', 'echo {{tool0turn0}} intent');
+      expect(resolved).toBe('echo DATA intent');
+    });
+
     it('passes through primitive values untouched', () => {
       const reg = new ToolOutputReferenceRegistry();
       const { resolved } = reg.resolve('r', {

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -187,6 +187,21 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(resolved).toBe('nothing to see here');
     });
 
+    it('leaves the top-level intent arg verbatim (display label, not a data channel)', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'HUGE-STORED-OUTPUT');
+      const { resolved } = reg.resolve('r', {
+        intent: 'Reusing {{tool0turn0}} for the next step',
+        command: 'cat {{tool0turn0}}',
+        nested: { intent: 'not top-level {{tool0turn0}}' },
+      });
+      expect(resolved).toEqual({
+        intent: 'Reusing {{tool0turn0}} for the next step',
+        command: 'cat HUGE-STORED-OUTPUT',
+        nested: { intent: 'not top-level HUGE-STORED-OUTPUT' },
+      });
+    });
+
     it('passes through primitive values untouched', () => {
       const reg = new ToolOutputReferenceRegistry();
       const { resolved } = reg.resolve('r', {

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -222,6 +222,54 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(resolved).toBe('echo DATA intent');
     });
 
+    it('substitutes a BUSINESS intent arg when the caller opts in', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'STORED');
+      const { resolved } = reg.resolve(
+        'r',
+        { intent: 'category {{tool0turn0}}', title: 'x {{tool0turn0}}' },
+        { substituteIntentKey: true }
+      );
+      expect(resolved).toEqual({
+        intent: 'category STORED',
+        title: 'x STORED',
+      });
+    });
+
+    it('substitutes a business intent inside stringified args when opted in', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'STORED');
+      const { resolved } = reg.resolve(
+        'r',
+        '{"intent":"category {{tool0turn0}}"}',
+        { substituteIntentKey: true }
+      );
+      expect(resolved).toBe('{"intent":"category STORED"}');
+    });
+
+    it('reports unresolved references from a business intent arg', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      const { unresolved } = reg.resolve(
+        'r',
+        { intent: 'category {{tool9turn9}}' },
+        { substituteIntentKey: true }
+      );
+      expect(unresolved).toEqual(['tool9turn9']);
+    });
+
+    it('snapshot views honor the opt-in too', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'STORED');
+      const view = reg.snapshot('r');
+      expect(view.resolve({ intent: 'x {{tool0turn0}}' }).resolved).toEqual({
+        intent: 'x {{tool0turn0}}',
+      });
+      expect(
+        view.resolve({ intent: 'x {{tool0turn0}}' }, { substituteIntentKey: true })
+          .resolved
+      ).toEqual({ intent: 'x STORED' });
+    });
+
     it('passes through primitive values untouched', () => {
       const reg = new ToolOutputReferenceRegistry();
       const { resolved } = reg.resolve('r', {

--- a/src/tools/intentArg.ts
+++ b/src/tools/intentArg.ts
@@ -46,6 +46,24 @@ export const INTENT_PROPERTY: JsonSchemaType = Object.freeze<JsonSchemaType>({
 });
 
 /**
+ * Discriminates the intent LABEL property from a tool's own business
+ * parameter that merely shares the name: the label contract always opens
+ * with the same instruction. Removal/sanitize passes must never strip a
+ * parameter the tool actually needs.
+ */
+export function isIntentLabelProperty(property: unknown): boolean {
+  if (property == null || typeof property !== 'object') {
+    return false;
+  }
+  const record = property as { type?: unknown; description?: unknown };
+  return (
+    record.type === 'string' &&
+    typeof record.description === 'string' &&
+    record.description.startsWith('ALWAYS write this field FIRST')
+  );
+}
+
+/**
  * Returns a copy of the parameters schema with `intent` prepended as the
  * FIRST property (object key order is insertion order and every provider
  * serializer preserves it — first key in the schema means first key in the
@@ -186,7 +204,10 @@ export function applyOutcome(
   }
   const patch = result?.outcome_patch;
   if (patch != null && patch.from !== '' && intent.includes(patch.from)) {
-    return intent.replace(patch.from, patch.to);
+    /** Replacement callback keeps `to` verbatim — a direct string second
+     *  argument would interpret `$&`/`$'`-style tokens in tool-authored
+     *  text (e.g. labels derived from shell syntax). */
+    return intent.replace(patch.from, () => patch.to);
   }
   return transformLeadingVerb(intent);
 }
@@ -218,15 +239,39 @@ function boundOutcomeLabel(label: string | undefined): string | undefined {
  * otherwise — the mechanical transform of a bare intent is left to the host
  * so the wire never carries a label the host can derive itself. The result
  * is collapsed to a bounded single line before emission.
+ *
+ * For failed calls (`isError`), only tool-AUTHORED text may label the call:
+ * an explicit `outcome`, or a patch whose `from` actually matches the
+ * intent. An unmatched patch must not fall through to the mechanical
+ * past-tense transform — wording drift in a failure patch would otherwise
+ * render a success-looking label for an error.
  */
 export function resolveToolOutcome(
   args: unknown,
   fields?: { outcome?: string; outcome_patch?: OutcomePatch } | null,
+  options?: { isError?: boolean },
 ): string | undefined {
   if (fields == null || (fields.outcome == null && fields.outcome_patch == null)) {
     return undefined;
   }
-  return boundOutcomeLabel(applyOutcome(readIntent(args), fields));
+  if (options?.isError !== true) {
+    return boundOutcomeLabel(applyOutcome(readIntent(args), fields));
+  }
+  const outcome = fields.outcome;
+  if (typeof outcome === 'string' && outcome.trim() !== '') {
+    return boundOutcomeLabel(outcome);
+  }
+  const intent = readIntent(args);
+  const patch = fields.outcome_patch;
+  if (
+    intent != null &&
+    patch != null &&
+    patch.from !== '' &&
+    intent.includes(patch.from)
+  ) {
+    return boundOutcomeLabel(intent.replace(patch.from, () => patch.to));
+  }
+  return undefined;
 }
 
 /**

--- a/src/tools/intentArg.ts
+++ b/src/tools/intentArg.ts
@@ -33,7 +33,13 @@ export const INTENT_DESCRIPTION =
   'When you make several calls to the same tool in one turn, each intent must ' +
   'distinguish that call from its siblings.';
 
-/** Frozen schema property injected as the first key of an intent-enabled tool. */
+/**
+ * Canonical (frozen) shape of the injected property. Always embed a COPY
+ * (`{ ...INTENT_PROPERTY }`): LangChain's JSON-schema validator stamps a
+ * `__absolute_uri__` marker onto every subschema it dereferences, which
+ * throws on a frozen object — and a single shared instance would be stamped
+ * with one schema's URI while embedded in many.
+ */
 export const INTENT_PROPERTY: JsonSchemaType = Object.freeze<JsonSchemaType>({
   type: 'string',
   description: INTENT_DESCRIPTION,
@@ -54,7 +60,7 @@ export function withIntent(parameters?: JsonSchemaType): JsonSchemaType {
   return {
     ...parameters,
     type: 'object',
-    properties: { [INTENT_ARG]: INTENT_PROPERTY, ...existingProps },
+    properties: { [INTENT_ARG]: { ...INTENT_PROPERTY }, ...existingProps },
   };
 }
 

--- a/src/tools/intentArg.ts
+++ b/src/tools/intentArg.ts
@@ -192,10 +192,32 @@ export function applyOutcome(
 }
 
 /**
+ * Hard cap on an emitted outcome label. The label is a single progress line
+ * in UI chrome; a tool that derives it from data (or a malformed patch)
+ * must not be able to inflate completion events or persisted parts.
+ */
+const MAX_OUTCOME_CHARS = 256;
+
+function boundOutcomeLabel(label: string | undefined): string | undefined {
+  if (label == null) {
+    return undefined;
+  }
+  const singleLine = label.replace(/\s+/g, ' ').trim();
+  if (singleLine === '') {
+    return undefined;
+  }
+  if (singleLine.length <= MAX_OUTCOME_CHARS) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, MAX_OUTCOME_CHARS - 1)}…`;
+}
+
+/**
  * Resolves the settled label to emit on a completion event: only when the
  * tool actually authored `outcome`/`outcome_patch` fields. Returns undefined
  * otherwise — the mechanical transform of a bare intent is left to the host
- * so the wire never carries a label the host can derive itself.
+ * so the wire never carries a label the host can derive itself. The result
+ * is collapsed to a bounded single line before emission.
  */
 export function resolveToolOutcome(
   args: unknown,
@@ -204,7 +226,7 @@ export function resolveToolOutcome(
   if (fields == null || (fields.outcome == null && fields.outcome_patch == null)) {
     return undefined;
   }
-  return applyOutcome(readIntent(args), fields);
+  return boundOutcomeLabel(applyOutcome(readIntent(args), fields));
 }
 
 /**

--- a/src/tools/intentArg.ts
+++ b/src/tools/intentArg.ts
@@ -1,0 +1,233 @@
+/**
+ * @fileoverview Tool intent labels.
+ *
+ * Lets a tool declare, as the FIRST property of its input schema, an `intent`
+ * string: one model-authored sentence stating what that specific call is about
+ * to do ("Searching for OAuth handling in the callback router"). Because the
+ * property is first, it is the first key providers stream in the tool-call
+ * args, so a host UI can render it as the call's live status label before the
+ * rest of the args exist. When the call settles, {@link applyOutcome} edits
+ * the sentence in place into its outcome form — a tool-supplied replacement
+ * (`outcome`), a tool-supplied span edit (`outcome_patch`), or a mechanical
+ * present-progressive→past-tense transform of the leading verb.
+ *
+ * The arg is always optional (never listed in `required`): the same schemas
+ * are callable from programmatic tool calling, where no UI renders a label
+ * and forcing generated code to fabricate one would be pure cost. Tool bodies
+ * must call {@link stripIntent} before using their args so no tool receives a
+ * parameter it did not declare.
+ */
+
+import type { JsonSchemaType, OutcomePatch } from '@/types';
+
+/** Argument carrying the model-authored label for a tool call. */
+export const INTENT_ARG = 'intent';
+
+/** Model-facing instruction for the injected `intent` property. */
+export const INTENT_DESCRIPTION =
+  'ALWAYS write this field FIRST, before any other argument. One short sentence, ' +
+  'present progressive, stating what this specific call is about to do: ' +
+  '"Searching for OAuth handling in the callback router". It is shown to the user ' +
+  'as the live status label for this call while it runs, so write it for a human ' +
+  'reading a progress line. Do not restate the tool name. Do not exceed one sentence. ' +
+  'When you make several calls to the same tool in one turn, each intent must ' +
+  'distinguish that call from its siblings.';
+
+/** Frozen schema property injected as the first key of an intent-enabled tool. */
+export const INTENT_PROPERTY: JsonSchemaType = Object.freeze<JsonSchemaType>({
+  type: 'string',
+  description: INTENT_DESCRIPTION,
+});
+
+/**
+ * Returns a copy of the parameters schema with `intent` prepended as the
+ * FIRST property (object key order is insertion order and every provider
+ * serializer preserves it — first key in the schema means first key in the
+ * streamed input). Never mutates the input; no-op when the schema already
+ * declares `intent`. The property is not added to `required`.
+ */
+export function withIntent(parameters?: JsonSchemaType): JsonSchemaType {
+  const existingProps = parameters?.properties ?? {};
+  if (INTENT_ARG in existingProps) {
+    return parameters as JsonSchemaType;
+  }
+  return {
+    ...parameters,
+    type: 'object',
+    properties: { [INTENT_ARG]: INTENT_PROPERTY, ...existingProps },
+  };
+}
+
+/**
+ * Coerces tool-call args to an object, parsing a stringified JSON object
+ * (some providers deliver args as a string). Returns undefined otherwise.
+ */
+function coerceArgsObject(args: unknown): Record<string, unknown> | undefined {
+  if (typeof args === 'object' && args !== null && !Array.isArray(args)) {
+    return args as Record<string, unknown>;
+  }
+  if (typeof args === 'string' && args.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(args) as unknown;
+      if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Reads the model-authored intent from tool-call args (handles stringified
+ * args). Returns undefined when absent, empty, or not a string.
+ */
+export function readIntent(args: unknown): string | undefined {
+  const value = coerceArgsObject(args)?.[INTENT_ARG];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+/**
+ * Returns the args without the `intent` key so downstream consumers that did
+ * not declare it never receive it. Parses stringified JSON object args;
+ * returns the value unchanged when the key is absent.
+ */
+export function stripIntent(args: unknown): unknown {
+  const obj = coerceArgsObject(args);
+  if (!obj || !(INTENT_ARG in obj)) {
+    return args;
+  }
+  const { [INTENT_ARG]: _omit, ...rest } = obj;
+  return rest;
+}
+
+/**
+ * Leading-verb map for the mechanical outcome transform, keyed by the
+ * lowercased first word of the intent. Deliberately small: an unknown leading
+ * word leaves the intent unchanged rather than mangling it.
+ */
+const OUTCOME_VERB_MAP: ReadonlyMap<string, string> = new Map([
+  ['searching', 'Searched'],
+  ['reading', 'Read'],
+  ['writing', 'Wrote'],
+  ['editing', 'Edited'],
+  ['running', 'Ran'],
+  ['creating', 'Created'],
+  ['checking', 'Checked'],
+  ['fetching', 'Fetched'],
+  ['listing', 'Listed'],
+  ['looking', 'Looked'],
+  ['building', 'Built'],
+  ['deleting', 'Deleted'],
+  ['updating', 'Updated'],
+  ['adding', 'Added'],
+  ['removing', 'Removed'],
+  ['verifying', 'Verified'],
+  ['analyzing', 'Analyzed'],
+  ['generating', 'Generated'],
+  ['delegating', 'Delegated'],
+  ['spawning', 'Spawned'],
+  ['compiling', 'Compiled'],
+  ['grepping', 'Grepped'],
+]);
+
+function matchLeadingCase(replacement: string, original: string): string {
+  if (original.charAt(0) === original.charAt(0).toLowerCase()) {
+    return replacement.charAt(0).toLowerCase() + replacement.slice(1);
+  }
+  return replacement;
+}
+
+function transformLeadingVerb(intent: string): string {
+  const spaceIdx = intent.search(/\s/);
+  const leading = spaceIdx === -1 ? intent : intent.slice(0, spaceIdx);
+  const mapped = OUTCOME_VERB_MAP.get(leading.toLowerCase());
+  if (mapped == null) {
+    return intent;
+  }
+  return matchLeadingCase(mapped, leading) + intent.slice(leading.length);
+}
+
+/**
+ * Resolves the settled label for a call from its model-authored `intent` and
+ * the tool's result fields, in precedence order:
+ *
+ *  1. `outcome` — full replacement authored by the tool.
+ *  2. `outcome_patch` — first occurrence of `from` in the intent replaced
+ *     with `to` (case-sensitive); no-op when `from` is absent or empty.
+ *  3. Mechanical transform — the leading word mapped present-progressive →
+ *     past tense; an unknown leading word leaves the intent unchanged.
+ *
+ * Returns undefined when there is neither an intent nor an outcome, so
+ * callers fall back to their default label. Pure and dependency-free — host
+ * UIs needing identical logic can import or mirror it.
+ */
+export function applyOutcome(
+  intent: string | undefined,
+  result?: { outcome?: string; outcome_patch?: OutcomePatch },
+): string | undefined {
+  const outcome = result?.outcome;
+  if (typeof outcome === 'string' && outcome.trim() !== '') {
+    return outcome;
+  }
+  if (intent == null || intent === '') {
+    return undefined;
+  }
+  const patch = result?.outcome_patch;
+  if (patch != null && patch.from !== '' && intent.includes(patch.from)) {
+    return intent.replace(patch.from, patch.to);
+  }
+  return transformLeadingVerb(intent);
+}
+
+/**
+ * Resolves the settled label to emit on a completion event: only when the
+ * tool actually authored `outcome`/`outcome_patch` fields. Returns undefined
+ * otherwise — the mechanical transform of a bare intent is left to the host
+ * so the wire never carries a label the host can derive itself.
+ */
+export function resolveToolOutcome(
+  args: unknown,
+  fields?: { outcome?: string; outcome_patch?: OutcomePatch } | null,
+): string | undefined {
+  if (fields == null || (fields.outcome == null && fields.outcome_patch == null)) {
+    return undefined;
+  }
+  return applyOutcome(readIntent(args), fields);
+}
+
+/**
+ * Extracts validated `outcome`/`outcome_patch` fields from an arbitrary
+ * value — the artifact channel through which an in-process
+ * `content_and_artifact` tool authors its settled label. Returns undefined
+ * when neither field is usable.
+ */
+export function readOutcomeFields(
+  source: unknown,
+): { outcome?: string; outcome_patch?: OutcomePatch } | undefined {
+  if (source == null || typeof source !== 'object' || Array.isArray(source)) {
+    return undefined;
+  }
+  const record = source as Record<string, unknown>;
+  const outcome =
+    typeof record.outcome === 'string' && record.outcome.trim() !== ''
+      ? record.outcome
+      : undefined;
+  let outcome_patch: OutcomePatch | undefined;
+  const rawPatch = record.outcome_patch;
+  if (rawPatch != null && typeof rawPatch === 'object' && !Array.isArray(rawPatch)) {
+    const patch = rawPatch as Record<string, unknown>;
+    if (typeof patch.from === 'string' && typeof patch.to === 'string') {
+      outcome_patch = { from: patch.from, to: patch.to };
+    }
+  }
+  if (outcome == null && outcome_patch == null) {
+    return undefined;
+  }
+  return { outcome, outcome_patch };
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -115,7 +115,7 @@ type SanitizedStepCompleted =
     };
 
 type SanitizedProcessedToolCall = Partial<
-  Pick<ProcessedToolCall, 'args' | 'id' | 'name' | 'output' | 'progress'>
+  Pick<ProcessedToolCall, 'args' | 'id' | 'name' | 'output' | 'progress' | 'outcome'>
 >;
 
 type SanitizedRunStepCompleted = {
@@ -1195,6 +1195,7 @@ function sanitizeProcessedToolCall(
     sanitized.args = call.args;
   }
   assignString(sanitized, 'output', call.output);
+  assignString(sanitized, 'outcome', call.outcome);
   assignNumber(sanitized, 'progress', call.progress);
   return sanitized;
 }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -32,6 +32,24 @@ import {
 import { isComputerCallOutputMessage } from '@/utils/toolContent';
 import { INTENT_ARG } from '@/tools/intentArg';
 
+/** Parses a stringified JSON object arg; undefined for anything else. */
+function parseStringifiedArgsObject(
+  value: string
+): Record<string, unknown> | undefined {
+  if (!value.trim().startsWith('{')) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 /**
  * Non-global matcher for a single `{{tool<i>turn<n>}}` placeholder.
  * Exported for consumers that want to detect references (e.g., syntax
@@ -372,6 +390,23 @@ export class ToolOutputReferenceRegistry {
       return { resolved: args, unresolved: [] };
     }
     const unresolved = new Set<string>();
+    /**
+     * Providers may deliver the args OBJECT as a JSON string. A plain
+     * string-root transform would expand placeholders inside the `intent`
+     * label too, bypassing the top-level exclusion below — parse, transform
+     * key-aware, and re-serialize so the label stays verbatim while every
+     * other field still substitutes. Only taken when an `intent` key is
+     * actually present; other strings keep the fast raw-string path.
+     */
+    if (typeof args === 'string') {
+      const parsedRoot = parseStringifiedArgsObject(args);
+      if (parsedRoot != null && INTENT_ARG in parsedRoot) {
+        const resolved = JSON.stringify(
+          this.transform(entries, parsedRoot, unresolved, true)
+        ) as T;
+        return { resolved, unresolved: Array.from(unresolved) };
+      }
+    }
     const resolved = this.transform(entries, args, unresolved, true) as T;
     return { resolved, unresolved: Array.from(unresolved) };
   }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -30,6 +30,7 @@ import {
   HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
 } from '@/utils/truncation';
 import { isComputerCallOutputMessage } from '@/utils/toolContent';
+import { INTENT_ARG } from '@/tools/intentArg';
 
 /**
  * Non-global matcher for a single `{{tool<i>turn<n>}}` placeholder.
@@ -371,14 +372,15 @@ export class ToolOutputReferenceRegistry {
       return { resolved: args, unresolved: [] };
     }
     const unresolved = new Set<string>();
-    const resolved = this.transform(entries, args, unresolved) as T;
+    const resolved = this.transform(entries, args, unresolved, true) as T;
     return { resolved, unresolved: Array.from(unresolved) };
   }
 
   private transform(
     entries: ReadonlyMap<string, string>,
     value: unknown,
-    unresolved: Set<string>
+    unresolved: Set<string>,
+    isRoot = false
   ): unknown {
     if (typeof value === 'string') {
       return this.replaceInString(entries, value, unresolved);
@@ -390,7 +392,16 @@ export class ToolOutputReferenceRegistry {
       const source = value as Record<string, unknown>;
       const next: Record<string, unknown> = {};
       for (const [key, item] of Object.entries(source)) {
-        next[key] = this.transform(entries, item, unresolved);
+        /**
+         * The top-level `intent` arg is a display label, never a data
+         * channel: expanding a `{{tool<i>turn<n>}}` placeholder there would
+         * dump a stored output (up to the registry cap) into a single-line
+         * UI label and persist it with the message. Left verbatim instead.
+         */
+        next[key] =
+          isRoot && key === INTENT_ARG
+            ? item
+            : this.transform(entries, item, unresolved);
       }
       return next;
     }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -108,8 +108,19 @@ export type ResolveResult<T> = {
  * point in time, ignoring any subsequent registrations.
  */
 export interface ToolOutputResolveView {
-  resolve<T>(args: T): ResolveResult<T>;
+  resolve<T>(args: T, options?: ResolveOptions): ResolveResult<T>;
 }
+
+/**
+ * Per-call resolution options. `substituteIntentKey` opts the top-level
+ * `intent` key back INTO placeholder substitution: the exemption protects
+ * the injected display label, but a tool whose own schema declares a
+ * business parameter named `intent` (the injectors skip such tools) still
+ * needs references piped into it like any other argument.
+ */
+export type ResolveOptions = {
+  substituteIntentKey?: boolean;
+};
 
 /**
  * Pre-resolved arg map keyed by `toolCallId`. Used by the mixed
@@ -352,12 +363,16 @@ export class ToolOutputReferenceRegistry {
    * the serialized args, the original input is returned without
    * walking the tree.
    */
-  resolve<T>(runId: string | undefined, args: T): ResolveResult<T> {
+  resolve<T>(
+    runId: string | undefined,
+    args: T,
+    options?: ResolveOptions
+  ): ResolveResult<T> {
     if (!hasAnyPlaceholder(args)) {
       return { resolved: args, unresolved: [] };
     }
     const bucket = this.runStates.get(this.keyFor(runId));
-    return this.resolveAgainst(bucket?.entries ?? EMPTY_ENTRIES, args);
+    return this.resolveAgainst(bucket?.entries ?? EMPTY_ENTRIES, args, options);
   }
 
   /**
@@ -377,18 +392,20 @@ export class ToolOutputReferenceRegistry {
       ? new Map(bucket.entries)
       : EMPTY_ENTRIES;
     return {
-      resolve: <T>(args: T): ResolveResult<T> =>
-        this.resolveAgainst(entries, args),
+      resolve: <T>(args: T, options?: ResolveOptions): ResolveResult<T> =>
+        this.resolveAgainst(entries, args, options),
     };
   }
 
   private resolveAgainst<T>(
     entries: ReadonlyMap<string, string>,
-    args: T
+    args: T,
+    options?: ResolveOptions
   ): ResolveResult<T> {
     if (!hasAnyPlaceholder(args)) {
       return { resolved: args, unresolved: [] };
     }
+    const exemptIntentKey = options?.substituteIntentKey !== true;
     const unresolved = new Set<string>();
     /**
      * Providers may deliver the args OBJECT as a JSON string. A plain
@@ -398,7 +415,7 @@ export class ToolOutputReferenceRegistry {
      * other field still substitutes. Only taken when an `intent` key is
      * actually present; other strings keep the fast raw-string path.
      */
-    if (typeof args === 'string') {
+    if (exemptIntentKey && typeof args === 'string') {
       const parsedRoot = parseStringifiedArgsObject(args);
       if (parsedRoot != null && INTENT_ARG in parsedRoot) {
         const resolved = JSON.stringify(
@@ -407,7 +424,12 @@ export class ToolOutputReferenceRegistry {
         return { resolved, unresolved: Array.from(unresolved) };
       }
     }
-    const resolved = this.transform(entries, args, unresolved, true) as T;
+    const resolved = this.transform(
+      entries,
+      args,
+      unresolved,
+      exemptIntentKey
+    ) as T;
     return { resolved, unresolved: Array.from(unresolved) };
   }
 
@@ -415,7 +437,7 @@ export class ToolOutputReferenceRegistry {
     entries: ReadonlyMap<string, string>,
     value: unknown,
     unresolved: Set<string>,
-    isRoot = false
+    exemptRootIntent = false
   ): unknown {
     if (typeof value === 'string') {
       return this.replaceInString(entries, value, unresolved);
@@ -434,7 +456,7 @@ export class ToolOutputReferenceRegistry {
          * UI label and persist it with the message. Left verbatim instead.
          */
         next[key] =
-          isRoot && key === INTENT_ARG
+          exemptRootIntent && key === INTENT_ARG
             ? item
             : this.transform(entries, item, unresolved);
       }

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -143,6 +143,13 @@ export type ProcessedToolCall = {
   id: string;
   output: string;
   progress: number;
+  /**
+   * Settled label for the call, resolved from the tool-supplied
+   * `outcome`/`outcome_patch` result fields against the model-authored
+   * `intent` arg. Only present when the tool authored one — hosts apply
+   * the mechanical intent transform themselves when absent.
+   */
+  outcome?: string;
 };
 
 export type ProcessedContent = {

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -344,6 +344,11 @@ export type ToolCallPart = {
   id?: string;
   /** If provided, the output of the tool call */
   output?: ToolResultContent['content'];
+  /**
+   * Tool-authored settled label for the call (see `ProcessedToolCall.outcome`),
+   * preserved through aggregation so it survives persistence/reload.
+   */
+  outcome?: string;
   /** Auth URL */
   auth?: string;
   /** Expiration time */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -236,8 +236,12 @@ export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;
 export type ToolEndEvent = {
   /** The Step Id of the Tool Call */
   id: string;
-  /** The Completed Tool Call */
-  tool_call: ToolCall;
+  /**
+   * The Completed Tool Call. Carries the tool-authored `outcome` label when
+   * present (see `ProcessedToolCall.outcome`) so `ON_RUN_STEP_COMPLETED`
+   * consumers can read it without an unsafe cast.
+   */
+  tool_call: ToolCall & { output?: string; progress?: number; outcome?: string };
   /** The content index of the tool call */
   index: number;
   type?: 'tool_call';

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -521,6 +521,17 @@ export type InjectedMessage = {
   skillName?: string;
 };
 
+/**
+ * In-place edit of a call's model-authored `intent` label: the first
+ * occurrence of `from` in the intent is replaced with `to` (case-sensitive).
+ * Lets a tool settle the label while preserving the model's own phrasing,
+ * e.g. `{ from: 'Searching', to: 'Searched' }`.
+ */
+export type OutcomePatch = {
+  from: string;
+  to: string;
+};
+
 /** Result for a single tool call in event-driven execution */
 export type ToolExecuteResult = {
   /** Matches ToolCallRequest.id */
@@ -533,6 +544,13 @@ export type ToolExecuteResult = {
   status: 'success' | 'error';
   /** Error message if status is 'error' */
   errorMessage?: string;
+  /**
+   * Settled human-readable label for this call, replacing the model-authored
+   * `intent` arg in the UI. Full replacement; wins over `outcome_patch`.
+   */
+  outcome?: string;
+  /** In-place edit of the model-authored `intent` label (see {@link OutcomePatch}). */
+  outcome_patch?: OutcomePatch;
   /**
    * Messages to inject into graph state after the ToolMessage for this call.
    * Placed after tool results to respect provider message ordering (tool_call -> tool_result adjacency).


### PR DESCRIPTION
## Summary

First slice of the **tool intent labels** feature (the fourth per-tool capability alongside `defer_loading`, `allowed_callers`, and `run_in_background`): a model-authored `intent` string declared as the **first property** of a tool's input schema, streamed by providers as the first key of the tool-call args so a host UI can render it as the call's live status label before the rest of the args exist — plus `outcome`/`outcome_patch` result fields through which a tool edits that sentence in place when the call settles.

This slice is machinery only. **No tool opts in yet** — schema injection for the native coding/search/subagent suite lands in a follow-up PR, and the LibreChat host capability (`tool_intents`) in a third.

### `src/tools/intentArg.ts` (new)

- `INTENT_ARG` / `INTENT_PROPERTY` / `INTENT_DESCRIPTION` — the frozen schema property, with the model instruction (write it FIRST; one sentence; present progressive; distinguish sibling calls).
- `withIntent(schema)` — non-mutating, idempotent first-key prepend (object key order is insertion order, and every provider serializer preserves it). Never added to `required`: the same schemas are callable from PTC, where no UI renders a label and forcing generated code to fabricate one is pure cost.
- `readIntent` / `stripIntent` — tolerant of both object and stringified-JSON args.
- `applyOutcome(intent, {outcome, outcome_patch})` — precedence: full replacement → first-occurrence case-sensitive span edit → mechanical leading-verb past-tense transform (`Searching…` → `Searched…`), unknown verbs pass through unchanged. Pure and dependency-free so hosts can import or mirror the exact resolution logic.

### Result threading

- `ToolExecuteResult` gains `outcome?` / `outcome_patch?`; `ProcessedToolCall` gains `outcome?`, emitted on `ON_RUN_STEP_COMPLETED` **only when the tool authored one** (bare-intent mechanical transforms are left to the host, so the wire never carries a label the host can derive itself).
- Covered paths: the event-driven batch loop, the early per-result fast path (`dispatchEarlyToolCompletion`), the eager streaming path (`dispatchEagerToolCompletions`), and the direct in-process path (artifact-borne fields via `readOutcomeFields`). Error results never settle a label — error/cancel framing stays a host concern.

### Tool output references

The top-level `intent` arg is excluded from `{{tool<i>turn<n>}}` placeholder substitution: it is a display label, not a data channel, and expanding a stored output there would dump up to the registry cap (~400 KB) into a single-line UI label and persist it with the message. Nested `intent` keys inside other args are unaffected.

## Testing

- `npx jest src/tools/__tests__/intentArg.test.ts` — 29 tests: first-key placement, non-mutation on frozen schemas, idempotence, required untouched, stringified-args tolerance, the full `applyOutcome` precedence table (case preservation, first-occurrence-only patches, unknown-verb passthrough, single-word intents), `resolveToolOutcome` / `readOutcomeFields` validation.
- `npx jest src/tools/__tests__/toolOutputReferences.test.ts` — includes the new root-`intent` exclusion test (top-level verbatim, nested still substituted).
- Focused runs of the suites touching edited files: `ToolNode.onResultCompletion`, `ToolNode.eagerEventExecution`, `ToolNode.outputReferences`, `ProgrammaticToolCalling`, `ToolSearch` — all pass (327 tests total).
- `npx tsc --noEmit` clean; `eslint` clean on all touched files (the one remaining warning in `ToolNode.ts` is pre-existing code outside this diff).

## Sequencing

1. **This PR** — core arg + outcome machinery.
2. Native tool schema injection (coding suite across all three engines, `web_search`, `subagent`, `skill`, `tool_search`) with a coverage-pin test.
3. LibreChat host capability `tool_intents` (injection for MCP/action tools, invoke-time strip, builder toggles) + UI streaming labels.