### PR TITLE
🏷️ ci: Release Squash-Merged Version Commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,15 +99,19 @@ jobs:
       - name: Detect version commit
         id: version
         run: |
-          VERSION=$(git log -1 --pretty=%s "$GITHUB_SHA")
-          if echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          # Squash-merged release PRs carry a " (#123)" suffix in the subject
+          # (v3.3.6/7/9 releases were silently skipped by an exact match) —
+          # accept it and strip it back to the bare version.
+          SUBJECT=$(git log -1 --pretty=%s "$GITHUB_SHA")
+          if echo "$SUBJECT" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+( \(#[0-9]+\))?$'; then
+            VERSION=$(echo "$SUBJECT" | sed -E 's/ \(#[0-9]+\)$//')
             echo "is_version=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "is_version=false" >> "$GITHUB_OUTPUT"
-          echo "Head commit subject '$VERSION' is not a release commit; skipping."
+          echo "Head commit subject '$SUBJECT' is not a release commit; skipping."
 
       - name: Validate package version
         if: steps.version.outputs.is_version == 'true'


### PR DESCRIPTION
## Summary

The `release` job in `publish.yml` detects version commits with an exact-match regex on the head commit subject (`^v[0-9]+\.[0-9]+\.[0-9]+$`). Squash-merged version PRs get a ` (#123)` suffix appended by GitHub, so they silently skip tagging and release creation — [v3.3.6 (#352)], [v3.3.7 (#355)], and [v3.3.9 (#365)] all published to npm but produced no GitHub release, while directly-pushed `v3.3.8` did.

This accepts the optional suffix and strips it back to the bare version before tagging:

- `v3.3.9` → match, version `v3.3.9` (unchanged)
- `v3.3.9 (#365)` → match, version `v3.3.9` (fixed)
- `feat: v3.3.9`, `v3.3.9 (#365) extra` → still skipped

The missing [v3.3.9 release](https://github.com/danny-avila/agents/releases/tag/v3.3.9) has been created manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)