### PR TITLE
🔌 feat(search): Allow Callers to Inject an HTTP(s) Agent for Outbound Requests

### DIFF
--- a/src/tools/search/crw-scraper.ts
+++ b/src/tools/search/crw-scraper.ts
@@ -27,6 +27,8 @@ export class CrwScraper implements t.BaseScraper {
   private xpath?: string;
   private proxy?: string;
   private stealth?: boolean;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor(config: t.CrwScraperConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.CRW_API_KEY ?? '';
@@ -49,6 +51,8 @@ export class CrwScraper implements t.BaseScraper {
     this.xpath = config.xpath;
     this.proxy = config.proxy;
     this.stealth = config.stealth;
+    this.httpAgent = config.httpAgent;
+    this.httpsAgent = config.httpsAgent;
 
     // Self-host fastCRW may run without auth, so a missing key is only a
     // warning — unlike Firecrawl/Tavily, scrapeUrl does NOT early-return on it.
@@ -96,6 +100,8 @@ export class CrwScraper implements t.BaseScraper {
         {
           headers,
           timeout: payloadTimeout + CRW_TIMEOUT_BUFFER,
+          httpAgent: this.httpAgent,
+          httpsAgent: this.httpsAgent,
         }
       );
 

--- a/src/tools/search/crw-search.ts
+++ b/src/tools/search/crw-search.ts
@@ -91,7 +91,12 @@ export const createCrwAPI = (
       const response = await axios.post<t.CrwSearchResponse>(
         config.apiUrl,
         payload,
-        { headers, timeout: config.timeout }
+        {
+          headers,
+          timeout: config.timeout,
+          httpAgent: options?.httpAgent,
+          httpsAgent: options?.httpsAgent,
+        }
       );
 
       const body = response.data;

--- a/src/tools/search/firecrawl.ts
+++ b/src/tools/search/firecrawl.ts
@@ -29,6 +29,8 @@ export class FirecrawlScraper implements t.BaseScraper {
   private location?: { country?: string; languages?: string[] };
   private onlyMainContent?: boolean;
   private changeTrackingOptions?: object;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor(config: t.FirecrawlScraperConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.FIRECRAWL_API_KEY ?? '';
@@ -61,6 +63,8 @@ export class FirecrawlScraper implements t.BaseScraper {
     this.location = config.location;
     this.onlyMainContent = config.onlyMainContent;
     this.changeTrackingOptions = config.changeTrackingOptions;
+    this.httpAgent = config.httpAgent;
+    this.httpsAgent = config.httpsAgent;
 
     if (!this.apiKey) {
       this.logger.warn('FIRECRAWL_API_KEY is not set. Scraping will not work.');
@@ -121,6 +125,8 @@ export class FirecrawlScraper implements t.BaseScraper {
           Authorization: `Bearer ${this.apiKey}`,
         },
         timeout: this.timeout,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
       });
 
       return [url, response.data];

--- a/src/tools/search/http-agent.test.ts
+++ b/src/tools/search/http-agent.test.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
+import { createFirecrawlScraper } from './firecrawl';
+import { createReranker } from './rerankers';
+import { createCrwAPI } from './crw-search';
+import { createSearchAPI } from './search';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const httpAgent = new HttpAgent();
+const httpsAgent = new HttpsAgent();
+
+describe('injected http(s) agent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('passes both agents to the firecrawl scraper request config', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { markdown: 'x' } },
+    });
+
+    const scraper = createFirecrawlScraper({
+      apiKey: 'test-key',
+      httpAgent,
+      httpsAgent,
+    });
+    await scraper.scrapeUrl('https://example.com');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ httpAgent, httpsAgent })
+    );
+  });
+
+  it('omits agents from the firecrawl request config when none are provided', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { markdown: 'x' } },
+    });
+
+    const scraper = createFirecrawlScraper({ apiKey: 'test-key' });
+    await scraper.scrapeUrl('https://example.com');
+
+    const requestConfig = mockedAxios.post.mock.calls[0][2];
+    expect(requestConfig?.httpAgent).toBeUndefined();
+    expect(requestConfig?.httpsAgent).toBeUndefined();
+  });
+
+  it('passes both agents to the Jina reranker request config', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { results: [] } });
+
+    const reranker = createReranker({
+      rerankerType: 'jina',
+      jinaApiKey: 'test-key',
+      httpAgent,
+      httpsAgent,
+    });
+    await reranker?.rerank('query', ['a', 'b'], 2);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ httpAgent, httpsAgent })
+    );
+  });
+
+  it('passes agents supplied through the crw search options bag', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { success: true, data: { web: [] } },
+    });
+
+    const api = createCrwAPI('test-key', undefined, { httpAgent, httpsAgent });
+    await api.getSources({ query: 'query' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ httpAgent, httpsAgent })
+    );
+  });
+
+  it('threads agents from the tool config into the serper search request', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { organic: [] } });
+
+    const api = createSearchAPI({
+      searchProvider: 'serper',
+      serperApiKey: 'test-key',
+      httpAgent,
+      httpsAgent,
+    });
+    await api.getSources({ query: 'query' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ httpAgent, httpsAgent })
+    );
+  });
+
+  it('threads agents from the tool config into the searxng search request', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { results: [] } });
+
+    const api = createSearchAPI({
+      searchProvider: 'searxng',
+      searxngInstanceUrl: 'https://searxng.example.com',
+      httpAgent,
+      httpsAgent,
+    });
+    await api.getSources({ query: 'query' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ httpAgent, httpsAgent })
+    );
+  });
+
+  it('omits agents from the serper search request when none are provided', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { organic: [] } });
+
+    const api = createSearchAPI({
+      searchProvider: 'serper',
+      serperApiKey: 'test-key',
+    });
+    await api.getSources({ query: 'query' });
+
+    const requestConfig = mockedAxios.post.mock.calls[0][2];
+    expect(requestConfig?.httpAgent).toBeUndefined();
+    expect(requestConfig?.httpsAgent).toBeUndefined();
+  });
+});

