### PR TITLE
🧭 fix: Anchor Summary Coverage to a Source Message ID

### DIFF
--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -27,6 +27,20 @@ import { Constants } from '@/common';
 const HANDOFF_INSTRUCTIONS_PATTERN = /(?:Instructions?|Context):\s*(.+)/is;
 const HANDOFF_INSTRUCTIONS_KEY = 'handoff_instructions';
 
+/**
+ * Handoff and fan-in prompts that route work between agents. Built in-run and
+ * never persisted as standalone payload entries, so they are marked synthetic:
+ * `messagesStateReducer` would otherwise give them a plain UUID and downstream
+ * consumers — compaction coverage anchors — could not tell them apart from a
+ * message replayed out of the payload.
+ */
+function buildRoutingPrompt(content: string): HumanMessage {
+  return new HumanMessage({
+    content,
+    additional_kwargs: { role: 'user', isMeta: true, source: 'routing' },
+  });
+}
+
 function getHandoffInstructions(
   input: Record<string, unknown>,
   promptKey: string,
@@ -986,12 +1000,12 @@ export class MultiAgentGraph extends StandardGraph {
                 new AIMessage(
                   `[Processed tool result and transferring to ${agentId}]`
                 ),
-                new HumanMessage(instructions),
+                buildRoutingPrompt(instructions),
               ];
             } else {
               messagesForAgent = [
                 ...filteredMessages,
-                new HumanMessage(instructions),
+                buildRoutingPrompt(instructions),
               ];
             }
           }
@@ -1204,7 +1218,7 @@ export class MultiAgentGraph extends StandardGraph {
               effectiveExcludeResults === false
             ) {
               return {
-                messages: [new HumanMessage(promptText)],
+                messages: [buildRoutingPrompt(promptText)],
               };
             }
 
