### PR TITLE
🩹 fix: Guard Optional input_tokens_details in Responses Cache-Write Extraction

### DIFF
--- a/src/llm/openai/cacheWriteTokens.test.ts
+++ b/src/llm/openai/cacheWriteTokens.test.ts
@@ -1,0 +1,112 @@
+import { AIMessage } from '@langchain/core/messages';
+import type { OpenAIClient } from '@langchain/openai';
+
+import {
+  getCacheWriteTokens,
+  attachCacheWriteUsage,
+  attachCacheWriteMetadata,
+} from './index';
+
+/**
+ * Regression coverage for a crash reported against OpenAI-compatible
+ * third-party servers (e.g. mlx_vlm.server) whose `/v1/responses` usage
+ * payload omits `input_tokens_details` entirely — a shape the OpenAI API
+ * itself always populates, but which `ResponsesUsageWithCacheWrite`
+ * declares optional. Reading `.cache_write_tokens` off that missing object
+ * without a second `?.` threw "Cannot read properties of undefined
+ * (reading 'cache_write_tokens')" on every completion from such a server.
+ */
+describe('cache write token extraction (Responses API)', () => {
+  describe('getCacheWriteTokens', () => {
+    it('returns undefined without throwing when usage has no input_tokens_details', () => {
+      const message = new AIMessage({
+        content: 'hi',
+        response_metadata: {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            total_tokens: 12,
+            // input_tokens_details intentionally omitted, mirroring a
+            // minimal OpenAI-compatible server's usage payload.
+          },
+        },
+      });
+
+      expect(() => getCacheWriteTokens(message)).not.toThrow();
+      expect(getCacheWriteTokens(message)).toBeUndefined();
+    });
+
+    it('returns undefined without throwing when there is no usage at all', () => {
+      const message = new AIMessage({
+        content: 'hi',
+        response_metadata: {},
+      });
+
+      expect(() => getCacheWriteTokens(message)).not.toThrow();
+      expect(getCacheWriteTokens(message)).toBeUndefined();
+    });
+
+    it('still reports cache_write_tokens when the field is present', () => {
+      const message = new AIMessage({
+        content: 'hi',
+        response_metadata: {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 2,
+            total_tokens: 12,
+            input_tokens_details: { cache_write_tokens: 5 },
+          },
+        },
+      });
+
+      expect(getCacheWriteTokens(message)).toBe(5);
+    });
+
+    it('falls back to the serialized metadata key when usage is absent', () => {
+      const message = new AIMessage({
+        content: 'hi',
+        response_metadata: {
+          metadata: { __librechat_cache_write_tokens: '7' },
+        },
+      });
+
+      expect(getCacheWriteTokens(message)).toBe(7);
+    });
+  });
+
+  describe('attachCacheWriteUsage', () => {
+    it('leaves usage_metadata untouched without throwing when input_tokens_details is missing', () => {
+      const message = new AIMessage({
+        content: 'hi',
+        response_metadata: {
+          usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        },
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 2,
+          total_tokens: 12,
+        },
+      });
+
+      expect(() => attachCacheWriteUsage(message)).not.toThrow();
+      expect(message.usage_metadata?.input_token_details).toBeUndefined();
+    });
+  });
+
+  describe('attachCacheWriteMetadata', () => {
+    it('returns the response unmodified without throwing when input_tokens_details is missing', () => {
+      const response = {
+        usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+      } as OpenAIClient.Responses.Response;
+
+      expect(() => attachCacheWriteMetadata(response)).not.toThrow();
+      expect(attachCacheWriteMetadata(response)).toBe(response);
+    });
+
+    it('returns the response unmodified without throwing when usage is missing entirely', () => {
+      const response = {} as OpenAIClient.Responses.Response;
+
+      expect(() => attachCacheWriteMetadata(response)).not.toThrow();
+    });
+  });
+});

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -245,7 +245,15 @@ type CacheableResponsePart = (
 ) & {
   prompt_cache_breakpoint?: { mode: 'explicit' };
 };
