### PR TITLE
🩹 fix: Coerce Non-Object toolUse Inputs in the Bedrock Converse Formatter

### DIFF
--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -79,6 +79,120 @@ describe('convertToConverseMessages — Anthropic tool replay', () => {
   });
 });
 
+/**
+ * Bedrock Converse requires `toolUse.input` to be a JSON object. History can
+ * carry non-object values: pre-3.x context-pressure truncation persisted
+ * `null` onto both a block's inline input and its `tool_calls` args (see the
+ * Anthropic-replay fix in PR #369), and Anthropic-shaped inline blocks keep
+ * the raw streamed JSON string. These must coerce — never ship as-is, never
+ * throw the whole request away.
+ */
+describe('convertToConverseMessages — non-object toolUse input coercion', () => {
+  const toolUseBlocks = (result: ConverseResult): ConverseBlock[] =>
+    assistantContent(result).filter((b) => b.toolUse != null);
+
+  it('coerces null args to {} when materializing from tool_calls', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('What is 9 * 9?'),
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'tool_use',
+            id: 'call_null',
+            name: 'calculator',
+            input: null,
+          },
+        ]),
+        tool_calls: [
+          {
+            id: 'call_null',
+            name: 'calculator',
+            args: null as never,
+          },
+        ],
+      }),
+    ];
+
+    const [block] = toolUseBlocks(convertToConverseMessages(messages));
+    expect(block.toolUse?.input).toEqual({});
+  });
+
+  it('parses a complete raw-string input on an unmirrored inline block instead of throwing', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'tool_use',
+            id: 'call_str',
+            name: 'search',
+            input: '{"query": "test"}',
+          },
+        ]),
+        tool_calls: [],
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).not.toThrow();
+    const [block] = toolUseBlocks(convertToConverseMessages(messages));
+    expect(block.toolUse?.input).toEqual({ query: 'test' });
+  });
+
+  it('degrades non-object inline inputs (partial string, number-string, null) to {}', () => {
+    for (const input of ['{"query": "tru', '123', null]) {
+      const messages: BaseMessage[] = [
+        new HumanMessage('Search'),
+        new AIMessage({
+          content: toLangChainContent([
+            { type: 'tool_use', id: 'call_bad', name: 'search', input },
+          ]),
+          tool_calls: [],
+        }),
+      ];
+
+      const [block] = toolUseBlocks(convertToConverseMessages(messages));
+      expect(block.toolUse?.input).toEqual({});
+    }
+  });
+
+  it('still rejects a tool_use block missing its id or name', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Search'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'tool_use', name: 'search', input: { query: 'x' } },
+        ]),
+        tool_calls: [],
+      }),
+    ];
+
+    expect(() => convertToConverseMessages(messages)).toThrow(
+      'Invalid Anthropic tool_use content block'
+    );
+  });
+
+  it('coerces null args on the v1 tool_call and tool_calls fallback paths', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Run both'),
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'tool_call', id: 'v1_block', name: 'search', args: null },
+        ]),
+        tool_calls: [
+          { id: 'v1_fallback', name: 'lookup', args: null as never },
+        ],
+        response_metadata: { output_version: 'v1' },
+      }),
+    ];
+
+    const blocks = toolUseBlocks(convertToConverseMessages(messages));
+    expect(blocks).toHaveLength(2);
+    for (const block of blocks) {
+      expect(block.toolUse?.input).toEqual({});
+    }
+  });
+});
+
 describe('convertToConverseMessages — native Bedrock reasoning serialization', () => {
   it('drops a signature-only reasoning block, keeping text and tool calls', () => {
     const messages: BaseMessage[] = [
@@ -491,9 +605,9 @@ describe('convertToConverseMessages — user-role run merging', () => {
       'toolResult' in block ? 'toolResult' : 'text'
     );
     expect(blockKinds).toEqual(['toolResult', 'text']);
-    expect(
-      (merged.content ?? []).find((block) => 'text' in block)?.text
-    ).toBe('Actually, focus on the second result.');
+    expect((merged.content ?? []).find((block) => 'text' in block)?.text).toBe(
+      'Actually, focus on the second result.'
+    );
   });
 
   it('still merges adjacent tool-result-only turns', () => {
@@ -513,7 +627,9 @@ describe('convertToConverseMessages — user-role run merging', () => {
 
     expect(converseMessages.map((m) => m.role)).toEqual(['assistant', 'user']);
     const toolResultIds = (converseMessages[1].content ?? [])
-      .map((block) => ('toolResult' in block ? block.toolResult?.toolUseId : undefined))
+      .map((block) =>
+        'toolResult' in block ? block.toolResult?.toolUseId : undefined
+      )
       .filter(Boolean);
     expect(toolResultIds).toEqual(['call_1', 'call_2']);
   });

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -762,8 +762,6 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
         ) {
           throw new Error('Invalid Anthropic tool_use content block');
         }
-        // A non-object input (raw streamed string, truncation-persisted null)
-        // is recoverable — coerce it rather than fail the whole request.
         contentBlocks.push({
           toolUse: {
             toolUseId: toolUse.id,

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -684,6 +684,33 @@ function convertSystemMessageToConverseMessage(
 /**
  * Convert an AI message to a Bedrock message.
  */
+/**
+ * Bedrock Converse requires `toolUse.input` to be a JSON object document.
+ * History can carry non-object values: streaming leaves the raw partial-JSON
+ * string on Anthropic-shaped inline blocks, and context-pressure truncation
+ * (pre-3.x `createBoundedTruncationValue`) could persist `null` onto BOTH a
+ * block's inline input and its `tool_calls` args. A string is parsed when it
+ * forms a complete JSON object; every other shape degrades to `{}` — the call
+ * already executed, so the replayed input is informational. Twin of
+ * `coerceAnthropicToolUseInput` in the Anthropic fork; duplicated so each
+ * fork stays self-contained against its upstream.
+ */
+function coerceBedrockToolUseInput(input: unknown): Record<string, unknown> {
+  let candidate: unknown = input;
+  if (typeof candidate === 'string') {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return {};
+    }
+  }
+  return typeof candidate === 'object' &&
+    candidate !== null &&
+    !Array.isArray(candidate)
+    ? (candidate as Record<string, unknown>)
+    : {};
+}
+
 function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
   // Check for v1 format from other providers (PR #9766 fix)
   const responseMetadata = msg.response_metadata as
@@ -731,17 +758,17 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
         }
         if (
           typeof toolUse.id !== 'string' ||
-          typeof toolUse.name !== 'string' ||
-          toolUse.input == null ||
-          typeof toolUse.input !== 'object'
+          typeof toolUse.name !== 'string'
         ) {
           throw new Error('Invalid Anthropic tool_use content block');
         }
+        // A non-object input (raw streamed string, truncation-persisted null)
+        // is recoverable — coerce it rather than fail the whole request.
         contentBlocks.push({
           toolUse: {
             toolUseId: toolUse.id,
             name: toolUse.name,
-            input: toolUse.input as Record<string, unknown>,
+            input: coerceBedrockToolUseInput(toolUse.input),
           },
         } as BedrockContentBlock);
       } else if (block.type === 'reasoning_content') {
@@ -804,7 +831,7 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
         toolUse: {
           toolUseId: toolCall.id,
           name: toolCall.name,
-          input: toolCall.args as Record<string, unknown>,
+          input: coerceBedrockToolUseInput(toolCall.args),
         },
       }));
     assistantMsg.content = [
@@ -862,7 +889,7 @@ function convertFromV1ToChatBedrockConverseMessage(
           toolUse: {
             toolUseId: toolCall.id,
             name: toolCall.name,
-            input: toolCall.args as Record<string, unknown>,
+            input: coerceBedrockToolUseInput(toolCall.args),
           },
         } as BedrockContentBlock);
       } else if (block.type === 'reasoning') {
@@ -914,7 +941,7 @@ function convertFromV1ToChatBedrockConverseMessage(
           toolUse: {
             toolUseId: tc.id,
             name: tc.name,
-            input: tc.args as Record<string, unknown>,
+            input: coerceBedrockToolUseInput(tc.args),
           },
         } as BedrockContentBlock);
       }


### PR DESCRIPTION
## Problem

Bedrock twin of the Anthropic replay hardening in #369. Two related holes in `src/llm/bedrock/utils/message_inputs.ts`:

1. **Persisted nulls ship as-is.** Conversations persisted before #369 can carry tool calls whose inline `input` and `tool_calls[].args` were truncated to `null` by the pruner's old envelope-overflow branch. Both `convertAIMessageToConverseMessage` (materialize-from-`tool_calls` path) and `convertFromV1ToChatBedrockConverseMessage` (v1 `tool_call` block + `tool_calls` fallback) shipped `input: toolCall.args` uncoerced — Converse rejects a non-object `toolUse.input`.
2. **Unmirrored inline blocks throw.** An Anthropic-shaped inline `tool_use` block whose id is absent from `tool_calls` keeps the raw streamed JSON string as its input; the formatter threw `Invalid Anthropic tool_use content block` before the request was even built — failing the whole turn on a recoverable shape.

## Fix

New `coerceBedrockToolUseInput` (deliberate duplicate of the Anthropic fork's `coerceAnthropicToolUseInput`, so each fork stays self-contained against its upstream): a string parses when it forms a complete JSON object; every other non-object shape degrades to `{}` — the call already executed, so the replayed input is informational.

Applied at all four emission sites:
- `convertAIMessageToConverseMessage`: unmirrored inline blocks coerce instead of throwing (blocks missing `id`/`name` still throw — nothing to build a `toolUse` from); `tool_calls` materialization coerces args.
- `convertFromV1ToChatBedrockConverseMessage`: v1 `tool_call` block path and `tool_calls` fallback both coerce.

## Tests

New `convertToConverseMessages — non-object toolUse input coercion` suite in `message_inputs.test.ts`:
- null inline input + null args → `toolUse.input: {}`
- unmirrored inline block with a complete JSON-object string parses instead of throwing
- partial-JSON string, `'123'`, and `null` inline inputs degrade to `{}`
- a block missing `id`/`name` still throws
- v1 `tool_call` block and `tool_calls` fallback both coerce null args

All `src/llm/bedrock/utils/` suites green (38 tests).