### PR TITLE
🧭 fix: Detach Langfuse Roots From Foreign Ambient Spans + Trace-Shaping Docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,18 @@
 
 `@librechat/agents` is a TypeScript library for LLM agent orchestration — tool calling, multi-agent graphs, message formatting, streaming, and provider abstraction (Anthropic, Bedrock, VertexAI, OpenAI, Google). Published as `@librechat/agents` on npm. This is a major backend dependency of [LibreChat](../LibreChat/CLAUDE.md) (same team).
 
-| Path            | Purpose                                             |
-| --------------- | --------------------------------------------------- |
-| `src/messages/` | Message formatting, caching, content processing     |
-| `src/graphs/`   | LangGraph-based agent graphs (single + multi-agent) |
-| `src/llm/`      | Provider-specific LLM wrappers and utilities        |
-| `src/tools/`    | Tool definitions and search                         |
-| `src/agents/`   | Agent definitions and handoff logic                 |
-| `src/types/`    | Shared TypeScript types                             |
-| `src/common/`   | Enums, constants                                    |
-| `src/run.ts`    | Main run orchestration                              |
-| `src/stream.ts` | Streaming logic                                     |
+| Path                                         | Purpose                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `src/messages/`                              | Message formatting, caching, content processing                                      |
+| `src/graphs/`                                | LangGraph-based agent graphs (single + multi-agent)                                  |
+| `src/llm/`                                   | Provider-specific LLM wrappers and utilities                                         |
+| `src/tools/`                                 | Tool definitions and search                                                          |
+| `src/agents/`                                | Agent definitions and handoff logic                                                  |
+| `src/types/`                                 | Shared TypeScript types                                                              |
+| `src/common/`                                | Enums, constants                                                                     |
+| `src/run.ts`                                 | Main run orchestration                                                               |
+| `src/stream.ts`                              | Streaming logic                                                                      |
+| `src/langfuse*.ts`, `src/instrumentation.ts` | Langfuse tracing integration (see [Langfuse Trace Shaping](#langfuse-trace-shaping)) |
 
 ---
 
@@ -115,6 +116,44 @@ Multi-line imports count total character length across all lines. Consolidate va
 - **MCP**: use real `@modelcontextprotocol/sdk` exports for servers, transports, and tool definitions. Mirror real scenarios, don't stub SDK internals.
 - Only mock what you cannot control: external HTTP APIs, rate-limited services, non-deterministic system calls.
 - Heavy mocking is a code smell, not a testing strategy.
+
+---
+
+## Langfuse Trace Shaping
+
+This library is LibreChat's tracing surface: every agent run it orchestrates is exported to Langfuse, and trace quality is a product feature. Any change that touches graphs, node naming, callbacks, tool execution, message serialization, streaming, or providers must keep traces well-shaped — ask "how will this look in Langfuse?" as part of the change, not after.
+
+### Module Map
+
+| Module                                                         | Responsibility                                                               |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `src/langfuseTraceShaping.ts`                                  | Export-time span rename/retype/drop rules (the shape itself)                 |
+| `src/langfuseToolOutputTracing.ts`                             | Span processor applying shaping hooks + tool-output redaction                |
+| `src/langfuse.ts`                                              | Callback handler, identity/tags/metadata, control-flow + usage normalization |
+| `src/instrumentation.ts`                                       | Tracer provider bootstrap, per-tenant routing, deterministic trace ids       |
+| `src/langfuseConfig.ts`                                        | Config resolution/merging (env vs run vs agent level)                        |
+| `src/langfuseRuntimeContext.ts`, `src/langfuseRuntimeScope.ts` | Per-run scoping so concurrent runs/tenants never cross-contaminate           |
+
+### Invariants — what "well-shaped" means
+
+These originated from direct Langfuse-team feedback (PRs #288, #316) and must survive all future changes:
+
+- **Stable, operation-describing span names.** `agent`, `tool-dispatch`, `llm` — never leak ephemeral agent ids (`agent=<provider__model>`) or provider class names (`ChatOpenAI`) into span names. The model belongs on the generation's model attribute; name-based logic downstream must not break when models switch.
+- **Correct observation types.** Agent trace roots and agent nodes are `agent` observations; tool dispatch is a `chain`; individual tool calls are `tool`; LLM calls are `generation`; title trace roots are `chain`.
+- **No plumbing noise.** LangGraph internals (`__start__` channel seeds, anonymous `RunnableLambda` pass-throughs) are dropped at export. A trace tree should read like the run's story — if a new node adds noise, extend the shaping/drop rules rather than shipping it raw.
+- **Trace input/output are the conversation, not the state.** Root input reduces to the user's question, output to the assistant's answer — never full serialized graph state. Tool-dispatch input is scoped to the pending tool calls.
+- **Control flow is not an error.** `GraphInterrupt` and `ParentCommand` end their traces as successful with `controlFlow` outputs, not as error traces.
+- **Usage/cost is accurate per provider.** e.g. Bedrock cache read/write tokens are folded into input tokens so Langfuse cost math is right.
+- **Redaction is honored everywhere tool output can surface** — tool spans, and any generation input that embeds tool results (e.g. the activity-label prompt).
+- **Identity and metadata always propagate**: `userId`, `sessionId`, tags, environment, and trace metadata (`messageId`, `parentMessageId`, `agentId`, `agentName`) — including across LangChain callbacks that fire outside the caller's OTEL context.
+- **Trace identity is self-contained.** Root observations never inherit trace ids or parents from foreign ambient OTEL spans (e.g. a host's HTTP auto-instrumentation): the callback handler detaches them so roots stay true roots, deterministic ids apply, and concurrent runs inside one request context (an agent run plus a title run) cannot merge into one trace. Spans created through the Langfuse tracer provider are honored as parents, so hosts can still group runs under their own Langfuse observations deliberately.
+- **Deterministic trace ids** when a run opts in (`LangfuseConfig.deterministicTraceId`), so host apps can attach scores/feedback by regenerating the id from the run id.
+
+### Verifying
+
+- Run the tracing specs after any change in this area: `npx jest langfuse deterministic-trace-id` (specs live in `src/specs/langfuse-*.test.ts` and `src/tools/__tests__/ToolNode.langfuse.test.ts`). New shaping rules get spec coverage in `langfuse-trace-shaping.test.ts`.
+- For structural changes, verify against a real Langfuse project: set `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY`/`LANGFUSE_BASE_URL`, run an agent, and inspect the observation tree in the UI or via `GET /api/public/traces` — confirm span names, observation types, and root input/output match the invariants above.
+- For nontrivial Langfuse SDK work, use Langfuse's own agent-facing resources instead of guessing SDK behavior: the [Langfuse skill](https://github.com/langfuse/skills/tree/main/skills/langfuse), the docs MCP server (`https://langfuse.com/api/mcp`), and [llms.txt](https://langfuse.com/llms.txt).
 
 ---
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { setLangfuseTracerProvider } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { context, ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
@@ -13,17 +13,16 @@ import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
-  createLibreChatTraceAttributes,
-  hasLangfuseConfigCredentials,
-  hasLangfuseEnvCredentials,
-  hasLangfuseEnvConfig,
-} from '@/langfuse';
+  getLangfuseDestinationKey,
+  getLangfuseSpanProcessorParams,
+  registerLangfuseManagedSpan,
+} from '@/langfuseSpanRegistry';
 import {
   resolveLangfuseConfigForSpan,
   resolveTraceIdSeedForSpan,
 } from '@/langfuseRuntimeScope';
 import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
-import { registerLangfuseManagedSpan } from '@/langfuseSpanRegistry';
+import { createLibreChatTraceAttributes } from '@/langfuse';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { isPresent } from '@/utils/misc';
 
@@ -76,79 +75,6 @@ export function ensureOpenTelemetryContextManager(): void {
   }
 }
 
-function resolveLangfuseEnvironment(
-  langfuse?: t.LangfuseConfig
-): string | undefined {
-  const candidates = [
-    langfuse?.environment,
-    process.env.LANGFUSE_TRACING_ENVIRONMENT,
-    process.env.NODE_ENV,
-  ];
-  for (const candidate of candidates) {
-    if (candidate != null && candidate.trim() !== '') {
-      return candidate.trim();
-    }
-  }
-  return undefined;
-}
-
-function getLangfuseSpanProcessorParams(
-  langfuse?: t.LangfuseConfig
-): LangfuseSpanProcessorParams | undefined {
-  if (langfuse?.enabled === false) {
-    return undefined;
-  }
-  const environment = resolveLangfuseEnvironment(langfuse);
-  if (hasLangfuseConfigCredentials(langfuse)) {
-    return {
-      publicKey: langfuse.publicKey,
-      secretKey: langfuse.secretKey,
-      ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
-      ...(isPresent(environment) ? { environment } : {}),
-    };
-  }
-  if (hasLangfuseEnvConfig()) {
-    const baseUrl =
-      langfuse?.baseUrl ??
-      process.env.LANGFUSE_BASE_URL ??
-      process.env.LANGFUSE_BASEURL;
-    return {
-      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
-      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
-      ...(isPresent(baseUrl) ? { baseUrl } : {}),
-      ...(isPresent(environment) ? { environment } : {}),
-    };
-  }
-  if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
-    return {
-      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
-      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
-      baseUrl: langfuse.baseUrl,
-      ...(isPresent(environment) ? { environment } : {}),
-    };
-  }
-  return undefined;
-}
-
-function hashCacheKeyValue(value: string | undefined): string | undefined {
-  return isPresent(value)
-    ? createHash('sha256').update(value, 'utf8').digest('hex')
-    : undefined;
-}
-
-function getLangfuseTracerProviderKey(
-  params: LangfuseSpanProcessorParams,
-  langfuse?: t.LangfuseConfig
-): string {
-  return JSON.stringify({
-    publicKey: params.publicKey,
-    secretKeyHash: hashCacheKeyValue(params.secretKey),
-    baseUrl: params.baseUrl,
-    environment: params.environment,
-    toolOutputTracing: langfuse?.toolOutputTracing,
-  });
-}
-
 class RoutingLangfuseSpanProcessor implements SpanProcessor {
   // Processors live for the process lifetime. LibreChat tenant Langfuse
   // destinations are expected to be a bounded admin-managed set, and shutdown
@@ -161,26 +87,42 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
     if (params == null) {
       return undefined;
     }
+    return this.ensureProcessorForKey(
+      getLangfuseDestinationKey(params, langfuse),
+      params,
+      langfuse
+    );
+  }
 
-    const processorKey = getLangfuseTracerProviderKey(params, langfuse);
-    const existing = this.processors.get(processorKey);
+  private ensureProcessorForKey(
+    destinationKey: string,
+    params: LangfuseSpanProcessorParams,
+    langfuse?: t.LangfuseConfig
+  ): SpanProcessor {
+    const existing = this.processors.get(destinationKey);
     if (existing != null) {
       return existing;
     }
 
     const processor = createLangfuseSpanProcessor(params, langfuse);
-    this.processors.set(processorKey, processor);
+    this.processors.set(destinationKey, processor);
     return processor;
   }
 
   onStart(span: Span, parentContext: Context): void {
     const langfuse = resolveLangfuseConfigForSpan(parentContext);
-    const processor = this.ensureProcessor(langfuse);
-    if (processor == null) {
+    const params = getLangfuseSpanProcessorParams(langfuse);
+    if (params == null) {
       return;
     }
 
-    registerLangfuseManagedSpan(span);
+    const destinationKey = getLangfuseDestinationKey(params, langfuse);
+    const processor = this.ensureProcessorForKey(
+      destinationKey,
+      params,
+      langfuse
+    );
+    registerLangfuseManagedSpan(span, destinationKey);
 
     const librechatTraceAttributes = createLibreChatTraceAttributes(
       langfuse?.librechatTraceAttributes ?? {}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -23,6 +23,7 @@ import {
   resolveTraceIdSeedForSpan,
 } from '@/langfuseRuntimeScope';
 import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
+import { registerLangfuseManagedSpan } from '@/langfuseSpanRegistry';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { isPresent } from '@/utils/misc';
 
@@ -178,6 +179,8 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
     if (processor == null) {
       return;
     }
+
+    registerLangfuseManagedSpan(span);
 
     const librechatTraceAttributes = createLibreChatTraceAttributes(
       langfuse?.librechatTraceAttributes ?? {}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -75,6 +75,19 @@ export function ensureOpenTelemetryContextManager(): void {
   }
 }
 
+/** Cache key for processor instances: the destination plus processor-level
+ *  policy (`toolOutputTracing` is baked into each processor's redaction
+ *  behavior), unlike the pure destination identity used for span parenting. */
+function getLangfuseProcessorCacheKey(
+  destinationKey: string,
+  langfuse?: t.LangfuseConfig
+): string {
+  return JSON.stringify({
+    destinationKey,
+    toolOutputTracing: langfuse?.toolOutputTracing,
+  });
+}
+
 class RoutingLangfuseSpanProcessor implements SpanProcessor {
   // Processors live for the process lifetime. LibreChat tenant Langfuse
   // destinations are expected to be a bounded admin-managed set, and shutdown
@@ -88,24 +101,24 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
       return undefined;
     }
     return this.ensureProcessorForKey(
-      getLangfuseDestinationKey(params, langfuse),
+      getLangfuseProcessorCacheKey(getLangfuseDestinationKey(params), langfuse),
       params,
       langfuse
     );
   }
 
   private ensureProcessorForKey(
-    destinationKey: string,
+    processorCacheKey: string,
     params: LangfuseSpanProcessorParams,
     langfuse?: t.LangfuseConfig
   ): SpanProcessor {
-    const existing = this.processors.get(destinationKey);
+    const existing = this.processors.get(processorCacheKey);
     if (existing != null) {
       return existing;
     }
 
     const processor = createLangfuseSpanProcessor(params, langfuse);
-    this.processors.set(destinationKey, processor);
+    this.processors.set(processorCacheKey, processor);
     return processor;
   }
 
@@ -116,9 +129,9 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
       return;
     }
 
-    const destinationKey = getLangfuseDestinationKey(params, langfuse);
+    const destinationKey = getLangfuseDestinationKey(params);
     const processor = this.ensureProcessorForKey(
-      destinationKey,
+      getLangfuseProcessorCacheKey(destinationKey, langfuse),
       params,
       langfuse
     );

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -24,8 +24,22 @@ import {
   resolveTraceIdSeedForSpan,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
-import { isLangfuseManagedSpan } from '@/langfuseSpanRegistry';
+import {
+  hasLangfuseConfigCredentials,
+  hasLangfuseEnvCredentials,
+  hasLangfuseEnvConfig,
+} from '@/langfuseConfig';
+import {
+  getLangfuseManagedSpanDestination,
+  resolveLangfuseDestinationKey,
+} from '@/langfuseSpanRegistry';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
+
+export {
+  hasLangfuseConfigCredentials,
+  hasLangfuseEnvCredentials,
+  hasLangfuseEnvConfig,
+};
 
 const TRACE_METADATA_MAX_LENGTH = 200;
 const LANGFUSE_FORCE_FLUSH_ON_DISPOSE = 'LANGFUSE_FORCE_FLUSH_ON_DISPOSE';
@@ -179,13 +193,23 @@ function normalizeBedrockUsageForLangfuse(output: LLMResult): LLMResult {
  * skipped because the span no longer looks like a root), collapses concurrent
  * runs inside one request context — an agent run and the previous turn's
  * title run — into a single merged trace with racing names and unioned tags,
- * and bypasses the seeded deterministic trace id generator. Spans created
- * through the Langfuse tracer provider are kept, so hosts can still group
- * runs under their own Langfuse observations deliberately.
+ * and bypasses the seeded deterministic trace id generator. Only a
+ * Langfuse-managed span bound to the same export destination as the starting
+ * run is a safe parent — that is the sanctioned way for hosts to group runs
+ * under their own Langfuse observations; a managed span from a different
+ * destination (another tenant's project) would leave this run's trace
+ * dangling in its own destination while inheriting the other trace's id.
  */
-function detachForeignAmbientSpan(activeContext: Context): Context {
+function detachForeignAmbientSpan(
+  activeContext: Context,
+  destinationKey?: string
+): Context {
   const activeSpan = otelTrace.getSpan(activeContext);
-  if (activeSpan == null || isLangfuseManagedSpan(activeSpan)) {
+  if (activeSpan == null) {
+    return activeContext;
+  }
+  const parentDestination = getLangfuseManagedSpanDestination(activeSpan);
+  if (parentDestination != null && parentDestination === destinationKey) {
     return activeContext;
   }
   return otelTrace.deleteSpan(activeContext);
@@ -236,11 +260,14 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
    */
   private withRuntimeContext<T>(action: () => T, isDetachedRun = false): T {
     const currentContext = otelContext.active();
-    const activeContext = isDetachedRun
-      ? detachForeignAmbientSpan(currentContext)
-      : currentContext;
     const langfuse =
-      resolveLangfuseConfigForSpan(activeContext) ?? this.langfuse;
+      resolveLangfuseConfigForSpan(currentContext) ?? this.langfuse;
+    const activeContext = isDetachedRun
+      ? detachForeignAmbientSpan(
+        currentContext,
+        resolveLangfuseDestinationKey(langfuse)
+      )
+      : currentContext;
     const seed = this.getDeterministicTraceSeed();
     const scoped = (): T =>
       withLangfuseRuntimeScope(
@@ -385,19 +412,6 @@ function hasLangfuseTraceAttributes(langfuse?: t.LangfuseConfig): boolean {
   );
 }
 
-export function hasLangfuseConfigCredentials(
-  langfuse?: t.LangfuseConfig
-): langfuse is t.LangfuseConfig & {
-  publicKey: string;
-  secretKey: string;
-} {
-  return (
-    langfuse != null &&
-    isPresent(langfuse.publicKey) &&
-    isPresent(langfuse.secretKey)
-  );
-}
-
 function hasLangfuseConfigBaseUrl(langfuse?: t.LangfuseConfig): boolean {
   return isPresent(langfuse?.baseUrl);
 }
@@ -499,17 +513,6 @@ export function getLangfuseTraceName(
 ): string {
   const agentName = traceMetadata?.agentName;
   return isPresent(agentName) ? `${fallback}: ${agentName}` : fallback;
-}
-
-export function hasLangfuseEnvConfig(): boolean {
-  return hasLangfuseEnvCredentials();
-}
-
-export function hasLangfuseEnvCredentials(): boolean {
-  return (
-    isPresent(process.env.LANGFUSE_SECRET_KEY) &&
-    isPresent(process.env.LANGFUSE_PUBLIC_KEY)
-  );
 }
 
 export function shouldCreateLangfuseHandler(

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,7 +1,7 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { context as otelContext } from '@opentelemetry/api';
 import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
 import { isGraphInterrupt, isParentCommand } from '@langchain/langgraph';
+import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import {
   getLangfuseTracerProvider,
   propagateAttributes,
@@ -17,12 +17,14 @@ import type {
   LLMResult,
 } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
+import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
   resolveLangfuseConfigForSpan,
   resolveTraceIdSeedForSpan,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import { isLangfuseManagedSpan } from '@/langfuseSpanRegistry';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
@@ -169,9 +171,30 @@ function normalizeBedrockUsageForLangfuse(output: LLMResult): LLMResult {
   return { ...output, generations };
 }
 
+/**
+ * Hosts often execute agent code inside their own OpenTelemetry spans (HTTP
+ * server auto-instrumentation on the global provider). Root observations must
+ * not inherit that ambient identity: the foreign parent is never exported to
+ * Langfuse, which orphans the trace root (root/trace input-output shaping is
+ * skipped because the span no longer looks like a root), collapses concurrent
+ * runs inside one request context — an agent run and the previous turn's
+ * title run — into a single merged trace with racing names and unioned tags,
+ * and bypasses the seeded deterministic trace id generator. Spans created
+ * through the Langfuse tracer provider are kept, so hosts can still group
+ * runs under their own Langfuse observations deliberately.
+ */
+function detachForeignAmbientSpan(activeContext: Context): Context {
+  const activeSpan = otelTrace.getSpan(activeContext);
+  if (activeSpan == null || isLangfuseManagedSpan(activeSpan)) {
+    return activeContext;
+  }
+  return otelTrace.deleteSpan(activeContext);
+}
+
 class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly langfuse?: t.LangfuseConfig;
   private readonly traceIdSeed?: string;
+  private readonly trackedRunIds = new Set<string>();
 
   constructor(params?: AgentLangfuseHandlerParams) {
     const { langfuse, traceIdSeed, ...handlerParams } = params ?? {};
@@ -186,18 +209,50 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
       : undefined;
   }
 
-  private withRuntimeContext<T>(action: () => T): T {
-    const activeContext = otelContext.active();
+  /**
+   * Mirrors the base handler's `runMap`: a start callback whose `parentRunId`
+   * this handler never observed gets no explicit parent span and falls back
+   * to the ambient OTEL context (`startAndRegisterOtelSpan`), so it needs the
+   * same foreign-span detachment as a true root. This happens whenever a
+   * handler is attached mid-graph — e.g. the per-agent handler created for a
+   * detached subagent's model invocations, whose surrounding graph runs were
+   * never traced.
+   */
+  private startsDetachedRun(runId: string, parentRunId?: string): boolean {
+    const detached =
+      parentRunId == null || !this.trackedRunIds.has(parentRunId);
+    this.trackedRunIds.add(runId);
+    return detached;
+  }
+
+  /**
+   * Detached runs (roots, or starts whose parent this handler never tracked)
+   * take their span parent from the ambient OTEL context, so drop any foreign
+   * ambient span first — a run launched from a host's instrumented request
+   * context must start its own trace, not join an unexported foreign one.
+   * Trace identity otherwise stays scope-first: an active runtime scope
+   * (agent overlay, or a per-path seed like the title/label scopes) wins over
+   * this handler's own configuration.
+   */
+  private withRuntimeContext<T>(action: () => T, isDetachedRun = false): T {
+    const currentContext = otelContext.active();
+    const activeContext = isDetachedRun
+      ? detachForeignAmbientSpan(currentContext)
+      : currentContext;
     const langfuse =
       resolveLangfuseConfigForSpan(activeContext) ?? this.langfuse;
     const seed = this.getDeterministicTraceSeed();
-    return withLangfuseRuntimeScope(
-      {
-        langfuse,
-        traceIdSeed: resolveTraceIdSeedForSpan(activeContext) ?? seed,
-      },
-      action
-    );
+    const scoped = (): T =>
+      withLangfuseRuntimeScope(
+        {
+          langfuse,
+          traceIdSeed: resolveTraceIdSeedForSpan(activeContext) ?? seed,
+        },
+        action
+      );
+    return activeContext === currentContext
+      ? scoped()
+      : otelContext.with(activeContext, scoped);
   }
 
   // LangChain may invoke callback handlers outside the caller's OTEL context.
@@ -206,7 +261,10 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleChainStart(
     ...args: Parameters<CallbackHandler['handleChainStart']>
   ): ReturnType<CallbackHandler['handleChainStart']> {
-    return this.withRuntimeContext(() => super.handleChainStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleChainStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 
   override handleChainError(
@@ -233,25 +291,37 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleAgentAction(
     ...args: Parameters<CallbackHandler['handleAgentAction']>
   ): ReturnType<CallbackHandler['handleAgentAction']> {
-    return this.withRuntimeContext(() => super.handleAgentAction(...args));
+    return this.withRuntimeContext(
+      () => super.handleAgentAction(...args),
+      this.startsDetachedRun(args[1], args[2])
+    );
   }
 
   override handleGenerationStart(
     ...args: Parameters<CallbackHandler['handleGenerationStart']>
   ): ReturnType<CallbackHandler['handleGenerationStart']> {
-    return this.withRuntimeContext(() => super.handleGenerationStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleGenerationStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 
   override handleChatModelStart(
     ...args: Parameters<CallbackHandler['handleChatModelStart']>
   ): ReturnType<CallbackHandler['handleChatModelStart']> {
-    return this.withRuntimeContext(() => super.handleChatModelStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleChatModelStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 
   override handleLLMStart(
     ...args: Parameters<CallbackHandler['handleLLMStart']>
   ): ReturnType<CallbackHandler['handleLLMStart']> {
-    return this.withRuntimeContext(() => super.handleLLMStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleLLMStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 
   override handleLLMEnd(
@@ -269,7 +339,10 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleToolStart(
     ...args: Parameters<CallbackHandler['handleToolStart']>
   ): ReturnType<CallbackHandler['handleToolStart']> {
-    return this.withRuntimeContext(() => super.handleToolStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleToolStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 
   override handleToolError(
@@ -289,7 +362,10 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleRetrieverStart(
     ...args: Parameters<CallbackHandler['handleRetrieverStart']>
   ): ReturnType<CallbackHandler['handleRetrieverStart']> {
-    return this.withRuntimeContext(() => super.handleRetrieverStart(...args));
+    return this.withRuntimeContext(
+      () => super.handleRetrieverStart(...args),
+      this.startsDetachedRun(args[2], args[3])
+    );
   }
 }
 

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -12,6 +12,30 @@ export function normalizeToolName(name: string): string {
   return name.trim().toLowerCase();
 }
 
+export function hasLangfuseConfigCredentials(
+  langfuse?: t.LangfuseConfig
+): langfuse is t.LangfuseConfig & {
+  publicKey: string;
+  secretKey: string;
+} {
+  return (
+    langfuse != null &&
+    isPresent(langfuse.publicKey) &&
+    isPresent(langfuse.secretKey)
+  );
+}
+
+export function hasLangfuseEnvCredentials(): boolean {
+  return (
+    isPresent(process.env.LANGFUSE_SECRET_KEY) &&
+    isPresent(process.env.LANGFUSE_PUBLIC_KEY)
+  );
+}
+
+export function hasLangfuseEnvConfig(): boolean {
+  return hasLangfuseEnvCredentials();
+}
+
 function normalizeToolNames(names: string[] | undefined): Set<string> {
   const normalized = new Set<string>();
   for (const name of names ?? []) {

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -1,23 +1,128 @@
+import { createHash } from 'node:crypto';
+import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Span } from '@opentelemetry/api';
+import type * as t from '@/types';
+import {
+  hasLangfuseConfigCredentials,
+  hasLangfuseEnvCredentials,
+  hasLangfuseEnvConfig,
+} from '@/langfuseConfig';
+import { isPresent } from '@/utils/misc';
 
 /**
- * Spans created through the Langfuse tracer provider, tracked so callback
- * handlers can distinguish them from ambient spans created by a host's own
- * OpenTelemetry instrumentation (e.g. HTTP server spans on the global
- * provider). Root observations must never inherit trace identity from a
- * foreign span: the foreign parent is never exported to Langfuse, which
- * orphans the trace root (its root/trace input-output shaping is skipped),
- * collapses concurrent runs inside one request context into a single merged
- * trace, and bypasses the seeded deterministic trace id generator. Spans
- * registered here are safe parents — hosts can still group runs under their
- * own Langfuse observations.
+ * Spans created through the Langfuse tracer provider, keyed by the export
+ * destination they were routed to. Callback handlers use this to distinguish
+ * safe ambient parents from spans a root observation must not inherit:
+ *
+ * - Foreign spans (a host's own OpenTelemetry instrumentation, e.g. HTTP
+ *   server spans on the global provider) are never exported to Langfuse —
+ *   inheriting one orphans the trace root (its root/trace input-output
+ *   shaping is skipped), collapses concurrent runs inside one request
+ *   context into a single merged trace, and bypasses the seeded
+ *   deterministic trace id generator.
+ * - Langfuse-managed spans bound to a *different* destination (another
+ *   tenant's project) would leave the new trace dangling in its own
+ *   destination while inheriting the other tenant's trace id.
+ *
+ * Only a managed span whose destination matches the starting run's resolved
+ * destination is a safe parent — that is the sanctioned way for hosts to
+ * group runs under their own Langfuse observations.
  */
-const langfuseManagedSpans = new WeakSet<Span>();
+const managedSpanDestinations = new WeakMap<Span, string>();
 
-export function registerLangfuseManagedSpan(span: Span): void {
-  langfuseManagedSpans.add(span);
+export function registerLangfuseManagedSpan(
+  span: Span,
+  destinationKey: string
+): void {
+  managedSpanDestinations.set(span, destinationKey);
 }
 
-export function isLangfuseManagedSpan(span: Span): boolean {
-  return langfuseManagedSpans.has(span);
+export function getLangfuseManagedSpanDestination(
+  span: Span
+): string | undefined {
+  return managedSpanDestinations.get(span);
+}
+
+function resolveLangfuseEnvironment(
+  langfuse?: t.LangfuseConfig
+): string | undefined {
+  const candidates = [
+    langfuse?.environment,
+    process.env.LANGFUSE_TRACING_ENVIRONMENT,
+    process.env.NODE_ENV,
+  ];
+  for (const candidate of candidates) {
+    if (candidate != null && candidate.trim() !== '') {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+export function getLangfuseSpanProcessorParams(
+  langfuse?: t.LangfuseConfig
+): LangfuseSpanProcessorParams | undefined {
+  if (langfuse?.enabled === false) {
+    return undefined;
+  }
+  const environment = resolveLangfuseEnvironment(langfuse);
+  if (hasLangfuseConfigCredentials(langfuse)) {
+    return {
+      publicKey: langfuse.publicKey,
+      secretKey: langfuse.secretKey,
+      ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
+      ...(isPresent(environment) ? { environment } : {}),
+    };
+  }
+  if (hasLangfuseEnvConfig()) {
+    const baseUrl =
+      langfuse?.baseUrl ??
+      process.env.LANGFUSE_BASE_URL ??
+      process.env.LANGFUSE_BASEURL;
+    return {
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
+      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
+      ...(isPresent(baseUrl) ? { baseUrl } : {}),
+      ...(isPresent(environment) ? { environment } : {}),
+    };
+  }
+  if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
+    return {
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
+      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
+      baseUrl: langfuse.baseUrl,
+      ...(isPresent(environment) ? { environment } : {}),
+    };
+  }
+  return undefined;
+}
+
+function hashCacheKeyValue(value: string | undefined): string | undefined {
+  return isPresent(value)
+    ? createHash('sha256').update(value, 'utf8').digest('hex')
+    : undefined;
+}
+
+export function getLangfuseDestinationKey(
+  params: LangfuseSpanProcessorParams,
+  langfuse?: t.LangfuseConfig
+): string {
+  return JSON.stringify({
+    publicKey: params.publicKey,
+    secretKeyHash: hashCacheKeyValue(params.secretKey),
+    baseUrl: params.baseUrl,
+    environment: params.environment,
+    toolOutputTracing: langfuse?.toolOutputTracing,
+  });
+}
+
+/** The export destination a run with this config resolves to, or `undefined`
+ *  when no Langfuse destination is configured. */
+export function resolveLangfuseDestinationKey(
+  langfuse?: t.LangfuseConfig
+): string | undefined {
+  const params = getLangfuseSpanProcessorParams(langfuse);
+  return params == null
+    ? undefined
+    : getLangfuseDestinationKey(params, langfuse);
 }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -103,16 +103,21 @@ function hashCacheKeyValue(value: string | undefined): string | undefined {
     : undefined;
 }
 
+/**
+ * Identity of an export destination (project credentials + endpoint +
+ * environment) only. Processor-level policies like `toolOutputTracing` are
+ * deliberately excluded: two spans exporting to the same project under
+ * different redaction settings still share a destination and may parent one
+ * another.
+ */
 export function getLangfuseDestinationKey(
-  params: LangfuseSpanProcessorParams,
-  langfuse?: t.LangfuseConfig
+  params: LangfuseSpanProcessorParams
 ): string {
   return JSON.stringify({
     publicKey: params.publicKey,
     secretKeyHash: hashCacheKeyValue(params.secretKey),
     baseUrl: params.baseUrl,
     environment: params.environment,
-    toolOutputTracing: langfuse?.toolOutputTracing,
   });
 }
 
@@ -122,7 +127,5 @@ export function resolveLangfuseDestinationKey(
   langfuse?: t.LangfuseConfig
 ): string | undefined {
   const params = getLangfuseSpanProcessorParams(langfuse);
-  return params == null
-    ? undefined
-    : getLangfuseDestinationKey(params, langfuse);
+  return params == null ? undefined : getLangfuseDestinationKey(params);
 }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -1,0 +1,23 @@
+import type { Span } from '@opentelemetry/api';
+
+/**
+ * Spans created through the Langfuse tracer provider, tracked so callback
+ * handlers can distinguish them from ambient spans created by a host's own
+ * OpenTelemetry instrumentation (e.g. HTTP server spans on the global
+ * provider). Root observations must never inherit trace identity from a
+ * foreign span: the foreign parent is never exported to Langfuse, which
+ * orphans the trace root (its root/trace input-output shaping is skipped),
+ * collapses concurrent runs inside one request context into a single merged
+ * trace, and bypasses the seeded deterministic trace id generator. Spans
+ * registered here are safe parents — hosts can still group runs under their
+ * own Langfuse observations.
+ */
+const langfuseManagedSpans = new WeakSet<Span>();
+
+export function registerLangfuseManagedSpan(span: Span): void {
+  langfuseManagedSpans.add(span);
+}
+
+export function isLangfuseManagedSpan(span: Span): boolean {
+  return langfuseManagedSpans.has(span);
+}

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -10,8 +10,11 @@ const TOOL_DISPATCH_SPAN_NAME = 'tool-dispatch';
 const GENERATION_SPAN_NAME = 'llm';
 const ROOT_OBSERVATION_TYPE = 'agent';
 const CHAIN_OBSERVATION_TYPE = 'chain';
+const TOOL_OBSERVATION_TYPE = 'tool';
 const AGENT_TRACE_TAG = 'agent';
 const TITLE_TRACE_TAG = 'title';
+const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
+const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
 
 type MutableSpan = ReadableSpan & {
   name: string;
@@ -284,6 +287,51 @@ function isGenerationSpan(span: MutableSpan): boolean {
   return typeof type === 'string' && type.toLowerCase() === 'generation';
 }
 
+function isToolSpan(span: MutableSpan): boolean {
+  const type = span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE];
+  return (
+    typeof type === 'string' && type.toLowerCase() === TOOL_OBSERVATION_TYPE
+  );
+}
+
+/**
+ * LibreChat ephemeral agents are identified as
+ * `endpoint__model___sender[____index]` (`__` encodes `:`; see LibreChat's
+ * `encodeEphemeralAgentId`), and the outer workflow node carries that id as
+ * its span name — so switching models renames the span (item 1). Returns the
+ * stable human `sender` segment when the name matches that encoding.
+ */
+function extractEphemeralAgentSender(name: string): string | undefined {
+  let workingId = name;
+  const indexSeparator = workingId.lastIndexOf(EPHEMERAL_AGENT_INDEX_SEPARATOR);
+  if (
+    indexSeparator !== -1 &&
+    /^\d+$/.test(
+      workingId.slice(indexSeparator + EPHEMERAL_AGENT_INDEX_SEPARATOR.length)
+    )
+  ) {
+    workingId = workingId.slice(0, indexSeparator);
+  }
+  const senderSeparator = workingId.indexOf(EPHEMERAL_AGENT_SENDER_SEPARATOR);
+  if (senderSeparator <= 0) {
+    return undefined;
+  }
+  const sender = workingId
+    .slice(senderSeparator + EPHEMERAL_AGENT_SENDER_SEPARATOR.length)
+    .replace(/__/g, ':');
+  return sender === '' ? undefined : sender;
+}
+
+function shapeEphemeralAgentNodeSpan(span: MutableSpan): void {
+  if (isToolSpan(span)) {
+    return;
+  }
+  const sender = extractEphemeralAgentSender(span.name);
+  if (sender != null) {
+    span.name = sender;
+  }
+}
+
 function hasTraceTag(span: MutableSpan, expectedTag: string): boolean {
   const tags = parseAttributeValue(
     span.attributes[LangfuseOtelSpanAttributes.TRACE_TAGS]
@@ -313,7 +361,8 @@ function shapeRootObservationType(span: MutableSpan): void {
  * Reshapes spans per Langfuse-team feedback before export:
  * - `agent=<id>` / `tools=<id>` node names carry the ephemeral agent id
  *   (`provider__model`) — strip it so switching models doesn't break
- *   name-based logic (item 1).
+ *   name-based logic (item 1). The outer workflow node is named with the
+ *   bare agent id; ephemeral ids reduce to their stable sender name.
  * - LLM generation spans keep the provider client class name (`ChatOpenAI`,
  *   `AzureChatOpenAI`, …); rename them to a provider-agnostic `llm` so the
  *   name reflects the operation, not the model (the model stays on the
@@ -333,6 +382,8 @@ export function shapeLangfuseSpan(span: ReadableSpan): void {
     shapeToolNodeSpan(mutable);
   } else if (isGenerationSpan(mutable)) {
     mutable.name = GENERATION_SPAN_NAME;
+  } else {
+    shapeEphemeralAgentNodeSpan(mutable);
   }
   if (!isRootSpan(span)) {
     return;

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -15,6 +15,7 @@ const AGENT_TRACE_TAG = 'agent';
 const TITLE_TRACE_TAG = 'title';
 const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
 const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
+const OBSERVATION_METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
 
 type MutableSpan = ReadableSpan & {
   name: string;
@@ -295,6 +296,16 @@ function isToolSpan(span: MutableSpan): boolean {
 }
 
 /**
+ * Whether the span is a LangGraph node execution whose node id is the span
+ * name — the shape of the outer workflow-agent node. `@langfuse/tracing`
+ * flattens object metadata to per-key attributes with string values stored
+ * raw, so LangGraph's `langgraph_node` arrives directly comparable.
+ */
+function isWorkflowNodeSpan(span: MutableSpan): boolean {
+  return span.attributes[OBSERVATION_METADATA_LANGGRAPH_NODE] === span.name;
+}
+
+/**
  * LibreChat ephemeral agents are identified as
  * `endpoint__model___sender[____index]` (`__` encodes `:`; see LibreChat's
  * `encodeEphemeralAgentId`), and the outer workflow node carries that id as
@@ -333,17 +344,23 @@ function extractEphemeralAgentSender(name: string): string | undefined {
   return sender === '' ? undefined : sender;
 }
 
-/** Workflow-agent node spans are always children of the run's root chain, so
- *  root observations (host-named run roots like `LibreChat Agent: <name>`)
- *  are never rename candidates. */
+/** Workflow-agent node spans are always children of the run's root chain and
+ *  always carry `langgraph_node` metadata equal to their name, so host-named
+ *  run roots (`LibreChat Agent: <name>`) and ordinary chains that merely look
+ *  like encoded ids (`pipeline__stage___EU`) are never rename candidates.
+ *  Successful decodes become `agent` observations, matching the inner
+ *  `agent=<id>` node shaping. */
 function shapeEphemeralAgentNodeSpan(span: MutableSpan): void {
-  if (isToolSpan(span) || isRootSpan(span)) {
+  if (isToolSpan(span) || isRootSpan(span) || !isWorkflowNodeSpan(span)) {
     return;
   }
   const sender = extractEphemeralAgentSender(span.name);
-  if (sender != null) {
-    span.name = sender;
+  if (sender == null) {
+    return;
   }
+  span.name = sender;
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    ROOT_OBSERVATION_TYPE;
 }
 
 function hasTraceTag(span: MutableSpan, expectedTag: string): boolean {

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -299,7 +299,10 @@ function isToolSpan(span: MutableSpan): boolean {
  * `endpoint__model___sender[____index]` (`__` encodes `:`; see LibreChat's
  * `encodeEphemeralAgentId`), and the outer workflow node carries that id as
  * its span name — so switching models renames the span (item 1). Returns the
- * stable human `sender` segment when the name matches that encoding.
+ * stable human `sender` segment only when the name matches that encoding:
+ * the `endpoint__model` prefix must contain both segments and — unlike
+ * display names such as `LibreChat Agent: Ops___EU` — never contains
+ * whitespace, so legitimate names that merely embed `___` are left alone.
  */
 function extractEphemeralAgentSender(name: string): string | undefined {
   let workingId = name;
@@ -316,14 +319,25 @@ function extractEphemeralAgentSender(name: string): string | undefined {
   if (senderSeparator <= 0) {
     return undefined;
   }
+  const encodedPrefix = workingId.slice(0, senderSeparator);
+  if (/\s/.test(encodedPrefix)) {
+    return undefined;
+  }
+  const prefixParts = encodedPrefix.split('__');
+  if (prefixParts.length < 2 || prefixParts.some((part) => part === '')) {
+    return undefined;
+  }
   const sender = workingId
     .slice(senderSeparator + EPHEMERAL_AGENT_SENDER_SEPARATOR.length)
     .replace(/__/g, ':');
   return sender === '' ? undefined : sender;
 }
 
+/** Workflow-agent node spans are always children of the run's root chain, so
+ *  root observations (host-named run roots like `LibreChat Agent: <name>`)
+ *  are never rename candidates. */
 function shapeEphemeralAgentNodeSpan(span: MutableSpan): void {
-  if (isToolSpan(span)) {
+  if (isToolSpan(span) || isRootSpan(span)) {
     return;
   }
   const sender = extractEphemeralAgentSender(span.name);

--- a/src/run.ts
+++ b/src/run.ts
@@ -40,6 +40,12 @@ import {
   buildActivityLabelPrompt,
 } from '@/prompts/activityLabel';
 import {
+  Callback,
+  GraphEvents,
+  TitleMethod,
+  DEFAULT_RECURSION_LIMIT,
+} from '@/common';
+import {
   appendCallbacks,
   findCallback,
   type CallbackEntry,
@@ -49,16 +55,10 @@ import {
   createTitleRunnable,
 } from '@/utils/title';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
-import { resolveMaxSeals } from '@/llm/preempt';
 import { initializeLangfuseTracing } from './instrumentation';
-import {
-  Callback,
-  GraphEvents,
-  TitleMethod,
-  DEFAULT_RECURSION_LIMIT,
-} from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
+import { resolveMaxSeals } from '@/llm/preempt';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -1438,13 +1438,16 @@ export class Run<_T extends t.BaseGraphState> {
     titlePromptTemplate,
   }: t.RunTitleOptions): Promise<{ language?: string; title?: string }> {
     let titleLangfuseHandler: CallbackEntry | undefined;
-    let titleLangfuseConfig: t.LangfuseConfig | undefined;
     let titleUserId: string | undefined;
     let titleSessionId: string | undefined;
     const titleContext =
       this.Graph == null
         ? undefined
         : this.Graph.agentContexts.get(this.Graph.defaultAgentId);
+    const titleLangfuseConfig = resolveLangfuseConfig(
+      this.langfuse,
+      titleContext?.langfuse
+    );
     const traceMetadata = createLangfuseTraceMetadata({
       messageId: 'title-' + this.id,
       agentName: titleContext?.name,
@@ -1460,10 +1463,6 @@ export class Run<_T extends t.BaseGraphState> {
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
           : undefined;
-      titleLangfuseConfig = resolveLangfuseConfig(
-        this.langfuse,
-        titleContext?.langfuse
-      );
       initializeLangfuseTracing(titleLangfuseConfig);
       titleLangfuseHandler = createLangfuseHandler({
         langfuse: titleLangfuseConfig,
@@ -1565,14 +1564,26 @@ export class Run<_T extends t.BaseGraphState> {
           )
       );
 
+    /** Seed policy mirrors `generateActivityLabel`:
+     *  `runWithLangfuseRuntimeContext` SPREADS the surrounding context, so an
+     *  absent seed INHERITS an active parent run's and collapses the title
+     *  into that run's trace. Seeded when determinism is opted into OR a
+     *  parent seed is live; otherwise unseeded, matching the other paths. */
+    const inheritedTraceSeed = getTraceIdSeed();
+    const titleRuntimeScope = resolveLangfuseRuntimeScope({
+      runLangfuse: this.langfuse,
+      langfuseOverlay: titleContext?.langfuse,
+      traceIdSeed:
+        titleLangfuseConfig?.deterministicTraceId === true ||
+        inheritedTraceSeed != null
+          ? 'title-' + this.id
+          : undefined,
+    });
+
     try {
       try {
-        return await withLangfuseRuntimeScope(
-          resolveLangfuseRuntimeScope({
-            runLangfuse: this.langfuse,
-            langfuseOverlay: titleContext?.langfuse,
-          }),
-          () => invokeTitleChain(invokeConfig)
+        return await withLangfuseRuntimeScope(titleRuntimeScope, () =>
+          invokeTitleChain(invokeConfig)
         );
       } catch (_e) {
         // Fallback: strip callbacks to avoid EventStream tracer errors in certain environments
@@ -1585,12 +1596,8 @@ export class Run<_T extends t.BaseGraphState> {
         const safeConfig = Object.assign({}, rest, {
           callbacks: langfuseHandler ? [langfuseHandler] : [],
         });
-        return await withLangfuseRuntimeScope(
-          resolveLangfuseRuntimeScope({
-            runLangfuse: this.langfuse,
-            langfuseOverlay: titleContext?.langfuse,
-          }),
-          () => invokeTitleChain(safeConfig as Partial<RunnableConfig>)
+        return await withLangfuseRuntimeScope(titleRuntimeScope, () =>
+          invokeTitleChain(safeConfig as Partial<RunnableConfig>)
         );
       }
     } finally {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -633,6 +633,38 @@ describe('Langfuse per-run routing integration', () => {
     expect(agentRoot?.parentSpanId).toBe(hostSpanContext.spanId);
   });
 
+  it('detaches root observations from managed ambient spans of another destination', async () => {
+    const hostTenantId = 'tenant-managed-a';
+    const runTenantId = 'tenant-managed-b';
+    const hostLangfuse = tenantLangfuse(hostTenantId);
+    initializeLangfuseTracing(hostLangfuse);
+    initializeLangfuseTracing(tenantLangfuse(runTenantId));
+
+    let hostSpan: MockSpan | undefined;
+    await withLangfuseRuntimeScope({ langfuse: hostLangfuse }, async () => {
+      hostSpan = createMockSpan('host-group');
+    });
+
+    // A managed span is only a safe parent for runs exporting to the SAME
+    // destination; nesting tenant-B under tenant-A's span would leave B's
+    // trace dangling in B's project with A's trace id.
+    await otelContext.with(
+      otelTrace.setSpan(otelContext.active(), hostSpan as never),
+      () => runTenantFlow(runTenantId)
+    );
+
+    const hostSpanContext = hostSpan?.spanContext() as {
+      traceId: string;
+      spanId: string;
+    };
+    const agentRoot = startsForTenant(runTenantId).find(
+      (record) => record.name === `LibreChat Agent: Parent ${runTenantId}`
+    );
+    expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${runTenantId}`));
+    expect(agentRoot?.traceId).not.toBe(hostSpanContext.traceId);
+    expect(agentRoot?.parentSpanId).toBeUndefined();
+  });
+
   it('routes spans from captured OTel context after ALS scope exits', () => {
     const langfuse = tenantLangfuse('tenant-otel');
     initializeLangfuseTracing(langfuse);

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -256,7 +256,9 @@ function expectChildSpanParentName({
   const children = starts.filter((record) => record.name === childName);
   expect(children).not.toHaveLength(0);
   for (const child of children) {
-    const parent = starts.find((record) => record.spanId === child.parentSpanId);
+    const parent = starts.find(
+      (record) => record.spanId === child.parentSpanId
+    );
     expect(parent?.name.startsWith(parentNamePrefix)).toBe(true);
   }
 }
@@ -558,6 +560,77 @@ describe('Langfuse per-run routing integration', () => {
         traceId: summaryTraceId,
       });
     }
+  });
+
+  it('detaches root observations from foreign ambient spans', async () => {
+    const tenantId = 'tenant-ambient';
+    const foreignTraceId = 'f0e1d2c3b4a5968778695a4b3c2d1e0f';
+    const foreignSpanId = 'a1b2c3d4e5f60718';
+    initializeLangfuseTracing(tenantLangfuse(tenantId));
+
+    // Simulates a host running agent code inside its own OpenTelemetry span
+    // (HTTP server auto-instrumentation on the global provider): the span is
+    // never exported to Langfuse, so inheriting it would orphan the trace
+    // root, merge concurrent runs in one request into a single trace, and
+    // bypass deterministic trace ids.
+    const foreignSpan = otelTrace.wrapSpanContext({
+      traceId: foreignTraceId,
+      spanId: foreignSpanId,
+      traceFlags: 1,
+    });
+    await otelContext.with(
+      otelTrace.setSpan(otelContext.active(), foreignSpan),
+      () => runTenantFlow(tenantId)
+    );
+
+    const starts = startsForTenant(tenantId);
+    expect(starts).not.toHaveLength(0);
+    expect(
+      starts.filter(
+        (record) =>
+          record.traceId === foreignTraceId ||
+          record.parentSpanId === foreignSpanId
+      )
+    ).toHaveLength(0);
+
+    const agentRoot = starts.find(
+      (record) => record.name === `LibreChat Agent: Parent ${tenantId}`
+    );
+    expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${tenantId}`));
+    expect(agentRoot?.parentSpanId).toBeUndefined();
+
+    const titleRoot = starts.find(
+      (record) => record.name === `LibreChat Title: Parent ${tenantId}`
+    );
+    expect(titleRoot?.traceId).toBe(
+      traceIdFromSeed(`title-routing-${tenantId}`)
+    );
+    expect(titleRoot?.parentSpanId).toBeUndefined();
+  });
+
+  it('keeps root observations nested under Langfuse-managed ambient spans', async () => {
+    const tenantId = 'tenant-managed';
+    const langfuse = tenantLangfuse(tenantId);
+    initializeLangfuseTracing(langfuse);
+
+    let hostSpan: MockSpan | undefined;
+    await withLangfuseRuntimeScope({ langfuse }, async () => {
+      hostSpan = createMockSpan('host-group');
+      await otelContext.with(
+        otelTrace.setSpan(otelContext.active(), hostSpan as never),
+        () => runTenantFlow(tenantId)
+      );
+    });
+
+    const hostSpanContext = hostSpan?.spanContext() as {
+      traceId: string;
+      spanId: string;
+    };
+    const agentRoot = startsForTenant(tenantId).find(
+      (record) => record.name === `LibreChat Agent: Parent ${tenantId}`
+    );
+    expect(agentRoot?.traceId).toBe(hostSpanContext.traceId);
+    expect(agentRoot?.parentSpanId).toBe(hostSpanContext.spanId);
   });
 
   it('routes spans from captured OTel context after ALS scope exits', () => {

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -1,0 +1,70 @@
+import type { Span } from '@opentelemetry/api';
+import type * as t from '@/types';
+import {
+  getLangfuseManagedSpanDestination,
+  registerLangfuseManagedSpan,
+  resolveLangfuseDestinationKey,
+} from '@/langfuseSpanRegistry';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function tenantConfig(
+  overrides: Partial<t.LangfuseConfig> = {}
+): t.LangfuseConfig {
+  return {
+    enabled: true,
+    publicKey: 'pk-registry',
+    secretKey: 'sk-registry',
+    baseUrl: 'https://langfuse.registry',
+    ...overrides,
+  };
+}
+
+describe('Langfuse span registry', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('tracks managed spans by destination', () => {
+    const span = { name: 'managed' } as unknown as Span;
+    const key = resolveLangfuseDestinationKey(tenantConfig());
+    expect(key).toBeDefined();
+    registerLangfuseManagedSpan(span, key as string);
+    expect(getLangfuseManagedSpanDestination(span)).toBe(key);
+
+    const untracked = { name: 'foreign' } as unknown as Span;
+    expect(getLangfuseManagedSpanDestination(untracked)).toBeUndefined();
+  });
+
+  it('treats processor policy as irrelevant to destination identity', () => {
+    const base = resolveLangfuseDestinationKey(tenantConfig());
+    const redacting = resolveLangfuseDestinationKey(
+      tenantConfig({ toolOutputTracing: { enabled: false } })
+    );
+    expect(redacting).toBe(base);
+  });
+
+  it('separates destinations by credentials, endpoint, and environment', () => {
+    const base = resolveLangfuseDestinationKey(tenantConfig());
+    expect(
+      resolveLangfuseDestinationKey(tenantConfig({ publicKey: 'pk-other' }))
+    ).not.toBe(base);
+    expect(
+      resolveLangfuseDestinationKey(
+        tenantConfig({ baseUrl: 'https://langfuse.other' })
+      )
+    ).not.toBe(base);
+    expect(
+      resolveLangfuseDestinationKey(tenantConfig({ environment: 'staging' }))
+    ).not.toBe(base);
+  });
+
+  it('resolves no destination without credentials', () => {
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    expect(resolveLangfuseDestinationKey(undefined)).toBeUndefined();
+    expect(
+      resolveLangfuseDestinationKey(tenantConfig({ enabled: false }))
+    ).toBeUndefined();
+  });
+});

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -184,6 +184,24 @@ describe('shapeLangfuseSpan', () => {
     expect(span.name).toBe('server__toolkit___lookup');
   });
 
+  it('keeps display names that merely embed triple underscores', () => {
+    const runName = createSpan('LibreChat Agent: Ops___EU', {}, 'parent-1');
+    shapeLangfuseSpan(runName);
+    expect(runName.name).toBe('LibreChat Agent: Ops___EU');
+
+    const noEncodedPrefix = createSpan('Ops___EU', {}, 'parent-1');
+    shapeLangfuseSpan(noEncodedPrefix);
+    expect(noEncodedPrefix.name).toBe('Ops___EU');
+  });
+
+  it('never renames root observations, even with an encoded-id shape', () => {
+    const span = createSpan('bedrock__claude-sonnet-5___ClickHouse Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('bedrock__claude-sonnet-5___ClickHouse Agent');
+  });
+
   it('sets root span and trace input/output to the question and answer', () => {
     const span = createSpan('LibreChat Agent', {
       [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -142,6 +142,48 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[INPUT]).toBe(original);
   });
 
+  it('reduces ephemeral agent ids on workflow node spans to the sender name', () => {
+    const span = createSpan(
+      'bedrock__claude-sonnet-5___ClickHouse Agent',
+      {},
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('ClickHouse Agent');
+  });
+
+  it('strips parallel-instance index suffixes from ephemeral agent ids', () => {
+    const span = createSpan('openAI__gpt-4o___GPT-4o____1', {}, 'parent-1');
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('GPT-4o');
+  });
+
+  it('restores encoded colons in ephemeral agent sender names', () => {
+    const span = createSpan('openAI__gpt-4o___alias__variant', {}, 'parent-1');
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('alias:variant');
+  });
+
+  it('keeps persisted agent ids and senderless ephemeral ids unchanged', () => {
+    const persisted = createSpan('agent_okvkCroi6wXM4-7BY4ud1', {}, 'parent-1');
+    shapeLangfuseSpan(persisted);
+    expect(persisted.name).toBe('agent_okvkCroi6wXM4-7BY4ud1');
+
+    const senderless = createSpan('openAI__gpt-4o', {}, 'parent-1');
+    shapeLangfuseSpan(senderless);
+    expect(senderless.name).toBe('openAI__gpt-4o');
+  });
+
+  it('does not rename tool observations whose names embed triple underscores', () => {
+    const span = createSpan(
+      'server__toolkit___lookup',
+      { [OBSERVATION_TYPE]: 'tool' },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(span.name).toBe('server__toolkit___lookup');
+  });
+
   it('sets root span and trace input/output to the question and answer', () => {
     const span = createSpan('LibreChat Agent', {
       [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -28,6 +28,13 @@ const TRACE_INPUT = LangfuseOtelSpanAttributes.TRACE_INPUT;
 const TRACE_OUTPUT = LangfuseOtelSpanAttributes.TRACE_OUTPUT;
 const OBSERVATION_TYPE = LangfuseOtelSpanAttributes.OBSERVATION_TYPE;
 const TRACE_TAGS = LangfuseOtelSpanAttributes.TRACE_TAGS;
+const METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
+
+/** The outer workflow node: a non-root LangGraph node span whose
+ *  `langgraph_node` metadata equals its name. */
+function createWorkflowNodeSpan(name: string): TestSpan {
+  return createSpan(name, { [METADATA_LANGGRAPH_NODE]: name }, 'parent-1');
+}
 
 describe('shouldDropLangfuseSpan', () => {
   it('drops langgraph __start__ seed spans', () => {
@@ -142,34 +149,33 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[INPUT]).toBe(original);
   });
 
-  it('reduces ephemeral agent ids on workflow node spans to the sender name', () => {
-    const span = createSpan(
-      'bedrock__claude-sonnet-5___ClickHouse Agent',
-      {},
-      'parent-1'
+  it('reduces ephemeral workflow-agent node ids to agent observations named by sender', () => {
+    const span = createWorkflowNodeSpan(
+      'bedrock__claude-sonnet-5___ClickHouse Agent'
     );
     shapeLangfuseSpan(span);
     expect(span.name).toBe('ClickHouse Agent');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
   });
 
   it('strips parallel-instance index suffixes from ephemeral agent ids', () => {
-    const span = createSpan('openAI__gpt-4o___GPT-4o____1', {}, 'parent-1');
+    const span = createWorkflowNodeSpan('openAI__gpt-4o___GPT-4o____1');
     shapeLangfuseSpan(span);
     expect(span.name).toBe('GPT-4o');
   });
 
   it('restores encoded colons in ephemeral agent sender names', () => {
-    const span = createSpan('openAI__gpt-4o___alias__variant', {}, 'parent-1');
+    const span = createWorkflowNodeSpan('openAI__gpt-4o___alias__variant');
     shapeLangfuseSpan(span);
     expect(span.name).toBe('alias:variant');
   });
 
   it('keeps persisted agent ids and senderless ephemeral ids unchanged', () => {
-    const persisted = createSpan('agent_okvkCroi6wXM4-7BY4ud1', {}, 'parent-1');
+    const persisted = createWorkflowNodeSpan('agent_okvkCroi6wXM4-7BY4ud1');
     shapeLangfuseSpan(persisted);
     expect(persisted.name).toBe('agent_okvkCroi6wXM4-7BY4ud1');
 
-    const senderless = createSpan('openAI__gpt-4o', {}, 'parent-1');
+    const senderless = createWorkflowNodeSpan('openAI__gpt-4o');
     shapeLangfuseSpan(senderless);
     expect(senderless.name).toBe('openAI__gpt-4o');
   });
@@ -184,19 +190,29 @@ describe('shapeLangfuseSpan', () => {
     expect(span.name).toBe('server__toolkit___lookup');
   });
 
-  it('keeps display names that merely embed triple underscores', () => {
+  it('only renames spans carrying matching langgraph node metadata', () => {
     const runName = createSpan('LibreChat Agent: Ops___EU', {}, 'parent-1');
     shapeLangfuseSpan(runName);
     expect(runName.name).toBe('LibreChat Agent: Ops___EU');
 
-    const noEncodedPrefix = createSpan('Ops___EU', {}, 'parent-1');
-    shapeLangfuseSpan(noEncodedPrefix);
-    expect(noEncodedPrefix.name).toBe('Ops___EU');
+    const ordinaryChain = createSpan('pipeline__stage___EU', {}, 'parent-1');
+    shapeLangfuseSpan(ordinaryChain);
+    expect(ordinaryChain.name).toBe('pipeline__stage___EU');
+    expect(ordinaryChain.attributes[OBSERVATION_TYPE]).toBeUndefined();
+
+    const mismatchedNode = createSpan(
+      'pipeline__stage___EU',
+      { [METADATA_LANGGRAPH_NODE]: 'some-other-node' },
+      'parent-1'
+    );
+    shapeLangfuseSpan(mismatchedNode);
+    expect(mismatchedNode.name).toBe('pipeline__stage___EU');
   });
 
   it('never renames root observations, even with an encoded-id shape', () => {
     const span = createSpan('bedrock__claude-sonnet-5___ClickHouse Agent', {
       [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+      [METADATA_LANGGRAPH_NODE]: 'bedrock__claude-sonnet-5___ClickHouse Agent',
     });
     shapeLangfuseSpan(span);
     expect(span.name).toBe('bedrock__claude-sonnet-5___ClickHouse Agent');


### PR DESCRIPTION
## Summary

Live production traces on Langfuse cloud surfaced three trace-shaping gaps. Investigation traced all three to one root cause, plus one independent naming leak. This PR fixes them, documents the trace-shaping invariants in AGENTS.md, and was verified against real Langfuse cloud ingestion.

### Root cause: foreign ambient OTEL spans hijack trace identity

LibreChat executes runs inside its host instrumentation's OpenTelemetry spans (HTTP server spans on the global provider). `@langfuse/langchain`'s `CallbackHandler` parents **root observations** on `context.active()`, so every trace root inherited a foreign span that is never exported to Langfuse. Observed live (trace `305e2aa9…`, `e7f635…`):

- **Null trace input/output**: roots arrived with dangling parents, so `shapeRootSpan` (which requires a true root) never fired — trace input/output stayed `null` and the root kept type `SPAN` instead of `agent`.
- **Merged agent + title traces**: an agent run and the previous turn's title generation fired inside one request context inherited the *same* foreign trace id — one merged trace with racing names (`AgentRun` vs `TitleRun`) and unioned tags (`agent` + `title`). Exactly the "title-tagged traces named AgentRun" seen in production.
- **`deterministicTraceId` silently broken**: the seeded id generator only runs for true roots, so an inherited ambient trace id bypassed it entirely.

### Fixes

1. **Foreign ambient span detachment** (`langfuse.ts`, `langfuseSpanRegistry.ts`, `instrumentation.ts`): `RoutingLangfuseSpanProcessor` registers every span it exports in a WeakSet; `ScopedLangfuseCallbackHandler` strips non-registered (foreign) ambient spans from the OTEL context for *detached runs* — roots, or starts whose `parentRunId` the handler never tracked (the base handler's runMap-miss fallback would otherwise parent them on the ambient span; this is how a detached subagent's model spans leaked). Langfuse-managed ambient spans still parent roots, so hosts can group runs under their own observations deliberately.
2. **Title runtime scope seed** (`run.ts`): `generateTitle` now seeds its runtime scope with `title-<runId>`, mirroring the activity-label path's documented fix — an inherited parent seed can no longer collapse the title into the run's trace.
3. **Ephemeral agent-id span rename** (`langfuseTraceShaping.ts`): the outer workflow node is named with the bare agent id; ids matching LibreChat's `encodeEphemeralAgentId` format (`endpoint__model___sender[____index]`) now reduce to their stable sender name — `bedrock__claude-sonnet-5___ClickHouse Agent` → `ClickHouse Agent` — so switching models no longer renames the span. Persisted `agent_*` ids (already stable) are untouched.

Plus the **AGENTS.md “Langfuse Trace Shaping” section**: module map, the invariants (from Langfuse-team feedback in #288/#316 + the new self-contained-identity rule), verification steps, and pointers to Langfuse's agent-facing docs (skill, docs MCP, llms.txt).

## Verification

- `npx jest langfuse deterministic-trace-id` — new specs: export-time ephemeral-id renames (5 cases) and two routing integration tests (foreign ambient span detached / managed ambient span preserved).
- Full CI-equivalent suite: **3360 passed, 0 failed**.
- **Live probe against Langfuse cloud** (env `ci`): ran an `AgentRun` stream + `TitleRun` title inside a simulated foreign host span with `deterministicTraceId: true`. Result: two separate traces at their seeded ids — agent trace root typed `agent` with trace input `"What is the probe answer?"` / output `"Deterministic probe answer."`, span named `Probe Agent`; title trace root typed `chain`, tags `[librechat, probe, title]`; nothing on the foreign trace id.

## Out of scope (pre-existing, filed separately)

`langfuse-routing.integration.test.ts` has two failures that reproduce on `main` with a clean `npm ci` and are invisible in CI (validate.yml ignores `integration.test.ts`): when two tenants' runs execute concurrently, some spans are exported through the *other* tenant's Langfuse processor (cross-tenant leak, e.g. the whole tenant-b summarization tree on tenant-a's credentials). Root cause is ambient-scope-first config resolution crossing concurrent runs' ALS contexts — needs its own precedence design; flagged as a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)