### PR TITLE
🔁 fix: Verify Eager Prestart Args Against Canonical Accumulation + Divergence Circuit Breaker

### DIFF
--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -615,6 +615,60 @@ describe('eager args divergence (LibreChat#14371)', () => {
       expect(toolExecuteCalls).toHaveLength(0);
     });
 
+    it('suppresses the eagerly executed name too when the identity mismatches', async () => {
+      // If the stream prestarts name A but the final request materializes as
+      // name B for the same call id, suppressing only B would let every
+      // retry prestart A again — repeating A's side effects while the run
+      // loops (Codex P2 on #368).
+      jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      installToolExecuteResponder();
+      const suppressions = new Set<string>();
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+      const request: t.ToolCallRequest = {
+        id: 'call_1',
+        name: 'tool_a',
+        args: { sql: 'SELECT 1;' },
+        stepId: 'step_1',
+        turn: 0,
+      };
+      eagerExecutions.set('call_1', {
+        toolCallId: 'call_1',
+        toolName: 'tool_a',
+        args: { sql: 'SELECT 1;' },
+        request,
+        promise: Promise.resolve({
+          results: [
+            { toolCallId: 'call_1', status: 'success', content: 'eager' },
+          ],
+        }),
+      });
+
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('tool_a'), createDummyTool('tool_b')],
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+        eagerEventToolSuppressions: suppressions,
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+      });
+      const result = (await toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'tool_b', args: { sql: 'SELECT 1;' } },
+            ],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toContain(
+        'changed after eager execution'
+      );
+      expect(suppressions.has('tool_b')).toBe(true);
+      expect(suppressions.has('tool_a')).toBe(true);
+    });
+
     it('stops prestarting a suppressed tool while siblings still prestart', async () => {
       const graph = createGraph();
       (graph.eagerEventToolSuppressions as Set<string>).add('db_query');

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -32,6 +32,12 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
+import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 import { GraphEvents, Providers, StepTypes } from '@/common';
 import { ChatModelStreamHandler } from '@/stream';
 import { ToolNode } from '@/tools/ToolNode';
@@ -327,6 +333,137 @@ describe('eager args divergence (LibreChat#14371)', () => {
 
     expect(toolExecuteCalls).toHaveLength(0);
     expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+  });
+
+  it('does not treat a pure-signal adapter seal as an args restatement (Bedrock)', async () => {
+    // Bedrock's contentBlockStop seal chunk carries `args: ''` — a pure
+    // signal, not a restatement. A repeated complete-JSON fragment leaves
+    // the heuristic accumulator with lastArgsFragment === argsText while the
+    // canonical concatenation differs; the seal must NOT bless that state as
+    // authoritative (Codex P1 on #368).
+    const bedrockMetadata = {
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+    };
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.BEDROCK,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'db_query' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    const fragment = '{"sql":"SELECT 1;"}';
+    for (const toolCallChunk of [
+      { id: 'call_1', name: 'db_query', args: fragment, index: 0 },
+      { args: fragment, index: 0 },
+    ]) {
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            tool_call_chunks: [toolCallChunk],
+            response_metadata: bedrockMetadata,
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      );
+    }
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ args: '', index: 0 }],
+          response_metadata: {
+            ...bedrockMetadata,
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              index: 0,
+            },
+          },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+  });
+
+  it('still prestarts adapter-sealed calls whose seal chunk restates the args (OpenAI Responses contract)', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'db_query' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const adapterMetadata = {
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+    };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_1', name: 'db_query', args: '{"sql":"SELE', index: 0 },
+          ],
+          response_metadata: adapterMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    // The `arguments.done` seal chunk restates the complete args.
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_1', args: '{"sql":"SELECT 1;"}', index: 0 },
+          ],
+          response_metadata: {
+            ...adapterMetadata,
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              id: 'call_1',
+              index: 0,
+            },
+          },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_1',
+      name: 'db_query',
+      args: { sql: 'SELECT 1;' },
+    });
   });
 
   it('still prestarts sealed calls whose fragments accumulate cleanly', async () => {

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -1,0 +1,562 @@
+/**
+ * Regression tests for danny-avila/LibreChat#14371: eager tool execution
+ * looped to the recursion limit for tools with large repetitive arguments.
+ *
+ * The eager prestart accumulator reconciles provider quirks with lossy
+ * heuristics (repeat-fragment dedupe, overlap merge) that can swallow
+ * legitimately repetitive payload fragments (SQL/code). The prestarted args
+ * then diverged from the canonical LangChain `tool_call_chunks` accumulation
+ * that materializes the final request, ToolNode's guard errored with "Tool
+ * call changed after eager execution started", and the model's retry
+ * re-prestarted and re-diverged — burning the whole recursion limit.
+ *
+ * Fixed two ways:
+ * 1. Seal-time verification: prestart only when the heuristic accumulation is
+ *    confirmed to match the canonical verbatim concatenation
+ *    (`getStreamedReadyToolCalls` in src/stream.ts).
+ * 2. Circuit breaker: if the "changed after eager execution" guard still
+ *    fires, the tool name is suppressed from eager prestart for the rest of
+ *    the run, so a retry executes normally and the loop is structurally
+ *    impossible (ToolNode.takeMatchingEagerEventExecution +
+ *    isEagerExecutionExcludedTool).
+ */
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import {
+  AIMessage,
+  AIMessageChunk,
+  ToolMessage,
+} from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { AgentContext } from '@/agents/AgentContext';
+import type { StandardGraph } from '@/graphs';
+import type * as t from '@/types';
+import { GraphEvents, Providers, StepTypes } from '@/common';
+import { ChatModelStreamHandler } from '@/stream';
+import { ToolNode } from '@/tools/ToolNode';
+import { HandlerRegistry } from '@/events';
+import * as events from '@/utils/events';
+
+function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
+  const runSteps = new Map<string, t.RunStep>();
+  const stepIdsByKey = new Map<string, string>();
+  let stepCounter = 0;
+  const handlerRegistry = new HandlerRegistry();
+  handlerRegistry.register(GraphEvents.ON_TOOL_EXECUTE, {
+    handle: async () => undefined,
+  });
+  const eagerUsageCount = new Map<string, number>();
+
+  const graph = {
+    config: {
+      configurable: { user_id: 'user_1' },
+      metadata: { run_id: 'run_1' },
+    },
+    eagerEventToolExecution: { enabled: true },
+    eagerEventToolExecutions: new Map(),
+    eagerEventToolUsageCount: eagerUsageCount,
+    getEagerEventToolUsageCount: jest.fn(() => eagerUsageCount),
+    eagerEventToolCallChunks: new Map(),
+    eagerEventToolSuppressions: new Set<string>(),
+    handlerRegistry,
+    hookRegistry: undefined,
+    humanInTheLoop: undefined,
+    toolOutputReferences: undefined,
+    sessions: new Map(),
+    toolCallStepIds: new Map(),
+    messageIdsByStepKey: new Map(),
+    messageStepHasToolCalls: new Map(),
+    prelimMessageIdsByStepKey: new Map(),
+    getAgentContext: jest.fn(
+      (): Partial<AgentContext> => ({
+        provider: Providers.ANTHROPIC,
+        reasoningKey: 'reasoning',
+        toolDefinitions: [{ name: 'db_query' }, { name: 'stock' }],
+        graphTools: [],
+        agentId: 'agent_1',
+      })
+    ),
+    getStepKey: jest.fn(() => 'step-key'),
+    getStepIdByKey: jest.fn((stepKey: string) => {
+      const stepId = stepIdsByKey.get(stepKey);
+      if (stepId == null) {
+        throw new Error('no current step');
+      }
+      return stepId;
+    }),
+    getRunStep: jest.fn((stepId: string) => runSteps.get(stepId)),
+    dispatchRunStep: jest.fn(async (stepKey: string, details: unknown) => {
+      const id = `step_${++stepCounter}`;
+      if (
+        (details as t.StepDetails).type === StepTypes.TOOL_CALLS &&
+        Array.isArray((details as t.ToolCallsDetails).tool_calls)
+      ) {
+        for (const toolCall of (details as t.ToolCallsDetails).tool_calls ??
+          []) {
+          if (toolCall.id != null && toolCall.id !== '') {
+            graph.toolCallStepIds.set(toolCall.id, id);
+          }
+        }
+      }
+      stepIdsByKey.set(stepKey, id);
+      runSteps.set(id, {
+        id,
+        type: (details as { type: t.RunStep['type'] }).type,
+        stepDetails: details as t.RunStep['stepDetails'],
+      } as t.RunStep);
+      return id;
+    }),
+    dispatchRunStepDelta: jest.fn(async () => undefined),
+    ...overrides,
+  };
+
+  return graph as unknown as StandardGraph;
+}
+
+function createDummyTool(name: string): StructuredToolInterface {
+  return tool(async () => 'direct should not run', {
+    name,
+    description: 'dummy',
+    schema: z.object({ sql: z.string() }),
+  }) as unknown as StructuredToolInterface;
+}
+
+function installToolExecuteResponder(): {
+  toolExecuteCalls: t.ToolExecuteBatchRequest[];
+  } {
+  const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+  jest
+    .spyOn(events, 'safeDispatchCustomEvent')
+    .mockImplementation(async (event, data): Promise<void> => {
+      if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+        return;
+      }
+      const batch = data as t.ToolExecuteBatchRequest;
+      toolExecuteCalls.push(batch);
+      batch.resolve(
+        batch.toolCalls.map((call) => ({
+          toolCallId: call.id,
+          status: 'success',
+          content: `ok ${call.name}`,
+        }))
+      );
+    });
+  return { toolExecuteCalls };
+}
+
+/**
+ * A realistic Anthropic input_json_delta fragment sequence for a repetitive
+ * payload: the model legitimately writes the same SQL statement three times
+ * and the provider splits deltas on statement boundaries. The 2nd occurrence
+ * collides with the overlap-merge heuristic (the accumulator ends with an
+ * >=8-char prefix of it) and the 3rd with the repeat-fragment dedupe.
+ */
+const STATEMENT = 'INSERT INTO t VALUES (1);';
+const REPETITIVE_FRAGMENTS = [
+  `{"sql":"${STATEMENT}`,
+  STATEMENT,
+  STATEMENT,
+  '"}',
+];
+const CANONICAL_SQL = `${STATEMENT}${STATEMENT}${STATEMENT}`;
+
+function toToolCallChunks(
+  callId: string,
+  name: string,
+  fragments: string[]
+): Array<Record<string, unknown>> {
+  return fragments.map((args, i) =>
+    i === 0 ? { id: callId, name, args, index: 0 } : { args, index: 0 }
+  );
+}
+
+async function streamChunks(args: {
+  handler: ChatModelStreamHandler;
+  graph: StandardGraph;
+  metadata: Record<string, unknown>;
+  toolCallChunks: Array<Record<string, unknown>>;
+}): Promise<void> {
+  const { handler, graph, metadata, toolCallChunks } = args;
+  for (const toolCallChunk of toolCallChunks) {
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [toolCallChunk],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+  }
+}
+
+/** Seal index 0 the way Anthropic does: the next tool-use block begins. */
+async function streamNextToolIndex(args: {
+  handler: ChatModelStreamHandler;
+  graph: StandardGraph;
+  metadata: Record<string, unknown>;
+  callId: string;
+}): Promise<void> {
+  const { handler, graph, metadata, callId } = args;
+  await handler.handle(
+    GraphEvents.CHAT_MODEL_STREAM,
+    {
+      chunk: {
+        content: '',
+        tool_call_chunks: [
+          { id: callId, name: 'stock', args: '{"ticker":"C', index: 1 },
+        ],
+      } as unknown as t.StreamChunk,
+    },
+    metadata,
+    graph
+  );
+}
+
+/**
+ * The canonical accumulation LangChain performs in the model node: concat all
+ * AIMessageChunks; the final message's tool_calls carry the args ToolNode
+ * receives as the request.
+ */
+function canonicalToolCall(
+  callId: string,
+  name: string,
+  fragments: string[]
+): { id: string; name: string; args: Record<string, unknown> } {
+  let accumulated: AIMessageChunk | undefined;
+  for (const toolCallChunk of toToolCallChunks(callId, name, fragments)) {
+    const chunk = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        { ...toolCallChunk, type: 'tool_call_chunk' },
+      ] as AIMessageChunk['tool_call_chunks'],
+    });
+    accumulated = accumulated == null ? chunk : accumulated.concat(chunk);
+  }
+  const toolCall = accumulated?.tool_calls?.[0];
+  if (toolCall?.id == null) {
+    throw new Error('canonical accumulation produced no tool call');
+  }
+  return {
+    id: toolCall.id,
+    name: toolCall.name,
+    args: toolCall.args as Record<string, unknown>,
+  };
+}
+
+describe('eager args divergence (LibreChat#14371)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sanity: the canonical LangChain concat preserves every repeated fragment', () => {
+    const canonical = canonicalToolCall(
+      'call_1',
+      'db_query',
+      REPETITIVE_FRAGMENTS
+    );
+    expect(canonical.args).toEqual({ sql: CANONICAL_SQL });
+  });
+
+  it('does not prestart when overlap merge + repeat dedupe diverge from the canonical accumulation', async () => {
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks(
+        'call_1',
+        'db_query',
+        REPETITIVE_FRAGMENTS
+      ),
+    });
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+    // Pre-fix: the seal prestarted `{"sql":"<one statement>"}` here — args
+    // the model never asked for — and the run then looped on the "changed
+    // after eager execution started" guard. Now the unconfirmed snapshot is
+    // skipped and the call falls through to normal execution.
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+  });
+
+  it('does not prestart when the overlap heuristic alone swallows legitimate payload', async () => {
+    // existing='{"code":"aaaaaaaaaa' ends with incoming.slice(0, 10), so the
+    // merge drops 10 legitimate chars; canonical has 20 a's.
+    const fragments = ['{"code":"aaaaaaaaaa', 'aaaaaaaaaab"}'];
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks('call_1', 'db_query', fragments),
+    });
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+  });
+
+  it('does not prestart when the repeat-fragment dedupe alone drops legitimate payload', async () => {
+    // 'AB' fragments are too short for the overlap merge (< 8 chars), so only
+    // isRepeatedObservedFragment fires — the 3rd fragment is dropped.
+    const fragments = ['{"sql":"AB', 'AB', 'AB', '"}'];
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks('call_1', 'db_query', fragments),
+    });
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+  });
+
+  it('still prestarts sealed calls whose fragments accumulate cleanly', async () => {
+    const fragments = ['{"sql":"SELECT ', '1;', '"}'];
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks('call_1', 'db_query', fragments),
+    });
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_1',
+      name: 'db_query',
+      args: { sql: 'SELECT 1;' },
+    });
+  });
+
+  it('the retry path no longer loops: every round executes normally with canonical args', async () => {
+    const metadata = { langgraph_node: 'agent' };
+    const guardErrors: string[] = [];
+    const normalExecutions: Array<Record<string, unknown>> = [];
+
+    // Simulate the agent loop that previously burned the recursion limit:
+    // each round the model streams the identical repetitive tool call and
+    // ToolNode materializes the canonical request.
+    for (let round = 0; round < 3; round += 1) {
+      const graph = createGraph();
+      const { toolExecuteCalls } = installToolExecuteResponder();
+      const handler = new ChatModelStreamHandler();
+      const callId = `call_round_${round}`;
+      await streamChunks({
+        handler,
+        graph,
+        metadata,
+        toolCallChunks: toToolCallChunks(
+          callId,
+          'db_query',
+          REPETITIVE_FRAGMENTS
+        ),
+      });
+      await streamNextToolIndex({
+        handler,
+        graph,
+        metadata,
+        callId: `${callId}_next`,
+      });
+
+      const canonical = canonicalToolCall(
+        callId,
+        'db_query',
+        REPETITIVE_FRAGMENTS
+      );
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('db_query')],
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: graph.eagerEventToolExecutions,
+        eagerEventToolUsageCount: graph.getEagerEventToolUsageCount(),
+        eagerEventToolSuppressions: graph.eagerEventToolSuppressions,
+        toolCallStepIds: graph.toolCallStepIds,
+      });
+      const result = (await toolNode.invoke({
+        messages: [new AIMessage({ content: '', tool_calls: [canonical] })],
+      })) as { messages: ToolMessage[] };
+
+      const toolMessage = result.messages.find(
+        (message) => message.tool_call_id === callId
+      );
+      if (
+        typeof toolMessage?.content === 'string' &&
+        toolMessage.content.includes('changed after eager execution')
+      ) {
+        guardErrors.push(toolMessage.content);
+      }
+      const dispatched = toolExecuteCalls
+        .flatMap((batch) => batch.toolCalls)
+        .find((call) => call.id === callId);
+      if (dispatched != null) {
+        normalExecutions.push(dispatched.args);
+      }
+      jest.restoreAllMocks();
+    }
+
+    // Pre-fix: 3/3 rounds errored with the guard and nothing ever executed
+    // with the args the model requested.
+    expect(guardErrors).toHaveLength(0);
+    expect(normalExecutions).toHaveLength(3);
+    for (const args of normalExecutions) {
+      expect(args).toEqual({ sql: CANONICAL_SQL });
+    }
+  });
+
+  describe('circuit breaker', () => {
+    it('suppresses eager prestart for a tool after the changed-args guard fires', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { toolExecuteCalls } = installToolExecuteResponder();
+      const suppressions = new Set<string>();
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+      const request: t.ToolCallRequest = {
+        id: 'call_1',
+        name: 'db_query',
+        args: { sql: 'diverged' },
+        stepId: 'step_1',
+        turn: 0,
+      };
+      eagerExecutions.set('call_1', {
+        toolCallId: 'call_1',
+        toolName: 'db_query',
+        args: { sql: 'diverged' },
+        request,
+        promise: Promise.resolve({
+          results: [
+            { toolCallId: 'call_1', status: 'success', content: 'eager' },
+          ],
+        }),
+      });
+
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('db_query')],
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+        eagerEventToolSuppressions: suppressions,
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+      });
+      const result = (await toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'db_query', args: { sql: CANONICAL_SQL } },
+            ],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toContain(
+        'changed after eager execution'
+      );
+      expect(suppressions.has('db_query')).toBe(true);
+      expect(toolExecuteCalls).toHaveLength(0);
+    });
+
+    it('stops prestarting a suppressed tool while siblings still prestart', async () => {
+      const graph = createGraph();
+      (graph.eagerEventToolSuppressions as Set<string>).add('db_query');
+      const { toolExecuteCalls } = installToolExecuteResponder();
+      const handler = new ChatModelStreamHandler();
+      const metadata = { langgraph_node: 'agent' };
+
+      // A clean, confirmable db_query stream: without the suppression this
+      // would prestart (see "still prestarts sealed calls" above).
+      await streamChunks({
+        handler,
+        graph,
+        metadata,
+        toolCallChunks: toToolCallChunks('call_1', 'db_query', [
+          '{"sql":"SELECT 1;"}',
+        ]),
+      });
+      await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+      expect(toolExecuteCalls).toHaveLength(0);
+      expect(graph.eagerEventToolExecutions.has('call_1')).toBe(false);
+
+      // The sibling tool (index 1) is not suppressed: sealing it via the
+      // final tool-call signal still prestarts it.
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            tool_call_chunks: [{ args: 'H"}', index: 1 }],
+            response_metadata: { finish_reason: 'tool_calls' },
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      );
+
+      expect(toolExecuteCalls).toHaveLength(1);
+      expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+        id: 'call_2',
+        name: 'stock',
+        args: { ticker: 'CH' },
+      });
+    });
+
+    it('lets the retry execute normally after suppression', async () => {
+      const { toolExecuteCalls } = installToolExecuteResponder();
+      const suppressions = new Set<string>(['db_query']);
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('db_query')],
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: new Map(),
+        eagerEventToolSuppressions: suppressions,
+        toolCallStepIds: new Map([['call_retry', 'step_1']]),
+      });
+
+      const result = (await toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_retry',
+                name: 'db_query',
+                args: { sql: CANONICAL_SQL },
+              },
+            ],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toBe('ok db_query');
+      expect(toolExecuteCalls).toHaveLength(1);
+      expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+        id: 'call_retry',
+        name: 'db_query',
+        args: { sql: CANONICAL_SQL },
+      });
+    });
+  });
+});

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -767,6 +767,15 @@ export abstract class Graph<
   eagerEventToolCallChunks: Map<string, t.EagerEventToolCallChunkState> =
     new Map();
   /**
+   * Per-run eager prestart circuit breaker, shared by reference with every
+   * ToolNode this graph compiles. When a prestarted execution's args turn
+   * out to differ from the final request, ToolNode records the tool name
+   * here and the stream handler stops prestarting that tool for the rest of
+   * the run — the retry then executes normally instead of re-diverging in a
+   * loop (LibreChat#14371).
+   */
+  eagerEventToolSuppressions: Set<string> = new Set();
+  /**
    * Run-scoped execution backend for built-in code tools. Defaults to the
    * remote Code API sandbox when unset.
    */
