### PR TITLE
fix: bound traced media and transient OpenAI retries

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -10,6 +10,8 @@ import {
 import type {
   AIMessageChunkFields,
   AIMessageFields,
+  BaseMessage,
+  MessageContent,
   UsageMetadata,
 } from '@langchain/core/messages';
 import type {
@@ -138,12 +140,113 @@ function getLangfuseBedrockUsage(
   };
 }
 
-function cloneMessageWithUsage(
+const OMITTED_IMAGE_URL = '[image URL omitted]';
+
+function summarizeImageUrl(url: unknown): string {
+  if (typeof url !== 'string') {
+    return OMITTED_IMAGE_URL;
+  }
+  const match =
+    /^data:(image\/[a-zA-Z0-9.+-]+);base64,([a-zA-Z0-9+/]*={0,2})$/i.exec(url);
+  if (match == null) {
+    return OMITTED_IMAGE_URL;
+  }
+  const padding = match[2].length - match[2].replace(/=+$/, '').length;
+  const bytes = Math.max(0, Math.floor((match[2].length * 3) / 4) - padding);
+  return `[image omitted; type=${match[1].toLowerCase()}; bytes=${bytes}]`;
+}
+
+function sanitizeImageValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return summarizeImageUrl(value);
+  }
+  if (value == null || typeof value !== 'object') {
+    return OMITTED_IMAGE_URL;
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    ...(record.detail != null && { detail: record.detail }),
+    url: summarizeImageUrl(record.url),
+  };
+}
+
+function sanitizeMessageContent(content: MessageContent): MessageContent {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  const sanitized = content.map((block) => {
+    const record = block as unknown as Record<string, unknown>;
+    if ('image_url' in record) {
+      return {
+        ...record,
+        image_url: sanitizeImageValue(record.image_url),
+      } as unknown as typeof block;
+    }
+    if (
+      record.type === 'image' &&
+      record.source != null &&
+      typeof record.source === 'object'
+    ) {
+      const source = record.source as Record<string, unknown>;
+      return {
+        ...record,
+        source: {
+          ...(source.type != null && { type: source.type }),
+          ...(source.media_type != null && { media_type: source.media_type }),
+          data: summarizeImageUrl(
+            typeof source.data === 'string' && source.media_type != null
+              ? `data:${String(source.media_type)};base64,${source.data}`
+              : source.data
+          ),
+        },
+      } as unknown as typeof block;
+    }
+    if (record.inlineData != null && typeof record.inlineData === 'object') {
+      const inlineData = record.inlineData as Record<string, unknown>;
+      return {
+        ...record,
+        inlineData: {
+          ...(inlineData.mimeType != null && { mimeType: inlineData.mimeType }),
+          data: summarizeImageUrl(
+            typeof inlineData.data === 'string' && inlineData.mimeType != null
+              ? `data:${String(inlineData.mimeType)};base64,${inlineData.data}`
+              : inlineData.data
+          ),
+        },
+      } as unknown as typeof block;
+    }
+    return block;
+  });
+  return sanitized.some((block, index) => block !== content[index])
+    ? sanitized
+    : content;
+}
+
+function cloneMessageWithContent(message: BaseMessage): BaseMessage {
+  const content = sanitizeMessageContent(message.content);
+  if (content === message.content) {
+    return message;
+  }
+  const clone = Object.create(
+    Object.getPrototypeOf(message),
+    Object.getOwnPropertyDescriptors(message)
+  ) as BaseMessage;
+  clone.content = content;
+  return clone;
+}
+
+function sanitizeChatMessagesForLangfuse(
+  messages: BaseMessage[][]
+): BaseMessage[][] {
+  return messages.map((batch) => batch.map(cloneMessageWithContent));
+}
+
+function cloneMessageForLangfuse(
   message: AIMessage | AIMessageChunk,
-  usageMetadata: UsageMetadata
+  usageMetadata: UsageMetadata | undefined
 ): AIMessage | AIMessageChunk {
   const fields: AIMessageFields = {
-    content: message.content,
+    content: sanitizeMessageContent(message.content),
     additional_kwargs: message.additional_kwargs,
     response_metadata: message.response_metadata,
     id: message.id,
@@ -175,13 +278,17 @@ function normalizeGenerationForLangfuse(generation: Generation): Generation {
   }
 
   const usageMetadata = getLangfuseBedrockUsage(message);
-  if (usageMetadata == null || usageMetadata === message.usage_metadata) {
+  const content = sanitizeMessageContent(message.content);
+  if (
+    (usageMetadata == null || usageMetadata === message.usage_metadata) &&
+    content === message.content
+  ) {
     return generation;
   }
 
   const chatGeneration: ChatGeneration = {
     ...(generation as ChatGeneration),
-    message: cloneMessageWithUsage(message, usageMetadata),
+    message: cloneMessageForLangfuse(message, usageMetadata),
   };
   return chatGeneration;
 }
@@ -524,8 +631,12 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleChatModelStart(
     ...args: Parameters<CallbackHandler['handleChatModelStart']>
   ): ReturnType<CallbackHandler['handleChatModelStart']> {
+    const sanitizedArgs = [...args] as Parameters<
+      CallbackHandler['handleChatModelStart']
+    >;
+    sanitizedArgs[1] = sanitizeChatMessagesForLangfuse(args[1]);
     return this.withRuntimeContext(
-      () => super.handleChatModelStart(...args),
+      () => super.handleChatModelStart(...sanitizedArgs),
       this.startsDetachedRun(args[2], args[3]),
       args[6]
     );

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -51,9 +51,10 @@ import {
   projectOpenAIResponsesToolMessageContent,
   projectToolStreamContentForProvider,
 } from '@/messages/core';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
+import { createOpenAIRetryCaller } from './retry';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const iife = <T>(fn: () => T) => fn();
@@ -123,6 +124,8 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
+  maxConcurrency?: number;
+  maxRetries?: number;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
@@ -1231,6 +1234,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
+    this.caller = createOpenAIRetryCaller(fields);
     this.includeReasoningContent = fields?.includeReasoningContent;
     this.includeReasoningDetails = fields?.includeReasoningDetails;
     this.convertReasoningDetailsToContent =
@@ -1654,6 +1658,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
+    this.caller = createOpenAIRetryCaller(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.responsesPromptCache = fields?.responsesPromptCache;
     this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
@@ -1795,6 +1800,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
+    this.caller = createOpenAIRetryCaller(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.safetyIdentifier = fields?.safety_identifier;
   }
@@ -1933,6 +1939,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
+    this.caller = createOpenAIRetryCaller(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.safetyIdentifier = fields?.safety_identifier;
   }

--- a/src/llm/openai/retry.test.ts
+++ b/src/llm/openai/retry.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { createOpenAIRetryCaller, handleOpenAIFailedAttempt } from './retry';
+
+function providerError(
+  status?: number,
+  code?: string
+): Error & {
+  code?: string;
+  status?: number;
+  retryAfterMs?: number;
+  headers?: Record<string, string>;
+} {
+  return Object.assign(new Error('provider failure'), { status, code });
+}
+
+describe('OpenAI retry policy', () => {
+  it.each([400, 401, 403, 409, 413, 422, 499])(
+    'does not retry client status %i',
+    (status) => {
+      const error = providerError(status);
+      expect(() => handleOpenAIFailedAttempt(error)).toThrow(error);
+    }
+  );
+
+  it.each([408, 429, 500, 503])('retries transient status %i', (status) => {
+    expect(() =>
+      handleOpenAIFailedAttempt(providerError(status))
+    ).not.toThrow();
+  });
+
+  it('retries recognized network failures but not programming errors', () => {
+    expect(() =>
+      handleOpenAIFailedAttempt(providerError(undefined, 'ECONNRESET'))
+    ).not.toThrow();
+    expect(() => handleOpenAIFailedAttempt(new Error('bad state'))).toThrow(
+      'bad state'
+    );
+  });
+
+  it('honors bounded Retry-After and rejects an excessive delay', () => {
+    const bounded = providerError(429);
+    bounded.headers = { 'Retry-After': '2' };
+    handleOpenAIFailedAttempt(bounded);
+    expect(bounded.retryAfterMs).toBe(2000);
+
+    const excessive = providerError(429);
+    excessive.headers = { 'Retry-After': '120' };
+    expect(() => handleOpenAIFailedAttempt(excessive)).toThrow(excessive);
+  });
+
+  it('uses one bounded retry layer', async () => {
+    const caller = createOpenAIRetryCaller({ maxRetries: 1 });
+    const operation = jest
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(providerError(503))
+      .mockResolvedValueOnce('ok');
+
+    await expect(caller.call(operation)).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/llm/openai/retry.ts
+++ b/src/llm/openai/retry.ts
@@ -1,0 +1,105 @@
+import {
+  AsyncCaller,
+  parseRetryAfterMs,
+} from '@langchain/core/utils/async_caller';
+
+const MAX_RETRY_AFTER_MS = 60_000;
+const NETWORK_ERROR_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+const NETWORK_ERROR_NAMES = new Set([
+  'APIConnectionError',
+  'APIConnectionTimeoutError',
+]);
+
+type RetryError = Error & {
+  code?: string;
+  status?: number;
+  statusCode?: number;
+  retryAfterMs?: number;
+  headers?: Headers | Record<string, string | undefined>;
+  response?: {
+    status?: number;
+    headers?: Headers | Record<string, string | undefined>;
+  };
+  error?: { code?: string };
+};
+
+function getStatus(error: RetryError): number | undefined {
+  return error.status ?? error.statusCode ?? error.response?.status;
+}
+
+function getHeader(
+  headers: RetryError['headers'],
+  name: string
+): string | undefined {
+  if (headers == null) {
+    return undefined;
+  }
+  if ('get' in headers && typeof headers.get === 'function') {
+    return headers.get(name) ?? undefined;
+  }
+  const record = headers as Record<string, string | undefined>;
+  return record[name] ?? record[name.toLowerCase()];
+}
+
+function getRetryAfterMs(error: RetryError): number | undefined {
+  const headers = error.headers ?? error.response?.headers;
+  const value = getHeader(headers, 'Retry-After');
+  return value == null ? undefined : parseRetryAfterMs(value);
+}
+
+function isNetworkError(error: RetryError): boolean {
+  return (
+    (error.code != null && NETWORK_ERROR_CODES.has(error.code)) ||
+    NETWORK_ERROR_NAMES.has(error.name) ||
+    (error instanceof TypeError && error.message === 'fetch failed')
+  );
+}
+
+export function handleOpenAIFailedAttempt(error: Error): void {
+  const providerError = error as RetryError;
+  if (providerError.name === 'AbortError') {
+    throw error;
+  }
+
+  const status = getStatus(providerError);
+  const code = providerError.code ?? providerError.error?.code;
+  const retryableStatus =
+    status === 408 || status === 429 || (status != null && status >= 500);
+  if (
+    (status == null && !isNetworkError(providerError)) ||
+    (status != null && !retryableStatus) ||
+    code === 'insufficient_quota'
+  ) {
+    throw error;
+  }
+
+  const retryAfterMs = getRetryAfterMs(providerError);
+  if (retryAfterMs != null) {
+    if (retryAfterMs > MAX_RETRY_AFTER_MS) {
+      throw error;
+    }
+    providerError.retryAfterMs = retryAfterMs;
+  }
+}
+
+export function createOpenAIRetryCaller(fields?: {
+  maxConcurrency?: number;
+  maxRetries?: number;
+}): AsyncCaller {
+  return new AsyncCaller({
+    maxConcurrency: fields?.maxConcurrency,
+    maxRetries: fields?.maxRetries,
+    onFailedAttempt: handleOpenAIFailedAttempt,
+  });
+}

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -18,6 +18,7 @@ import {
   isInterrupted,
 } from '@langchain/langgraph';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type * as t from '@/types';
 import { handleConverseStreamMetadata } from '@/llm/bedrock/utils/message_outputs';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
@@ -1454,6 +1455,68 @@ describe('Langfuse callback composition', () => {
         input_cache_creation: 10000,
       })
     );
+  });
+
+  it('bounds image inputs and outputs without mutating provider messages', async () => {
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+    });
+    const handler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+    const inputBase64 = Buffer.alloc(20_000, 'a').toString('base64');
+    const outputBase64 = Buffer.alloc(18_000, 'b').toString('base64');
+    const inputUrl = `data:image/png;base64,${inputBase64}`;
+    const outputUrl = `data:image/jpeg;base64,${outputBase64}`;
+    const signedUrl =
+      'https://storage.example.test/image.png?sp=r&sig=private-signature';
+    const input = new HumanMessage({
+      content: [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image_url', image_url: { url: inputUrl } },
+        { type: 'image_url', image_url: { url: signedUrl } },
+      ],
+    });
+    const output = new AIMessage({
+      content: [{ type: 'image_url', image_url: { url: outputUrl } }],
+    });
+    const generation: ChatGeneration = { text: '', message: output };
+    const runId = 'bounded-media-run';
+
+    await handler?.handleChatModelStart(
+      { lc: 1, type: 'constructor', id: ['AzureChatOpenAI'], kwargs: {} },
+      [[input]],
+      runId
+    );
+    await handler?.handleLLMEnd({ generations: [[generation]] }, runId);
+
+    const serializedAttributes = JSON.stringify(mockSpanAttributeSets);
+    expect(serializedAttributes).toContain('image omitted');
+    expect(serializedAttributes).toContain('type=image/png');
+    expect(serializedAttributes).toContain('bytes=20000');
+    expect(serializedAttributes).toContain('type=image/jpeg');
+    expect(serializedAttributes).toContain('bytes=18000');
+    expect(serializedAttributes).not.toContain(inputBase64.slice(0, 64));
+    expect(serializedAttributes).not.toContain(outputBase64.slice(0, 64));
+    expect(serializedAttributes).not.toContain('private-signature');
+    expect(
+      (input.content[1] as unknown as { image_url: { url: string } }).image_url
+        .url
+    ).toBe(inputUrl);
+    expect(
+      (input.content[2] as unknown as { image_url: { url: string } }).image_url
+        .url
+    ).toBe(signedUrl);
+    expect(
+      (output.content[0] as unknown as { image_url: { url: string } }).image_url
+        .url
+    ).toBe(outputUrl);
   });
 
   it('uses deterministic trace ids when tracing is configured from env only', async () => {


### PR DESCRIPTION
## Summary

- removes image bytes and signed URLs from Langfuse chat-model input/output attributes before OTEL serialization while preserving bounded media type/byte-count metadata
- clones callback-only messages so provider inputs/outputs are never mutated
- replaces the existing LangChain `AsyncCaller` policy on OpenAI/Azure wrappers with an exact transient classifier
- retries only 408, 429, 5xx, recognized network failures, and fetch failures
- honors `Retry-After` up to 60 seconds; aborts, quota exhaustion, invalid payload/content-filter responses, and other 4xx failures are terminal

This remains one retry layer: the OpenAI SDK clients are already configured with native `maxRetries: 0`; the existing LangChain caller still supplies bounded exponential backoff and jitter.

## Production evidence

During the 2026-07-31 Agentic Karl Datadog EU audit, image requests produced 6 `OTEL request body exceeds 16MB` warnings, 12 `OTEL oversized span detected` warnings, and transient Foundry 408/5xx responses. Invalid-payload 400s must remain non-retryable.

## Verification

- `src/specs/langfuse-callbacks.test.ts` + `src/llm/openai/retry.test.ts`: 43 tests passed
- `npm run build`
- focused ESLint passed (one pre-existing warning remains at `src/llm/openai/index.ts:468`)
- touched-file import-order check passed

## Rollout

Publish the merged SDK version, then bump Agentic Karl's `@librechat/agents` dependency and lockfile. After deployment, verify zero new oversized OTEL warnings and compare Foundry status counts with terminal `result:error` generation metrics. No live provider or observability state was changed.
