### PR TITLE
🔭 fix: Keep Generation-Root Observation Input in Langfuse Traces

### DIFF
--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -254,11 +254,20 @@ function shapeRootSpan(span: MutableSpan): void {
     parseAttributeValue(span.attributes[outputKey]),
     'assistant'
   );
-  if (question != null) {
-    span.attributes[inputKey] = question;
-  }
-  if (answer != null) {
-    span.attributes[outputKey] = answer;
+  /** A generation that IS the trace root — a bare `model.invoke` with no
+   *  wrapping chain, i.e. the activity-label path — is also the only
+   *  observation carrying its own prompt: reducing its observation input
+   *  would discard the SystemMessage from the one place it is traced.
+   *  Chain/agent roots keep the full reduction; their child generations
+   *  still record the complete prompt. Trace-level input/output reduce
+   *  either way, so the trace list keeps showing question and answer. */
+  if (!isGenerationSpan(span)) {
+    if (question != null) {
+      span.attributes[inputKey] = question;
+    }
+    if (answer != null) {
+      span.attributes[outputKey] = answer;
+    }
   }
   const traceInput = question ?? span.attributes[inputKey];
   const traceOutput = answer ?? span.attributes[outputKey];

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -262,4 +262,51 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[TRACE_INPUT]).toBe('Generate a title');
     expect(span.attributes[TRACE_OUTPUT]).toBe('A useful title');
   });
+
+  it('keeps a generation root\'s full observation input while reducing trace input', () => {
+    /** The activity-label path: a bare model.invoke traces the generation
+     *  as its own root, so the observation input is the ONLY record of
+     *  the system prompt. The exact shape @langfuse/langchain exports. */
+    const originalInput = JSON.stringify([
+      { role: 'system', content: 'Write a short label describing…' },
+      { role: 'user', content: 'Tool calls:\n- bash(ls) → ok\n\nLabel:' },
+    ]);
+    const originalOutput = JSON.stringify({
+      role: 'assistant',
+      content: 'Confirmed /mnt/data persists',
+    });
+    const span = createSpan('LibreChat Activity Label', {
+      [OBSERVATION_TYPE]: 'generation',
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'activity-label']),
+      [INPUT]: originalInput,
+      [OUTPUT]: originalOutput,
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.name).toBe('llm');
+    expect(span.attributes[INPUT]).toBe(originalInput);
+    expect(span.attributes[OUTPUT]).toBe(originalOutput);
+    expect(span.attributes[TRACE_INPUT]).toBe(
+      'Tool calls:\n- bash(ls) → ok\n\nLabel:'
+    );
+    expect(span.attributes[TRACE_OUTPUT]).toBe(originalOutput);
+  });
+
+  it('still reduces observation input on non-generation roots', () => {
+    const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+      [INPUT]: JSON.stringify({
+        messages: [
+          { type: 'system', content: 'You are helpful.' },
+          { type: 'human', content: 'What is ClickHouse?' },
+        ],
+      }),
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.attributes[INPUT]).toBe('What is ClickHouse?');
+    expect(span.attributes[TRACE_INPUT]).toBe('What is ClickHouse?');
+  });
 });


### PR DESCRIPTION
## Problem

`shapeRootSpan` (from #288/#316, per Langfuse-team feedback) reduces every **root** span's observation input/output to the last user question and assistant answer. For chain/agent roots that is pure presentation — the child generation still records the complete prompt. But a generation that **is** the trace root — a bare `model.invoke` with no wrapping chain, which today means the **activity-label** path — has no child. The reduction discarded the `SystemMessage` (the entire label instruction, the quality surface of the feature) from the only place it is traced, making the instruction impossible to A/B against production traffic.

Diagnosed empirically with an OTLP-capture probe against the published 3.3.8 dist: the span is created with the full `[system, user]` message array as its input, and exports with only the user prompt — the rewrite happens in `shapeLangfuseSpan` at export time. Titles are unaffected (they pipe through a chain, so their root is a chain span); the main stream is unaffected (its root is a LangGraph chain span).

## Fix

In `shapeRootSpan`, skip the **observation-level** input/output reduction when the root is itself a generation span. **Trace-level** input/output still reduce, so the trace list keeps showing the question and answer exactly as before — including the "trace input begins with `Previous headers in this run…`" property that the continuity rollout validation relies on.

## Verification

- Two new tests: a generation root (the exact attribute shape `@langfuse/langchain` exports for the label path) keeps its full observation input/output while trace input reduces; a non-generation root keeps the existing full reduction. All 19 trace-shaping tests pass.
- End-to-end OTLP capture against this branch's built dist: the exported label generation now carries both messages (`system prompt present: true`), span still exports as the shaped `llm` root, trace input still reduces to the user prompt.