### PR TITLE
📡 chore: Replace Scarf With REO Install Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@langfuse/tracing": "^5.4.1",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/sdk-node": "^0.220.0",
-        "@scarf/scarf": "^1.4.0",
         "@types/diff": "^7.0.2",
         "ai-tokenizer": "^1.0.6",
         "axios": "^1.18.1",
@@ -41,6 +40,7 @@
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
         "openai": "^6.46.0",
+        "reo-census": "^1.2.9",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -4504,13 +4504,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -11022,6 +11015,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reo-census": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/reo-census/-/reo-census-1.2.9.tgz",
+      "integrity": "sha512-QPnAyRk6gUK9h2XJy9yTXiA91+LEHahmzbRdfb6DigAoe1S/nKg2LXc+/m3//HGyMPAkCFVz/FJJ8YrKm5IrXw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -234,7 +234,6 @@
     "@langfuse/tracing": "^5.4.1",
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/sdk-node": "^0.220.0",
-    "@scarf/scarf": "^1.4.0",
     "@types/diff": "^7.0.2",
     "ai-tokenizer": "^1.0.6",
     "axios": "^1.18.1",
@@ -246,6 +245,7 @@
     "nanoid": "^3.3.7",
     "okapibm25": "^1.4.1",
     "openai": "^6.46.0",
+    "reo-census": "^1.2.9",
     "uuid": "^11.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

I replaced Scarf’s npm-install analytics dependency with REO’s dedicated `reo-census` SDK for `@librechat/agents`.

- Removed `@scarf/scarf`.
- Added `reo-census@^1.2.9` and regenerated the npm lockfile.
- Preserved dependency-driven install tracking while moving events to REO’s telemetry endpoint.
- Verified package discovery in partial-data mode with telemetry disabled during testing.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm audit --audit-level=low`
- `npm run build`
- `npx tsc --noEmit`
- `npx eslint src/`
- `npx jest src/graphs/__tests__/composition.smoke.test.ts --runInBand`
- `PACKAGE_TRACKER_ANALYTICS=false PACKAGE_TRACKER_VERBOSE=true node index.js` from the installed `reo-census` directory

### **Test Configuration**:

- Node/npm from the local agents development environment
- `@librechat/agents@3.3.8`
- `reo-census@1.2.9`
- Telemetry disabled during validation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes