### PR TITLE
📦 chore: v3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.4",
+  "version": "3.4.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Version bump → npm publish (publish.yml ships on merge since `package.json` will exceed npm's 3.3.4).

## Since 3.3.4

- #335 — 🔪 Cooperative mid-generation stream preemption (`RunConfig.preemption`, `PreemptBoundary` hook, seal gate, halt semantics, strict-alternation wire shaping). **Opt-in**: nothing activates without `preemption` configured; the shared-path changes (Bedrock converter user-run merging, steer anchor, coalescer) are live-verified on 8 providers.
- #346 — 🧵 Predecessor prefill handoff cue for bare direct-edge multi-agent successors on Claude (fixes #345).
- #343 — 🧪 Jest module mapping for ESM-only `@langchain/mistralai`.
- #337, #348, #350 — Keenable scraper, Langfuse GraphInterrupt trace normalization, delta content-part fixes.

LibreChat consumes this via a follow-up `^3.4.0` bump PR on `dev` (prerequisite for the steering server PR).