### PR TITLE
v3.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.8",
+      "version": "3.3.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## v3.3.9

Patch release carrying the Langfuse trace-quality/isolation fixes and the tool-call robustness follow-ups:

### Langfuse
- #361 — 🧭 Detach Langfuse roots from foreign ambient spans + trace-shaping docs (trace input/output restored, agent/title trace separation, deterministic ids honored, ephemeral agent-id span rename, destination-aware managed-span parenting)
- #362 — 🔭 Keep generation-root observation input in Langfuse traces
- #363 — 🏷️ Reference-material framing for the activity-label prompt
- #364 — 🔒 Stamp Langfuse runtime scopes with run identity (fixes cross-tenant span routing under concurrent runs on LangChain's shared background callback queue; replace-mode foreign-scope rejection covering config, seed, tool-output policy, and propagated identity; per-agent overlay scoping)

### Tool-call robustness
- #366 — 🛡️ Synthesize tool results for invalid tool calls (+ ask tool_call_id attribution)
- #368 — 🔁 Verify eager prestart args against canonical accumulation + divergence circuit breaker
- #369 — 🩹 Keep truncated tool-call inputs JSON objects on Anthropic replay
- #370 — 🩹 Coerce non-object toolUse inputs in the Bedrock Converse formatter

### Dependencies & chores
- #367 — 📦 Bump `@langchain/langgraph` to 1.4.8
- #360 — 🧪 SDK-side activity-label prose eval harness
- #359 — 📡 Replace Scarf with Reo install analytics

Verified: full suite green, `langfuse-routing` integration suite fully green, and live end-to-end verification against Langfuse cloud (concurrent-run isolation, identity separation, deterministic trace ids).