### PR TITLE
🎯 feat: Intent-First Schemas for Native Tools

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -41,7 +41,7 @@ import {
 } from '@/utils/truncation';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
-import { resolveToolOutcome } from '@/tools/intentArg';
+import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
 
@@ -860,9 +860,11 @@ async function dispatchEagerToolCompletions(args: {
         maxToolResultChars
       ).content;
     }
-    const outcome = resolveToolOutcome(record.request.args, result, {
-      isError: result.status === 'error',
-    });
+    const outcome = resolveToolOutcome(
+      record.request.args,
+      outcomeFieldsFromResult(result),
+      { isError: result.status === 'error' }
+    );
 
     try {
       const dispatched = await safeDispatchCustomEvent(

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -39,9 +39,9 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
+import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
-import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
 

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -3,7 +3,6 @@ import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { INTENT_PROPERTY } from '@/tools/intentArg';
 import {
   BASH_SHELL_GUIDANCE,
   CODE_ARTIFACT_PATH_GUIDANCE,
@@ -17,6 +16,7 @@ import {
   normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
 } from './CodeExecutor';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -3,6 +3,7 @@ import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import {
   BASH_SHELL_GUIDANCE,
   CODE_ARTIFACT_PATH_GUIDANCE,
@@ -26,6 +27,7 @@ const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
 export const BashExecutionToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     command: {
       type: 'string',
       description: `The bash command or script to execute.
@@ -187,16 +189,20 @@ function createBashExecutionTool(
       /* Drop any model-supplied `runtime_session_hint` from the raw args: the
        * hint must only come from ToolNode's injected `_runtime_session_hint`
        * (below), never from the tool call itself. */
+      /* `intent` is a UI display label — never part of the wire body. */
       const {
         command,
+        intent: _ignoredIntent,
         runtime_session_hint: _ignoredModelHint,
         ...rest
       } = rawInput as {
         command: string;
+        intent?: unknown;
         runtime_session_hint?: unknown;
         args?: string[];
       };
       void _ignoredModelHint;
+      void _ignoredIntent;
       const { session_id, _injected_files, _runtime_session_hint } =
         (config.toolCall ?? {}) as {
           session_id?: string;

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -21,6 +21,7 @@ import {
   executeTools,
   formatCompletedResponse,
 } from './ProgrammaticToolCalling';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();
@@ -115,6 +116,7 @@ export function createBashProgrammaticToolCallingSchema(
   return {
     type: 'object',
     properties: {
+      intent: { ...INTENT_PROPERTY },
       code: {
         type: 'string',
         minLength: 1,

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -5,6 +5,7 @@ import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { appendCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { EnvVar, Constants } from '@/common';
 
 export {
@@ -75,6 +76,7 @@ const SUPPORTED_LANGUAGES = [
 export const CodeExecutionToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     lang: {
       type: 'string',
       enum: SUPPORTED_LANGUAGES,
@@ -346,18 +348,22 @@ function createCodeExecutionTool(
        * injected `_runtime_session_hint` (below). Spreading `...rest` into
        * postData would otherwise let a tool call opt itself into / pick a
        * stateful runtime even when statefulSessions is off. */
+      /* `intent` is a UI display label — never part of the wire body. */
       const {
         lang,
         code,
+        intent: _ignoredIntent,
         runtime_session_hint: _ignoredModelHint,
         ...rest
       } = rawInput as {
         lang: SupportedLanguage;
         code: string;
+        intent?: unknown;
         runtime_session_hint?: unknown;
         args?: string[];
       };
       void _ignoredModelHint;
+      void _ignoredIntent;
       /**
        * Extract session context from config.toolCall (injected by ToolNode).
        * - session_id: associates with the previous run.

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -24,6 +24,7 @@ import {
   createCodeApiRunTimeoutSchema,
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();
@@ -89,6 +90,7 @@ export function createProgrammaticToolCallingSchema(
   return {
     type: 'object',
     properties: {
+      intent: { ...INTENT_PROPERTY },
       code: {
         type: 'string',
         minLength: 1,

--- a/src/tools/ReadFile.ts
+++ b/src/tools/ReadFile.ts
@@ -1,4 +1,5 @@
 // src/tools/ReadFile.ts
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 export const ReadFileToolName = Constants.READ_FILE;
@@ -22,6 +23,7 @@ CONSTRAINTS:
 export const ReadFileToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     path: {
       type: 'string',
       description:

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,4 +1,5 @@
 // src/tools/SkillTool.ts
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 export const SkillToolName = Constants.SKILL_TOOL;
@@ -26,6 +27,7 @@ CONSTRAINTS:
 export const SkillToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     skillName: {
       type: 'string',
       description:

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -1,5 +1,6 @@
 import type { JsonSchemaType, LCTool } from '@/types/tools';
 import type { SubagentConfig } from '@/types';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 export const SubagentToolName = Constants.SUBAGENT;
@@ -29,6 +30,7 @@ const SUBAGENT_TYPE_PROP_DESCRIPTION =
 export const SubagentToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     description: {
       type: 'string',
       description: DESCRIPTION_PROP_DESCRIPTION,
@@ -67,6 +69,7 @@ export function buildSubagentToolParams(configs: SubagentConfig[]): {
     schema: {
       type: 'object',
       properties: {
+        intent: { ...INTENT_PROPERTY },
         description: {
           type: 'string',
           description: DESCRIPTION_PROP_DESCRIPTION,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -58,6 +58,7 @@ import {
   readOutcomeFields,
   resolveToolOutcome,
   isIntentLabelProperty,
+  outcomeFieldsFromResult,
 } from '@/tools/intentArg';
 import {
   resolveLangfuseRuntimeScope,
@@ -3217,7 +3218,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             contentString,
             config,
             request?.turn,
-            resolveToolOutcome(request?.args, result, {
+            resolveToolOutcome(request?.args, outcomeFieldsFromResult(result), {
               isError: result.status === 'error',
             })
           );
@@ -3553,7 +3554,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       output,
       config,
       request.turn,
-      resolveToolOutcome(request.args, result, {
+      resolveToolOutcome(request.args, outcomeFieldsFromResult(result), {
         isError: result.status === 'error',
       })
     );

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -49,6 +49,13 @@ import {
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
+  INTENT_ARG,
+  readOutcomeFields,
+  resolveToolOutcome,
+  isIntentLabelProperty,
+  outcomeFieldsFromResult,
+} from '@/tools/intentArg';
+import {
   buildToolExecutionRequestPlan,
   resolveRuntimeSessionHint,
   recordArgsEqual,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -61,13 +61,6 @@ import {
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
-  INTENT_ARG,
-  readOutcomeFields,
-  resolveToolOutcome,
-  isIntentLabelProperty,
-  outcomeFieldsFromResult,
-} from '@/tools/intentArg';
-import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -24,6 +24,7 @@ import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { getCodeBaseURL } from './CodeExecutor';
 import { Constants } from '@/common';
 
@@ -51,6 +52,7 @@ const MCP_SERVER_DESCRIPTION =
 export const ToolSearchToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     query: {
       type: 'string',
       maxLength: MAX_PATTERN_LENGTH,
@@ -117,6 +119,7 @@ function createToolSearchSchema(mode: t.ToolSearchMode): ToolSearchSchema {
   return {
     type: 'object',
     properties: {
+      intent: { ...INTENT_PROPERTY },
       query: {
         type: 'string',
         maxLength: MAX_PATTERN_LENGTH,

--- a/src/tools/__tests__/intentCoverage.test.ts
+++ b/src/tools/__tests__/intentCoverage.test.ts
@@ -24,6 +24,7 @@ import { LOCAL_CODING_BUNDLE_NAMES } from '@/common';
 import { BashProgrammaticToolCallingSchema } from '../BashProgrammaticToolCalling';
 import { ProgrammaticToolCallingSchema } from '../ProgrammaticToolCalling';
 import { WebSearchToolSchema } from '../search/schema';
+import { createSearchTool } from '../search/tool';
 import { ReadFileToolDefinition } from '../ReadFile';
 import { ToolSearchToolSchema } from '../ToolSearch';
 import { SkillToolDefinition } from '../SkillTool';
@@ -118,5 +119,21 @@ describe('intent coverage', () => {
     );
     expectIntentFirst('tool_search', ToolSearchToolSchema);
     expectIntentFirst('web_search', WebSearchToolSchema);
+  });
+
+  it('the createSearchTool FACTORY emits intent first (runtime schema, not the static def)', () => {
+    const serperTool = createSearchTool({
+      searchProvider: 'serper',
+      scraperProvider: 'serper',
+      serperApiKey: 'test-key',
+    });
+    expectIntentFirst('web_search:serper', serperTool.schema as SchemaLike);
+    const searxngTool = createSearchTool({
+      searchProvider: 'searxng',
+      scraperProvider: 'serper',
+      serperApiKey: 'test-key',
+      searxngInstanceUrl: 'http://localhost:8080',
+    });
+    expectIntentFirst('web_search:searxng', searxngTool.schema as SchemaLike);
   });
 });

--- a/src/tools/__tests__/intentCoverage.test.ts
+++ b/src/tools/__tests__/intentCoverage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from '@jest/globals';
+import type { CloudflareSandboxRuntime } from '@/types';
+import {
+  createLocalCodingTools,
+  createLocalCodingToolDefinitions,
+} from '../local/LocalCodingTools';
+import {
+  CLOUDFLARE_CODING_TOOL_NAMES,
+  createCloudflareCodingTools,
+} from '../cloudflare/CloudflareSandboxTools';
+import {
+  BashExecutionToolSchema,
+  buildBashExecutionToolSchema,
+} from '../BashExecutor';
+import {
+  CodeExecutionToolSchema,
+  buildCodeExecutionToolSchema,
+} from '../CodeExecutor';
+import {
+  SubagentToolSchema,
+  createSubagentToolDefinition,
+} from '../SubagentTool';
+import { LOCAL_CODING_BUNDLE_NAMES } from '@/common';
+import { BashProgrammaticToolCallingSchema } from '../BashProgrammaticToolCalling';
+import { ProgrammaticToolCallingSchema } from '../ProgrammaticToolCalling';
+import { WebSearchToolSchema } from '../search/schema';
+import { ReadFileToolDefinition } from '../ReadFile';
+import { ToolSearchToolSchema } from '../ToolSearch';
+import { SkillToolDefinition } from '../SkillTool';
+import { INTENT_ARG } from '../intentArg';
+
+type SchemaLike = {
+  properties?: Record<string, unknown>;
+  required?: readonly string[];
+};
+
+function firstKey(schema: SchemaLike | undefined): string | undefined {
+  return Object.keys(schema?.properties ?? {})[0];
+}
+
+function expectIntentFirst(name: string, schema: SchemaLike | undefined): void {
+  expect(`${name}:${firstKey(schema)}`).toBe(`${name}:${INTENT_ARG}`);
+  expect(schema?.required ?? []).not.toContain(INTENT_ARG);
+}
+
+const stubSandbox: CloudflareSandboxRuntime = {
+  exec: () => Promise.reject(new Error('schema-only stub')),
+  readFile: () => Promise.reject(new Error('schema-only stub')),
+  writeFile: () => Promise.reject(new Error('schema-only stub')),
+  mkdir: () => Promise.reject(new Error('schema-only stub')),
+  listFiles: () => Promise.reject(new Error('schema-only stub')),
+  deleteFile: () => Promise.reject(new Error('schema-only stub')),
+};
+
+/**
+ * Coverage pin for the tool-intent capability: every native coding tool, on
+ * every engine, must emit `intent` as the FIRST schema property (and never
+ * require it). Mirrors the `LOCAL_CODING_BUNDLE_NAMES` pin so "did we get
+ * them all" is a failing test rather than a review question.
+ */
+describe('intent coverage', () => {
+  it('every local bundle tool emits intent as its first schema property', () => {
+    const tools = createLocalCodingTools();
+    expect(tools.map((tool) => tool.name).sort()).toEqual(
+      [...LOCAL_CODING_BUNDLE_NAMES].sort()
+    );
+    for (const tool of tools) {
+      expectIntentFirst(tool.name, tool.schema as SchemaLike);
+    }
+  });
+
+  it('every local registry definition emits intent first', () => {
+    for (const def of createLocalCodingToolDefinitions()) {
+      expectIntentFirst(def.name, def.parameters);
+    }
+  });
+
+  it('every cloudflare bundle tool emits intent first', () => {
+    const tools = createCloudflareCodingTools({ sandbox: stubSandbox });
+    expect(tools.map((tool) => tool.name).sort()).toEqual(
+      [...CLOUDFLARE_CODING_TOOL_NAMES].sort()
+    );
+    for (const tool of tools) {
+      expectIntentFirst(tool.name, tool.schema as SchemaLike);
+    }
+  });
+
+  it('shared execution schemas emit intent first (all engines)', () => {
+    expectIntentFirst('bash_tool', BashExecutionToolSchema);
+    expectIntentFirst('execute_code', CodeExecutionToolSchema);
+    expectIntentFirst(
+      'bash_tool:stateful',
+      buildBashExecutionToolSchema({ statefulSessions: true })
+    );
+    expectIntentFirst(
+      'execute_code:stateful',
+      buildCodeExecutionToolSchema({ statefulSessions: true })
+    );
+    expectIntentFirst(
+      'run_tools_with_code',
+      ProgrammaticToolCallingSchema
+    );
+    expectIntentFirst(
+      'run_tools_with_bash',
+      BashProgrammaticToolCallingSchema
+    );
+  });
+
+  it('read_file, skill, subagent, tool_search, and web_search emit intent first', () => {
+    expectIntentFirst('read_file', ReadFileToolDefinition.parameters);
+    expectIntentFirst('skill', SkillToolDefinition.parameters);
+    expectIntentFirst('subagent', SubagentToolSchema);
+    expectIntentFirst(
+      'subagent:runtime',
+      createSubagentToolDefinition([
+        { type: 'researcher', name: 'Researcher', description: 'Researches' },
+      ]).parameters
+    );
+    expectIntentFirst('tool_search', ToolSearchToolSchema);
+    expectIntentFirst('web_search', WebSearchToolSchema);
+  });
+});

--- a/src/tools/__tests__/intentCoverage.test.ts
+++ b/src/tools/__tests__/intentCoverage.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from '@jest/globals';
 import type { CloudflareSandboxRuntime } from '@/types';
 import {
-  createLocalCodingTools,
-  createLocalCodingToolDefinitions,
-} from '../local/LocalCodingTools';
-import {
   CLOUDFLARE_CODING_TOOL_NAMES,
   createCloudflareCodingTools,
 } from '../cloudflare/CloudflareSandboxTools';
+import {
+  createLocalCodingTools,
+  createLocalCodingToolDefinitions,
+} from '../local/LocalCodingTools';
 import {
   BashExecutionToolSchema,
   buildBashExecutionToolSchema,
@@ -20,14 +20,14 @@ import {
   SubagentToolSchema,
   createSubagentToolDefinition,
 } from '../SubagentTool';
-import { LOCAL_CODING_BUNDLE_NAMES } from '@/common';
 import { BashProgrammaticToolCallingSchema } from '../BashProgrammaticToolCalling';
 import { ProgrammaticToolCallingSchema } from '../ProgrammaticToolCalling';
 import { WebSearchToolSchema } from '../search/schema';
-import { createSearchTool } from '../search/tool';
+import { LOCAL_CODING_BUNDLE_NAMES } from '@/common';
 import { ReadFileToolDefinition } from '../ReadFile';
 import { ToolSearchToolSchema } from '../ToolSearch';
 import { SkillToolDefinition } from '../SkillTool';
+import { createSearchTool } from '../search/tool';
 import { INTENT_ARG } from '../intentArg';
 
 type SchemaLike = {

--- a/src/tools/intentArg.ts
+++ b/src/tools/intentArg.ts
@@ -275,6 +275,23 @@ export function resolveToolOutcome(
 }
 
 /**
+ * Reads the outcome fields off a tool-execution result: the typed
+ * `outcome`/`outcome_patch` fields when present, else the artifact channel
+ * (see {@link readOutcomeFields}) — so a `content_and_artifact` tool authors
+ * its label the same way on the direct and event-driven paths.
+ */
+export function outcomeFieldsFromResult(result: {
+  outcome?: string;
+  outcome_patch?: OutcomePatch;
+  artifact?: unknown;
+}): { outcome?: string; outcome_patch?: OutcomePatch } | undefined {
+  if (result.outcome != null || result.outcome_patch != null) {
+    return result;
+  }
+  return readOutcomeFields(result.artifact);
+}
+
+/**
  * Extracts validated `outcome`/`outcome_patch` fields from an arbitrary
  * value — the artifact channel through which an in-process
  * `content_and_artifact` tool authors its settled label. Returns undefined

--- a/src/tools/local/CompileCheckTool.ts
+++ b/src/tools/local/CompileCheckTool.ts
@@ -27,7 +27,6 @@ import { resolve } from 'path';
 import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type { WorkspaceFS } from './workspaceFS';
-import { isWorkspaceClientTimeoutError } from './workspaceFS';
 import type * as t from '@/types';
 import {
   getLocalCwd,
@@ -36,6 +35,7 @@ import {
   truncateLocalOutput,
   validateBashCommand,
 } from './LocalExecutionEngine';
+import { isWorkspaceClientTimeoutError } from './workspaceFS';
 import { withIntent } from '@/tools/intentArg';
 import { Constants } from '@/common';
 

--- a/src/tools/local/CompileCheckTool.ts
+++ b/src/tools/local/CompileCheckTool.ts
@@ -36,12 +36,13 @@ import {
   truncateLocalOutput,
   validateBashCommand,
 } from './LocalExecutionEngine';
+import { withIntent } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 /** Back-compat alias; canonical name lives on `Constants.COMPILE_CHECK`. */
 export const CompileCheckToolName = Constants.COMPILE_CHECK;
 
-const CompileCheckSchema: t.JsonSchemaType = {
+const CompileCheckSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     command: {
@@ -55,7 +56,7 @@ const CompileCheckSchema: t.JsonSchemaType = {
         'Optional timeout in milliseconds. Defaults to 120000 (2 min).',
     },
   },
-};
+});
 
 type DetectedKind =
   | 'typescript'

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -28,6 +28,7 @@ import { createLocalFileCheckpointer } from './FileCheckpointer';
 import { applyEdit, locateEdit } from './editStrategies';
 import { decodeFile, encodeFile } from './textEncoding';
 import { runPostEditSyntaxCheck } from './syntaxCheck';
+import { withIntent } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 const MAX_READ_CHARS = 256000;
@@ -47,7 +48,7 @@ export const LocalGrepSearchToolName = Constants.GREP_SEARCH;
 export const LocalGlobSearchToolName = Constants.GLOB_SEARCH;
 export const LocalListDirectoryToolName = Constants.LIST_DIRECTORY;
 
-export const LocalReadFileToolSchema: t.JsonSchemaType = {
+export const LocalReadFileToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     path: {
@@ -65,9 +66,9 @@ export const LocalReadFileToolSchema: t.JsonSchemaType = {
     },
   },
   required: ['path'],
-};
+});
 
-export const LocalWriteFileToolSchema: t.JsonSchemaType = {
+export const LocalWriteFileToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     path: {
@@ -81,9 +82,9 @@ export const LocalWriteFileToolSchema: t.JsonSchemaType = {
     },
   },
   required: ['path', 'content'],
-};
+});
 
-export const LocalEditFileToolSchema: t.JsonSchemaType = {
+export const LocalEditFileToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     path: {
@@ -114,9 +115,9 @@ export const LocalEditFileToolSchema: t.JsonSchemaType = {
     },
   },
   required: ['path'],
-};
+});
 
-export const LocalGrepSearchToolSchema: t.JsonSchemaType = {
+export const LocalGrepSearchToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     pattern: {
@@ -137,9 +138,9 @@ export const LocalGrepSearchToolSchema: t.JsonSchemaType = {
     },
   },
   required: ['pattern'],
-};
+});
 
-export const LocalGlobSearchToolSchema: t.JsonSchemaType = {
+export const LocalGlobSearchToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     pattern: {
@@ -156,9 +157,9 @@ export const LocalGlobSearchToolSchema: t.JsonSchemaType = {
     },
   },
   required: ['pattern'],
-};
+});
 
-export const LocalListDirectoryToolSchema: t.JsonSchemaType = {
+export const LocalListDirectoryToolSchema: t.JsonSchemaType = withIntent({
   type: 'object',
   properties: {
     path: {
@@ -166,7 +167,7 @@ export const LocalListDirectoryToolSchema: t.JsonSchemaType = {
       description: 'Directory to list. Defaults to cwd.',
     },
   },
-};
+});
 
 function lineWindow(
   content: string,

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -3,7 +3,6 @@ import { createTwoFilesPatch } from 'diff';
 import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { isWorkspaceClientTimeoutError } from './workspaceFS';
 import {
   createLocalBashProgrammaticToolCallingTool,
   createLocalProgrammaticToolCallingTool,
@@ -25,6 +24,7 @@ import {
 } from './CompileCheckTool';
 import { classifyAttachment, imageAttachmentContent } from './attachments';
 import { createLocalFileCheckpointer } from './FileCheckpointer';
+import { isWorkspaceClientTimeoutError } from './workspaceFS';
 import { applyEdit, locateEdit } from './editStrategies';
 import { decodeFile, encodeFile } from './textEncoding';
 import { runPostEditSyntaxCheck } from './syntaxCheck';

--- a/src/tools/ptcTimeout.ts
+++ b/src/tools/ptcTimeout.ts
@@ -1,3 +1,4 @@
+import type { JsonSchemaType } from '@/types';
 import { EnvVar } from '@/common';
 
 export const DEFAULT_CODE_API_RUN_TIMEOUT_MS = 15_000;
@@ -15,6 +16,7 @@ type TimeoutSchema = {
 export type ProgrammaticToolCallingJsonSchema = {
   type: 'object';
   properties: {
+    intent: JsonSchemaType;
     code: {
       type: 'string';
       minLength: number;

--- a/src/tools/search/outcome.test.ts
+++ b/src/tools/search/outcome.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from '@jest/globals';
+import type * as t from './types';
+import { resolveSearchOutcome } from './tool';
+
+const data = (partial: Partial<t.SearchResultData>): t.SearchResultData =>
+  ({ turn: 0, ...partial }) as t.SearchResultData;
+
+describe('resolveSearchOutcome', () => {
+  it('authors a FAILURE label when the processor caught an error', () => {
+    expect(
+      resolveSearchOutcome(
+        data({ error: 'provider timeout', organic: [] }),
+        'oauth handling'
+      )
+    ).toBe('Search failed for "oauth handling"');
+  });
+
+  it('prefers the failure label over any partial results', () => {
+    expect(
+      resolveSearchOutcome(
+        data({
+          error: 'partial failure',
+          organic: [{ link: 'a' }] as t.SearchResultData['organic'],
+        }),
+        'oauth'
+      )
+    ).toBe('Search failed for "oauth"');
+  });
+
+  it('ignores an empty-string error', () => {
+    expect(
+      resolveSearchOutcome(
+        data({
+          error: '',
+          organic: [{ link: 'a' }] as t.SearchResultData['organic'],
+        }),
+        'oauth'
+      )
+    ).toBe('Found 1 result for "oauth"');
+  });
+
+  it('counts every rendered collection kind', () => {
+    expect(
+      resolveSearchOutcome(
+        data({
+          organic: [
+            { link: 'a' },
+            { link: 'b' },
+          ] as t.SearchResultData['organic'],
+          topStories: [{ link: 'c' }] as t.SearchResultData['topStories'],
+          images: [{ imageUrl: 'd' }] as t.SearchResultData['images'],
+          videos: [{ link: 'e' }] as t.SearchResultData['videos'],
+          places: [{ name: 'f' }] as t.SearchResultData['places'],
+          peopleAlsoAsk: [
+            { question: 'g' },
+          ] as t.SearchResultData['peopleAlsoAsk'],
+        }),
+        'oauth'
+      )
+    ).toBe('Found 7 results for "oauth"');
+  });
+
+  it('counts singleton structured results (knowledge graph / answer box)', () => {
+    expect(
+      resolveSearchOutcome(
+        data({
+          knowledgeGraph: {
+            title: 'OAuth',
+          } as t.SearchResultData['knowledgeGraph'],
+        }),
+        'oauth'
+      )
+    ).toBe('Found 1 result for "oauth"');
+    expect(
+      resolveSearchOutcome(
+        data({
+          answerBox: { snippet: 'x' } as t.SearchResultData['answerBox'],
+          knowledgeGraph: {
+            title: 'OAuth',
+          } as t.SearchResultData['knowledgeGraph'],
+        }),
+        'oauth'
+      )
+    ).toBe('Found 2 results for "oauth"');
+  });
+
+  it('leaves a genuine zero-result search to the mechanical transform', () => {
+    expect(resolveSearchOutcome(data({ organic: [] }), 'oauth')).toBeUndefined();
+  });
+});

--- a/src/tools/search/schema.ts
+++ b/src/tools/search/schema.ts
@@ -1,3 +1,5 @@
+import { INTENT_PROPERTY } from '@/tools/intentArg';
+
 export enum DATE_RANGE {
   PAST_HOUR = 'h',
   PAST_24_HOURS = 'd',
@@ -71,6 +73,7 @@ export const newsSchema = {
 export const WebSearchToolSchema = {
   type: 'object',
   properties: {
+    intent: { ...INTENT_PROPERTY },
     query: querySchema,
     date: dateSchema,
     country: countrySchema,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -335,7 +335,16 @@ function createTool({
         maxOutputChars
       );
       const data: t.SearchResultData = { turn, ...searchResult, references };
-      return [output, { [Constants.WEB_SEARCH]: data }];
+      /** Settled label for the call's intent (see `intentArg.ts`). */
+      const referenceCount = references.length;
+      const outcome =
+        referenceCount > 0
+          ? `Found ${referenceCount} result${referenceCount === 1 ? '' : 's'} for "${query}"`
+          : undefined;
+      return [
+        output,
+        { [Constants.WEB_SEARCH]: data, ...(outcome != null && { outcome }) },
+      ];
     },
     {
       name: WebSearchToolName,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -17,9 +17,9 @@ import { createKeenableScraper } from './keenable-scraper';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
-import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
 import { createReranker } from './rerankers';
@@ -441,7 +441,6 @@ export const createSearchTool = (
       }
       : tavilySearchOptions;
 
-  /** `intent` FIRST — mirrors `WebSearchToolSchema` (see `intentArg.ts`). */
   const schemaProperties: Record<string, unknown> = {
     intent: { ...INTENT_PROPERTY },
     query: querySchema,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -335,11 +335,22 @@ function createTool({
         maxOutputChars
       );
       const data: t.SearchResultData = { turn, ...searchResult, references };
-      /** Settled label for the call's intent (see `intentArg.ts`). */
-      const referenceCount = references.length;
+      /**
+       * Settled label for the call's intent (see `intentArg.ts`). Counts the
+       * actual result collections — `references` only tracks links embedded
+       * in extracted highlights, so it undercounts ordinary results and can
+       * overcount when one highlight embeds several links.
+       */
+      const resultCount =
+        (data.organic?.length ?? 0) +
+        (data.topStories?.length ?? 0) +
+        (data.news?.length ?? 0) +
+        (data.images?.length ?? 0) +
+        (data.videos?.length ?? 0) +
+        (data.places?.length ?? 0);
       const outcome =
-        referenceCount > 0
-          ? `Found ${referenceCount} result${referenceCount === 1 ? '' : 's'} for "${query}"`
+        resultCount > 0
+          ? `Found ${resultCount} result${resultCount === 1 ? '' : 's'} for "${query}"`
           : undefined;
       return [
         output,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -19,6 +19,7 @@ import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
 import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
+import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
 import { createReranker } from './rerankers';
@@ -440,7 +441,9 @@ export const createSearchTool = (
       }
       : tavilySearchOptions;
 
+  /** `intent` FIRST — mirrors `WebSearchToolSchema` (see `intentArg.ts`). */
   const schemaProperties: Record<string, unknown> = {
+    intent: { ...INTENT_PROPERTY },
     query: querySchema,
     date: dateSchema,
     images: imagesSchema,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -26,6 +26,46 @@ import { createReranker } from './rerankers';
 import { Constants } from '@/common';
 
 /**
+ * Settled label for a `web_search` call's intent (see `intentArg.ts`).
+ *
+ * Counts the result kinds `formatResultsForLLM` actually renders —
+ * `references` only tracks links embedded in extracted highlights, so it
+ * undercounts ordinary results and can overcount when one highlight embeds
+ * several links.
+ *
+ * A caught provider or processing failure is reported through `data.error`
+ * while the tool still returns NORMALLY, so that case must author its own
+ * label: the `ToolMessage` carries success status, and a bare intent would
+ * otherwise settle mechanically from "Searching…" to "Searched…" and present
+ * a failed search as a successful one.
+ *
+ * Returns undefined for a genuine zero-result search, leaving the host's
+ * mechanical past-tense transform to label it.
+ */
+export function resolveSearchOutcome(
+  data: t.SearchResultData,
+  query: string
+): string | undefined {
+  if (data.error != null && data.error !== '') {
+    return `Search failed for "${query}"`;
+  }
+  const count =
+    (data.organic?.length ?? 0) +
+    (data.topStories?.length ?? 0) +
+    (data.news?.length ?? 0) +
+    (data.images?.length ?? 0) +
+    (data.videos?.length ?? 0) +
+    (data.places?.length ?? 0) +
+    (data.peopleAlsoAsk?.length ?? 0) +
+    (data.knowledgeGraph != null ? 1 : 0) +
+    (data.answerBox != null ? 1 : 0);
+  if (count === 0) {
+    return undefined;
+  }
+  return `Found ${count} result${count === 1 ? '' : 's'} for "${query}"`;
+}
+
+/**
  * Executes parallel searches and merges the results,
  * deduplicating top stories by link
  */
@@ -336,23 +376,7 @@ function createTool({
         maxOutputChars
       );
       const data: t.SearchResultData = { turn, ...searchResult, references };
-      /**
-       * Settled label for the call's intent (see `intentArg.ts`). Counts the
-       * actual result collections — `references` only tracks links embedded
-       * in extracted highlights, so it undercounts ordinary results and can
-       * overcount when one highlight embeds several links.
-       */
-      const resultCount =
-        (data.organic?.length ?? 0) +
-        (data.topStories?.length ?? 0) +
-        (data.news?.length ?? 0) +
-        (data.images?.length ?? 0) +
-        (data.videos?.length ?? 0) +
-        (data.places?.length ?? 0);
-      const outcome =
-        resultCount > 0
-          ? `Found ${resultCount} result${resultCount === 1 ? '' : 's'} for "${query}"`
-          : undefined;
+      const outcome = resolveSearchOutcome(data, query);
       return [
         output,
         { [Constants.WEB_SEARCH]: data, ...(outcome != null && { outcome }) },


### PR DESCRIPTION
## Summary

Second slice of tool intent labels, **stacked on #347** (retarget to `main` once that merges). Opts the native tool suite into the `intent` arg: every coding tool on every engine, plus `web_search`, `subagent`, `skill`, and `tool_search`, now declares `intent` as the **first schema property** — optional, never in `required`.

### Injection strategy: schemas, not factories

Cloudflare has no file tools of its own — `CloudflareSandboxTools.ts` imports the local factories and reuses the shared bash/code schemas — so injecting at the schema definition covers all three engines from a handful of edit sites:

| Site | Covers |
|---|---|
| 6 local coding schemas (`local/LocalCodingTools.ts`) + `local/CompileCheckTool.ts`, via `withIntent(...)` | local **and** cloudflare-sandbox engines |
| `BashExecutionToolSchema` / `CodeExecutionToolSchema`, inline first key | remote, local, and cloudflare `bash_tool` / `execute_code` (incl. the stateful `build*Schema` variants, which spread the base) |
| both PTC schema factories (+ `intent` on the closed `ProgrammaticToolCallingJsonSchema` type) | `run_tools_with_code` / `run_tools_with_bash` on all engines — the local/cloudflare variants inherit through their property spreads |
| `ReadFileToolSchema`, `SkillToolSchema`, `SubagentToolSchema` (+ the runtime `buildSubagentToolParams` variant), `ToolSearchToolSchema` (+ `createToolSearchSchema`), `WebSearchToolSchema` | the rest of the native surface |

### The two real hazards this had to defuse

- **`...rest` wire-body leaks:** `BashExecutor`/`CodeExecutor` spread unrecognized args straight into the Code API POST body. `intent` is now destructured out exactly like `runtime_session_hint`. Every other native body reads specific fields, so the optional extra key is inert.
- **Frozen-instance validation crash:** LangChain's JSON-schema validator (`@cfworker/json-schema`) stamps `__absolute_uri__` onto every subschema it dereferences, which throws on a frozen object. The property is now always embedded as a **copy** of the frozen canonical `INTENT_PROPERTY` (fix backported to #347's `withIntent`). Caught by the execution suites, now pinned by a unit test.

### Outcome authoring

- `outcomeFieldsFromResult`: completion events honor **artifact-borne** `outcome`/`outcome_patch` on the event-driven paths too, so a `content_and_artifact` tool authors its settled label the same way everywhere.
- `web_search` is the first author: `Found N results for "query"` rides its artifact next to the citation data.

### Coverage pin

`intentCoverage.test.ts` asserts every name in `LOCAL_CODING_BUNDLE_NAMES` and `CLOUDFLARE_CODING_TOOL_NAMES` — plus `read_file`, `skill`, `subagent` (static + runtime), `tool_search`, `web_search`, the stateful schema variants, and both PTC runners — emits `intent` first and never requires it. "Did we get them all" is now a failing test instead of a review question.

## Testing

- 447 tests across the 11 affected suites (`intentArg`, `intentCoverage`, `localToolNames`, `LocalExecutionTools`, `CloudflareSandboxExecution`, `BashExecutor`, `ProgrammaticToolCalling`, `SkillTool`, `SubagentTool`, `ToolSearch`, `ReadFile`) — all pass.
- `npx tsc --noEmit` clean; eslint clean on the diff (remaining warnings in touched files pre-date it).