### PR TITLE
v3.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.9",
+      "version": "3.3.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## v3.3.10

Patch release:

- [🧭 fix: Expose discovered tools across interrupts](https://github.com/danny-avila/agents/pull/374) — exposes canonical deferred-tool discovery state through the public agent runtime so hosts can persist tool schemas when a nested graph interrupts before its messages reach the outer graph reducer
- [🏷️ ci: Release Squash-Merged Version Commits](https://github.com/danny-avila/agents/pull/372) — squash-merged version PRs now tag and create GitHub releases automatically (this release doubles as the fix's first live run)

**Full Changelog**: https://github.com/danny-avila/agents/compare/v3.3.9...v3.3.10