@@ -1212,7 +1226,7 @@ export class MultiAgentGraph extends StandardGraph {
              * to pass filtered messages + prompt to the destination agent
              */
             const filteredMessages = state.messages.slice(0, this.startIndex);
-            const promptMessage = new HumanMessage(promptText);
+            const promptMessage = buildRoutingPrompt(promptText);
             return {
               messages: [promptMessage],
               agentMessages: messagesStateReducer(filteredMessages, [

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1353,6 +1353,19 @@ function applySummaryBoundary(
   };
 }
 
+function measureValueChars(value: unknown): number {
+  if (typeof value === 'string') {
+    return value.length;
+  }
+  if (value == null || typeof value !== 'object') {
+    return 0;
+  }
+  const measured = serializeStructuredValueBounded(value, 0).originalChars;
+  return measured === Number.MAX_SAFE_INTEGER
+    ? HARD_MAX_TOOL_RESULT_CHARS
+    : Math.min(measured, HARD_MAX_TOOL_RESULT_CHARS);
+}
+
 function contentPartCharLength(part: MessageContentComplex): number {
   const record = part as Record<string, unknown>;
   let len = 0;
@@ -1362,15 +1375,15 @@ function contentPartCharLength(part: MessageContentComplex): number {
   if (typeof record.thinking === 'string') {
     len += record.thinking.length;
   }
-  const { input } = record;
-  if (typeof input === 'string') {
-    len += input.length;
-  } else if (input != null && typeof input === 'object') {
-    const measured = serializeStructuredValueBounded(input, 0).originalChars;
-    len +=
-      measured === Number.MAX_SAFE_INTEGER
-        ? HARD_MAX_TOOL_RESULT_CHARS
-        : Math.min(measured, HARD_MAX_TOOL_RESULT_CHARS);
+  len += measureValueChars(record.input);
+  /** Tool calls nest their payload a level down, so measuring only the
+   *  top-level fields scores an entire tool turn as zero characters. */
+  const { tool_call: toolCall } = record;
+  if (toolCall != null && typeof toolCall === 'object') {
+    const call = toolCall as Record<string, unknown>;
+    len += measureValueChars(call.name);
+    len += measureValueChars(call.args);
+    len += measureValueChars(call.output);
   }
   return len;
 }
@@ -1849,14 +1862,21 @@ export const formatAgentMessages = (
         const content = payload[originalIndex]
           .content as MessageContentComplex[];
         let retainedCharLen = 0;
+        let retainedParts = 0;
         for (let p = 0; p < content.length; p++) {
           if (content[p]?.type !== ContentTypes.SUMMARY) {
             retainedCharLen += contentPartCharLength(content[p]);
+            retainedParts++;
           }
         }
         const summaryCharLen = summaryCharsByIndex.get(originalIndex) ?? 0;
         const totalCharLen = retainedCharLen + summaryCharLen;
-        if (summaryCharLen > 0 && totalCharLen > 0) {
+        /** Retained parts that measure as nothing mean the content is a shape
+         *  the char heuristic cannot see, not that it is absent — scaling on
+         *  that would erase a real payload's tokens. Keeping the original
+         *  over-counts, which prunes early rather than overflowing. */
+        const retainedIsMeasurable = retainedParts === 0 || retainedCharLen > 0;
+        if (summaryCharLen > 0 && totalCharLen > 0 && retainedIsMeasurable) {
           const original = tokenCount;
           tokenCount = Math.max(
             1,

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1211,12 +1211,22 @@ type SummaryBoundary =
       tokenCount: number;
     };
 
+type SummaryTokenAdjustment = {
+  original: number;
+  adjusted: number;
+  /** Positional path: characters retained after the slice, and the entry total. */
+  remainingChars?: number;
+  totalChars?: number;
+  /** Coverage path: the summary's own recorded token count, subtracted. */
+  summaryTokens?: number;
+};
+
 type SummaryScan = {
   boundary?: SummaryBoundary;
-  /** Payload index → characters of summary text it carries. Summary blocks nest
-   *  their text under `content[]`, which `contentPartCharLength` does not read,
-   *  so the length is captured here where the text is already extracted. */
-  summaryCharsByIndex: Map<number, number>;
+  /** Payload index → tokens of summary text it carries, as recorded on the block
+   *  itself. Used to discount the entry that holds a summary, in token units
+   *  rather than by measuring characters. */
+  summaryTokensByIndex: Map<number, number>;
 };
 
 function resolveCoverageIndex(
@@ -1240,7 +1250,7 @@ function resolveCoverageIndex(
 
 function scanSummaryBlocks(payload: TPayload): SummaryScan {
   let boundary: SummaryBoundary | undefined;
-  const summaryCharsByIndex = new Map<number, number>();
+  const summaryTokensByIndex = new Map<number, number>();
   /** Filled as the scan advances, so a coverage lookup only ever resolves to a
    *  message already passed — no second pass over the payload. */
   const indexBySourceId = new Map<string, number>();
@@ -1282,16 +1292,18 @@ function scanSummaryBlocks(payload: TPayload): SummaryScan {
         continue;
       }
 
-      summaryCharsByIndex.set(
-        i,
-        (summaryCharsByIndex.get(i) ?? 0) + summaryText.length
-      );
-
       const tokenCount =
         typeof summaryPart.tokenCount === 'number' &&
         Number.isFinite(summaryPart.tokenCount)
           ? summaryPart.tokenCount
           : 0;
+
+      if (tokenCount > 0) {
+        summaryTokensByIndex.set(
+          i,
+          (summaryTokensByIndex.get(i) ?? 0) + tokenCount
+        );
+      }
       const retainedIndex = resolveCoverageIndex(
         summaryPart.coverage,
         indexBySourceId,
@@ -1316,7 +1328,7 @@ function scanSummaryBlocks(payload: TPayload): SummaryScan {
     }
   }
 
-  return { boundary, summaryCharsByIndex };
+  return { boundary, summaryTokensByIndex };
 }
 
 function applySummaryBoundary(
@@ -1351,28 +1363,6 @@ function applySummaryBoundary(
     ...message,
     content: message.content.slice(summaryBoundary.contentIndex + 1),
   };
-}
-
-/**
- * Whether `formatAssistantMessage` filters this part out of the emitted message.
- * Such a part contributes no prompt tokens, so measuring it as zero characters
- * is accurate rather than a blind spot — it must not be mistaken for content the
- * char heuristic cannot see.
- */
-function isDroppedByFormatting(
-  part: MessageContentComplex | undefined
-): boolean {
-  if (part == null) {
-    return true;
-  }
-  if (
-    part.type === ContentTypes.ERROR ||
-    part.type === ContentTypes.AGENT_UPDATE ||
-    part.type === ContentTypes.ACTIVITY_LABEL
-  ) {
-    return true;
-  }
-  return part.type === ContentTypes.TEXT && getTextContent(part).trim() === '';
 }
 
 function measureValueChars(value: unknown): number {
@@ -1456,14 +1446,10 @@ export const formatAgentMessages = (
   /** Cross-run summary extracted from the payload. Should be forwarded to the
    *  agent run so it can be included in the system message via AgentContext. */
   summary?: { text: string; tokenCount: number };
-  /** When a summary boundary sliced content from a message, the token count
-   *  was proportionally reduced. Returned so the caller can log it. */
-  boundaryTokenAdjustment?: {
-    original: number;
-    adjusted: number;
-    remainingChars: number;
-    totalChars: number;
-  };
+  /** When a summary reduced a message's token count, returned so the caller can
+   *  log it. The positional path scales by the share of characters that survive
+   *  the slice; the coverage path subtracts the summary's own token count. */
+  boundaryTokenAdjustment?: SummaryTokenAdjustment;
 } => {
   const messages: Array<
     | RoleBearingMessage<HumanMessage>
@@ -1503,17 +1489,10 @@ export const formatAgentMessages = (
   };
   // If indexTokenCountMap is provided, create a new map to track the updated indices
   const updatedIndexTokenCountMap: Record<number, number> = {};
-  let boundaryTokenAdjustment:
-    | {
-        original: number;
-        adjusted: number;
-        remainingChars: number;
-        totalChars: number;
-      }
-    | undefined;
+  let boundaryTokenAdjustment: SummaryTokenAdjustment | undefined;
   // Keep track of the mapping from original payload indices to result indices
   const indexMapping: Record<number, number[] | undefined> = {};
-  const { boundary: summaryBoundary, summaryCharsByIndex } =
+  const { boundary: summaryBoundary, summaryTokensByIndex } =
     scanSummaryBlocks(payload);
 
   // Summary metadata is returned to the caller so it can be forwarded to the
@@ -1872,59 +1851,32 @@ export const formatAgentMessages = (
             };
           }
         }
-      } else if (
-        summaryBoundary?.mode === 'coverage' &&
-        summaryCharsByIndex.has(originalIndex) &&
-        Array.isArray(payload[originalIndex].content)
-      ) {
-        /** Coverage keeps the block's own message, but `formatAssistantMessage`
-         *  filters the summary part out of it and the text is accounted
-         *  separately as `summary.tokenCount`. Charging the entry for both
-         *  double-counts, inflating the prompt estimate and pruning early. */
-        const content = payload[originalIndex]
-          .content as MessageContentComplex[];
-        let retainedCharLen = 0;
-        /** Every retained part must be represented, not merely the total. A part
-         *  the char heuristic cannot see — media, and anything else carrying its
-         *  payload outside the fields measured above — still costs real tokens,
-         *  so scaling a mix of measurable text and an unmeasurable image would
-         *  charge the entry for the caption alone and erase the image. Keeping
-         *  the original over-counts, which prunes early rather than sending an
-         *  over-context request. */
-        let everyRetainedPartMeasurable = true;
-        for (let p = 0; p < content.length; p++) {
-          const part = content[p];
-          /** Null-guarded first, so the type check below needs no optional chain. */
-          if (
-            isDroppedByFormatting(part) ||
-            part.type === ContentTypes.SUMMARY
-          ) {
-            continue;
-          }
-          const charLen = contentPartCharLength(part);
-          if (charLen === 0) {
-            everyRetainedPartMeasurable = false;
-            break;
-          }
-          retainedCharLen += charLen;
-        }
-        const summaryCharLen = summaryCharsByIndex.get(originalIndex) ?? 0;
-        const totalCharLen = retainedCharLen + summaryCharLen;
-        if (
-          summaryCharLen > 0 &&
-          totalCharLen > 0 &&
-          everyRetainedPartMeasurable
-        ) {
+      } else if (summaryBoundary?.mode === 'coverage') {
+        /**
+         * Coverage keeps the message holding the block, but
+         * `formatAssistantMessage` filters the summary part out of it while the
+         * text is accounted separately as `summary.tokenCount`. Charging the
+         * entry for both double-counts, inflating the prompt estimate and
+         * pruning early.
+         *
+         * Subtracts the summary's own recorded token count rather than scaling
+         * by a share of characters. Character length is the wrong proxy here:
+         * media, tool-call payloads, and nested media inside a tool output all
+         * cost tokens out of proportion to the characters a heuristic can see,
+         * so any ratio built from characters erases whatever it cannot measure.
+         * Subtraction needs no measurement of the retained content at all.
+         */
+        const summaryTokens = summaryTokensByIndex.get(originalIndex) ?? 0;
+        /** A summary claiming the whole entry means the two counts do not share
+         *  a basis; leaving the original over-counts, which prunes early rather
+         *  than sending an over-context request. */
+        if (summaryTokens > 0 && summaryTokens < tokenCount) {
           const original = tokenCount;
-          tokenCount = Math.max(
-            1,
-            Math.round(tokenCount * (retainedCharLen / totalCharLen))
-          );
+          tokenCount -= summaryTokens;
           boundaryTokenAdjustment = {
             original,
             adjusted: tokenCount,
-            remainingChars: retainedCharLen,
-            totalChars: totalCharLen,
+            summaryTokens,
           };
         }
       }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1351,6 +1351,28 @@ function applySummaryBoundary(
   };
 }
 
+/**
+ * Whether `formatAssistantMessage` filters this part out of the emitted message.
+ * Such a part contributes no prompt tokens, so measuring it as zero characters
+ * is accurate — it must not be mistaken for content the heuristic cannot see.
+ */
+function isDroppedByFormatting(
+  part: MessageContentComplex | undefined
+): boolean {
+  if (part == null) {
+    return true;
+  }
+  if (
+    part.type === ContentTypes.SUMMARY ||
+    part.type === ContentTypes.ERROR ||
+    part.type === ContentTypes.AGENT_UPDATE ||
+    part.type === ContentTypes.ACTIVITY_LABEL
+  ) {
+    return true;
+  }
+  return part.type === ContentTypes.TEXT && getTextContent(part).trim() === '';
+}
+
 function measureValueChars(value: unknown): number {
   if (typeof value === 'string') {
     return value.length;
@@ -1830,14 +1852,26 @@ export const formatAgentMessages = (
         if (contentIndex >= 0 && contentIndex < content.length - 1) {
           let totalCharLen = 0;
           let remainingCharLen = 0;
+          /** Every *retained* part must be represented before scaling. A part the
+           *  heuristic cannot see — atomic media above all — still costs its
+           *  fixed provider price, so a ratio that counts only the measurable
+           *  siblings scales that cost away: an entry keeping just an image after
+           *  the summary collapses to 1. Keeping the original over-counts, which
+           *  prunes early rather than exceeding the window. */
+          let everyRetainedPartMeasurable = true;
           for (let p = 0; p < content.length; p++) {
-            const charLen = contentPartCharLength(content[p]);
+            const part = content[p];
+            const charLen = contentPartCharLength(part);
             totalCharLen += charLen;
             if (p > contentIndex) {
+              if (charLen === 0 && !isDroppedByFormatting(part)) {
+                everyRetainedPartMeasurable = false;
+                break;
+              }
               remainingCharLen += charLen;
             }
           }
-          if (totalCharLen > 0) {
+          if (totalCharLen > 0 && everyRetainedPartMeasurable) {
             const original = tokenCount;
             tokenCount = Math.max(
               1,

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1386,6 +1386,26 @@ function measureValueChars(value: unknown): number {
     : Math.min(measured, HARD_MAX_TOOL_RESULT_CHARS);
 }
 
+/**
+ * Whether a retained part's whole prompt cost is the text the char heuristic
+ * reads, making it safe to represent in a character ratio.
+ *
+ * An allowlist, not a denylist. Media, resources, and tool calls carry cost that
+ * is unrelated to their serialized length — a short image URL nested in
+ * `tool_call.output` stands in for a fixed four-figure media charge — and
+ * rejecting those case by case has repeatedly missed a nesting level. Listing
+ * the two shapes whose characters `contentPartCharLength` actually reads makes
+ * every other shape, present or future, ineligible by default: the ratio is
+ * skipped and the entry keeps its original count, which prunes early rather than
+ * exceeding the window.
+ */
+function isCharRatioEligible(part: MessageContentComplex | undefined): boolean {
+  if (part == null) {
+    return false;
+  }
+  return part.type === ContentTypes.TEXT || part.type === ContentTypes.THINKING;
+}
+
 function contentPartCharLength(part: MessageContentComplex): number {
   const record = part as Record<string, unknown>;
   let len = 0;
@@ -1852,19 +1872,22 @@ export const formatAgentMessages = (
         if (contentIndex >= 0 && contentIndex < content.length - 1) {
           let totalCharLen = 0;
           let remainingCharLen = 0;
-          /** Every *retained* part must be represented before scaling. A part the
-           *  heuristic cannot see — atomic media above all — still costs its
-           *  fixed provider price, so a ratio that counts only the measurable
-           *  siblings scales that cost away: an entry keeping just an image after
-           *  the summary collapses to 1. Keeping the original over-counts, which
-           *  prunes early rather than exceeding the window. */
+          /** Every *retained* part must be one the ratio can represent. A part
+           *  carrying cost unrelated to its length — atomic media above all,
+           *  including media nested inside a tool output — would have that cost
+           *  scaled away: an entry keeping just an image after the summary
+           *  collapses to 1. Parts formatting drops are exempt, contributing
+           *  nothing to either side. */
           let everyRetainedPartMeasurable = true;
           for (let p = 0; p < content.length; p++) {
             const part = content[p];
             const charLen = contentPartCharLength(part);
             totalCharLen += charLen;
             if (p > contentIndex) {
-              if (charLen === 0 && !isDroppedByFormatting(part)) {
+              if (isDroppedByFormatting(part)) {
+                continue;
+              }
+              if (!isCharRatioEligible(part) || charLen === 0) {
                 everyRetainedPartMeasurable = false;
                 break;
               }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -20,6 +20,7 @@ import type {
   MessageContentComplex,
   ReasoningContentText,
   SummaryContentBlock,
+  SummaryCoverage,
   ThinkingContentText,
   ToolCallContent,
   ToolResultContent,
@@ -1185,20 +1186,64 @@ function extractToolNamesFromSearchOutput(output: string): string[] {
   return [];
 }
 
-type SummaryBoundary = {
-  messageIndex: number;
-  contentIndex: number;
-  text: string;
-  tokenCount: number;
-};
+/**
+ * How far back a persisted summary reaches.
+ *
+ * `coverage` is authoritative: the block declared the last source message it
+ * replaced, so a recency tail retained at compaction time survives even though
+ * it sits earlier in the payload than the block itself. `positional` is the
+ * legacy reading for blocks written before coverage existed (or whose covered
+ * message is no longer in the payload) — the block's own location is the
+ * boundary, which is why it cannot distinguish a retained tail from history.
+ */
+type SummaryBoundary =
+  | {
+      mode: 'coverage';
+      messageIndex: number;
+      text: string;
+      tokenCount: number;
+    }
+  | {
+      mode: 'positional';
+      messageIndex: number;
+      contentIndex: number;
+      text: string;
+      tokenCount: number;
+    };
+
+function resolveCoverageIndex(
+  coverage: SummaryCoverage | undefined,
+  indexBySourceId: Map<string, number>,
+  summaryMessageIndex: number
+): number | undefined {
+  /** Persisted JSON, so the declared string type is not a runtime guarantee. */
+  if (typeof coverage?.throughMessageId !== 'string') {
+    return undefined;
+  }
+  const throughMessageId = coverage.throughMessageId.trim();
+  if (throughMessageId === '') {
+    return undefined;
+  }
+  const coveredIndex = indexBySourceId.get(throughMessageId);
+  return coveredIndex != null && coveredIndex < summaryMessageIndex
+    ? coveredIndex
+    : undefined;
+}
 
 function getLatestSummaryBoundary(
   payload: TPayload
 ): SummaryBoundary | undefined {
   let summaryBoundary: SummaryBoundary | undefined;
+  /** Filled as the scan advances, so a coverage lookup only ever resolves to a
+   *  message already passed — no second pass over the payload. */
+  const indexBySourceId = new Map<string, number>();
 
   for (let i = 0; i < payload.length; i++) {
     const message = payload[i];
+    const sourceMessageId = getSourceMessageId(message);
+    if (sourceMessageId != null) {
+      indexBySourceId.set(sourceMessageId, i);
+    }
     if (!Array.isArray(message.content)) {
       continue;
     }
@@ -1230,16 +1275,32 @@ function getLatestSummaryBoundary(
         continue;
       }
 
-      summaryBoundary = {
-        messageIndex: i,
-        contentIndex: j,
-        text: summaryText,
-        tokenCount:
-          typeof summaryPart.tokenCount === 'number' &&
-          Number.isFinite(summaryPart.tokenCount)
-            ? summaryPart.tokenCount
-            : 0,
-      };
+      const tokenCount =
+        typeof summaryPart.tokenCount === 'number' &&
+        Number.isFinite(summaryPart.tokenCount)
+          ? summaryPart.tokenCount
+          : 0;
+      const coveredIndex = resolveCoverageIndex(
+        summaryPart.coverage,
+        indexBySourceId,
+        i
+      );
+
+      summaryBoundary =
+        coveredIndex != null
+          ? {
+            mode: 'coverage',
+            messageIndex: coveredIndex,
+            text: summaryText,
+            tokenCount,
+          }
+          : {
+            mode: 'positional',
+            messageIndex: i,
+            contentIndex: j,
+            text: summaryText,
+            tokenCount,
+          };
     }
   }
 
@@ -1253,6 +1314,14 @@ function applySummaryBoundary(
 ): Partial<TMessage> | null {
   if (!summaryBoundary) {
     return message;
+  }
+
+  /** The covered message is replaced by the summary, so the boundary is
+   *  inclusive; everything after it — including a retained recency tail —
+   *  stays verbatim. The block's own message is untouched: its summary part
+   *  is dropped later by `formatAssistantMessage`. */
+  if (summaryBoundary.mode === 'coverage') {
+    return messageIndex <= summaryBoundary.messageIndex ? null : message;
   }
 
   if (messageIndex < summaryBoundary.messageIndex) {
@@ -1724,7 +1793,7 @@ export const formatAgentMessages = (
       }
 
       if (
-        summaryBoundary &&
+        summaryBoundary?.mode === 'positional' &&
         originalIndex === summaryBoundary.messageIndex &&
         Array.isArray(payload[originalIndex].content)
       ) {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1862,21 +1862,32 @@ export const formatAgentMessages = (
         const content = payload[originalIndex]
           .content as MessageContentComplex[];
         let retainedCharLen = 0;
-        let retainedParts = 0;
+        /** Every retained part must be represented, not merely the total. A part
+         *  the char heuristic cannot see — media, and anything else carrying its
+         *  payload outside the fields measured above — still costs real tokens,
+         *  so scaling a mix of measurable text and an unmeasurable image would
+         *  charge the entry for the caption alone and erase the image. Keeping
+         *  the original over-counts, which prunes early rather than sending an
+         *  over-context request. */
+        let everyRetainedPartMeasurable = true;
         for (let p = 0; p < content.length; p++) {
-          if (content[p]?.type !== ContentTypes.SUMMARY) {
-            retainedCharLen += contentPartCharLength(content[p]);
-            retainedParts++;
+          if (content[p]?.type === ContentTypes.SUMMARY) {
+            continue;
           }
+          const charLen = contentPartCharLength(content[p]);
+          if (charLen === 0) {
+            everyRetainedPartMeasurable = false;
+            break;
+          }
+          retainedCharLen += charLen;
         }
         const summaryCharLen = summaryCharsByIndex.get(originalIndex) ?? 0;
         const totalCharLen = retainedCharLen + summaryCharLen;
-        /** Retained parts that measure as nothing mean the content is a shape
-         *  the char heuristic cannot see, not that it is absent — scaling on
-         *  that would erase a real payload's tokens. Keeping the original
-         *  over-counts, which prunes early rather than overflowing. */
-        const retainedIsMeasurable = retainedParts === 0 || retainedCharLen > 0;
-        if (summaryCharLen > 0 && totalCharLen > 0 && retainedIsMeasurable) {
+        if (
+          summaryCharLen > 0 &&
+          totalCharLen > 0 &&
+          everyRetainedPartMeasurable
+        ) {
           const original = tokenCount;
           tokenCount = Math.max(
             1,

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1223,9 +1223,10 @@ type SummaryTokenAdjustment = {
 
 type SummaryScan = {
   boundary?: SummaryBoundary;
-  /** Payload index → tokens of summary text it carries, as recorded on the block
-   *  itself. Used to discount the entry that holds a summary, in token units
-   *  rather than by measuring characters. */
+  /** Payload index → the summary text's cost in the consumer's tokenizer, from
+   *  the block's `rawTokenCount`. Used to discount the entry that holds a
+   *  summary: the same units as `indexTokenCountMap`, and no character
+   *  measurement of the retained content. */
   summaryTokensByIndex: Map<number, number>;
 };
 
@@ -1298,10 +1299,20 @@ function scanSummaryBlocks(payload: TPayload): SummaryScan {
           ? summaryPart.tokenCount
           : 0;
 
-      if (tokenCount > 0) {
+      /** Only `rawTokenCount` is comparable with `indexTokenCountMap`.
+       *  `tokenCount` is the injection budget: provider output-token space when
+       *  usage was reported, plus the wrapper added at injection time. Blocks
+       *  written before this field existed simply get no discount. */
+      const rawTokenCount =
+        typeof summaryPart.rawTokenCount === 'number' &&
+        Number.isFinite(summaryPart.rawTokenCount)
+          ? summaryPart.rawTokenCount
+          : 0;
+
+      if (rawTokenCount > 0) {
         summaryTokensByIndex.set(
           i,
-          (summaryTokensByIndex.get(i) ?? 0) + tokenCount
+          (summaryTokensByIndex.get(i) ?? 0) + rawTokenCount
         );
       }
       const retainedIndex = resolveCoverageIndex(

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1872,25 +1872,44 @@ export const formatAgentMessages = (
         if (contentIndex >= 0 && contentIndex < content.length - 1) {
           let totalCharLen = 0;
           let remainingCharLen = 0;
-          /** Every *retained* part must be one the ratio can represent. A part
-           *  carrying cost unrelated to its length — atomic media above all,
-           *  including media nested inside a tool output — would have that cost
-           *  scaled away: an entry keeping just an image after the summary
-           *  collapses to 1. Parts formatting drops are exempt, contributing
-           *  nothing to either side. */
+          /**
+           * The ratio applies only when *every* part of the entry is one whose
+           * token cost tracks its character length. A single ineligible part
+           * cancels the discount, whichever side of the boundary it sits on.
+           *
+           * Both sides can break it, in opposite directions. A retained image has
+           * its fixed cost scaled away, collapsing the entry. A removed base64
+           * payload inflates the denominator — serializing to a huge length while
+           * the counter charges a fixed estimate — dragging retained text below
+           * its real cost. Either way the request can exceed the window.
+           *
+           * Telling a text-bearing tool payload from a media-bearing one means
+           * recursing into arbitrary nested output, which has already missed a
+           * level twice here. Cancelling instead keeps the original count: an
+           * over-count that prunes early rather than overflowing. Entries of
+           * plain text and reasoning — the common shape — still proportion.
+           */
           let everyRetainedPartMeasurable = true;
           for (let p = 0; p < content.length; p++) {
             const part = content[p];
+            const retained = p > contentIndex;
+
+            if (isDroppedByFormatting(part)) {
+              /** Removed summary text is real removed content: it is read as
+               *  plain text and belongs in the denominator. */
+              if (!retained && part.type === ContentTypes.SUMMARY) {
+                totalCharLen += contentPartCharLength(part);
+              }
+              continue;
+            }
+
             const charLen = contentPartCharLength(part);
+            if (!isCharRatioEligible(part) || (retained && charLen === 0)) {
+              everyRetainedPartMeasurable = false;
+              break;
+            }
             totalCharLen += charLen;
-            if (p > contentIndex) {
-              if (isDroppedByFormatting(part)) {
-                continue;
-              }
-              if (!isCharRatioEligible(part) || charLen === 0) {
-                everyRetainedPartMeasurable = false;
-                break;
-              }
+            if (retained) {
               remainingCharLen += charLen;
             }
           }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1214,20 +1214,12 @@ type SummaryBoundary =
 type SummaryTokenAdjustment = {
   original: number;
   adjusted: number;
-  /** Positional path: characters retained after the slice, and the entry total. */
-  remainingChars?: number;
-  totalChars?: number;
-  /** Coverage path: the summary's own recorded token count, subtracted. */
-  summaryTokens?: number;
+  remainingChars: number;
+  totalChars: number;
 };
 
 type SummaryScan = {
   boundary?: SummaryBoundary;
-  /** Payload index → the summary text's cost in the consumer's tokenizer, from
-   *  the block's `rawTokenCount`. Used to discount the entry that holds a
-   *  summary: the same units as `indexTokenCountMap`, and no character
-   *  measurement of the retained content. */
-  summaryTokensByIndex: Map<number, number>;
 };
 
 function resolveCoverageIndex(
@@ -1251,7 +1243,6 @@ function resolveCoverageIndex(
 
 function scanSummaryBlocks(payload: TPayload): SummaryScan {
   let boundary: SummaryBoundary | undefined;
-  const summaryTokensByIndex = new Map<number, number>();
   /** Filled as the scan advances, so a coverage lookup only ever resolves to a
    *  message already passed — no second pass over the payload. */
   const indexBySourceId = new Map<string, number>();
@@ -1299,22 +1290,6 @@ function scanSummaryBlocks(payload: TPayload): SummaryScan {
           ? summaryPart.tokenCount
           : 0;
 
-      /** Only `rawTokenCount` is comparable with `indexTokenCountMap`.
-       *  `tokenCount` is the injection budget: provider output-token space when
-       *  usage was reported, plus the wrapper added at injection time. Blocks
-       *  written before this field existed simply get no discount. */
-      const rawTokenCount =
-        typeof summaryPart.rawTokenCount === 'number' &&
-        Number.isFinite(summaryPart.rawTokenCount)
-          ? summaryPart.rawTokenCount
-          : 0;
-
-      if (rawTokenCount > 0) {
-        summaryTokensByIndex.set(
-          i,
-          (summaryTokensByIndex.get(i) ?? 0) + rawTokenCount
-        );
-      }
       const retainedIndex = resolveCoverageIndex(
         summaryPart.coverage,
         indexBySourceId,
@@ -1339,7 +1314,7 @@ function scanSummaryBlocks(payload: TPayload): SummaryScan {
     }
   }
 
-  return { boundary, summaryTokensByIndex };
+  return { boundary };
 }
 
 function applySummaryBoundary(
@@ -1457,9 +1432,8 @@ export const formatAgentMessages = (
   /** Cross-run summary extracted from the payload. Should be forwarded to the
    *  agent run so it can be included in the system message via AgentContext. */
   summary?: { text: string; tokenCount: number };
-  /** When a summary reduced a message's token count, returned so the caller can
-   *  log it. The positional path scales by the share of characters that survive
-   *  the slice; the coverage path subtracts the summary's own token count. */
+  /** When a positional summary boundary sliced content from a message, the token
+   *  count was proportionally reduced. Returned so the caller can log it. */
   boundaryTokenAdjustment?: SummaryTokenAdjustment;
 } => {
   const messages: Array<
@@ -1503,8 +1477,7 @@ export const formatAgentMessages = (
   let boundaryTokenAdjustment: SummaryTokenAdjustment | undefined;
   // Keep track of the mapping from original payload indices to result indices
   const indexMapping: Record<number, number[] | undefined> = {};
-  const { boundary: summaryBoundary, summaryTokensByIndex } =
-    scanSummaryBlocks(payload);
+  const { boundary: summaryBoundary } = scanSummaryBlocks(payload);
 
   // Summary metadata is returned to the caller so it can be forwarded to the
   // agent run and included in the single system message via AgentContext.
@@ -1830,6 +1803,22 @@ export const formatAgentMessages = (
         continue;
       }
 
+      /**
+       * Coverage mode deliberately leaves the count alone, even though the entry
+       * holding the block is charged for summary text that `formatAssistantMessage`
+       * filters out and `summary.tokenCount` accounts separately.
+       *
+       * Discounting it needs the summary's cost in the same units as
+       * `indexTokenCountMap`, and that figure is not obtainable here: this
+       * function receives no tokenizer, and a count recorded at write time is in
+       * the writing run's units — `Run.create` derives its counter from the model
+       * in play, and a consumer may supply its own — so a conversation continued
+       * on a different model would subtract across encodings. Attempts to proxy
+       * it (character ratios, provider identity) all under-count some shape,
+       * which risks an over-context request; over-counting merely prunes early.
+       * Fixing it properly means passing the reader a tokenizer, which is a
+       * consumer-facing change and out of scope here.
+       */
       if (
         summaryBoundary?.mode === 'positional' &&
         originalIndex === summaryBoundary.messageIndex &&
@@ -1861,34 +1850,6 @@ export const formatAgentMessages = (
               totalChars: totalCharLen,
             };
           }
-        }
-      } else if (summaryBoundary?.mode === 'coverage') {
-        /**
-         * Coverage keeps the message holding the block, but
-         * `formatAssistantMessage` filters the summary part out of it while the
-         * text is accounted separately as `summary.tokenCount`. Charging the
-         * entry for both double-counts, inflating the prompt estimate and
-         * pruning early.
-         *
-         * Subtracts the summary's own recorded token count rather than scaling
-         * by a share of characters. Character length is the wrong proxy here:
-         * media, tool-call payloads, and nested media inside a tool output all
-         * cost tokens out of proportion to the characters a heuristic can see,
-         * so any ratio built from characters erases whatever it cannot measure.
-         * Subtraction needs no measurement of the retained content at all.
-         */
-        const summaryTokens = summaryTokensByIndex.get(originalIndex) ?? 0;
-        /** A summary claiming the whole entry means the two counts do not share
-         *  a basis; leaving the original over-counts, which prunes early rather
-         *  than sending an over-context request. */
-        if (summaryTokens > 0 && summaryTokens < tokenCount) {
-          const original = tokenCount;
-          tokenCount -= summaryTokens;
-          boundaryTokenAdjustment = {
-            original,
-            adjusted: tokenCount,
-            summaryTokens,
-          };
         }
       }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1189,12 +1189,12 @@ function extractToolNamesFromSearchOutput(output: string): string[] {
 /**
  * How far back a persisted summary reaches.
  *
- * `coverage` is authoritative: the block declared the last source message it
- * replaced, so a recency tail retained at compaction time survives even though
- * it sits earlier in the payload than the block itself. `positional` is the
- * legacy reading for blocks written before coverage existed (or whose covered
- * message is no longer in the payload) — the block's own location is the
- * boundary, which is why it cannot distinguish a retained tail from history.
+ * `coverage` is authoritative: the block named the first source message that
+ * compaction retained, so `messageIndex` is exclusive — everything before it is
+ * covered and it survives whole. `positional` is the legacy reading for blocks
+ * written before coverage existed (or whose anchor is no longer in the payload)
+ * — the block's own location is the boundary, which is why it cannot
+ * distinguish a retained tail from covered history.
  */
 type SummaryBoundary =
   | {
@@ -1211,29 +1211,36 @@ type SummaryBoundary =
       tokenCount: number;
     };
 
+type SummaryScan = {
+  boundary?: SummaryBoundary;
+  /** Payload index → characters of summary text it carries. Summary blocks nest
+   *  their text under `content[]`, which `contentPartCharLength` does not read,
+   *  so the length is captured here where the text is already extracted. */
+  summaryCharsByIndex: Map<number, number>;
+};
+
 function resolveCoverageIndex(
   coverage: SummaryCoverage | undefined,
   indexBySourceId: Map<string, number>,
   summaryMessageIndex: number
 ): number | undefined {
   /** Persisted JSON, so the declared string type is not a runtime guarantee. */
-  if (typeof coverage?.throughMessageId !== 'string') {
+  if (typeof coverage?.retainedFromMessageId !== 'string') {
     return undefined;
   }
-  const throughMessageId = coverage.throughMessageId.trim();
-  if (throughMessageId === '') {
+  const retainedFromMessageId = coverage.retainedFromMessageId.trim();
+  if (retainedFromMessageId === '') {
     return undefined;
   }
-  const coveredIndex = indexBySourceId.get(throughMessageId);
-  return coveredIndex != null && coveredIndex < summaryMessageIndex
-    ? coveredIndex
+  const retainedIndex = indexBySourceId.get(retainedFromMessageId);
+  return retainedIndex != null && retainedIndex <= summaryMessageIndex
+    ? retainedIndex
     : undefined;
 }
 
-function getLatestSummaryBoundary(
-  payload: TPayload
-): SummaryBoundary | undefined {
-  let summaryBoundary: SummaryBoundary | undefined;
+function scanSummaryBlocks(payload: TPayload): SummaryScan {
+  let boundary: SummaryBoundary | undefined;
+  const summaryCharsByIndex = new Map<number, number>();
   /** Filled as the scan advances, so a coverage lookup only ever resolves to a
    *  message already passed — no second pass over the payload. */
   const indexBySourceId = new Map<string, number>();
@@ -1275,22 +1282,27 @@ function getLatestSummaryBoundary(
         continue;
       }
 
+      summaryCharsByIndex.set(
+        i,
+        (summaryCharsByIndex.get(i) ?? 0) + summaryText.length
+      );
+
       const tokenCount =
         typeof summaryPart.tokenCount === 'number' &&
         Number.isFinite(summaryPart.tokenCount)
           ? summaryPart.tokenCount
           : 0;
-      const coveredIndex = resolveCoverageIndex(
+      const retainedIndex = resolveCoverageIndex(
         summaryPart.coverage,
         indexBySourceId,
         i
       );
 
-      summaryBoundary =
-        coveredIndex != null
+      boundary =
+        retainedIndex != null
           ? {
             mode: 'coverage',
-            messageIndex: coveredIndex,
+            messageIndex: retainedIndex,
             text: summaryText,
             tokenCount,
           }
@@ -1304,7 +1316,7 @@ function getLatestSummaryBoundary(
     }
   }
 
-  return summaryBoundary;
+  return { boundary, summaryCharsByIndex };
 }
 
 function applySummaryBoundary(
@@ -1316,12 +1328,12 @@ function applySummaryBoundary(
     return message;
   }
 
-  /** The covered message is replaced by the summary, so the boundary is
-   *  inclusive; everything after it — including a retained recency tail —
-   *  stays verbatim. The block's own message is untouched: its summary part
-   *  is dropped later by `formatAssistantMessage`. */
+  /** The boundary names the first retained message, so it is exclusive: that
+   *  message and everything after it — the recency tail included — stays
+   *  verbatim, and only genuinely covered history is dropped. Summary parts on
+   *  surviving messages are filtered later by `formatAssistantMessage`. */
   if (summaryBoundary.mode === 'coverage') {
-    return messageIndex <= summaryBoundary.messageIndex ? null : message;
+    return messageIndex < summaryBoundary.messageIndex ? null : message;
   }
 
   if (messageIndex < summaryBoundary.messageIndex) {
@@ -1466,7 +1478,8 @@ export const formatAgentMessages = (
     | undefined;
   // Keep track of the mapping from original payload indices to result indices
   const indexMapping: Record<number, number[] | undefined> = {};
-  const summaryBoundary = getLatestSummaryBoundary(payload);
+  const { boundary: summaryBoundary, summaryCharsByIndex } =
+    scanSummaryBlocks(payload);
 
   // Summary metadata is returned to the caller so it can be forwarded to the
   // agent run and included in the single system message via AgentContext.
@@ -1823,6 +1836,38 @@ export const formatAgentMessages = (
               totalChars: totalCharLen,
             };
           }
+        }
+      } else if (
+        summaryBoundary?.mode === 'coverage' &&
+        summaryCharsByIndex.has(originalIndex) &&
+        Array.isArray(payload[originalIndex].content)
+      ) {
+        /** Coverage keeps the block's own message, but `formatAssistantMessage`
+         *  filters the summary part out of it and the text is accounted
+         *  separately as `summary.tokenCount`. Charging the entry for both
+         *  double-counts, inflating the prompt estimate and pruning early. */
+        const content = payload[originalIndex]
+          .content as MessageContentComplex[];
+        let retainedCharLen = 0;
+        for (let p = 0; p < content.length; p++) {
+          if (content[p]?.type !== ContentTypes.SUMMARY) {
+            retainedCharLen += contentPartCharLength(content[p]);
+          }
+        }
+        const summaryCharLen = summaryCharsByIndex.get(originalIndex) ?? 0;
+        const totalCharLen = retainedCharLen + summaryCharLen;
+        if (summaryCharLen > 0 && totalCharLen > 0) {
+          const original = tokenCount;
+          tokenCount = Math.max(
+            1,
+            Math.round(tokenCount * (retainedCharLen / totalCharLen))
+          );
+          boundaryTokenAdjustment = {
+            original,
+            adjusted: tokenCount,
+            remainingChars: retainedCharLen,
+            totalChars: totalCharLen,
+          };
         }
       }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -1353,6 +1353,28 @@ function applySummaryBoundary(
   };
 }
 
+/**
+ * Whether `formatAssistantMessage` filters this part out of the emitted message.
+ * Such a part contributes no prompt tokens, so measuring it as zero characters
+ * is accurate rather than a blind spot — it must not be mistaken for content the
+ * char heuristic cannot see.
+ */
+function isDroppedByFormatting(
+  part: MessageContentComplex | undefined
+): boolean {
+  if (part == null) {
+    return true;
+  }
+  if (
+    part.type === ContentTypes.ERROR ||
+    part.type === ContentTypes.AGENT_UPDATE ||
+    part.type === ContentTypes.ACTIVITY_LABEL
+  ) {
+    return true;
+  }
+  return part.type === ContentTypes.TEXT && getTextContent(part).trim() === '';
+}
+
 function measureValueChars(value: unknown): number {
   if (typeof value === 'string') {
     return value.length;
@@ -1871,10 +1893,15 @@ export const formatAgentMessages = (
          *  over-context request. */
         let everyRetainedPartMeasurable = true;
         for (let p = 0; p < content.length; p++) {
-          if (content[p]?.type === ContentTypes.SUMMARY) {
+          const part = content[p];
+          /** Null-guarded first, so the type check below needs no optional chain. */
+          if (
+            isDroppedByFormatting(part) ||
+            part.type === ContentTypes.SUMMARY
+          ) {
             continue;
           }
-          const charLen = contentPartCharLength(content[p]);
+          const charLen = contentPartCharLength(part);
           if (charLen === 0) {
             everyRetainedPartMeasurable = false;
             break;

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -4783,6 +4783,77 @@ describe('formatAgentMessages', () => {
   });
 
   describe('summary boundary token count adjustment', () => {
+    /** Atomic media costs a fixed provider price the character heuristic cannot
+     *  see, so scaling by the measurable siblings alone erases it. Both shapes
+     *  collapsed a four-figure count to 1 before this guard. */
+    it.each([
+      [
+        'text before the summary',
+        { type: ContentTypes.TEXT, text: 'hello there' },
+      ],
+      [
+        'a tool call before the summary',
+        {
+          type: ContentTypes.TOOL_CALL,
+          tool_call: {
+            id: 'tc1',
+            name: 'search',
+            args: '{"q":"x"}',
+            output: 'result text',
+          },
+        },
+      ],
+    ])(
+      'skips the positional discount when retained media is unmeasurable, with %s',
+      (_label, leading) => {
+        const payload: TPayload = [
+          {
+            role: 'assistant',
+            content: [
+              leading as MessageContentComplex,
+              {
+                type: ContentTypes.SUMMARY,
+                text: 'S'.repeat(400),
+                tokenCount: 100,
+              },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,x' },
+              },
+            ],
+          },
+        ];
+
+        const result = formatAgentMessages(payload, { 0: 1200 });
+
+        expect(result.indexTokenCountMap?.[0]).toBe(1200);
+        expect(result.boundaryTokenAdjustment).toBeUndefined();
+      }
+    );
+
+    it('still proportions when every retained part is measurable', () => {
+      const payload: TPayload = [
+        {
+          role: 'assistant',
+          content: [
+            { type: ContentTypes.TEXT, text: 'a'.repeat(400) },
+            {
+              type: ContentTypes.SUMMARY,
+              text: 'S'.repeat(100),
+              tokenCount: 20,
+            },
+            { type: ContentTypes.TEXT, text: 'b'.repeat(100) },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 600 });
+
+      expect(result.boundaryTokenAdjustment?.original).toBe(600);
+      expect(result.indexTokenCountMap?.[0]).toBeLessThan(600);
+      expect(result.indexTokenCountMap?.[0]).toBeGreaterThan(0);
+    });
+
     it('should proportion token count when thinking block is sliced off by boundary', () => {
       const thinkingText = 'x'.repeat(1000);
       const payload: TPayload = [

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5143,6 +5143,38 @@ describe('formatAgentMessages', () => {
       expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
+    /** A measurable caption alongside an unmeasurable image must not license the
+     *  discount: the caption's characters would stand in for the image's real
+     *  token cost and scale roughly a thousand image tokens down to nearly 1. */
+    it('leaves the count alone when only some retained parts are measurable', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        { messageId: 'm2', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
+              tokenCount: 120,
+              coverage: { retainedFromMessageId: 'm2' },
+            },
+            { type: ContentTypes.TEXT, text: 'Here it is' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,x' },
+            },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 1100 });
+
+      expect(result.indexTokenCountMap?.[1]).toBe(1100);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
+    });
+
     /** The summary text is returned separately as `summary.tokenCount`, so
      *  leaving it in its own entry's count charges the prompt for it twice. */
     it('discounts the filtered summary text from its own entry', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -4831,6 +4831,48 @@ describe('formatAgentMessages', () => {
       }
     );
 
+    /** The media sits a level down, inside `tool_call.output`, where serializing
+     *  gives it a nonzero length while the token counter charges its fixed media
+     *  cost. Eligibility is decided by part type, so nesting depth is irrelevant. */
+    it('skips the positional discount when retained tool output carries media', () => {
+      const payload: TPayload = [
+        {
+          role: 'assistant',
+          content: [
+            { type: ContentTypes.TEXT, text: 'a'.repeat(4000) },
+            {
+              type: ContentTypes.SUMMARY,
+              text: 'S'.repeat(400),
+              tokenCount: 100,
+            },
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'tc1',
+                name: 'render',
+                args: '{}',
+                output: [
+                  {
+                    type: 'image_url',
+                    image_url: { url: 'data:image/png;base64,y' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 4000 });
+
+      const emitted = Object.values(result.indexTokenCountMap ?? {}).reduce(
+        (sum, value) => sum + value,
+        0
+      );
+      expect(emitted).toBe(4000);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
+    });
+
     it('still proportions when every retained part is measurable', () => {
       const payload: TPayload = [
         {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5007,6 +5007,7 @@ describe('formatAgentMessages', () => {
         { type: ContentTypes.TEXT, text: 'Summary of the earliest turns' },
       ],
       tokenCount: 12,
+      rawTokenCount: 12,
       ...(coverage != null ? { coverage } : {}),
     });
 
@@ -5128,7 +5129,8 @@ describe('formatAgentMessages', () => {
             {
               type: ContentTypes.SUMMARY,
               content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 120,
+              tokenCount: 999,
+              rawTokenCount: 120,
               coverage: { retainedFromMessageId: 'm2' },
             },
             part as MessageContentComplex,
@@ -5146,6 +5148,34 @@ describe('formatAgentMessages', () => {
       expect(result.boundaryTokenAdjustment?.adjusted).toBe(980);
     });
 
+    /** `tokenCount` is the injection budget — provider output-token space plus a
+     *  wrapper — so it is not comparable with `indexTokenCountMap`. A block that
+     *  carries only that figure must not be subtracted from the entry. */
+    it('ignores the provider-space token count when no raw count is recorded', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        { messageId: 'm2', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
+              tokenCount: 900,
+              coverage: { retainedFromMessageId: 'm2' },
+            },
+            { type: ContentTypes.TEXT, text: 'Reply' },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 1000 });
+
+      expect(result.indexTokenCountMap?.[1]).toBe(1000);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
+    });
+
     it('leaves the count alone when the summary claims the whole entry', () => {
       const payload: TPayload = [
         { messageId: 'm1', role: 'user', content: 'Covered question' },
@@ -5158,6 +5188,7 @@ describe('formatAgentMessages', () => {
               type: ContentTypes.SUMMARY,
               content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
               tokenCount: 500,
+              rawTokenCount: 500,
               coverage: { retainedFromMessageId: 'm2' },
             },
             { type: ContentTypes.TEXT, text: 'Short reply' },

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -4929,7 +4929,10 @@ describe('formatAgentMessages', () => {
       expect(result.indexTokenCountMap?.[1]).toBe(8);
     });
 
-    it('should proportion token count when thinking + tool_use are sliced off', () => {
+    /** Reframed: a tool call anywhere in the entry now cancels the ratio, since
+     *  telling a text-bearing tool payload from a media-bearing one requires
+     *  recursing into arbitrary nested output. The entry keeps its count. */
+    it('should not proportion when a tool_use part is present', () => {
       const thinkingText = 'a'.repeat(800);
       const toolInput = JSON.stringify({ data: 'b'.repeat(400) });
       const payload: TPayload = [
@@ -4965,8 +4968,8 @@ describe('formatAgentMessages', () => {
         result.indexTokenCountMap || {}
       ).reduce((sum, v) => sum + v, 0);
 
-      expect(totalOutputTokens).toBeLessThan(200);
-      expect(totalOutputTokens).toBeGreaterThan(0);
+      expect(totalOutputTokens).toBe(2000);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
     it('should roughly halve token count when content is evenly split around boundary', () => {
@@ -5022,7 +5025,11 @@ describe('formatAgentMessages', () => {
       expect(result.indexTokenCountMap?.[1]).toBe(10);
     });
 
-    it('should account for tool_use input size in the char-length ratio', () => {
+    /** Previously the removed `tool_use` input was counted into the denominator.
+     *  A base64 payload there serializes to a huge length while the counter
+     *  charges a fixed estimate, so the ratio dragged retained text below its
+     *  real cost. The discount is cancelled instead. */
+    it('should not use tool_use input size in the char-length ratio', () => {
       const hugeInput = JSON.stringify({ payload: 'z'.repeat(5000) });
       const payload: TPayload = [
         {
@@ -5048,8 +5055,8 @@ describe('formatAgentMessages', () => {
       expect(result.summary).toBeDefined();
 
       const adjustedTokens = result.indexTokenCountMap?.[0] ?? 0;
-      expect(adjustedTokens).toBeLessThan(100);
-      expect(adjustedTokens).toBeGreaterThan(0);
+      expect(adjustedTokens).toBe(3000);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
     it('should handle multiple content parts after the boundary', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5076,46 +5076,48 @@ describe('formatAgentMessages', () => {
       expect(Object.keys(result.indexTokenCountMap ?? {})).toHaveLength(3);
     });
 
-    /** The tool call and its ToolMessage are still sent, so scaling the entry
-     *  down to the summary's share would hide nearly all of its tokens from
-     *  the pruner and let the request overflow the context window. */
-    it('keeps tool-call tokens when discounting a summary alongside them', () => {
-      const payload: TPayload = [
-        { messageId: 'm1', role: 'user', content: 'Covered question' },
-        { messageId: 'm2', role: 'user', content: 'Retained question' },
+    /** The summary text is returned separately as `summary.tokenCount`, so
+     *  leaving it in its own entry's count charges the prompt for it twice. */
+    it('subtracts the summary tokens from the entry that carries it', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ retainedFromMessageId: 'm3' }),
+        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
+      );
+
+      expect(result.indexTokenCountMap?.[2]).toBe(28);
+      expect(result.boundaryTokenAdjustment).toEqual({
+        original: 40,
+        adjusted: 28,
+        summaryTokens: 12,
+      });
+    });
+
+    /** Subtraction is in token units, so content the character heuristic cannot
+     *  see — media, tool-call payloads, media nested inside a tool output —
+     *  keeps its cost instead of being scaled away by a ratio. */
+    it.each([
+      [
+        'an image',
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,x' } },
+      ],
+      [
+        'a tool call whose output is media',
         {
-          messageId: 'm3',
-          role: 'assistant',
-          content: [
-            {
-              type: ContentTypes.SUMMARY,
-              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 120,
-              coverage: { retainedFromMessageId: 'm2' },
-            },
-            {
-              type: ContentTypes.TOOL_CALL,
-              tool_call: {
-                id: 'tc1',
-                name: 'search',
-                args: JSON.stringify({ q: 'x'.repeat(4000) }),
-                output: 'y'.repeat(4000),
+          type: ContentTypes.TOOL_CALL,
+          tool_call: {
+            id: 'tc1',
+            name: 'render',
+            args: '{}',
+            output: [
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,y' },
               },
-            },
-          ],
+            ],
+          },
         },
-      ];
-
-      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 3000 });
-
-      const emittedTotal = Object.values(
-        result.indexTokenCountMap ?? {}
-      ).reduce((sum, value) => sum + value, 0);
-      expect(emittedTotal).toBeGreaterThan(2500);
-      expect(result.boundaryTokenAdjustment?.adjusted).toBeGreaterThan(2500);
-    });
-
-    it('leaves the count alone when retained parts cannot be measured', () => {
+      ],
+    ])('preserves non-summary tokens alongside %s', (_label, part) => {
       const payload: TPayload = [
         { messageId: 'm1', role: 'user', content: 'Covered question' },
         { messageId: 'm2', role: 'user', content: 'Retained question' },
@@ -5129,56 +5131,22 @@ describe('formatAgentMessages', () => {
               tokenCount: 120,
               coverage: { retainedFromMessageId: 'm2' },
             },
-            {
-              type: 'image_url',
-              image_url: { url: 'data:image/png;base64,x' },
-            },
-          ],
-        },
-      ];
-
-      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 900 });
-
-      expect(result.indexTokenCountMap?.[1]).toBe(900);
-      expect(result.boundaryTokenAdjustment).toBeUndefined();
-    });
-
-    /** A measurable caption alongside an unmeasurable image must not license the
-     *  discount: the caption's characters would stand in for the image's real
-     *  token cost and scale roughly a thousand image tokens down to nearly 1. */
-    it('leaves the count alone when only some retained parts are measurable', () => {
-      const payload: TPayload = [
-        { messageId: 'm1', role: 'user', content: 'Covered question' },
-        { messageId: 'm2', role: 'user', content: 'Retained question' },
-        {
-          messageId: 'm3',
-          role: 'assistant',
-          content: [
-            {
-              type: ContentTypes.SUMMARY,
-              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 120,
-              coverage: { retainedFromMessageId: 'm2' },
-            },
-            { type: ContentTypes.TEXT, text: 'Here it is' },
-            {
-              type: 'image_url',
-              image_url: { url: 'data:image/png;base64,x' },
-            },
+            part as MessageContentComplex,
           ],
         },
       ];
 
       const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 1100 });
 
-      expect(result.indexTokenCountMap?.[1]).toBe(1100);
-      expect(result.boundaryTokenAdjustment).toBeUndefined();
+      const emitted = Object.values(result.indexTokenCountMap ?? {}).reduce(
+        (sum, value) => sum + value,
+        0
+      );
+      expect(emitted).toBe(1100 - 120 + 6);
+      expect(result.boundaryTokenAdjustment?.adjusted).toBe(980);
     });
 
-    /** An empty text block is dropped by formatting and costs no tokens, so its
-     *  zero length is accurate — it must not be read as unmeasurable content and
-     *  disable the discount, which would restore the double count. */
-    it('still discounts when a retained part is zero-cost rather than unmeasurable', () => {
+    it('leaves the count alone when the summary claims the whole entry', () => {
       const payload: TPayload = [
         { messageId: 'm1', role: 'user', content: 'Covered question' },
         { messageId: 'm2', role: 'user', content: 'Retained question' },
@@ -5189,37 +5157,18 @@ describe('formatAgentMessages', () => {
             {
               type: ContentTypes.SUMMARY,
               content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 120,
+              tokenCount: 500,
               coverage: { retainedFromMessageId: 'm2' },
             },
-            { type: ContentTypes.TEXT, text: '' },
-            { type: ContentTypes.TEXT, text: 'R'.repeat(500) },
+            { type: ContentTypes.TEXT, text: 'Short reply' },
           ],
         },
       ];
 
-      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 300 });
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 400 });
 
-      expect(result.boundaryTokenAdjustment?.original).toBe(300);
-      expect(result.indexTokenCountMap?.[1]).toBeLessThan(300);
-      expect(result.indexTokenCountMap?.[1]).toBeGreaterThan(100);
-    });
-
-    /** The summary text is returned separately as `summary.tokenCount`, so
-     *  leaving it in its own entry's count charges the prompt for it twice. */
-    it('discounts the filtered summary text from its own entry', () => {
-      const withSummary = formatAgentMessages(
-        compactedPayload({ retainedFromMessageId: 'm3' }),
-        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
-      );
-
-      const blockEntryTokens = withSummary.indexTokenCountMap?.[2];
-      expect(blockEntryTokens).toBeLessThan(40);
-      expect(blockEntryTokens).toBeGreaterThan(0);
-      expect(withSummary.boundaryTokenAdjustment?.original).toBe(40);
-      expect(withSummary.boundaryTokenAdjustment?.adjusted).toBe(
-        blockEntryTokens
-      );
+      expect(result.indexTokenCountMap?.[1]).toBe(400);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
     it('leaves entries without summary parts untouched', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5007,7 +5007,6 @@ describe('formatAgentMessages', () => {
         { type: ContentTypes.TEXT, text: 'Summary of the earliest turns' },
       ],
       tokenCount: 12,
-      rawTokenCount: 12,
       ...(coverage != null ? { coverage } : {}),
     });
 
@@ -5066,59 +5065,12 @@ describe('formatAgentMessages', () => {
       ]);
     });
 
-    it('keeps token counts for the retained tail and drops covered entries', () => {
-      const result = formatAgentMessages(
-        compactedPayload({ retainedFromMessageId: 'm3' }),
-        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
-      );
-
-      expect(result.indexTokenCountMap?.[0]).toBe(7);
-      expect(result.indexTokenCountMap?.[1]).toBe(8);
-      expect(Object.keys(result.indexTokenCountMap ?? {})).toHaveLength(3);
-    });
-
-    /** The summary text is returned separately as `summary.tokenCount`, so
-     *  leaving it in its own entry's count charges the prompt for it twice. */
-    it('subtracts the summary tokens from the entry that carries it', () => {
-      const result = formatAgentMessages(
-        compactedPayload({ retainedFromMessageId: 'm3' }),
-        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
-      );
-
-      expect(result.indexTokenCountMap?.[2]).toBe(28);
-      expect(result.boundaryTokenAdjustment).toEqual({
-        original: 40,
-        adjusted: 28,
-        summaryTokens: 12,
-      });
-    });
-
-    /** Subtraction is in token units, so content the character heuristic cannot
-     *  see — media, tool-call payloads, media nested inside a tool output —
-     *  keeps its cost instead of being scaled away by a ratio. */
-    it.each([
-      [
-        'an image',
-        { type: 'image_url', image_url: { url: 'data:image/png;base64,x' } },
-      ],
-      [
-        'a tool call whose output is media',
-        {
-          type: ContentTypes.TOOL_CALL,
-          tool_call: {
-            id: 'tc1',
-            name: 'render',
-            args: '{}',
-            output: [
-              {
-                type: 'image_url',
-                image_url: { url: 'data:image/png;base64,y' },
-              },
-            ],
-          },
-        },
-      ],
-    ])('preserves non-summary tokens alongside %s', (_label, part) => {
+    /** Coverage mode leaves the block's entry at its full count on purpose. The
+     *  summary's cost in the reader's token units is not obtainable here — no
+     *  tokenizer reaches this function, and a figure recorded at write time is
+     *  in the writing run's units. Over-counting prunes early; under-counting
+     *  would risk an over-context request. */
+    it('does not discount the entry carrying the summary block', () => {
       const payload: TPayload = [
         { messageId: 'm1', role: 'user', content: 'Covered question' },
         { messageId: 'm2', role: 'user', content: 'Retained question' },
@@ -5129,40 +5081,7 @@ describe('formatAgentMessages', () => {
             {
               type: ContentTypes.SUMMARY,
               content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 999,
-              rawTokenCount: 120,
-              coverage: { retainedFromMessageId: 'm2' },
-            },
-            part as MessageContentComplex,
-          ],
-        },
-      ];
-
-      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 1100 });
-
-      const emitted = Object.values(result.indexTokenCountMap ?? {}).reduce(
-        (sum, value) => sum + value,
-        0
-      );
-      expect(emitted).toBe(1100 - 120 + 6);
-      expect(result.boundaryTokenAdjustment?.adjusted).toBe(980);
-    });
-
-    /** `tokenCount` is the injection budget — provider output-token space plus a
-     *  wrapper — so it is not comparable with `indexTokenCountMap`. A block that
-     *  carries only that figure must not be subtracted from the entry. */
-    it('ignores the provider-space token count when no raw count is recorded', () => {
-      const payload: TPayload = [
-        { messageId: 'm1', role: 'user', content: 'Covered question' },
-        { messageId: 'm2', role: 'user', content: 'Retained question' },
-        {
-          messageId: 'm3',
-          role: 'assistant',
-          content: [
-            {
-              type: ContentTypes.SUMMARY,
-              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 900,
+              tokenCount: 120,
               coverage: { retainedFromMessageId: 'm2' },
             },
             { type: ContentTypes.TEXT, text: 'Reply' },
@@ -5176,30 +5095,15 @@ describe('formatAgentMessages', () => {
       expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
-    it('leaves the count alone when the summary claims the whole entry', () => {
-      const payload: TPayload = [
-        { messageId: 'm1', role: 'user', content: 'Covered question' },
-        { messageId: 'm2', role: 'user', content: 'Retained question' },
-        {
-          messageId: 'm3',
-          role: 'assistant',
-          content: [
-            {
-              type: ContentTypes.SUMMARY,
-              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
-              tokenCount: 500,
-              rawTokenCount: 500,
-              coverage: { retainedFromMessageId: 'm2' },
-            },
-            { type: ContentTypes.TEXT, text: 'Short reply' },
-          ],
-        },
-      ];
+    it('keeps token counts for the retained tail and drops covered entries', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ retainedFromMessageId: 'm3' }),
+        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
+      );
 
-      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 400 });
-
-      expect(result.indexTokenCountMap?.[1]).toBe(400);
-      expect(result.boundaryTokenAdjustment).toBeUndefined();
+      expect(result.indexTokenCountMap?.[0]).toBe(7);
+      expect(result.indexTokenCountMap?.[1]).toBe(8);
+      expect(Object.keys(result.indexTokenCountMap ?? {})).toHaveLength(3);
     });
 
     it('leaves entries without summary parts untouched', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5076,6 +5076,73 @@ describe('formatAgentMessages', () => {
       expect(Object.keys(result.indexTokenCountMap ?? {})).toHaveLength(3);
     });
 
+    /** The tool call and its ToolMessage are still sent, so scaling the entry
+     *  down to the summary's share would hide nearly all of its tokens from
+     *  the pruner and let the request overflow the context window. */
+    it('keeps tool-call tokens when discounting a summary alongside them', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        { messageId: 'm2', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
+              tokenCount: 120,
+              coverage: { retainedFromMessageId: 'm2' },
+            },
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'tc1',
+                name: 'search',
+                args: JSON.stringify({ q: 'x'.repeat(4000) }),
+                output: 'y'.repeat(4000),
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 3000 });
+
+      const emittedTotal = Object.values(
+        result.indexTokenCountMap ?? {}
+      ).reduce((sum, value) => sum + value, 0);
+      expect(emittedTotal).toBeGreaterThan(2500);
+      expect(result.boundaryTokenAdjustment?.adjusted).toBeGreaterThan(2500);
+    });
+
+    it('leaves the count alone when retained parts cannot be measured', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        { messageId: 'm2', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
+              tokenCount: 120,
+              coverage: { retainedFromMessageId: 'm2' },
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,x' },
+            },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 900 });
+
+      expect(result.indexTokenCountMap?.[1]).toBe(900);
+      expect(result.boundaryTokenAdjustment).toBeUndefined();
+    });
+
     /** The summary text is returned separately as `summary.tokenCount`, so
      *  leaving it in its own entry's count charges the prompt for it twice. */
     it('discounts the filtered summary text from its own entry', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -4999,7 +4999,9 @@ describe('formatAgentMessages', () => {
   });
 
   describe('summary coverage boundary', () => {
-    const buildSummaryPart = (coverage?: { throughMessageId: string }) => ({
+    const buildSummaryPart = (coverage?: {
+      retainedFromMessageId: string;
+    }) => ({
       type: ContentTypes.SUMMARY,
       content: [
         { type: ContentTypes.TEXT, text: 'Summary of the earliest turns' },
@@ -5012,7 +5014,7 @@ describe('formatAgentMessages', () => {
      *  into the summary, m3/m4 are the retained tail, and the block itself is
      *  persisted on the assistant message that came after all of them. */
     const compactedPayload = (coverage?: {
-      throughMessageId: string;
+      retainedFromMessageId: string;
     }): TPayload => [
       { messageId: 'm1', role: 'user', content: 'Covered question' },
       { messageId: 'm2', role: 'assistant', content: 'Covered answer' },
@@ -5040,7 +5042,7 @@ describe('formatAgentMessages', () => {
 
     it('preserves the retained tail that the summary never covered', () => {
       const result = formatAgentMessages(
-        compactedPayload({ throughMessageId: 'm2' })
+        compactedPayload({ retainedFromMessageId: 'm3' })
       );
 
       expect(result.messages.map(textOf)).toEqual([
@@ -5052,9 +5054,9 @@ describe('formatAgentMessages', () => {
       expect(result.summary!.tokenCount).toBe(12);
     });
 
-    it('drops the covered message itself, not just everything before it', () => {
+    it('retains the anchor message itself, dropping only what precedes it', () => {
       const result = formatAgentMessages(
-        compactedPayload({ throughMessageId: 'm3' })
+        compactedPayload({ retainedFromMessageId: 'm4' })
       );
 
       expect(result.messages.map(textOf)).toEqual([
@@ -5065,11 +5067,40 @@ describe('formatAgentMessages', () => {
 
     it('keeps token counts for the retained tail and drops covered entries', () => {
       const result = formatAgentMessages(
-        compactedPayload({ throughMessageId: 'm2' }),
+        compactedPayload({ retainedFromMessageId: 'm3' }),
         { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
       );
 
-      expect(result.indexTokenCountMap).toEqual({ 0: 7, 1: 8, 2: 40 });
+      expect(result.indexTokenCountMap?.[0]).toBe(7);
+      expect(result.indexTokenCountMap?.[1]).toBe(8);
+      expect(Object.keys(result.indexTokenCountMap ?? {})).toHaveLength(3);
+    });
+
+    /** The summary text is returned separately as `summary.tokenCount`, so
+     *  leaving it in its own entry's count charges the prompt for it twice. */
+    it('discounts the filtered summary text from its own entry', () => {
+      const withSummary = formatAgentMessages(
+        compactedPayload({ retainedFromMessageId: 'm3' }),
+        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
+      );
+
+      const blockEntryTokens = withSummary.indexTokenCountMap?.[2];
+      expect(blockEntryTokens).toBeLessThan(40);
+      expect(blockEntryTokens).toBeGreaterThan(0);
+      expect(withSummary.boundaryTokenAdjustment?.original).toBe(40);
+      expect(withSummary.boundaryTokenAdjustment?.adjusted).toBe(
+        blockEntryTokens
+      );
+    });
+
+    it('leaves entries without summary parts untouched', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ retainedFromMessageId: 'm3' }),
+        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
+      );
+
+      expect(result.indexTokenCountMap?.[0]).toBe(7);
+      expect(result.indexTokenCountMap?.[1]).toBe(8);
     });
 
     it('falls back to positional trimming for legacy blocks without coverage', () => {
@@ -5081,18 +5112,22 @@ describe('formatAgentMessages', () => {
 
     it('falls back to positional trimming when coverage cannot be resolved', () => {
       const result = formatAgentMessages(
-        compactedPayload({ throughMessageId: 'pruned-from-payload' })
+        compactedPayload({ retainedFromMessageId: 'pruned-from-payload' })
       );
 
       expect(result.messages.map(textOf)).toEqual(['Post-compaction reply']);
     });
 
-    it('ignores coverage pointing at or past its own block', () => {
-      const result = formatAgentMessages(
-        compactedPayload({ throughMessageId: 'm5' })
-      );
+    it('ignores an anchor pointing past its own block', () => {
+      const result = formatAgentMessages([
+        ...compactedPayload({ retainedFromMessageId: 'm6' }),
+        { messageId: 'm6', role: 'user', content: 'Later question' },
+      ]);
 
-      expect(result.messages.map(textOf)).toEqual(['Post-compaction reply']);
+      expect(result.messages.map(textOf)).toEqual([
+        'Post-compaction reply',
+        'Later question',
+      ]);
     });
 
     it('applies last-summary-wins across mixed coverage and legacy blocks', () => {
@@ -5115,7 +5150,7 @@ describe('formatAgentMessages', () => {
           messageId: 'm4',
           role: 'assistant',
           content: [
-            buildSummaryPart({ throughMessageId: 'm2' }),
+            buildSummaryPart({ retainedFromMessageId: 'm3' }),
             { type: ContentTypes.TEXT, text: 'Newest reply' },
           ],
         },

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -11,6 +11,7 @@ import {
   convertMessagesToResponsesInput,
   convertResponsesMessageToAIMessage,
 } from '@langchain/openai';
+import type { BaseMessage } from '@langchain/core/messages';
 import type { MessageContentComplex, TPayload } from '@/types';
 import {
   convertMessagesToContent,
@@ -4994,6 +4995,139 @@ describe('formatAgentMessages', () => {
       const adjustedTokens = result.indexTokenCountMap?.[0];
       expect(adjustedTokens).toBeDefined();
       expect(Number.isInteger(adjustedTokens)).toBe(true);
+    });
+  });
+
+  describe('summary coverage boundary', () => {
+    const buildSummaryPart = (coverage?: { throughMessageId: string }) => ({
+      type: ContentTypes.SUMMARY,
+      content: [
+        { type: ContentTypes.TEXT, text: 'Summary of the earliest turns' },
+      ],
+      tokenCount: 12,
+      ...(coverage != null ? { coverage } : {}),
+    });
+
+    /** Mirrors a compaction with `retainRecent.turns: 1`: m1/m2 were refined
+     *  into the summary, m3/m4 are the retained tail, and the block itself is
+     *  persisted on the assistant message that came after all of them. */
+    const compactedPayload = (coverage?: {
+      throughMessageId: string;
+    }): TPayload => [
+      { messageId: 'm1', role: 'user', content: 'Covered question' },
+      { messageId: 'm2', role: 'assistant', content: 'Covered answer' },
+      { messageId: 'm3', role: 'user', content: 'Retained question' },
+      { messageId: 'm4', role: 'assistant', content: 'Retained answer' },
+      {
+        messageId: 'm5',
+        role: 'assistant',
+        content: [
+          buildSummaryPart(coverage),
+          { type: ContentTypes.TEXT, text: 'Post-compaction reply' },
+        ],
+      },
+    ];
+
+    const textOf = (message: BaseMessage): string => {
+      const { content } = message;
+      if (typeof content === 'string') {
+        return content;
+      }
+      return (content as MessageContentComplex[])
+        .map((part) => ('text' in part ? (part as { text: string }).text : ''))
+        .join('');
+    };
+
+    it('preserves the retained tail that the summary never covered', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ throughMessageId: 'm2' })
+      );
+
+      expect(result.messages.map(textOf)).toEqual([
+        'Retained question',
+        'Retained answer',
+        'Post-compaction reply',
+      ]);
+      expect(result.summary!.text).toBe('Summary of the earliest turns');
+      expect(result.summary!.tokenCount).toBe(12);
+    });
+
+    it('drops the covered message itself, not just everything before it', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ throughMessageId: 'm3' })
+      );
+
+      expect(result.messages.map(textOf)).toEqual([
+        'Retained answer',
+        'Post-compaction reply',
+      ]);
+    });
+
+    it('keeps token counts for the retained tail and drops covered entries', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ throughMessageId: 'm2' }),
+        { 0: 5, 1: 6, 2: 7, 3: 8, 4: 40 }
+      );
+
+      expect(result.indexTokenCountMap).toEqual({ 0: 7, 1: 8, 2: 40 });
+    });
+
+    it('falls back to positional trimming for legacy blocks without coverage', () => {
+      const result = formatAgentMessages(compactedPayload());
+
+      expect(result.messages.map(textOf)).toEqual(['Post-compaction reply']);
+      expect(result.summary!.text).toBe('Summary of the earliest turns');
+    });
+
+    it('falls back to positional trimming when coverage cannot be resolved', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ throughMessageId: 'pruned-from-payload' })
+      );
+
+      expect(result.messages.map(textOf)).toEqual(['Post-compaction reply']);
+    });
+
+    it('ignores coverage pointing at or past its own block', () => {
+      const result = formatAgentMessages(
+        compactedPayload({ throughMessageId: 'm5' })
+      );
+
+      expect(result.messages.map(textOf)).toEqual(['Post-compaction reply']);
+    });
+
+    it('applies last-summary-wins across mixed coverage and legacy blocks', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        {
+          messageId: 'm2',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              text: 'Older summary',
+              tokenCount: 3,
+            },
+            { type: ContentTypes.TEXT, text: 'Older tail' },
+          ],
+        },
+        { messageId: 'm3', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm4',
+          role: 'assistant',
+          content: [
+            buildSummaryPart({ throughMessageId: 'm2' }),
+            { type: ContentTypes.TEXT, text: 'Newest reply' },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload);
+
+      expect(result.messages.map(textOf)).toEqual([
+        'Retained question',
+        'Newest reply',
+      ]);
+      expect(result.summary!.text).toBe('Summary of the earliest turns');
     });
   });
 

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5175,6 +5175,36 @@ describe('formatAgentMessages', () => {
       expect(result.boundaryTokenAdjustment).toBeUndefined();
     });
 
+    /** An empty text block is dropped by formatting and costs no tokens, so its
+     *  zero length is accurate — it must not be read as unmeasurable content and
+     *  disable the discount, which would restore the double count. */
+    it('still discounts when a retained part is zero-cost rather than unmeasurable', () => {
+      const payload: TPayload = [
+        { messageId: 'm1', role: 'user', content: 'Covered question' },
+        { messageId: 'm2', role: 'user', content: 'Retained question' },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.SUMMARY,
+              content: [{ type: ContentTypes.TEXT, text: 'S'.repeat(500) }],
+              tokenCount: 120,
+              coverage: { retainedFromMessageId: 'm2' },
+            },
+            { type: ContentTypes.TEXT, text: '' },
+            { type: ContentTypes.TEXT, text: 'R'.repeat(500) },
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(payload, { 0: 5, 1: 6, 2: 300 });
+
+      expect(result.boundaryTokenAdjustment?.original).toBe(300);
+      expect(result.indexTokenCountMap?.[1]).toBeLessThan(300);
+      expect(result.indexTokenCountMap?.[1]).toBeGreaterThan(100);
+    });
+
     /** The summary text is returned separately as `summary.tokenCount`, so
      *  leaving it in its own entry's count charges the prompt for it twice. */
     it('discounts the filtered summary text from its own entry', () => {

--- a/src/messages/injected.test.ts
+++ b/src/messages/injected.test.ts
@@ -34,7 +34,7 @@ describe('convertInjectedMessages', () => {
 
   it('carries isMeta, source and skillName only when set', () => {
     const [bare] = convertInjectedMessages([{ role: 'user', content: 'x' }]);
-    expect(bare.additional_kwargs).toEqual({ role: 'user' });
+    expect(bare.additional_kwargs).toEqual({ role: 'user', injected: true });
 
     const [full] = convertInjectedMessages([
       {
@@ -47,10 +47,27 @@ describe('convertInjectedMessages', () => {
     ]);
     expect(full.additional_kwargs).toEqual({
       role: 'user',
+      injected: true,
       isMeta: true,
       source: 'steer',
       skillName: 'writing',
     });
+  });
+
+  /** Both marker fields are optional on `InjectedMessage`, so consumers that
+   *  must tell in-run context from payload-replayed messages — compaction
+   *  coverage anchors — cannot rely on them. `injected` is unconditional. */
+  it('always records injected provenance, whatever the caller supplied', () => {
+    const converted = convertInjectedMessages([
+      { role: 'user', content: 'bare' },
+      { role: 'system', content: 'hook output', source: 'hook' },
+      { role: 'user', content: 'injected steer', source: 'steer' },
+    ]);
+
+    expect(converted).toHaveLength(3);
+    for (const message of converted) {
+      expect(message.additional_kwargs.injected).toBe(true);
+    }
   });
 
   it('passes multimodal content through as a content array', () => {

--- a/src/messages/injected.ts
+++ b/src/messages/injected.ts
@@ -2,8 +2,8 @@
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { InjectedMessage } from '@/types/tools';
-import { ContentTypes } from '@/common';
 import { toLangChainContent } from './langchain';
+import { ContentTypes } from '@/common';
 
 /**
  * Converts `InjectedMessage` instances to LangChain `HumanMessage` objects.
@@ -56,8 +56,15 @@ export function convertInjectedMessages(
     if (isEmptyInjectedContent(msg.content)) {
       continue;
     }
+    /** Provenance, recorded here because this is the only place that knows it.
+     *  `isMeta` and `source` are both optional on `InjectedMessage`, so a bare
+     *  entry is otherwise indistinguishable from a message replayed out of the
+     *  payload — and downstream consumers such as compaction coverage need to
+     *  know that this message has no persisted source ID to name. Kept separate
+     *  from `isMeta`, which carries UI and cache meaning of its own. */
     const additional_kwargs: Record<string, unknown> = {
       role: msg.role,
+      injected: true,
     };
     if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
     if (msg.source != null) additional_kwargs.source = msg.source;

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -987,7 +987,7 @@ describe('recency window — first-turn protection', () => {
       return summaryBlock;
     };
 
-    it('records the last refined message as the covered boundary', async () => {
+    it('records the first retained message as the coverage anchor', async () => {
       const summaryBlock = await runCompaction([
         new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
         new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
@@ -995,21 +995,21 @@ describe('recency window — first-turn protection', () => {
         new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
       ]);
 
-      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm2' });
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
     });
 
-    it('falls back to the last refined message that carries a source id', async () => {
+    it('skips a retained message that carries no source id', async () => {
       const summaryBlock = await runCompaction([
         new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
-        new AIMessage({ content: 'mid-run step' }),
-        new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+        new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+        new HumanMessage({ content: 'turn 2 query' }),
         new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
       ]);
 
-      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm1' });
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm4' });
     });
 
-    it('omits coverage when no refined message carries a source id', async () => {
+    it('omits coverage when no retained message carries a source id', async () => {
       const summaryBlock = await runCompaction([
         new HumanMessage('turn 1 query'),
         new AIMessage('turn 1 reply'),
@@ -1021,9 +1021,9 @@ describe('recency window — first-turn protection', () => {
     });
 
     /** A steer expands one source message into pre-steer, steer, and post-steer
-     *  messages that all carry its ID, and the recency split lands on the steer.
-     *  Declaring `m2` would drop the half the tail kept. */
-    it('skips a source id that straddles the recency boundary', async () => {
+     *  messages sharing its ID, and the recency split lands on the steer. The
+     *  straddling message is the anchor, so it survives whole. */
+    it('anchors on a source id that straddles the recency boundary', async () => {
       const summaryBlock = await runCompaction([
         new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
         new AIMessage({ content: 'pre-steer reply', id: 'm2' }),
@@ -1031,17 +1031,17 @@ describe('recency window — first-turn protection', () => {
         new AIMessage({ content: 'post-steer reply', id: 'm2' }),
       ]);
 
-      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm1' });
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
     });
 
-    it('omits coverage when every refined id straddles the boundary', async () => {
+    it('anchors on the straddling id when it is the only source', async () => {
       const summaryBlock = await runCompaction([
         new AIMessage({ content: 'pre-steer reply', id: 'm1' }),
         new HumanMessage({ content: 'steer', id: 'm1' }),
         new AIMessage({ content: 'post-steer reply', id: 'm1' }),
       ]);
 
-      expect(summaryBlock?.coverage).toBeUndefined();
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm1' });
     });
   });
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -948,7 +948,8 @@ describe('recency window — first-turn protection', () => {
 
   describe('summary coverage', () => {
     const runCompaction = async (
-      messages: BaseMessage[]
+      messages: BaseMessage[],
+      turns = 1
     ): Promise<t.SummaryContentBlock | undefined> => {
       captureEvents();
       jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -967,7 +968,7 @@ describe('recency window — first-turn protection', () => {
       });
       const summarizeNode = createSummarizeNode({
         agentContext: createAgentContext({
-          summarizationConfig: { retainRecent: { turns: 1 } },
+          summarizationConfig: { retainRecent: { turns } },
         } as never),
         graph: graph as never,
         generateStepId,
@@ -1032,6 +1033,28 @@ describe('recency window — first-turn protection', () => {
       ]);
 
       expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
+    });
+
+    /** Hook and skill-body context enters as marked `HumanMessage`s that the
+     *  reducer stamps with a UUID no payload entry carries. Anchoring there
+     *  would degrade to positional trimming on the next run. */
+    it('skips injected context when choosing the anchor', async () => {
+      const summaryBlock = await runCompaction(
+        [
+          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+          new HumanMessage({
+            content: 'injected skill body',
+            id: 'reducer-uuid',
+            additional_kwargs: { isMeta: true, source: 'skill' },
+          }),
+          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+        ],
+        2
+      );
+
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
     });
 
     it('anchors on the straddling id when it is the only source', async () => {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1019,6 +1019,30 @@ describe('recency window — first-turn protection', () => {
 
       expect(summaryBlock?.coverage).toBeUndefined();
     });
+
+    /** A steer expands one source message into pre-steer, steer, and post-steer
+     *  messages that all carry its ID, and the recency split lands on the steer.
+     *  Declaring `m2` would drop the half the tail kept. */
+    it('skips a source id that straddles the recency boundary', async () => {
+      const summaryBlock = await runCompaction([
+        new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+        new AIMessage({ content: 'pre-steer reply', id: 'm2' }),
+        new HumanMessage({ content: 'steer', id: 'm2' }),
+        new AIMessage({ content: 'post-steer reply', id: 'm2' }),
+      ]);
+
+      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm1' });
+    });
+
+    it('omits coverage when every refined id straddles the boundary', async () => {
+      const summaryBlock = await runCompaction([
+        new AIMessage({ content: 'pre-steer reply', id: 'm1' }),
+        new HumanMessage({ content: 'steer', id: 'm1' }),
+        new AIMessage({ content: 'post-steer reply', id: 'm1' }),
+      ]);
+
+      expect(summaryBlock?.coverage).toBeUndefined();
+    });
   });
 
   it('keeps the masked tail content (does not re-inject restored tool payloads into state)', async () => {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1028,8 +1028,30 @@ describe('recency window — first-turn protection', () => {
       const summaryBlock = await runCompaction([
         new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
         new AIMessage({ content: 'pre-steer reply', id: 'm2' }),
-        new HumanMessage({ content: 'steer', id: 'm2' }),
+        new HumanMessage({
+          content: 'steer',
+          id: 'm2',
+          additional_kwargs: { role: 'user', source: 'steer' },
+        }),
         new AIMessage({ content: 'post-steer reply', id: 'm2' }),
+      ]);
+
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
+    });
+
+    /** A steer carries `source: 'steer'` but is replayed from a payload entry
+     *  and stamped with its ID, so it is a valid anchor. When compaction lands
+     *  before any post-steer message exists it is the *only* retained entry —
+     *  treating every marked message as synthetic drops it. */
+    it('anchors on a retained steer with no post-steer message', async () => {
+      const summaryBlock = await runCompaction([
+        new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+        new AIMessage({ content: 'pre-steer reply', id: 'm2' }),
+        new HumanMessage({
+          content: 'steer',
+          id: 'm2',
+          additional_kwargs: { role: 'user', source: 'steer' },
+        }),
       ]);
 
       expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
@@ -1060,7 +1082,11 @@ describe('recency window — first-turn protection', () => {
     it('anchors on the straddling id when it is the only source', async () => {
       const summaryBlock = await runCompaction([
         new AIMessage({ content: 'pre-steer reply', id: 'm1' }),
-        new HumanMessage({ content: 'steer', id: 'm1' }),
+        new HumanMessage({
+          content: 'steer',
+          id: 'm1',
+          additional_kwargs: { role: 'user', source: 'steer' },
+        }),
         new AIMessage({ content: 'post-steer reply', id: 'm1' }),
       ]);
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1057,50 +1057,6 @@ describe('recency window — first-turn protection', () => {
       expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
     });
 
-    /** Hook and skill-body context enters as marked `HumanMessage`s that the
-     *  reducer stamps with a UUID no payload entry carries. Anchoring there
-     *  would degrade to positional trimming on the next run. */
-    it('skips injected context when choosing the anchor', async () => {
-      const summaryBlock = await runCompaction(
-        [
-          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
-          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
-          new HumanMessage({
-            content: 'injected skill body',
-            id: 'reducer-uuid',
-            additional_kwargs: { isMeta: true, source: 'skill' },
-          }),
-          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
-          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
-        ],
-        2
-      );
-
-      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
-    });
-
-    /** `InjectedMessage` leaves `isMeta` optional for every source, so a hook
-     *  returning `source: 'skill'` alone is still synthetic and its reducer UUID
-     *  can never resolve in the next payload. */
-    it('skips injected sources that omit isMeta', async () => {
-      const summaryBlock = await runCompaction(
-        [
-          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
-          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
-          new HumanMessage({
-            content: 'injected skill body',
-            id: 'reducer-uuid',
-            additional_kwargs: { role: 'user', source: 'skill' },
-          }),
-          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
-          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
-        ],
-        2
-      );
-
-      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
-    });
-
     it('anchors on the straddling id when it is the only source', async () => {
       const summaryBlock = await runCompaction([
         new AIMessage({ content: 'pre-steer reply', id: 'm1' }),

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1079,6 +1079,28 @@ describe('recency window — first-turn protection', () => {
       expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
     });
 
+    /** `InjectedMessage` leaves `isMeta` optional for every source, so a hook
+     *  returning `source: 'skill'` alone is still synthetic and its reducer UUID
+     *  can never resolve in the next payload. */
+    it('skips injected sources that omit isMeta', async () => {
+      const summaryBlock = await runCompaction(
+        [
+          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+          new HumanMessage({
+            content: 'injected skill body',
+            id: 'reducer-uuid',
+            additional_kwargs: { role: 'user', source: 'skill' },
+          }),
+          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+        ],
+        2
+      );
+
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
+    });
+
     it('anchors on the straddling id when it is the only source', async () => {
       const summaryBlock = await runCompaction([
         new AIMessage({ content: 'pre-steer reply', id: 'm1' }),

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1,5 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
   createSummarizeNode,
@@ -943,6 +944,81 @@ describe('recency window — first-turn protection', () => {
     expect(result.messages!.slice(1)).toHaveLength(2);
     expect((result.messages![1] as HumanMessage).content).toBe('turn 2 query');
     expect((result.messages![2] as AIMessage).content).toBe('turn 2 reply');
+  });
+
+  describe('summary coverage', () => {
+    const runCompaction = async (
+      messages: BaseMessage[]
+    ): Promise<t.SummaryContentBlock | undefined> => {
+      captureEvents();
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return mockInvokeModel('Summary of older turns');
+          }
+        } as never
+      );
+
+      let summaryBlock: t.SummaryContentBlock | undefined;
+      const graph = mockGraph((_stepId, result) => {
+        if (result.type === 'summary') {
+          summaryBlock = result.summary;
+        }
+      });
+      const summarizeNode = createSummarizeNode({
+        agentContext: createAgentContext({
+          summarizationConfig: { retainRecent: { turns: 1 } },
+        } as never),
+        graph: graph as never,
+        generateStepId,
+      });
+
+      await summarizeNode(
+        {
+          messages,
+          summarizationRequest: {
+            remainingContextTokens: 0,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      return summaryBlock;
+    };
+
+    it('records the last refined message as the covered boundary', async () => {
+      const summaryBlock = await runCompaction([
+        new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+        new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+        new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+        new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+      ]);
+
+      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm2' });
+    });
+
+    it('falls back to the last refined message that carries a source id', async () => {
+      const summaryBlock = await runCompaction([
+        new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+        new AIMessage({ content: 'mid-run step' }),
+        new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+        new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+      ]);
+
+      expect(summaryBlock?.coverage).toEqual({ throughMessageId: 'm1' });
+    });
+
+    it('omits coverage when no refined message carries a source id', async () => {
+      const summaryBlock = await runCompaction([
+        new HumanMessage('turn 1 query'),
+        new AIMessage('turn 1 reply'),
+        new HumanMessage('turn 2 query'),
+        new AIMessage('turn 2 reply'),
+      ]);
+
+      expect(summaryBlock?.coverage).toBeUndefined();
+    });
   });
 
   it('keeps the masked tail content (does not re-inject restored tool payloads into state)', async () => {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
 } from '@/summarization/node';
+import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
@@ -1076,6 +1077,38 @@ describe('recency window — first-turn protection', () => {
               skillName: 'demo',
             },
           }),
+          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+        ],
+        2
+      );
+
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
+    });
+
+    /** `InjectedMessage` leaves both `isMeta` and `source` optional, so a bare
+     *  injected turn carries no marker of its own — and an injected `steer` is
+     *  otherwise indistinguishable from a replayed one. `convertInjectedMessages`
+     *  records `injected` on everything it builds, which decides both. */
+    it.each([
+      ['a bare injected turn', { role: 'user' as const, content: 'injected' }],
+      [
+        'an injected steer',
+        {
+          role: 'user' as const,
+          content: 'injected steer',
+          source: 'steer' as const,
+        },
+      ],
+    ])('skips %s when anchoring', async (_label, injected) => {
+      const [converted] = convertInjectedMessages([injected]);
+      converted.id = 'reducer-uuid';
+
+      const summaryBlock = await runCompaction(
+        [
+          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+          converted,
           new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
           new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
         ],

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1057,6 +1057,34 @@ describe('recency window — first-turn protection', () => {
       expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm2' });
     });
 
+    /** `formatAgentMessages` reconstructs skill bodies inside its payload loop
+     *  and keeps processing payload entries after, so this unstamped entry — a
+     *  reducer UUID by the time compaction sees it — precedes stamped messages.
+     *  Anchoring on it would resolve to nothing on the next run. */
+    it('skips a reconstructed skill body to reach the stamped message behind it', async () => {
+      const summaryBlock = await runCompaction(
+        [
+          new HumanMessage({ content: 'turn 1 query', id: 'm1' }),
+          new AIMessage({ content: 'turn 1 reply', id: 'm2' }),
+          new HumanMessage({
+            content: 'skill body',
+            id: 'reducer-uuid',
+            additional_kwargs: {
+              role: 'user',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'demo',
+            },
+          }),
+          new HumanMessage({ content: 'turn 2 query', id: 'm3' }),
+          new AIMessage({ content: 'turn 2 reply', id: 'm4' }),
+        ],
+        2
+      );
+
+      expect(summaryBlock?.coverage).toEqual({ retainedFromMessageId: 'm3' });
+    });
+
     it('anchors on the straddling id when it is the only source', async () => {
       const summaryBlock = await runCompaction([
         new AIMessage({ content: 'pre-steer reply', id: 'm1' }),

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -386,13 +386,29 @@ function computeSummaryTokenCount(
  * summary can declare what it covers rather than leaving the next run to infer
  * coverage from where the block happens to sit. Messages generated mid-run have
  * no source ID; readers fall back to positional semantics when this is absent.
+ *
+ * One source message can expand into several messages — a steer splits an
+ * assistant entry into pre-steer, steer, and post-steer messages that all carry
+ * its ID — and the recency split lands on any human-type message, including the
+ * steer. An ID still present in the retained tail is therefore only partially
+ * covered, and declaring it would make the next run drop content this run kept.
+ * Such IDs are skipped in favor of the newest fully covered one.
  */
 function resolveSummaryCoverage(
-  messagesToRefine: BaseMessage[]
+  messagesToRefine: BaseMessage[],
+  messagesToRetain: BaseMessage[]
 ): t.SummaryCoverage | undefined {
+  const retainedIds = new Set<string>();
+  for (let i = 0; i < messagesToRetain.length; i++) {
+    const id = messagesToRetain[i].id?.trim();
+    if (id != null && id !== '') {
+      retainedIds.add(id);
+    }
+  }
+
   for (let i = messagesToRefine.length - 1; i >= 0; i--) {
     const id = messagesToRefine[i].id?.trim();
-    if (id != null && id !== '') {
+    if (id != null && id !== '' && !retainedIds.has(id)) {
       return { throughMessageId: id };
     }
   }
@@ -1165,7 +1181,7 @@ export function createSummarizeNode({
     const summaryBlock = buildSummaryBlock({
       summaryText,
       tokenCount,
-      coverage: resolveSummaryCoverage(messagesToRefine),
+      coverage: resolveSummaryCoverage(messagesToRefine, messagesToRetain),
       stepId,
       stepIndex: runStep.index,
       modelName: clientConfig.modelName,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -394,19 +394,21 @@ function computeSummaryTokenCount(
  * naming the first *retained* message makes that same message the anchor, so it
  * survives whole and everything before it is unambiguously covered.
  *
- * Injected and meta entries are skipped. `convertInjectedMessages` builds hook
- * and skill-body context as `HumanMessage`s marked via `additional_kwargs`, and
- * `messagesStateReducer` stamps them with a UUID that matches no payload entry
- * — anchoring there would look resolvable at write time and silently degrade to
- * positional trimming on read. Passing over them reaches a source-backed
- * message when one follows.
+ * In-run context is skipped: hook output and anything flagged `isMeta` is
+ * created during the run, so `messagesStateReducer` stamps it with a UUID no
+ * payload entry carries and anchoring there would degrade to positional
+ * trimming on read.
  *
- * Anything still unresolvable on read — a mid-run tail with no payload-backed
- * message at all — falls back to positional semantics, as does `undefined`.
+ * The check is deliberately narrow. A steer carries `source: 'steer'` but is
+ * replayed by `formatAgentMessages` from a payload entry and stamped with its
+ * ID, so it is a valid anchor — treating every non-null `source` as synthetic
+ * would skip it and drop the retained steer this coverage exists to protect.
+ * Skipping too little only costs an unresolvable anchor, which falls back to
+ * positional semantics; skipping too much loses history.
  */
 function isInjectedContext(message: BaseMessage): boolean {
   const { additional_kwargs: kwargs } = message;
-  return kwargs.isMeta === true || kwargs.source != null;
+  return kwargs.isMeta === true || kwargs.source === 'hook';
 }
 
 function resolveSummaryCoverage(

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -381,10 +381,29 @@ function computeSummaryTokenCount(
   return 0;
 }
 
+/**
+ * Resolves the last refined message that carries a source message ID, so the
+ * summary can declare what it covers rather than leaving the next run to infer
+ * coverage from where the block happens to sit. Messages generated mid-run have
+ * no source ID; readers fall back to positional semantics when this is absent.
+ */
+function resolveSummaryCoverage(
+  messagesToRefine: BaseMessage[]
+): t.SummaryCoverage | undefined {
+  for (let i = messagesToRefine.length - 1; i >= 0; i--) {
+    const id = messagesToRefine[i].id?.trim();
+    if (id != null && id !== '') {
+      return { throughMessageId: id };
+    }
+  }
+  return undefined;
+}
+
 /** Constructs the SummaryContentBlock persisted in the run step and dispatched to events. */
 function buildSummaryBlock(params: {
   summaryText: string;
   tokenCount: number;
+  coverage?: t.SummaryCoverage;
   stepId: string;
   stepIndex: number;
   modelName?: string;
@@ -400,6 +419,7 @@ function buildSummaryBlock(params: {
       } as t.MessageContentComplex,
     ],
     tokenCount: params.tokenCount,
+    ...(params.coverage != null ? { coverage: params.coverage } : {}),
     summaryVersion: params.summaryVersion,
     boundary: {
       messageId: params.stepId,
@@ -1145,6 +1165,7 @@ export function createSummarizeNode({
     const summaryBlock = buildSummaryBlock({
       summaryText,
       tokenCount,
+      coverage: resolveSummaryCoverage(messagesToRefine),
       stepId,
       stepIndex: runStep.index,
       modelName: clientConfig.modelName,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -394,15 +394,30 @@ function computeSummaryTokenCount(
  * naming the first *retained* message makes that same message the anchor, so it
  * survives whole and everything before it is unambiguously covered.
  *
- * Messages generated mid-run carry reducer-assigned IDs matching no payload
- * entry. Readers cannot resolve those and fall back to positional semantics,
- * which is also what happens when this returns `undefined`.
+ * Injected and meta entries are skipped. `convertInjectedMessages` builds hook
+ * and skill-body context as `HumanMessage`s marked via `additional_kwargs`, and
+ * `messagesStateReducer` stamps them with a UUID that matches no payload entry
+ * — anchoring there would look resolvable at write time and silently degrade to
+ * positional trimming on read. Passing over them reaches a source-backed
+ * message when one follows.
+ *
+ * Anything still unresolvable on read — a mid-run tail with no payload-backed
+ * message at all — falls back to positional semantics, as does `undefined`.
  */
+function isInjectedContext(message: BaseMessage): boolean {
+  const { additional_kwargs: kwargs } = message;
+  return kwargs.isMeta === true || kwargs.source != null;
+}
+
 function resolveSummaryCoverage(
   messagesToRetain: BaseMessage[]
 ): t.SummaryCoverage | undefined {
   for (let i = 0; i < messagesToRetain.length; i++) {
-    const id = messagesToRetain[i].id?.trim();
+    const message = messagesToRetain[i];
+    if (isInjectedContext(message)) {
+      continue;
+    }
+    const id = message.id?.trim();
     if (id != null && id !== '') {
       return { retainedFromMessageId: id };
     }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -399,12 +399,13 @@ function computeSummaryTokenCount(
  * payload entry carries and anchoring there would degrade to positional
  * trimming on read.
  *
- * The check is deliberately narrow. A steer carries `source: 'steer'` but is
- * replayed by `formatAgentMessages` from a payload entry and stamped with its
- * ID, so it is a valid anchor — treating every non-null `source` as synthetic
- * would skip it and drop the retained steer this coverage exists to protect.
- * Skipping too little only costs an unresolvable anchor, which falls back to
- * positional semantics; skipping too much loses history.
+ * `steer` is the one source label that is *not* synthetic: a steer is replayed
+ * by `formatAgentMessages` from a payload entry and stamped with its ID, so it
+ * is a valid anchor and skipping it would drop the retained steer this coverage
+ * exists to protect. Every other label — `hook`, `skill`, `system` — is created
+ * in-run, and `InjectedMessage` leaves `isMeta` optional for all of them, so the
+ * flag alone cannot be relied on. Hence an allowlist of one rather than a
+ * denylist that has to enumerate the rest.
  *
  * Known limitation: a payload entry that omits `messageId` is never stamped, so
  * the reducer's UUID is recorded and cannot resolve on the next run. There is
@@ -414,7 +415,10 @@ function computeSummaryTokenCount(
  */
 function isInjectedContext(message: BaseMessage): boolean {
   const { additional_kwargs: kwargs } = message;
-  return kwargs.isMeta === true || kwargs.source === 'hook';
+  if (kwargs.isMeta === true) {
+    return true;
+  }
+  return kwargs.source != null && kwargs.source !== 'steer';
 }
 
 function resolveSummaryCoverage(

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -382,34 +382,29 @@ function computeSummaryTokenCount(
 }
 
 /**
- * Resolves the last refined message that carries a source message ID, so the
- * summary can declare what it covers rather than leaving the next run to infer
- * coverage from where the block happens to sit. Messages generated mid-run have
- * no source ID; readers fall back to positional semantics when this is absent.
+ * Names the first retained message so the summary declares its own extent
+ * rather than leaving the next run to infer coverage from where the block
+ * happens to sit.
  *
- * One source message can expand into several messages — a steer splits an
- * assistant entry into pre-steer, steer, and post-steer messages that all carry
- * its ID — and the recency split lands on any human-type message, including the
- * steer. An ID still present in the retained tail is therefore only partially
- * covered, and declaring it would make the next run drop content this run kept.
- * Such IDs are skipped in favor of the newest fully covered one.
+ * Anchored to the retained side, not the covered side. One source message can
+ * expand into several messages — a steer splits an assistant entry into
+ * pre-steer, steer, and post-steer entries sharing its ID — and the recency
+ * split lands on any human-type message, including the steer. Naming the last
+ * *covered* message would then name a half-covered ID with no correct reading;
+ * naming the first *retained* message makes that same message the anchor, so it
+ * survives whole and everything before it is unambiguously covered.
+ *
+ * Messages generated mid-run carry reducer-assigned IDs matching no payload
+ * entry. Readers cannot resolve those and fall back to positional semantics,
+ * which is also what happens when this returns `undefined`.
  */
 function resolveSummaryCoverage(
-  messagesToRefine: BaseMessage[],
   messagesToRetain: BaseMessage[]
 ): t.SummaryCoverage | undefined {
-  const retainedIds = new Set<string>();
   for (let i = 0; i < messagesToRetain.length; i++) {
     const id = messagesToRetain[i].id?.trim();
     if (id != null && id !== '') {
-      retainedIds.add(id);
-    }
-  }
-
-  for (let i = messagesToRefine.length - 1; i >= 0; i--) {
-    const id = messagesToRefine[i].id?.trim();
-    if (id != null && id !== '' && !retainedIds.has(id)) {
-      return { throughMessageId: id };
+      return { retainedFromMessageId: id };
     }
   }
   return undefined;
@@ -1181,7 +1176,7 @@ export function createSummarizeNode({
     const summaryBlock = buildSummaryBlock({
       summaryText,
       tokenCount,
-      coverage: resolveSummaryCoverage(messagesToRefine, messagesToRetain),
+      coverage: resolveSummaryCoverage(messagesToRetain),
       stepId,
       stepIndex: runStep.index,
       modelName: clientConfig.modelName,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -445,10 +445,29 @@ function resolveSummaryCoverage(
   return undefined;
 }
 
+/**
+ * The summary text's cost in the consumer's own tokenizer, with no injection
+ * wrapper. `tokenCount` cannot serve this purpose: it is the injection budget,
+ * so it sits in provider output-token space whenever usage was reported and it
+ * includes the wrapper added later at injection time. Readers that discount the
+ * entry carrying the block need a figure in the same space as their own
+ * per-message counts, which is what the consumer's `tokenCounter` provides.
+ */
+function computeSummaryRawTokenCount(
+  summaryText: string,
+  tokenCounter?: (message: BaseMessage) => number
+): number {
+  if (tokenCounter == null) {
+    return 0;
+  }
+  return tokenCounter(new SystemMessage(summaryText));
+}
+
 /** Constructs the SummaryContentBlock persisted in the run step and dispatched to events. */
 function buildSummaryBlock(params: {
   summaryText: string;
   tokenCount: number;
+  rawTokenCount: number;
   coverage?: t.SummaryCoverage;
   stepId: string;
   stepIndex: number;
@@ -465,6 +484,9 @@ function buildSummaryBlock(params: {
       } as t.MessageContentComplex,
     ],
     tokenCount: params.tokenCount,
+    ...(params.rawTokenCount > 0
+      ? { rawTokenCount: params.rawTokenCount }
+      : {}),
     ...(params.coverage != null ? { coverage: params.coverage } : {}),
     summaryVersion: params.summaryVersion,
     boundary: {
@@ -1211,6 +1233,10 @@ export function createSummarizeNode({
     const summaryBlock = buildSummaryBlock({
       summaryText,
       tokenCount,
+      rawTokenCount: computeSummaryRawTokenCount(
+        summaryText,
+        agentContext.tokenCounter
+      ),
       coverage: resolveSummaryCoverage(messagesToRetain),
       stepId,
       stepIndex: runStep.index,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -394,28 +394,45 @@ function computeSummaryTokenCount(
  * naming the first *retained* message makes that same message the anchor, so it
  * survives whole and everything before it is unambiguously covered.
  *
- * Provenance is deliberately not inferred here. Whether an ID resolves is a
- * question only the reader can answer — it holds the payload — and
- * `additional_kwargs` does not record where a message came from: an in-run
- * injected entry and a replayed payload steer can carry identical markers, and
- * `messagesStateReducer` gives both a plain `id`. Filtering on those markers
- * cost a real bug (skipping `source: 'steer'` dropped the retained steers this
- * coverage exists to protect) without buying anything, because in-run context is
- * always *appended* — `[...toolMessages, ...injected]` in `ToolNode`, and the
- * same in `StandardGraph` — so a tail that begins with injected context has no
- * payload-backed message later to reach instead.
+ * Synthetic entries are skipped, because they can sit *before* a resolvable
+ * one. `formatAgentMessages` reconstructs skill bodies inside its payload loop
+ * (see the `pendingSkillNames` block) and keeps processing payload entries
+ * afterwards, so an unstamped skill body — which `messagesStateReducer` then
+ * gives a UUID no payload entry carries — is followed by stamped messages.
+ * Anchoring on the UUID would look resolvable at write time and degrade to
+ * positional trimming on read, dropping the retained tail. Skipping it reaches
+ * the stamped message behind it.
  *
- * An anchor the reader cannot resolve therefore falls back to positional
- * trimming, which is what `main` does for every summary today. The same applies
- * to a payload entry that omits `messageId`: it is unaddressable in the next
- * payload too, so no anchor could name it. The failure mode is a degraded
- * anchor, never a misleading one.
+ * `steer` is exempt: a steer is replayed from a payload entry and stamped with
+ * its ID, so it is a valid anchor, and skipping it dropped retained steers when
+ * this check was once written to reject every marked `source`.
+ *
+ * Known limitation: `InjectedMessage` also permits `source: 'steer'`, and an
+ * in-run injected steer is unstamped, so the exemption accepts a UUID for it.
+ * Nothing in `additional_kwargs` separates that from a replayed steer. Both
+ * directions of the ambiguity bottom out in the reader's positional fallback —
+ * what `main` does for every summary today — so the exemption is set to favour
+ * replayed steers, which are the common case. A payload entry that omits
+ * `messageId` degrades the same way: it is unaddressable in the next payload
+ * too, so no anchor could name it.
  */
+function isSyntheticContext(message: BaseMessage): boolean {
+  const { additional_kwargs: kwargs } = message;
+  if (kwargs.isMeta === true) {
+    return true;
+  }
+  return kwargs.source != null && kwargs.source !== 'steer';
+}
+
 function resolveSummaryCoverage(
   messagesToRetain: BaseMessage[]
 ): t.SummaryCoverage | undefined {
   for (let i = 0; i < messagesToRetain.length; i++) {
-    const id = messagesToRetain[i].id?.trim();
+    const message = messagesToRetain[i];
+    if (isSyntheticContext(message)) {
+      continue;
+    }
+    const id = message.id?.trim();
     if (id != null && id !== '') {
       return { retainedFromMessageId: id };
     }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -394,42 +394,28 @@ function computeSummaryTokenCount(
  * naming the first *retained* message makes that same message the anchor, so it
  * survives whole and everything before it is unambiguously covered.
  *
- * In-run context is skipped: hook output and anything flagged `isMeta` is
- * created during the run, so `messagesStateReducer` stamps it with a UUID no
- * payload entry carries and anchoring there would degrade to positional
- * trimming on read.
+ * Provenance is deliberately not inferred here. Whether an ID resolves is a
+ * question only the reader can answer — it holds the payload — and
+ * `additional_kwargs` does not record where a message came from: an in-run
+ * injected entry and a replayed payload steer can carry identical markers, and
+ * `messagesStateReducer` gives both a plain `id`. Filtering on those markers
+ * cost a real bug (skipping `source: 'steer'` dropped the retained steers this
+ * coverage exists to protect) without buying anything, because in-run context is
+ * always *appended* — `[...toolMessages, ...injected]` in `ToolNode`, and the
+ * same in `StandardGraph` — so a tail that begins with injected context has no
+ * payload-backed message later to reach instead.
  *
- * `steer` is the one source label that is *not* synthetic: a steer is replayed
- * by `formatAgentMessages` from a payload entry and stamped with its ID, so it
- * is a valid anchor and skipping it would drop the retained steer this coverage
- * exists to protect. Every other label — `hook`, `skill`, `system` — is created
- * in-run, and `InjectedMessage` leaves `isMeta` optional for all of them, so the
- * flag alone cannot be relied on. Hence an allowlist of one rather than a
- * denylist that has to enumerate the rest.
- *
- * Known limitation: a payload entry that omits `messageId` is never stamped, so
- * the reducer's UUID is recorded and cannot resolve on the next run. There is
- * no write-time fix — such an entry has no stable ID to name in the next
- * payload either — and the reader's positional fallback is what `main` already
- * does, so the anchor degrades rather than misleads.
+ * An anchor the reader cannot resolve therefore falls back to positional
+ * trimming, which is what `main` does for every summary today. The same applies
+ * to a payload entry that omits `messageId`: it is unaddressable in the next
+ * payload too, so no anchor could name it. The failure mode is a degraded
+ * anchor, never a misleading one.
  */
-function isInjectedContext(message: BaseMessage): boolean {
-  const { additional_kwargs: kwargs } = message;
-  if (kwargs.isMeta === true) {
-    return true;
-  }
-  return kwargs.source != null && kwargs.source !== 'steer';
-}
-
 function resolveSummaryCoverage(
   messagesToRetain: BaseMessage[]
 ): t.SummaryCoverage | undefined {
   for (let i = 0; i < messagesToRetain.length; i++) {
-    const message = messagesToRetain[i];
-    if (isInjectedContext(message)) {
-      continue;
-    }
-    const id = message.id?.trim();
+    const id = messagesToRetain[i].id?.trim();
     if (id != null && id !== '') {
       return { retainedFromMessageId: id };
     }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -445,29 +445,10 @@ function resolveSummaryCoverage(
   return undefined;
 }
 
-/**
- * The summary text's cost in the consumer's own tokenizer, with no injection
- * wrapper. `tokenCount` cannot serve this purpose: it is the injection budget,
- * so it sits in provider output-token space whenever usage was reported and it
- * includes the wrapper added later at injection time. Readers that discount the
- * entry carrying the block need a figure in the same space as their own
- * per-message counts, which is what the consumer's `tokenCounter` provides.
- */
-function computeSummaryRawTokenCount(
-  summaryText: string,
-  tokenCounter?: (message: BaseMessage) => number
-): number {
-  if (tokenCounter == null) {
-    return 0;
-  }
-  return tokenCounter(new SystemMessage(summaryText));
-}
-
 /** Constructs the SummaryContentBlock persisted in the run step and dispatched to events. */
 function buildSummaryBlock(params: {
   summaryText: string;
   tokenCount: number;
-  rawTokenCount: number;
   coverage?: t.SummaryCoverage;
   stepId: string;
   stepIndex: number;
@@ -484,9 +465,6 @@ function buildSummaryBlock(params: {
       } as t.MessageContentComplex,
     ],
     tokenCount: params.tokenCount,
-    ...(params.rawTokenCount > 0
-      ? { rawTokenCount: params.rawTokenCount }
-      : {}),
     ...(params.coverage != null ? { coverage: params.coverage } : {}),
     summaryVersion: params.summaryVersion,
     boundary: {
@@ -1233,10 +1211,6 @@ export function createSummarizeNode({
     const summaryBlock = buildSummaryBlock({
       summaryText,
       tokenCount,
-      rawTokenCount: computeSummaryRawTokenCount(
-        summaryText,
-        agentContext.tokenCounter
-      ),
       coverage: resolveSummaryCoverage(messagesToRetain),
       stepId,
       stepIndex: runStep.index,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -403,22 +403,27 @@ function computeSummaryTokenCount(
  * positional trimming on read, dropping the retained tail. Skipping it reaches
  * the stamped message behind it.
  *
- * `steer` is exempt: a steer is replayed from a payload entry and stamped with
- * its ID, so it is a valid anchor, and skipping it dropped retained steers when
- * this check was once written to reject every marked `source`.
+ * `convertInjectedMessages` records `injected` on everything it builds, which is
+ * what makes this decidable: `isMeta` and `source` are both optional on
+ * `InjectedMessage`, so a bare entry carries no marker of its own, and an
+ * injected `source: 'steer'` is otherwise indistinguishable from a replayed one.
+ * The remaining `isMeta`/`source` checks cover the constructors that build
+ * synthetic entries directly instead of going through that funnel — hook context
+ * in `ToolNode` and `StandardGraph`, handoff cues, reconstructed skill bodies.
  *
- * Known limitation: `InjectedMessage` also permits `source: 'steer'`, and an
- * in-run injected steer is unstamped, so the exemption accepts a UUID for it.
- * Nothing in `additional_kwargs` separates that from a replayed steer. Both
- * directions of the ambiguity bottom out in the reader's positional fallback —
- * what `main` does for every summary today — so the exemption is set to favour
- * replayed steers, which are the common case. A payload entry that omits
- * `messageId` degrades the same way: it is unaddressable in the next payload
- * too, so no anchor could name it.
+ * `steer` is exempt from the `source` check because a replayed steer *is*
+ * stamped from its payload entry; rejecting every marked `source` once dropped
+ * exactly those retained steers. Injected steers are still caught, by `injected`.
+ *
+ * Known limitation: a payload entry that omits `messageId` is never stamped, so
+ * the reducer's UUID is recorded and cannot resolve on the next run. There is no
+ * write-time fix — such an entry has no stable ID to name in the next payload
+ * either — and the reader's positional fallback is what `main` already does, so
+ * the anchor degrades rather than misleads.
  */
 function isSyntheticContext(message: BaseMessage): boolean {
   const { additional_kwargs: kwargs } = message;
-  if (kwargs.isMeta === true) {
+  if (kwargs.injected === true || kwargs.isMeta === true) {
     return true;
   }
   return kwargs.source != null && kwargs.source !== 'steer';

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -405,6 +405,12 @@ function computeSummaryTokenCount(
  * would skip it and drop the retained steer this coverage exists to protect.
  * Skipping too little only costs an unresolvable anchor, which falls back to
  * positional semantics; skipping too much loses history.
+ *
+ * Known limitation: a payload entry that omits `messageId` is never stamped, so
+ * the reducer's UUID is recorded and cannot resolve on the next run. There is
+ * no write-time fix — such an entry has no stable ID to name in the next
+ * payload either — and the reader's positional fallback is what `main` already
+ * does, so the anchor degrades rather than misleads.
  */
 function isInjectedContext(message: BaseMessage): boolean {
   const { additional_kwargs: kwargs } = message;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -295,10 +295,21 @@ export type SummaryBoundary = {
   contentIndex: number;
 };
 
+/**
+ * Semantic extent of a summary: the last source message it actually covers.
+ * Distinct from `boundary`, which records where the block was emitted. A
+ * recency tail retained at compaction time sits *before* the block's own
+ * position, so position alone cannot say what the summary replaced.
+ */
+export type SummaryCoverage = {
+  throughMessageId: string;
+};
+
 export type SummaryContentBlock = {
   type: ContentTypes.SUMMARY;
   content?: MessageContentComplex[];
   tokenCount?: number;
+  coverage?: SummaryCoverage;
   boundary?: SummaryBoundary;
   summaryVersion?: number;
   model?: string;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -296,13 +296,19 @@ export type SummaryBoundary = {
 };
 
 /**
- * Semantic extent of a summary: the last source message it actually covers.
- * Distinct from `boundary`, which records where the block was emitted. A
- * recency tail retained at compaction time sits *before* the block's own
- * position, so position alone cannot say what the summary replaced.
+ * Semantic extent of a summary: the first source message compaction retained
+ * verbatim, meaning everything before it is covered. Distinct from `boundary`,
+ * which records where the block was emitted — a retained recency tail sits
+ * *before* the block's own position, so position alone cannot say what the
+ * summary replaced.
+ *
+ * Anchored to the retained side rather than the covered side so that a source
+ * message expanding into several messages (a steer splits an assistant entry
+ * into pre-steer, steer, and post-steer entries sharing one ID) stays whole:
+ * such a message is the retained anchor and survives intact.
  */
 export type SummaryCoverage = {
-  throughMessageId: string;
+  retainedFromMessageId: string;
 };
 
 export type SummaryContentBlock = {

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -314,7 +314,13 @@ export type SummaryCoverage = {
 export type SummaryContentBlock = {
   type: ContentTypes.SUMMARY;
   content?: MessageContentComplex[];
+  /** Injection budget: provider output-token space when usage was reported, plus
+   *  the wrapper added at injection time. Not comparable with per-message counts. */
   tokenCount?: number;
+  /** The summary text's cost in the consumer's own tokenizer, with no injection
+   *  wrapper — the units `indexTokenCountMap` is kept in. Recorded separately so
+   *  a reader can discount the entry carrying this block without mixing spaces. */
+  rawTokenCount?: number;
   coverage?: SummaryCoverage;
   boundary?: SummaryBoundary;
   summaryVersion?: number;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -315,12 +315,9 @@ export type SummaryContentBlock = {
   type: ContentTypes.SUMMARY;
   content?: MessageContentComplex[];
   /** Injection budget: provider output-token space when usage was reported, plus
-   *  the wrapper added at injection time. Not comparable with per-message counts. */
+   *  the wrapper added at injection time. Not comparable with per-message counts
+   *  such as `indexTokenCountMap`, which are in the consumer's own tokenizer. */
   tokenCount?: number;
-  /** The summary text's cost in the consumer's own tokenizer, with no injection
-   *  wrapper — the units `indexTokenCountMap` is kept in. Recorded separately so
-   *  a reader can discount the entry carrying this block without mixing spaces. */
-  rawTokenCount?: number;
   coverage?: SummaryCoverage;
   boundary?: SummaryBoundary;
   summaryVersion?: number;


### PR DESCRIPTION
## Summary

A persisted summary's reach was inferred from **where its content block sits in the payload** — the scan located the block at `(messageIndex, contentIndex)` and `applySummaryBoundary` dropped everything before it.

That position is not what the summary covers. The block is emitted on the assistant message that *follows* compaction, while the recency tail retained by `retainRecent` sits earlier in the payload. Positional trimming cannot tell the retained tail apart from covered history.

Concretely, with `retainRecent.turns: 1` over `m1 … m5`:

| | covered by summary | retained verbatim | holds the block |
|---|---|---|---|
| messages | `m1`, `m2` | `m3`, `m4` | `m5` |

The block lives on `m5`, so the next run dropped `m1`–`m4`. `m3` and `m4` were never summarized and no longer appeared anywhere in the prompt — silent loss of exactly the turns `retainRecent` exists to keep. In-run the tail survives; across runs it did not.

## Change

Summaries now declare their own extent instead of leaving the next run to infer it.

- `SummaryCoverage` (`{ retainedFromMessageId }`) added to `SummaryContentBlock`, separate from the existing `boundary` field, which records where the block was *emitted*.
- `createSummarizeNode` names the first message compaction retained. `formatAgentMessages` resolves that ID against the payload and drops everything strictly before it, leaving the anchor and the rest of the tail verbatim.

**Anchored to the retained side, not the covered side.** This is the part worth reviewing closely. A steer expands one source message into pre-steer, steer, and post-steer entries that all carry its ID, and `splitAtRecencyBoundary` splits on any human-type message — including the steer. Naming the last *covered* message therefore names a half-retained ID with no correct reading, and needs an escape hatch for each straddling shape. Naming the first *retained* message makes that same message the anchor, so it survives whole and everything before it is unambiguously covered. It also reads the ID from the retained tail rather than the head, whose final message can be a reducer-stamped synthetic (the unstamped steer anchor) matching no payload entry.

Synthetic entries are skipped when choosing the anchor, because they can sit *before* a resolvable one: `formatAgentMessages` reconstructs skill bodies inside its own payload loop and keeps processing payload entries afterwards, so an unstamped body — a reducer UUID by the time compaction sees it — is followed by stamped messages.

Provenance is recorded rather than inferred, at each point that knows it. `convertInjectedMessages` stamps `injected: true` on everything it builds, since `InjectedMessage` leaves both `isMeta` and `source` optional. Multi-agent handoff and fan-in prompts, previously bare `HumanMessage`s, are stamped at construction too. (Deliberately not via `isMeta` for the injected funnel, which carries prompt-cache meaning through `isMetaOrSkillMessage`.) The residual `isMeta`/`source` checks cover the remaining direct constructors — hook context in `ToolNode`/`StandardGraph`, handoff cues, reconstructed skill bodies. `steer` is exempt from the `source` check because a replayed steer is stamped from its payload entry; injected steers are caught by `injected`.

The ID lookup is built during the existing payload scan, so there is no second pass.

## Token accounting: a known, deliberate over-count

Coverage keeps the message holding the block, and `formatAssistantMessage` filters the summary part out of it while the text is accounted separately as `summary.tokenCount`. The entry is therefore charged for tokens the provider never receives, over-stating the prompt and pruning earlier than strictly necessary.

**This PR does not correct that**, after three attempts that each failed at the level of approach rather than detail: characters as a proxy for tokens (media and tool payloads cost tokens out of proportion to any character heuristic — a 1100-token entry reported 151), the block's `tokenCount` (provider output-token space plus the injection wrapper — 1000 reported as 100), and a separately recorded raw count (measured with the writing run's tokenizer, which differs once a conversation continues on another model).

The quantity simply is not available here: `formatAgentMessages` receives no tokenizer and no reliable identity for one, and every proxy tried under-counts some shape. Under-counting risks an over-context request; over-counting only prunes early. The safe direction is taken deliberately, the reasoning is recorded at the call site, and the real fix — passing the reader a tokenizer — is consumer-facing work outside this PR.

`contentPartCharLength` does now measure `tool_call.name/args/output`, an accuracy fix for the *positional* path, which stays within one run's units and previously scored an entire tool turn as zero.

That path is also gated. It scales by the characters surviving the slice, and content whose cost is unrelated to its length — atomic media above all — has that cost scaled away: an entry retaining only an image after its summary collapsed to 1 token. **This is pre-existing on `main`** (verified there, `[text, summary, image]` takes a 1200-token entry to 1); measuring tool-call content widened which shapes reach it, and media nested inside `tool_call.output` reached it through a serialized length of its own (4000 → 68).

The gate is an allowlist rather than another rejection rule: only `TEXT` and `THINKING`, the shapes whose characters `contentPartCharLength` actually reads, are eligible. Every other shape is ineligible at any nesting depth, including types added later, and a single ineligible part cancels the discount wherever it sits — a removed base64 payload inflates the denominator just as a retained one collapses the numerator (4000 → 68 in the first case, 1200 → 1 in the second).

**This changes pre-existing behaviour:** a legacy entry containing any tool call now keeps its full count rather than being proportioned, over-counting by the sliced-away payload and pruning earlier. Two tests encoding the old behaviour are reframed. Over-counting degrades quality; under-counting sends a request the provider rejects. Entries of plain text and reasoning — the common shape for a mid-message summary — still proportion as before.

Recording a token contribution at write time was considered as an alternative to characters entirely, and does not work: it is in the writing run's tokenizer and diverges once a conversation continues on another model. With no tokenizer at the reader, characters restricted to the shapes they measure faithfully is the only self-consistent option.

Positional was gated rather than removed because the two paths are not equivalent: coverage mode only over-counted the summary text, whereas positional slices content out of the message, so removing its adjustment would charge the entry for everything the slice removed.

## Compatibility

Blocks with no resolvable anchor — written before this field existed, or anchored to a message no longer in the payload — keep the positional reading **unchanged**. Existing compacted conversations behave exactly as they do today; only summaries written after this change get the corrected semantics. Three of the new tests pin that legacy path and pass against `main` unmodified.

Nothing is required of consumers: summary blocks are persisted as opaque content parts, so `coverage` rides along with no LibreChat-side change.

## Testing

- 12 reader tests in `formatAgentMessages.test.ts` (retained tail preserved, anchor retained, token map, exact summary-token subtraction, retained image and retained tool-call-with-media both keeping their cost, mismatched-basis guard, legacy fallback, unresolvable anchor, out-of-range anchor, last-summary-wins across mixed blocks) and 9 writer tests in `summarization/__tests__/node.test.ts` (both straddling-boundary shapes, a retained steer with no post-steer message, an unstamped retained message, a reconstructed skill body preceding a stamped one, a bare injected turn, an injected steer), plus two in `injected.test.ts` pinning the provenance marker.
- Steer fixtures carry the real `{ role: 'user', source: 'steer' }` marker that `formatAgentMessages` emits, after fixture drift let a regression through in review round three.
- Verified the behavioral reader tests **fail against `main`'s source** while the legacy-fallback tests pass there, so they pin current behavior rather than restating the new code.
- Full CI-equivalent unit suite: **3,311 passed**, 58 skipped, 0 failures.
- `src/specs/summarization.test.ts -t "no API keys"`: 15 passed.
- `npx tsc --noEmit`, `npx eslint`, and `npm run build` all clean.

## Review history

Fourteen review rounds, twenty findings, all addressed:

- **`2b6012ce`** — two P1s on the coverage anchor, one P2 on token accounting → `18547312`. Both P1s shared a cause, so the anchor moved to the retained side rather than gaining a sentinel state and provenance metadata.
- **`18547312`** — a P1 on unmeasured tool-call content and a P1 on synthetic anchor IDs → `51376bbf`. The first was reproduced before fixing (a 3000-token entry reporting 1); the second was hardened despite its premise not holding, since injected messages are appended rather than interleaved.

- **`51376bbf`** — a P1 on the injected-context guard → `2e26c1d1`. The guard added in the previous round was too broad: it treated every marked `source` as synthetic and so skipped steers, which *are* source-backed. A defensive guard breaking the primary path, caught because the existing straddle fixtures did not carry the real steer marker.

- **`2e26c1d1`** — a P2 on unstamped payload entries → documented in `fb2ed1d4`, no code change. An entry omitting `messageId` has no stable ID in the next payload either, so no anchor can name it; the reader's positional fallback is what `main` already does.

- **`fb2ed1d4`** — a P1 on the measurability backstop → `c8127e45`. The round-two backstop tested the aggregate retained length rather than each part, so a caption beside a retained image licensed the discount and a 1100-token entry reported 22. Reproduced before fixing; the earlier test used an image alone, where the aggregate check already held.

- **`c8127e45`** — two P2s, on conflating zero-cost with unmeasurable parts and on the injected-source denylist → `6ac48d9f`. Both were tradeoffs taken deliberately in earlier rounds that turned out tighter than they needed to be.

- **`6ac48d9f`** — a P1 on media nested inside a tool output and a P2 on injected steers → `20b392d4`, which retired both predicates rather than patching them a fifth and fourth time respectively. The character heuristic was replaced by token subtraction, and the marker-based provenance filter was removed in favour of the reader's resolve-or-fallback. That reverses changes made in rounds three and six; the thread records why.

- **`20b392d4`** — a P1 showing that removing the synthetic-context filter was wrong → `649626d2`. I had argued in-run context is always appended, which holds for `ToolNode` and `StandardGraph` but not for `formatAgentMessages`, whose skill-body reconstruction runs mid-loop. Filter restored.

- **`649626d2`** — a P2 on bare injected messages, which carry neither optional marker → `688e7f2c`. Fixed at the source: `convertInjectedMessages` now records provenance unconditionally, which retires the whole class of marker-inference findings and also resolves the injected-steer case the previous round had documented as unfixable.

- **`688e7f2c`** — a P1 on mixing token spaces in the subtraction and a P2 on unmarked multi-agent routing prompts → `5dcc4d64`. The subtraction now uses a figure recorded in the reader's own units, and the routing prompts are stamped at construction.

- **`5dcc4d64`** — a P1 showing a write-time token count is in the writing run's units, which diverge once a conversation continues on another model → `7665fdd0`, which removes the discount rather than attempting a fourth proxy.

- **`7665fdd0`** — a P1 on the positional path collapsing an entry whose retained content is atomic media → `10945d16`. Pre-existing on `main`; this branch widened which shapes reach it, so it is fixed here with the same per-part guard.

- **`10945d16`** — a P1 on media nested inside `tool_call.output` clearing the new guard → `68d2fba6`, which inverts the guard into an allowlist so nesting depth stops mattering.
- **`68d2fba6`** — a P1 on the mirror case, a removed media payload inflating the denominator → `ad43f1f4`, which requires both sides to be eligible and changes pre-existing behaviour for tool-bearing legacy entries.

The threads record where I disagreed on severity and why some fixes took a different shape than proposed. Five of the twenty findings were bugs introduced *by* earlier rounds of this review, one corrected an argument of mine that was simply wrong, and one turned out to be a fault older than the branch.

Two lessons ran through it. Where a property could be recorded at the point it is known — message provenance — that beat every attempt to infer it downstream. Where a quantity could not be obtained at all — the summary's cost in the reader's token units — the right answer was to stop deriving it and accept the safe error instead.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Context

Supersedes the compaction-boundary portion of #314, which bundled this fix with three unrelated changes (a new hard `current_turn_exceeds_context` throw, a summarizer prompt rewrite, and a `toolControl.disableTools` contract) and regressed the `retainRecent.turns: 0` path by removing the pending-summary exception in the empty-messages guard.