--- a/src/tools/search/keenable-scraper.ts
+++ b/src/tools/search/keenable-scraper.ts
@@ -15,6 +15,8 @@ export class KeenableScraper implements t.BaseScraper {
   private timeout: number;
   private attributionTitle: string;
   private logger: t.Logger;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor(config: t.KeenableScraperConfig = {}) {
     const resolvedKey = config.apiKey ?? process.env.KEENABLE_API_KEY;
@@ -28,6 +30,8 @@ export class KeenableScraper implements t.BaseScraper {
         : KEENABLE_FETCH_PUBLIC_URL);
     this.timeout = config.timeout ?? DEFAULT_KEENABLE_SCRAPE_TIMEOUT;
     this.attributionTitle = config.attributionTitle ?? 'LibreChat';
+    this.httpAgent = config.httpAgent;
+    this.httpsAgent = config.httpsAgent;
     this.logger = config.logger || createDefaultLogger();
   }
 
@@ -57,6 +61,8 @@ export class KeenableScraper implements t.BaseScraper {
         params: { url },
         headers: this.buildHeaders(),
         timeout: options.timeout ?? this.timeout,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
       });
 
       const data = response.data;

--- a/src/tools/search/keenable-search.ts
+++ b/src/tools/search/keenable-search.ts
@@ -65,7 +65,12 @@ export const createKeenableAPI = (
       const response = await axios.post<t.KeenableSearchResponse>(
         resolvedUrl,
         payload,
-        { headers, timeout }
+        {
+          headers,
+          timeout,
+          httpAgent: options?.httpAgent,
+          httpsAgent: options?.httpsAgent,
+        }
       );
 
       const maxResults = Math.min(

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -42,22 +42,28 @@ export abstract class BaseReranker {
 export class JinaReranker extends BaseReranker {
   private apiUrl: string;
   private timeout: number;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor({
     apiKey = process.env.JINA_API_KEY,
     apiUrl = getDefaultJinaApiUrl(),
     timeout = DEFAULT_RERANKER_TIMEOUT,
     logger,
+    httpAgent,
+    httpsAgent,
   }: {
     apiKey?: string;
     apiUrl?: string;
     timeout?: number;
     logger?: t.Logger;
-  }) {
+  } & t.HttpAgentConfig) {
     super(logger);
     this.apiKey = apiKey;
     this.apiUrl = apiUrl;
     this.timeout = timeout;
+    this.httpAgent = httpAgent;
+    this.httpsAgent = httpsAgent;
   }
 
   async rerank(
@@ -92,6 +98,8 @@ export class JinaReranker extends BaseReranker {
             Authorization: `Bearer ${this.apiKey}`,
           },
           timeout: this.timeout,
+          httpAgent: this.httpAgent,
+          httpsAgent: this.httpsAgent,
         }
       );
 
@@ -135,19 +143,25 @@ export class JinaReranker extends BaseReranker {
 
 export class CohereReranker extends BaseReranker {
   private timeout: number;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor({
     apiKey = process.env.COHERE_API_KEY,
     timeout = DEFAULT_RERANKER_TIMEOUT,
     logger,
+    httpAgent,
+    httpsAgent,
   }: {
     apiKey?: string;
     timeout?: number;
     logger?: t.Logger;
-  }) {
+  } & t.HttpAgentConfig) {
     super(logger);
     this.apiKey = apiKey;
     this.timeout = timeout;
+    this.httpAgent = httpAgent;
+    this.httpsAgent = httpsAgent;
   }
 
   async rerank(
@@ -179,6 +193,8 @@ export class CohereReranker extends BaseReranker {
             Authorization: `Bearer ${this.apiKey}`,
           },
           timeout: this.timeout,
+          httpAgent: this.httpAgent,
+          httpsAgent: this.httpsAgent,
         }
       );
 
@@ -231,14 +247,16 @@ export class InfinityReranker extends BaseReranker {
 /**
  * Creates the appropriate reranker based on type and configuration
  */
-export const createReranker = (config: {
-  rerankerType: t.RerankerType;
-  jinaApiKey?: string;
-  jinaApiUrl?: string;
-  cohereApiKey?: string;
-  rerankerTimeout?: number;
-  logger?: t.Logger;
-}): BaseReranker | undefined => {
+export const createReranker = (
+  config: {
+    rerankerType: t.RerankerType;
+    jinaApiKey?: string;
+    jinaApiUrl?: string;
+    cohereApiKey?: string;
+    rerankerTimeout?: number;
+    logger?: t.Logger;
+  } & t.HttpAgentConfig
+): BaseReranker | undefined => {
   const {
     rerankerType,
     jinaApiKey,
@@ -246,6 +264,8 @@ export const createReranker = (config: {
     cohereApiKey,
     rerankerTimeout,
     logger,
+    httpAgent,
+    httpsAgent,
   } = config;
 
   // Create a default logger if none is provided
@@ -258,12 +278,16 @@ export const createReranker = (config: {
       apiUrl: jinaApiUrl,
       timeout: rerankerTimeout,
       logger: defaultLogger,
+      httpAgent,
+      httpsAgent,
     });
   case 'cohere':
     return new CohereReranker({
       apiKey: cohereApiKey,
       timeout: rerankerTimeout,
       logger: defaultLogger,
+      httpAgent,
+      httpsAgent,
     });
   case 'infinity':
     return new InfinityReranker(defaultLogger);
@@ -279,6 +303,8 @@ export const createReranker = (config: {
       apiUrl: jinaApiUrl,
       timeout: rerankerTimeout,
       logger: defaultLogger,
+      httpAgent,
+      httpsAgent,
     });
   }
 };

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -185,7 +185,8 @@ const getHighlights = async ({
 };
 
 const createSerperAPI = (
-  apiKey?: string
+  apiKey?: string,
+  agents?: t.HttpAgentConfig
 ): {
   getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
 } => {
@@ -251,6 +252,8 @@ const createSerperAPI = (
             'Content-Type': 'application/json',
           },
           timeout: config.timeout,
+          httpAgent: agents?.httpAgent,
+          httpsAgent: agents?.httpsAgent,
         }
       );
 
@@ -280,7 +283,8 @@ const createSerperAPI = (
 
 const createSearXNGAPI = (
   instanceUrl?: string,
-  apiKey?: string
+  apiKey?: string,
+  agents?: t.HttpAgentConfig
 ): {
   getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
 } => {
@@ -349,6 +353,8 @@ const createSearXNGAPI = (
         headers,
         params,
         timeout: config.timeout,
+        httpAgent: agents?.httpAgent,
+        httpsAgent: agents?.httpsAgent,
       });
 
       const data = response.data;
@@ -493,22 +499,34 @@ export const createSearchAPI = (
     crwApiKey,
     crwApiUrl,
     crwSearchOptions,
+    httpAgent,
+    httpsAgent,
   } = config;
 
+  const agents: t.HttpAgentConfig = { httpAgent, httpsAgent };
+
   if (searchProvider.toLowerCase() === 'serper') {
-    return createSerperAPI(serperApiKey);
+    return createSerperAPI(serperApiKey, agents);
   } else if (searchProvider.toLowerCase() === 'searxng') {
-    return createSearXNGAPI(searxngInstanceUrl, searxngApiKey);
+    return createSearXNGAPI(searxngInstanceUrl, searxngApiKey, agents);
   } else if (searchProvider.toLowerCase() === 'tavily') {
-    return createTavilyAPI(tavilyApiKey, tavilySearchUrl, tavilySearchOptions);
+    return createTavilyAPI(tavilyApiKey, tavilySearchUrl, {
+      ...tavilySearchOptions,
+      httpAgent,
+      httpsAgent,
+    });
   } else if (searchProvider.toLowerCase() === 'keenable') {
-    return createKeenableAPI(
-      keenableApiKey,
-      keenableApiUrl,
-      keenableSearchOptions
-    );
+    return createKeenableAPI(keenableApiKey, keenableApiUrl, {
+      ...keenableSearchOptions,
+      httpAgent,
+      httpsAgent,
+    });
   } else if (searchProvider.toLowerCase() === 'crw') {
-    return createCrwAPI(crwApiKey, crwApiUrl, crwSearchOptions);
+    return createCrwAPI(crwApiKey, crwApiUrl, {
+      ...crwSearchOptions,
+      httpAgent,
+      httpsAgent,
+    });
   } else {
     throw new Error(
       `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', 'keenable', or 'crw'`

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -512,20 +512,20 @@ export const createSearchAPI = (
   } else if (searchProvider.toLowerCase() === 'tavily') {
     return createTavilyAPI(tavilyApiKey, tavilySearchUrl, {
       ...tavilySearchOptions,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? tavilySearchOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? tavilySearchOptions?.httpsAgent,
     });
   } else if (searchProvider.toLowerCase() === 'keenable') {
     return createKeenableAPI(keenableApiKey, keenableApiUrl, {
       ...keenableSearchOptions,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? keenableSearchOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? keenableSearchOptions?.httpsAgent,
     });
   } else if (searchProvider.toLowerCase() === 'crw') {
     return createCrwAPI(crwApiKey, crwApiUrl, {
       ...crwSearchOptions,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? crwSearchOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? crwSearchOptions?.httpsAgent,
     });
   } else {
     throw new Error(

--- a/src/tools/search/serper-scraper.ts
+++ b/src/tools/search/serper-scraper.ts
@@ -33,6 +33,8 @@ export class SerperScraper implements t.BaseScraper {
   private timeout: number;
   private logger: t.Logger;
   private includeMarkdown: boolean;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor(config: t.SerperScraperConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.SERPER_API_KEY ?? '';
@@ -44,6 +46,8 @@ export class SerperScraper implements t.BaseScraper {
 
     this.timeout = config.timeout ?? 7500;
     this.includeMarkdown = config.includeMarkdown ?? true;
+    this.httpAgent = config.httpAgent;
+    this.httpsAgent = config.httpsAgent;
 
     this.logger = config.logger || createDefaultLogger();
 
@@ -88,6 +92,8 @@ export class SerperScraper implements t.BaseScraper {
           'Content-Type': 'application/json',
         },
         timeout: options.timeout ?? this.timeout,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
       });
 
       return [url, { success: true, data: response.data }];

--- a/src/tools/search/tavily-scraper.ts
+++ b/src/tools/search/tavily-scraper.ts
@@ -45,6 +45,8 @@ export class TavilyScraper implements t.BaseScraper {
   private includeImages: boolean;
   private includeFavicon: boolean;
   private format: 'markdown' | 'text' | undefined;
+  private httpAgent?: t.HttpAgent;
+  private httpsAgent?: t.HttpsAgent;
 
   constructor(config: t.TavilyScraperConfig = {}) {
     this.apiKey = config.apiKey ?? process.env.TAVILY_API_KEY ?? '';
@@ -58,6 +60,8 @@ export class TavilyScraper implements t.BaseScraper {
     this.includeImages = config.includeImages ?? false;
     this.includeFavicon = config.includeFavicon ?? false;
     this.format = config.format;
+    this.httpAgent = config.httpAgent;
+    this.httpsAgent = config.httpsAgent;
     this.logger = config.logger || createDefaultLogger();
 
     if (!this.apiKey) {
@@ -140,6 +144,8 @@ export class TavilyScraper implements t.BaseScraper {
           'Content-Type': 'application/json',
         },
         timeout: effectiveTimeout,
+        httpAgent: this.httpAgent,
+        httpsAgent: this.httpsAgent,
       });
 
       const data = response.data;

--- a/src/tools/search/tavily-search.ts
+++ b/src/tools/search/tavily-search.ts
@@ -359,6 +359,8 @@ export const createTavilyAPI = (
             'Content-Type': 'application/json',
           },
           timeout: config.timeout,
+          httpAgent: options?.httpAgent,
+          httpsAgent: options?.httpsAgent,
         }
       );
 

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -452,6 +452,8 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    httpAgent,
+    httpsAgent,
     onSearchResults: _onSearchResults,
     onGetHighlights,
   } = config;
@@ -498,6 +500,8 @@ export const createSearchTool = (
     crwApiKey,
     crwApiUrl,
     crwSearchOptions,
+    httpAgent,
+    httpsAgent,
   });
 
   /** Create scraper based on scraperProvider */
@@ -508,6 +512,8 @@ export const createSearchTool = (
       ...serperScraperOptions,
       apiKey: serperApiKey,
       timeout: scraperTimeout ?? serperScraperOptions?.timeout,
+      httpAgent,
+      httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'tavily') {
@@ -519,6 +525,8 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
+      httpAgent,
+      httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'crw') {
@@ -528,6 +536,8 @@ export const createSearchTool = (
       apiUrl: crwScraperOptions?.apiUrl ?? crwApiUrl,
       timeout: scraperTimeout ?? crwScraperOptions?.timeout,
       formats: crwScraperOptions?.formats ?? ['markdown', 'rawHtml'],
+      httpAgent,
+      httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'keenable') {
@@ -538,6 +548,8 @@ export const createSearchTool = (
       attributionTitle:
         keenableScraperOptions?.attributionTitle ??
         keenableSearchOptions?.attributionTitle,
+      httpAgent,
+      httpsAgent,
       logger,
     });
   } else {
@@ -548,6 +560,8 @@ export const createSearchTool = (
       version: firecrawlVersion,
       timeout: scraperTimeout ?? firecrawlOptions?.timeout,
       formats: firecrawlOptions?.formats ?? ['markdown', 'rawHtml'],
+      httpAgent,
+      httpsAgent,
       logger,
     });
   }
@@ -558,6 +572,8 @@ export const createSearchTool = (
     jinaApiUrl,
     cohereApiKey,
     rerankerTimeout,
+    httpAgent,
+    httpsAgent,
     logger,
   });
 

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -512,8 +512,8 @@ export const createSearchTool = (
       ...serperScraperOptions,
       apiKey: serperApiKey,
       timeout: scraperTimeout ?? serperScraperOptions?.timeout,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? serperScraperOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? serperScraperOptions?.httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'tavily') {
@@ -525,8 +525,8 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? tavilyScraperOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? tavilyScraperOptions?.httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'crw') {
@@ -536,8 +536,8 @@ export const createSearchTool = (
       apiUrl: crwScraperOptions?.apiUrl ?? crwApiUrl,
       timeout: scraperTimeout ?? crwScraperOptions?.timeout,
       formats: crwScraperOptions?.formats ?? ['markdown', 'rawHtml'],
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? crwScraperOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? crwScraperOptions?.httpsAgent,
       logger,
     });
   } else if (scraperProvider === 'keenable') {
@@ -548,8 +548,8 @@ export const createSearchTool = (
       attributionTitle:
         keenableScraperOptions?.attributionTitle ??
         keenableSearchOptions?.attributionTitle,
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? keenableScraperOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? keenableScraperOptions?.httpsAgent,
       logger,
     });
   } else {
@@ -560,8 +560,8 @@ export const createSearchTool = (
       version: firecrawlVersion,
       timeout: scraperTimeout ?? firecrawlOptions?.timeout,
       formats: firecrawlOptions?.formats ?? ['markdown', 'rawHtml'],
-      httpAgent,
-      httpsAgent,
+      httpAgent: httpAgent ?? firecrawlOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? firecrawlOptions?.httpsAgent,
       logger,
     });
   }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -1,7 +1,16 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { Logger as WinstonLogger } from 'winston';
+import type { Agent as HttpsAgent } from 'https';
+import type { Agent as HttpAgent } from 'http';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
+
+export type { HttpAgent, HttpsAgent };
+
+export interface HttpAgentConfig {
+  httpAgent?: HttpAgent;
+  httpsAgent?: HttpsAgent;
+}
 
 export type SearchProvider =
   | 'serper'
@@ -81,7 +90,7 @@ export type TavilyTimeRangeInput =
   | 'm'
   | 'y';
 
-export interface TavilySearchOptions {
+export interface TavilySearchOptions extends HttpAgentConfig {
   searchDepth?: 'basic' | 'advanced' | 'fast' | 'ultra-fast';
   maxResults?: number;
   includeImages?: boolean;
@@ -116,7 +125,7 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
-export interface CrwSearchOptions {
+export interface CrwSearchOptions extends HttpAgentConfig {
   /** Max results to request (maps to `limit`; clamped 1..20). */
   maxResults?: number;
   /** Add 'images' to the sources array. */
@@ -164,7 +173,7 @@ export interface CrwSearchResponse {
   error_code?: string;
 }
 
-export interface SearchConfig {
+export interface SearchConfig extends HttpAgentConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
   searxngInstanceUrl?: string;
@@ -181,7 +190,7 @@ export interface SearchConfig {
   crwSearchOptions?: CrwSearchOptions;
 }
 
-export interface KeenableSearchOptions {
+export interface KeenableSearchOptions extends HttpAgentConfig {
   maxResults?: number;
   /** Restrict results to a single domain, e.g. "github.com". */
   site?: string;
@@ -208,7 +217,7 @@ export interface KeenableSearchResponse {
   results?: KeenableSearchResult[];
 }
 
-export interface KeenableScraperConfig {
+export interface KeenableScraperConfig extends HttpAgentConfig {
   apiKey?: string;
   /** Override the fetch endpoint base (default: public keyless, keyed when a
    * key is set). Env fallback: KEENABLE_FETCH_URL. */
@@ -221,7 +230,7 @@ export interface KeenableScraperConfig {
 
 export type KeenableScrapeOptions = Omit<
   KeenableScraperConfig,
-  'apiKey' | 'apiUrl' | 'logger'
+  'apiKey' | 'apiUrl' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
 /** Raw JSON shape returned by GET /v1/fetch{,/public}?url=... */
@@ -287,7 +296,7 @@ export interface FirecrawlConfig {
   firecrawlOptions?: FirecrawlScraperConfig;
 }
 
-export interface SerperScraperConfig {
+export interface SerperScraperConfig extends HttpAgentConfig {
   apiKey?: string;
   apiUrl?: string;
   timeout?: number;
@@ -295,7 +304,7 @@ export interface SerperScraperConfig {
   includeMarkdown?: boolean;
 }
 
-export interface TavilyScraperConfig {
+export interface TavilyScraperConfig extends HttpAgentConfig {
   apiKey?: string;
   apiUrl?: string;
   timeout?: number;
@@ -421,10 +430,10 @@ export interface BaseScraper {
 /** Firecrawl */
 export type FirecrawlScrapeOptions = Omit<
   FirecrawlScraperConfig,
-  'apiKey' | 'apiUrl' | 'version' | 'logger'
+  'apiKey' | 'apiUrl' | 'version' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
-export interface CrwScraperConfig {
+export interface CrwScraperConfig extends HttpAgentConfig {
   apiKey?: string;
   apiUrl?: string;
   formats?: string[];
@@ -444,17 +453,17 @@ export interface CrwScraperConfig {
 
 export type CrwScrapeOptions = Omit<
   CrwScraperConfig,
-  'apiKey' | 'apiUrl' | 'logger'
+  'apiKey' | 'apiUrl' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
 export type SerperScrapeOptions = Omit<
   SerperScraperConfig,
-  'apiKey' | 'apiUrl' | 'logger'
+  'apiKey' | 'apiUrl' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
 export type TavilyScrapeOptions = Omit<
   TavilyScraperConfig,
-  'apiKey' | 'apiUrl' | 'logger'
+  'apiKey' | 'apiUrl' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
 export interface TavilyExtractPayload {
@@ -620,7 +629,7 @@ export interface TavilyExtractResult {
   error?: string;
 }
 
-export interface FirecrawlScraperConfig {
+export interface FirecrawlScraperConfig extends HttpAgentConfig {
   apiKey?: string;
   apiUrl?: string;
   version?: string;

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -12,6 +12,14 @@ export interface HttpAgentConfig {
   httpsAgent?: HttpsAgent;
 }
 
+/** Transport and credential fields shared by every provider scraper config. */
+export interface BaseSearchProviderConfig extends HttpAgentConfig {
+  apiKey?: string;
+  apiUrl?: string;
+  timeout?: number;
+  logger?: Logger;
+}
+
 export type SearchProvider =
   | 'serper'
   | 'searxng'
@@ -217,13 +225,10 @@ export interface KeenableSearchResponse {
   results?: KeenableSearchResult[];
 }
 
-export interface KeenableScraperConfig extends HttpAgentConfig {
-  apiKey?: string;
+export interface KeenableScraperConfig extends BaseSearchProviderConfig {
   /** Override the fetch endpoint base (default: public keyless, keyed when a
    * key is set). Env fallback: KEENABLE_FETCH_URL. */
   apiUrl?: string;
-  timeout?: number;
-  logger?: Logger;
   /** Sent as the X-Keenable-Title attribution header. Defaults to "LibreChat". */
   attributionTitle?: string;
 }
@@ -296,19 +301,11 @@ export interface FirecrawlConfig {
   firecrawlOptions?: FirecrawlScraperConfig;
 }
 
-export interface SerperScraperConfig extends HttpAgentConfig {
-  apiKey?: string;
-  apiUrl?: string;
-  timeout?: number;
-  logger?: Logger;
+export interface SerperScraperConfig extends BaseSearchProviderConfig {
   includeMarkdown?: boolean;
 }
 
-export interface TavilyScraperConfig extends HttpAgentConfig {
-  apiKey?: string;
-  apiUrl?: string;
-  timeout?: number;
-  logger?: Logger;
+export interface TavilyScraperConfig extends BaseSearchProviderConfig {
   extractDepth?: 'basic' | 'advanced';
   includeImages?: boolean;
   includeFavicon?: boolean;
@@ -433,12 +430,8 @@ export type FirecrawlScrapeOptions = Omit<
   'apiKey' | 'apiUrl' | 'version' | 'logger' | 'httpAgent' | 'httpsAgent'
 >;
 
-export interface CrwScraperConfig extends HttpAgentConfig {
-  apiKey?: string;
-  apiUrl?: string;
+export interface CrwScraperConfig extends BaseSearchProviderConfig {
   formats?: string[];
-  timeout?: number;
-  logger?: Logger;
   onlyMainContent?: boolean;
   includeTags?: string[];
   excludeTags?: string[];
@@ -629,13 +622,9 @@ export interface TavilyExtractResult {
   error?: string;
 }
 
-export interface FirecrawlScraperConfig extends HttpAgentConfig {
-  apiKey?: string;
-  apiUrl?: string;
+export interface FirecrawlScraperConfig extends BaseSearchProviderConfig {
   version?: string;
   formats?: string[];
-  timeout?: number;
-  logger?: Logger;
   includeTags?: string[];
   excludeTags?: string[];
   waitFor?: number;


### PR DESCRIPTION
## Summary

I add optional `httpAgent` and `httpsAgent` fields to the web-search tool config and apply them to every outbound request the search, scrape, and rerank clients make, so a host application can constrain outbound connection policy (connection pooling, egress rules, resolved-IP validation) on this traffic. It is opt-in and defaults to current behavior.

- Add `httpAgent`/`httpsAgent` to `SearchToolConfig` (`src/tools/search/types.ts`) and thread them through the per-provider factories in `tool.ts` and `search.ts` and the reranker in `rerankers.ts`.
- Apply both agents on every outbound axios call under `src/tools/search/`: firecrawl, serper, tavily (scraper and search), keenable (scraper and search), fastCRW (scraper and search), the serper and searxng search APIs, and the jina and cohere rerankers.
- Pass both agents on every call so a protocol-changing redirect still uses a caller-controlled agent, since `follow-redirects` selects the http or https agent per hop.
- Keep it fully backward compatible: both fields are optional and default to undefined, so with no agent supplied axios behaves exactly as before.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npm run build` (tsdown + tsc): clean.
- `npx jest src/tools/search`: 156 passed across 10 suites, including 7 new cases in `src/tools/search/http-agent.test.ts` that cover each threading shape (scraper config object, reranker config object, options-bag search factory, internal-config Serper POST and SearXNG GET) plus backward-compat guards asserting no agent is attached when the fields are omitted.
- `npx eslint "src/**/*.ts"`: clean.
