### PR TITLE
🛡️ fix: Synthesize Tool Results for Invalid Tool Calls (+ ask tool_call_id attribution)

### DIFF
--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -80,6 +80,46 @@ function extractLegacyHandoffInstructions(
   return content.match(HANDOFF_INSTRUCTIONS_PATTERN)?.[1]?.trim() ?? null;
 }
 
+/** Whether a tool name marks a handoff transfer (static or conditional). */
+function isTransferToolName(name: unknown): boolean {
+  return (
+    typeof name === 'string' &&
+    (name.startsWith(Constants.LC_TRANSFER_TO_) ||
+      name === 'conditional_transfer')
+  );
+}
+
+/**
+ * Drop transfer `tool_use` content blocks from an AI message's array content.
+ * Companion to the reception's tool-call filtering: array-content providers
+ * (Anthropic) serialize retained blocks verbatim, so a transfer block whose
+ * call/result the reception stripped — or a parallel sibling's transfer block,
+ * whose result never reaches this recipient's state — would replay as an
+ * unmatched `tool_use`. Matched by the gathered ids AND by transfer name
+ * (sibling blocks have no collectable id here). String content passes through.
+ */
+function filterTransferToolUseBlocks(
+  content: AIMessage['content'],
+  transferToolCallIds: ReadonlySet<string>
+): AIMessage['content'] {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  return content.filter((block) => {
+    if (
+      typeof block !== 'object' ||
+      (block as { type?: string } | null)?.type !== 'tool_use'
+    ) {
+      return true;
+    }
+    const toolUse = block as { id?: string; name?: string };
+    if (toolUse.id != null && transferToolCallIds.has(toolUse.id)) {
+      return false;
+    }
+    return !isTransferToolName(toolUse.name);
+  });
+}
+
 function isValidHandoffGroupId(value: unknown): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
 }
