### PR TITLE
feat(messages): persist provider reasoning across runs

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1904,6 +1904,179 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(messageDeltas[0]?.delta).toEqual({ content: [toolCallPart] });
   });
 
+  it('captures raw Anthropic thinking text and signatures for replay', async () => {
+    const dispatchReasoningDelta = jest.fn<
+      StandardGraph['dispatchReasoningDelta']
+    >(async () => undefined);
+    const graph = createGraph({
+      dispatchReasoningDelta,
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-sonnet-5' },
+          reasoningKey: 'reasoning',
+          currentTokenType: ContentTypes.THINK,
+          toolDefinitions: [],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    for (const content of [
+      [{ type: ContentTypes.THINKING, thinking: 'private thought' }],
+      [{ type: ContentTypes.THINKING, signature: 'signed-thinking' }],
+      [{ type: 'redacted_thinking', data: 'encrypted-redaction' }],
+    ] satisfies t.MessageContentComplex[][]) {
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: { content } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      );
+    }
+
+    expect(dispatchReasoningDelta).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^step_/),
+      {
+        content: [
+          {
+            type: ContentTypes.THINK,
+            think: 'private thought',
+            provider_replay: {
+              anthropic: {
+                model: 'claude-sonnet-5',
+                blocks: [
+                  {
+                    type: ContentTypes.THINKING,
+                    thinking: 'private thought',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      metadata
+    );
+    expect(dispatchReasoningDelta).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^step_/),
+      {
+        content: [
+          {
+            type: ContentTypes.THINK,
+            think: '',
+            provider_replay: {
+              anthropic: {
+                model: 'claude-sonnet-5',
+                blocks: [
+                  {
+                    type: ContentTypes.THINKING,
+                    signature: 'signed-thinking',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      metadata
+    );
+    expect(dispatchReasoningDelta).toHaveBeenNthCalledWith(
+      3,
+      expect.stringMatching(/^step_/),
+      {
+        content: [
+          {
+            type: ContentTypes.THINK,
+            think: '',
+            provider_replay: {
+              anthropic: {
+                model: 'claude-sonnet-5',
+                blocks: [
+                  {
+                    type: 'redacted_thinking',
+                    data: 'encrypted-redaction',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      metadata
+    );
+  });
+
+  it('captures signed Anthropic reasoning normalized by inherited stream events', async () => {
+    const dispatchReasoningDelta = jest.fn<
+      StandardGraph['dispatchReasoningDelta']
+    >(async () => undefined);
+    const graph = createGraph({
+      dispatchReasoningDelta,
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: 'Raw Anthropic E2E' as Providers,
+          clientOptions: { model: 'claude-sonnet-5' },
+          reasoningKey: 'reasoning',
+          currentTokenType: ContentTypes.THINK,
+          toolDefinitions: [],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const metadata = { langgraph_node: 'agent' };
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: [
+            {
+              type: ContentTypes.REASONING,
+              reasoning: 'normalized thought',
+              signature: 'normalized-signature',
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchReasoningDelta).toHaveBeenCalledWith(
+      expect.stringMatching(/^step_/),
+      {
+        content: [
+          {
+            type: ContentTypes.THINK,
+            think: 'normalized thought',
+            provider_replay: {
+              anthropic: {
+                model: 'claude-sonnet-5',
+                blocks: [
+                  {
+                    type: ContentTypes.THINKING,
+                    thinking: 'normalized thought',
+                    signature: 'normalized-signature',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      metadata
+    );
+  });
+
   it('dispatches Gemini server-side tool context when reasoning is present', async () => {
     const dispatchMessageDelta = jest.fn<StandardGraph['dispatchMessageDelta']>(
       async () => undefined

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1904,6 +1904,87 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(messageDeltas[0]?.delta).toEqual({ content: [toolCallPart] });
   });
 
+  it('dispatches later revisions of an OpenAI reasoning item once', async () => {
+    const dispatchReasoningDelta = jest.fn<
+      StandardGraph['dispatchReasoningDelta']
+    >(async () => undefined);
+    const snapshotsById = new Map<string, string>();
+    const graph = createGraph({
+      dispatchReasoningDelta,
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          clientOptions: { model: 'gpt-5.4' },
+          reasoningKey: 'reasoning_content',
+          currentTokenType: ContentTypes.THINK,
+          openAIResponsesReasoningReplaySnapshotsById: snapshotsById,
+          toolDefinitions: [],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const inProgress = {
+      type: 'reasoning',
+      id: 'rs_123',
+      status: 'in_progress',
+      summary: [],
+      encrypted_content: 'encrypted-reasoning',
+    };
+    const completed = {
+      ...inProgress,
+      status: 'completed',
+      summary: [
+        {
+          type: 'summary_text',
+          text: 'Checked the final constraint.',
+        },
+      ],
+    };
+
+    for (const item of [inProgress, completed, structuredClone(completed)]) {
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            additional_kwargs: {
+              openai_responses_reasoning_replay: [item],
+            },
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      );
+    }
+
+    expect(dispatchReasoningDelta).toHaveBeenCalledTimes(2);
+    expect(dispatchReasoningDelta).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^step_/),
+      {
+        content: [
+          {
+            type: ContentTypes.THINK,
+            think: '',
+            provider_replay: {
+              openai_responses: {
+                provider: Providers.OPENAI,
+                model: 'gpt-5.4',
+                items: [completed],
+              },
+            },
+          },
+        ],
+      },
+      metadata
+    );
+    expect(snapshotsById.size).toBe(1);
+    expect(JSON.parse(snapshotsById.get('rs_123') ?? '{}')).toEqual(completed);
+  });
+
   it('captures raw Anthropic thinking text and signatures for replay', async () => {
     const dispatchReasoningDelta = jest.fn<
       StandardGraph['dispatchReasoningDelta']

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -290,6 +290,8 @@ export class AgentContext {
   tokenTypeSwitch?: 'reasoning' | 'content';
   /** Tracks how many reasoning→text transitions have occurred (ensures unique post-reasoning step keys) */
   reasoningTransitionCount = 0;
+  /** OpenAI Responses reasoning items already emitted during this run */
+  openAIResponsesReasoningReplayIds: Set<string> = new Set();
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
@@ -1014,6 +1016,7 @@ export class AgentContext {
     this.lastStreamCall = undefined;
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
+    this.openAIResponsesReasoningReplayIds.clear();
     this.currentTokenType = ContentTypes.TEXT;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -290,8 +290,14 @@ export class AgentContext {
   tokenTypeSwitch?: 'reasoning' | 'content';
   /** Tracks how many reasoning→text transitions have occurred (ensures unique post-reasoning step keys) */
   reasoningTransitionCount = 0;
-  /** OpenAI Responses reasoning items already emitted during this run */
-  openAIResponsesReasoningReplayIds: Set<string> = new Set();
+  /** Latest emitted OpenAI Responses reasoning snapshot, keyed by item ID. */
+  openAIResponsesReasoningReplaySnapshotsById: Map<string, string> = new Map();
+  /** Native replay shape currently present in formatted conversation messages. */
+  reasoningReplaySource?: {
+    provider: Providers;
+    model?: string;
+    useResponsesApi?: boolean;
+  };
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
@@ -1016,7 +1022,8 @@ export class AgentContext {
     this.lastStreamCall = undefined;
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
-    this.openAIResponsesReasoningReplayIds.clear();
+    this.openAIResponsesReasoningReplaySnapshotsById.clear();
+    this.reasoningReplaySource = undefined;
     this.currentTokenType = ContentTypes.TEXT;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1490,6 +1490,7 @@ describe('AgentContext', () => {
       ctx.systemMessageTokens = 100;
       ctx.indexTokenCountMap = { '0': 50 };
       ctx.currentUsage = { input_tokens: 100 };
+      ctx.openAIResponsesReasoningReplayIds.add('rs_123');
 
       ctx.reset();
 
@@ -1497,6 +1498,7 @@ describe('AgentContext', () => {
       expect(ctx.instructionTokens).toBe(0);
       expect(ctx.indexTokenCountMap).toEqual({});
       expect(ctx.currentUsage).toBeUndefined();
+      expect(ctx.openAIResponsesReasoningReplayIds.size).toBe(0);
     });
 
     it('preserves summarization settings across resets', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1490,7 +1490,15 @@ describe('AgentContext', () => {
       ctx.systemMessageTokens = 100;
       ctx.indexTokenCountMap = { '0': 50 };
       ctx.currentUsage = { input_tokens: 100 };
-      ctx.openAIResponsesReasoningReplayIds.add('rs_123');
+      ctx.openAIResponsesReasoningReplaySnapshotsById.set(
+        'rs_123',
+        'in_progress'
+      );
+      ctx.reasoningReplaySource = {
+        provider: Providers.OPENAI,
+        model: 'gpt-5.4',
+        useResponsesApi: true,
+      };
 
       ctx.reset();
 
@@ -1498,7 +1506,8 @@ describe('AgentContext', () => {
       expect(ctx.instructionTokens).toBe(0);
       expect(ctx.indexTokenCountMap).toEqual({});
       expect(ctx.currentUsage).toBeUndefined();
-      expect(ctx.openAIResponsesReasoningReplayIds.size).toBe(0);
+      expect(ctx.openAIResponsesReasoningReplaySnapshotsById.size).toBe(0);
+      expect(ctx.reasoningReplaySource).toBeUndefined();
     });
 
     it('preserves summarization settings across resets', () => {

--- a/src/aggregator.test.ts
+++ b/src/aggregator.test.ts
@@ -1,6 +1,9 @@
 import type * as t from '@/types';
-import { GraphEvents, StepTypes, ContentTypes } from '@/common';
+import { GraphEvents, StepTypes, ContentTypes, Providers } from '@/common';
 import { createContentAggregator } from './stream';
+
+const bedrockModel = 'anthropic.claude-sonnet-5-v1:0';
+const anthropicModel = 'claude-sonnet-5';
 
 const createRunStep = (id: string): t.RunStep => ({
   id,
@@ -63,6 +66,305 @@ describe('ContentAggregator empty deltas', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('ContentAggregator Bedrock reasoning replay', () => {
+  it('merges streamed reasoning text and signature into one persisted replay block', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_bedrock_reasoning'),
+    });
+
+    for (const content of [
+      {
+        type: ContentTypes.THINK,
+        think: 'first ',
+        provider_replay: {
+          bedrock: {
+            model: bedrockModel,
+            blocks: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: { text: 'first ' },
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: ContentTypes.THINK,
+        think: 'second',
+        provider_replay: {
+          bedrock: {
+            model: bedrockModel,
+            blocks: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: { text: 'second' },
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: ContentTypes.THINK,
+        think: '',
+        provider_replay: {
+          bedrock: {
+            model: bedrockModel,
+            blocks: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: { signature: 'sig-abc' },
+              },
+            ],
+          },
+        },
+      },
+    ] satisfies t.ReasoningContentText[]) {
+      aggregateContent({
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: {
+          id: 'step_bedrock_reasoning',
+          delta: { content: [content] },
+        },
+      });
+    }
+
+    expect(contentParts).toEqual([
+      {
+        type: ContentTypes.THINK,
+        think: 'first second',
+        provider_replay: {
+          bedrock: {
+            model: bedrockModel,
+            blocks: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: {
+                  text: 'first second',
+                  signature: 'sig-abc',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+  });
+});
+
+describe('ContentAggregator Anthropic reasoning replay', () => {
+  it('merges streamed thinking and signature while preserving redacted blocks', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_anthropic_reasoning'),
+    });
+
+    for (const content of [
+      {
+        type: ContentTypes.THINK,
+        think: 'first ',
+        provider_replay: {
+          anthropic: {
+            model: anthropicModel,
+            blocks: [{ type: ContentTypes.THINKING, thinking: 'first ' }],
+          },
+        },
+      },
+      {
+        type: ContentTypes.THINK,
+        think: 'second',
+        provider_replay: {
+          anthropic: {
+            model: anthropicModel,
+            blocks: [{ type: ContentTypes.THINKING, thinking: 'second' }],
+          },
+        },
+      },
+      {
+        type: ContentTypes.THINK,
+        think: '',
+        provider_replay: {
+          anthropic: {
+            model: anthropicModel,
+            blocks: [{ type: ContentTypes.THINKING, signature: 'sig-abc' }],
+          },
+        },
+      },
+      {
+        type: ContentTypes.THINK,
+        think: '',
+        provider_replay: {
+          anthropic: {
+            model: anthropicModel,
+            blocks: [{ type: 'redacted_thinking', data: 'encrypted-thinking' }],
+          },
+        },
+      },
+    ] satisfies t.ReasoningContentText[]) {
+      aggregateContent({
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: {
+          id: 'step_anthropic_reasoning',
+          delta: { content: [content] },
+        },
+      });
+    }
+
+    expect(contentParts).toEqual([
+      {
+        type: ContentTypes.THINK,
+        think: 'first second',
+        provider_replay: {
+          anthropic: {
+            model: anthropicModel,
+            blocks: [
+              {
+                type: ContentTypes.THINKING,
+                thinking: 'first second',
+                signature: 'sig-abc',
+              },
+              {
+                type: 'redacted_thinking',
+                data: 'encrypted-thinking',
+              },
+            ],
+          },
+        },
+      },
+    ]);
+  });
+});
+
+describe('ContentAggregator OpenAI Responses reasoning replay', () => {
+  it('persists ordered encrypted reasoning items without duplicating final metadata', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_openai_reasoning'),
+    });
+    aggregateContent({
+      event: GraphEvents.ON_REASONING_DELTA,
+      data: {
+        id: 'step_openai_reasoning',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.THINK,
+              think: 'Checked the constraint.',
+            },
+          ],
+        },
+      },
+    });
+    aggregateContent({
+      event: GraphEvents.ON_REASONING_DELTA,
+      data: {
+        id: 'step_openai_reasoning',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.THINK,
+              think: '',
+              provider_replay: {
+                openai_responses: {
+                  provider: Providers.OPENAI,
+                  model: 'gpt-5.4',
+                  items: [
+                    {
+                      type: 'reasoning',
+                      id: 'rs_123',
+                      status: 'in_progress',
+                      summary: [],
+                      encrypted_content: 'encrypted-reasoning',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    aggregateContent({
+      event: GraphEvents.ON_REASONING_DELTA,
+      data: {
+        id: 'step_openai_reasoning',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.THINK,
+              think: '',
+              provider_replay: {
+                openai_responses: {
+                  provider: Providers.OPENAI,
+                  model: 'gpt-5.4',
+                  items: [
+                    {
+                      type: 'reasoning',
+                      id: 'rs_123',
+                      status: 'completed',
+                      summary: [
+                        {
+                          type: 'summary_text',
+                          text: 'Checked the constraint.',
+                        },
+                      ],
+                      encrypted_content: 'encrypted-reasoning',
+                    },
+                    {
+                      type: 'reasoning',
+                      id: 'rs_456',
+                      status: 'completed',
+                      summary: [],
+                      encrypted_content: 'encrypted-follow-up',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(contentParts).toEqual([
+      {
+        type: ContentTypes.THINK,
+        think: 'Checked the constraint.',
+        provider_replay: {
+          openai_responses: {
+            provider: Providers.OPENAI,
+            model: 'gpt-5.4',
+            items: [
+              {
+                type: 'reasoning',
+                id: 'rs_123',
+                status: 'completed',
+                summary: [
+                  {
+                    type: 'summary_text',
+                    text: 'Checked the constraint.',
+                  },
+                ],
+                encrypted_content: 'encrypted-reasoning',
+              },
+              {
+                type: 'reasoning',
+                id: 'rs_456',
+                status: 'completed',
+                summary: [],
+                encrypted_content: 'encrypted-follow-up',
+              },
+            ],
+          },
+        },
+      },
+    ]);
   });
 });
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -61,6 +61,7 @@ import {
   getFallbackOverflowCandidates,
   projectMessagesForProvider,
   resolveServingModelId,
+  resolveReasoningReplaySource,
 } from '@/llm/invoke';
 import {
   resetIfNotEmpty,
@@ -2000,6 +2001,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         model = agentContext.systemRunnable.pipe(model as Runnable);
       }
 
+      agentContext.reasoningReplaySource = resolveReasoningReplaySource({
+        model: (this.overrideModel ?? model) as t.ChatModel,
+        provider: agentContext.provider,
+        clientOptions: agentContext.clientOptions,
+        callOptions: config,
+      });
+
       if (agentContext.tokenCalculationPromise) {
         await agentContext.tokenCalculationPromise;
       }
@@ -3304,6 +3312,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   estimatedPromptTokens: getEstimatedPromptTokens(contextUsage),
                   maxContextTokens: agentContext.maxContextTokens,
                 },
+                reasoningReplaySource: agentContext.reasoningReplaySource,
                 prepareProviderMessages: ({
                   model: fallbackModel,
                   messages: fallbackMessages,
@@ -3311,6 +3320,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   maxContextTokens: fallbackMaxContextTokens,
                   config: fallbackConfig,
                 }) => {
+                  const replayValidatedFallbackMessages =
+                    trackProviderMessageOrigins(
+                      fallbackBaseMessages,
+                      fallbackMessages
+                    );
                   const fallbackToolResultChars =
                     agentContext.maxToolResultChars ??
                     calculateMaxToolResultChars(
@@ -3327,14 +3341,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                    * attemptInvoke funnel pass then finds nothing to change.
                    */
                   const cueShapedFallbackMessages = trackProviderMessageOrigins(
-                    fallbackMessages,
+                    replayValidatedFallbackMessages,
                     isAnthropicLike(fallbackProvider, {
                       model: resolveServingModelId(fallbackModel),
                     })
-                      ? appendPredecessorHandoffCue(fallbackMessages, (m) =>
-                        this.isRunProducedMessage(m)
+                      ? appendPredecessorHandoffCue(
+                        replayValidatedFallbackMessages,
+                        (m) => this.isRunProducedMessage(m)
                       )
-                      : removePredecessorHandoffCue(fallbackMessages)
+                      : removePredecessorHandoffCue(
+                        replayValidatedFallbackMessages
+                      )
                   );
                   const projectedFallbackMessages = trackProviderMessageOrigins(
                     cueShapedFallbackMessages,

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -275,6 +275,45 @@ describe('StandardGraph final response reasoning fallback', () => {
     streamUsage: false,
   };
 
+  it('records replay compatibility from the actual override model', async () => {
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-replay-override-model',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const overrideModel = new InvokeOnlyMessageModel(
+      new AIMessageChunk({ content: 'Done.' })
+    ) as InvokeOnlyMessageModel & {
+      model: string;
+      _useResponsesApi: () => boolean;
+    };
+    overrideModel.model = 'gpt-override-responses';
+    overrideModel._useResponsesApi = () => true;
+    run.Graph.overrideModel = overrideModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('Use the override')] },
+      config
+    );
+
+    expect(
+      run.Graph.agentContexts.get('default')?.reasoningReplaySource
+    ).toEqual({
+      provider: Providers.OPENAI,
+      model: 'gpt-override-responses',
+      useResponsesApi: true,
+    });
+  });
+
   it('emits reasoning_content from invoke-only final responses', async () => {
     const reasoningText = 'Need to inspect the Home Assistant tool state.';
     const reasoningDeltas: t.ReasoningDeltaEvent[] = [];

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -14,13 +14,18 @@ import {
 } from '@langchain/openai';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { ReasoningReplaySource } from '@/llm/invoke';
 import type * as t from '@/types';
+import {
+  attemptInvoke,
+  filterReasoningReplayForInvocation,
+  tryFallbackProviders,
+} from '@/llm/invoke';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { convertMessageContentToParts } from '@/llm/google/utils/common';
-import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { Constants, ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from '@/messages/langchain';
-import { Constants, Providers } from '@/common';
 import { ToolNode } from '@/tools/ToolNode';
 import { ChatOpenAI } from '@/llm/openai';
 
@@ -30,6 +35,7 @@ import { ChatOpenAI } from '@/llm/openai';
  * extending the real `BaseChatModel` would pull in too much surface.
  */
 type StubModel = {
+  model?: string;
   _useResponsesApi?: (options?: unknown) => boolean;
   defaultOptions?: unknown;
   last?: unknown;
@@ -829,6 +835,318 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
   });
 });
 
+describe('reasoning replay compatibility', () => {
+  const anthropicReplay = (): BaseMessage[] => [
+    new AIMessage({
+      content: [
+        {
+          type: ContentTypes.THINKING,
+          thinking: 'primary reasoning',
+          signature: 'anthropic-primary-signature',
+        },
+        { type: ContentTypes.TEXT, text: 'visible answer' },
+      ],
+    }),
+  ];
+  const bedrockReplay = (): BaseMessage[] => [
+    new AIMessage({
+      content: [
+        {
+          type: ContentTypes.REASONING_CONTENT,
+          reasoningText: {
+            text: 'primary reasoning',
+            signature: 'bedrock-primary-signature',
+          },
+        },
+        { type: ContentTypes.TEXT, text: 'visible answer' },
+      ],
+    }),
+  ];
+  const openAIReplay = (): BaseMessage[] => [
+    new AIMessage({
+      content: 'visible answer',
+      additional_kwargs: {
+        openai_responses_reasoning_replay: [
+          {
+            type: 'reasoning',
+            id: 'rs_persisted',
+            encrypted_content: 'openai-persisted-reasoning',
+          },
+        ],
+        reasoning: {
+          type: 'reasoning',
+          id: 'rs_run_produced',
+          encrypted_content: 'openai-run-produced-reasoning',
+        },
+      },
+      response_metadata: {
+        output: [
+          {
+            type: 'reasoning',
+            id: 'rs_response_output',
+            encrypted_content: 'openai-response-output-reasoning',
+          },
+          {
+            type: 'message',
+            id: 'msg_visible',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                text: 'visible answer',
+                annotations: [],
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  ];
+
+  const anthropicSource: ReasoningReplaySource = {
+    provider: Providers.ANTHROPIC,
+    model: 'claude-sonnet-primary',
+  };
+  const bedrockSource: ReasoningReplaySource = {
+    provider: Providers.BEDROCK,
+    model: 'claude-sonnet-primary',
+  };
+  const openAISource: ReasoningReplaySource = {
+    provider: Providers.OPENAI,
+    model: 'gpt-5.4',
+    useResponsesApi: true,
+  };
+  const compatibilityCases: Array<{
+    name: string;
+    messages: () => BaseMessage[];
+    source: ReasoningReplaySource;
+    target: ReasoningReplaySource;
+    markers: string[];
+    retained: boolean;
+  }> = [
+    {
+      name: 'retains exact Anthropic replay',
+      messages: anthropicReplay,
+      source: anthropicSource,
+      target: anthropicSource,
+      markers: ['anthropic-primary-signature'],
+      retained: true,
+    },
+    {
+      name: 'strips replay for another Anthropic model',
+      messages: anthropicReplay,
+      source: anthropicSource,
+      target: { ...anthropicSource, model: 'claude-opus-fallback' },
+      markers: ['anthropic-primary-signature'],
+      retained: false,
+    },
+    {
+      name: 'retains exact Bedrock replay',
+      messages: bedrockReplay,
+      source: bedrockSource,
+      target: bedrockSource,
+      markers: ['bedrock-primary-signature'],
+      retained: true,
+    },
+    {
+      name: 'strips replay across providers',
+      messages: bedrockReplay,
+      source: bedrockSource,
+      target: anthropicSource,
+      markers: ['bedrock-primary-signature'],
+      retained: false,
+    },
+    {
+      name: 'retains exact OpenAI Responses replay',
+      messages: openAIReplay,
+      source: openAISource,
+      target: openAISource,
+      markers: [
+        'openai-persisted-reasoning',
+        'openai-run-produced-reasoning',
+        'openai-response-output-reasoning',
+      ],
+      retained: true,
+    },
+    {
+      name: 'strips replay when switching to Chat Completions',
+      messages: openAIReplay,
+      source: openAISource,
+      target: { ...openAISource, useResponsesApi: false },
+      markers: [
+        'openai-persisted-reasoning',
+        'openai-run-produced-reasoning',
+        'openai-response-output-reasoning',
+      ],
+      retained: false,
+    },
+    {
+      name: 'strips replay for another OpenAI Responses model',
+      messages: openAIReplay,
+      source: openAISource,
+      target: { ...openAISource, model: 'gpt-5.5' },
+      markers: [
+        'openai-persisted-reasoning',
+        'openai-run-produced-reasoning',
+        'openai-response-output-reasoning',
+      ],
+      retained: false,
+    },
+  ];
+
+  it.each(compatibilityCases)(
+    '$name',
+    ({ messages, source, target, markers, retained }) => {
+      const input = messages();
+      const filtered = filterReasoningReplayForInvocation({
+        messages: input,
+        source,
+        target,
+      });
+      const serialized = JSON.stringify(filtered);
+
+      for (const marker of markers) {
+        if (retained) {
+          expect(serialized).toContain(marker);
+        } else {
+          expect(serialized).not.toContain(marker);
+        }
+      }
+      expect(serialized).toContain('visible answer');
+      if (retained) {
+        expect(filtered).toBe(input);
+      }
+    }
+  );
+
+  it('uses the initialized fallback identity when filtering replay', async () => {
+    const invoked: BaseMessage[][] = [];
+    jest.doMock('@/llm/init', () => ({
+      initializeModel: ({
+        clientOptions,
+      }: {
+        clientOptions?: { model?: string };
+      }): StubModel => ({
+        model: clientOptions?.model,
+        invoke: jest.fn(async (messages: BaseMessage[]): Promise<AIMessage> => {
+          invoked.push(messages);
+          return new AIMessage({ content: 'ok' });
+        }),
+      }),
+    }));
+    jest.resetModules();
+
+    try {
+      const { tryFallbackProviders: freshTry } = (await import(
+        '@/llm/invoke'
+      )) as { tryFallbackProviders: typeof tryFallbackProviders };
+      await freshTry({
+        fallbacks: [
+          {
+            provider: Providers.ANTHROPIC,
+            clientOptions: { model: 'claude-opus-fallback' },
+          },
+        ],
+        messages: anthropicReplay(),
+        primaryError: new Error('primary failed'),
+        reasoningReplaySource: anthropicSource,
+      });
+
+      expect(JSON.stringify(invoked[0])).not.toContain(
+        'anthropic-primary-signature'
+      );
+      expect(JSON.stringify(invoked[0])).toContain('visible answer');
+    } finally {
+      jest.dontMock('@/llm/init');
+      jest.resetModules();
+    }
+  });
+
+  it('preserves message identity when there is no native replay to remove', () => {
+    const message = new AIMessage({ content: 'visible answer' });
+    const filtered = filterReasoningReplayForInvocation({
+      messages: [message],
+      source: anthropicSource,
+      target: openAISource,
+    });
+
+    expect(filtered[0]).toBe(message);
+  });
+
+  it('removes signed generic Anthropic reasoning', () => {
+    const filtered = filterReasoningReplayForInvocation({
+      messages: [
+        new AIMessage({
+          content: [
+            {
+              type: ContentTypes.REASONING,
+              reasoning: 'private reasoning',
+              signature: 'anthropic-generic-signature',
+            },
+            { type: ContentTypes.TEXT, text: 'visible answer' },
+          ],
+        }),
+      ],
+      source: anthropicSource,
+      target: openAISource,
+    });
+
+    expect(JSON.stringify(filtered)).not.toContain(
+      'anthropic-generic-signature'
+    );
+    expect(JSON.stringify(filtered)).toContain('visible answer');
+  });
+
+  it.each([
+    {
+      name: 'Bedrock array content',
+      messages: [
+        new AIMessage({
+          content: [
+            {
+              type: ContentTypes.REASONING_CONTENT,
+              reasoningText: {
+                text: 'reasoning only',
+                signature: 'bedrock-only-signature',
+              },
+            },
+          ],
+        }),
+      ],
+      source: bedrockSource,
+    },
+    {
+      name: 'OpenAI empty string content',
+      messages: [
+        new AIMessage({
+          content: '',
+          additional_kwargs: {
+            openai_responses_reasoning_replay: [
+              {
+                type: 'reasoning',
+                id: 'rs_only',
+                encrypted_content: 'encrypted-only-reasoning',
+              },
+            ],
+          },
+        }),
+      ],
+      source: openAISource,
+    },
+  ])(
+    'removes replay-only assistant messages with $name',
+    ({ messages, source }) => {
+      expect(
+        filterReasoningReplayForInvocation({
+          messages,
+          source,
+          target: anthropicSource,
+        })
+      ).toEqual([]);
+    }
+  );
+});
 describe('invocation attribution metadata', () => {
   it('stamps INVOKED_PROVIDER on the config passed to the model', async () => {
     const capturedConfigs: unknown[] = [];

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1,14 +1,14 @@
 import { concat } from '@langchain/core/utils/stream';
-import { AIMessageChunk } from '@langchain/core/messages';
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import {
   CallbackManager,
   CallbackManagerForLLMRun,
   type Callbacks,
 } from '@langchain/core/callbacks/manager';
-import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import type { Serialized } from '@langchain/core/load/serializable';
-import type { ChatGeneration } from '@langchain/core/outputs';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
@@ -25,27 +25,27 @@ import {
   projectToolStreamContentForProvider,
 } from '@/messages/core';
 import {
-  stripAnthropicCacheControl,
-  stripBedrockCacheControl,
-} from '@/messages/cache';
-import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
-import { assertNotTruncatedToolCall } from '@/llm/truncation';
-import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
-import { manualToolStreamProviders } from '@/llm/providers';
-import { appendCallbacks } from '@/utils/callbacks';
-import { safeDispatchCustomEvent } from '@/utils/events';
-import { getContextOverflowInfo } from '@/utils/errors';
-import {
   modifyDeltaProperties,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
   appendPredecessorHandoffCue,
   removePredecessorHandoffCue,
 } from '@/messages';
-import { canSealPreempt } from '@/llm/preempt';
+import {
+  stripAnthropicCacheControl,
+  stripBedrockCacheControl,
+} from '@/messages/cache';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
-import { initializeModel } from '@/llm/init';
+import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
+import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
+import { assertNotTruncatedToolCall } from '@/llm/truncation';
+import { manualToolStreamProviders } from '@/llm/providers';
 import { isAnthropicLike, isOpenAILike } from '@/utils/llm';
+import { safeDispatchCustomEvent } from '@/utils/events';
+import { getContextOverflowInfo } from '@/utils/errors';
+import { appendCallbacks } from '@/utils/callbacks';
+import { canSealPreempt } from '@/llm/preempt';
+import { initializeModel } from '@/llm/init';
 
 /**
  * Context passed to `attemptInvoke`. Matches the subset of Graph that
@@ -550,6 +550,147 @@ export function resolveServingModelId(model: unknown): string | undefined {
   return undefined;
 }
 
+export interface ReasoningReplaySource {
+  provider: Providers;
+  model?: string;
+  useResponsesApi?: boolean;
+}
+
+/** Resolves the replay identity of the model that will serve an invocation. */
+export function resolveReasoningReplaySource({
+  model,
+  provider,
+  clientOptions,
+  callOptions,
+}: {
+  model: t.ChatModel;
+  provider: Providers;
+  clientOptions?: t.ClientOptions;
+  callOptions?: unknown;
+}): ReasoningReplaySource {
+  return {
+    provider,
+    model:
+      resolveServingModelId(model) ?? extractClientOptionsModel(clientOptions),
+    useResponsesApi: usesNativeOpenAIResponses(model, provider, callOptions),
+  };
+}
+
+/**
+ * Removes provider-native reasoning that is not valid for the model serving
+ * this invocation. Fallbacks start from messages formatted for the primary,
+ * so compatibility must be checked again after the fallback model is known.
+ */
+export function filterReasoningReplayForInvocation({
+  messages,
+  source,
+  target,
+}: {
+  messages: BaseMessage[];
+  source: ReasoningReplaySource;
+  target: ReasoningReplaySource;
+}): BaseMessage[] {
+  const isOpenAIResponsesReplay =
+    source.provider === Providers.OPENAI || source.provider === Providers.AZURE;
+  const compatible =
+    source.provider === target.provider &&
+    source.model != null &&
+    source.model === target.model &&
+    (!isOpenAIResponsesReplay ||
+      (source.useResponsesApi === true && target.useResponsesApi === true));
+  if (compatible) {
+    return messages;
+  }
+
+  return messages.flatMap((message) => {
+    if (message.getType() !== 'ai') {
+      return [message];
+    }
+    const aiMessage = message as AIMessage;
+    let content = aiMessage.content;
+    if (Array.isArray(content)) {
+      if (source.provider === Providers.ANTHROPIC) {
+        const filtered = content.filter(
+          (part) =>
+            part.type !== ContentTypes.THINKING &&
+            part.type !== 'redacted_thinking' &&
+            !(
+              part.type === ContentTypes.REASONING &&
+              typeof (part as { signature?: unknown }).signature === 'string'
+            )
+        );
+        if (filtered.length !== content.length) {
+          content = filtered;
+        }
+      } else if (source.provider === Providers.BEDROCK) {
+        const filtered = content.filter(
+          (part) => part.type !== ContentTypes.REASONING_CONTENT
+        );
+        if (filtered.length !== content.length) {
+          content = filtered;
+        }
+      }
+    }
+
+    let additionalKwargs = aiMessage.additional_kwargs;
+    let responseMetadata = aiMessage.response_metadata;
+    if (isOpenAIResponsesReplay) {
+      const {
+        openai_responses_reasoning_replay: _,
+        reasoning: __,
+        ...rest
+      } = additionalKwargs;
+      if (
+        'openai_responses_reasoning_replay' in additionalKwargs ||
+        'reasoning' in additionalKwargs
+      ) {
+        additionalKwargs = rest;
+      }
+      if (Array.isArray(responseMetadata.output)) {
+        const filteredOutput = responseMetadata.output.filter(
+          (item) =>
+            item == null ||
+            typeof item !== 'object' ||
+            !('type' in item) ||
+            item.type !== 'reasoning'
+        );
+        if (filteredOutput.length !== responseMetadata.output.length) {
+          responseMetadata = {
+            ...responseMetadata,
+            output: filteredOutput,
+          };
+        }
+      }
+    }
+    if (
+      content === aiMessage.content &&
+      additionalKwargs === aiMessage.additional_kwargs &&
+      responseMetadata === aiMessage.response_metadata
+    ) {
+      return [message];
+    }
+    if (
+      (content === '' || (Array.isArray(content) && content.length === 0)) &&
+      (aiMessage.tool_calls?.length ?? 0) === 0 &&
+      (aiMessage.invalid_tool_calls?.length ?? 0) === 0
+    ) {
+      return [];
+    }
+    return [
+      new AIMessage({
+        id: aiMessage.id,
+        name: aiMessage.name,
+        content,
+        additional_kwargs: additionalKwargs,
+        response_metadata: responseMetadata,
+        tool_calls: aiMessage.tool_calls,
+        invalid_tool_calls: aiMessage.invalid_tool_calls,
+        usage_metadata: aiMessage.usage_metadata,
+      }),
+    ];
+  });
+}
+
 async function endSealedModelRun(
   context: InvokeContext | undefined,
   chunk: AIMessageChunk,
@@ -677,11 +818,7 @@ export async function attemptInvoke(
   });
   const registry = context?.getOrCreateToolOutputRegistry();
   const runId = config?.configurable?.run_id as string | undefined;
-  const annotated = annotateMessagesForLLM(
-    invocationMessages,
-    registry,
-    runId
-  );
+  const annotated = annotateMessagesForLLM(invocationMessages, registry, runId);
   /**
    * Keyed on the provider ACTUALLY serving this call, not the agent's primary.
    * `createCallModel` normalizes for the primary, but `tryFallbackProviders`
@@ -951,7 +1088,7 @@ export function getFallbackOverflowCandidates(
  * Best-effort read of the configured model name from client options.
  * Providers disagree on the key (`model` vs `modelName`).
  */
-function extractClientOptionsModel(
+export function extractClientOptionsModel(
   clientOptions: t.ClientOptions | undefined
 ): string | undefined {
   const options = clientOptions as
@@ -985,6 +1122,7 @@ export async function tryFallbackProviders({
   onChunk,
   overflowContext,
   prepareProviderMessages,
+  reasoningReplaySource,
 }: {
   fallbacks: t.FallbackConfig[];
   tools?: t.GraphTools;
@@ -1013,6 +1151,8 @@ export async function tryFallbackProviders({
     maxContextTokens?: number;
     config?: RunnableConfig;
   }) => BaseMessage[] | Promise<BaseMessage[]>;
+  /** Provider/model identity used when native reasoning entered `messages`. */
+  reasoningReplaySource?: ReasoningReplaySource;
 }): Promise<Partial<t.BaseGraphState> | undefined> {
   const isOverflow = (
     error: unknown,
@@ -1054,15 +1194,28 @@ export async function tryFallbackProviders({
               [Constants.INVOKED_MODEL]: fbModelName,
             },
           };
+      const replayValidatedMessages =
+        reasoningReplaySource == null
+          ? messages
+          : filterReasoningReplayForInvocation({
+            messages,
+            source: reasoningReplaySource,
+            target: resolveReasoningReplaySource({
+              model: fbModel as t.ChatModel,
+              provider: fb.provider,
+              clientOptions: fb.clientOptions,
+              callOptions: fbConfig,
+            }),
+          });
       const fallbackMessages =
         (await prepareProviderMessages?.({
           model: fbModel as t.ChatModel,
-          messages,
+          messages: replayValidatedMessages,
           provider: fb.provider,
           clientOptions: fb.clientOptions,
           maxContextTokens: fb.maxContextTokens,
           config: fbConfig,
-        })) ?? messages;
+        })) ?? replayValidatedMessages;
       const result = await attemptInvoke(
         {
           model: fbModel as t.ChatModel,

--- a/src/llm/openai/contentBlocks.test.ts
+++ b/src/llm/openai/contentBlocks.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { convertMessagesToResponsesInput } from '@langchain/openai';
 import {
   AIMessage,
   AIMessageChunk,
@@ -9,6 +11,10 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import {
+  attachOpenAIResponsesReasoningReplay,
+  expandOpenAIResponsesReasoningReplay,
+} from './index';
 import { _convertOpenAIResponsesDeltaToBaseMessageChunk } from './utils';
 
 describe('OpenAI content block translator compatibility', () => {
@@ -113,6 +119,85 @@ describe('OpenAI content block translator compatibility', () => {
   });
 
   describe('Responses', () => {
+    test('copies all final encrypted reasoning items onto the streamed chunk', () => {
+      const reasoning = [
+        {
+          type: 'reasoning',
+          id: 'rs_first',
+          summary: [],
+          encrypted_content: 'encrypted-first-reasoning',
+        },
+        {
+          type: 'reasoning',
+          id: 'rs_second',
+          summary: [],
+          encrypted_content: 'encrypted-second-reasoning',
+        },
+      ];
+      const chunk = new ChatGenerationChunk({
+        text: '',
+        message: new AIMessageChunk({
+          content: '',
+          response_metadata: {
+            output: [
+              reasoning[0],
+              { type: 'message', content: [] },
+              reasoning[1],
+            ],
+          },
+        }),
+      });
+
+      expect(
+        attachOpenAIResponsesReasoningReplay(chunk).message.additional_kwargs
+          .openai_responses_reasoning_replay
+      ).toEqual(reasoning);
+    });
+
+    test('replays every encrypted reasoning item before the assistant message', () => {
+      const reasoning = [
+        {
+          type: 'reasoning' as const,
+          id: 'rs_first',
+          status: 'completed' as const,
+          summary: [],
+          encrypted_content: 'encrypted-first-reasoning',
+        },
+        {
+          type: 'reasoning' as const,
+          id: 'rs_second',
+          status: 'completed' as const,
+          summary: [],
+          encrypted_content: 'encrypted-second-reasoning',
+        },
+      ];
+      const messages = expandOpenAIResponsesReasoningReplay([
+        new AIMessage({
+          content: 'Final answer',
+          additional_kwargs: {
+            openai_responses_reasoning_replay: reasoning,
+          },
+        }),
+      ]);
+
+      expect(
+        convertMessagesToResponsesInput({
+          messages,
+          zdrEnabled: true,
+          model: 'gpt-5.6-terra',
+        })
+      ).toEqual([
+        reasoning[0],
+        reasoning[1],
+        {
+          type: 'message',
+          role: 'assistant',
+          content: 'Final answer',
+          phase: undefined,
+        },
+      ]);
+    });
+
     test('marks Responses function call arguments done as an explicit tool-call seal', () => {
       const chunk = _convertOpenAIResponsesDeltaToBaseMessageChunk({
         type: 'response.function_call_arguments.done',
@@ -121,7 +206,9 @@ describe('OpenAI content block translator compatibility', () => {
         output_index: 1,
         name: 'search',
         arguments: '{"query":"weather"}',
-      } as Parameters<typeof _convertOpenAIResponsesDeltaToBaseMessageChunk>[0]);
+      } as Parameters<
+        typeof _convertOpenAIResponsesDeltaToBaseMessageChunk
+      >[0]);
       const message = chunk?.message as AIMessageChunk | undefined;
 
       expect(message?.tool_call_chunks).toEqual([

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -51,8 +51,8 @@ import {
   projectOpenAIResponsesToolMessageContent,
   projectToolStreamContentForProvider,
 } from '@/messages/core';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -495,7 +495,7 @@ export function shouldIncludeEncryptedReasoning(
       | undefined
   )?.context;
   return (
-    /^gpt-5\.6(?:-|$)/i.test(model) &&
+    /(?:^|[./:])gpt-5\.6(?:-|$)/i.test(model) &&
     (params.store === false || reasoningContext !== 'current_turn')
   );
 }
@@ -1646,6 +1646,89 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   }
 }
 
+function attachOpenAIResponsesReasoningReplayToMessage<
+  T extends BaseMessage | BaseMessageChunk,
+>(message: T): T {
+  const output = (message.response_metadata as { output?: unknown } | undefined)
+    ?.output;
+  if (!Array.isArray(output)) {
+    return message;
+  }
+  const reasoning = output.filter(
+    (item) =>
+      item != null &&
+      typeof item === 'object' &&
+      (item as { type?: unknown }).type === 'reasoning' &&
+      typeof (item as { encrypted_content?: unknown }).encrypted_content ===
+        'string' &&
+      (item as { encrypted_content: string }).encrypted_content !== ''
+  );
+  if (reasoning.length > 0) {
+    message.additional_kwargs.openai_responses_reasoning_replay = reasoning;
+  }
+  return message;
+}
+
+export function attachOpenAIResponsesReasoningReplay(
+  chunk: ChatGenerationChunk
+): ChatGenerationChunk {
+  attachOpenAIResponsesReasoningReplayToMessage(chunk.message);
+  return chunk;
+}
+
+export function expandOpenAIResponsesReasoningReplay(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  return messages.flatMap((message) => {
+    if (!isAIMessage(message)) {
+      return [message];
+    }
+    const candidates =
+      message.additional_kwargs.openai_responses_reasoning_replay;
+    if (!Array.isArray(candidates)) {
+      return [message];
+    }
+    const reasoning = candidates.filter(
+      (item): item is OpenAIClient.Responses.ResponseReasoningItem =>
+        item != null &&
+        typeof item === 'object' &&
+        (item as { type?: unknown }).type === 'reasoning' &&
+        typeof (item as { encrypted_content?: unknown }).encrypted_content ===
+          'string' &&
+        (item as { encrypted_content: string }).encrypted_content !== ''
+    );
+    if (reasoning.length === 0) {
+      return [message];
+    }
+
+    const additionalKwargs = { ...message.additional_kwargs };
+    delete additionalKwargs.openai_responses_reasoning_replay;
+    const finalReasoning = reasoning[reasoning.length - 1];
+    return [
+      ...reasoning.slice(0, -1).map(
+        (item) =>
+          new AIMessage({
+            content: [],
+            additional_kwargs: { reasoning: item },
+          })
+      ),
+      new AIMessage({
+        id: message.id,
+        name: message.name,
+        content: message.content,
+        tool_calls: message.tool_calls,
+        invalid_tool_calls: message.invalid_tool_calls,
+        usage_metadata: message.usage_metadata,
+        response_metadata: message.response_metadata,
+        additional_kwargs: {
+          ...additionalKwargs,
+          reasoning: finalReasoning,
+        },
+      }),
+    ];
+  });
+}
+
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   private promptCacheExplicit?: boolean;
   private responsesPromptCache?: boolean;
@@ -1739,12 +1822,15 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     const result = await super._generate(
-      projectOpenAIResponsesProviderMessages(messages),
+      expandOpenAIResponsesReasoningReplay(
+        projectOpenAIResponsesProviderMessages(messages)
+      ),
       options,
       runManager
     );
     for (const generation of result.generations) {
       attachCacheWriteUsage(generation.message);
+      attachOpenAIResponsesReasoningReplayToMessage(generation.message);
     }
     return result;
   }
@@ -1755,12 +1841,14 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     for await (const chunk of super._streamResponseChunks(
-      projectOpenAIResponsesProviderMessages(messages),
+      expandOpenAIResponsesReasoningReplay(
+        projectOpenAIResponsesProviderMessages(messages)
+      ),
       options,
       runManager
     )) {
       attachCacheWriteUsage(chunk.message);
-      yield chunk;
+      yield attachOpenAIResponsesReasoningReplay(chunk);
     }
   }
 
@@ -1770,7 +1858,9 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatModelStreamEvent> {
     yield* super._streamChatModelEvents(
-      projectOpenAIResponsesProviderMessages(messages),
+      expandOpenAIResponsesReasoningReplay(
+        projectOpenAIResponsesProviderMessages(messages)
+      ),
       options,
       runManager
     );
@@ -1988,9 +2078,14 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
-    const result = await super._generate(messages, options, runManager);
+    const result = await super._generate(
+      expandOpenAIResponsesReasoningReplay(messages),
+      options,
+      runManager
+    );
     for (const generation of result.generations) {
       attachCacheWriteUsage(generation.message);
+      attachOpenAIResponsesReasoningReplayToMessage(generation.message);
     }
     return result;
   }
@@ -2001,12 +2096,12 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     for await (const chunk of super._streamResponseChunks(
-      messages,
+      expandOpenAIResponsesReasoningReplay(messages),
       options,
       runManager
     )) {
       attachCacheWriteUsage(chunk.message);
-      yield chunk;
+      yield attachOpenAIResponsesReasoningReplay(chunk);
     }
   }
 

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -161,6 +161,9 @@ describe('managed GPT-5.6 request fields', () => {
 
   it('requests encrypted reasoning whenever persisted or stateless replay may be needed', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-5.6', {})).toBe(true);
+    expect(shouldIncludeEncryptedReasoning('openai.gpt-5.6-terra', {})).toBe(
+      true
+    );
     expect(
       shouldIncludeEncryptedReasoning('gpt-5.6', {
         reasoning: { context: 'all_turns' },

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -14,10 +14,15 @@ import type {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
+  AnthropicReasoningReplay,
+  AnthropicReasoningReplayBlock,
+  BedrockReasoningReplay,
+  BedrockReasoningReplayBlock,
   BedrockReasoningContentText,
   ExtendedMessageContent,
   GoogleReasoningContentText,
   MessageContentComplex,
+  OpenAIResponsesReasoningReplay,
   ReasoningContentText,
   SummaryContentBlock,
   SummaryCoverage,
@@ -336,13 +341,17 @@ export const formatFromLangChain = (
 };
 
 interface FormatAssistantMessageOptions {
+  model?: string;
   preserveUnpairedServerToolUses?: boolean;
   preserveReasoningContent?: boolean;
   provider?: Providers;
+  useResponsesApi?: boolean;
 }
 
 interface FormatAgentMessagesOptions {
+  model?: string;
   provider?: Providers;
+  useResponsesApi?: boolean;
   /** Reconstruct hidden `reasoning_content` from `THINK` parts onto prior
    *  tool-call messages. Explicit opt-in for OpenAI-compatible endpoints that
    *  replay reasoning across turns; defaults to on for DeepSeek thinking-mode. */
@@ -376,6 +385,173 @@ function extractReasoningContent(
     return typeof reasoningText.text === 'string' ? reasoningText.text : '';
   }
   return '';
+}
+
+function extractBedrockReasoningReplay(
+  part: MessageContentComplex | undefined | null
+): BedrockReasoningReplay | undefined {
+  if (part?.type !== ContentTypes.THINK) {
+    return undefined;
+  }
+  const replay = (part as ReasoningContentText).provider_replay?.bedrock;
+  if (
+    replay == null ||
+    typeof replay.model !== 'string' ||
+    replay.model === '' ||
+    !Array.isArray(replay.blocks)
+  ) {
+    return undefined;
+  }
+  const blocks = replay.blocks.flatMap(
+    (block): BedrockReasoningReplayBlock[] => {
+      const { reasoningText, redactedContent } = block;
+      if (
+        typeof reasoningText?.text === 'string' &&
+        reasoningText.text !== '' &&
+        typeof reasoningText.signature === 'string' &&
+        reasoningText.signature !== ''
+      ) {
+        return [
+          {
+            type: ContentTypes.REASONING_CONTENT,
+            reasoningText: {
+              text: reasoningText.text,
+              signature: reasoningText.signature,
+            },
+          },
+        ];
+      }
+      if (typeof redactedContent === 'string' && redactedContent !== '') {
+        return [
+          {
+            type: ContentTypes.REASONING_CONTENT,
+            redactedContent,
+          },
+        ];
+      }
+      return [];
+    }
+  );
+  return blocks.length > 0 ? { model: replay.model, blocks } : undefined;
+}
+
+function extractAnthropicReasoningReplay(
+  part: MessageContentComplex | undefined | null
+): AnthropicReasoningReplay | undefined {
+  if (part?.type !== ContentTypes.THINK) {
+    return undefined;
+  }
+  const replay = (part as ReasoningContentText).provider_replay?.anthropic;
+  if (
+    replay == null ||
+    typeof replay.model !== 'string' ||
+    replay.model === '' ||
+    !Array.isArray(replay.blocks)
+  ) {
+    return undefined;
+  }
+  const blocks = replay.blocks.flatMap(
+    (block): AnthropicReasoningReplayBlock[] => {
+      if (
+        block.type === ContentTypes.THINKING &&
+        typeof block.signature === 'string' &&
+        block.signature !== ''
+      ) {
+        return [
+          {
+            type: ContentTypes.THINKING,
+            thinking: block.thinking ?? '',
+            signature: block.signature,
+          },
+        ];
+      }
+      if (
+        block.type === 'redacted_thinking' &&
+        typeof block.data === 'string' &&
+        block.data !== ''
+      ) {
+        return [{ type: 'redacted_thinking', data: block.data }];
+      }
+      return [];
+    }
+  );
+  return blocks.length > 0 ? { model: replay.model, blocks } : undefined;
+}
+
+function extractOpenAIResponsesReasoningReplay(
+  part: MessageContentComplex | undefined | null
+): OpenAIResponsesReasoningReplay | undefined {
+  if (part?.type !== ContentTypes.THINK) {
+    return undefined;
+  }
+  const replay = (part as ReasoningContentText).provider_replay
+    ?.openai_responses;
+  if (
+    replay == null ||
+    (replay.provider !== Providers.OPENAI &&
+      replay.provider !== Providers.AZURE) ||
+    !Array.isArray(replay.items) ||
+    replay.items.length === 0 ||
+    replay.items.some(
+      (item) =>
+        typeof item.id !== 'string' ||
+        item.id === '' ||
+        typeof item.encrypted_content !== 'string' ||
+        item.encrypted_content === '' ||
+        !Array.isArray(item.summary)
+    )
+  ) {
+    return undefined;
+  }
+  return structuredClone(replay);
+}
+
+function shouldInvalidateReplayTokenCount(
+  message: Partial<TMessage>,
+  options?: FormatAssistantMessageOptions
+): boolean {
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
+  let hasReplay = false;
+  let hasCompatibleReplay = false;
+  for (const part of message.content as Array<
+    MessageContentComplex | undefined | null
+  >) {
+    if (part?.type !== ContentTypes.THINK) {
+      continue;
+    }
+    const replay = (part as ReasoningContentText).provider_replay;
+    if (replay == null) {
+      continue;
+    }
+    if (replay.anthropic != null) {
+      hasReplay = true;
+      const anthropic = extractAnthropicReasoningReplay(part);
+      hasCompatibleReplay ||=
+        options?.provider === Providers.ANTHROPIC &&
+        options.model != null &&
+        anthropic?.model === options.model;
+    }
+    if (replay.bedrock != null) {
+      hasReplay = true;
+      const bedrock = extractBedrockReasoningReplay(part);
+      hasCompatibleReplay ||=
+        options?.provider === Providers.BEDROCK &&
+        options.model != null &&
+        bedrock?.model === options.model;
+    }
+    if (replay.openai_responses != null) {
+      hasReplay = true;
+      const openAI = extractOpenAIResponsesReasoningReplay(part);
+      hasCompatibleReplay ||=
+        openAI?.provider === options?.provider &&
+        options?.useResponsesApi === true &&
+        options?.model != null &&
+        openAI?.model === options.model;
+    }
+  }
+  return hasReplay && !hasCompatibleReplay;
 }
 
 type ServerToolInput = Exclude<NonNullable<ToolCallPart['args']>, string>;
@@ -518,6 +694,9 @@ function formatAssistantMessage(
   let lastAIMessage: RoleBearingMessage<AIMessage> | null = null;
   let hasReasoning = false;
   let pendingReasoningContent = '';
+  let pendingAnthropicReasoning: AnthropicReasoningReplay | undefined;
+  let pendingBedrockReasoning: BedrockReasoningReplay | undefined;
+  let pendingOpenAIReasoning: OpenAIResponsesReasoningReplay | undefined;
   const emittedServerToolUseIds = new Set<string>();
   const pendingServerToolUses = new Map<string, MessageContentComplex>();
   const shouldPreserveReasoningContent =
@@ -534,15 +713,98 @@ function formatAssistantMessage(
     return reasoningContent;
   };
 
+  const takePendingBedrockReasoning = (): BedrockReasoningReplayBlock[] => {
+    if (
+      options?.provider !== Providers.BEDROCK ||
+      options.model == null ||
+      pendingBedrockReasoning?.model !== options.model
+    ) {
+      pendingBedrockReasoning = undefined;
+      return [];
+    }
+    const blocks = pendingBedrockReasoning.blocks;
+    pendingBedrockReasoning = undefined;
+    return blocks;
+  };
+
+  const takePendingAnthropicReasoning = (): AnthropicReasoningReplayBlock[] => {
+    if (
+      options?.provider !== Providers.ANTHROPIC ||
+      options.model == null ||
+      pendingAnthropicReasoning?.model !== options.model
+    ) {
+      pendingAnthropicReasoning = undefined;
+      return [];
+    }
+    const blocks = pendingAnthropicReasoning.blocks;
+    pendingAnthropicReasoning = undefined;
+    return blocks;
+  };
+
+  const takePendingOpenAIReasoning = ():
+    | OpenAIResponsesReasoningReplay
+    | undefined => {
+    const isOpenAIResponses =
+      (options?.provider === Providers.OPENAI ||
+        options?.provider === Providers.AZURE) &&
+      options.useResponsesApi === true;
+    if (
+      !isOpenAIResponses ||
+      options.model == null ||
+      pendingOpenAIReasoning?.provider !== options.provider ||
+      pendingOpenAIReasoning?.model !== options.model
+    ) {
+      pendingOpenAIReasoning = undefined;
+      return undefined;
+    }
+    const replay = pendingOpenAIReasoning;
+    pendingOpenAIReasoning = undefined;
+    return replay;
+  };
+
+  const normalizeReplayContent = (
+    content: MessageContent
+  ): MessageContentComplex[] => {
+    if (typeof content !== 'string') {
+      return content as MessageContentComplex[];
+    }
+    if (content === '') {
+      return [];
+    }
+    return [{ type: ContentTypes.TEXT, text: content }];
+  };
+
   const createAIMessage = (
     content: MessageContent
   ): RoleBearingMessage<AIMessage> => {
     const reasoningContent = takePendingReasoningContent();
+    const anthropicReasoning = takePendingAnthropicReasoning();
+    const bedrockReasoning = takePendingBedrockReasoning();
+    const openAIReasoning = takePendingOpenAIReasoning();
+    let replayContent = content;
+    if (anthropicReasoning.length > 0 || bedrockReasoning.length > 0) {
+      replayContent = [
+        ...anthropicReasoning,
+        ...bedrockReasoning,
+        ...normalizeReplayContent(content),
+      ] as MessageContent;
+    }
     return withMessageRole(
       new AIMessage({
-        content,
+        content: replayContent,
         ...(reasoningContent != null && {
-          additional_kwargs: { reasoning_content: reasoningContent },
+          additional_kwargs: {
+            reasoning_content: reasoningContent,
+            ...(openAIReasoning != null && {
+              openai_responses_reasoning_replay: openAIReasoning.items,
+            }),
+          },
+        }),
+        ...(reasoningContent == null &&
+          openAIReasoning != null && {
+          additional_kwargs: {
+            openai_responses_reasoning_replay: openAIReasoning.items,
+          },
         }),
       }),
       'assistant'
@@ -558,6 +820,37 @@ function formatAssistantMessage(
       typeof aiMessage.additional_kwargs.reasoning_content === 'string'
         ? `${aiMessage.additional_kwargs.reasoning_content}${reasoningContent}`
         : reasoningContent;
+  };
+
+  const attachPendingBedrockReasoning = (aiMessage: AIMessage): void => {
+    const bedrockReasoning = takePendingBedrockReasoning();
+    if (bedrockReasoning.length === 0) {
+      return;
+    }
+    aiMessage.content = [
+      ...normalizeReplayContent(aiMessage.content),
+      ...bedrockReasoning,
+    ] as MessageContent;
+  };
+
+  const attachPendingAnthropicReasoning = (aiMessage: AIMessage): void => {
+    const anthropicReasoning = takePendingAnthropicReasoning();
+    if (anthropicReasoning.length === 0) {
+      return;
+    }
+    aiMessage.content = [
+      ...normalizeReplayContent(aiMessage.content),
+      ...anthropicReasoning,
+    ] as MessageContent;
+  };
+
+  const attachPendingOpenAIReasoning = (aiMessage: AIMessage): void => {
+    const replay = takePendingOpenAIReasoning();
+    if (replay == null) {
+      return;
+    }
+    aiMessage.additional_kwargs.openai_responses_reasoning_replay =
+      replay.items;
   };
 
   const flushPendingServerToolUse = (toolUseId: string): void => {
@@ -714,6 +1007,9 @@ function formatAssistantMessage(
           formattedMessages.push(lastAIMessage);
         } else {
           attachPendingReasoningContent(lastAIMessage);
+          attachPendingAnthropicReasoning(lastAIMessage);
+          attachPendingBedrockReasoning(lastAIMessage);
+          attachPendingOpenAIReasoning(lastAIMessage);
         }
 
         const tool_call: ToolCallPart = _tool_call;
@@ -768,6 +1064,12 @@ function formatAssistantMessage(
       ) {
         hasReasoning = true;
         pendingReasoningContent += extractReasoningContent(part);
+        pendingAnthropicReasoning =
+          extractAnthropicReasoningReplay(part) ?? pendingAnthropicReasoning;
+        pendingBedrockReasoning =
+          extractBedrockReasoningReplay(part) ?? pendingBedrockReasoning;
+        pendingOpenAIReasoning =
+          extractOpenAIResponsesReasoningReplay(part) ?? pendingOpenAIReasoning;
         continue;
       } else if (part.type === ContentTypes.STEER) {
         /*
@@ -833,6 +1135,9 @@ function formatAssistantMessage(
          *  flushed above or intentionally dropped when not preserving). */
         hasReasoning = false;
         pendingReasoningContent = '';
+        pendingAnthropicReasoning = undefined;
+        pendingBedrockReasoning = undefined;
+        pendingOpenAIReasoning = undefined;
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||
@@ -870,6 +1175,12 @@ function formatAssistantMessage(
     }
   } else if (currentContent.length > 0) {
     formattedMessages.push(createAIMessage(toLangChainContent(currentContent)));
+  } else if (pendingOpenAIReasoning != null) {
+    if (lastAIMessage != null) {
+      attachPendingOpenAIReasoning(lastAIMessage);
+    } else {
+      formattedMessages.push(createAIMessage(''));
+    }
   }
 
   return formattedMessages;
@@ -1519,6 +1830,7 @@ export const formatAgentMessages = (
   let boundaryTokenAdjustment: SummaryTokenAdjustment | undefined;
   // Keep track of the mapping from original payload indices to result indices
   const indexMapping: Record<number, number[] | undefined> = {};
+  const invalidatedReplayTokenCounts = new Set<number>();
   const { boundary: summaryBoundary } = scanSummaryBlocks(payload);
 
   // Summary metadata is returned to the caller so it can be forwarded to the
@@ -1740,13 +2052,24 @@ export const formatAgentMessages = (
       }
     }
 
-    const formattedMessages = formatAssistantMessage(processedMessage, {
+    const assistantFormatOptions: FormatAssistantMessageOptions = {
       preserveUnpairedServerToolUses: i === payload.length - 1,
       preserveReasoningContent:
         options?.preserveReasoningContent ??
         options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
-    });
+      model: options?.model,
+      useResponsesApi: options?.useResponsesApi,
+    };
+    if (
+      shouldInvalidateReplayTokenCount(processedMessage, assistantFormatOptions)
+    ) {
+      invalidatedReplayTokenCounts.add(i);
+    }
+    const formattedMessages = formatAssistantMessage(
+      processedMessage,
+      assistantFormatOptions
+    );
     if (sourceMessageId != null && sourceMessageId !== '') {
       for (const formattedMessage of formattedMessages) {
         formattedMessage.id = sourceMessageId;
@@ -1841,7 +2164,10 @@ export const formatAgentMessages = (
       const resultIndices = indexMapping[originalIndex] || [];
       let tokenCount = indexTokenCountMap[originalIndex];
 
-      if (tokenCount === undefined) {
+      if (
+        tokenCount === undefined ||
+        invalidatedReplayTokenCounts.has(originalIndex)
+      ) {
         continue;
       }
 

--- a/src/messages/formatAgentMessages.anthropicReplay.test.ts
+++ b/src/messages/formatAgentMessages.anthropicReplay.test.ts
@@ -1,0 +1,143 @@
+import type { TMessage } from '@/types';
+import { ContentTypes, Providers } from '@/common';
+import { formatAgentMessages } from './format';
+
+const model = 'claude-sonnet-5-20260701';
+
+describe('formatAgentMessages Anthropic reasoning replay', () => {
+  const persistedMessage: TMessage = {
+    role: 'assistant',
+    content: [
+      {
+        type: ContentTypes.THINK,
+        think: '',
+        provider_replay: {
+          anthropic: {
+            model,
+            blocks: [
+              {
+                type: ContentTypes.THINKING,
+                thinking: '',
+                signature: 'signed-encrypted-thinking',
+              },
+              {
+                type: 'redacted_thinking',
+                data: 'redacted-encrypted-thinking',
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'toolu_123',
+          name: 'lookup',
+          args: '{"value":42}',
+          output: 'done',
+        },
+      },
+    ],
+  };
+
+  it('reconstructs signed and redacted blocks before Anthropic tool use', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      [persistedMessage],
+      { 0: 700 },
+      undefined,
+      undefined,
+      { provider: Providers.ANTHROPIC, model }
+    );
+
+    expect(messages[0].content).toEqual([
+      {
+        type: ContentTypes.THINKING,
+        thinking: '',
+        signature: 'signed-encrypted-thinking',
+      },
+      {
+        type: 'redacted_thinking',
+        data: 'redacted-encrypted-thinking',
+      },
+      {
+        type: 'tool_use',
+        id: 'toolu_123',
+        name: 'lookup',
+        input: { value: 42 },
+      },
+    ]);
+    expect(
+      Object.values(indexTokenCountMap ?? {}).reduce(
+        (total, count) => total + count,
+        0
+      )
+    ).toBe(700);
+  });
+
+  it('does not replay Anthropic blocks to another provider and invalidates their token weight', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      [persistedMessage],
+      { 0: 700 },
+      undefined,
+      undefined,
+      { provider: Providers.BEDROCK, model: 'anthropic.claude-sonnet-5-v1:0' }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('signed-encrypted-thinking');
+    expect(JSON.stringify(messages)).not.toContain(
+      'redacted-encrypted-thinking'
+    );
+    expect(indexTokenCountMap).toEqual({});
+  });
+
+  it('does not replay thinking from another Anthropic model', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      [persistedMessage],
+      { 0: 700 },
+      undefined,
+      undefined,
+      { provider: Providers.ANTHROPIC, model: 'claude-opus-4-8' }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('signed-encrypted-thinking');
+    expect(JSON.stringify(messages)).not.toContain(
+      'redacted-encrypted-thinking'
+    );
+    expect(indexTokenCountMap).toEqual({});
+  });
+
+  it('rejects unsigned persisted thinking blocks', () => {
+    const message: TMessage = {
+      role: 'assistant',
+      content: [
+        {
+          type: ContentTypes.THINK,
+          think: 'visible summary',
+          provider_replay: {
+            anthropic: {
+              model,
+              blocks: [
+                {
+                  type: ContentTypes.THINKING,
+                  thinking: 'visible summary',
+                },
+              ],
+            },
+          },
+        },
+        { type: ContentTypes.TEXT, text: 'answer' },
+      ],
+    };
+
+    const { messages } = formatAgentMessages(
+      [message],
+      undefined,
+      undefined,
+      undefined,
+      { provider: Providers.ANTHROPIC, model }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('"signature"');
+    expect(messages[0].content).toBe('answer');
+  });
+});

--- a/src/messages/formatAgentMessages.bedrockReplay.test.ts
+++ b/src/messages/formatAgentMessages.bedrockReplay.test.ts
@@ -1,0 +1,133 @@
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import { ContentTypes, Providers } from '@/common';
+import { formatAgentMessages } from './format';
+
+const model = 'anthropic.claude-sonnet-5-20260701-v1:0';
+const payload: TPayload = [
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: ContentTypes.THINK,
+        think: 'reasoned answer',
+        provider_replay: {
+          bedrock: {
+            model,
+            blocks: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: {
+                  text: 'reasoned answer',
+                  signature: 'sig-bedrock',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'tool-1',
+          name: 'calculator',
+          args: { expression: '6 * 7' },
+          output: '42',
+        },
+      },
+      {
+        type: ContentTypes.TEXT,
+        text: '42',
+      },
+    ],
+  },
+];
+
+describe('formatAgentMessages Bedrock reasoning replay', () => {
+  it('reconstructs signed native reasoning before its Bedrock tool call', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      payload,
+      { 0: 500 },
+      new Set(['calculator']),
+      undefined,
+      { provider: Providers.BEDROCK, model }
+    );
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toBeInstanceOf(AIMessage);
+    expect(messages[0].content).toEqual([
+      {
+        type: ContentTypes.REASONING_CONTENT,
+        reasoningText: {
+          text: 'reasoned answer',
+          signature: 'sig-bedrock',
+        },
+      },
+    ]);
+    expect((messages[0] as AIMessage).tool_calls).toEqual([
+      {
+        id: 'tool-1',
+        name: 'calculator',
+        args: { expression: '6 * 7' },
+      },
+    ]);
+    expect(messages[1]).toBeInstanceOf(ToolMessage);
+    expect(messages[2].content).toBe('42');
+    expect(
+      Object.values(indexTokenCountMap ?? {}).reduce(
+        (total, count) => total + count,
+        0
+      )
+    ).toBe(500);
+  });
+
+  it('does not replay a Bedrock signature to another provider and invalidates its token weight', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      payload,
+      { 0: 500 },
+      new Set(['calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC, model: 'claude-sonnet-5' }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('sig-bedrock');
+    expect(JSON.stringify(messages)).not.toContain('reasoning_content');
+    expect(indexTokenCountMap).toEqual({});
+  });
+
+  it('does not replay signed reasoning to another Bedrock model', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      payload,
+      { 0: 500 },
+      new Set(['calculator']),
+      undefined,
+      { provider: Providers.BEDROCK, model: 'amazon.nova-2-lite-v1:0' }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('sig-bedrock');
+    expect(JSON.stringify(messages)).not.toContain('reasoning_content');
+    expect(indexTokenCountMap).toEqual({});
+  });
+
+  it('drops incomplete persisted reasoning instead of sending unsigned native content', () => {
+    const incompletePayload = structuredClone(payload);
+    const think = incompletePayload[0].content?.[0];
+    if (typeof think === 'object' && 'provider_replay' in think) {
+      const block = think.provider_replay.bedrock?.blocks[0];
+      if (block?.reasoningText != null) {
+        block.reasoningText.signature = '';
+      }
+    }
+
+    const { messages } = formatAgentMessages(
+      incompletePayload,
+      undefined,
+      new Set(['calculator']),
+      undefined,
+      { provider: Providers.BEDROCK, model }
+    );
+
+    expect(JSON.stringify(messages)).not.toContain('reasoning_content');
+    expect(JSON.stringify(messages)).not.toContain('sig-bedrock');
+  });
+});

--- a/src/messages/formatAgentMessages.openAIResponsesReplay.test.ts
+++ b/src/messages/formatAgentMessages.openAIResponsesReplay.test.ts
@@ -1,0 +1,142 @@
+import { AIMessage } from '@langchain/core/messages';
+import { convertMessagesToResponsesInput } from '@langchain/openai';
+import type { TPayload } from '@/types';
+import { expandOpenAIResponsesReasoningReplay } from '@/llm/openai';
+import { ContentTypes, Providers } from '@/common';
+import { formatAgentMessages } from './format';
+
+const model = 'gpt-5.4';
+const encryptedContent = 'encrypted-reasoning';
+const replayItems = [
+  {
+    type: 'reasoning' as const,
+    id: 'rs_123',
+    status: 'completed' as const,
+    summary: [
+      {
+        type: 'summary_text' as const,
+        text: 'Checked the constraint.',
+      },
+    ],
+    encrypted_content: encryptedContent,
+  },
+  {
+    type: 'reasoning' as const,
+    id: 'rs_456',
+    status: 'completed' as const,
+    summary: [],
+    encrypted_content: 'encrypted-follow-up',
+  },
+];
+const payload: TPayload = [
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: ContentTypes.THINK,
+        think: 'Checked the constraint.',
+        provider_replay: {
+          openai_responses: {
+            provider: Providers.OPENAI,
+            model,
+            items: replayItems,
+          },
+        },
+      },
+      {
+        type: ContentTypes.TEXT,
+        text: 'The answer is 42.',
+      },
+    ],
+  },
+];
+
+describe('formatAgentMessages OpenAI Responses reasoning replay', () => {
+  it('reconstructs encrypted reasoning for a stateless Responses request', () => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      payload,
+      { 0: 900 },
+      undefined,
+      undefined,
+      {
+        provider: Providers.OPENAI,
+        model,
+        useResponsesApi: true,
+      }
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toBeInstanceOf(AIMessage);
+    expect(
+      (messages[0] as AIMessage).additional_kwargs
+        .openai_responses_reasoning_replay
+    ).toEqual(replayItems);
+
+    const input = convertMessagesToResponsesInput({
+      messages: expandOpenAIResponsesReasoningReplay(messages),
+      model,
+      zdrEnabled: true,
+    });
+    expect(input[0]).toMatchObject({
+      type: 'reasoning',
+      id: 'rs_123',
+      encrypted_content: encryptedContent,
+    });
+    expect(input[1]).toMatchObject({
+      type: 'reasoning',
+      id: 'rs_456',
+      encrypted_content: 'encrypted-follow-up',
+    });
+    expect(input[2]).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+    });
+    expect(indexTokenCountMap).toEqual({ 0: 900 });
+  });
+
+  it.each([
+    {
+      name: 'a different model',
+      options: {
+        provider: Providers.OPENAI,
+        model: 'gpt-5.5',
+        useResponsesApi: true,
+      },
+    },
+    {
+      name: 'Chat Completions',
+      options: {
+        provider: Providers.OPENAI,
+        model,
+        useResponsesApi: false,
+      },
+    },
+    {
+      name: 'Azure OpenAI',
+      options: {
+        provider: Providers.AZURE,
+        model,
+        useResponsesApi: true,
+      },
+    },
+    {
+      name: 'a different provider',
+      options: {
+        provider: Providers.ANTHROPIC,
+        model,
+        useResponsesApi: true,
+      },
+    },
+  ])('does not replay encrypted reasoning to $name', ({ options }) => {
+    const { messages, indexTokenCountMap } = formatAgentMessages(
+      payload,
+      { 0: 900 },
+      undefined,
+      undefined,
+      options
+    );
+
+    expect(JSON.stringify(messages)).not.toContain(encryptedContent);
+    expect(indexTokenCountMap).toEqual({});
+  });
+});

--- a/src/stream.test.ts
+++ b/src/stream.test.ts
@@ -72,6 +72,44 @@ describe('getChunkContent', () => {
     expect(result).toBe('Regular content');
   });
 
+  it('preserves structured Bedrock reasoning when additional kwargs duplicate its text', () => {
+    const content = [
+      {
+        type: 'reasoning_content',
+        reasoningText: { text: 'Reasoning summary text' },
+      },
+    ];
+    const chunk: Partial<AIMessageChunk> = {
+      content,
+      additional_kwargs: {
+        reasoning_content: 'Reasoning summary text',
+      },
+    };
+
+    const result = getChunkContent({
+      chunk,
+      provider: Providers.BEDROCK,
+      reasoningKey: 'reasoning_content',
+    });
+
+    expect(result).toBe(content);
+  });
+
+  it('uses Bedrock reasoning kwargs when structured content is empty', () => {
+    const result = getChunkContent({
+      chunk: {
+        content: [],
+        additional_kwargs: {
+          reasoning_content: 'Reasoning summary text',
+        },
+      },
+      provider: Providers.BEDROCK,
+      reasoningKey: 'reasoning_content',
+    });
+
+    expect(result).toBe('Reasoning summary text');
+  });
+
   it('should prefer visible OpenRouter content over reasoning_content on the same chunk', () => {
     const chunk: Partial<AIMessageChunk> = {
       content: 'Regular content',

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -435,6 +435,121 @@ function getReasoningTextFromContentPart(
   );
 }
 
+function getBedrockReasoningReplay(
+  contentPart: t.MessageContentComplex,
+  agentContext: AgentContext
+): t.ProviderReasoningReplay | undefined {
+  const model = (agentContext.clientOptions as { model?: unknown } | undefined)
+    ?.model;
+  if (
+    typeof model !== 'string' ||
+    model === '' ||
+    contentPart.type !== ContentTypes.REASONING_CONTENT
+  ) {
+    return undefined;
+  }
+  const block = contentPart as Partial<t.BedrockReasoningReplayBlock>;
+  const reasoningText = block.reasoningText;
+  if (
+    reasoningText != null &&
+    (typeof reasoningText.text === 'string' ||
+      typeof reasoningText.signature === 'string')
+  ) {
+    return {
+      bedrock: {
+        model,
+        blocks: [
+          {
+            type: ContentTypes.REASONING_CONTENT,
+            reasoningText: {
+              ...(typeof reasoningText.text === 'string' && {
+                text: reasoningText.text,
+              }),
+              ...(typeof reasoningText.signature === 'string' && {
+                signature: reasoningText.signature,
+              }),
+            },
+          },
+        ],
+      },
+    };
+  }
+  if (
+    typeof block.redactedContent === 'string' &&
+    block.redactedContent !== ''
+  ) {
+    return {
+      bedrock: {
+        model,
+        blocks: [
+          {
+            type: ContentTypes.REASONING_CONTENT,
+            redactedContent: block.redactedContent,
+          },
+        ],
+      },
+    };
+  }
+  return undefined;
+}
+
+function getAnthropicReasoningReplay(
+  contentPart: t.MessageContentComplex,
+  agentContext: AgentContext
+): t.ProviderReasoningReplay | undefined {
+  const model = (agentContext.clientOptions as { model?: unknown } | undefined)
+    ?.model;
+  if (typeof model !== 'string' || model === '') {
+    return undefined;
+  }
+  if (
+    contentPart.type === ContentTypes.THINKING ||
+    contentPart.type === ContentTypes.REASONING
+  ) {
+    const block = contentPart as Partial<t.AnthropicReasoningReplayBlock> & {
+      thinking?: string;
+      reasoning?: string;
+      signature?: string;
+    };
+    const thinking =
+      contentPart.type === ContentTypes.THINKING
+        ? block.thinking
+        : block.reasoning;
+    if (typeof thinking !== 'string' && typeof block.signature !== 'string') {
+      return undefined;
+    }
+    return {
+      anthropic: {
+        model,
+        blocks: [
+          {
+            type: ContentTypes.THINKING,
+            ...(typeof thinking === 'string' && {
+              thinking,
+            }),
+            ...(typeof block.signature === 'string' && {
+              signature: block.signature,
+            }),
+          },
+        ],
+      },
+    };
+  }
+  if (contentPart.type === 'redacted_thinking') {
+    const data = (contentPart as { data?: unknown }).data;
+    if (typeof data !== 'string' || data === '') {
+      return undefined;
+    }
+    return {
+      anthropic: {
+        model,
+        blocks: [{ type: 'redacted_thinking', data }],
+      },
+    };
+  }
+  return undefined;
+}
+
 function getReasoningTextFromChunk(
   chunk: Partial<AIMessageChunk>,
   agentContext: AgentContext
@@ -1407,6 +1522,154 @@ function shouldSkipLateOpenRouterReasoningChunk({
   );
 }
 
+function normalizeOpenAIResponsesReasoningReplayItem(
+  candidate: unknown
+): t.OpenAIResponsesReasoningReplayItem | undefined {
+  if (candidate == null || typeof candidate !== 'object') {
+    return undefined;
+  }
+  const item = candidate as Record<string, unknown>;
+  if (
+    item.type !== 'reasoning' ||
+    typeof item.id !== 'string' ||
+    item.id === '' ||
+    typeof item.encrypted_content !== 'string' ||
+    item.encrypted_content === '' ||
+    !Array.isArray(item.summary)
+  ) {
+    return undefined;
+  }
+  const summary = item.summary.flatMap(
+    (part): t.OpenAIResponsesReasoningReplayItem['summary'] => {
+      if (
+        part == null ||
+        typeof part !== 'object' ||
+        (part as { type?: unknown }).type !== 'summary_text' ||
+        typeof (part as { text?: unknown }).text !== 'string'
+      ) {
+        return [];
+      }
+      return [
+        {
+          type: 'summary_text',
+          text: (part as { text: string }).text,
+        },
+      ];
+    }
+  );
+  const rawContent = item.content;
+  const content = Array.isArray(rawContent)
+    ? rawContent.flatMap(
+      (
+        part
+      ): NonNullable<t.OpenAIResponsesReasoningReplayItem['content']> => {
+        if (
+          part == null ||
+            typeof part !== 'object' ||
+            (part as { type?: unknown }).type !== 'reasoning_text' ||
+            typeof (part as { text?: unknown }).text !== 'string'
+        ) {
+          return [];
+        }
+        return [
+          {
+            type: 'reasoning_text',
+            text: (part as { text: string }).text,
+          },
+        ];
+      }
+    )
+    : undefined;
+  const status =
+    item.status === 'in_progress' ||
+    item.status === 'completed' ||
+    item.status === 'incomplete'
+      ? item.status
+      : undefined;
+  return {
+    type: 'reasoning',
+    id: item.id,
+    summary,
+    ...(content != null && { content }),
+    encrypted_content: item.encrypted_content,
+    ...(status != null && { status }),
+  };
+}
+
+function getOpenAIResponsesReasoningReplay(
+  chunk: Partial<AIMessageChunk>,
+  agentContext: AgentContext
+): t.OpenAIResponsesReasoningReplay | undefined {
+  if (
+    agentContext.provider !== Providers.OPENAI &&
+    agentContext.provider !== Providers.AZURE
+  ) {
+    return undefined;
+  }
+  const model = (agentContext.clientOptions as { model?: unknown } | undefined)
+    ?.model;
+  const candidates = chunk.additional_kwargs?.openai_responses_reasoning_replay;
+  if (typeof model !== 'string' || model === '' || !Array.isArray(candidates)) {
+    return undefined;
+  }
+  const items = candidates.flatMap(
+    (candidate): t.OpenAIResponsesReasoningReplayItem[] => {
+      const item = normalizeOpenAIResponsesReasoningReplayItem(candidate);
+      return item == null ? [] : [item];
+    }
+  );
+  if (items.length === 0) {
+    return undefined;
+  }
+  const unseenItems = items.filter(
+    (item) => !agentContext.openAIResponsesReasoningReplayIds.has(item.id)
+  );
+  for (const item of unseenItems) {
+    agentContext.openAIResponsesReasoningReplayIds.add(item.id);
+  }
+  return unseenItems.length === 0
+    ? undefined
+    : { provider: agentContext.provider, model, items: unseenItems };
+}
+
+async function dispatchOpenAIResponsesReasoningReplay({
+  graph,
+  agentContext,
+  replay,
+  metadata,
+}: {
+  graph: StandardGraph;
+  agentContext: AgentContext;
+  replay: t.OpenAIResponsesReasoningReplay;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  agentContext.currentTokenType = ContentTypes.THINK;
+  agentContext.tokenTypeSwitch = 'reasoning';
+  const stepKey = graph.getStepKey(metadata);
+  const messageId = getMessageId(stepKey, graph) ?? '';
+  await graph.dispatchRunStep(
+    stepKey,
+    {
+      type: StepTypes.MESSAGE_CREATION,
+      message_creation: { message_id: messageId },
+    },
+    metadata
+  );
+  await graph.dispatchReasoningDelta(
+    graph.getStepIdByKey(stepKey),
+    {
+      content: [
+        {
+          type: ContentTypes.THINK,
+          think: '',
+          provider_replay: { openai_responses: replay },
+        },
+      ],
+    },
+    metadata
+  );
+}
+
 /**
  * Brands a handler as one that dispatches content parts for the SDK — either
  * `ChatModelStreamHandler` itself or a wrapper forwarding to one.
@@ -1456,6 +1719,19 @@ export class ChatModelStreamHandler implements t.EventHandler {
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
+    const openAIResponsesReplay = getOpenAIResponsesReasoningReplay(
+      chunk,
+      agentContext
+    );
+    if (openAIResponsesReplay != null) {
+      await dispatchOpenAIResponsesReasoningReplay({
+        graph,
+        agentContext,
+        replay: openAIResponsesReplay,
+        metadata,
+      });
+      return;
+    }
 
     const content = getChunkContent({
       chunk,
@@ -1756,15 +2032,28 @@ hasToolCallChunks: ${hasToolCallChunks}
       await graph.dispatchReasoningDelta(
         stepId,
         {
-          content: content.map((c) => ({
-            type: ContentTypes.THINK,
-            think:
-              (c as t.ThinkingContentText).thinking ??
-              (c as Partial<t.GoogleReasoningContentText>).reasoning ??
-              (c as Partial<t.BedrockReasoningContentText>).reasoningText
-                ?.text ??
-              '',
-          })),
+          content: content.map((c) => {
+            const isAnthropicReplayShape =
+              c.type === ContentTypes.THINKING ||
+              c.type === 'redacted_thinking' ||
+              (c.type === ContentTypes.REASONING &&
+                typeof (c as { signature?: unknown }).signature === 'string');
+            const providerReplay = isAnthropicReplayShape
+              ? getAnthropicReasoningReplay(c, agentContext)
+              : getBedrockReasoningReplay(c, agentContext);
+            return {
+              type: ContentTypes.THINK,
+              think:
+                (c as t.ThinkingContentText).thinking ??
+                (c as Partial<t.GoogleReasoningContentText>).reasoning ??
+                (c as Partial<t.BedrockReasoningContentText>).reasoningText
+                  ?.text ??
+                '',
+              ...(providerReplay != null && {
+                provider_replay: providerReplay,
+              }),
+            };
+          }),
         },
         metadata
       );
@@ -1856,6 +2145,127 @@ hasToolCallChunks: ${hasToolCallChunks}
     }
     agentContext.lastToken = chunk.content;
   }
+}
+
+function mergeOpenAIResponsesReasoningReplay(
+  existing: t.OpenAIResponsesReasoningReplay | undefined,
+  incoming: t.OpenAIResponsesReasoningReplay | undefined
+): t.OpenAIResponsesReasoningReplay | undefined {
+  if (incoming == null) {
+    return existing;
+  }
+  if (
+    existing == null ||
+    existing.provider !== incoming.provider ||
+    existing.model !== incoming.model
+  ) {
+    return structuredClone(incoming);
+  }
+  const items = structuredClone(existing.items);
+  const indexes = new Map(items.map((item, index) => [item.id, index]));
+  for (const item of incoming.items) {
+    const index = indexes.get(item.id);
+    if (index == null) {
+      indexes.set(item.id, items.length);
+      items.push(structuredClone(item));
+      continue;
+    }
+    items[index] = structuredClone(item);
+  }
+  return { provider: incoming.provider, model: incoming.model, items };
+}
+
+function mergeProviderReasoningReplay(
+  existing: t.ProviderReasoningReplay | undefined,
+  incoming: t.ProviderReasoningReplay | undefined
+): t.ProviderReasoningReplay | undefined {
+  if (incoming == null) {
+    return existing;
+  }
+  const anthropicModelChanged =
+    incoming.anthropic != null &&
+    existing?.anthropic?.model !== incoming.anthropic.model;
+  const anthropic = anthropicModelChanged
+    ? structuredClone(incoming.anthropic)
+    : structuredClone(existing?.anthropic);
+  if (
+    !anthropicModelChanged &&
+    anthropic != null &&
+    incoming.anthropic != null
+  ) {
+    for (const incomingBlock of incoming.anthropic.blocks) {
+      const lastBlock = anthropic.blocks[anthropic.blocks.length - 1];
+      const startsNewSignedBlock =
+        incomingBlock.type === ContentTypes.THINKING &&
+        typeof incomingBlock.thinking === 'string' &&
+        anthropic.blocks.length > 0 &&
+        lastBlock.type === ContentTypes.THINKING &&
+        typeof lastBlock.signature === 'string' &&
+        lastBlock.signature !== '';
+      if (
+        incomingBlock.type === ContentTypes.THINKING &&
+        anthropic.blocks.length > 0 &&
+        lastBlock.type === ContentTypes.THINKING &&
+        !startsNewSignedBlock
+      ) {
+        if (typeof incomingBlock.thinking === 'string') {
+          lastBlock.thinking =
+            (lastBlock.thinking ?? '') + incomingBlock.thinking;
+        }
+        if (typeof incomingBlock.signature === 'string') {
+          lastBlock.signature =
+            (lastBlock.signature ?? '') + incomingBlock.signature;
+        }
+        continue;
+      }
+      anthropic.blocks.push(structuredClone(incomingBlock));
+    }
+  }
+  const bedrockModelChanged =
+    incoming.bedrock != null &&
+    existing?.bedrock?.model !== incoming.bedrock.model;
+  const bedrock = bedrockModelChanged
+    ? structuredClone(incoming.bedrock)
+    : structuredClone(existing?.bedrock);
+  if (!bedrockModelChanged && bedrock != null && incoming.bedrock != null) {
+    for (const incomingBlock of incoming.bedrock.blocks) {
+      const incomingReasoningText = incomingBlock.reasoningText;
+      const lastBlock = bedrock.blocks[bedrock.blocks.length - 1];
+      const lastReasoningText =
+        bedrock.blocks.length > 0 ? lastBlock.reasoningText : undefined;
+      const startsNewSignedBlock =
+        typeof incomingReasoningText?.text === 'string' &&
+        lastReasoningText?.signature != null;
+      if (
+        incomingReasoningText != null &&
+        lastReasoningText != null &&
+        !startsNewSignedBlock
+      ) {
+        if (typeof incomingReasoningText.text === 'string') {
+          lastReasoningText.text =
+            (lastReasoningText.text ?? '') + incomingReasoningText.text;
+        }
+        if (typeof incomingReasoningText.signature === 'string') {
+          lastReasoningText.signature =
+            (lastReasoningText.signature ?? '') +
+            incomingReasoningText.signature;
+        }
+        continue;
+      }
+      bedrock.blocks.push(structuredClone(incomingBlock));
+    }
+  }
+  const openaiResponses = mergeOpenAIResponsesReasoningReplay(
+    existing?.openai_responses,
+    incoming.openai_responses
+  );
+  return {
+    ...(anthropic != null && anthropic.blocks.length > 0 && { anthropic }),
+    ...(bedrock != null && bedrock.blocks.length > 0 && { bedrock }),
+    ...(openaiResponses != null && {
+      openai_responses: structuredClone(openaiResponses),
+    }),
+  };
 }
 
 export function createContentAggregator(): t.ContentAggregatorResult {
@@ -2072,6 +2482,10 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       const update: t.ReasoningDeltaUpdate = {
         type: ContentTypes.THINK,
         think: (currentContent.think || '') + contentPart.think,
+        provider_replay: mergeProviderReasoningReplay(
+          currentContent.provider_replay,
+          (contentPart as t.ReasoningContentText).provider_replay
+        ),
       };
       contentParts[index] = update;
     } else if (
@@ -2325,7 +2739,9 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      for (const contentPart of getDeltaContentParts(messageDelta.delta.content)) {
+      for (const contentPart of getDeltaContentParts(
+        messageDelta.delta.content
+      )) {
         updateContent(runStep.index, contentPart);
       }
     } else if (
@@ -2354,7 +2770,9 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      for (const contentPart of getDeltaContentParts(reasoningDelta.delta.content)) {
+      for (const contentPart of getDeltaContentParts(
+        reasoningDelta.delta.content
+      )) {
         updateContent(runStep.index, contentPart);
       }
     } else if (event === GraphEvents.ON_RUN_STEP_DELTA) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1339,6 +1339,15 @@ export function getChunkContent({
   }
 
   if (
+    provider === Providers.BEDROCK &&
+    Array.isArray(chunk?.content) &&
+    chunk.content.length > 0 &&
+    chunk.content.every((contentPart) => isReasoningContentPart(contentPart))
+  ) {
+    return chunk.content;
+  }
+
+  if (
     (provider === Providers.OPENAI || provider === Providers.AZURE) &&
     (
       chunk?.additional_kwargs?.reasoning as
@@ -1621,12 +1630,20 @@ function getOpenAIResponsesReasoningReplay(
   if (items.length === 0) {
     return undefined;
   }
-  const unseenItems = items.filter(
-    (item) => !agentContext.openAIResponsesReasoningReplayIds.has(item.id)
-  );
-  for (const item of unseenItems) {
-    agentContext.openAIResponsesReasoningReplayIds.add(item.id);
-  }
+  const unseenItems = items.filter((item) => {
+    const snapshot = JSON.stringify(item);
+    if (
+      agentContext.openAIResponsesReasoningReplaySnapshotsById.get(item.id) ===
+      snapshot
+    ) {
+      return false;
+    }
+    agentContext.openAIResponsesReasoningReplaySnapshotsById.set(
+      item.id,
+      snapshot
+    );
+    return true;
+  });
   return unseenItems.length === 0
     ? undefined
     : { provider: agentContext.provider, model, items: unseenItems };

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -7,8 +7,8 @@ import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
 } from '@/summarization/node';
+import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import { convertInjectedMessages } from '@/messages/injected';
-import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
@@ -274,6 +274,157 @@ describe('createSummarizeNode', () => {
     expect(config.metadata?.[Constants.INVOKED_MODEL]).toBe('gpt-4.1-mini');
     expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
       Providers.OPENAI
+    );
+  });
+
+  it('removes main-model native reasoning before a different summarizer invocation', async () => {
+    captureEvents();
+
+    const capturedMessages: BaseMessage[][] = [];
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        model = 'gpt-5.4-mini';
+
+        invoke = jest.fn(async (messages: BaseMessage[]) => {
+          capturedMessages.push(messages);
+          return { content: 'Summary text' };
+        });
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      provider: Providers.BEDROCK,
+      clientOptions: { model: 'claude-sonnet-primary' },
+      reasoningReplaySource: {
+        provider: Providers.BEDROCK,
+        model: 'claude-sonnet-primary',
+      },
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        provider: Providers.OPENAI,
+        model: 'gpt-5.4-mini',
+      },
+    });
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [
+          new AIMessage({
+            content: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: {
+                  text: 'private reasoning',
+                  signature: 'bedrock-main-signature',
+                },
+              },
+              { type: ContentTypes.TEXT, text: 'visible answer' },
+            ],
+          }),
+          new HumanMessage('Continue'),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(JSON.stringify(capturedMessages[0])).not.toContain(
+      'bedrock-main-signature'
+    );
+    expect(JSON.stringify(capturedMessages[0])).toContain('visible answer');
+  });
+
+  it('revalidates summarizer-native reasoning for the fallback that serves the call', async () => {
+    captureEvents();
+
+    const capturedInvocations: Array<{
+      provider: Providers;
+      messages: BaseMessage[];
+    }> = [];
+    jest.spyOn(providers, 'getChatModelClass').mockImplementation(
+      (provider: Providers) =>
+        class {
+          model: string;
+
+          constructor(options: { model?: string }) {
+            this.model = options.model ?? '';
+          }
+
+          invoke = jest.fn(async (messages: BaseMessage[]) => {
+            capturedInvocations.push({ provider, messages });
+            if (provider === Providers.BEDROCK) {
+              throw new Error('Primary summarizer unavailable');
+            }
+            return new AIMessage({ content: 'Fallback summary' });
+          });
+        } as never
+    );
+
+    const agentContext = createAgentContext({
+      provider: Providers.BEDROCK,
+      clientOptions: {
+        model: 'claude-sonnet-primary',
+        fallbacks: [
+          {
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-5.4-mini' },
+          },
+        ],
+      },
+      reasoningReplaySource: {
+        provider: Providers.BEDROCK,
+        model: 'claude-sonnet-primary',
+      },
+      summarizationConfig: { retainRecent: { turns: 0 } },
+    });
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [
+          new AIMessage({
+            content: [
+              {
+                type: ContentTypes.REASONING_CONTENT,
+                reasoningText: {
+                  text: 'private reasoning',
+                  signature: 'summarizer-primary-signature',
+                },
+              },
+              { type: ContentTypes.TEXT, text: 'visible answer' },
+            ],
+          }),
+          new HumanMessage('Continue'),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedInvocations).toHaveLength(2);
+    expect(JSON.stringify(capturedInvocations[0].messages)).toContain(
+      'summarizer-primary-signature'
+    );
+    expect(JSON.stringify(capturedInvocations[1].messages)).not.toContain(
+      'summarizer-primary-signature'
+    );
+    expect(JSON.stringify(capturedInvocations[1].messages)).toContain(
+      'visible answer'
     );
   });
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -6,10 +6,17 @@ import {
 } from '@langchain/core/messages';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { OnChunk, ReasoningReplaySource } from '@/llm/invoke';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
-import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
+import {
+  attemptInvoke,
+  tryFallbackProviders,
+  extractClientOptionsModel,
+  filterReasoningReplayForInvocation,
+  resolveReasoningReplaySource,
+} from '@/llm/invoke';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
@@ -33,7 +40,6 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { getMaxOutputTokensKey } from '@/llm/request';
@@ -636,6 +642,15 @@ async function executeSummarizationWithFallback(params: {
   let summaryText = '';
   let summaryUsage: Partial<UsageMetadata> | undefined;
   let usedMetadataStub = false;
+  let summarizationMessages = messages;
+  let reasoningReplaySource: ReasoningReplaySource =
+    agentContext.reasoningReplaySource ?? {
+      provider: agentContext.provider,
+      model: extractClientOptionsModel(agentContext.clientOptions),
+      useResponsesApi:
+        agentContext.provider === Providers.OPENAI ||
+        agentContext.provider === Providers.AZURE,
+    };
 
   try {
     /**
@@ -649,9 +664,23 @@ async function executeSummarizationWithFallback(params: {
       tools: agentContext.getToolsForBinding(),
     }) as t.ChatModel;
 
+    const summarizationProvider = clientConfig.provider as Providers;
+    const summarizationReplaySource = resolveReasoningReplaySource({
+      model: summarizationModel,
+      provider: summarizationProvider,
+      clientOptions: clientConfig.clientOptions as t.ClientOptions,
+      callOptions: summarizeConfig,
+    });
+    summarizationMessages = filterReasoningReplayForInvocation({
+      messages,
+      source: reasoningReplaySource,
+      target: summarizationReplaySource,
+    });
+    reasoningReplaySource = summarizationReplaySource;
+
     const result = await summarizeWithCacheHit({
       model: summarizationModel,
-      messages,
+      messages: summarizationMessages,
       promptText: clientConfig.promptText,
       updatePromptText: clientConfig.updatePromptText,
       priorSummaryText,
@@ -702,7 +731,7 @@ async function executeSummarizationWithFallback(params: {
           fallbacks,
           tools: agentContext.getToolsForBinding(),
           messages: [
-            ...messages,
+            ...summarizationMessages,
             new HumanMessage(
               buildSummarizationInstruction(
                 clientConfig.promptText,
@@ -714,6 +743,7 @@ async function executeSummarizationWithFallback(params: {
           config: traceConfig(summarizeConfig, 'cache_hit_compaction'),
           primaryError,
           onChunk,
+          reasoningReplaySource,
         });
         const fbMsg = fbResult?.messages?.[0];
         if (fbMsg) {

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -11,7 +11,7 @@ import type { Command } from '@langchain/langgraph';
 import type { AnthropicContentBlock } from '@/llm/anthropic/types';
 import type { SummarizeCompleteEvent } from '@/types/summarize';
 import type { ToolEndEvent } from '@/types/tools';
-import { StepTypes, ContentTypes, GraphEvents } from '@/common/enum';
+import { StepTypes, ContentTypes, GraphEvents, Providers } from '@/common/enum';
 
 export type HandleLLMEnd = (
   output: LLMResult,
@@ -281,7 +281,59 @@ export type MessageDeltaUpdate = {
   text: string;
   tool_call_ids?: string[];
 };
-export type ReasoningDeltaUpdate = { type: ContentTypes.THINK; think: string };
+export type BedrockReasoningReplayBlock = {
+  type: ContentTypes.REASONING_CONTENT;
+  reasoningText?: { text?: string; signature?: string };
+  redactedContent?: string;
+};
+
+export type AnthropicReasoningReplayBlock =
+  | {
+      type: ContentTypes.THINKING;
+      thinking?: string;
+      signature?: string;
+    }
+  | {
+      type: 'redacted_thinking';
+      data: string;
+    };
+
+export type OpenAIResponsesReasoningReplayItem = {
+  type: 'reasoning';
+  id: string;
+  summary: Array<{ type: 'summary_text'; text: string }>;
+  content?: Array<{ type: 'reasoning_text'; text: string }>;
+  encrypted_content: string;
+  status?: 'in_progress' | 'completed' | 'incomplete';
+};
+
+export type OpenAIResponsesReasoningReplay = {
+  provider: Providers.OPENAI | Providers.AZURE;
+  model: string;
+  items: OpenAIResponsesReasoningReplayItem[];
+};
+
+export type AnthropicReasoningReplay = {
+  model: string;
+  blocks: AnthropicReasoningReplayBlock[];
+};
+
+export type BedrockReasoningReplay = {
+  model: string;
+  blocks: BedrockReasoningReplayBlock[];
+};
+
+export type ProviderReasoningReplay = {
+  anthropic?: AnthropicReasoningReplay;
+  bedrock?: BedrockReasoningReplay;
+  openai_responses?: OpenAIResponsesReasoningReplay;
+};
+
+export type ReasoningDeltaUpdate = {
+  type: ContentTypes.THINK;
+  think: string;
+  provider_replay?: ProviderReasoningReplay;
+};
 
 export type ContentType =
   | 'text'
@@ -294,6 +346,7 @@ export type ContentType =
 export type ReasoningContentText = {
   type: ContentTypes.THINK;
   think: string;
+  provider_replay?: ProviderReasoningReplay;
 };
 
 export type SummaryBoundary = {


### PR DESCRIPTION
## Summary

Persist provider-native signed or encrypted reasoning across runs for Bedrock, Anthropic Messages, and OpenAI/Azure Responses. Replay is limited to the originating provider, model, and API mode; incompatible replay is removed and context weight is recalculated.

Cache reads and writes will increase because more prior reasoning is retained in the prompt. In exchange, generated output tokens and the number of turns needed to finish a task may decrease: later turns can reuse prior knowledge and decisions instead of exploring them again. The measurements below come from a local toy conversation. They demonstrate persistence and cache reuse, but we still need measurements from representative real workloads to quantify the effect on quality, task length, latency, and total cost.

## Cache and cost impact

Reasoning replay preserves more context, so higher cache writes and reads are expected. A reasoning block is new suffix content when it first enters the next request: it is written once, then becomes a cache read on later turns.

Five-turn advancing local validation used independently keyed replay and stripped-control conversations with identical prompts and visible history:

| Provider/API | Cache writes: stripped → replay | Cache reads: stripped → replay |
|---|---:|---:|
| OpenAI Responses, GPT-5.6 Terra | 3,127 → 4,241 (**+1,114**) | 11,750 → 13,654 (**+1,904**) |
| Bedrock Mantle Responses, GPT-5.6 Terra | 3,131 → 4,192 (**+1,061**) | 11,761 → 13,585 (**+1,824**) |
| Anthropic Messages, Claude Sonnet 5 | 5,853 → 8,686 (**+2,833**) | 22,182 → 27,164 (**+4,982**) |
| Bedrock Converse, Claude Sonnet 5 | 5,832 → 8,831 (**+2,999**) | 22,282 → 27,544 (**+5,262**) |

The Bedrock Sonnet 5 run also measured billable output and total cost at the current promotional rates:

| Conversation length | Total cost: stripped → replay | Output tokens: stripped → replay |
|---|---:|---:|
| Five turns | $0.08356 → $0.08428 (**+0.9%**) | 5,576 → 4,343 (**-1,233**) |
| Six turns, after MongoDB/process boundary | $0.09733 → $0.09248 (**-5.0%**) | 6,791 → 4,490 (**-2,301**) |

In this toy example, the reduction in generated output more than offset the additional cached-input cost after six turns. Output is model-dependent, so this is not evidence of a general saving; representative real workloads must determine whether shorter outputs and tasks consistently compensate for the larger cached prompt.

The boundary run loaded five signed reasoning blocks from MongoDB in a second LibreChat process. Its next cache-read increase exactly matched the prior **+2,999** replay-write delta, confirming that persisted reasoning was reused after restart.

Pricing calculation: $2/M uncached input, $4/M one-hour cache writes, $0.20/M cache reads, and $10/M output under [Claude Sonnet 5 promotional pricing](https://aws.amazon.com/bedrock/pricing/) through August 31, 2026. Billable output includes the model's full thinking tokens, not only the visible summary.

## Validation

- 219 focused tests passed.
- Package build passed.
- MongoDB persistence and provider/model switching are covered by the companion LibreChat integration suite.
- Five advancing live turns passed across OpenAI direct, Bedrock Mantle/OpenAI, Anthropic direct, and Bedrock Claude.
- A sixth Bedrock Claude turn passed through a second LibreChat process with retained MongoDB.
