### PR TITLE
🧭 fix: Normalize GraphInterrupt Langfuse Traces

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,7 +1,7 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { isGraphInterrupt, isParentCommand } from '@langchain/langgraph';
 import { context as otelContext } from '@opentelemetry/api';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import { isGraphInterrupt, isParentCommand } from '@langchain/langgraph';
 import {
   getLangfuseTracerProvider,
   propagateAttributes,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,5 +1,5 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { isParentCommand } from '@langchain/langgraph';
+import { isGraphInterrupt, isParentCommand } from '@langchain/langgraph';
 import { context as otelContext } from '@opentelemetry/api';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import {
@@ -27,6 +27,10 @@ import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
+const GRAPH_INTERRUPT_CONTROL_FLOW = { controlFlow: 'GraphInterrupt' } as const;
+const GRAPH_INTERRUPT_TOOL_OUTPUT = JSON.stringify(
+  GRAPH_INTERRUPT_CONTROL_FLOW
+);
 
 export type LangfuseTraceMetadata = Record<string, string>;
 export type LangfuseTraceAttributes = Record<string, string | number | boolean>;
@@ -209,6 +213,13 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleChainError']>
   ): ReturnType<CallbackHandler['handleChainError']> {
     const [error, runId, parentRunId] = args;
+    if (error != null && parentRunId != null && isGraphInterrupt(error)) {
+      return super.handleChainEnd(
+        GRAPH_INTERRUPT_CONTROL_FLOW,
+        runId,
+        parentRunId
+      );
+    }
     if (error != null && parentRunId != null && isParentCommand(error)) {
       return super.handleChainEnd(
         { controlFlow: 'ParentCommand' },
@@ -259,6 +270,20 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleToolStart']>
   ): ReturnType<CallbackHandler['handleToolStart']> {
     return this.withRuntimeContext(() => super.handleToolStart(...args));
+  }
+
+  override handleToolError(
+    ...args: Parameters<CallbackHandler['handleToolError']>
+  ): ReturnType<CallbackHandler['handleToolError']> {
+    const [error, runId, parentRunId] = args;
+    if (error != null && parentRunId != null && isGraphInterrupt(error)) {
+      return super.handleToolEnd(
+        GRAPH_INTERRUPT_TOOL_OUTPUT,
+        runId,
+        parentRunId
+      );
+    }
+    return super.handleToolError(...args);
   }
 
   override handleRetrieverStart(

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,13 +1,30 @@
-import { HumanMessage } from '@langchain/core/messages';
-import { Command, ParentCommand } from '@langchain/langgraph';
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  Command,
+  END,
+  GraphInterrupt,
+  MemorySaver,
+  MessagesAnnotation,
+  NodeInterrupt,
+  ParentCommand,
+  START,
+  StateGraph,
+  isGraphInterrupt,
+  isInterrupted,
+} from '@langchain/langgraph';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { Constants, Providers } from '@/common';
+import { askUserQuestion } from '@/hitl';
+import { ToolNode } from '@/tools/ToolNode';
 import { Run } from '@/run';
 
 const mockProcessorStarts: Array<{
@@ -15,6 +32,8 @@ const mockProcessorStarts: Array<{
   traceId: string;
 }> = [];
 const mockSpanAttributeSets: Array<Record<string, unknown>> = [];
+let mockSpansStarted = 0;
+let mockSpansEnded = 0;
 let mockProviderInput:
   | {
       spanProcessors?: Array<{
@@ -29,6 +48,7 @@ let mockProviderInput:
   | undefined;
 
 const createMockSpan = (traceIdOverride?: string) => {
+  mockSpansStarted += 1;
   const traceId =
     traceIdOverride ??
     mockProviderInput?.idGenerator?.generateTraceId() ??
@@ -36,6 +56,7 @@ const createMockSpan = (traceIdOverride?: string) => {
   const spanId = mockProviderInput?.idGenerator?.generateSpanId() ?? 'span-id';
   const span = {
     end: jest.fn(() => {
+      mockSpansEnded += 1;
       for (const processor of mockProviderInput?.spanProcessors ?? []) {
         processor.onEnd?.(span);
       }
@@ -104,6 +125,8 @@ describe('Langfuse callback composition', () => {
     jest.clearAllMocks();
     mockProcessorStarts.length = 0;
     mockSpanAttributeSets.length = 0;
+    mockSpansStarted = 0;
+    mockSpansEnded = 0;
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_BASE_URL;
@@ -430,6 +453,311 @@ describe('Langfuse callback composition', () => {
     );
   });
 
+  it('ends nested GraphInterrupt control flow without reporting an error', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-graph-interrupt',
+      secretKey: 'sk-graph-interrupt',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-graph-interrupt';
+    const sensitiveQuestion = 'sensitive question payload';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['InterruptedChain'] },
+      { input: 'ask' },
+      runId,
+      'parent-run'
+    );
+    await handler?.handleChainError(
+      new GraphInterrupt([
+        {
+          value: {
+            type: 'ask_user_question',
+            question: sensitiveQuestion,
+          },
+        },
+      ]),
+      runId,
+      'parent-run'
+    );
+
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          controlFlow: 'GraphInterrupt',
+        }),
+      })
+    );
+    expect(JSON.stringify(mockSpanAttributeSets)).not.toContain(
+      sensitiveQuestion
+    );
+  });
+
+  it('ends nested GraphInterrupt tool control flow without reporting an error', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-tool-graph-interrupt',
+      secretKey: 'sk-tool-graph-interrupt',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-tool-graph-interrupt';
+    const sensitiveQuestion = 'sensitive tool question payload';
+
+    await handler?.handleToolStart(
+      { lc: 1, type: 'not_implemented', id: ['AskUserQuestion'] },
+      '{}',
+      runId,
+      'parent-run'
+    );
+    await handler?.handleToolError(
+      new GraphInterrupt([
+        {
+          value: {
+            type: 'ask_user_question',
+            question: sensitiveQuestion,
+          },
+        },
+      ]),
+      runId,
+      'parent-run'
+    );
+
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          controlFlow: 'GraphInterrupt',
+        }),
+      })
+    );
+    expect(JSON.stringify(mockSpanAttributeSets)).not.toContain(
+      sensitiveQuestion
+    );
+  });
+
+  it('normalizes a real ask_user_question pause and preserves resume behavior', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-ask-user-question',
+      secretKey: 'sk-ask-user-question',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    expect(handler).toBeDefined();
+
+    const sensitiveQuestion = 'Should the workflow continue?';
+    const askTool = tool(
+      async () => {
+        const { answer } = askUserQuestion({ question: sensitiveQuestion });
+        return `answered: ${answer}`;
+      },
+      {
+        name: 'ask_user_question',
+        description: 'suspends to collect a human answer',
+        schema: z.object({}).passthrough(),
+      }
+    ) as unknown as StructuredToolInterface;
+    const toolNode = new ToolNode({
+      tools: [askTool],
+      eventDrivenMode: true,
+      directToolNames: new Set(['ask_user_question']),
+      interruptingToolNames: new Set(['ask_user_question']),
+    });
+    const graph = new StateGraph(MessagesAnnotation)
+      .addNode('agent', () => ({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'ask-call', name: 'ask_user_question', args: {} },
+            ],
+          }),
+        ],
+      }))
+      .addNode('tools', toolNode)
+      .addEdge(START, 'agent')
+      .addEdge('agent', 'tools')
+      .addEdge('tools', END)
+      .compile({ checkpointer: new MemorySaver() });
+    const chainErrorSpy = jest.spyOn(handler!, 'handleChainError');
+    const toolErrorSpy = jest.spyOn(handler!, 'handleToolError');
+    const config = {
+      callbacks: [handler!],
+      configurable: { thread_id: 'ask-user-question-langfuse' },
+    };
+
+    const first = await graph.invoke({ messages: [] }, config);
+
+    expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+    expect(
+      (
+        first as {
+          __interrupt__?: Array<{
+            value?: t.HumanInterruptPayload;
+          }>;
+        }
+      ).__interrupt__?.[0]?.value
+    ).toMatchObject({
+      type: 'ask_user_question',
+      question: { question: sensitiveQuestion },
+    });
+    expect(
+      chainErrorSpy.mock.calls.some(
+        ([error, , parentRunId]) =>
+          isGraphInterrupt(error) && parentRunId != null
+      )
+    ).toBe(true);
+    expect(
+      toolErrorSpy.mock.calls.some(
+        ([error, , parentRunId]) =>
+          isGraphInterrupt(error) && parentRunId != null
+      )
+    ).toBe(true);
+    const controlFlowOutputs = mockSpanAttributeSets.filter(
+      (attributes) =>
+        attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] ===
+        JSON.stringify({ controlFlow: 'GraphInterrupt' })
+    );
+    expect(controlFlowOutputs.length).toBeGreaterThanOrEqual(2);
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]:
+          expect.stringContaining('GraphInterrupt'),
+      })
+    );
+    expect(mockSpansEnded).toBe(mockSpansStarted);
+
+    const second = await graph.invoke(
+      new Command({ resume: { answer: 'yes' } }),
+      config
+    );
+
+    expect(isInterrupted<t.HumanInterruptPayload>(second)).toBe(false);
+    const messages = (second as { messages: ToolMessage[] }).messages;
+    expect(
+      messages.find(
+        (message) =>
+          message instanceof ToolMessage && message.name === 'ask_user_question'
+      )?.content
+    ).toBe('answered: yes');
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpansEnded).toBe(mockSpansStarted);
+  });
+
+  it('defensively reports a synthetic root GraphInterrupt as an error', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-root-graph-interrupt',
+      secretKey: 'sk-root-graph-interrupt',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-root-graph-interrupt';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['RootChain'] },
+      { input: 'root interrupt' },
+      runId
+    );
+    await handler?.handleChainError(new GraphInterrupt(), runId);
+
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+  });
+
+  it('normalizes nested NodeInterrupt control flow', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-node-interrupt',
+      secretKey: 'sk-node-interrupt',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-node-interrupt';
+
+    await handler?.handleChainStart(
+      { lc: 1, type: 'not_implemented', id: ['InterruptedChain'] },
+      { input: 'ask' },
+      runId,
+      'parent-run'
+    );
+    await handler?.handleChainError(
+      new NodeInterrupt('pause'),
+      runId,
+      'parent-run'
+    );
+
+    expect(mockSpanAttributeSets).not.toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+      })
+    );
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          controlFlow: 'GraphInterrupt',
+        }),
+      })
+    );
+  });
+
+  it('continues reporting genuine nested tool failures as errors', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-genuine-tool-error',
+      secretKey: 'sk-genuine-tool-error',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-genuine-tool-error';
+
+    await handler?.handleToolStart(
+      { lc: 1, type: 'not_implemented', id: ['FailingTool'] },
+      '{}',
+      runId,
+      'parent-run'
+    );
+    await handler?.handleToolError(new Error('tool boom'), runId, 'parent-run');
+
+    expect(mockSpanAttributeSets).toContainEqual(
+      expect.objectContaining({
+        [LangfuseOtelSpanAttributes.OBSERVATION_LEVEL]: 'ERROR',
+        [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]:
+          'Error: tool boom',
+      })
+    );
+  });
+
   it('reports a ParentCommand that escapes the root graph as an error', async () => {
     const { createLangfuseHandler } = await import('@/langfuse');
     const { initializeLangfuseTracing } = await import('@/instrumentation');
@@ -509,6 +837,29 @@ describe('Langfuse callback composition', () => {
 
     await expect(
       handler?.handleChainError(null, runId, 'parent-run')
+    ).resolves.toBeUndefined();
+  });
+
+  it('delegates null tool errors without throwing during classification', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const langfuse = {
+      publicKey: 'pk-null-tool-error',
+      secretKey: 'sk-null-tool-error',
+    };
+    initializeLangfuseTracing(langfuse);
+    const handler = createLangfuseHandler({ langfuse });
+    const runId = 'test-langfuse-null-tool-error';
+
+    await handler?.handleToolStart(
+      { lc: 1, type: 'not_implemented', id: ['NullErrorTool'] },
+      '{}',
+      runId,
+      'parent-run'
+    );
+
+    await expect(
+      handler?.handleToolError(null, runId, 'parent-run')
     ).resolves.toBeUndefined();
   });
 

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import { CallbackManager } from '@langchain/core/callbacks/manager';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import {
   Command,
   END,
@@ -14,17 +17,13 @@ import {
   isGraphInterrupt,
   isInterrupted,
 } from '@langchain/langgraph';
-import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
-import { CallbackManager } from '@langchain/core/callbacks/manager';
-import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import type { ToolCall } from '@langchain/core/messages/tool';
-import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { Constants, Providers } from '@/common';
-import { askUserQuestion } from '@/hitl';
 import { ToolNode } from '@/tools/ToolNode';
+import { askUserQuestion } from '@/hitl';
 import { Run } from '@/run';
 
 const mockProcessorStarts: Array<{
@@ -571,7 +570,7 @@ describe('Langfuse callback composition', () => {
         description: 'suspends to collect a human answer',
         schema: z.object({}).passthrough(),
       }
-    ) as unknown as StructuredToolInterface;
+    );
     const toolNode = new ToolNode({
       tools: [askTool],
       eventDrivenMode: true,


### PR DESCRIPTION
I normalized expected LangGraph human-in-the-loop interruptions in Langfuse so `ask_user_question` pauses no longer inflate production error telemetry.

- Classify nested `GraphInterrupt` and `NodeInterrupt` chain callbacks as successful control-flow endings.
- Close nested interrupted tool observations through `handleToolEnd` with a sanitized `{"controlFlow":"GraphInterrupt"}` marker.
- Preserve genuine nested failures and defensively retain root-level error handling for synthetic callback sequences.
- Add a real `StateGraph` + `MemorySaver` pause/resume regression covering callback ancestry, checkpointed interrupt payloads, resumed tool output, sanitized telemetry, and balanced spans.
- Add focused coverage for nested chain/tool interruptions, `NodeInterrupt`, null errors, and genuine failures.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I exercised the real `ask_user_question` pause/resume path and verified the callback classification directly.

- `npm test -- --runTestsByPath src/specs/langfuse-callbacks.test.ts --runInBand`
- `npx eslint src/langfuse.ts src/specs/langfuse-callbacks.test.ts`
- `npx prettier --check src/langfuse.ts src/specs/langfuse-callbacks.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

### Test Configuration

- Node.js 24-compatible local toolchain
- `@langchain/langgraph` 1.4.6
- `@librechat/agents` 3.3.4 development checkout

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
