### PR TITLE
fix(openai): retry a transient 429 instead of ending the run

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
+    "probe:ratelimit": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/rate-limit-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",
     "subagent:tools": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-tools-debug.ts",

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -57,15 +57,16 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
-import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
 import {
   hasReasoningKwargs,
   hasToolCallChunks,
   getReasoningKwargsText,
 } from '@/llm/stream/chunkAdapters';
+import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
+import { withRateLimitRetry } from '@/utils/rateLimit';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const iife = <T>(fn: () => T) => fn();
@@ -2393,7 +2394,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
 function withLibreChatOpenAIFields(
   fields?: LibreChatOpenAIFields
 ): LibreChatOpenAIFields {
-  const nextFields = fields ?? {};
+  const nextFields = withRateLimitRetry(fields ?? {});
   return {
     ...nextFields,
     completions:
@@ -2503,7 +2504,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   _lc_stream_delay: number;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
-    super(fields);
+    super(withRateLimitRetry(fields));
     this.completions = new LibreChatAzureOpenAICompletions(fields);
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
@@ -2619,7 +2620,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       _lc_stream_delay?: number;
     }
   ) {
-    super(fields);
+    super(withRateLimitRetry(fields));
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
@@ -3142,7 +3143,7 @@ export class ChatXAI extends OriginalChatXAI {
       _lc_stream_delay?: number;
     }
   ) {
-    super(fields);
+    super(withRateLimitRetry(fields));
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     const customBaseURL =
       fields?.configuration?.baseURL ?? fields?.clientConfig?.baseURL;

--- a/src/scripts/rate-limit-probe.ts
+++ b/src/scripts/rate-limit-probe.ts
@@ -1,0 +1,97 @@
+/**
+ * Rate-limit retry probe.
+ *
+ * Drives a provider into a 429 on purpose and reports whether the run survived
+ * it, so `src/utils/rateLimit.ts` stays grounded in what providers actually
+ * send instead of in phrases someone expected them to send.
+ *
+ * The cheap way in is the concurrency limit: many tiny requests at once. That
+ * costs a handful of tokens and trips the same 429 as the token bucket on
+ * providers that answer every limit with one body - Scaleway being the reason
+ * this exists.
+ *
+ * Run:
+ *   OPENAI_LIKE_API_KEY=... OPENAI_LIKE_BASE_URL=https://api.scaleway.ai/v1 \
+ *     node --loader ./tsconfig-paths-bootstrap.mjs \
+ *     --experimental-specifier-resolution=node ./src/scripts/rate-limit-probe.ts
+ *
+ * Flags:
+ *   --model <id>        model to call (default: glm-5.2)
+ *   --concurrency <n>   simultaneous requests (default: 40)
+ *   --filler <tokens>   pad each prompt, to drain a tokens-per-minute bucket
+ *                       instead of the concurrency one. Costs real tokens.
+ *   --no-retry          construct the model with LangChain's stock policy, to
+ *                       show the failure this handler exists to prevent
+ */
+import { config as loadEnv } from 'dotenv';
+import { ChatOpenAI as StockChatOpenAI } from '@langchain/openai';
+import { ChatOpenAI } from '@/llm/openai';
+import { extractErrorMessage } from '@/utils/errors';
+
+loadEnv({ path: process.env.DOTENV_CONFIG_PATH ?? '.env' });
+
+function flag(name: string, fallback: string): string {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 && process.argv[index + 1] != null
+    ? process.argv[index + 1]
+    : fallback;
+}
+
+const apiKey = process.env.OPENAI_LIKE_API_KEY ?? process.env.SCALEWAY_API_KEY;
+const baseURL =
+  process.env.OPENAI_LIKE_BASE_URL ??
+  process.env.SCALEWAY_BASE_URL ??
+  'https://api.scaleway.ai/v1';
+const model = flag('model', 'glm-5.2');
+const concurrency = parseInt(flag('concurrency', '40'), 10);
+const fillerTokens = parseInt(flag('filler', '0'), 10);
+const withoutRetry = process.argv.includes('--no-retry');
+
+/** Roughly one token per repetition, which is close enough to aim a bucket at. */
+const prompt = fillerTokens > 0 ? 'lorem ipsum '.repeat(fillerTokens) : 'hi';
+
+if (apiKey == null || apiKey === '') {
+  console.error('Set OPENAI_LIKE_API_KEY (or SCALEWAY_API_KEY) first.');
+  process.exit(1);
+}
+
+/**
+ * `--no-retry` builds the upstream class instead of ours, which is the honest
+ * comparison: the handler cannot be switched off by passing `undefined`,
+ * because that is indistinguishable from not passing it at all.
+ */
+const fields = { model, apiKey, configuration: { baseURL }, maxTokens: 1 };
+const llm = withoutRetry ? new StockChatOpenAI(fields) : new ChatOpenAI(fields);
+
+async function main(): Promise<void> {
+  console.log(
+    `${concurrency} concurrent requests to ${model} at ${baseURL} (${
+      withoutRetry ? 'stock LangChain policy' : 'with retry handler'
+    })`
+  );
+
+  const started = Date.now();
+  const results = await Promise.all(
+    Array.from({ length: concurrency }, async (_unused, index) => {
+      try {
+        await llm.invoke(prompt);
+        return { index, ok: true, message: '' };
+      } catch (error) {
+        return { index, ok: false, message: extractErrorMessage(error) };
+      }
+    })
+  );
+
+  const failures = results.filter((result) => !result.ok);
+  console.log(
+    `succeeded ${results.length - failures.length}/${results.length} in ${
+      Date.now() - started
+    }ms`
+  );
+  for (const message of new Set(failures.map((failure) => failure.message))) {
+    console.log(`  failure: ${message}`);
+  }
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+void main();

--- a/src/utils/__tests__/rateLimit.test.ts
+++ b/src/utils/__tests__/rateLimit.test.ts
@@ -1,0 +1,237 @@
+import { APIError } from 'openai';
+import { describe, expect, it } from '@jest/globals';
+import {
+  isRetryableRateLimit,
+  withRateLimitRetry,
+  handleRateLimitedAttempt,
+} from '@/utils/rateLimit';
+import {
+  ChatXAI,
+  ChatOpenAI,
+  ChatDeepSeek,
+  ChatMoonshot,
+  AzureChatOpenAI,
+} from '@/llm/openai';
+import { ChatOpenRouter } from '@/llm/openrouter';
+
+/**
+ * Builds the error the OpenAI SDK actually throws for a given response body, so
+ * the assertions run against the shape production sees - `message` derived from
+ * `body.error` alone, with `body.message` already gone.
+ */
+function apiError(
+  status: number,
+  body: object,
+  headers: Record<string, string> = {}
+): Error {
+  return APIError.generate(
+    status,
+    body,
+    undefined,
+    new Headers({ 'content-type': 'application/json', ...headers })
+  ) as Error;
+}
+
+/** Captured from api.scaleway.ai on 2026-07-30; only `message` differs per axis. */
+const scalewayBody = (message: string) => ({
+  status: 429,
+  error: 'INSUFFICIENT QUOTA',
+  message,
+});
+
+const scalewayConcurrency = () =>
+  apiError(
+    429,
+    scalewayBody('You exceeded your current limit of concurrent requests.')
+  );
+const scalewayTokensPerMinute = () =>
+  apiError(
+    429,
+    scalewayBody('You exceeded your current quota of tokens per minute.')
+  );
+
+/** OpenAI's genuine billing wall: a structured code, not just quota wording. */
+const openAIInsufficientQuota = () =>
+  apiError(429, {
+    error: {
+      code: 'insufficient_quota',
+      type: 'insufficient_quota',
+      message:
+        'You exceeded your current quota, please check your plan and billing details.',
+    },
+  });
+
+/** A 429 that is really an oversized request - waiting can never make it fit. */
+const openAIRequestTooLarge = () =>
+  apiError(429, {
+    error: {
+      code: 'rate_limit_exceeded',
+      type: 'tokens',
+      message:
+        'Request too large for gpt-5-nano in organization org-test on tokens per min (TPM): Limit 200000, Requested 480002. The input or output tokens must be reduced in order to run successfully.',
+    },
+  });
+
+describe('isRetryableRateLimit', () => {
+  it('retries every Scaleway rate limit, which all read "INSUFFICIENT QUOTA"', () => {
+    expect(isRetryableRateLimit(scalewayConcurrency())).toBe(true);
+    expect(isRetryableRateLimit(scalewayTokensPerMinute())).toBe(true);
+  });
+
+  it('does not retry a structured insufficient_quota', () => {
+    expect(isRetryableRateLimit(openAIInsufficientQuota())).toBe(false);
+  });
+
+  it('does not retry wording that names billing or credit', () => {
+    expect(
+      isRetryableRateLimit(
+        apiError(429, {
+          error: {
+            message: 'Your credit balance is too low to access this model.',
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('does not retry a request too large for the per-minute allowance', () => {
+    expect(isRetryableRateLimit(openAIRequestTooLarge())).toBe(false);
+  });
+
+  it('is only about 429s', () => {
+    expect(
+      isRetryableRateLimit(apiError(500, { error: { message: 'oops' } }))
+    ).toBe(false);
+    expect(isRetryableRateLimit(new Error('nothing to do with HTTP'))).toBe(
+      false
+    );
+  });
+});
+
+describe('handleRateLimitedAttempt', () => {
+  const resolves = (error: unknown) =>
+    expect(handleRateLimitedAttempt(error)).resolves.toBeUndefined();
+
+  it('lets the attempt be retried for a Scaleway 429', async () => {
+    await resolves(scalewayConcurrency());
+    await resolves(scalewayTokensPerMinute());
+  });
+
+  it('rethrows a spent quota so the run ends instead of looping', async () => {
+    await expect(
+      handleRateLimitedAttempt(openAIInsufficientQuota())
+    ).rejects.toThrow(/insufficient_quota|quota/i);
+  });
+
+  it('rethrows an oversized request, leaving it to overflow recovery', async () => {
+    await expect(
+      handleRateLimitedAttempt(openAIRequestTooLarge())
+    ).rejects.toThrow(/Request too large/i);
+  });
+
+  it('keeps the never-retry statuses terminal', async () => {
+    for (const status of [400, 401, 402, 403, 404, 405, 406, 407, 409]) {
+      await expect(
+        handleRateLimitedAttempt(
+          apiError(status, { error: { message: 'nope' } })
+        )
+      ).rejects.toThrow();
+    }
+  });
+
+  it('retries what is worth retrying: connection errors and 5xx', async () => {
+    await resolves(apiError(500, { error: { message: 'internal' } }));
+    await resolves(apiError(503, { error: { message: 'unavailable' } }));
+    await resolves(
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    );
+  });
+
+  it('never retries a cancelled request', async () => {
+    await expect(
+      handleRateLimitedAttempt(
+        Object.assign(new Error('boom'), { name: 'AbortError' })
+      )
+    ).rejects.toThrow();
+    await expect(
+      handleRateLimitedAttempt(new Error('Cancel: user left'))
+    ).rejects.toThrow();
+    await expect(
+      handleRateLimitedAttempt(
+        Object.assign(new Error('gone'), { code: 'ECONNABORTED' })
+      )
+    ).rejects.toThrow();
+  });
+
+  it('waits out a short Retry-After', async () => {
+    const started = Date.now();
+    await resolves(scalewayBodyWithRetryAfter('1'));
+    expect(Date.now() - started).toBeGreaterThanOrEqual(900);
+  });
+
+  it('gives up when Retry-After is longer than a minute', async () => {
+    await expect(
+      handleRateLimitedAttempt(scalewayBodyWithRetryAfter('3600'))
+    ).rejects.toThrow();
+  });
+});
+
+function scalewayBodyWithRetryAfter(seconds: string): Error {
+  return apiError(
+    429,
+    scalewayBody('You exceeded your current quota of tokens per minute.'),
+    {
+      'retry-after': seconds,
+    }
+  );
+}
+
+describe('withRateLimitRetry', () => {
+  it('leaves a caller-supplied handler alone', () => {
+    const own = async (): Promise<void> => undefined;
+    expect(withRateLimitRetry({ onFailedAttempt: own }).onFailedAttempt).toBe(
+      own
+    );
+  });
+
+  it('handles being called without fields', () => {
+    expect(
+      withRateLimitRetry<{ onFailedAttempt?: unknown }>().onFailedAttempt
+    ).toBe(handleRateLimitedAttempt);
+  });
+});
+
+describe('OpenAI-compatible clients', () => {
+  /** The retry policy is only worth anything if it reaches the model's caller. */
+  it.each([
+    ['ChatOpenAI', () => new ChatOpenAI({ apiKey: 'test' })],
+    [
+      'AzureChatOpenAI',
+      () =>
+        new AzureChatOpenAI({
+          azureOpenAIApiKey: 'test',
+          azureOpenAIApiDeploymentName: 'd',
+          azureOpenAIApiVersion: 'v',
+          azureOpenAIApiInstanceName: 'i',
+        }),
+    ],
+    ['ChatDeepSeek', () => new ChatDeepSeek({ apiKey: 'test' })],
+    ['ChatXAI', () => new ChatXAI({ apiKey: 'test' })],
+    ['ChatMoonshot', () => new ChatMoonshot({ apiKey: 'test' })],
+    ['ChatOpenRouter', () => new ChatOpenRouter({ apiKey: 'test' })],
+  ])('%s retries transient 429s', (_name, create) => {
+    const model = create() as unknown as {
+      caller: { onFailedAttempt?: unknown };
+    };
+    expect(model.caller.onFailedAttempt).toBe(handleRateLimitedAttempt);
+  });
+
+  it('still lets a caller override the policy', () => {
+    const own = async (): Promise<void> => undefined;
+    const model = new ChatOpenAI({
+      apiKey: 'test',
+      onFailedAttempt: own,
+    }) as unknown as { caller: { onFailedAttempt?: unknown } };
+    expect(model.caller.onFailedAttempt).toBe(own);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './tokens';
 export * from './schema';
 export * from './truncation';
 export * from './errors';
+export * from './rateLimit';

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,0 +1,226 @@
+/**
+ * Retry policy for provider 429s.
+ *
+ * LangChain refuses to retry a 429 whose text reads like a spent allowance:
+ * `classifyRateLimitError` matches `/insufficient[_ -]?quota/i` and
+ * `/exceeded (?:your|the current|the available).+quota/i`, returns `stop`, and
+ * its default failed-attempt handler turns that into a thrown
+ * `RateLimitQuotaExhaustedError` before p-retry ever gets a second attempt.
+ * For OpenAI that is correct - `insufficient_quota` means the account is out
+ * of credit and waiting achieves nothing.
+ *
+ * Scaleway answers all three of its rate limits with the same wording, and
+ * nothing else to go on:
+ *
+ *     HTTP/2 429
+ *     content-type: application/json
+ *     {"status":429,"error":"INSUFFICIENT QUOTA",
+ *      "message":"You exceeded your current limit of concurrent requests."}
+ *
+ * Measured against api.scaleway.ai on 2026-07-30. The tokens-per-minute and
+ * requests-per-minute limits differ from that only in `message` - and `message`
+ * is exactly what the OpenAI SDK drops, since `APIError` keeps `body.error`
+ * alone. So the classifier only ever sees `429 "INSUFFICIENT QUOTA"`, reads it
+ * as a billing wall, and kills the run. There are no `x-ratelimit-*` and no
+ * `retry-after` headers on the 429 either, although successful responses do
+ * carry the former.
+ *
+ * All three of those limits clear on their own - in milliseconds for
+ * concurrency, inside the minute for the token bucket - so the attempt should
+ * wait and try again instead of failing the turn. This handler restores that
+ * while keeping every genuinely terminal case terminal: a structured
+ * `insufficient_quota`, wording that names billing or credit, and a single
+ * request too large for the per-minute allowance, which no amount of waiting
+ * can make fit.
+ */
+
+import { parseRetryAfterMs } from '@langchain/core/utils/async_caller';
+import type { FailedAttemptHandler } from '@langchain/core/utils/async_caller';
+import { extractErrorMessage, isContextOverflowError } from '@/utils/errors';
+
+/**
+ * Statuses LangChain never retries. Mirrored rather than imported because
+ * `defaultFailedAttemptHandler` is not exported, and this handler replaces it
+ * wholesale - anything missing here would turn into a retry loop on an error
+ * that can only ever fail.
+ */
+const STATUS_NO_RETRY = new Set([400, 401, 402, 403, 404, 405, 406, 407, 409]);
+
+/**
+ * Wording that means the allowance will not come back by itself.
+ *
+ * `insufficient_quota` is matched with the underscore only: that spelling is
+ * OpenAI's error code for an account out of credit, while Scaleway writes its
+ * transient rate limit as "INSUFFICIENT QUOTA" with a space.
+ */
+const BILLING_EXHAUSTED_RE =
+  /insufficient_quota|billing|credit balance|out of credits|payment required|purchase|upgrade your plan|exceeded your monthly/i;
+
+/**
+ * A `Retry-After` beyond this is capacity planning rather than throttling.
+ * Failing fast is better than holding a request open for minutes; the value
+ * matches LangChain's own threshold for the same decision.
+ */
+const MAX_RETRY_AFTER_WAIT_MS = 60_000;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function getStatus(error: unknown): number | undefined {
+  const record = asRecord(error);
+  if (record == null) {
+    return undefined;
+  }
+  if (typeof record.status === 'number') {
+    return record.status;
+  }
+  if (typeof record.statusCode === 'number') {
+    return record.statusCode;
+  }
+  const response = asRecord(record.response);
+  return typeof response?.status === 'number' ? response.status : undefined;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  const record = asRecord(error);
+  if (record == null) {
+    return undefined;
+  }
+  if (typeof record.code === 'string') {
+    return record.code;
+  }
+  const nested = asRecord(record.error);
+  return typeof nested?.code === 'string' ? nested.code : undefined;
+}
+
+/** Reads `retry-after` from either a `Headers` instance or a plain object. */
+function getRetryAfterHeader(error: unknown): string | undefined {
+  const record = asRecord(error);
+  const containers = [record?.headers, asRecord(record?.response)?.headers];
+  for (const container of containers) {
+    if (container == null) {
+      continue;
+    }
+    const getter = (container as { get?: unknown }).get;
+    if (typeof getter === 'function') {
+      const value = (container as Headers).get('retry-after');
+      if (value != null) {
+        return value;
+      }
+      continue;
+    }
+    const plain = asRecord(container);
+    const value = plain?.['retry-after'] ?? plain?.['Retry-After'];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/** Requests the caller cancelled. Retrying one would ignore the cancellation. */
+function isAborted(error: unknown): boolean {
+  const record = asRecord(error);
+  if (record == null) {
+    return false;
+  }
+  const message = typeof record.message === 'string' ? record.message : '';
+  return (
+    message.startsWith('Cancel') ||
+    message.startsWith('AbortError') ||
+    record.name === 'AbortError' ||
+    record.code === 'ECONNABORTED'
+  );
+}
+
+function toError(error: unknown, fallbackMessage: string): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  const coerced = new Error(extractErrorMessage(error) || fallbackMessage);
+  const record = asRecord(error);
+  if (record != null) {
+    Object.assign(coerced, record);
+  }
+  return coerced;
+}
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Whether a 429 describes a limit that clears on its own.
+ *
+ * Exported for the retry decision to be assertable without driving a live
+ * provider.
+ */
+export function isRetryableRateLimit(error: unknown): boolean {
+  if (getStatus(error) !== 429) {
+    return false;
+  }
+  if (getErrorCode(error) === 'insufficient_quota') {
+    return false;
+  }
+  if (BILLING_EXHAUSTED_RE.test(extractErrorMessage(error))) {
+    return false;
+  }
+  /**
+   * A 429 that is really "this one request is bigger than the whole per-minute
+   * allowance" never fits, however long the caller waits. Throwing hands it to
+   * the graph's overflow recovery, which shrinks the prompt instead.
+   */
+  return !isContextOverflowError(error);
+}
+
+/**
+ * Failed-attempt handler for OpenAI-compatible providers.
+ *
+ * Returning lets p-retry apply its randomized exponential backoff; throwing
+ * ends the attempts and surfaces the error.
+ */
+export const handleRateLimitedAttempt: FailedAttemptHandler = async (
+  error: unknown
+): Promise<void> => {
+  if (isAborted(error)) {
+    throw toError(error, 'Request was aborted');
+  }
+
+  const status = getStatus(error);
+  if (status != null && STATUS_NO_RETRY.has(status)) {
+    throw toError(error, `Request failed with status ${status}`);
+  }
+
+  /** Connection errors and 5xx: nothing to classify, the backoff is enough. */
+  if (status !== 429) {
+    return;
+  }
+
+  if (!isRetryableRateLimit(error)) {
+    throw toError(error, 'Rate limit exceeded');
+  }
+
+  const retryAfterMs = parseRetryAfterMs(getRetryAfterHeader(error));
+  if (retryAfterMs == null) {
+    return;
+  }
+  if (retryAfterMs > MAX_RETRY_AFTER_WAIT_MS) {
+    throw toError(error, 'Rate limit exceeded');
+  }
+  await wait(retryAfterMs);
+};
+
+/**
+ * Adds the handler to constructor fields unless the caller brought its own.
+ */
+export function withRateLimitRetry<T extends object>(fields?: T): T {
+  const next = (fields ?? {}) as T & {
+    onFailedAttempt?: FailedAttemptHandler;
+  };
+  if (next.onFailedAttempt != null) {
+    return next;
+  }
+  return { ...next, onFailedAttempt: handleRateLimitedAttempt };
+}


### PR DESCRIPTION
Fixes #357.

## The problem

Any 429 whose text reads like a spent allowance is never retried. `@langchain/core`'s `classifyRateLimitError` matches `/insufficient[_ -]?quota/i`, returns `{ action: 'stop' }`, and `defaultFailedAttemptHandler` throws before p-retry gets a second attempt. For OpenAI that is right - `insufficient_quota` means out of credit.

Scaleway answers **all three** of its rate limits with that wording and nothing else to go on:

```
HTTP/2 429
content-type: application/json
{"status":429,"error":"INSUFFICIENT QUOTA",
 "message":"You exceeded your current limit of concurrent requests."}
```

Tokens-per-minute and requests-per-minute differ only in `message`, which the OpenAI SDK drops - `APIError` keeps `body.error` alone - so the classifier only ever sees `429 "INSUFFICIENT QUOTA"` and reads a limit that clears in milliseconds as a billing wall. No `x-ratelimit-*` and no `retry-after` on the 429 either, although successful responses carry the former.

## The fix

An `onFailedAttempt` handler on the OpenAI-compatible constructors that retries a 429 unless something *structured* says the allowance is gone:

- `error.code === 'insufficient_quota'` - OpenAI's billing wall - stop
- wording naming billing, credit balance, out of credits, payment - stop
- a single request larger than the per-minute allowance - stop, and hand it to the existing context-overflow recovery, which shrinks the prompt instead
- LangChain's never-retry statuses and cancelled requests - stop
- everything else - return, so p-retry's randomized exponential backoff runs

The discriminator between the two quota meanings is the underscore: `insufficient_quota` is OpenAI's error code, `INSUFFICIENT QUOTA` with a space is Scaleway's rate-limit label. A caller-supplied `onFailedAttempt` still wins, so nothing that already sets one changes behaviour.

Applied to `ChatOpenAI` (hence Moonshot and OpenRouter), `AzureChatOpenAI`, `ChatDeepSeek` and `ChatXAI`.

## Measured

Against api.scaleway.ai on 2026-07-30, driven through `ChatOpenAI` from this package with the added probe script (`npm run probe:ratelimit`):

| Load | stock policy | with the handler |
|---|---|---|
| 150 concurrent 2-token requests | 123/150 in 2.5s | **150/150** in 3.3s |
| 4 x 30k-token requests (drains a 100k/min bucket) | 2/4 in 4.0s | **4/4** in 58.3s |

The 58s is the token bucket refilling, and that is the trade this makes: a slow turn instead of a dead one. A rejected request is not billed, so the retries cost waiting and nothing else.

## Tests

22 unit tests built on real `APIError` instances generated by the OpenAI SDK rather than hand-written objects, so the assertions run against the shape production sees - including a wiring test that the handler reaches `model.caller.onFailedAttempt` for all six classes, and that an explicit handler is left alone. `src/utils` + `src/llm/openai`: 300 tests green.

The probe script follows `context-overflow-probe.ts`: it exists so the retry policy stays grounded in what providers send instead of in phrases someone expected them to send.