@@ -815,6 +824,7 @@ export abstract class Graph<
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
+    this.eagerEventToolSuppressions.clear();
     this.toolExecution = undefined;
     this.handlerDispatchedEventCounts.clear();
     /**
@@ -1144,6 +1154,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
+    this.eagerEventToolSuppressions.clear();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1672,6 +1683,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         eagerEventToolUsageCount: this.getEagerEventToolUsageCount(
           agentContext?.agentId
         ),
+        eagerEventToolSuppressions: this.eagerEventToolSuppressions,
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         interruptingToolNames:

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -135,6 +135,7 @@ describe('LangGraph composition smoke tests', () => {
     const usageCount = graph.eagerEventToolUsageCount;
     const scopedUsageCount = graph.getEagerEventToolUsageCount('agent');
     const chunks = graph.eagerEventToolCallChunks;
+    const suppressions = graph.eagerEventToolSuppressions;
 
     graph.eagerEventToolExecutions.set(
       'call_weather',
@@ -143,6 +144,7 @@ describe('LangGraph composition smoke tests', () => {
     graph.eagerEventToolUsageCount.set('weather', 1);
     scopedUsageCount.set('weather', 1);
     graph.eagerEventToolCallChunks.set('0', { argsText: '{"city":"NYC"}' });
+    graph.eagerEventToolSuppressions.add('weather');
 
     graph.resetValues();
 
@@ -150,10 +152,12 @@ describe('LangGraph composition smoke tests', () => {
     expect(graph.eagerEventToolUsageCount).toBe(usageCount);
     expect(graph.getEagerEventToolUsageCount('agent')).toBe(scopedUsageCount);
     expect(graph.eagerEventToolCallChunks).toBe(chunks);
+    expect(graph.eagerEventToolSuppressions).toBe(suppressions);
     expect(graph.eagerEventToolExecutions.size).toBe(0);
     expect(graph.eagerEventToolUsageCount.size).toBe(0);
     expect(scopedUsageCount.size).toBe(0);
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
+    expect(graph.eagerEventToolSuppressions.size).toBe(0);
   });
 
   it('compiles and invokes the standard single-agent graph', async () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -25,6 +25,7 @@ import {
   buildToolExecutionRequestPlan,
   coerceRecordArgs,
   normalizeError,
+  recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
   serializeStructuredValueBounded,
@@ -160,6 +161,13 @@ function isEagerExecutionExcludedTool(
   }
   const excluded = graph.eagerEventToolExecution?.excludeToolNames;
   if (excluded != null && excluded.includes(name)) {
+    return true;
+  }
+  // Run-scoped circuit breaker: once a prestart for this tool diverged from
+  // the final request ("changed after eager execution started"), stop
+  // prestarting it so the model's retry executes normally instead of
+  // re-diverging in a loop (LibreChat#14371).
+  if (graph.eagerEventToolSuppressions?.has(name) === true) {
     return true;
   }
   // A code-session participant writes to the shared sandbox, so it is
@@ -1058,6 +1066,10 @@ function recordEagerToolCallChunks(args: {
       id,
       name,
       argsText,
+      // Canonical accumulation: LangChain concats fragments verbatim, so the
+      // final request's args always come from this text — never from the
+      // heuristic `argsText` above, which may reconcile away real payload.
+      rawArgsText: `${existing.rawArgsText ?? ''}${incomingArgs}`,
       index: getEagerToolChunkIndex(toolCallChunk) ?? existing.index,
       lastArgsFragment:
         incomingArgs !== '' ? incomingArgs : existing.lastArgsFragment,
@@ -1095,6 +1107,7 @@ function getStreamedReadyToolCalls(args: {
   const readyEntries: Array<{
     key: string;
     state: t.EagerEventToolCallChunkState;
+    sealedByAdapter: boolean;
   }> = [];
 
   for (const [key, state] of graph.eagerEventToolCallChunks) {
@@ -1124,7 +1137,11 @@ function getStreamedReadyToolCalls(args: {
       isSealedByLaterChunk ||
       isSealedExplicitly
     ) {
-      readyEntries.push({ key, state });
+      readyEntries.push({
+        key,
+        state,
+        sealedByAdapter: isSealedExplicitly || seal?.kind === 'all',
+      });
     }
   }
 
@@ -1143,10 +1160,32 @@ function getStreamedReadyToolCalls(args: {
 
   return readyEntries
     .sort((left, right) => (left.state.index ?? 0) - (right.state.index ?? 0))
-    .flatMap(({ state }) => {
+    .flatMap(({ state, sealedByAdapter }) => {
       const args = coerceRecordArgs(state.argsText);
       if (args == null) {
         return [];
+      }
+      // Adapter seals may restate the finished call's full args on the seal
+      // chunk itself (OpenAI Responses `function_call_arguments.done`). When
+      // the accumulated text IS that final restatement, the adapter has
+      // vouched for it — plain concatenation intentionally differs there.
+      const isAuthoritativeRestatement =
+        sealedByAdapter &&
+        state.lastArgsFragment != null &&
+        state.lastArgsFragment === state.argsText;
+      // Otherwise the final request's args come from LangChain's canonical
+      // verbatim concatenation (`rawArgsText`), while `argsText` reconciles
+      // provider quirks with lossy heuristics that can also swallow
+      // legitimately repetitive payload fragments (LibreChat#14371).
+      // Prestarting an unconfirmed snapshot trips the "changed after eager
+      // execution started" guard and burns a retry loop, so only prestart
+      // when both views agree — otherwise leave the call to normal ToolNode
+      // execution with final args.
+      if (!isAuthoritativeRestatement && state.rawArgsText !== state.argsText) {
+        const rawArgs = coerceRecordArgs(state.rawArgsText ?? '');
+        if (rawArgs == null || !recordArgsEqual(args, rawArgs)) {
+          return [];
+        }
       }
       return [
         {
@@ -2325,7 +2364,9 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      for (const contentPart of getDeltaContentParts(messageDelta.delta.content)) {
+      for (const contentPart of getDeltaContentParts(
+        messageDelta.delta.content
+      )) {
         updateContent(runStep.index, contentPart);
       }
     } else if (
@@ -2354,7 +2395,9 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      for (const contentPart of getDeltaContentParts(reasoningDelta.delta.content)) {
+      for (const contentPart of getDeltaContentParts(
+        reasoningDelta.delta.content
+      )) {
         updateContent(runStep.index, contentPart);
       }
     } else if (event === GraphEvents.ON_RUN_STEP_DELTA) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -25,7 +25,6 @@ import {
   buildToolExecutionRequestPlan,
   coerceRecordArgs,
   normalizeError,
-  recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
   serializeStructuredValueBounded,
@@ -1077,10 +1076,12 @@ function recordEagerToolCallChunks(args: {
       id,
       name,
       argsText,
-      // Canonical accumulation: LangChain concats fragments verbatim, so the
-      // final request's args always come from this text — never from the
-      // heuristic `argsText` above, which may reconcile away real payload.
-      rawArgsText: `${existing.rawArgsText ?? ''}${incomingArgs}`,
+      // Canonical accumulation length: LangChain concats fragments verbatim
+      // to build the final request, and every reconciliation branch above
+      // yields text no longer than that concat — equal exactly when every
+      // merge was a pure append. Tracking the length (not the text) keeps
+      // cumulative/restating streams from retaining every prefix.
+      rawArgsLength: (existing.rawArgsLength ?? 0) + incomingArgs.length,
       index,
       lastArgsFragment:
         incomingArgs !== '' ? incomingArgs : existing.lastArgsFragment,
@@ -1180,29 +1181,31 @@ function getStreamedReadyToolCalls(args: {
       if (args == null) {
         return [];
       }
-      // Adapter seals may restate the finished call's full args on the seal
-      // chunk itself (OpenAI Responses `function_call_arguments.done`). Only
-      // when the seal-carrying chunk supplied that fragment AND the
-      // accumulated text IS that restatement has the adapter vouched for it —
-      // plain concatenation intentionally differs there. Pure-signal seals
-      // (Bedrock contentBlockStop, `args: ''`) never qualify.
+      // The final request's args come from LangChain's canonical verbatim
+      // concatenation of fragments, while `argsText` reconciles provider
+      // quirks with lossy heuristics that can also swallow legitimately
+      // repetitive payload fragments (LibreChat#14371). `argsText` can never
+      // be LONGER than the plain concat, so length equality proves it IS the
+      // canonical accumulation.
+      const isCanonicalAccumulation =
+        state.rawArgsLength != null &&
+        state.argsText.length === state.rawArgsLength;
+      // Adapter seals may instead restate the finished call's full args on
+      // the seal chunk itself (OpenAI Responses
+      // `function_call_arguments.done`). Only when the seal-carrying chunk
+      // supplied that fragment AND the accumulated text IS that restatement
+      // has the adapter vouched for it — plain concatenation intentionally
+      // differs there. Pure-signal seals (Bedrock contentBlockStop,
+      // `args: ''`) never qualify.
       const isAuthoritativeRestatement =
         sealedByAdapter &&
         state.sealedArgsFragment != null &&
         state.sealedArgsFragment === state.argsText;
-      // Otherwise the final request's args come from LangChain's canonical
-      // verbatim concatenation (`rawArgsText`), while `argsText` reconciles
-      // provider quirks with lossy heuristics that can also swallow
-      // legitimately repetitive payload fragments (LibreChat#14371).
       // Prestarting an unconfirmed snapshot trips the "changed after eager
-      // execution started" guard and burns a retry loop, so only prestart
-      // when both views agree — otherwise leave the call to normal ToolNode
-      // execution with final args.
-      if (!isAuthoritativeRestatement && state.rawArgsText !== state.argsText) {
-        const rawArgs = coerceRecordArgs(state.rawArgsText ?? '');
-        if (rawArgs == null || !recordArgsEqual(args, rawArgs)) {
-          return [];
-        }
+      // execution started" guard and burns a retry loop — leave unconfirmed
+      // calls to normal ToolNode execution with final args.
+      if (!isCanonicalAccumulation && !isAuthoritativeRestatement) {
+        return [];
       }
       return [
         {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1014,8 +1014,9 @@ function recordEagerToolCallChunks(args: {
   graph: StandardGraph;
   stepKey: string;
   toolCallChunks?: ToolCallChunk[];
+  seal?: StreamedToolCallSeal;
 }): void {
-  const { graph, stepKey, toolCallChunks } = args;
+  const { graph, stepKey, toolCallChunks, seal } = args;
   if (toolCallChunks == null || toolCallChunks.length === 0) {
     return;
   }
@@ -1062,6 +1063,16 @@ function recordEagerToolCallChunks(args: {
     const argsText = isRepeatedObservedFragment
       ? existing.argsText
       : mergeToolCallArgsText(existing.argsText, incomingArgs);
+    const index = getEagerToolChunkIndex(toolCallChunk) ?? existing.index;
+    // Only a chunk whose explicit adapter seal covers THIS call may supply a
+    // full-args restatement (OpenAI Responses `arguments.done`). Pure-signal
+    // seals carry empty args and never set this.
+    const sealCoversChunk =
+      seal != null &&
+      (seal.kind === 'all' ||
+        (seal.kind === 'single' &&
+          ((seal.id != null && seal.id === id) ||
+            (seal.index != null && seal.index === index))));
     const next = {
       id,
       name,
@@ -1070,9 +1081,13 @@ function recordEagerToolCallChunks(args: {
       // final request's args always come from this text — never from the
       // heuristic `argsText` above, which may reconcile away real payload.
       rawArgsText: `${existing.rawArgsText ?? ''}${incomingArgs}`,
-      index: getEagerToolChunkIndex(toolCallChunk) ?? existing.index,
+      index,
       lastArgsFragment:
         incomingArgs !== '' ? incomingArgs : existing.lastArgsFragment,
+      sealedArgsFragment:
+        sealCoversChunk && incomingArgs !== ''
+          ? incomingArgs
+          : existing.sealedArgsFragment,
     };
     graph.eagerEventToolCallChunks.set(key, next);
   }
@@ -1166,13 +1181,15 @@ function getStreamedReadyToolCalls(args: {
         return [];
       }
       // Adapter seals may restate the finished call's full args on the seal
-      // chunk itself (OpenAI Responses `function_call_arguments.done`). When
-      // the accumulated text IS that final restatement, the adapter has
-      // vouched for it — plain concatenation intentionally differs there.
+      // chunk itself (OpenAI Responses `function_call_arguments.done`). Only
+      // when the seal-carrying chunk supplied that fragment AND the
+      // accumulated text IS that restatement has the adapter vouched for it —
+      // plain concatenation intentionally differs there. Pure-signal seals
+      // (Bedrock contentBlockStop, `args: ''`) never qualify.
       const isAuthoritativeRestatement =
         sealedByAdapter &&
-        state.lastArgsFragment != null &&
-        state.lastArgsFragment === state.argsText;
+        state.sealedArgsFragment != null &&
+        state.sealedArgsFragment === state.argsText;
       // Otherwise the final request's args come from LangChain's canonical
       // verbatim concatenation (`rawArgsText`), while `argsText` reconciles
       // provider quirks with lossy heuristics that can also swallow
@@ -1625,6 +1642,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
           graph,
           stepKey,
           toolCallChunks: chunk.tool_call_chunks,
+          seal: streamedToolCallSeal,
         });
       }
       await handleToolCallChunks({

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3325,7 +3325,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // snapshot cannot be trusted for this tool in this run. Without this,
       // the model retries the call, the retry prestarts and diverges the
       // same way, and the run loops to the recursion limit (LibreChat#14371).
+      // On an identity mismatch, suppress the eagerly executed name too —
+      // otherwise a retry that deterministically streams name A but
+      // materializes name B keeps prestarting A (and repeating its side
+      // effects) every round.
       this.eagerEventToolSuppressions?.add(request.name);
+      this.eagerEventToolSuppressions?.add(execution.toolName);
       // eslint-disable-next-line no-console
       console.warn(
         '[ToolNode] eager prestart args diverged from the final request for ' +

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -572,6 +572,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private eagerEventToolExecutions?: Map<string, t.EagerEventToolExecution>;
   /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */
   private eagerEventToolUsageCount?: Map<string, number>;
