### PR TITLE
v3.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.10",
+      "version": "3.3.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## v3.3.11

Patch release:

- [🛡️ fix: Neutralize Preempted Responses References](https://github.com/danny-avila/agents/pull/376) — prevents interrupted OpenAI Responses turns from replaying unretained `rs_*` and provider-tool IDs, while preserving safe partial text, images, encrypted reasoning, and bounded server-tool results across native and fallback resumes

**Full Changelog**: https://github.com/danny-avila/agents/compare/v3.3.10...v3.3.11
