### PR TITLE
fix(tools): match proxy agent to the PROXY scheme and honour NO_PROXY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "okapibm25": "^1.4.1",
         "openai": "^6.46.0",
         "reo-census": "^1.2.9",
+        "socks-proxy-agent": "^8.0.5",
         "uuid": "^11.1.1"
       },
       "devDependencies": {
@@ -8391,6 +8392,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -11450,6 +11460,44 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "okapibm25": "^1.4.1",
     "openai": "^6.46.0",
     "reo-census": "^1.2.9",
+    "socks-proxy-agent": "^8.0.5",
     "uuid": "^11.1.1"
   },
   "peerDependencies": {

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -1,6 +1,5 @@
 import { config } from 'dotenv';
 import fetch, { RequestInit } from 'node-fetch';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
@@ -16,6 +15,7 @@ import {
   normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
 } from './CodeExecutor';
+import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
@@ -253,8 +253,9 @@ function createBashExecutionTool(
           body: JSON.stringify(postData),
         };
 
-        if (process.env.PROXY != null && process.env.PROXY !== '') {
-          fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+        const proxyAgent = resolveFetchProxyAgent(EXEC_ENDPOINT);
+        if (proxyAgent) {
+          fetchOptions.agent = proxyAgent;
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -1,10 +1,10 @@
 import { config } from 'dotenv';
 import fetch, { RequestInit } from 'node-fetch';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { appendCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
+import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { EnvVar, Constants } from '@/common';
 
@@ -426,8 +426,9 @@ function createCodeExecutionTool(
           body: JSON.stringify(postData),
         };
 
-        if (process.env.PROXY != null && process.env.PROXY !== '') {
-          fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+        const proxyAgent = resolveFetchProxyAgent(EXEC_ENDPOINT);
+        if (proxyAgent) {
+          fetchOptions.agent = proxyAgent;
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -1,7 +1,6 @@
 // src/tools/ProgrammaticToolCalling.ts
 import { config } from 'dotenv';
 import fetch, { RequestInit } from 'node-fetch';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { ProgrammaticToolCallingJsonSchema } from './ptcTimeout';
@@ -24,6 +23,7 @@ import {
   createCodeApiRunTimeoutSchema,
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
+import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
@@ -438,8 +438,9 @@ export async function fetchSessionFiles(
       },
     };
 
-    if (proxy != null && proxy !== '') {
-      fetchOptions.agent = new HttpsProxyAgent(proxy);
+    const proxyAgent = resolveFetchProxyAgent(filesEndpoint, proxy);
+    if (proxyAgent) {
+      fetchOptions.agent = proxyAgent;
     }
 
     const response = await fetch(filesEndpoint, fetchOptions);
@@ -491,8 +492,9 @@ export async function makeRequest(
       body: JSON.stringify(body),
     };
 
-    if (proxy != null && proxy !== '') {
-      fetchOptions.agent = new HttpsProxyAgent(proxy);
+    const proxyAgent = resolveFetchProxyAgent(endpoint, proxy);
+    if (proxyAgent) {
+      fetchOptions.agent = proxyAgent;
     }
 
     const response = await fetch(endpoint, fetchOptions);

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -21,7 +21,7 @@ function getBM25Function(): BM25Fn {
 
 const BM25 = getBM25Function();
 import fetch, { RequestInit } from 'node-fetch';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
@@ -1102,8 +1102,9 @@ ${mcpNote}${toolsListSection}
           body: JSON.stringify(postData),
         };
 
-        if (process.env.PROXY != null && process.env.PROXY !== '') {
-          fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+        const proxyAgent = resolveFetchProxyAgent(EXEC_ENDPOINT);
+        if (proxyAgent) {
+          fetchOptions.agent = proxyAgent;
         }
 
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './graph';
 export * from './llm';
 export * from './misc';
+export * from './proxy';
 export * from './handlers';
 export * from './run';
 export * from './tokens';

--- a/src/utils/proxy.test.ts
+++ b/src/utils/proxy.test.ts
@@ -1,0 +1,176 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import { resolveFetchProxyAgent, shouldBypassProxy } from './proxy';
+
+const CODE_ENDPOINT = 'http://codeapi:3112/v1/exec';
+
+describe('shouldBypassProxy', () => {
+  it('is false without a NO_PROXY list', () => {
+    expect(shouldBypassProxy(CODE_ENDPOINT, undefined)).toBe(false);
+    expect(shouldBypassProxy(CODE_ENDPOINT, '  ')).toBe(false);
+  });
+
+  it('matches a bare hostname', () => {
+    expect(shouldBypassProxy(CODE_ENDPOINT, 'codeapi')).toBe(true);
+    expect(shouldBypassProxy(CODE_ENDPOINT, 'other')).toBe(false);
+  });
+
+  it('accepts comma and whitespace separated lists', () => {
+    expect(
+      shouldBypassProxy(CODE_ENDPOINT, 'localhost,codeapi,127.0.0.1')
+    ).toBe(true);
+    expect(shouldBypassProxy(CODE_ENDPOINT, 'localhost codeapi')).toBe(true);
+  });
+
+  it('treats a leading dot as host-and-subdomains', () => {
+    expect(
+      shouldBypassProxy('http://codeapi.internal:3112/v1', '.internal')
+    ).toBe(true);
+    expect(shouldBypassProxy('http://internal:3112/v1', '.internal')).toBe(
+      true
+    );
+    expect(shouldBypassProxy('http://notinternal:3112/v1', '.internal')).toBe(
+      false
+    );
+  });
+
+  it('honours a port suffix only when it matches', () => {
+    expect(shouldBypassProxy(CODE_ENDPOINT, 'codeapi:3112')).toBe(true);
+    expect(shouldBypassProxy(CODE_ENDPOINT, 'codeapi:9999')).toBe(false);
+  });
+
+  it('defaults the port from the scheme when the URL omits it', () => {
+    expect(
+      shouldBypassProxy('https://api.example.com/v1', 'api.example.com:443')
+    ).toBe(true);
+    expect(
+      shouldBypassProxy('http://api.example.com/v1', 'api.example.com:80')
+    ).toBe(true);
+    expect(
+      shouldBypassProxy('https://api.example.com/v1', 'api.example.com:80')
+    ).toBe(false);
+  });
+
+  it('supports the wildcard entry', () => {
+    expect(shouldBypassProxy('https://anything.example.com', '*')).toBe(true);
+  });
+
+  it('does not claim a bypass for an unparsable target', () => {
+    expect(shouldBypassProxy('not a url', '*')).toBe(false);
+  });
+});
+
+describe('resolveFetchProxyAgent', () => {
+  const saved = { ...process.env };
+
+  afterEach(() => {
+    for (const key of ['PROXY', 'NO_PROXY', 'no_proxy']) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, saved);
+  });
+
+  function clearProxyEnv(): void {
+    for (const key of ['PROXY', 'NO_PROXY', 'no_proxy']) {
+      delete process.env[key];
+    }
+  }
+
+  it('returns undefined when no proxy is configured', () => {
+    clearProxyEnv();
+    expect(resolveFetchProxyAgent(CODE_ENDPOINT)).toBeUndefined();
+  });
+
+  /**
+   * The defect this module exists for: HttpsProxyAgent speaks HTTP CONNECT, so
+   * driving a socks5 proxy with it produces "Proxy connection ended before
+   * receiving CONNECT response" rather than a working tunnel.
+   */
+  it('uses a SOCKS agent for socks schemes', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'socks5://127.0.0.1:1080';
+
+    const agent = resolveFetchProxyAgent('https://api.example.com/v1');
+
+    expect(agent).toBeInstanceOf(SocksProxyAgent);
+    expect(agent).not.toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it.each(['socks://host:1080', 'socks4://host:1080', 'socks5h://host:1080'])(
+    'recognises %s as SOCKS',
+    (proxy) => {
+      clearProxyEnv();
+      process.env.PROXY = proxy;
+      expect(
+        resolveFetchProxyAgent('https://api.example.com/v1')
+      ).toBeInstanceOf(SocksProxyAgent);
+    }
+  );
+
+  it('uses an HTTP agent for http schemes', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'http://proxy.internal:3128';
+
+    expect(resolveFetchProxyAgent('https://api.example.com/v1')).toBeInstanceOf(
+      HttpsProxyAgent
+    );
+  });
+
+  /**
+   * Code execution targets an internal endpoint. Without NO_PROXY support the
+   * feature is unusable for anyone with PROXY set, because the internal host is
+   * not reachable through an external proxy and there is no way to opt out.
+   */
+  it('bypasses the proxy for a NO_PROXY host', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'socks5://127.0.0.1:1080';
+    process.env.NO_PROXY = 'codeapi,localhost';
+
+    expect(resolveFetchProxyAgent(CODE_ENDPOINT)).toBeUndefined();
+  });
+
+  it('still proxies hosts outside NO_PROXY', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'socks5://127.0.0.1:1080';
+    process.env.NO_PROXY = 'codeapi';
+
+    expect(resolveFetchProxyAgent('https://api.example.com/v1')).toBeInstanceOf(
+      SocksProxyAgent
+    );
+  });
+
+  it('honours the lowercase no_proxy spelling', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'http://proxy.internal:3128';
+    process.env.no_proxy = 'codeapi';
+
+    expect(resolveFetchProxyAgent(CODE_ENDPOINT)).toBeUndefined();
+  });
+
+  it('prefers an explicit proxy argument over the environment', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'http://from-env:3128';
+
+    expect(
+      resolveFetchProxyAgent(
+        'https://api.example.com/v1',
+        'socks5://explicit:1080'
+      )
+    ).toBeInstanceOf(SocksProxyAgent);
+  });
+
+  /**
+   * An empty explicit proxy means "no proxy for this call", not "fall back to
+   * the environment" — matching the original `proxy != null && proxy !== ''`
+   * guard, where callers resolve `initParams.proxy ?? process.env.PROXY`
+   * themselves and an empty result disables proxying.
+   */
+  it('treats an empty explicit proxy as no proxy rather than falling back to env', () => {
+    clearProxyEnv();
+    process.env.PROXY = 'http://from-env:3128';
+
+    expect(
+      resolveFetchProxyAgent('https://api.example.com/v1', '')
+    ).toBeUndefined();
+  });
+});

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,93 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import type { RequestInit } from 'node-fetch';
+
+type FetchAgent = NonNullable<RequestInit['agent']>;
+
+/**
+ * Whether `targetUrl` is excluded from proxying by a NO_PROXY list.
+ *
+ * Follows the de facto convention: comma or whitespace separated entries, an
+ * optional leading dot meaning "this host and its subdomains", an optional
+ * `:port` suffix that must match when present, and `*` meaning "bypass
+ * everything".
+ */
+export function shouldBypassProxy(
+  targetUrl: string,
+  noProxy?: string
+): boolean {
+  const list = (noProxy ?? '').trim();
+  if (list === '') {
+    return false;
+  }
+
+  let hostname: string;
+  let port: string;
+  try {
+    const url = new URL(targetUrl);
+    hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    port = url.port || (url.protocol === 'https:' ? '443' : '80');
+  } catch {
+    /* An unparsable target tells us nothing, so do not claim a bypass. */
+    return false;
+  }
+
+  return list
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .some((raw) => {
+      if (raw === '*') {
+        return true;
+      }
+      const match = /^(.*?)(?::(\d+))?$/.exec(raw);
+      if (!match) {
+        return false;
+      }
+      const entryHost = (match[1] ?? '').replace(/^\./, '').toLowerCase();
+      const entryPort = match[2];
+      if (entryHost === '') {
+        return false;
+      }
+      if (entryPort != null && entryPort !== port) {
+        return false;
+      }
+      return hostname === entryHost || hostname.endsWith(`.${entryHost}`);
+    });
+}
+
+/**
+ * Build the proxy agent for a `node-fetch` request, or `undefined` when the
+ * request should go direct.
+ *
+ * Two rules that a bare `new HttpsProxyAgent(process.env.PROXY)` gets wrong:
+ *
+ *  - The agent must match the proxy scheme. `HttpsProxyAgent` speaks HTTP
+ *    CONNECT; handing it a `socks5://` URL produces a request the proxy never
+ *    answers in that protocol, surfacing as "Proxy connection ended before
+ *    receiving CONNECT response".
+ *  - NO_PROXY has to be honoured. Code execution targets an internal endpoint
+ *    (`http://codeapi:3112`), and forcing that through an external proxy makes
+ *    the whole feature unusable for anyone who has PROXY set, with no way to
+ *    opt out.
+ *
+ * @param targetUrl Absolute URL the request is going to.
+ * @param proxyUrl Explicit proxy; falls back to the PROXY environment variable.
+ */
+export function resolveFetchProxyAgent(
+  targetUrl: string,
+  proxyUrl?: string
+): FetchAgent | undefined {
+  const proxy = (proxyUrl ?? process.env.PROXY ?? '').trim();
+  if (proxy === '') {
+    return undefined;
+  }
+
+  const noProxy = process.env.NO_PROXY ?? process.env.no_proxy;
+  if (shouldBypassProxy(targetUrl, noProxy)) {
+    return undefined;
+  }
+
+  return /^socks/i.test(proxy)
+    ? (new SocksProxyAgent(proxy) as unknown as FetchAgent)
+    : (new HttpsProxyAgent(proxy) as unknown as FetchAgent);
+}


### PR DESCRIPTION
fix(tools): match proxy agent to the PROXY scheme and honour NO_PROXY
The code-execution tools applied HttpsProxyAgent to whatever PROXY held:

    if (process.env.PROXY != null && process.env.PROXY !== '') {
      fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
    }

Two consequences.

A socks5:// proxy is driven by an HTTP-CONNECT agent. The proxy never
answers in that protocol, so every execution fails with "Proxy connection
ended before receiving CONNECT response".

NO_PROXY is never read. Code execution targets an internal endpoint —
http://codeapi:3112 — and forcing that through an external proxy makes
the feature unusable for anyone who has PROXY set, with no way to opt out.

Adds src/utils/proxy.ts:

- resolveFetchProxyAgent(targetUrl, proxyUrl?) picks SocksProxyAgent for
  socks schemes and HttpsProxyAgent otherwise, and returns undefined when
  the target is excluded by NO_PROXY.
- shouldBypassProxy() implements the usual NO_PROXY conventions: comma or
  whitespace separated entries, a leading dot meaning host-and-subdomains,
  an optional :port that must match, and * for everything.

Applied at all five call sites across BashExecutor, CodeExecutor,
ToolSearch and ProgrammaticToolCalling. The last passes an explicit proxy
rather than reading the environment, so the helper accepts one and treats
an empty string as "no proxy", preserving the previous
`proxy != null && proxy !== ''` semantics.

socks-proxy-agent is added to dependencies — it was not declared and
resolved only incidentally through hoisting in consumer trees, so a clean
install would have failed.

Verified: tsc --noEmit clean; 19 new tests covering scheme selection and
NO_PROXY forms. Failing suites under src/tools/__tests__ are identical
before and after the change (same six test names on a stashed tree).