### PR TITLE
v3.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Release `v3.3.6`.

Ships the tool intent & outcome label capability, landed across two PRs since `v3.3.5`:

- #347 — **core**: `intentArg.ts` (`withIntent`, `readIntent`, `stripIntent`, `applyOutcome`), `outcome`/`outcome_patch` on tool results threaded through to `ON_RUN_STEP_COMPLETED`, `{{tool…}}` substitution exempted for the display label, and the OpenAI strict-mode sanitizer on both the Completions and Responses delegates.
- #349 — **native tools**: intent-first schemas for the coding suite across all three engines (local, cloudflare sandbox, remote), plus `web_search`, `subagent`, `skill`, and `tool_search`; `web_search` authors its own `outcome`.

Two pre-existing `ToolNode` bugs were found and fixed along the way, both of which could drop a call's terminal event entirely:
- A tool that **returns** a `ToolMessage` with `status: 'error'` never enters the catch path, so `errorHandler` never ran — yet the output loop skipped it assuming the handler had dispatched, emitting no `ON_RUN_STEP_COMPLETED` at all.
- Error-completion ownership lived on the ToolNode **instance** while tool-call ids are provider-scoped and synthetic ids repeat, so concurrent `run()`s cross-consumed markers (and interrupts leaked stale ones). Now batch-local.

Version bump only — no code changes in this PR.