-type ResponsesUsageWithCacheWrite = OpenAIClient.Responses.ResponseUsage & {
+// `Omit` before re-adding `input_tokens_details` as optional matters: the SDK's own
+// `ResponseUsage` declares it required (true for OpenAI itself), so a plain intersection
+// would keep it required in the merged type despite the `?:` here — masking, at the type
+// level, that OpenAI-*compatible* servers (e.g. mlx_vlm.server) may omit it entirely.
+// Mirrors `CompletionUsageWithCacheWrite`'s handling of the analogous Completions API field.
+type ResponsesUsageWithCacheWrite = Omit<
+  OpenAIClient.Responses.ResponseUsage,
+  'input_tokens_details'
+> & {
   input_tokens_details?: OpenAIClient.Responses.ResponseUsage['input_tokens_details'] & {
     cache_write_tokens?: number;
   };
@@ -509,13 +517,13 @@ export function shouldIncludeEncryptedReasoning(
   );
 }
 
-function getCacheWriteTokens(message: BaseMessage): number | undefined {
+export function getCacheWriteTokens(message: BaseMessage): number | undefined {
   const responseMetadata = message.response_metadata as {
     usage?: ResponsesUsageWithCacheWrite;
     metadata?: Record<string, string>;
   };
   const reported =
-    responseMetadata.usage?.input_tokens_details.cache_write_tokens;
+    responseMetadata.usage?.input_tokens_details?.cache_write_tokens;
   if (reported != null) {
     return reported;
   }
@@ -527,7 +535,7 @@ function getCacheWriteTokens(message: BaseMessage): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function attachCacheWriteUsage(message: BaseMessage): void {
+export function attachCacheWriteUsage(message: BaseMessage): void {
   const cacheWriteTokens = getCacheWriteTokens(message);
   if (
     cacheWriteTokens == null ||
@@ -554,11 +562,11 @@ function attachCacheWriteUsage(message: BaseMessage): void {
   };
 }
 
-function attachCacheWriteMetadata(
+export function attachCacheWriteMetadata(
   response: OpenAIClient.Responses.Response
 ): OpenAIClient.Responses.Response {
   const usage = response.usage as ResponsesUsageWithCacheWrite | undefined;
-  const cacheWriteTokens = usage?.input_tokens_details.cache_write_tokens;
+  const cacheWriteTokens = usage?.input_tokens_details?.cache_write_tokens;
   if (cacheWriteTokens == null) {
     return response;
   }


### PR DESCRIPTION
## Summary

`getCacheWriteTokens` / `attachCacheWriteMetadata` in `src/llm/openai/index.ts` read `usage.input_tokens_details.cache_write_tokens` with only the outer `?.` (on `usage`) — safe against OpenAI itself, which always populates `input_tokens_details`, but **any OpenAI-compatible server that omits it** throws:

```
TypeError: Cannot read properties of undefined (reading 'cache_write_tokens')
```

on every single completion. Hit this running LibreChat against a local `mlx_vlm.server` backend (any OpenAI-compatible server without OpenAI's exact `usage` shape hits the same crash) — every agent response failed with `[api/server/controllers/agents/client.js #sendCompletion] Unhandled error type Cannot read properties of undefined (reading 'cache_write_tokens')`.

## Root cause

`ResponsesUsageWithCacheWrite` is a plain intersection with the SDK's `ResponseUsage` type:

```ts
type ResponsesUsageWithCacheWrite = OpenAIClient.Responses.ResponseUsage & {
  input_tokens_details?: OpenAIClient.Responses.ResponseUsage['input_tokens_details'] & {
    cache_write_tokens?: number;
  };
};
```

The SDK declares `input_tokens_details` **required** (true for OpenAI itself), so the intersection keeps it required in the merged type despite the local `?:` redeclaration — TypeScript intersections don't let a narrower member relax a wider one's requiredness. This is also why a bare `?.` fix trips `@typescript-eslint/no-unnecessary-condition`: the type system is (internally-consistently, if incorrectly for this use case) certain the field can't be missing.

## Fix

- Added the missing `?.` before `.cache_write_tokens` in both `getCacheWriteTokens` and `attachCacheWriteMetadata`.
- Switched `ResponsesUsageWithCacheWrite` to the same `Omit`-then-redeclare pattern this file already uses for `CompletionUsageWithCacheWrite` (the analogous Completions API field, see `deepseek.test.ts`), so the type honestly reflects that the field is optional for non-OpenAI backends — this resolves the lint warning at its actual source instead of just silencing it.
- Exported the three helper functions (previously module-private) for direct unit test coverage.

## Test plan
- [x] New `src/llm/openai/cacheWriteTokens.test.ts`: 7 cases covering missing `input_tokens_details`, missing `usage` entirely, the field-present success path, and the serialized-metadata fallback, across all three functions.
- [x] Verified the new tests fail with the original `TypeError` when the fix is reverted (confirms they actually catch the regression, not just exercise the code path).
- [x] `npx jest src/llm/openai/` — 171/171 pass, no regressions.
- [x] `npx eslint src/llm/openai/index.ts src/llm/openai/cacheWriteTokens.test.ts` — clean, no warnings (the `no-unnecessary-condition` warning from the `?.`-only version of this fix is gone with the `Omit` type change).
- [x] `npx tsc --noEmit` — clean.