### PR TITLE
📦 chore: Bump `@langchain/langgraph` to 1.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,13 +2237,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.6.tgz",
-      "integrity": "sha512-5xaohfKGmA2Aw1P9TfzC15RI8SqVP2Vi9Xtfz8ClBeksd5NXImBp6e0Hss6FnErDPgXP5uTohpm50ca4t5Pljg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
+      "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.25",
+        "@langchain/langgraph-sdk": "~1.9.26",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -2252,13 +2252,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.48",
-        "zod": "^3.25.32 || ^4.2.0",
-        "zod-to-json-schema": "^3.x"
-      },
-      "peerDependenciesMeta": {
-        "zod-to-json-schema": {
-          "optional": true
-        }
+        "zod": "^3.25.32 || ^4.2.0"
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
@@ -2291,9 +2285,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
-      "integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
@@ -2324,9 +2318,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@langchain/google-gauth": "2.2.0",
         "@langchain/google-genai": "2.2.0",
         "@langchain/google-vertexai": "2.2.0",
-        "@langchain/langgraph": "^1.4.6",
+        "@langchain/langgraph": "1.4.8",
         "@langchain/mistralai": "^1.2.0",
         "@langchain/openai": "1.5.5",
         "@langchain/textsplitters": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "@langchain/google-gauth": "2.2.0",
     "@langchain/google-genai": "2.2.0",
     "@langchain/google-vertexai": "2.2.0",
-    "@langchain/langgraph": "^1.4.6",
+    "@langchain/langgraph": "1.4.8",
     "@langchain/mistralai": "^1.2.0",
     "@langchain/openai": "1.5.5",
     "@langchain/textsplitters": "^1.0.1",


### PR DESCRIPTION
## Summary

Bumps `@langchain/langgraph` 1.4.6 → 1.4.8 and pins it exactly (`^1.4.6` → `1.4.8` in `package.json`), matching the exact-pin convention used for the other `@langchain` provider deps (openai, anthropic, google-*).

### Why

- **1.4.8** — [langchain-ai/langgraphjs#2604](https://github.com/langchain-ai/langgraphjs/pull/2604) `fix(pregel): wait for completed-superstep persistence with sync durability`. Checkpoint `put()`/`putWrites()` from a completed superstep now settle **before the next superstep dispatches** when `durability: 'sync'`; previously they were only awaited at final cleanup and could overlap later supersteps. Our `'exit'` default ([`run.ts`](https://github.com/danny-avila/agents/blob/main/src/run.ts#L876-L883)) is explicitly preserved by the fix; consumers passing `durability: 'sync'` through the run config (exercised in `hitl.test.ts`) now get true per-superstep persistence barriers for HITL interrupt/resume.
- **1.4.7** — [langchain-ai/langgraphjs#2571](https://github.com/langchain-ai/langgraphjs/pull/2571) drops the vestigial `zod-to-json-schema@^3.x` peer, the last source of Zod v4 install-time peer conflicts. Verified in the new lockfile: langgraph's peers are now just `@langchain/core` + `zod` (v3/v4); the remaining `zod-to-json-schema` in the tree comes from `@mistralai/mistralai`, unrelated.

### Transitive

- `@langchain/langgraph-sdk` 1.9.25 → 1.9.28 (client-side SSE/useStream fixes; not imported directly by this repo)
- `p-queue` 9.3.0 → 9.3.3

### No code changes needed

We had no workarounds for the old sync-durability behavior, and the `'exit'` default + comment in `run.ts` remain accurate.

## Testing

- Targeted: `hitl.test.ts` + `durability-checkpoint.integration.test.ts` (real in-memory Mongo saver) + `agent-handoffs.test.ts` — 107/107 passed
- Full CI-equivalent unit suite (same ignore patterns as `validate.yml`): 3343 passed, 58 skipped (env-gated), 0 failures