### PR TITLE
v3.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Release `v3.3.7`. Version bump only — no code changes in this PR.

Ships #353, which refines the tool intent label capability based on the first real-provider run of the feature:

- **Removed the tense verb map.** `applyOutcome` no longer rewrites a leading gerund to past tense. A closed English verb list never fires for the non-English labels this feature expects, and fires for some sibling calls but not others inside one group — a live run produced *"Recording the location of the OAuth callback router"*, which was not in the map, beside labels that were. Completion is now conveyed by UI state rather than tense; tools that want past tense say so explicitly via `outcome` / `outcome_patch`.
- **Trimmed `INTENT_DESCRIPTION`** 502 → 289 chars (~126 → ~72 tokens). It rides every opted-in schema on every request, so this returns roughly 800 tokens per request across a full coding bundle, keeping every load-bearing clause.
- **Exported `INTENT_LABEL_MARKER`.** The description's opening words are the discriminator separating the injected label from a tool's own business parameter named `intent`. Hosts reimplement the same strip passes and were duplicating it as a string literal; drift makes the host silently stop recognizing SDK-native labels and fail **open**.
- **Added `withoutIntent()`** — the embedder opt-out. Native schemas apply `withIntent` at module scope, so a consumer rendering no status label previously had no lever and paid the tokens unconditionally.

Downstream: `danny-avila/LibreChat#14499` pins this release, replaces its duplicated marker literal with the exported constant, and re-runs its real-provider e2e to confirm the shorter description still yields first-position, distinct sibling labels.