### PR TITLE
🩹 fix: Keep Truncated Tool-Call Inputs JSON Objects on Anthropic Replay

### DIFF
--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -388,6 +388,34 @@ function _ensureMessageContents(
   return updatedMsgs as (SystemMessage | HumanMessage | AIMessage)[];
 }
 
+/**
+ * Anthropic requires `tool_use.input` to be a JSON object; anything else is
+ * rejected with a 400 (`tool_use.input: Input should be an object`).
+ * History can carry non-object inputs: streaming leaves the raw partial-JSON
+ * string on the content block, and upstream context projections can leave
+ * `null` (observed live on a summarization-retained tool call replayed after
+ * compaction). A string is parsed when it forms complete JSON; every other
+ * shape degrades to `{}` — the call already executed, so the replayed input
+ * is informational and an empty object is the safe representation.
+ */
+export function coerceAnthropicToolUseInput(
+  input: unknown
+): Record<string, unknown> {
+  let candidate: unknown = input;
+  if (typeof candidate === 'string') {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return {};
+    }
+  }
+  return typeof candidate === 'object' &&
+    candidate !== null &&
+    !Array.isArray(candidate)
+    ? (candidate as Record<string, unknown>)
+    : {};
+}
+
 export function _convertLangChainToolCallToAnthropic(
   toolCall: ToolCall
 ): AnthropicToolResponse {
@@ -401,7 +429,7 @@ export function _convertLangChainToolCallToAnthropic(
     type: isServerTool ? 'server_tool_use' : 'tool_use',
     id: isServerTool ? toolCall.id : normalizeAnthropicToolCallId(toolCall.id),
     name: toolCall.name,
-    input: toolCall.args,
+    input: coerceAnthropicToolUseInput(toolCall.args),
   };
 }
 
@@ -949,14 +977,29 @@ function _formatContent(message: BaseMessage) {
           }
         }
 
