### PR TITLE
🛡️ fix: Neutralize Preempted Responses References

### DIFF
--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -45,17 +45,72 @@ type RedactionResult = {
 };
 
 type RedactionContext = {
+  generatedImageData: Set<string>;
+  generatedImageIds: Set<string>;
   toolNamesByCallId: Map<string, string>;
 };
 
 const TOOL_OUTPUT_FIELD_KEYS = ['content', 'artifact'];
 
-const RESPONSES_REPLAY_OUTPUT_DESCRIPTORS = {
-  local_shell_call_output: { outputField: 'output', toolName: 'local_shell' },
-  shell_call_output: { outputField: 'output', toolName: 'shell' },
-  apply_patch_call_output: { outputField: 'output', toolName: 'apply_patch' },
-  program_output: { outputField: 'result', toolName: 'program' },
-} as const;
+type ResponsesReplayOutputDescriptor = {
+  nestedOutputFields?: Readonly<Record<string, readonly string[]>>;
+  outputFields: readonly string[];
+  resolveToolNameFromCallId?: boolean;
+  toolName?: string;
+};
+
+const RESPONSES_REPLAY_OUTPUT_DESCRIPTORS: Readonly<
+  Record<string, ResponsesReplayOutputDescriptor>
+> = {
+  local_shell_call_output: {
+    outputFields: ['output'],
+    toolName: 'local_shell',
+  },
+  shell_call_output: { outputFields: ['output'], toolName: 'shell' },
+  apply_patch_call_output: {
+    outputFields: ['output'],
+    toolName: 'apply_patch',
+  },
+  program_output: { outputFields: ['result'], toolName: 'program' },
+  code_interpreter_call: {
+    outputFields: ['outputs'],
+    toolName: 'code_interpreter',
+  },
+  mcp_call: { outputFields: ['output', 'error'], toolName: 'mcp' },
+  mcp_list_tools: {
+    outputFields: ['tools', 'error'],
+    toolName: 'mcp_list_tools',
+  },
+  image_generation_call: {
+    outputFields: ['result'],
+    toolName: 'image_generation',
+  },
+  file_search_call: {
+    outputFields: ['results'],
+    toolName: 'file_search',
+  },
+  web_search_call: {
+    nestedOutputFields: { action: ['sources'] },
+    outputFields: [],
+    toolName: 'web_search',
+  },
+  tool_search_output: {
+    outputFields: ['tools'],
+    toolName: 'tool_search',
+  },
+  function_call_output: {
+    outputFields: ['output'],
+    resolveToolNameFromCallId: true,
+  },
+  custom_tool_call_output: {
+    outputFields: ['output'],
+    resolveToolNameFromCallId: true,
+  },
+  computer_call_output: {
+    outputFields: ['output'],
+    toolName: 'computer_use',
+  },
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -127,6 +182,8 @@ function getSerializedToolCallId(
 ): string | undefined {
   return (
     getStringField(value, 'tool_call_id') ??
+    getStringField(value, 'toolCallId') ??
+    getStringField(value, 'call_id') ??
     getNestedStringField(value, 'kwargs', 'tool_call_id') ??
     getNestedStringField(value, 'additional_kwargs', 'tool_call_id') ??
     getNestedStringField(value, 'data', 'tool_call_id') ??
@@ -223,39 +280,106 @@ function redactToolContentFields(
 
 function redactResponsesReplayOutput(
   value: Record<string, unknown>,
-  config: ResolvedLangfuseToolOutputTracingConfig
+  config: ResolvedLangfuseToolOutputTracingConfig,
+  redactionContext: RedactionContext
 ): RedactionResult | undefined {
   const type = getStringField(value, 'type');
-  if (type == null || !(type in RESPONSES_REPLAY_OUTPUT_DESCRIPTORS)) {
+  if (
+    type == null ||
+    !Object.prototype.hasOwnProperty.call(
+      RESPONSES_REPLAY_OUTPUT_DESCRIPTORS,
+      type
+    )
+  ) {
     return undefined;
   }
   const descriptor =
     RESPONSES_REPLAY_OUTPUT_DESCRIPTORS[
       type as keyof typeof RESPONSES_REPLAY_OUTPUT_DESCRIPTORS
     ];
-  if (
-    !(descriptor.outputField in value) ||
-    !shouldRedactTool(descriptor.toolName, config)
-  ) {
+  const hasDirectOutput = descriptor.outputFields.some(
+    (outputField) => outputField in value
+  );
+  const hasNestedOutput = Object.entries(
+    descriptor.nestedOutputFields ?? {}
+  ).some(([objectField, outputFields]) => {
+    const nested = value[objectField];
+    return (
+      isRecord(nested) &&
+      outputFields.some((outputField) => outputField in nested)
+    );
+  });
+  if (!hasDirectOutput && !hasNestedOutput) {
     return undefined;
   }
+  let toolName = descriptor.toolName;
+  if (descriptor.resolveToolNameFromCallId === true) {
+    toolName = getSerializedToolName(value, redactionContext);
+  } else if (type === 'mcp_call') {
+    toolName = getStringField(value, 'name') ?? descriptor.toolName;
+  }
+  if (!shouldRedactTool(toolName, config)) {
+    return undefined;
+  }
+  const redacted = { ...value };
+  for (const outputField of descriptor.outputFields) {
+    if (outputField in redacted) {
+      redacted[outputField] = config.redactionText;
+    }
+  }
+  for (const [objectField, outputFields] of Object.entries(
+    descriptor.nestedOutputFields ?? {}
+  )) {
+    const nested = redacted[objectField];
+    if (!isRecord(nested)) {
+      continue;
+    }
+    const redactedNested = { ...nested };
+    for (const outputField of outputFields) {
+      if (outputField in redactedNested) {
+        redactedNested[outputField] = config.redactionText;
+      }
+    }
+    redacted[objectField] = redactedNested;
+  }
   return {
-    value: {
-      ...value,
-      [descriptor.outputField]: config.redactionText,
-    },
+    value: redacted,
     changed: true,
   };
 }
 
-function redactNeutralServerToolResult(
+function redactStandardServerToolResult(
+  value: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig,
+  redactionContext: RedactionContext
+): RedactionResult | undefined {
+  if (
+    getStringField(value, 'type') !== 'server_tool_call_result' ||
+    !('output' in value)
+  ) {
+    return undefined;
+  }
+  const toolName =
+    getNestedStringField(value, 'extras', 'name') ??
+    getSerializedToolName(value, redactionContext);
+  if (!shouldRedactTool(toolName, config)) {
+    return undefined;
+  }
+  return {
+    value: { ...value, output: config.redactionText },
+    changed: true,
+  };
+}
+
+function redactMarkedServerToolResult(
   value: Record<string, unknown>,
   config: ResolvedLangfuseToolOutputTracingConfig
 ): RedactionResult | undefined {
-  if (getStringField(value, 'type') !== 'text') {
+  const type = getStringField(value, 'type');
+  if (type !== 'text' && type !== 'image') {
     return undefined;
   }
-  const text = getStringField(value, 'text');
+  const text = type === 'text' ? getStringField(value, 'text') : undefined;
   const extras = value.extras;
   const marker = isRecord(extras)
     ? extras.librechatServerToolResult
@@ -282,19 +406,56 @@ function redactNeutralServerToolResult(
   if (!shouldRedactTool(toolName, config)) {
     return undefined;
   }
+  if (type === 'image') {
+    const redacted = { ...value };
+    let changed = false;
+    for (const outputField of ['data', 'url', 'fileId']) {
+      if (outputField in redacted) {
+        redacted[outputField] = config.redactionText;
+        changed = true;
+      }
+    }
+    return changed ? { value: redacted, changed: true } : undefined;
+  }
   return {
     value: { ...value, text: config.redactionText },
     changed: true,
   };
 }
 
-function collectToolCallNames(
+function redactGeneratedImageBlock(
+  value: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig,
+  redactionContext: RedactionContext
+): RedactionResult | undefined {
+  if (
+    getStringField(value, 'type') !== 'image' ||
+    !shouldRedactTool('image_generation', config)
+  ) {
+    return undefined;
+  }
+  const id = getStringField(value, 'id');
+  const data = getStringField(value, 'data');
+  const isGeneratedImage =
+    id != null
+      ? redactionContext.generatedImageIds.has(id)
+      : data != null && redactionContext.generatedImageData.has(data);
+  if (!isGeneratedImage) {
+    return undefined;
+  }
+  return {
+    value: { ...value, data: config.redactionText },
+    changed: true,
+  };
+}
+
+function collectRedactionContext(
   value: unknown,
   redactionContext: RedactionContext
 ): void {
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectToolCallNames(item, redactionContext);
+      collectRedactionContext(item, redactionContext);
     }
     return;
   }
@@ -309,8 +470,19 @@ function collectToolCallNames(
     redactionContext.toolNamesByCallId.set(toolCallId, toolName);
   }
 
+  if (getStringField(value, 'type') === 'image_generation_call') {
+    const id = getStringField(value, 'id');
+    const result = getStringField(value, 'result');
+    if (id != null) {
+      redactionContext.generatedImageIds.add(id);
+    }
+    if (result != null) {
+      redactionContext.generatedImageData.add(result);
+    }
+  }
+
   for (const child of Object.values(value)) {
-    collectToolCallNames(child, redactionContext);
+    collectRedactionContext(child, redactionContext);
   }
 }
 
@@ -336,13 +508,33 @@ function redactValue(
     return { value, changed: false };
   }
 
-  const replayOutput = redactResponsesReplayOutput(value, config);
+  const replayOutput = redactResponsesReplayOutput(
+    value,
+    config,
+    redactionContext
+  );
   if (replayOutput != null) {
     return replayOutput;
   }
-  const neutralServerToolResult = redactNeutralServerToolResult(value, config);
-  if (neutralServerToolResult != null) {
-    return neutralServerToolResult;
+  const standardServerToolResult = redactStandardServerToolResult(
+    value,
+    config,
+    redactionContext
+  );
+  if (standardServerToolResult != null) {
+    return standardServerToolResult;
+  }
+  const markedServerToolResult = redactMarkedServerToolResult(value, config);
+  if (markedServerToolResult != null) {
+    return markedServerToolResult;
+  }
+  const generatedImageBlock = redactGeneratedImageBlock(
+    value,
+    config,
+    redactionContext
+  );
+  if (generatedImageBlock != null) {
+    return generatedImageBlock;
   }
 
   const toolName = getSerializedToolName(value, redactionContext);
@@ -371,10 +563,12 @@ function redactSerializedValue(
   config: ResolvedLangfuseToolOutputTracingConfig
 ): RedactionResult {
   const redactionContext: RedactionContext = {
+    generatedImageData: new Set(),
+    generatedImageIds: new Set(),
     toolNamesByCallId: new Map(),
   };
   if (typeof value !== 'string') {
-    collectToolCallNames(value, redactionContext);
+    collectRedactionContext(value, redactionContext);
     return redactValue(value, config, redactionContext);
   }
 
@@ -385,7 +579,7 @@ function redactSerializedValue(
 
   try {
     const parsed = JSON.parse(value) as unknown;
-    collectToolCallNames(parsed, redactionContext);
+    collectRedactionContext(parsed, redactionContext);
     const result = redactValue(parsed, config, redactionContext);
     return result.changed
       ? { value: JSON.stringify(result.value), changed: true }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -26,6 +26,7 @@ export { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT, resolveLangfuseConfig };
 
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
 const SERVER_TOOL_RESULT_PREFIX = '{"serverToolResult":';
+const SERVER_TOOL_RESULT_REPLAY_MARKER_KEY = 'librechatResponsesReplay';
 
 const CHAT_ROLES = new Set([
   'assistant',
@@ -403,6 +404,9 @@ function parseSerializedServerToolResultMarker(
       return undefined;
     }
     const result = parsed.serverToolResult;
+    if (result[SERVER_TOOL_RESULT_REPLAY_MARKER_KEY] !== true) {
+      return undefined;
+    }
     const status = getStringField(result, 'status');
     if (
       (status !== 'error' && status !== 'success') ||
@@ -414,7 +418,7 @@ function parseSerializedServerToolResultMarker(
     return toolName != null ? { toolName } : {};
   } catch {
     const match =
-      /^\{"serverToolResult":\{(?:"toolName":("(?:\\.|[^"\\])*"),)?"status":"(?:error|success)","output":/.exec(
+      /^\{"serverToolResult":\{"librechatResponsesReplay":true,(?:"toolName":("(?:\\.|[^"\\])*"),)?"status":"(?:error|success)","output":/.exec(
         text.slice(0, 512)
       );
     if (match == null) {
@@ -480,7 +484,8 @@ function redactMarkedServerToolResult(
 function redactGeneratedImageBlock(
   value: Record<string, unknown>,
   config: ResolvedLangfuseToolOutputTracingConfig,
-  redactionContext: RedactionContext
+  redactionContext: RedactionContext,
+  isAssistantContent: boolean
 ): RedactionResult | undefined {
   if (
     getStringField(value, 'type') !== 'image' ||
@@ -488,12 +493,27 @@ function redactGeneratedImageBlock(
   ) {
     return undefined;
   }
+  const extras = value.extras;
+  const explicitMarker = isRecord(extras)
+    ? extras.librechatServerToolResult
+    : undefined;
+  const explicitToolName = isRecord(explicitMarker)
+    ? getStringField(explicitMarker, 'toolName')
+    : undefined;
+  if (
+    explicitToolName != null &&
+    normalizeToolName(explicitToolName) !== 'image_generation'
+  ) {
+    return undefined;
+  }
   const id = getStringField(value, 'id');
   const data = getStringField(value, 'data');
   const isGeneratedImage =
-    id != null
+    explicitToolName != null ||
+    isAssistantContent ||
+    (id != null
       ? redactionContext.generatedImageIds.has(id)
-      : data != null && redactionContext.generatedImageData.has(data);
+      : data != null && redactionContext.generatedImageData.has(data));
   if (!isGeneratedImage) {
     return undefined;
   }
@@ -603,7 +623,8 @@ function redactValue(
   const generatedImageBlock = redactGeneratedImageBlock(
     value,
     config,
-    redactionContext
+    redactionContext,
+    allowSerializedMarker
   );
   if (generatedImageBlock != null) {
     return generatedImageBlock;
@@ -662,7 +683,12 @@ function redactSerializedValue(
       ? { value: JSON.stringify(result.value), changed: true }
       : { value, changed: false };
   } catch {
-    return { value, changed: false };
+    // OpenTelemetry truncates string attributes before span processors run.
+    // Langfuse serializes structured message values to JSON first, so a
+    // truncated attribute can still contain tool output even though it is no
+    // longer parseable. Fail closed for JSON-shaped attributes whenever tool
+    // output redaction is active instead of exporting a partial secret.
+    return { value: config.redactionText, changed: true };
   }
 }
 
@@ -752,6 +778,17 @@ export function redactLangfuseSpanToolOutputs(
   }
 }
 
+export function prepareLangfuseSpanForExport(
+  span: ReadableSpan,
+  config?: ResolvedLangfuseToolOutputTracingConfig
+): void {
+  classifyLangfuseToolNodeSpan(span);
+  if (config != null) {
+    redactLangfuseSpanToolOutputs(span, config);
+  }
+  shapeLangfuseSpan(span);
+}
+
 class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   private readonly processor: LangfuseSpanProcessor;
   private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
@@ -785,12 +822,8 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
     if (shouldDropLangfuseSpan(span.name)) {
       return;
     }
-    classifyLangfuseToolNodeSpan(span);
-    shapeLangfuseSpan(span);
     const config = this.spanConfigs.get(span) ?? this.fallbackConfig;
-    if (config != null) {
-      redactLangfuseSpanToolOutputs(span, config);
-    }
+    prepareLangfuseSpanForExport(span, config);
     this.processor.onEnd(span);
   }
 

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -245,6 +245,26 @@ function hasToolMessageIdentity(value: Record<string, unknown>): boolean {
   );
 }
 
+function hasAssistantMessageIdentity(value: Record<string, unknown>): boolean {
+  const role = getStringField(value, 'role');
+  if (role?.toLowerCase() === 'assistant') {
+    return true;
+  }
+  const type = getStringField(value, 'type') ?? getStringField(value, '_type');
+  if (type === 'ai' || type === 'assistant') {
+    return true;
+  }
+  const id = value.id;
+  return (
+    Array.isArray(id) &&
+    id.some(
+      (part) =>
+        typeof part === 'string' &&
+        (part === 'AIMessage' || part === 'AIMessageChunk')
+    )
+  );
+}
+
 function redactToolContentFields(
   value: Record<string, unknown>,
   config: ResolvedLangfuseToolOutputTracingConfig
@@ -415,7 +435,8 @@ function parseSerializedServerToolResultMarker(
 
 function redactMarkedServerToolResult(
   value: Record<string, unknown>,
-  config: ResolvedLangfuseToolOutputTracingConfig
+  config: ResolvedLangfuseToolOutputTracingConfig,
+  allowSerializedMarker: boolean
 ): RedactionResult | undefined {
   const type = getStringField(value, 'type');
   if (type !== 'text' && type !== 'image') {
@@ -427,7 +448,9 @@ function redactMarkedServerToolResult(
     ? extras.librechatServerToolResult
     : undefined;
   const serializedMarker =
-    text != null ? parseSerializedServerToolResultMarker(text) : undefined;
+    allowSerializedMarker && text != null
+      ? parseSerializedServerToolResultMarker(text)
+      : undefined;
   if (!isRecord(marker) && serializedMarker == null) {
     return undefined;
   }
@@ -525,13 +548,19 @@ function collectRedactionContext(
 function redactValue(
   value: unknown,
   config: ResolvedLangfuseToolOutputTracingConfig,
-  redactionContext: RedactionContext
+  redactionContext: RedactionContext,
+  allowSerializedServerToolResult = false
 ): RedactionResult {
   if (Array.isArray(value)) {
     let changed = false;
     const next: unknown[] = [];
     for (const item of value) {
-      const result = redactValue(item, config, redactionContext);
+      const result = redactValue(
+        item,
+        config,
+        redactionContext,
+        allowSerializedServerToolResult
+      );
       if (result.changed) {
         changed = true;
       }
@@ -543,6 +572,9 @@ function redactValue(
   if (!isRecord(value)) {
     return { value, changed: false };
   }
+
+  const allowSerializedMarker =
+    allowSerializedServerToolResult || hasAssistantMessageIdentity(value);
 
   const replayOutput = redactResponsesReplayOutput(
     value,
@@ -560,7 +592,11 @@ function redactValue(
   if (standardServerToolResult != null) {
     return standardServerToolResult;
   }
-  const markedServerToolResult = redactMarkedServerToolResult(value, config);
+  const markedServerToolResult = redactMarkedServerToolResult(
+    value,
+    config,
+    allowSerializedMarker
+  );
   if (markedServerToolResult != null) {
     return markedServerToolResult;
   }
@@ -584,7 +620,12 @@ function redactValue(
   let changed = false;
   const next: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {
-    const result = redactValue(child, config, redactionContext);
+    const result = redactValue(
+      child,
+      config,
+      redactionContext,
+      allowSerializedMarker
+    );
     if (result.changed) {
       changed = true;
     }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -508,9 +508,17 @@ function redactGeneratedImageBlock(
   }
   const id = getStringField(value, 'id');
   const data = getStringField(value, 'data');
+  const metadata = value.metadata;
+  const normalizedStatus = isRecord(metadata)
+    ? getStringField(metadata, 'status')
+    : undefined;
+  const hasNormalizedGeneratedImageIdentity =
+    isAssistantContent &&
+    id?.startsWith('ig_') === true &&
+    isPresent(normalizedStatus);
   const isGeneratedImage =
     explicitToolName != null ||
-    isAssistantContent ||
+    hasNormalizedGeneratedImageIdentity ||
     (id != null
       ? redactionContext.generatedImageIds.has(id)
       : data != null && redactionContext.generatedImageData.has(data));

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -25,6 +25,7 @@ import { resolveToolOutputTracingConfigForSpan } from '@/langfuseRuntimeScope';
 export { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT, resolveLangfuseConfig };
 
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
+const SERVER_TOOL_RESULT_PREFIX = '{"serverToolResult":';
 
 const CHAT_ROLES = new Set([
   'assistant',
@@ -48,6 +49,13 @@ type RedactionContext = {
 };
 
 const TOOL_OUTPUT_FIELD_KEYS = ['content', 'artifact'];
+
+const RESPONSES_REPLAY_OUTPUT_DESCRIPTORS = {
+  local_shell_call_output: { outputField: 'output', toolName: 'local_shell' },
+  shell_call_output: { outputField: 'output', toolName: 'shell' },
+  apply_patch_call_output: { outputField: 'output', toolName: 'apply_patch' },
+  program_output: { outputField: 'result', toolName: 'program' },
+} as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -213,6 +221,73 @@ function redactToolContentFields(
   return next;
 }
 
+function redactResponsesReplayOutput(
+  value: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): RedactionResult | undefined {
+  const type = getStringField(value, 'type');
+  if (type == null || !(type in RESPONSES_REPLAY_OUTPUT_DESCRIPTORS)) {
+    return undefined;
+  }
+  const descriptor =
+    RESPONSES_REPLAY_OUTPUT_DESCRIPTORS[
+      type as keyof typeof RESPONSES_REPLAY_OUTPUT_DESCRIPTORS
+    ];
+  if (
+    !(descriptor.outputField in value) ||
+    !shouldRedactTool(descriptor.toolName, config)
+  ) {
+    return undefined;
+  }
+  return {
+    value: {
+      ...value,
+      [descriptor.outputField]: config.redactionText,
+    },
+    changed: true,
+  };
+}
+
+function redactNeutralServerToolResult(
+  value: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): RedactionResult | undefined {
+  if (getStringField(value, 'type') !== 'text') {
+    return undefined;
+  }
+  const text = getStringField(value, 'text');
+  const extras = value.extras;
+  const marker = isRecord(extras)
+    ? extras.librechatServerToolResult
+    : undefined;
+  const hasSerializedMarker =
+    text?.startsWith(SERVER_TOOL_RESULT_PREFIX) === true;
+  if (!isRecord(marker) && !hasSerializedMarker) {
+    return undefined;
+  }
+  let toolName = isRecord(marker)
+    ? getStringField(marker, 'toolName')
+    : undefined;
+  if (toolName == null && hasSerializedMarker) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (isRecord(parsed) && isRecord(parsed.serverToolResult)) {
+        toolName = getStringField(parsed.serverToolResult, 'toolName');
+      }
+    } catch {
+      const match = /"toolName":"([^"\\]+)"/.exec(text.slice(0, 256));
+      toolName = match?.[1];
+    }
+  }
+  if (!shouldRedactTool(toolName, config)) {
+    return undefined;
+  }
+  return {
+    value: { ...value, text: config.redactionText },
+    changed: true,
+  };
+}
+
 function collectToolCallNames(
   value: unknown,
   redactionContext: RedactionContext
@@ -259,6 +334,15 @@ function redactValue(
 
   if (!isRecord(value)) {
     return { value, changed: false };
+  }
+
+  const replayOutput = redactResponsesReplayOutput(value, config);
+  if (replayOutput != null) {
+    return replayOutput;
+  }
+  const neutralServerToolResult = redactNeutralServerToolResult(value, config);
+  if (neutralServerToolResult != null) {
+    return neutralServerToolResult;
   }
 
   const toolName = getSerializedToolName(value, redactionContext);

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -91,7 +91,7 @@ const RESPONSES_REPLAY_OUTPUT_DESCRIPTORS: Readonly<
   },
   web_search_call: {
     nestedOutputFields: { action: ['sources'] },
-    outputFields: [],
+    outputFields: ['results'],
     toolName: 'web_search',
   },
   tool_search_output: {
@@ -371,6 +371,48 @@ function redactStandardServerToolResult(
   };
 }
 
+function parseSerializedServerToolResultMarker(
+  text: string
+): { toolName?: string } | undefined {
+  if (!text.startsWith(SERVER_TOOL_RESULT_PREFIX)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.serverToolResult)) {
+      return undefined;
+    }
+    const result = parsed.serverToolResult;
+    const status = getStringField(result, 'status');
+    if (
+      (status !== 'error' && status !== 'success') ||
+      !Object.prototype.hasOwnProperty.call(result, 'output')
+    ) {
+      return undefined;
+    }
+    const toolName = getStringField(result, 'toolName');
+    return toolName != null ? { toolName } : {};
+  } catch {
+    const match =
+      /^\{"serverToolResult":\{(?:"toolName":("(?:\\.|[^"\\])*"),)?"status":"(?:error|success)","output":/.exec(
+        text.slice(0, 512)
+      );
+    if (match == null) {
+      return undefined;
+    }
+    const encodedToolName = match.at(1);
+    if (encodedToolName == null) {
+      return {};
+    }
+    try {
+      const toolName = JSON.parse(encodedToolName) as unknown;
+      return typeof toolName === 'string' ? { toolName } : {};
+    } catch {
+      return {};
+    }
+  }
+}
+
 function redactMarkedServerToolResult(
   value: Record<string, unknown>,
   config: ResolvedLangfuseToolOutputTracingConfig
@@ -384,25 +426,14 @@ function redactMarkedServerToolResult(
   const marker = isRecord(extras)
     ? extras.librechatServerToolResult
     : undefined;
-  const hasSerializedMarker =
-    text?.startsWith(SERVER_TOOL_RESULT_PREFIX) === true;
-  if (!isRecord(marker) && !hasSerializedMarker) {
+  const serializedMarker =
+    text != null ? parseSerializedServerToolResultMarker(text) : undefined;
+  if (!isRecord(marker) && serializedMarker == null) {
     return undefined;
   }
-  let toolName = isRecord(marker)
+  const toolName = isRecord(marker)
     ? getStringField(marker, 'toolName')
-    : undefined;
-  if (toolName == null && hasSerializedMarker) {
-    try {
-      const parsed = JSON.parse(text) as unknown;
-      if (isRecord(parsed) && isRecord(parsed.serverToolResult)) {
-        toolName = getStringField(parsed.serverToolResult, 'toolName');
-      }
-    } catch {
-      const match = /"toolName":"([^"\\]+)"/.exec(text.slice(0, 256));
-      toolName = match?.[1];
-    }
-  }
+    : serializedMarker?.toolName;
   if (!shouldRedactTool(toolName, config)) {
     return undefined;
   }
@@ -443,10 +474,15 @@ function redactGeneratedImageBlock(
   if (!isGeneratedImage) {
     return undefined;
   }
-  return {
-    value: { ...value, data: config.redactionText },
-    changed: true,
-  };
+  const redacted = { ...value };
+  let changed = false;
+  for (const outputField of ['data', 'url', 'fileId']) {
+    if (outputField in redacted) {
+      redacted[outputField] = config.redactionText;
+      changed = true;
+    }
+  }
+  return changed ? { value: redacted, changed: true } : undefined;
 }
 
 function collectRedactionContext(

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -517,6 +517,99 @@ describe('custom chat model class smoke tests', () => {
     ]);
   });
 
+  it.each(['response.completed', 'response.incomplete'] as const)(
+    'removes provisional replay outputs after %s supplies the authoritative output',
+    async (terminalType) => {
+      const model = new ChatOpenAI({
+        model: 'gpt-5',
+        apiKey: 'test-key',
+        useResponsesApi: true,
+      });
+      const responses = (
+        model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+      ).responses;
+      const streamedToolOutput = {
+        id: 'web_search_item',
+        type: 'web_search_call',
+        status: 'completed',
+      } as const;
+      const provisionalReplayOutput = {
+        id: 'local_output_item',
+        type: 'local_shell_call_output',
+        status: 'completed',
+        output: 'unique authoritative local output',
+      } as const;
+      responses.completionWithRetry = async () =>
+        (async function* () {
+          yield {
+            type: 'response.output_item.done',
+            sequence_number: 0,
+            output_index: 0,
+            item: streamedToolOutput,
+          } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+          yield {
+            type: 'response.output_item.done',
+            sequence_number: 1,
+            output_index: 1,
+            item: provisionalReplayOutput,
+          } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+          yield {
+            type: terminalType,
+            sequence_number: 2,
+            response: {
+              id: 'resp_terminal',
+              model: 'gpt-5',
+              output: [streamedToolOutput, provisionalReplayOutput],
+              status:
+                terminalType === 'response.completed'
+                  ? 'completed'
+                  : 'incomplete',
+              usage: null,
+            },
+          } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+        })();
+
+      let tracedResult: unknown;
+      const chunks: AIMessageChunk[] = [];
+      const stream = await model.stream([new HumanMessage('run tools')], {
+        callbacks: [
+          {
+            handleLLMEnd(result: unknown): void {
+              tracedResult = result;
+            },
+          },
+        ],
+      });
+      for await (const chunk of stream) {
+        chunks.push(chunk as AIMessageChunk);
+      }
+      const combined = chunks.reduce<AIMessageChunk | undefined>(
+        (current, chunk) =>
+          current == null ? chunk : (current.concat(chunk) as AIMessageChunk),
+        undefined
+      );
+
+      expect(combined?.additional_kwargs.tool_outputs).toEqual([
+        streamedToolOutput,
+      ]);
+      expect(combined?.response_metadata.output).toEqual([
+        streamedToolOutput,
+        provisionalReplayOutput,
+      ]);
+      expect(combined?.toJSON()).toEqual(
+        expect.objectContaining({
+          id: ['langchain_core', 'messages', 'AIMessageChunk'],
+        })
+      );
+      expect(
+        JSON.stringify(combined).match(/unique authoritative local output/g)
+      ).toHaveLength(1);
+      expect(
+        JSON.stringify(tracedResult).match(/unique authoritative local output/g)
+      ).toHaveLength(1);
+    }
+  );
+
   it('keeps a raw server result between distinct Responses output messages', async () => {
     const model = new ChatOpenAI({
       model: 'gpt-5',

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -37,6 +37,11 @@ type OpenAIResponsesDelegate = {
   client?: unknown;
   _getClientOptions: (options?: OpenAIRequestOptions) => OpenAIRequestOptions;
 };
+type StreamingOpenAIResponsesDelegate = OpenAIResponsesDelegate & {
+  completionWithRetry: (
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming
+  ) => Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+};
 type AnthropicCallOptions = Parameters<
   CustomAnthropic['invocationParams']
 >[0] & {
@@ -399,6 +404,88 @@ describe('custom chat model class smoke tests', () => {
     expect(requestOptions?.headers).toEqual(
       expect.objectContaining({ 'x-smoke': 'responses' })
     );
+  });
+
+  it('retains replayable Responses output items before a terminal event', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+    ).responses;
+    const items = [
+      {
+        id: 'local_output_item',
+        type: 'local_shell_call_output',
+        status: 'completed',
+        output: 'local output',
+      },
+      {
+        id: 'shell_output_item',
+        call_id: 'shell_call_id',
+        type: 'shell_call_output',
+        status: 'completed',
+        max_output_length: 1_000,
+        output: [
+          {
+            stdout: 'shell output',
+            stderr: '',
+            outcome: { type: 'exit', exit_code: 0 },
+          },
+        ],
+      },
+      {
+        id: 'patch_output_item',
+        call_id: 'patch_call_id',
+        type: 'apply_patch_call_output',
+        status: 'completed',
+        output: 'patch output',
+      },
+      {
+        id: 'program_output_item',
+        call_id: 'program_call_id',
+        type: 'program_output',
+        status: 'completed',
+        result: 'program output',
+      },
+    ] as const;
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        for (let i = 0; i < items.length; i++) {
+          yield {
+            type: 'response.output_item.done',
+            sequence_number: i,
+            output_index: i,
+            item: items[i],
+          } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+        }
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: items.length,
+          output_index: items.length,
+          content_index: 0,
+          item_id: 'msg_partial',
+          delta: 'Partial answer.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    const chunks: AIMessageChunk[] = [];
+    const stream = await model.stream([new HumanMessage('run tools')]);
+    for await (const chunk of stream) {
+      chunks.push(chunk as AIMessageChunk);
+    }
+    const combined = chunks.reduce<AIMessageChunk | undefined>(
+      (current, chunk) =>
+        current == null ? chunk : (current.concat(chunk) as AIMessageChunk),
+      undefined
+    );
+
+    expect(chunks).toHaveLength(items.length + 1);
+    expect(combined?.text).toBe('Partial answer.');
+    expect(combined?.additional_kwargs.tool_outputs).toEqual(items);
   });
 
   it('keeps Azure client customization and gates reasoning to reasoning models', () => {

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -629,9 +629,32 @@ describe('custom chat model class smoke tests', () => {
           },
         } as OpenAIClient.Responses.ResponseStreamEvent;
         yield {
-          type: 'response.output_text.delta',
+          type: 'response.output_item.added',
           sequence_number: 3,
           output_index: 3,
+          item: {
+            id: 'rs_middle',
+            type: 'reasoning',
+            status: 'in_progress',
+            summary: [],
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.done',
+          sequence_number: 4,
+          output_index: 3,
+          item: {
+            id: 'rs_middle',
+            type: 'reasoning',
+            status: 'incomplete',
+            summary: [],
+            encrypted_content: 'opaque-middle-reasoning',
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 5,
+          output_index: 4,
           content_index: 0,
           item_id: 'msg_second',
           delta: 'Second narration.',
@@ -648,6 +671,13 @@ describe('custom chat model class smoke tests', () => {
           : (combined.concat(chunk as AIMessageChunk) as AIMessageChunk);
     }
     expect(combined).toBeDefined();
+    expect(combined!.additional_kwargs.reasoning).toEqual({
+      id: 'rs_middle',
+      type: 'reasoning',
+      status: 'incomplete',
+      summary: [],
+      encrypted_content: 'opaque-middle-reasoning',
+    });
     expect(
       combined!.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
     ).toEqual([
@@ -659,11 +689,12 @@ describe('custom chat model class smoke tests', () => {
       },
       { itemId: 'ig_middle', kind: 'output', outputIndex: 1 },
       { itemId: 'local_middle', kind: 'output', outputIndex: 2 },
+      { itemId: 'rs_middle', kind: 'reasoning', outputIndex: 3 },
       {
         contentIndex: 0,
         itemId: 'msg_second',
         kind: 'text',
-        outputIndex: 3,
+        outputIndex: 4,
       },
     ]);
     combined!.response_metadata.preempted = true;
@@ -678,12 +709,14 @@ describe('custom chat model class smoke tests', () => {
     const firstIndex = serialized.indexOf('First narration.');
     const imageIndex = serialized.indexOf('data:image/png;base64,AA==');
     const resultIndex = serialized.indexOf('middle server result');
+    const reasoningIndex = serialized.indexOf('opaque-middle-reasoning');
     const secondIndex = serialized.indexOf('Second narration.');
 
     expect(firstIndex).toBeGreaterThanOrEqual(0);
     expect(firstIndex).toBeLessThan(imageIndex);
     expect(imageIndex).toBeLessThan(resultIndex);
-    expect(resultIndex).toBeLessThan(secondIndex);
+    expect(resultIndex).toBeLessThan(reasoningIndex);
+    expect(reasoningIndex).toBeLessThan(secondIndex);
     expect(serialized).not.toContain('ig_middle');
     expect(serialized).not.toContain('local_middle');
     expect(projected.additional_kwargs).not.toHaveProperty(

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -617,14 +617,89 @@ describe('custom chat model class smoke tests', () => {
       expect(combined?.lc_kwargs.additional_kwargs).toEqual(
         expect.objectContaining({ tool_outputs: [streamedToolOutput] })
       );
+      expect(combined?.additional_kwargs).not.toHaveProperty(
+        OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+      );
+      expect(combined?.lc_kwargs.additional_kwargs).not.toHaveProperty(
+        OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+      );
       expect(
         JSON.stringify(tracedResult).match(/unique authoritative local output/g)
       ).toHaveLength(1);
       expect(JSON.stringify(tracedResult)).not.toContain(
         'stale provisional local output'
       );
+      expect(JSON.stringify(tracedResult)).not.toContain(
+        OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+      );
     }
   );
+
+  it('removes replay positions on a text-only terminal response', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+    ).responses;
+    const messageItem = {
+      id: 'msg_terminal',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        {
+          type: 'output_text',
+          text: 'Complete answer.',
+          annotations: [],
+          logprobs: [],
+        },
+      ],
+    } as const;
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: messageItem.id,
+          delta: messageItem.content[0].text,
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.completed',
+          sequence_number: 1,
+          response: {
+            id: 'resp_text_terminal',
+            model: 'gpt-5',
+            output: [messageItem],
+            status: 'completed',
+            usage: null,
+          },
+        } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    let combined: AIMessageChunk | undefined;
+    const stream = await model.stream([new HumanMessage('answer')]);
+    for await (const chunk of stream) {
+      combined =
+        combined == null
+          ? (chunk as AIMessageChunk)
+          : (combined.concat(chunk as AIMessageChunk) as AIMessageChunk);
+    }
+
+    expect(combined?.text).toBe('Complete answer.');
+    expect(combined?.response_metadata.output).toEqual([messageItem]);
+    expect(combined?.additional_kwargs).not.toHaveProperty(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+    expect(combined?.lc_kwargs.additional_kwargs).not.toHaveProperty(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+  });
 
   it('keeps a raw server result between distinct Responses output messages', async () => {
     const model = new ChatOpenAI({

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -586,6 +586,111 @@ describe('custom chat model class smoke tests', () => {
     expect(resultIndex).toBeLessThan(secondIndex);
   });
 
+  it('keeps streamed generated images and server results in cross-item order', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+    ).responses;
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_first',
+          delta: 'First narration.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.done',
+          sequence_number: 1,
+          output_index: 1,
+          item: {
+            id: 'ig_middle',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.done',
+          sequence_number: 2,
+          output_index: 2,
+          item: {
+            id: 'local_middle',
+            type: 'local_shell_call_output',
+            status: 'completed',
+            output: 'middle server result',
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 3,
+          output_index: 3,
+          content_index: 0,
+          item_id: 'msg_second',
+          delta: 'Second narration.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    let combined: AIMessageChunk | undefined;
+    const stream = await model.stream([new HumanMessage('generate and run')]);
+    for await (const chunk of stream) {
+      combined =
+        combined == null
+          ? (chunk as AIMessageChunk)
+          : (combined.concat(chunk as AIMessageChunk) as AIMessageChunk);
+    }
+    expect(combined).toBeDefined();
+    expect(
+      combined!.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
+    ).toEqual([
+      {
+        contentIndex: 0,
+        itemId: 'msg_first',
+        kind: 'text',
+        outputIndex: 0,
+      },
+      { itemId: 'ig_middle', kind: 'output', outputIndex: 1 },
+      { itemId: 'local_middle', kind: 'output', outputIndex: 2 },
+      {
+        contentIndex: 0,
+        itemId: 'msg_second',
+        kind: 'text',
+        outputIndex: 3,
+      },
+    ]);
+    combined!.response_metadata.preempted = true;
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([combined!]);
+    const providerInput = convertMessagesToResponsesInput({
+      messages: [projected],
+      model: 'gpt-5',
+      zdrEnabled: false,
+    });
+    const serialized = JSON.stringify(providerInput);
+    const firstIndex = serialized.indexOf('First narration.');
+    const imageIndex = serialized.indexOf('data:image/png;base64,AA==');
+    const resultIndex = serialized.indexOf('middle server result');
+    const secondIndex = serialized.indexOf('Second narration.');
+
+    expect(firstIndex).toBeGreaterThanOrEqual(0);
+    expect(firstIndex).toBeLessThan(imageIndex);
+    expect(imageIndex).toBeLessThan(resultIndex);
+    expect(resultIndex).toBeLessThan(secondIndex);
+    expect(serialized).not.toContain('ig_middle');
+    expect(serialized).not.toContain('local_middle');
+    expect(projected.additional_kwargs).not.toHaveProperty(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+  });
+
   it('keeps Azure client customization and gates reasoning to reasoning models', () => {
     const model = new AzureChatOpenAI({
       ...baseAzureFields,

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -537,6 +537,10 @@ describe('custom chat model class smoke tests', () => {
         id: 'local_output_item',
         type: 'local_shell_call_output',
         status: 'completed',
+        output: 'stale provisional local output',
+      } as const;
+      const authoritativeReplayOutput = {
+        ...provisionalReplayOutput,
         output: 'unique authoritative local output',
       } as const;
       responses.completionWithRetry = async () =>
@@ -559,7 +563,7 @@ describe('custom chat model class smoke tests', () => {
             response: {
               id: 'resp_terminal',
               model: 'gpt-5',
-              output: [streamedToolOutput, provisionalReplayOutput],
+              output: [streamedToolOutput, authoritativeReplayOutput],
               status:
                 terminalType === 'response.completed'
                   ? 'completed'
@@ -594,7 +598,7 @@ describe('custom chat model class smoke tests', () => {
       ]);
       expect(combined?.response_metadata.output).toEqual([
         streamedToolOutput,
-        provisionalReplayOutput,
+        authoritativeReplayOutput,
       ]);
       expect(combined?.toJSON()).toEqual(
         expect.objectContaining({
@@ -604,9 +608,21 @@ describe('custom chat model class smoke tests', () => {
       expect(
         JSON.stringify(combined).match(/unique authoritative local output/g)
       ).toHaveLength(1);
+      expect(JSON.stringify(combined)).not.toContain(
+        'stale provisional local output'
+      );
+      expect(JSON.stringify(combined?.lc_kwargs)).not.toContain(
+        'stale provisional local output'
+      );
+      expect(combined?.lc_kwargs.additional_kwargs).toEqual(
+        expect.objectContaining({ tool_outputs: [streamedToolOutput] })
+      );
       expect(
         JSON.stringify(tracedResult).match(/unique authoritative local output/g)
       ).toHaveLength(1);
+      expect(JSON.stringify(tracedResult)).not.toContain(
+        'stale provisional local output'
+      );
     }
   );
 

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -1,3 +1,4 @@
+import { convertMessagesToResponsesInput } from '@langchain/openai';
 import {
   AIMessage,
   AIMessageChunk,
@@ -21,6 +22,10 @@ import {
   CustomOpenAIClient,
   CustomAzureOpenAIClient,
 } from '@/llm/openai';
+import {
+  OPENAI_RESPONSES_REPLAY_POSITIONS_KEY,
+  projectOpenAIResponsesToolMessageContent,
+} from '@/messages/core';
 import { CustomChatGoogleGenerativeAI } from '@/llm/google';
 import { CustomChatBedrockConverse } from '@/llm/bedrock';
 import { ChatOpenRouter } from '@/llm/openrouter';
@@ -467,7 +472,16 @@ describe('custom chat model class smoke tests', () => {
           output_index: items.length,
           content_index: 0,
           item_id: 'msg_partial',
-          delta: 'Partial answer.',
+          delta: 'Partial ',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: items.length + 1,
+          output_index: items.length,
+          content_index: 0,
+          item_id: 'msg_partial',
+          delta: 'answer.',
           logprobs: [],
         } as OpenAIClient.Responses.ResponseStreamEvent;
       })();
@@ -483,9 +497,93 @@ describe('custom chat model class smoke tests', () => {
       undefined
     );
 
-    expect(chunks).toHaveLength(items.length + 1);
+    expect(chunks).toHaveLength(items.length + 2);
     expect(combined?.text).toBe('Partial answer.');
     expect(combined?.additional_kwargs.tool_outputs).toEqual(items);
+    expect(
+      combined?.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
+    ).toEqual([
+      ...items.map((item, outputIndex) => ({
+        itemId: item.id,
+        kind: 'output',
+        outputIndex,
+      })),
+      {
+        contentIndex: 0,
+        itemId: 'msg_partial',
+        kind: 'text',
+        outputIndex: items.length,
+      },
+    ]);
+  });
+
+  it('keeps a raw server result between distinct Responses output messages', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+    ).responses;
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_first',
+          delta: 'First narration.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.done',
+          sequence_number: 1,
+          output_index: 1,
+          item: {
+            id: 'local_output_item',
+            type: 'local_shell_call_output',
+            status: 'completed',
+            output: 'middle server result',
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 2,
+          output_index: 2,
+          content_index: 0,
+          item_id: 'msg_second',
+          delta: 'Second narration.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    let combined: AIMessageChunk | undefined;
+    const stream = await model.stream([new HumanMessage('run a server tool')]);
+    for await (const chunk of stream) {
+      combined =
+        combined == null
+          ? (chunk as AIMessageChunk)
+          : (combined.concat(chunk as AIMessageChunk) as AIMessageChunk);
+    }
+    expect(combined).toBeDefined();
+    combined!.response_metadata.preempted = true;
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([combined!]);
+    const providerInput = convertMessagesToResponsesInput({
+      messages: [projected],
+      model: 'gpt-5',
+      zdrEnabled: false,
+    });
+    const serialized = JSON.stringify(providerInput);
+    const firstIndex = serialized.indexOf('First narration.');
+    const resultIndex = serialized.indexOf('middle server result');
+    const secondIndex = serialized.indexOf('Second narration.');
+
+    expect(firstIndex).toBeGreaterThanOrEqual(0);
+    expect(firstIndex).toBeLessThan(resultIndex);
+    expect(resultIndex).toBeLessThan(secondIndex);
   });
 
   it('keeps Azure client customization and gates reasoning to reasoning models', () => {

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -467,8 +467,20 @@ describe('custom chat model class smoke tests', () => {
           } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
         }
         yield {
-          type: 'response.output_text.delta',
+          type: 'response.output_item.added',
           sequence_number: items.length,
+          output_index: items.length,
+          item: {
+            id: 'msg_partial',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: items.length + 1,
           output_index: items.length,
           content_index: 0,
           item_id: 'msg_partial',
@@ -477,7 +489,7 @@ describe('custom chat model class smoke tests', () => {
         } as OpenAIClient.Responses.ResponseStreamEvent;
         yield {
           type: 'response.output_text.delta',
-          sequence_number: items.length + 1,
+          sequence_number: items.length + 2,
           output_index: items.length,
           content_index: 0,
           item_id: 'msg_partial',
@@ -497,7 +509,7 @@ describe('custom chat model class smoke tests', () => {
       undefined
     );
 
-    expect(chunks).toHaveLength(items.length + 2);
+    expect(chunks).toHaveLength(items.length + 3);
     expect(combined?.text).toBe('Partial answer.');
     expect(combined?.additional_kwargs.tool_outputs).toEqual(items);
     expect(
@@ -509,10 +521,64 @@ describe('custom chat model class smoke tests', () => {
         outputIndex,
       })),
       {
+        itemId: 'msg_partial',
+        kind: 'message',
+        outputIndex: items.length,
+      },
+      {
         contentIndex: 0,
         itemId: 'msg_partial',
         kind: 'text',
         outputIndex: items.length,
+      },
+    ]);
+  });
+
+  it('rehydrates one-chunk Responses replay ordering from constructor kwargs', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingOpenAIResponsesDelegate }
+    ).responses;
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 3,
+          content_index: 2,
+          item_id: 'msg_one_chunk',
+          delta: 'Partial answer.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    const stream = await model.stream([new HumanMessage('answer')]);
+    const result = await stream.next();
+    expect(result.done).toBe(false);
+    const chunk = result.value as AIMessageChunk;
+    const serializedFields = JSON.parse(
+      JSON.stringify(chunk.lc_kwargs)
+    ) as ConstructorParameters<typeof AIMessageChunk>[0];
+    const rehydrated = new AIMessageChunk(serializedFields);
+
+    expect(chunk.content).toEqual([
+      { type: 'text', text: 'Partial answer.', index: 0 },
+    ]);
+    expect(rehydrated.content).toEqual([
+      { type: 'text', text: 'Partial answer.', index: 0 },
+    ]);
+    expect(
+      rehydrated.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
+    ).toEqual([
+      {
+        contentIndex: 2,
+        itemId: 'msg_one_chunk',
+        kind: 'text',
+        outputIndex: 3,
       },
     ]);
   });

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -47,6 +47,24 @@ type StreamingOpenAIResponsesDelegate = OpenAIResponsesDelegate & {
     request: OpenAIClient.Responses.ResponseCreateParamsStreaming
   ) => Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
 };
+type MockableResponsesDelegate = OpenAIResponsesDelegate & {
+  completionWithRetry: (request: {
+    input?: unknown;
+    stream?: boolean;
+  }) => Promise<unknown>;
+  _generate: (
+    messages: AIMessage[],
+    options: Record<string, unknown>
+  ) => Promise<unknown>;
+  _streamChatModelEvents: (
+    messages: AIMessage[],
+    options: Record<string, unknown>
+  ) => AsyncGenerator<unknown>;
+  _streamResponseChunks: (
+    messages: AIMessage[],
+    options: Record<string, unknown>
+  ) => AsyncGenerator<ChatGenerationChunk>;
+};
 type AnthropicCallOptions = Parameters<
   CustomAnthropic['invocationParams']
 >[0] & {
@@ -192,6 +210,107 @@ const baseAzureFields = {
   azureOpenAIApiInstanceName: 'test-instance',
   azureOpenAIApiDeploymentName: 'test-deployment',
 };
+
+function createPersistedPreemptedAzureMessage(): AIMessage {
+  return new AIMessage({
+    id: 'msg_persisted_azure',
+    content: [{ type: 'text', text: 'Partial Azure answer.' }],
+    additional_kwargs: {
+      reasoning: {
+        id: 'rs_persisted_azure',
+        type: 'reasoning',
+        status: 'in_progress',
+        summary: [],
+      },
+      tool_outputs: [
+        {
+          id: 'local_persisted_azure',
+          type: 'local_shell_call_output',
+          status: 'completed',
+          output: 'AZURE_SERVER_RESULT',
+        },
+      ],
+      [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+        {
+          itemId: 'local_persisted_azure',
+          kind: 'output',
+          outputIndex: 0,
+        },
+        {
+          itemId: 'rs_persisted_azure',
+          kind: 'reasoning',
+          outputIndex: 1,
+        },
+        {
+          itemId: 'msg_persisted_azure',
+          kind: 'text',
+          outputIndex: 2,
+          contentIndex: 0,
+        },
+      ],
+    },
+    response_metadata: {
+      id: 'resp_persisted_azure',
+      model_provider: 'openai',
+      preempted: true,
+    },
+  });
+}
+
+function expectNeutralizedAzureResponsesRequest(request: unknown): void {
+  const serialized = JSON.stringify(request);
+  expect(serialized).toContain('AZURE_SERVER_RESULT');
+  expect(serialized.match(/AZURE_SERVER_RESULT/g)).toHaveLength(1);
+  expect(serialized).toContain('serverToolResult');
+  expect(serialized).not.toContain('msg_persisted_azure');
+  expect(serialized).not.toContain('rs_persisted_azure');
+  expect(serialized).not.toContain('local_persisted_azure');
+  expect(serialized).not.toContain('resp_persisted_azure');
+  expect(serialized).not.toContain(OPENAI_RESPONSES_REPLAY_POSITIONS_KEY);
+  expect(serialized).not.toContain('local_shell_call_output');
+}
+
+function createCompletedAzureResponse(): OpenAIClient.Responses.Response {
+  return {
+    id: 'resp_fresh_azure',
+    created_at: 0,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: {},
+    model: 'gpt-5',
+    object: 'response',
+    output: [
+      {
+        id: 'msg_fresh_azure',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: 'Fresh Azure answer.',
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    output_text: 'Fresh Azure answer.',
+    parallel_tool_calls: true,
+    status: 'completed',
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    usage: {
+      input_tokens: 1,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+      output_tokens: 1,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 2,
+    },
+  } as OpenAIClient.Responses.Response;
+}
 
 const waitForFetchOutcome = (
   promise: Promise<Response>,
@@ -1015,6 +1134,61 @@ describe('custom chat model class smoke tests', () => {
     nonReasoningModel.model = 'gpt-4o';
     nonReasoningModel.reasoning = { effort: 'low' };
     expect(nonReasoningModel.getReasoningParams()).toBeUndefined();
+  });
+
+  it('sanitizes persisted preempted history on direct Azure Responses streams', async () => {
+    const model = new AzureChatOpenAI({
+      ...baseAzureFields,
+    });
+    model.model = 'gpt-5';
+    const responses = (
+      model as unknown as { responses: MockableResponsesDelegate }
+    ).responses;
+    const requests: unknown[] = [];
+    responses.completionWithRetry = async (request) => {
+      requests.push(request);
+      return (async function* () {})();
+    };
+    const message = createPersistedPreemptedAzureMessage();
+    const originalSerialized = JSON.stringify(message.toJSON());
+
+    for await (const _chunk of responses._streamResponseChunks([message], {})) {
+      // The empty mock stream intentionally yields no chunks.
+    }
+    for await (const _event of responses._streamChatModelEvents(
+      [message],
+      {}
+    )) {
+      // The empty mock stream intentionally yields no events.
+    }
+
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expectNeutralizedAzureResponsesRequest(request);
+    }
+    expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+  });
+
+  it('sanitizes persisted preempted history on direct Azure Responses generation', async () => {
+    const model = new AzureChatOpenAI({
+      ...baseAzureFields,
+    });
+    model.model = 'gpt-5';
+    const responses = (
+      model as unknown as { responses: MockableResponsesDelegate }
+    ).responses;
+    let request: unknown;
+    responses.completionWithRetry = async (nextRequest) => {
+      request = nextRequest;
+      return createCompletedAzureResponse();
+    };
+    const message = createPersistedPreemptedAzureMessage();
+    const originalSerialized = JSON.stringify(message.toJSON());
+
+    await responses._generate([message], {});
+
+    expectNeutralizedAzureResponsesRequest(request);
+    expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
   });
 
   it('keeps DeepSeek, Moonshot, and xAI on LibreChat wrapper semantics', () => {

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -18,6 +18,7 @@ import type * as t from '@/types';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { convertMessageContentToParts } from '@/llm/google/utils/common';
+import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { toLangChainContent } from '@/messages/langchain';
 import { Constants, Providers } from '@/common';
@@ -823,6 +824,103 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
     expect(invokeMessages[invokeMessages.length - 1][0].content).toBe(
       '[ref: tool0turn0]\noutput'
     );
+
+    jest.dontMock('@/llm/init');
+    jest.resetModules();
+  });
+
+  it('neutralizes preempted Responses history before an OpenAI Chat fallback', async () => {
+    const reasoning = {
+      id: 'rs_fallback',
+      type: 'reasoning',
+      status: 'completed',
+      summary: [],
+      encrypted_content: 'opaque-fallback-reasoning',
+    };
+    const toolOutput = {
+      id: 'ci_fallback',
+      type: 'code_interpreter_call',
+      status: 'completed',
+      code: 'print("fallback result")',
+      outputs: [{ type: 'logs', logs: 'fallback result' }],
+    };
+    const translatedMessage = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: {
+        reasoning,
+        tool_outputs: [toolOutput],
+      },
+      response_metadata: { model_provider: 'openai' },
+    });
+    const message = new AIMessage({
+      contentBlocks: [
+        ...translatedMessage.contentBlocks,
+        {
+          type: 'non_standard',
+          value: {
+            id: 'rs_bare_fallback',
+            type: 'reasoning',
+            summary: [],
+          },
+        },
+        {
+          type: 'image',
+          mimeType: 'image/png',
+          data: 'AA==',
+          id: 'ig_fallback',
+          metadata: { status: 'completed' },
+        },
+      ],
+      additional_kwargs: {
+        reasoning,
+        tool_outputs: [toolOutput],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        output_version: 'v1',
+        preempted: true,
+      },
+    });
+    const { invokeMessages, model } = buildCapturingModel();
+    model._useResponsesApi = () => false;
+    jest.doMock('@/llm/init', () => ({
+      initializeModel: (): unknown => model,
+    }));
+    jest.resetModules();
+    const { tryFallbackProviders: freshTry } = (await import(
+      '@/llm/invoke'
+    )) as { tryFallbackProviders: typeof tryFallbackProviders };
+
+    await freshTry({
+      fallbacks: [
+        {
+          provider: Providers.OPENAI,
+          clientOptions: { model: 'gpt-5.6' },
+        },
+      ],
+      messages: [message],
+      primaryError: new Error('primary failed'),
+    });
+
+    const sent = invokeMessages[invokeMessages.length - 1][0] as AIMessage;
+    expect(sent).not.toBe(message);
+    expect(sent.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      { type: 'text', text: expect.stringContaining('fallback result') },
+    ]);
+    expect(sent.additional_kwargs).toEqual({});
+    expect(JSON.stringify(sent.toJSON())).not.toMatch(/rs_|ci_|ig_/);
+    const chatPayload = _convertMessagesToOpenAIParams([sent], 'gpt-5.6');
+    expect(chatPayload).toEqual([
+      {
+        role: 'assistant',
+        content: sent.content,
+      },
+    ]);
+    expect(JSON.stringify(chatPayload)).not.toMatch(/rs_|ci_|ig_/);
+    expect(JSON.stringify(message.toJSON())).toContain('rs_fallback');
+    expect(JSON.stringify(message.toJSON())).toContain('ci_fallback');
+    expect(JSON.stringify(message.toJSON())).toContain('ig_fallback');
 
     jest.dontMock('@/llm/init');
     jest.resetModules();

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1,14 +1,14 @@
 import { concat } from '@langchain/core/utils/stream';
 import { AIMessageChunk } from '@langchain/core/messages';
+import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import {
   CallbackManager,
   CallbackManagerForLLMRun,
   type Callbacks,
 } from '@langchain/core/callbacks/manager';
-import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import type { Serialized } from '@langchain/core/load/serializable';
-import type { ChatGeneration } from '@langchain/core/outputs';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ChatGeneration } from '@langchain/core/outputs';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
@@ -25,27 +25,27 @@ import {
   projectToolStreamContentForProvider,
 } from '@/messages/core';
 import {
-  stripAnthropicCacheControl,
-  stripBedrockCacheControl,
-} from '@/messages/cache';
-import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
-import { assertNotTruncatedToolCall } from '@/llm/truncation';
-import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
-import { manualToolStreamProviders } from '@/llm/providers';
-import { appendCallbacks } from '@/utils/callbacks';
-import { safeDispatchCustomEvent } from '@/utils/events';
-import { getContextOverflowInfo } from '@/utils/errors';
-import {
   modifyDeltaProperties,
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
   appendPredecessorHandoffCue,
   removePredecessorHandoffCue,
 } from '@/messages';
-import { canSealPreempt } from '@/llm/preempt';
+import {
+  stripAnthropicCacheControl,
+  stripBedrockCacheControl,
+} from '@/messages/cache';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
-import { initializeModel } from '@/llm/init';
+import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
+import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
+import { assertNotTruncatedToolCall } from '@/llm/truncation';
+import { manualToolStreamProviders } from '@/llm/providers';
 import { isAnthropicLike, isOpenAILike } from '@/utils/llm';
+import { safeDispatchCustomEvent } from '@/utils/events';
+import { getContextOverflowInfo } from '@/utils/errors';
+import { appendCallbacks } from '@/utils/callbacks';
+import { canSealPreempt } from '@/llm/preempt';
+import { initializeModel } from '@/llm/init';
 
 /**
  * Context passed to `attemptInvoke`. Matches the subset of Graph that
@@ -174,8 +174,17 @@ export function projectMessagesForProvider({
   maxToolResultChars?: number;
   callOptions?: unknown;
 }): BaseMessage[] {
-  const providerInputMessages = projectToolStreamContentForProvider(messages);
-  if (usesNativeOpenAIResponses(model, provider, callOptions)) {
+  const nativeOpenAIResponses = usesNativeOpenAIResponses(
+    model,
+    provider,
+    callOptions
+  );
+  const providerInputMessages = projectToolStreamContentForProvider(
+    messages,
+    nativeOpenAIResponses ? 'native' : 'fallback',
+    maxToolResultChars
+  );
+  if (nativeOpenAIResponses) {
     return projectOpenAIResponsesToolMessageContent(
       stripAnthropicCacheControl(
         stripBedrockCacheControl(providerInputMessages)
@@ -677,11 +686,7 @@ export async function attemptInvoke(
   });
   const registry = context?.getOrCreateToolOutputRegistry();
   const runId = config?.configurable?.run_id as string | undefined;
-  const annotated = annotateMessagesForLLM(
-    invocationMessages,
-    registry,
-    runId
-  );
+  const annotated = annotateMessagesForLLM(invocationMessages, registry, runId);
   /**
    * Keyed on the provider ACTUALLY serving this call, not the agent's primary.
    * `createCallModel` normalizes for the primary, but `tryFallbackProviders`

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -442,15 +442,19 @@ function synthesizeSealedUsage(
   const inputTokens =
     (countSealedTokens(context, metadata, prompt) ?? 0) +
     sealedInstructionOverhead(context, metadata);
-  chunk.usage_metadata = {
+  const usageMetadata = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
     total_tokens: inputTokens + outputTokens,
   };
-  chunk.response_metadata = {
+  chunk.usage_metadata = usageMetadata;
+  chunk.lc_kwargs.usage_metadata = usageMetadata;
+  const responseMetadata = {
     ...chunk.response_metadata,
     estimated_usage: true,
   };
+  chunk.response_metadata = responseMetadata;
+  chunk.lc_kwargs.response_metadata = responseMetadata;
 }
 
 function getMessageText(chunk: AIMessageChunk): string {
@@ -865,10 +869,12 @@ export async function attemptInvoke(
     }
 
     if (preempted && finalChunk != null) {
-      finalChunk.response_metadata = {
+      const responseMetadata = {
         ...finalChunk.response_metadata,
         preempted: true,
       };
+      finalChunk.response_metadata = responseMetadata;
+      finalChunk.lc_kwargs.response_metadata = responseMetadata;
       await endSealedModelRun(
         context,
         finalChunk,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -584,6 +584,75 @@ const RESPONSES_REPLAY_OUTPUT_ITEM_TYPES = new Set([
   'program_output',
 ]);
 
+function isResponsesReplayOutputItem(item: unknown): boolean {
+  return (
+    typeof item === 'object' &&
+    item != null &&
+    'type' in item &&
+    typeof item.type === 'string' &&
+    RESPONSES_REPLAY_OUTPUT_ITEM_TYPES.has(item.type)
+  );
+}
+
+/**
+ * LangChain's Responses converter places the authoritative terminal output in
+ * response_metadata.output. Its chunk merge has no way to delete provisional
+ * tool_outputs, so remove only our preemption-only captures once that terminal
+ * output arrives. A stream that is interrupted has no terminal chunk and keeps
+ * the captures for replay.
+ */
+class ResponsesReplayAIMessageChunk extends AIMessageChunk {
+  override get lc_id(): string[] {
+    return [...this.lc_namespace, AIMessageChunk.lc_name()];
+  }
+
+  override concat(chunk: AIMessageChunk): this {
+    const combined = super.concat(chunk);
+    if (!Array.isArray(combined.response_metadata.output)) {
+      return combined;
+    }
+    const toolOutputs = combined.additional_kwargs.tool_outputs;
+    if (!Array.isArray(toolOutputs)) {
+      return combined;
+    }
+    const retainedToolOutputs = toolOutputs.filter(
+      (item) => !isResponsesReplayOutputItem(item)
+    );
+    if (retainedToolOutputs.length === toolOutputs.length) {
+      return combined;
+    }
+    const additionalKwargs = { ...combined.additional_kwargs };
+    if (retainedToolOutputs.length > 0) {
+      additionalKwargs.tool_outputs = retainedToolOutputs;
+    } else {
+      delete additionalKwargs.tool_outputs;
+    }
+    combined.additional_kwargs = additionalKwargs;
+    return combined;
+  }
+}
+
+function makeResponsesReplayAggregationSafe(
+  chunk: ChatGenerationChunk
+): ChatGenerationChunk {
+  if (!AIMessageChunk.isInstance(chunk.message)) {
+    return chunk;
+  }
+  const message = chunk.message;
+  chunk.message = new ResponsesReplayAIMessageChunk({
+    id: message.id,
+    name: message.name,
+    content: message.content,
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+    tool_calls: message.tool_calls,
+    invalid_tool_calls: message.invalid_tool_calls,
+    tool_call_chunks: message.tool_call_chunks,
+    usage_metadata: message.usage_metadata,
+  });
+  return chunk;
+}
+
 function remapResponsesTextBlockIndex(
   chunk: ChatGenerationChunk,
   event: OpenAIClient.Responses.ResponseStreamEvent,
@@ -740,16 +809,16 @@ async function* convertLibreChatResponsesStream(
       if (options.signal?.aborted === true) {
         return;
       }
-      const chunk =
+      const convertedChunk =
         convertResponsesDeltaToChatGenerationChunk(event) ??
         convertDroppedResponsesReplayOutput(event);
-      if (chunk == null) {
+      if (convertedChunk == null) {
         continue;
       }
+      const chunk = makeResponsesReplayAggregationSafe(convertedChunk);
       remapResponsesTextBlockIndex(chunk, event, responsesTextBlockIndices);
       attachResponsesReplayPosition(chunk, event, seenReplayPositions);
       attachCacheWriteUsage(chunk.message);
-      yield chunk;
       await runManager?.handleLLMNewToken(
         chunk.text || '',
         {
@@ -761,6 +830,7 @@ async function* convertLibreChatResponsesStream(
         undefined,
         { chunk }
       );
+      yield chunk;
     }
   } catch (e) {
     throw wrapOpenAIClientError(e);

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -684,11 +684,13 @@ function remapResponsesTextBlockIndex(
     blockIndex = textBlockIndices.size;
     textBlockIndices.set(key, blockIndex);
   }
-  chunk.message.content = chunk.message.content.map((block) =>
+  const content = chunk.message.content.map((block) =>
     typeof block === 'object' && block.type === 'text'
       ? { ...block, index: blockIndex }
       : block
   );
+  chunk.message.content = content;
+  chunk.message.lc_kwargs.content = content;
 }
 
 function convertDroppedResponsesReplayOutput(
@@ -744,6 +746,17 @@ function attachResponsesReplayPosition(
     };
   } else if (
     event.type === 'response.output_item.added' &&
+    event.item.type === 'message' &&
+    typeof event.item.id === 'string' &&
+    event.item.id.length > 0
+  ) {
+    position = {
+      itemId: event.item.id,
+      kind: 'message',
+      outputIndex: event.output_index,
+    };
+  } else if (
+    event.type === 'response.output_item.added' &&
     event.item.type === 'reasoning' &&
     typeof event.item.id === 'string' &&
     event.item.id.length > 0
@@ -787,13 +800,15 @@ function attachResponsesReplayPosition(
   const existing = chunk.message.additional_kwargs[
     OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
   ] as unknown;
-  chunk.message.additional_kwargs = {
+  const additionalKwargs = {
     ...chunk.message.additional_kwargs,
     [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
       ...(Array.isArray(existing) ? existing : []),
       position,
     ],
   };
+  chunk.message.additional_kwargs = additionalKwargs;
+  chunk.message.lc_kwargs.additional_kwargs = additionalKwargs;
 }
 
 async function* convertLibreChatResponsesStream(
@@ -805,9 +820,7 @@ async function* convertLibreChatResponsesStream(
   const responsesTextBlockIndices = new Map<string, number>();
   try {
     for await (const event of stream) {
-      if (options.signal?.aborted === true) {
-        return;
-      }
+      options.signal?.throwIfAborted();
       const convertedChunk =
         convertResponsesDeltaToChatGenerationChunk(event) ??
         convertDroppedResponsesReplayOutput(event);

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -16,7 +16,10 @@ import {
 import {
   getEndpoint,
   OpenAIClient,
+  wrapOpenAIClientError,
   getHeadersWithUserAgent,
+  convertMessagesToResponsesInput,
+  convertResponsesDeltaToChatGenerationChunk,
   ChatOpenAI as OriginalChatOpenAI,
   ChatOpenAIResponses as OriginalChatOpenAIResponses,
   ChatOpenAICompletions as OriginalChatOpenAICompletions,
@@ -51,8 +54,8 @@ import {
   projectOpenAIResponsesToolMessageContent,
   projectToolStreamContentForProvider,
 } from '@/messages/core';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -224,6 +227,10 @@ type ResponsesRequest =
 type ResponsesResult =
   | AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>
   | OpenAIClient.Responses.Response;
+type ResponsesStreamChunkOptions = {
+  promptIndex?: number;
+  signal?: AbortSignal;
+};
 type CacheableChatPart = {
   type: 'text' | 'image_url' | 'input_audio' | 'file' | 'refusal';
   prompt_cache_breakpoint?: { mode: 'explicit' };
@@ -566,6 +573,67 @@ function isResponsesStream(
   result: ResponsesResult
 ): result is AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent> {
   return Symbol.asyncIterator in result;
+}
+
+const RESPONSES_REPLAY_OUTPUT_ITEM_TYPES = new Set([
+  'local_shell_call_output',
+  'shell_call_output',
+  'apply_patch_call_output',
+  'program_output',
+]);
+
+function convertDroppedResponsesReplayOutput(
+  event: OpenAIClient.Responses.ResponseStreamEvent
+): ChatGenerationChunk | null {
+  if (
+    event.type !== 'response.output_item.done' ||
+    !RESPONSES_REPLAY_OUTPUT_ITEM_TYPES.has(event.item.type)
+  ) {
+    return null;
+  }
+  return new ChatGenerationChunk({
+    text: '',
+    message: new AIMessageChunk({
+      content: [],
+      additional_kwargs: { tool_outputs: [event.item] },
+      response_metadata: { model_provider: 'openai' },
+    }),
+  });
+}
+
+async function* convertLibreChatResponsesStream(
+  stream: AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>,
+  options: ResponsesStreamChunkOptions,
+  runManager?: CallbackManagerForLLMRun
+): AsyncGenerator<ChatGenerationChunk> {
+  try {
+    for await (const event of stream) {
+      if (options.signal?.aborted === true) {
+        return;
+      }
+      const chunk =
+        convertResponsesDeltaToChatGenerationChunk(event) ??
+        convertDroppedResponsesReplayOutput(event);
+      if (chunk == null) {
+        continue;
+      }
+      attachCacheWriteUsage(chunk.message);
+      yield chunk;
+      await runManager?.handleLLMNewToken(
+        chunk.text || '',
+        {
+          prompt: options.promptIndex ?? 0,
+          completion: 0,
+        },
+        undefined,
+        undefined,
+        undefined,
+        { chunk }
+      );
+    }
+  } catch (e) {
+    throw wrapOpenAIClientError(e);
+  }
 }
 
 function createUsageMetadata(
@@ -1754,14 +1822,20 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
-    for await (const chunk of super._streamResponseChunks(
-      projectOpenAIResponsesProviderMessages(messages),
-      options,
-      runManager
-    )) {
-      attachCacheWriteUsage(chunk.message);
-      yield chunk;
-    }
+    const projectedMessages = projectOpenAIResponsesProviderMessages(messages);
+    const stream = await this.completionWithRetry(
+      {
+        ...this.invocationParams(options),
+        input: convertMessagesToResponsesInput({
+          messages: projectedMessages,
+          zdrEnabled: this.zdrEnabled ?? false,
+          model: this.model,
+        }),
+        stream: true,
+      },
+      options
+    );
+    yield* convertLibreChatResponsesStream(stream, options, runManager);
   }
 
   async *_streamChatModelEvents(
@@ -2000,14 +2074,19 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
-    for await (const chunk of super._streamResponseChunks(
-      messages,
-      options,
-      runManager
-    )) {
-      attachCacheWriteUsage(chunk.message);
-      yield chunk;
-    }
+    const stream = await this.completionWithRetry(
+      {
+        ...this.invocationParams(options),
+        input: convertMessagesToResponsesInput({
+          messages,
+          zdrEnabled: this.zdrEnabled ?? false,
+          model: this.model,
+        }),
+        stream: true,
+      },
+      options
+    );
+    yield* convertLibreChatResponsesStream(stream, options, runManager);
   }
 
   protected _getReasoningParams(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -37,6 +37,7 @@ import type { BindToolsInput } from '@langchain/core/language_models/chat_models
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
+import type { ResponsesReplayPosition } from '@/messages/core';
 import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
 import type { PromptCacheTtl } from '@/messages/cache';
@@ -582,13 +583,6 @@ const RESPONSES_REPLAY_OUTPUT_ITEM_TYPES = new Set([
   'apply_patch_call_output',
   'program_output',
 ]);
-
-type ResponsesReplayPosition = {
-  contentIndex?: number;
-  itemId: string;
-  kind: 'output' | 'text';
-  outputIndex: number;
-};
 
 function remapResponsesTextBlockIndex(
   chunk: ChatGenerationChunk,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -626,10 +626,29 @@ function remapResponsesTextBlockIndex(
 function convertDroppedResponsesReplayOutput(
   event: OpenAIClient.Responses.ResponseStreamEvent
 ): ChatGenerationChunk | null {
-  if (
-    event.type !== 'response.output_item.done' ||
-    !RESPONSES_REPLAY_OUTPUT_ITEM_TYPES.has(event.item.type)
-  ) {
+  if (event.type !== 'response.output_item.done') {
+    return null;
+  }
+  if (event.item.type === 'reasoning') {
+    // Added/summary events already stream id, type, and summary. Only merge
+    // terminal fields here so chunk concatenation does not duplicate summary.
+    return new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({
+        content: [],
+        additional_kwargs: {
+          reasoning: {
+            status: event.item.status,
+            ...(typeof event.item.encrypted_content === 'string'
+              ? { encrypted_content: event.item.encrypted_content }
+              : {}),
+          },
+        },
+        response_metadata: { model_provider: 'openai' },
+      }),
+    });
+  }
+  if (!RESPONSES_REPLAY_OUTPUT_ITEM_TYPES.has(event.item.type)) {
     return null;
   }
   return new ChatGenerationChunk({
@@ -653,6 +672,17 @@ function attachResponsesReplayPosition(
       contentIndex: event.content_index,
       itemId: event.item_id,
       kind: 'text',
+      outputIndex: event.output_index,
+    };
+  } else if (
+    event.type === 'response.output_item.added' &&
+    event.item.type === 'reasoning' &&
+    typeof event.item.id === 'string' &&
+    event.item.id.length > 0
+  ) {
+    position = {
+      itemId: event.item.id,
+      kind: 'reasoning',
       outputIndex: event.output_index,
     };
   } else if (

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -2275,7 +2275,11 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
-    const result = await super._generate(messages, options, runManager);
+    const result = await super._generate(
+      projectOpenAIResponsesProviderMessages(messages),
+      options,
+      runManager
+    );
     for (const generation of result.generations) {
       attachCacheWriteUsage(generation.message);
     }
@@ -2287,11 +2291,12 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    const projectedMessages = projectOpenAIResponsesProviderMessages(messages);
     const stream = await this.completionWithRetry(
       {
         ...this.invocationParams(options),
         input: convertMessagesToResponsesInput({
-          messages,
+          messages: projectedMessages,
           zdrEnabled: this.zdrEnabled ?? false,
           model: this.model,
         }),
@@ -2300,6 +2305,18 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       options
     );
     yield* convertLibreChatResponsesStream(stream, options, runManager);
+  }
+
+  async *_streamChatModelEvents(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatModelStreamEvent> {
+    yield* super._streamChatModelEvents(
+      projectOpenAIResponsesProviderMessages(messages),
+      options,
+      runManager
+    );
   }
 
   protected _getReasoningParams(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -41,6 +41,11 @@ import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
 import type { PromptCacheTtl } from '@/messages/cache';
 import {
+  OPENAI_RESPONSES_REPLAY_POSITIONS_KEY,
+  projectOpenAIResponsesToolMessageContent,
+  projectToolStreamContentForProvider,
+} from '@/messages/core';
+import {
   buildAnthropicCacheControl,
   resolvePromptCacheTtl,
   stripAnthropicCacheControl,
@@ -50,10 +55,6 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import {
-  projectOpenAIResponsesToolMessageContent,
-  projectToolStreamContentForProvider,
-} from '@/messages/core';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
@@ -393,6 +394,10 @@ function isResponseMessage(
   return item.type === 'message';
 }
 
+function isResponseInputRole(role: string): boolean {
+  return role === 'system' || role === 'developer' || role === 'user';
+}
+
 /** Only `input_text`/`input_image`/`input_file` accept a Responses breakpoint;
  *  `output_text`/`refusal` (replayed assistant blocks) are rejected with a 400. */
 function isCacheableResponsePart(part: unknown): part is CacheableResponsePart {
@@ -466,11 +471,7 @@ export function addResponseCacheBreakpoints(
         /** Only input roles take a Responses breakpoint. Assistant/tool turns
          *  carry output content (string or output_text) that the API rejects
          *  under an input marker, so they're never eligible. */
-        if (
-          item.role !== 'system' &&
-          item.role !== 'developer' &&
-          item.role !== 'user'
-        ) {
+        if (!isResponseInputRole(item.role)) {
           return false;
         }
         const content = item.content as
@@ -582,6 +583,52 @@ const RESPONSES_REPLAY_OUTPUT_ITEM_TYPES = new Set([
   'program_output',
 ]);
 
+type ResponsesReplayPosition = {
+  contentIndex?: number;
+  itemId: string;
+  kind: 'output' | 'text';
+  outputIndex: number;
+};
+
+function remapResponsesTextBlockIndex(
+  chunk: ChatGenerationChunk,
+  event: OpenAIClient.Responses.ResponseStreamEvent,
+  textBlockIndices: Map<string, number>
+): void {
+  const position = iife(() => {
+    if (
+      event.type === 'response.output_text.delta' ||
+      event.type === 'response.output_text.annotation.added'
+    ) {
+      return {
+        contentIndex: event.content_index,
+        outputIndex: event.output_index,
+      };
+    }
+    if (
+      event.type === 'response.output_item.added' &&
+      event.item.type === 'message'
+    ) {
+      return { contentIndex: 0, outputIndex: event.output_index };
+    }
+    return undefined;
+  });
+  if (position == null || !Array.isArray(chunk.message.content)) {
+    return;
+  }
+  const key = `${position.outputIndex}:${position.contentIndex}`;
+  let blockIndex = textBlockIndices.get(key);
+  if (blockIndex == null) {
+    blockIndex = textBlockIndices.size;
+    textBlockIndices.set(key, blockIndex);
+  }
+  chunk.message.content = chunk.message.content.map((block) =>
+    typeof block === 'object' && block.type === 'text'
+      ? { ...block, index: blockIndex }
+      : block
+  );
+}
+
 function convertDroppedResponsesReplayOutput(
   event: OpenAIClient.Responses.ResponseStreamEvent
 ): ChatGenerationChunk | null {
@@ -601,11 +648,69 @@ function convertDroppedResponsesReplayOutput(
   });
 }
 
+function attachResponsesReplayPosition(
+  chunk: ChatGenerationChunk,
+  event: OpenAIClient.Responses.ResponseStreamEvent,
+  seenPositions: Set<string>
+): void {
+  let position: ResponsesReplayPosition | undefined;
+  if (event.type === 'response.output_text.delta' && event.delta.length > 0) {
+    position = {
+      contentIndex: event.content_index,
+      itemId: event.item_id,
+      kind: 'text',
+      outputIndex: event.output_index,
+    };
+  } else if (
+    event.type === 'response.output_item.done' &&
+    (RESPONSES_REPLAY_OUTPUT_ITEM_TYPES.has(event.item.type) ||
+      Array.isArray(chunk.message.additional_kwargs.tool_outputs))
+  ) {
+    let itemId: string | undefined;
+    if (typeof event.item.id === 'string' && event.item.id.length > 0) {
+      itemId = event.item.id;
+    } else if (
+      'call_id' in event.item &&
+      typeof event.item.call_id === 'string' &&
+      event.item.call_id.length > 0
+    ) {
+      itemId = event.item.call_id;
+    }
+    if (itemId != null) {
+      position = {
+        itemId,
+        kind: 'output',
+        outputIndex: event.output_index,
+      };
+    }
+  }
+  if (position == null) {
+    return;
+  }
+  const positionKey = `${position.kind}:${position.itemId}:${position.outputIndex}:${position.contentIndex ?? ''}`;
+  if (seenPositions.has(positionKey)) {
+    return;
+  }
+  seenPositions.add(positionKey);
+  const existing = chunk.message.additional_kwargs[
+    OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+  ] as unknown;
+  chunk.message.additional_kwargs = {
+    ...chunk.message.additional_kwargs,
+    [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+      ...(Array.isArray(existing) ? existing : []),
+      position,
+    ],
+  };
+}
+
 async function* convertLibreChatResponsesStream(
   stream: AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>,
   options: ResponsesStreamChunkOptions,
   runManager?: CallbackManagerForLLMRun
 ): AsyncGenerator<ChatGenerationChunk> {
+  const seenReplayPositions = new Set<string>();
+  const responsesTextBlockIndices = new Map<string, number>();
   try {
     for await (const event of stream) {
       if (options.signal?.aborted === true) {
@@ -617,6 +722,8 @@ async function* convertLibreChatResponsesStream(
       if (chunk == null) {
         continue;
       }
+      remapResponsesTextBlockIndex(chunk, event, responsesTextBlockIndices);
+      attachResponsesReplayPosition(chunk, event, seenReplayPositions);
       attachCacheWriteUsage(chunk.message);
       yield chunk;
       await runManager?.handleLLMNewToken(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -621,13 +621,11 @@ class ResponsesReplayAIMessageChunk extends AIMessageChunk {
     if (retainedToolOutputs.length === toolOutputs.length) {
       return combined;
     }
-    const additionalKwargs = { ...combined.additional_kwargs };
     if (retainedToolOutputs.length > 0) {
-      additionalKwargs.tool_outputs = retainedToolOutputs;
+      combined.additional_kwargs.tool_outputs = retainedToolOutputs;
     } else {
-      delete additionalKwargs.tool_outputs;
+      delete combined.additional_kwargs.tool_outputs;
     }
-    combined.additional_kwargs = additionalKwargs;
     return combined;
   }
 }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -597,9 +597,9 @@ function isResponsesReplayOutputItem(item: unknown): boolean {
 /**
  * LangChain's Responses converter places the authoritative terminal output in
  * response_metadata.output. Its chunk merge has no way to delete provisional
- * tool_outputs, so remove only our preemption-only captures once that terminal
- * output arrives. A stream that is interrupted has no terminal chunk and keeps
- * the captures for replay.
+ * tool_outputs or replay-position sidecars, so remove those preemption-only
+ * captures once that terminal output arrives. An interrupted stream has no
+ * terminal chunk and keeps the captures for replay.
  */
 class ResponsesReplayAIMessageChunk extends AIMessageChunk {
   override get lc_id(): string[] {
@@ -608,9 +608,10 @@ class ResponsesReplayAIMessageChunk extends AIMessageChunk {
 
   override concat(chunk: AIMessageChunk): this {
     const combined = super.concat(chunk);
-    if (!Array.isArray(combined.response_metadata.output)) {
+    if (!Array.isArray(chunk.response_metadata.output)) {
       return combined;
     }
+    delete combined.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY];
     const toolOutputs = combined.additional_kwargs.tool_outputs;
     if (!Array.isArray(toolOutputs)) {
       return combined;

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -1133,6 +1133,49 @@ describe('ChatOpenAIResponses streaming callback dispatch', () => {
 
     expect(events).toEqual(['callback:visible chunk', 'yield:visible chunk']);
   });
+
+  it('propagates an abort received with the next buffered event', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = responsesOf<ResponsesStreamDelegate>(model);
+    const controller = new AbortController();
+    const abortReason = new Error('buffered Responses stream aborted');
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_abort',
+          delta: 'partial',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        controller.abort(abortReason);
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 1,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_abort',
+          delta: ' must not complete normally',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    const stream = responses._streamResponseChunks([new HumanMessage('test')], {
+      signal: controller.signal,
+    });
+
+    await expect(stream.next()).resolves.toMatchObject({
+      done: false,
+      value: { text: 'partial' },
+    });
+    await expect(stream.next()).rejects.toBe(abortReason);
+  });
 });
 
 describe('ChatOpenAICompletions reasoning_content compatibility', () => {

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -82,6 +82,17 @@ type CompletionsStreamDelegate = {
   ) => AsyncGenerator<ChatGenerationChunk>;
 };
 
+type ResponsesStreamDelegate = {
+  completionWithRetry: (
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming
+  ) => Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+  _streamResponseChunks: (
+    messages: BaseMessage[],
+    options: Record<string, unknown>,
+    runManager?: CallbackManagerForLLMRun
+  ) => AsyncGenerator<ChatGenerationChunk>;
+};
+
 type InvocationParamsDelegate = {
   invocationParams: (
     options: Record<string, unknown>,
@@ -108,6 +119,9 @@ function completionsDelegateOf(model: ChatOpenAI): CompletionsDelegate {
 
 const completionsOf = <T>(model: ChatOpenAI): T =>
   (model as unknown as { completions: T }).completions;
+
+const responsesOf = <T>(model: ChatOpenAI): T =>
+  (model as unknown as { responses: T }).responses;
 
 function newOpenAI(): ChatOpenAI {
   return new ChatOpenAI({ model: 'gpt-4o-mini', apiKey: 'test-key' });
@@ -1080,6 +1094,47 @@ describe('ChatOpenAICompletions streaming usage_metadata callback', () => {
   });
 });
 
+describe('ChatOpenAIResponses streaming callback dispatch', () => {
+  it('emits the callback before a consumer stops at the yielded chunk', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = responsesOf<ResponsesStreamDelegate>(model);
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_callback',
+          delta: 'visible chunk',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    const events: string[] = [];
+    const runManager = {
+      handleLLMNewToken(token: string): void {
+        events.push(`callback:${token}`);
+      },
+    } as unknown as CallbackManagerForLLMRun;
+
+    for await (const chunk of responses._streamResponseChunks(
+      [new HumanMessage('test')],
+      {},
+      runManager
+    )) {
+      events.push(`yield:${chunk.text}`);
+      break;
+    }
+
+    expect(events).toEqual(['callback:visible chunk', 'yield:visible chunk']);
+  });
+});
+
 describe('ChatOpenAICompletions reasoning_content compatibility', () => {
   it('should preserve reasoning_content on streamed assistant chunks', async () => {
     const model = new ChatOpenAI({
@@ -1237,11 +1292,15 @@ describe('ChatOpenAICompletions strict tools for structured output', () => {
       }) as unknown as {
         tools?: { function: { parameters: { properties: object } } }[];
       };
-      return Object.keys(params.tools?.[0]?.function.parameters.properties ?? {});
+      return Object.keys(
+        params.tools?.[0]?.function.parameters.properties ?? {}
+      );
     }
 
     it('drops the optional label when strict is auto-enabled (invalid otherwise)', () => {
-      expect(toolProperties({ response_format: jsonSchemaResponseFormat })).toEqual(['query']);
+      expect(
+        toolProperties({ response_format: jsonSchemaResponseFormat })
+      ).toEqual(['query']);
     });
 
     it('keeps the label on non-strict requests', () => {
@@ -1305,10 +1364,9 @@ describe('ChatOpenAICompletions strict tools for structured output', () => {
       }) as unknown as {
         tools?: { function: { parameters: { properties: object } } }[];
       };
-      expect(Object.keys(params.tools?.[0]?.function.parameters.properties ?? {})).toEqual([
-        'intent',
-        'title',
-      ]);
+      expect(
+        Object.keys(params.tools?.[0]?.function.parameters.properties ?? {})
+      ).toEqual(['intent', 'title']);
     });
   });
 });

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -674,7 +674,7 @@ export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
 export type ResponsesReplayPosition = {
   contentIndex?: number;
   itemId: string;
-  kind: 'output' | 'reasoning' | 'text';
+  kind: 'message' | 'output' | 'reasoning' | 'text';
   outputIndex: number;
 };
 
@@ -686,9 +686,11 @@ type CompletedGeneratedImages = {
 
 type ResponsesReplayArtifacts = {
   generatedImages: CompletedGeneratedImages;
+  messagePositions: ResponsesReplayPosition[];
   positionsByItemId: Map<string, ResponsesReplayItemPosition>;
   positionedServerToolResultIds: Set<string>;
   serverToolResults: PositionedResponsesReplayBlock[];
+  textPositions: ResponsesReplayPosition[];
 };
 
 type ResponsesReplayItemPosition = Pick<
@@ -823,7 +825,9 @@ function projectPreemptedResponsesV1Content(
   originalImages?: PositionedResponsesImages,
   serverToolResults?: PositionedResponsesReplayBlock[],
   positionedServerToolResultIds?: ReadonlySet<string>,
-  reasoningPosition?: ResponsesReplayItemPosition
+  reasoningPosition?: ResponsesReplayItemPosition,
+  textPositions?: readonly ResponsesReplayPosition[],
+  messagePositions?: readonly ResponsesReplayPosition[]
 ): {
   content: AIMessage['content'];
   preservedServerToolResult: boolean;
@@ -888,7 +892,10 @@ function projectPreemptedResponsesV1Content(
     }
   };
 
-  const appendReplayBlocks = (throughTextIndex?: number): void => {
+  const appendReplayBlocks = (
+    throughTextIndex?: number,
+    beforeOutputIndex?: number
+  ): void => {
     for (;;) {
       const generatedImage = generatedImages?.blocks[generatedImageIndex];
       const serverToolResult = serverToolResults?.[serverToolResultIndex];
@@ -920,6 +927,12 @@ function projectPreemptedResponsesV1Content(
       ) {
         return;
       }
+      if (
+        beforeOutputIndex != null &&
+        positionedResult.outputIndex >= beforeOutputIndex
+      ) {
+        return;
+      }
       if (selected.kind === 'generatedImage') {
         generatedImageIndex++;
       } else if (selected.kind === 'serverToolResult') {
@@ -941,6 +954,28 @@ function projectPreemptedResponsesV1Content(
       changed = true;
       preservedServerToolResult ||= selected.kind === 'serverToolResult';
     }
+  };
+
+  const appendPositionedOriginalImages = (throughTextIndex?: number): void => {
+    const nextOriginalImage = originalImages?.blocks[originalImageIndex];
+    if (
+      nextOriginalImage == null ||
+      (throughTextIndex != null &&
+        nextOriginalImage.textIndex > throughTextIndex)
+    ) {
+      return;
+    }
+    const followingTextPosition = textPositions?.[nextOriginalImage.textIndex];
+    const imageOnlyMessagePosition =
+      originalImages?.textCount === 0 ? messagePositions?.[0] : undefined;
+    const outputBoundary = followingTextPosition ?? imageOnlyMessagePosition;
+    if (outputBoundary != null) {
+      appendReplayBlocks(
+        nextOriginalImage.textIndex,
+        outputBoundary.outputIndex
+      );
+    }
+    appendOriginalImages(throughTextIndex);
   };
 
   for (let i = 0; i < contentBlocks.length; i++) {
@@ -972,7 +1007,7 @@ function projectPreemptedResponsesV1Content(
       continue;
     }
     if (block.type === 'text') {
-      appendOriginalImages(sourceTextIndex);
+      appendPositionedOriginalImages(sourceTextIndex);
       appendReplayBlocks(sourceTextIndex);
       if (replayProjection === 'fallback') {
         projected.push({ type: 'text', text: block.text });
@@ -984,7 +1019,7 @@ function projectPreemptedResponsesV1Content(
       continue;
     }
     if (originalImages != null && sourceTextIndex >= originalImages.textCount) {
-      appendOriginalImages();
+      appendPositionedOriginalImages();
     }
     if (
       block.type === 'server_tool_call' ||
@@ -1048,7 +1083,7 @@ function projectPreemptedResponsesV1Content(
     projected.splice(reasoningInsertionIndex ?? 0, 0, reasoningBlock);
     changed = true;
   }
-  appendOriginalImages();
+  appendPositionedOriginalImages();
   appendReplayBlocks();
   return {
     content: changed ? toLangChainContent(projected) : content,
@@ -1073,7 +1108,8 @@ function isResponsesReplayPosition(
   }
   const position = value as Partial<ResponsesReplayPosition>;
   return (
-    (position.kind === 'output' ||
+    (position.kind === 'message' ||
+      position.kind === 'output' ||
       position.kind === 'reasoning' ||
       position.kind === 'text') &&
     typeof position.itemId === 'string' &&
@@ -1155,11 +1191,19 @@ function getResponsesReplayArtifacts(
     ? replayPositionValue.filter(isResponsesReplayPosition)
     : [];
   const authoritativeOutputIndicesByItemId = new Map<string, number>();
+  const messagePositionsByKey = new Map<string, ResponsesReplayPosition>();
   const outputPositionsByItemId = new Map<string, ResponsesReplayPosition>();
   const textPositionsByKey = new Map<string, ResponsesReplayPosition>();
   for (const position of replayPositions) {
     if (position.kind === 'output' || position.kind === 'reasoning') {
       outputPositionsByItemId.set(position.itemId, position);
+      continue;
+    }
+    if (position.kind === 'message') {
+      messagePositionsByKey.set(
+        `${position.itemId}:${position.outputIndex}`,
+        position
+      );
       continue;
     }
     textPositionsByKey.set(
@@ -1183,6 +1227,15 @@ function getResponsesReplayArtifacts(
       continue;
     }
     hasAuthoritativeMessage = true;
+    const messageItemId =
+      'id' in item && typeof item.id === 'string'
+        ? item.id
+        : `message-${outputIndex}`;
+    messagePositionsByKey.set(`${messageItemId}:${outputIndex}`, {
+      itemId: messageItemId,
+      kind: 'message',
+      outputIndex,
+    });
     if (!('content' in item) || !Array.isArray(item.content)) {
       continue;
     }
@@ -1228,6 +1281,9 @@ function getResponsesReplayArtifacts(
     (a, b) =>
       a.outputIndex - b.outputIndex ||
       (a.contentIndex ?? 0) - (b.contentIndex ?? 0)
+  );
+  const messagePositions = [...messagePositionsByKey.values()].sort(
+    (a, b) => a.outputIndex - b.outputIndex
   );
   const textCountBeforeOutputIndex = new Map<number, number>();
   const positionedOutputIndexSet = new Set<number>();
@@ -1556,11 +1612,13 @@ function getResponsesReplayArtifacts(
       data,
       ids,
     },
+    messagePositions,
     positionedServerToolResultIds,
     positionsByItemId,
     serverToolResults: serverToolResults.sort(
       comparePositionedResponsesReplayBlocks
     ),
+    textPositions,
   };
 }
 
@@ -1581,9 +1639,12 @@ function getSelfContainedResponsesV0Images(
     }
     if (
       block.type === 'image' &&
-      (('url' in block &&
-        typeof block.url === 'string' &&
-        block.url.length > 0) ||
+      (('fileId' in block &&
+        typeof block.fileId === 'string' &&
+        block.fileId.length > 0) ||
+        ('url' in block &&
+          typeof block.url === 'string' &&
+          block.url.length > 0) ||
         ('data' in block &&
           ((typeof block.data === 'string' && block.data.length > 0) ||
             (block.data instanceof Uint8Array && block.data.length > 0))))
@@ -1666,9 +1727,11 @@ function projectPreemptedOpenAIResponsesMessage(
   const authoritativeOutput = getAuthoritativeResponsesOutput(message);
   const {
     generatedImages,
+    messagePositions,
     positionedServerToolResultIds,
     positionsByItemId,
     serverToolResults,
+    textPositions,
   } = getResponsesReplayArtifacts(
     authoritativeOutput,
     maxChars,
@@ -1711,7 +1774,9 @@ function projectPreemptedOpenAIResponsesMessage(
     originalImages,
     serverToolResults,
     positionedServerToolResultIds,
-    reasoningPosition
+    reasoningPosition,
+    textPositions,
+    messagePositions
   );
   const promotesV0 =
     !isV1 &&

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -580,7 +580,9 @@ function cloneAIMessageWithContent(
       ...lcKwargs,
       value: {
         ...(lcKwargs.value as Record<string, unknown>),
-        content,
+        ...(message.response_metadata.output_version === 'v1'
+          ? { content: undefined, contentBlocks: content }
+          : { content }),
       },
     };
   }
@@ -664,76 +666,232 @@ function hasReplayableEncryptedReasoning(reasoning: unknown): boolean {
   );
 }
 
-function isUnsafePreemptedResponsesV1Block(
-  block: LangChainContentBlock.Standard
-): boolean {
-  switch (block.type) {
-  case 'reasoning':
-  case 'server_tool_call':
-  case 'server_tool_call_chunk':
-  case 'server_tool_call_result':
-    return true;
-  case 'non_standard':
-    return !hasReplayableEncryptedReasoning(block.value);
-  default:
-    return false;
-  }
-}
+type ResponsesReplayProjection = 'fallback' | 'native';
+
+type CompletedGeneratedImages = {
+  blocks: LangChainContentBlock.Multimodal.Image[];
+  data: Set<string>;
+  ids: Set<string>;
+};
+
+type ResponsesReplayArtifacts = {
+  generatedImages: CompletedGeneratedImages;
+  serverToolResults: LangChainContentBlock.Standard[];
+};
+
+type PositionedResponsesImage = {
+  block: LangChainContentBlock.Multimodal.Image;
+  textIndex: number;
+};
+
+type PositionedResponsesImages = {
+  blocks: PositionedResponsesImage[];
+  textCount: number;
+};
 
 function isProviderGeneratedImageBlock(
   block: LangChainContentBlock.Multimodal.Image,
-  generatedImages: ReturnType<typeof getCompletedGeneratedImages>
+  generatedImages: CompletedGeneratedImages,
+  allowDataFallback = true
 ): boolean {
   if (typeof block.id === 'string' && block.id.length > 0) {
     return generatedImages.ids.has(block.id);
   }
   return (
+    allowDataFallback &&
     typeof block.data === 'string' &&
     generatedImages.data.has(block.data) &&
     block.metadata != null &&
     typeof block.metadata === 'object' &&
-    'status' in block.metadata
+    block.metadata.status === 'completed'
   );
+}
+
+function hasMeaningfulServerToolOutput(output: unknown): boolean {
+  if (output == null || output === '') {
+    return false;
+  }
+  if (Array.isArray(output)) {
+    return output.length > 0;
+  }
+  if (typeof output !== 'object') {
+    return true;
+  }
+  try {
+    return Object.keys(output).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function createNeutralServerToolResult(
+  output: unknown,
+  status: 'error' | 'success',
+  maxChars: number
+): LangChainContentBlock.Text | undefined {
+  if (!hasMeaningfulServerToolOutput(output)) {
+    return undefined;
+  }
+  return {
+    type: 'text',
+    text: serializeToolContentBounded(
+      { serverToolResult: { status, output } },
+      maxChars
+    ),
+  };
+}
+
+function isCompleteToolStreamContentBlock(block: unknown): boolean {
+  if (block == null || typeof block !== 'object') {
+    return true;
+  }
+  try {
+    if (isProxy(block)) {
+      return false;
+    }
+    const type = Object.getOwnPropertyDescriptor(block, 'type');
+    if (type == null) {
+      return true;
+    }
+    if (type.enumerable !== true || !('value' in type)) {
+      return false;
+    }
+    if (type.value !== 'text') {
+      return true;
+    }
+    const text = Object.getOwnPropertyDescriptor(block, 'text');
+    return (
+      text?.enumerable === true &&
+      'value' in text &&
+      typeof text.value === 'string' &&
+      text.value !== ''
+    );
+  } catch {
+    return false;
+  }
 }
 
 function projectPreemptedResponsesV1Content(
   content: AIMessage['content'],
   reasoning: unknown,
-  generatedImages?: ReturnType<typeof getCompletedGeneratedImages>,
-  originalImages?: LangChainContentBlock.Multimodal.Image[]
-): AIMessage['content'] {
+  maxChars: number,
+  replayProjection: ResponsesReplayProjection,
+  generatedImages?: CompletedGeneratedImages,
+  originalImages?: PositionedResponsesImages,
+  serverToolResults?: LangChainContentBlock.Standard[]
+): {
+  content: AIMessage['content'];
+  preservedServerToolResult: boolean;
+} {
   if (!Array.isArray(content)) {
-    return content;
+    return { content, preservedServerToolResult: false };
   }
 
   const contentBlocks = content as LangChainContentBlock.Standard[];
-  const encryptedReasoning = hasReplayableEncryptedReasoning(reasoning)
-    ? reasoning
-    : undefined;
-  let projected: LangChainContentBlock.Standard[] | undefined;
+  const encryptedReasoning =
+    replayProjection === 'native' && hasReplayableEncryptedReasoning(reasoning)
+      ? reasoning
+      : undefined;
+  const projected: LangChainContentBlock.Standard[] = [];
+  let changed = false;
   let hasEncryptedReasoning = false;
+  let preservedServerToolResult = false;
   let reasoningInsertionIndex: number | undefined;
+  let originalImageIndex = 0;
+  let sourceTextIndex = 0;
+
+  const appendOriginalImages = (throughTextIndex?: number): void => {
+    if (replayProjection !== 'native' || originalImages == null) {
+      return;
+    }
+    while (originalImageIndex < originalImages.blocks.length) {
+      const positionedImage = originalImages.blocks[originalImageIndex];
+      if (
+        throughTextIndex != null &&
+        positionedImage.textIndex > throughTextIndex
+      ) {
+        return;
+      }
+      originalImageIndex++;
+      if (
+        generatedImages != null &&
+        isProviderGeneratedImageBlock(
+          positionedImage.block,
+          generatedImages,
+          false
+        )
+      ) {
+        continue;
+      }
+      projected.push(positionedImage.block);
+      changed = true;
+    }
+  };
+
   for (let i = 0; i < contentBlocks.length; i++) {
     const block = contentBlocks[i];
-    if (
-      block.type === 'non_standard' &&
-      hasReplayableEncryptedReasoning(block.value)
-    ) {
-      hasEncryptedReasoning = true;
+    if (!isCompleteToolStreamContentBlock(block)) {
+      changed = true;
+      continue;
     }
-    if (
-      isUnsafePreemptedResponsesV1Block(block) ||
-      (generatedImages != null &&
-        block.type === 'image' &&
-        isProviderGeneratedImageBlock(block, generatedImages))
-    ) {
-      projected ??= contentBlocks.slice(0, i);
-      if (block.type === 'reasoning') {
-        reasoningInsertionIndex ??= projected.length;
+    if (block.type === 'reasoning') {
+      reasoningInsertionIndex ??= projected.length;
+      changed = true;
+      continue;
+    }
+    if (block.type === 'non_standard') {
+      if (
+        replayProjection === 'native' &&
+        !hasEncryptedReasoning &&
+        hasReplayableEncryptedReasoning(block.value)
+      ) {
+        hasEncryptedReasoning = true;
+        projected.push(block);
+      } else {
+        changed = true;
       }
       continue;
     }
-    projected?.push(block);
+    if (block.type === 'text') {
+      appendOriginalImages(sourceTextIndex);
+      projected.push(block);
+      sourceTextIndex++;
+      continue;
+    }
+    if (originalImages != null && sourceTextIndex >= originalImages.textCount) {
+      appendOriginalImages();
+    }
+    if (
+      block.type === 'server_tool_call' ||
+      block.type === 'server_tool_call_chunk'
+    ) {
+      changed = true;
+      continue;
+    }
+    if (block.type === 'server_tool_call_result') {
+      const result = createNeutralServerToolResult(
+        block.output,
+        block.status,
+        maxChars
+      );
+      changed = true;
+      if (result != null) {
+        projected.push(result);
+        preservedServerToolResult = true;
+      }
+      continue;
+    }
+    if (block.type === 'image') {
+      if (
+        replayProjection === 'fallback' ||
+        (generatedImages != null &&
+          isProviderGeneratedImageBlock(block, generatedImages))
+      ) {
+        changed = true;
+        continue;
+      }
+    }
+    projected.push(block);
   }
 
   if (encryptedReasoning != null && !hasEncryptedReasoning) {
@@ -741,97 +899,303 @@ function projectPreemptedResponsesV1Content(
       type: 'non_standard',
       value: encryptedReasoning,
     };
-    if (projected != null) {
-      projected.splice(reasoningInsertionIndex ?? 0, 0, reasoningBlock);
-    } else {
-      projected = [reasoningBlock, ...contentBlocks];
+    projected.splice(reasoningInsertionIndex ?? 0, 0, reasoningBlock);
+    changed = true;
+  }
+  appendOriginalImages();
+  if (serverToolResults != null) {
+    projected.push(...serverToolResults);
+    if (serverToolResults.length > 0) {
+      changed = true;
+      preservedServerToolResult = true;
     }
   }
-  if (originalImages != null) {
-    projected ??= [...contentBlocks];
-    for (const block of originalImages) {
-      const isGeneratedImage =
-        generatedImages != null &&
-        isProviderGeneratedImageBlock(block, generatedImages);
-      if (!isGeneratedImage) {
-        projected.push(block);
-      }
-    }
-  }
-  if (generatedImages != null) {
-    projected ??= [...contentBlocks];
+  if (replayProjection === 'native' && generatedImages != null) {
     projected.push(...generatedImages.blocks);
+    changed ||= generatedImages.blocks.length > 0;
   }
-  return projected ?? content;
+  return {
+    content: changed ? toLangChainContent(projected) : content,
+    preservedServerToolResult,
+  };
 }
 
-function getCompletedGeneratedImages(message: AIMessage): {
-  blocks: LangChainContentBlock.Multimodal.Image[];
-  data: Set<string>;
-  ids: Set<string>;
-} {
+function getAuthoritativeResponsesOutput(message: AIMessage): unknown[] {
   const responseOutput = message.response_metadata.output;
   const toolOutputs = message.additional_kwargs.tool_outputs;
-  const responseOutputIsAuthoritative =
-    Array.isArray(responseOutput) && responseOutput.length > 0;
+  if (Array.isArray(responseOutput) && responseOutput.length > 0) {
+    return responseOutput;
+  }
+  return Array.isArray(toolOutputs) ? toolOutputs : [];
+}
+
+function getResponsesReplayArtifacts(
+  output: readonly unknown[],
+  maxChars: number,
+  replayProjection: ResponsesReplayProjection
+): ResponsesReplayArtifacts {
   const blocks: LangChainContentBlock.Multimodal.Image[] = [];
   const data = new Set<string>();
   const ids = new Set<string>();
-  const sources = [
-    [responseOutput, responseOutputIsAuthoritative],
-    [toolOutputs, !responseOutputIsAuthoritative],
-  ] as const;
-  for (const [output, isAuthoritative] of sources) {
-    for (const item of Array.isArray(output) ? output : []) {
+  const emittedData = new Set<string>();
+  const emittedIds = new Set<string>();
+  const serverToolResults: LangChainContentBlock.Standard[] = [];
+  for (const item of output) {
+    if (item == null || typeof item !== 'object' || !('type' in item)) {
+      continue;
+    }
+    if (item.type === 'code_interpreter_call') {
       if (
-        item == null ||
-        typeof item !== 'object' ||
-        !('type' in item) ||
-        item.type !== 'image_generation_call'
+        !('outputs' in item) ||
+        !Array.isArray(item.outputs) ||
+        !('status' in item) ||
+        (item.status !== 'completed' && item.status !== 'failed')
       ) {
         continue;
       }
-      if ('id' in item && typeof item.id === 'string' && item.id.length > 0) {
-        ids.add(item.id);
+      for (const result of item.outputs) {
+        if (
+          result == null ||
+          typeof result !== 'object' ||
+          !('type' in result) ||
+          result.type !== 'image' ||
+          !('url' in result) ||
+          typeof result.url !== 'string' ||
+          result.url.length === 0
+        ) {
+          continue;
+        }
+        const resultUrl: string = result.url;
+        if (
+          replayProjection === 'native' &&
+          resultUrl.startsWith('data:image/')
+        ) {
+          serverToolResults.push({ type: 'image', url: resultUrl });
+          continue;
+        }
+        const mediaResult = createNeutralServerToolResult(
+          { type: 'code_interpreter_image', url: resultUrl },
+          item.status === 'failed' ? 'error' : 'success',
+          maxChars
+        );
+        if (mediaResult != null) {
+          serverToolResults.push(mediaResult);
+        }
       }
+      continue;
+    }
+    if (item.type === 'mcp_list_tools') {
+      const hasError =
+        'error' in item &&
+        typeof item.error === 'string' &&
+        item.error.length > 0;
+      const listToolsResult = createNeutralServerToolResult(
+        {
+          ...('server_label' in item && typeof item.server_label === 'string'
+            ? { serverLabel: item.server_label }
+            : {}),
+          ...('tools' in item && Array.isArray(item.tools)
+            ? { tools: item.tools }
+            : {}),
+          ...(hasError ? { error: item.error } : {}),
+        },
+        hasError ? 'error' : 'success',
+        maxChars
+      );
+      if (listToolsResult != null) {
+        serverToolResults.push(listToolsResult);
+      }
+      continue;
+    }
+    if (item.type === 'mcp_call') {
+      const hasOutput =
+        'output' in item &&
+        typeof item.output === 'string' &&
+        item.output.length > 0;
+      const hasError =
+        'error' in item &&
+        typeof item.error === 'string' &&
+        item.error.length > 0;
+      if (!hasOutput && !hasError) {
+        continue;
+      }
+      const mcpOutput = {
+        ...('name' in item && typeof item.name === 'string'
+          ? { name: item.name }
+          : {}),
+        ...('server_label' in item && typeof item.server_label === 'string'
+          ? { serverLabel: item.server_label }
+          : {}),
+        ...('output' in item && typeof item.output === 'string'
+          ? { output: item.output }
+          : {}),
+        ...('error' in item && typeof item.error === 'string'
+          ? { error: item.error }
+          : {}),
+      };
+      const mcpResult = createNeutralServerToolResult(
+        mcpOutput,
+        hasError ||
+          ('status' in item &&
+            (item.status === 'failed' || item.status === 'incomplete'))
+          ? 'error'
+          : 'success',
+        maxChars
+      );
+      if (mcpResult != null) {
+        serverToolResults.push(mcpResult);
+      }
+      continue;
+    }
+    if (
+      item.type === 'local_shell_call_output' ||
+      item.type === 'shell_call_output' ||
+      item.type === 'apply_patch_call_output'
+    ) {
+      if (!('output' in item)) {
+        continue;
+      }
+      const result = createNeutralServerToolResult(
+        item.output,
+        'status' in item &&
+          (item.status === 'failed' || item.status === 'incomplete')
+          ? 'error'
+          : 'success',
+        maxChars
+      );
+      if (result != null) {
+        serverToolResults.push(result);
+      }
+      continue;
+    }
+    if (item.type === 'program_output') {
+      if (!('result' in item)) {
+        continue;
+      }
+      const result = createNeutralServerToolResult(
+        item.result,
+        'status' in item && item.status === 'incomplete' ? 'error' : 'success',
+        maxChars
+      );
+      if (result != null) {
+        serverToolResults.push(result);
+      }
+      continue;
+    }
+    if (item.type !== 'image_generation_call') {
+      continue;
+    }
+    if ('id' in item && typeof item.id === 'string' && item.id.length > 0) {
+      ids.add(item.id);
+    }
+    if (
+      !('result' in item) ||
+      typeof item.result !== 'string' ||
+      item.result.length === 0
+    ) {
+      continue;
+    }
+    data.add(item.result);
+    if ('status' in item && item.status === 'completed') {
+      const itemId =
+        'id' in item && typeof item.id === 'string' && item.id.length > 0
+          ? item.id
+          : undefined;
       if (
-        !('result' in item) ||
-        typeof item.result !== 'string' ||
-        item.result.length === 0
+        (itemId != null && emittedIds.has(itemId)) ||
+        (itemId == null && emittedData.has(item.result))
       ) {
         continue;
       }
-      data.add(item.result);
-      if (isAuthoritative && 'status' in item && item.status === 'completed') {
-        blocks.push({
-          type: 'image',
-          mimeType: 'image/png',
-          data: item.result,
-        });
+      if (itemId != null) {
+        emittedIds.add(itemId);
+      } else {
+        emittedData.add(item.result);
       }
+      blocks.push({
+        type: 'image',
+        mimeType: 'image/png',
+        data: item.result,
+      });
     }
   }
-  return { blocks, data, ids };
+  return {
+    generatedImages: { blocks, data, ids },
+    serverToolResults,
+  };
 }
 
 function getSelfContainedResponsesV0Images(
   message: AIMessage
-): LangChainContentBlock.Multimodal.Image[] {
+): PositionedResponsesImages {
   if (!Array.isArray(message.content)) {
-    return [];
+    return { blocks: [], textCount: 0 };
   }
-  const images: LangChainContentBlock.Multimodal.Image[] = [];
+  const images: PositionedResponsesImage[] = [];
+  let textCount = 0;
   for (const block of message.content as LangChainContentBlock.Standard[]) {
+    if (block.type === 'text') {
+      textCount++;
+      continue;
+    }
     if (
       block.type === 'image' &&
       'data' in block &&
       ((typeof block.data === 'string' && block.data.length > 0) ||
         (block.data instanceof Uint8Array && block.data.length > 0))
     ) {
-      images.push(block);
+      images.push({ block, textIndex: textCount });
     }
   }
-  return images;
+  return { blocks: images, textCount };
+}
+
+function getResponsesV0ContentBlocks(
+  message: AIMessage,
+  authoritativeOutput: unknown[]
+): AIMessage['content'] {
+  let content = message.content;
+  if (typeof content === 'string') {
+    content = toLangChainContent(
+      content.length > 0 ? [{ type: 'text', text: content }] : []
+    );
+  }
+  const translationMessage = cloneAIMessageWithResponsesReplayState(
+    message,
+    content,
+    message.id,
+    {
+      ...message.additional_kwargs,
+      tool_outputs: authoritativeOutput,
+    },
+    {
+      ...message.response_metadata,
+      model_provider: 'openai',
+    }
+  );
+  return toLangChainContent(translationMessage.contentBlocks);
+}
+
+function isPreemptedOpenAIResponsesMessage(message: AIMessage): boolean {
+  const metadata = message.response_metadata;
+  if (metadata.preempted !== true || metadata.model_provider !== 'openai') {
+    return false;
+  }
+  if (
+    message.id?.startsWith('msg_') === true ||
+    message.id?.startsWith('resp_') === true ||
+    (typeof metadata.id === 'string' && metadata.id.startsWith('resp_')) ||
+    Array.isArray(metadata.output) ||
+    metadata.tool_outputs != null ||
+    Array.isArray(message.additional_kwargs.tool_outputs) ||
+    message.additional_kwargs.__openai_function_call_ids__ != null ||
+    message.additional_kwargs.__openai_custom_tool_call_ids__ != null ||
+    (message.additional_kwargs.reasoning != null &&
+      typeof message.additional_kwargs.reasoning === 'object')
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -840,37 +1204,70 @@ function getSelfContainedResponsesV0Images(
  * Project a provider-neutral clone while preserving self-contained encrypted
  * reasoning and the original graph/checkpoint message.
  */
-function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
-  const metadata = message.response_metadata;
-  if (metadata.preempted !== true) {
+function projectPreemptedOpenAIResponsesMessage(
+  message: AIMessage,
+  maxChars: number,
+  replayProjection: ResponsesReplayProjection
+): AIMessage {
+  if (!isPreemptedOpenAIResponsesMessage(message)) {
     return message;
   }
 
+  const metadata = message.response_metadata;
   const additionalKwargs = { ...message.additional_kwargs };
-  const hasEncryptedReasoning = hasReplayableEncryptedReasoning(
-    additionalKwargs.reasoning
+  const retainsEncryptedReasoning =
+    replayProjection === 'native' &&
+    hasReplayableEncryptedReasoning(additionalKwargs.reasoning);
+  const authoritativeOutput = getAuthoritativeResponsesOutput(message);
+  const { generatedImages, serverToolResults } = getResponsesReplayArtifacts(
+    authoritativeOutput,
+    maxChars,
+    replayProjection
   );
-  const generatedImages =
-    metadata.output_version === 'v1'
-      ? undefined
-      : getCompletedGeneratedImages(message);
-  const promotesGeneratedImages = (generatedImages?.blocks.length ?? 0) > 0;
+  const isV1 = metadata.output_version === 'v1';
+  const translatesV0 =
+    !isV1 &&
+    (replayProjection === 'fallback' || authoritativeOutput.length > 0);
   const originalImages =
-    promotesGeneratedImages && metadata.model_provider === 'openai'
+    replayProjection === 'native' && translatesV0
       ? getSelfContainedResponsesV0Images(message)
       : undefined;
-  const content = projectPreemptedResponsesV1Content(
-    metadata.output_version === 'v1' || promotesGeneratedImages
-      ? message.contentBlocks
-      : message.content,
-    additionalKwargs.reasoning,
-    promotesGeneratedImages ? generatedImages : undefined,
-    originalImages
+  let contentForProjection = message.content;
+  if (!isV1 && translatesV0) {
+    contentForProjection = getResponsesV0ContentBlocks(
+      message,
+      authoritativeOutput
+    );
+  }
+  const projectedContent = projectPreemptedResponsesV1Content(
+    contentForProjection,
+    isV1 || translatesV0 ? additionalKwargs.reasoning : undefined,
+    maxChars,
+    replayProjection,
+    replayProjection === 'native' ? generatedImages : undefined,
+    originalImages,
+    serverToolResults
   );
+  const promotesV0 =
+    !isV1 &&
+    (replayProjection === 'fallback' ||
+      generatedImages.blocks.length > 0 ||
+      projectedContent.preservedServerToolResult);
+  const unpromotedV0Content =
+    contentForProjection === message.content
+      ? projectedContent.content
+      : projectPreemptedResponsesV1Content(
+        message.content,
+        undefined,
+        maxChars,
+        replayProjection
+      ).content;
+  const content =
+    isV1 || promotesV0 ? projectedContent.content : unpromotedV0Content;
   const hasUnsafeProviderReferences =
     content !== message.content ||
     message.id?.startsWith('msg_') === true ||
-    (!hasEncryptedReasoning && additionalKwargs.reasoning != null) ||
+    (!retainsEncryptedReasoning && additionalKwargs.reasoning != null) ||
     additionalKwargs.tool_outputs != null ||
     additionalKwargs.__openai_function_call_ids__ != null ||
     additionalKwargs.__openai_custom_tool_call_ids__ != null ||
@@ -880,7 +1277,7 @@ function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
   if (!hasUnsafeProviderReferences) {
     return message;
   }
-  if (!hasEncryptedReasoning) {
+  if (!retainsEncryptedReasoning) {
     delete additionalKwargs.reasoning;
   }
   delete additionalKwargs.tool_outputs;
@@ -891,8 +1288,7 @@ function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
   delete responseMetadata.id;
   delete responseMetadata.output;
   delete responseMetadata.tool_outputs;
-  if (promotesGeneratedImages) {
-    responseMetadata.model_provider = 'openai';
+  if (promotesV0) {
     responseMetadata.output_version = 'v1';
   }
 
@@ -905,55 +1301,46 @@ function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
   );
 }
 
-/**
- * Drops incomplete streamed text-input fragments that some providers retain
- * beside the assembled parsed tool call. They are neither user-visible text
- * nor valid content blocks for a subsequent provider.
- */
+/** Applies sealed-Responses safety and drops incomplete streamed text input. */
 export function projectToolStreamContentForProvider(
-  messages: BaseMessage[]
+  messages: BaseMessage[],
+  responsesReplayProjection?: ResponsesReplayProjection,
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS
 ): BaseMessage[] {
   let projected: BaseMessage[] | undefined;
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
-    if (message.getType() !== 'ai' || !Array.isArray(message.content)) {
+    if (message.getType() !== 'ai') {
       continue;
     }
-    const content = message.content.filter((block) => {
-      if (block == null || typeof block !== 'object') {
-        return true;
+    const assistantMessage = message as AIMessage;
+    if (
+      responsesReplayProjection != null &&
+      isPreemptedOpenAIResponsesMessage(assistantMessage)
+    ) {
+      const replaySafeMessage = projectPreemptedOpenAIResponsesMessage(
+        assistantMessage,
+        maxChars,
+        responsesReplayProjection
+      );
+      if (replaySafeMessage !== assistantMessage) {
+        projected ??= [...messages];
+        projected[i] = replaySafeMessage;
       }
-      try {
-        if (isProxy(block)) {
-          return false;
-        }
-        const type = Object.getOwnPropertyDescriptor(block, 'type');
-        if (type == null) {
-          return true;
-        }
-        if (type.enumerable !== true || !('value' in type)) {
-          return false;
-        }
-        if (type.value !== 'text') {
-          return true;
-        }
-        const text = Object.getOwnPropertyDescriptor(block, 'text');
-        return (
-          text?.enumerable === true &&
-          'value' in text &&
-          typeof text.value === 'string' &&
-          text.value !== ''
-        );
-      } catch {
-        return false;
-      }
-    });
-    if (content.length === message.content.length) {
+      continue;
+    }
+    if (!Array.isArray(assistantMessage.content)) {
+      continue;
+    }
+    const content = assistantMessage.content.filter(
+      isCompleteToolStreamContentBlock
+    );
+    if (content.length === assistantMessage.content.length) {
       continue;
     }
     projected ??= [...messages];
     projected[i] = cloneAIMessageWithContent(
-      message as AIMessage,
+      assistantMessage,
       toLangChainContent(content)
     );
   }
@@ -1017,8 +1404,11 @@ function projectOpenAIToolMessageContentInternal(
     if (isAssistant) {
       let assistantMessage = message as AIMessage;
       if (nativeResponsesProjection) {
-        const replaySafeMessage =
-          projectPreemptedOpenAIResponsesMessage(assistantMessage);
+        const replaySafeMessage = projectPreemptedOpenAIResponsesMessage(
+          assistantMessage,
+          maxChars,
+          'native'
+        );
         if (replaySafeMessage !== assistantMessage) {
           projected ??= [...messages];
           projected[i] = replaySafeMessage;

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -668,6 +668,16 @@ function hasReplayableEncryptedReasoning(reasoning: unknown): boolean {
 
 type ResponsesReplayProjection = 'fallback' | 'native';
 
+export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
+  '__openai_responses_replay_positions__';
+
+type ResponsesReplayPosition = {
+  contentIndex?: number;
+  itemId: string;
+  kind: 'output' | 'text';
+  outputIndex: number;
+};
+
 type CompletedGeneratedImages = {
   blocks: LangChainContentBlock.Multimodal.Image[];
   data: Set<string>;
@@ -676,7 +686,13 @@ type CompletedGeneratedImages = {
 
 type ResponsesReplayArtifacts = {
   generatedImages: CompletedGeneratedImages;
-  serverToolResults: LangChainContentBlock.Standard[];
+  serverToolResults: PositionedResponsesReplayBlock[];
+};
+
+type PositionedResponsesReplayBlock = {
+  block: LangChainContentBlock.Standard;
+  outputIndex: number;
+  textIndex?: number;
 };
 
 type PositionedResponsesImage = {
@@ -727,7 +743,8 @@ function hasMeaningfulServerToolOutput(output: unknown): boolean {
 function createNeutralServerToolResult(
   output: unknown,
   status: 'error' | 'success',
-  maxChars: number
+  maxChars: number,
+  toolName?: string
 ): LangChainContentBlock.Text | undefined {
   if (!hasMeaningfulServerToolOutput(output)) {
     return undefined;
@@ -735,9 +752,20 @@ function createNeutralServerToolResult(
   return {
     type: 'text',
     text: serializeToolContentBounded(
-      { serverToolResult: { status, output } },
+      {
+        serverToolResult: {
+          ...(toolName != null ? { toolName } : {}),
+          status,
+          output,
+        },
+      },
       maxChars
     ),
+    extras: {
+      librechatServerToolResult: {
+        ...(toolName != null ? { toolName } : {}),
+      },
+    },
   };
 }
 
@@ -778,7 +806,7 @@ function projectPreemptedResponsesV1Content(
   replayProjection: ResponsesReplayProjection,
   generatedImages?: CompletedGeneratedImages,
   originalImages?: PositionedResponsesImages,
-  serverToolResults?: LangChainContentBlock.Standard[]
+  serverToolResults?: PositionedResponsesReplayBlock[]
 ): {
   content: AIMessage['content'];
   preservedServerToolResult: boolean;
@@ -798,7 +826,9 @@ function projectPreemptedResponsesV1Content(
   let preservedServerToolResult = false;
   let reasoningInsertionIndex: number | undefined;
   let originalImageIndex = 0;
+  let serverToolResultIndex = 0;
   let sourceTextIndex = 0;
+  const serverToolNamesByCallId = new Map<string, string>();
 
   const appendOriginalImages = (throughTextIndex?: number): void => {
     if (replayProjection !== 'native' || originalImages == null) {
@@ -828,6 +858,36 @@ function projectPreemptedResponsesV1Content(
     }
   };
 
+  const appendServerToolResults = (throughTextIndex?: number): void => {
+    if (serverToolResults == null) {
+      return;
+    }
+    while (serverToolResultIndex < serverToolResults.length) {
+      const positionedResult = serverToolResults[serverToolResultIndex];
+      if (
+        throughTextIndex != null &&
+        (positionedResult.textIndex == null ||
+          positionedResult.textIndex > throughTextIndex)
+      ) {
+        return;
+      }
+      serverToolResultIndex++;
+      if (
+        replayProjection === 'fallback' &&
+        positionedResult.block.type === 'text'
+      ) {
+        projected.push({
+          type: 'text',
+          text: positionedResult.block.text,
+        });
+      } else {
+        projected.push(positionedResult.block);
+      }
+      changed = true;
+      preservedServerToolResult = true;
+    }
+  };
+
   for (let i = 0; i < contentBlocks.length; i++) {
     const block = contentBlocks[i];
     if (!isCompleteToolStreamContentBlock(block)) {
@@ -854,7 +914,13 @@ function projectPreemptedResponsesV1Content(
     }
     if (block.type === 'text') {
       appendOriginalImages(sourceTextIndex);
-      projected.push(block);
+      appendServerToolResults(sourceTextIndex);
+      if (replayProjection === 'fallback') {
+        projected.push({ type: 'text', text: block.text });
+        changed = true;
+      } else {
+        projected.push(block);
+      }
       sourceTextIndex++;
       continue;
     }
@@ -865,6 +931,14 @@ function projectPreemptedResponsesV1Content(
       block.type === 'server_tool_call' ||
       block.type === 'server_tool_call_chunk'
     ) {
+      if (
+        typeof block.id === 'string' &&
+        block.id.length > 0 &&
+        typeof block.name === 'string' &&
+        block.name.length > 0
+      ) {
+        serverToolNamesByCallId.set(block.id, block.name);
+      }
       changed = true;
       continue;
     }
@@ -872,11 +946,16 @@ function projectPreemptedResponsesV1Content(
       const result = createNeutralServerToolResult(
         block.output,
         block.status,
-        maxChars
+        maxChars,
+        serverToolNamesByCallId.get(block.toolCallId)
       );
       changed = true;
       if (result != null) {
-        projected.push(result);
+        projected.push(
+          replayProjection === 'fallback'
+            ? { type: 'text', text: result.text }
+            : result
+        );
         preservedServerToolResult = true;
       }
       continue;
@@ -903,13 +982,7 @@ function projectPreemptedResponsesV1Content(
     changed = true;
   }
   appendOriginalImages();
-  if (serverToolResults != null) {
-    projected.push(...serverToolResults);
-    if (serverToolResults.length > 0) {
-      changed = true;
-      preservedServerToolResult = true;
-    }
-  }
+  appendServerToolResults();
   if (replayProjection === 'native' && generatedImages != null) {
     projected.push(...generatedImages.blocks);
     changed ||= generatedImages.blocks.length > 0;
@@ -929,17 +1002,178 @@ function getAuthoritativeResponsesOutput(message: AIMessage): unknown[] {
   return Array.isArray(toolOutputs) ? toolOutputs : [];
 }
 
+function isResponsesReplayPosition(
+  value: unknown
+): value is ResponsesReplayPosition {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const position = value as Partial<ResponsesReplayPosition>;
+  return (
+    (position.kind === 'output' || position.kind === 'text') &&
+    typeof position.itemId === 'string' &&
+    position.itemId.length > 0 &&
+    typeof position.outputIndex === 'number' &&
+    Number.isSafeInteger(position.outputIndex) &&
+    position.outputIndex >= 0 &&
+    (position.contentIndex == null ||
+      (typeof position.contentIndex === 'number' &&
+        Number.isSafeInteger(position.contentIndex) &&
+        position.contentIndex >= 0))
+  );
+}
+
+function getGeneratedImageMimeType(data: string): string {
+  const bytes = Buffer.from(data.slice(0, 16), 'base64');
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return 'image/png';
+}
+
+function getResponsesReplayItemKey(
+  item: Record<string, unknown>
+): string | undefined {
+  if (typeof item.id === 'string' && item.id.length > 0) {
+    return item.id;
+  }
+  return typeof item.call_id === 'string' && item.call_id.length > 0
+    ? item.call_id
+    : undefined;
+}
+
+const RESPONSES_REPLAY_OUTPUT_TOOL_NAMES = {
+  apply_patch_call_output: 'apply_patch',
+  local_shell_call_output: 'local_shell',
+  shell_call_output: 'shell',
+} as const;
+
 function getResponsesReplayArtifacts(
   output: readonly unknown[],
   maxChars: number,
-  replayProjection: ResponsesReplayProjection
+  replayProjection: ResponsesReplayProjection,
+  replayPositionValue?: unknown
 ): ResponsesReplayArtifacts {
   const blocks: LangChainContentBlock.Multimodal.Image[] = [];
   const data = new Set<string>();
   const ids = new Set<string>();
   const emittedData = new Set<string>();
   const emittedIds = new Set<string>();
-  const serverToolResults: LangChainContentBlock.Standard[] = [];
+  const serverToolResults: PositionedResponsesReplayBlock[] = [];
+  const replayPositions = Array.isArray(replayPositionValue)
+    ? replayPositionValue.filter(isResponsesReplayPosition)
+    : [];
+  const outputPositionsByItemId = new Map<string, ResponsesReplayPosition>();
+  const textPositionsByKey = new Map<string, ResponsesReplayPosition>();
+  for (const position of replayPositions) {
+    if (position.kind === 'output') {
+      outputPositionsByItemId.set(position.itemId, position);
+      continue;
+    }
+    textPositionsByKey.set(
+      `${position.itemId}:${position.outputIndex}:${position.contentIndex ?? 0}`,
+      position
+    );
+  }
+  const hasAuthoritativeMessage = output.some(
+    (item) =>
+      item != null &&
+      typeof item === 'object' &&
+      'type' in item &&
+      item.type === 'message'
+  );
+  if (hasAuthoritativeMessage) {
+    for (let outputIndex = 0; outputIndex < output.length; outputIndex++) {
+      const item = output[outputIndex];
+      if (item == null || typeof item !== 'object') {
+        continue;
+      }
+      const itemRecord = item as Record<string, unknown>;
+      const itemKey = getResponsesReplayItemKey(itemRecord);
+      if (itemKey != null) {
+        outputPositionsByItemId.set(itemKey, {
+          itemId: itemKey,
+          kind: 'output',
+          outputIndex,
+        });
+      }
+      if (
+        !('type' in item) ||
+        item.type !== 'message' ||
+        !('content' in item) ||
+        !Array.isArray(item.content)
+      ) {
+        continue;
+      }
+      for (
+        let contentIndex = 0;
+        contentIndex < item.content.length;
+        contentIndex++
+      ) {
+        const content = item.content[contentIndex];
+        if (
+          content == null ||
+          typeof content !== 'object' ||
+          !('type' in content) ||
+          content.type !== 'output_text'
+        ) {
+          continue;
+        }
+        const itemId =
+          'id' in item && typeof item.id === 'string'
+            ? item.id
+            : `message-${outputIndex}`;
+        textPositionsByKey.set(`${itemId}:${outputIndex}:${contentIndex}`, {
+          contentIndex,
+          itemId,
+          kind: 'text',
+          outputIndex,
+        });
+      }
+    }
+  }
+  const textPositions = [...textPositionsByKey.values()].sort(
+    (a, b) =>
+      a.outputIndex - b.outputIndex ||
+      (a.contentIndex ?? 0) - (b.contentIndex ?? 0)
+  );
+  const getPosition = (
+    item: Record<string, unknown>
+  ): Pick<PositionedResponsesReplayBlock, 'outputIndex' | 'textIndex'> => {
+    const itemId = getResponsesReplayItemKey(item);
+    const position =
+      itemId != null ? outputPositionsByItemId.get(itemId) : undefined;
+    if (position == null) {
+      return { outputIndex: Number.MAX_SAFE_INTEGER };
+    }
+    return {
+      outputIndex: position.outputIndex,
+      textIndex: textPositions.filter(
+        (textPosition) => textPosition.outputIndex < position.outputIndex
+      ).length,
+    };
+  };
+  const pushServerToolResult = (
+    block: LangChainContentBlock.Standard | undefined,
+    item: Record<string, unknown>
+  ): void => {
+    if (block == null) {
+      return;
+    }
+    serverToolResults.push({ block, ...getPosition(item) });
+  };
   for (const item of output) {
     if (item == null || typeof item !== 'object' || !('type' in item)) {
       continue;
@@ -970,17 +1204,16 @@ function getResponsesReplayArtifacts(
           replayProjection === 'native' &&
           resultUrl.startsWith('data:image/')
         ) {
-          serverToolResults.push({ type: 'image', url: resultUrl });
+          pushServerToolResult({ type: 'image', url: resultUrl }, item);
           continue;
         }
         const mediaResult = createNeutralServerToolResult(
           { type: 'code_interpreter_image', url: resultUrl },
           item.status === 'failed' ? 'error' : 'success',
-          maxChars
+          maxChars,
+          'code_interpreter'
         );
-        if (mediaResult != null) {
-          serverToolResults.push(mediaResult);
-        }
+        pushServerToolResult(mediaResult, item);
       }
       continue;
     }
@@ -1000,11 +1233,10 @@ function getResponsesReplayArtifacts(
           ...(hasError ? { error: item.error } : {}),
         },
         hasError ? 'error' : 'success',
-        maxChars
+        maxChars,
+        'mcp_list_tools'
       );
-      if (listToolsResult != null) {
-        serverToolResults.push(listToolsResult);
-      }
+      pushServerToolResult(listToolsResult, item);
       continue;
     }
     if (item.type === 'mcp_call') {
@@ -1040,11 +1272,12 @@ function getResponsesReplayArtifacts(
             (item.status === 'failed' || item.status === 'incomplete'))
           ? 'error'
           : 'success',
-        maxChars
+        maxChars,
+        'name' in item && typeof item.name === 'string' && item.name.length > 0
+          ? item.name
+          : 'mcp'
       );
-      if (mcpResult != null) {
-        serverToolResults.push(mcpResult);
-      }
+      pushServerToolResult(mcpResult, item);
       continue;
     }
     if (
@@ -1061,11 +1294,10 @@ function getResponsesReplayArtifacts(
           (item.status === 'failed' || item.status === 'incomplete')
           ? 'error'
           : 'success',
-        maxChars
+        maxChars,
+        RESPONSES_REPLAY_OUTPUT_TOOL_NAMES[item.type]
       );
-      if (result != null) {
-        serverToolResults.push(result);
-      }
+      pushServerToolResult(result, item);
       continue;
     }
     if (item.type === 'program_output') {
@@ -1075,11 +1307,10 @@ function getResponsesReplayArtifacts(
       const result = createNeutralServerToolResult(
         item.result,
         'status' in item && item.status === 'incomplete' ? 'error' : 'success',
-        maxChars
+        maxChars,
+        'program'
       );
-      if (result != null) {
-        serverToolResults.push(result);
-      }
+      pushServerToolResult(result, item);
       continue;
     }
     if (item.type !== 'image_generation_call') {
@@ -1114,14 +1345,19 @@ function getResponsesReplayArtifacts(
       }
       blocks.push({
         type: 'image',
-        mimeType: 'image/png',
+        mimeType: getGeneratedImageMimeType(item.result),
         data: item.result,
       });
     }
   }
   return {
     generatedImages: { blocks, data, ids },
-    serverToolResults,
+    serverToolResults: serverToolResults.sort(
+      (a, b) =>
+        (a.textIndex ?? Number.MAX_SAFE_INTEGER) -
+          (b.textIndex ?? Number.MAX_SAFE_INTEGER) ||
+        a.outputIndex - b.outputIndex
+    ),
   };
 }
 
@@ -1188,6 +1424,7 @@ function isPreemptedOpenAIResponsesMessage(message: AIMessage): boolean {
     Array.isArray(metadata.output) ||
     metadata.tool_outputs != null ||
     Array.isArray(message.additional_kwargs.tool_outputs) ||
+    message.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY] != null ||
     message.additional_kwargs.__openai_function_call_ids__ != null ||
     message.additional_kwargs.__openai_custom_tool_call_ids__ != null ||
     (message.additional_kwargs.reasoning != null &&
@@ -1222,7 +1459,8 @@ function projectPreemptedOpenAIResponsesMessage(
   const { generatedImages, serverToolResults } = getResponsesReplayArtifacts(
     authoritativeOutput,
     maxChars,
-    replayProjection
+    replayProjection,
+    additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
   );
   const isV1 = metadata.output_version === 'v1';
   const translatesV0 =
@@ -1269,6 +1507,7 @@ function projectPreemptedOpenAIResponsesMessage(
     message.id?.startsWith('msg_') === true ||
     (!retainsEncryptedReasoning && additionalKwargs.reasoning != null) ||
     additionalKwargs.tool_outputs != null ||
+    additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY] != null ||
     additionalKwargs.__openai_function_call_ids__ != null ||
     additionalKwargs.__openai_custom_tool_call_ids__ != null ||
     metadata.id != null ||
@@ -1281,6 +1520,7 @@ function projectPreemptedOpenAIResponsesMessage(
     delete additionalKwargs.reasoning;
   }
   delete additionalKwargs.tool_outputs;
+  delete additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY];
   delete additionalKwargs.__openai_function_call_ids__;
   delete additionalKwargs.__openai_custom_tool_call_ids__;
 

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -590,14 +590,6 @@ function cloneAIMessageWithContent(
   ) as AIMessage;
 }
 
-type ResponsesReplayMetadata = {
-  [key: string]: unknown;
-  id?: unknown;
-  output?: unknown;
-  preempted?: unknown;
-  tool_outputs?: unknown;
-};
-
 function cloneAIMessageWithResponsesReplayState(
   message: AIMessage,
   content: AIMessage['content'],
@@ -688,41 +680,56 @@ function isUnsafePreemptedResponsesV1Block(
   }
 }
 
+function isProviderGeneratedImageBlock(
+  block: LangChainContentBlock.Multimodal.Image,
+  generatedImages: ReturnType<typeof getCompletedGeneratedImages>
+): boolean {
+  if (typeof block.id === 'string' && block.id.length > 0) {
+    return generatedImages.ids.has(block.id);
+  }
+  return (
+    typeof block.data === 'string' &&
+    generatedImages.data.has(block.data) &&
+    block.metadata != null &&
+    typeof block.metadata === 'object' &&
+    'status' in block.metadata
+  );
+}
+
 function projectPreemptedResponsesV1Content(
-  message: AIMessage,
-  reasoning: unknown
+  content: AIMessage['content'],
+  reasoning: unknown,
+  generatedImages?: ReturnType<typeof getCompletedGeneratedImages>,
+  originalImages?: LangChainContentBlock.Multimodal.Image[]
 ): AIMessage['content'] {
-  if (
-    message.response_metadata.output_version !== 'v1' ||
-    !Array.isArray(message.content)
-  ) {
-    return message.content;
+  if (!Array.isArray(content)) {
+    return content;
   }
 
-  const content = message.content as LangChainContentBlock.Standard[];
+  const contentBlocks = content as LangChainContentBlock.Standard[];
   const encryptedReasoning = hasReplayableEncryptedReasoning(reasoning)
     ? reasoning
     : undefined;
   let projected: LangChainContentBlock.Standard[] | undefined;
-  let hasEncryptedReasoning = content.some(
-    (block) =>
+  let hasEncryptedReasoning = false;
+  let reasoningInsertionIndex: number | undefined;
+  for (let i = 0; i < contentBlocks.length; i++) {
+    const block = contentBlocks[i];
+    if (
       block.type === 'non_standard' &&
       hasReplayableEncryptedReasoning(block.value)
-  );
-  for (let i = 0; i < content.length; i++) {
-    const block = content[i];
-    if (isUnsafePreemptedResponsesV1Block(block)) {
-      projected ??= content.slice(0, i);
-      if (
-        block.type === 'reasoning' &&
-        encryptedReasoning != null &&
-        !hasEncryptedReasoning
-      ) {
-        projected.push({
-          type: 'non_standard',
-          value: encryptedReasoning,
-        });
-        hasEncryptedReasoning = true;
+    ) {
+      hasEncryptedReasoning = true;
+    }
+    if (
+      isUnsafePreemptedResponsesV1Block(block) ||
+      (generatedImages != null &&
+        block.type === 'image' &&
+        isProviderGeneratedImageBlock(block, generatedImages))
+    ) {
+      projected ??= contentBlocks.slice(0, i);
+      if (block.type === 'reasoning') {
+        reasoningInsertionIndex ??= projected.length;
       }
       continue;
     }
@@ -730,12 +737,101 @@ function projectPreemptedResponsesV1Content(
   }
 
   if (encryptedReasoning != null && !hasEncryptedReasoning) {
-    projected = [
-      { type: 'non_standard', value: encryptedReasoning },
-      ...(projected ?? content),
-    ];
+    const reasoningBlock: LangChainContentBlock.Standard = {
+      type: 'non_standard',
+      value: encryptedReasoning,
+    };
+    if (projected != null) {
+      projected.splice(reasoningInsertionIndex ?? 0, 0, reasoningBlock);
+    } else {
+      projected = [reasoningBlock, ...contentBlocks];
+    }
   }
-  return projected ?? message.content;
+  if (originalImages != null) {
+    projected ??= [...contentBlocks];
+    for (const block of originalImages) {
+      const isGeneratedImage =
+        generatedImages != null &&
+        isProviderGeneratedImageBlock(block, generatedImages);
+      if (!isGeneratedImage) {
+        projected.push(block);
+      }
+    }
+  }
+  if (generatedImages != null) {
+    projected ??= [...contentBlocks];
+    projected.push(...generatedImages.blocks);
+  }
+  return projected ?? content;
+}
+
+function getCompletedGeneratedImages(message: AIMessage): {
+  blocks: LangChainContentBlock.Multimodal.Image[];
+  data: Set<string>;
+  ids: Set<string>;
+} {
+  const responseOutput = message.response_metadata.output;
+  const toolOutputs = message.additional_kwargs.tool_outputs;
+  const responseOutputIsAuthoritative =
+    Array.isArray(responseOutput) && responseOutput.length > 0;
+  const blocks: LangChainContentBlock.Multimodal.Image[] = [];
+  const data = new Set<string>();
+  const ids = new Set<string>();
+  const sources = [
+    [responseOutput, responseOutputIsAuthoritative],
+    [toolOutputs, !responseOutputIsAuthoritative],
+  ] as const;
+  for (const [output, isAuthoritative] of sources) {
+    for (const item of Array.isArray(output) ? output : []) {
+      if (
+        item == null ||
+        typeof item !== 'object' ||
+        !('type' in item) ||
+        item.type !== 'image_generation_call'
+      ) {
+        continue;
+      }
+      if ('id' in item && typeof item.id === 'string' && item.id.length > 0) {
+        ids.add(item.id);
+      }
+      if (
+        !('result' in item) ||
+        typeof item.result !== 'string' ||
+        item.result.length === 0
+      ) {
+        continue;
+      }
+      data.add(item.result);
+      if (isAuthoritative && 'status' in item && item.status === 'completed') {
+        blocks.push({
+          type: 'image',
+          mimeType: 'image/png',
+          data: item.result,
+        });
+      }
+    }
+  }
+  return { blocks, data, ids };
+}
+
+function getSelfContainedResponsesV0Images(
+  message: AIMessage
+): LangChainContentBlock.Multimodal.Image[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+  const images: LangChainContentBlock.Multimodal.Image[] = [];
+  for (const block of message.content as LangChainContentBlock.Standard[]) {
+    if (
+      block.type === 'image' &&
+      'data' in block &&
+      ((typeof block.data === 'string' && block.data.length > 0) ||
+        (block.data instanceof Uint8Array && block.data.length > 0))
+    ) {
+      images.push(block);
+    }
+  }
+  return images;
 }
 
 /**
@@ -745,7 +841,7 @@ function projectPreemptedResponsesV1Content(
  * reasoning and the original graph/checkpoint message.
  */
 function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
-  const metadata = message.response_metadata as ResponsesReplayMetadata;
+  const metadata = message.response_metadata;
   if (metadata.preempted !== true) {
     return message;
   }
@@ -754,9 +850,22 @@ function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
   const hasEncryptedReasoning = hasReplayableEncryptedReasoning(
     additionalKwargs.reasoning
   );
+  const generatedImages =
+    metadata.output_version === 'v1'
+      ? undefined
+      : getCompletedGeneratedImages(message);
+  const promotesGeneratedImages = (generatedImages?.blocks.length ?? 0) > 0;
+  const originalImages =
+    promotesGeneratedImages && metadata.model_provider === 'openai'
+      ? getSelfContainedResponsesV0Images(message)
+      : undefined;
   const content = projectPreemptedResponsesV1Content(
-    message,
-    additionalKwargs.reasoning
+    metadata.output_version === 'v1' || promotesGeneratedImages
+      ? message.contentBlocks
+      : message.content,
+    additionalKwargs.reasoning,
+    promotesGeneratedImages ? generatedImages : undefined,
+    originalImages
   );
   const hasUnsafeProviderReferences =
     content !== message.content ||
@@ -778,10 +887,14 @@ function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
   delete additionalKwargs.__openai_function_call_ids__;
   delete additionalKwargs.__openai_custom_tool_call_ids__;
 
-  const responseMetadata: ResponsesReplayMetadata = { ...metadata };
+  const responseMetadata: AIMessage['response_metadata'] = { ...metadata };
   delete responseMetadata.id;
   delete responseMetadata.output;
   delete responseMetadata.tool_outputs;
+  if (promotesGeneratedImages) {
+    responseMetadata.model_provider = 'openai';
+    responseMetadata.output_version = 'v1';
+  }
 
   return cloneAIMessageWithResponsesReplayState(
     message,

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -674,7 +674,7 @@ export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
 export type ResponsesReplayPosition = {
   contentIndex?: number;
   itemId: string;
-  kind: 'output' | 'text';
+  kind: 'output' | 'reasoning' | 'text';
   outputIndex: number;
 };
 
@@ -686,12 +686,20 @@ type CompletedGeneratedImages = {
 
 type ResponsesReplayArtifacts = {
   generatedImages: CompletedGeneratedImages;
+  positionsByItemId: Map<string, ResponsesReplayItemPosition>;
+  positionedServerToolResultIds: Set<string>;
   serverToolResults: PositionedResponsesReplayBlock[];
 };
+
+type ResponsesReplayItemPosition = Pick<
+  PositionedResponsesReplayBlock,
+  'outputIndex' | 'textIndex'
+>;
 
 type PositionedResponsesReplayBlock = {
   block: LangChainContentBlock.Standard;
   outputIndex: number;
+  subIndex: number;
   textIndex?: number;
 };
 
@@ -764,6 +772,7 @@ function createNeutralServerToolResult(
     text: serializeToolContentBounded(
       {
         serverToolResult: {
+          librechatResponsesReplay: true,
           ...(toolName != null ? { toolName } : {}),
           status,
           output,
@@ -812,7 +821,9 @@ function projectPreemptedResponsesV1Content(
   replayProjection: ResponsesReplayProjection,
   generatedImages?: CompletedGeneratedImages,
   originalImages?: PositionedResponsesImages,
-  serverToolResults?: PositionedResponsesReplayBlock[]
+  serverToolResults?: PositionedResponsesReplayBlock[],
+  positionedServerToolResultIds?: ReadonlySet<string>,
+  reasoningPosition?: ResponsesReplayItemPosition
 ): {
   content: AIMessage['content'];
   preservedServerToolResult: boolean;
@@ -826,6 +837,17 @@ function projectPreemptedResponsesV1Content(
     replayProjection === 'native' && hasReplayableEncryptedReasoning(reasoning)
       ? reasoning
       : undefined;
+  const positionedReasoning: PositionedResponsesReplayBlock | undefined =
+    encryptedReasoning != null && reasoningPosition != null
+      ? {
+        block: {
+          type: 'non_standard' as const,
+          value: encryptedReasoning,
+        },
+        ...reasoningPosition,
+        subIndex: 0,
+      }
+      : undefined;
   const projected: LangChainContentBlock.Standard[] = [];
   let changed = false;
   let hasEncryptedReasoning = false;
@@ -833,6 +855,7 @@ function projectPreemptedResponsesV1Content(
   let reasoningInsertionIndex: number | undefined;
   let generatedImageIndex = 0;
   let originalImageIndex = 0;
+  let reasoningPending = positionedReasoning;
   let serverToolResultIndex = 0;
   let sourceTextIndex = 0;
   const serverToolNamesByCallId = new Map<string, string>();
@@ -869,19 +892,27 @@ function projectPreemptedResponsesV1Content(
     for (;;) {
       const generatedImage = generatedImages?.blocks[generatedImageIndex];
       const serverToolResult = serverToolResults?.[serverToolResultIndex];
-      const useGeneratedImage =
-        generatedImage != null &&
-        (serverToolResult == null ||
-          comparePositionedResponsesReplayBlocks(
-            generatedImage,
-            serverToolResult
-          ) <= 0);
-      const positionedResult = useGeneratedImage
-        ? generatedImage
-        : serverToolResult;
-      if (positionedResult == null) {
+      const candidates: Array<{
+        kind: 'generatedImage' | 'reasoning' | 'serverToolResult';
+        value: PositionedResponsesReplayBlock;
+      }> = [];
+      if (generatedImage != null) {
+        candidates.push({ kind: 'generatedImage', value: generatedImage });
+      }
+      if (serverToolResult != null) {
+        candidates.push({ kind: 'serverToolResult', value: serverToolResult });
+      }
+      if (reasoningPending != null) {
+        candidates.push({ kind: 'reasoning', value: reasoningPending });
+      }
+      if (candidates.length === 0) {
         return;
       }
+      candidates.sort((a, b) =>
+        comparePositionedResponsesReplayBlocks(a.value, b.value)
+      );
+      const selected = candidates[0];
+      const positionedResult = selected.value;
       if (
         throughTextIndex != null &&
         (positionedResult.textIndex == null ||
@@ -889,10 +920,12 @@ function projectPreemptedResponsesV1Content(
       ) {
         return;
       }
-      if (useGeneratedImage) {
+      if (selected.kind === 'generatedImage') {
         generatedImageIndex++;
-      } else {
+      } else if (selected.kind === 'serverToolResult') {
         serverToolResultIndex++;
+      } else {
+        reasoningPending = undefined;
       }
       if (
         replayProjection === 'fallback' &&
@@ -906,7 +939,7 @@ function projectPreemptedResponsesV1Content(
         projected.push(positionedResult.block);
       }
       changed = true;
-      preservedServerToolResult ||= !useGeneratedImage;
+      preservedServerToolResult ||= selected.kind === 'serverToolResult';
     }
   };
 
@@ -928,7 +961,11 @@ function projectPreemptedResponsesV1Content(
         hasReplayableEncryptedReasoning(block.value)
       ) {
         hasEncryptedReasoning = true;
-        projected.push(block);
+        if (positionedReasoning == null) {
+          projected.push(block);
+        } else {
+          changed = true;
+        }
       } else {
         changed = true;
       }
@@ -965,6 +1002,10 @@ function projectPreemptedResponsesV1Content(
       continue;
     }
     if (block.type === 'server_tool_call_result') {
+      if (positionedServerToolResultIds?.has(block.toolCallId) === true) {
+        changed = true;
+        continue;
+      }
       const result = createNeutralServerToolResult(
         block.output,
         block.status,
@@ -995,7 +1036,11 @@ function projectPreemptedResponsesV1Content(
     projected.push(block);
   }
 
-  if (encryptedReasoning != null && !hasEncryptedReasoning) {
+  if (
+    encryptedReasoning != null &&
+    !hasEncryptedReasoning &&
+    positionedReasoning == null
+  ) {
     const reasoningBlock: LangChainContentBlock.Standard = {
       type: 'non_standard',
       value: encryptedReasoning,
@@ -1028,7 +1073,9 @@ function isResponsesReplayPosition(
   }
   const position = value as Partial<ResponsesReplayPosition>;
   return (
-    (position.kind === 'output' || position.kind === 'text') &&
+    (position.kind === 'output' ||
+      position.kind === 'reasoning' ||
+      position.kind === 'text') &&
     typeof position.itemId === 'string' &&
     position.itemId.length > 0 &&
     typeof position.outputIndex === 'number' &&
@@ -1078,7 +1125,9 @@ function comparePositionedResponsesReplayBlocks(
 ): number {
   return (
     (a.textIndex ?? Number.MAX_SAFE_INTEGER) -
-      (b.textIndex ?? Number.MAX_SAFE_INTEGER) || a.outputIndex - b.outputIndex
+      (b.textIndex ?? Number.MAX_SAFE_INTEGER) ||
+    a.outputIndex - b.outputIndex ||
+    a.subIndex - b.subIndex
   );
 }
 
@@ -1099,6 +1148,8 @@ function getResponsesReplayArtifacts(
   const ids = new Set<string>();
   const emittedData = new Set<string>();
   const emittedIds = new Set<string>();
+  const positionedServerToolResultIds = new Set<string>();
+  const rawOutputIndices = new Map<Record<string, unknown>, number>();
   const serverToolResults: PositionedResponsesReplayBlock[] = [];
   const replayPositions = Array.isArray(replayPositionValue)
     ? replayPositionValue.filter(isResponsesReplayPosition)
@@ -1106,7 +1157,7 @@ function getResponsesReplayArtifacts(
   const outputPositionsByItemId = new Map<string, ResponsesReplayPosition>();
   const textPositionsByKey = new Map<string, ResponsesReplayPosition>();
   for (const position of replayPositions) {
-    if (position.kind === 'output') {
+    if (position.kind === 'output' || position.kind === 'reasoning') {
       outputPositionsByItemId.set(position.itemId, position);
       continue;
     }
@@ -1122,6 +1173,12 @@ function getResponsesReplayArtifacts(
       'type' in item &&
       item.type === 'message'
   );
+  for (let outputIndex = 0; outputIndex < output.length; outputIndex++) {
+    const item = output[outputIndex];
+    if (item != null && typeof item === 'object') {
+      rawOutputIndices.set(item as Record<string, unknown>, outputIndex);
+    }
+  }
   if (hasAuthoritativeMessage) {
     for (let outputIndex = 0; outputIndex < output.length; outputIndex++) {
       const item = output[outputIndex];
@@ -1155,7 +1212,10 @@ function getResponsesReplayArtifacts(
           content == null ||
           typeof content !== 'object' ||
           !('type' in content) ||
-          content.type !== 'output_text'
+          content.type !== 'output_text' ||
+          !('text' in content) ||
+          typeof content.text !== 'string' ||
+          content.text.length === 0
         ) {
           continue;
         }
@@ -1180,9 +1240,14 @@ function getResponsesReplayArtifacts(
   const textCountBeforeOutputIndex = new Map<number, number>();
   const positionedOutputIndices = [
     ...new Set(
-      [...outputPositionsByItemId.values()].map(
-        (position) => position.outputIndex
-      )
+      [
+        ...outputPositionsByItemId.values(),
+        ...(hasAuthoritativeMessage
+          ? [...rawOutputIndices.values()].map((outputIndex) => ({
+            outputIndex,
+          }))
+          : []),
+      ].map((position) => position.outputIndex)
     ),
   ].sort((a, b) => a - b);
   let textPositionIndex = 0;
@@ -1195,28 +1260,44 @@ function getResponsesReplayArtifacts(
     }
     textCountBeforeOutputIndex.set(outputIndex, textPositionIndex);
   }
-  const getPosition = (
-    item: Record<string, unknown>
-  ): Pick<PositionedResponsesReplayBlock, 'outputIndex' | 'textIndex'> => {
-    const itemId = getResponsesReplayItemKey(item);
-    const position =
-      itemId != null ? outputPositionsByItemId.get(itemId) : undefined;
-    if (position == null) {
-      return { outputIndex: Number.MAX_SAFE_INTEGER };
-    }
-    return {
+  const positionsByItemId = new Map<string, ResponsesReplayItemPosition>();
+  for (const [itemId, position] of outputPositionsByItemId) {
+    positionsByItemId.set(itemId, {
       outputIndex: position.outputIndex,
       textIndex: textCountBeforeOutputIndex.get(position.outputIndex) ?? 0,
-    };
+    });
+  }
+  const getPosition = (
+    item: Record<string, unknown>
+  ): ResponsesReplayItemPosition => {
+    const itemId = getResponsesReplayItemKey(item);
+    const position = itemId != null ? positionsByItemId.get(itemId) : undefined;
+    if (position == null) {
+      const rawOutputIndex = rawOutputIndices.get(item);
+      return {
+        outputIndex: rawOutputIndex ?? Number.MAX_SAFE_INTEGER,
+        ...(hasAuthoritativeMessage && rawOutputIndex != null
+          ? {
+            textIndex: textCountBeforeOutputIndex.get(rawOutputIndex) ?? 0,
+          }
+          : {}),
+      };
+    }
+    return position;
   };
   const pushServerToolResult = (
     block: LangChainContentBlock.Standard | undefined,
-    item: Record<string, unknown>
+    item: Record<string, unknown>,
+    subIndex = 0
   ): void => {
     if (block == null) {
       return;
     }
-    serverToolResults.push({ block, ...getPosition(item) });
+    const itemId = getResponsesReplayItemKey(item);
+    if (itemId != null) {
+      positionedServerToolResultIds.add(itemId);
+    }
+    serverToolResults.push({ block, ...getPosition(item), subIndex });
   };
   for (const item of output) {
     if (item == null || typeof item !== 'object' || !('type' in item)) {
@@ -1226,16 +1307,47 @@ function getResponsesReplayArtifacts(
       if (
         !('outputs' in item) ||
         !Array.isArray(item.outputs) ||
-        !('status' in item) ||
-        (item.status !== 'completed' && item.status !== 'failed')
+        !('status' in item)
       ) {
         continue;
       }
-      for (const result of item.outputs) {
+      const resultStatus = item.status === 'completed' ? 'success' : 'error';
+      const returnCode = item.status === 'completed' ? 0 : 1;
+      for (
+        let resultIndex = 0;
+        resultIndex < item.outputs.length;
+        resultIndex++
+      ) {
+        const result = item.outputs[resultIndex];
         if (
           result == null ||
           typeof result !== 'object' ||
-          !('type' in result) ||
+          !('type' in result)
+        ) {
+          continue;
+        }
+        if (
+          result.type === 'logs' &&
+          'logs' in result &&
+          typeof result.logs === 'string'
+        ) {
+          pushServerToolResult(
+            createNeutralServerToolResult(
+              {
+                type: 'code_interpreter_output',
+                returnCode,
+                stdout: result.logs,
+              },
+              resultStatus,
+              maxChars,
+              'code_interpreter'
+            ),
+            item,
+            resultIndex
+          );
+          continue;
+        }
+        if (
           result.type !== 'image' ||
           !('url' in result) ||
           typeof result.url !== 'string' ||
@@ -1254,18 +1366,58 @@ function getResponsesReplayArtifacts(
               url: resultUrl,
               extras: createServerToolResultExtras('code_interpreter'),
             },
-            item
+            item,
+            resultIndex
           );
           continue;
         }
         const mediaResult = createNeutralServerToolResult(
           { type: 'code_interpreter_image', url: resultUrl },
-          item.status === 'failed' ? 'error' : 'success',
+          resultStatus,
           maxChars,
           'code_interpreter'
         );
-        pushServerToolResult(mediaResult, item);
+        pushServerToolResult(mediaResult, item, resultIndex);
       }
+      continue;
+    }
+    if (item.type === 'file_search_call') {
+      const result = createNeutralServerToolResult(
+        'results' in item && Array.isArray(item.results)
+          ? { results: item.results }
+          : undefined,
+        'status' in item && item.status === 'completed' ? 'success' : 'error',
+        maxChars,
+        'file_search'
+      );
+      pushServerToolResult(result, item);
+      continue;
+    }
+    if (item.type === 'web_search_call') {
+      const result = createNeutralServerToolResult(
+        {
+          ...('action' in item ? { action: item.action } : {}),
+          ...('results' in item && Array.isArray(item.results)
+            ? { results: item.results }
+            : {}),
+        },
+        'status' in item && item.status === 'completed' ? 'success' : 'error',
+        maxChars,
+        'web_search'
+      );
+      pushServerToolResult(result, item);
+      continue;
+    }
+    if (item.type === 'tool_search_output') {
+      const result = createNeutralServerToolResult(
+        'tools' in item && Array.isArray(item.tools)
+          ? { tools: item.tools }
+          : undefined,
+        'status' in item && item.status === 'completed' ? 'success' : 'error',
+        maxChars,
+        'tool_search'
+      );
+      pushServerToolResult(result, item);
       continue;
     }
     if (item.type === 'mcp_list_tools') {
@@ -1402,6 +1554,7 @@ function getResponsesReplayArtifacts(
           extras: createServerToolResultExtras('image_generation'),
         },
         ...getPosition(item),
+        subIndex: 0,
       });
     }
   }
@@ -1411,6 +1564,8 @@ function getResponsesReplayArtifacts(
       data,
       ids,
     },
+    positionedServerToolResultIds,
+    positionsByItemId,
     serverToolResults: serverToolResults.sort(
       comparePositionedResponsesReplayBlocks
     ),
@@ -1512,12 +1667,29 @@ function projectPreemptedOpenAIResponsesMessage(
     replayProjection === 'native' &&
     hasReplayableEncryptedReasoning(additionalKwargs.reasoning);
   const authoritativeOutput = getAuthoritativeResponsesOutput(message);
-  const { generatedImages, serverToolResults } = getResponsesReplayArtifacts(
+  const {
+    generatedImages,
+    positionedServerToolResultIds,
+    positionsByItemId,
+    serverToolResults,
+  } = getResponsesReplayArtifacts(
     authoritativeOutput,
     maxChars,
     replayProjection,
     additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
   );
+  const reasoningItemId =
+    retainsEncryptedReasoning &&
+    additionalKwargs.reasoning != null &&
+    typeof additionalKwargs.reasoning === 'object' &&
+    'id' in additionalKwargs.reasoning &&
+    typeof additionalKwargs.reasoning.id === 'string'
+      ? additionalKwargs.reasoning.id
+      : undefined;
+  const reasoningPosition =
+    reasoningItemId != null
+      ? positionsByItemId.get(reasoningItemId)
+      : undefined;
   const isV1 = metadata.output_version === 'v1';
   const translatesV0 =
     !isV1 &&
@@ -1540,7 +1712,9 @@ function projectPreemptedOpenAIResponsesMessage(
     replayProjection,
     replayProjection === 'native' ? generatedImages : undefined,
     originalImages,
-    serverToolResults
+    serverToolResults,
+    positionedServerToolResultIds,
+    reasoningPosition
   );
   const promotesV0 =
     !isV1 &&

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -7,6 +7,7 @@ import {
   HumanMessage,
   AIMessageChunk,
 } from '@langchain/core/messages';
+import type { ContentBlock as LangChainContentBlock } from '@langchain/core/messages';
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
@@ -589,6 +590,208 @@ function cloneAIMessageWithContent(
   ) as AIMessage;
 }
 
+type ResponsesReplayMetadata = {
+  [key: string]: unknown;
+  id?: unknown;
+  output?: unknown;
+  preempted?: unknown;
+  tool_outputs?: unknown;
+};
+
+function cloneAIMessageWithResponsesReplayState(
+  message: AIMessage,
+  content: AIMessage['content'],
+  id: string | undefined,
+  additionalKwargs: AIMessage['additional_kwargs'],
+  responseMetadata: AIMessage['response_metadata']
+): AIMessage {
+  const descriptors = Object.getOwnPropertyDescriptors(message) as Record<
+    string,
+    PropertyDescriptor | undefined
+  >;
+  const replacements = {
+    content,
+    id,
+    additional_kwargs: additionalKwargs,
+    response_metadata: responseMetadata,
+  };
+  for (const [key, value] of Object.entries(replacements)) {
+    const descriptor = descriptors[key];
+    descriptors[key] = {
+      configurable: descriptor?.configurable ?? true,
+      enumerable: descriptor?.enumerable ?? true,
+      value,
+      writable: descriptor?.writable ?? true,
+    };
+  }
+  const lcKwargs = descriptors.lc_kwargs;
+  if (
+    lcKwargs != null &&
+    'value' in lcKwargs &&
+    typeof lcKwargs.value === 'object' &&
+    lcKwargs.value != null
+  ) {
+    descriptors.lc_kwargs = {
+      ...lcKwargs,
+      value: {
+        ...(lcKwargs.value as Record<string, unknown>),
+        ...replacements,
+        ...(responseMetadata.output_version === 'v1'
+          ? { content: undefined, contentBlocks: content }
+          : {}),
+      },
+    };
+  }
+  return Object.create(
+    Object.getPrototypeOf(message),
+    descriptors as PropertyDescriptorMap
+  ) as AIMessage;
+}
+
+function hasReplayableEncryptedReasoning(reasoning: unknown): boolean {
+  if (reasoning == null || typeof reasoning !== 'object') {
+    return false;
+  }
+  const item = reasoning as {
+    encrypted_content?: unknown;
+    id?: unknown;
+    status?: unknown;
+    summary?: unknown;
+    type?: unknown;
+  };
+  return (
+    item.type === 'reasoning' &&
+    typeof item.id === 'string' &&
+    item.id.length > 0 &&
+    Array.isArray(item.summary) &&
+    typeof item.encrypted_content === 'string' &&
+    item.encrypted_content.length > 0 &&
+    (item.status === undefined ||
+      item.status === 'completed' ||
+      item.status === 'incomplete')
+  );
+}
+
+function isUnsafePreemptedResponsesV1Block(
+  block: LangChainContentBlock.Standard
+): boolean {
+  switch (block.type) {
+  case 'reasoning':
+  case 'server_tool_call':
+  case 'server_tool_call_chunk':
+  case 'server_tool_call_result':
+    return true;
+  case 'non_standard':
+    return !hasReplayableEncryptedReasoning(block.value);
+  default:
+    return false;
+  }
+}
+
+function projectPreemptedResponsesV1Content(
+  message: AIMessage,
+  reasoning: unknown
+): AIMessage['content'] {
+  if (
+    message.response_metadata.output_version !== 'v1' ||
+    !Array.isArray(message.content)
+  ) {
+    return message.content;
+  }
+
+  const content = message.content as LangChainContentBlock.Standard[];
+  const encryptedReasoning = hasReplayableEncryptedReasoning(reasoning)
+    ? reasoning
+    : undefined;
+  let projected: LangChainContentBlock.Standard[] | undefined;
+  let hasEncryptedReasoning = content.some(
+    (block) =>
+      block.type === 'non_standard' &&
+      hasReplayableEncryptedReasoning(block.value)
+  );
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i];
+    if (isUnsafePreemptedResponsesV1Block(block)) {
+      projected ??= content.slice(0, i);
+      if (
+        block.type === 'reasoning' &&
+        encryptedReasoning != null &&
+        !hasEncryptedReasoning
+      ) {
+        projected.push({
+          type: 'non_standard',
+          value: encryptedReasoning,
+        });
+        hasEncryptedReasoning = true;
+      }
+      continue;
+    }
+    projected?.push(block);
+  }
+
+  if (encryptedReasoning != null && !hasEncryptedReasoning) {
+    projected = [
+      { type: 'non_standard', value: encryptedReasoning },
+      ...(projected ?? content),
+    ];
+  }
+  return projected ?? message.content;
+}
+
+/**
+ * A sealed Responses turn cannot prove that provider-side item ids were
+ * retained: the response object does not echo the request's `store` flag.
+ * Project a provider-neutral clone while preserving self-contained encrypted
+ * reasoning and the original graph/checkpoint message.
+ */
+function projectPreemptedOpenAIResponsesMessage(message: AIMessage): AIMessage {
+  const metadata = message.response_metadata as ResponsesReplayMetadata;
+  if (metadata.preempted !== true) {
+    return message;
+  }
+
+  const additionalKwargs = { ...message.additional_kwargs };
+  const hasEncryptedReasoning = hasReplayableEncryptedReasoning(
+    additionalKwargs.reasoning
+  );
+  const content = projectPreemptedResponsesV1Content(
+    message,
+    additionalKwargs.reasoning
+  );
+  const hasUnsafeProviderReferences =
+    content !== message.content ||
+    message.id?.startsWith('msg_') === true ||
+    (!hasEncryptedReasoning && additionalKwargs.reasoning != null) ||
+    additionalKwargs.tool_outputs != null ||
+    additionalKwargs.__openai_function_call_ids__ != null ||
+    additionalKwargs.__openai_custom_tool_call_ids__ != null ||
+    metadata.id != null ||
+    metadata.output != null ||
+    metadata.tool_outputs != null;
+  if (!hasUnsafeProviderReferences) {
+    return message;
+  }
+  if (!hasEncryptedReasoning) {
+    delete additionalKwargs.reasoning;
+  }
+  delete additionalKwargs.tool_outputs;
+  delete additionalKwargs.__openai_function_call_ids__;
+  delete additionalKwargs.__openai_custom_tool_call_ids__;
+
+  const responseMetadata: ResponsesReplayMetadata = { ...metadata };
+  delete responseMetadata.id;
+  delete responseMetadata.output;
+  delete responseMetadata.tool_outputs;
+
+  return cloneAIMessageWithResponsesReplayState(
+    message,
+    content,
+    message.id?.startsWith('msg_') === true ? undefined : message.id,
+    additionalKwargs,
+    responseMetadata
+  );
+}
+
 /**
  * Drops incomplete streamed text-input fragments that some providers retain
  * beside the assembled parsed tool call. They are neither user-visible text
@@ -687,7 +890,7 @@ function projectStructuredOpenAIToolContent(
 function projectOpenAIToolMessageContentInternal(
   messages: BaseMessage[],
   maxChars: number,
-  deduplicateResponsesComputerCalls: boolean,
+  nativeResponsesProjection: boolean,
   cacheControlledTextProjection: CacheControlledTextProjection
 ): BaseMessage[] {
   const pendingComputerCallIds: string[] = [];
@@ -699,8 +902,18 @@ function projectOpenAIToolMessageContentInternal(
     const isAssistant =
       message.getType() === 'ai' || messageRole === 'assistant';
     if (isAssistant) {
+      let assistantMessage = message as AIMessage;
+      if (nativeResponsesProjection) {
+        const replaySafeMessage =
+          projectPreemptedOpenAIResponsesMessage(assistantMessage);
+        if (replaySafeMessage !== assistantMessage) {
+          projected ??= [...messages];
+          projected[i] = replaySafeMessage;
+          assistantMessage = replaySafeMessage;
+        }
+      }
       const parsedComputerCallIds = new Set<string>();
-      const toolCalls = (message as AIMessage).tool_calls;
+      const toolCalls = assistantMessage.tool_calls;
       if (Array.isArray(toolCalls)) {
         for (const toolCall of toolCalls) {
           const record = toolCall as ToolCall & {
@@ -727,12 +940,12 @@ function projectOpenAIToolMessageContentInternal(
       }
 
       const rawOutput = (
-        message.response_metadata as {
+        assistantMessage.response_metadata as {
           output?: unknown;
         }
       ).output;
       const fallbackOutput = (
-        message.additional_kwargs as {
+        assistantMessage.additional_kwargs as {
           tool_outputs?: unknown;
         }
       ).tool_outputs;
@@ -775,7 +988,7 @@ function projectOpenAIToolMessageContentInternal(
       }
 
       if (
-        deduplicateResponsesComputerCalls &&
+        nativeResponsesProjection &&
         Array.isArray(toolCalls) &&
         rawComputerCallIds.size > 0
       ) {
@@ -794,7 +1007,7 @@ function projectOpenAIToolMessageContentInternal(
         if (projectedToolCalls.length !== toolCalls.length) {
           projected ??= [...messages];
           projected[i] = cloneAIMessageWithToolCalls(
-            message as AIMessage,
+            assistantMessage,
             projectedToolCalls,
             rawComputerCallIds
           );

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -1574,7 +1574,9 @@ function getSelfContainedResponsesV0Images(
   let textCount = 0;
   for (const block of message.content as LangChainContentBlock.Standard[]) {
     if (block.type === 'text') {
-      textCount++;
+      if (isCompleteToolStreamContentBlock(block)) {
+        textCount++;
+      }
       continue;
     }
     if (

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -671,7 +671,7 @@ type ResponsesReplayProjection = 'fallback' | 'native';
 export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
   '__openai_responses_replay_positions__';
 
-type ResponsesReplayPosition = {
+export type ResponsesReplayPosition = {
   contentIndex?: number;
   itemId: string;
   kind: 'output' | 'text';
@@ -679,7 +679,7 @@ type ResponsesReplayPosition = {
 };
 
 type CompletedGeneratedImages = {
-  blocks: LangChainContentBlock.Multimodal.Image[];
+  blocks: PositionedResponsesReplayBlock[];
   data: Set<string>;
   ids: Set<string>;
 };
@@ -740,6 +740,16 @@ function hasMeaningfulServerToolOutput(output: unknown): boolean {
   }
 }
 
+function createServerToolResultExtras(toolName?: string): {
+  librechatServerToolResult: { toolName?: string };
+} {
+  return {
+    librechatServerToolResult: {
+      ...(toolName != null ? { toolName } : {}),
+    },
+  };
+}
+
 function createNeutralServerToolResult(
   output: unknown,
   status: 'error' | 'success',
@@ -761,11 +771,7 @@ function createNeutralServerToolResult(
       },
       maxChars
     ),
-    extras: {
-      librechatServerToolResult: {
-        ...(toolName != null ? { toolName } : {}),
-      },
-    },
+    extras: createServerToolResultExtras(toolName),
   };
 }
 
@@ -825,6 +831,7 @@ function projectPreemptedResponsesV1Content(
   let hasEncryptedReasoning = false;
   let preservedServerToolResult = false;
   let reasoningInsertionIndex: number | undefined;
+  let generatedImageIndex = 0;
   let originalImageIndex = 0;
   let serverToolResultIndex = 0;
   let sourceTextIndex = 0;
@@ -858,12 +865,23 @@ function projectPreemptedResponsesV1Content(
     }
   };
 
-  const appendServerToolResults = (throughTextIndex?: number): void => {
-    if (serverToolResults == null) {
-      return;
-    }
-    while (serverToolResultIndex < serverToolResults.length) {
-      const positionedResult = serverToolResults[serverToolResultIndex];
+  const appendReplayBlocks = (throughTextIndex?: number): void => {
+    for (;;) {
+      const generatedImage = generatedImages?.blocks[generatedImageIndex];
+      const serverToolResult = serverToolResults?.[serverToolResultIndex];
+      const useGeneratedImage =
+        generatedImage != null &&
+        (serverToolResult == null ||
+          comparePositionedResponsesReplayBlocks(
+            generatedImage,
+            serverToolResult
+          ) <= 0);
+      const positionedResult = useGeneratedImage
+        ? generatedImage
+        : serverToolResult;
+      if (positionedResult == null) {
+        return;
+      }
       if (
         throughTextIndex != null &&
         (positionedResult.textIndex == null ||
@@ -871,7 +889,11 @@ function projectPreemptedResponsesV1Content(
       ) {
         return;
       }
-      serverToolResultIndex++;
+      if (useGeneratedImage) {
+        generatedImageIndex++;
+      } else {
+        serverToolResultIndex++;
+      }
       if (
         replayProjection === 'fallback' &&
         positionedResult.block.type === 'text'
@@ -884,7 +906,7 @@ function projectPreemptedResponsesV1Content(
         projected.push(positionedResult.block);
       }
       changed = true;
-      preservedServerToolResult = true;
+      preservedServerToolResult ||= !useGeneratedImage;
     }
   };
 
@@ -914,7 +936,7 @@ function projectPreemptedResponsesV1Content(
     }
     if (block.type === 'text') {
       appendOriginalImages(sourceTextIndex);
-      appendServerToolResults(sourceTextIndex);
+      appendReplayBlocks(sourceTextIndex);
       if (replayProjection === 'fallback') {
         projected.push({ type: 'text', text: block.text });
         changed = true;
@@ -982,11 +1004,7 @@ function projectPreemptedResponsesV1Content(
     changed = true;
   }
   appendOriginalImages();
-  appendServerToolResults();
-  if (replayProjection === 'native' && generatedImages != null) {
-    projected.push(...generatedImages.blocks);
-    changed ||= generatedImages.blocks.length > 0;
-  }
+  appendReplayBlocks();
   return {
     content: changed ? toLangChainContent(projected) : content,
     preservedServerToolResult,
@@ -1054,6 +1072,16 @@ function getResponsesReplayItemKey(
     : undefined;
 }
 
+function comparePositionedResponsesReplayBlocks(
+  a: PositionedResponsesReplayBlock,
+  b: PositionedResponsesReplayBlock
+): number {
+  return (
+    (a.textIndex ?? Number.MAX_SAFE_INTEGER) -
+      (b.textIndex ?? Number.MAX_SAFE_INTEGER) || a.outputIndex - b.outputIndex
+  );
+}
+
 const RESPONSES_REPLAY_OUTPUT_TOOL_NAMES = {
   apply_patch_call_output: 'apply_patch',
   local_shell_call_output: 'local_shell',
@@ -1066,7 +1094,7 @@ function getResponsesReplayArtifacts(
   replayProjection: ResponsesReplayProjection,
   replayPositionValue?: unknown
 ): ResponsesReplayArtifacts {
-  const blocks: LangChainContentBlock.Multimodal.Image[] = [];
+  const blocks: PositionedResponsesReplayBlock[] = [];
   const data = new Set<string>();
   const ids = new Set<string>();
   const emittedData = new Set<string>();
@@ -1149,6 +1177,24 @@ function getResponsesReplayArtifacts(
       a.outputIndex - b.outputIndex ||
       (a.contentIndex ?? 0) - (b.contentIndex ?? 0)
   );
+  const textCountBeforeOutputIndex = new Map<number, number>();
+  const positionedOutputIndices = [
+    ...new Set(
+      [...outputPositionsByItemId.values()].map(
+        (position) => position.outputIndex
+      )
+    ),
+  ].sort((a, b) => a - b);
+  let textPositionIndex = 0;
+  for (const outputIndex of positionedOutputIndices) {
+    while (
+      textPositionIndex < textPositions.length &&
+      textPositions[textPositionIndex].outputIndex < outputIndex
+    ) {
+      textPositionIndex++;
+    }
+    textCountBeforeOutputIndex.set(outputIndex, textPositionIndex);
+  }
   const getPosition = (
     item: Record<string, unknown>
   ): Pick<PositionedResponsesReplayBlock, 'outputIndex' | 'textIndex'> => {
@@ -1160,9 +1206,7 @@ function getResponsesReplayArtifacts(
     }
     return {
       outputIndex: position.outputIndex,
-      textIndex: textPositions.filter(
-        (textPosition) => textPosition.outputIndex < position.outputIndex
-      ).length,
+      textIndex: textCountBeforeOutputIndex.get(position.outputIndex) ?? 0,
     };
   };
   const pushServerToolResult = (
@@ -1204,7 +1248,14 @@ function getResponsesReplayArtifacts(
           replayProjection === 'native' &&
           resultUrl.startsWith('data:image/')
         ) {
-          pushServerToolResult({ type: 'image', url: resultUrl }, item);
+          pushServerToolResult(
+            {
+              type: 'image',
+              url: resultUrl,
+              extras: createServerToolResultExtras('code_interpreter'),
+            },
+            item
+          );
           continue;
         }
         const mediaResult = createNeutralServerToolResult(
@@ -1344,19 +1395,24 @@ function getResponsesReplayArtifacts(
         emittedData.add(item.result);
       }
       blocks.push({
-        type: 'image',
-        mimeType: getGeneratedImageMimeType(item.result),
-        data: item.result,
+        block: {
+          type: 'image',
+          mimeType: getGeneratedImageMimeType(item.result),
+          data: item.result,
+          extras: createServerToolResultExtras('image_generation'),
+        },
+        ...getPosition(item),
       });
     }
   }
   return {
-    generatedImages: { blocks, data, ids },
+    generatedImages: {
+      blocks: blocks.sort(comparePositionedResponsesReplayBlocks),
+      data,
+      ids,
+    },
     serverToolResults: serverToolResults.sort(
-      (a, b) =>
-        (a.textIndex ?? Number.MAX_SAFE_INTEGER) -
-          (b.textIndex ?? Number.MAX_SAFE_INTEGER) ||
-        a.outputIndex - b.outputIndex
+      comparePositionedResponsesReplayBlocks
     ),
   };
 }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -1154,6 +1154,7 @@ function getResponsesReplayArtifacts(
   const replayPositions = Array.isArray(replayPositionValue)
     ? replayPositionValue.filter(isResponsesReplayPosition)
     : [];
+  const authoritativeOutputIndicesByItemId = new Map<string, number>();
   const outputPositionsByItemId = new Map<string, ResponsesReplayPosition>();
   const textPositionsByKey = new Map<string, ResponsesReplayPosition>();
   for (const position of replayPositions) {
@@ -1166,70 +1167,61 @@ function getResponsesReplayArtifacts(
       position
     );
   }
-  const hasAuthoritativeMessage = output.some(
-    (item) =>
-      item != null &&
-      typeof item === 'object' &&
-      'type' in item &&
-      item.type === 'message'
-  );
+  let hasAuthoritativeMessage = false;
   for (let outputIndex = 0; outputIndex < output.length; outputIndex++) {
     const item = output[outputIndex];
-    if (item != null && typeof item === 'object') {
-      rawOutputIndices.set(item as Record<string, unknown>, outputIndex);
+    if (item == null || typeof item !== 'object') {
+      continue;
+    }
+    const itemRecord = item as Record<string, unknown>;
+    rawOutputIndices.set(itemRecord, outputIndex);
+    const itemKey = getResponsesReplayItemKey(itemRecord);
+    if (itemKey != null) {
+      authoritativeOutputIndicesByItemId.set(itemKey, outputIndex);
+    }
+    if (!('type' in item) || item.type !== 'message') {
+      continue;
+    }
+    hasAuthoritativeMessage = true;
+    if (!('content' in item) || !Array.isArray(item.content)) {
+      continue;
+    }
+    for (
+      let contentIndex = 0;
+      contentIndex < item.content.length;
+      contentIndex++
+    ) {
+      const content = item.content[contentIndex];
+      if (
+        content == null ||
+        typeof content !== 'object' ||
+        !('type' in content) ||
+        content.type !== 'output_text' ||
+        !('text' in content) ||
+        typeof content.text !== 'string' ||
+        content.text.length === 0
+      ) {
+        continue;
+      }
+      const itemId =
+        'id' in item && typeof item.id === 'string'
+          ? item.id
+          : `message-${outputIndex}`;
+      textPositionsByKey.set(`${itemId}:${outputIndex}:${contentIndex}`, {
+        contentIndex,
+        itemId,
+        kind: 'text',
+        outputIndex,
+      });
     }
   }
   if (hasAuthoritativeMessage) {
-    for (let outputIndex = 0; outputIndex < output.length; outputIndex++) {
-      const item = output[outputIndex];
-      if (item == null || typeof item !== 'object') {
-        continue;
-      }
-      const itemRecord = item as Record<string, unknown>;
-      const itemKey = getResponsesReplayItemKey(itemRecord);
-      if (itemKey != null) {
-        outputPositionsByItemId.set(itemKey, {
-          itemId: itemKey,
-          kind: 'output',
-          outputIndex,
-        });
-      }
-      if (
-        !('type' in item) ||
-        item.type !== 'message' ||
-        !('content' in item) ||
-        !Array.isArray(item.content)
-      ) {
-        continue;
-      }
-      for (
-        let contentIndex = 0;
-        contentIndex < item.content.length;
-        contentIndex++
-      ) {
-        const content = item.content[contentIndex];
-        if (
-          content == null ||
-          typeof content !== 'object' ||
-          !('type' in content) ||
-          content.type !== 'output_text' ||
-          !('text' in content) ||
-          typeof content.text !== 'string' ||
-          content.text.length === 0
-        ) {
-          continue;
-        }
-        const itemId =
-          'id' in item && typeof item.id === 'string'
-            ? item.id
-            : `message-${outputIndex}`;
-        textPositionsByKey.set(`${itemId}:${outputIndex}:${contentIndex}`, {
-          contentIndex,
-          itemId,
-          kind: 'text',
-          outputIndex,
-        });
-      }
+    for (const [itemId, outputIndex] of authoritativeOutputIndicesByItemId) {
+      outputPositionsByItemId.set(itemId, {
+        itemId,
+        kind: 'output',
+        outputIndex,
+      });
     }
   }
   const textPositions = [...textPositionsByKey.values()].sort(
@@ -1238,18 +1230,18 @@ function getResponsesReplayArtifacts(
       (a.contentIndex ?? 0) - (b.contentIndex ?? 0)
   );
   const textCountBeforeOutputIndex = new Map<number, number>();
-  const positionedOutputIndices = [
-    ...new Set(
-      [
-        ...outputPositionsByItemId.values(),
-        ...(hasAuthoritativeMessage
-          ? [...rawOutputIndices.values()].map((outputIndex) => ({
-            outputIndex,
-          }))
-          : []),
-      ].map((position) => position.outputIndex)
-    ),
-  ].sort((a, b) => a - b);
+  const positionedOutputIndexSet = new Set<number>();
+  for (const position of outputPositionsByItemId.values()) {
+    positionedOutputIndexSet.add(position.outputIndex);
+  }
+  if (hasAuthoritativeMessage) {
+    for (const outputIndex of rawOutputIndices.values()) {
+      positionedOutputIndexSet.add(outputIndex);
+    }
+  }
+  const positionedOutputIndices = [...positionedOutputIndexSet].sort(
+    (a, b) => a - b
+  );
   let textPositionIndex = 0;
   for (const outputIndex of positionedOutputIndices) {
     while (
@@ -1587,9 +1579,12 @@ function getSelfContainedResponsesV0Images(
     }
     if (
       block.type === 'image' &&
-      'data' in block &&
-      ((typeof block.data === 'string' && block.data.length > 0) ||
-        (block.data instanceof Uint8Array && block.data.length > 0))
+      (('url' in block &&
+        typeof block.url === 'string' &&
+        block.url.length > 0) ||
+        ('data' in block &&
+          ((typeof block.data === 'string' && block.data.length > 0) ||
+            (block.data instanceof Uint8Array && block.data.length > 0))))
     ) {
       images.push({ block, textIndex: textCount });
     }

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -44,6 +44,13 @@ type AnthropicPayloadBlock = {
   type: string;
 };
 
+const CODE_INTERPRETER_REPLAY_EXTRAS = {
+  librechatServerToolResult: { toolName: 'code_interpreter' },
+} as const;
+const IMAGE_GENERATION_REPLAY_EXTRAS = {
+  librechatServerToolResult: { toolName: 'image_generation' },
+} as const;
+
 const getAnthropicPayloadBlocks = (
   content: unknown
 ): AnthropicPayloadBlock[] => {
@@ -2224,7 +2231,12 @@ describe('formatAgentMessages', () => {
       expect(projectedMessage.content).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ type: 'text', text: 'Partial answer.' }),
-          { type: 'image', mimeType: 'image/png', data: 'AA==' },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'AA==',
+            extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+          },
         ])
       );
       expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
@@ -2270,6 +2282,137 @@ describe('formatAgentMessages', () => {
     }
   );
 
+  it('keeps completed v1 generated images in their Responses output positions', () => {
+    const firstGeneratedImage = {
+      id: 'ig_before_text',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: 'AA==',
+    };
+    const secondGeneratedImage = {
+      id: 'ig_between_text',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: 'AQ==',
+    };
+    const message = new AIMessage({
+      content: [
+        {
+          type: 'image',
+          mimeType: 'image/png',
+          data: firstGeneratedImage.result,
+          id: firstGeneratedImage.id,
+          metadata: { status: 'completed' },
+        },
+        { type: 'text', text: 'The image above is the first result.' },
+        {
+          type: 'image',
+          mimeType: 'image/png',
+          data: secondGeneratedImage.result,
+          id: secondGeneratedImage.id,
+          metadata: { status: 'completed' },
+        },
+        { type: 'text', text: 'The second image is directly above.' },
+      ],
+      response_metadata: {
+        model_provider: 'openai',
+        output_version: 'v1',
+        preempted: true,
+        output: [
+          firstGeneratedImage,
+          {
+            id: 'msg_first_narration',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                text: 'The image above is the first result.',
+                annotations: [],
+              },
+            ],
+          },
+          secondGeneratedImage,
+          {
+            id: 'msg_second_narration',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [
+              {
+                type: 'output_text',
+                text: 'The second image is directly above.',
+                annotations: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage.content).toEqual([
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
+      { type: 'text', text: 'The image above is the first result.' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AQ==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
+      { type: 'text', text: 'The second image is directly above.' },
+    ]);
+    expect(providerInput).toEqual([
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,AA==',
+          },
+          {
+            type: 'output_text',
+            text: 'The image above is the first result.',
+            annotations: [],
+          },
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,AQ==',
+          },
+          {
+            type: 'output_text',
+            text: 'The second image is directly above.',
+            annotations: [],
+          },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toMatch(
+      /ig_(before|between)_text/
+    );
+    expect(message.response_metadata).toHaveProperty('output');
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
   it.each([
     ['v0', 'jpeg', '/9j/4AAQSkZJRg==', 'image/jpeg'],
     ['v1', 'jpeg', '/9j/4AAQSkZJRg==', 'image/jpeg'],
@@ -2304,6 +2447,7 @@ describe('formatAgentMessages', () => {
               preempted: true,
             },
           });
+      const originalSerialized = JSON.stringify(message.toJSON());
 
       const projected = projectOpenAIResponsesToolMessageContent([message]);
       const projectedMessage = projected[0] as AIMessage;
@@ -2314,13 +2458,43 @@ describe('formatAgentMessages', () => {
       });
 
       expect(projectedMessage.content).toEqual(
-        expect.arrayContaining([{ type: 'image', mimeType, data }])
+        expect.arrayContaining([
+          {
+            type: 'image',
+            mimeType,
+            data,
+            extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+          },
+        ])
       );
       expect(JSON.stringify(providerInput)).toContain(
         `data:${mimeType};base64,${data}`
       );
       expect(JSON.stringify(providerInput)).not.toContain(generatedImage.id);
-      expect(JSON.stringify(message.toJSON())).toContain(generatedImage.id);
+      expect(JSON.stringify(providerInput)).not.toContain(
+        'librechatServerToolResult'
+      );
+      expect(JSON.stringify(providerInput)).not.toContain('extras');
+
+      const fallback = projectToolStreamContentForProvider(
+        [message],
+        'fallback'
+      );
+      expect((fallback[0] as AIMessage).content).toEqual([
+        { type: 'text', text: 'Generated image.' },
+      ]);
+      expect(_convertMessagesToOpenAIParams(fallback)).toEqual([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Generated image.' }],
+        },
+      ]);
+      expect(JSON.stringify(fallback[0].toJSON())).not.toContain(
+        'librechatServerToolResult'
+      );
+      expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+      expect(originalSerialized).toContain(generatedImage.id);
+      expect(originalSerialized).not.toContain('librechatServerToolResult');
 
       const projectedAgain =
         projectOpenAIResponsesToolMessageContent(projected);
@@ -2405,7 +2579,12 @@ describe('formatAgentMessages', () => {
 
     expect(projectedMessage.content).toEqual([
       { type: 'text', text: 'Partial answer.' },
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
     expect(JSON.stringify(providerInput)).toContain(
       'data:image/png;base64,AA=='
@@ -2446,7 +2625,12 @@ describe('formatAgentMessages', () => {
     expect(projectedMessage.content).toEqual([
       { type: 'text', text: 'Partial answer.' },
       applicationImage,
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
     expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
       'ig_interrupted'
@@ -2507,7 +2691,12 @@ describe('formatAgentMessages', () => {
       imageB,
       { type: 'text', text: 'Second.' },
       imageC,
-      { type: 'image', mimeType: 'image/png', data: 'BA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'BA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
     expect(providerInput).toEqual([
       {
@@ -2592,7 +2781,12 @@ describe('formatAgentMessages', () => {
     expect(projected.content).toEqual([
       { type: 'non_standard', value: reasoning },
       applicationImage,
-      { type: 'image', mimeType: 'image/png', data: 'Ag==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'Ag==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
   });
 
@@ -2630,7 +2824,12 @@ describe('formatAgentMessages', () => {
     expect(projected.content).toEqual([
       applicationImage,
       applicationImage,
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
   });
 
@@ -2663,7 +2862,12 @@ describe('formatAgentMessages', () => {
 
     expect(projected.content).toEqual([
       applicationImage,
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
   });
 
@@ -2689,9 +2893,128 @@ describe('formatAgentMessages', () => {
 
     expect(projected.content).toEqual([
       { type: 'text', text: 'Partial answer.' },
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
   });
+
+  it.each(['v0', 'v1'] as const)(
+    'marks native %s code-interpreter data-url image replay without changing provider payload',
+    (outputVersion) => {
+      const dataUrl = 'data:image/png;base64,AA==';
+      const toolOutput = {
+        id: `ci_inline_${outputVersion}`,
+        type: 'code_interpreter_call',
+        status: 'completed',
+        code: 'display(chart)',
+        outputs: [{ type: 'image', url: dataUrl }],
+      };
+      const v0Message = new AIMessage({
+        content: [{ type: 'text', text: 'Partial answer.' }],
+        additional_kwargs: { tool_outputs: [toolOutput] },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const message =
+        outputVersion === 'v0'
+          ? v0Message
+          : new AIMessage({
+            contentBlocks: v0Message.contentBlocks,
+            additional_kwargs: v0Message.additional_kwargs,
+            response_metadata: {
+              model_provider: 'openai',
+              output_version: 'v1',
+              preempted: true,
+            },
+          });
+      const originalSerialized = JSON.stringify(message.toJSON());
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+
+      expect(projectedMessage.content).toEqual([
+        { type: 'text', text: 'Partial answer.' },
+        {
+          type: 'image',
+          url: dataUrl,
+          extras: CODE_INTERPRETER_REPLAY_EXTRAS,
+        },
+      ]);
+      expect(providerInput).toEqual([
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Partial answer.',
+              annotations: [],
+            },
+            {
+              type: 'input_image',
+              detail: 'auto',
+              image_url: dataUrl,
+            },
+          ],
+        },
+      ]);
+      expect(JSON.stringify(providerInput)).not.toContain(
+        'librechatServerToolResult'
+      );
+      expect(JSON.stringify(providerInput)).not.toContain('extras');
+
+      const fallback = projectToolStreamContentForProvider(
+        [message],
+        'fallback'
+      );
+      const fallbackMessage = fallback[0] as AIMessage;
+      expect(fallbackMessage.content).toEqual([
+        { type: 'text', text: 'Partial answer.' },
+        {
+          type: 'text',
+          text: JSON.stringify({
+            serverToolResult: {
+              toolName: 'code_interpreter',
+              status: 'success',
+              output: {
+                type: 'code_interpreter_image',
+                url: dataUrl,
+              },
+            },
+          }),
+        },
+      ]);
+      expect(_convertMessagesToOpenAIParams(fallback)).toEqual([
+        {
+          role: 'assistant',
+          content: fallbackMessage.content,
+        },
+      ]);
+      expect(JSON.stringify(fallbackMessage.toJSON())).not.toContain('extras');
+      expect(JSON.stringify(fallbackMessage.toJSON())).not.toContain(
+        'librechatServerToolResult'
+      );
+      expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+      expect(originalSerialized).toContain(toolOutput.id);
+      expect(originalSerialized).not.toContain('librechatServerToolResult');
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
 
   it.each(['v0', 'v1'] as const)(
     'preserves completed %s server-tool results without replay ids',
@@ -3205,7 +3528,12 @@ describe('formatAgentMessages', () => {
           librechatServerToolResult: { toolName: 'code_interpreter' },
         },
       },
-      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
     ]);
     expect(projectedMessage.additional_kwargs).toEqual({});
     const serialized = JSON.stringify(projectedMessage.toJSON());

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -14,6 +14,7 @@ import {
 import type { BaseMessage } from '@langchain/core/messages';
 import type { MessageContentComplex, TPayload } from '@/types';
 import {
+  OPENAI_RESPONSES_REPLAY_POSITIONS_KEY,
   convertMessagesToContent,
   formatAnthropicArtifactContent,
   formatArtifactPayload,
@@ -1901,6 +1902,54 @@ describe('formatAgentMessages', () => {
     }
   );
 
+  it('normalizes Responses text metadata before OpenAI Chat fallback replay', () => {
+    const annotatedText = {
+      type: 'text' as const,
+      text: 'Cited answer.',
+      annotations: [
+        {
+          type: 'citation' as const,
+          url: 'https://example.com/source',
+          title: 'Source',
+        },
+      ],
+      extras: { phase: 'final_answer' },
+      index: 0,
+    };
+    const message = new AIMessage({
+      content: [annotatedText],
+      response_metadata: {
+        model_provider: 'openai',
+        output: [],
+        output_version: 'v1',
+        preempted: true,
+      },
+    });
+
+    const native = projectToolStreamContentForProvider([message], 'native');
+    const fallback = projectToolStreamContentForProvider([message], 'fallback');
+    const fallbackMessage = fallback[0] as AIMessage;
+
+    expect((native[0] as AIMessage).content).toEqual([annotatedText]);
+    expect(fallbackMessage.content).toEqual([
+      { type: 'text', text: 'Cited answer.' },
+    ]);
+    expect(_convertMessagesToOpenAIParams(fallback)).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Cited answer.' }],
+      },
+    ]);
+    expect(message.content).toEqual([annotatedText]);
+
+    const fallbackAgain = projectToolStreamContentForProvider(
+      fallback,
+      'fallback'
+    );
+    expect(fallbackAgain).toBe(fallback);
+    expect(fallbackAgain[0]).toBe(fallbackMessage);
+  });
+
   it.each([
     [
       'Responses projector',
@@ -2213,6 +2262,65 @@ describe('formatAgentMessages', () => {
         );
         expect(JSON.stringify(providerInput)).not.toContain('ig_interrupted');
       }
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it.each([
+    ['v0', 'jpeg', '/9j/4AAQSkZJRg==', 'image/jpeg'],
+    ['v1', 'jpeg', '/9j/4AAQSkZJRg==', 'image/jpeg'],
+    ['v0', 'webp', 'UklGRgAAAABXRUJQ', 'image/webp'],
+    ['v1', 'webp', 'UklGRgAAAABXRUJQ', 'image/webp'],
+  ] as const)(
+    'preserves %s generated %s media type during replay',
+    (outputVersion, _format, data, mimeType) => {
+      const generatedImage = {
+        id: `ig_${outputVersion}_${_format}`,
+        type: 'image_generation_call',
+        status: 'completed',
+        result: data,
+      };
+      const v0Message = new AIMessage({
+        content: [{ type: 'text', text: 'Generated image.' }],
+        additional_kwargs: { tool_outputs: [generatedImage] },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const message =
+        outputVersion === 'v0'
+          ? v0Message
+          : new AIMessage({
+            contentBlocks: v0Message.contentBlocks,
+            additional_kwargs: v0Message.additional_kwargs,
+            response_metadata: {
+              model_provider: 'openai',
+              output_version: 'v1',
+              preempted: true,
+            },
+          });
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+
+      expect(projectedMessage.content).toEqual(
+        expect.arrayContaining([{ type: 'image', mimeType, data }])
+      );
+      expect(JSON.stringify(providerInput)).toContain(
+        `data:${mimeType};base64,${data}`
+      );
+      expect(JSON.stringify(providerInput)).not.toContain(generatedImage.id);
+      expect(JSON.stringify(message.toJSON())).toContain(generatedImage.id);
 
       const projectedAgain =
         projectOpenAIResponsesToolMessageContent(projected);
@@ -2639,12 +2747,18 @@ describe('formatAgentMessages', () => {
         {
           type: 'text',
           text: expect.stringContaining('computed'),
+          extras: {
+            librechatServerToolResult: { toolName: 'code_interpreter' },
+          },
         },
         {
           type: 'text',
           text: expect.stringContaining(
             'https://example.com/ephemeral-chart.png'
           ),
+          extras: {
+            librechatServerToolResult: { toolName: 'code_interpreter' },
+          },
         },
       ]);
       expect(
@@ -2856,6 +2970,121 @@ describe('formatAgentMessages', () => {
     }
   );
 
+  it('replays captured server-tool results at their output positions', () => {
+    const makeResult = (id: string, output: string) => ({
+      id,
+      type: 'local_shell_call_output',
+      status: 'completed',
+      output,
+    });
+    const results = [
+      makeResult('result_after', 'after result'),
+      {
+        call_id: 'patch_without_item_id',
+        type: 'apply_patch_call_output',
+        status: 'completed',
+        output: 'no-id patch result',
+      },
+      makeResult('result_before', 'before result'),
+      makeResult('result_middle', 'middle result'),
+    ];
+    const message = new AIMessage({
+      content: [
+        { type: 'text', text: 'First narration.' },
+        { type: 'text', text: 'Second narration.' },
+      ],
+      additional_kwargs: {
+        tool_outputs: results,
+        [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+          {
+            itemId: 'result_after',
+            kind: 'output',
+            outputIndex: 5,
+          },
+          {
+            itemId: 'msg_first',
+            kind: 'text',
+            outputIndex: 1,
+            contentIndex: 0,
+          },
+          {
+            itemId: 'result_before',
+            kind: 'output',
+            outputIndex: 0,
+          },
+          {
+            itemId: 'msg_first',
+            kind: 'text',
+            outputIndex: 1,
+            contentIndex: 0,
+          },
+          {
+            itemId: 'result_middle',
+            kind: 'output',
+            outputIndex: 3,
+          },
+          {
+            itemId: 'patch_without_item_id',
+            kind: 'output',
+            outputIndex: 2,
+          },
+          {
+            itemId: 'msg_second',
+            kind: 'text',
+            outputIndex: 4,
+            contentIndex: 0,
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const orderedText = (
+      projectedMessage.content as Array<{
+        extras?: { librechatServerToolResult?: unknown };
+        text?: string;
+        type: string;
+      }>
+    ).map((block) => {
+      if (block.extras?.librechatServerToolResult != null) {
+        return (
+          JSON.parse(block.text!) as {
+            serverToolResult: { output: string };
+          }
+        ).serverToolResult.output;
+      }
+      return block.text;
+    });
+
+    expect(orderedText).toEqual([
+      'before result',
+      'First narration.',
+      'no-id patch result',
+      'middle result',
+      'Second narration.',
+      'after result',
+    ]);
+    expect(projectedMessage.additional_kwargs).not.toHaveProperty(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toMatch(/result_/);
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+      'patch_without_item_id'
+    );
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
   it('neutralizes provider references duplicated into v1 content blocks', () => {
     const reasoning = {
       id: 'rs_interrupted',
@@ -2963,6 +3192,7 @@ describe('formatAgentMessages', () => {
         type: 'text',
         text: JSON.stringify({
           serverToolResult: {
+            toolName: 'code_interpreter',
             status: 'success',
             output: {
               type: 'code_interpreter_output',
@@ -2971,6 +3201,9 @@ describe('formatAgentMessages', () => {
             },
           },
         }),
+        extras: {
+          librechatServerToolResult: { toolName: 'code_interpreter' },
+        },
       },
       { type: 'image', mimeType: 'image/png', data: 'AA==' },
     ]);
@@ -2983,6 +3216,36 @@ describe('formatAgentMessages', () => {
     expect(serialized).not.toContain('image_generation_call');
     expect(JSON.stringify(message.toJSON())).toContain('rs_interrupted');
     expect(JSON.stringify(message.toJSON())).toContain('ci_interrupted');
+
+    const fallback = projectToolStreamContentForProvider([message], 'fallback');
+    const fallbackMessage = fallback[0] as AIMessage;
+    expect(fallbackMessage.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      {
+        type: 'text',
+        text: JSON.stringify({
+          serverToolResult: {
+            toolName: 'code_interpreter',
+            status: 'success',
+            output: {
+              type: 'code_interpreter_output',
+              returnCode: 0,
+              stdout: '1',
+            },
+          },
+        }),
+      },
+    ]);
+    expect(_convertMessagesToOpenAIParams(fallback)).toEqual([
+      {
+        role: 'assistant',
+        content: fallbackMessage.content,
+      },
+    ]);
+    expect(JSON.stringify(fallbackMessage.toJSON())).not.toContain('extras');
+    expect(JSON.stringify(fallbackMessage.toJSON())).not.toContain(
+      'librechatServerToolResult'
+    );
 
     const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
     expect(projectedAgain).toBe(projected);

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -2638,14 +2638,27 @@ describe('formatAgentMessages', () => {
   });
 
   it.each([
-    ['data URL', 'data:image/png;base64,AQ=='],
-    ['HTTPS URL', 'https://example.com/application-image.png'],
+    [
+      'data URL',
+      { url: 'data:image/png;base64,AQ==' },
+      'data:image/png;base64,AQ==',
+    ],
+    [
+      'HTTPS URL',
+      { url: 'https://example.com/application-image.png' },
+      'https://example.com/application-image.png',
+    ],
+    [
+      'file ID',
+      { fileId: 'file_application_image' },
+      '"file_id":"file_application_image"',
+    ],
   ])(
     'preserves an unrelated v0 application image backed by a %s',
-    (_label, url) => {
+    (_label, source, providerFragment) => {
       const applicationImage = {
         type: 'image' as const,
-        url,
+        ...source,
         metadata: { source: 'application' },
       };
       const providerImage = {
@@ -2677,6 +2690,11 @@ describe('formatAgentMessages', () => {
       });
 
       const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+      const providerInput = convertMessagesToResponsesInput({
+        messages: [projected],
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
 
       expect(projected.content).toEqual([
         applicationImage,
@@ -2691,6 +2709,7 @@ describe('formatAgentMessages', () => {
       expect(JSON.stringify(projected.toJSON())).not.toContain(
         providerImage.id
       );
+      expect(JSON.stringify(providerInput)).toContain(providerFragment);
     }
   );
 
@@ -2734,6 +2753,79 @@ describe('formatAgentMessages', () => {
         extras: IMAGE_GENERATION_REPLAY_EXTRAS,
       },
     ]);
+  });
+
+  it.each([
+    ['an earlier replay item before a leading image', true],
+    ['a trailing image before a later replay item', false],
+  ] as const)('keeps %s during v0 promotion', (_label, imageFirst) => {
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AQ==',
+    };
+    const narration = { type: 'text' as const, text: 'Narration.' };
+    const generatedImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'Ag==',
+      extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+    };
+    const generatedImageId = `ig_${imageFirst ? 'before' : 'after'}_image`;
+    const message = new AIMessage({
+      content: imageFirst
+        ? [applicationImage, narration]
+        : [narration, applicationImage],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: generatedImageId,
+            type: 'image_generation_call',
+            status: 'completed',
+            result: generatedImage.data,
+          },
+        ],
+        [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: imageFirst
+          ? [
+            {
+              itemId: generatedImageId,
+              kind: 'output',
+              outputIndex: 0,
+            },
+            {
+              itemId: 'msg_after_image',
+              kind: 'text',
+              outputIndex: 1,
+              contentIndex: 0,
+            },
+          ]
+          : [
+            {
+              itemId: 'msg_before_image',
+              kind: 'text',
+              outputIndex: 0,
+              contentIndex: 0,
+            },
+            {
+              itemId: generatedImageId,
+              kind: 'output',
+              outputIndex: 1,
+            },
+          ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual(
+      imageFirst
+        ? [generatedImage, applicationImage, narration]
+        : [narration, applicationImage, generatedImage]
+    );
   });
 
   it('restores v0 image positions before appending a generated image', () => {
@@ -2860,6 +2952,23 @@ describe('formatAgentMessages', () => {
       content: [applicationImage],
       additional_kwargs: {
         reasoning,
+        [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+          {
+            itemId: reasoning.id,
+            kind: 'reasoning',
+            outputIndex: 0,
+          },
+          {
+            itemId: 'msg_image_only',
+            kind: 'message',
+            outputIndex: 1,
+          },
+          {
+            itemId: 'ig_image_only',
+            kind: 'output',
+            outputIndex: 2,
+          },
+        ],
         tool_outputs: [
           {
             id: 'ig_image_only',

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -1912,6 +1912,259 @@ describe('formatAgentMessages', () => {
     expect(message.response_metadata).toHaveProperty('output');
   });
 
+  it.each(['additional_kwargs', 'response_metadata'] as const)(
+    'preserves completed v0 generated images from %s without provider ids',
+    (imageSource) => {
+      const events: Parameters<
+        typeof convertResponsesDeltaToChatGenerationChunk
+      >[0][] = [
+        {
+          type: 'response.output_item.done',
+          sequence_number: 0,
+          output_index: 0,
+          item: {
+            id: 'ig_interrupted',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          sequence_number: 1,
+          output_index: 1,
+          item: {
+            id: 'msg_interrupted',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          sequence_number: 2,
+          output_index: 1,
+          content_index: 0,
+          item_id: 'msg_interrupted',
+          delta: 'Partial answer.',
+          logprobs: [],
+        },
+      ];
+      let streamedMessage: AIMessageChunk | undefined;
+      for (const event of events) {
+        const generation = convertResponsesDeltaToChatGenerationChunk(event);
+        if (generation == null) {
+          continue;
+        }
+        streamedMessage =
+          streamedMessage == null
+            ? (generation.message as AIMessageChunk)
+            : (streamedMessage.concat(
+                generation.message as AIMessageChunk
+            ) as AIMessageChunk);
+      }
+      expect(streamedMessage).toBeDefined();
+      const toolOutputs = streamedMessage!.additional_kwargs.tool_outputs;
+      const message =
+        imageSource === 'additional_kwargs'
+          ? streamedMessage!
+          : new AIMessage({
+            content: 'Partial answer.',
+            response_metadata: {
+              model_provider: 'openai',
+              output: toolOutputs,
+            },
+          });
+      message.response_metadata.preempted = true;
+
+      const unsafeProviderInput = convertMessagesToResponsesInput({
+        messages: [message],
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+
+      expect(JSON.stringify(unsafeProviderInput)).toContain('ig_interrupted');
+      expect(projectedMessage.response_metadata).toMatchObject({
+        model_provider: 'openai',
+        output_version: 'v1',
+        preempted: true,
+      });
+      expect(projectedMessage.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'text', text: 'Partial answer.' }),
+          { type: 'image', mimeType: 'image/png', data: 'AA==' },
+        ])
+      );
+      expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+        'ig_interrupted'
+      );
+      expect(JSON.stringify(message.toJSON())).toContain('ig_interrupted');
+
+      for (const zdrEnabled of [false, true]) {
+        const providerInput = convertMessagesToResponsesInput({
+          messages: projected,
+          zdrEnabled,
+          model: 'gpt-5.6',
+        });
+        expect(providerInput).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'message',
+              role: 'assistant',
+              content: expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'output_text',
+                  text: 'Partial answer.',
+                }),
+                {
+                  type: 'input_image',
+                  detail: 'auto',
+                  image_url: 'data:image/png;base64,AA==',
+                },
+              ]),
+            }),
+          ])
+        );
+        expect(JSON.stringify(providerInput)).not.toContain(
+          'image_generation_call'
+        );
+        expect(JSON.stringify(providerInput)).not.toContain('ig_interrupted');
+      }
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it.each([
+    ['in_progress', 'AA=='],
+    ['completed', ''],
+  ] as const)(
+    'does not promote %s v0 generated image data %j',
+    (status, result) => {
+      const message = new AIMessage({
+        content: 'Partial answer.',
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: 'ig_unusable',
+              type: 'image_generation_call',
+              status,
+              result,
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+
+      const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected as AIMessage;
+      const providerInput = convertMessagesToResponsesInput({
+        messages: [projected],
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+
+      expect(projectedMessage.response_metadata.output_version).toBeUndefined();
+      expect(JSON.stringify(providerInput)).toContain('Partial answer.');
+      expect(JSON.stringify(providerInput)).not.toContain('input_image');
+      expect(JSON.stringify(providerInput)).not.toContain('ig_unusable');
+    }
+  );
+
+  it('uses response output over stale v0 generated-image tool outputs', () => {
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_stale',
+            type: 'image_generation_call',
+            status: 'in_progress',
+            result: 'AQ==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        output: [
+          {
+            id: 'ig_authoritative',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        ],
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: [projected],
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+    ]);
+    expect(JSON.stringify(providerInput)).toContain(
+      'data:image/png;base64,AA=='
+    );
+    expect(JSON.stringify(providerInput)).not.toContain('AQ==');
+    expect(JSON.stringify(providerInput)).not.toContain('ig_stale');
+    expect(JSON.stringify(providerInput)).not.toContain('ig_authoritative');
+  });
+
+  it('preserves unrelated self-contained image blocks during v0 promotion', () => {
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AQ==',
+      metadata: { status: 'ready' },
+    };
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }, applicationImage],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_interrupted',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected as AIMessage;
+
+    expect(projectedMessage.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      applicationImage,
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+    ]);
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+      'ig_interrupted'
+    );
+  });
+
   it('neutralizes provider references duplicated into v1 content blocks', () => {
     const reasoning = {
       id: 'rs_interrupted',

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -22,6 +22,7 @@ import {
   projectComputerCallOutputsToText,
   projectOpenAIToolMessageContent,
   projectOpenAIResponsesToolMessageContent,
+  projectToolStreamContentForProvider,
 } from './core';
 import {
   _convertMessagesToOpenAIParams,
@@ -1776,6 +1777,7 @@ describe('formatAgentMessages', () => {
       },
       response_metadata: {
         id: 'resp_interrupted',
+        model_provider: 'openai',
         output: [],
         tool_outputs: [{ id: 'ci_interrupted' }],
         model_name: 'gpt-5.6',
@@ -1808,6 +1810,7 @@ describe('formatAgentMessages', () => {
       retained: 'application metadata',
     });
     expect(projectedMessage.response_metadata).toEqual({
+      model_provider: 'openai',
       model_name: 'gpt-5.6',
       preempted: true,
     });
@@ -1838,7 +1841,7 @@ describe('formatAgentMessages', () => {
       id: 'msg_interrupted',
       content: 'Partial answer.',
       additional_kwargs: { reasoning },
-      response_metadata: { preempted: true },
+      response_metadata: { model_provider: 'openai', preempted: true },
     });
 
     const [projected] = projectOpenAIResponsesToolMessageContent([message]);
@@ -1859,6 +1862,181 @@ describe('formatAgentMessages', () => {
     );
   });
 
+  it.each([
+    [
+      'Responses projector',
+      (messages: BaseMessage[]) =>
+        projectOpenAIResponsesToolMessageContent(messages),
+    ],
+    [
+      'common native projector',
+      (messages: BaseMessage[]) =>
+        projectToolStreamContentForProvider(messages, 'native'),
+    ],
+  ])(
+    'does not classify provider-neutral v1 Chat content as Responses through the %s',
+    (_name, project) => {
+      const applicationBlock = {
+        type: 'non_standard' as const,
+        value: { source: 'application' },
+      };
+      const message = new AIMessage({
+        content: [{ type: 'text', text: 'Chat answer.' }, applicationBlock],
+        response_metadata: {
+          model_provider: 'openai',
+          output_version: 'v1',
+          preempted: true,
+        },
+      });
+      const messages = [message];
+
+      const projected = project(messages);
+
+      expect(projected).toBe(messages);
+      expect(projected[0]).toBe(message);
+      expect(message.content).toEqual([
+        { type: 'text', text: 'Chat answer.' },
+        applicationBlock,
+      ]);
+    }
+  );
+
+  it.each([
+    [
+      'Responses projector',
+      (messages: BaseMessage[]) =>
+        projectOpenAIResponsesToolMessageContent(messages),
+    ],
+    [
+      'common native projector',
+      (messages: BaseMessage[]) =>
+        projectToolStreamContentForProvider(messages, 'native'),
+    ],
+  ])('sanitizes native v0 fragments through the %s', (_name, project) => {
+    const emptyText = { type: 'text' as const, text: '' };
+    const partialText = { type: 'text' as const, text: 'Partial answer.' };
+    const bareReasoning = {
+      type: 'reasoning' as const,
+      reasoning: 'summary',
+    };
+    const message = new AIMessage({
+      id: 'resp_fragmented',
+      content: [emptyText, partialText, bareReasoning],
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+    const messages = [message];
+
+    const projected = project(messages);
+    const projectedMessage = projected[0] as AIMessage;
+
+    expect(projected).not.toBe(messages);
+    expect(projectedMessage.content).toEqual([partialText]);
+    expect(projectedMessage.response_metadata.output_version).toBeUndefined();
+    expect(message.content).toEqual([emptyText, partialText, bareReasoning]);
+
+    const projectedAgain = project(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it.each([
+    [
+      'Responses projector',
+      (messages: BaseMessage[]) =>
+        projectOpenAIResponsesToolMessageContent(messages),
+    ],
+    [
+      'common native projector',
+      (messages: BaseMessage[]) =>
+        projectToolStreamContentForProvider(messages, 'native'),
+    ],
+  ])(
+    'sanitizes unpromoted translated v0 content through the %s',
+    (_name, project) => {
+      const emptyText = { type: 'text' as const, text: '' };
+      const partialText = { type: 'text' as const, text: 'Partial answer.' };
+      const applicationImage = {
+        type: 'image' as const,
+        mimeType: 'image/png',
+        data: 'AQ==',
+      };
+      const bareReasoning = {
+        type: 'reasoning' as const,
+        reasoning: 'unfinished summary',
+      };
+      const message = new AIMessage({
+        id: 'msg_unpromoted',
+        content: [emptyText, partialText, applicationImage, bareReasoning],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: 'ig_unusable',
+              type: 'image_generation_call',
+              status: 'in_progress',
+              result: 'AA==',
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const messages = [message];
+
+      const projected = project(messages);
+      const projectedMessage = projected[0] as AIMessage;
+
+      expect(projected).not.toBe(messages);
+      expect(projectedMessage.id).toBeUndefined();
+      expect(projectedMessage.content).toEqual([partialText, applicationImage]);
+      expect(projectedMessage.additional_kwargs).not.toHaveProperty(
+        'tool_outputs'
+      );
+      expect(projectedMessage.response_metadata.output_version).toBeUndefined();
+      expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+        'ig_unusable'
+      );
+      expect(message.content).toEqual([
+        emptyText,
+        partialText,
+        applicationImage,
+        bareReasoning,
+      ]);
+
+      const projectedAgain = project(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it('recognizes response_metadata.tool_outputs as a Responses marker', () => {
+    const message = new AIMessage({
+      content: 'Partial answer.',
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+        tool_outputs: [{ id: 'ci_metadata_only' }],
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+
+    expect(projectedMessage).not.toBe(message);
+    expect(projectedMessage.content).toBe('Partial answer.');
+    expect(projectedMessage.response_metadata).not.toHaveProperty(
+      'tool_outputs'
+    );
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+      'ci_metadata_only'
+    );
+    expect(message.response_metadata).toHaveProperty('tool_outputs');
+  });
+
   it('neutralizes terminal Responses ids when request retention is unknown', () => {
     const message = new AIMessage({
       id: 'msg_completed',
@@ -1871,6 +2049,7 @@ describe('formatAgentMessages', () => {
         },
       },
       response_metadata: {
+        model_provider: 'openai',
         preempted: true,
         status: 'completed',
         output: [
@@ -1903,6 +2082,7 @@ describe('formatAgentMessages', () => {
     expect(projectedMessage.id).toBeUndefined();
     expect(projectedMessage.additional_kwargs.reasoning).toBeUndefined();
     expect(projectedMessage.response_metadata).toEqual({
+      model_provider: 'openai',
       preempted: true,
       status: 'completed',
     });
@@ -2165,6 +2345,517 @@ describe('formatAgentMessages', () => {
     );
   });
 
+  it('restores v0 image positions before appending a generated image', () => {
+    const imageA = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AQ==',
+    };
+    const imageB = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'Ag==',
+    };
+    const imageC = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'Aw==',
+    };
+    const message = new AIMessage({
+      content: [
+        imageA,
+        { type: 'text', text: 'First.' },
+        imageB,
+        { type: 'text', text: 'Second.' },
+        imageC,
+      ],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_ordered',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'BA==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage.content).toEqual([
+      imageA,
+      { type: 'text', text: 'First.' },
+      imageB,
+      { type: 'text', text: 'Second.' },
+      imageC,
+      { type: 'image', mimeType: 'image/png', data: 'BA==' },
+    ]);
+    expect(providerInput).toEqual([
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,AQ==',
+          },
+          { type: 'output_text', text: 'First.', annotations: [] },
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,Ag==',
+          },
+          { type: 'output_text', text: 'Second.', annotations: [] },
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,Aw==',
+          },
+          {
+            type: 'input_image',
+            detail: 'auto',
+            image_url: 'data:image/png;base64,BA==',
+          },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+      'ig_ordered'
+    );
+    expect(message.content).toEqual([
+      imageA,
+      { type: 'text', text: 'First.' },
+      imageB,
+      { type: 'text', text: 'Second.' },
+      imageC,
+    ]);
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it('keeps encrypted reasoning before image-only v0 content', () => {
+    const reasoning = {
+      id: 'rs_image_only',
+      type: 'reasoning',
+      status: 'completed',
+      summary: [],
+      encrypted_content: 'opaque-image-reasoning',
+    };
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AQ==',
+    };
+    const message = new AIMessage({
+      content: [applicationImage],
+      additional_kwargs: {
+        reasoning,
+        tool_outputs: [
+          {
+            id: 'ig_image_only',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'Ag==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual([
+      { type: 'non_standard', value: reasoning },
+      applicationImage,
+      { type: 'image', mimeType: 'image/png', data: 'Ag==' },
+    ]);
+  });
+
+  it('does not collapse identical application images during v0 promotion', () => {
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AA==',
+    };
+    const providerImage = {
+      ...applicationImage,
+      id: 'ig_duplicate',
+      metadata: { status: 'completed' },
+    };
+    const message = new AIMessage({
+      content: [applicationImage, applicationImage, providerImage],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_duplicate',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual([
+      applicationImage,
+      applicationImage,
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+    ]);
+  });
+
+  it('keeps an id-less completed application image with generated bytes', () => {
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AA==',
+      metadata: { source: 'application', status: 'completed' },
+    };
+    const message = new AIMessage({
+      content: [applicationImage],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_same_bytes',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual([
+      applicationImage,
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+    ]);
+  });
+
+  it('deduplicates repeated authoritative generated-image items by id', () => {
+    const generatedImage = {
+      id: 'ig_duplicate_output',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: 'AA==',
+    };
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: {
+        tool_outputs: [generatedImage, { ...generatedImage }],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
+    ]);
+  });
+
+  it.each(['v0', 'v1'] as const)(
+    'preserves completed %s server-tool results without replay ids',
+    (outputVersion) => {
+      const toolOutput = {
+        id: 'ci_completed',
+        type: 'code_interpreter_call',
+        status: 'completed',
+        code: 'print("computed")',
+        outputs: [
+          { type: 'logs', logs: `computed${'x'.repeat(1_000)}` },
+          {
+            type: 'image',
+            url: 'https://example.com/ephemeral-chart.png',
+          },
+        ],
+      };
+      const v0Message = new AIMessage({
+        content: [{ type: 'text', text: 'Partial answer.' }],
+        additional_kwargs: { tool_outputs: [toolOutput] },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const message =
+        outputVersion === 'v0'
+          ? v0Message
+          : new AIMessage({
+            contentBlocks: v0Message.contentBlocks,
+            additional_kwargs: v0Message.additional_kwargs,
+            response_metadata: {
+              model_provider: 'openai',
+              output_version: 'v1',
+              preempted: true,
+            },
+          });
+
+      const projected = projectOpenAIResponsesToolMessageContent(
+        [message],
+        200
+      );
+      const projectedMessage = projected[0] as AIMessage;
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+
+      expect(projectedMessage.response_metadata.output_version).toBe('v1');
+      expect(projectedMessage.content).toEqual([
+        { type: 'text', text: 'Partial answer.' },
+        {
+          type: 'text',
+          text: expect.stringContaining('computed'),
+        },
+        {
+          type: 'text',
+          text: expect.stringContaining(
+            'https://example.com/ephemeral-chart.png'
+          ),
+        },
+      ]);
+      expect(
+        (projectedMessage.content[1] as { text: string }).text.length
+      ).toBeLessThanOrEqual(200);
+      const serializedProviderInput = JSON.stringify(providerInput);
+      expect(serializedProviderInput).toContain('computed');
+      expect(serializedProviderInput).toContain('ephemeral-chart.png');
+      expect(serializedProviderInput).not.toContain('ci_completed');
+      expect(serializedProviderInput).not.toContain('function_call_output');
+      expect(serializedProviderInput).not.toContain('server_tool_call');
+      expect(JSON.stringify(message.toJSON())).toContain('ci_completed');
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it('uses response output over stale v0 server-tool results', () => {
+    const makeCodeOutput = (id: string, logs: string) => ({
+      id,
+      type: 'code_interpreter_call',
+      status: 'completed',
+      code: `print(${JSON.stringify(logs)})`,
+      outputs: [{ type: 'logs', logs }],
+    });
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: {
+        tool_outputs: [makeCodeOutput('ci_stale', 'stale result')],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        output: [makeCodeOutput('ci_authoritative', 'current result')],
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+    const serialized = JSON.stringify(projected.content);
+
+    expect(serialized).toContain('current result');
+    expect(serialized).not.toContain('stale result');
+    expect(serialized).not.toContain('ci_authoritative');
+    expect(serialized).not.toContain('ci_stale');
+  });
+
+  it.each(['v0', 'v1'] as const)(
+    'preserves embedded %s MCP output without its provider id',
+    (outputVersion) => {
+      const mcpOutput = {
+        id: 'mcp_provider_item',
+        type: 'mcp_call',
+        name: 'lookup',
+        server_label: 'documents',
+        arguments: '{"query":"answer"}',
+        status: 'completed',
+        output: 'MCP answer',
+      };
+      const v0Message = new AIMessage({
+        content: [{ type: 'text', text: 'Partial answer.' }],
+        additional_kwargs: { tool_outputs: [mcpOutput] },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const message =
+        outputVersion === 'v0'
+          ? v0Message
+          : new AIMessage({
+            contentBlocks: v0Message.contentBlocks,
+            additional_kwargs: v0Message.additional_kwargs,
+            response_metadata: {
+              model_provider: 'openai',
+              output_version: 'v1',
+              preempted: true,
+            },
+          });
+
+      const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected as AIMessage;
+      const serialized = JSON.stringify(projected.content);
+
+      expect(projectedMessage.response_metadata.output_version).toBe('v1');
+      expect(serialized).toContain('MCP answer');
+      expect(serialized).toContain('documents');
+      expect(serialized).not.toContain('mcp_provider_item');
+      expect(JSON.stringify(message.toJSON())).toContain('mcp_provider_item');
+    }
+  );
+
+  it.each(['v0', 'v1'] as const)(
+    'preserves captured %s Responses results that LangChain does not convert',
+    (outputVersion) => {
+      const toolOutputs = [
+        {
+          id: 'local_output_item',
+          type: 'local_shell_call_output',
+          status: 'incomplete',
+          output: 'local shell partial output',
+        },
+        {
+          id: 'shell_output_item',
+          call_id: 'shell_call_id',
+          type: 'shell_call_output',
+          status: 'incomplete',
+          output: [
+            {
+              stdout: 'shell partial output',
+              stderr: '',
+              outcome: { type: 'exit', exit_code: 0 },
+            },
+          ],
+        },
+        {
+          id: 'patch_output_item',
+          call_id: 'patch_call_id',
+          type: 'apply_patch_call_output',
+          status: 'failed',
+          output: 'patch failed output',
+        },
+        {
+          id: 'program_output_item',
+          call_id: 'program_call_id',
+          type: 'program_output',
+          status: 'incomplete',
+          result: 'program partial output',
+        },
+        {
+          id: 'mcp_list_item',
+          type: 'mcp_list_tools',
+          server_label: 'documents',
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Look up a document',
+              input_schema: { type: 'object' },
+            },
+          ],
+          error: 'listing was incomplete',
+        },
+      ];
+      const v0Message = new AIMessage({
+        content: [{ type: 'text', text: 'Partial answer.' }],
+        additional_kwargs: { tool_outputs: toolOutputs },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+      const message =
+        outputVersion === 'v0'
+          ? v0Message
+          : new AIMessage({
+            contentBlocks: v0Message.contentBlocks,
+            additional_kwargs: v0Message.additional_kwargs,
+            response_metadata: {
+              model_provider: 'openai',
+              output_version: 'v1',
+              preempted: true,
+            },
+          });
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const serialized = JSON.stringify(projectedMessage.content);
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+      const serializedProviderInput = JSON.stringify(providerInput);
+      const replayStatuses = (
+        projectedMessage.content as Array<{ text?: string; type: string }>
+      )
+        .filter(
+          (block) =>
+            block.type === 'text' &&
+            block.text?.startsWith('{"serverToolResult":') === true
+        )
+        .map(
+          (block) =>
+            (
+              JSON.parse(block.text!) as {
+                serverToolResult: { status: string };
+              }
+            ).serverToolResult.status
+        );
+
+      expect(projectedMessage.response_metadata.output_version).toBe('v1');
+      expect(serialized).toContain('local shell partial output');
+      expect(serialized).toContain('shell partial output');
+      expect(serialized).toContain('patch failed output');
+      expect(serialized).toContain('program partial output');
+      expect(serialized).toContain('listing was incomplete');
+      expect(serialized).toContain('lookup');
+      expect(replayStatuses).toEqual(Array(5).fill('error'));
+      expect(serializedProviderInput).not.toContain('local_output_item');
+      expect(serializedProviderInput).not.toContain('shell_call_id');
+      expect(serializedProviderInput).not.toContain('patch_call_id');
+      expect(serializedProviderInput).not.toContain('program_call_id');
+      expect(serializedProviderInput).not.toContain('mcp_list_item');
+      expect(serializedProviderInput).not.toContain('shell_call_output');
+      expect(serializedProviderInput).not.toContain('apply_patch_call_output');
+      expect(serializedProviderInput).not.toContain('program_output');
+    }
+  );
+
   it('neutralizes provider references duplicated into v1 content blocks', () => {
     const reasoning = {
       id: 'rs_interrupted',
@@ -2269,12 +2960,19 @@ describe('formatAgentMessages', () => {
     expect(projectedMessage.content).toEqual([
       { type: 'text', text: 'Partial answer.' },
       {
-        type: 'image',
-        mimeType: 'image/png',
-        data: 'AA==',
-        id: 'ig_interrupted',
-        metadata: { status: 'completed' },
+        type: 'text',
+        text: JSON.stringify({
+          serverToolResult: {
+            status: 'success',
+            output: {
+              type: 'code_interpreter_output',
+              returnCode: 0,
+              stdout: '1',
+            },
+          },
+        }),
       },
+      { type: 'image', mimeType: 'image/png', data: 'AA==' },
     ]);
     expect(projectedMessage.additional_kwargs).toEqual({});
     const serialized = JSON.stringify(projectedMessage.toJSON());

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -2637,6 +2637,63 @@ describe('formatAgentMessages', () => {
     );
   });
 
+  it.each([
+    ['data URL', 'data:image/png;base64,AQ=='],
+    ['HTTPS URL', 'https://example.com/application-image.png'],
+  ])(
+    'preserves an unrelated v0 application image backed by a %s',
+    (_label, url) => {
+      const applicationImage = {
+        type: 'image' as const,
+        url,
+        metadata: { source: 'application' },
+      };
+      const providerImage = {
+        type: 'image' as const,
+        id: 'ig_url_provider',
+        url: 'data:image/png;base64,AA==',
+        metadata: { status: 'completed' },
+      };
+      const message = new AIMessage({
+        content: [
+          applicationImage,
+          { type: 'text', text: 'Partial answer.' },
+          providerImage,
+        ],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: providerImage.id,
+              type: 'image_generation_call',
+              status: 'completed',
+              result: 'AA==',
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+
+      const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+      expect(projected.content).toEqual([
+        applicationImage,
+        { type: 'text', text: 'Partial answer.' },
+        {
+          type: 'image',
+          mimeType: 'image/png',
+          data: 'AA==',
+          extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+        },
+      ]);
+      expect(JSON.stringify(projected.toJSON())).not.toContain(
+        providerImage.id
+      );
+    }
+  );
+
   it('restores v0 image positions before appending a generated image', () => {
     const imageA = {
       type: 'image' as const,

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -2694,6 +2694,48 @@ describe('formatAgentMessages', () => {
     }
   );
 
+  it('ignores dropped v0 text placeholders when restoring image positions', () => {
+    const applicationImage = {
+      type: 'image' as const,
+      mimeType: 'image/png',
+      data: 'AQ==',
+    };
+    const message = new AIMessage({
+      content: [
+        { type: 'text', text: '' },
+        applicationImage,
+        { type: 'text', text: 'Later narration.' },
+      ],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'ig_after_placeholder',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'AA==',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+
+    expect(projected.content).toEqual([
+      applicationImage,
+      { type: 'text', text: 'Later narration.' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        extras: IMAGE_GENERATION_REPLAY_EXTRAS,
+      },
+    ]);
+  });
+
   it('restores v0 image positions before appending a generated image', () => {
     const imageA = {
       type: 'image' as const,

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -2985,6 +2985,7 @@ describe('formatAgentMessages', () => {
           type: 'text',
           text: JSON.stringify({
             serverToolResult: {
+              librechatResponsesReplay: true,
               toolName: 'code_interpreter',
               status: 'success',
               output: {
@@ -3055,7 +3056,7 @@ describe('formatAgentMessages', () => {
 
       const projected = projectOpenAIResponsesToolMessageContent(
         [message],
-        200
+        400
       );
       const projectedMessage = projected[0] as AIMessage;
       const providerInput = convertMessagesToResponsesInput({
@@ -3086,7 +3087,7 @@ describe('formatAgentMessages', () => {
       ]);
       expect(
         (projectedMessage.content[1] as { text: string }).text.length
-      ).toBeLessThanOrEqual(200);
+      ).toBeLessThanOrEqual(400);
       const serializedProviderInput = JSON.stringify(providerInput);
       expect(serializedProviderInput).toContain('computed');
       expect(serializedProviderInput).toContain('ephemeral-chart.png');
@@ -3099,6 +3100,332 @@ describe('formatAgentMessages', () => {
         projectOpenAIResponsesToolMessageContent(projected);
       expect(projectedAgain).toBe(projected);
       expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it('uses captured output positions for translated v0 server-tool results', () => {
+    const toolOutputs = [
+      {
+        id: 'ci_position_item',
+        type: 'code_interpreter_call',
+        status: 'completed',
+        code: 'print("CODE_BEFORE_TEXT")',
+        outputs: [{ type: 'logs', logs: 'CODE_BEFORE_TEXT' }],
+      },
+      {
+        id: 'fs_position_item',
+        type: 'file_search_call',
+        status: 'completed',
+        queries: ['positioned file result'],
+        results: [
+          {
+            file_id: 'file_without_provider_replay',
+            filename: 'position.txt',
+            score: 1,
+            text: 'FILE_BETWEEN_TEXT',
+          },
+        ],
+      },
+      {
+        id: 'ws_position_item',
+        type: 'web_search_call',
+        status: 'completed',
+        action: { type: 'search', query: 'positioned web result' },
+        results: [{ title: 'WEB_BETWEEN_TEXT' }],
+      },
+      {
+        id: 'ts_position_item',
+        type: 'tool_search_output',
+        status: 'completed',
+        tools: [
+          {
+            type: 'function',
+            name: 'TOOL_BETWEEN_TEXT',
+            description: 'positioned tool-search result',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
+      },
+    ];
+    const message = new AIMessage({
+      content: [
+        { type: 'text', text: 'First narration.' },
+        { type: 'text', text: 'Second narration.' },
+      ],
+      additional_kwargs: {
+        tool_outputs: toolOutputs,
+        [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+          { itemId: 'ci_position_item', kind: 'output', outputIndex: 0 },
+          {
+            itemId: 'msg_first_position',
+            kind: 'text',
+            outputIndex: 1,
+            contentIndex: 0,
+          },
+          { itemId: 'fs_position_item', kind: 'output', outputIndex: 2 },
+          { itemId: 'ws_position_item', kind: 'output', outputIndex: 3 },
+          { itemId: 'ts_position_item', kind: 'output', outputIndex: 4 },
+          {
+            itemId: 'msg_second_position',
+            kind: 'text',
+            outputIndex: 5,
+            contentIndex: 0,
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+    const originalSerialized = JSON.stringify(message.toJSON());
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const markers = [
+      'CODE_BEFORE_TEXT',
+      'FILE_BETWEEN_TEXT',
+      'WEB_BETWEEN_TEXT',
+      'TOOL_BETWEEN_TEXT',
+    ];
+    const orderedContent = (
+      projectedMessage.content as Array<{ text?: string; type: string }>
+    ).map((block) => {
+      if (
+        block.text === 'First narration.' ||
+        block.text === 'Second narration.'
+      ) {
+        return block.text;
+      }
+      return markers.find((marker) => block.text?.includes(marker) === true);
+    });
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+    const serializedProviderInput = JSON.stringify(providerInput);
+
+    expect(orderedContent).toEqual([
+      'CODE_BEFORE_TEXT',
+      'First narration.',
+      'FILE_BETWEEN_TEXT',
+      'WEB_BETWEEN_TEXT',
+      'TOOL_BETWEEN_TEXT',
+      'Second narration.',
+    ]);
+    expect(serializedProviderInput).toContain('WEB_BETWEEN_TEXT');
+    for (const toolOutput of toolOutputs) {
+      expect(serializedProviderInput).not.toContain(toolOutput.id);
+    }
+    expect(projectedMessage.additional_kwargs).not.toHaveProperty(
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    );
+    expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it.each(['v0', 'v1'] as const)(
+    'preserves terminal incomplete %s file-search and code-interpreter outputs',
+    (outputVersion) => {
+      const dataUrl = 'data:image/png;base64,AA==';
+      const toolOutputs = [
+        {
+          id: `fs_incomplete_${outputVersion}`,
+          type: 'file_search_call',
+          status: 'incomplete',
+          queries: ['partial result'],
+          results: [
+            {
+              file_id: 'partial_file',
+              filename: 'partial.txt',
+              score: 0.5,
+              text: 'PARTIAL_FILE_RESULT',
+            },
+          ],
+        },
+        {
+          id: `ci_incomplete_${outputVersion}`,
+          type: 'code_interpreter_call',
+          status: 'incomplete',
+          code: 'display(partial_chart)',
+          outputs: [
+            { type: 'logs', logs: 'PARTIAL_CODE_LOG' },
+            { type: 'image', url: dataUrl },
+          ],
+        },
+      ];
+      const message = new AIMessage({
+        content: [{ type: 'text', text: 'Partial narration.' }],
+        additional_kwargs: {
+          tool_outputs: toolOutputs,
+          [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+            {
+              itemId: toolOutputs[0].id,
+              kind: 'output',
+              outputIndex: 0,
+            },
+            {
+              itemId: toolOutputs[1].id,
+              kind: 'output',
+              outputIndex: 1,
+            },
+            {
+              itemId: 'msg_incomplete',
+              kind: 'text',
+              outputIndex: 2,
+              contentIndex: 0,
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          ...(outputVersion === 'v1' ? { output_version: 'v1' } : {}),
+          preempted: true,
+        },
+      });
+      const originalSerialized = JSON.stringify(message.toJSON());
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+      const serialized = JSON.stringify(projectedMessage.content);
+      const serializedProviderInput = JSON.stringify(providerInput);
+      const serverResults = (
+        projectedMessage.content as Array<{ text?: string; type: string }>
+      )
+        .filter(
+          (block) =>
+            block.type === 'text' &&
+            block.text?.startsWith('{"serverToolResult":') === true
+        )
+        .map(
+          (block) =>
+            (
+              JSON.parse(block.text!) as {
+                serverToolResult: { output: unknown; status: string };
+              }
+            ).serverToolResult
+        );
+
+      expect(serverResults).toEqual([
+        expect.objectContaining({ status: 'error' }),
+        expect.objectContaining({ status: 'error' }),
+      ]);
+      expect(serialized).toContain('PARTIAL_FILE_RESULT');
+      expect(serialized).toContain('PARTIAL_CODE_LOG');
+      expect(projectedMessage.content).toEqual(
+        expect.arrayContaining([
+          {
+            type: 'image',
+            url: dataUrl,
+            extras: CODE_INTERPRETER_REPLAY_EXTRAS,
+          },
+        ])
+      );
+      expect(serializedProviderInput).toContain(dataUrl);
+      expect(serializedProviderInput).not.toContain(toolOutputs[0].id);
+      expect(serializedProviderInput).not.toContain(toolOutputs[1].id);
+      expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
+  it.each([
+    ['logs then image', ['logs', 'image']],
+    ['image then logs', ['image', 'logs']],
+  ] as const)(
+    'preserves code-interpreter %s order at its cross-item position',
+    (_label, outputOrder) => {
+      const dataUrl = 'data:image/png;base64,AQ==';
+      const outputs = outputOrder.map((type) =>
+        type === 'logs'
+          ? { type: 'logs', logs: 'ORDERED_CODE_LOG' }
+          : { type: 'image', url: dataUrl }
+      );
+      const message = new AIMessage({
+        content: [
+          { type: 'text', text: 'First narration.' },
+          { type: 'text', text: 'Second narration.' },
+        ],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: 'ci_ordered_outputs',
+              type: 'code_interpreter_call',
+              status: 'completed',
+              code: 'display(result)',
+              outputs,
+            },
+          ],
+          [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+            {
+              itemId: 'msg_order_first',
+              kind: 'text',
+              outputIndex: 0,
+              contentIndex: 0,
+            },
+            {
+              itemId: 'ci_ordered_outputs',
+              kind: 'output',
+              outputIndex: 1,
+            },
+            {
+              itemId: 'msg_order_second',
+              kind: 'text',
+              outputIndex: 2,
+              contentIndex: 0,
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+        },
+      });
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const orderedContent = (
+        projectedMessage.content as Array<{
+          text?: string;
+          type: string;
+          url?: string;
+        }>
+      ).map((block) => {
+        if (
+          block.text === 'First narration.' ||
+          block.text === 'Second narration.'
+        ) {
+          return block.text;
+        }
+        if (block.type === 'image' && block.url === dataUrl) {
+          return 'image';
+        }
+        return block.text?.includes('ORDERED_CODE_LOG') === true
+          ? 'logs'
+          : undefined;
+      });
+
+      expect(orderedContent).toEqual([
+        'First narration.',
+        ...outputOrder,
+        'Second narration.',
+      ]);
+      expect(JSON.stringify(projectedMessage.toJSON())).not.toContain(
+        'ci_ordered_outputs'
+      );
     }
   );
 
@@ -3408,6 +3735,215 @@ describe('formatAgentMessages', () => {
     expect(projectedAgain[0]).toBe(projectedMessage);
   });
 
+  it('derives id-less server-result positions from authoritative output', () => {
+    const output = [
+      {
+        type: 'local_shell_call_output',
+        status: 'completed',
+        output: 'IDLESS_BEFORE_TEXT',
+      },
+      {
+        id: 'msg_authoritative_first',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: 'First narration.',
+            annotations: [],
+          },
+        ],
+      },
+      {
+        id: 'msg_authoritative_empty',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: '',
+            annotations: [],
+          },
+        ],
+      },
+      {
+        type: 'program_output',
+        status: 'completed',
+        result: 'IDLESS_BETWEEN_TEXT',
+      },
+      {
+        id: 'msg_authoritative_second',
+        type: 'message',
+        role: 'assistant',
+        status: 'in_progress',
+        content: [
+          {
+            type: 'output_text',
+            text: 'Second narration.',
+            annotations: [],
+          },
+        ],
+      },
+    ];
+    const message = new AIMessage({
+      content: [
+        { type: 'text', text: 'First narration.' },
+        { type: 'text', text: 'Second narration.' },
+      ],
+      response_metadata: {
+        model_provider: 'openai',
+        output,
+        output_version: 'v1',
+        preempted: true,
+      },
+    });
+    const originalSerialized = JSON.stringify(message.toJSON());
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const orderedContent = (
+      projectedMessage.content as Array<{ text?: string; type: string }>
+    ).map((block) => {
+      if (
+        block.text === 'First narration.' ||
+        block.text === 'Second narration.'
+      ) {
+        return block.text;
+      }
+      if (block.text?.includes('IDLESS_BEFORE_TEXT') === true) {
+        return 'IDLESS_BEFORE_TEXT';
+      }
+      return block.text?.includes('IDLESS_BETWEEN_TEXT') === true
+        ? 'IDLESS_BETWEEN_TEXT'
+        : undefined;
+    });
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(orderedContent).toEqual([
+      'IDLESS_BEFORE_TEXT',
+      'First narration.',
+      'IDLESS_BETWEEN_TEXT',
+      'Second narration.',
+    ]);
+    expect(JSON.stringify(providerInput)).not.toContain(
+      'local_shell_call_output'
+    );
+    expect(JSON.stringify(providerInput)).not.toContain('program_output');
+    expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it.each(['v0', 'v1'] as const)(
+    'replays encrypted %s reasoning at its captured output position',
+    (outputVersion) => {
+      const reasoning = {
+        id: `rs_positioned_${outputVersion}`,
+        type: 'reasoning',
+        status: 'completed',
+        summary: [],
+        encrypted_content: `opaque-positioned-${outputVersion}`,
+      };
+      const serverResult = {
+        id: `local_before_reasoning_${outputVersion}`,
+        type: 'local_shell_call_output',
+        status: 'completed',
+        output: 'RESULT_BEFORE_REASONING',
+      };
+      const message = new AIMessage({
+        content: [
+          { type: 'reasoning', reasoning: 'unfinished summary' },
+          { type: 'text', text: 'Narration after reasoning.' },
+        ],
+        additional_kwargs: {
+          reasoning,
+          tool_outputs: [serverResult],
+          [OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]: [
+            {
+              itemId: serverResult.id,
+              kind: 'output',
+              outputIndex: 0,
+            },
+            {
+              itemId: reasoning.id,
+              kind: 'reasoning',
+              outputIndex: 1,
+            },
+            {
+              itemId: 'msg_after_reasoning',
+              kind: 'text',
+              outputIndex: 2,
+              contentIndex: 0,
+            },
+          ],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          ...(outputVersion === 'v1' ? { output_version: 'v1' } : {}),
+          preempted: true,
+        },
+      });
+      const originalSerialized = JSON.stringify(message.toJSON());
+
+      const projected = projectOpenAIResponsesToolMessageContent([message]);
+      const projectedMessage = projected[0] as AIMessage;
+      const replayOrder = (
+        projectedMessage.content as Array<{
+          text?: string;
+          type: string;
+          value?: unknown;
+        }>
+      ).map((block) => {
+        if (block.type === 'non_standard' && block.value === reasoning) {
+          return 'reasoning';
+        }
+        if (block.text === 'Narration after reasoning.') {
+          return 'narration';
+        }
+        return block.text?.includes('RESULT_BEFORE_REASONING') === true
+          ? 'result'
+          : undefined;
+      });
+      const providerInput = convertMessagesToResponsesInput({
+        messages: projected,
+        zdrEnabled: false,
+        model: 'gpt-5.6',
+      });
+      const serializedProviderInput = JSON.stringify(providerInput);
+      const resultIndex = serializedProviderInput.indexOf(
+        'RESULT_BEFORE_REASONING'
+      );
+      const reasoningIndex = serializedProviderInput.indexOf(reasoning.id);
+      const narrationIndex = serializedProviderInput.indexOf(
+        'Narration after reasoning.'
+      );
+
+      expect(replayOrder).toEqual(['result', 'reasoning', 'narration']);
+      expect(resultIndex).toBeGreaterThanOrEqual(0);
+      expect(resultIndex).toBeLessThan(reasoningIndex);
+      expect(reasoningIndex).toBeLessThan(narrationIndex);
+      expect(serializedProviderInput).not.toContain(serverResult.id);
+      expect(projectedMessage.additional_kwargs.reasoning).toBe(reasoning);
+      expect(projectedMessage.additional_kwargs).not.toHaveProperty(
+        OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+      );
+      expect(JSON.stringify(message.toJSON())).toBe(originalSerialized);
+
+      const projectedAgain =
+        projectOpenAIResponsesToolMessageContent(projected);
+      expect(projectedAgain).toBe(projected);
+      expect(projectedAgain[0]).toBe(projectedMessage);
+    }
+  );
+
   it('neutralizes provider references duplicated into v1 content blocks', () => {
     const reasoning = {
       id: 'rs_interrupted',
@@ -3515,6 +4051,7 @@ describe('formatAgentMessages', () => {
         type: 'text',
         text: JSON.stringify({
           serverToolResult: {
+            librechatResponsesReplay: true,
             toolName: 'code_interpreter',
             status: 'success',
             output: {
@@ -3553,6 +4090,7 @@ describe('formatAgentMessages', () => {
         type: 'text',
         text: JSON.stringify({
           serverToolResult: {
+            librechatResponsesReplay: true,
             toolName: 'code_interpreter',
             status: 'success',
             output: {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -1753,6 +1753,341 @@ describe('formatAgentMessages', () => {
     });
   });
 
+  it('neutralizes nonterminal Responses references on preempted provider input', () => {
+    const message = new AIMessage({
+      id: 'msg_interrupted',
+      content: 'Partial answer.',
+      additional_kwargs: {
+        reasoning: {
+          id: 'rs_interrupted',
+          type: 'reasoning',
+          summary: [],
+        },
+        tool_outputs: [
+          {
+            id: 'ci_interrupted',
+            type: 'code_interpreter_call',
+            status: 'completed',
+          },
+        ],
+        __openai_function_call_ids__: { call_1: 'fc_interrupted' },
+        __openai_custom_tool_call_ids__: { call_2: 'ctc_interrupted' },
+        retained: 'application metadata',
+      },
+      response_metadata: {
+        id: 'resp_interrupted',
+        output: [],
+        tool_outputs: [{ id: 'ci_interrupted' }],
+        model_name: 'gpt-5.6',
+        preempted: true,
+      },
+    });
+
+    const messages = [message];
+    const unsafeProviderInput = convertMessagesToResponsesInput({
+      messages,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+    const projected = projectOpenAIResponsesToolMessageContent(messages);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projected).not.toBe(messages);
+    expect(projectedMessage).not.toBe(message);
+    expect(Object.getPrototypeOf(projectedMessage)).toBe(
+      Object.getPrototypeOf(message)
+    );
+    expect(projectedMessage.id).toBeUndefined();
+    expect(projectedMessage.content).toBe('Partial answer.');
+    expect(projectedMessage.additional_kwargs).toEqual({
+      retained: 'application metadata',
+    });
+    expect(projectedMessage.response_metadata).toEqual({
+      model_name: 'gpt-5.6',
+      preempted: true,
+    });
+    const unsafeSerializedInput = JSON.stringify(unsafeProviderInput);
+    const serializedInput = JSON.stringify(providerInput);
+    expect(unsafeSerializedInput).toContain('rs_interrupted');
+    expect(unsafeSerializedInput).toContain('ci_interrupted');
+    expect(serializedInput).toContain('Partial answer.');
+    expect(serializedInput).not.toContain('interrupted');
+    expect(message.id).toBe('msg_interrupted');
+    expect(message.additional_kwargs.reasoning).toBeDefined();
+    expect(message.response_metadata).toHaveProperty('output');
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it('retains self-contained encrypted reasoning on preempted Responses input', () => {
+    const reasoning = {
+      id: 'rs_encrypted',
+      type: 'reasoning',
+      status: 'completed',
+      summary: [],
+      encrypted_content: 'opaque-reasoning',
+    };
+    const message = new AIMessage({
+      id: 'msg_interrupted',
+      content: 'Partial answer.',
+      additional_kwargs: { reasoning },
+      response_metadata: { preempted: true },
+    });
+
+    const [projected] = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: [projected],
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage.additional_kwargs.reasoning).toBe(reasoning);
+    expect(providerInput).toContainEqual(
+      expect.objectContaining({
+        id: 'rs_encrypted',
+        type: 'reasoning',
+        encrypted_content: 'opaque-reasoning',
+      })
+    );
+  });
+
+  it('neutralizes terminal Responses ids when request retention is unknown', () => {
+    const message = new AIMessage({
+      id: 'msg_completed',
+      content: 'Complete answer.',
+      additional_kwargs: {
+        reasoning: {
+          id: 'rs_completed',
+          type: 'reasoning',
+          summary: [],
+        },
+      },
+      response_metadata: {
+        preempted: true,
+        status: 'completed',
+        output: [
+          {
+            id: 'msg_completed',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Complete answer.',
+                annotations: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage).not.toBe(message);
+    expect(projectedMessage.id).toBeUndefined();
+    expect(projectedMessage.additional_kwargs.reasoning).toBeUndefined();
+    expect(projectedMessage.response_metadata).toEqual({
+      preempted: true,
+      status: 'completed',
+    });
+    expect(JSON.stringify(providerInput)).toContain('Complete answer.');
+    expect(JSON.stringify(providerInput)).not.toContain('msg_completed');
+    expect(JSON.stringify(providerInput)).not.toContain('rs_completed');
+    expect(message.response_metadata).toHaveProperty('output');
+  });
+
+  it('neutralizes provider references duplicated into v1 content blocks', () => {
+    const reasoning = {
+      id: 'rs_interrupted',
+      type: 'reasoning',
+      status: 'in_progress',
+      summary: [],
+    };
+    const toolOutputs = [
+      {
+        id: 'ci_interrupted',
+        type: 'code_interpreter_call',
+        status: 'completed',
+        code: 'print(1)',
+        outputs: [{ type: 'logs', logs: '1' }],
+      },
+      {
+        type: 'image_generation_call',
+        id: 'ig_interrupted',
+        status: 'completed',
+        result: 'AA==',
+      },
+    ];
+    const providerMessage = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: { reasoning, tool_outputs: toolOutputs },
+      response_metadata: { model_provider: 'openai' },
+    });
+    const message = new AIMessage({
+      contentBlocks: providerMessage.contentBlocks,
+      additional_kwargs: providerMessage.additional_kwargs,
+      response_metadata: {
+        id: 'resp_interrupted',
+        model_provider: 'openai',
+        output_version: 'v1',
+        preempted: true,
+      },
+    });
+
+    expect(message.content).toEqual([
+      { type: 'reasoning', reasoning: '' },
+      { type: 'text', text: 'Partial answer.' },
+      {
+        type: 'server_tool_call',
+        id: 'ci_interrupted',
+        name: 'code_interpreter',
+        args: { code: 'print(1)' },
+      },
+      {
+        type: 'server_tool_call_result',
+        toolCallId: 'ci_interrupted',
+        status: 'success',
+        output: {
+          type: 'code_interpreter_output',
+          returnCode: 0,
+          stderr: undefined,
+          stdout: '1',
+        },
+      },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        id: 'ig_interrupted',
+        metadata: { status: 'completed' },
+      },
+      {
+        type: 'non_standard',
+        value: toolOutputs[1],
+      },
+    ]);
+    expect(message.additional_kwargs.tool_outputs).toBe(toolOutputs);
+
+    const unsafeProviderInput = convertMessagesToResponsesInput({
+      messages: [message],
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(unsafeProviderInput).toContainEqual(
+      expect.objectContaining({ type: 'reasoning' })
+    );
+    expect(JSON.stringify(unsafeProviderInput)).toContain('ci_interrupted');
+    expect(JSON.stringify(unsafeProviderInput)).toContain(
+      'image_generation_call'
+    );
+    expect(JSON.stringify(providerInput)).toContain('Partial answer.');
+    expect(JSON.stringify(providerInput)).toContain(
+      'data:image/png;base64,AA=='
+    );
+    expect(JSON.stringify(providerInput)).not.toContain('rs_interrupted');
+    expect(JSON.stringify(providerInput)).not.toContain('ci_interrupted');
+    expect(JSON.stringify(providerInput)).not.toContain(
+      'image_generation_call'
+    );
+    expect(projectedMessage.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      {
+        type: 'image',
+        mimeType: 'image/png',
+        data: 'AA==',
+        id: 'ig_interrupted',
+        metadata: { status: 'completed' },
+      },
+    ]);
+    expect(projectedMessage.additional_kwargs).toEqual({});
+    const serialized = JSON.stringify(projectedMessage.toJSON());
+    expect(serialized).toContain('Partial answer.');
+    expect(serialized).toContain('AA==');
+    expect(serialized).not.toContain('rs_interrupted');
+    expect(serialized).not.toContain('ci_interrupted');
+    expect(serialized).not.toContain('image_generation_call');
+    expect(JSON.stringify(message.toJSON())).toContain('rs_interrupted');
+    expect(JSON.stringify(message.toJSON())).toContain('ci_interrupted');
+
+    const projectedAgain = projectOpenAIResponsesToolMessageContent(projected);
+    expect(projectedAgain).toBe(projected);
+    expect(projectedAgain[0]).toBe(projectedMessage);
+  });
+
+  it('retains exactly one self-contained encrypted reasoning item in v1', () => {
+    const reasoning = {
+      id: 'rs_encrypted',
+      type: 'reasoning',
+      status: 'completed',
+      summary: [],
+      encrypted_content: 'opaque-reasoning',
+    };
+    const message = new AIMessage({
+      content: [
+        {
+          type: 'reasoning',
+          reasoning: 'summary',
+        },
+        { type: 'text', text: 'Partial answer.' },
+      ],
+      additional_kwargs: { reasoning },
+      response_metadata: {
+        model_provider: 'openai',
+        output_version: 'v1',
+        preempted: true,
+      },
+    });
+
+    const projected = projectOpenAIResponsesToolMessageContent([message]);
+    const projectedMessage = projected[0] as AIMessage;
+    const providerInput = convertMessagesToResponsesInput({
+      messages: projected,
+      zdrEnabled: false,
+      model: 'gpt-5.6',
+    });
+
+    expect(projectedMessage.content).toEqual([
+      { type: 'non_standard', value: reasoning },
+      { type: 'text', text: 'Partial answer.' },
+    ]);
+    expect(
+      providerInput.filter(
+        (item) => item.type === 'reasoning' && item.id === 'rs_encrypted'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        id: 'rs_encrypted',
+        type: 'reasoning',
+        encrypted_content: 'opaque-reasoning',
+      }),
+    ]);
+    expect(JSON.stringify(providerInput)).toContain('Partial answer.');
+  });
+
   it('preserves Responses computer outputs handled as provider-native media', () => {
     const computerCall = new AIMessage({
       content: '',

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -510,6 +510,7 @@ describe('Langfuse tool output tracing redaction', () => {
       },
       {
         type: 'web_search_call',
+        results: [{ title: 'private web result' }],
         action: {
           type: 'search',
           queries: ['public web query'],
@@ -584,6 +585,7 @@ describe('Langfuse tool output tracing redaction', () => {
       results: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
     });
     expect(redacted[11]).toMatchObject({
+      results: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
       action: {
         type: 'search',
         queries: ['public web query'],
@@ -858,6 +860,12 @@ describe('Langfuse tool output tracing redaction', () => {
       const span = createSpan('gpt-5.6', {
         [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
           message.toJSON(),
+          {
+            type: 'image',
+            id: generatedById.id,
+            url: 'private-generated-image-url',
+            fileId: 'private-generated-image-file-id',
+          },
         ]),
       });
 
@@ -868,6 +876,8 @@ describe('Langfuse tool output tracing redaction', () => {
       ] as string;
       expect(redacted).not.toContain(generatedById.result);
       expect(redacted).not.toContain(generatedByDataFallback.result);
+      expect(redacted).not.toContain('private-generated-image-url');
+      expect(redacted).not.toContain('private-generated-image-file-id');
       expect(redacted).toContain('public-user-image-data');
       expect(redacted).toContain(generatedById.id);
       expect(redacted).toContain(generatedByDataFallback.id);
@@ -900,6 +910,28 @@ describe('Langfuse tool output tracing redaction', () => {
     expect(redacted).not.toContain('secret head');
     expect(redacted).not.toContain('secret tail');
     expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('preserves ordinary text that only resembles a server-tool result', () => {
+    const ordinaryText =
+      '{"serverToolResult":{"status":"draft","output":"public literal text"}}';
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: ordinaryText }],
+        },
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]
+    ).toContain('public literal text');
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]
+    ).not.toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
   });
 
   it('redacts neutralized replay results from resumed generation input', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -934,6 +934,34 @@ describe('Langfuse tool output tracing redaction', () => {
     ).not.toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
   });
 
+  it('recognizes serialized fallback results only inside assistant messages', () => {
+    const userLiteral =
+      '{"serverToolResult":{"status":"success","output":"public user literal"}}';
+    const assistantResult =
+      '{"serverToolResult":{"status":"success","output":"private replay result"}}';
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: userLiteral }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: assistantResult }],
+        },
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(redacted).toContain('public user literal');
+    expect(redacted).not.toContain('private replay result');
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
   it('redacts neutralized replay results from resumed generation input', () => {
     const message = new AIMessage({
       content: [{ type: 'text', text: 'Partial answer.' }],

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -825,8 +825,8 @@ describe('Langfuse tool output tracing redaction', () => {
         status: 'completed',
         result: 'private-generated-image-by-id',
       };
-      const generatedByDataFallback = {
-        id: 'ig_normal_response_without_content_id',
+      const generatedSecond = {
+        id: 'ig_normal_response_second',
         type: 'image_generation_call',
         status: 'completed',
         result: 'private-generated-image-by-data',
@@ -838,11 +838,14 @@ describe('Langfuse tool output tracing redaction', () => {
             mimeType: 'image/png',
             data: generatedById.result,
             id: generatedById.id,
+            metadata: { status: generatedById.status },
           },
           {
             type: 'image',
             mimeType: 'image/png',
-            data: generatedByDataFallback.result,
+            data: generatedSecond.result,
+            id: generatedSecond.id,
+            metadata: { status: generatedSecond.status },
           },
           {
             type: 'image',
@@ -850,14 +853,22 @@ describe('Langfuse tool output tracing redaction', () => {
             id: generatedById.id,
             url: 'private-generated-image-url',
             fileId: 'private-generated-image-file-id',
+            metadata: { status: generatedById.status },
+          },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'public-assistant-application-image',
+            id: 'application-image',
+            metadata: { status: 'completed' },
           },
         ],
         additional_kwargs: {
-          tool_outputs: [generatedById, generatedByDataFallback],
+          tool_outputs: [generatedById, generatedSecond],
         },
         response_metadata: {
           model_provider: 'openai',
-          output: [generatedById, generatedByDataFallback],
+          output: [generatedById, generatedSecond],
         },
       });
       const serializedMessage = serializeMessageForLangfuse(message);
@@ -888,9 +899,10 @@ describe('Langfuse tool output tracing redaction', () => {
         LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
       ] as string;
       expect(redacted).not.toContain(generatedById.result);
-      expect(redacted).not.toContain(generatedByDataFallback.result);
+      expect(redacted).not.toContain(generatedSecond.result);
       expect(redacted).not.toContain('private-generated-image-url');
       expect(redacted).not.toContain('private-generated-image-file-id');
+      expect(redacted).toContain('public-assistant-application-image');
       expect(redacted).toContain('public-user-image-data');
       expect(redacted).toContain(generatedById.id);
       expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -8,6 +8,7 @@ import type { TPayload } from '@/types';
 import {
   LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
   classifyLangfuseToolNodeSpan,
+  prepareLangfuseSpanForExport,
   redactLangfuseSpanToolOutputs,
   shouldTraceToolNodeForLangfuse,
 } from '@/langfuseToolOutputTracing';
@@ -816,7 +817,7 @@ describe('Langfuse tool output tracing redaction', () => {
       createConfig({ redactedToolNames: new Set(['image_generation']) }),
     ],
   ] as const)(
-    'redacts normalized generated images %s without touching user images',
+    'redacts serialized normalized generated images %s without touching user images',
     (_scope, config) => {
       const generatedById = {
         id: 'ig_normal_response',
@@ -846,7 +847,9 @@ describe('Langfuse tool output tracing redaction', () => {
           {
             type: 'image',
             mimeType: 'image/png',
-            data: 'public-user-image-data',
+            id: generatedById.id,
+            url: 'private-generated-image-url',
+            fileId: 'private-generated-image-file-id',
           },
         ],
         additional_kwargs: {
@@ -857,15 +860,25 @@ describe('Langfuse tool output tracing redaction', () => {
           output: [generatedById, generatedByDataFallback],
         },
       });
+      const serializedMessage = serializeMessageForLangfuse(message);
+      const serializedUserMessage = serializeMessageForLangfuse(
+        new HumanMessage({
+          content: [
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'public-user-image-data',
+            },
+          ],
+        })
+      );
+      expect(JSON.stringify(serializedMessage)).not.toContain(
+        'image_generation_call'
+      );
       const span = createSpan('gpt-5.6', {
         [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
-          message.toJSON(),
-          {
-            type: 'image',
-            id: generatedById.id,
-            url: 'private-generated-image-url',
-            fileId: 'private-generated-image-file-id',
-          },
+          serializedMessage,
+          serializedUserMessage,
         ]),
       });
 
@@ -880,14 +893,83 @@ describe('Langfuse tool output tracing redaction', () => {
       expect(redacted).not.toContain('private-generated-image-file-id');
       expect(redacted).toContain('public-user-image-data');
       expect(redacted).toContain(generatedById.id);
-      expect(redacted).toContain(generatedByDataFallback.id);
       expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
     }
   );
 
+  it('does not reclassify a marked code-interpreter image as image generation', () => {
+    const codeImage = 'data:image/png;base64,public-code-image';
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'image',
+              url: codeImage,
+              extras: {
+                librechatServerToolResult: {
+                  toolName: 'code_interpreter',
+                },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['image_generation']),
+      })
+    );
+
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+    ).toContain(codeImage);
+    expect(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+    ).not.toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('fails closed when OpenTelemetry truncates a JSON-shaped attribute', () => {
+    const secret = 'private truncated tool output';
+    const serialized = JSON.stringify([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              serverToolResult: {
+                toolName: 'shell',
+                status: 'success',
+                output: secret,
+              },
+            }),
+          },
+        ],
+      },
+    ]);
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: serialized.slice(0, -1),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({ redactedToolNames: new Set(['shell']) })
+    );
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(JSON.stringify(span.attributes)).not.toContain(secret);
+  });
+
   it('redacts marked bounded replay text without parsing its payload', () => {
     const truncatedSecret =
-      '{"serverToolResult":{"status":"success","output":"secret head…secret tail"';
+      '{"serverToolResult":{"librechatResponsesReplay":true,"status":"success","output":"secret head…secret tail"';
     const span = createSpan('gpt-5.6', {
       [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
         {
@@ -912,9 +994,69 @@ describe('Langfuse tool output tracing redaction', () => {
     expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
   });
 
+  it('redacts replay output before root-span answer shaping', () => {
+    const rootSecret = 'private root replay result';
+    const span = createSpan('LangGraph', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        { role: 'user', content: 'Continue.' },
+      ]),
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Partial answer. ' },
+            {
+              type: 'text',
+              text: JSON.stringify({
+                serverToolResult: {
+                  toolName: 'shell',
+                  status: 'success',
+                  output: rootSecret,
+                },
+              }),
+              extras: {
+                librechatServerToolResult: { toolName: 'shell' },
+              },
+            },
+          ],
+        },
+      ]),
+    });
+
+    prepareLangfuseSpanForExport(span, createConfig({ enabled: false }));
+
+    for (const key of [
+      LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+      LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+    ]) {
+      const output = span.attributes[key] as string;
+      expect(output).toContain('Partial answer.');
+      expect(output).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+      expect(output).not.toContain(rootSecret);
+    }
+  });
+
+  it('redacts a root tool output before deriving trace output', () => {
+    const rootSecret = 'private root tool result';
+    const span = createSpan('shell', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: rootSecret,
+    });
+
+    prepareLangfuseSpanForExport(span, createConfig({ enabled: false }));
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(JSON.stringify(span.attributes)).not.toContain(rootSecret);
+  });
+
   it('preserves ordinary text that only resembles a server-tool result', () => {
     const ordinaryText =
-      '{"serverToolResult":{"status":"draft","output":"public literal text"}}';
+      '{"serverToolResult":{"status":"success","output":"public literal text"}}';
     const span = createSpan('gpt-5.6', {
       [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
         {
@@ -938,7 +1080,7 @@ describe('Langfuse tool output tracing redaction', () => {
     const userLiteral =
       '{"serverToolResult":{"status":"success","output":"public user literal"}}';
     const assistantResult =
-      '{"serverToolResult":{"status":"success","output":"private replay result"}}';
+      '{"serverToolResult":{"librechatResponsesReplay":true,"status":"success","output":"private replay result"}}';
     const span = createSpan('gpt-5.6', {
       [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
         {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -309,6 +309,95 @@ describe('Langfuse tool output tracing redaction', () => {
         status: 'completed',
         result: 'program secret',
       },
+      {
+        id: 'code_interpreter_call',
+        type: 'code_interpreter_call',
+        code: 'code input stays visible',
+        container_id: 'container_1',
+        status: 'completed',
+        outputs: [{ type: 'logs', logs: 'code interpreter secret' }],
+      },
+      {
+        id: 'mcp_call',
+        type: 'mcp_call',
+        name: 'private_mcp_tool',
+        arguments: '{"query":"mcp input stays visible"}',
+        server_label: 'mcp_server',
+        status: 'failed',
+        output: 'mcp output secret',
+        error: 'mcp error secret',
+      },
+      {
+        id: 'mcp_list',
+        type: 'mcp_list_tools',
+        server_label: 'mcp_server',
+        tools: [{ name: 'listed secret tool', input_schema: {} }],
+        error: 'mcp list error secret',
+      },
+      {
+        id: 'image_generation_call',
+        type: 'image_generation_call',
+        status: 'completed',
+        revised_prompt: 'image prompt stays visible',
+        result: 'image generation secret',
+      },
+      {
+        id: 'file_search_call',
+        type: 'file_search_call',
+        status: 'completed',
+        queries: ['file query stays visible'],
+        results: [{ text: 'file search secret' }],
+      },
+      {
+        id: 'web_search_call',
+        type: 'web_search_call',
+        status: 'completed',
+        action: {
+          type: 'search',
+          queries: ['web query stays visible'],
+          sources: [{ type: 'url', url: 'web source secret' }],
+        },
+      },
+      {
+        id: 'tool_search_output',
+        call_id: 'tool_search_call',
+        type: 'tool_search_output',
+        status: 'completed',
+        tools: [{ type: 'function', name: 'tool definition secret' }],
+      },
+      {
+        id: 'function_call',
+        call_id: 'function_call_id',
+        type: 'function_call',
+        name: 'private_function',
+        arguments: 'function input stays visible',
+      },
+      {
+        id: 'function_output',
+        call_id: 'function_call_id',
+        type: 'function_call_output',
+        output: 'function output secret',
+      },
+      {
+        id: 'custom_call',
+        call_id: 'custom_call_id',
+        type: 'custom_tool_call',
+        name: 'private_custom',
+        input: 'custom input stays visible',
+      },
+      {
+        id: 'custom_output',
+        call_id: 'custom_call_id',
+        type: 'custom_tool_call_output',
+        output: 'custom output secret',
+      },
+      {
+        id: 'computer_output',
+        call_id: 'computer_call_id',
+        type: 'computer_call_output',
+        acknowledged_safety_checks: ['computer input stays visible'],
+        output: 'computer output secret',
+      },
     ];
     const serializedMessage = {
       role: 'assistant',
@@ -331,14 +420,46 @@ describe('Langfuse tool output tracing redaction', () => {
     const redacted = span.attributes[
       LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
     ] as string;
-    expect(redacted).not.toMatch(
-      /local shell secret|shell secret|patch secret|program secret/
-    );
+    for (const secret of [
+      'local shell secret',
+      'shell secret',
+      'patch secret',
+      'program secret',
+      'code interpreter secret',
+      'mcp output secret',
+      'mcp error secret',
+      'listed secret tool',
+      'mcp list error secret',
+      'image generation secret',
+      'file search secret',
+      'web source secret',
+      'tool definition secret',
+      'function output secret',
+      'custom output secret',
+      'computer output secret',
+    ]) {
+      expect(redacted).not.toContain(secret);
+    }
     expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
-    expect(redacted).toContain('local_output');
-    expect(redacted).toContain('shell_call');
-    expect(redacted).toContain('patch_call');
-    expect(redacted).toContain('program_call');
+    for (const input of [
+      'local_output',
+      'shell_call',
+      'patch_call',
+      'program_call',
+      'code input stays visible',
+      'mcp input stays visible',
+      'private_mcp_tool',
+      'mcp_server',
+      'image prompt stays visible',
+      'file query stays visible',
+      'web query stays visible',
+      'tool_search_call',
+      'function input stays visible',
+      'custom input stays visible',
+      'computer input stays visible',
+    ]) {
+      expect(redacted).toContain(input);
+    }
   });
 
   it('selectively redacts captured Responses outputs by canonical tool name', () => {
@@ -350,6 +471,61 @@ describe('Langfuse tool output tracing redaction', () => {
       { type: 'shell_call_output', output: 'private shell output' },
       { type: 'apply_patch_call_output', output: 'public patch output' },
       { type: 'program_output', result: 'private program output' },
+      {
+        type: 'code_interpreter_call',
+        code: 'public code input',
+        outputs: [{ type: 'logs', logs: 'private code output' }],
+      },
+      {
+        type: 'mcp_call',
+        name: 'private_mcp_tool',
+        arguments: 'public mcp input',
+        output: 'private named mcp output',
+        error: 'private named mcp error',
+      },
+      {
+        type: 'mcp_call',
+        name: 'public_mcp_tool',
+        output: 'public named mcp output',
+      },
+      {
+        type: 'mcp_call',
+        output: 'private fallback mcp output',
+      },
+      {
+        type: 'mcp_list_tools',
+        server_label: 'public server label',
+        tools: [{ name: 'private listed tool' }],
+        error: 'private list error',
+      },
+      {
+        type: 'image_generation_call',
+        revised_prompt: 'public image prompt',
+        result: 'private generated image',
+      },
+      {
+        type: 'file_search_call',
+        queries: ['public file query'],
+        results: [{ text: 'private file result' }],
+      },
+      {
+        type: 'web_search_call',
+        action: {
+          type: 'search',
+          queries: ['public web query'],
+          sources: [{ url: 'private web source' }],
+        },
+      },
+      {
+        type: 'tool_search_output',
+        call_id: 'public tool search call id',
+        tools: [{ name: 'private tool definition' }],
+      },
+      {
+        type: 'computer_call_output',
+        acknowledged_safety_checks: ['public computer input'],
+        output: 'private computer output',
+      },
     ];
     const span = createSpan('gpt-5.6', {
       [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(outputs),
@@ -357,7 +533,21 @@ describe('Langfuse tool output tracing redaction', () => {
 
     redactLangfuseSpanToolOutputs(
       span,
-      createConfig({ redactedToolNames: new Set(['shell', 'program']) })
+      createConfig({
+        redactedToolNames: new Set([
+          'shell',
+          'program',
+          'code_interpreter',
+          'private_mcp_tool',
+          'mcp',
+          'mcp_list_tools',
+          'image_generation',
+          'file_search',
+          'web_search',
+          'tool_search',
+          'computer_use',
+        ]),
+      })
     );
 
     const redacted = readJsonAttribute<Array<Record<string, unknown>>>(
@@ -368,7 +558,322 @@ describe('Langfuse tool output tracing redaction', () => {
     expect(redacted[1].output).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
     expect(redacted[2].output).toBe('public patch output');
     expect(redacted[3].result).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[4]).toMatchObject({
+      code: 'public code input',
+      outputs: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[5]).toMatchObject({
+      name: 'private_mcp_tool',
+      arguments: 'public mcp input',
+      output: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+      error: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[6].output).toBe('public named mcp output');
+    expect(redacted[7].output).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[8]).toMatchObject({
+      server_label: 'public server label',
+      tools: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+      error: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[9]).toMatchObject({
+      revised_prompt: 'public image prompt',
+      result: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[10]).toMatchObject({
+      queries: ['public file query'],
+      results: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[11]).toMatchObject({
+      action: {
+        type: 'search',
+        queries: ['public web query'],
+        sources: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+      },
+    });
+    expect(redacted[12]).toMatchObject({
+      call_id: 'public tool search call id',
+      tools: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
+    expect(redacted[13]).toMatchObject({
+      acknowledged_safety_checks: ['public computer input'],
+      output: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    });
   });
+
+  it('maps Responses function and custom outputs to their call names', () => {
+    const outputs = [
+      {
+        type: 'function_call',
+        call_id: 'private_function_call',
+        name: 'execute_sql',
+        arguments: 'private function input stays visible',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'private_function_call',
+        output: 'private function output',
+      },
+      {
+        type: 'function_call',
+        call_id: 'public_function_call',
+        name: 'public_function',
+        arguments: 'public function input',
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'public_function_call',
+        output: 'public function output',
+      },
+      {
+        type: 'custom_tool_call',
+        call_id: 'private_custom_call',
+        name: 'private_custom_tool',
+        input: 'private custom input stays visible',
+      },
+      {
+        type: 'custom_tool_call_output',
+        call_id: 'private_custom_call',
+        output: 'private custom output',
+      },
+      {
+        type: 'custom_tool_call_output',
+        call_id: 'unmatched_custom_call',
+        output: 'unmatched custom output stays visible',
+      },
+    ];
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(outputs),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql', 'private_custom_tool']),
+      })
+    );
+
+    const redacted = readJsonAttribute<Array<Record<string, unknown>>>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[0].arguments).toBe('private function input stays visible');
+    expect(redacted[1].output).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[3].output).toBe('public function output');
+    expect(redacted[4].input).toBe('private custom input stays visible');
+    expect(redacted[5].output).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[6].output).toBe('unmatched custom output stays visible');
+  });
+
+  it('redacts standard server-tool results globally and by paired call name', () => {
+    const blocks = [
+      {
+        type: 'server_tool_call',
+        id: 'private_server_call',
+        name: 'file_search',
+        args: { query: 'private server input stays visible' },
+      },
+      {
+        type: 'server_tool_call_result',
+        toolCallId: 'private_server_call',
+        status: 'success',
+        output: { results: ['private standard server result'] },
+      },
+      {
+        type: 'server_tool_call',
+        id: 'public_server_call',
+        name: 'web_search',
+        args: { query: 'public server input' },
+      },
+      {
+        type: 'server_tool_call_result',
+        toolCallId: 'public_server_call',
+        status: 'success',
+        output: 'public standard server result',
+      },
+      {
+        type: 'server_tool_call_result',
+        toolCallId: 'unknown_server_call',
+        status: 'success',
+        output: 'unmatched standard server result',
+      },
+    ];
+    const selectiveSpan = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(blocks),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      selectiveSpan,
+      createConfig({ redactedToolNames: new Set(['file_search']) })
+    );
+
+    const selectivelyRedacted = readJsonAttribute<
+      Array<Record<string, unknown>>
+    >(selectiveSpan, LangfuseOtelSpanAttributes.OBSERVATION_INPUT);
+    expect(selectivelyRedacted[0]).toMatchObject({
+      args: { query: 'private server input stays visible' },
+    });
+    expect(selectivelyRedacted[1].output).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(selectivelyRedacted[3].output).toBe('public standard server result');
+    expect(selectivelyRedacted[4].output).toBe(
+      'unmatched standard server result'
+    );
+
+    const globalSpan = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(blocks),
+    });
+    redactLangfuseSpanToolOutputs(globalSpan, createConfig({ enabled: false }));
+    const globallyRedacted = readJsonAttribute<Array<Record<string, unknown>>>(
+      globalSpan,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(globallyRedacted[1].output).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(globallyRedacted[3].output).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(globallyRedacted[4].output).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+  });
+
+  it('redacts marked projected server-tool images without touching user images', () => {
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer stays visible.' }],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'code_image_call',
+            type: 'code_interpreter_call',
+            code: 'public image-producing code',
+            status: 'completed',
+            outputs: [
+              {
+                type: 'image',
+                url: 'data:image/png;base64,private-code-image-data',
+              },
+            ],
+          },
+          {
+            id: 'generated_image_call',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: 'private-generated-image-data',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+    const [projected] = projectToolStreamContentForProvider(
+      [message],
+      'native'
+    );
+    const projectedJson = projected.toJSON();
+    const serializedProjection = JSON.stringify(projectedJson);
+    expect(serializedProjection).toContain('private-code-image-data');
+    expect(serializedProjection).toContain('private-generated-image-data');
+    expect(serializedProjection).toContain('librechatServerToolResult');
+
+    const userImage = {
+      type: 'image',
+      mimeType: 'image/png',
+      data: 'public-user-image-data',
+    };
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        projectedJson,
+        userImage,
+      ]),
+    });
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['code_interpreter', 'image_generation']),
+      })
+    );
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(redacted).toContain('Partial answer stays visible.');
+    expect(redacted).toContain('public-user-image-data');
+    expect(redacted).not.toContain('private-code-image-data');
+    expect(redacted).not.toContain('private-generated-image-data');
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it.each([
+    ['globally', createConfig({ enabled: false })],
+    [
+      'selectively',
+      createConfig({ redactedToolNames: new Set(['image_generation']) }),
+    ],
+  ] as const)(
+    'redacts normalized generated images %s without touching user images',
+    (_scope, config) => {
+      const generatedById = {
+        id: 'ig_normal_response',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: 'private-generated-image-by-id',
+      };
+      const generatedByDataFallback = {
+        id: 'ig_normal_response_without_content_id',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: 'private-generated-image-by-data',
+      };
+      const message = new AIMessage({
+        content: [
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: generatedById.result,
+            id: generatedById.id,
+          },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: generatedByDataFallback.result,
+          },
+          {
+            type: 'image',
+            mimeType: 'image/png',
+            data: 'public-user-image-data',
+          },
+        ],
+        additional_kwargs: {
+          tool_outputs: [generatedById, generatedByDataFallback],
+        },
+        response_metadata: {
+          model_provider: 'openai',
+          output: [generatedById, generatedByDataFallback],
+        },
+      });
+      const span = createSpan('gpt-5.6', {
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
+          message.toJSON(),
+        ]),
+      });
+
+      redactLangfuseSpanToolOutputs(span, config);
+
+      const redacted = span.attributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
+      ] as string;
+      expect(redacted).not.toContain(generatedById.result);
+      expect(redacted).not.toContain(generatedByDataFallback.result);
+      expect(redacted).toContain('public-user-image-data');
+      expect(redacted).toContain(generatedById.id);
+      expect(redacted).toContain(generatedByDataFallback.id);
+      expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    }
+  );
 
   it('redacts marked bounded replay text without parsing its payload', () => {
     const truncatedSecret =

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -26,6 +26,7 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import { ensureOpenTelemetryContextManager } from '@/instrumentation';
+import { projectToolStreamContentForProvider } from '@/messages/core';
 import { formatAgentMessages } from '@/messages/format';
 import { ContentTypes } from '@/common';
 
@@ -277,6 +278,173 @@ describe('Langfuse tool output tracing redaction', () => {
     ) as Array<{ role: string; content: string }>;
     expect(redacted[0].content).toBe('show tables');
     expect(redacted[1].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('redacts captured Responses server-tool outputs wherever they are serialized', () => {
+    const outputs = [
+      {
+        id: 'local_output',
+        type: 'local_shell_call_output',
+        status: 'completed',
+        output: 'local shell secret',
+      },
+      {
+        id: 'shell_output',
+        call_id: 'shell_call',
+        type: 'shell_call_output',
+        status: 'completed',
+        output: 'shell secret',
+      },
+      {
+        id: 'patch_output',
+        call_id: 'patch_call',
+        type: 'apply_patch_call_output',
+        status: 'completed',
+        output: 'patch secret',
+      },
+      {
+        id: 'program_output',
+        call_id: 'program_call',
+        type: 'program_output',
+        status: 'completed',
+        result: 'program secret',
+      },
+    ];
+    const serializedMessage = {
+      role: 'assistant',
+      content: outputs.map((value) => ({ type: 'non_standard', value })),
+      content_blocks: outputs.map((value) => ({
+        type: 'non_standard',
+        value,
+      })),
+      additional_kwargs: { tool_outputs: outputs },
+    };
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify([
+        serializedMessage,
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT
+    ] as string;
+    expect(redacted).not.toMatch(
+      /local shell secret|shell secret|patch secret|program secret/
+    );
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted).toContain('local_output');
+    expect(redacted).toContain('shell_call');
+    expect(redacted).toContain('patch_call');
+    expect(redacted).toContain('program_call');
+  });
+
+  it('selectively redacts captured Responses outputs by canonical tool name', () => {
+    const outputs = [
+      {
+        type: 'local_shell_call_output',
+        output: 'public local output',
+      },
+      { type: 'shell_call_output', output: 'private shell output' },
+      { type: 'apply_patch_call_output', output: 'public patch output' },
+      { type: 'program_output', result: 'private program output' },
+    ];
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(outputs),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({ redactedToolNames: new Set(['shell', 'program']) })
+    );
+
+    const redacted = readJsonAttribute<Array<Record<string, unknown>>>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[0].output).toBe('public local output');
+    expect(redacted[1].output).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[2].output).toBe('public patch output');
+    expect(redacted[3].result).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('redacts marked bounded replay text without parsing its payload', () => {
+    const truncatedSecret =
+      '{"serverToolResult":{"status":"success","output":"secret head…secret tail"';
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: truncatedSecret,
+            },
+          ],
+        },
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(redacted).not.toContain('secret head');
+    expect(redacted).not.toContain('secret tail');
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('redacts neutralized replay results from resumed generation input', () => {
+    const message = new AIMessage({
+      content: [{ type: 'text', text: 'Partial answer.' }],
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            id: 'shell_output_item',
+            call_id: 'shell_call',
+            type: 'shell_call_output',
+            status: 'completed',
+            output: 'resumed generation secret',
+          },
+        ],
+      },
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+      },
+    });
+    const [projected] = projectToolStreamContentForProvider(
+      [message],
+      'fallback'
+    );
+    expect(projected.content).toEqual([
+      { type: 'text', text: 'Partial answer.' },
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('resumed generation secret'),
+      }),
+    ]);
+    expect(JSON.stringify(projected.content)).not.toContain('extras');
+    const span = createSpan('gpt-5.6', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        projected.toJSON(),
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({ redactedToolNames: new Set(['shell']) })
+    );
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(redacted).toContain('Partial answer.');
+    expect(redacted).not.toContain('resumed generation secret');
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
   });
 
   it('redacts only configured tool names when output tracing stays enabled', () => {

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -7,13 +7,17 @@
  * CHAT_MODEL_STREAM handler), which is the only loop allowed to seal.
  */
 import { HumanMessage } from '@langchain/core/messages';
-import type { BaseMessage } from '@langchain/core/messages';
 import { RunnableBinding } from '@langchain/core/runnables';
-import type * as t from '@/types';
-import { Providers } from '@/common';
-import { HookRegistry } from '@/hooks/HookRegistry';
+import {
+  convertMessagesToResponsesInput,
+  convertResponsesDeltaToChatGenerationChunk,
+} from '@langchain/openai';
+import type { BaseMessage } from '@langchain/core/messages';
 import type { HookCallback } from '@/hooks/types';
+import type * as t from '@/types';
+import { HookRegistry } from '@/hooks/HookRegistry';
 import { FakeChatModel } from '@/llm/fake';
+import { Providers } from '@/common';
 import { Run } from '@/run';
 
 const FULL_RESPONSE = 'Alpha beta gamma delta epsilon zeta';
@@ -86,6 +90,102 @@ class CountingChatModel extends FakeChatModel {
   ): ReturnType<FakeChatModel['_streamResponseChunks']> {
     this.invocations += 1;
     yield* super._streamResponseChunks(...args);
+  }
+}
+
+class ResponsesReasoningChatModel extends FakeChatModel {
+  invocations: BaseMessage[][] = [];
+
+  _useResponsesApi(): boolean {
+    return true;
+  }
+
+  override async *_streamResponseChunks(
+    ...args: Parameters<FakeChatModel['_streamResponseChunks']>
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    const [messages] = args;
+    this.invocations.push(messages);
+    if (this.invocations.length !== 1) {
+      yield* super._streamResponseChunks(...args);
+      return;
+    }
+
+    const events: Parameters<
+      typeof convertResponsesDeltaToChatGenerationChunk
+    >[0][] = [
+      {
+        type: 'response.created',
+        sequence_number: 0,
+        response: {
+          id: 'resp_interrupted',
+          created_at: 0,
+          output_text: '',
+          error: null,
+          incomplete_details: null,
+          instructions: null,
+          metadata: null,
+          model: 'gpt-5.6',
+          object: 'response',
+          output: [],
+          parallel_tool_calls: true,
+          temperature: null,
+          tool_choice: 'auto',
+          tools: [],
+          top_p: null,
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_item.added',
+        sequence_number: 1,
+        output_index: 0,
+        item: {
+          id: 'rs_interrupted',
+          type: 'reasoning',
+          status: 'in_progress',
+          summary: [],
+        },
+      },
+      {
+        type: 'response.output_item.done',
+        sequence_number: 2,
+        output_index: 0,
+        item: {
+          id: 'rs_interrupted',
+          type: 'reasoning',
+          status: 'completed',
+          summary: [],
+          encrypted_content: 'encrypted-reasoning',
+        },
+      },
+      {
+        type: 'response.output_item.added',
+        sequence_number: 3,
+        output_index: 1,
+        item: {
+          id: 'msg_interrupted',
+          type: 'message',
+          role: 'assistant',
+          status: 'in_progress',
+          content: [],
+        },
+      },
+      {
+        type: 'response.output_text.delta',
+        sequence_number: 4,
+        output_index: 1,
+        content_index: 0,
+        item_id: 'msg_interrupted',
+        delta: 'Partial answer.',
+        logprobs: [],
+      },
+    ];
+    for (const event of events) {
+      const chunk = convertResponsesDeltaToChatGenerationChunk(event);
+      if (chunk != null) {
+        yield chunk;
+      }
+    }
   }
 }
 
@@ -272,7 +372,11 @@ describe('cooperative seal (end-to-end via Run)', () => {
       runId: 'seal-inject-resume',
       hook: async () => ({
         injectedMessages: [
-          { role: 'user' as const, content: 'Make it shorter.', source: 'steer' },
+          {
+            role: 'user' as const,
+            content: 'Make it shorter.',
+            source: 'steer',
+          },
         ],
       }),
       responses: [FULL_RESPONSE, RESUMED_RESPONSE],
@@ -306,4 +410,58 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(contents[0].length).toBeLessThan(FULL_RESPONSE.length);
     expect(contents[1]).toBe(RESUMED_RESPONSE);
   });
+
+  it.each(['v0', 'v1'] as const)(
+    'does not replay interrupted OpenAI Responses item ids on %s resume',
+    async (outputVersion) => {
+      const run = await createSealRun({
+        runId: `seal-openai-responses-reasoning-${outputVersion}`,
+        hook: async () => ({
+          injectedMessages: [
+            { role: 'user' as const, content: 'Go on.', source: 'steer' },
+          ],
+        }),
+        responses: [],
+      });
+      const model = new ResponsesReasoningChatModel({
+        responses: [RESUMED_RESPONSE],
+      });
+      model.outputVersion = outputVersion;
+      run.Graph!.overrideModel = model;
+
+      await run.processStream(
+        { messages: [new HumanMessage('hello there')] },
+        streamConfig
+      );
+
+      expect(model.invocations).toHaveLength(2);
+      const sealedMessage = model.invocations[1].find(
+        (message) => message.getType() === 'ai'
+      );
+      expect(sealedMessage).toBeDefined();
+      expect(sealedMessage?.text).toBe('Partial answer.');
+      expect(sealedMessage?.response_metadata).not.toHaveProperty('id');
+      const actualOutputVersion = (
+        sealedMessage?.response_metadata as { output_version?: unknown }
+      ).output_version;
+      expect(actualOutputVersion).toBe(
+        outputVersion === 'v1' ? 'v1' : undefined
+      );
+
+      const providerInput = convertMessagesToResponsesInput({
+        messages: model.invocations[1],
+        model: 'gpt-5.6',
+        zdrEnabled: false,
+      });
+      const unsafeReasoning = providerInput.find(
+        (item) =>
+          item.type === 'reasoning' &&
+          item.id === 'rs_interrupted' &&
+          (typeof item.encrypted_content !== 'string' ||
+            item.encrypted_content.length === 0)
+      );
+      expect(unsafeReasoning).toBeUndefined();
+      expect(JSON.stringify(providerInput)).toContain('Partial answer.');
+    }
+  );
 });

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -629,6 +629,9 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(resumedInput).toContain('Partial answer.');
     expect(resumedInput).toContain('local shell result');
     expect(resumedInput).toContain('serverToolResult');
+    expect(resumedInput.indexOf('local shell result')).toBeLessThan(
+      resumedInput.indexOf('Partial answer.')
+    );
     expect(resumedInput).not.toContain('local_output_item');
     expect(resumedInput).not.toContain('local_shell_call_output');
     expect(resumedInput).not.toContain('rs_interrupted');

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -6,13 +6,14 @@
  * the dispatch-synchronous loop in `attemptInvoke` (no registered
  * CHAT_MODEL_STREAM handler), which is the only loop allowed to seal.
  */
-import { HumanMessage } from '@langchain/core/messages';
 import { RunnableBinding } from '@langchain/core/runnables';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
 import {
   type OpenAIClient,
   convertMessagesToResponsesInput,
   convertResponsesDeltaToChatGenerationChunk,
 } from '@langchain/openai';
+import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { HookCallback } from '@/hooks/types';
 import type * as t from '@/types';
@@ -335,6 +336,43 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(run.Graph?.preemptSealCount).toBe(1);
     expect(starts).toBe(2);
     expect(ends).toBe(2);
+  });
+
+  it('preserves the preempted marker through constructor-kwargs rehydration', async () => {
+    let sealedChunk: AIMessageChunk | undefined;
+    const run = await createSealRun({
+      runId: 'seal-serialized-preempted-marker',
+      hook: async () => ({ preventContinuation: true }),
+      responses: [FULL_RESPONSE],
+      modelCallbacks: [
+        {
+          handleLLMEnd(output: LLMResult): void {
+            const generation = output.generations[0]?.[0] as
+              | ChatGeneration
+              | undefined;
+            const message = generation?.message;
+            if (
+              AIMessageChunk.isInstance(message) &&
+              message.response_metadata.preempted === true
+            ) {
+              sealedChunk = message;
+            }
+          },
+        },
+      ],
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    expect(sealedChunk).toBeDefined();
+    const serializedFields = JSON.parse(
+      JSON.stringify(sealedChunk!.lc_kwargs)
+    ) as ConstructorParameters<typeof AIMessageChunk>[0];
+    const rehydrated = new AIMessageChunk(serializedFields);
+    expect(rehydrated.response_metadata.preempted).toBe(true);
   });
 
   it('a halting boundary stops multi-agent successors, not just the sealed subgraph', async () => {

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -9,6 +9,7 @@
 import { HumanMessage } from '@langchain/core/messages';
 import { RunnableBinding } from '@langchain/core/runnables';
 import {
+  type OpenAIClient,
   convertMessagesToResponsesInput,
   convertResponsesDeltaToChatGenerationChunk,
 } from '@langchain/openai';
@@ -17,6 +18,7 @@ import type { HookCallback } from '@/hooks/types';
 import type * as t from '@/types';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { FakeChatModel } from '@/llm/fake';
+import { ChatOpenAI } from '@/llm/openai';
 import { Providers } from '@/common';
 import { Run } from '@/run';
 
@@ -95,6 +97,7 @@ class CountingChatModel extends FakeChatModel {
 
 class ResponsesReasoningChatModel extends FakeChatModel {
   invocations: BaseMessage[][] = [];
+  includeServerToolResult = false;
 
   _useResponsesApi(): boolean {
     return true;
@@ -110,6 +113,7 @@ class ResponsesReasoningChatModel extends FakeChatModel {
       return;
     }
 
+    const outputOffset = this.includeServerToolResult ? 1 : 0;
     const events: Parameters<
       typeof convertResponsesDeltaToChatGenerationChunk
     >[0][] = [
@@ -135,10 +139,33 @@ class ResponsesReasoningChatModel extends FakeChatModel {
           status: 'in_progress',
         },
       },
+      ...(this.includeServerToolResult
+        ? [
+          {
+            type: 'response.output_item.done' as const,
+            sequence_number: 1,
+            output_index: 0,
+            item: {
+              id: 'ci_interrupted',
+              type: 'code_interpreter_call' as const,
+              status: 'completed' as const,
+              code: 'print("server result")',
+              container_id: 'container_interrupted',
+              outputs: [
+                { type: 'logs' as const, logs: 'server result' },
+                {
+                  type: 'image' as const,
+                  url: 'https://example.com/ephemeral-chart.png',
+                },
+              ],
+            },
+          },
+        ]
+        : []),
       {
         type: 'response.output_item.added',
-        sequence_number: 1,
-        output_index: 0,
+        sequence_number: 1 + outputOffset,
+        output_index: outputOffset,
         item: {
           id: 'rs_interrupted',
           type: 'reasoning',
@@ -148,8 +175,8 @@ class ResponsesReasoningChatModel extends FakeChatModel {
       },
       {
         type: 'response.output_item.done',
-        sequence_number: 2,
-        output_index: 0,
+        sequence_number: 2 + outputOffset,
+        output_index: outputOffset,
         item: {
           id: 'rs_interrupted',
           type: 'reasoning',
@@ -160,8 +187,8 @@ class ResponsesReasoningChatModel extends FakeChatModel {
       },
       {
         type: 'response.output_item.added',
-        sequence_number: 3,
-        output_index: 1,
+        sequence_number: 3 + outputOffset,
+        output_index: 1 + outputOffset,
         item: {
           id: 'msg_interrupted',
           type: 'message',
@@ -172,8 +199,8 @@ class ResponsesReasoningChatModel extends FakeChatModel {
       },
       {
         type: 'response.output_text.delta',
-        sequence_number: 4,
-        output_index: 1,
+        sequence_number: 4 + outputOffset,
+        output_index: 1 + outputOffset,
         content_index: 0,
         item_id: 'msg_interrupted',
         delta: 'Partial answer.',
@@ -188,6 +215,12 @@ class ResponsesReasoningChatModel extends FakeChatModel {
     }
   }
 }
+
+type StreamingResponsesDelegate = {
+  completionWithRetry: (
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming
+  ) => Promise<AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>>;
+};
 
 const aiContents = (messages: BaseMessage[]): string[] =>
   messages
@@ -464,4 +497,141 @@ describe('cooperative seal (end-to-end via Run)', () => {
       expect(JSON.stringify(providerInput)).toContain('Partial answer.');
     }
   );
+
+  it.each(['v0', 'v1'] as const)(
+    'preserves completed Responses server results on %s resume without ids',
+    async (outputVersion) => {
+      const run = await createSealRun({
+        runId: `seal-openai-responses-server-result-${outputVersion}`,
+        hook: async () => ({
+          injectedMessages: [
+            { role: 'user' as const, content: 'Go on.', source: 'steer' },
+          ],
+        }),
+        responses: [],
+      });
+      const model = new ResponsesReasoningChatModel({
+        responses: [RESUMED_RESPONSE],
+      });
+      model.outputVersion = outputVersion;
+      model.includeServerToolResult = true;
+      run.Graph!.overrideModel = model;
+
+      await run.processStream(
+        { messages: [new HumanMessage('hello there')] },
+        streamConfig
+      );
+
+      expect(model.invocations).toHaveLength(2);
+      const sealedMessage = model.invocations[1].find(
+        (message) => message.getType() === 'ai'
+      );
+      expect(sealedMessage).toBeDefined();
+      expect(sealedMessage?.text).toContain('Partial answer.');
+      expect(sealedMessage?.text).toContain('server result');
+      expect(sealedMessage?.text).toContain('ephemeral-chart.png');
+      expect(
+        (sealedMessage?.response_metadata as { output_version?: unknown })
+          .output_version
+      ).toBe('v1');
+
+      const providerInput = convertMessagesToResponsesInput({
+        messages: model.invocations[1],
+        model: 'gpt-5.6',
+        zdrEnabled: false,
+      });
+      const serializedProviderInput = JSON.stringify(providerInput);
+      expect(serializedProviderInput).toContain('server result');
+      expect(serializedProviderInput).toContain('ephemeral-chart.png');
+      expect(serializedProviderInput).not.toContain('ci_interrupted');
+      expect(serializedProviderInput).not.toContain('code_interpreter_call');
+      expect(serializedProviderInput).not.toContain('function_call_output');
+    }
+  );
+
+  it('preserves dropped raw Responses results through a real model resume', async () => {
+    const run = await createSealRun({
+      runId: 'seal-openai-responses-raw-result',
+      hook: async () => ({
+        injectedMessages: [
+          { role: 'user' as const, content: 'Go on.', source: 'steer' },
+        ],
+      }),
+      responses: [],
+    });
+    const model = new ChatOpenAI({
+      model: 'gpt-5.6',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingResponsesDelegate }
+    ).responses;
+    const requests: OpenAIClient.Responses.ResponseCreateParamsStreaming[] = [];
+    responses.completionWithRetry = async (request) => {
+      requests.push(request);
+      const invocation = requests.length;
+      return (async function* () {
+        if (invocation === 1) {
+          yield {
+            type: 'response.output_item.done',
+            sequence_number: 0,
+            output_index: 0,
+            item: {
+              id: 'local_output_item',
+              type: 'local_shell_call_output',
+              status: 'completed',
+              output: 'local shell result',
+            },
+          } as OpenAIClient.Responses.ResponseStreamEvent;
+          yield {
+            type: 'response.output_item.added',
+            sequence_number: 1,
+            output_index: 1,
+            item: {
+              id: 'rs_interrupted',
+              type: 'reasoning',
+              status: 'in_progress',
+              summary: [],
+            },
+          } as OpenAIClient.Responses.ResponseStreamEvent;
+          yield {
+            type: 'response.output_text.delta',
+            sequence_number: 2,
+            output_index: 2,
+            content_index: 0,
+            item_id: 'msg_interrupted',
+            delta: 'Partial answer.',
+            logprobs: [],
+          } as OpenAIClient.Responses.ResponseStreamEvent;
+          return;
+        }
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 0,
+          output_index: 0,
+          content_index: 0,
+          item_id: 'msg_resumed',
+          delta: RESUMED_RESPONSE,
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+    };
+    run.Graph!.overrideModel = model;
+
+    await run.processStream(
+      { messages: [new HumanMessage('hello there')] },
+      streamConfig
+    );
+
+    expect(requests).toHaveLength(2);
+    const resumedInput = JSON.stringify(requests[1].input);
+    expect(resumedInput).toContain('Partial answer.');
+    expect(resumedInput).toContain('local shell result');
+    expect(resumedInput).toContain('serverToolResult');
+    expect(resumedInput).not.toContain('local_output_item');
+    expect(resumedInput).not.toContain('local_shell_call_output');
+    expect(resumedInput).not.toContain('rs_interrupted');
+    expect(run.getHaltReason()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- project preempted OpenAI Responses assistant turns to a provider-neutral clone before the next invocation
- strip unretained response, message, reasoning, server-tool, and provider-call references while retaining visible assistant text and ordinary application metadata
- preserve validated encrypted reasoning, completed generated images, and bounded server-tool results across LangChain v0 and v1 output formats
- capture terminal reasoning status and `encrypted_content` without duplicating streamed summary text, then restore reasoning at its exact output position
- capture the four terminal Responses output types LangChain currently drops (`local_shell_call_output`, `shell_call_output`, `apply_patch_call_output`, and `program_output`) for both OpenAI and Azure delegates
- deliver token callbacks before exposing each Responses chunk, including when a cooperative-preemption consumer stops at that chunk
- propagate buffered stream aborts through the error path and persist sealed metadata, usage estimates, content indices, and replay positions through LangChain constructor-kwargs checkpoint rehydration
- discard replay-only provisional output copies and ordering sidecars after a completed or incomplete terminal response supplies the authoritative output, including from LangChain's serialized constructor state and tracing aggregate
- preserve raw code-interpreter logs/images, file/web/tool-search results, generated images, and incomplete terminal outputs in exact streamed order, including output items without an `id`, using a shared linear-time replay-position index
- sanitize Responses history across direct OpenAI/Azure generation, chunk, and event paths before provider serialization or fallback projection, while preserving data-, URL-, and `fileId`-backed application image order
- prepare authoritative replay ordering in one indexed pass before artifact projection, avoiding repeated traversal of shared response output arrays
- preserve generated-image MIME types and comprehensively redact raw, normalized, and neutralized Responses tool outputs before Langfuse root-span shaping, including serialized generated images and truncated attributes, without weakening replay or redacting ordinary application images
- keep graph/checkpoint messages immutable and make every replay projection idempotent and serialization-safe

## Root cause

Cooperative preemption can stop a native Responses stream after visible text but before the terminal response event. LangChain 1.5.5 captures the early `rs_*` reasoning item reference, while the completed item carrying `encrypted_content` may not be incorporated. Replaying that partial assistant turn can therefore send an unretained provider item ID and OpenAI responds with `404 Item ... not found`.

Some terminal server-tool output events are also currently discarded by LangChain's Responses stream converter. Capturing and neutralizing those outputs preserves useful completed work without replaying provider-managed item or call IDs.

## Validation

- focused replay projection, streamed-transport, OpenAI/Azure callback, smoke, and Langfuse suites: 349 passed, 1 skipped
- credential-independent suite (including integration tests): 183 suites / 3,503 tests passed, 91 skipped
- `npm run build`
- `npx tsc --noEmit`
- targeted ESLint: zero errors and zero warnings
- import-order and `git diff --check`
- independent focused audits of replay ordering, serialization, image MIME handling, and tracing redaction

The real `Run` E2E streams raw local-shell output plus partial text and an `rs_*` reasoning item, seals the turn cooperatively, then verifies the next Responses request retains the safe result in its original position plus the text while omitting all provider-managed IDs.

## Upstream context

- langchain-ai/langchainjs#10844
- langchain-ai/langchainjs#10845

The unrestricted test command also discovered credential-gated live provider specs; those fail only for unavailable Anthropic/Google credentials and retired Vertex preview models. The repository's CI-equivalent offline suite is green.