+  /**
+   * Shared per-run eager prestart circuit breaker. Tool names added here
+   * (when a prestarted execution's args mismatch the final request) are no
+   * longer prestarted by the stream handler for the rest of the run.
+   */
+  private eagerEventToolSuppressions?: Set<string>;
   /** Agent ID for event-driven mode */
   private agentId?: string;
   /**
@@ -656,6 +662,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     eagerEventToolExecution,
     eagerEventToolExecutions,
     eagerEventToolUsageCount,
+    eagerEventToolSuppressions,
     agentId,
     executingAgentId,
     directToolNames,
@@ -693,6 +700,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.eagerEventToolExecution = eagerEventToolExecution;
     this.eagerEventToolExecutions = eagerEventToolExecutions;
     this.eagerEventToolUsageCount = eagerEventToolUsageCount;
+    this.eagerEventToolSuppressions = eagerEventToolSuppressions;
     this.agentId = agentId;
     // Default to agentId so callers constructing ToolNode directly (who pass the
     // existing agentId option) still get attribution without knowing the new option.
@@ -3313,6 +3321,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       execution.toolName !== request.name ||
       !recordArgsEqual(execution.args, request.args)
     ) {
+      // Circuit breaker: a prestart/final mismatch means the streamed eager
+      // snapshot cannot be trusted for this tool in this run. Without this,
+      // the model retries the call, the retry prestarts and diverges the
+      // same way, and the run loops to the recursion limit (LibreChat#14371).
+      this.eagerEventToolSuppressions?.add(request.name);
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[ToolNode] eager prestart args diverged from the final request for ' +
+          `tool "${request.name}" (toolCallId=${request.id}); suppressing ` +
+          'eager prestart for this tool for the rest of the run'
+      );
       return {
         toolCallId: request.id,
         toolName: request.name,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -76,20 +76,23 @@ export type EagerEventToolCallChunkState = {
   index?: number;
   lastArgsFragment?: string;
   /**
-   * Plain in-order concatenation of every observed args fragment — the same
-   * accumulation LangChain's `AIMessageChunk.concat` performs to build the
-   * final tool call. `argsText` applies lossy reconciliation heuristics
-   * (repeat dedupe, overlap merge) that can drop legitimately repetitive
-   * payload fragments; prestart must only trust `argsText` when it matches
-   * this canonical text, since the final request's args come from the
-   * canonical accumulation.
+   * Cumulative length of every observed args fragment — the length of the
+   * plain in-order concatenation that LangChain's `AIMessageChunk.concat`
+   * performs to build the final tool call. Every reconciliation branch in
+   * `mergeToolCallArgsText` (and the repeat-fragment dedupe) produces text no
+   * longer than plain concatenation, with equality exactly when every merge
+   * was a pure append — so `argsText.length === rawArgsLength` proves
+   * `argsText` IS the canonical accumulation the final request will carry.
+   * Tracking only the length keeps cumulative/restating streams from
+   * retaining every prefix (quadratic growth) while still letting seal-time
+   * prestart verify the snapshot.
    */