-        if ('input' in contentPartCopy) {
-          // Anthropic tool use inputs should be valid objects, when applicable.
-          if (typeof contentPartCopy.input === 'string') {
-            try {
-              contentPartCopy.input = JSON.parse(contentPartCopy.input);
-            } catch {
-              contentPartCopy.input = {};
-            }
+        if (
+          contentPartCopy.type === 'tool_use' ||
+          contentPartCopy.type === 'server_tool_use'
+        ) {
+          /**
+           * The API requires `input` to be a JSON object. Streaming leaves the
+           * raw partial-JSON string here, and context-pressure truncation can
+           * leave `null` on BOTH the block and its `tool_calls` mirror — so
+           * the restore above may itself restore a non-object. Coerce last,
+           * after every restore path has run.
+           */
+          contentPartCopy.input = coerceAnthropicToolUseInput(
+            'input' in contentPartCopy ? contentPartCopy.input : undefined
+          );
+        } else if (
+          'input' in contentPartCopy &&
+          typeof contentPartCopy.input === 'string'
+        ) {
+          // Non-tool_use tool blocks keep their legacy string handling.
+          try {
+            contentPartCopy.input = JSON.parse(contentPartCopy.input);
+          } catch {
+            contentPartCopy.input = {};
           }
         }
 

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -398,6 +398,16 @@ function _ensureMessageContents(
  * shape degrades to `{}` — the call already executed, so the replayed input
  * is informational and an empty object is the safe representation.
  */
+/** True for `{}` — no own enumerable keys on a non-array, non-null object. */
+function isEmptyPlainObject(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
+}
+
 export function coerceAnthropicToolUseInput(
   input: unknown
 ): Record<string, unknown> {
@@ -677,19 +687,11 @@ function _formatContent(message: BaseMessage) {
         'name' in contentPart
       ) {
         const rawPart = contentPart as Record<string, unknown>;
-        let input = rawPart.input ?? rawPart.args;
-        if (typeof input === 'string') {
-          try {
-            input = JSON.parse(input);
-          } catch {
-            input = {};
-          }
-        }
         const corrected: AnthropicServerToolUseBlockParam = {
           type: 'server_tool_use',
           id: rawPart.id as string,
           name: (rawPart.name ?? 'web_search') as 'web_search',
-          input: (input ?? {}) as Record<string, unknown>,
+          input: coerceAnthropicToolUseInput(rawPart.input ?? rawPart.args),
         };
         return corrected;
       }
@@ -944,10 +946,16 @@ function _formatContent(message: BaseMessage) {
         // Core's streaming aggregation can leave the inline tool_use input empty
         // (the assembled arguments live in `message.tool_calls` or, for persisted
         // messages, in sibling input_json_delta blocks). Restore it when missing.
+        // An empty plain object counts as missing too: context-pressure
+        // truncation degrades an inline input to `{}` while a small `args`
+        // mirror survives intact, and a genuinely empty call's mirror is also
+        // `{}`, so preferring the mirror never loses information.
         if (
           contentPartCopy.type === 'tool_use' &&
           typeof contentPartCopy.id === 'string' &&
-          (contentPartCopy.input === '' || contentPartCopy.input == null)
+          (contentPartCopy.input === '' ||
+            contentPartCopy.input == null ||
+            isEmptyPlainObject(contentPartCopy.input))
         ) {
           const matchingToolCall = isAIMessage(message)
             ? message.tool_calls?.find(

--- a/src/llm/anthropic/utils/streaming-tool-input.test.ts
+++ b/src/llm/anthropic/utils/streaming-tool-input.test.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AnthropicMessageCreateParams,
+  AnthropicServerToolUseBlockParam,
+  AnthropicToolUseBlockParam,
+} from '@/llm/anthropic/types';
 import { _makeMessageChunkFromAnthropicEvent } from './message_outputs';
 import { _convertMessagesToAnthropicPayload } from './message_inputs';
 
@@ -155,28 +161,45 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
  * conversion must never emit a non-object input, whatever shape history is in.
  */
 describe('_convertMessagesToAnthropicPayload — non-object tool_use input replay', () => {
-  const buildHistory = (input: unknown, args: unknown): BaseMessage[] => [
+  /** History shapes context-pressure truncation can leave behind in state. */
+  type DegradedToolInput = string | Record<string, unknown> | null | undefined;
+
+  const buildHistory = (
+    input: DegradedToolInput,
+    args: DegradedToolInput
+  ): BaseMessage[] => [
     new HumanMessage('What is 9 * 9?'),
     new AIMessage({
-      content: [
-        { type: 'tool_use', id: 'toolu_x', name: 'calculator', input } as any,
-      ],
+      content: [{ type: 'tool_use', id: 'toolu_x', name: 'calculator', input }],
       tool_calls: [
         {
           id: 'toolu_x',
           name: 'calculator',
-          args: args as any,
+          args: args as ToolCall['args'],
           type: 'tool_call',
         },
       ],
     }),
   ];
 
-  const getToolUse = (history: BaseMessage[]): any => {
-    const payload = _convertMessagesToAnthropicPayload(history);
-    const assistant = payload.messages.find((m: any) => m.role === 'assistant');
-    return (assistant!.content as any[]).find((b) => b.type === 'tool_use');
+  const findAssistantBlock = (
+    payload: AnthropicMessageCreateParams,
+    type: 'tool_use' | 'server_tool_use'
+  ): AnthropicToolUseBlockParam | AnthropicServerToolUseBlockParam => {
+    const assistant = payload.messages.find((m) => m.role === 'assistant');
+    const content = assistant?.content;
+    const block = (Array.isArray(content) ? content : []).find(
+      (b): b is AnthropicToolUseBlockParam | AnthropicServerToolUseBlockParam =>
+        b.type === type
+    );
+    expect(block).toBeDefined();
+    return block!;
   };
+
+  const getToolUse = (
+    history: BaseMessage[]
+  ): AnthropicToolUseBlockParam | AnthropicServerToolUseBlockParam =>
+    findAssistantBlock(_convertMessagesToAnthropicPayload(history), 'tool_use');
 
   it('ships an empty object when input and args were both truncated to null', () => {
     const toolUse = getToolUse(buildHistory(null, null));
@@ -204,12 +227,13 @@ describe('_convertMessagesToAnthropicPayload — non-object tool_use input repla
   });
 
   it('coerces non-object inputs on the srvtoolu_ server-tool normalization branch', () => {
-    for (const [raw, expected] of [
+    const cases: Array<[DegradedToolInput, Record<string, unknown>]> = [
       ['123', {}],
       ['[1,2]', {}],
       ['{"query": "x"}', { query: 'x' }],
       [null, {}],
-    ] as Array<[unknown, Record<string, unknown>]>) {
+    ];
+    for (const [raw, expected] of cases) {
       const history: BaseMessage[] = [
         new HumanMessage('search'),
         new AIMessage({
@@ -219,16 +243,13 @@ describe('_convertMessagesToAnthropicPayload — non-object tool_use input repla
               id: 'srvtoolu_abc',
               name: 'web_search',
               input: raw,
-            } as any,
+            },
           ],
         }),
       ];
-      const payload = _convertMessagesToAnthropicPayload(history);
-      const assistant = payload.messages.find(
-        (m: any) => m.role === 'assistant'
-      );
-      const block = (assistant!.content as any[]).find(
-        (b) => b.type === 'server_tool_use'
+      const block = findAssistantBlock(
+        _convertMessagesToAnthropicPayload(history),
+        'server_tool_use'
       );
       expect(block.input).toEqual(expected);
     }
@@ -255,7 +276,7 @@ describe('_convertMessagesToAnthropicPayload — non-object tool_use input repla
           {
             id: 'toolu_x',
             name: 'calculator',
-            args: null as any,
+            args: null as unknown as ToolCall['args'],
             type: 'tool_call',
           },
         ],

--- a/src/llm/anthropic/utils/streaming-tool-input.test.ts
+++ b/src/llm/anthropic/utils/streaming-tool-input.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-import { _convertMessagesToAnthropicPayload } from './message_inputs';
 import { _makeMessageChunkFromAnthropicEvent } from './message_outputs';
+import { _convertMessagesToAnthropicPayload } from './message_inputs';
 
 /**
  * Regression for @langchain/core >= 1.1.46 streaming aggregation: a tool call's
@@ -40,7 +40,9 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
   ];
 
   it('does not throw on the orphaned text-with-input block', () => {
-    expect(() => _convertMessagesToAnthropicPayload(buildHistory())).not.toThrow();
+    expect(() =>
+      _convertMessagesToAnthropicPayload(buildHistory())
+    ).not.toThrow();
   });
 
   it('restores tool_use input from message.tool_calls and drops the orphan block', () => {
@@ -60,13 +62,16 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
     // No leftover delta: no text block carrying `input`, no input_json_delta.
     expect(
       blocks.find(
-        (b) => (b.type === 'text' && 'input' in b) || b.type === 'input_json_delta'
+        (b) =>
+          (b.type === 'text' && 'input' in b) || b.type === 'input_json_delta'
       )
     ).toBeUndefined();
 
     // The real assistant text is preserved.
     expect(
-      blocks.some((b) => b.type === 'text' && b.text === 'Let me calculate that.')
+      blocks.some(
+        (b) => b.type === 'text' && b.text === 'Let me calculate that.'
+      )
     ).toBe(true);
   });
 
@@ -94,7 +99,9 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
     ];
     const payload = _convertMessagesToAnthropicPayload(history);
     const assistant = payload.messages.find((m: any) => m.role === 'assistant');
-    const toolUse = (assistant!.content as any[]).find((b) => b.type === 'tool_use');
+    const toolUse = (assistant!.content as any[]).find(
+      (b) => b.type === 'tool_use'
+    );
     expect(toolUse.input).toEqual({ input: '2 + 2' });
   });
 
@@ -105,8 +112,18 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
       new HumanMessage('What\'s the weather in Seattle tomorrow?'),
       new AIMessage({
         content: [
-          { type: 'text', index: 1, text: 'I need to call the get_weather tool' },
-          { type: 'tool_use', index: 2, name: 'get_weather', id: 'tool_call_id', input: '' },
+          {
+            type: 'text',
+            index: 1,
+            text: 'I need to call the get_weather tool',
+          },
+          {
+            type: 'tool_use',
+            index: 2,
+            name: 'get_weather',
+            id: 'tool_call_id',
+            input: '',
+          },
           { type: 'input_json_delta', index: 2, input: '{"city": "' },
           { type: 'input_json_delta', index: 2, input: 'Seattle", "da' },
           { type: 'input_json_delta', index: 2, input: 'te": "to' },
@@ -129,6 +146,84 @@ describe('_convertMessagesToAnthropicPayload — aggregated streaming tool input
   });
 });
 
+/**
+ * Regression for the summarization-CI flake: context-pressure truncation
+ * (`preFlightTruncateToolCallInputs` under a tight budget) used to null BOTH a
+ * tool_use block's inline `input` and its `tool_calls` args in graph state.
+ * Replaying that message shipped `"input": null` and Anthropic rejected the
+ * request with 400 `tool_use.input: Input should be an object`. The payload
+ * conversion must never emit a non-object input, whatever shape history is in.
+ */
+describe('_convertMessagesToAnthropicPayload — non-object tool_use input replay', () => {
+  const buildHistory = (input: unknown, args: unknown): BaseMessage[] => [
+    new HumanMessage('What is 9 * 9?'),
+    new AIMessage({
+      content: [
+        { type: 'tool_use', id: 'toolu_x', name: 'calculator', input } as any,
+      ],
+      tool_calls: [
+        {
+          id: 'toolu_x',
+          name: 'calculator',
+          args: args as any,
+          type: 'tool_call',
+        },
+      ],
+    }),
+  ];
+
+  const getToolUse = (history: BaseMessage[]): any => {
+    const payload = _convertMessagesToAnthropicPayload(history);
+    const assistant = payload.messages.find((m: any) => m.role === 'assistant');
+    return (assistant!.content as any[]).find((b) => b.type === 'tool_use');
+  };
+
+  it('ships an empty object when input and args were both truncated to null', () => {
+    const toolUse = getToolUse(buildHistory(null, null));
+    expect(toolUse.input).toEqual({});
+  });
+
+  it('restores object args when only the inline input was nulled', () => {
+    const toolUse = getToolUse(buildHistory(null, { input: '9 * 9' }));
+    expect(toolUse.input).toEqual({ input: '9 * 9' });
+  });
+
+  it('coerces a string input that parses to a non-object', () => {
+    for (const raw of ['123', '[1,2]', '"text"', 'null']) {
+      const toolUse = getToolUse(buildHistory(raw, undefined));
+      expect(toolUse.input).toEqual({});
+    }
+  });
+
+  it('still parses a complete JSON-object string input', () => {
+    const toolUse = getToolUse(buildHistory('{"input": "9 * 9"}', undefined));
+    expect(toolUse.input).toEqual({ input: '9 * 9' });
+  });
+
+  it('coerces non-object args on the string-content tool_calls path', () => {
+    const history: BaseMessage[] = [
+      new HumanMessage('What is 9 * 9?'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'toolu_x',
+            name: 'calculator',
+            args: null as any,
+            type: 'tool_call',
+          },
+        ],
+      }),
+    ];
+    const payload = _convertMessagesToAnthropicPayload(history);
+    const assistant = payload.messages.find((m: any) => m.role === 'assistant');
+    const toolUse = (assistant!.content as any[]).find(
+      (b) => b.type === 'tool_use'
+    );
+    expect(toolUse.input).toEqual({});
+  });
+});
+
 describe('_makeMessageChunkFromAnthropicEvent — streamed tool input merges into content', () => {
   const fields = { streamUsage: true, coerceContentToString: false };
 
@@ -137,7 +232,12 @@ describe('_makeMessageChunkFromAnthropicEvent — streamed tool input merges int
       {
         type: 'content_block_start',
         index: 0,
-        content_block: { type: 'tool_use', id: 'toolu_1', name: 'calculator', input: {} },
+        content_block: {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'calculator',
+          input: {},
+        },
       },
       {
         type: 'content_block_delta',
@@ -168,13 +268,21 @@ describe('_makeMessageChunkFromAnthropicEvent — streamed tool input merges int
     const blocks = merged.content as any[];
 
     const toolUse = blocks.find((b) => b.type === 'tool_use');
-    expect(toolUse).toMatchObject({ type: 'tool_use', id: 'toolu_1', name: 'calculator' });
+    expect(toolUse).toMatchObject({
+      type: 'tool_use',
+      id: 'toolu_1',
+      name: 'calculator',
+    });
     const parsed =
-      typeof toolUse.input === 'string' ? JSON.parse(toolUse.input) : toolUse.input;
+      typeof toolUse.input === 'string'
+        ? JSON.parse(toolUse.input)
+        : toolUse.input;
     expect(parsed).toEqual({ input: '2 + 2' });
 
     // no orphaned delta block survives aggregation
-    expect(blocks.filter((b) => b.type !== 'tool_use' && 'input' in b)).toHaveLength(0);
+    expect(
+      blocks.filter((b) => b.type !== 'tool_use' && 'input' in b)
+    ).toHaveLength(0);
 
     // tool_calls remain correctly aggregated
     expect(merged.tool_calls?.[0]).toMatchObject({

--- a/src/llm/anthropic/utils/streaming-tool-input.test.ts
+++ b/src/llm/anthropic/utils/streaming-tool-input.test.ts
@@ -188,6 +188,52 @@ describe('_convertMessagesToAnthropicPayload — non-object tool_use input repla
     expect(toolUse.input).toEqual({ input: '9 * 9' });
   });
 
+  it('restores intact args when the inline input degraded to an empty object', () => {
+    // Asymmetric truncation: the raw string input serializes longer than the
+    // args object, so a near-envelope cap can degrade the inline input to {}
+    // while the tool_calls mirror survives. Replay must prefer the mirror.
+    const toolUse = getToolUse(
+      buildHistory({}, { input: '670592745 / 99991' })
+    );
+    expect(toolUse.input).toEqual({ input: '670592745 / 99991' });
+  });
+
+  it('ships an empty object when the inline input is {} and args were nulled too', () => {
+    const toolUse = getToolUse(buildHistory({}, null));
+    expect(toolUse.input).toEqual({});
+  });
+
+  it('coerces non-object inputs on the srvtoolu_ server-tool normalization branch', () => {
+    for (const [raw, expected] of [
+      ['123', {}],
+      ['[1,2]', {}],
+      ['{"query": "x"}', { query: 'x' }],
+      [null, {}],
+    ] as Array<[unknown, Record<string, unknown>]>) {
+      const history: BaseMessage[] = [
+        new HumanMessage('search'),
+        new AIMessage({
+          content: [
+            {
+              type: 'server_tool_use',
+              id: 'srvtoolu_abc',
+              name: 'web_search',
+              input: raw,
+            } as any,
+          ],
+        }),
+      ];
+      const payload = _convertMessagesToAnthropicPayload(history);
+      const assistant = payload.messages.find(
+        (m: any) => m.role === 'assistant'
+      );
+      const block = (assistant!.content as any[]).find(
+        (b) => b.type === 'server_tool_use'
+      );
+      expect(block.input).toEqual(expected);
+    }
+  });
+
   it('coerces a string input that parses to a non-object', () => {
     for (const raw of ['123', '[1,2]', '"text"', 'null']) {
       const toolUse = getToolUse(buildHistory(raw, undefined));

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1403,7 +1403,18 @@ function createBoundedTruncationValue(
     _originalChars: originalChars,
   };
   if (JSON.stringify(emptyEnvelope).length > normalizedMaxChars) {
-    return null;
+    /**
+     * Even the empty envelope overflows the cap, so no preview survives —
+     * but the result must still be a JSON OBJECT, never `null`. This value
+     * replaces a `tool_use.input` / tool-call `args` on messages that are
+     * mutated IN PLACE into graph state (`preFlightTruncateToolCallInputs`),
+     * and Anthropic rejects a replayed non-object input with a 400
+     * (`tool_use.input: Input should be an object`). Observed live: a tight
+     * summarization budget shrank the cap below the envelope, nulled a
+     * retained calculator call's input and args, and the next model call
+     * failed on replay.
+     */
+    return {};
   }
 
   let low = 0;

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -1444,7 +1444,44 @@ describe('Prune Messages Tests', () => {
       expect(calculateMaxToolCallInputChars(0)).toBe(200_000);
       expect(calculateMaxToolCallInputChars(1_000)).toBe(600);
       expect(calculateMaxToolCallInputChars(1_000_000)).toBe(200_000);
-      expect(serializeToolCallInput(undefined, 4)).toBe('null');
+      // Even below the envelope floor, serialized args stay a JSON object —
+      // 'null' here poisoned replayed tool calls (Anthropic 400s a non-object
+      // tool_use.input).
+      expect(serializeToolCallInput(undefined, 4)).toBe('{}');
+    });
+
+    it('never nulls an input when the cap is below the truncation envelope', () => {
+      // Regression: a tight summarization budget can shrink the per-input cap
+      // below the `{_truncated, _originalChars}` envelope size (~38 chars).
+      // The projection used to return `null` for BOTH the inline block input
+      // and the tool_calls args; the nulls were written back into graph state
+      // by preFlightTruncateToolCallInputs and later replayed to Anthropic as
+      // `tool_use.input: null` → 400 "Input should be an object".
+      const chunk = new AIMessageChunk({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tiny-cap-call',
+            name: 'calculator',
+            // Streaming leaves the raw JSON string on the block.
+            input: '{"input": "670592745 / 99991"}',
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tiny-cap-call',
+            name: 'calculator',
+            args: { input: '670592745 / 99991' },
+          },
+        ],
+      });
+
+      const [projected] = projectToolCallInputs([chunk], 20);
+      const block = (
+        (projected as AIMessageChunk).content as Array<Record<string, unknown>>
+      )[0];
+      expect(block.input).toEqual({});
+      expect((projected as AIMessageChunk).tool_calls?.[0].args).toEqual({});
     });
 
     it('returns the original array when every input is already safe and bounded', () => {


### PR DESCRIPTION
## Problem

The `validate / summarization tests (anthropic)` job intermittently fails (~2/15 main runs, e.g. [d8ab3494's run](https://github.com/danny-avila/agents/actions/runs/30559695284)) with:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.3.content.0.tool_use.input: Input should be an object"}}
```

## Root cause

**Not a model-side `max_tokens` truncation.** The #280 `OutputTruncationError` guard works — verified live end-to-end: a genuinely truncated tool-call turn throws and never enters state.

The real chain, reproduced live by intercepting `createStreamWithRetry` payloads in a descending-budget loop matching the CI test:

1. In a summarization-enabled run under a tight budget, the pruner's fit-to-budget pass calls `preFlightTruncateToolCallInputs` with an effective budget of a few dozen tokens → per-input cap ≈ **20 chars**.
2. A streamed `tool_use` block keeps its input as the raw partial-JSON **string**; it exceeds the cap, and the `{_truncated, _originalChars}` envelope (~38 chars) *also* exceeds it — so `createBoundedTruncationValue` returned **`null`** for both the block's inline `input` and its `tool_calls[].args` mirror.
3. The projection **mutates the live state array**, so the nulls persist into summarization-retained history.
4. On the next Anthropic call, the outbound sanitizer only handled *string* inputs (`typeof null === 'object'`), so the request shipped `"input": null` → 400.

The flakiness comes from an asymmetry: the escaped string serializes ~7 chars longer than the args object, so short inputs (`9 * 9`) kept their args and self-healed via the `tool_calls` restore path, while longer ones nulled both and failed.

## Fix (both ends)

- **`src/messages/prune.ts`** — `createBoundedTruncationValue` returns `{}` instead of `null` when even the empty envelope overflows the cap, so graph state never carries a non-object input. Also upgrades `serializeToolCallInput`'s degenerate output from `'null'` to `'{}'` on the OpenAI arguments path.
- **`src/llm/anthropic/utils/message_inputs.ts`** — new `coerceAnthropicToolUseInput` guarantees every outbound `tool_use`/`server_tool_use` input is a JSON object, applied after all restore paths in `_formatContent` and in `_convertLangChainToolCallToAnthropic`: complete-JSON strings parse; null / arrays / strings parsing to non-objects degrade to `{}`.

## Tests

- `src/specs/prune.test.ts` — regression: a cap below the truncation envelope yields `{}` (never `null`) for both the inline block input and `tool_calls[].args`; updated the `serializeToolCallInput(undefined, 4)` expectation from `'null'` to `'{}'`.
- `src/llm/anthropic/utils/streaming-tool-input.test.ts` — regression suite for non-object input replay: null input + null args ships `{}`; null input + intact args restores the args; string inputs parsing to non-objects (`'123'`, `'[1,2]'`, `'"text"'`, `'null'`) coerce to `{}`; complete JSON-object strings still parse; the string-content `tool_calls` path coerces null args.
- Live: the `cross-provider summarization` spec passes with the fix, and the payload-intercepting repro loop — with summarization firing on the previously-failing turn — produces zero bad payloads.

## Out of scope

The co-occurring `final_context_overflow` failures (e.g. runs 30446609385, 30389041546) are a **distinct** tight-budget mode — instructions + summary consume the entire descending test budget and the pre-invoke guard correctly refuses — confirmed to fire independently of the 400. Tracked separately.