@@ -842,9 +882,23 @@ export class MultiAgentGraph extends StandardGraph {
               remainingToolCalls.length > 0 ||
               (typeof aiMsg.content === 'string' && aiMsg.content.trim())
             ) {
-              /** Keep the message but without transfer tool calls */
+              /**
+               * Keep the message but without transfer tool calls — AND
+               * without their `tool_use` content blocks. Array-content
+               * providers (Anthropic) serialize the retained blocks
+               * verbatim, so a transfer block whose call/result this
+               * filter just stripped would reach the receiving agent as
+               * an unmatched `tool_use` and the provider rejects the
+               * request. Filtered by transfer NAME as well as the
+               * gathered ids: a parallel sibling's transfer block has no
+               * result in THIS recipient's state, so its id is never
+               * collected, but its name still marks it.
+               */
               const filteredAiMsg = new AIMessage({
-                content: aiMsg.content,
+                content: filterTransferToolUseBlocks(
+                  aiMsg.content,
+                  transferToolCallIds
+                ),
                 tool_calls: remainingToolCalls,
                 id: aiMsg.id,
               });

--- a/src/hitl/askUserQuestion.ts
+++ b/src/hitl/askUserQuestion.ts
@@ -60,11 +60,24 @@ import type {
  * ```
  */
 export function askUserQuestion(
-  question: AskUserQuestionRequest
+  question: AskUserQuestionRequest,
+  options?: {
+    /**
+     * The calling tool's `tool_call_id`, surfaced on the interrupt payload
+     * as `tool_call_id` so hosts can attribute the question (and answer) to
+     * the exact tool-call content part. Tool bodies created with
+     * `tool(fn, …)` receive it as `config.toolCall.id` — LangChain stamps
+     * the full ToolCall onto the config when a tool is invoked with one.
+     * Optional: positional hosts and custom nodes can omit it.
+     */
+    toolCallId?: string;
+  }
 ): AskUserQuestionResolution {
   const payload: AskUserQuestionInterruptPayload = {
     type: 'ask_user_question',
     question,
+    ...(options?.toolCallId != null &&
+      options.toolCallId !== '' && { tool_call_id: options.toolCallId }),
   };
   return interrupt<AskUserQuestionInterruptPayload, AskUserQuestionResolution>(
     payload

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -1,5 +1,6 @@
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { Constants } from '@/common';
 
 const LANGGRAPH_START_NODE = '__start__';
 const ANONYMOUS_LAMBDA_NAME = 'RunnableLambda';
@@ -199,7 +200,14 @@ function getMessageInvalidToolCalls(
   }
   const calls: SerializedToolCall[] = [];
   for (const rawCall of rawCalls) {
-    if (!isRecord(rawCall) || typeof rawCall.id !== 'string') {
+    // Same attribution predicate ToolNode executes with (id-bearing,
+    // non-server) so the span never claims calls the node deliberately skips.
+    if (
+      !isRecord(rawCall) ||
+      typeof rawCall.id !== 'string' ||
+      rawCall.id === '' ||
+      rawCall.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+    ) {
       continue;
     }
     const call = normalizeToolCall(rawCall);

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -188,8 +188,30 @@ function getMessageToolCalls(
  * keeps the full serialized graph state as its input, and a mixed dispatch
  * silently omits the malformed call. `args` stays the raw unparsed string.
  */
+/** Tool-result ids present in the serialized state — ToolNode's
+ *  `!toolMessageIds.has(id)` execution filter, mirrored for the span. */
+function getToolResultIds(
+  messages: Record<string, unknown>[]
+): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (getMessageRole(message) !== 'tool') {
+      continue;
+    }
+    const rawId =
+      message.tool_call_id ??
+      (isRecord(message.kwargs) ? message.kwargs.tool_call_id : undefined) ??
+      (isRecord(message.data) ? message.data.tool_call_id : undefined);
+    if (typeof rawId === 'string' && rawId !== '') {
+      ids.add(rawId);
+    }
+  }
+  return ids;
+}
+
 function getMessageInvalidToolCalls(
-  message: Record<string, unknown>
+  message: Record<string, unknown>,
+  answeredIds: ReadonlySet<string>
 ): SerializedToolCall[] {
   const rawCalls =
     message.invalid_tool_calls ??
@@ -206,6 +228,7 @@ function getMessageInvalidToolCalls(
       !isRecord(rawCall) ||
       typeof rawCall.id !== 'string' ||
       rawCall.id === '' ||
+      answeredIds.has(rawCall.id) ||
       rawCall.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
     ) {
       continue;
@@ -250,6 +273,9 @@ function findPendingToolCalls(value: unknown): SerializedToolCall[] {
    * `canPromoteInvalidCalls` so the span never reports skipped calls.
    */
   const invalidCallsApply = !Array.isArray(value);
+  const answeredIds = invalidCallsApply
+    ? getToolResultIds(messages)
+    : undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     if (getMessageRole(messages[i]) !== 'assistant') {
       continue;
@@ -257,7 +283,7 @@ function findPendingToolCalls(value: unknown): SerializedToolCall[] {
     const calls = [
       ...getMessageToolCalls(messages[i]),
       ...(invalidCallsApply && getSerializedMessageId(messages[i]) != null
-        ? getMessageInvalidToolCalls(messages[i])
+        ? getMessageInvalidToolCalls(messages[i], answeredIds!)
         : []),
     ];
     if (calls.length > 0) {

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -222,19 +222,41 @@ function getMessageInvalidToolCalls(
   return calls;
 }
 
+/** The serialized message's own id (uuid), NOT the LC-serialization type id
+ *  array that `message.id` carries in constructor dumps. */
+function getSerializedMessageId(
+  message: Record<string, unknown>
+): string | undefined {
+  const kwargsId = isRecord(message.kwargs) ? message.kwargs.id : undefined;
+  const dataId = isRecord(message.data) ? message.data.id : undefined;
+  const rawId = message.id;
+  const id = kwargsId ?? dataId ?? rawId;
+  return typeof id === 'string' && id !== '' ? id : undefined;
+}
+
 /** Latest assistant turn's tool calls — the calls this tool node is executing. */
 function findPendingToolCalls(value: unknown): SerializedToolCall[] {
   const messages = getMessageArray(value);
   if (messages == null) {
     return [];
   }
+  /**
+   * Invalid calls count only where ToolNode's own gate lets them execute:
+   * the messages-state form (a bare-array state means the node returns a
+   * plain output list and skips invalid handling) with an id-bearing
+   * assistant message (no id, no reducer upsert). Mirrors
+   * `canPromoteInvalidCalls` so the span never reports skipped calls.
+   */
+  const invalidCallsApply = !Array.isArray(value);
   for (let i = messages.length - 1; i >= 0; i--) {
     if (getMessageRole(messages[i]) !== 'assistant') {
       continue;
     }
     const calls = [
       ...getMessageToolCalls(messages[i]),
-      ...getMessageInvalidToolCalls(messages[i]),
+      ...(invalidCallsApply && getSerializedMessageId(messages[i]) != null
+        ? getMessageInvalidToolCalls(messages[i])
+        : []),
     ];
     if (calls.length > 0) {
       return calls;

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -213,7 +213,9 @@ function getMessageInvalidToolCalls(
     // Same name fallback ToolNode synthesizes with — a nameless attributable
     // call still gets a result, so it must still count in the span input.
     const call = normalizeToolCall(
-      typeof rawCall.name === 'string' ? rawCall : { ...rawCall, name: 'unknown' }
+      typeof rawCall.name === 'string' && rawCall.name !== ''
+        ? rawCall
+        : { ...rawCall, name: 'unknown' }
     );
     if (call != null) {
       calls.push(call);

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -210,7 +210,11 @@ function getMessageInvalidToolCalls(
     ) {
       continue;
     }
-    const call = normalizeToolCall(rawCall);
+    // Same name fallback ToolNode synthesizes with — a nameless attributable
+    // call still gets a result, so it must still count in the span input.
+    const call = normalizeToolCall(
+      typeof rawCall.name === 'string' ? rawCall : { ...rawCall, name: 'unknown' }
+    );
     if (call != null) {
       calls.push(call);
     }

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -179,6 +179,37 @@ function getMessageToolCalls(
   return calls;
 }
 
+/**
+ * Id-bearing `invalid_tool_calls` on the assistant turn. ToolNode pairs these
+ * with synthesized error results (and an invalid-only turn is routed on them
+ * alone), so the tool-dispatch span must count them as part of the executing
+ * batch — otherwise an invalid-only dispatch finds zero calls and the span
+ * keeps the full serialized graph state as its input, and a mixed dispatch
+ * silently omits the malformed call. `args` stays the raw unparsed string.
+ */
+function getMessageInvalidToolCalls(
+  message: Record<string, unknown>
+): SerializedToolCall[] {
+  const rawCalls =
+    message.invalid_tool_calls ??
+    (isRecord(message.kwargs) ? message.kwargs.invalid_tool_calls : undefined) ??
+    (isRecord(message.data) ? message.data.invalid_tool_calls : undefined);
+  if (!Array.isArray(rawCalls)) {
+    return [];
+  }
+  const calls: SerializedToolCall[] = [];
+  for (const rawCall of rawCalls) {
+    if (!isRecord(rawCall) || typeof rawCall.id !== 'string') {
+      continue;
+    }
+    const call = normalizeToolCall(rawCall);
+    if (call != null) {
+      calls.push(call);
+    }
+  }
+  return calls;
+}
+
 /** Latest assistant turn's tool calls — the calls this tool node is executing. */
 function findPendingToolCalls(value: unknown): SerializedToolCall[] {
   const messages = getMessageArray(value);
@@ -189,7 +220,10 @@ function findPendingToolCalls(value: unknown): SerializedToolCall[] {
     if (getMessageRole(messages[i]) !== 'assistant') {
       continue;
     }
-    const calls = getMessageToolCalls(messages[i]);
+    const calls = [
+      ...getMessageToolCalls(messages[i]),
+      ...getMessageInvalidToolCalls(messages[i]),
+    ];
     if (calls.length > 0) {
       return calls;
     }

--- a/src/session/messageSerialization.ts
+++ b/src/session/messageSerialization.ts
@@ -6,7 +6,7 @@ import {
   ToolMessage,
   BaseMessage,
 } from '@langchain/core/messages';
-import type { ToolCall } from '@langchain/core/messages/tool';
+import type { ToolCall, InvalidToolCall } from '@langchain/core/messages/tool';
 import type { UsageMetadata } from '@langchain/core/messages';
 import type { JsonObject, JsonValue, SerializedSessionMessage } from './types';
 
@@ -15,6 +15,7 @@ type MessageExtras = {
   name?: string;
   tool_call_id?: string;
   tool_calls?: ToolCall[];
+  invalid_tool_calls?: InvalidToolCall[];
   usage_metadata?: UsageMetadata;
   additional_kwargs?: unknown;
   response_metadata?: unknown;
@@ -133,6 +134,13 @@ export function serializeMessage(
   if (extras.tool_calls) {
     serialized.toolCalls = toJsonValue(extras.tool_calls);
   }
+  /** Malformed-call metadata must round-trip with the calls: the content
+   *  (with any raw `tool_use` blocks) survives serialization, so dropping
+   *  `invalid_tool_calls` would strand those blocks without the entries
+   *  ToolNode repairs the pairing from on restore. */
+  if (extras.invalid_tool_calls && extras.invalid_tool_calls.length > 0) {
+    serialized.invalidToolCalls = toJsonValue(extras.invalid_tool_calls);
+  }
   return serialized;
 }
 
@@ -153,6 +161,9 @@ export function deserializeMessage(
     return new AIMessage({
       ...common,
       tool_calls: serialized.toolCalls as ToolCall[] | undefined,
+      invalid_tool_calls: serialized.invalidToolCalls as
+        | InvalidToolCall[]
+        | undefined,
       usage_metadata: serialized.usageMetadata as UsageMetadata | undefined,
     });
   }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -52,6 +52,7 @@ export interface SerializedSessionMessage {
   name?: string;
   toolCallId?: string;
   toolCalls?: JsonValue;
+  invalidToolCalls?: JsonValue;
   usageMetadata?: JsonObject;
 }
 

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -125,6 +125,7 @@ type HandoffReceptionProbe = {
   ): {
     instructions: string | null;
     parallelGroupId?: number;
+    filteredMessages?: t.BaseGraphState['messages'];
   } | null;
 };
 
@@ -2373,6 +2374,92 @@ describe('Agent Handoffs Tests', () => {
       expect(leftReply).toBeDefined();
       expect(rightReply).toBeDefined();
       expectPromotedPairing(finalMessages!);
+    });
+
+    it('reception strips transfer tool_use content blocks alongside the calls (array-content providers)', async () => {
+      /**
+       * The retained filtered AI message used to keep `content` verbatim:
+       * with the promoted sibling holding the message in state, an
+       * Anthropic child would replay the stripped transfer's `tool_use`
+       * block (and a parallel sibling's block, whose result never reaches
+       * this recipient) as unmatched calls. Both must be filtered with the
+       * tool-call filtering; non-transfer blocks stay.
+       */
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('left', 'You are the left specialist'),
+        createBasicAgent('right', 'You are the right specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        { from: 'router', to: 'left', edgeType: 'handoff' },
+        { from: 'router', to: 'right', edgeType: 'handoff' },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      const graph = run.Graph as unknown as HandoffReceptionProbe;
+
+      const transferLeft = {
+        id: 'tc_transfer_left',
+        name: `${Constants.LC_TRANSFER_TO_}left`,
+        args: {},
+      };
+      const context = graph.processHandoffReception(
+        [
+          new AIMessage({
+            id: 'ai_reception_blocks',
+            content: [
+              { type: 'text', text: 'Routing.' },
+              {
+                type: 'tool_use',
+                id: 'tc_transfer_left',
+                name: `${Constants.LC_TRANSFER_TO_}left`,
+                input: {},
+              },
+              {
+                type: 'tool_use',
+                id: 'tc_transfer_right_sibling',
+                name: `${Constants.LC_TRANSFER_TO_}right`,
+                input: {},
+              },
+              {
+                type: 'tool_use',
+                id: 'tc_promoted_sibling',
+                name: 'unknown',
+                input: {},
+              },
+            ],
+            tool_calls: [
+              transferLeft,
+              { id: 'tc_promoted_sibling', name: 'unknown', args: {} },
+            ],
+          }),
+          new ToolMessage({
+            content: 'Successfully transferred to left',
+            name: transferLeft.name,
+            tool_call_id: transferLeft.id,
+          }),
+          new ToolMessage({
+            content: 'Error: Malformed args.',
+            name: 'unknown',
+            tool_call_id: 'tc_promoted_sibling',
+          }),
+        ],
+        'left'
+      );
+
+      const retained = context?.filteredMessages?.find(
+        (msg): msg is AIMessage => msg.getType() === 'ai'
+      );
+      expect(retained).toBeDefined();
+      expect(retained!.tool_calls?.map((call) => call.id)).toEqual([
+        'tc_promoted_sibling',
+      ]);
+      const blocks = retained!.content as Array<{ type?: string; id?: string }>;
+      /** Both this recipient's transfer block AND the parallel sibling's
+       *  are gone; the text and the promoted sibling's block remain. */
+      expect(blocks.map((block) => block.id ?? block.type)).toEqual([
+        'text',
+        'tc_promoted_sibling',
+      ]);
     });
   });
 });

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -2156,4 +2156,223 @@ describe('Agent Handoffs Tests', () => {
       );
     });
   });
+
+  describe('Handoffs with a malformed sibling call (invalid_tool_calls regression)', () => {
+    /**
+     * Regression for the invalid-call promotion crossing handoff boundaries:
+     * a handoff tool snapshots `update.messages` from the PRE-promotion state
+     * with a filtered same-id copy of the AI message, and commands apply
+     * after sibling reducer updates. Un-patched, the stale copy overwrote the
+     * promoted replacement and a parallel Send child's state omitted the
+     * synthesized result — the child agent's provider request then carried an
+     * invalid call/result pairing. `validateToolHistory` inside the scripted
+     * model asserts the pairing on EVERY model invocation, including the
+     * children's.
+     */
+    const MALFORMED_CALL_ID = 'tool_call_malformed_sibling';
+
+    /** Corrupts the malformed sibling's streamed args into a non-object JSON
+     *  string so `collapseToolCallChunks` files it under `invalid_tool_calls`
+     *  — the shape a malformed provider stream produces. */
+    class MalformedSiblingHandoffModel extends ScriptedHandoffModel {
+      override async *_streamResponseChunks(
+        messages: t.BaseGraphState['messages'],
+        options: this['ParsedCallOptions'],
+        runManager?: CallbackManagerForLLMRun
+      ): AsyncGenerator<ChatGenerationChunk> {
+        for await (const chunk of super._streamResponseChunks(
+          messages,
+          options,
+          runManager
+        )) {
+          const chunkMessage = chunk.message as unknown as {
+            tool_call_chunks?: Array<{ id?: string; args?: string }>;
+          };
+          for (const toolCallChunk of chunkMessage.tool_call_chunks ?? []) {
+            if (toolCallChunk.id === MALFORMED_CALL_ID) {
+              toolCallChunk.args = '"malformed';
+            }
+          }
+          yield chunk;
+        }
+      }
+    }
+
+    const expectPromotedPairing = (
+      finalMessages: t.BaseGraphState['messages']
+    ): void => {
+      const promoted = finalMessages.find(
+        (msg): msg is AIMessage =>
+          msg.getType() === 'ai' &&
+          ((msg as AIMessage).tool_calls ?? []).some(
+            (call) => call.id === MALFORMED_CALL_ID
+          )
+      );
+      expect(promoted).toBeDefined();
+      expect(promoted!.invalid_tool_calls ?? []).toHaveLength(0);
+      const synthesized = finalMessages.find(
+        (msg): msg is ToolMessage =>
+          msg.getType() === 'tool' &&
+          (msg as ToolMessage).tool_call_id === MALFORMED_CALL_ID
+      );
+      expect(synthesized).toBeDefined();
+      expect(String(synthesized!.content)).toContain('Malformed');
+    };
+
+    it('single handoff: the child state keeps the promoted call and its synthesized result', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('specialist', 'You are the specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'specialist',
+          edgeType: 'handoff',
+          prompt: 'Work the specialist task',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      run.Graph.overrideModel = new MalformedSiblingHandoffModel([
+        {
+          promptMarker: 'single-malformed-request-marker',
+          response: 'Routing with a malformed sibling',
+          toolCalls: [
+            {
+              id: 'tool_call_transfer_specialist',
+              name: `${Constants.LC_TRANSFER_TO_}specialist`,
+              args: { instructions: 'single-specialist-instructions-marker' },
+            } as ToolCall,
+            {
+              id: MALFORMED_CALL_ID,
+              name: 'broken_tool',
+              args: {},
+            } as ToolCall,
+          ],
+        },
+        {
+          promptMarker: 'single-specialist-instructions-marker',
+          response: 'Specialist complete',
+        },
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-handoff-malformed-single-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('single-malformed-request-marker')] },
+        config
+      );
+
+      const finalMessages = run.getRunMessages();
+      expect(finalMessages).toBeDefined();
+      /** The child agent actually ran — its scripted response is present —
+       *  and every model call it made passed validateToolHistory. */
+      const specialistReply = finalMessages!.find(
+        (msg) =>
+          msg.getType() === 'ai' &&
+          String(msg.content).includes('Specialist complete')
+      );
+      expect(specialistReply).toBeDefined();
+      expectPromotedPairing(finalMessages!);
+    });
+
+    it('parallel Send handoffs: each child state keeps the promoted call and its synthesized result', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('left', 'You are the left specialist'),
+        createBasicAgent('right', 'You are the right specialist'),
+      ];
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'left',
+          edgeType: 'handoff',
+          prompt: 'Work the left task',
+        },
+        {
+          from: 'router',
+          to: 'right',
+          edgeType: 'handoff',
+          prompt: 'Work the right task',
+        },
+      ];
+      const run = await Run.create(createTestConfig(agents, edges));
+      if (run.Graph == null) {
+        throw new Error('Expected a multi-agent graph');
+      }
+      run.Graph.overrideModel = new MalformedSiblingHandoffModel([
+        {
+          promptMarker: 'parallel-malformed-request-marker',
+          response: 'Routing both with a malformed sibling',
+          toolCalls: [
+            {
+              id: 'tool_call_transfer_left',
+              name: `${Constants.LC_TRANSFER_TO_}left`,
+              args: { instructions: 'parallel-left-instructions-marker' },
+            } as ToolCall,
+            {
+              id: 'tool_call_transfer_right',
+              name: `${Constants.LC_TRANSFER_TO_}right`,
+              args: { instructions: 'parallel-right-instructions-marker' },
+            } as ToolCall,
+            {
+              id: MALFORMED_CALL_ID,
+              name: 'broken_tool',
+              args: {},
+            } as ToolCall,
+          ],
+        },
+        {
+          promptMarker: 'parallel-left-instructions-marker',
+          response: 'Left complete',
+        },
+        {
+          promptMarker: 'parallel-right-instructions-marker',
+          response: 'Right complete',
+        },
+      ]);
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: { thread_id: 'test-handoff-malformed-parallel-thread' },
+        streamMode: 'values',
+        version: 'v2',
+      };
+      await run.processStream(
+        { messages: [new HumanMessage('parallel-malformed-request-marker')] },
+        config
+      );
+
+      const finalMessages = run.getRunMessages();
+      expect(finalMessages).toBeDefined();
+      /** Both Send children ran off their patched child states, and every
+       *  child model call passed validateToolHistory — the un-patched Send
+       *  state omitted the synthesized result and carried the stale same-id
+       *  copy instead. */
+      const leftReply = finalMessages!.find(
+        (msg) =>
+          msg.getType() === 'ai' &&
+          String(msg.content).includes('Left complete')
+      );
+      const rightReply = finalMessages!.find(
+        (msg) =>
+          msg.getType() === 'ai' &&
+          String(msg.content).includes('Right complete')
+      );
+      expect(leftReply).toBeDefined();
+      expect(rightReply).toBeDefined();
+      expectPromotedPairing(finalMessages!);
+    });
+  });
 });

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -142,6 +142,7 @@ describe('shapeLangfuseSpan', () => {
     const mixed = [
       {
         type: 'ai',
+        id: 'ai_mixed_span',
         tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
         invalid_tool_calls: [
           {
@@ -187,6 +188,7 @@ describe('shapeLangfuseSpan', () => {
     const invalidOnly = [
       {
         type: 'ai',
+        id: 'ai_invalid_only_span',
         tool_calls: [],
         invalid_tool_calls: [
           {
@@ -207,6 +209,58 @@ describe('shapeLangfuseSpan', () => {
     shapeLangfuseSpan(invalidOnlySpan);
     expect(JSON.parse(invalidOnlySpan.attributes[INPUT] as string)).toEqual([
       { name: 'echo', args: 'garbage' },
+    ]);
+  });
+
+  it('excludes invalid calls when ToolNode would skip them (array state / id-less message)', () => {
+    /** Mirrors ToolNode's canPromoteInvalidCalls gate: a bare-array state
+     *  returns a plain output list (invalid handling skipped) and an id-less
+     *  message cannot take the reducer upsert — the span must not report
+     *  those calls as pending work. Valid calls still count. */
+    const invalidCall = {
+      name: 'echo',
+      args: 'garbage',
+      id: 'tc_gated',
+      error: 'Malformed args.',
+      type: 'invalid_tool_call',
+    };
+    const arrayStateSpan = createSpan(
+      'tools=agent_abc',
+      {
+        [INPUT]: JSON.stringify([
+          {
+            type: 'ai',
+            id: 'ai_array_span',
+            tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
+            invalid_tool_calls: [invalidCall],
+          },
+        ]),
+      },
+      'parent-1'
+    );
+    shapeLangfuseSpan(arrayStateSpan);
+    expect(JSON.parse(arrayStateSpan.attributes[INPUT] as string)).toEqual([
+      { name: 'echo', args: { command: 'hi' } },
+    ]);
+
+    const idlessSpan = createSpan(
+      'tools=agent_abc',
+      {
+        [INPUT]: JSON.stringify({
+          messages: [
+            {
+              type: 'ai',
+              tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
+              invalid_tool_calls: [invalidCall],
+            },
+          ],
+        }),
+      },
+      'parent-1'
+    );
+    shapeLangfuseSpan(idlessSpan);
+    expect(JSON.parse(idlessSpan.attributes[INPUT] as string)).toEqual([
+      { name: 'echo', args: { command: 'hi' } },
     ]);
   });
 

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -264,6 +264,47 @@ describe('shapeLangfuseSpan', () => {
     ]);
   });
 
+  it('excludes invalid calls already answered by a ToolMessage in the state', () => {
+    /** Mirrors ToolNode's !toolMessageIds.has(id) execution filter: an
+     *  answered invalid call is not pending work, even when the same turn
+     *  still has a pending valid call. */
+    const span = createSpan(
+      'tools=agent_abc',
+      {
+        [INPUT]: JSON.stringify({
+          messages: [
+            {
+              type: 'ai',
+              id: 'ai_answered_invalid',
+              tool_calls: [
+                { name: 'echo', args: { command: 'hi' }, id: 'tc_pending' },
+              ],
+              invalid_tool_calls: [
+                {
+                  name: 'echo',
+                  args: 'garbage',
+                  id: 'tc_answered_invalid',
+                  error: 'Malformed args.',
+                  type: 'invalid_tool_call',
+                },
+              ],
+            },
+            {
+              type: 'tool',
+              tool_call_id: 'tc_answered_invalid',
+              content: 'Error: Malformed args.',
+            },
+          ],
+        }),
+      },
+      'parent-1'
+    );
+    shapeLangfuseSpan(span);
+    expect(JSON.parse(span.attributes[INPUT] as string)).toEqual([
+      { name: 'echo', args: { command: 'hi' } },
+    ]);
+  });
+
   it('keeps a stable tool-dispatch shape when no tool calls are found', () => {
     const original = JSON.stringify({
       messages: [{ type: 'human', content: 'hi' }],

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -152,6 +152,18 @@ describe('shapeLangfuseSpan', () => {
             type: 'invalid_tool_call',
           },
           { name: 'echo', args: 'no-id — excluded', error: 'Malformed args.' },
+          {
+            name: 'echo',
+            args: 'empty-id — excluded',
+            id: '',
+            error: 'Malformed args.',
+          },
+          {
+            name: 'web_search',
+            args: 'server-tool — excluded',
+            id: 'srvtoolu_xyz',
+            error: 'Malformed args.',
+          },
         ],
       },
     ];

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -164,6 +164,11 @@ describe('shapeLangfuseSpan', () => {
             id: 'srvtoolu_xyz',
             error: 'Malformed args.',
           },
+          {
+            args: 'nameless — included with the unknown fallback',
+            id: 'tc_nameless',
+            error: 'Malformed args.',
+          },
         ],
       },
     ];
@@ -176,6 +181,7 @@ describe('shapeLangfuseSpan', () => {
     expect(JSON.parse(mixedSpan.attributes[INPUT] as string)).toEqual([
       { name: 'echo', args: { command: 'hi' } },
       { name: 'echo', args: '"raw unparsed' },
+      { name: 'unknown', args: 'nameless — included with the unknown fallback' },
     ]);
 
     const invalidOnly = [

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -134,6 +134,64 @@ describe('shapeLangfuseSpan', () => {
     expect(span.name).toBe('tool-dispatch');
   });
 
+  it('counts id-bearing invalid_tool_calls in the dispatch input (mixed and invalid-only)', () => {
+    /** ToolNode pairs attributable invalid calls with synthesized error
+     *  results (and routes invalid-only turns on them alone), so the span
+     *  input must include them — invalid-only used to find zero calls and
+     *  keep the full serialized graph state as the input. */
+    const mixed = [
+      {
+        type: 'ai',
+        tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
+        invalid_tool_calls: [
+          {
+            name: 'echo',
+            args: '"raw unparsed',
+            id: 'tc_bad',
+            error: 'Malformed args.',
+            type: 'invalid_tool_call',
+          },
+          { name: 'echo', args: 'no-id — excluded', error: 'Malformed args.' },
+        ],
+      },
+    ];
+    const mixedSpan = createSpan(
+      'tools=agent_abc',
+      { [INPUT]: JSON.stringify({ messages: mixed }) },
+      'parent-1'
+    );
+    shapeLangfuseSpan(mixedSpan);
+    expect(JSON.parse(mixedSpan.attributes[INPUT] as string)).toEqual([
+      { name: 'echo', args: { command: 'hi' } },
+      { name: 'echo', args: '"raw unparsed' },
+    ]);
+
+    const invalidOnly = [
+      {
+        type: 'ai',
+        tool_calls: [],
+        invalid_tool_calls: [
+          {
+            name: 'echo',
+            args: 'garbage',
+            id: 'tc_solo',
+            error: 'Malformed args.',
+            type: 'invalid_tool_call',
+          },
+        ],
+      },
+    ];
+    const invalidOnlySpan = createSpan(
+      'tools=agent_abc',
+      { [INPUT]: JSON.stringify({ messages: invalidOnly }) },
+      'parent-1'
+    );
+    shapeLangfuseSpan(invalidOnlySpan);
+    expect(JSON.parse(invalidOnlySpan.attributes[INPUT] as string)).toEqual([
+      { name: 'echo', args: 'garbage' },
+    ]);
+  });
+
   it('keeps a stable tool-dispatch shape when no tool calls are found', () => {
     const original = JSON.stringify({
       messages: [{ type: 'human', content: 'hi' }],

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3832,6 +3832,40 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           );
         }) ?? [];
 
+      /**
+       * Synthesize error results for `invalid_tool_calls` — calls whose
+       * streamed args never collapsed into a JSON object (`@langchain/core`
+       * files them separately with `error: "Malformed args."`, and they never
+       * enter `tool_calls`). Their `tool_use` blocks still ride the AI
+       * message content the provider receives, so skipping them leaves a
+       * `tool_use` with no `tool_result` and the NEXT model call is rejected
+       * (Anthropic 400 INVALID_TOOL_RESULTS) — fatal on HITL resume, where
+       * the paused AI message is replayed from the checkpoint. Only calls
+       * with an id can be paired (and only those produce the 400); the
+       * already-processed / server-tool filters mirror `filteredCalls`.
+       */
+      const invalidCallResults = (aiMessage.invalid_tool_calls ?? [])
+        .filter(
+          (call) =>
+            call.id != null &&
+            call.id !== '' &&
+            !toolMessageIds.has(call.id) &&
+            !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+        )
+        .map(
+          (call) =>
+            new ToolMessage({
+              status: 'error',
+              content: truncateToolResultContent(
+                `Error: ${call.error ?? 'Malformed tool call arguments.'} ` +
+                  'The tool call input could not be parsed as a JSON object; the tool was not run.\n Please fix your mistakes.',
+                this.maxToolResultChars
+              ),
+              name: call.name ?? 'unknown',
+              tool_call_id: call.id!,
+            })
+        );
+
       if (this.eventDrivenMode && filteredCalls.length > 0) {
         const directToolNames = this.directToolNames;
         const hasRegisteredHandoffTool = this.hasRegisteredHandoffTool();
@@ -3854,7 +3888,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           }
         }
 
-        if (directEntries.length === 0) {
+        if (directEntries.length === 0 && invalidCallResults.length === 0) {
           return this.executeViaEvent(filteredCalls, config, input, {
             batchIndices: eventEntries.map((entry) => entry.batchIndex),
             turn,
@@ -3975,6 +4009,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         outputs = [
           ...directOutputs,
           ...eventResult.toolMessages,
+          // Synthesized invalid-call errors sit with the real tool results,
+          // before injected context, to keep provider tool-result adjacency.
+          ...invalidCallResults,
           ...directInjected,
           ...eventResult.injected,
         ];
@@ -4013,6 +4050,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           directAdditionalContexts.length > 0
             ? [
               ...toolOutputs,
+              ...invalidCallResults,
               new HumanMessage({
                 content: directAdditionalContexts.join('\n\n'),
                 // Same system-role marker the event-driven path
@@ -4021,7 +4059,30 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 additional_kwargs: { role: 'system', source: 'hook' },
               }),
             ]
-            : toolOutputs;
+            : [...toolOutputs, ...invalidCallResults];
+      }
+
+      /**
+       * Resolve the streamed tool-call cards for invalid calls, best-effort.
+       * Runs AFTER the direct batch settled: on an interrupting first pass
+       * this line is unreachable (the node unwound), so interrupt/resume
+       * flows emit the completion exactly once — same reasoning as the
+       * deferred blocked-call side effects. Skipped when the stream never
+       * registered a step for the call (non-streaming providers), where a
+       * completion could not be routed to a card anyway.
+       */
+      for (const result of invalidCallResults) {
+        const invalidStepId = this.toolCallStepIds?.get(result.tool_call_id);
+        if (invalidStepId == null || invalidStepId === '') {
+          continue;
+        }
+        await this.dispatchStepCompleted(
+          result.tool_call_id,
+          result.name ?? 'unknown',
+          {},
+          typeof result.content === 'string' ? result.content : '',
+          config
+        );
       }
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import { ToolCall } from '@langchain/core/messages/tool';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import {
+  AIMessage,
   ToolMessage,
   HumanMessage,
   isAIMessage,
@@ -24,7 +25,7 @@ import type {
   ToolRuntime,
   StructuredToolInterface,
 } from '@langchain/core/tools';
-import type { BaseMessage, AIMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type {
   ToolOutputResolveView,
@@ -3844,27 +3845,66 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * with an id can be paired (and only those produce the 400); the
        * already-processed / server-tool filters mirror `filteredCalls`.
        */
-      const invalidCallResults = (aiMessage.invalid_tool_calls ?? [])
-        .filter(
-          (call) =>
-            call.id != null &&
-            call.id !== '' &&
-            !toolMessageIds.has(call.id) &&
-            !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
-        )
-        .map(
-          (call) =>
-            new ToolMessage({
-              status: 'error',
-              content: truncateToolResultContent(
-                `Error: ${call.error ?? 'Malformed tool call arguments.'} ` +
-                  'The tool call input could not be parsed as a JSON object; the tool was not run.\n Please fix your mistakes.',
-                this.maxToolResultChars
-              ),
-              name: call.name ?? 'unknown',
-              tool_call_id: call.id!,
-            })
-        );
+      const attributableInvalidCalls = (aiMessage.invalid_tool_calls ?? []).filter(
+        (call) =>
+          call.id != null &&
+          call.id !== '' &&
+          !toolMessageIds.has(call.id) &&
+          !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+      );
+      const invalidCallResults = attributableInvalidCalls.map(
+        (call) =>
+          new ToolMessage({
+            status: 'error',
+            content: truncateToolResultContent(
+              `Error: ${call.error ?? 'Malformed tool call arguments.'} ` +
+                'The tool call input could not be parsed as a JSON object; the tool was not run.\n Please fix your mistakes.',
+              this.maxToolResultChars
+            ),
+            name: call.name ?? 'unknown',
+            tool_call_id: call.id!,
+          })
+      );
+
+      /**
+       * Promote the answered invalid calls into well-formed `tool_calls` on a
+       * REPLACEMENT copy of the AI message (`messagesStateReducer` upserts by
+       * id). Without this, provider converters that rebuild the call side of
+       * the wire from `tool_calls` — OpenAI Completions `tool_calls`, OpenAI
+       * Responses `function_call` items, Gemini/Bedrock function-call parts —
+       * drop the invalid call while the synthesized result above still
+       * references it, inverting the dangling-pair rejection (an output whose
+       * call is missing). Promoting at this single seam keeps the call and
+       * result sides agreeing for EVERY provider; args become `{}` (the raw
+       * string never parsed — the paired error result tells the model why).
+       * Skipped when the message has no id: the reducer would append a
+       * duplicate instead of replacing, which is worse than the dangle.
+       */
+      const promotedAiMessage =
+        attributableInvalidCalls.length > 0 &&
+        typeof aiMessage.id === 'string' &&
+        aiMessage.id.length > 0
+          ? new AIMessage({
+            id: aiMessage.id,
+            content: aiMessage.content,
+            name: aiMessage.name,
+            additional_kwargs: aiMessage.additional_kwargs,
+            response_metadata: aiMessage.response_metadata,
+            usage_metadata: aiMessage.usage_metadata,
+            tool_calls: [
+              ...(aiMessage.tool_calls ?? []),
+              ...attributableInvalidCalls.map((call) => ({
+                id: call.id!,
+                name: call.name ?? 'unknown',
+                args: {},
+                type: 'tool_call' as const,
+              })),
+            ],
+            invalid_tool_calls: (aiMessage.invalid_tool_calls ?? []).filter(
+              (call) => !attributableInvalidCalls.includes(call)
+            ),
+          })
+          : undefined;
 
       if (this.eventDrivenMode && filteredCalls.length > 0) {
         const directToolNames = this.directToolNames;
@@ -4007,6 +4047,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             ]
             : [];
         outputs = [
+          // Replacement AI message first (reducer upsert-by-id), then results.
+          ...(promotedAiMessage != null ? [promotedAiMessage] : []),
           ...directOutputs,
           ...eventResult.toolMessages,
           // Synthesized invalid-call errors sit with the real tool results,
@@ -4046,9 +4088,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
         // Append accumulated additionalContexts as a single
         // HumanMessage so the next model turn sees them. Codex P2 #39.
+        const promotedPrefix = promotedAiMessage != null ? [promotedAiMessage] : [];
         outputs =
           directAdditionalContexts.length > 0
             ? [
+              ...promotedPrefix,
               ...toolOutputs,
               ...invalidCallResults,
               new HumanMessage({
@@ -4059,7 +4103,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 additional_kwargs: { role: 'system', source: 'hook' },
               }),
             ]
-            : [...toolOutputs, ...invalidCallResults];
+            : [...promotedPrefix, ...toolOutputs, ...invalidCallResults];
       }
 
       /**
@@ -4239,6 +4283,24 @@ function areToolCallsInvoked(
   );
 }
 
+/**
+ * Whether the message carries an `invalid_tool_calls` entry ToolNode can pair a
+ * synthesized error result with (id-bearing, non-server). Shared by the routing
+ * condition below so an invalid-only turn still enters ToolNode — otherwise the
+ * malformed `tool_use` block is committed with no `tool_result` and the next
+ * model call is rejected by pairing-strict providers.
+ */
+function hasAttributableInvalidToolCalls(message: AIMessage): boolean {
+  return (
+    message.invalid_tool_calls?.some(
+      (call) =>
+        call.id != null &&
+        call.id !== '' &&
+        !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+    ) ?? false
+  );
+}
+
 export function toolsCondition<T extends string>(
   state: BaseMessage[] | typeof MessagesAnnotation.State,
   toolNode: T,
@@ -4252,6 +4314,20 @@ export function toolsCondition<T extends string>(
     'tool_calls' in message &&
     (message.tool_calls?.length ?? 0) > 0 &&
     !areToolCallsInvoked(message, invokedToolIds)
+  ) {
+    return toolNode;
+  }
+  /**
+   * Invalid-only turn: no valid calls to route on, but ToolNode still owes the
+   * malformed calls their synthesized error results. Restricted to the
+   * zero-valid-calls case on purpose — when valid calls exist they either
+   * routed above, or were ALL invoked externally (`invokedToolIds`), where
+   * entering ToolNode would re-execute them.
+   */
+  if (
+    message &&
+    (message.tool_calls?.length ?? 0) === 0 &&
+    hasAttributableInvalidToolCalls(message)
   ) {
     return toolNode;
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -4389,6 +4389,22 @@ function sanitizeInvalidToolUseBlocks(
  * materializes them (synthesized result, promoted tool_calls entry, sanitized
  * block, handoff patch): `''` is normalized like `undefined` — providers
  * reject nameless calls, so an empty string would defeat the promotion.
+ *
+ * INVARIANT MAP — a tool call lives in several parallel representations, and
+ * any surface that materializes, copies, filters, routes on, or reports one
+ * must keep ALL of them agreeing (`tool_calls`, `invalid_tool_calls`,
+ * provider content blocks, paired results). The attribution predicate is:
+ * id-bearing (non-empty), non-server (`srvtoolu_`), unanswered
+ * (`toolMessageIds`), messages-state input, id-bearing AI message. Surfaces
+ * that apply it today — extend this list when adding another:
+ *   - `run()`'s `canPromoteInvalidCalls` gate + attributable filter
+ *   - `toolsCondition`'s invalid-only / server-mix routing branch
+ *   - `sanitizeInvalidToolUseBlocks` (block input AND name)
+ *   - `patchCommandUpdateForPromotedInvalidCalls` (handoff snapshots)
+ *   - `processHandoffReception`'s transfer-block filtering (MultiAgentGraph)
+ *   - `findPendingToolCalls` in langfuseTraceShaping (span claims)
+ *   - `serializeMessage`/`deserializeMessage` (session round-trip keeps
+ *     `invalid_tool_calls` with the content blocks they repair)
  */
 function normalizeInvalidCallName(name: string | undefined | null): string {
   return name != null && name !== '' ? name : 'unknown';

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3885,7 +3885,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 'The tool call input could not be parsed as a JSON object; the tool was not run.\n Please fix your mistakes.',
               this.maxToolResultChars
             ),
-            name: call.name ?? 'unknown',
+            name: normalizeInvalidCallName(call.name),
             tool_call_id: call.id!,
           })
       );
@@ -3920,7 +3920,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               ...(aiMessage.tool_calls ?? []),
               ...attributableInvalidCalls.map((call) => ({
                 id: call.id!,
-                name: call.name ?? 'unknown',
+                name: normalizeInvalidCallName(call.name),
                 args: {},
                 type: 'tool_call' as const,
               })),
@@ -4351,7 +4351,7 @@ function sanitizeInvalidToolUseBlocks(
   const promotedNamesById = new Map(
     promotedCalls
       .filter((call) => call.id != null)
-      .map((call) => [call.id!, call.name ?? 'unknown'])
+      .map((call) => [call.id!, normalizeInvalidCallName(call.name)])
   );
   return content.map((block) => {
     if (
@@ -4382,6 +4382,16 @@ function sanitizeInvalidToolUseBlocks(
       ...(nameIsValid ? {} : { name: promotedNamesById.get(toolUse.id) }),
     };
   });
+}
+
+/**
+ * Name fallback for attributable invalid calls, shared by every surface that
+ * materializes them (synthesized result, promoted tool_calls entry, sanitized
+ * block, handoff patch): `''` is normalized like `undefined` — providers
+ * reject nameless calls, so an empty string would defeat the promotion.
+ */
+function normalizeInvalidCallName(name: string | undefined | null): string {
+  return name != null && name !== '' ? name : 'unknown';
 }
 
 /**
@@ -4425,7 +4435,7 @@ function patchCommandUpdateForPromotedInvalidCalls(
       .filter((result) => !existingIds.has(result.tool_call_id))
       .map((result) => ({
         id: result.tool_call_id,
-        name: result.name ?? 'unknown',
+        name: normalizeInvalidCallName(result.name),
         args: {},
         type: 'tool_call' as const,
       }));

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3845,13 +3845,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * with an id can be paired (and only those produce the 400); the
        * already-processed / server-tool filters mirror `filteredCalls`.
        */
-      const attributableInvalidCalls = (aiMessage.invalid_tool_calls ?? []).filter(
-        (call) =>
-          call.id != null &&
-          call.id !== '' &&
-          !toolMessageIds.has(call.id) &&
-          !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
-      );
+      /**
+       * Invalid-call handling only applies to the MESSAGES-STATE input form,
+       * where the returned messages flow through `messagesStateReducer` and
+       * the replacement AI message below upserts by id. A `BaseMessage[]`
+       * caller receives a plain output LIST it appends to its own history —
+       * the replacement would duplicate the assistant turn and the
+       * synthesized results would reference calls its history formatting
+       * never emits. Array callers keep the untouched status quo.
+       */
+      const attributableInvalidCalls = Array.isArray(input)
+        ? []
+        : (aiMessage.invalid_tool_calls ?? []).filter(
+          (call) =>
+            call.id != null &&
+            call.id !== '' &&
+            !toolMessageIds.has(call.id) &&
+            !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+        );
       const invalidCallResults = attributableInvalidCalls.map(
         (call) =>
           new ToolMessage({
@@ -4363,16 +4374,23 @@ export function toolsCondition<T extends string>(
     return toolNode;
   }
   /**
-   * Invalid-only turn: no valid calls to route on, but ToolNode still owes the
-   * malformed calls their synthesized error results. Restricted to the
-   * zero-valid-calls case on purpose — when valid calls exist they either
-   * routed above, or were ALL invoked externally (`invokedToolIds`), where
-   * entering ToolNode would re-execute them.
+   * The valid calls (if any) did not route above, but ToolNode still owes any
+   * malformed calls their synthesized error results. Route when EVERY valid
+   * call is provider-server-executed (`srvtoolu_` — ToolNode's batch filter
+   * excludes those before execution, so nothing re-runs): that covers both the
+   * invalid-only turn and the Anthropic server-call + malformed-client-call
+   * mix, where `handleAnthropicSearchResults` marks the server call invoked
+   * and the first branch declines. A valid NON-server call that was invoked
+   * externally stays conservative (no routing) — ToolNode does not filter on
+   * `invokedToolIds`, so entering it would re-execute that call.
    */
   if (
     message &&
-    (message.tool_calls?.length ?? 0) === 0 &&
-    hasAttributableInvalidToolCalls(message)
+    hasAttributableInvalidToolCalls(message) &&
+    (message.tool_calls ?? []).every(
+      (call) =>
+        call.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) === true
+    )
   ) {
     return toolNode;
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3718,6 +3718,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
     const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
+    /** Hoisted from the messages-state branch so the Command tail can carry
+     *  the promotion into handoff updates (same-id state copies there would
+     *  otherwise overwrite the replacement message). */
+    let promotedAiMessage: AIMessage | undefined;
+    let invalidCallResults: ToolMessage[] = [];
 
     if (this.isSendInput(input)) {
       const isLocalTool =
@@ -3871,7 +3876,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             !toolMessageIds.has(call.id) &&
             !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
         );
-      const invalidCallResults = attributableInvalidCalls.map(
+      invalidCallResults = attributableInvalidCalls.map(
         (call) =>
           new ToolMessage({
             status: 'error',
@@ -3899,7 +3904,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * Skipped when the message has no id: the reducer would append a
        * duplicate instead of replacing, which is worse than the dangle.
        */
-      const promotedAiMessage =
+      promotedAiMessage =
         attributableInvalidCalls.length > 0
           ? new AIMessage({
             id: aiMessage.id,
@@ -4154,6 +4159,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
     }
 
+    /**
+     * Carry the invalid-call promotion into handoff commands. A handoff
+     * tool's Command snapshots `update.messages` from the PRE-promotion
+     * state (MultiAgentGraph builds a filtered same-id copy of the original
+     * AI message), and commands apply after the sibling reducer updates —
+     * so the stale copy would overwrite the replacement message, and a
+     * Send handoff's child state could omit the synthesized results
+     * entirely. Patch each command's same-id AI message with the promotion
+     * and append any missing synthesized results.
+     */
+    if (promotedAiMessage != null) {
+      outputs = outputs.map((output) =>
+        isCommand(output)
+          ? patchCommandUpdateForPromotedInvalidCalls(
+            output,
+            promotedAiMessage!,
+            invalidCallResults
+          )
+          : output
+      );
+    }
+
     const combinedOutputs: (
       | { messages: BaseMessage[] }
       | BaseMessage[]
@@ -4316,13 +4343,15 @@ function areToolCallsInvoked(
  */
 function sanitizeInvalidToolUseBlocks(
   content: AIMessage['content'],
-  promotedCalls: ReadonlyArray<{ id?: string }>
+  promotedCalls: ReadonlyArray<{ id?: string; name?: string }>
 ): AIMessage['content'] {
   if (!Array.isArray(content)) {
     return content;
   }
-  const promotedIds = new Set(
-    promotedCalls.map((call) => call.id).filter((id) => id != null)
+  const promotedNamesById = new Map(
+    promotedCalls
+      .filter((call) => call.id != null)
+      .map((call) => [call.id!, call.name ?? 'unknown'])
   );
   return content.map((block) => {
     if (
@@ -4331,17 +4360,99 @@ function sanitizeInvalidToolUseBlocks(
     ) {
       return block;
     }
-    const toolUse = block as { id?: string; input?: unknown };
-    if (
-      toolUse.id == null ||
-      !promotedIds.has(toolUse.id) ||
-      (typeof toolUse.input === 'object' &&
-        toolUse.input != null &&
-        !Array.isArray(toolUse.input))
-    ) {
+    const toolUse = block as { id?: string; name?: string; input?: unknown };
+    if (toolUse.id == null || !promotedNamesById.has(toolUse.id)) {
       return block;
     }
-    return { ...block, input: {} };
+    const inputIsObject =
+      typeof toolUse.input === 'object' &&
+      toolUse.input != null &&
+      !Array.isArray(toolUse.input);
+    /** `name` normalizes with the SAME fallback the promoted `tool_calls`
+     *  entry uses — a nameless block would fail provider validation on its
+     *  own even with a valid input. */
+    const nameIsValid =
+      typeof toolUse.name === 'string' && toolUse.name !== '';
+    if (inputIsObject && nameIsValid) {
+      return block;
+    }
+    return {
+      ...block,
+      ...(inputIsObject ? {} : { input: {} }),
+      ...(nameIsValid ? {} : { name: promotedNamesById.get(toolUse.id) }),
+    };
+  });
+}
+
+/**
+ * Rewrite a handoff Command's `update.messages` so the invalid-call promotion
+ * survives into the child state: the same-id AI message copy (snapshotted
+ * pre-promotion by the handoff tool) gets the sanitized content, the promoted
+ * `tool_calls` entries for the answered invalid calls, and the leftover
+ * `invalid_tool_calls`; synthesized results missing from the update are
+ * appended so the child's history keeps every call/result pair. The update
+ * copy's own `tool_calls` narrowing (parallel handoffs filter to a single
+ * call) is preserved. Commands without a same-id AI message pass through.
+ */
+function patchCommandUpdateForPromotedInvalidCalls(
+  command: Command,
+  promoted: AIMessage,
+  invalidResults: ToolMessage[]
+): Command {
+  const update = command.update as { messages?: BaseMessage[] } | undefined;
+  const messages = update?.messages;
+  if (
+    !Array.isArray(messages) ||
+    promoted.id == null ||
+    invalidResults.length === 0
+  ) {
+    return command;
+  }
+  const hasSameIdAiMessage = messages.some(
+    (msg) => isAIMessage(msg) && msg.id === promoted.id
+  );
+  if (!hasSameIdAiMessage) {
+    return command;
+  }
+  const next: BaseMessage[] = messages.map((msg) => {
+    if (!isAIMessage(msg) || msg.id !== promoted.id) {
+      return msg;
+    }
+    const existingIds = new Set(
+      (msg.tool_calls ?? []).map((call) => call.id)
+    );
+    const promotedEntries = invalidResults
+      .filter((result) => !existingIds.has(result.tool_call_id))
+      .map((result) => ({
+        id: result.tool_call_id,
+        name: result.name ?? 'unknown',
+        args: {},
+        type: 'tool_call' as const,
+      }));
+    return new AIMessage({
+      id: msg.id,
+      content: promoted.content,
+      name: msg.name,
+      additional_kwargs: msg.additional_kwargs,
+      response_metadata: msg.response_metadata,
+      usage_metadata: msg.usage_metadata,
+      tool_calls: [...(msg.tool_calls ?? []), ...promotedEntries],
+      invalid_tool_calls: promoted.invalid_tool_calls,
+    });
+  });
+  const presentResultIds = new Set(
+    next
+      .filter((msg): msg is ToolMessage => msg._getType() === 'tool')
+      .map((msg) => msg.tool_call_id)
+  );
+  const missingResults = invalidResults.filter(
+    (result) => !presentResultIds.has(result.tool_call_id)
+  );
+  return new Command({
+    graph: command.graph,
+    goto: command.goto,
+    resume: command.resume,
+    update: { ...update, messages: [...next, ...missingResults] },
   });
 }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3846,15 +3846,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * already-processed / server-tool filters mirror `filteredCalls`.
        */
       /**
-       * Invalid-call handling only applies to the MESSAGES-STATE input form,
-       * where the returned messages flow through `messagesStateReducer` and
-       * the replacement AI message below upserts by id. A `BaseMessage[]`
+       * Invalid-call handling only applies when the replacement AI message
+       * can actually land: the MESSAGES-STATE input form (the returned
+       * messages flow through `messagesStateReducer` and the replacement
+       * upserts by id) with an id-bearing AI message. A `BaseMessage[]`
        * caller receives a plain output LIST it appends to its own history —
-       * the replacement would duplicate the assistant turn and the
-       * synthesized results would reference calls its history formatting
-       * never emits. Array callers keep the untouched status quo.
+       * the replacement would duplicate the assistant turn — and an id-less
+       * message cannot be upserted. In both cases the synthesized results
+       * are skipped TOO: results and promotion are all-or-nothing, or the
+       * next provider request would carry an output whose call the
+       * converters never emit (the inverted rejection). Such callers keep
+       * the untouched status quo.
        */
-      const attributableInvalidCalls = Array.isArray(input)
+      const canPromoteInvalidCalls =
+        !Array.isArray(input) &&
+        typeof aiMessage.id === 'string' &&
+        aiMessage.id.length > 0;
+      const attributableInvalidCalls = !canPromoteInvalidCalls
         ? []
         : (aiMessage.invalid_tool_calls ?? []).filter(
           (call) =>
@@ -3892,9 +3900,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * duplicate instead of replacing, which is worse than the dangle.
        */
       const promotedAiMessage =
-        attributableInvalidCalls.length > 0 &&
-        typeof aiMessage.id === 'string' &&
-        aiMessage.id.length > 0
+        attributableInvalidCalls.length > 0
           ? new AIMessage({
             id: aiMessage.id,
             content: sanitizeInvalidToolUseBlocks(
@@ -4383,9 +4389,17 @@ export function toolsCondition<T extends string>(
    * and the first branch declines. A valid NON-server call that was invoked
    * externally stays conservative (no routing) — ToolNode does not filter on
    * `invokedToolIds`, so entering it would re-execute that call.
+   *
+   * Mirrors ToolNode's own gating exactly, or the routed turn would no-op and
+   * bounce back to the model with the dangle intact: array-state graphs get a
+   * plain output list (no reducer upsert — ToolNode skips invalid handling
+   * there), and an id-less message cannot take the replacement upsert either.
    */
   if (
+    !Array.isArray(state) &&
     message &&
+    typeof message.id === 'string' &&
+    message.id.length > 0 &&
     hasAttributableInvalidToolCalls(message) &&
     (message.tool_calls ?? []).every(
       (call) =>

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3886,7 +3886,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         aiMessage.id.length > 0
           ? new AIMessage({
             id: aiMessage.id,
-            content: aiMessage.content,
+            content: sanitizeInvalidToolUseBlocks(
+              aiMessage.content,
+              attributableInvalidCalls
+            ),
             name: aiMessage.name,
             additional_kwargs: aiMessage.additional_kwargs,
             response_metadata: aiMessage.response_metadata,
@@ -4281,6 +4284,48 @@ function areToolCallsInvoked(
       (toolCall) => toolCall.id != null && invokedToolIds.has(toolCall.id)
     ) ?? false
   );
+}
+
+/**
+ * Normalize the `tool_use` content blocks of promoted invalid calls so the
+ * replacement AI message is valid on EVERY provider surface, not just
+ * `tool_calls`. Anthropic formats an array-content AI message from its blocks
+ * verbatim, and a call whose streamed `input_json` never parsed leaves the
+ * block's `input` as the raw accumulated STRING — replayed as-is, the API
+ * rejects it with `tool_use.input: Input should be an object` before pairing
+ * is even checked. Blocks matching a promoted call id get `input: {}`
+ * (mirroring the promoted args); everything else passes through untouched.
+ * String content (OpenAI-style) is returned as-is.
+ */
+function sanitizeInvalidToolUseBlocks(
+  content: AIMessage['content'],
+  promotedCalls: ReadonlyArray<{ id?: string }>
+): AIMessage['content'] {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  const promotedIds = new Set(
+    promotedCalls.map((call) => call.id).filter((id) => id != null)
+  );
+  return content.map((block) => {
+    if (
+      typeof block !== 'object' ||
+      (block as { type?: string } | null)?.type !== 'tool_use'
+    ) {
+      return block;
+    }
+    const toolUse = block as { id?: string; input?: unknown };
+    if (
+      toolUse.id == null ||
+      !promotedIds.has(toolUse.id) ||
+      (typeof toolUse.input === 'object' &&
+        toolUse.input != null &&
+        !Array.isArray(toolUse.input))
+    ) {
+      return block;
+    }
+    return { ...block, input: {} };
+  });
 }
 
 /**

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -37,12 +37,21 @@ function createEchoTool(name = 'echo'): StructuredToolInterface {
   }) as unknown as StructuredToolInterface;
 }
 
-function toToolMessages(result: unknown): ToolMessage[] {
-  const messages = Array.isArray(result)
+function resultMessages(result: unknown): BaseMessage[] {
+  return Array.isArray(result)
     ? result
     : (result as { messages: BaseMessage[] }).messages;
-  return messages.filter(
+}
+
+function toToolMessages(result: unknown): ToolMessage[] {
+  return resultMessages(result).filter(
     (msg): msg is ToolMessage => msg._getType() === 'tool'
+  );
+}
+
+function toPromotedAiMessage(result: unknown): AIMessage | undefined {
+  return resultMessages(result).find(
+    (msg): msg is AIMessage => msg._getType() === 'ai'
   );
 }
 
@@ -50,6 +59,7 @@ describe('ToolNode invalid_tool_calls handling', () => {
   it('synthesizes an error ToolMessage for an invalid call alongside real results (direct batch)', async () => {
     const node = new ToolNode({ tools: [createEchoTool()] });
     const aiMsg = new AIMessage({
+      id: 'ai_mixed',
       content: '',
       tool_calls: [{ id: 'tc_valid', name: 'echo', args: { command: 'hi' } }],
       invalid_tool_calls: [
@@ -78,6 +88,43 @@ describe('ToolNode invalid_tool_calls handling', () => {
     )!;
     expect(String(invalidResult.content)).toContain('Malformed args.');
     expect(invalidResult.name).toBe('echo');
+
+    /** Replacement AI message (reducer upsert-by-id): the answered invalid
+     *  call is promoted into tool_calls so provider converters that rebuild
+     *  the call side from tool_calls emit it alongside its synthesized
+     *  result. */
+    const promoted = toPromotedAiMessage(result);
+    expect(promoted?.id).toBe('ai_mixed');
+    expect(promoted?.tool_calls?.map((c) => c.id).sort()).toEqual([
+      'tc_invalid',
+      'tc_valid',
+    ]);
+    expect(promoted?.invalid_tool_calls).toHaveLength(0);
+  });
+
+  it('does NOT emit a replacement AI message when the original has no id (reducer would append, not replace)', async () => {
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      content: '',
+      tool_calls: [],
+      invalid_tool_calls: [
+        {
+          id: 'tc_no_promote',
+          name: 'echo',
+          args: 'garbage',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-no-id' } }
+    );
+
+    expect(toToolMessages(result).map((m) => m.tool_call_id)).toEqual(['tc_no_promote']);
+    expect(toPromotedAiMessage(result)).toBeUndefined();
   });
 
   it('synthesizes error ToolMessages when EVERY call in the batch is invalid', async () => {
@@ -259,5 +306,144 @@ describe('ToolNode invalid_tool_calls handling', () => {
      *  replays; each must have a paired result or the call 400s. */
     expect(resultIds.has('tc_ask_valid')).toBe(true);
     expect(resultIds.has('tc_ask_invalid')).toBe(true);
+  });
+
+  it('routes an INVALID-ONLY turn through ToolNode at the graph level (toolsCondition)', async () => {
+    /**
+     * Codex P1: `toolsCondition` used to return END when `tool_calls` was
+     * empty, so a turn whose only call was malformed never entered ToolNode —
+     * the dangling `tool_use` was committed with no result and no promotion.
+     * This drives the REAL graph routing (agent → toolsCondition → toolNode →
+     * agent) via a scripted model, not a direct node.invoke.
+     */
+    const modelInvocations: BaseMessage[][] = [];
+    const buildModel = (responses: string[], emitCalls: boolean) => {
+      const model = new FakeChatModel({
+        responses,
+        toolCalls: emitCalls
+          ? [{ name: 'echo', args: {}, id: 'tc_solo_invalid', type: 'tool_call' }]
+          : [],
+      });
+      const orig = model._streamResponseChunks.bind(model);
+      model._streamResponseChunks = async function* (
+        messages,
+        options,
+        runManager
+      ): AsyncGenerator<ChatGenerationChunk> {
+        modelInvocations.push(messages);
+        for await (const chunk of orig(messages, options, runManager)) {
+          const chunkMessage = chunk.message as unknown as {
+            tool_call_chunks?: Array<{ id?: string; args?: string }>;
+          };
+          for (const tc of chunkMessage.tool_call_chunks ?? []) {
+            if (tc.id === 'tc_solo_invalid') {
+              tc.args = '"malformed"';
+            }
+          }
+          yield chunk;
+        }
+      };
+      return model;
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: 'invalid-only-graph',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'agent-invalid-only',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4o-mini', streaming: true },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+            graphTools: [createEchoTool()],
+          },
+        ],
+      },
+      returnContent: true,
+      customHandlers: {},
+      tokenCounter: ((text: string) =>
+        String(text).length) as unknown as t.RunConfig['tokenCounter'],
+      indexTokenCountMap: {},
+    });
+    run.Graph!.overrideModel = buildModel(['Calling.', 'Recovered.'], true);
+
+    const invalidOnlyConfig = {
+      configurable: { thread_id: 'invalid-only-thread' },
+      streamMode: 'values' as const,
+      version: 'v2' as const,
+    };
+    await run.processStream(
+      { messages: [new HumanMessage('go')] },
+      invalidOnlyConfig
+    );
+
+    /** A second model call happened at all (END would have stopped after one),
+     *  and it sees the promoted call paired with its synthesized result. */
+    expect(modelInvocations.length).toBeGreaterThan(1);
+    const followUp = modelInvocations[1];
+    const aiMsg = followUp.find(
+      (msg): msg is AIMessage => msg._getType() === 'ai'
+    )!;
+    expect(aiMsg.tool_calls?.map((c) => c.id)).toEqual(['tc_solo_invalid']);
+    expect(aiMsg.invalid_tool_calls).toHaveLength(0);
+    const toolMsg = followUp.find(
+      (msg): msg is ToolMessage => msg._getType() === 'tool'
+    )!;
+    expect(toolMsg.tool_call_id).toBe('tc_solo_invalid');
+    expect(String(toolMsg.content)).toContain('Malformed');
+  });
+
+  it('round-trips through the REAL OpenAI Responses outbound converter with call/output pairing intact', async () => {
+    /**
+     * Codex P1: `_convertMessagesToOpenAIResponsesParams` rebuilds
+     * `function_call` items from `tool_calls` only, so an un-promoted invalid
+     * call would vanish while its synthesized `function_call_output` remained
+     * — an output whose call_id has no matching call. The promotion keeps the
+     * two sides agreeing; this exercises the real outbound converter over the
+     * exact message shapes ToolNode emits for a mixed valid/invalid batch.
+     */
+    const { _convertMessagesToOpenAIResponsesParams } = await import(
+      '@/llm/openai/utils'
+    );
+
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      id: 'ai_responses',
+      content: 'Two calls.',
+      tool_calls: [{ id: 'tc_ok', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_bad',
+          name: 'echo',
+          args: '"malformed"',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-responses' } }
+    );
+    const promoted = toPromotedAiMessage(result)!;
+    const toolMessages = toToolMessages(result);
+
+    const items = _convertMessagesToOpenAIResponsesParams(
+      [new HumanMessage('go'), promoted, ...toolMessages],
+      'gpt-4o-mini'
+    ) as Array<{ type?: string; call_id?: string }>;
+
+    const callIds = items
+      .filter((item) => item.type === 'function_call')
+      .map((item) => item.call_id)
+      .sort();
+    const outputIds = items
+      .filter((item) => item.type === 'function_call_output')
+      .map((item) => item.call_id)
+      .sort();
+    expect(callIds).toEqual(['tc_bad', 'tc_ok']);
+    expect(outputIds).toEqual(['tc_bad', 'tc_ok']);
   });
 });

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -1,0 +1,263 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { MemorySaver } from '@langchain/langgraph';
+import { describe, it, expect } from '@jest/globals';
+import {
+  AIMessage,
+  ToolMessage,
+  HumanMessage,
+} from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import type * as t from '@/types';
+import { askUserQuestion } from '@/hitl/askUserQuestion';
+import { FakeChatModel } from '@/llm/fake';
+import { Providers } from '@/common';
+import { ToolNode } from '../ToolNode';
+import { Run } from '@/run';
+
+/**
+ * `invalid_tool_calls` coverage: a streamed tool call whose accumulated args
+ * never collapse into a JSON object is filed by `@langchain/core` under
+ * `invalid_tool_calls` (never `tool_calls`), yet its `tool_use` block still
+ * rides the AI message content the provider receives. ToolNode must
+ * synthesize an error `ToolMessage` for it — skipping it leaves a `tool_use`
+ * with no `tool_result` and the next model call is rejected (Anthropic 400
+ * INVALID_TOOL_RESULTS). Fatal on HITL resume, where the paused AI message
+ * is replayed from the checkpoint (observed with two parallel
+ * `ask_user_question` calls, one malformed).
+ */
+
+function createEchoTool(name = 'echo'): StructuredToolInterface {
+  return tool(async (input) => `ran:${(input as { command: string }).command}`, {
+    name,
+    description: 'Echo test tool',
+    schema: z.object({ command: z.string() }),
+  }) as unknown as StructuredToolInterface;
+}
+
+function toToolMessages(result: unknown): ToolMessage[] {
+  const messages = Array.isArray(result)
+    ? result
+    : (result as { messages: BaseMessage[] }).messages;
+  return messages.filter(
+    (msg): msg is ToolMessage => msg._getType() === 'tool'
+  );
+}
+
+describe('ToolNode invalid_tool_calls handling', () => {
+  it('synthesizes an error ToolMessage for an invalid call alongside real results (direct batch)', async () => {
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'tc_valid', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_invalid',
+          name: 'echo',
+          args: '"not an object"',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-mixed' } }
+    );
+    const toolMessages = toToolMessages(result);
+
+    expect(toolMessages.map((m) => m.tool_call_id).sort()).toEqual([
+      'tc_invalid',
+      'tc_valid',
+    ]);
+    const invalidResult = toolMessages.find(
+      (m) => m.tool_call_id === 'tc_invalid'
+    )!;
+    expect(String(invalidResult.content)).toContain('Malformed args.');
+    expect(invalidResult.name).toBe('echo');
+  });
+
+  it('synthesizes error ToolMessages when EVERY call in the batch is invalid', async () => {
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      content: '',
+      tool_calls: [],
+      invalid_tool_calls: [
+        {
+          id: 'tc_only_invalid',
+          name: 'echo',
+          args: 'garbage',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-only' } }
+    );
+    const toolMessages = toToolMessages(result);
+
+    expect(toolMessages).toHaveLength(1);
+    expect(toolMessages[0].tool_call_id).toBe('tc_only_invalid');
+  });
+
+  it('skips invalid calls that already have a ToolMessage or carry no id', async () => {
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      content: '',
+      tool_calls: [],
+      invalid_tool_calls: [
+        {
+          id: 'tc_answered',
+          name: 'echo',
+          args: 'garbage',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+        {
+          name: 'echo',
+          args: 'garbage-no-id',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+    const priorResult = new ToolMessage({
+      content: 'already answered',
+      tool_call_id: 'tc_answered',
+      name: 'echo',
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg, priorResult] },
+      { configurable: { run_id: 'invalid-skip' } }
+    );
+
+    expect(toToolMessages(result)).toHaveLength(0);
+  });
+
+  it('HITL resume regression: a malformed sibling of a paused ask_user_question gets a result instead of dangling', async () => {
+    const ASK_TOOL = 'ask_user_question';
+    const askTool = tool(
+      async (input) => {
+        const { answer } = askUserQuestion(
+          input as { question: string }
+        );
+        return answer;
+      },
+      {
+        name: ASK_TOOL,
+        description: 'Ask the user a question.',
+        schema: z.object({ question: z.string() }),
+      }
+    );
+
+    /** Model invocation capture: the post-resume call's message list is the
+     *  payload the real provider would validate tool_use/tool_result pairing
+     *  on. */
+    const modelInvocations: BaseMessage[][] = [];
+    const buildModel = (responses: string[], emitCalls: boolean) => {
+      const model = new FakeChatModel({
+        responses,
+        toolCalls: emitCalls
+          ? [
+            { name: ASK_TOOL, args: {}, id: 'tc_ask_invalid', type: 'tool_call' },
+            {
+              name: ASK_TOOL,
+              args: { question: 'Which one?' },
+              id: 'tc_ask_valid',
+              type: 'tool_call',
+            },
+          ]
+          : [],
+      });
+      const orig = model._streamResponseChunks.bind(model);
+      model._streamResponseChunks = async function* (
+        messages,
+        options,
+        runManager
+      ): AsyncGenerator<ChatGenerationChunk> {
+        modelInvocations.push(messages);
+        for await (const chunk of orig(messages, options, runManager)) {
+          /** Corrupt the first ask call's streamed args into a non-object
+           *  JSON string so `collapseToolCallChunks` files it under
+           *  `invalid_tool_calls` — the shape a malformed provider stream
+           *  produces. */
+          const chunkMessage = chunk.message as unknown as {
+            tool_call_chunks?: Array<{ id?: string; args?: string }>;
+          };
+          for (const tc of chunkMessage.tool_call_chunks ?? []) {
+            if (tc.id === 'tc_ask_invalid') {
+              tc.args = '"malformed"';
+            }
+          }
+          yield chunk;
+        }
+      };
+      return model;
+    };
+
+    const saver = new MemorySaver();
+    const buildRun = async (responses: string[], emitCalls: boolean) => {
+      const run = await Run.create<t.IState>({
+        runId: 'invalid-ask-resume',
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            {
+              agentId: 'agent-invalid-ask',
+              provider: Providers.OPENAI,
+              clientOptions: { model: 'gpt-4o-mini', streaming: true },
+              instructions: 'noop',
+              maxContextTokens: 8000,
+              graphTools: [askTool],
+            },
+          ],
+          compileOptions: { checkpointer: saver },
+        },
+        returnContent: true,
+        customHandlers: {},
+        tokenCounter: ((text: string) =>
+          String(text).length) as unknown as t.RunConfig['tokenCounter'],
+        indexTokenCountMap: {},
+      });
+      run.Graph!.overrideModel = buildModel(responses, emitCalls);
+      return run;
+    };
+    const config = {
+      configurable: { thread_id: 'invalid-ask-thread' },
+      streamMode: 'values' as const,
+      version: 'v2' as const,
+    };
+
+    const run = await buildRun(['Asking.'], true);
+    await run.processStream(
+      { messages: [new HumanMessage('go')] },
+      config
+    );
+    expect(run.getInterrupt()?.payload).toMatchObject({
+      type: 'ask_user_question',
+      question: { question: 'Which one?' },
+    });
+
+    const resumed = await buildRun(['Done.'], false);
+    await resumed.resume({ answer: 'the first one' }, config);
+    expect(resumed.getInterrupt()).toBeUndefined();
+
+    const finalCall = modelInvocations[modelInvocations.length - 1];
+    const resultIds = new Set(
+      finalCall
+        .filter((msg) => msg._getType() === 'tool')
+        .map((msg) => (msg as ToolMessage).tool_call_id)
+    );
+    /** Both tool_use blocks ride the paused AI message the provider
+     *  replays; each must have a paired result or the call 400s. */
+    expect(resultIds.has('tc_ask_valid')).toBe(true);
+    expect(resultIds.has('tc_ask_invalid')).toBe(true);
+  });
+});

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -11,6 +11,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type * as t from '@/types';
+import { _convertMessagesToOpenAIResponsesParams } from '@/llm/openai/utils';
 import { askUserQuestion } from '@/hitl/askUserQuestion';
 import { FakeChatModel } from '@/llm/fake';
 import { Providers } from '@/common';
@@ -186,6 +187,7 @@ describe('ToolNode invalid_tool_calls handling', () => {
      * NON-server call stays conservative: no routing, even when invoked.
      */
     const serverMix = new AIMessage({
+      id: 'ai_server_mix',
       content: '',
       tool_calls: [{ id: 'srvtoolu_abc', name: 'web_search', args: { q: 'x' } }],
       invalid_tool_calls: [
@@ -199,20 +201,34 @@ describe('ToolNode invalid_tool_calls handling', () => {
       ],
     });
     expect(
-      toolsCondition([serverMix], 'tools', new Set(['srvtoolu_abc']))
+      toolsCondition({ messages: [serverMix] }, 'tools', new Set(['srvtoolu_abc']))
     ).toBe('tools');
 
     const clientMix = new AIMessage({
+      id: 'ai_client_mix',
       content: '',
       tool_calls: [{ id: 'tc_regular', name: 'echo', args: { command: 'hi' } }],
       invalid_tool_calls: serverMix.invalid_tool_calls,
     });
-    expect(toolsCondition([clientMix], 'tools', new Set(['tc_regular']))).toBe(
+    expect(
+      toolsCondition({ messages: [clientMix] }, 'tools', new Set(['tc_regular']))
+    ).toBe('__end__');
+
+    /** Mirrors ToolNode's own gating: array-state graphs get a plain output
+     *  list (invalid handling is skipped there), and an id-less message
+     *  cannot take the replacement upsert — routing either would no-op. */
+    expect(toolsCondition([serverMix], 'tools', new Set(['srvtoolu_abc']))).toBe(
       '__end__'
     );
+    const noIdMix = new AIMessage({
+      content: '',
+      tool_calls: [],
+      invalid_tool_calls: serverMix.invalid_tool_calls,
+    });
+    expect(toolsCondition({ messages: [noIdMix] }, 'tools')).toBe('__end__');
   });
 
-  it('does NOT emit a replacement AI message when the original has no id (reducer would append, not replace)', async () => {
+  it('keeps the full status quo when the AI message has no id (results and replacement are all-or-nothing)', async () => {
     const node = new ToolNode({ tools: [createEchoTool()] });
     const aiMsg = new AIMessage({
       content: '',
@@ -233,13 +249,17 @@ describe('ToolNode invalid_tool_calls handling', () => {
       { configurable: { run_id: 'invalid-no-id' } }
     );
 
-    expect(toToolMessages(result).map((m) => m.tool_call_id)).toEqual(['tc_no_promote']);
+    /** No replacement can upsert without an id, so the synthesized result is
+     *  suppressed too — emitting it alone would strand an output whose call
+     *  the provider converters never reconstruct. */
+    expect(toToolMessages(result)).toHaveLength(0);
     expect(toPromotedAiMessage(result)).toBeUndefined();
   });
 
   it('synthesizes error ToolMessages when EVERY call in the batch is invalid', async () => {
     const node = new ToolNode({ tools: [createEchoTool()] });
     const aiMsg = new AIMessage({
+      id: 'ai_only_invalid',
       content: '',
       tool_calls: [],
       invalid_tool_calls: [
@@ -514,10 +534,6 @@ describe('ToolNode invalid_tool_calls handling', () => {
      * two sides agreeing; this exercises the real outbound converter over the
      * exact message shapes ToolNode emits for a mixed valid/invalid batch.
      */
-    const { _convertMessagesToOpenAIResponsesParams } = await import(
-      '@/llm/openai/utils'
-    );
-
     const node = new ToolNode({ tools: [createEchoTool()] });
     const aiMsg = new AIMessage({
       id: 'ai_responses',

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -14,7 +14,7 @@ import type * as t from '@/types';
 import { askUserQuestion } from '@/hitl/askUserQuestion';
 import { FakeChatModel } from '@/llm/fake';
 import { Providers } from '@/common';
-import { ToolNode } from '../ToolNode';
+import { ToolNode, toolsCondition } from '../ToolNode';
 import { Run } from '@/run';
 
 /**
@@ -143,6 +143,73 @@ describe('ToolNode invalid_tool_calls handling', () => {
     expect(blocks.find((b) => b.id === 'tc_bad')?.input).toEqual({});
     expect(blocks.find((b) => b.id === 'tc_ok')?.input).toEqual({ command: 'hi' });
     expect(blocks[0]).toEqual({ type: 'text', text: 'Two calls.' });
+  });
+
+  it('leaves BaseMessage[] (array-input) callers at the status quo — no synthesized results, no replacement', async () => {
+    /**
+     * The array input form returns a plain output LIST the caller appends to
+     * its own history: a replacement AI message would duplicate the assistant
+     * turn, and synthesized results would reference calls the caller's
+     * history formatting never emits. Both are reducer-shaped writes, so
+     * they only apply to the messages-state form.
+     */
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      id: 'ai_array_input',
+      content: '',
+      tool_calls: [{ id: 'tc_ok', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_bad',
+          name: 'echo',
+          args: 'garbage',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke([aiMsg], {
+      configurable: { run_id: 'invalid-array-input' },
+    });
+
+    expect(toToolMessages(result).map((m) => m.tool_call_id)).toEqual(['tc_ok']);
+    expect(toPromotedAiMessage(result)).toBeUndefined();
+  });
+
+  it('toolsCondition routes a server-call + malformed-client-call mix to the tool node', () => {
+    /**
+     * `handleAnthropicSearchResults` marks completed server calls invoked, so
+     * the valid-calls branch declines; every valid call is `srvtoolu_`-
+     * prefixed (ToolNode's batch filter excludes those), so routing cannot
+     * re-execute anything and the malformed call gets its result. A valid
+     * NON-server call stays conservative: no routing, even when invoked.
+     */
+    const serverMix = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'srvtoolu_abc', name: 'web_search', args: { q: 'x' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_bad',
+          name: 'echo',
+          args: 'garbage',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+    expect(
+      toolsCondition([serverMix], 'tools', new Set(['srvtoolu_abc']))
+    ).toBe('tools');
+
+    const clientMix = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'tc_regular', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: serverMix.invalid_tool_calls,
+    });
+    expect(toolsCondition([clientMix], 'tools', new Set(['tc_regular']))).toBe(
+      '__end__'
+    );
   });
 
   it('does NOT emit a replacement AI message when the original has no id (reducer would append, not replace)', async () => {

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -12,6 +12,10 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type * as t from '@/types';
 import { _convertMessagesToOpenAIResponsesParams } from '@/llm/openai/utils';
+import {
+  serializeMessage,
+  deserializeMessage,
+} from '@/session/messageSerialization';
 import { askUserQuestion } from '@/hitl/askUserQuestion';
 import { FakeChatModel } from '@/llm/fake';
 import { Providers } from '@/common';
@@ -282,6 +286,46 @@ describe('ToolNode invalid_tool_calls handling', () => {
       .map((msg) => msg.tool_call_id)
       .sort();
     expect(resultIds).toEqual(['tc_bad', 'tc_handoff']);
+  });
+
+  it('session serialization round-trips invalid_tool_calls with the content blocks they repair', async () => {
+    /**
+     * The durable-session layer keeps the serialized content (including any
+     * raw malformed tool_use blocks) — dropping `invalid_tool_calls` there
+     * would strand those blocks without the entries ToolNode synthesizes
+     * results and promotions from on restore.
+     */
+    const original = new AIMessage({
+      id: 'ai_session_roundtrip',
+      content: [
+        { type: 'tool_use', id: 'tc_rt_bad', name: 'echo', input: '"raw unparsed' },
+      ],
+      tool_calls: [{ id: 'tc_rt_ok', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_rt_bad',
+          name: 'echo',
+          args: '"raw unparsed',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const restored = deserializeMessage(serializeMessage(original)) as AIMessage;
+    expect(restored.tool_calls).toEqual(original.tool_calls);
+    expect(restored.invalid_tool_calls).toEqual(original.invalid_tool_calls);
+
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const result = await node.invoke(
+      { messages: [restored] },
+      { configurable: { run_id: 'invalid-session-roundtrip' } }
+    );
+    expect(toToolMessages(result).map((m) => m.tool_call_id).sort()).toEqual([
+      'tc_rt_bad',
+      'tc_rt_ok',
+    ]);
+    expect(toPromotedAiMessage(result)?.invalid_tool_calls).toHaveLength(0);
   });
 
   it('leaves BaseMessage[] (array-input) callers at the status quo — no synthesized results, no replacement', async () => {

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -102,6 +102,49 @@ describe('ToolNode invalid_tool_calls handling', () => {
     expect(promoted?.invalid_tool_calls).toHaveLength(0);
   });
 
+  it('sanitizes the promoted call\'s Anthropic tool_use content block (raw string input → {})', async () => {
+    /**
+     * Anthropic formats array-content AI messages from the blocks verbatim; a
+     * call whose streamed input never parsed leaves `input` as the raw
+     * accumulated string, which the API rejects with "Input should be an
+     * object" on replay. The replacement message must normalize the block to
+     * match the promoted args; valid siblings' blocks stay untouched.
+     */
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      id: 'ai_blocks',
+      content: [
+        { type: 'text', text: 'Two calls.' },
+        { type: 'tool_use', id: 'tc_ok', name: 'echo', input: { command: 'hi' } },
+        { type: 'tool_use', id: 'tc_bad', name: 'echo', input: '"raw unparsed' },
+      ],
+      tool_calls: [{ id: 'tc_ok', name: 'echo', args: { command: 'hi' } }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_bad',
+          name: 'echo',
+          args: '"raw unparsed',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-blocks' } }
+    );
+    const promoted = toPromotedAiMessage(result)!;
+    const blocks = promoted.content as Array<{
+      type?: string;
+      id?: string;
+      input?: unknown;
+    }>;
+    expect(blocks.find((b) => b.id === 'tc_bad')?.input).toEqual({});
+    expect(blocks.find((b) => b.id === 'tc_ok')?.input).toEqual({ command: 'hi' });
+    expect(blocks[0]).toEqual({ type: 'text', text: 'Two calls.' });
+  });
+
   it('does NOT emit a replacement AI message when the original has no id (reducer would append, not replace)', async () => {
     const node = new ToolNode({ tools: [createEchoTool()] });
     const aiMsg = new AIMessage({

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -152,11 +152,19 @@ describe('ToolNode invalid_tool_calls handling', () => {
       id: 'ai_nameless_block',
       content: [
         { type: 'tool_use', id: 'tc_noname', input: '"raw unparsed' },
+        { type: 'tool_use', id: 'tc_emptyname', name: '', input: '"raw unparsed' },
       ],
       tool_calls: [],
       invalid_tool_calls: [
         {
           id: 'tc_noname',
+          args: '"raw unparsed',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+        {
+          id: 'tc_emptyname',
+          name: '',
           args: '"raw unparsed',
           error: 'Malformed args.',
           type: 'invalid_tool_call',
@@ -169,17 +177,21 @@ describe('ToolNode invalid_tool_calls handling', () => {
       { configurable: { run_id: 'invalid-nameless-block' } }
     );
     const promoted = toPromotedAiMessage(result)!;
-    const block = (promoted.content as Array<{ id?: string }>).find(
-      (b) => b.id === 'tc_noname'
-    ) as { name?: string; input?: unknown };
-    /** Same fallback the promoted tool_calls entry uses — a nameless block
-     *  fails provider validation on its own even with a valid input. */
-    expect(block.name).toBe('unknown');
-    expect(block.input).toEqual({});
-    expect(promoted.tool_calls?.[0]).toMatchObject({
-      id: 'tc_noname',
-      name: 'unknown',
-    });
+    const blocks = promoted.content as Array<{ id?: string; name?: string; input?: unknown }>;
+    /** Same fallback the promoted tool_calls entries use — missing AND
+     *  empty-string names both fail provider validation on their own. */
+    for (const id of ['tc_noname', 'tc_emptyname']) {
+      const block = blocks.find((b) => b.id === id)!;
+      expect(block.name).toBe('unknown');
+      expect(block.input).toEqual({});
+      expect(promoted.tool_calls?.find((c) => c.id === id)).toMatchObject({
+        name: 'unknown',
+      });
+      const synthesized = toToolMessages(result).find(
+        (m) => m.tool_call_id === id
+      )!;
+      expect(synthesized.name).toBe('unknown');
+    }
   });
 
   it('carries the promotion into a handoff Command update (same-id state copy + missing result)', async () => {

--- a/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
+++ b/src/tools/__tests__/ToolNode.invalidToolCalls.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { MemorySaver } from '@langchain/langgraph';
+import { Command, MemorySaver } from '@langchain/langgraph';
 import { describe, it, expect } from '@jest/globals';
 import {
   AIMessage,
@@ -144,6 +144,132 @@ describe('ToolNode invalid_tool_calls handling', () => {
     expect(blocks.find((b) => b.id === 'tc_bad')?.input).toEqual({});
     expect(blocks.find((b) => b.id === 'tc_ok')?.input).toEqual({ command: 'hi' });
     expect(blocks[0]).toEqual({ type: 'text', text: 'Two calls.' });
+  });
+
+  it('normalizes a nameless promoted call\'s tool_use block name (provider validation)', async () => {
+    const node = new ToolNode({ tools: [createEchoTool()] });
+    const aiMsg = new AIMessage({
+      id: 'ai_nameless_block',
+      content: [
+        { type: 'tool_use', id: 'tc_noname', input: '"raw unparsed' },
+      ],
+      tool_calls: [],
+      invalid_tool_calls: [
+        {
+          id: 'tc_noname',
+          args: '"raw unparsed',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-nameless-block' } }
+    );
+    const promoted = toPromotedAiMessage(result)!;
+    const block = (promoted.content as Array<{ id?: string }>).find(
+      (b) => b.id === 'tc_noname'
+    ) as { name?: string; input?: unknown };
+    /** Same fallback the promoted tool_calls entry uses — a nameless block
+     *  fails provider validation on its own even with a valid input. */
+    expect(block.name).toBe('unknown');
+    expect(block.input).toEqual({});
+    expect(promoted.tool_calls?.[0]).toMatchObject({
+      id: 'tc_noname',
+      name: 'unknown',
+    });
+  });
+
+  it('carries the promotion into a handoff Command update (same-id state copy + missing result)', async () => {
+    /**
+     * A handoff tool snapshots `update.messages` from the PRE-promotion
+     * state with a filtered SAME-ID copy of the AI message, and commands
+     * apply after sibling reducer updates — un-patched, that stale copy
+     * overwrites the promotion and the child state omits the synthesized
+     * result, recreating the dangling pair inside the child graph.
+     */
+    const prePromotionCopy = () =>
+      new AIMessage({
+        id: 'ai_handoff',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_handoff',
+            name: 'transfer_to_agent_b',
+            input: {},
+          },
+          { type: 'tool_use', id: 'tc_bad', name: 'echo', input: '"raw unparsed' },
+        ],
+        tool_calls: [
+          { id: 'tc_handoff', name: 'transfer_to_agent_b', args: {} },
+        ],
+      });
+    const handoffTool = tool(
+      async () =>
+        new Command({
+          graph: Command.PARENT,
+          goto: 'agent_b',
+          update: {
+            messages: [
+              prePromotionCopy(),
+              new ToolMessage({
+                content: 'transferred',
+                tool_call_id: 'tc_handoff',
+                name: 'transfer_to_agent_b',
+              }),
+            ],
+          },
+        }),
+      {
+        name: 'transfer_to_agent_b',
+        description: 'handoff',
+        schema: z.object({}),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const node = new ToolNode({ tools: [handoffTool] });
+    const aiMsg = new AIMessage({
+      id: 'ai_handoff',
+      content: prePromotionCopy().content,
+      tool_calls: [{ id: 'tc_handoff', name: 'transfer_to_agent_b', args: {} }],
+      invalid_tool_calls: [
+        {
+          id: 'tc_bad',
+          name: 'echo',
+          args: '"raw unparsed',
+          error: 'Malformed args.',
+          type: 'invalid_tool_call',
+        },
+      ],
+    });
+
+    const result = (await node.invoke(
+      { messages: [aiMsg] },
+      { configurable: { run_id: 'invalid-handoff' } }
+    )) as Array<Command | { messages: BaseMessage[] }>;
+
+    const command = result.find((entry) => entry instanceof Command) as Command;
+    expect(command).toBeDefined();
+    const update = command.update as { messages: BaseMessage[] };
+    const patchedAi = update.messages.find(
+      (msg): msg is AIMessage => msg._getType() === 'ai'
+    )!;
+    expect(patchedAi.tool_calls?.map((c) => c.id).sort()).toEqual([
+      'tc_bad',
+      'tc_handoff',
+    ]);
+    expect(patchedAi.invalid_tool_calls).toHaveLength(0);
+    const patchedBlock = (patchedAi.content as Array<{ id?: string }>).find(
+      (b) => b.id === 'tc_bad'
+    ) as { input?: unknown };
+    expect(patchedBlock.input).toEqual({});
+    const resultIds = update.messages
+      .filter((msg): msg is ToolMessage => msg._getType() === 'tool')
+      .map((msg) => msg.tool_call_id)
+      .sort();
+    expect(resultIds).toEqual(['tc_bad', 'tc_handoff']);
   });
 
   it('leaves BaseMessage[] (array-input) callers at the status quo — no synthesized results, no replacement', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -4354,6 +4354,65 @@ describe('AskUserQuestion — interrupt + resume', () => {
     expect(String(toolMessage!.content)).toBe('staging');
   });
 
+  it('askUserQuestion surfaces the calling tool_call_id on the interrupt payload when the body supplies it', async () => {
+    /**
+     * LangChain stamps the full ToolCall onto the config a `tool(fn, …)`
+     * body receives, so the body can attribute its interrupt to the exact
+     * call. Hosts use `payload.tool_call_id` to stamp the question/answer
+     * onto the right content part when a model emits several ask calls in
+     * one turn — positional guessing mislabels the cards.
+     */
+    const { askUserQuestion } = await import('@/hitl');
+
+    const askTool = tool(
+      async (input: { question: string }, config) => {
+        const resolution = askUserQuestion(input, {
+          toolCallId: config.toolCall?.id,
+        });
+        return resolution.answer;
+      },
+      {
+        name: 'ask_user_question',
+        description: 'Ask the user a clarifying question.',
+        schema: z.object({ question: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const node = new ToolNode({ tools: [askTool] });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_ask_id_1',
+        name: 'ask_user_question',
+        args: { question: 'Which region?' },
+      },
+    ]);
+    const config = { configurable: { thread_id: 'thread-ask-call-id' } };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+    if (!isInterrupted<t.HumanInterruptPayload>(interrupted)) {
+      throw new Error('expected interrupt');
+    }
+    const payload = interrupted.__interrupt__[0].value!;
+    if (payload.type !== 'ask_user_question') {
+      throw new Error('expected ask_user_question payload');
+    }
+    expect(payload.tool_call_id).toBe('call_ask_id_1');
+    expect(payload.question.question).toBe('Which region?');
+
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      { answer: 'us-east' } satisfies t.AskUserQuestionResolution,
+      config
+    )) as MessagesUpdate;
+    const toolMessage = resumed.messages.find(
+      (m): m is ToolMessage =>
+        m._getType() === 'tool' &&
+        (m as ToolMessage).tool_call_id === 'call_ask_id_1'
+    );
+    expect(String(toolMessage!.content)).toBe('us-east');
+  });
+
   it('isAskUserQuestionInterrupt narrows the payload union correctly', async () => {
     const { isAskUserQuestionInterrupt, isToolApprovalInterrupt } =
       await import('@/types/hitl');

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -35,6 +35,7 @@ import type * as t from '@/types';
 import { Providers as providers, GraphEvents } from '@/common';
 import * as events from '@/utils/events';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
+import { askUserQuestion } from '@/hitl';
 import { ToolNode } from '../ToolNode';
 
 async function flushAsyncWork(): Promise<void> {
@@ -4362,8 +4363,6 @@ describe('AskUserQuestion — interrupt + resume', () => {
      * onto the right content part when a model emits several ask calls in
      * one turn — positional guessing mislabels the cards.
      */
-    const { askUserQuestion } = await import('@/hitl');
-
     const askTool = tool(
       async (input: { question: string }, config) => {
         const resolution = askUserQuestion(input, {

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -158,6 +158,14 @@ export interface AskUserQuestionRequest {
 export interface AskUserQuestionInterruptPayload {
   type: 'ask_user_question';
   question: AskUserQuestionRequest;
+  /**
+   * The `tool_call_id` of the ask-tool call that raised this interrupt,
+   * when the tool body supplied it (see `askUserQuestion`'s `options`).
+   * Lets hosts attribute the question — and later the answer — to the
+   * exact tool-call content part instead of guessing by position, which
+   * mislabels cards when a model emits several ask calls in one turn.
+   */
+  tool_call_id?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a dangling-`tool_use` failure that rejects the next model call with a provider 400 (Anthropic `INVALID_TOOL_RESULTS`), observed in production via LibreChat's `ask_user_question` HITL resume — and hardens the whole invalid-call pipeline surfaced by five adversarial review rounds.

### The core defect

A streamed tool call whose accumulated args never collapse into a JSON object is filed by `@langchain/core` (`collapseToolCallChunks`) under `invalid_tool_calls` and never enters `tool_calls` — yet its `tool_use` block still rides the AI message content the provider receives. ToolNode only iterated `tool_calls`, so the invalid call never executed and never got a ToolMessage. The next LLM call in the same turn (any multi-tool turn, no HITL required) then carries a `tool_use` with no `tool_result` and is rejected. On HITL resume the paused AI message is replayed from the checkpoint, making the failure terminal for the turn.

### The fix, layer by layer

1. **Synthesized results** (`b87b84da`): `ToolNode.run()` emits an error `ToolMessage` for every attributable (id-bearing, non-server, unanswered) `invalid_tool_calls` entry, adjacent to real results in all non-Send exits, with best-effort step-completion dispatch placed so interrupt/resume flows emit exactly once.
2. **Promotion** (`043dbaf3`): a REPLACEMENT copy of the AI message (`messagesStateReducer` upserts by id) promotes answered invalid calls into well-formed `tool_calls` entries (`args: {}`), so every provider converter that rebuilds the call side from `tool_calls` (OpenAI Completions/Responses, Gemini/Bedrock) emits the call its synthesized result references. Also routes invalid-only turns through the tool node (`toolsCondition` returned END on empty `tool_calls`).
3. **Content-block sanitization** (`b065b6bd`, `c6185ab6`): the promoted message's matching Anthropic `tool_use` blocks are normalized (`input` string → `{}`, missing `name` → `'unknown'`) — array-content messages replay from blocks verbatim, and a raw unparsed input string 400s on its own.
4. **One attribution predicate everywhere** (`05e3db96`, `003d6f06`): routing, `run()` gating, and trace shaping share the same rules — messages-state input + id-bearing message + id-bearing/non-server calls; server-call+invalid mixes route (ToolNode's batch filter excludes `srvtoolu_`); `BaseMessage[]` callers and id-less messages keep the exact status quo (results and promotion are all-or-nothing).
5. **Handoff propagation** (`c6185ab6`): handoff Commands snapshot `update.messages` pre-promotion with a filtered same-id copy, and commands apply after sibling reducer updates — the stale copy overwrote the promotion and a Send child's state omitted the synthesized results. `patchCommandUpdateForPromotedInvalidCalls` rewrites the same-id copy and appends missing results before the handoff aggregation, covering single, parallel-Send, and parent-command paths.
6. **Observability** (`003d6f06`, `85e16dcb`): the Langfuse tool-dispatch span counts exactly the calls ToolNode will execute — invalid-only dispatches no longer dump full graph state as the span input.

### `tool_call_id` on ask interrupts (`f327f900`)

`askUserQuestion()` accepts an optional `toolCallId` (tool bodies read `config.toolCall.id`) and surfaces it as `tool_call_id` on the interrupt payload, letting hosts attribute the question/answer to the exact tool-call part in multi-ask turns. Optional and additive. Companion consumer: danny-avila/LibreChat#14539.

## Tests

- `ToolNode.invalidToolCalls.test.ts` (new, 12 tests): direct/mixed/all-invalid batches, promotion + block sanitization (incl. nameless), array-input and no-id status quo, `toolsCondition` routing matrix, handoff Command patching, a Run-level HITL pause/resume regression reconstructing the production failure, and a round-trip through the real `_convertMessagesToOpenAIResponsesParams` asserting call/output pairing.
- `agent-handoffs.test.ts` (+2): graph-level regressions driving the real edge → transfer-tool → Command/Send machinery with a malformed sibling; `validateToolHistory` asserts pairing on every model invocation including the children's. Both fail with the Command patching disabled.
- `langfuse-trace-shaping.test.ts` (+2) and `hitl.test.ts` (+1): shaper attribution matrix and the `tool_call_id` round-trip.

## Notes

- The `validate / summarization tests (anthropic)` job is a live suite that flakes on main (~2/15) with a pre-existing `tool_use.input` replay failure (verified on main run for `d8ab3494`); unrelated to this PR and tracked separately.