-  rawArgsText?: string;
+  rawArgsLength?: number;
   /**
    * The non-empty args fragment carried by a chunk whose explicit adapter
    * seal covered this call. Some adapters restate the finished call's full
    * args on the seal chunk (OpenAI Responses `function_call_arguments.done`);
-   * only such a restatement may override the `rawArgsText` comparison at
+   * only such a restatement may override the canonical-accumulation check at
    * seal time. Pure-signal seals (Bedrock `contentBlockStop`, `args: ''`)
    * never set this.
    */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -85,6 +85,15 @@ export type EagerEventToolCallChunkState = {
    * canonical accumulation.
    */
   rawArgsText?: string;
+  /**
+   * The non-empty args fragment carried by a chunk whose explicit adapter
+   * seal covered this call. Some adapters restate the finished call's full
+   * args on the seal chunk (OpenAI Responses `function_call_arguments.done`);
+   * only such a restatement may override the `rawArgsText` comparison at
+   * seal time. Pure-signal seals (Bedrock `contentBlockStop`, `args: ''`)
+   * never set this.
+   */
+  sealedArgsFragment?: string;
 };
 
 export type ToolNodeOptions = {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -75,6 +75,16 @@ export type EagerEventToolCallChunkState = {
   argsText: string;
   index?: number;
   lastArgsFragment?: string;
+  /**
+   * Plain in-order concatenation of every observed args fragment — the same
+   * accumulation LangChain's `AIMessageChunk.concat` performs to build the
+   * final tool call. `argsText` applies lossy reconciliation heuristics
+   * (repeat dedupe, overlap merge) that can drop legitimately repetitive
+   * payload fragments; prestart must only trust `argsText` when it matches
+   * this canonical text, since the final request's args come from the
+   * canonical accumulation.
+   */
+  rawArgsText?: string;
 };
 
 export type ToolNodeOptions = {
@@ -156,6 +166,14 @@ export type ToolNodeOptions = {
   eagerEventToolExecutions?: Map<string, EagerEventToolExecution>;
   /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */
   eagerEventToolUsageCount?: Map<string, number>;
+  /**
+   * Shared per-run circuit breaker for eager prestart. When a prestarted
+   * execution's args turn out to differ from the final request ("changed
+   * after eager execution started"), the ToolNode adds the tool name here
+   * and the stream handler stops prestarting that tool for the remainder of
+   * the run, so the model's retry executes normally instead of looping.
+   */
+  eagerEventToolSuppressions?: Set<string>;
   /**
    * Hook registry for PreToolUse/PostToolUse/PostToolUseFailure/
    * PermissionDenied lifecycle hooks. Fires for **every** tool the
@@ -241,7 +259,11 @@ export type ToolEndEvent = {
    * present (see `ProcessedToolCall.outcome`) so `ON_RUN_STEP_COMPLETED`
    * consumers can read it without an unsafe cast.
    */
-  tool_call: ToolCall & { output?: string; progress?: number; outcome?: string };
+  tool_call: ToolCall & {
+    output?: string;
+    progress?: number;
+    outcome?: string;
+  };
   /** The content index of the tool call */
   index: number;
   type?: 'tool_call';


### PR DESCRIPTION
## Summary

Fixes the root cause of danny-avila/LibreChat#14371: eager tool execution loops to the recursion limit for tools with large (repetitive) arguments.

**Root cause (reproduced with a runnable probe before fixing):** `src/stream.ts` maintains a second args accumulator for eager prestart (`graph.eagerEventToolCallChunks`) with lossy reconciliation heuristics:

- `isRepeatedObservedFragment` drops an incoming fragment identical to the previous one — legitimate repeats in SQL/code get deduped.
- `mergeToolCallArgsText`'s overlap heuristic (`overlap >= 8`) merges self-colliding repetitive payloads — the second occurrence of a repeated ≥8-char fragment is swallowed entirely.

A stream of `['{"sql":"INSERT INTO t VALUES (1);', 'INSERT INTO t VALUES (1);', 'INSERT INTO t VALUES (1);', '"}']` (three legitimate statements, deltas split on statement boundaries) sealed as **one** statement while the canonical LangChain `tool_call_chunks` accumulation — what ToolNode receives as the final request — has three. The eager execution ran with args the model never requested, `recordArgsEqual` in `takeMatchingEagerEventExecution` errored with *"Tool call changed after eager execution started"*, the model retried, the retry re-prestarted and re-diverged, and the run consumed the recursion limit. The pre-fix probe confirmed the guard fired on 3/3 simulated retries.

## Fix (two complementary parts)

**1. Canonical seal-time verification (`src/stream.ts`)**
The accumulator tracks `rawArgsLength` — the cumulative length of every observed args fragment, i.e. the length of the verbatim concatenation `AIMessageChunk.concat` performs to materialize the final request. Every reconciliation branch in `mergeToolCallArgsText` (and the repeat dedupe) yields text **no longer than** plain concatenation, with equality exactly when every merge was a pure append — so `argsText.length === rawArgsLength` proves the heuristic snapshot IS the canonical accumulation. `getStreamedReadyToolCalls` only prestarts verified snapshots; unverified calls fall through to normal ToolNode execution with final args. Length-only tracking costs O(1) memory for any stream shape (no retained prefixes for cumulative/restating streams, no seal-time parse of raw text).

One provider nuance: OpenAI Responses' `function_call_arguments.done` seal chunk **restates** the call's full args, so plain concatenation intentionally differs there. A non-empty fragment supplied by the chunk carrying an explicit seal for the call (`sealedArgsFragment`) that equals the accumulated text is honored as an authoritative restatement. Pure-signal seals (Bedrock `contentBlockStop`, `args: ''`) never qualify, and Google seals whole calls on arrival, so both stay on the length rule.

**2. Run-scoped circuit breaker (`ToolNode` + `Graph` + stream gating)**
If the changed-args guard still fires, ToolNode records **both** the final request's name and the eagerly executed name in `graph.eagerEventToolSuppressions` (shared by reference with every compiled ToolNode and the stream handler). `isEagerExecutionExcludedTool` then blocks eager prestart for those tools for the remainder of the run — the retry executes normally, making the loop structurally impossible even for divergence modes not covered by (1). The set clears per run (`resetValues`/`clearHeavyState`), and suppression is per tool name, so sibling tools keep prestarting.

The issue's proposed per-agent `eager_execution` toggle is an operator workaround, not this fix; it can still be added separately if desired.

## Tests

New regression suite `src/__tests__/stream.eagerArgsDivergence.test.ts` (13 tests):
- canonical-concat sanity for repeated fragments
- no prestart when overlap merge + repeat dedupe diverge (combined, and each heuristic in isolation)
- pure-signal adapter seals (Bedrock) are never treated as args restatements; OpenAI Responses restatement seals still prestart
- clean delta streams still prestart at the sequential seal
- the previously-looping 3-round retry sequence now executes normally with canonical args every round (0 guard errors)
- circuit breaker: guard fire suppresses both names on identity mismatch; suppressed tool stops prestarting while siblings still do; retry executes normally after suppression

Also extends `composition.smoke.test.ts` reset coverage to the new suppression set.

`NODE_OPTIONS='--experimental-vm-modules' npx jest`: all suites pass except live provider specs requiring credentials/model access (with local keys the Anthropic live suite passes fully; remaining Google/Vertex failures are HTTP-level errors from Google's API — 404s for pinned `gemini-3.x` preview models — in inherited upstream specs untouched by this diff). CI is green.

## Codex review cycle

- P1 (pure-signal seal blessed reconciled args as restatement): reproduced, fixed via `sealedArgsFragment`.
- P2 (quadratic `rawArgsText` retention for cumulative streams): fixed by replacing retained text with length-based verification.
- P2 (identity mismatch left the eagerly executed name unsuppressed): fixed, both names suppressed.