### PR TITLE
🚦 feat: Circuit-Break Runaway Streamed Tool-Call Arguments

### DIFF
--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -523,6 +523,57 @@ describe('eager args divergence (LibreChat#14371)', () => {
     expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 
+  it('drops eager dispatch when the run scope is replaced during tool-call handling', async () => {
+    const graph = createGraph({
+      runScope: Object.freeze({
+        epoch: 1,
+        controller: new AbortController(),
+      }),
+    } as Partial<StandardGraph>);
+    /** The handler passes its entry checks, then a full reset lands while
+     * handleToolCalls awaits the run-step dispatch. The event now belongs
+     * to a dead run; dispatching eagerly would compose the NEW run's live
+     * controller and config. */
+    const originalDispatch = graph.dispatchRunStep;
+    graph.dispatchRunStep = (async (
+      stepKey: string,
+      details: unknown
+    ): Promise<string> => {
+      const stepId = await (
+        originalDispatch as unknown as (
+          stepKey: string,
+          details: unknown
+        ) => Promise<string>
+      )(stepKey, details);
+      (graph as { runScope: unknown }).runScope = Object.freeze({
+        epoch: 2,
+        controller: new AbortController(),
+      });
+      return stepId;
+    }) as typeof graph.dispatchRunStep;
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await expect(
+      handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'db_query', args: { sql: 'SELECT 1;' } },
+            ],
+            response_metadata: { finish_reason: 'tool_calls' },
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      )
+    ).resolves.toBeUndefined();
+    expect(toolExecuteCalls).toHaveLength(0);
+  });
+
   it('does not prestart eager tools when the breaker trips during tool-call handling', async () => {
     const graph = createGraph();
     const trip = new StreamLimitExceededError({

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -38,6 +38,10 @@ import {
   BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import {
+  STREAM_LIMIT_EPOCH_KEY,
+  StreamLimitExceededError,
+} from '@/llm/streamLimits';
 import { GraphEvents, Providers, StepTypes } from '@/common';
 import { ChatModelStreamHandler } from '@/stream';
 import { ToolNode } from '@/tools/ToolNode';
@@ -488,6 +492,83 @@ describe('eager args divergence (LibreChat#14371)', () => {
       name: 'db_query',
       args: { sql: 'SELECT 1;' },
     });
+  });
+
+  it('does not prestart eager tools for stale-epoch events', async () => {
+    const graph = createGraph({ breakerEpoch: 5 } as Partial<StandardGraph>);
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = {
+      langgraph_node: 'agent',
+      [STREAM_LIMIT_EPOCH_KEY]: 4,
+    };
+
+    /** A final tool-call chunk from a failed run handled after resetValues
+     * advanced the epoch: dropped outright, so the dead run's call cannot
+     * dispatch a host tool into the run now using the live controller. */
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [{ id: 'call_1', name: 'db_query', args: { sql: 'SELECT 1;' } }],
+          response_metadata: { finish_reason: 'tool_calls' },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart eager tools when the breaker trips during tool-call handling', async () => {
+    const graph = createGraph();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const originalDispatch = graph.dispatchRunStep;
+    graph.dispatchRunStep = (async (
+      stepKey: string,
+      details: unknown
+    ): Promise<string> => {
+      const stepId = await (
+        originalDispatch as unknown as (
+          stepKey: string,
+          details: unknown
+        ) => Promise<string>
+      )(stepKey, details);
+      graph.breakerAbort.abort(trip);
+      return stepId;
+    }) as typeof graph.dispatchRunStep;
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    /** The trip lands while handleToolCalls awaits the run-step dispatch —
+     * after the queued-event guard already passed. The recheck before the
+     * eager path must stop the prestart. */
+    await expect(
+      handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'db_query', args: { sql: 'SELECT 1;' } },
+            ],
+            response_metadata: { finish_reason: 'tool_calls' },
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      )
+    ).rejects.toBe(trip);
+    expect(toolExecuteCalls).toHaveLength(0);
   });
 
   it('sends a breaker-composed abort signal with eager prestart requests', async () => {

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -59,6 +59,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
       configurable: { user_id: 'user_1' },
       metadata: { run_id: 'run_1' },
     },
+    breakerAbort: new AbortController(),
     eagerEventToolExecution: { enabled: true },
     eagerEventToolExecutions: new Map(),
     eagerEventToolUsageCount: eagerUsageCount,
@@ -487,6 +488,31 @@ describe('eager args divergence (LibreChat#14371)', () => {
       name: 'db_query',
       args: { sql: 'SELECT 1;' },
     });
+  });
+
+  it('sends a breaker-composed abort signal with eager prestart requests', async () => {
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks('call_1', 'db_query', [
+        '{"sql":"SELECT 1;"}',
+      ]),
+    });
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    const { signal } = toolExecuteCalls[0];
+    expect(signal).toBeDefined();
+    expect(signal?.aborted).toBe(false);
+
+    graph.breakerAbort.abort(new Error('stream limit breach'));
+    expect(signal?.aborted).toBe(true);
   });
 
   it('the retry path no longer loops: every round executes normally with canonical args', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -44,6 +44,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
       configurable: { user_id: 'user_1' },
       metadata: { run_id: 'run_1' },
     },
+    breakerAbort: new AbortController(),
     eagerEventToolExecution: { enabled: true },
     eagerEventToolExecutions: new Map(),
     eagerEventToolUsageCount: eagerUsageCount,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
   STREAM_LIMIT_REDISPATCH_KEY,
+  StreamLimitExceededError,
   enforceStreamLimitsForWireChunk,
   resolveGenerationKey,
   resolveStreamLimits,
@@ -995,6 +996,84 @@ describe('per-tool argument byte overrides', () => {
       limit: 1_000,
       toolName: 'create_file',
     });
+  });
+
+  it('stops queued events once the shared breaker has tripped', async () => {
+    const handler = new ChatModelStreamHandler();
+    const breakerAbort = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    breakerAbort.abort(trip);
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits(),
+      breakerAbort,
+    });
+
+    /** A sibling branch tripped the breaker while this event sat queued in
+     * streamEvents; the handler must rethrow instead of continuing into
+     * content handling or the eager-tool dispatch paths. */
+    await expect(
+      streamEvent({ handler, graph, chunk: { content: 'queued text' } })
+    ).rejects.toBe(trip);
+  });
+
+  it('treats empty tool-call ids as anonymous, keeping parallel calls apart', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    /** OpenAI-compatible adapters can emit index-less parallel calls whose
+     * ids are empty placeholders; a shared ':c:' identity would merge the
+     * two 60-byte calls into a phantom 120-byte one and falsely trip. */
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: '', args: 'x'.repeat(60) },
+            { id: '', args: 'x'.repeat(60) },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not hand a lone parsed call\'s override to multiple id-less chunks', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    /** Mixed event: two id-less raw chunks while only one call is parseable.
+     * Positional correlation is ambiguous here — naming both chunks
+     * 'create_file' would judge the unrelated 500-byte call against the
+     * higher override and bypass the global cap. */
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { args: 'x'.repeat(50), index: 0 },
+            { args: 'x'.repeat(500), index: 1 },
+          ],
+          tool_calls: [
+            { id: 'call_1', name: 'create_file', args: { content: 'x' } },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', limit: 100 });
   });
 
   it('prefers the id-correlated complete name over a raw name fragment', async () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -750,6 +750,53 @@ describe('per-tool argument byte overrides', () => {
     ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
   });
 
+  it('keeps charging a mutable chunk object re-yielded across emissions', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const reused: Record<string, unknown> = {
+      content: '',
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    };
+
+    await streamEvent({ handler, graph, chunk: reused });
+    reused.tool_call_chunks = [{ args: 'a'.repeat(40), index: 0 }];
+    await streamEvent({ handler, graph, chunk: reused });
+    reused.tool_call_chunks = [{ args: 'a', index: 0 }];
+
+    await expect(streamEvent({ handler, graph, chunk: reused })).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+    });
+  });
+
+  it('pairs producer and echo charges per emission for reused chunk objects', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const reused: Record<string, unknown> = {
+      content: '',
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    };
+
+    enforceStreamLimitsForWireChunk({ graph, metadata: {}, chunk: reused as never });
+    await streamEvent({ handler, graph, chunk: reused });
+    reused.tool_call_chunks = [{ args: 'a'.repeat(40), index: 0 }];
+    enforceStreamLimitsForWireChunk({ graph, metadata: {}, chunk: reused as never });
+    await streamEvent({ handler, graph, chunk: reused });
+    reused.tool_call_chunks = [{ args: 'a', index: 0 }];
+
+    let thrown: unknown;
+    try {
+      enforceStreamLimitsForWireChunk({ graph, metadata: {}, chunk: reused as never });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toMatchObject({ kind: 'tool_call_args', observed: 101 });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -997,6 +997,85 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('keeps an index 0 call and an id "0" call on separate budgets', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'a_tool', args: 'a'.repeat(60), index: 0 }],
+    });
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: '0', name: 'b_tool', args: 'b'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: '0', args: 'b'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'b_tool',
+    });
+  });
+
+  it('adopts an anonymous tally when a later delta adds only an index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'writer', args: 'a'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a'.repeat(41), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
+  it('names id-less raw chunks from a single parsed call so overrides apply', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ args: 'x'.repeat(500), index: 0 }],
+          tool_calls: [
+            { id: 'call_1', name: 'create_file', args: { content: 'x'.repeat(500) } },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@/tools/streamedToolCallSeals';
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  STREAM_LIMIT_REDISPATCH_KEY,
   resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
@@ -551,6 +552,101 @@ describe('per-tool argument byte overrides', () => {
       limit: 1_000,
       toolName: '__proto__',
     });
+  });
+
+  it('keeps charging a call whose later deltas omit both id and index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a'.repeat(60) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      observed: 120,
+      toolName: 'writer',
+    });
+  });
+
+  it('does not charge argument bytes for marked OpenRouter redispatches', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+    await streamEvent({
+      handler,
+      graph,
+      metadata: { [STREAM_LIMIT_REDISPATCH_KEY]: true },
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ args: 'a'.repeat(60), index: 0 }],
+      },
+    });
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ args: 'a'.repeat(40), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a', index: 0 }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
+  });
+
+  it('judges client tool chunks arriving with a server-tool result before the early return', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    (graph.getAgentContext as jest.Mock).mockReturnValue({
+      provider: Providers.ANTHROPIC,
+      reasoningKey: 'reasoning_content',
+      toolDefinitions: [],
+      graphTools: [],
+      agentId: 'agent_1',
+    });
+    await graph.dispatchRunStep('step-key', {
+      type: StepTypes.TOOL_CALLS,
+      tool_calls: [{ id: 'srvtoolu_1', name: 'web_search', args: {} }],
+    });
+    graph.toolCallStepIds.set('srvtoolu_1', 'step_1');
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: [
+            { type: 'web_search_tool_result', tool_use_id: 'srvtoolu_1', content: [] },
+          ],
+          tool_call_chunks: [
+            { id: 'call_big', name: 'side_effect', args: 'x'.repeat(200), index: 0 },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'side_effect' });
   });
 
   it('normalizes override entries like the global field', () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -865,6 +865,52 @@ describe('per-tool argument byte overrides', () => {
     ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
   });
 
+  it('judges parsed calls even when a raw chunk representation is present', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ id: 'call_1', name: 'side_effect', args: '', index: 0 }],
+          tool_calls: [
+            { id: 'call_1', name: 'side_effect', args: { payload: 'x'.repeat(200) } },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'side_effect' });
+  });
+
+  it('keeps one budget when a call drops its index but keeps its id', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', args: 'a'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1484,6 +1484,31 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('adopts the sole anonymous tally when a later nonzero index appears', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'writer', args: 'x'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(41), index: 1 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
   it('applies a late anonymous name before charging its lower override', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1154,6 +1154,60 @@ describe('per-tool argument byte overrides', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('judges invalid parsed tool calls that arrive without raw chunks', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          invalid_tool_calls: [
+            {
+              id: 'call_1',
+              name: 'side_effect',
+              args: 'x'.repeat(200),
+              error: 'Unparseable arguments',
+            },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      toolName: 'side_effect',
+    });
+  });
+
+  it('keeps one budget when an index-only call drops its index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -797,6 +797,74 @@ describe('per-tool argument byte overrides', () => {
     expect(thrown).toMatchObject({ kind: 'tool_call_args', observed: 101 });
   });
 
+  it('keeps parallel index-less calls on distinct budgets when one seals', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_a', name: 'a_tool', args: 'a'.repeat(60) }],
+    });
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_b', name: 'b_tool', args: 'b'.repeat(60) }],
+    });
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ id: 'call_a', args: '' }],
+        response_metadata: {
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', id: 'call_a' },
+        },
+      },
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'b'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'b_tool',
+    });
+  });
+
+  it('scopes charge credits per generation for shared chunk objects', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const shared: Record<string, unknown> = {
+      content: '',
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    };
+
+    await streamEvent({ handler, graph, chunk: shared, metadata: generation(1) });
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata: generation(2),
+      chunk: shared as never,
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a'.repeat(41), index: 0 }],
+        metadata: generation(2),
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1167,6 +1167,31 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('allocates nothing when overrides contain only zero-valued disables', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 0,
+        maxToolCallArgBytesByTool: { writer: 0 },
+      }),
+    });
+
+    /** `{ writer: 0 }` is a per-tool disable, not a limit — with the global
+     * cap off too, no argument limit can fire and accounting must not
+     * allocate. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'writer', args: 'x'.repeat(100_000), index: 0 },
+        ],
+      })
+    ).resolves.toBeUndefined();
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+    expect(graph.streamedToolCallArgTallies).toBeUndefined();
+  });
+
   it('allocates no charge bookkeeping when every guard is disabled', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({
@@ -1183,10 +1208,7 @@ describe('per-tool argument byte overrides', () => {
       })
     ).resolves.toBeUndefined();
     expect(graph.streamLimitChargeCredits).toBeUndefined();
-    expect(graph.streamedToolCallArgTallies ?? new Map()).toHaveProperty(
-      'size',
-      0
-    );
+    expect(graph.streamedToolCallArgTallies).toBeUndefined();
   });
 
   it('binds consumer trips to the event epoch, sparing a newer run', async () => {
@@ -1794,7 +1816,7 @@ describe('per-generation delta event circuit breaker', () => {
     });
 
     await emptyChunkEvent(2);
-    expect(graph.streamDeltaEventCounts.get('|agent|2|')).toBe(1);
+    expect(graph.streamDeltaEventCounts.get('|agent|2|')?.count).toBe(1);
   });
 
   it('never counts when left at the default (disabled)', async () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -688,6 +688,37 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('charges a chunk once when the handler echo wins the race', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const wireChunk = {
+      content: '',
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    };
+
+    await streamEvent({ handler, graph, chunk: wireChunk });
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata: {},
+      chunk: wireChunk as never,
+    });
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ args: 'a'.repeat(40), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a', index: 0 }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
+  });
+
   it('charges wire chunks synchronously and skips the handler echo', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
   STREAM_LIMIT_REDISPATCH_KEY,
+  enforceStreamLimitsForWireChunk,
   resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
@@ -647,6 +648,75 @@ describe('per-tool argument byte overrides', () => {
         },
       })
     ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'side_effect' });
+  });
+
+  it('judges complete parsed tool calls that arrive without raw chunks', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_calls: [
+          { id: 'call_1', name: 'create_file', args: { content: 'x'.repeat(500) } },
+        ],
+      },
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_calls: [
+            { id: 'call_2', name: 'side_effect', args: { payload: 'x'.repeat(200) } },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      toolName: 'side_effect',
+    });
+  });
+
+  it('charges wire chunks synchronously and skips the handler echo', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const wireChunk = {
+      content: '',
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    };
+
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata: {},
+      chunk: wireChunk as never,
+    });
+    await streamEvent({ handler, graph, chunk: wireChunk });
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ args: 'a'.repeat(40), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a', index: 0 }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 101 });
   });
 
   it('normalizes override entries like the global field', () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1022,6 +1022,43 @@ describe('per-tool argument byte overrides', () => {
     ).rejects.toBe(trip);
   });
 
+  it('does not charge an anonymous sparse delta to an identified call\'s override', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    /** Parallel batch: two identified calls share one event, so batch
+     * positions are NOT stable identities for later sparse events. */
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_a', name: 'create_file', args: 'x'.repeat(50) },
+            { id: 'call_b', name: 'db_query', args: 'x'.repeat(10) },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+
+    /** A sparse continuation event with a single anonymous delta lands on
+     * batch position 0 — inheriting call_a's tally would judge these bytes
+     * under create_file's 1000-byte override and bypass the global cap. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(200) }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', limit: 100 });
+  });
+
   it('binds consumer trips to the event epoch, sparing a newer run', async () => {
     const handler = new ChatModelStreamHandler();
     const newRunBreaker = new AbortController();

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -284,7 +284,45 @@ describe('streamed tool-call argument circuit breaker', () => {
     });
 
     const key = `${resolveGenerationKey({})}:0`;
-    expect(graph.streamedToolCallArgTallies.get(key)?.bytes).toBe(40);
+    expect(graph.streamedToolCallArgTallies.has(key)).toBe(false);
+    expect(graph.streamedToolCallArgTallies.size).toBe(0);
+  });
+
+  it('keeps parallel anonymous arrival-sealed calls on separate budgets (Google)', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 64 }),
+    });
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [
+          { name: 'search_a', args: 'x'.repeat(40) },
+          { name: 'search_b', args: 'y'.repeat(40) },
+        ],
+        response_metadata: {
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+        },
+      },
+    });
+    expect(graph.streamedToolCallArgTallies.size).toBe(0);
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ name: 'search_c', args: 'z'.repeat(70) }],
+          response_metadata: {
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+          },
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'search_c' });
   });
 
   it('streams unbounded when explicitly disabled', async () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -936,6 +936,67 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('adopts the existing tally when a later delta adds an index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', args: 'a'.repeat(41), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
+  it('names anonymous raw chunks from parsed calls so overrides apply', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ id: 'call_1', args: 'x'.repeat(500), index: 0 }],
+          tool_calls: [
+            { id: 'call_1', name: 'create_file', args: { content: 'x'.repeat(500) } },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(501), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 1_000,
+      toolName: 'create_file',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Regression tests for the streamed tool-argument circuit breaker.
+ *
+ * Incident: a model streamed a single malformed tool-call argument (a SQL
+ * query) to 149,923 characters over 26 minutes, never completing it, until
+ * the 64k output-token ceiling ended the run. Nothing bounded a single tool
+ * call's streamed argument growth mid-flight.
+ *
+ * The guard lives on the SDK stream dispatch path: `ChatModelStreamHandler`
+ * enforces `Graph.streamLimits` on every streamed chunk event and throws
+ * `StreamLimitExceededError` out of the run's `streamEvents` loop, which
+ * tears down the in-flight provider request (see the mid-flight halt notes
+ * in `Run.processStream`).
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import type { AgentContext } from '@/agents/AgentContext';
+import type { StandardGraph } from '@/graphs';
+import type * as t from '@/types';
+import {
+  DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  resolveStreamLimits,
+} from '@/llm/streamLimits';
+import { GraphEvents, Providers, StepTypes } from '@/common';
+import { ChatModelStreamHandler } from '@/stream';
+import { HandlerRegistry } from '@/events';
+
+function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
+  const runSteps = new Map<string, t.RunStep>();
+  const stepIdsByKey = new Map<string, string>();
+  let stepCounter = 0;
+
+  const graph = {
+    config: {
+      configurable: { user_id: 'user_1' },
+      metadata: { run_id: 'run_1' },
+    },
+    eagerEventToolExecution: undefined,
+    eagerEventToolExecutions: new Map(),
+    eagerEventToolCallChunks: new Map(),
+    eagerEventToolSuppressions: new Set<string>(),
+    handlerRegistry: new HandlerRegistry(),
+    hookRegistry: undefined,
+    humanInTheLoop: undefined,
+    toolOutputReferences: undefined,
+    sessions: new Map(),
+    toolCallStepIds: new Map(),
+    messageIdsByStepKey: new Map(),
+    messageStepHasToolCalls: new Map(),
+    prelimMessageIdsByStepKey: new Map(),
+    getAgentContext: jest.fn(
+      (): Partial<AgentContext> => ({
+        provider: Providers.OPENAI,
+        reasoningKey: 'reasoning_content',
+        toolDefinitions: [],
+        graphTools: [],
+        agentId: 'agent_1',
+      })
+    ),
+    getStepKey: jest.fn(() => 'step-key'),
+    getStepIdByKey: jest.fn((stepKey: string) => {
+      const stepId = stepIdsByKey.get(stepKey);
+      if (stepId == null) {
+        throw new Error('no current step');
+      }
+      return stepId;
+    }),
+    getRunStep: jest.fn((stepId: string) => runSteps.get(stepId)),
+    dispatchRunStep: jest.fn(async (stepKey: string, details: unknown) => {
+      const id = `step_${++stepCounter}`;
+      stepIdsByKey.set(stepKey, id);
+      runSteps.set(id, {
+        id,
+        type: (details as { type: t.RunStep['type'] }).type,
+        stepDetails: details as t.RunStep['stepDetails'],
+      } as t.RunStep);
+      return id;
+    }),
+    dispatchRunStepDelta: jest.fn(async () => undefined),
+    ...overrides,
+  };
+
+  return graph as unknown as StandardGraph;
+}
+
+async function streamToolCallChunks(args: {
+  handler: ChatModelStreamHandler;
+  graph: StandardGraph;
+  chunks: Array<Record<string, unknown>>;
+}): Promise<void> {
+  const { handler, graph, chunks } = args;
+  for (const toolCallChunk of chunks) {
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [toolCallChunk],
+        } as unknown as t.StreamChunk,
+      },
+      {},
+      graph
+    );
+  }
+}
+
+describe('streamed tool-call argument circuit breaker', () => {
+  it('aborts the stream once a single call exceeds the default 64 KiB', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({ streamLimits: resolveStreamLimits() });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [
+        { id: 'call_1', name: 'query_database', args: '', index: 0 },
+        ...Array.from({ length: 8 }, () => ({
+          args: 'x'.repeat(8_192),
+          index: 0,
+        })),
+      ],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x', index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      name: 'StreamLimitExceededError',
+      kind: 'tool_call_args',
+      limit: DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+      observed: DEFAULT_MAX_TOOL_CALL_ARG_BYTES + 1,
+      toolName: 'query_database',
+    });
+
+    const dispatchDelta = graph.dispatchRunStepDelta as jest.Mock;
+    expect(dispatchDelta).toHaveBeenCalledTimes(9);
+  });
+
+  it('keeps parallel tool calls on independent budgets', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_1', name: 'first', args: 'a'.repeat(60), index: 0 },
+            { id: 'call_2', name: 'second', args: 'b'.repeat(60), index: 1 },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      {},
+      graph
+    );
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'b'.repeat(41), index: 1 }],
+      })
+    ).rejects.toThrow('(tool call: second)');
+  });
+
+  it('counts argument bytes, not characters', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 1_000 }),
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'writer', args: '€'.repeat(300), index: 0 },
+          { args: '€'.repeat(100), index: 0 },
+        ],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 1_200 });
+  });
+
+  it('streams unbounded when explicitly disabled', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 0 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [
+        { id: 'call_1', name: 'query_database', args: '', index: 0 },
+        ...Array.from({ length: 4 }, () => ({
+          args: 'x'.repeat(65_536),
+          index: 0,
+        })),
+      ],
+    });
+
+    const dispatchDelta = graph.dispatchRunStepDelta as jest.Mock;
+    expect(dispatchDelta).toHaveBeenCalledTimes(5);
+    expect(graph.streamedToolCallArgTallies).toBeUndefined();
+  });
+
+  it('creates the tool_calls run step before the breaker can trip', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'query_database', args: '{"q":', index: 0 }],
+    });
+
+    const dispatchStep = graph.dispatchRunStep as jest.Mock;
+    const dispatchedTypes = dispatchStep.mock.calls.map(
+      (call) => (call[1] as { type: string }).type
+    );
+    expect(dispatchedTypes).toContain(StepTypes.TOOL_CALLS);
+  });
+});
+
+describe('per-turn delta event circuit breaker', () => {
+  it('is opt-in and counts every streamed chunk event, including empty ones', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 3 }),
+    });
+
+    const emptyChunkEvent = (): Promise<void> =>
+      handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        { chunk: { content: '' } as unknown as t.StreamChunk },
+        {},
+        graph
+      );
+
+    await emptyChunkEvent();
+    await emptyChunkEvent();
+    await emptyChunkEvent();
+    await expect(emptyChunkEvent()).rejects.toMatchObject({
+      name: 'StreamLimitExceededError',
+      kind: 'delta_events',
+      limit: 3,
+      observed: 4,
+    });
+  });
+
+  it('scopes the budget per generation turn', async () => {
+    const handler = new ChatModelStreamHandler();
+    let turn = 'turn-1';
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
+      getStepKey: jest.fn(() => turn) as unknown as StandardGraph['getStepKey'],
+    });
+
+    const emptyChunkEvent = (): Promise<void> =>
+      handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        { chunk: { content: '' } as unknown as t.StreamChunk },
+        {},
+        graph
+      );
+
+    await emptyChunkEvent();
+    await emptyChunkEvent();
+    turn = 'turn-2';
+    await emptyChunkEvent();
+    await emptyChunkEvent();
+    await expect(emptyChunkEvent()).rejects.toMatchObject({
+      kind: 'delta_events',
+      observed: 3,
+    });
+  });
+
+  it('never counts when left at the default (disabled)', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({ streamLimits: resolveStreamLimits() });
+
+    for (let i = 0; i < 10; i++) {
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        { chunk: { content: '' } as unknown as t.StreamChunk },
+        {},
+        graph
+      );
+    }
+    expect(graph.streamDeltaEventCounts).toBeUndefined();
+  });
+});

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -911,6 +911,31 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('keeps one budget when a call drops both identifiers on later deltas', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'a'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1059,6 +1059,136 @@ describe('per-tool argument byte overrides', () => {
     ).rejects.toMatchObject({ kind: 'tool_call_args', limit: 100 });
   });
 
+  it('judges ambiguous sparse deltas under each candidate\'s own limit', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 1_000,
+        maxToolCallArgBytesByTool: { tight_tool: 50 },
+      }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_a', name: 'tight_tool', args: 'x'.repeat(10) },
+            { id: 'call_b', name: 'db_query', args: 'x'.repeat(10) },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+
+    /** The anonymous continuation might belong to tight_tool, whose 50-byte
+     * override is LOWER than the raised global cap — judging candidates
+     * only against the global limit would let it stream past indefinitely. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(60) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 50,
+      toolName: 'tight_tool',
+    });
+  });
+
+  it('keeps the sole live call\'s budget continuous across anonymous continuations', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_a', name: 'writer', args: 'x'.repeat(60) }],
+    });
+    /** A second id-only call takes over the #0 position alias, then seals —
+     * releasing it removes the alias while call_a stays live under its id. */
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_b', name: 'other', args: 'x'.repeat(10) }],
+    });
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ id: 'call_b', args: '' }],
+        response_metadata: {
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+            kind: 'single',
+            id: 'call_b',
+          },
+        },
+      },
+    });
+
+    /** The anonymous continuation must charge call_a's existing 60-byte
+     * tally — a fresh #0 tally would reset the sole remaining call's
+     * budget and let combined args exceed the cap. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(60) }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', limit: 100 });
+  });
+
+  it('still accounts when per-tool overrides exist with the global cap off', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 0,
+        maxToolCallArgBytesByTool: { create_file: 500 },
+      }),
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'create_file', args: 'x'.repeat(501), index: 0 },
+        ],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 500,
+      toolName: 'create_file',
+    });
+  });
+
+  it('allocates no charge bookkeeping when every guard is disabled', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 0 }),
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'writer', args: 'x'.repeat(100_000), index: 0 },
+        ],
+      })
+    ).resolves.toBeUndefined();
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+    expect(graph.streamedToolCallArgTallies ?? new Map()).toHaveProperty(
+      'size',
+      0
+    );
+  });
+
   it('binds consumer trips to the event epoch, sparing a newer run', async () => {
     const handler = new ChatModelStreamHandler();
     const newRunBreaker = new AbortController();

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1446,6 +1446,97 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('adopts a sparse indexed continuation by its stable call index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { wide_tool: 1_000 },
+      }),
+    });
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [
+          { name: 'wide_tool', args: 'x'.repeat(60) },
+          { name: 'tight_tool', args: 'x'.repeat(40) },
+        ],
+      },
+    });
+
+    /** The event position is 0, but index 1 identifies the second call from
+     * the original parallel batch. Its existing 40 bytes must stay under
+     * the global cap rather than adopting wide_tool's raised allowance. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(61), index: 1 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      observed: 101,
+      toolName: 'tight_tool',
+    });
+  });
+
+  it('applies a late anonymous name before charging its lower override', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 1_000,
+        maxToolCallArgBytesByTool: { tight_tool: 50 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ args: 'x'.repeat(40) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ name: 'tight_tool', args: 'x'.repeat(11) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 50,
+      observed: 51,
+      toolName: 'tight_tool',
+    });
+  });
+
+  it('assembles a late anonymous name before applying its higher override', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'create_', args: 'x'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ name: 'file', args: 'x'.repeat(60) }],
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it('names id-less raw chunks from a single parsed call so overrides apply', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -17,7 +17,13 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
 import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
 import { GraphEvents, Providers, StepTypes } from '@/common';
@@ -82,24 +88,41 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   return graph as unknown as StandardGraph;
 }
 
+const generation = (step: number): Record<string, unknown> => ({
+  langgraph_checkpoint_ns: '',
+  langgraph_node: 'agent',
+  langgraph_step: step,
+});
+
+async function streamEvent(args: {
+  handler: ChatModelStreamHandler;
+  graph: StandardGraph;
+  chunk: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  const { handler, graph, chunk, metadata } = args;
+  await handler.handle(
+    GraphEvents.CHAT_MODEL_STREAM,
+    { chunk: chunk as unknown as t.StreamChunk },
+    metadata ?? {},
+    graph
+  );
+}
+
 async function streamToolCallChunks(args: {
   handler: ChatModelStreamHandler;
   graph: StandardGraph;
   chunks: Array<Record<string, unknown>>;
+  metadata?: Record<string, unknown>;
 }): Promise<void> {
-  const { handler, graph, chunks } = args;
+  const { handler, graph, chunks, metadata } = args;
   for (const toolCallChunk of chunks) {
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      {
-        chunk: {
-          content: '',
-          tool_call_chunks: [toolCallChunk],
-        } as unknown as t.StreamChunk,
-      },
-      {},
-      graph
-    );
+    await streamEvent({
+      handler,
+      graph,
+      metadata,
+      chunk: { content: '', tool_call_chunks: [toolCallChunk] },
+    });
   }
 }
 
@@ -144,20 +167,17 @@ describe('streamed tool-call argument circuit breaker', () => {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
     });
 
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      {
-        chunk: {
-          content: '',
-          tool_call_chunks: [
-            { id: 'call_1', name: 'first', args: 'a'.repeat(60), index: 0 },
-            { id: 'call_2', name: 'second', args: 'b'.repeat(60), index: 1 },
-          ],
-        } as unknown as t.StreamChunk,
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [
+          { id: 'call_1', name: 'first', args: 'a'.repeat(60), index: 0 },
+          { id: 'call_2', name: 'second', args: 'b'.repeat(60), index: 1 },
+        ],
       },
-      {},
-      graph
-    );
+    });
 
     await expect(
       streamToolCallChunks({
@@ -184,6 +204,87 @@ describe('streamed tool-call argument circuit breaker', () => {
         ],
       })
     ).rejects.toMatchObject({ kind: 'tool_call_args', observed: 1_200 });
+  });
+
+  it('enforces the cap before a complete arrival-sealed call can dispatch', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+    const oversized = JSON.stringify({ payload: 'x'.repeat(200) });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_calls: [
+            { id: 'call_1', name: 'side_effect', args: { payload: 'x'.repeat(200) } },
+          ],
+          tool_call_chunks: [
+            { id: 'call_1', name: 'side_effect', args: oversized, index: 0 },
+          ],
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'side_effect' });
+
+    const dispatchStep = graph.dispatchRunStep as jest.Mock;
+    expect(dispatchStep).not.toHaveBeenCalled();
+  });
+
+  it('enforces the cap for chunks that carry no numeric index', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'no_index_tool', args: 'x'.repeat(80) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', args: 'x'.repeat(21) }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'no_index_tool' });
+  });
+
+  it('does not double-count OpenAI Responses seal restatements', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+    });
+    const fullArgs = 'x'.repeat(40);
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [
+        { args: fullArgs.slice(0, 20), index: 0 },
+        { args: fullArgs.slice(20), index: 0 },
+      ],
+    });
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ name: 'writer', args: fullArgs, index: 0 }],
+        response_metadata: {
+          [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+            OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
+        },
+      },
+    });
+
+    const key = `${resolveGenerationKey({})}:0`;
+    expect(graph.streamedToolCallArgTallies.get(key)?.bytes).toBe(40);
   });
 
   it('streams unbounded when explicitly disabled', async () => {
@@ -229,7 +330,7 @@ describe('streamed tool-call argument circuit breaker', () => {
   });
 });
 
-describe('per-turn delta event circuit breaker', () => {
+describe('per-generation delta event circuit breaker', () => {
   it('is opt-in and counts every streamed chunk event, including empty ones', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({
@@ -237,12 +338,7 @@ describe('per-turn delta event circuit breaker', () => {
     });
 
     const emptyChunkEvent = (): Promise<void> =>
-      handler.handle(
-        GraphEvents.CHAT_MODEL_STREAM,
-        { chunk: { content: '' } as unknown as t.StreamChunk },
-        {},
-        graph
-      );
+      streamEvent({ handler, graph, chunk: { content: '' }, metadata: generation(1) });
 
     await emptyChunkEvent();
     await emptyChunkEvent();
@@ -255,31 +351,27 @@ describe('per-turn delta event circuit breaker', () => {
     });
   });
 
-  it('scopes the budget per generation turn', async () => {
+  it('scopes the budget per model generation, surviving step-key forks', async () => {
     const handler = new ChatModelStreamHandler();
-    let turn = 'turn-1';
+    let stepKey = 'reasoning-key';
     const graph = createGraph({
       streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
-      getStepKey: jest.fn(() => turn) as unknown as StandardGraph['getStepKey'],
+      getStepKey: jest.fn(() => stepKey) as unknown as StandardGraph['getStepKey'],
     });
 
-    const emptyChunkEvent = (): Promise<void> =>
-      handler.handle(
-        GraphEvents.CHAT_MODEL_STREAM,
-        { chunk: { content: '' } as unknown as t.StreamChunk },
-        {},
-        graph
-      );
+    const emptyChunkEvent = (step: number): Promise<void> =>
+      streamEvent({ handler, graph, chunk: { content: '' }, metadata: generation(step) });
 
-    await emptyChunkEvent();
-    await emptyChunkEvent();
-    turn = 'turn-2';
-    await emptyChunkEvent();
-    await emptyChunkEvent();
-    await expect(emptyChunkEvent()).rejects.toMatchObject({
+    await emptyChunkEvent(1);
+    stepKey = 'post-reasoning-key';
+    await emptyChunkEvent(1);
+    await expect(emptyChunkEvent(1)).rejects.toMatchObject({
       kind: 'delta_events',
       observed: 3,
     });
+
+    await emptyChunkEvent(2);
+    expect(graph.streamDeltaEventCounts.get('|agent|2')).toBe(1);
   });
 
   it('never counts when left at the default (disabled)', async () => {
@@ -287,12 +379,7 @@ describe('per-turn delta event circuit breaker', () => {
     const graph = createGraph({ streamLimits: resolveStreamLimits() });
 
     for (let i = 0; i < 10; i++) {
-      await handler.handle(
-        GraphEvents.CHAT_MODEL_STREAM,
-        { chunk: { content: '' } as unknown as t.StreamChunk },
-        {},
-        graph
-      );
+      await streamEvent({ handler, graph, chunk: { content: '' }, metadata: generation(1) });
     }
     expect(graph.streamDeltaEventCounts).toBeUndefined();
   });

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -997,6 +997,52 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('prefers the id-correlated complete name over a raw name fragment', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    /** A custom adapter can emit a raw chunk whose name is only a FRAGMENT
+     * ("create_") alongside the complete parsed call for the same id. The
+     * complete call's name must select the per-tool override — judging the
+     * bytes under the fragment would trip the global cap instead. */
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            { id: 'call_1', name: 'create_', args: 'x'.repeat(500), index: 0 },
+          ],
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'create_file',
+              args: { content: 'x'.repeat(500) },
+            },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(501), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 1_000,
+      toolName: 'create_file',
+    });
+  });
+
   it('keeps an index 0 call and an id "0" call on separate budgets', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1032,8 +1032,9 @@ describe('per-tool argument byte overrides', () => {
     });
 
     /** A straggling oversized chunk from a failed run (epoch 4) handled
-     * after resetValues installed epoch 5: the breach still rejects, but
-     * the new run's controller must stay live. */
+     * after resetValues installed epoch 5 is dropped outright — acting on
+     * it (content handling, eager dispatch) would compose the new run's
+     * live controller — and the new run's controller stays live. */
     await expect(
       streamToolCallChunks({
         handler,
@@ -1043,7 +1044,7 @@ describe('per-tool argument byte overrides', () => {
         ],
         metadata: { [STREAM_LIMIT_EPOCH_KEY]: 4 },
       })
-    ).rejects.toMatchObject({ kind: 'tool_call_args' });
+    ).resolves.toBeUndefined();
     expect(newRunBreaker.signal.aborted).toBe(false);
 
     /** Same breach with the matching epoch trips the controller. */

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1076,6 +1076,38 @@ describe('per-tool argument byte overrides', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('matches a dual-identifier seal against a chunk carrying only its id', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ id: 'call_1', args: 'a'.repeat(60) }],
+          response_metadata: {
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              index: 0,
+              id: 'call_1',
+            },
+          },
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(graph.streamedToolCallArgTallies.size).toBe(0);
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1273,6 +1273,38 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('matches a seal by id when the indices disagree', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ id: 'call_1', args: 'a'.repeat(60), index: 1 }],
+          response_metadata: {
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              index: 0,
+              id: 'call_1',
+            },
+          },
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(graph.streamedToolCallArgTallies.size).toBe(0);
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -368,6 +368,151 @@ describe('streamed tool-call argument circuit breaker', () => {
   });
 });
 
+describe('per-tool argument byte overrides', () => {
+  it('raises the cap for the named tool without loosening others', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [
+        { id: 'call_1', name: 'create_file', args: 'x'.repeat(500), index: 0 },
+      ],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_2', name: 'query_database', args: 'y'.repeat(101), index: 1 },
+        ],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      toolName: 'query_database',
+    });
+  });
+
+  it('trips the named tool at its own lower cap', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 1_000,
+        maxToolCallArgBytesByTool: { chatty_tool: 50 },
+      }),
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'chatty_tool', args: 'x'.repeat(51), index: 0 },
+        ],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 50,
+      toolName: 'chatty_tool',
+    });
+  });
+
+  it('enforces a per-tool cap even when the global cap is disabled', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 0,
+        maxToolCallArgBytesByTool: { create_file: 100 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [
+        { id: 'call_1', name: 'unbounded_tool', args: 'x'.repeat(500), index: 0 },
+      ],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_2', name: 'create_file', args: 'y'.repeat(101), index: 1 },
+        ],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+      toolName: 'create_file',
+    });
+  });
+
+  it('applies overrides to arrival-sealed complete calls', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 64,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ name: 'create_file', args: 'x'.repeat(500) }],
+        response_metadata: {
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+        },
+      },
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ name: 'search_c', args: 'z'.repeat(70) }],
+          response_metadata: {
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+          },
+        },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'search_c' });
+  });
+
+  it('normalizes override entries like the global field', () => {
+    const resolved = resolveStreamLimits({
+      maxToolCallArgBytes: 100,
+      maxToolCallArgBytesByTool: {
+        create_file: 131_072.9,
+        disabled_tool: -5,
+        unlimited_tool: Infinity,
+        invalid_tool: Number.NaN,
+        '': 42,
+      },
+    });
+
+    expect(resolved.maxToolCallArgBytesByTool).toEqual({
+      create_file: 131_072,
+      disabled_tool: 0,
+      unlimited_tool: 0,
+    });
+  });
+});
+
 describe('per-generation delta event circuit breaker', () => {
   it('is opt-in and counts every streamed chunk event, including empty ones', async () => {
     const handler = new ChatModelStreamHandler();

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
   STREAM_LIMIT_REDISPATCH_KEY,
+  STREAM_LIMIT_EPOCH_KEY,
   StreamLimitExceededError,
   enforceStreamLimitsForWireChunk,
   resolveGenerationKey,
@@ -1019,6 +1020,84 @@ describe('per-tool argument byte overrides', () => {
     await expect(
       streamEvent({ handler, graph, chunk: { content: 'queued text' } })
     ).rejects.toBe(trip);
+  });
+
+  it('binds consumer trips to the event epoch, sparing a newer run', async () => {
+    const handler = new ChatModelStreamHandler();
+    const newRunBreaker = new AbortController();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+      breakerAbort: newRunBreaker,
+      breakerEpoch: 5,
+    });
+
+    /** A straggling oversized chunk from a failed run (epoch 4) handled
+     * after resetValues installed epoch 5: the breach still rejects, but
+     * the new run's controller must stay live. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_1', name: 'writer', args: 'x'.repeat(101), index: 0 },
+        ],
+        metadata: { [STREAM_LIMIT_EPOCH_KEY]: 4 },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args' });
+    expect(newRunBreaker.signal.aborted).toBe(false);
+
+    /** Same breach with the matching epoch trips the controller. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [
+          { id: 'call_2', name: 'writer', args: 'x'.repeat(101), index: 0 },
+        ],
+        metadata: { [STREAM_LIMIT_EPOCH_KEY]: 5 },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args' });
+    expect(newRunBreaker.signal.aborted).toBe(true);
+  });
+
+  it('lets stale-epoch events pass the queued-event breaker check', async () => {
+    const handler = new ChatModelStreamHandler();
+    const breakerAbort = new AbortController();
+    breakerAbort.abort(
+      new StreamLimitExceededError({
+        kind: 'tool_call_args',
+        limit: 10,
+        observed: 11,
+        toolName: 'db_query',
+      })
+    );
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits(),
+      breakerAbort,
+      breakerEpoch: 5,
+    });
+
+    /** The tripped controller belongs to the CURRENT run (epoch 5); an
+     * old-run chunk (epoch 4) must not be failed against it. The same
+     * event WITH the matching epoch throws, proving only the epoch gate
+     * differs. */
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: { content: '' },
+        metadata: { [STREAM_LIMIT_EPOCH_KEY]: 4 },
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: { content: '' },
+        metadata: { [STREAM_LIMIT_EPOCH_KEY]: 5 },
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args' });
   });
 
   it('treats empty tool-call ids as anonymous, keeping parallel calls apart', async () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -409,7 +409,7 @@ describe('per-generation delta event circuit breaker', () => {
     });
 
     await emptyChunkEvent(2);
-    expect(graph.streamDeltaEventCounts.get('|agent|2')).toBe(1);
+    expect(graph.streamDeltaEventCounts.get('|agent|2|')).toBe(1);
   });
 
   it('never counts when left at the default (disabled)', async () => {

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1208,6 +1208,71 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('names unnamed raw chunks from invalid calls so overrides apply', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await expect(
+      streamEvent({
+        handler,
+        graph,
+        chunk: {
+          content: '',
+          tool_call_chunks: [{ id: 'call_1', args: 'x'.repeat(500), index: 0 }],
+          invalid_tool_calls: [
+            {
+              id: 'call_1',
+              name: 'create_file',
+              args: 'x'.repeat(500),
+              error: 'Unparseable arguments',
+            },
+          ],
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accumulates fragmented tool names before selecting overrides', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { create_file: 1_000 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: 'create_', args: 'x'.repeat(50), index: 0 }],
+    });
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ name: 'file', args: 'x'.repeat(100), index: 0 }],
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(900), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 1_000,
+      observed: 1_050,
+      toolName: 'create_file',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1305,6 +1305,62 @@ describe('per-tool argument byte overrides', () => {
     expect(graph.streamedToolCallArgTallies.size).toBe(0);
   });
 
+  it('trips the shared graph breaker when the consumer path detects a breach', async () => {
+    const handler = new ChatModelStreamHandler();
+    const breakerAbort = new AbortController();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+      breakerAbort,
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', name: 'writer', args: 'a'.repeat(101), index: 0 }],
+      })
+    ).rejects.toMatchObject({ kind: 'tool_call_args' });
+
+    expect(breakerAbort.signal.aborted).toBe(true);
+    expect(breakerAbort.signal.reason).toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+    });
+  });
+
+  it('allocates no charge credits for text-only deltas with the event cap off', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits(),
+      dispatchMessageDelta: jest.fn(async () => undefined),
+      dispatchReasoningDelta: jest.fn(async () => undefined),
+    } as never);
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: { content: 'an ordinary text delta' },
+    });
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata: {},
+      chunk: { tool_call_chunks: undefined } as never,
+    });
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [{ id: 'call_1', name: 'writer', args: 'x', index: 0 }],
+      },
+    });
+    expect(graph.streamLimitChargeCredits).toBeDefined();
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1108,6 +1108,52 @@ describe('per-tool argument byte overrides', () => {
     expect(graph.streamedToolCallArgTallies.size).toBe(0);
   });
 
+  it('adopts an anonymous tally when a later delta adds only an id', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ name: 'writer', args: 'a'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', args: 'a'.repeat(41) }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      observed: 101,
+      toolName: 'writer',
+    });
+  });
+
+  it('does not adopt a live id-bearing call through its position alias', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_a', name: 'a_tool', args: 'a'.repeat(60) }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_b', name: 'b_tool', args: 'b'.repeat(60) }],
+      })
+    ).resolves.toBeUndefined();
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -493,6 +493,66 @@ describe('per-tool argument byte overrides', () => {
     ).rejects.toMatchObject({ kind: 'tool_call_args', toolName: 'search_c' });
   });
 
+  it('re-judges tallied bytes when the tool name arrives on a later empty chunk', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 1_000,
+        maxToolCallArgBytesByTool: { capped_tool: 50 },
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ args: 'x'.repeat(60), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ id: 'call_1', name: 'capped_tool', args: '', index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 50,
+      observed: 60,
+      toolName: 'capped_tool',
+    });
+  });
+
+  it('honors an override for a tool named __proto__', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: JSON.parse('{"__proto__": 1000}') as Record<
+          string,
+          number
+        >,
+      }),
+    });
+
+    await streamToolCallChunks({
+      handler,
+      graph,
+      chunks: [{ id: 'call_1', name: '__proto__', args: 'x'.repeat(500), index: 0 }],
+    });
+
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(501), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 1_000,
+      toolName: '__proto__',
+    });
+  });
+
   it('normalizes override entries like the global field', () => {
     const resolved = resolveStreamLimits({
       maxToolCallArgBytes: 100,

--- a/src/__tests__/stream.streamLimits.test.ts
+++ b/src/__tests__/stream.streamLimits.test.ts
@@ -1509,6 +1509,41 @@ describe('per-tool argument byte overrides', () => {
     });
   });
 
+  it('does not use the sole anonymous fallback while another call is live', async () => {
+    const handler = new ChatModelStreamHandler();
+    const graph = createGraph({
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 100,
+        maxToolCallArgBytesByTool: { wide_tool: 1_000 },
+      }),
+    });
+
+    await streamEvent({
+      handler,
+      graph,
+      chunk: {
+        content: '',
+        tool_call_chunks: [
+          { id: 'call_a', name: 'tight_tool', args: 'x'.repeat(10) },
+          { name: 'wide_tool', args: 'x'.repeat(10) },
+        ],
+      },
+    });
+
+    /** Index 0 could identify call_a; the one anonymous tally belongs to
+     * batch position 1 and must not lend wide_tool's raised override. */
+    await expect(
+      streamToolCallChunks({
+        handler,
+        graph,
+        chunks: [{ args: 'x'.repeat(101), index: 0 }],
+      })
+    ).rejects.toMatchObject({
+      kind: 'tool_call_args',
+      limit: 100,
+    });
+  });
+
   it('applies a late anonymous name before charging its lower override', async () => {
     const handler = new ChatModelStreamHandler();
     const graph = createGraph({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1208,12 +1208,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
-    /** Run-start is the only safe recreation point for a tripped breaker:
-     * end-of-run cleanup must leave it aborted so straggling parallel
-     * children from the failed run cannot start on a fresh signal. */
-    if (this.breakerAbort.signal.aborted) {
-      this.breakerAbort = new AbortController();
-    }
+    /** Run-start is the only safe replacement point for the breaker:
+     * end-of-run cleanup must leave it in place so straggling parallel
+     * children from the failed run cannot start on a fresh signal.
+     * Replaced UNCONDITIONALLY here — a run that failed on an ordinary
+     * error leaves the controller un-aborted, and stragglers still settling
+     * hold their entry-time capture of it; a late stream-limit trip on that
+     * old controller must not cancel the run starting now. */
+    this.breakerAbort = new AbortController();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1997,6 +1999,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * fresh controller. Trips and reason reads below stay on this
        * capture. */
       const attemptBreaker = this.breakerAbort;
+      /** Already-tripped-at-entry: a parallel sibling's breach has failed
+       * the run before this node was scheduled. Rethrow before hooks or the
+       * provider call — a custom provider that doesn't synchronously reject
+       * an aborted signal would otherwise start another model request on a
+       * failed run. */
+      const entryTripReason = this.resolveTrippedBreakerReason(
+        attemptBreaker.signal
+      );
+      if (entryTripReason != null) {
+        throw entryTripReason;
+      }
       const agentContext = this.agentContexts.get(agentId);
       if (!agentContext) {
         throw new Error(`Agent context not found for agentId: ${agentId}`);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4181,6 +4181,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             ) {
               writeChargeCredits(value);
             },
+            /** Read per attempt: a sibling branch tripping the run breaker
+             * must also cancel in-flight summarization model calls. */
+            getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
             dispatchRunStep: async (runStep, nodeConfig) => {
               const resolvedConfig = nodeConfig ?? this.config;
               if (runStep.agentId != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1080,6 +1080,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * otherwise grow by one attempt-stamped entry per model call for the
    * graph's lifetime. */
   streamLimitChargeCredits?: WeakMap<object, Map<string, number>>;
+  /** Run-scoped abort shared by every SubagentExecutor this graph builds, so
+   * one child tripping a stream circuit breaker stops subagents running
+   * under other parallel agent nodes too. Recreated by both reset paths —
+   * the abort is one-way within a run, and a reused graph must start its
+   * next run unaborted. */
+  subagentBreakerAbort = new AbortController();
   /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
    * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
@@ -1196,6 +1202,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
+    if (this.subagentBreakerAbort.signal.aborted) {
+      this.subagentBreakerAbort = new AbortController();
+    }
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1256,6 +1265,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
+    if (this.subagentBreakerAbort.signal.aborted) {
+      this.subagentBreakerAbort = new AbortController();
+    }
     /**
      * Turn state only. The reported totals must outlive cleanup — this runs
      * in `processStream`'s `finally`, and the host reads `getPreemptStats()`
@@ -3887,6 +3899,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const executor = new SubagentExecutor({
           configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
           parentSignal: this.signal,
+          breakerScope: {
+            signal: (): AbortSignal => this.subagentBreakerAbort.signal,
+            trip: (reason: unknown): void =>
+              this.subagentBreakerAbort.abort(reason),
+          },
           hookRegistry: this.hookRegistry,
           /** Lazy — Run wires the registry onto the graph AFTER
            *  `createWorkflow()` runs, so a direct capture here would be

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1087,6 +1087,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * propagates. Recreated by both reset paths — the abort is one-way within
    * a run, and a reused graph must start its next run unaborted. */
   breakerAbort = new AbortController();
+
+  /** The stream-limit error behind an already-fired breaker, whether this
+   * graph's own controller tripped or a parent run's breaker arrived through
+   * the composed constructor signal (child graphs own separate controllers).
+   * Providers can translate either abort into a generic error, and recovery
+   * paths must not run in that state. */
+  protected resolveTrippedBreakerReason(): StreamLimitExceededError | undefined {
+    if (
+      this.breakerAbort.signal.aborted &&
+      this.breakerAbort.signal.reason instanceof StreamLimitExceededError
+    ) {
+      return this.breakerAbort.signal.reason;
+    }
+    if (
+      this.signal?.aborted === true &&
+      this.signal.reason instanceof StreamLimitExceededError
+    ) {
+      return this.signal.reason;
+    }
+    return undefined;
+  }
   /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
    * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
@@ -3267,11 +3288,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * abort error; entering overflow planning or the fallback chain
          * would start new provider work after the run-wide breaker fired.
          * Rethrow the breaker's own stream-limit reason instead. */
-        if (
-          this.breakerAbort.signal.aborted &&
-          this.breakerAbort.signal.reason instanceof StreamLimitExceededError
-        ) {
-          throw this.breakerAbort.signal.reason;
+        {
+          const trippedReason = this.resolveTrippedBreakerReason();
+          if (trippedReason != null) {
+            throw trippedReason;
+          }
         }
         /**
          * A context overflow is a deterministic consequence of the payload,
@@ -3513,12 +3534,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             this.breakerAbort.abort(fallbackError);
             throw fallbackError;
           }
-          if (
-            this.breakerAbort.signal.aborted &&
-            this.breakerAbort.signal.reason instanceof StreamLimitExceededError
-          ) {
+          {
             /** Same sibling-abort translation guard as the primary catch. */
-            throw this.breakerAbort.signal.reason;
+            const trippedReason = this.resolveTrippedBreakerReason();
+            if (trippedReason != null) {
+              throw trippedReason;
+            }
           }
           const overflowCandidates =
             getFallbackOverflowCandidates(fallbackError);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -17,6 +17,10 @@ import type {
   MessageContent,
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type {
+  ResolvedStreamLimits,
+  StreamedToolCallArgTally,
+} from '@/llm/streamLimits';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
 import type { HookRegistry } from '@/hooks';
@@ -115,10 +119,6 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import type {
-  ResolvedStreamLimits,
-  StreamedToolCallArgTally,
-} from '@/llm/streamLimits';
 import {
   resolveStreamLimits,
   StreamLimitExceededError,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1203,6 +1203,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
+    /** Run-start is the only safe recreation point for a tripped breaker:
+     * end-of-run cleanup must leave it aborted so straggling parallel
+     * children from the failed run cannot start on a fresh signal. */
     if (this.breakerAbort.signal.aborted) {
       this.breakerAbort = new AbortController();
     }
@@ -1266,9 +1269,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
-    if (this.breakerAbort.signal.aborted) {
-      this.breakerAbort = new AbortController();
-    }
+    /** Deliberately NOT recreating a tripped breakerAbort here: this runs in
+     * `processStream`'s cleanup, which a rejected parallel batch reaches
+     * while sibling subagents can still be pre-invoke — a fresh controller
+     * would hand them an un-aborted signal and let provider requests start
+     * after the run already failed. `resetValues` recreates it when the next
+     * run begins. */
     /**
      * Turn state only. The reported totals must outlive cleanup — this runs
      * in `processStream`'s `finally`, and the host reads `getPreemptStats()`

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4065,6 +4065,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             runId: this.runId,
             isMultiAgent: this.isMultiAgentGraph(),
             hookRegistry: this.hookRegistry,
+            /**
+             * Live references (both maps are cleared in place, never
+             * replaced), so summarization streams share the run's event
+             * budget accounting under their own generation key.
+             */
+            streamLimits: this.streamLimits,
+            streamDeltaEventCounts: this.streamDeltaEventCounts,
+            streamedToolCallArgTallies: this.streamedToolCallArgTallies,
             dispatchRunStep: async (runStep, nodeConfig) => {
               const resolvedConfig = nodeConfig ?? this.config;
               if (runStep.agentId != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1282,9 +1282,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
-    this.streamedToolCallArgTallies.clear();
-    this.streamDeltaEventCounts.clear();
-    this.streamLimitChargeCredits = undefined;
+    /** Stream-limit accounting (argument tallies, event counts, charge
+     * credits) deliberately SURVIVES cleanup: this runs in `processStream`'s
+     * finally, which an ordinary parallel-branch failure reaches while
+     * sibling attempts are still unwinding on the retained breaker — a
+     * cancellation-ignoring provider's late chunks would otherwise recreate
+     * their budgets from zero and stream another full allowance. The maps
+     * are bounded by in-flight call sizes and `resetValues` clears them at
+     * the next run start, where the epoch bump already drops stamped
+     * straggler events before accounting. */
     /** Deliberately NOT recreating a tripped breakerAbort here: this runs in
      * `processStream`'s cleanup, which a rejected parallel batch reaches
      * while sibling subagents can still be pre-invoke — a fresh controller

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1093,12 +1093,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * the composed constructor signal (child graphs own separate controllers).
    * Providers can translate either abort into a generic error, and recovery
    * paths must not run in that state. */
-  protected resolveTrippedBreakerReason(): StreamLimitExceededError | undefined {
+  protected resolveTrippedBreakerReason(
+    breakerSignal: AbortSignal = this.breakerAbort.signal
+  ): StreamLimitExceededError | undefined {
     if (
-      this.breakerAbort.signal.aborted &&
-      this.breakerAbort.signal.reason instanceof StreamLimitExceededError
+      breakerSignal.aborted &&
+      breakerSignal.reason instanceof StreamLimitExceededError
     ) {
-      return this.breakerAbort.signal.reason;
+      return breakerSignal.reason;
     }
     if (
       this.signal?.aborted === true &&
@@ -3195,12 +3197,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentName: agentContext.name,
       });
       let langfuseHandler: CallbackEntry | undefined;
+      /** Captured per attempt, like subagent executions: a failed run's
+       * reset replaces the controller, and an old attempt's catch reading
+       * the live controller would miss its own run's trip. Trips and reason
+       * reads below bind to this capture. */
+      const attemptBreaker = this.breakerAbort;
       let invokeConfig = {
         ...config,
         /** The run-scoped breaker composed in, so a stream-limit trip in one
          * parallel agent node also cancels sibling nodes' in-flight model
          * calls, not only their subagents. */
-        signal: composeAbortSignals(config.signal, this.breakerAbort.signal),
+        signal: composeAbortSignals(config.signal, attemptBreaker.signal),
         metadata: {
           ...(config.metadata ?? {}),
           ...traceMetadata,
@@ -3280,7 +3287,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (primaryError instanceof StreamLimitExceededError) {
           /** Tripped before rethrowing so parallel agent nodes' in-flight
            * model calls and subagents stop while the rejection propagates. */
-          this.breakerAbort.abort(primaryError);
+          attemptBreaker.abort(primaryError);
           throw primaryError;
         }
         /** A sibling that tripped the shared breaker aborts this branch's
@@ -3289,7 +3296,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * would start new provider work after the run-wide breaker fired.
          * Rethrow the breaker's own stream-limit reason instead. */
         {
-          const trippedReason = this.resolveTrippedBreakerReason();
+          const trippedReason = this.resolveTrippedBreakerReason(attemptBreaker.signal);
           if (trippedReason != null) {
             throw trippedReason;
           }
@@ -3531,12 +3538,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             /** Same treatment as the primary path: a fallback stream that
              * trips the breaker must stop parallel agent nodes' model calls
              * and subagents before the rejection propagates. */
-            this.breakerAbort.abort(fallbackError);
+            attemptBreaker.abort(fallbackError);
             throw fallbackError;
           }
           {
             /** Same sibling-abort translation guard as the primary catch. */
-            const trippedReason = this.resolveTrippedBreakerReason();
+            const trippedReason = this.resolveTrippedBreakerReason(attemptBreaker.signal);
             if (trippedReason != null) {
               throw trippedReason;
             }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1080,12 +1080,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * otherwise grow by one attempt-stamped entry per model call for the
    * graph's lifetime. */
   streamLimitChargeCredits?: WeakMap<object, Map<string, number>>;
-  /** Run-scoped abort shared by every SubagentExecutor this graph builds, so
-   * one child tripping a stream circuit breaker stops subagents running
-   * under other parallel agent nodes too. Recreated by both reset paths —
-   * the abort is one-way within a run, and a reused graph must start its
-   * next run unaborted. */
-  subagentBreakerAbort = new AbortController();
+  /** Run-scoped breaker abort: composed into every model invocation and
+   * every SubagentExecutor child signal, and tripped when a stream circuit
+   * breaker fires anywhere in the run, so parallel agent nodes' in-flight
+   * provider calls and subagents stop consuming quota while the rejection
+   * propagates. Recreated by both reset paths — the abort is one-way within
+   * a run, and a reused graph must start its next run unaborted. */
+  breakerAbort = new AbortController();
   /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
    * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
@@ -1202,8 +1203,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
-    if (this.subagentBreakerAbort.signal.aborted) {
-      this.subagentBreakerAbort = new AbortController();
+    if (this.breakerAbort.signal.aborted) {
+      this.breakerAbort = new AbortController();
     }
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
@@ -1265,8 +1266,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
     this.streamLimitChargeCredits = undefined;
-    if (this.subagentBreakerAbort.signal.aborted) {
-      this.subagentBreakerAbort = new AbortController();
+    if (this.breakerAbort.signal.aborted) {
+      this.breakerAbort = new AbortController();
     }
     /**
      * Turn state only. The reported totals must outlive cleanup — this runs
@@ -3169,6 +3170,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       let langfuseHandler: CallbackEntry | undefined;
       let invokeConfig = {
         ...config,
+        /** The run-scoped breaker composed in, so a stream-limit trip in one
+         * parallel agent node also cancels sibling nodes' in-flight model
+         * calls, not only their subagents. */
+        signal: composeAbortSignals(config.signal, this.breakerAbort.signal),
         metadata: {
           ...(config.metadata ?? {}),
           ...traceMetadata,
@@ -3246,6 +3251,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * must reject. Rethrow before any recovery path.
          */
         if (primaryError instanceof StreamLimitExceededError) {
+          /** Tripped before rethrowing so parallel agent nodes' in-flight
+           * model calls and subagents stop while the rejection propagates. */
+          this.breakerAbort.abort(primaryError);
           throw primaryError;
         }
         /**
@@ -3900,9 +3908,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
           parentSignal: this.signal,
           breakerScope: {
-            signal: (): AbortSignal => this.subagentBreakerAbort.signal,
+            signal: (): AbortSignal => this.breakerAbort.signal,
             trip: (reason: unknown): void =>
-              this.subagentBreakerAbort.abort(reason),
+              this.breakerAbort.abort(reason),
           },
           hookRegistry: this.hookRegistry,
           /** Lazy — Run wires the registry onto the graph AFTER

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -123,6 +123,7 @@ import {
 import {
   resolveStreamLimits,
   StreamLimitExceededError,
+  STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
@@ -1070,6 +1071,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * a run, and a reused graph must start its next run unaborted. */
   breakerAbort = new AbortController();
 
+  /** Incremented whenever `breakerAbort` is replaced. Stamped into each
+   * model attempt's metadata ({@link STREAM_LIMIT_EPOCH_KEY}) so the stream
+   * handler's consumer-side trip binds to the run that produced the event
+   * rather than whichever controller is live when a straggling chunk is
+   * finally handled. */
+  breakerEpoch = 0;
+
   /** The stream-limit error behind an already-fired breaker, whether this
    * graph's own controller tripped or a parent run's breaker arrived through
    * the composed constructor signal (child graphs own separate controllers).
@@ -1216,6 +1224,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * hold their entry-time capture of it; a late stream-limit trip on that
      * old controller must not cancel the run starting now. */
     this.breakerAbort = new AbortController();
+    this.breakerEpoch += 1;
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1999,6 +2008,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * fresh controller. Trips and reason reads below stay on this
        * capture. */
       const attemptBreaker = this.breakerAbort;
+      const attemptBreakerEpoch = this.breakerEpoch;
       /** Already-tripped-at-entry: a parallel sibling's breach has failed
        * the run before this node was scheduled. Rethrow before hooks or the
        * provider call — a custom provider that doesn't synchronously reject
@@ -3215,6 +3225,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            *  length cap, but scope trust (`isForeignScope`) needs the id
            *  verbatim regardless of length. */
           agentId,
+          [STREAM_LIMIT_EPOCH_KEY]: attemptBreakerEpoch,
         },
       };
       initializeLangfuseTracing(langfuse);
@@ -3252,6 +3263,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       try {
         if (preInvokeContextOverflowError != null) {
           throw preInvokeContextOverflowError;
+        }
+        /** Rechecked after the pre-invoke awaits (context-usage dispatch,
+         * hooks): a sibling can trip the breaker while this node is paused
+         * in one of them, and a provider that doesn't synchronously reject
+         * an aborted signal would still start the request. */
+        {
+          const preInvokeTrip = this.resolveTrippedBreakerReason(
+            attemptBreaker.signal
+          );
+          if (preInvokeTrip != null) {
+            throw preInvokeTrip;
+          }
         }
         result = await withLangfuseRuntimeScope(
           resolveLangfuseRuntimeScope({
@@ -4188,6 +4211,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             /** Read per attempt: a sibling branch tripping the run breaker
              * must also cancel in-flight summarization model calls. */
             getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
+            /** The node captures this at entry so its own chunk handler's
+             * breach trips the run that STARTED the summarization, not a
+             * controller installed by a later reset. */
+            getBreakerController: (): AbortController => this.breakerAbort,
             dispatchRunStep: async (runStep, nodeConfig) => {
               const resolvedConfig = nodeConfig ?? this.config;
               if (runStep.agentId != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -73,6 +73,7 @@ import {
   isGoogleLike,
   apportionTokenCounts,
   calculateMaxToolResultChars,
+  composeAbortSignals,
   joinKeys,
   sleep,
 } from '@/utils';
@@ -161,25 +162,6 @@ const EMPTY_PREEMPT_BOUNDARY: PreemptBoundaryResult = {
   messages: [],
   preventContinuation: false,
 };
-
-/**
- * One signal that fires when either input fires. `AbortSignal.any` is skipped
- * when the inputs collapse to a single signal — the composite is a fresh
- * object per call, and the common cases (one channel, or the host reusing the
- * same controller for both) don't need one.
- */
-function composeAbortSignals(
-  a: AbortSignal | undefined,
-  b: AbortSignal | undefined
-): AbortSignal | undefined {
-  if (a == null || a === b) {
-    return b;
-  }
-  if (b == null) {
-    return a;
-  }
-  return AbortSignal.any([a, b]);
-}
 
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
@@ -1813,6 +1795,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         maxToolResultChars: agentContext?.maxToolResultChars,
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
         fileCheckpointer: this.getOrCreateFileCheckpointer(),
+        getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
         errorHandler: (data, metadata): Promise<boolean> =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
@@ -1880,6 +1863,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       maxToolResultChars: agentContext?.maxToolResultChars,
       toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
       fileCheckpointer: this.getOrCreateFileCheckpointer(),
+      getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
     });
     this.registerCompiledToolNode(node);
     return node;
@@ -2006,6 +1990,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       state: t.AgentSubgraphState,
       config?: RunnableConfig
     ): Promise<Partial<t.AgentSubgraphState>> => {
+      /** Captured at node ENTRY, before any host-facing await (context-usage
+       * dispatch, hooks): a sibling's trip can fail the run and a prompt
+       * next run can reset the controller while this node is paused in one
+       * of those awaits, and a later capture would bind this attempt to the
+       * fresh controller. Trips and reason reads below stay on this
+       * capture. */
+      const attemptBreaker = this.breakerAbort;
       const agentContext = this.agentContexts.get(agentId);
       if (!agentContext) {
         throw new Error(`Agent context not found for agentId: ${agentId}`);
@@ -3197,11 +3188,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentName: agentContext.name,
       });
       let langfuseHandler: CallbackEntry | undefined;
-      /** Captured per attempt, like subagent executions: a failed run's
-       * reset replaces the controller, and an old attempt's catch reading
-       * the live controller would miss its own run's trip. Trips and reason
-       * reads below bind to this capture. */
-      const attemptBreaker = this.breakerAbort;
       let invokeConfig = {
         ...config,
         /** The run-scoped breaker composed in, so a stream-limit trip in one

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -19,6 +19,7 @@ import type {
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
   ResolvedStreamLimits,
+  RunBreakerScope,
   StreamedToolCallArgTally,
   StreamDeltaEventTally,
 } from '@/llm/streamLimits';
@@ -126,6 +127,7 @@ import {
   StreamLimitExceededError,
   sweepStaleStreamLimitEntries,
   STREAM_LIMIT_EPOCH_KEY,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
 } from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
@@ -1080,6 +1082,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * finally handled. */
   breakerEpoch = 0;
 
+  /** Immutable snapshot of the run's breaker identity (epoch + controller),
+   * replaced as ONE object whenever `resetValues` installs a fresh
+   * controller. Sites that pause across awaits capture it at entry and
+   * revalidate by REFERENCE afterwards — a single identity comparison
+   * proves no reset happened while suspended, where separate epoch and
+   * controller reads could interleave with one. */
+  runScope: RunBreakerScope = Object.freeze({
+    epoch: 0,
+    controller: this.breakerAbort,
+  });
+
+  /** Generation keys of model attempts still in flight (see
+   * `StreamLimitState.activeStreamLimitGenerations`). Lazily created by the
+   * attempt lease; spans resets on purpose. */
+  activeStreamLimitGenerations?: Set<string>;
+
   /** The stream-limit error behind an already-fired breaker, whether this
    * graph's own controller tripped or a parent run's breaker arrived through
    * the composed constructor signal (child graphs own separate controllers).
@@ -1223,9 +1241,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * original budgets; older entries are removed. */
     sweepStaleStreamLimitEntries(
       this.streamedToolCallArgTallies,
-      this.breakerEpoch
+      this.breakerEpoch,
+      this.activeStreamLimitGenerations
     );
-    sweepStaleStreamLimitEntries(this.streamDeltaEventCounts, this.breakerEpoch);
+    sweepStaleStreamLimitEntries(
+      this.streamDeltaEventCounts,
+      this.breakerEpoch,
+      this.activeStreamLimitGenerations
+    );
     this.streamLimitChargeCredits = undefined;
     /** Run-start is the only safe replacement point for the breaker:
      * end-of-run cleanup must leave it in place so straggling parallel
@@ -1236,6 +1259,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * old controller must not cancel the run starting now. */
     this.breakerAbort = new AbortController();
     this.breakerEpoch += 1;
+    this.runScope = Object.freeze({
+      epoch: this.breakerEpoch,
+      controller: this.breakerAbort,
+    });
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1830,6 +1857,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
         fileCheckpointer: this.getOrCreateFileCheckpointer(),
         getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
+        getRunScope: (): RunBreakerScope => this.runScope,
         errorHandler: (data, metadata): Promise<boolean> =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
@@ -1898,6 +1926,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
       fileCheckpointer: this.getOrCreateFileCheckpointer(),
       getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
+      getRunScope: (): RunBreakerScope => this.runScope,
     });
     this.registerCompiledToolNode(node);
     return node;
@@ -4087,11 +4116,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const toolCall = (config as { toolCall?: { id?: string } }).toolCall;
           const parentToolCallId =
             typeof toolCall?.id === 'string' ? toolCall.id : undefined;
+          /** The parent tool batch's entry-captured scope (stamped by
+           * ToolNode before PreToolUse hooks) — binds this child to the
+           * run that dispatched it, not to whatever controller a reset
+           * installed while the hooks were awaited. */
+          const batchScope = config.configurable?.[
+            RUN_BREAKER_SCOPE_CONFIG_KEY
+          ] as RunBreakerScope | undefined;
           const result = await executor.execute({
             description,
             subagentType,
             threadId,
             parentToolCallId,
+            breaker: batchScope?.controller,
             /**
              * Forward the parent's `configurable` so host-set fields
              * (`requestBody`, `user`, etc.) propagate into the child
@@ -4181,6 +4218,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       | WeakMap<object, Map<string, number>>
       | undefined => this.streamLimitChargeCredits;
     const readBreakerEpoch = (): number => this.breakerEpoch;
+    const readActiveGenerations = (): Set<string> | undefined =>
+      this.activeStreamLimitGenerations;
+    const writeActiveGenerations = (value: Set<string> | undefined): void => {
+      this.activeStreamLimitGenerations = value;
+    };
     const writeChargeCredits = (
       value: WeakMap<object, Map<string, number>> | undefined
     ): void => {
@@ -4237,6 +4279,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
              * entries. */
             get breakerEpoch(): number {
               return readBreakerEpoch();
+            },
+            /** Accessor pair like the charge credits: summary attempts
+             * lease their generations on the GRAPH's active set, and the
+             * lazy `??=` in the lease helper must install there. */
+            get activeStreamLimitGenerations(): Set<string> | undefined {
+              return readActiveGenerations();
+            },
+            set activeStreamLimitGenerations(value: Set<string> | undefined) {
+              writeActiveGenerations(value);
             },
             /** Read per attempt: a sibling branch tripping the run breaker
              * must also cancel in-flight summarization model calls. */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -20,6 +20,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
   ResolvedStreamLimits,
   StreamedToolCallArgTally,
+  StreamDeltaEventTally,
 } from '@/llm/streamLimits';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
@@ -123,6 +124,7 @@ import {
 import {
   resolveStreamLimits,
   StreamLimitExceededError,
+  sweepStaleStreamLimitEntries,
   STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
@@ -1056,7 +1058,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   streamedToolCallArgTallies: Map<string, StreamedToolCallArgTally> =
     new Map();
   /** Streamed chunk events per model generation, keyed by generation key. */
-  streamDeltaEventCounts: Map<string, number> = new Map();
+  streamDeltaEventCounts: Map<string, StreamDeltaEventTally> = new Map();
   /** Per-chunk-object, per-generation charge balances (lazily created; see
    * `StreamLimitState`). Reinitialized by both reset paths: a model may
    * retain and re-yield one mutable chunk object, whose nested map would
@@ -1213,8 +1215,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
     this.eagerEventToolSuppressions.clear();
-    this.streamedToolCallArgTallies.clear();
-    this.streamDeltaEventCounts.clear();
+    /** Grace sweep instead of a clear: producer loops of straggling
+     * attempts use these maps directly and sit outside the consumer-only
+     * epoch gate — clearing would hand a cancellation-ignoring provider a
+     * fresh allowance at every run start. Entries from the epoch that is
+     * ending survive exactly one reset so those stragglers stay on their
+     * original budgets; older entries are removed. */
+    sweepStaleStreamLimitEntries(
+      this.streamedToolCallArgTallies,
+      this.breakerEpoch
+    );
+    sweepStaleStreamLimitEntries(this.streamDeltaEventCounts, this.breakerEpoch);
     this.streamLimitChargeCredits = undefined;
     /** Run-start is the only safe replacement point for the breaker:
      * end-of-run cleanup must leave it in place so straggling parallel
@@ -1579,13 +1590,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /* Misc.*/
 
   getRunMessages(): BaseMessage[] | undefined {
-    if (this.messages == null) {
+    /** Runtime-honest widening: a disposed-but-cached graph (HITL
+     * resume/reconnect through a WeakRef cache) can carry null here despite
+     * the field type. */
+    const messages = this.messages as BaseMessage[] | undefined;
+    if (messages == null) {
       return this.cachedRunMessages;
     }
-    if (this.messages.length === 0 && this.cachedRunMessages != null) {
+    if (messages.length === 0 && this.cachedRunMessages != null) {
       return this.cachedRunMessages;
     }
-    return this.messages.slice(this.startIndex);
+    return messages.slice(this.startIndex);
   }
 
   override getDiscoveredTools(agentId?: string): string[] {
@@ -1637,10 +1652,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     // `messages` can be null/undefined on a graph that has been disposed
     // (clearHeavyState) but is still reachable via a cache (e.g. RedisJobStore's
     // WeakRef) during a HITL resume/reconnect. Guard instead of dereferencing null.
-    if (this.messages == null) {
+    const messages = this.messages as BaseMessage[] | undefined;
+    if (messages == null) {
       return undefined;
     }
-    return convertMessagesToContent(this.messages.slice(this.startIndex));
+    return convertMessagesToContent(messages.slice(this.startIndex));
   }
 
   getCalibrationRatio(): number {
@@ -1675,13 +1691,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     // `contentData` can be null/undefined on a disposed-but-cached graph during a
     // HITL resume/reconnect; without this guard `[...this.contentData]` throws
     // "this.contentData is not iterable".
-    if (this.contentData == null) {
+    const contentData = this.contentData as t.RunStep[] | undefined;
+    if (contentData == null) {
       return [];
     }
     if (agentId == null || agentId === '') {
-      return [...this.contentData];
+      return [...contentData];
     }
-    return this.contentData.filter((step) => step.agentId === agentId);
+    return contentData.filter((step) => step.agentId === agentId);
   }
 
   /**
@@ -4163,6 +4180,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const readChargeCredits = ():
       | WeakMap<object, Map<string, number>>
       | undefined => this.streamLimitChargeCredits;
+    const readBreakerEpoch = (): number => this.breakerEpoch;
     const writeChargeCredits = (
       value: WeakMap<object, Map<string, number>> | undefined
     ): void => {
@@ -4213,6 +4231,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               value: WeakMap<object, Map<string, number>> | undefined
             ) {
               writeChargeCredits(value);
+            },
+            /** Live epoch, so summary tallies are creation-tagged and the
+             * resetValues grace sweep treats them like model-attempt
+             * entries. */
+            get breakerEpoch(): number {
+              return readBreakerEpoch();
             },
             /** Read per attempt: a sibling branch tripping the run breaker
              * must also cancel in-flight summarization model calls. */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3262,6 +3262,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           this.breakerAbort.abort(primaryError);
           throw primaryError;
         }
+        /** A sibling that tripped the shared breaker aborts this branch's
+         * composed signal, and some providers surface that as a generic
+         * abort error; entering overflow planning or the fallback chain
+         * would start new provider work after the run-wide breaker fired.
+         * Rethrow the breaker's own stream-limit reason instead. */
+        if (
+          this.breakerAbort.signal.aborted &&
+          this.breakerAbort.signal.reason instanceof StreamLimitExceededError
+        ) {
+          throw this.breakerAbort.signal.reason;
+        }
         /**
          * A context overflow is a deterministic consequence of the payload,
          * not a provider being unavailable — so it is answered by compacting
@@ -3501,6 +3512,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
              * and subagents before the rejection propagates. */
             this.breakerAbort.abort(fallbackError);
             throw fallbackError;
+          }
+          if (
+            this.breakerAbort.signal.aborted &&
+            this.breakerAbort.signal.reason instanceof StreamLimitExceededError
+          ) {
+            /** Same sibling-abort translation guard as the primary catch. */
+            throw this.breakerAbort.signal.reason;
           }
           const overflowCandidates =
             getFallbackOverflowCandidates(fallbackError);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1074,6 +1074,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     new Map();
   /** Streamed chunk events per model generation, keyed by generation key. */
   streamDeltaEventCounts: Map<string, number> = new Map();
+  /** Per-chunk-object, per-generation charge balances (lazily created; see
+   * `StreamLimitState`). Reinitialized by both reset paths: a model may
+   * retain and re-yield one mutable chunk object, whose nested map would
+   * otherwise grow by one attempt-stamped entry per model call for the
+   * graph's lifetime. */
+  streamLimitChargeCredits?: WeakMap<object, Map<string, number>>;
   /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
    * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
@@ -1189,6 +1195,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.eagerEventToolSuppressions.clear();
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
+    this.streamLimitChargeCredits = undefined;
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1248,6 +1255,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.overrideModel = undefined;
     this.streamedToolCallArgTallies.clear();
     this.streamDeltaEventCounts.clear();
+    this.streamLimitChargeCredits = undefined;
     /**
      * Turn state only. The reported totals must outlive cleanup — this runs
      * in `processStream`'s `finally`, and the host reads `getPreemptStats()`

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -115,6 +115,11 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
+import {
+  resolveStreamLimits,
+  type ResolvedStreamLimits,
+  type StreamedToolCallArgTally,
+} from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
@@ -1052,6 +1057,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /** See {@link t.StandardGraphInput.preemption}. */
   preemption?: t.StreamPreemption;
   /**
+   * Stream circuit breakers, resolved once from
+   * {@link t.StandardGraphInput.streamLimits}. The stream handler enforces
+   * these on every streamed chunk event.
+   */
+  streamLimits: ResolvedStreamLimits;
+  /**
+   * Cumulative streamed argument bytes per in-flight tool call, keyed by
+   * `stepKey:index`. Per-run accumulation state, cleared by both reset
+   * paths.
+   */
+  streamedToolCallArgTallies: Map<string, StreamedToolCallArgTally> =
+    new Map();
+  /** Streamed chunk events per generation turn, keyed by stepKey. */
+  streamDeltaEventCounts: Map<string, number> = new Map();
+  /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both
    * reset paths so a fresh turn gets a fresh budget, while a HITL resume —
    * which skips `resetValues` — keeps what it had left.
@@ -1108,6 +1128,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     subagentUsageSink,
     subagentScope,
     preemption,
+    streamLimits,
   }: t.StandardGraphInput) {
     super();
     this.runId = runId;
@@ -1117,6 +1138,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.subagentUsageSink = subagentUsageSink;
     this.subagentScope = subagentScope === true;
     this.preemption = preemption;
+    this.streamLimits = resolveStreamLimits(streamLimits);
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -1162,6 +1184,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
     this.eagerEventToolSuppressions.clear();
+    this.streamedToolCallArgTallies.clear();
+    this.streamDeltaEventCounts.clear();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
@@ -1219,6 +1243,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
+    this.streamedToolCallArgTallies.clear();
+    this.streamDeltaEventCounts.clear();
     /**
      * Turn state only. The reported totals must outlive cleanup — this runs
      * in `processStream`'s `finally`, and the host reads `getPreemptStats()`

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -119,7 +119,10 @@ import type {
   ResolvedStreamLimits,
   StreamedToolCallArgTally,
 } from '@/llm/streamLimits';
-import { resolveStreamLimits } from '@/llm/streamLimits';
+import {
+  resolveStreamLimits,
+  StreamLimitExceededError,
+} from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
@@ -3216,6 +3219,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           metadata,
         });
         /**
+         * A tripped stream circuit breaker is a deliberate abort, not a
+         * provider failure: entering overflow recovery or the fallback chain
+         * would spend more provider work after the safety limit fired, and a
+         * succeeding fallback would resolve a run the public contract says
+         * must reject. Rethrow before any recovery path.
+         */
+        if (primaryError instanceof StreamLimitExceededError) {
+          throw primaryError;
+        }
+        /**
          * A context overflow is a deterministic consequence of the payload,
          * not a provider being unavailable — so it is answered by compacting
          * and retrying rather than by re-sending the same oversized prompt
@@ -3876,6 +3889,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           langfuse: this.langfuse,
           tokenCounter: agentContext.tokenCounter,
           usageSink: this.subagentUsageSink,
+          streamLimits: this.streamLimits,
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4215,6 +4215,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
              * breach trips the run that STARTED the summarization, not a
              * controller installed by a later reset. */
             getBreakerController: (): AbortController => this.breakerAbort,
+            /** Captured at node entry and stamped into the summary attempt
+             * metadata, so the wire consumer epoch-gates old-run summary
+             * chunks exactly like model-attempt chunks. */
+            getBreakerEpoch: (): number => this.breakerEpoch,
             dispatchRunStep: async (runStep, nodeConfig) => {
               const resolvedConfig = nodeConfig ?? this.config;
               if (runStep.agentId != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4050,6 +4050,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }),
     });
 
+    const readChargeCredits = ():
+      | WeakMap<object, Map<string, number>>
+      | undefined => this.streamLimitChargeCredits;
+    const writeChargeCredits = (
+      value: WeakMap<object, Map<string, number>> | undefined
+    ): void => {
+      this.streamLimitChargeCredits = value;
+    };
+
     const workflow = new StateGraph(StateAnnotation)
       .addNode(agentNode, this.createCallModel(agentId))
       .addNode(
@@ -4081,6 +4090,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             streamLimits: this.streamLimits,
             streamDeltaEventCounts: this.streamDeltaEventCounts,
             streamedToolCallArgTallies: this.streamedToolCallArgTallies,
+            /** Accessor pair, not a value copy: unlike the two maps above,
+             * the credit map is REPLACED by graph resets rather than cleared
+             * in place, and the guards' lazy `??=` must install onto the
+             * graph — a copy held here would survive resets and grow one
+             * attempt-stamped entry per compaction for a retained reused
+             * chunk object. */
+            get streamLimitChargeCredits() {
+              return readChargeCredits();
+            },
+            set streamLimitChargeCredits(
+              value: WeakMap<object, Map<string, number>> | undefined
+            ) {
+              writeChargeCredits(value);
+            },
             dispatchRunStep: async (runStep, nodeConfig) => {
               const resolvedConfig = nodeConfig ?? this.config;
               if (runStep.agentId != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3953,9 +3953,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
           parentSignal: this.signal,
           breakerScope: {
-            signal: (): AbortSignal => this.breakerAbort.signal,
-            trip: (reason: unknown): void =>
-              this.breakerAbort.abort(reason),
+            controller: (): AbortController => this.breakerAbort,
           },
           hookRegistry: this.hookRegistry,
           /** Lazy — Run wires the registry onto the graph AFTER

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3489,6 +3489,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               })
           );
         } catch (fallbackError) {
+          if (fallbackError instanceof StreamLimitExceededError) {
+            /** Same treatment as the primary path: a fallback stream that
+             * trips the breaker must stop parallel agent nodes' model calls
+             * and subagents before the rejection propagates. */
+            this.breakerAbort.abort(fallbackError);
+            throw fallbackError;
+          }
           const overflowCandidates =
             getFallbackOverflowCandidates(fallbackError);
           let fallbackRecovery: OverflowRecoveryPlan | null = null;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -115,11 +115,11 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import {
-  resolveStreamLimits,
-  type ResolvedStreamLimits,
-  type StreamedToolCallArgTally,
+import type {
+  ResolvedStreamLimits,
+  StreamedToolCallArgTally,
 } from '@/llm/streamLimits';
+import { resolveStreamLimits } from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
@@ -1064,12 +1064,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   streamLimits: ResolvedStreamLimits;
   /**
    * Cumulative streamed argument bytes per in-flight tool call, keyed by
-   * `stepKey:index`. Per-run accumulation state, cleared by both reset
-   * paths.
+   * generation key + chunk index (see `resolveGenerationKey`). Per-run
+   * accumulation state, cleared by both reset paths.
    */
   streamedToolCallArgTallies: Map<string, StreamedToolCallArgTally> =
     new Map();
-  /** Streamed chunk events per generation turn, keyed by stepKey. */
+  /** Streamed chunk events per model generation, keyed by generation key. */
   streamDeltaEventCounts: Map<string, number> = new Map();
   /**
    * Seals charged against `preemption.maxSeals`. Per-turn: cleared by both

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -130,6 +130,37 @@ describe('run breaker lifecycle', () => {
     expect(graph.activeStreamLimitGenerations?.size ?? 0).toBe(0);
   });
 
+  it('takes no attempt lease when every guard is disabled', async () => {
+    const { attemptInvoke } = await import('@/llm/invoke');
+    const { resolveStreamLimits } = await import('@/llm/streamLimits');
+    const { AIMessage, HumanMessage } = await import(
+      '@langchain/core/messages'
+    );
+    const graph = makeGraph();
+    graph.streamLimits = resolveStreamLimits({
+      maxToolCallArgBytes: 0,
+      maxToolCallArgBytesByTool: { writer: 0 },
+    });
+    const model = {
+      invoke: async (): Promise<InstanceType<typeof AIMessage>> =>
+        new AIMessage({ content: 'ok' }),
+    };
+
+    await attemptInvoke(
+      {
+        model: model as unknown as t.ChatModel,
+        messages: [new HumanMessage('hi')],
+        provider: Providers.OPENAI,
+        context: graph as Parameters<typeof attemptInvoke>[0]['context'],
+      },
+      { metadata: {} }
+    );
+
+    /** The lease only protects accounting entries; with no guard able to
+     * fire there are none, and per-attempt bookkeeping must not allocate. */
+    expect(graph.activeStreamLimitGenerations).toBeUndefined();
+  });
+
   it('holds a post-reset producer straggler to its original byte budget', async () => {
     const { enforceStreamLimitsForWireChunk } = await import(
       '@/llm/streamLimits'

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -40,26 +40,77 @@ describe('run breaker lifecycle', () => {
     expect(graph.breakerAbort.signal.aborted).toBe(false);
   });
 
-  it('preserves stream-limit accounting through end-of-run cleanup', () => {
+  it('keeps straggler accounting through cleanup and one reset, then sweeps it', () => {
     const graph = makeGraph();
-    graph.streamedToolCallArgTallies.set('gen:i:0', { bytes: 42 });
-    graph.streamDeltaEventCounts.set('gen', 7);
+    const epoch = graph.breakerEpoch;
+    graph.streamedToolCallArgTallies.set('gen:i:0', { bytes: 42, epoch });
+    graph.streamDeltaEventCounts.set('gen', { count: 7, epoch });
     graph.streamLimitChargeCredits = new WeakMap();
 
     /** Cleanup runs while sibling attempts can still be unwinding on the
      * retained breaker; clearing here would hand a cancellation-ignoring
      * provider's late chunks a fresh budget. */
     graph.clearHeavyState();
-    expect(graph.streamedToolCallArgTallies.size).toBe(1);
-    expect(graph.streamDeltaEventCounts.size).toBe(1);
+    expect(graph.streamedToolCallArgTallies.get('gen:i:0')?.bytes).toBe(42);
+    expect(graph.streamDeltaEventCounts.get('gen')?.count).toBe(7);
     expect(graph.streamLimitChargeCredits).toBeDefined();
 
-    /** The next run start clears them — its epoch bump already drops
-     * stamped straggler events before accounting. */
+    /** Producer loops of straggling attempts sit OUTSIDE the consumer-only
+     * epoch gate, so their entries must survive the next run start too —
+     * one grace reset keeps them on their original budgets. */
+    graph.resetValues();
+    expect(graph.streamedToolCallArgTallies.get('gen:i:0')?.bytes).toBe(42);
+    expect(graph.streamDeltaEventCounts.get('gen')?.count).toBe(7);
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+
+    /** A second reset sweeps entries from older epochs. */
     graph.resetValues();
     expect(graph.streamedToolCallArgTallies.size).toBe(0);
     expect(graph.streamDeltaEventCounts.size).toBe(0);
-    expect(graph.streamLimitChargeCredits).toBeUndefined();
+  });
+
+  it('holds a post-reset producer straggler to its original byte budget', async () => {
+    const { enforceStreamLimitsForWireChunk } = await import(
+      '@/llm/streamLimits'
+    );
+    const graph = makeGraph();
+    graph.streamLimits = {
+      maxToolCallArgBytes: 100,
+      maxDeltaEventsPerTurn: 0,
+      hasEnforceableToolCallArgLimit: true,
+    };
+    const metadata = {
+      langgraph_checkpoint_ns: '',
+      langgraph_node: 'agent',
+      langgraph_step: 1,
+    };
+    const chunkOf = (
+      args: string
+    ): { tool_call_chunks: Array<Record<string, unknown>> } => ({
+      tool_call_chunks: [{ id: 'call_1', name: 'writer', args, index: 0 }],
+    });
+
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata,
+      chunk: chunkOf('x'.repeat(60)) as Parameters<
+        typeof enforceStreamLimitsForWireChunk
+      >[0]['chunk'],
+    });
+
+    /** The next run starts while this producer is still draining. Its next
+     * chunk must land on the ORIGINAL 60-byte tally and trip, not open a
+     * fresh allowance. */
+    graph.resetValues();
+    expect(() =>
+      enforceStreamLimitsForWireChunk({
+        graph,
+        metadata,
+        chunk: chunkOf('x'.repeat(60)) as Parameters<
+          typeof enforceStreamLimitsForWireChunk
+        >[0]['chunk'],
+      })
+    ).toThrow(StreamLimitExceededError);
   });
 
   it('rejects a model node at entry when the breaker has already tripped', async () => {

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -69,6 +69,67 @@ describe('run breaker lifecycle', () => {
     expect(graph.streamDeltaEventCounts.size).toBe(0);
   });
 
+  it('holds a leased producer straggler to its budget across two run resets', async () => {
+    const { attemptInvoke } = await import('@/llm/invoke');
+    const { resolveStreamLimits } = await import('@/llm/streamLimits');
+    const { AIMessageChunk, HumanMessage } = await import(
+      '@langchain/core/messages'
+    );
+    const graph = makeGraph();
+    graph.streamLimits = resolveStreamLimits({ maxToolCallArgBytes: 100 });
+    const chunkOf = (args: string): InstanceType<typeof AIMessageChunk> =>
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [
+          {
+            type: 'tool_call_chunk',
+            id: 'call_1',
+            name: 'writer',
+            args,
+            index: 0,
+          },
+        ],
+      });
+    let yields = 0;
+    const model = {
+      stream: async function* (): AsyncGenerator<
+        InstanceType<typeof AIMessageChunk>
+        > {
+        yields += 1;
+        yield chunkOf('x'.repeat(60));
+        /** Two prompt runs start and reset while this attempt is still
+         * draining. Its lease must keep the tally alive — reset counting
+         * cannot prove the attempt finished. */
+        graph.resetValues();
+        graph.resetValues();
+        yields += 1;
+        yield chunkOf('x'.repeat(60));
+        yields += 1;
+        yield chunkOf('x');
+      },
+    };
+
+    await expect(
+      attemptInvoke(
+        {
+          model: model as unknown as t.ChatModel,
+          messages: [new HumanMessage('hi')],
+          provider: Providers.OPENAI,
+          context: graph as Parameters<
+            typeof attemptInvoke
+          >[0]['context'],
+          onChunk: () => {
+            /* producer loop enforcement is under test */
+          },
+        },
+        { metadata: {} }
+      )
+    ).rejects.toMatchObject({ kind: 'tool_call_args', limit: 100 });
+    expect(yields).toBe(2);
+    /** The attempt's finally released its lease and entries. */
+    expect(graph.activeStreamLimitGenerations?.size ?? 0).toBe(0);
+  });
+
   it('holds a post-reset producer straggler to its original byte budget', async () => {
     const { enforceStreamLimitsForWireChunk } = await import(
       '@/llm/streamLimits'

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -40,6 +40,28 @@ describe('run breaker lifecycle', () => {
     expect(graph.breakerAbort.signal.aborted).toBe(false);
   });
 
+  it('preserves stream-limit accounting through end-of-run cleanup', () => {
+    const graph = makeGraph();
+    graph.streamedToolCallArgTallies.set('gen:i:0', { bytes: 42 });
+    graph.streamDeltaEventCounts.set('gen', 7);
+    graph.streamLimitChargeCredits = new WeakMap();
+
+    /** Cleanup runs while sibling attempts can still be unwinding on the
+     * retained breaker; clearing here would hand a cancellation-ignoring
+     * provider's late chunks a fresh budget. */
+    graph.clearHeavyState();
+    expect(graph.streamedToolCallArgTallies.size).toBe(1);
+    expect(graph.streamDeltaEventCounts.size).toBe(1);
+    expect(graph.streamLimitChargeCredits).toBeDefined();
+
+    /** The next run start clears them — its epoch bump already drops
+     * stamped straggler events before accounting. */
+    graph.resetValues();
+    expect(graph.streamedToolCallArgTallies.size).toBe(0);
+    expect(graph.streamDeltaEventCounts.size).toBe(0);
+    expect(graph.streamLimitChargeCredits).toBeUndefined();
+  });
+
   it('rejects a model node at entry when the breaker has already tripped', async () => {
     const graph = makeGraph();
     const trip = makeTrip();

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
+import { Providers } from '@/common';
+import { StandardGraph } from '../Graph';
+
+const makeAgent = (agentId: string): t.AgentInputs => ({
+  agentId,
+  provider: Providers.OPENAI,
+  instructions: `You are ${agentId}.`,
+});
+
+const makeGraph = (): StandardGraph =>
+  new StandardGraph({
+    runId: 'run_1',
+    agents: [makeAgent('agent')],
+  });
+
+const makeTrip = (): StreamLimitExceededError =>
+  new StreamLimitExceededError({
+    kind: 'tool_call_args',
+    limit: 10,
+    observed: 11,
+    toolName: 'db_query',
+  });
+
+describe('run breaker lifecycle', () => {
+  it('replaces the breaker at every run start, even when un-aborted', () => {
+    const graph = makeGraph();
+    const previous = graph.breakerAbort;
+    expect(previous.signal.aborted).toBe(false);
+
+    graph.resetValues();
+
+    expect(graph.breakerAbort).not.toBe(previous);
+    /** A straggler from the failed run trips the controller it captured;
+     * the run starting now must not observe it. */
+    previous.abort(makeTrip());
+    expect(graph.breakerAbort.signal.aborted).toBe(false);
+  });
+
+  it('rejects a model node at entry when the breaker has already tripped', async () => {
+    const graph = makeGraph();
+    const trip = makeTrip();
+    graph.breakerAbort.abort(trip);
+
+    const node = graph.createCallModel('agent');
+    await expect(
+      node(
+        { messages: [] } as unknown as t.AgentSubgraphState,
+        {} as RunnableConfig
+      )
+    ).rejects.toBe(trip);
+  });
+
+  it('lets a model node proceed past entry when the breaker is live', async () => {
+    const graph = makeGraph();
+    const node = graph.createCallModel('agent');
+    /** With a live breaker the entry guard must not fire; the node then
+     * fails later, on the missing config, proving it got past the guard. */
+    await expect(
+      node(
+        { messages: [] } as unknown as t.AgentSubgraphState,
+        undefined
+      )
+    ).rejects.toThrow('No config provided');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,3 +82,14 @@ export { initializeModel } from './llm/init';
 export { attemptInvoke, tryFallbackProviders } from './llm/invoke';
 export { canSealPreempt } from './llm/preempt';
 export { isThinkingEnabled, getMaxOutputTokensKey } from './llm/request';
+export {
+  DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  StreamLimitExceededError,
+  resolveStreamLimits,
+} from './llm/streamLimits';
+export type {
+  StreamedToolCallArgTally,
+  ResolvedStreamLimits,
+  StreamLimitState,
+  StreamLimitKind,
+} from './llm/streamLimits';

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -46,6 +46,7 @@ import {
   supportsBedrockToolCache,
   type PromptCacheTtl,
 } from '@/messages/cache';
+import { linkStreamLimitCanonical } from '@/llm/streamLimits';
 import { applyCachePointsToConversePayload } from './cachePoints';
 import { insertBedrockToolCachePoint } from './toolCache';
 
@@ -572,8 +573,17 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           }
 
           const deltaChunk = handleConverseStreamContentBlockDelta(splitDelta);
+          const enrichedChunk = this.enrichChunk(deltaChunk, seenBlockIndices);
+          if (enrichedChunk !== deltaChunk) {
+            /** The callback copy is the same emission as the enriched yield;
+             * without the link, stream-limit accounting charges both message
+             * objects and Bedrock tool arguments falsely trip near half the
+             * cap. Linked on the messages, which are what the accounting
+             * observes. */
+            linkStreamLimitCanonical(deltaChunk.message, enrichedChunk.message);
+          }
           await enqueueChunk({
-            chunk: this.enrichChunk(deltaChunk, seenBlockIndices),
+            chunk: enrichedChunk,
             callbackChunk: deltaChunk,
             callbackToken: deltaChunk.text,
             smooth,
@@ -602,8 +612,18 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
                     toolUseBlockIndices.add(idx);
                   }
                 }
+                const enrichedStart = this.enrichChunk(
+                  startChunk,
+                  seenBlockIndices
+                );
+                if (enrichedStart !== startChunk) {
+                  linkStreamLimitCanonical(
+                    startChunk.message,
+                    enrichedStart.message
+                  );
+                }
                 await enqueueChunk({
-                  chunk: this.enrichChunk(startChunk, seenBlockIndices),
+                  chunk: enrichedStart,
                   callbackChunk: startChunk,
                   callbackToken: startChunk.text,
                 });

--- a/src/llm/invoke.streamLimits.test.ts
+++ b/src/llm/invoke.streamLimits.test.ts
@@ -1,0 +1,142 @@
+/**
+ * `attemptInvoke`'s local stream branch (no registered SDK dispatcher) must
+ * charge the event budget even for chunks that produce no handling chunk:
+ * a pure OpenRouter reasoning-replay chunk is skipped for content handling,
+ * and in this branch no `streamEvents` consumer counts the wire event
+ * either, so a looping replay stream would otherwise bypass an enabled
+ * `maxDeltaEventsPerTurn` indefinitely.
+ */
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest } from '@jest/globals';
+import type { AgentContext } from '@/agents/AgentContext';
+import type { StandardGraph } from '@/graphs';
+import type * as t from '@/types';
+import {
+  StreamLimitExceededError,
+  resolveStreamLimits,
+} from '@/llm/streamLimits';
+import { attemptInvoke } from '@/llm/invoke';
+import { ContentTypes, Providers } from '@/common';
+
+function createContext(
+  overrides: Partial<StandardGraph> = {}
+): StandardGraph {
+  const runSteps = new Map<string, t.RunStep>();
+  const stepIdsByKey = new Map<string, string>();
+  let stepCounter = 0;
+
+  const graph = {
+    config: { configurable: { user_id: 'user_1' }, metadata: { run_id: 'r1' } },
+    eagerEventToolExecution: undefined,
+    eagerEventToolExecutions: new Map(),
+    eagerEventToolCallChunks: new Map(),
+    eagerEventToolSuppressions: new Set<string>(),
+    handlerRegistry: undefined,
+    hookRegistry: undefined,
+    humanInTheLoop: undefined,
+    toolOutputReferences: undefined,
+    sessions: new Map(),
+    toolCallStepIds: new Map(),
+    messageIdsByStepKey: new Map(),
+    messageStepHasToolCalls: new Map(),
+    prelimMessageIdsByStepKey: new Map([['step-key', 'msg_1']]),
+    getAgentContext: jest.fn(
+      (): Partial<AgentContext> => ({
+        provider: Providers.OPENAI,
+        reasoningKey: 'reasoning_content',
+        currentTokenType: ContentTypes.TEXT,
+        toolDefinitions: [],
+        graphTools: [],
+        agentId: 'agent_1',
+      })
+    ),
+    getOrCreateToolOutputRegistry: jest.fn(() => undefined),
+    shouldPreemptStream: jest.fn(() => false),
+    claimPreemptSeal: jest.fn(() => false),
+    getStepKey: jest.fn(() => 'step-key'),
+    getStepIdByKey: jest.fn((stepKey: string) => {
+      const stepId = stepIdsByKey.get(stepKey);
+      if (stepId == null) {
+        throw new Error('no current step');
+      }
+      return stepId;
+    }),
+    getRunStep: jest.fn((stepId: string) => runSteps.get(stepId)),
+    dispatchRunStep: jest.fn(async (stepKey: string, details: unknown) => {
+      const id = `step_${++stepCounter}`;
+      stepIdsByKey.set(stepKey, id);
+      runSteps.set(id, {
+        id,
+        type: (details as { type: t.RunStep['type'] }).type,
+        stepDetails: details as t.RunStep['stepDetails'],
+      } as t.RunStep);
+      return id;
+    }),
+    dispatchRunStepDelta: jest.fn(async () => undefined),
+    dispatchMessageDelta: jest.fn(async () => undefined),
+    dispatchReasoningDelta: jest.fn(async () => undefined),
+    ...overrides,
+  };
+  return graph as unknown as StandardGraph;
+}
+
+const replayChunk = (): AIMessageChunk =>
+  new AIMessageChunk({
+    content: 'abc',
+    additional_kwargs: { reasoning_details: [{ type: 'reasoning.text' }] },
+  });
+
+function createReplayModel(replays: number): t.ChatModel {
+  return {
+    stream: async function* stream(): AsyncGenerator<AIMessageChunk> {
+      yield new AIMessageChunk({ content: 'abc' });
+      for (let i = 0; i < replays; i++) {
+        yield replayChunk();
+      }
+    },
+  } as unknown as t.ChatModel;
+}
+
+describe('attemptInvoke local branch stream limits', () => {
+  it('charges skipped OpenRouter replay chunks against the event budget', async () => {
+    const context = createContext({
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 3 }),
+    });
+
+    let caught: unknown;
+    try {
+      await attemptInvoke(
+        {
+          model: createReplayModel(10),
+          messages: [new HumanMessage('hi')],
+          provider: Providers.OPENROUTER,
+          context: context as unknown as Parameters<
+            typeof attemptInvoke
+          >[0]['context'],
+        },
+        { metadata: { langgraph_node: 'agent', langgraph_step: 1 } }
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(StreamLimitExceededError);
+    expect((caught as StreamLimitExceededError).kind).toBe('delta_events');
+  });
+
+  it('leaves replay streams unbounded when the cap is disabled', async () => {
+    const context = createContext({ streamLimits: resolveStreamLimits() });
+
+    const result = await attemptInvoke(
+      {
+        model: createReplayModel(10),
+        messages: [new HumanMessage('hi')],
+        provider: Providers.OPENROUTER,
+        context: context as unknown as Parameters<
+          typeof attemptInvoke
+        >[0]['context'],
+      },
+      { metadata: { langgraph_node: 'agent', langgraph_step: 1 } }
+    );
+    expect(result.messages).toHaveLength(1);
+  });
+});

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -556,7 +556,7 @@ describe('attemptInvoke applies lazy ref annotation', () => {
     responses.model.defaultOptions = { tools: [] };
     responses.model._useResponsesApi = (options) =>
       Array.isArray((options as { tools?: unknown[] } | undefined)?.tools) &&
-      ((options as { tools: unknown[] }).tools.length ?? 0) > 0;
+      (options as { tools: unknown[] }).tools.length > 0;
 
     await attemptInvoke(
       {

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -829,6 +829,54 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
     jest.resetModules();
   });
 
+  it('rejects before invoking a fallback when the breaker tripped during preparation', async () => {
+    const abort = new AbortController();
+    const { invokeMessages, model } = buildCapturingModel();
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('@/llm/init', () => ({
+        initializeModel: (): unknown => model,
+      }));
+      const { tryFallbackProviders: freshTry } = (await import(
+        '@/llm/invoke'
+      )) as { tryFallbackProviders: typeof tryFallbackProviders };
+      const { StreamLimitExceededError: FreshStreamLimitError } = (await import(
+        '@/llm/streamLimits'
+      )) as typeof import('@/llm/streamLimits');
+      const trip = new FreshStreamLimitError({
+        kind: 'tool_call_args',
+        limit: 10,
+        observed: 11,
+        toolName: 'db_query',
+      });
+
+      /** The sibling's trip lands while fallback preparation is awaited; the
+       * fallback must not be invoked at all — a provider that ignores the
+       * aborted signal and SUCCEEDS would resolve a run that must reject. */
+      await expect(
+        freshTry({
+          fallbacks: [{ provider: Providers.ANTHROPIC }],
+          messages: [
+            new ToolMessage({
+              name: 'echo',
+              tool_call_id: 'tc1',
+              status: 'success',
+              content: 'output',
+            }),
+          ],
+          primaryError: new Error('primary failed'),
+          config: { signal: abort.signal },
+          prepareProviderMessages: async ({ messages: preparedMessages }) => {
+            abort.abort(trip);
+            return preparedMessages;
+          },
+        })
+      ).rejects.toBe(trip);
+    });
+    expect(invokeMessages).toHaveLength(0);
+
+    jest.dontMock('@/llm/init');
+  });
+
   it('neutralizes preempted Responses history before an OpenAI Chat fallback', async () => {
     const reasoning = {
       id: 'rs_fallback',

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -19,6 +19,7 @@ import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/messag
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { convertMessageContentToParts } from '@/llm/google/utils/common';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { toLangChainContent } from '@/messages/langchain';
 import { Constants, Providers } from '@/common';
@@ -827,6 +828,45 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
 
     jest.dontMock('@/llm/init');
     jest.resetModules();
+  });
+
+  it('stops draining a cancellation-ignoring stream once the breaker trips', async () => {
+    const abort = new AbortController();
+    /** Statically imported class: neighboring tests reset the module
+     * registry, and a dynamically imported instance would fail the
+     * statically-linked drain loop's instanceof check. */
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    let yields = 0;
+    const model: StubModel = {
+      stream: jest.fn(async function* (): AsyncGenerator<AIMessageChunk> {
+        for (let i = 0; i < 5; i++) {
+          yields += 1;
+          yield new AIMessageChunk({ content: `c${i}` });
+        }
+      }),
+    };
+
+    /** The stub ignores the abort signal entirely; only the per-chunk
+     * breaker check in the drain loop can stop it. */
+    await expect(
+      attemptInvoke(
+        {
+          model: model as t.ChatModel,
+          messages: [new HumanMessage('hi')],
+          provider: Providers.ANTHROPIC,
+          onChunk: () => {
+            abort.abort(trip);
+          },
+        },
+        { signal: abort.signal }
+      )
+    ).rejects.toBe(trip);
+    expect(yields).toBeLessThanOrEqual(2);
   });
 
   it('rejects before invoking a fallback when the breaker tripped during preparation', async () => {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -39,6 +39,7 @@ import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
   enforceStreamDeltaEventLimit,
+  enforceStreamLimitsForWireChunk,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
   STREAM_LIMIT_ATTEMPT_KEY,
@@ -888,6 +889,16 @@ export async function attemptInvoke(
        */
       let redispatchMetadata: Record<string, unknown> | undefined;
       for await (const chunk of stream) {
+        /**
+         * Charged synchronously, ahead of the decoupled `streamEvents`
+         * reader that will echo this same chunk to the registered handler:
+         * a lagging reader would otherwise let an oversized complete call
+         * return to LangGraph and reach ToolNode before the queued handler
+         * throws. The chunk is marked so the echo skips accounting.
+         */
+        if (context != null) {
+          enforceStreamLimitsForWireChunk({ graph: context, metadata, chunk });
+        }
         const handlingChunk = getStreamHandlingChunk({
           current: finalChunk,
           next: chunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -849,9 +849,16 @@ export async function attemptInvoke(
            * either — yet a cumulative OpenRouter replay can still carry
            * `tool_call_chunks` or complete `tool_calls` that are appended
            * below. Charge the full limits (event budget and argument bytes)
-           * directly so neither cap can be bypassed.
+           * directly so neither cap can be bypassed. Consumer side: the
+           * local handler.handle call above claims as consumer, and one
+           * reused chunk object can alternate between these two arms.
            */
-          enforceStreamLimitsForWireChunk({ graph: context, metadata, chunk });
+          enforceStreamLimitsForWireChunk({
+            graph: context,
+            metadata,
+            chunk,
+            side: 'consumer',
+          });
         }
         finalChunk = appendStreamChunk({
           current: finalChunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -12,6 +12,7 @@ import type { ChatGeneration } from '@langchain/core/outputs';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { StreamLimitState } from '@/llm/streamLimits';
 import type { ContextOverflowContext } from '@/utils/errors';
 import type * as t from '@/types';
 import {
@@ -39,6 +40,9 @@ import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
   enforceStreamLimitsForWireChunk,
+  registerActiveStreamLimitGeneration,
+  releaseStreamLimitGeneration,
+  resolveGenerationKey,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
   STREAM_LIMIT_ATTEMPT_KEY,
@@ -675,21 +679,74 @@ function appendStreamChunk({
  * Pass an `onChunk` callback to override this with custom chunk processing
  * (e.g. summarization delta events).
  */
+interface AttemptInvokeParams {
+  model: t.ChatModel;
+  messages: BaseMessage[];
+  provider: Providers;
+  context?: InvokeContext;
+  onChunk?: OnChunk;
+  /** Accounting owner for callers that deliberately pass no `context`
+   * (summarization) — used ONLY for the attempt's accounting lease, never
+   * for charge claims. */
+  streamLimitState?: StreamLimitState;
+}
+
+/**
+ * One model attempt. Stamps the attempt identity into callback metadata
+ * (see the generation-key notes in `streamLimits.ts`), leases the attempt's
+ * accounting for its LIFETIME, and releases both from `finally`: retention
+ * must follow the attempt — a cancellation-ignoring straggler keeps its
+ * original budget no matter how many runs start and reset while it drains.
+ */
 export async function attemptInvoke(
+  params: AttemptInvokeParams,
+  config?: RunnableConfig
+): Promise<Partial<t.BaseGraphState>> {
+  const stampedConfig: RunnableConfig = {
+    ...config,
+    metadata: {
+      ...(config?.metadata ?? {}),
+      [Constants.INVOKED_PROVIDER]: params.provider,
+      /**
+       * One `attemptInvoke` call is one model attempt; primary, fallback,
+       * and retry attempts within a node otherwise share the same langgraph
+       * metadata, so without a unique attempt stamp a fallback re-streaming
+       * a tool call from scratch would be charged the failed primary's
+       * partial bytes (or a same-named sibling fallback's) and could
+       * falsely trip the stream limits. The stamp rides the same metadata
+       * rebuild that already attributes the serving provider.
+       */
+      [STREAM_LIMIT_ATTEMPT_KEY]: ++streamLimitAttemptSeq,
+    },
+  };
+  const leaseTarget = params.context ?? params.streamLimitState;
+  const generationKey =
+    leaseTarget != null
+      ? resolveGenerationKey(
+        stampedConfig.metadata as Record<string, unknown>
+      )
+      : undefined;
+  if (leaseTarget != null && generationKey != null) {
+    registerActiveStreamLimitGeneration(leaseTarget, generationKey);
+  }
+  try {
+    return await attemptInvokeBody(params, stampedConfig);
+  } finally {
+    if (leaseTarget != null && generationKey != null) {
+      releaseStreamLimitGeneration(leaseTarget, generationKey);
+    }
+  }
+}
+
+async function attemptInvokeBody(
   {
     model,
     messages,
     provider,
     context,
     onChunk,
-  }: {
-    model: t.ChatModel;
-    messages: BaseMessage[];
-    provider: Providers;
-    context?: InvokeContext;
-    onChunk?: OnChunk;
-  },
-  config?: RunnableConfig
+  }: AttemptInvokeParams,
+  config: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
   /**
    * Pull the run-scoped tool output registry off the graph (when one
@@ -705,7 +762,7 @@ export async function attemptInvoke(
     callOptions: config,
   });
   const registry = context?.getOrCreateToolOutputRegistry();
-  const runId = config?.configurable?.run_id as string | undefined;
+  const runId = config.configurable?.run_id as string | undefined;
   const annotated = annotateMessagesForLLM(invocationMessages, registry, runId);
   /**
    * Keyed on the provider ACTUALLY serving this call, not the agent's primary.
@@ -764,24 +821,6 @@ export async function attemptInvoke(
    * wrong for fallback-served calls — or `ls_provider` — which derived
    * providers inherit from their base class.
    */
-  config = {
-    ...config,
-    metadata: {
-      ...(config?.metadata ?? {}),
-      [Constants.INVOKED_PROVIDER]: provider,
-      /**
-       * One `attemptInvoke` call is one model attempt; primary, fallback,
-       * and retry attempts within a node otherwise share the same langgraph
-       * metadata, so without a unique attempt stamp a fallback re-streaming
-       * a tool call from scratch would be charged the failed primary's
-       * partial bytes (or a same-named sibling fallback's) and could
-       * falsely trip the stream limits. The stamp rides the same metadata
-       * rebuild that already attributes the serving provider.
-       */
-      [STREAM_LIMIT_ATTEMPT_KEY]: ++streamLimitAttemptSeq,
-    },
-  };
-
   if (model.stream) {
     /**
      * Observed, not dictated. `handleChatModelStart` fires with the chat
@@ -1091,6 +1130,7 @@ export async function tryFallbackProviders({
   primaryError,
   context,
   onChunk,
+  streamLimitState,
   overflowContext,
   prepareProviderMessages,
 }: {
@@ -1101,6 +1141,9 @@ export async function tryFallbackProviders({
   primaryError: unknown;
   context?: InvokeContext;
   onChunk?: OnChunk;
+  /** Accounting-lease owner forwarded to each fallback attempt (see
+   * `AttemptInvokeParams.streamLimitState`). */
+  streamLimitState?: StreamLimitState;
   /**
    * Prompt-size corroboration for signatures that are not self-describing.
    * Vertex AI's overflow is a bare `400` with no reason, so without this a
@@ -1188,6 +1231,7 @@ export async function tryFallbackProviders({
           provider: fb.provider,
           context,
           onChunk,
+          streamLimitState,
         },
         fbConfig
       );

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -38,9 +38,9 @@ import {
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
-  resetStreamLimitTallies,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
+  STREAM_LIMIT_ATTEMPT_KEY,
 } from '@/llm/streamLimits';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
@@ -88,8 +88,18 @@ export type InvokeContext = NonNullable<
 /**
  * Per-chunk callback for custom stream processing.
  * When provided, replaces the default `ChatModelStreamHandler`.
+ *
+ * `metadata` is the attempt's callback metadata (carrying the provider and
+ * stream-limit attempt stamps), so consumers that count against the stream
+ * limits key each model attempt separately.
  */
-export type OnChunk = (chunk: AIMessageChunk) => void | Promise<void>;
+export type OnChunk = (
+  chunk: AIMessageChunk,
+  metadata?: Record<string, unknown>
+) => void | Promise<void>;
+
+/** Unique per-model-attempt sequence; see the stamp in `attemptInvoke`. */
+let streamLimitAttemptSeq = 0;
 
 export function usesNativeOpenAIResponses(
   model: t.ChatModel,
@@ -681,17 +691,6 @@ export async function attemptInvoke(
   config?: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
   /**
-   * One `attemptInvoke` call is one model attempt; primary, fallback, and
-   * retry attempts within a node share the same langgraph metadata, so a
-   * fallback that re-streams a tool call from scratch would otherwise be
-   * charged the failed primary's partial bytes and could falsely trip the
-   * stream limits.
-   */
-  resetStreamLimitTallies({
-    graph: context,
-    metadata: config?.metadata as Record<string, unknown> | undefined,
-  });
-  /**
    * Pull the run-scoped tool output registry off the graph (when one
    * exists) and project ToolMessages carrying ref metadata into a
    * transient annotated copy. The original `messages` array stays
@@ -769,6 +768,16 @@ export async function attemptInvoke(
     metadata: {
       ...(config?.metadata ?? {}),
       [Constants.INVOKED_PROVIDER]: provider,
+      /**
+       * One `attemptInvoke` call is one model attempt; primary, fallback,
+       * and retry attempts within a node otherwise share the same langgraph
+       * metadata, so without a unique attempt stamp a fallback re-streaming
+       * a tool call from scratch would be charged the failed primary's
+       * partial bytes (or a same-named sibling fallback's) and could
+       * falsely trip the stream limits. The stamp rides the same metadata
+       * rebuild that already attributes the serving provider.
+       */
+      [STREAM_LIMIT_ATTEMPT_KEY]: ++streamLimitAttemptSeq,
     },
   };
 
@@ -805,8 +814,11 @@ export async function attemptInvoke(
       getRegisteredDefaultChatStreamHandler(context);
 
     if (onChunk) {
+      const attemptMetadata = config.metadata as
+        | Record<string, unknown>
+        | undefined;
       for await (const chunk of stream) {
-        await onChunk(chunk);
+        await onChunk(chunk, attemptMetadata);
         finalChunk = appendStreamChunk({
           current: finalChunk,
           next: chunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -43,6 +43,7 @@ import {
   registerActiveStreamLimitGeneration,
   releaseStreamLimitGeneration,
   resolveGenerationKey,
+  streamLimitAccountingEnabled,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
   STREAM_LIMIT_ATTEMPT_KEY,
@@ -719,7 +720,14 @@ export async function attemptInvoke(
       [STREAM_LIMIT_ATTEMPT_KEY]: ++streamLimitAttemptSeq,
     },
   };
-  const leaseTarget = params.context ?? params.streamLimitState;
+  const rawLeaseTarget = params.context ?? params.streamLimitState;
+  /** No lease when no guard can fire: the lease only protects accounting
+   * entries, and fully disabled guards must allocate no bookkeeping at
+   * all — per-attempt included. */
+  const leaseTarget =
+    rawLeaseTarget != null && streamLimitAccountingEnabled(rawLeaseTarget)
+      ? rawLeaseTarget
+      : undefined;
   const generationKey =
     leaseTarget != null
       ? resolveGenerationKey(

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -38,6 +38,7 @@ import {
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
+  enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
   STREAM_LIMIT_ATTEMPT_KEY,
@@ -841,6 +842,14 @@ export async function attemptInvoke(
             metadata,
             context
           );
+        } else if (context != null) {
+          /**
+           * A pure OpenRouter reasoning-replay chunk yields no handling
+           * chunk, and in this local branch no `streamEvents` consumer
+           * counts the wire event either. Charge the event budget directly
+           * so a looping replay stream cannot bypass an enabled cap.
+           */
+          enforceStreamDeltaEventLimit({ graph: context, metadata });
         }
         finalChunk = appendStreamChunk({
           current: finalChunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1173,6 +1173,16 @@ export async function tryFallbackProviders({
       if (e instanceof StreamLimitExceededError) {
         throw e;
       }
+      /** A parallel sibling's trip aborts this branch's composed signal, and
+       * a provider can surface that as a generic abort error; advancing to
+       * the next fallback would start new provider work after the safety
+       * abort. Rethrow the breaker's own reason instead. */
+      if (
+        config?.signal?.aborted === true &&
+        config.signal.reason instanceof StreamLimitExceededError
+      ) {
+        throw config.signal.reason;
+      }
       lastError = e;
       const fallbackOverflowContext: ContextOverflowContext = {
         provider: fb.provider,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -37,6 +37,10 @@ import {
 } from '@/messages/cache';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
+import {
+  resetStreamLimitTallies,
+  StreamLimitExceededError,
+} from '@/llm/streamLimits';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { manualToolStreamProviders } from '@/llm/providers';
@@ -676,6 +680,17 @@ export async function attemptInvoke(
   config?: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
   /**
+   * One `attemptInvoke` call is one model attempt; primary, fallback, and
+   * retry attempts within a node share the same langgraph metadata, so a
+   * fallback that re-streams a tool call from scratch would otherwise be
+   * charged the failed primary's partial bytes and could falsely trip the
+   * stream limits.
+   */
+  resetStreamLimitTallies({
+    graph: context,
+    metadata: config?.metadata as Record<string, unknown> | undefined,
+  });
+  /**
    * Pull the run-scoped tool output registry off the graph (when one
    * exists) and project ToolMessages carrying ref metadata into a
    * transient annotated copy. The original `messages` array stays
@@ -1086,6 +1101,14 @@ export async function tryFallbackProviders({
       );
       return result;
     } catch (e) {
+      /**
+       * A tripped stream circuit breaker is a deliberate abort, not a
+       * provider failure. Continuing would try the remaining fallbacks and a
+       * succeeding one would resolve a run that must reject.
+       */
+      if (e instanceof StreamLimitExceededError) {
+        throw e;
+      }
       lastError = e;
       const fallbackOverflowContext: ContextOverflowContext = {
         provider: fb.provider,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -38,7 +38,6 @@ import {
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
-  enforceStreamDeltaEventLimit,
   enforceStreamLimitsForWireChunk,
   StreamLimitExceededError,
   STREAM_LIMIT_REDISPATCH_KEY,
@@ -845,12 +844,14 @@ export async function attemptInvoke(
           );
         } else if (context != null) {
           /**
-           * A pure OpenRouter reasoning-replay chunk yields no handling
-           * chunk, and in this local branch no `streamEvents` consumer
-           * counts the wire event either. Charge the event budget directly
-           * so a looping replay stream cannot bypass an enabled cap.
+           * A replay-skipped chunk yields no handling chunk, and in this
+           * local branch no `streamEvents` consumer judges the wire event
+           * either — yet a cumulative OpenRouter replay can still carry
+           * `tool_call_chunks` or complete `tool_calls` that are appended
+           * below. Charge the full limits (event budget and argument bytes)
+           * directly so neither cap can be bypassed.
            */
-          enforceStreamDeltaEventLimit({ graph: context, metadata });
+          enforceStreamLimitsForWireChunk({ graph: context, metadata, chunk });
         }
         finalChunk = appendStreamChunk({
           current: finalChunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -813,12 +813,27 @@ export async function attemptInvoke(
     let preempted = false;
     const registeredStreamHandler =
       getRegisteredDefaultChatStreamHandler(context);
+    /** A sibling's trip aborts the composed signal, but an adapter that
+     * ignores cancellation keeps yielding — and text-only chunks with the
+     * event cap off never throw in enforcement, so nothing else would stop
+     * the drain. Checked on every yielded chunk in all three loops;
+     * throwing closes the iterator and tears down the provider stream. */
+    const throwIfBreakerTripped = (): void => {
+      const signal = config.signal;
+      if (
+        signal?.aborted === true &&
+        signal.reason instanceof StreamLimitExceededError
+      ) {
+        throw signal.reason;
+      }
+    };
 
     if (onChunk) {
       const attemptMetadata = config.metadata as
         | Record<string, unknown>
         | undefined;
       for await (const chunk of stream) {
+        throwIfBreakerTripped();
         /** An onChunk consumer replaces the stream handler entirely, so
          * stream limits are enforced here for every such caller — public
          * package consumers get no other accounting. The internal
@@ -842,6 +857,7 @@ export async function attemptInvoke(
       const metadata = config.metadata as Record<string, unknown> | undefined;
       const streamHandler = new ChatModelStreamHandler();
       for await (const chunk of stream) {
+        throwIfBreakerTripped();
         const handlingChunk = getStreamHandlingChunk({
           current: finalChunk,
           next: chunk,
@@ -909,6 +925,7 @@ export async function attemptInvoke(
        */
       let redispatchMetadata: Record<string, unknown> | undefined;
       for await (const chunk of stream) {
+        throwIfBreakerTripped();
         /**
          * Charged synchronously, ahead of the decoupled `streamEvents`
          * reader that will echo this same chunk to the registered handler:

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -40,6 +40,7 @@ import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import {
   resetStreamLimitTallies,
   StreamLimitExceededError,
+  STREAM_LIMIT_REDISPATCH_KEY,
 } from '@/llm/streamLimits';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
@@ -857,6 +858,14 @@ export async function attemptInvoke(
       }
     } else {
       const metadata = config.metadata as Record<string, unknown> | undefined;
+      /**
+       * The original wire chunk still reaches the registered handler through
+       * `streamEvents` (where the late-reasoning skip discards it AFTER the
+       * event guard counts it), so this inline re-dispatch of the transformed
+       * chunk is marked to not consume a second event-budget slot. Allocated
+       * once per attempt, only when a transformation occurs.
+       */
+      let redispatchMetadata: Record<string, unknown> | undefined;
       for await (const chunk of stream) {
         const handlingChunk = getStreamHandlingChunk({
           current: finalChunk,
@@ -864,10 +873,14 @@ export async function attemptInvoke(
           provider,
         });
         if (handlingChunk != null && handlingChunk !== chunk) {
+          redispatchMetadata ??= {
+            ...(metadata ?? {}),
+            [STREAM_LIMIT_REDISPATCH_KEY]: true,
+          };
           await registeredStreamHandler.handle(
             GraphEvents.CHAT_MODEL_STREAM,
             { chunk: handlingChunk },
-            metadata,
+            redispatchMetadata,
             context
           );
         }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -819,6 +819,17 @@ export async function attemptInvoke(
         | Record<string, unknown>
         | undefined;
       for await (const chunk of stream) {
+        /** An onChunk consumer replaces the stream handler entirely, so
+         * stream limits are enforced here for every such caller — public
+         * package consumers get no other accounting, and the internal
+         * summarization onChunk relies on this same charge. */
+        if (context != null) {
+          enforceStreamLimitsForWireChunk({
+            graph: context,
+            metadata: attemptMetadata,
+            chunk,
+          });
+        }
         await onChunk(chunk, attemptMetadata);
         finalChunk = appendStreamChunk({
           current: finalChunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1154,6 +1154,16 @@ export async function tryFallbackProviders({
           maxContextTokens: fb.maxContextTokens,
           config: fbConfig,
         })) ?? messages;
+      /** A sibling can trip the breaker while the preparation above is
+       * awaited — and the catch below only sees attempts that THROW, so a
+       * provider that ignores an aborted signal and succeeds would resolve
+       * a run that must reject. Check before every fallback invocation. */
+      if (
+        config?.signal?.aborted === true &&
+        config.signal.reason instanceof StreamLimitExceededError
+      ) {
+        throw config.signal.reason;
+      }
       const result = await attemptInvoke(
         {
           model: fbModel as t.ChatModel,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -821,8 +821,9 @@ export async function attemptInvoke(
       for await (const chunk of stream) {
         /** An onChunk consumer replaces the stream handler entirely, so
          * stream limits are enforced here for every such caller — public
-         * package consumers get no other accounting, and the internal
-         * summarization onChunk relies on this same charge. */
+         * package consumers get no other accounting. The internal
+         * summarization onChunk charges producer-side itself and passes no
+         * context, precisely so this claim and its own never stack. */
         if (context != null) {
           enforceStreamLimitsForWireChunk({
             graph: context,

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -102,8 +102,8 @@ describe('resolveGenerationKey', () => {
       metadata: attemptTwo,
       toolCallChunks: [chunk({ args: '12345678', index: 0 })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|7:0')?.bytes).toBe(8);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|8:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|7:i:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|8:i:0')?.bytes).toBe(8);
   });
 });
 
@@ -160,7 +160,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         toolCallChunks: [chunk({ args: '€€', index: 0 })],
       })
     ).toThrow(StreamLimitExceededError);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:i:0')?.bytes).toBe(6);
   });
 
   it('reconciles surrogate pairs split across chunk boundaries', () => {
@@ -179,7 +179,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
       metadata,
       toolCallChunks: [chunk({ args: low, index: 0 })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(4);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:i:0')?.bytes).toBe(4);
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
@@ -204,7 +204,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
       metadata,
       toolCallChunks: [chunk({ args: 'abc', index: 0 })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:i:0')?.bytes).toBe(6);
   });
 
   it('tallies parallel tool calls and generations independently', () => {
@@ -248,7 +248,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
       metadata,
       toolCallChunks: [chunk({ id: 'call_b', name: 'b_tool', args: '123456' })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:call_a')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:c:call_a')?.bytes).toBe(6);
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
@@ -333,7 +333,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:i:0')).toBe(false);
   });
 
   it('releases the tally on a Bedrock Converse stop chunk without counting it', () => {
@@ -356,7 +356,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:i:0')).toBe(false);
   });
 
   it('does nothing when disabled', () => {

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -12,6 +12,7 @@ import {
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
+  resetStreamLimitTallies,
   resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
@@ -165,7 +166,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
     ).toThrow('(tool call: second)');
   });
 
-  it('falls back to the chunk id, then a shared bucket, when index is absent', () => {
+  it('falls back to the chunk id when index is absent', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),
     };
@@ -188,6 +189,55 @@ describe('enforceStreamedToolCallArgLimit', () => {
         toolCallChunks: [chunk({ id: 'call_b', args: '789' })],
       })
     ).toThrow('(tool call: b_tool)');
+  });
+
+  it('keys anonymous chunks by batch position so parallel calls stay separate', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),
+    };
+    const metadata = generation(1);
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [
+        chunk({ name: 'anon_a', args: '123456' }),
+        chunk({ name: 'anon_b', args: '123456' }),
+      ],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:#0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:#1')?.bytes).toBe(6);
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata,
+        toolCallChunks: [chunk({ args: '789' })],
+      })
+    ).toThrow(StreamLimitExceededError);
+  });
+
+  it('checks arrival-sealed complete calls standalone, keeping no tally', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 64 }),
+    };
+    const sealAll = { [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' } };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: generation(1),
+      toolCallChunks: [
+        chunk({ args: 'x'.repeat(40) }),
+        chunk({ args: 'y'.repeat(40) }),
+      ],
+      responseMetadata: sealAll,
+    });
+    expect(graph.streamedToolCallArgTallies?.size).toBe(0);
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata: generation(1),
+        toolCallChunks: [chunk({ name: 'big_call', args: 'z'.repeat(70) })],
+        responseMetadata: sealAll,
+      })
+    ).toThrow('(tool call: big_call)');
   });
 
   it('replaces the tally when a single-seal chunk restates complete args (OpenAI Responses)', () => {
@@ -216,10 +266,10 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(40);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
   });
 
-  it('ignores empty-args seal chunks (Bedrock Converse stop chunks)', () => {
+  it('releases the tally on a Bedrock Converse stop chunk without counting it', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
     };
@@ -239,7 +289,48 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(10);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
+  });
+
+  it('resets one generation on a new model attempt, keeping other generations', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({
+        maxToolCallArgBytes: 10,
+        maxDeltaEventsPerTurn: 5,
+      }),
+    };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: generation(1),
+      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: generation(2),
+      toolCallChunks: [chunk({ args: '1234', index: 0 })],
+    });
+    enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
+
+    resetStreamLimitTallies({ graph, metadata: generation(1) });
+
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|2:0')?.bytes).toBe(4);
+    expect(graph.streamDeltaEventCounts?.has('|agent|1')).toBe(false);
+
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: generation(1),
+      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(8);
+  });
+
+  it('reset is a no-op when nothing was counted', () => {
+    const graph: StreamLimitState = {};
+    resetStreamLimitTallies({ graph, metadata: generation(1) });
+    resetStreamLimitTallies({ graph: undefined, metadata: generation(1) });
+    expect(graph.streamedToolCallArgTallies).toBeUndefined();
+    expect(graph.streamDeltaEventCounts).toBeUndefined();
   });
 
   it('does nothing when disabled', () => {

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -163,6 +163,50 @@ describe('enforceStreamedToolCallArgLimit', () => {
     expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(6);
   });
 
+  it('reconciles surrogate pairs split across chunk boundaries', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 4 }),
+    };
+    const metadata = generation(1);
+    const [high, low] = ['\uD83D', '\uDE00'];
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: high, index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: low, index: 0 })],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(4);
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata,
+        toolCallChunks: [chunk({ args: 'x', index: 0 })],
+      })
+    ).toThrow(StreamLimitExceededError);
+  });
+
+  it('keeps counting unpaired surrogates conservatively', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    };
+    const metadata = generation(1);
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: '\uD83D', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: 'abc', index: 0 })],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(6);
+  });
+
   it('tallies parallel tool calls and generations independently', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -10,14 +10,13 @@ import {
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
   STREAM_LIMIT_REDISPATCH_KEY,
+  STREAM_LIMIT_ATTEMPT_KEY,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
-  resetStreamLimitTallies,
   resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
-import { Constants } from '@/common';
 
 const chunk = (fields: Partial<ToolCallChunk>): ToolCallChunk =>
   ({ type: 'tool_call_chunk', ...fields }) as ToolCallChunk;
@@ -85,26 +84,26 @@ describe('resolveGenerationKey', () => {
     expect(resolveGenerationKey({})).toBe('|||');
   });
 
-  it('scopes fallback attempts via the INVOKED_MODEL metadata stamp', () => {
-    const primary = generation(1);
-    const fallback = { ...generation(1), [Constants.INVOKED_MODEL]: 'fb-model' };
-    expect(resolveGenerationKey(fallback)).not.toBe(resolveGenerationKey(primary));
+  it('scopes model attempts via the attempt stamp, even for identical models', () => {
+    const attemptOne = { ...generation(1), [STREAM_LIMIT_ATTEMPT_KEY]: 7 };
+    const attemptTwo = { ...generation(1), [STREAM_LIMIT_ATTEMPT_KEY]: 8 };
+    expect(resolveGenerationKey(attemptOne)).not.toBe(resolveGenerationKey(attemptTwo));
 
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 10 }),
     };
     enforceStreamedToolCallArgLimit({
       graph,
-      metadata: primary,
+      metadata: attemptOne,
       toolCallChunks: [chunk({ args: '12345678', index: 0 })],
     });
     enforceStreamedToolCallArgLimit({
       graph,
-      metadata: fallback,
+      metadata: attemptTwo,
       toolCallChunks: [chunk({ args: '12345678', index: 0 })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(8);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|fb-model:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|7:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|8:0')?.bytes).toBe(8);
   });
 });
 
@@ -314,47 +313,6 @@ describe('enforceStreamedToolCallArgLimit', () => {
       },
     });
     expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
-  });
-
-  it('resets one generation on a new model attempt, keeping other generations', () => {
-    const graph: StreamLimitState = {
-      streamLimits: resolveStreamLimits({
-        maxToolCallArgBytes: 10,
-        maxDeltaEventsPerTurn: 5,
-      }),
-    };
-    enforceStreamedToolCallArgLimit({
-      graph,
-      metadata: generation(1),
-      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
-    });
-    enforceStreamedToolCallArgLimit({
-      graph,
-      metadata: generation(2),
-      toolCallChunks: [chunk({ args: '1234', index: 0 })],
-    });
-    enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
-
-    resetStreamLimitTallies({ graph, metadata: generation(1) });
-
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|2|:0')?.bytes).toBe(4);
-    expect(graph.streamDeltaEventCounts?.has('|agent|1|')).toBe(false);
-
-    enforceStreamedToolCallArgLimit({
-      graph,
-      metadata: generation(1),
-      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
-    });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(8);
-  });
-
-  it('reset is a no-op when nothing was counted', () => {
-    const graph: StreamLimitState = {};
-    resetStreamLimitTallies({ graph, metadata: generation(1) });
-    resetStreamLimitTallies({ graph: undefined, metadata: generation(1) });
-    expect(graph.streamedToolCallArgTallies).toBeUndefined();
-    expect(graph.streamDeltaEventCounts).toBeUndefined();
   });
 
   it('does nothing when disabled', () => {

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from '@jest/globals';
+import type { ToolCallChunk } from '@langchain/core/messages/tool';
+import type { StreamLimitState } from '@/llm/streamLimits';
+import {
+  DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  enforceStreamedToolCallArgLimit,
+  enforceStreamDeltaEventLimit,
+  StreamLimitExceededError,
+  resolveStreamLimits,
+} from '@/llm/streamLimits';
+
+const chunk = (fields: Partial<ToolCallChunk>): ToolCallChunk =>
+  ({ type: 'tool_call_chunk', ...fields }) as ToolCallChunk;
+
+describe('resolveStreamLimits', () => {
+  it('defaults the byte cap ON and the event cap OFF', () => {
+    expect(resolveStreamLimits()).toEqual({
+      maxToolCallArgBytes: DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+      maxDeltaEventsPerTurn: 0,
+    });
+    expect(resolveStreamLimits({})).toEqual({
+      maxToolCallArgBytes: DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+      maxDeltaEventsPerTurn: 0,
+    });
+  });
+
+  it('honors explicit values and floors fractions', () => {
+    expect(
+      resolveStreamLimits({ maxToolCallArgBytes: 100.9, maxDeltaEventsPerTurn: 5 })
+    ).toEqual({ maxToolCallArgBytes: 100, maxDeltaEventsPerTurn: 5 });
+  });
+
+  it('treats 0, negatives, and Infinity as disabled', () => {
+    expect(resolveStreamLimits({ maxToolCallArgBytes: 0 }).maxToolCallArgBytes).toBe(0);
+    expect(resolveStreamLimits({ maxToolCallArgBytes: -5 }).maxToolCallArgBytes).toBe(0);
+    expect(
+      resolveStreamLimits({ maxToolCallArgBytes: Infinity }).maxToolCallArgBytes
+    ).toBe(0);
+    expect(
+      resolveStreamLimits({ maxDeltaEventsPerTurn: -1 }).maxDeltaEventsPerTurn
+    ).toBe(0);
+  });
+
+  it('falls back to the default on NaN', () => {
+    expect(resolveStreamLimits({ maxToolCallArgBytes: NaN }).maxToolCallArgBytes).toBe(
+      DEFAULT_MAX_TOOL_CALL_ARG_BYTES
+    );
+  });
+});
+
+describe('enforceStreamedToolCallArgLimit', () => {
+  it('accumulates across chunk events and throws past the limit', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 10 }),
+    };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'step',
+      toolCallChunks: [chunk({ name: 'db_query', id: 'call_1', args: '', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'step',
+      toolCallChunks: [chunk({ args: '12345', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'step',
+      toolCallChunks: [chunk({ args: '67890', index: 0 })],
+    });
+    let caught: unknown;
+    try {
+      enforceStreamedToolCallArgLimit({
+        graph,
+        stepKey: 'step',
+        toolCallChunks: [chunk({ args: '!', index: 0 })],
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(StreamLimitExceededError);
+    const limitError = caught as StreamLimitExceededError;
+    expect(limitError.kind).toBe('tool_call_args');
+    expect(limitError.limit).toBe(10);
+    expect(limitError.observed).toBe(11);
+    expect(limitError.toolName).toBe('db_query');
+    expect(limitError.message).toContain('10-byte');
+    expect(limitError.message).toContain('(tool call: db_query)');
+    expect(limitError.message).toContain('maxToolCallArgBytes');
+  });
+
+  it('counts UTF-8 bytes, not string length', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 5 }),
+    };
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        stepKey: 'step',
+        toolCallChunks: [chunk({ args: '€€', index: 0 })],
+      })
+    ).toThrow(StreamLimitExceededError);
+    expect(graph.streamedToolCallArgTallies?.get('step:0')?.bytes).toBe(6);
+  });
+
+  it('tallies parallel tool calls and turns independently', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),
+    };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'turn-1',
+      toolCallChunks: [
+        chunk({ name: 'first', args: '123456', index: 0 }),
+        chunk({ name: 'second', args: '123456', index: 1 }),
+      ],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'turn-2',
+      toolCallChunks: [chunk({ args: '123456', index: 0 })],
+    });
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        stepKey: 'turn-1',
+        toolCallChunks: [chunk({ args: '789', index: 1 })],
+      })
+    ).toThrow('(tool call: second)');
+  });
+
+  it('does nothing when disabled', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 0 }),
+    };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'step',
+      toolCallChunks: [chunk({ args: 'x'.repeat(1_000_000), index: 0 })],
+    });
+    expect(graph.streamedToolCallArgTallies).toBeUndefined();
+  });
+
+  it('applies the default limit when graph state was never resolved', () => {
+    const graph: StreamLimitState = {};
+    enforceStreamedToolCallArgLimit({
+      graph,
+      stepKey: 'step',
+      toolCallChunks: [
+        chunk({ args: 'x'.repeat(DEFAULT_MAX_TOOL_CALL_ARG_BYTES), index: 0 }),
+      ],
+    });
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        stepKey: 'step',
+        toolCallChunks: [chunk({ args: 'x', index: 0 })],
+      })
+    ).toThrow(StreamLimitExceededError);
+  });
+});
+
+describe('enforceStreamDeltaEventLimit', () => {
+  it('throws once a single turn exceeds the event limit', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 3 }),
+    };
+    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    let caught: unknown;
+    try {
+      enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(StreamLimitExceededError);
+    const limitError = caught as StreamLimitExceededError;
+    expect(limitError.kind).toBe('delta_events');
+    expect(limitError.limit).toBe(3);
+    expect(limitError.observed).toBe(4);
+    expect(limitError.message).toContain('maxDeltaEventsPerTurn');
+    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-2' });
+    expect(graph.streamDeltaEventCounts?.get('turn-2')).toBe(1);
+  });
+
+  it('is disabled by default and allocates nothing', () => {
+    const graph: StreamLimitState = {};
+    for (let i = 0; i < 10; i++) {
+      enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    }
+    expect(graph.streamDeltaEventCounts).toBeUndefined();
+  });
+});

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -32,17 +32,23 @@ describe('resolveStreamLimits', () => {
     expect(resolveStreamLimits()).toEqual({
       maxToolCallArgBytes: DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
       maxDeltaEventsPerTurn: 0,
+      hasEnforceableToolCallArgLimit: true,
     });
     expect(resolveStreamLimits({})).toEqual({
       maxToolCallArgBytes: DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
       maxDeltaEventsPerTurn: 0,
+      hasEnforceableToolCallArgLimit: true,
     });
   });
 
   it('honors explicit values and floors fractions', () => {
     expect(
       resolveStreamLimits({ maxToolCallArgBytes: 100.9, maxDeltaEventsPerTurn: 5 })
-    ).toEqual({ maxToolCallArgBytes: 100, maxDeltaEventsPerTurn: 5 });
+    ).toEqual({
+      maxToolCallArgBytes: 100,
+      maxDeltaEventsPerTurn: 5,
+      hasEnforceableToolCallArgLimit: true,
+    });
   });
 
   it('treats 0, negatives, and Infinity as disabled', () => {
@@ -413,7 +419,7 @@ describe('enforceStreamDeltaEventLimit', () => {
     expect(limitError.observed).toBe(4);
     expect(limitError.message).toContain('maxDeltaEventsPerTurn');
     enforceStreamDeltaEventLimit({ graph, metadata: generation(2) });
-    expect(graph.streamDeltaEventCounts?.get('|agent|2|')).toBe(1);
+    expect(graph.streamDeltaEventCounts?.get('|agent|2|')?.count).toBe(1);
   });
 
   it('is disabled by default and allocates nothing', () => {

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@/tools/streamedToolCallSeals';
 import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
+  STREAM_LIMIT_REDISPATCH_KEY,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
@@ -16,6 +17,7 @@ import {
   resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
+import { Constants } from '@/common';
 
 const chunk = (fields: Partial<ToolCallChunk>): ToolCallChunk =>
   ({ type: 'tool_call_chunk', ...fields }) as ToolCallChunk;
@@ -64,7 +66,7 @@ describe('resolveStreamLimits', () => {
 
 describe('resolveGenerationKey', () => {
   it('derives a stable key from langgraph node-execution metadata', () => {
-    expect(resolveGenerationKey(generation(3))).toBe('|agent|3');
+    expect(resolveGenerationKey(generation(3))).toBe('|agent|3|');
     expect(resolveGenerationKey(generation(3))).toBe(resolveGenerationKey(generation(3)));
   });
 
@@ -80,7 +82,29 @@ describe('resolveGenerationKey', () => {
 
   it('degrades to a shared bucket when metadata is absent', () => {
     expect(resolveGenerationKey(undefined)).toBe('');
-    expect(resolveGenerationKey({})).toBe('||');
+    expect(resolveGenerationKey({})).toBe('|||');
+  });
+
+  it('scopes fallback attempts via the INVOKED_MODEL metadata stamp', () => {
+    const primary = generation(1);
+    const fallback = { ...generation(1), [Constants.INVOKED_MODEL]: 'fb-model' };
+    expect(resolveGenerationKey(fallback)).not.toBe(resolveGenerationKey(primary));
+
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 10 }),
+    };
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: primary,
+      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata: fallback,
+      toolCallChunks: [chunk({ args: '12345678', index: 0 })],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|fb-model:0')?.bytes).toBe(8);
   });
 });
 
@@ -137,7 +161,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         toolCallChunks: [chunk({ args: '€€', index: 0 })],
       })
     ).toThrow(StreamLimitExceededError);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(6);
   });
 
   it('tallies parallel tool calls and generations independently', () => {
@@ -181,7 +205,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
       metadata,
       toolCallChunks: [chunk({ id: 'call_b', name: 'b_tool', args: '123456' })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:call_a')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:call_a')?.bytes).toBe(6);
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
@@ -204,8 +228,8 @@ describe('enforceStreamedToolCallArgLimit', () => {
         chunk({ name: 'anon_b', args: '123456' }),
       ],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:#0')?.bytes).toBe(6);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:#1')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:#0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:#1')?.bytes).toBe(6);
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
@@ -266,7 +290,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
   });
 
   it('releases the tally on a Bedrock Converse stop chunk without counting it', () => {
@@ -289,7 +313,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
         [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
       },
     });
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
   });
 
   it('resets one generation on a new model attempt, keeping other generations', () => {
@@ -313,16 +337,16 @@ describe('enforceStreamedToolCallArgLimit', () => {
 
     resetStreamLimitTallies({ graph, metadata: generation(1) });
 
-    expect(graph.streamedToolCallArgTallies?.has('|agent|1:0')).toBe(false);
-    expect(graph.streamedToolCallArgTallies?.get('|agent|2:0')?.bytes).toBe(4);
-    expect(graph.streamDeltaEventCounts?.has('|agent|1')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.has('|agent|1|:0')).toBe(false);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|2|:0')?.bytes).toBe(4);
+    expect(graph.streamDeltaEventCounts?.has('|agent|1|')).toBe(false);
 
     enforceStreamedToolCallArgLimit({
       graph,
       metadata: generation(1),
       toolCallChunks: [chunk({ args: '12345678', index: 0 })],
     });
-    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(8);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1|:0')?.bytes).toBe(8);
   });
 
   it('reset is a no-op when nothing was counted', () => {
@@ -387,7 +411,7 @@ describe('enforceStreamDeltaEventLimit', () => {
     expect(limitError.observed).toBe(4);
     expect(limitError.message).toContain('maxDeltaEventsPerTurn');
     enforceStreamDeltaEventLimit({ graph, metadata: generation(2) });
-    expect(graph.streamDeltaEventCounts?.get('|agent|2')).toBe(1);
+    expect(graph.streamDeltaEventCounts?.get('|agent|2|')).toBe(1);
   });
 
   it('is disabled by default and allocates nothing', () => {
@@ -396,5 +420,23 @@ describe('enforceStreamDeltaEventLimit', () => {
       enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
     }
     expect(graph.streamDeltaEventCounts).toBeUndefined();
+  });
+
+  it('does not double-count inline re-dispatched transformed chunks', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
+    };
+    const redispatch = {
+      ...generation(1),
+      [STREAM_LIMIT_REDISPATCH_KEY]: true,
+    };
+    for (let i = 0; i < 10; i++) {
+      enforceStreamDeltaEventLimit({ graph, metadata: redispatch });
+    }
+    enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
+    enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
+    expect(() =>
+      enforceStreamDeltaEventLimit({ graph, metadata: generation(1) })
+    ).toThrow(StreamLimitExceededError);
   });
 });

--- a/src/llm/streamLimits.test.ts
+++ b/src/llm/streamLimits.test.ts
@@ -2,15 +2,28 @@ import { describe, it, expect } from '@jest/globals';
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import {
   DEFAULT_MAX_TOOL_CALL_ARG_BYTES,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
+  resolveGenerationKey,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
 
 const chunk = (fields: Partial<ToolCallChunk>): ToolCallChunk =>
   ({ type: 'tool_call_chunk', ...fields }) as ToolCallChunk;
+
+const generation = (step: number): Record<string, unknown> => ({
+  langgraph_checkpoint_ns: '',
+  langgraph_node: 'agent',
+  langgraph_step: step,
+});
 
 describe('resolveStreamLimits', () => {
   it('defaults the byte cap ON and the event cap OFF', () => {
@@ -48,31 +61,54 @@ describe('resolveStreamLimits', () => {
   });
 });
 
+describe('resolveGenerationKey', () => {
+  it('derives a stable key from langgraph node-execution metadata', () => {
+    expect(resolveGenerationKey(generation(3))).toBe('|agent|3');
+    expect(resolveGenerationKey(generation(3))).toBe(resolveGenerationKey(generation(3)));
+  });
+
+  it('separates supersteps, nodes, and namespaces', () => {
+    expect(resolveGenerationKey(generation(3))).not.toBe(resolveGenerationKey(generation(4)));
+    expect(
+      resolveGenerationKey({ ...generation(3), langgraph_node: 'other_agent' })
+    ).not.toBe(resolveGenerationKey(generation(3)));
+    expect(
+      resolveGenerationKey({ ...generation(3), langgraph_checkpoint_ns: 'child' })
+    ).not.toBe(resolveGenerationKey(generation(3)));
+  });
+
+  it('degrades to a shared bucket when metadata is absent', () => {
+    expect(resolveGenerationKey(undefined)).toBe('');
+    expect(resolveGenerationKey({})).toBe('||');
+  });
+});
+
 describe('enforceStreamedToolCallArgLimit', () => {
   it('accumulates across chunk events and throws past the limit', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 10 }),
     };
+    const metadata = generation(1);
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'step',
+      metadata,
       toolCallChunks: [chunk({ name: 'db_query', id: 'call_1', args: '', index: 0 })],
     });
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'step',
+      metadata,
       toolCallChunks: [chunk({ args: '12345', index: 0 })],
     });
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'step',
+      metadata,
       toolCallChunks: [chunk({ args: '67890', index: 0 })],
     });
     let caught: unknown;
     try {
       enforceStreamedToolCallArgLimit({
         graph,
-        stepKey: 'step',
+        metadata,
         toolCallChunks: [chunk({ args: '!', index: 0 })],
       });
     } catch (error) {
@@ -96,20 +132,20 @@ describe('enforceStreamedToolCallArgLimit', () => {
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
-        stepKey: 'step',
+        metadata: generation(1),
         toolCallChunks: [chunk({ args: '€€', index: 0 })],
       })
     ).toThrow(StreamLimitExceededError);
-    expect(graph.streamedToolCallArgTallies?.get('step:0')?.bytes).toBe(6);
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(6);
   });
 
-  it('tallies parallel tool calls and turns independently', () => {
+  it('tallies parallel tool calls and generations independently', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),
     };
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'turn-1',
+      metadata: generation(1),
       toolCallChunks: [
         chunk({ name: 'first', args: '123456', index: 0 }),
         chunk({ name: 'second', args: '123456', index: 1 }),
@@ -117,16 +153,93 @@ describe('enforceStreamedToolCallArgLimit', () => {
     });
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'turn-2',
+      metadata: generation(2),
       toolCallChunks: [chunk({ args: '123456', index: 0 })],
     });
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
-        stepKey: 'turn-1',
+        metadata: generation(1),
         toolCallChunks: [chunk({ args: '789', index: 1 })],
       })
     ).toThrow('(tool call: second)');
+  });
+
+  it('falls back to the chunk id, then a shared bucket, when index is absent', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 8 }),
+    };
+    const metadata = generation(1);
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ id: 'call_a', name: 'a_tool', args: '123456' })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ id: 'call_b', name: 'b_tool', args: '123456' })],
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:call_a')?.bytes).toBe(6);
+    expect(() =>
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata,
+        toolCallChunks: [chunk({ id: 'call_b', args: '789' })],
+      })
+    ).toThrow('(tool call: b_tool)');
+  });
+
+  it('replaces the tally when a single-seal chunk restates complete args (OpenAI Responses)', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+    };
+    const metadata = generation(1);
+    const fullArgs = 'x'.repeat(40);
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: fullArgs.slice(0, 20), index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: fullArgs.slice(20), index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ name: 'writer', args: fullArgs, index: 0 })],
+      responseMetadata: {
+        [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+          OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
+      },
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(40);
+  });
+
+  it('ignores empty-args seal chunks (Bedrock Converse stop chunks)', () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+    };
+    const metadata = generation(1);
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: '1234567890', index: 0 })],
+    });
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: [chunk({ args: '', index: 0 })],
+      responseMetadata: {
+        [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+          BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 0 },
+      },
+    });
+    expect(graph.streamedToolCallArgTallies?.get('|agent|1:0')?.bytes).toBe(10);
   });
 
   it('does nothing when disabled', () => {
@@ -135,7 +248,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
     };
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'step',
+      metadata: generation(1),
       toolCallChunks: [chunk({ args: 'x'.repeat(1_000_000), index: 0 })],
     });
     expect(graph.streamedToolCallArgTallies).toBeUndefined();
@@ -143,9 +256,10 @@ describe('enforceStreamedToolCallArgLimit', () => {
 
   it('applies the default limit when graph state was never resolved', () => {
     const graph: StreamLimitState = {};
+    const metadata = generation(1);
     enforceStreamedToolCallArgLimit({
       graph,
-      stepKey: 'step',
+      metadata,
       toolCallChunks: [
         chunk({ args: 'x'.repeat(DEFAULT_MAX_TOOL_CALL_ARG_BYTES), index: 0 }),
       ],
@@ -153,7 +267,7 @@ describe('enforceStreamedToolCallArgLimit', () => {
     expect(() =>
       enforceStreamedToolCallArgLimit({
         graph,
-        stepKey: 'step',
+        metadata,
         toolCallChunks: [chunk({ args: 'x', index: 0 })],
       })
     ).toThrow(StreamLimitExceededError);
@@ -161,16 +275,17 @@ describe('enforceStreamedToolCallArgLimit', () => {
 });
 
 describe('enforceStreamDeltaEventLimit', () => {
-  it('throws once a single turn exceeds the event limit', () => {
+  it('throws once a single generation exceeds the event limit', () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 3 }),
     };
-    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
-    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
-    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+    const metadata = generation(1);
+    enforceStreamDeltaEventLimit({ graph, metadata });
+    enforceStreamDeltaEventLimit({ graph, metadata });
+    enforceStreamDeltaEventLimit({ graph, metadata });
     let caught: unknown;
     try {
-      enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+      enforceStreamDeltaEventLimit({ graph, metadata });
     } catch (error) {
       caught = error;
     }
@@ -180,14 +295,14 @@ describe('enforceStreamDeltaEventLimit', () => {
     expect(limitError.limit).toBe(3);
     expect(limitError.observed).toBe(4);
     expect(limitError.message).toContain('maxDeltaEventsPerTurn');
-    enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-2' });
-    expect(graph.streamDeltaEventCounts?.get('turn-2')).toBe(1);
+    enforceStreamDeltaEventLimit({ graph, metadata: generation(2) });
+    expect(graph.streamDeltaEventCounts?.get('|agent|2')).toBe(1);
   });
 
   it('is disabled by default and allocates nothing', () => {
     const graph: StreamLimitState = {};
     for (let i = 0; i < 10; i++) {
-      enforceStreamDeltaEventLimit({ graph, stepKey: 'turn-1' });
+      enforceStreamDeltaEventLimit({ graph, metadata: generation(1) });
     }
     expect(graph.streamDeltaEventCounts).toBeUndefined();
   });

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -472,6 +472,34 @@ export function enforceStreamedToolCallArgLimit({
       }
       registerAliasKeys(target, [`${generationKey}:#${i}`]);
     };
+    /** Applies this chunk's name contribution and reports whether the
+     * effective name changed. Adapters may stream the name in FRAGMENTS
+     * ("create_" then "file"), so unsealed fragments append — matching
+     * langchain's own tool-call-chunk merge — while a sealing chunk's name
+     * is a full restatement and replaces, mirroring how sealed args replace
+     * the tally bytes. Parsed-call correlation fills in only when the chunk
+     * carries no fragment. */
+    const applyChunkName = (target: StreamedToolCallArgTally): boolean => {
+      const fragment = chunkToolName(chunk);
+      let next = target.name;
+      if (fragment != null) {
+        if (sealed || target.name == null) {
+          next = fragment;
+        } else if (fragment !== target.name) {
+          /** A fragment identical to the accumulated name is a repeated
+           * full-name delta (a common provider shape) and is a no-op; a
+           * differing fragment is a continuation and appends. */
+          next = target.name + fragment;
+        }
+      } else if (target.name == null) {
+        next = resolveChunkName(chunk);
+      }
+      if (next === target.name) {
+        return false;
+      }
+      target.name = next;
+      return true;
+    };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
       if (target.keys == null) {
@@ -498,25 +526,25 @@ export function enforceStreamedToolCallArgLimit({
       if (!sealed) {
         registerAliases(tally);
       }
-      if (tally.name == null) {
-        const lateName = resolveChunkName(chunk);
-        if (lateName != null) {
-          /** Bytes tallied before the name arrived were only held against the
-           * global cap; a newly applicable per-tool override must re-judge
-           * them, including on a sealing chunk about to release the tally. */
-          tally.name = lateName;
-          const limit =
-            byTool != null && Object.hasOwn(byTool, lateName)
-              ? byTool[lateName]
-              : globalLimit;
-          if (limit > 0 && tally.bytes > limit) {
-            throw new StreamLimitExceededError({
-              kind: 'tool_call_args',
-              limit,
-              observed: tally.bytes,
-              toolName: lateName,
-            });
-          }
+      if (applyChunkName(tally)) {
+        /** Bytes tallied under the previous (or absent) name were held
+         * against that name's limit; a changed name — late arrival or a
+         * completed fragment — must re-judge them, including on a sealing
+         * chunk about to release the tally. */
+        const rejudgedName = tally.name;
+        const limit =
+          byTool != null &&
+          rejudgedName != null &&
+          Object.hasOwn(byTool, rejudgedName)
+            ? byTool[rejudgedName]
+            : globalLimit;
+        if (limit > 0 && tally.bytes > limit) {
+          throw new StreamLimitExceededError({
+            kind: 'tool_call_args',
+            limit,
+            observed: tally.bytes,
+            toolName: rejudgedName,
+          });
         }
       }
       if (sealed) {
@@ -532,9 +560,7 @@ export function enforceStreamedToolCallArgLimit({
     if (!sealed) {
       registerAliases(tally);
     }
-    if (tally.name == null) {
-      tally.name = resolveChunkName(chunk);
-    }
+    applyChunkName(tally);
     const argBytes = Buffer.byteLength(args, 'utf8');
     if (sealed) {
       tally.bytes = argBytes;
@@ -730,13 +756,18 @@ export function enforceStreamLimitsForWireChunk({
     return;
   }
   enforceStreamDeltaEventLimit({ graph, metadata });
+  /** Combined view computed first so the raw-chunk guard can correlate
+   * names from BOTH parsed and invalid calls in the same event; an unnamed
+   * raw chunk twinned with a named invalid call must select that tool's
+   * override, not the global cap. */
+  const completeCalls = combineCompleteToolCalls(chunk);
   if (chunk.tool_call_chunks != null && chunk.tool_call_chunks.length > 0) {
     enforceStreamedToolCallArgLimit({
       graph,
       metadata,
       toolCallChunks: chunk.tool_call_chunks,
       responseMetadata: chunk.response_metadata,
-      parsedToolCalls: chunk.tool_calls,
+      parsedToolCalls: completeCalls,
     });
   }
   /** Judged whenever parsed calls are present, not only when raw chunks are
@@ -746,7 +777,6 @@ export function enforceStreamLimitsForWireChunk({
    * are included — ToolNode processes and promotes them, and a malformed
    * call streaming oversized arguments is the exact pathology this breaker
    * exists to stop. */
-  const completeCalls = combineCompleteToolCalls(chunk);
   if (completeCalls != null) {
     enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: completeCalls });
   }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -54,12 +54,14 @@ export interface StreamLimitState {
   streamLimits?: ResolvedStreamLimits;
   streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
   streamDeltaEventCounts?: Map<string, number>;
-  /** Per-chunk-object charge balance: producer visits increment, consumer
-   * (handler echo) visits decrement, and a visit only charges when the other
-   * side has not pre-charged the same emission. Count-balancing rather than
-   * a lifetime set, because a streaming model may mutate and re-yield the
-   * same chunk object — each such emission must be charged exactly once. */
-  streamLimitChargeCredits?: WeakMap<object, number>;
+  /** Per-chunk-object, per-generation charge balance: producer visits
+   * increment, consumer (handler echo) visits decrement, and a visit only
+   * charges when the other side has not pre-charged the same emission.
+   * Count-balancing rather than a lifetime set, because a streaming model
+   * may mutate and re-yield the same chunk object; scoped by generation so
+   * parallel generations sharing one reused object cannot cancel each
+   * other's charges. */
+  streamLimitChargeCredits?: WeakMap<object, Map<string, number>>;
 }
 
 function resolveLimit(value: number | undefined, fallback: number): number {
@@ -342,14 +344,25 @@ export function enforceStreamedToolCallArgLimit({
       if (positionAliasKey == null) {
         return;
       }
-      if (tallies.get(positionAliasKey) !== target) {
-        tallies.set(positionAliasKey, target);
-        target.aliasKey = positionAliasKey;
+      const currentOwner = tallies.get(positionAliasKey);
+      if (currentOwner === target) {
+        return;
       }
+      /** Parallel index-less calls all land on batch position #i, so the
+       * newest live call takes the alias over and the previous owner is
+       * disowned — its seal must not delete an alias it no longer holds. */
+      if (currentOwner?.aliasKey === positionAliasKey) {
+        currentOwner.aliasKey = undefined;
+      }
+      tallies.set(positionAliasKey, target);
+      target.aliasKey = positionAliasKey;
     };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
-      if (target.aliasKey != null) {
+      if (
+        target.aliasKey != null &&
+        tallies.get(target.aliasKey) === target
+      ) {
         tallies.delete(target.aliasKey);
       }
     };
@@ -362,7 +375,11 @@ export function enforceStreamedToolCallArgLimit({
         }
         continue;
       }
-      registerPositionAlias(tally);
+      /** A sealing chunk is about to release this tally; taking the position
+       * alias here would steal it from a still-live parallel call. */
+      if (!sealed) {
+        registerPositionAlias(tally);
+      }
       if (tally.name == null) {
         const lateName = chunkToolName(chunk);
         if (lateName != null) {
@@ -393,7 +410,9 @@ export function enforceStreamedToolCallArgLimit({
       tally = { bytes: 0 };
       tallies.set(key, tally);
     }
-    registerPositionAlias(tally);
+    if (!sealed) {
+      registerPositionAlias(tally);
+    }
     if (tally.name == null) {
       tally.name = chunkToolName(chunk);
     }
@@ -501,24 +520,33 @@ export function enforceCompleteToolCallArgLimit({
  * emission (positive balance = producer ahead, negative = consumer ahead).
  * Paths where only one side ever observes the chunk (summarization, local
  * replay-skip) charge every visit, since their balance never crosses zero
- * the other way. Non-object chunks cannot be identity-tracked and are always
+ * the other way. Balances are scoped by generation identity so parallel
+ * generations sharing one reused chunk object cannot cancel each other's
+ * charges. Non-object chunks cannot be identity-tracked and are always
  * claimable.
  */
 export function claimStreamLimitCharge(
   graph: StreamLimitState,
   chunk: unknown,
-  side: 'producer' | 'consumer'
+  side: 'producer' | 'consumer',
+  metadata: Record<string, unknown> | undefined
 ): boolean {
   if (typeof chunk !== 'object' || chunk == null) {
     return true;
   }
   const credits = (graph.streamLimitChargeCredits ??= new WeakMap());
-  const balance = credits.get(chunk) ?? 0;
+  let byGeneration = credits.get(chunk);
+  if (byGeneration == null) {
+    byGeneration = new Map();
+    credits.set(chunk, byGeneration);
+  }
+  const generationKey = resolveGenerationKey(metadata);
+  const balance = byGeneration.get(generationKey) ?? 0;
   if (side === 'producer') {
-    credits.set(chunk, balance + 1);
+    byGeneration.set(generationKey, balance + 1);
     return balance >= 0;
   }
-  credits.set(chunk, balance - 1);
+  byGeneration.set(generationKey, balance - 1);
   return balance <= 0;
 }
 
@@ -551,7 +579,7 @@ export function enforceStreamLimitsForWireChunk({
    * producer/echo and swallow a charge. */
   side?: 'producer' | 'consumer';
 }): void {
-  if (!claimStreamLimitCharge(graph, chunk, side)) {
+  if (!claimStreamLimitCharge(graph, chunk, side, metadata)) {
     return;
   }
   enforceStreamDeltaEventLimit({ graph, metadata });

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -881,6 +881,19 @@ export function requiresStreamLimitAccounting(
   );
 }
 
+/** True when any stream-limit guard can fire for this graph. The attempt
+ * lease and per-chunk claims are both gated on it — fully disabled guards
+ * must allocate no bookkeeping at all, per-attempt included. */
+export function streamLimitAccountingEnabled(
+  graph: StreamLimitState
+): boolean {
+  const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
+  return (
+    resolved.hasEnforceableToolCallArgLimit ||
+    resolved.maxDeltaEventsPerTurn > 0
+  );
+}
+
 /** Leases a model attempt's generation: entries under it are exempt from
  * the reset sweep until {@link releaseStreamLimitGeneration} runs from the
  * attempt's `finally`. */

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -419,20 +419,23 @@ export function enforceStreamedToolCallArgLimit({
      * value — index 0 and id "0" — cannot alias distinct calls onto one
      * tally. Empty-string ids are placeholders, not identities. */
     const chunkId = chunkCallId(chunk);
-    /** A single identifier-less event after several calls are live is a
-     * sparse parallel continuation: its position is relative to this event,
-     * not to the original batch, so `#0` cannot identify which call it
-     * belongs to. Charge the bytes against every live candidate using the
-     * global limit. This is conservative, but it prevents the continuation
-     * from inheriting whichever candidate currently owns the position alias,
-     * including a raised or disabled per-tool override. */
+    /** A single identifier-less event while calls are live is a sparse
+     * parallel continuation: its position is relative to this event, not to
+     * the original batch, so `#0` cannot identify which call it belongs to.
+     * With exactly one live call the association is unambiguous — charge
+     * that tally, keeping its budget continuous (a fresh `#0` tally here
+     * would RESET the sole remaining call's byte budget). With several,
+     * charge every live candidate. Each tally is judged under its OWN
+     * name-specific limit: comparing only against the global cap would let
+     * a call with a lower per-tool override stream past it indefinitely
+     * while its chunks stay anonymous. */
     if (
       chunk.index == null &&
       chunkId == null &&
       toolCallChunks.length === 1
     ) {
       const liveTallies = getLiveGenerationTallies();
-      if (liveTallies.length > 1) {
+      if (liveTallies.length > 0) {
         if (hasArgs) {
           const argBytes = Buffer.byteLength(args, 'utf8');
           for (const liveTally of liveTallies) {
@@ -443,11 +446,18 @@ export function enforceStreamedToolCallArgLimit({
             liveTally.pendingHighSurrogate = isHighSurrogate(
               args.charCodeAt(args.length - 1)
             );
-            if (globalLimit > 0 && liveTally.bytes > globalLimit) {
+            const tallyLimit =
+              byTool != null &&
+              liveTally.name != null &&
+              Object.hasOwn(byTool, liveTally.name)
+                ? byTool[liveTally.name]
+                : globalLimit;
+            if (tallyLimit > 0 && liveTally.bytes > tallyLimit) {
               throw new StreamLimitExceededError({
                 kind: 'tool_call_args',
-                limit: globalLimit,
+                limit: tallyLimit,
                 observed: liveTally.bytes,
+                toolName: liveTally.name,
               });
             }
           }
@@ -779,6 +789,17 @@ export function requiresStreamLimitAccounting(
   const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
   if (resolved.maxDeltaEventsPerTurn > 0) {
     return true;
+  }
+  /** With the byte cap disabled and no per-tool overrides, neither
+   * enforcement function can fire — hosts that explicitly disable the
+   * guards for legitimate large arguments must not pay per-chunk claim
+   * allocations (generation keys, WeakMap entries, nested Maps) for
+   * bookkeeping that judges nothing. */
+  if (
+    resolved.maxToolCallArgBytes <= 0 &&
+    resolved.maxToolCallArgBytesByTool == null
+  ) {
+    return false;
   }
   return (
     (chunk.tool_call_chunks?.length ?? 0) > 0 ||

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -26,12 +26,22 @@ export interface ResolvedStreamLimits {
   /** Per-tool overrides of the byte cap, keyed by model-facing tool name. */
   maxToolCallArgBytesByTool?: Readonly<Record<string, number>>;
   maxDeltaEventsPerTurn: number;
+  /** Precomputed once: whether ANY argument byte limit can fire. False when
+   * the global cap is disabled and every per-tool entry is a zero-valued
+   * disable — accounting must not allocate for guards that judge nothing. */
+  hasEnforceableToolCallArgLimit: boolean;
 }
 
 /** Cumulative streamed argument bytes for one in-flight tool call. */
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
+  /** The graph's breaker epoch when this tally was created. Entries from
+   * the epoch that is ending survive one `resetValues` sweep, so producer
+   * loops of straggling attempts — which are not behind the consumer-only
+   * epoch gate — stay on their original budgets instead of receiving a
+   * fresh allowance at every run start. */
+  epoch?: number;
   /** Every tally-map key this tally is registered under: its primary key
    * (which can migrate through identifier transitions), the batch-position
    * fallback for id-bearing chunks, and the id for chunks carrying both
@@ -47,6 +57,14 @@ export interface StreamedToolCallArgTally {
   pendingHighSurrogate?: boolean;
 }
 
+/** Streamed chunk events counted against one generation's event cap. */
+export interface StreamDeltaEventTally {
+  count: number;
+  /** Creation-epoch tag, same grace semantics as
+   * {@link StreamedToolCallArgTally.epoch}. */
+  epoch?: number;
+}
+
 /**
  * The graph-owned state the guards read and write. Structural on purpose:
  * handler-level tests stub graphs with plain objects, and the guards lazily
@@ -55,7 +73,10 @@ export interface StreamedToolCallArgTally {
 export interface StreamLimitState {
   streamLimits?: ResolvedStreamLimits;
   streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
-  streamDeltaEventCounts?: Map<string, number>;
+  streamDeltaEventCounts?: Map<string, StreamDeltaEventTally>;
+  /** The graph's live breaker epoch; new accounting entries are tagged with
+   * it so `resetValues` can sweep by age instead of clearing outright. */
+  breakerEpoch?: number;
   /** Per-chunk-object, per-generation charge balance: producer visits
    * increment, consumer (handler echo) visits decrement, and a visit only
    * charges when the other side has not pre-charged the same emission.
@@ -114,10 +135,15 @@ export function resolveStreamLimits(
       );
     }
   }
+  const hasEnforceableToolCallArgLimit =
+    maxToolCallArgBytes > 0 ||
+    (maxToolCallArgBytesByTool != null &&
+      Object.values(maxToolCallArgBytesByTool).some((value) => value > 0));
   return {
     maxToolCallArgBytes,
     ...(maxToolCallArgBytesByTool != null && { maxToolCallArgBytesByTool }),
     maxDeltaEventsPerTurn: resolveLimit(limits?.maxDeltaEventsPerTurn, 0),
+    hasEnforceableToolCallArgLimit,
   };
 }
 
@@ -324,7 +350,7 @@ export function enforceStreamedToolCallArgLimit({
   const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
   const globalLimit = resolved.maxToolCallArgBytes;
   const byTool = resolved.maxToolCallArgBytesByTool;
-  if (globalLimit <= 0 && byTool == null) {
+  if (!resolved.hasEnforceableToolCallArgLimit) {
     return;
   }
   /** An inline re-dispatch of a transformed chunk (OpenRouter final-reasoning
@@ -629,7 +655,12 @@ export function enforceStreamedToolCallArgLimit({
     if (!hasArgs) {
       if (tally == null) {
         if (!sealed) {
-          tally = { bytes: 0, name: resolveChunkName(chunk), keys: [key] };
+          tally = {
+            bytes: 0,
+            name: resolveChunkName(chunk),
+            keys: [key],
+            epoch: graph.breakerEpoch,
+          };
           tallies.set(key, tally);
           registerAliases(tally);
           registerCreationPositionAlias(tally);
@@ -668,7 +699,7 @@ export function enforceStreamedToolCallArgLimit({
       continue;
     }
     if (tally == null) {
-      tally = { bytes: 0, keys: [key] };
+      tally = { bytes: 0, keys: [key], epoch: graph.breakerEpoch };
       tallies.set(key, tally);
       registerCreationPositionAlias(tally);
     }
@@ -733,7 +764,7 @@ export function enforceCompleteToolCallArgLimit({
   const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
   const globalLimit = resolved.maxToolCallArgBytes;
   const byTool = resolved.maxToolCallArgBytesByTool;
-  if (globalLimit <= 0 && byTool == null) {
+  if (!resolved.hasEnforceableToolCallArgLimit) {
     return;
   }
   if (metadata?.[STREAM_LIMIT_REDISPATCH_KEY] === true) {
@@ -790,15 +821,12 @@ export function requiresStreamLimitAccounting(
   if (resolved.maxDeltaEventsPerTurn > 0) {
     return true;
   }
-  /** With the byte cap disabled and no per-tool overrides, neither
-   * enforcement function can fire — hosts that explicitly disable the
-   * guards for legitimate large arguments must not pay per-chunk claim
-   * allocations (generation keys, WeakMap entries, nested Maps) for
-   * bookkeeping that judges nothing. */
-  if (
-    resolved.maxToolCallArgBytes <= 0 &&
-    resolved.maxToolCallArgBytesByTool == null
-  ) {
+  /** With no argument limit able to fire (byte cap disabled and every
+   * per-tool entry a zero-valued disable), neither enforcement function can
+   * trip — hosts that explicitly disable the guards for legitimate large
+   * arguments must not pay per-chunk claim allocations (generation keys,
+   * WeakMap entries, nested Maps) for bookkeeping that judges nothing. */
+  if (!resolved.hasEnforceableToolCallArgLimit) {
     return false;
   }
   return (
@@ -806,6 +834,26 @@ export function requiresStreamLimitAccounting(
     (chunk.tool_calls?.length ?? 0) > 0 ||
     (chunk.invalid_tool_calls?.length ?? 0) > 0
   );
+}
+
+/**
+ * Deletes accounting entries older than the epoch that is ending. Called by
+ * `resetValues` INSTEAD of clearing: producer loops of straggling attempts
+ * use the graph's maps directly and are not behind the consumer-only epoch
+ * gate, so a clear would hand a cancellation-ignoring provider a fresh
+ * allowance at every run start. Entries tagged with the ending epoch
+ * survive exactly one reset (keeping those stragglers on their original
+ * budgets); untagged entries and anything older are removed.
+ */
+export function sweepStaleStreamLimitEntries(
+  entries: Map<string, { epoch?: number }>,
+  endingEpoch: number
+): void {
+  for (const [key, value] of entries) {
+    if (value.epoch !== endingEpoch) {
+      entries.delete(key);
+    }
+  }
 }
 
 /** Links a secondary representation of a wire chunk (e.g. a provider
@@ -980,7 +1028,8 @@ export function enforceStreamDeltaEventLimit({
   }
   const counts = (graph.streamDeltaEventCounts ??= new Map());
   const key = resolveGenerationKey(metadata);
-  const next = (counts.get(key) ?? 0) + 1;
+  const existing = counts.get(key);
+  const next = (existing?.count ?? 0) + 1;
   if (next > limit) {
     throw new StreamLimitExceededError({
       kind: 'delta_events',
@@ -988,5 +1037,9 @@ export function enforceStreamDeltaEventLimit({
       observed: next,
     });
   }
-  counts.set(key, next);
+  if (existing != null) {
+    existing.count = next;
+  } else {
+    counts.set(key, { count: next, epoch: graph.breakerEpoch });
+  }
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -254,11 +254,20 @@ function sealsChunk(
   ) {
     return true;
   }
-  return seal.id != null && chunk.id != null && seal.id === chunk.id;
+  const sealId = seal.id != null && seal.id !== '' ? seal.id : undefined;
+  return sealId != null && sealId === chunkCallId(chunk);
 }
 
 function chunkToolName(chunk: ToolCallChunk): string | undefined {
   return chunk.name != null && chunk.name !== '' ? chunk.name : undefined;
+}
+
+/** The chunk's id with empty-string placeholders treated as absent —
+ * OpenAI-compatible adapters emit `id: ''` on continuation deltas, and a
+ * shared placeholder must not merge independent calls onto one identity
+ * (mirrors `getEagerToolChunkKey`). */
+function chunkCallId(chunk: ToolCallChunk): string | undefined {
+  return chunk.id != null && chunk.id !== '' ? chunk.id : undefined;
 }
 
 function isHighSurrogate(code: number): boolean {
@@ -333,18 +342,22 @@ export function enforceStreamedToolCallArgLimit({
     return undefined;
   };
   const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
+    const chunkId = chunkCallId(chunk);
     const correlated =
-      chunk.id != null ? correlateParsedNameById(chunk.id) : undefined;
+      chunkId != null ? correlateParsedNameById(chunkId) : undefined;
     if (correlated != null) {
       return correlated;
     }
     const name = chunkToolName(chunk);
-    if (name != null || parsedToolCalls == null || chunk.id != null) {
+    if (name != null || parsedToolCalls == null || chunkId != null) {
       return name;
     }
-    /** No id to correlate on; only a single-parsed-call event is an
-     * unambiguous association. */
-    if (parsedToolCalls.length === 1) {
+    /** No id to correlate on; positional association is unambiguous only
+     * when the event carries exactly one raw chunk AND one parsed call —
+     * with several id-less raw chunks in flight, handing one parsed call's
+     * name (and its override) to all of them would let an unrelated
+     * still-partial call bypass the global cap. */
+    if (parsedToolCalls.length === 1 && toolCallChunks.length === 1) {
       const only = parsedToolCalls[0];
       if (only.name != null && only.name !== '') {
         return only.name;
@@ -379,12 +392,13 @@ export function enforceStreamedToolCallArgLimit({
     /** Keys are namespaced by identity kind (`i:` index, `c:` id, `#`
      * batch position) so an index and a string id with the same textual
      * value — index 0 and id "0" — cannot alias distinct calls onto one
-     * tally. */
+     * tally. Empty-string ids are placeholders, not identities. */
+    const chunkId = chunkCallId(chunk);
     let key: string;
     if (chunk.index != null) {
       key = `${generationKey}:i:${chunk.index}`;
-    } else if (chunk.id != null) {
-      key = `${generationKey}:c:${chunk.id}`;
+    } else if (chunkId != null) {
+      key = `${generationKey}:c:${chunkId}`;
     } else {
       key = `${generationKey}:#${i}`;
     }
@@ -394,10 +408,10 @@ export function enforceStreamedToolCallArgLimit({
      * id-bearing chunks register the batch-position fallback, and chunks
      * carrying both identifiers additionally register the id. */
     const aliasCandidates: string[] = [];
-    if (chunk.id != null) {
+    if (chunkId != null) {
       aliasCandidates.push(`${generationKey}:#${i}`);
       if (chunk.index != null) {
-        aliasCandidates.push(`${generationKey}:c:${chunk.id}`);
+        aliasCandidates.push(`${generationKey}:c:${chunkId}`);
       }
     }
     let tally = tallies.get(key);
@@ -411,10 +425,10 @@ export function enforceStreamedToolCallArgLimit({
      * an alias and released together with the rest. */
     if (tally == null) {
       const adoptionCandidates: string[] = [];
-      if (chunk.id != null) {
-        adoptionCandidates.push(`${generationKey}:c:${chunk.id}`);
+      if (chunkId != null) {
+        adoptionCandidates.push(`${generationKey}:c:${chunkId}`);
       }
-      if (chunk.id != null || chunk.index != null) {
+      if (chunkId != null || chunk.index != null) {
         adoptionCandidates.push(`${generationKey}:#${i}`);
       }
       for (const adoptionKey of adoptionCandidates) {
@@ -478,7 +492,7 @@ export function enforceStreamedToolCallArgLimit({
     const registerCreationPositionAlias = (
       target: StreamedToolCallArgTally
     ): void => {
-      if (chunk.id != null || chunk.index == null || sealed) {
+      if (chunkId != null || chunk.index == null || sealed) {
         return;
       }
       registerAliasKeys(target, [`${generationKey}:#${i}`]);
@@ -493,7 +507,7 @@ export function enforceStreamedToolCallArgLimit({
      * the chunk carries no fragment. */
     const applyChunkName = (target: StreamedToolCallArgTally): boolean => {
       const correlated =
-        chunk.id != null ? correlateParsedNameById(chunk.id) : undefined;
+        chunkId != null ? correlateParsedNameById(chunkId) : undefined;
       const fragment = chunkToolName(chunk);
       let next = target.name;
       if (correlated != null) {

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -2,6 +2,7 @@
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { getStreamedToolCallSeal } from '@/tools/streamedToolCallSeals';
+import { Constants } from '@/common';
 
 /**
  * Circuit breakers for pathological model streams.
@@ -139,6 +140,13 @@ export class StreamLimitExceededError extends Error {
  * segment. One agent-node execution is one superstep, so
  * `checkpoint_ns + node + step` stays stable for the whole generation and
  * distinguishes parallel agents in the same superstep.
+ *
+ * The `INVOKED_MODEL` stamp scopes attempts within one node execution:
+ * `tryFallbackProviders` (and summarization's fallback path) stamps it into
+ * each fallback's config metadata, so a fallback's chunks key separately
+ * from the failed primary's even when the decoupled `streamEvents` reader
+ * drains the primary's buffered chunks late. Those late chunks land in the
+ * primary's own bucket instead of polluting the fallback's.
  */
 export function resolveGenerationKey(
   metadata: Record<string, unknown> | undefined
@@ -149,8 +157,18 @@ export function resolveGenerationKey(
   const checkpointNs = metadata.langgraph_checkpoint_ns ?? '';
   const node = metadata.langgraph_node ?? '';
   const step = metadata.langgraph_step ?? '';
-  return `${checkpointNs}|${node}|${step}`;
+  const invokedModel = metadata[Constants.INVOKED_MODEL] ?? '';
+  return `${checkpointNs}|${node}|${step}|${invokedModel}`;
 }
+
+/**
+ * Event-metadata marker for a chunk the SDK re-dispatches inline after
+ * transforming it (`attemptInvoke`'s OpenRouter final-reasoning replay). The
+ * original wire chunk still reaches the handler through `streamEvents` and
+ * is counted there, so the re-dispatch must not consume a second
+ * event-budget slot.
+ */
+export const STREAM_LIMIT_REDISPATCH_KEY = 'lc_stream_limit_redispatch';
 
 /**
  * True when the event's `single` seal marks this chunk's own call as
@@ -286,6 +304,9 @@ export function enforceStreamDeltaEventLimit({
   const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
     .maxDeltaEventsPerTurn;
   if (limit <= 0) {
+    return;
+  }
+  if (metadata?.[STREAM_LIMIT_REDISPATCH_KEY] === true) {
     return;
   }
   const counts = (graph.streamDeltaEventCounts ??= new Map());

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -659,6 +659,33 @@ export function enforceCompleteToolCallArgLimit({
   }
 }
 
+/**
+ * Whether a chunk needs charge accounting at all. With the event cap off
+ * (the default) and no tool payload on the chunk, there is nothing a claim
+ * could ever gate — skipping restores the documented zero-cost-disabled
+ * behavior by avoiding a WeakMap entry and nested Map per ordinary text
+ * delta. Both the producer and consumer paths use this same predicate on
+ * the same chunk, so claim pairing is unaffected.
+ */
+export function requiresStreamLimitAccounting(
+  graph: StreamLimitState,
+  chunk: {
+    tool_call_chunks?: unknown[];
+    tool_calls?: unknown[];
+    invalid_tool_calls?: unknown[];
+  }
+): boolean {
+  const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
+  if (resolved.maxDeltaEventsPerTurn > 0) {
+    return true;
+  }
+  return (
+    (chunk.tool_call_chunks?.length ?? 0) > 0 ||
+    (chunk.tool_calls?.length ?? 0) > 0 ||
+    (chunk.invalid_tool_calls?.length ?? 0) > 0
+  );
+}
+
 /** Links a secondary representation of a wire chunk (e.g. a provider
  * adapter's callback copy) to its canonical emission object, so claim
  * accounting treats both as one emission even though their identities
@@ -756,6 +783,9 @@ export function enforceStreamLimitsForWireChunk({
    * producer/echo and swallow a charge. */
   side?: 'producer' | 'consumer';
 }): void {
+  if (!requiresStreamLimitAccounting(graph, chunk)) {
+    return;
+  }
   if (!claimStreamLimitCharge(graph, chunk, side, metadata)) {
     return;
   }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -399,17 +399,31 @@ export function enforceStreamedToolCallArgLimit({
      * is unambiguous within the generation. The old identity is recorded as
      * an alias and released together with the rest. */
     if (tally == null) {
-      let adoptionKey: string | undefined;
+      const adoptionCandidates: string[] = [];
       if (chunk.id != null) {
-        adoptionKey = `${generationKey}:c:${chunk.id}`;
-      } else if (chunk.index != null) {
-        adoptionKey = `${generationKey}:#${i}`;
+        adoptionCandidates.push(`${generationKey}:c:${chunk.id}`);
       }
-      const existing =
-        adoptionKey == null || adoptionKey === key
-          ? undefined
-          : tallies.get(adoptionKey);
-      if (existing != null && adoptionKey != null) {
+      if (chunk.id != null || chunk.index != null) {
+        adoptionCandidates.push(`${generationKey}:#${i}`);
+      }
+      for (const adoptionKey of adoptionCandidates) {
+        if (adoptionKey === key) {
+          continue;
+        }
+        const existing = tallies.get(adoptionKey);
+        if (existing == null) {
+          continue;
+        }
+        /** A position entry may only be adopted when the tally was CREATED
+         * anonymous (its first key is the position): id-bearing calls also
+         * alias their position, and adopting a live parallel call's alias
+         * would merge distinct budgets. */
+        if (
+          adoptionKey.includes(':#') &&
+          existing.keys?.[0] !== adoptionKey
+        ) {
+          continue;
+        }
         tally = existing;
         tallies.set(key, existing);
         if (existing.keys?.includes(adoptionKey) !== true) {
@@ -418,6 +432,7 @@ export function enforceStreamedToolCallArgLimit({
         if (existing.keys?.includes(key) !== true) {
           (existing.keys ??= []).push(key);
         }
+        break;
       }
     }
     const registerAliases = (target: StreamedToolCallArgTally): void => {
@@ -594,6 +609,31 @@ export function enforceCompleteToolCallArgLimit({
   }
 }
 
+/** Links a secondary representation of a wire chunk (e.g. a provider
+ * adapter's callback copy) to its canonical emission object, so claim
+ * accounting treats both as one emission even though their identities
+ * differ. Non-enumerable, so the link stays out of serialization and chunk
+ * merges. */
+const STREAM_LIMIT_CANONICAL: unique symbol = Symbol('streamLimitCanonical');
+
+export function linkStreamLimitCanonical(
+  copy: object,
+  canonical: object
+): void {
+  Object.defineProperty(copy, STREAM_LIMIT_CANONICAL, {
+    value: canonical,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+function canonicalChunk(chunk: object): object {
+  const linked = (chunk as Record<PropertyKey, unknown>)[
+    STREAM_LIMIT_CANONICAL
+  ];
+  return typeof linked === 'object' && linked != null ? linked : chunk;
+}
+
 /**
  * Claims accounting ownership of one EMISSION of a wire chunk. LangChain can
  * hand the same chunk object to the decoupled `streamEvents` handler
@@ -619,11 +659,12 @@ export function claimStreamLimitCharge(
   if (typeof chunk !== 'object' || chunk == null) {
     return true;
   }
+  const emission = canonicalChunk(chunk);
   const credits = (graph.streamLimitChargeCredits ??= new WeakMap());
-  let byGeneration = credits.get(chunk);
+  let byGeneration = credits.get(emission);
   if (byGeneration == null) {
     byGeneration = new Map();
-    credits.set(chunk, byGeneration);
+    credits.set(emission, byGeneration);
   }
   const generationKey = resolveGenerationKey(metadata);
   const balance = byGeneration.get(generationKey) ?? 0;

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -1,6 +1,7 @@
 // src/llm/streamLimits.ts
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
+import { getStreamedToolCallSeal } from '@/tools/streamedToolCallSeals';
 
 /**
  * Circuit breakers for pathological model streams.
@@ -130,20 +131,73 @@ export class StreamLimitExceededError extends Error {
 }
 
 /**
+ * Identity of one model generation, derived from langgraph's node-execution
+ * metadata. Deliberately NOT `Graph.getStepKey()`: the step key forks within
+ * a single generation on reasoning transitions (`'reasoning'` /
+ * `post-reasoning-<n>` suffixes in `getKeyList`) and on mid-turn server-tool
+ * results (`invokedToolIds` count), which would hand a fresh budget to each
+ * segment. One agent-node execution is one superstep, so
+ * `checkpoint_ns + node + step` stays stable for the whole generation and
+ * distinguishes parallel agents in the same superstep.
+ */
+export function resolveGenerationKey(
+  metadata: Record<string, unknown> | undefined
+): string {
+  if (metadata == null) {
+    return '';
+  }
+  const checkpointNs = metadata.langgraph_checkpoint_ns ?? '';
+  const node = metadata.langgraph_node ?? '';
+  const step = metadata.langgraph_step ?? '';
+  return `${checkpointNs}|${node}|${step}`;
+}
+
+/**
+ * True when this chunk restates an already-streamed argument string instead
+ * of extending it. The OpenAI Responses adapter attaches a `single` seal to
+ * its `response.function_call_arguments.done` chunk, whose `args` is the
+ * complete argument string all over again; summing it would double-count
+ * every legitimate call. Adapters that seal without restating are unaffected:
+ * Bedrock Converse seals with an empty-args chunk (skipped before this
+ * check) and Google seals atomic single-chunk calls with `kind: 'all'`.
+ */
+function isSealRestatement(
+  seal: ReturnType<typeof getStreamedToolCallSeal>,
+  chunk: ToolCallChunk
+): boolean {
+  if (seal == null || seal.kind !== 'single') {
+    return false;
+  }
+  if (seal.index != null) {
+    return seal.index === chunk.index;
+  }
+  return seal.id != null && seal.id === chunk.id;
+}
+
+/**
  * Accumulates the UTF-8 byte size of streamed tool-call argument chunks per
- * in-flight tool call (keyed by `stepKey:index`) and throws once a single
- * call's cumulative bytes exceed `maxToolCallArgBytes`. Runs once per
- * streamed chunk event, before the chunks are recorded or dispatched, so a
- * tripped limit stops the run without accumulating further.
+ * in-flight tool call and throws once a single call's cumulative bytes
+ * exceed `maxToolCallArgBytes`. Runs once per streamed chunk event, before
+ * complete tool calls are dispatched or eagerly executed and before chunks
+ * are recorded, so a tripped limit stops the run without dispatching the
+ * offending call.
+ *
+ * Calls are keyed by generation and chunk `index`, falling back to the
+ * chunk `id` and then to a shared bucket when a provider identifies chunks
+ * by neither. The shared-bucket fallback is deliberately conservative: such
+ * chunks cannot be attributed to distinct calls anywhere in the pipeline,
+ * and a runaway stream is exactly the case that must still be bounded.
  */
 export function enforceStreamedToolCallArgLimit({
   graph,
-  stepKey,
+  metadata,
   toolCallChunks,
+  responseMetadata,
 }: {
   graph: StreamLimitState;
-  stepKey: string;
+  metadata: Record<string, unknown> | undefined;
   toolCallChunks: ToolCallChunk[];
+  responseMetadata?: Record<string, unknown>;
 }): void {
   const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
     .maxToolCallArgBytes;
@@ -151,8 +205,10 @@ export function enforceStreamedToolCallArgLimit({
     return;
   }
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
+  const generationKey = resolveGenerationKey(metadata);
+  const seal = getStreamedToolCallSeal(responseMetadata);
   for (const chunk of toolCallChunks) {
-    const key = `${stepKey}:${chunk.index ?? 0}`;
+    const key = `${generationKey}:${chunk.index ?? chunk.id ?? 0}`;
     let tally = tallies.get(key);
     if (tally == null) {
       tally = { bytes: 0 };
@@ -165,7 +221,10 @@ export function enforceStreamedToolCallArgLimit({
     if (typeof args !== 'string' || args === '') {
       continue;
     }
-    tally.bytes += Buffer.byteLength(args, 'utf8');
+    const argBytes = Buffer.byteLength(args, 'utf8');
+    tally.bytes = isSealRestatement(seal, chunk)
+      ? argBytes
+      : tally.bytes + argBytes;
     if (tally.bytes > limit) {
       throw new StreamLimitExceededError({
         kind: 'tool_call_args',
@@ -178,17 +237,17 @@ export function enforceStreamedToolCallArgLimit({
 }
 
 /**
- * Counts streamed chunk events per generation turn (stepKey) and throws once
- * a single turn exceeds `maxDeltaEventsPerTurn`. Opt-in defense in depth for
+ * Counts streamed chunk events per model generation and throws once a single
+ * generation exceeds `maxDeltaEventsPerTurn`. Opt-in defense in depth for
  * pathologies a byte cap cannot see, such as a provider stream looping on
  * empty chunks. Zero cost while disabled.
  */
 export function enforceStreamDeltaEventLimit({
   graph,
-  stepKey,
+  metadata,
 }: {
   graph: StreamLimitState;
-  stepKey: string;
+  metadata: Record<string, unknown> | undefined;
 }): void {
   const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
     .maxDeltaEventsPerTurn;
@@ -196,7 +255,8 @@ export function enforceStreamDeltaEventLimit({
     return;
   }
   const counts = (graph.streamDeltaEventCounts ??= new Map());
-  const next = (counts.get(stepKey) ?? 0) + 1;
+  const key = resolveGenerationKey(metadata);
+  const next = (counts.get(key) ?? 0) + 1;
   if (next > limit) {
     throw new StreamLimitExceededError({
       kind: 'delta_events',
@@ -204,5 +264,5 @@ export function enforceStreamDeltaEventLimit({
       observed: next,
     });
   }
-  counts.set(stepKey, next);
+  counts.set(key, next);
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -318,22 +318,29 @@ export function enforceStreamedToolCallArgLimit({
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
   const generationKey = resolveGenerationKey(metadata);
   const seal = getStreamedToolCallSeal(responseMetadata);
-  const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
-    const name = chunkToolName(chunk);
-    if (name != null || parsedToolCalls == null) {
-      return name;
-    }
-    if (chunk.id != null) {
-      for (const parsed of parsedToolCalls) {
-        if (
-          parsed.id === chunk.id &&
-          parsed.name != null &&
-          parsed.name !== ''
-        ) {
-          return parsed.name;
-        }
-      }
+  /** The complete call in this event sharing the chunk's id — the strongest
+   * name evidence: adapters may stream raw names in FRAGMENTS, and an
+   * id-correlated complete call states the full name outright. */
+  const correlateParsedNameById = (id: string): string | undefined => {
+    if (parsedToolCalls == null) {
       return undefined;
+    }
+    for (const parsed of parsedToolCalls) {
+      if (parsed.id === id && parsed.name != null && parsed.name !== '') {
+        return parsed.name;
+      }
+    }
+    return undefined;
+  };
+  const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
+    const correlated =
+      chunk.id != null ? correlateParsedNameById(chunk.id) : undefined;
+    if (correlated != null) {
+      return correlated;
+    }
+    const name = chunkToolName(chunk);
+    if (name != null || parsedToolCalls == null || chunk.id != null) {
+      return name;
     }
     /** No id to correlate on; only a single-parsed-call event is an
      * unambiguous association. */
@@ -481,12 +488,20 @@ export function enforceStreamedToolCallArgLimit({
      * ("create_" then "file"), so unsealed fragments append — matching
      * langchain's own tool-call-chunk merge — while a sealing chunk's name
      * is a full restatement and replaces, mirroring how sealed args replace
-     * the tally bytes. Parsed-call correlation fills in only when the chunk
-     * carries no fragment. */
+     * the tally bytes. An id-correlated complete call in the same event
+     * outranks both; positional parsed-call correlation fills in only when
+     * the chunk carries no fragment. */
     const applyChunkName = (target: StreamedToolCallArgTally): boolean => {
+      const correlated =
+        chunk.id != null ? correlateParsedNameById(chunk.id) : undefined;
       const fragment = chunkToolName(chunk);
       let next = target.name;
-      if (fragment != null) {
+      if (correlated != null) {
+        /** An id-correlated complete call wins over fragment accumulation:
+         * a raw name like "create_" must not hide the "create_file"
+         * override behind the global cap. */
+        next = correlated;
+      } else if (fragment != null) {
         if (sealed || target.name == null) {
           next = fragment;
         } else if (fragment !== target.name) {

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -335,7 +335,11 @@ export function enforceStreamedToolCallArgLimit({
   if (metadata?.[STREAM_LIMIT_REDISPATCH_KEY] === true) {
     return;
   }
-  const tallies = (graph.streamedToolCallArgTallies ??= new Map());
+  const tallies: Map<string, StreamedToolCallArgTally> =
+    (graph.streamedToolCallArgTallies ??= new Map<
+      string,
+      StreamedToolCallArgTally
+    >());
   const generationKey = resolveGenerationKey(metadata);
   const seal = getStreamedToolCallSeal(responseMetadata);
   /** The complete call in this event sharing the chunk's id — the strongest
@@ -519,8 +523,8 @@ export function enforceStreamedToolCallArgLimit({
         if (existing.keys?.includes(adoptionKey) !== true) {
           (existing.keys ??= []).push(adoptionKey);
         }
-        if (existing.keys?.includes(key) !== true) {
-          (existing.keys ??= []).push(key);
+        if (!existing.keys.includes(key)) {
+          existing.keys.push(key);
         }
         break;
       }
@@ -742,7 +746,7 @@ export function enforceCompleteToolCallArgLimit({
     } else if (args == null) {
       serialized = '';
     } else {
-      serialized = JSON.stringify(args) ?? '';
+      serialized = JSON.stringify(args);
     }
     const bytes = Buffer.byteLength(serialized, 'utf8');
     if (bytes > limit) {

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -310,12 +310,27 @@ export function enforceStreamedToolCallArgLimit({
   const seal = getStreamedToolCallSeal(responseMetadata);
   const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
     const name = chunkToolName(chunk);
-    if (name != null || chunk.id == null || parsedToolCalls == null) {
+    if (name != null || parsedToolCalls == null) {
       return name;
     }
-    for (const parsed of parsedToolCalls) {
-      if (parsed.id === chunk.id && parsed.name != null && parsed.name !== '') {
-        return parsed.name;
+    if (chunk.id != null) {
+      for (const parsed of parsedToolCalls) {
+        if (
+          parsed.id === chunk.id &&
+          parsed.name != null &&
+          parsed.name !== ''
+        ) {
+          return parsed.name;
+        }
+      }
+      return undefined;
+    }
+    /** No id to correlate on; only a single-parsed-call event is an
+     * unambiguous association. */
+    if (parsedToolCalls.length === 1) {
+      const only = parsedToolCalls[0];
+      if (only.name != null && only.name !== '') {
+        return only.name;
       }
     }
     return undefined;
@@ -344,7 +359,18 @@ export function enforceStreamedToolCallArgLimit({
       }
       continue;
     }
-    const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
+    /** Keys are namespaced by identity kind (`i:` index, `c:` id, `#`
+     * batch position) so an index and a string id with the same textual
+     * value — index 0 and id "0" — cannot alias distinct calls onto one
+     * tally. */
+    let key: string;
+    if (chunk.index != null) {
+      key = `${generationKey}:i:${chunk.index}`;
+    } else if (chunk.id != null) {
+      key = `${generationKey}:c:${chunk.id}`;
+    } else {
+      key = `${generationKey}:#${i}`;
+    }
     const sealed = sealsChunk(seal, chunk);
     /** Secondary keys this call is also reachable under, so a later delta
      * that drops one or both identifiers still lands on the same tally:
@@ -354,24 +380,34 @@ export function enforceStreamedToolCallArgLimit({
     if (chunk.id != null) {
       aliasCandidates.push(`${generationKey}:#${i}`);
       if (chunk.index != null) {
-        aliasCandidates.push(`${generationKey}:${chunk.id}`);
+        aliasCandidates.push(`${generationKey}:c:${chunk.id}`);
       }
     }
     let tally = tallies.get(key);
-    /** A later delta can also ADD an identifier (id-only start, id+index
-     * delta), which changes the primary key; adopt the call's existing tally
-     * through its id — and only its id: the batch position is a weak
-     * fallback identity that different parallel calls legitimately share, so
-     * adopting through it would merge their budgets. The old identity is
-     * recorded as an alias and released together with the rest. */
-    if (tally == null && chunk.id != null) {
-      const idKey = `${generationKey}:${chunk.id}`;
-      const existing = idKey === key ? undefined : tallies.get(idKey);
-      if (existing != null) {
+    /** A later delta can also ADD an identifier, changing the primary key;
+     * adopt the call's existing tally through a stronger prior identity
+     * before allocating. Id-bearing chunks adopt through the id — never the
+     * batch position, which different parallel calls legitimately share.
+     * Id-less indexed chunks adopt through their batch position: a position
+     * tally is singular per position, so an anonymous call gaining an index
+     * is unambiguous within the generation. The old identity is recorded as
+     * an alias and released together with the rest. */
+    if (tally == null) {
+      let adoptionKey: string | undefined;
+      if (chunk.id != null) {
+        adoptionKey = `${generationKey}:c:${chunk.id}`;
+      } else if (chunk.index != null) {
+        adoptionKey = `${generationKey}:#${i}`;
+      }
+      const existing =
+        adoptionKey == null || adoptionKey === key
+          ? undefined
+          : tallies.get(adoptionKey);
+      if (existing != null && adoptionKey != null) {
         tally = existing;
         tallies.set(key, existing);
-        if (existing.aliasKeys?.includes(idKey) !== true) {
-          (existing.aliasKeys ??= []).push(idKey);
+        if (existing.aliasKeys?.includes(adoptionKey) !== true) {
+          (existing.aliasKeys ??= []).push(adoptionKey);
         }
       }
     }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -603,7 +603,22 @@ export function enforceStreamedToolCallArgLimit({
       if (chunk.index != null) {
         /** An index is stable across sparse events; the loop position is
          * merely this event's position and may be 0 for call index 1. */
-        adoptionCandidates.push(`${generationKey}:#${chunk.index}`);
+        const indexedPositionKey = `${generationKey}:#${chunk.index}`;
+        adoptionCandidates.push(indexedPositionKey);
+        /** A single anonymous call may first appear alone at event position
+         * #0 and reveal a nonzero provider index only later. Exact indexed
+         * position wins above; when it does not exist, one anonymous tally
+         * is still an unambiguous fallback. */
+        const anonymousTallies = getLiveGenerationTallies().filter(
+          (liveTally: StreamedToolCallArgTally) =>
+            liveTally.keys?.[0]?.startsWith(`${generationPrefix}#`) === true
+        );
+        if (anonymousTallies.length === 1) {
+          const anonymousKey = anonymousTallies[0].keys?.[0];
+          if (anonymousKey != null && anonymousKey !== indexedPositionKey) {
+            adoptionCandidates.push(anonymousKey);
+          }
+        }
       } else if (chunkId != null) {
         const anonymousTallies = getLiveGenerationTallies().filter(
           (liveTally: StreamedToolCallArgTally) =>

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -87,7 +87,14 @@ export function resolveStreamLimits(
       if (name === '' || Number.isNaN(value)) {
         continue;
       }
-      (maxToolCallArgBytesByTool ??= {})[name] = resolveLimit(
+      /** Prototype-free: bracket-assigning a `__proto__` tool name into a
+       * plain object invokes the prototype setter instead of creating an own
+       * property, silently dropping that tool's configured override. */
+      maxToolCallArgBytesByTool ??= Object.create(null) as Record<
+        string,
+        number
+      >;
+      maxToolCallArgBytesByTool[name] = resolveLimit(
         value,
         maxToolCallArgBytes
       );
@@ -308,10 +315,31 @@ export function enforceStreamedToolCallArgLimit({
         if (!sealed) {
           tallies.set(key, { bytes: 0, name: chunkToolName(chunk) });
         }
-      } else if (sealed) {
+        continue;
+      }
+      if (tally.name == null) {
+        const lateName = chunkToolName(chunk);
+        if (lateName != null) {
+          /** Bytes tallied before the name arrived were only held against the
+           * global cap; a newly applicable per-tool override must re-judge
+           * them, including on a sealing chunk about to release the tally. */
+          tally.name = lateName;
+          const limit =
+            byTool != null && Object.hasOwn(byTool, lateName)
+              ? byTool[lateName]
+              : globalLimit;
+          if (limit > 0 && tally.bytes > limit) {
+            throw new StreamLimitExceededError({
+              kind: 'tool_call_args',
+              limit,
+              observed: tally.bytes,
+              toolName: lateName,
+            });
+          }
+        }
+      }
+      if (sealed) {
         tallies.delete(key);
-      } else if (tally.name == null) {
-        tally.name = chunkToolName(chunk);
       }
       continue;
     }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -32,9 +32,10 @@ export interface ResolvedStreamLimits {
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
-  /** Batch-position key this id-keyed tally is also registered under, so an
-   * id-less later delta of the same call shares the budget; both entries are
-   * released together. */
+  /** Secondary key this tally is also registered under — the batch position
+   * for id-only chunks, or the id for chunks carrying both identifiers — so
+   * a later delta that drops an identifier still shares the budget; both
+   * entries are released together. */
   aliasKey?: string;
   /**
    * True when the previous chunk ended on an unpaired UTF-16 high surrogate.
@@ -330,32 +331,34 @@ export function enforceStreamedToolCallArgLimit({
     const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
     const sealed = sealsChunk(seal, chunk);
     let tally = tallies.get(key);
-    /** An index-less adapter can put the call id only on the first chunk and
-     * omit it from later argument deltas, which would fall back to the
-     * batch-position key and split one call's budget across two tallies. An
-     * id-keyed tally therefore also registers itself under its position key
-     * (same object, shared bytes), extending the position-stability
-     * assumption the `#i` fallback already makes. */
-    const positionAliasKey =
-      chunk.index == null && chunk.id != null
-        ? `${generationKey}:#${i}`
-        : undefined;
-    const registerPositionAlias = (target: StreamedToolCallArgTally): void => {
-      if (positionAliasKey == null) {
+    /** Secondary key this call is also reachable under, so a later delta
+     * that drops an identifier still lands on the same tally: the
+     * batch-position fallback for id-only chunks (an index-less adapter can
+     * put the id only on the first chunk), or the id itself for chunks
+     * carrying both identifiers (an adapter can drop the index later). */
+    let chunkAliasKey: string | undefined;
+    if (chunk.id != null) {
+      chunkAliasKey =
+        chunk.index == null
+          ? `${generationKey}:#${i}`
+          : `${generationKey}:${chunk.id}`;
+    }
+    const registerAliasKey = (target: StreamedToolCallArgTally): void => {
+      if (chunkAliasKey == null) {
         return;
       }
-      const currentOwner = tallies.get(positionAliasKey);
+      const currentOwner = tallies.get(chunkAliasKey);
       if (currentOwner === target) {
         return;
       }
       /** Parallel index-less calls all land on batch position #i, so the
        * newest live call takes the alias over and the previous owner is
        * disowned — its seal must not delete an alias it no longer holds. */
-      if (currentOwner?.aliasKey === positionAliasKey) {
+      if (currentOwner?.aliasKey === chunkAliasKey) {
         currentOwner.aliasKey = undefined;
       }
-      tallies.set(positionAliasKey, target);
-      target.aliasKey = positionAliasKey;
+      tallies.set(chunkAliasKey, target);
+      target.aliasKey = chunkAliasKey;
     };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
@@ -371,14 +374,14 @@ export function enforceStreamedToolCallArgLimit({
         if (!sealed) {
           tally = { bytes: 0, name: chunkToolName(chunk) };
           tallies.set(key, tally);
-          registerPositionAlias(tally);
+          registerAliasKey(tally);
         }
         continue;
       }
       /** A sealing chunk is about to release this tally; taking the position
        * alias here would steal it from a still-live parallel call. */
       if (!sealed) {
-        registerPositionAlias(tally);
+        registerAliasKey(tally);
       }
       if (tally.name == null) {
         const lateName = chunkToolName(chunk);
@@ -411,7 +414,7 @@ export function enforceStreamedToolCallArgLimit({
       tallies.set(key, tally);
     }
     if (!sealed) {
-      registerPositionAlias(tally);
+      registerAliasKey(tally);
     }
     if (tally.name == null) {
       tally.name = chunkToolName(chunk);
@@ -590,7 +593,12 @@ export function enforceStreamLimitsForWireChunk({
       toolCallChunks: chunk.tool_call_chunks,
       responseMetadata: chunk.response_metadata,
     });
-  } else if (chunk.tool_calls != null && chunk.tool_calls.length > 0) {
+  }
+  /** Judged whenever parsed calls are present, not only when raw chunks are
+   * absent: an adapter can pair an empty or partial raw chunk with a
+   * complete parsed call, and the standalone check is stateless so the
+   * common both-present case is not double-tallied. */
+  if (chunk.tool_calls != null && chunk.tool_calls.length > 0) {
     enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: chunk.tool_calls });
   }
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -23,6 +23,8 @@ export const DEFAULT_MAX_TOOL_CALL_ARG_BYTES = 65_536;
 /** Limits normalized by {@link resolveStreamLimits}; `0` uniformly means disabled. */
 export interface ResolvedStreamLimits {
   maxToolCallArgBytes: number;
+  /** Per-tool overrides of the byte cap, keyed by model-facing tool name. */
+  maxToolCallArgBytesByTool?: Readonly<Record<string, number>>;
   maxDeltaEventsPerTurn: number;
 }
 
@@ -71,11 +73,29 @@ function resolveLimit(value: number | undefined, fallback: number): number {
 export function resolveStreamLimits(
   limits?: t.StreamLimits
 ): ResolvedStreamLimits {
+  const maxToolCallArgBytes = resolveLimit(
+    limits?.maxToolCallArgBytes,
+    DEFAULT_MAX_TOOL_CALL_ARG_BYTES
+  );
+  let maxToolCallArgBytesByTool: Record<string, number> | undefined;
+  if (limits?.maxToolCallArgBytesByTool != null) {
+    for (const [name, value] of Object.entries(
+      limits.maxToolCallArgBytesByTool
+    )) {
+      /** An unusable entry (NaN) falls back to the global cap by omission,
+       * matching how the global field treats NaN. */
+      if (name === '' || Number.isNaN(value)) {
+        continue;
+      }
+      (maxToolCallArgBytesByTool ??= {})[name] = resolveLimit(
+        value,
+        maxToolCallArgBytes
+      );
+    }
+  }
   return {
-    maxToolCallArgBytes: resolveLimit(
-      limits?.maxToolCallArgBytes,
-      DEFAULT_MAX_TOOL_CALL_ARG_BYTES
-    ),
+    maxToolCallArgBytes,
+    ...(maxToolCallArgBytesByTool != null && { maxToolCallArgBytesByTool }),
     maxDeltaEventsPerTurn: resolveLimit(limits?.maxDeltaEventsPerTurn, 0),
   };
 }
@@ -95,8 +115,8 @@ function buildLimitMessage(
     return (
       `Streamed tool call arguments exceeded the ${limit}-byte safety limit${named}. ` +
       'The generation was aborted mid-stream: arguments growing this large without completing ' +
-      'usually indicate a runaway or malformed tool call. Raise \'maxToolCallArgBytes\' if your ' +
-      'tools legitimately need larger arguments.'
+      'usually indicate a runaway or malformed tool call. Raise \'maxToolCallArgBytes\' (or the ' +
+      'tool\'s \'maxToolCallArgBytesByTool\' entry) if your tools legitimately need larger arguments.'
     );
   }
   return (
@@ -247,9 +267,10 @@ export function enforceStreamedToolCallArgLimit({
   toolCallChunks: ToolCallChunk[];
   responseMetadata?: Record<string, unknown>;
 }): void {
-  const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
-    .maxToolCallArgBytes;
-  if (limit <= 0) {
+  const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
+  const globalLimit = resolved.maxToolCallArgBytes;
+  const byTool = resolved.maxToolCallArgBytesByTool;
+  if (globalLimit <= 0 && byTool == null) {
     return;
   }
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
@@ -264,12 +285,17 @@ export function enforceStreamedToolCallArgLimit({
         continue;
       }
       const bytes = Buffer.byteLength(args, 'utf8');
-      if (bytes > limit) {
+      const sealedName = chunkToolName(chunk);
+      const limit =
+        byTool != null && sealedName != null && Object.hasOwn(byTool, sealedName)
+          ? byTool[sealedName]
+          : globalLimit;
+      if (limit > 0 && bytes > limit) {
         throw new StreamLimitExceededError({
           kind: 'tool_call_args',
           limit,
           observed: bytes,
-          toolName: chunkToolName(chunk),
+          toolName: sealedName,
         });
       }
       continue;
@@ -307,12 +333,17 @@ export function enforceStreamedToolCallArgLimit({
     }
     tally.pendingHighSurrogate =
       !sealed && isHighSurrogate(args.charCodeAt(args.length - 1));
-    if (tally.bytes > limit) {
+    const toolName = tally.name ?? chunkToolName(chunk);
+    const limit =
+      byTool != null && toolName != null && Object.hasOwn(byTool, toolName)
+        ? byTool[toolName]
+        : globalLimit;
+    if (limit > 0 && tally.bytes > limit) {
       throw new StreamLimitExceededError({
         kind: 'tool_call_args',
         limit,
         observed: tally.bytes,
-        toolName: tally.name ?? chunkToolName(chunk),
+        toolName,
       });
     }
     if (sealed) {

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -435,8 +435,11 @@ export function enforceStreamedToolCallArgLimit({
         break;
       }
     }
-    const registerAliases = (target: StreamedToolCallArgTally): void => {
-      for (const aliasKey of aliasCandidates) {
+    const registerAliasKeys = (
+      target: StreamedToolCallArgTally,
+      candidates: string[]
+    ): void => {
+      for (const aliasKey of candidates) {
         const currentOwner = tallies.get(aliasKey);
         if (currentOwner === target) {
           continue;
@@ -453,6 +456,21 @@ export function enforceStreamedToolCallArgLimit({
         tallies.set(aliasKey, target);
         (target.keys ??= []).push(aliasKey);
       }
+    };
+    const registerAliases = (target: StreamedToolCallArgTally): void => {
+      registerAliasKeys(target, aliasCandidates);
+    };
+    /** Index-only calls register their batch position ONCE, at creation:
+     * later deltas that drop the index then land on the same tally, while
+     * the per-delta hot path (indexed id-less deltas) stays free of alias
+     * work. */
+    const registerCreationPositionAlias = (
+      target: StreamedToolCallArgTally
+    ): void => {
+      if (chunk.id != null || chunk.index == null || sealed) {
+        return;
+      }
+      registerAliasKeys(target, [`${generationKey}:#${i}`]);
     };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
@@ -471,6 +489,7 @@ export function enforceStreamedToolCallArgLimit({
           tally = { bytes: 0, name: resolveChunkName(chunk), keys: [key] };
           tallies.set(key, tally);
           registerAliases(tally);
+          registerCreationPositionAlias(tally);
         }
         continue;
       }
@@ -508,6 +527,7 @@ export function enforceStreamedToolCallArgLimit({
     if (tally == null) {
       tally = { bytes: 0, keys: [key] };
       tallies.set(key, tally);
+      registerCreationPositionAlias(tally);
     }
     if (!sealed) {
       registerAliases(tally);
@@ -697,6 +717,7 @@ export function enforceStreamLimitsForWireChunk({
   chunk: {
     tool_call_chunks?: ToolCallChunk[];
     tool_calls?: CompleteToolCallLike[];
+    invalid_tool_calls?: CompleteToolCallLike[];
     response_metadata?: Record<string, unknown>;
   };
   /** Claim side for the credit balance. The local dispatch branch charges
@@ -721,10 +742,33 @@ export function enforceStreamLimitsForWireChunk({
   /** Judged whenever parsed calls are present, not only when raw chunks are
    * absent: an adapter can pair an empty or partial raw chunk with a
    * complete parsed call, and the standalone check is stateless so the
-   * common both-present case is not double-tallied. */
-  if (chunk.tool_calls != null && chunk.tool_calls.length > 0) {
-    enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: chunk.tool_calls });
+   * common both-present case is not double-tallied. `invalid_tool_calls`
+   * are included — ToolNode processes and promotes them, and a malformed
+   * call streaming oversized arguments is the exact pathology this breaker
+   * exists to stop. */
+  const completeCalls = combineCompleteToolCalls(chunk);
+  if (completeCalls != null) {
+    enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: completeCalls });
   }
+}
+
+/** Combined view of a chunk's parsed and invalid complete calls, avoiding
+ * allocation on the common paths where one or both are absent. */
+export function combineCompleteToolCalls(chunk: {
+  tool_calls?: CompleteToolCallLike[];
+  invalid_tool_calls?: CompleteToolCallLike[];
+}): CompleteToolCallLike[] | undefined {
+  const parsed = chunk.tool_calls;
+  const invalid = chunk.invalid_tool_calls;
+  const hasParsed = parsed != null && parsed.length > 0;
+  const hasInvalid = invalid != null && invalid.length > 0;
+  if (hasParsed && hasInvalid) {
+    return [...parsed, ...invalid];
+  }
+  if (hasParsed) {
+    return parsed;
+  }
+  return hasInvalid ? invalid : undefined;
 }
 
 /**

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -1,0 +1,208 @@
+// src/llm/streamLimits.ts
+import type { ToolCallChunk } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+
+/**
+ * Circuit breakers for pathological model streams.
+ *
+ * A malformed generation can stream a single tool call's arguments for many
+ * minutes at the provider's full token rate while the arguments never become
+ * executable (observed live: one 149,923-char SQL argument streamed for 26
+ * minutes before the 64k output-token ceiling finally ended the run). These
+ * guards fail fast instead: when a limit trips, the stream handler throws
+ * `StreamLimitExceededError` out of the run's `streamEvents` loop, which
+ * tears down the in-flight provider request where it stands (see the
+ * mid-flight halt notes in `Run.processStream`: leaving the loop cancels the
+ * reader and langgraph aborts the model call).
+ */
+
+/** Default cap on a single streamed tool call's cumulative argument bytes (64 KiB). */
+export const DEFAULT_MAX_TOOL_CALL_ARG_BYTES = 65_536;
+
+/** Limits normalized by {@link resolveStreamLimits}; `0` uniformly means disabled. */
+export interface ResolvedStreamLimits {
+  maxToolCallArgBytes: number;
+  maxDeltaEventsPerTurn: number;
+}
+
+/** Cumulative streamed argument bytes for one in-flight tool call. */
+export interface StreamedToolCallArgTally {
+  bytes: number;
+  name?: string;
+}
+
+/**
+ * The graph-owned state the guards read and write. Structural on purpose:
+ * handler-level tests stub graphs with plain objects, and the guards lazily
+ * create the tally maps so partial stubs need no extra setup.
+ */
+export interface StreamLimitState {
+  streamLimits?: ResolvedStreamLimits;
+  streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
+  streamDeltaEventCounts?: Map<string, number>;
+}
+
+function resolveLimit(value: number | undefined, fallback: number): number {
+  if (value == null || Number.isNaN(value)) {
+    return fallback;
+  }
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const whole = Math.floor(value);
+  return whole > 0 ? whole : 0;
+}
+
+/**
+ * Normalizes host-supplied limits once at graph construction. `undefined`
+ * applies the default for each guard (the tool-argument byte cap is ON by
+ * default, the per-turn event cap is opt-in), `0` and negative values
+ * disable a guard, `Infinity` means "no limit" and also disables, and `NaN`
+ * falls back to the default.
+ */
+export function resolveStreamLimits(
+  limits?: t.StreamLimits
+): ResolvedStreamLimits {
+  return {
+    maxToolCallArgBytes: resolveLimit(
+      limits?.maxToolCallArgBytes,
+      DEFAULT_MAX_TOOL_CALL_ARG_BYTES
+    ),
+    maxDeltaEventsPerTurn: resolveLimit(limits?.maxDeltaEventsPerTurn, 0),
+  };
+}
+
+const DEFAULT_RESOLVED_LIMITS: ResolvedStreamLimits = resolveStreamLimits();
+
+export type StreamLimitKind = 'tool_call_args' | 'delta_events';
+
+function buildLimitMessage(
+  kind: StreamLimitKind,
+  limit: number,
+  toolName?: string
+): string {
+  if (kind === 'tool_call_args') {
+    const named =
+      toolName != null && toolName !== '' ? ` (tool call: ${toolName})` : '';
+    return (
+      `Streamed tool call arguments exceeded the ${limit}-byte safety limit${named}. ` +
+      'The generation was aborted mid-stream: arguments growing this large without completing ' +
+      'usually indicate a runaway or malformed tool call. Raise \'maxToolCallArgBytes\' if your ' +
+      'tools legitimately need larger arguments.'
+    );
+  }
+  return (
+    `Model stream exceeded the ${limit}-event safety limit for a single generation turn. ` +
+    'The generation was aborted mid-stream: this usually indicates a looping or duplicated ' +
+    'provider stream. Raise \'maxDeltaEventsPerTurn\' if legitimate generations need more stream events.'
+  );
+}
+
+/**
+ * Raised when a {@link t.StreamLimits} guard trips. Thrown from inside the
+ * run's `streamEvents` loop, so the in-flight provider request is torn down
+ * and `processStream` rejects with this error.
+ */
+export class StreamLimitExceededError extends Error {
+  readonly kind: StreamLimitKind;
+  readonly limit: number;
+  readonly observed: number;
+  readonly toolName?: string;
+
+  constructor({
+    kind,
+    limit,
+    observed,
+    toolName,
+  }: {
+    kind: StreamLimitKind;
+    limit: number;
+    observed: number;
+    toolName?: string;
+  }) {
+    super(buildLimitMessage(kind, limit, toolName));
+    this.name = 'StreamLimitExceededError';
+    this.kind = kind;
+    this.limit = limit;
+    this.observed = observed;
+    this.toolName = toolName;
+  }
+}
+
+/**
+ * Accumulates the UTF-8 byte size of streamed tool-call argument chunks per
+ * in-flight tool call (keyed by `stepKey:index`) and throws once a single
+ * call's cumulative bytes exceed `maxToolCallArgBytes`. Runs once per
+ * streamed chunk event, before the chunks are recorded or dispatched, so a
+ * tripped limit stops the run without accumulating further.
+ */
+export function enforceStreamedToolCallArgLimit({
+  graph,
+  stepKey,
+  toolCallChunks,
+}: {
+  graph: StreamLimitState;
+  stepKey: string;
+  toolCallChunks: ToolCallChunk[];
+}): void {
+  const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
+    .maxToolCallArgBytes;
+  if (limit <= 0) {
+    return;
+  }
+  const tallies = (graph.streamedToolCallArgTallies ??= new Map());
+  for (const chunk of toolCallChunks) {
+    const key = `${stepKey}:${chunk.index ?? 0}`;
+    let tally = tallies.get(key);
+    if (tally == null) {
+      tally = { bytes: 0 };
+      tallies.set(key, tally);
+    }
+    if (tally.name == null && chunk.name != null && chunk.name !== '') {
+      tally.name = chunk.name;
+    }
+    const args = chunk.args;
+    if (typeof args !== 'string' || args === '') {
+      continue;
+    }
+    tally.bytes += Buffer.byteLength(args, 'utf8');
+    if (tally.bytes > limit) {
+      throw new StreamLimitExceededError({
+        kind: 'tool_call_args',
+        limit,
+        observed: tally.bytes,
+        toolName: tally.name,
+      });
+    }
+  }
+}
+
+/**
+ * Counts streamed chunk events per generation turn (stepKey) and throws once
+ * a single turn exceeds `maxDeltaEventsPerTurn`. Opt-in defense in depth for
+ * pathologies a byte cap cannot see, such as a provider stream looping on
+ * empty chunks. Zero cost while disabled.
+ */
+export function enforceStreamDeltaEventLimit({
+  graph,
+  stepKey,
+}: {
+  graph: StreamLimitState;
+  stepKey: string;
+}): void {
+  const limit = (graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS)
+    .maxDeltaEventsPerTurn;
+  if (limit <= 0) {
+    return;
+  }
+  const counts = (graph.streamDeltaEventCounts ??= new Map());
+  const next = (counts.get(stepKey) ?? 0) + 1;
+  if (next > limit) {
+    throw new StreamLimitExceededError({
+      kind: 'delta_events',
+      limit,
+      observed: next,
+    });
+  }
+  counts.set(stepKey, next);
+}

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -153,15 +153,14 @@ export function resolveGenerationKey(
 }
 
 /**
- * True when this chunk restates an already-streamed argument string instead
- * of extending it. The OpenAI Responses adapter attaches a `single` seal to
- * its `response.function_call_arguments.done` chunk, whose `args` is the
- * complete argument string all over again; summing it would double-count
- * every legitimate call. Adapters that seal without restating are unaffected:
- * Bedrock Converse seals with an empty-args chunk (skipped before this
- * check) and Google seals atomic single-chunk calls with `kind: 'all'`.
+ * True when the event's `single` seal marks this chunk's own call as
+ * complete. On the OpenAI Responses adapter the sealing chunk RESTATES the
+ * full argument string (`response.function_call_arguments.done`), so summing
+ * it would double-count every legitimate call; on Bedrock Converse the
+ * sealing chunk carries empty args. Either way the call is finished: its
+ * tally is replaced by the sealing chunk's own bytes, checked, and released.
  */
-function isSealRestatement(
+function sealsChunk(
   seal: ReturnType<typeof getStreamedToolCallSeal>,
   chunk: ToolCallChunk
 ): boolean {
@@ -174,6 +173,10 @@ function isSealRestatement(
   return seal.id != null && seal.id === chunk.id;
 }
 
+function chunkToolName(chunk: ToolCallChunk): string | undefined {
+  return chunk.name != null && chunk.name !== '' ? chunk.name : undefined;
+}
+
 /**
  * Accumulates the UTF-8 byte size of streamed tool-call argument chunks per
  * in-flight tool call and throws once a single call's cumulative bytes
@@ -183,10 +186,13 @@ function isSealRestatement(
  * offending call.
  *
  * Calls are keyed by generation and chunk `index`, falling back to the
- * chunk `id` and then to a shared bucket when a provider identifies chunks
- * by neither. The shared-bucket fallback is deliberately conservative: such
- * chunks cannot be attributed to distinct calls anywhere in the pipeline,
- * and a runaway stream is exactly the case that must still be bounded.
+ * chunk `id` and then to the chunk's position within the event's batch when
+ * a provider identifies chunks by neither (Google emits complete parallel
+ * calls with optional ids and no index). A `kind: 'all'` arrival seal marks
+ * every chunk in the event as its own complete call, so those are checked
+ * standalone and never share a budget; a matching `kind: 'single'` seal
+ * replaces the call's tally with the sealing chunk's own bytes (the OpenAI
+ * Responses done-chunk restates the full argument string) and releases it.
  */
 export function enforceStreamedToolCallArgLimit({
   graph,
@@ -207,31 +213,59 @@ export function enforceStreamedToolCallArgLimit({
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
   const generationKey = resolveGenerationKey(metadata);
   const seal = getStreamedToolCallSeal(responseMetadata);
-  for (const chunk of toolCallChunks) {
-    const key = `${generationKey}:${chunk.index ?? chunk.id ?? 0}`;
+  for (let i = 0; i < toolCallChunks.length; i++) {
+    const chunk = toolCallChunks[i];
+    const args = chunk.args;
+    const hasArgs = typeof args === 'string' && args !== '';
+    if (seal?.kind === 'all') {
+      if (!hasArgs) {
+        continue;
+      }
+      const bytes = Buffer.byteLength(args, 'utf8');
+      if (bytes > limit) {
+        throw new StreamLimitExceededError({
+          kind: 'tool_call_args',
+          limit,
+          observed: bytes,
+          toolName: chunkToolName(chunk),
+        });
+      }
+      continue;
+    }
+    const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
+    const sealed = sealsChunk(seal, chunk);
     let tally = tallies.get(key);
+    if (!hasArgs) {
+      if (tally == null) {
+        if (!sealed) {
+          tallies.set(key, { bytes: 0, name: chunkToolName(chunk) });
+        }
+      } else if (sealed) {
+        tallies.delete(key);
+      } else if (tally.name == null) {
+        tally.name = chunkToolName(chunk);
+      }
+      continue;
+    }
     if (tally == null) {
       tally = { bytes: 0 };
       tallies.set(key, tally);
     }
-    if (tally.name == null && chunk.name != null && chunk.name !== '') {
-      tally.name = chunk.name;
-    }
-    const args = chunk.args;
-    if (typeof args !== 'string' || args === '') {
-      continue;
+    if (tally.name == null) {
+      tally.name = chunkToolName(chunk);
     }
     const argBytes = Buffer.byteLength(args, 'utf8');
-    tally.bytes = isSealRestatement(seal, chunk)
-      ? argBytes
-      : tally.bytes + argBytes;
+    tally.bytes = sealed ? argBytes : tally.bytes + argBytes;
     if (tally.bytes > limit) {
       throw new StreamLimitExceededError({
         kind: 'tool_call_args',
         limit,
         observed: tally.bytes,
-        toolName: tally.name,
+        toolName: tally.name ?? chunkToolName(chunk),
       });
+    }
+    if (sealed) {
+      tallies.delete(key);
     }
   }
 }
@@ -265,4 +299,46 @@ export function enforceStreamDeltaEventLimit({
     });
   }
   counts.set(key, next);
+}
+
+/**
+ * Releases one generation's tallies and event count. Called at the start of
+ * every model attempt (`attemptInvoke`): primary, fallback, and retry
+ * attempts within one node share the same langgraph metadata, so without
+ * this a fallback that re-streams a tool call from scratch would be charged
+ * the failed primary's partial bytes and could falsely trip the limit. The
+ * decoupled `streamEvents` reader can lag an attempt boundary by whatever it
+ * has buffered, so attribution is best-effort by design; the reset shrinks a
+ * mischarge from "the whole failed attempt" to that small in-flight tail.
+ * No-ops on two size checks while nothing was counted.
+ */
+export function resetStreamLimitTallies({
+  graph,
+  metadata,
+}: {
+  graph: StreamLimitState | undefined;
+  metadata: Record<string, unknown> | undefined;
+}): void {
+  if (graph == null) {
+    return;
+  }
+  const tallies = graph.streamedToolCallArgTallies;
+  const counts = graph.streamDeltaEventCounts;
+  const hasTallies = tallies != null && tallies.size > 0;
+  const hasCounts = counts != null && counts.size > 0;
+  if (!hasTallies && !hasCounts) {
+    return;
+  }
+  const generationKey = resolveGenerationKey(metadata);
+  if (hasTallies) {
+    const prefix = `${generationKey}:`;
+    for (const key of tallies.keys()) {
+      if (key.startsWith(prefix)) {
+        tallies.delete(key);
+      }
+    }
+  }
+  if (hasCounts) {
+    counts.delete(generationKey);
+  }
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -54,6 +54,9 @@ export interface StreamLimitState {
   streamLimits?: ResolvedStreamLimits;
   streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
   streamDeltaEventCounts?: Map<string, number>;
+  /** Wire chunks already charged synchronously by the producer loop, so the
+   * decoupled handler echo of the same object does not charge them again. */
+  streamLimitPrecountedChunks?: WeakSet<object>;
 }
 
 function resolveLimit(value: number | undefined, fallback: number): number {
@@ -419,6 +422,117 @@ export function enforceStreamedToolCallArgLimit({
       releaseTally(tally);
     }
   }
+}
+
+/** Structural subset of a complete parsed tool call. */
+interface CompleteToolCallLike {
+  name?: string;
+  args?: unknown;
+}
+
+/**
+ * Standalone byte check for complete parsed tool calls that arrive without a
+ * raw chunk representation: a streaming custom or OpenAI-compatible
+ * `ChatModel` can yield fully parsed `tool_calls` with empty
+ * `tool_call_chunks`, which would otherwise dispatch without consuming any
+ * byte budget. Complete calls are self-contained, so each is judged
+ * standalone without tallying.
+ */
+export function enforceCompleteToolCallArgLimit({
+  graph,
+  metadata,
+  toolCalls,
+}: {
+  graph: StreamLimitState;
+  metadata: Record<string, unknown> | undefined;
+  toolCalls: CompleteToolCallLike[];
+}): void {
+  const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
+  const globalLimit = resolved.maxToolCallArgBytes;
+  const byTool = resolved.maxToolCallArgBytesByTool;
+  if (globalLimit <= 0 && byTool == null) {
+    return;
+  }
+  if (metadata?.[STREAM_LIMIT_REDISPATCH_KEY] === true) {
+    return;
+  }
+  for (const toolCall of toolCalls) {
+    const name =
+      toolCall.name != null && toolCall.name !== '' ? toolCall.name : undefined;
+    const limit =
+      byTool != null && name != null && Object.hasOwn(byTool, name)
+        ? byTool[name]
+        : globalLimit;
+    if (limit <= 0) {
+      continue;
+    }
+    const args = toolCall.args;
+    let serialized: string;
+    if (typeof args === 'string') {
+      serialized = args;
+    } else if (args == null) {
+      serialized = '';
+    } else {
+      serialized = JSON.stringify(args) ?? '';
+    }
+    const bytes = Buffer.byteLength(serialized, 'utf8');
+    if (bytes > limit) {
+      throw new StreamLimitExceededError({
+        kind: 'tool_call_args',
+        limit,
+        observed: bytes,
+        toolName: name,
+      });
+    }
+  }
+}
+
+/**
+ * Synchronous producer-side accounting for the registered-handler dispatch
+ * branch, where original wire chunks are otherwise judged only when the
+ * decoupled `streamEvents` reader catches up. A lagging reader would let an
+ * oversized complete call return to LangGraph and reach `ToolNode` before
+ * the queued handler throws; charging in the producer loop keeps the breaker
+ * ahead of graph progression. The chunk object is marked so the later
+ * handler echo of the same object skips accounting.
+ */
+export function enforceStreamLimitsForWireChunk({
+  graph,
+  metadata,
+  chunk,
+}: {
+  graph: StreamLimitState;
+  metadata: Record<string, unknown> | undefined;
+  chunk: {
+    tool_call_chunks?: ToolCallChunk[];
+    tool_calls?: CompleteToolCallLike[];
+    response_metadata?: Record<string, unknown>;
+  };
+}): void {
+  (graph.streamLimitPrecountedChunks ??= new WeakSet()).add(chunk as object);
+  enforceStreamDeltaEventLimit({ graph, metadata });
+  if (chunk.tool_call_chunks != null && chunk.tool_call_chunks.length > 0) {
+    enforceStreamedToolCallArgLimit({
+      graph,
+      metadata,
+      toolCallChunks: chunk.tool_call_chunks,
+      responseMetadata: chunk.response_metadata,
+    });
+  } else if (chunk.tool_calls != null && chunk.tool_calls.length > 0) {
+    enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: chunk.tool_calls });
+  }
+}
+
+/** True when the producer loop already charged this exact chunk object. */
+export function wasStreamLimitPrecounted(
+  graph: StreamLimitState,
+  chunk: unknown
+): boolean {
+  return (
+    typeof chunk === 'object' &&
+    chunk != null &&
+    graph.streamLimitPrecountedChunks?.has(chunk) === true
+  );
 }
 
 /**

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -242,13 +242,17 @@ function sealsChunk(
   if (seal == null || seal.kind !== 'single') {
     return false;
   }
-  /** Either supplied identifier is sufficient (matching the eager-call seal
-   * handling in stream.ts): a seal carrying both index and id must still
-   * match a sealing chunk that carries only one of them, or an OpenAI-style
-   * full-argument restatement gets ADDED to the tally instead of replacing
-   * it, and an empty seal leaves the tally unreleased. */
-  if (seal.index != null && chunk.index != null) {
-    return seal.index === chunk.index;
+  /** Either supplied identifier agreeing is sufficient (matching the
+   * eager-call seal handling in stream.ts): a mismatch on one identifier
+   * must not veto a match on the other, or an OpenAI-style full-argument
+   * restatement gets ADDED to the tally instead of replacing it, and an
+   * empty seal leaves the tally unreleased. */
+  if (
+    seal.index != null &&
+    chunk.index != null &&
+    seal.index === chunk.index
+  ) {
+    return true;
   }
   return seal.id != null && chunk.id != null && seal.id === chunk.id;
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -609,13 +609,13 @@ export function enforceStreamedToolCallArgLimit({
          * #0 and reveal a nonzero provider index only later. Exact indexed
          * position wins above; when it does not exist, one anonymous tally
          * is still an unambiguous fallback. */
-        const anonymousTallies = getLiveGenerationTallies().filter(
-          (liveTally: StreamedToolCallArgTally) =>
-            liveTally.keys?.[0]?.startsWith(`${generationPrefix}#`) === true
-        );
-        if (anonymousTallies.length === 1) {
-          const anonymousKey = anonymousTallies[0].keys?.[0];
-          if (anonymousKey != null && anonymousKey !== indexedPositionKey) {
+        const liveTallies = getLiveGenerationTallies();
+        const soleTally = liveTallies.length === 1 ? liveTallies[0] : undefined;
+        if (
+          soleTally?.keys?.[0]?.startsWith(`${generationPrefix}#`) === true
+        ) {
+          const anonymousKey = soleTally.keys[0];
+          if (anonymousKey !== indexedPositionKey) {
             adoptionCandidates.push(anonymousKey);
           }
         }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -32,6 +32,10 @@ export interface ResolvedStreamLimits {
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
+  /** Batch-position key this id-keyed tally is also registered under, so an
+   * id-less later delta of the same call shares the budget; both entries are
+   * released together. */
+  aliasKey?: string;
   /**
    * True when the previous chunk ended on an unpaired UTF-16 high surrogate.
    * Counting each half of a split surrogate pair alone yields 3 bytes per
@@ -280,6 +284,14 @@ export function enforceStreamedToolCallArgLimit({
   if (globalLimit <= 0 && byTool == null) {
     return;
   }
+  /** An inline re-dispatch of a transformed chunk (OpenRouter final-reasoning
+   * replay) duplicates tool-call chunks the original `streamEvents` event
+   * already charged — the original always survives the content-specific
+   * skips when it carries tool calls, so counting the marked copy would
+   * double every legitimate argument byte. */
+  if (metadata?.[STREAM_LIMIT_REDISPATCH_KEY] === true) {
+    return;
+  }
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
   const generationKey = resolveGenerationKey(metadata);
   const seal = getStreamedToolCallSeal(responseMetadata);
@@ -310,13 +322,41 @@ export function enforceStreamedToolCallArgLimit({
     const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
     const sealed = sealsChunk(seal, chunk);
     let tally = tallies.get(key);
+    /** An index-less adapter can put the call id only on the first chunk and
+     * omit it from later argument deltas, which would fall back to the
+     * batch-position key and split one call's budget across two tallies. An
+     * id-keyed tally therefore also registers itself under its position key
+     * (same object, shared bytes), extending the position-stability
+     * assumption the `#i` fallback already makes. */
+    const positionAliasKey =
+      chunk.index == null && chunk.id != null
+        ? `${generationKey}:#${i}`
+        : undefined;
+    const registerPositionAlias = (target: StreamedToolCallArgTally): void => {
+      if (positionAliasKey == null) {
+        return;
+      }
+      if (tallies.get(positionAliasKey) !== target) {
+        tallies.set(positionAliasKey, target);
+        target.aliasKey = positionAliasKey;
+      }
+    };
+    const releaseTally = (target: StreamedToolCallArgTally): void => {
+      tallies.delete(key);
+      if (target.aliasKey != null) {
+        tallies.delete(target.aliasKey);
+      }
+    };
     if (!hasArgs) {
       if (tally == null) {
         if (!sealed) {
-          tallies.set(key, { bytes: 0, name: chunkToolName(chunk) });
+          tally = { bytes: 0, name: chunkToolName(chunk) };
+          tallies.set(key, tally);
+          registerPositionAlias(tally);
         }
         continue;
       }
+      registerPositionAlias(tally);
       if (tally.name == null) {
         const lateName = chunkToolName(chunk);
         if (lateName != null) {
@@ -339,7 +379,7 @@ export function enforceStreamedToolCallArgLimit({
         }
       }
       if (sealed) {
-        tallies.delete(key);
+        releaseTally(tally);
       }
       continue;
     }
@@ -347,6 +387,7 @@ export function enforceStreamedToolCallArgLimit({
       tally = { bytes: 0 };
       tallies.set(key, tally);
     }
+    registerPositionAlias(tally);
     if (tally.name == null) {
       tally.name = chunkToolName(chunk);
     }
@@ -375,7 +416,7 @@ export function enforceStreamedToolCallArgLimit({
       });
     }
     if (sealed) {
-      tallies.delete(key);
+      releaseTally(tally);
     }
   }
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -2,7 +2,6 @@
 import type { ToolCallChunk } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { getStreamedToolCallSeal } from '@/tools/streamedToolCallSeals';
-import { Constants } from '@/common';
 
 /**
  * Circuit breakers for pathological model streams.
@@ -141,12 +140,15 @@ export class StreamLimitExceededError extends Error {
  * `checkpoint_ns + node + step` stays stable for the whole generation and
  * distinguishes parallel agents in the same superstep.
  *
- * The `INVOKED_MODEL` stamp scopes attempts within one node execution:
- * `tryFallbackProviders` (and summarization's fallback path) stamps it into
- * each fallback's config metadata, so a fallback's chunks key separately
- * from the failed primary's even when the decoupled `streamEvents` reader
- * drains the primary's buffered chunks late. Those late chunks land in the
- * primary's own bucket instead of polluting the fallback's.
+ * The attempt stamp scopes attempts within one node execution:
+ * `attemptInvoke` is the single funnel for primary, fallback, and
+ * summarization model calls and stamps {@link STREAM_LIMIT_ATTEMPT_KEY}
+ * with a unique sequence number into each attempt's callback metadata. A
+ * fallback's chunks therefore key separately from the failed primary's,
+ * even for two fallbacks configured with the same provider and model name,
+ * and even when the decoupled `streamEvents` reader drains a failed
+ * attempt's buffered chunks late. Those late chunks land in their own
+ * attempt's bucket instead of polluting the next one's.
  */
 export function resolveGenerationKey(
   metadata: Record<string, unknown> | undefined
@@ -157,9 +159,16 @@ export function resolveGenerationKey(
   const checkpointNs = metadata.langgraph_checkpoint_ns ?? '';
   const node = metadata.langgraph_node ?? '';
   const step = metadata.langgraph_step ?? '';
-  const invokedModel = metadata[Constants.INVOKED_MODEL] ?? '';
-  return `${checkpointNs}|${node}|${step}|${invokedModel}`;
+  const attempt = metadata[STREAM_LIMIT_ATTEMPT_KEY] ?? '';
+  return `${checkpointNs}|${node}|${step}|${attempt}`;
 }
+
+/**
+ * Metadata key carrying the unique per-model-attempt sequence number that
+ * `attemptInvoke` stamps into every attempt's callback metadata. Part of
+ * the generation key so budgets never alias across attempts.
+ */
+export const STREAM_LIMIT_ATTEMPT_KEY = 'lc_stream_limit_attempt';
 
 /**
  * Event-metadata marker for a chunk the SDK re-dispatches inline after
@@ -320,46 +329,4 @@ export function enforceStreamDeltaEventLimit({
     });
   }
   counts.set(key, next);
-}
-
-/**
- * Releases one generation's tallies and event count. Called at the start of
- * every model attempt (`attemptInvoke`): primary, fallback, and retry
- * attempts within one node share the same langgraph metadata, so without
- * this a fallback that re-streams a tool call from scratch would be charged
- * the failed primary's partial bytes and could falsely trip the limit. The
- * decoupled `streamEvents` reader can lag an attempt boundary by whatever it
- * has buffered, so attribution is best-effort by design; the reset shrinks a
- * mischarge from "the whole failed attempt" to that small in-flight tail.
- * No-ops on two size checks while nothing was counted.
- */
-export function resetStreamLimitTallies({
-  graph,
-  metadata,
-}: {
-  graph: StreamLimitState | undefined;
-  metadata: Record<string, unknown> | undefined;
-}): void {
-  if (graph == null) {
-    return;
-  }
-  const tallies = graph.streamedToolCallArgTallies;
-  const counts = graph.streamDeltaEventCounts;
-  const hasTallies = tallies != null && tallies.size > 0;
-  const hasCounts = counts != null && counts.size > 0;
-  if (!hasTallies && !hasCounts) {
-    return;
-  }
-  const generationKey = resolveGenerationKey(metadata);
-  if (hasTallies) {
-    const prefix = `${generationKey}:`;
-    for (const key of tallies.keys()) {
-      if (key.startsWith(prefix)) {
-        tallies.delete(key);
-      }
-    }
-  }
-  if (hasCounts) {
-    counts.delete(generationKey);
-  }
 }

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -30,6 +30,13 @@ export interface ResolvedStreamLimits {
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
+  /**
+   * True when the previous chunk ended on an unpaired UTF-16 high surrogate.
+   * Counting each half of a split surrogate pair alone yields 3 bytes per
+   * half (the replacement-character encoding) versus 4 for the pair, so the
+   * next chunk starting with the low surrogate reconciles by subtracting 2.
+   */
+  pendingHighSurrogate?: boolean;
 }
 
 /**
@@ -204,6 +211,14 @@ function chunkToolName(chunk: ToolCallChunk): string | undefined {
   return chunk.name != null && chunk.name !== '' ? chunk.name : undefined;
 }
 
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
 /**
  * Accumulates the UTF-8 byte size of streamed tool-call argument chunks per
  * in-flight tool call and throws once a single call's cumulative bytes
@@ -282,7 +297,16 @@ export function enforceStreamedToolCallArgLimit({
       tally.name = chunkToolName(chunk);
     }
     const argBytes = Buffer.byteLength(args, 'utf8');
-    tally.bytes = sealed ? argBytes : tally.bytes + argBytes;
+    if (sealed) {
+      tally.bytes = argBytes;
+    } else {
+      const reconcilesSplitPair =
+        tally.pendingHighSurrogate === true &&
+        isLowSurrogate(args.charCodeAt(0));
+      tally.bytes += reconcilesSplitPair ? argBytes - 2 : argBytes;
+    }
+    tally.pendingHighSurrogate =
+      !sealed && isHighSurrogate(args.charCodeAt(args.length - 1));
     if (tally.bytes > limit) {
       throw new StreamLimitExceededError({
         kind: 'tool_call_args',

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -281,11 +281,15 @@ export function enforceStreamedToolCallArgLimit({
   metadata,
   toolCallChunks,
   responseMetadata,
+  parsedToolCalls,
 }: {
   graph: StreamLimitState;
   metadata: Record<string, unknown> | undefined;
   toolCallChunks: ToolCallChunk[];
   responseMetadata?: Record<string, unknown>;
+  /** Complete parsed calls from the same event, used to name anonymous raw
+   * chunks so per-tool overrides are honored before the global cap trips. */
+  parsedToolCalls?: CompleteToolCallLike[];
 }): void {
   const resolved = graph.streamLimits ?? DEFAULT_RESOLVED_LIMITS;
   const globalLimit = resolved.maxToolCallArgBytes;
@@ -304,6 +308,18 @@ export function enforceStreamedToolCallArgLimit({
   const tallies = (graph.streamedToolCallArgTallies ??= new Map());
   const generationKey = resolveGenerationKey(metadata);
   const seal = getStreamedToolCallSeal(responseMetadata);
+  const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
+    const name = chunkToolName(chunk);
+    if (name != null || chunk.id == null || parsedToolCalls == null) {
+      return name;
+    }
+    for (const parsed of parsedToolCalls) {
+      if (parsed.id === chunk.id && parsed.name != null && parsed.name !== '') {
+        return parsed.name;
+      }
+    }
+    return undefined;
+  };
   for (let i = 0; i < toolCallChunks.length; i++) {
     const chunk = toolCallChunks[i];
     const args = chunk.args;
@@ -313,7 +329,7 @@ export function enforceStreamedToolCallArgLimit({
         continue;
       }
       const bytes = Buffer.byteLength(args, 'utf8');
-      const sealedName = chunkToolName(chunk);
+      const sealedName = resolveChunkName(chunk);
       const limit =
         byTool != null && sealedName != null && Object.hasOwn(byTool, sealedName)
           ? byTool[sealedName]
@@ -330,7 +346,6 @@ export function enforceStreamedToolCallArgLimit({
     }
     const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
     const sealed = sealsChunk(seal, chunk);
-    let tally = tallies.get(key);
     /** Secondary keys this call is also reachable under, so a later delta
      * that drops one or both identifiers still lands on the same tally:
      * id-bearing chunks register the batch-position fallback, and chunks
@@ -340,6 +355,24 @@ export function enforceStreamedToolCallArgLimit({
       aliasCandidates.push(`${generationKey}:#${i}`);
       if (chunk.index != null) {
         aliasCandidates.push(`${generationKey}:${chunk.id}`);
+      }
+    }
+    let tally = tallies.get(key);
+    /** A later delta can also ADD an identifier (id-only start, id+index
+     * delta), which changes the primary key; adopt the call's existing tally
+     * through its id — and only its id: the batch position is a weak
+     * fallback identity that different parallel calls legitimately share, so
+     * adopting through it would merge their budgets. The old identity is
+     * recorded as an alias and released together with the rest. */
+    if (tally == null && chunk.id != null) {
+      const idKey = `${generationKey}:${chunk.id}`;
+      const existing = idKey === key ? undefined : tallies.get(idKey);
+      if (existing != null) {
+        tally = existing;
+        tallies.set(key, existing);
+        if (existing.aliasKeys?.includes(idKey) !== true) {
+          (existing.aliasKeys ??= []).push(idKey);
+        }
       }
     }
     const registerAliases = (target: StreamedToolCallArgTally): void => {
@@ -375,7 +408,7 @@ export function enforceStreamedToolCallArgLimit({
     if (!hasArgs) {
       if (tally == null) {
         if (!sealed) {
-          tally = { bytes: 0, name: chunkToolName(chunk) };
+          tally = { bytes: 0, name: resolveChunkName(chunk) };
           tallies.set(key, tally);
           registerAliases(tally);
         }
@@ -387,7 +420,7 @@ export function enforceStreamedToolCallArgLimit({
         registerAliases(tally);
       }
       if (tally.name == null) {
-        const lateName = chunkToolName(chunk);
+        const lateName = resolveChunkName(chunk);
         if (lateName != null) {
           /** Bytes tallied before the name arrived were only held against the
            * global cap; a newly applicable per-tool override must re-judge
@@ -420,7 +453,7 @@ export function enforceStreamedToolCallArgLimit({
       registerAliases(tally);
     }
     if (tally.name == null) {
-      tally.name = chunkToolName(chunk);
+      tally.name = resolveChunkName(chunk);
     }
     const argBytes = Buffer.byteLength(args, 'utf8');
     if (sealed) {
@@ -433,7 +466,7 @@ export function enforceStreamedToolCallArgLimit({
     }
     tally.pendingHighSurrogate =
       !sealed && isHighSurrogate(args.charCodeAt(args.length - 1));
-    const toolName = tally.name ?? chunkToolName(chunk);
+    const toolName = tally.name ?? resolveChunkName(chunk);
     const limit =
       byTool != null && toolName != null && Object.hasOwn(byTool, toolName)
         ? byTool[toolName]
@@ -454,6 +487,7 @@ export function enforceStreamedToolCallArgLimit({
 
 /** Structural subset of a complete parsed tool call. */
 interface CompleteToolCallLike {
+  id?: string;
   name?: string;
   args?: unknown;
 }
@@ -595,6 +629,7 @@ export function enforceStreamLimitsForWireChunk({
       metadata,
       toolCallChunks: chunk.tool_call_chunks,
       responseMetadata: chunk.response_metadata,
+      parsedToolCalls: chunk.tool_calls,
     });
   }
   /** Judged whenever parsed calls are present, not only when raw chunks are

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -439,6 +439,22 @@ export function enforceStreamedToolCallArgLimit({
     }
     return undefined;
   };
+  const enforceTallyLimit = (target: StreamedToolCallArgTally): void => {
+    const tallyLimit =
+      byTool != null &&
+      target.name != null &&
+      Object.hasOwn(byTool, target.name)
+        ? byTool[target.name]
+        : globalLimit;
+    if (tallyLimit > 0 && target.bytes > tallyLimit) {
+      throw new StreamLimitExceededError({
+        kind: 'tool_call_args',
+        limit: tallyLimit,
+        observed: target.bytes,
+        toolName: target.name,
+      });
+    }
+  };
   for (let i = 0; i < toolCallChunks.length; i++) {
     const chunk = toolCallChunks[i];
     const args = chunk.args;
@@ -468,6 +484,43 @@ export function enforceStreamedToolCallArgLimit({
      * value — index 0 and id "0" — cannot alias distinct calls onto one
      * tally. Empty-string ids are placeholders, not identities. */
     const chunkId = chunkCallId(chunk);
+    const sealed = sealsChunk(seal, chunk);
+    /** Applies this chunk's name contribution and reports whether the
+     * effective name changed. Adapters may stream the name in FRAGMENTS
+     * ("create_" then "file"), so unsealed fragments append — matching
+     * langchain's own tool-call-chunk merge — while a sealing chunk's name
+     * is a full restatement and replaces, mirroring how sealed args replace
+     * the tally bytes. An id-correlated complete call in the same event
+     * outranks both; positional parsed-call correlation fills in only when
+     * the chunk carries no fragment. */
+    const applyChunkName = (target: StreamedToolCallArgTally): boolean => {
+      const correlated =
+        chunkId != null ? correlateParsedNameById(chunkId) : undefined;
+      const fragment = chunkToolName(chunk);
+      let next = target.name;
+      if (correlated != null) {
+        /** An id-correlated complete call wins over fragment accumulation:
+         * a raw name like "create_" must not hide the "create_file"
+         * override behind the global cap. */
+        next = correlated;
+      } else if (fragment != null) {
+        if (sealed || target.name == null) {
+          next = fragment;
+        } else if (fragment !== target.name) {
+          /** A fragment identical to the accumulated name is a repeated
+           * full-name delta (a common provider shape) and is a no-op; a
+           * differing fragment is a continuation and appends. */
+          next = target.name + fragment;
+        }
+      } else if (target.name == null) {
+        next = resolveChunkName(chunk);
+      }
+      if (next === target.name) {
+        return false;
+      }
+      target.name = next;
+      return true;
+    };
     /** A single identifier-less event while calls are live is a sparse
      * parallel continuation: its position is relative to this event, not to
      * the original batch, so `#0` cannot identify which call it belongs to.
@@ -485,6 +538,12 @@ export function enforceStreamedToolCallArgLimit({
     ) {
       const liveTallies = getLiveGenerationTallies();
       if (liveTallies.length > 0) {
+        if (liveTallies.length === 1 && applyChunkName(liveTallies[0])) {
+          /** A late name can select a lower override than the limit under
+           * which prior bytes were accepted, so re-judge before charging
+           * this continuation. */
+          enforceTallyLimit(liveTallies[0]);
+        }
         if (hasArgs) {
           const argBytes = Buffer.byteLength(args, 'utf8');
           for (const liveTally of liveTallies) {
@@ -495,20 +554,7 @@ export function enforceStreamedToolCallArgLimit({
             liveTally.pendingHighSurrogate = isHighSurrogate(
               args.charCodeAt(args.length - 1)
             );
-            const tallyLimit =
-              byTool != null &&
-              liveTally.name != null &&
-              Object.hasOwn(byTool, liveTally.name)
-                ? byTool[liveTally.name]
-                : globalLimit;
-            if (tallyLimit > 0 && liveTally.bytes > tallyLimit) {
-              throw new StreamLimitExceededError({
-                kind: 'tool_call_args',
-                limit: tallyLimit,
-                observed: liveTally.bytes,
-                toolName: liveTally.name,
-              });
-            }
+            enforceTallyLimit(liveTally);
           }
         }
         continue;
@@ -522,7 +568,6 @@ export function enforceStreamedToolCallArgLimit({
     } else {
       key = `${generationKey}:#${i}`;
     }
-    const sealed = sealsChunk(seal, chunk);
     /** Batch position is a stable identity only when the event carries a
      * single chunk: sparse parallel events reuse position 0 for whichever
      * call happens to continue, and a position alias would hand one call's
@@ -545,19 +590,31 @@ export function enforceStreamedToolCallArgLimit({
     let tally = tallies.get(key);
     /** A later delta can also ADD an identifier, changing the primary key;
      * adopt the call's existing tally through a stronger prior identity
-     * before allocating. Id-bearing chunks adopt through the id — never the
-     * batch position, which different parallel calls legitimately share.
-     * Id-less indexed chunks adopt through their batch position: a position
-     * tally is singular per position, so an anonymous call gaining an index
-     * is unambiguous within the generation. The old identity is recorded as
+     * before allocating. An index maps to that call's original batch
+     * position, never this sparse event's position. A newly arrived id can
+     * adopt a position only when one anonymous tally is live; with several,
+     * positional association is ambiguous. The old identity is recorded as
      * an alias and released together with the rest. */
     if (tally == null) {
       const adoptionCandidates: string[] = [];
       if (chunkId != null) {
         adoptionCandidates.push(`${generationKey}:c:${chunkId}`);
       }
-      if (chunkId != null || chunk.index != null) {
-        adoptionCandidates.push(`${generationKey}:#${i}`);
+      if (chunk.index != null) {
+        /** An index is stable across sparse events; the loop position is
+         * merely this event's position and may be 0 for call index 1. */
+        adoptionCandidates.push(`${generationKey}:#${chunk.index}`);
+      } else if (chunkId != null) {
+        const anonymousTallies = getLiveGenerationTallies().filter(
+          (liveTally: StreamedToolCallArgTally) =>
+            liveTally.keys?.[0]?.startsWith(`${generationPrefix}#`) === true
+        );
+        if (anonymousTallies.length === 1) {
+          const anonymousKey = anonymousTallies[0].keys?.[0];
+          if (anonymousKey != null) {
+            adoptionCandidates.push(anonymousKey);
+          }
+        }
       }
       for (const adoptionKey of adoptionCandidates) {
         if (adoptionKey === key) {
@@ -628,42 +685,6 @@ export function enforceStreamedToolCallArgLimit({
       }
       registerAliasKeys(target, [`${generationKey}:#${i}`]);
     };
-    /** Applies this chunk's name contribution and reports whether the
-     * effective name changed. Adapters may stream the name in FRAGMENTS
-     * ("create_" then "file"), so unsealed fragments append — matching
-     * langchain's own tool-call-chunk merge — while a sealing chunk's name
-     * is a full restatement and replaces, mirroring how sealed args replace
-     * the tally bytes. An id-correlated complete call in the same event
-     * outranks both; positional parsed-call correlation fills in only when
-     * the chunk carries no fragment. */
-    const applyChunkName = (target: StreamedToolCallArgTally): boolean => {
-      const correlated =
-        chunkId != null ? correlateParsedNameById(chunkId) : undefined;
-      const fragment = chunkToolName(chunk);
-      let next = target.name;
-      if (correlated != null) {
-        /** An id-correlated complete call wins over fragment accumulation:
-         * a raw name like "create_" must not hide the "create_file"
-         * override behind the global cap. */
-        next = correlated;
-      } else if (fragment != null) {
-        if (sealed || target.name == null) {
-          next = fragment;
-        } else if (fragment !== target.name) {
-          /** A fragment identical to the accumulated name is a repeated
-           * full-name delta (a common provider shape) and is a no-op; a
-           * differing fragment is a continuation and appends. */
-          next = target.name + fragment;
-        }
-      } else if (target.name == null) {
-        next = resolveChunkName(chunk);
-      }
-      if (next === target.name) {
-        return false;
-      }
-      target.name = next;
-      return true;
-    };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
       if (target.keys == null) {
@@ -700,21 +721,7 @@ export function enforceStreamedToolCallArgLimit({
          * against that name's limit; a changed name — late arrival or a
          * completed fragment — must re-judge them, including on a sealing
          * chunk about to release the tally. */
-        const rejudgedName = tally.name;
-        const limit =
-          byTool != null &&
-          rejudgedName != null &&
-          Object.hasOwn(byTool, rejudgedName)
-            ? byTool[rejudgedName]
-            : globalLimit;
-        if (limit > 0 && tally.bytes > limit) {
-          throw new StreamLimitExceededError({
-            kind: 'tool_call_args',
-            limit,
-            observed: tally.bytes,
-            toolName: rejudgedName,
-          });
-        }
+        enforceTallyLimit(tally);
       }
       if (sealed) {
         releaseTally(tally);

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -352,6 +352,16 @@ export function enforceStreamedToolCallArgLimit({
     }
     return undefined;
   };
+  const generationPrefix = `${generationKey}:`;
+  const getLiveGenerationTallies = (): StreamedToolCallArgTally[] => {
+    const live = new Set<StreamedToolCallArgTally>();
+    for (const [tallyKey, tally] of tallies) {
+      if (tallyKey.startsWith(generationPrefix)) {
+        live.add(tally);
+      }
+    }
+    return [...live];
+  };
   const resolveChunkName = (chunk: ToolCallChunk): string | undefined => {
     const chunkId = chunkCallId(chunk);
     const correlated =
@@ -405,6 +415,42 @@ export function enforceStreamedToolCallArgLimit({
      * value — index 0 and id "0" — cannot alias distinct calls onto one
      * tally. Empty-string ids are placeholders, not identities. */
     const chunkId = chunkCallId(chunk);
+    /** A single identifier-less event after several calls are live is a
+     * sparse parallel continuation: its position is relative to this event,
+     * not to the original batch, so `#0` cannot identify which call it
+     * belongs to. Charge the bytes against every live candidate using the
+     * global limit. This is conservative, but it prevents the continuation
+     * from inheriting whichever candidate currently owns the position alias,
+     * including a raised or disabled per-tool override. */
+    if (
+      chunk.index == null &&
+      chunkId == null &&
+      toolCallChunks.length === 1
+    ) {
+      const liveTallies = getLiveGenerationTallies();
+      if (liveTallies.length > 1) {
+        if (hasArgs) {
+          const argBytes = Buffer.byteLength(args, 'utf8');
+          for (const liveTally of liveTallies) {
+            const reconcilesSplitPair =
+              liveTally.pendingHighSurrogate === true &&
+              isLowSurrogate(args.charCodeAt(0));
+            liveTally.bytes += reconcilesSplitPair ? argBytes - 2 : argBytes;
+            liveTally.pendingHighSurrogate = isHighSurrogate(
+              args.charCodeAt(args.length - 1)
+            );
+            if (globalLimit > 0 && liveTally.bytes > globalLimit) {
+              throw new StreamLimitExceededError({
+                kind: 'tool_call_args',
+                limit: globalLimit,
+                observed: liveTally.bytes,
+              });
+            }
+          }
+        }
+        continue;
+      }
+    }
     let key: string;
     if (chunk.index != null) {
       key = `${generationKey}:i:${chunk.index}`;
@@ -414,13 +460,21 @@ export function enforceStreamedToolCallArgLimit({
       key = `${generationKey}:#${i}`;
     }
     const sealed = sealsChunk(seal, chunk);
+    /** Batch position is a stable identity only when the event carries a
+     * single chunk: sparse parallel events reuse position 0 for whichever
+     * call happens to continue, and a position alias would hand one call's
+     * tally — and its per-tool override — to another live call's deltas. */
+    const positionAliasSafe = toolCallChunks.length === 1;
     /** Secondary keys this call is also reachable under, so a later delta
      * that drops one or both identifiers still lands on the same tally:
-     * id-bearing chunks register the batch-position fallback, and chunks
-     * carrying both identifiers additionally register the id. */
+     * id-bearing chunks register the batch-position fallback (single-chunk
+     * events only), and chunks carrying both identifiers additionally
+     * register the id. */
     const aliasCandidates: string[] = [];
     if (chunkId != null) {
-      aliasCandidates.push(`${generationKey}:#${i}`);
+      if (positionAliasSafe) {
+        aliasCandidates.push(`${generationKey}:#${i}`);
+      }
       if (chunk.index != null) {
         aliasCandidates.push(`${generationKey}:c:${chunkId}`);
       }
@@ -504,6 +558,9 @@ export function enforceStreamedToolCallArgLimit({
       target: StreamedToolCallArgTally
     ): void => {
       if (chunkId != null || chunk.index == null || sealed) {
+        return;
+      }
+      if (!positionAliasSafe) {
         return;
       }
       registerAliasKeys(target, [`${generationKey}:#${i}`]);

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -32,11 +32,12 @@ export interface ResolvedStreamLimits {
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
-  /** Secondary keys this tally is also registered under — the batch
-   * position for any id-bearing chunk, plus the id for chunks carrying both
-   * identifiers — so a later delta that drops one or both identifiers still
-   * shares the budget; all entries are released together. */
-  aliasKeys?: string[];
+  /** Every tally-map key this tally is registered under: its primary key
+   * (which can migrate through identifier transitions), the batch-position
+   * fallback for id-bearing chunks, and the id for chunks carrying both
+   * identifiers. Release deletes all of them — a call sealed through one
+   * identity must not leave entries behind under another. */
+  keys?: string[];
   /**
    * True when the previous chunk ended on an unpaired UTF-16 high surrogate.
    * Counting each half of a split surrogate pair alone yields 3 bytes per
@@ -241,10 +242,15 @@ function sealsChunk(
   if (seal == null || seal.kind !== 'single') {
     return false;
   }
-  if (seal.index != null) {
+  /** Either supplied identifier is sufficient (matching the eager-call seal
+   * handling in stream.ts): a seal carrying both index and id must still
+   * match a sealing chunk that carries only one of them, or an OpenAI-style
+   * full-argument restatement gets ADDED to the tally instead of replacing
+   * it, and an empty seal leaves the tally unreleased. */
+  if (seal.index != null && chunk.index != null) {
     return seal.index === chunk.index;
   }
-  return seal.id != null && seal.id === chunk.id;
+  return seal.id != null && chunk.id != null && seal.id === chunk.id;
 }
 
 function chunkToolName(chunk: ToolCallChunk): string | undefined {
@@ -406,8 +412,11 @@ export function enforceStreamedToolCallArgLimit({
       if (existing != null && adoptionKey != null) {
         tally = existing;
         tallies.set(key, existing);
-        if (existing.aliasKeys?.includes(adoptionKey) !== true) {
-          (existing.aliasKeys ??= []).push(adoptionKey);
+        if (existing.keys?.includes(adoptionKey) !== true) {
+          (existing.keys ??= []).push(adoptionKey);
+        }
+        if (existing.keys?.includes(key) !== true) {
+          (existing.keys ??= []).push(key);
         }
       }
     }
@@ -420,22 +429,22 @@ export function enforceStreamedToolCallArgLimit({
         /** Parallel calls can contend for one batch position, so the newest
          * live call takes the alias over and the previous owner is disowned
          * — its seal must not delete a key it no longer holds. */
-        if (currentOwner?.aliasKeys != null) {
-          const remaining = currentOwner.aliasKeys.filter(
+        if (currentOwner?.keys != null) {
+          const remaining = currentOwner.keys.filter(
             (ownedKey: string) => ownedKey !== aliasKey
           );
-          currentOwner.aliasKeys = remaining.length > 0 ? remaining : undefined;
+          currentOwner.keys = remaining.length > 0 ? remaining : undefined;
         }
         tallies.set(aliasKey, target);
-        (target.aliasKeys ??= []).push(aliasKey);
+        (target.keys ??= []).push(aliasKey);
       }
     };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
-      if (target.aliasKeys == null) {
+      if (target.keys == null) {
         return;
       }
-      for (const aliasKey of target.aliasKeys) {
+      for (const aliasKey of target.keys) {
         if (tallies.get(aliasKey) === target) {
           tallies.delete(aliasKey);
         }
@@ -444,7 +453,7 @@ export function enforceStreamedToolCallArgLimit({
     if (!hasArgs) {
       if (tally == null) {
         if (!sealed) {
-          tally = { bytes: 0, name: resolveChunkName(chunk) };
+          tally = { bytes: 0, name: resolveChunkName(chunk), keys: [key] };
           tallies.set(key, tally);
           registerAliases(tally);
         }
@@ -482,7 +491,7 @@ export function enforceStreamedToolCallArgLimit({
       continue;
     }
     if (tally == null) {
-      tally = { bytes: 0 };
+      tally = { bytes: 0, keys: [key] };
       tallies.set(key, tally);
     }
     if (!sealed) {

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -57,6 +57,14 @@ export interface StreamedToolCallArgTally {
   pendingHighSurrogate?: boolean;
 }
 
+/** Immutable snapshot of one run's breaker identity. Captured at
+ * model/event/tool-batch entry and revalidated by REFERENCE after awaits —
+ * one identity comparison proves no reset interleaved. */
+export interface RunBreakerScope {
+  readonly epoch: number;
+  readonly controller: AbortController;
+}
+
 /** Streamed chunk events counted against one generation's event cap. */
 export interface StreamDeltaEventTally {
   count: number;
@@ -77,6 +85,12 @@ export interface StreamLimitState {
   /** The graph's live breaker epoch; new accounting entries are tagged with
    * it so `resetValues` can sweep by age instead of clearing outright. */
   breakerEpoch?: number;
+  /** Generation keys of model attempts still in flight. Each attempt leases
+   * its generation at entry and releases it (with its accounting entries)
+   * from its `finally`, so retention follows ATTEMPT LIFETIME — a
+   * cancellation-ignoring straggler keeps its original budget no matter how
+   * many runs start and reset while it drains. */
+  activeStreamLimitGenerations?: Set<string>;
   /** Per-chunk-object, per-generation charge balance: producer visits
    * increment, consumer (handler echo) visits decrement, and a visit only
    * charges when the other side has not pre-charged the same emission.
@@ -263,6 +277,15 @@ export const STREAM_LIMIT_REDISPATCH_KEY = 'lc_stream_limit_redispatch';
  * for tracing.
  */
 export const STREAM_LIMIT_EPOCH_KEY = 'lc_stream_limit_epoch';
+
+/**
+ * Configurable key carrying the tool batch's entry-captured
+ * {@link RunBreakerScope} to tools that spawn their own runs (subagents).
+ * Captured BEFORE PreToolUse hooks, so a reset during a hook cannot rebind
+ * the spawned child to the new run's controller. Stripped from host-facing
+ * batch requests and from child-graph configurables.
+ */
+export const RUN_BREAKER_SCOPE_CONFIG_KEY = 'lc_run_breaker_scope';
 
 /**
  * True when the event's `single` seal marks this chunk's own call as
@@ -836,23 +859,78 @@ export function requiresStreamLimitAccounting(
   );
 }
 
+/** Leases a model attempt's generation: entries under it are exempt from
+ * the reset sweep until {@link releaseStreamLimitGeneration} runs from the
+ * attempt's `finally`. */
+export function registerActiveStreamLimitGeneration(
+  graph: StreamLimitState,
+  generationKey: string
+): void {
+  (graph.activeStreamLimitGenerations ??= new Set()).add(generationKey);
+}
+
+/** Ends an attempt's lease and deletes its accounting entries — the
+ * authoritative retirement point for attempt-scoped state. */
+export function releaseStreamLimitGeneration(
+  graph: StreamLimitState,
+  generationKey: string
+): void {
+  graph.activeStreamLimitGenerations?.delete(generationKey);
+  deleteGenerationEntries(graph.streamedToolCallArgTallies, generationKey);
+  deleteGenerationEntries(graph.streamDeltaEventCounts, generationKey);
+}
+
+function deleteGenerationEntries(
+  entries: Map<string, unknown> | undefined,
+  generationKey: string
+): void {
+  if (entries == null) {
+    return;
+  }
+  const prefix = `${generationKey}:`;
+  for (const key of entries.keys()) {
+    if (key === generationKey || key.startsWith(prefix)) {
+      entries.delete(key);
+    }
+  }
+}
+
+function isOwnedByActiveGeneration(
+  key: string,
+  activeGenerations: ReadonlySet<string>
+): boolean {
+  for (const generationKey of activeGenerations) {
+    if (key === generationKey || key.startsWith(`${generationKey}:`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
- * Deletes accounting entries older than the epoch that is ending. Called by
- * `resetValues` INSTEAD of clearing: producer loops of straggling attempts
- * use the graph's maps directly and are not behind the consumer-only epoch
- * gate, so a clear would hand a cancellation-ignoring provider a fresh
- * allowance at every run start. Entries tagged with the ending epoch
- * survive exactly one reset (keeping those stragglers on their original
- * budgets); untagged entries and anything older are removed.
+ * Deletes accounting entries older than the epoch that is ending, EXCEPT
+ * entries leased by a still-active attempt. Called by `resetValues` instead
+ * of clearing: producer loops of straggling attempts use the graph's maps
+ * directly and are not behind the consumer-only epoch gate, so a clear
+ * would hand a cancellation-ignoring provider a fresh allowance at every
+ * run start. Leased entries live until their attempt's `finally` releases
+ * them; unleased entries (direct callers with no attempt stamp) get one
+ * grace reset via their epoch tag.
  */
 export function sweepStaleStreamLimitEntries(
   entries: Map<string, { epoch?: number }>,
-  endingEpoch: number
+  endingEpoch: number,
+  activeGenerations?: ReadonlySet<string>
 ): void {
+  const hasActive = activeGenerations != null && activeGenerations.size > 0;
   for (const [key, value] of entries) {
-    if (value.epoch !== endingEpoch) {
-      entries.delete(key);
+    if (value.epoch === endingEpoch) {
+      continue;
     }
+    if (hasActive && isOwnedByActiveGeneration(key, activeGenerations)) {
+      continue;
+    }
+    entries.delete(key);
   }
 }
 

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -228,6 +228,17 @@ export const STREAM_LIMIT_ATTEMPT_KEY = 'lc_stream_limit_attempt';
 export const STREAM_LIMIT_REDISPATCH_KEY = 'lc_stream_limit_redispatch';
 
 /**
+ * Metadata key carrying the graph's breaker epoch at the time a model
+ * attempt started. The stream handler trips the shared breaker only when
+ * the event's epoch matches the live controller's — a straggling chunk from
+ * a failed run that outlived `resetValues()` must fail its own (dead) run,
+ * not abort the controller now serving the next one. A primitive rather
+ * than the controller itself so attempt metadata stays serialization-safe
+ * for tracing.
+ */
+export const STREAM_LIMIT_EPOCH_KEY = 'lc_stream_limit_epoch';
+
+/**
  * True when the event's `single` seal marks this chunk's own call as
  * complete. On the OpenAI Responses adapter the sealing chunk RESTATES the
  * full argument string (`response.function_call_arguments.done`), so summing

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -54,9 +54,11 @@ export interface StreamLimitState {
   streamLimits?: ResolvedStreamLimits;
   streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
   streamDeltaEventCounts?: Map<string, number>;
-  /** Wire chunks already charged synchronously by the producer loop, so the
-   * decoupled handler echo of the same object does not charge them again. */
-  streamLimitPrecountedChunks?: WeakSet<object>;
+  /** Wire chunks some accounting path has already charged. The producer loop
+   * and the decoupled handler can observe the same chunk object in either
+   * order, so charging is claim-based: first claimer charges, the other
+   * skips. */
+  streamLimitChargedChunks?: WeakSet<object>;
 }
 
 function resolveLimit(value: number | undefined, fallback: number): number {
@@ -488,13 +490,36 @@ export function enforceCompleteToolCallArgLimit({
 }
 
 /**
- * Synchronous producer-side accounting for the registered-handler dispatch
- * branch, where original wire chunks are otherwise judged only when the
- * decoupled `streamEvents` reader catches up. A lagging reader would let an
- * oversized complete call return to LangGraph and reach `ToolNode` before
- * the queued handler throws; charging in the producer loop keeps the breaker
- * ahead of graph progression. The chunk object is marked so the later
- * handler echo of the same object skips accounting.
+ * Claims accounting ownership of a wire chunk. LangChain can hand the same
+ * chunk object to the decoupled `streamEvents` handler and to the producer
+ * loop in either order, so exactly one caller — whichever arrives first —
+ * charges it. Non-object chunks cannot be identity-tracked and are always
+ * claimable.
+ */
+export function claimStreamLimitCharge(
+  graph: StreamLimitState,
+  chunk: unknown
+): boolean {
+  if (typeof chunk !== 'object' || chunk == null) {
+    return true;
+  }
+  const charged = (graph.streamLimitChargedChunks ??= new WeakSet());
+  if (charged.has(chunk)) {
+    return false;
+  }
+  charged.add(chunk);
+  return true;
+}
+
+/**
+ * Synchronous producer-side accounting for wire chunks that would otherwise
+ * be judged only when the decoupled `streamEvents` reader catches up — or,
+ * on replay-skipped and summarization chunks, not at all. A lagging reader
+ * would let an oversized complete call return to LangGraph and reach
+ * `ToolNode` before the queued handler throws; charging in the producer
+ * loop keeps the breaker ahead of graph progression. Claim-based, so
+ * whichever of this path and the handler echo sees the chunk object first
+ * charges it and the other skips.
  */
 export function enforceStreamLimitsForWireChunk({
   graph,
@@ -509,7 +534,9 @@ export function enforceStreamLimitsForWireChunk({
     response_metadata?: Record<string, unknown>;
   };
 }): void {
-  (graph.streamLimitPrecountedChunks ??= new WeakSet()).add(chunk as object);
+  if (!claimStreamLimitCharge(graph, chunk)) {
+    return;
+  }
   enforceStreamDeltaEventLimit({ graph, metadata });
   if (chunk.tool_call_chunks != null && chunk.tool_call_chunks.length > 0) {
     enforceStreamedToolCallArgLimit({
@@ -521,18 +548,6 @@ export function enforceStreamLimitsForWireChunk({
   } else if (chunk.tool_calls != null && chunk.tool_calls.length > 0) {
     enforceCompleteToolCallArgLimit({ graph, metadata, toolCalls: chunk.tool_calls });
   }
-}
-
-/** True when the producer loop already charged this exact chunk object. */
-export function wasStreamLimitPrecounted(
-  graph: StreamLimitState,
-  chunk: unknown
-): boolean {
-  return (
-    typeof chunk === 'object' &&
-    chunk != null &&
-    graph.streamLimitPrecountedChunks?.has(chunk) === true
-  );
 }
 
 /**

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -32,11 +32,11 @@ export interface ResolvedStreamLimits {
 export interface StreamedToolCallArgTally {
   bytes: number;
   name?: string;
-  /** Secondary key this tally is also registered under — the batch position
-   * for id-only chunks, or the id for chunks carrying both identifiers — so
-   * a later delta that drops an identifier still shares the budget; both
-   * entries are released together. */
-  aliasKey?: string;
+  /** Secondary keys this tally is also registered under — the batch
+   * position for any id-bearing chunk, plus the id for chunks carrying both
+   * identifiers — so a later delta that drops one or both identifiers still
+   * shares the budget; all entries are released together. */
+  aliasKeys?: string[];
   /**
    * True when the previous chunk ended on an unpaired UTF-16 high surrogate.
    * Counting each half of a split surrogate pair alone yields 3 bytes per
@@ -331,42 +331,45 @@ export function enforceStreamedToolCallArgLimit({
     const key = `${generationKey}:${chunk.index ?? chunk.id ?? `#${i}`}`;
     const sealed = sealsChunk(seal, chunk);
     let tally = tallies.get(key);
-    /** Secondary key this call is also reachable under, so a later delta
-     * that drops an identifier still lands on the same tally: the
-     * batch-position fallback for id-only chunks (an index-less adapter can
-     * put the id only on the first chunk), or the id itself for chunks
-     * carrying both identifiers (an adapter can drop the index later). */
-    let chunkAliasKey: string | undefined;
+    /** Secondary keys this call is also reachable under, so a later delta
+     * that drops one or both identifiers still lands on the same tally:
+     * id-bearing chunks register the batch-position fallback, and chunks
+     * carrying both identifiers additionally register the id. */
+    const aliasCandidates: string[] = [];
     if (chunk.id != null) {
-      chunkAliasKey =
-        chunk.index == null
-          ? `${generationKey}:#${i}`
-          : `${generationKey}:${chunk.id}`;
+      aliasCandidates.push(`${generationKey}:#${i}`);
+      if (chunk.index != null) {
+        aliasCandidates.push(`${generationKey}:${chunk.id}`);
+      }
     }
-    const registerAliasKey = (target: StreamedToolCallArgTally): void => {
-      if (chunkAliasKey == null) {
-        return;
+    const registerAliases = (target: StreamedToolCallArgTally): void => {
+      for (const aliasKey of aliasCandidates) {
+        const currentOwner = tallies.get(aliasKey);
+        if (currentOwner === target) {
+          continue;
+        }
+        /** Parallel calls can contend for one batch position, so the newest
+         * live call takes the alias over and the previous owner is disowned
+         * — its seal must not delete a key it no longer holds. */
+        if (currentOwner?.aliasKeys != null) {
+          const remaining = currentOwner.aliasKeys.filter(
+            (ownedKey: string) => ownedKey !== aliasKey
+          );
+          currentOwner.aliasKeys = remaining.length > 0 ? remaining : undefined;
+        }
+        tallies.set(aliasKey, target);
+        (target.aliasKeys ??= []).push(aliasKey);
       }
-      const currentOwner = tallies.get(chunkAliasKey);
-      if (currentOwner === target) {
-        return;
-      }
-      /** Parallel index-less calls all land on batch position #i, so the
-       * newest live call takes the alias over and the previous owner is
-       * disowned — its seal must not delete an alias it no longer holds. */
-      if (currentOwner?.aliasKey === chunkAliasKey) {
-        currentOwner.aliasKey = undefined;
-      }
-      tallies.set(chunkAliasKey, target);
-      target.aliasKey = chunkAliasKey;
     };
     const releaseTally = (target: StreamedToolCallArgTally): void => {
       tallies.delete(key);
-      if (
-        target.aliasKey != null &&
-        tallies.get(target.aliasKey) === target
-      ) {
-        tallies.delete(target.aliasKey);
+      if (target.aliasKeys == null) {
+        return;
+      }
+      for (const aliasKey of target.aliasKeys) {
+        if (tallies.get(aliasKey) === target) {
+          tallies.delete(aliasKey);
+        }
       }
     };
     if (!hasArgs) {
@@ -374,14 +377,14 @@ export function enforceStreamedToolCallArgLimit({
         if (!sealed) {
           tally = { bytes: 0, name: chunkToolName(chunk) };
           tallies.set(key, tally);
-          registerAliasKey(tally);
+          registerAliases(tally);
         }
         continue;
       }
       /** A sealing chunk is about to release this tally; taking the position
        * alias here would steal it from a still-live parallel call. */
       if (!sealed) {
-        registerAliasKey(tally);
+        registerAliases(tally);
       }
       if (tally.name == null) {
         const lateName = chunkToolName(chunk);
@@ -414,7 +417,7 @@ export function enforceStreamedToolCallArgLimit({
       tallies.set(key, tally);
     }
     if (!sealed) {
-      registerAliasKey(tally);
+      registerAliases(tally);
     }
     if (tally.name == null) {
       tally.name = chunkToolName(chunk);

--- a/src/llm/streamLimits.ts
+++ b/src/llm/streamLimits.ts
@@ -54,11 +54,12 @@ export interface StreamLimitState {
   streamLimits?: ResolvedStreamLimits;
   streamedToolCallArgTallies?: Map<string, StreamedToolCallArgTally>;
   streamDeltaEventCounts?: Map<string, number>;
-  /** Wire chunks some accounting path has already charged. The producer loop
-   * and the decoupled handler can observe the same chunk object in either
-   * order, so charging is claim-based: first claimer charges, the other
-   * skips. */
-  streamLimitChargedChunks?: WeakSet<object>;
+  /** Per-chunk-object charge balance: producer visits increment, consumer
+   * (handler echo) visits decrement, and a visit only charges when the other
+   * side has not pre-charged the same emission. Count-balancing rather than
+   * a lifetime set, because a streaming model may mutate and re-yield the
+   * same chunk object — each such emission must be charged exactly once. */
+  streamLimitChargeCredits?: WeakMap<object, number>;
 }
 
 function resolveLimit(value: number | undefined, fallback: number): number {
@@ -490,25 +491,35 @@ export function enforceCompleteToolCallArgLimit({
 }
 
 /**
- * Claims accounting ownership of a wire chunk. LangChain can hand the same
- * chunk object to the decoupled `streamEvents` handler and to the producer
- * loop in either order, so exactly one caller — whichever arrives first —
- * charges it. Non-object chunks cannot be identity-tracked and are always
+ * Claims accounting ownership of one EMISSION of a wire chunk. LangChain can
+ * hand the same chunk object to the decoupled `streamEvents` handler
+ * (`consumer`) and to the dispatch loop (`producer`) in either order, and a
+ * streaming model may mutate and re-yield the same object across emissions —
+ * so dedup is a signed credit balance per object rather than a lifetime set.
+ * Each producer visit adds a credit, each consumer visit removes one, and a
+ * visit charges only when the other side has not already charged that
+ * emission (positive balance = producer ahead, negative = consumer ahead).
+ * Paths where only one side ever observes the chunk (summarization, local
+ * replay-skip) charge every visit, since their balance never crosses zero
+ * the other way. Non-object chunks cannot be identity-tracked and are always
  * claimable.
  */
 export function claimStreamLimitCharge(
   graph: StreamLimitState,
-  chunk: unknown
+  chunk: unknown,
+  side: 'producer' | 'consumer'
 ): boolean {
   if (typeof chunk !== 'object' || chunk == null) {
     return true;
   }
-  const charged = (graph.streamLimitChargedChunks ??= new WeakSet());
-  if (charged.has(chunk)) {
-    return false;
+  const credits = (graph.streamLimitChargeCredits ??= new WeakMap());
+  const balance = credits.get(chunk) ?? 0;
+  if (side === 'producer') {
+    credits.set(chunk, balance + 1);
+    return balance >= 0;
   }
-  charged.add(chunk);
-  return true;
+  credits.set(chunk, balance - 1);
+  return balance <= 0;
 }
 
 /**
@@ -525,6 +536,7 @@ export function enforceStreamLimitsForWireChunk({
   graph,
   metadata,
   chunk,
+  side = 'producer',
 }: {
   graph: StreamLimitState;
   metadata: Record<string, unknown> | undefined;
@@ -533,8 +545,13 @@ export function enforceStreamLimitsForWireChunk({
     tool_calls?: CompleteToolCallLike[];
     response_metadata?: Record<string, unknown>;
   };
+  /** Claim side for the credit balance. The local dispatch branch charges
+   * as `consumer` because its handler-handled and replay-skipped emissions
+   * of one reused object ALTERNATE — mixed sides would pair them as
+   * producer/echo and swallow a charge. */
+  side?: 'producer' | 'consumer';
 }): void {
-  if (!claimStreamLimitCharge(graph, chunk)) {
+  if (!claimStreamLimitCharge(graph, chunk, side)) {
     return;
   }
   enforceStreamDeltaEventLimit({ graph, metadata });

--- a/src/run.ts
+++ b/src/run.ts
@@ -148,6 +148,7 @@ export class Run<_T extends t.BaseGraphState> {
   private toolExecution?: t.ToolExecutionConfig;
   private subagentUsageSink?: t.SubagentUsageSink;
   private preemption?: t.StreamPreemption;
+  private streamLimits?: t.StreamLimits;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -210,6 +211,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
     this.preemption = config.preemption;
+    this.streamLimits = config.streamLimits;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -285,6 +287,7 @@ export class Run<_T extends t.BaseGraphState> {
       calibrationRatio: this.calibrationRatio,
       subagentUsageSink: this.subagentUsageSink,
       preemption: this.preemption,
+      streamLimits: this.streamLimits,
     });
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = this.applyHITLCheckpointerFallback(
@@ -317,6 +320,7 @@ export class Run<_T extends t.BaseGraphState> {
       calibrationRatio: this.calibrationRatio,
       subagentUsageSink: this.subagentUsageSink,
       preemption: this.preemption,
+      streamLimits: this.streamLimits,
     });
 
     multiAgentGraph.compileOptions =

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -25,6 +25,7 @@ import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import { deserializeMessage } from './messageSerialization';
 import { createSummarizeNode } from '@/summarization/node';
+import { resolveStreamLimits } from '@/llm/streamLimits';
 import { JsonlSessionStore } from './JsonlSessionStore';
 import { AgentContext } from '@/agents/AgentContext';
 import { ContentTypes, GraphEvents } from '@/common';
@@ -610,6 +611,8 @@ function createManualCompactGraph(params: {
   runId: string;
   customHandlers?: Record<string, t.EventHandler>;
   hooks?: HookRegistry;
+  /** Session run-level stream limits, so manual compaction honors them. */
+  streamLimits?: t.StreamLimits;
 }): {
   graph: Parameters<typeof createSummarizeNode>[0]['graph'];
   completedSummary?: t.SummaryContentBlock;
@@ -626,6 +629,7 @@ function createManualCompactGraph(params: {
       runId: params.runId,
       isMultiAgent: false,
       hookRegistry: params.hooks,
+      streamLimits: resolveStreamLimits(params.streamLimits),
       dispatchRunStep: async (runStep): Promise<void> => {
         contentData.push(runStep);
         contentIndexMap.set(runStep.id, runStep.index);
@@ -1251,6 +1255,7 @@ export class AgentSession {
       runId: compactRunId,
       customHandlers: this.runConfig.customHandlers,
       hooks: this.runConfig.hooks,
+      streamLimits: this.runConfig.streamLimits,
     });
     const summarizeNode = createSummarizeNode({
       agentContext,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1516,6 +1516,14 @@ export class ChatModelStreamHandler implements t.EventHandler {
       return;
     }
 
+    /**
+     * Counted before every content-specific early return below
+     * (server-tool results, deferred mixed reasoning, late OpenRouter
+     * reasoning): a looping provider can flood through any of those paths,
+     * and an uncounted early return would leave the event budget untouched.
+     */
+    enforceStreamDeltaEventLimit({ graph, metadata });
+
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
@@ -1549,7 +1557,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
     }
     this.handleReasoning(chunk, agentContext);
     const stepKey = graph.getStepKey(metadata);
-    enforceStreamDeltaEventLimit({ graph, metadata });
     let hasToolCalls = false;
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -40,10 +40,10 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import {
+  claimStreamLimitCharge,
   enforceCompleteToolCallArgLimit,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
-  wasStreamLimitPrecounted,
 } from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
@@ -1527,14 +1527,14 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * a coalesced event can carry client `tool_call_chunks` alongside a
      * server-tool result, and the complete-call dispatch branch further
      * down can prestart a side-effecting tool from an arrival-sealed
-     * oversized call. Chunks the producer loop already charged
-     * synchronously (registered-handler dispatch) are skipped so the
-     * decoupled echo does not double-count. The argument guard is
+     * oversized call. Charging is claim-based: the producer loop and this
+     * decoupled echo can observe the same chunk object in either order, and
+     * only the first claimer charges it. The argument guard is
      * deliberately NOT gated on numeric chunk indices, so id-only or
      * index-less runaway streams stay bounded, and complete parsed
      * `tool_calls` without a raw chunk representation are judged standalone.
      */
-    if (!wasStreamLimitPrecounted(graph, data.chunk)) {
+    if (claimStreamLimitCharge(graph, data.chunk)) {
       enforceStreamDeltaEventLimit({ graph, metadata });
       if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
         enforceStreamedToolCallArgLimit({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -39,6 +39,10 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
+import {
+  enforceStreamedToolCallArgLimit,
+  enforceStreamDeltaEventLimit,
+} from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
@@ -1545,6 +1549,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     }
     this.handleReasoning(chunk, agentContext);
     const stepKey = graph.getStepKey(metadata);
+    enforceStreamDeltaEventLimit({ graph, stepKey });
     let hasToolCalls = false;
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
@@ -1628,6 +1633,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
+      enforceStreamedToolCallArgLimit({
+        graph,
+        stepKey,
+        toolCallChunks: chunk.tool_call_chunks,
+      });
       const streamedToolCallSeal = getStreamedToolCallSeal(
         chunk.response_metadata as Record<string, unknown> | undefined
       );

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1549,10 +1549,28 @@ export class ChatModelStreamHandler implements t.EventHandler {
     }
     this.handleReasoning(chunk, agentContext);
     const stepKey = graph.getStepKey(metadata);
-    enforceStreamDeltaEventLimit({ graph, stepKey });
+    enforceStreamDeltaEventLimit({ graph, metadata });
     let hasToolCalls = false;
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
+    /**
+     * Enforced before the complete-call branch below: an arrival-sealed
+     * oversized call (Google/Vertex) carries both `tool_calls` and
+     * `tool_call_chunks` in one event, and the complete-call branch can
+     * dispatch it and prestart a side-effecting tool. Also deliberately NOT
+     * gated on numeric chunk indices, unlike the dispatch branch further
+     * down, so id-only or index-less runaway streams stay bounded.
+     */
+    if (hasToolCallChunks && chunk.tool_call_chunks) {
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata,
+        toolCallChunks: chunk.tool_call_chunks,
+        responseMetadata: chunk.response_metadata as
+          | Record<string, unknown>
+          | undefined,
+      });
+    }
     const hasGoogleServerSideToolContent =
       isGoogleLike(agentContext.provider) &&
       Array.isArray(content) &&
@@ -1633,11 +1651,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
-      enforceStreamedToolCallArgLimit({
-        graph,
-        stepKey,
-        toolCallChunks: chunk.tool_call_chunks,
-      });
       const streamedToolCallSeal = getStreamedToolCallSeal(
         chunk.response_metadata as Record<string, unknown> | undefined
       );

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1534,7 +1534,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * index-less runaway streams stay bounded, and complete parsed
      * `tool_calls` without a raw chunk representation are judged standalone.
      */
-    if (claimStreamLimitCharge(graph, data.chunk)) {
+    if (claimStreamLimitCharge(graph, data.chunk, 'consumer')) {
       enforceStreamDeltaEventLimit({ graph, metadata });
       if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
         enforceStreamedToolCallArgLimit({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -51,6 +51,7 @@ import {
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
+import { composeAbortSignals } from '@/utils/misc';
 import { isGoogleLike } from '@/utils/llm';
 import { getMessageId } from '@/messages';
 
@@ -787,6 +788,10 @@ function startEagerToolExecutions(args: {
         | Record<string, unknown>
         | undefined,
       metadata,
+      signal: composeAbortSignals(
+        graph.config?.signal,
+        graph.breakerAbort.signal
+      ),
       resolve: (results): void => {
         resultSettled = true;
         settledResults = results;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -47,6 +47,7 @@ import {
   enforceStreamDeltaEventLimit,
   requiresStreamLimitAccounting,
   StreamLimitExceededError,
+  STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
@@ -1528,6 +1529,19 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
 
+    /** The breaker this event's run owns. Attempts stamp their breaker
+     * epoch into event metadata; a mismatch marks a straggling chunk from a
+     * failed run that outlived `resetValues()`, and tripping (or
+     * consulting) the LIVE controller for it would cancel the unrelated run
+     * now using it. Events without a stamp (direct handler callers, partial
+     * stubs) keep the live-controller behavior. */
+    const eventEpoch = metadata?.[STREAM_LIMIT_EPOCH_KEY];
+    const eventBreaker =
+      graph.breakerAbort instanceof AbortController &&
+      (eventEpoch == null || eventEpoch === graph.breakerEpoch)
+        ? graph.breakerAbort
+        : undefined;
+
     /**
      * Enforced before every content-specific early return below
      * (server-tool results, deferred mixed reasoning, late OpenRouter
@@ -1580,13 +1594,10 @@ export class ChatModelStreamHandler implements t.EventHandler {
         /** A breach detected on this consumer path must still stop parallel
          * fan-out work: the producer skips its own enforcement once this
          * side has claimed the emission, so createCallModel's breaker-abort
-         * never fires for it. Trip the shared graph breaker before the
-         * throw rejects the run. */
-        if (
-          error instanceof StreamLimitExceededError &&
-          graph.breakerAbort instanceof AbortController
-        ) {
-          graph.breakerAbort.abort(error);
+         * never fires for it. Trip the EVENT's run-bound breaker before the
+         * throw rejects the run — never the live controller of a newer run. */
+        if (error instanceof StreamLimitExceededError && eventBreaker != null) {
+          eventBreaker.abort(error);
         }
         throw error;
       }
@@ -1597,11 +1608,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * eager-tool paths below — those can dispatch a side-effecting host
      * tool with an already-aborted signal the handler never inspects. */
     if (
-      graph.breakerAbort instanceof AbortController &&
-      graph.breakerAbort.signal.aborted &&
-      graph.breakerAbort.signal.reason instanceof StreamLimitExceededError
+      eventBreaker != null &&
+      eventBreaker.signal.aborted &&
+      eventBreaker.signal.reason instanceof StreamLimitExceededError
     ) {
-      throw graph.breakerAbort.signal.reason;
+      throw eventBreaker.signal.reason;
     }
 
     const agentContext = graph.getAgentContext(metadata);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -40,8 +40,10 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import {
+  enforceCompleteToolCallArgLimit,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
+  wasStreamLimitPrecounted,
 } from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
@@ -1516,40 +1518,43 @@ export class ChatModelStreamHandler implements t.EventHandler {
       return;
     }
 
-    /**
-     * Counted before every content-specific early return below
-     * (server-tool results, deferred mixed reasoning, late OpenRouter
-     * reasoning): a looping provider can flood through any of those paths,
-     * and an uncounted early return would leave the event budget untouched.
-     */
-    enforceStreamDeltaEventLimit({ graph, metadata });
-
-    const agentContext = graph.getAgentContext(metadata);
-
     const chunk = data.chunk as Partial<AIMessageChunk>;
 
     /**
-     * Enforced before every content-specific early return below, like the
-     * event counter above: a coalesced event can carry client
-     * `tool_call_chunks` alongside a server-tool result, and the
-     * server-result return would otherwise release those chunks into the
-     * accumulated message unjudged. Also enforced before the complete-call
-     * dispatch branch further down — an arrival-sealed oversized call
-     * (Google/Vertex) carries both `tool_calls` and `tool_call_chunks` in
-     * one event and can prestart a side-effecting tool — and deliberately
-     * NOT gated on numeric chunk indices, so id-only or index-less runaway
-     * streams stay bounded.
+     * Enforced before every content-specific early return below
+     * (server-tool results, deferred mixed reasoning, late OpenRouter
+     * reasoning): a looping provider can flood through any of those paths,
+     * a coalesced event can carry client `tool_call_chunks` alongside a
+     * server-tool result, and the complete-call dispatch branch further
+     * down can prestart a side-effecting tool from an arrival-sealed
+     * oversized call. Chunks the producer loop already charged
+     * synchronously (registered-handler dispatch) are skipped so the
+     * decoupled echo does not double-count. The argument guard is
+     * deliberately NOT gated on numeric chunk indices, so id-only or
+     * index-less runaway streams stay bounded, and complete parsed
+     * `tool_calls` without a raw chunk representation are judged standalone.
      */
-    if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
-      enforceStreamedToolCallArgLimit({
-        graph,
-        metadata,
-        toolCallChunks: chunk.tool_call_chunks,
-        responseMetadata: chunk.response_metadata as
-          | Record<string, unknown>
-          | undefined,
-      });
+    if (!wasStreamLimitPrecounted(graph, data.chunk)) {
+      enforceStreamDeltaEventLimit({ graph, metadata });
+      if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
+        enforceStreamedToolCallArgLimit({
+          graph,
+          metadata,
+          toolCallChunks: chunk.tool_call_chunks,
+          responseMetadata: chunk.response_metadata as
+            | Record<string, unknown>
+            | undefined,
+        });
+      } else if (chunk.tool_calls && chunk.tool_calls.length > 0) {
+        enforceCompleteToolCallArgLimit({
+          graph,
+          metadata,
+          toolCalls: chunk.tool_calls,
+        });
+      }
     }
+
+    const agentContext = graph.getAgentContext(metadata);
 
     const content = getChunkContent({
       chunk,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1534,7 +1534,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * index-less runaway streams stay bounded, and complete parsed
      * `tool_calls` without a raw chunk representation are judged standalone.
      */
-    if (claimStreamLimitCharge(graph, data.chunk, 'consumer')) {
+    if (claimStreamLimitCharge(graph, data.chunk, 'consumer', metadata)) {
       enforceStreamDeltaEventLimit({ graph, metadata });
       if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
         enforceStreamedToolCallArgLimit({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1528,6 +1528,29 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
 
+    /**
+     * Enforced before every content-specific early return below, like the
+     * event counter above: a coalesced event can carry client
+     * `tool_call_chunks` alongside a server-tool result, and the
+     * server-result return would otherwise release those chunks into the
+     * accumulated message unjudged. Also enforced before the complete-call
+     * dispatch branch further down — an arrival-sealed oversized call
+     * (Google/Vertex) carries both `tool_calls` and `tool_call_chunks` in
+     * one event and can prestart a side-effecting tool — and deliberately
+     * NOT gated on numeric chunk indices, so id-only or index-less runaway
+     * streams stay bounded.
+     */
+    if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
+      enforceStreamedToolCallArgLimit({
+        graph,
+        metadata,
+        toolCallChunks: chunk.tool_call_chunks,
+        responseMetadata: chunk.response_metadata as
+          | Record<string, unknown>
+          | undefined,
+      });
+    }
+
     const content = getChunkContent({
       chunk,
       reasoningKey: agentContext.reasoningKey,
@@ -1560,24 +1583,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
     let hasToolCalls = false;
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
-    /**
-     * Enforced before the complete-call branch below: an arrival-sealed
-     * oversized call (Google/Vertex) carries both `tool_calls` and
-     * `tool_call_chunks` in one event, and the complete-call branch can
-     * dispatch it and prestart a side-effecting tool. Also deliberately NOT
-     * gated on numeric chunk indices, unlike the dispatch branch further
-     * down, so id-only or index-less runaway streams stay bounded.
-     */
-    if (hasToolCallChunks && chunk.tool_call_chunks) {
-      enforceStreamedToolCallArgLimit({
-        graph,
-        metadata,
-        toolCallChunks: chunk.tool_call_chunks,
-        responseMetadata: chunk.response_metadata as
-          | Record<string, unknown>
-          | undefined,
-      });
-    }
     const hasGoogleServerSideToolContent =
       isGoogleLike(agentContext.provider) &&
       Array.isArray(content) &&

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -41,6 +41,7 @@ import {
 } from '@/utils/truncation';
 import {
   claimStreamLimitCharge,
+  combineCompleteToolCalls,
   enforceCompleteToolCallArgLimit,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
@@ -1550,12 +1551,14 @@ export class ChatModelStreamHandler implements t.EventHandler {
       /** Judged whenever parsed calls are present, not only when raw chunks
        * are absent — an adapter can pair an empty or partial raw chunk with
        * a complete parsed call; the standalone check is stateless, so the
-       * common both-present case is not double-tallied. */
-      if (chunk.tool_calls && chunk.tool_calls.length > 0) {
+       * common both-present case is not double-tallied. Invalid calls are
+       * included because ToolNode processes and promotes them. */
+      const completeCalls = combineCompleteToolCalls(chunk);
+      if (completeCalls != null) {
         enforceCompleteToolCallArgLimit({
           graph,
           metadata,
-          toolCalls: chunk.tool_calls,
+          toolCalls: completeCalls,
         });
       }
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1537,6 +1537,10 @@ export class ChatModelStreamHandler implements t.EventHandler {
      */
     if (claimStreamLimitCharge(graph, data.chunk, 'consumer', metadata)) {
       enforceStreamDeltaEventLimit({ graph, metadata });
+      /** Combined first so raw-chunk name correlation sees invalid calls
+       * too; an unnamed raw chunk twinned with a named invalid call must
+       * select that tool's override, not the global cap. */
+      const completeCalls = combineCompleteToolCalls(chunk);
       if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
         enforceStreamedToolCallArgLimit({
           graph,
@@ -1545,7 +1549,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
           responseMetadata: chunk.response_metadata as
             | Record<string, unknown>
             | undefined,
-          parsedToolCalls: chunk.tool_calls,
+          parsedToolCalls: completeCalls,
         });
       }
       /** Judged whenever parsed calls are present, not only when raw chunks
@@ -1553,7 +1557,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
        * a complete parsed call; the standalone check is stateless, so the
        * common both-present case is not double-tallied. Invalid calls are
        * included because ToolNode processes and promotes them. */
-      const completeCalls = combineCompleteToolCalls(chunk);
       if (completeCalls != null) {
         enforceCompleteToolCallArgLimit({
           graph,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -45,6 +45,8 @@ import {
   enforceCompleteToolCallArgLimit,
   enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
+  requiresStreamLimitAccounting,
+  StreamLimitExceededError,
 } from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
@@ -1535,34 +1537,53 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * index-less runaway streams stay bounded, and complete parsed
      * `tool_calls` without a raw chunk representation are judged standalone.
      */
-    if (claimStreamLimitCharge(graph, data.chunk, 'consumer', metadata)) {
-      enforceStreamDeltaEventLimit({ graph, metadata });
-      /** Combined first so raw-chunk name correlation sees invalid calls
-       * too; an unnamed raw chunk twinned with a named invalid call must
-       * select that tool's override, not the global cap. */
-      const completeCalls = combineCompleteToolCalls(chunk);
-      if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
-        enforceStreamedToolCallArgLimit({
-          graph,
-          metadata,
-          toolCallChunks: chunk.tool_call_chunks,
-          responseMetadata: chunk.response_metadata as
-            | Record<string, unknown>
-            | undefined,
-          parsedToolCalls: completeCalls,
-        });
-      }
-      /** Judged whenever parsed calls are present, not only when raw chunks
-       * are absent — an adapter can pair an empty or partial raw chunk with
-       * a complete parsed call; the standalone check is stateless, so the
-       * common both-present case is not double-tallied. Invalid calls are
-       * included because ToolNode processes and promotes them. */
-      if (completeCalls != null) {
-        enforceCompleteToolCallArgLimit({
-          graph,
-          metadata,
-          toolCalls: completeCalls,
-        });
+    if (
+      requiresStreamLimitAccounting(graph, chunk) &&
+      claimStreamLimitCharge(graph, data.chunk, 'consumer', metadata)
+    ) {
+      try {
+        enforceStreamDeltaEventLimit({ graph, metadata });
+        /** Combined first so raw-chunk name correlation sees invalid calls
+         * too; an unnamed raw chunk twinned with a named invalid call must
+         * select that tool's override, not the global cap. */
+        const completeCalls = combineCompleteToolCalls(chunk);
+        if (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) {
+          enforceStreamedToolCallArgLimit({
+            graph,
+            metadata,
+            toolCallChunks: chunk.tool_call_chunks,
+            responseMetadata: chunk.response_metadata as
+              | Record<string, unknown>
+              | undefined,
+            parsedToolCalls: completeCalls,
+          });
+        }
+        /** Judged whenever parsed calls are present, not only when raw
+         * chunks are absent — an adapter can pair an empty or partial raw
+         * chunk with a complete parsed call; the standalone check is
+         * stateless, so the common both-present case is not double-tallied.
+         * Invalid calls are included because ToolNode processes and
+         * promotes them. */
+        if (completeCalls != null) {
+          enforceCompleteToolCallArgLimit({
+            graph,
+            metadata,
+            toolCalls: completeCalls,
+          });
+        }
+      } catch (error) {
+        /** A breach detected on this consumer path must still stop parallel
+         * fan-out work: the producer skips its own enforcement once this
+         * side has claimed the emission, so createCallModel's breaker-abort
+         * never fires for it. Trip the shared graph breaker before the
+         * throw rejects the run. */
+        if (
+          error instanceof StreamLimitExceededError &&
+          graph.breakerAbort instanceof AbortController
+        ) {
+          graph.breakerAbort.abort(error);
+        }
+        throw error;
       }
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1592,6 +1592,18 @@ export class ChatModelStreamHandler implements t.EventHandler {
       }
     }
 
+    /** A parallel producer can trip the shared breaker while this event was
+     * already queued in `streamEvents`. Stop before content handling or the
+     * eager-tool paths below — those can dispatch a side-effecting host
+     * tool with an already-aborted signal the handler never inspects. */
+    if (
+      graph.breakerAbort instanceof AbortController &&
+      graph.breakerAbort.signal.aborted &&
+      graph.breakerAbort.signal.reason instanceof StreamLimitExceededError
+    ) {
+      throw graph.breakerAbort.signal.reason;
+    }
+
     const agentContext = graph.getAgentContext(metadata);
 
     const content = getChunkContent({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1544,6 +1544,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
           responseMetadata: chunk.response_metadata as
             | Record<string, unknown>
             | undefined,
+          parsedToolCalls: chunk.tool_calls,
         });
       }
       /** Judged whenever parsed calls are present, not only when raw chunks

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1545,7 +1545,12 @@ export class ChatModelStreamHandler implements t.EventHandler {
             | Record<string, unknown>
             | undefined,
         });
-      } else if (chunk.tool_calls && chunk.tool_calls.length > 0) {
+      }
+      /** Judged whenever parsed calls are present, not only when raw chunks
+       * are absent — an adapter can pair an empty or partial raw chunk with
+       * a complete parsed call; the standalone check is stateless, so the
+       * common both-present case is not double-tallied. */
+      if (chunk.tool_calls && chunk.tool_calls.length > 0) {
         enforceCompleteToolCallArgLimit({
           graph,
           metadata,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1529,18 +1529,34 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
 
-    /** The breaker this event's run owns. Attempts stamp their breaker
-     * epoch into event metadata; a mismatch marks a straggling chunk from a
-     * failed run that outlived `resetValues()`, and tripping (or
-     * consulting) the LIVE controller for it would cancel the unrelated run
-     * now using it. Events without a stamp (direct handler callers, partial
-     * stubs) keep the live-controller behavior. */
+    /** Attempts stamp their breaker epoch into event metadata; a mismatch
+     * marks a straggling chunk from a failed run that outlived
+     * `resetValues()`. Dropped OUTRIGHT: content handling and the eager
+     * paths below compose the LIVE controller, so acting on a dead run's
+     * chunk could dispatch host tools into the run now using it. Events
+     * without a stamp (direct handler callers, partial stubs) keep the
+     * live-controller behavior. */
     const eventEpoch = metadata?.[STREAM_LIMIT_EPOCH_KEY];
+    if (
+      eventEpoch != null &&
+      graph.breakerEpoch != null &&
+      eventEpoch !== graph.breakerEpoch
+    ) {
+      return;
+    }
     const eventBreaker =
-      graph.breakerAbort instanceof AbortController &&
-      (eventEpoch == null || eventEpoch === graph.breakerEpoch)
+      graph.breakerAbort instanceof AbortController
         ? graph.breakerAbort
         : undefined;
+    const throwIfRunBreakerTripped = (): void => {
+      if (
+        eventBreaker != null &&
+        eventBreaker.signal.aborted &&
+        eventBreaker.signal.reason instanceof StreamLimitExceededError
+      ) {
+        throw eventBreaker.signal.reason;
+      }
+    };
 
     /**
      * Enforced before every content-specific early return below
@@ -1606,14 +1622,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
     /** A parallel producer can trip the shared breaker while this event was
      * already queued in `streamEvents`. Stop before content handling or the
      * eager-tool paths below — those can dispatch a side-effecting host
-     * tool with an already-aborted signal the handler never inspects. */
-    if (
-      eventBreaker != null &&
-      eventBreaker.signal.aborted &&
-      eventBreaker.signal.reason instanceof StreamLimitExceededError
-    ) {
-      throw eventBreaker.signal.reason;
-    }
+     * tool with an already-aborted signal the handler never inspects.
+     * Rechecked again immediately before each eager dispatch: the awaits in
+     * between (server-tool results, tool-call handling, content dispatch)
+     * are windows for a sibling's trip. */
+    throwIfRunBreakerTripped();
 
     const agentContext = graph.getAgentContext(metadata);
 
@@ -1677,6 +1690,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
+      throwIfRunBreakerTripped();
       if (hasFinalToolCallSignal(chunk)) {
         startEagerToolExecutions({
           graph,
@@ -1756,6 +1770,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
         metadata,
       });
       if (canStreamEager) {
+        throwIfRunBreakerTripped();
         startReadyStreamedEagerToolExecutions({
           graph,
           metadata,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -39,6 +39,7 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import {
   claimStreamLimitCharge,
   combineCompleteToolCalls,
@@ -177,7 +178,10 @@ function isEagerExecutionExcludedTool(
   // the final request ("changed after eager execution started"), stop
   // prestarting it so the model's retry executes normally instead of
   // re-diverging in a loop (LibreChat#14371).
-  if (graph.eagerEventToolSuppressions?.has(name) === true) {
+  if (
+    (graph.eagerEventToolSuppressions as Set<string> | undefined)?.has(name) ===
+    true
+  ) {
     return true;
   }
   // A code-session participant writes to the shared sandbox, so it is
@@ -1084,9 +1088,8 @@ function recordEagerToolCallChunks(args: {
     const sealCoversChunk =
       seal != null &&
       (seal.kind === 'all' ||
-        (seal.kind === 'single' &&
-          ((seal.id != null && seal.id === id) ||
-            (seal.index != null && seal.index === index))));
+        (seal.id != null && seal.id === id) ||
+        (seal.index != null && seal.index === index));
     const next = {
       id,
       name,
@@ -1537,17 +1540,23 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * without a stamp (direct handler callers, partial stubs) keep the
      * live-controller behavior. */
     const eventEpoch = metadata?.[STREAM_LIMIT_EPOCH_KEY];
-    if (
-      eventEpoch != null &&
-      graph.breakerEpoch != null &&
-      eventEpoch !== graph.breakerEpoch
-    ) {
+    /** Runtime-honest widening: partial handler stubs carry neither an
+     * epoch nor a run scope despite the field types. */
+    const liveEpoch = graph.breakerEpoch as number | undefined;
+    if (eventEpoch != null && liveEpoch != null && eventEpoch !== liveEpoch) {
       return;
     }
     const eventBreaker =
       graph.breakerAbort instanceof AbortController
         ? graph.breakerAbort
         : undefined;
+    /** Immutable scope captured at handler entry. A reset while this
+     * handler is suspended in an await replaces the object, so ONE
+     * reference comparison proves the event still belongs to the live run
+     * before anything composes `graph.breakerAbort` or `graph.config`. */
+    const entryRunScope = graph.runScope as RunBreakerScope | undefined;
+    const runScopeInvalidated = (): boolean =>
+      entryRunScope != null && graph.runScope !== entryRunScope;
     const throwIfRunBreakerTripped = (): void => {
       if (
         eventBreaker != null &&
@@ -1625,7 +1634,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
      * tool with an already-aborted signal the handler never inspects.
      * Rechecked again immediately before each eager dispatch: the awaits in
      * between (server-tool results, tool-call handling, content dispatch)
-     * are windows for a sibling's trip. */
+     * are windows for a sibling's trip — or for a full reset, after which
+     * this event belongs to a dead run and is dropped. */
+    if (runScopeInvalidated()) {
+      return;
+    }
     throwIfRunBreakerTripped();
 
     const agentContext = graph.getAgentContext(metadata);
@@ -1690,6 +1703,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
+      if (runScopeInvalidated()) {
+        return;
+      }
       throwIfRunBreakerTripped();
       if (hasFinalToolCallSignal(chunk)) {
         startEagerToolExecutions({
@@ -1770,6 +1786,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
         metadata,
       });
       if (canStreamEager) {
+        if (runScopeInvalidated()) {
+          return;
+        }
         throwIfRunBreakerTripped();
         startReadyStreamedEagerToolExecutions({
           graph,

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1710,6 +1710,56 @@ describe('createSummarizeNode — overflow recovery', () => {
 });
 
 describe('summarize node breaker capture', () => {
+  it('rethrows a parent trip on the config signal instead of degrading to the stub', async () => {
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    /** Child graph's own breaker stays live: in a subagent, a ROOT
+     * sibling's trip arrives only through the composed invocation signal. */
+    const childBreaker = new AbortController();
+    const configAbort = new AbortController();
+    captureEvents();
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest.fn().mockImplementation(async () => {
+              configAbort.abort(trip);
+              throw new Error('The operation was aborted');
+            }),
+          };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    const graph = {
+      ...mockGraph(),
+      getBreakerSignal: (): AbortSignal => childBreaker.signal,
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await expect(
+      node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        { signal: configAbort.signal } as RunnableConfig
+      )
+    ).rejects.toBe(trip);
+  });
+
   it('rejects at entry when the breaker has already tripped', async () => {
     const trip = new StreamLimitExceededError({
       kind: 'tool_call_args',

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1707,3 +1707,70 @@ describe('createSummarizeNode — overflow recovery', () => {
     expect(agentContext.hasSummary()).toBe(true);
   });
 });
+
+describe('summarize node breaker capture', () => {
+  it('binds the model call to the breaker signal read at node entry', async () => {
+    const entryBreaker = new AbortController();
+    const lateBreaker = new AbortController();
+    let started = false;
+    jest.spyOn(eventUtils, 'safeDispatchCustomEvent').mockImplementation((async (
+      ...args: unknown[]
+    ) => {
+      if (args[0] === GraphEvents.ON_SUMMARIZE_START) {
+        started = true;
+      }
+    }) as never);
+
+    const capturedSignals: Array<AbortSignal | undefined> = [];
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest
+              .fn()
+              .mockImplementation(
+                async (_messages: unknown, config?: unknown) => {
+                  capturedSignals.push(
+                    (config as RunnableConfig | undefined)?.signal
+                  );
+                  return { content: 'Summary text' };
+                }
+              ),
+          };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    /** Simulates a graph reset between node entry and the model call: once
+     * ON_SUMMARIZE_START has been awaited, the live accessor hands out a
+     * fresh controller's signal. The model call must still see the signal
+     * captured at entry. */
+    const graph = {
+      ...mockGraph(),
+      getBreakerSignal: (): AbortSignal =>
+        started ? lateBreaker.signal : entryBreaker.signal,
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedSignals.length).toBeGreaterThan(0);
+    for (const signal of capturedSignals) {
+      expect(signal).toBe(entryBreaker.signal);
+    }
+  });
+});

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1760,6 +1760,59 @@ describe('summarize node breaker capture', () => {
     }
   });
 
+  it('rejects before the model call when the breaker trips during pre-call awaits', async () => {
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const entryBreaker = new AbortController();
+    /** The trip lands while ON_SUMMARIZE_START is awaited — after the
+     * entry check already passed. */
+    jest.spyOn(eventUtils, 'safeDispatchCustomEvent').mockImplementation((async (
+      ...args: unknown[]
+    ) => {
+      if (args[0] === GraphEvents.ON_SUMMARIZE_START) {
+        entryBreaker.abort(trip);
+      }
+    }) as never);
+    const modelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockReturnValue(
+        class {
+          constructor() {
+            return mockInvokeModel('should never run');
+          }
+        } as never
+      );
+
+    const agentContext = createAgentContext();
+    const graph = {
+      ...mockGraph(),
+      getBreakerSignal: (): AbortSignal => entryBreaker.signal,
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await expect(
+      node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      )
+    ).rejects.toBe(trip);
+    expect(modelClassSpy).not.toHaveBeenCalled();
+  });
+
   it('rethrows a parent trip on the config signal instead of degrading to the stub', async () => {
     const trip = new StreamLimitExceededError({
       kind: 'tool_call_args',

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
 } from '@/summarization/node';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
@@ -1709,6 +1710,54 @@ describe('createSummarizeNode — overflow recovery', () => {
 });
 
 describe('summarize node breaker capture', () => {
+  it('rejects at entry when the breaker has already tripped', async () => {
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const entryBreaker = new AbortController();
+    entryBreaker.abort(trip);
+
+    const modelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockReturnValue(
+        class {
+          constructor() {
+            return mockInvokeModel('should never run');
+          }
+        } as never
+      );
+
+    const agentContext = createAgentContext();
+    const graph = {
+      ...mockGraph(),
+      getBreakerSignal: (): AbortSignal => entryBreaker.signal,
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await expect(
+      node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      )
+    ).rejects.toBe(trip);
+
+    expect(graph.contentData).toHaveLength(0);
+    expect(modelClassSpy).not.toHaveBeenCalled();
+  });
+
   it('binds the model call to the breaker signal read at node entry', async () => {
     const entryBreaker = new AbortController();
     const lateBreaker = new AbortController();

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1710,6 +1710,56 @@ describe('createSummarizeNode — overflow recovery', () => {
 });
 
 describe('summarize node breaker capture', () => {
+  it('stamps the entry-captured breaker epoch into summary attempt metadata', async () => {
+    captureEvents();
+    const capturedConfigs: Array<{ metadata?: Record<string, unknown> }> = [];
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest
+              .fn()
+              .mockImplementation(
+                async (_messages: unknown, config?: unknown) => {
+                  capturedConfigs.push(
+                    config as { metadata?: Record<string, unknown> }
+                  );
+                  return { content: 'Summary text' };
+                }
+              ),
+          };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    const graph = {
+      ...mockGraph(),
+      getBreakerEpoch: (): number => 7,
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedConfigs.length).toBeGreaterThan(0);
+    for (const config of capturedConfigs) {
+      expect(config.metadata?.lc_stream_limit_epoch).toBe(7);
+    }
+  });
+
   it('rethrows a parent trip on the config signal instead of degrading to the stub', async () => {
     const trip = new StreamLimitExceededError({
       kind: 'tool_call_args',

--- a/src/summarization/chunkHandler.test.ts
+++ b/src/summarization/chunkHandler.test.ts
@@ -82,6 +82,39 @@ describe('createSummarizationChunkHandler stream limits', () => {
     );
   });
 
+  it('trips the run breaker when its own enforcement breaches', async () => {
+    const breaker = new AbortController();
+    const graph: StreamLimitState & {
+      getBreakerController?: () => AbortController;
+    } = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+      getBreakerController: () => breaker,
+    };
+    const onChunk = createSummarizationChunkHandler({
+      stepId: 'step_1',
+      config: { metadata: { langgraph_node: 'summarize', langgraph_step: 4 } },
+      provider: Providers.OPENAI,
+      reasoningKey: 'reasoning_content',
+      graph,
+    });
+    const toolChunk = (args: string): AIMessageChunk =>
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [
+          { type: 'tool_call_chunk', name: 'db_query', args, index: 0 },
+        ],
+      });
+
+    /** This producer claim wins the race, so the wire consumer's
+     * breaker-aborting catch never fires for the same chunk — the trip has
+     * to happen here or sibling branches keep consuming quota. */
+    await expect(async () => onChunk!(toolChunk('x'.repeat(60)))).rejects.toThrow(
+      StreamLimitExceededError
+    );
+    expect(breaker.signal.aborted).toBe(true);
+    expect(breaker.signal.reason).toMatchObject({ kind: 'tool_call_args' });
+  });
+
   it('charges a chunk once when the run wire consumer also claims it', async () => {
     const graph: StreamLimitState = {
       streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),

--- a/src/summarization/chunkHandler.test.ts
+++ b/src/summarization/chunkHandler.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Summarization streams replace `ChatModelStreamHandler` with an `onChunk`
+ * callback, so the stream circuit breakers are enforced inside
+ * `createSummarizationChunkHandler`: the per-generation event cap, and the
+ * argument byte cap for tool calls a tool-bound summarization model may
+ * emit. Keys derive from the attempt metadata `attemptInvoke` hands each
+ * chunk, so a fallback summary attempt never inherits the failed primary's
+ * counts.
+ */
+import { AIMessageChunk } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { StreamLimitState } from '@/llm/streamLimits';
+import {
+  STREAM_LIMIT_ATTEMPT_KEY,
+  StreamLimitExceededError,
+  resolveStreamLimits,
+} from '@/llm/streamLimits';
+import { createSummarizationChunkHandler } from '@/summarization/node';
+import { Providers } from '@/common';
+
+const makeHandler = (graph: StreamLimitState) =>
+  createSummarizationChunkHandler({
+    stepId: 'step_1',
+    config: { metadata: { langgraph_node: 'summarize', langgraph_step: 4 } },
+    provider: Providers.OPENAI,
+    reasoningKey: 'reasoning_content',
+    graph,
+  });
+
+const textChunk = (): AIMessageChunk => new AIMessageChunk({ content: 'part' });
+
+describe('createSummarizationChunkHandler stream limits', () => {
+  it('enforces the event cap on summary streams', async () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
+    };
+    const onChunk = makeHandler(graph);
+    expect(onChunk).toBeDefined();
+    await onChunk!(textChunk());
+    await onChunk!(textChunk());
+    await expect(async () => onChunk!(textChunk())).rejects.toThrow(
+      StreamLimitExceededError
+    );
+  });
+
+  it('keys each summary attempt by the metadata attemptInvoke hands the chunk', async () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
+    };
+    const onChunk = makeHandler(graph);
+    const primary = {
+      langgraph_node: 'summarize',
+      langgraph_step: 4,
+      [STREAM_LIMIT_ATTEMPT_KEY]: 1,
+    };
+    const fallback = { ...primary, [STREAM_LIMIT_ATTEMPT_KEY]: 2 };
+    await onChunk!(textChunk(), primary);
+    await onChunk!(textChunk(), primary);
+    await onChunk!(textChunk(), fallback);
+    await onChunk!(textChunk(), fallback);
+    await expect(async () => onChunk!(textChunk(), fallback)).rejects.toThrow(
+      StreamLimitExceededError
+    );
+  });
+
+  it('enforces the argument byte cap on tool calls from tool-bound summary models', async () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 50 }),
+    };
+    const onChunk = makeHandler(graph);
+    const toolChunk = (args: string): AIMessageChunk =>
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [
+          { type: 'tool_call_chunk', name: 'db_query', args, index: 0 },
+        ],
+      });
+    await onChunk!(toolChunk('x'.repeat(40)));
+    await expect(async () => onChunk!(toolChunk('x'.repeat(20)))).rejects.toThrow(
+      '(tool call: db_query)'
+    );
+  });
+
+  it('stays inert without graph state', async () => {
+    const onChunk = createSummarizationChunkHandler({
+      stepId: 'step_1',
+      config: { metadata: {} },
+      provider: Providers.OPENAI,
+    });
+    for (let i = 0; i < 10; i++) {
+      await onChunk!(textChunk());
+    }
+  });
+});

--- a/src/summarization/chunkHandler.test.ts
+++ b/src/summarization/chunkHandler.test.ts
@@ -13,6 +13,7 @@ import type { StreamLimitState } from '@/llm/streamLimits';
 import {
   STREAM_LIMIT_ATTEMPT_KEY,
   StreamLimitExceededError,
+  enforceStreamLimitsForWireChunk,
   resolveStreamLimits,
 } from '@/llm/streamLimits';
 import { createSummarizationChunkHandler } from '@/summarization/node';
@@ -78,6 +79,74 @@ describe('createSummarizationChunkHandler stream limits', () => {
     await onChunk!(toolChunk('x'.repeat(40)));
     await expect(async () => onChunk!(toolChunk('x'.repeat(20)))).rejects.toThrow(
       '(tool call: db_query)'
+    );
+  });
+
+  it('charges a chunk once when the run wire consumer also claims it', async () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxToolCallArgBytes: 100 }),
+    };
+    const onChunk = makeHandler(graph);
+    const metadata = { langgraph_node: 'summarize', langgraph_step: 4 };
+    const toolChunk = (args: string): AIMessageChunk =>
+      new AIMessageChunk({
+        content: '',
+        tool_call_chunks: [
+          { type: 'tool_call_chunk', name: 'db_query', args, index: 0 },
+        ],
+      });
+
+    /** Inside a live run the provider callbacks route the same chunk object
+     * through the graph's registered stream consumer as well. Wire consumer
+     * first, then the summarization handler: 60 bytes must be tallied once
+     * (a second same-side claim would put the tally at 120 and trip). */
+    const first = toolChunk('x'.repeat(60));
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata,
+      chunk: first,
+      side: 'consumer',
+    });
+    await onChunk!(first, metadata);
+
+    /** Opposite order for the next chunk: handler (producer) before wire
+     * consumer. 60 + 39 = 99 stays under the cap only when each chunk was
+     * charged exactly once. */
+    const second = toolChunk('x'.repeat(39));
+    await onChunk!(second, metadata);
+    enforceStreamLimitsForWireChunk({
+      graph,
+      metadata,
+      chunk: second,
+      side: 'consumer',
+    });
+
+    /** Enforcement stays armed: two more bytes cross the 100-byte cap. */
+    await expect(async () => onChunk!(toolChunk('xx'), metadata)).rejects.toThrow(
+      StreamLimitExceededError
+    );
+  });
+
+  it('counts dual-consumed events once against the event cap', async () => {
+    const graph: StreamLimitState = {
+      streamLimits: resolveStreamLimits({ maxDeltaEventsPerTurn: 2 }),
+    };
+    const onChunk = makeHandler(graph);
+    const metadata = { langgraph_node: 'summarize', langgraph_step: 4 };
+    const passBoth = async (chunk: AIMessageChunk): Promise<void> => {
+      enforceStreamLimitsForWireChunk({
+        graph,
+        metadata,
+        chunk,
+        side: 'consumer',
+      });
+      await onChunk!(chunk, metadata);
+    };
+
+    await passBoth(textChunk());
+    await passBoth(textChunk());
+    await expect(async () => passBoth(textChunk())).rejects.toThrow(
+      StreamLimitExceededError
     );
   });
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -710,14 +710,16 @@ async function executeSummarizationWithFallback(params: {
     /** A parallel branch's trip aborts the composed summarization signal,
      * and a provider can surface that as a generic abort error; entering
      * fallback recovery or degrading to the metadata stub would continue
-     * work after the run-wide safety abort. Rethrow the breaker's reason. */
+     * work after the run-wide safety abort. Checked on BOTH channels: the
+     * graph's own breaker, and the composed config signal that carries a
+     * parent run's trip into subagent child graphs. */
     {
-      const breakerSignal = graph?.getBreakerSignal?.();
-      if (
-        breakerSignal?.aborted === true &&
-        breakerSignal.reason instanceof StreamLimitExceededError
-      ) {
-        throw breakerSignal.reason;
+      const trippedReason = findStreamLimitAbortReason(
+        graph?.getBreakerSignal?.(),
+        summarizeConfig?.signal
+      );
+      if (trippedReason != null) {
+        throw trippedReason;
       }
     }
 
@@ -929,6 +931,24 @@ function withBreakerSignal<T extends { signal?: AbortSignal }>(
   return { ...config, signal: AbortSignal.any([existing, breakerSignal]) };
 }
 
+/** First stream-limit reason found on any of the given signals. Checked
+ * alongside the graph's own breaker because a subagent child graph receives
+ * a ROOT sibling's trip through its constructor/invocation signal — the
+ * child's private breaker never fires for it. */
+function findStreamLimitAbortReason(
+  ...signals: Array<AbortSignal | undefined>
+): StreamLimitExceededError | undefined {
+  for (const signal of signals) {
+    if (
+      signal?.aborted === true &&
+      signal.reason instanceof StreamLimitExceededError
+    ) {
+      return signal.reason;
+    }
+  }
+  return undefined;
+}
+
 export function createSummarizeNode({
   agentContext,
   graph: adapterGraph,
@@ -960,15 +980,17 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
     /** Already-tripped-at-entry: a parallel sibling's breach failed the run
-     * before this node was scheduled. Rethrow before dispatching steps,
-     * hooks, or the model call — an adapter that doesn't synchronously
-     * reject an aborted signal would otherwise spend summarization provider
-     * work on a failed run. */
-    if (
-      entryBreakerSignal?.aborted === true &&
-      entryBreakerSignal.reason instanceof StreamLimitExceededError
-    ) {
-      throw entryBreakerSignal.reason;
+     * before this node was scheduled — via this graph's own breaker or, in
+     * a subagent child graph, the parent trip on the invocation signal.
+     * Rethrow before dispatching steps, hooks, or the model call — an
+     * adapter that doesn't synchronously reject an aborted signal would
+     * otherwise spend summarization provider work on a failed run. */
+    const entryTripReason = findStreamLimitAbortReason(
+      entryBreakerSignal,
+      config?.signal
+    );
+    if (entryTripReason != null) {
+      throw entryTripReason;
     }
 
     /**

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -696,16 +696,24 @@ async function executeSummarizationWithFallback(params: {
       messagesToRefineCount: messages.length,
     });
 
+    /**
+     * A tripped stream circuit breaker is a safety abort, not a
+     * summarization failure to recover from: retrying on fallback providers
+     * would spend more provider work after the limit fired, and degrading to
+     * the metadata stub would let the run continue (and periodic compaction
+     * commit the stub) despite the `StreamLimits` contract that a breach
+     * rejects the run. Rethrown so the summarize node fails the run with
+     * the actionable limit error, consistent with agent turns and subagents.
+     */
+    if (primaryError instanceof StreamLimitExceededError) {
+      throw primaryError;
+    }
+
     const rawFallbacks = (
       clientConfig.clientOptions as unknown as t.LLMConfig | undefined
     )?.fallbacks;
     const fallbacks = Array.isArray(rawFallbacks) ? rawFallbacks : [];
-    /**
-     * A tripped stream circuit breaker is a safety abort: retrying the
-     * summary on fallback providers would spend more provider work after
-     * the limit fired. Skip straight to the metadata stub below.
-     */
-    if (fallbacks.length > 0 && !(primaryError instanceof StreamLimitExceededError)) {
+    if (fallbacks.length > 0) {
       try {
         const onChunk = createSummarizationChunkHandler({
           stepId,
@@ -738,6 +746,9 @@ async function executeSummarizationWithFallback(params: {
           );
         }
       } catch (fbErr) {
+        if (fbErr instanceof StreamLimitExceededError) {
+          throw fbErr;
+        }
         const fbDescribed = describeFallbackError(fbErr, fallbacks);
         log('warn', `Fallback providers also failed ${fbDescribed.suffix}`, {
           ...fbDescribed.data,
@@ -1373,9 +1384,9 @@ export function createSummarizationChunkHandler({
      * tool calls a tool-bound summarization model may emit. Keyed by the
      * attempt metadata `attemptInvoke` hands each chunk, so a fallback
      * summary attempt never inherits the failed primary's counts. A trip
-     * tears down the model stream; the caller then skips fallbacks and
-     * degrades to the metadata stub instead of aborting the user's run
-     * over an auxiliary stream.
+     * tears down the model stream and `executeSummarizationWithFallback`
+     * rethrows it past fallbacks and the metadata stub, failing the run
+     * with the limit error like any other breach.
      */
     if (graph != null) {
       const metadata = attemptMetadata ?? limitMetadata;

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1253,6 +1253,20 @@ export function createSummarizeNode({
       }
       : undefined;
 
+    /** Rechecked after the pre-call awaits (dispatchRunStep,
+     * ON_SUMMARIZE_START, PreCompact): a sibling can trip the breaker while
+     * this node is paused in one of them, and a provider that doesn't
+     * synchronously reject an aborted signal would still start the
+     * summarization call. Mirrors the model node's pre-invoke recheck. */
+    {
+      const preCallTrip = findStreamLimitAbortReason(
+        entryBreakerSignal,
+        config?.signal
+      );
+      if (preCallTrip != null) {
+        throw preCallTrip;
+      }
+    }
     const {
       text: rawText,
       usage: summaryUsage,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -959,6 +959,17 @@ export function createSummarizeNode({
     if (request == null) {
       return { summarizationRequest: undefined };
     }
+    /** Already-tripped-at-entry: a parallel sibling's breach failed the run
+     * before this node was scheduled. Rethrow before dispatching steps,
+     * hooks, or the model call — an adapter that doesn't synchronously
+     * reject an aborted signal would otherwise spend summarization provider
+     * work on a failed run. */
+    if (
+      entryBreakerSignal?.aborted === true &&
+      entryBreakerSignal.reason instanceof StreamLimitExceededError
+    ) {
+      throw entryBreakerSignal.reason;
+    }
 
     /**
      * Overflow recovery routes through this node purely to get back to the

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -37,6 +37,7 @@ import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import {
   enforceStreamLimitsForWireChunk,
   StreamLimitExceededError,
+  STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -910,6 +911,10 @@ interface CreateSummarizeNodeParams {
      * accessor: the node captures it at entry so a breach detected by its
      * own chunk handler trips the run that STARTED the summarization. */
     getBreakerController?: () => AbortController;
+    /** The controller's epoch, captured at entry and stamped into summary
+     * attempt metadata so the wire consumer epoch-gates old-run summary
+     * chunks like model-attempt chunks. */
+    getBreakerEpoch?: () => number;
   } & StreamLimitState;
   generateStepId: (stepKey: string) => [string, number];
 }
@@ -975,6 +980,7 @@ export function createSummarizeNode({
     const entryBreakerController = adapterGraph.getBreakerController?.();
     const entryBreakerSignal =
       entryBreakerController?.signal ?? adapterGraph.getBreakerSignal?.();
+    const entryBreakerEpoch = adapterGraph.getBreakerEpoch?.();
     const graph =
       entryBreakerSignal == null
         ? adapterGraph
@@ -1235,6 +1241,13 @@ export function createSummarizeNode({
              */
           ...(clientConfig.modelName != null && clientConfig.modelName !== ''
             ? { [Constants.INVOKED_MODEL]: clientConfig.modelName }
+            : {}),
+          /** Entry-captured breaker epoch: the wire consumer epoch-gates
+           * old-run summary chunks exactly like model-attempt chunks —
+           * without the stamp, a straggling summary from a failed run
+           * reads as current and could abort the next run's controller. */
+          ...(entryBreakerEpoch != null
+            ? { [STREAM_LIMIT_EPOCH_KEY]: entryBreakerEpoch }
             : {}),
         },
       }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -906,6 +906,10 @@ interface CreateSummarizeNodeParams {
      * model attempt so a sibling branch tripping a stream limit also
      * cancels in-flight summaries. */
     getBreakerSignal?: () => AbortSignal;
+    /** The run's shared breaker controller. Preferred over the bare signal
+     * accessor: the node captures it at entry so a breach detected by its
+     * own chunk handler trips the run that STARTED the summarization. */
+    getBreakerController?: () => AbortController;
   } & StreamLimitState;
   generateStepId: (stepKey: string) => [string, number];
 }
@@ -968,12 +972,19 @@ export function createSummarizeNode({
      * to the fresh controller. `Object.create` freezes the signal while
      * DELEGATING every other adapter member — spreading would snapshot the
      * charge-credit accessor pair and detach it from graph resets. */
-    const entryBreakerSignal = adapterGraph.getBreakerSignal?.();
+    const entryBreakerController = adapterGraph.getBreakerController?.();
+    const entryBreakerSignal =
+      entryBreakerController?.signal ?? adapterGraph.getBreakerSignal?.();
     const graph =
       entryBreakerSignal == null
         ? adapterGraph
         : (Object.create(adapterGraph, {
           getBreakerSignal: { value: (): AbortSignal => entryBreakerSignal },
+          ...(entryBreakerController != null && {
+            getBreakerController: {
+              value: (): AbortController => entryBreakerController,
+            },
+          }),
         }) as typeof adapterGraph);
     const request = state.summarizationRequest;
     if (request == null) {
@@ -1457,7 +1468,7 @@ export function createSummarizationChunkHandler({
   config?: RunnableConfig;
   provider?: Providers;
   reasoningKey?: 'reasoning_content' | 'reasoning';
-  graph?: StreamLimitState;
+  graph?: StreamLimitState & { getBreakerController?: () => AbortController };
 }): OnChunk | undefined {
   if (stepId == null || stepId === '' || !config) {
     return undefined;
@@ -1473,19 +1484,30 @@ export function createSummarizationChunkHandler({
      * no registered handler) still get single-sided enforcement from this
      * one claim. Summarization deliberately passes NO `context` to
      * `attemptInvoke`, whose onChunk branch would otherwise add a second
-     * producer claim. A trip tears down the model stream and
-     * `executeSummarizationWithFallback` rethrows it past fallbacks and the
-     * metadata stub, failing the run with the limit error like any other
-     * breach.
+     * producer claim. A breach trips the run's shared breaker (the
+     * ENTRY-captured controller when the adapter provides one) before
+     * rethrowing: this producer claim wins the race, so the wire consumer's
+     * breaker-aborting catch never fires for the same chunk — without the
+     * trip here, sibling model calls, tools, and subagents would keep
+     * consuming quota while the summary branch rejects.
+     * `executeSummarizationWithFallback` then rethrows past fallbacks and
+     * the metadata stub, failing the run like any other breach.
      */
     if (graph != null) {
-      enforceStreamLimitsForWireChunk({
-        graph,
-        metadata: attemptMetadata ?? limitMetadata,
-        chunk: chunk as Parameters<
-          typeof enforceStreamLimitsForWireChunk
-        >[0]['chunk'],
-      });
+      try {
+        enforceStreamLimitsForWireChunk({
+          graph,
+          metadata: attemptMetadata ?? limitMetadata,
+          chunk: chunk as Parameters<
+            typeof enforceStreamLimitsForWireChunk
+          >[0]['chunk'],
+        });
+      } catch (error) {
+        if (error instanceof StreamLimitExceededError) {
+          graph.getBreakerController?.().abort(error);
+        }
+        throw error;
+      }
     }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];
     const raw = getChunkContent({ chunk: chunkAny, provider, reasoningKey });

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -35,8 +35,7 @@ import {
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import {
-  enforceStreamedToolCallArgLimit,
-  enforceStreamDeltaEventLimit,
+  enforceStreamLimitsForWireChunk,
   StreamLimitExceededError,
 } from '@/llm/streamLimits';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
@@ -1390,17 +1389,13 @@ export function createSummarizationChunkHandler({
      */
     if (graph != null) {
       const metadata = attemptMetadata ?? limitMetadata;
-      enforceStreamDeltaEventLimit({ graph, metadata });
-      if (chunk.tool_call_chunks != null && chunk.tool_call_chunks.length > 0) {
-        enforceStreamedToolCallArgLimit({
-          graph,
-          metadata,
-          toolCallChunks: chunk.tool_call_chunks,
-          responseMetadata: chunk.response_metadata as
-            | Record<string, unknown>
-            | undefined,
-        });
-      }
+      enforceStreamLimitsForWireChunk({
+        graph,
+        metadata,
+        chunk: chunk as Parameters<
+          typeof enforceStreamLimitsForWireChunk
+        >[0]['chunk'],
+      });
     }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];
     const raw = getChunkContent({ chunk: chunkAny, provider, reasoningKey });

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -931,7 +931,7 @@ function withBreakerSignal<T extends { signal?: AbortSignal }>(
 
 export function createSummarizeNode({
   agentContext,
-  graph,
+  graph: adapterGraph,
   generateStepId,
 }: CreateSummarizeNodeParams) {
   return async (
@@ -941,6 +941,20 @@ export function createSummarizeNode({
     },
     config?: RunnableConfig
   ): Promise<{ summarizationRequest: undefined; messages?: BaseMessage[] }> => {
+    /** The breaker signal is captured at node ENTRY, before dispatchRunStep,
+     * ON_SUMMARIZE_START, or PreCompact awaits: a sibling's trip plus a
+     * prompt next run can reset the controller during one of those awaits,
+     * and resolving the live accessor later would bind this summarization
+     * to the fresh controller. `Object.create` freezes the signal while
+     * DELEGATING every other adapter member — spreading would snapshot the
+     * charge-credit accessor pair and detach it from graph resets. */
+    const entryBreakerSignal = adapterGraph.getBreakerSignal?.();
+    const graph =
+      entryBreakerSignal == null
+        ? adapterGraph
+        : (Object.create(adapterGraph, {
+          getBreakerSignal: { value: (): AbortSignal => entryBreakerSignal },
+        }) as typeof adapterGraph);
     const request = state.summarizationRequest;
     if (request == null) {
       return { summarizationRequest: undefined };

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1432,11 +1432,15 @@ export function createSummarizationChunkHandler({
   const limitMetadata = config.metadata as Record<string, unknown> | undefined;
   return (chunk, attemptMetadata) => {
     /**
-     * Charged as `consumer` so it PAIRS with the producer-side charge in
-     * `attemptInvoke`'s onChunk branch: through attemptInvoke each emission
-     * is charged exactly once regardless of order, and a direct caller of
-     * this closure (tests, custom hosts) still gets single-sided
-     * enforcement. A trip tears down the model stream and
+     * Charged as `producer` so it PAIRS with the run's registered stream
+     * handler: inside a live run the provider callbacks route each chunk
+     * through the graph's `on_chat_model_stream` consumer too, and two
+     * same-side consumer claims would charge the chunk twice — halving an
+     * opt-in event cap. Standalone callers (tests, custom hosts, runs with
+     * no registered handler) still get single-sided enforcement from this
+     * one claim. Summarization deliberately passes NO `context` to
+     * `attemptInvoke`, whose onChunk branch would otherwise add a second
+     * producer claim. A trip tears down the model stream and
      * `executeSummarizationWithFallback` rethrows it past fallbacks and the
      * metadata stub, failing the run with the limit error like any other
      * breach.
@@ -1448,7 +1452,6 @@ export function createSummarizationChunkHandler({
         chunk: chunk as Parameters<
           typeof enforceStreamLimitsForWireChunk
         >[0]['chunk'],
-        side: 'consumer',
       });
     }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -6,6 +6,7 @@ import {
 } from '@langchain/core/messages';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { StreamLimitState } from '@/llm/streamLimits';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
@@ -33,7 +34,6 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import type { StreamLimitState } from '@/llm/streamLimits';
 import {
   enforceStreamLimitsForWireChunk,
   StreamLimitExceededError,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -707,6 +707,19 @@ async function executeSummarizationWithFallback(params: {
     if (primaryError instanceof StreamLimitExceededError) {
       throw primaryError;
     }
+    /** A parallel branch's trip aborts the composed summarization signal,
+     * and a provider can surface that as a generic abort error; entering
+     * fallback recovery or degrading to the metadata stub would continue
+     * work after the run-wide safety abort. Rethrow the breaker's reason. */
+    {
+      const breakerSignal = graph?.getBreakerSignal?.();
+      if (
+        breakerSignal?.aborted === true &&
+        breakerSignal.reason instanceof StreamLimitExceededError
+      ) {
+        throw breakerSignal.reason;
+      }
+    }
 
     const rawFallbacks = (
       clientConfig.clientOptions as unknown as t.LLMConfig | undefined

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -617,7 +617,7 @@ async function executeSummarizationWithFallback(params: {
   usePromptCache: boolean;
   log: LogFn;
   /** Carries the run's stream limits so the event cap covers summary streams. */
-  graph?: StreamLimitState;
+  graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
 }): Promise<{
   text: string;
   usage?: Partial<UsageMetadata>;
@@ -734,7 +734,10 @@ async function executeSummarizationWithFallback(params: {
               )
             ),
           ],
-          config: traceConfig(summarizeConfig, 'cache_hit_compaction'),
+          config: withBreakerSignal(
+            traceConfig(summarizeConfig, 'cache_hit_compaction'),
+            graph
+          ),
           primaryError,
           onChunk,
         });
@@ -884,8 +887,33 @@ interface CreateSummarizeNodeParams {
       result: t.StepCompleted,
       config?: RunnableConfig
     ) => Promise<void>;
+    /** The run's shared breaker signal, composed into every summarization
+     * model attempt so a sibling branch tripping a stream limit also
+     * cancels in-flight summaries. */
+    getBreakerSignal?: () => AbortSignal;
   } & StreamLimitState;
   generateStepId: (stepKey: string) => [string, number];
+}
+
+/** Composes the run's breaker signal (when the adapter provides one) into a
+ * summarization attempt's config, so breaches in sibling branches cancel
+ * summaries too. */
+function withBreakerSignal<T extends { signal?: AbortSignal }>(
+  config: T | undefined,
+  graph?: { getBreakerSignal?: () => AbortSignal }
+): T | undefined {
+  const breakerSignal = graph?.getBreakerSignal?.();
+  if (breakerSignal == null) {
+    return config;
+  }
+  if (config == null) {
+    return { signal: breakerSignal } as T;
+  }
+  const existing = config.signal;
+  if (existing == null || existing === breakerSignal) {
+    return { ...config, signal: breakerSignal };
+  }
+  return { ...config, signal: AbortSignal.any([existing, breakerSignal]) };
 }
 
 export function createSummarizeNode({
@@ -1468,7 +1496,7 @@ async function summarizeWithCacheHit({
   stepId?: string;
   provider: Providers;
   reasoningKey?: 'reasoning_content' | 'reasoning';
-  graph?: StreamLimitState;
+  graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
   usePromptCache?: boolean;
   promptCacheTtl?: PromptCacheTtl;
   log?: LogFn;
@@ -1498,7 +1526,7 @@ async function summarizeWithCacheHit({
         graph,
       }),
     },
-    traceConfig(config, 'cache_hit_compaction')
+    withBreakerSignal(traceConfig(config, 'cache_hit_compaction'), graph)
   );
 
   const responseMsg = result.messages?.[0];

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -35,6 +35,7 @@ import {
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import {
+  enforceStreamedToolCallArgLimit,
   enforceStreamDeltaEventLimit,
   StreamLimitExceededError,
 } from '@/llm/streamLimits';
@@ -1347,7 +1348,7 @@ function buildSummarizationInstruction(
 }
 
 /** Creates an `onChunk` callback that dispatches `ON_SUMMARIZE_DELTA` events for streaming. */
-function createSummarizationChunkHandler({
+export function createSummarizationChunkHandler({
   stepId,
   config,
   provider,
@@ -1364,16 +1365,31 @@ function createSummarizationChunkHandler({
     return undefined;
   }
   const limitMetadata = config.metadata as Record<string, unknown> | undefined;
-  return (chunk) => {
+  return (chunk, attemptMetadata) => {
     /**
      * Summarization streams bypass `ChatModelStreamHandler` (this onChunk
-     * replaces it in `attemptInvoke`), so the per-generation event cap is
-     * enforced here. A trip tears down the model stream; the caller then
-     * skips fallbacks and degrades to the metadata stub instead of aborting
-     * the user's run over an auxiliary stream.
+     * replaces it in `attemptInvoke`), so both stream limits are enforced
+     * here: the per-generation event cap, and the argument byte cap for
+     * tool calls a tool-bound summarization model may emit. Keyed by the
+     * attempt metadata `attemptInvoke` hands each chunk, so a fallback
+     * summary attempt never inherits the failed primary's counts. A trip
+     * tears down the model stream; the caller then skips fallbacks and
+     * degrades to the metadata stub instead of aborting the user's run
+     * over an auxiliary stream.
      */
     if (graph != null) {
-      enforceStreamDeltaEventLimit({ graph, metadata: limitMetadata });
+      const metadata = attemptMetadata ?? limitMetadata;
+      enforceStreamDeltaEventLimit({ graph, metadata });
+      if (chunk.tool_call_chunks != null && chunk.tool_call_chunks.length > 0) {
+        enforceStreamedToolCallArgLimit({
+          graph,
+          metadata,
+          toolCallChunks: chunk.tool_call_chunks,
+          responseMetadata: chunk.response_metadata as
+            | Record<string, unknown>
+            | undefined,
+        });
+      }
     }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];
     const raw = getChunkContent({ chunk: chunkAny, provider, reasoningKey });

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -756,6 +756,7 @@ async function executeSummarizationWithFallback(params: {
           ),
           primaryError,
           onChunk,
+          streamLimitState: graph,
         });
         const fbMsg = fbResult?.messages?.[0];
         if (fbMsg) {
@@ -1637,6 +1638,9 @@ async function summarizeWithCacheHit({
         reasoningKey,
         graph,
       }),
+      /** Accounting lease only (summarization passes no `context` so its
+       * producer claim never stacks with the onChunk handler's). */
+      streamLimitState: graph,
     },
     withBreakerSignal(traceConfig(config, 'cache_hit_compaction'), graph)
   );

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1377,24 +1377,23 @@ export function createSummarizationChunkHandler({
   const limitMetadata = config.metadata as Record<string, unknown> | undefined;
   return (chunk, attemptMetadata) => {
     /**
-     * Summarization streams bypass `ChatModelStreamHandler` (this onChunk
-     * replaces it in `attemptInvoke`), so both stream limits are enforced
-     * here: the per-generation event cap, and the argument byte cap for
-     * tool calls a tool-bound summarization model may emit. Keyed by the
-     * attempt metadata `attemptInvoke` hands each chunk, so a fallback
-     * summary attempt never inherits the failed primary's counts. A trip
-     * tears down the model stream and `executeSummarizationWithFallback`
-     * rethrows it past fallbacks and the metadata stub, failing the run
-     * with the limit error like any other breach.
+     * Charged as `consumer` so it PAIRS with the producer-side charge in
+     * `attemptInvoke`'s onChunk branch: through attemptInvoke each emission
+     * is charged exactly once regardless of order, and a direct caller of
+     * this closure (tests, custom hosts) still gets single-sided
+     * enforcement. A trip tears down the model stream and
+     * `executeSummarizationWithFallback` rethrows it past fallbacks and the
+     * metadata stub, failing the run with the limit error like any other
+     * breach.
      */
     if (graph != null) {
-      const metadata = attemptMetadata ?? limitMetadata;
       enforceStreamLimitsForWireChunk({
         graph,
-        metadata,
+        metadata: attemptMetadata ?? limitMetadata,
         chunk: chunk as Parameters<
           typeof enforceStreamLimitsForWireChunk
         >[0]['chunk'],
+        side: 'consumer',
       });
     }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -33,6 +33,11 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
+import type { StreamLimitState } from '@/llm/streamLimits';
+import {
+  enforceStreamDeltaEventLimit,
+  StreamLimitExceededError,
+} from '@/llm/streamLimits';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -611,6 +616,8 @@ async function executeSummarizationWithFallback(params: {
   stepId: string;
   usePromptCache: boolean;
   log: LogFn;
+  /** Carries the run's stream limits so the event cap covers summary streams. */
+  graph?: StreamLimitState;
 }): Promise<{
   text: string;
   usage?: Partial<UsageMetadata>;
@@ -629,6 +636,7 @@ async function executeSummarizationWithFallback(params: {
     stepId,
     usePromptCache,
     log,
+    graph,
   } = params;
 
   const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
@@ -659,6 +667,7 @@ async function executeSummarizationWithFallback(params: {
       stepId,
       provider: clientConfig.provider as Providers,
       reasoningKey: agentContext.reasoningKey,
+      graph,
       usePromptCache,
       promptCacheTtl:
         (clientConfig.provider as Providers) === Providers.ANTHROPIC ||
@@ -690,13 +699,19 @@ async function executeSummarizationWithFallback(params: {
       clientConfig.clientOptions as unknown as t.LLMConfig | undefined
     )?.fallbacks;
     const fallbacks = Array.isArray(rawFallbacks) ? rawFallbacks : [];
-    if (fallbacks.length > 0) {
+    /**
+     * A tripped stream circuit breaker is a safety abort: retrying the
+     * summary on fallback providers would spend more provider work after
+     * the limit fired. Skip straight to the metadata stub below.
+     */
+    if (fallbacks.length > 0 && !(primaryError instanceof StreamLimitExceededError)) {
       try {
         const onChunk = createSummarizationChunkHandler({
           stepId,
           config: traceConfig(summarizeConfig, 'cache_hit_compaction'),
           provider: clientConfig.provider as Providers,
           reasoningKey: agentContext.reasoningKey,
+          graph,
         });
         const fbResult = await tryFallbackProviders({
           fallbacks,
@@ -858,7 +873,7 @@ interface CreateSummarizeNodeParams {
       result: t.StepCompleted,
       config?: RunnableConfig
     ) => Promise<void>;
-  };
+  } & StreamLimitState;
   generateStepId: (stepKey: string) => [string, number];
 }
 
@@ -1127,6 +1142,7 @@ export function createSummarizeNode({
       stepId,
       usePromptCache: isSelfSummarizeModel && hasPromptCache,
       log,
+      graph,
     });
 
     /**
@@ -1336,16 +1352,29 @@ function createSummarizationChunkHandler({
   config,
   provider,
   reasoningKey = 'reasoning_content',
+  graph,
 }: {
   stepId?: string;
   config?: RunnableConfig;
   provider?: Providers;
   reasoningKey?: 'reasoning_content' | 'reasoning';
+  graph?: StreamLimitState;
 }): OnChunk | undefined {
   if (stepId == null || stepId === '' || !config) {
     return undefined;
   }
+  const limitMetadata = config.metadata as Record<string, unknown> | undefined;
   return (chunk) => {
+    /**
+     * Summarization streams bypass `ChatModelStreamHandler` (this onChunk
+     * replaces it in `attemptInvoke`), so the per-generation event cap is
+     * enforced here. A trip tears down the model stream; the caller then
+     * skips fallbacks and degrades to the metadata stub instead of aborting
+     * the user's run over an auxiliary stream.
+     */
+    if (graph != null) {
+      enforceStreamDeltaEventLimit({ graph, metadata: limitMetadata });
+    }
     const chunkAny = chunk as Parameters<typeof getChunkContent>[0]['chunk'];
     const raw = getChunkContent({ chunk: chunkAny, provider, reasoningKey });
     if (raw == null || (typeof raw === 'string' && !raw)) {
@@ -1404,6 +1433,7 @@ async function summarizeWithCacheHit({
   stepId,
   provider,
   reasoningKey,
+  graph,
   usePromptCache,
   promptCacheTtl,
   log,
@@ -1417,6 +1447,7 @@ async function summarizeWithCacheHit({
   stepId?: string;
   provider: Providers;
   reasoningKey?: 'reasoning_content' | 'reasoning';
+  graph?: StreamLimitState;
   usePromptCache?: boolean;
   promptCacheTtl?: PromptCacheTtl;
   log?: LogFn;
@@ -1443,6 +1474,7 @@ async function summarizeWithCacheHit({
         config: traceConfig(config, 'cache_hit_compaction'),
         provider,
         reasoningKey,
+        graph,
       }),
     },
     traceConfig(config, 'cache_hit_compaction')

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3743,6 +3743,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (composedSignal !== config.signal) {
       config = { ...config, signal: composedSignal };
     }
+    /** Already-tripped-at-entry: a parallel sibling's breach failed the run
+     * before this batch was scheduled. Rethrow before hooks, direct
+     * `tool.invoke` calls, or ON_TOOL_EXECUTE dispatch — a tool or host
+     * handler that doesn't synchronously inspect an aborted signal would
+     * otherwise perform side effects on a failed run. */
+    if (
+      composedSignal?.aborted === true &&
+      composedSignal.reason instanceof StreamLimitExceededError
+    ) {
+      throw composedSignal.reason;
+    }
     this.toolCallTurns.clear();
     /**
      * Per-batch local map for resolved (post-substitution) args.

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -82,7 +82,7 @@ import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
-import { RunnableCallable } from '@/utils';
+import { RunnableCallable, composeAbortSignals } from '@/utils';
 import { executeHooks } from '@/hooks';
 
 /**
@@ -637,6 +637,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolOutputRegistry?: ToolOutputReferenceRegistry;
   /** Run-scoped selection for swapping remote code tools to local executors. */
   private toolExecution?: t.ToolExecutionConfig;
+  /** Owning graph's run-scoped breaker signal, composed into each batch's config. */
+  private getBreakerSignal?: () => AbortSignal | undefined;
   /**
    * Monotonic counter used to mint a unique scope id for anonymous
    * batches (ones invoked without a `run_id` in
@@ -678,6 +680,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolOutputRegistry,
     toolExecution,
     fileCheckpointer,
+    getBreakerSignal,
   }: t.ToolNodeConstructorParams) {
     super({
       name: name ?? TOOL_NODE_RUN_NAME,
@@ -721,6 +724,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.hookRegistry = hookRegistry;
     this.humanInTheLoop = humanInTheLoop;
     this.toolExecution = toolExecution;
+    this.getBreakerSignal = getBreakerSignal;
     // Caller-provided checkpointer wins. Graphs use this to share a
     // single per-Run instance across every ToolNode they compile so
     // `Run.rewindFiles()` reaches the same snapshot store regardless
@@ -3003,6 +3007,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               metadata: config.metadata as
                   | Record<string, unknown>
                   | undefined,
+              signal: config.signal,
               resolve: (results): void => {
                 resultSettled = true;
                 settledResults = results;
@@ -3727,6 +3732,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
+    /**
+     * Breaker read once at batch entry: every downstream path (direct
+     * `tool.invoke` runtimes and the ON_TOOL_EXECUTE dispatch) inherits this
+     * config, and a graph reset mid-batch must not detach in-flight tools
+     * from an already-tripped signal.
+     */
+    const breakerSignal = this.getBreakerSignal?.();
+    const composedSignal = composeAbortSignals(config.signal, breakerSignal);
+    if (composedSignal !== config.signal) {
+      config = { ...config, signal: composedSignal };
+    }
     this.toolCallTurns.clear();
     /**
      * Per-batch local map for resolved (post-substitution) args.

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2250,11 +2250,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * 4. Injected messages from results are collected and returned alongside
    *    ToolMessages (appended AFTER to respect provider ordering).
    */
+  /** Rethrows a stream-limit trip carried on the batch config's composed
+   * signal. Rechecked at each later execution/dispatch stage because a tool
+   * that ignores cancellation can complete normally across the trip, and
+   * the next stage would otherwise start fresh side effects on a failed
+   * run. */
+  private throwIfBreakerTripped(config: RunnableConfig): void {
+    const signal = config.signal;
+    if (
+      signal?.aborted === true &&
+      signal.reason instanceof StreamLimitExceededError
+    ) {
+      throw signal.reason;
+    }
+  }
+
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig,
     batchContext: DispatchBatchContext = {}
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
+    this.throwIfBreakerTripped(config);
     const {
       batchIndices,
       turn,
@@ -3691,6 +3707,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     interruptingPositions.forEach((i, k) => {
       outputs[i] = interruptingOutputs[k];
     });
+
+    /** The breaker can trip while the interrupting group is awaited — e.g.
+     * a tool that ignores cancellation and completes normally. Recheck
+     * before starting the non-idempotent siblings. */
+    this.throwIfBreakerTripped(config);
 
     // No interrupting call suspended — safe to run the remaining siblings.
     const regularOutputs = await Promise.all(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -79,6 +79,7 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { RunnableCallable } from '@/utils';
@@ -1321,6 +1322,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         throw e;
       }
       if (isGraphInterrupt(e)) {
+        throw e;
+      }
+      /**
+       * A stream circuit breaker tripped by a child run (subagent) is a
+       * safety abort, not a tool failure to report back to the model. It
+       * passes through like an interrupt so the whole run rejects.
+       */
+      if (e instanceof StreamLimitExceededError) {
         throw e;
       }
       if (this.errorHandler) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1217,6 +1217,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           (config.configurable?.writer as ToolRuntime<T>['writer']) ??
           null,
       };
+      /** A sibling can trip the breaker while the PreToolUse hooks above
+       * are awaited; a tool that never inspects its runtime signal would
+       * still run. Recheck at the last moment before execution. */
+      this.throwIfBreakerTripped(config);
       const output = await tool.invoke(invokeParams, runtime);
       if (isCommand(output)) {
         return output;
@@ -2995,6 +2999,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
       };
 
+      /** The approval hooks above are awaited; a sibling's trip during them
+       * must stop the approved batch before it reaches a host handler that
+       * may never inspect the request signal. */
+      if (dispatchRequests.length > 0) {
+        this.throwIfBreakerTripped(config);
+      }
       const dispatchPromise =
         dispatchRequests.length === 0
           ? Promise.resolve([] as t.ToolExecuteResult[])

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -79,7 +79,23 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
-import { StreamLimitExceededError } from '@/llm/streamLimits';
+import type { RunBreakerScope } from '@/llm/streamLimits';
+import {
+  StreamLimitExceededError,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
+} from '@/llm/streamLimits';
+
+/** Host-facing batch requests must not carry the batch's breaker scope —
+ * hosts spread `configurable` into their own run configs. */
+function stripRunBreakerScope(
+  configurable: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (configurable == null || !(RUN_BREAKER_SCOPE_CONFIG_KEY in configurable)) {
+    return configurable;
+  }
+  const { [RUN_BREAKER_SCOPE_CONFIG_KEY]: _scope, ...rest } = configurable;
+  return rest;
+}
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { RunnableCallable, composeAbortSignals } from '@/utils';
@@ -639,6 +655,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolExecution?: t.ToolExecutionConfig;
   /** Owning graph's run-scoped breaker signal, composed into each batch's config. */
   private getBreakerSignal?: () => AbortSignal | undefined;
+  /** Owning graph's immutable run scope; captured once per batch. */
+  private getRunScope?: () => RunBreakerScope;
   /**
    * Monotonic counter used to mint a unique scope id for anonymous
    * batches (ones invoked without a `run_id` in
@@ -681,6 +699,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolExecution,
     fileCheckpointer,
     getBreakerSignal,
+    getRunScope,
   }: t.ToolNodeConstructorParams) {
     super({
       name: name ?? TOOL_NODE_RUN_NAME,
@@ -725,6 +744,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.humanInTheLoop = humanInTheLoop;
     this.toolExecution = toolExecution;
     this.getBreakerSignal = getBreakerSignal;
+    this.getRunScope = getRunScope;
     // Caller-provided checkpointer wins. Graphs use this to share a
     // single per-Run instance across every ToolNode they compile so
     // `Run.rewindFiles()` reaches the same snapshot store regardless
@@ -2974,9 +2994,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         dispatchRequests.map((request) => [request.id, request])
       );
       const onResult = (result: t.ToolExecuteResult): void => {
+        /** Runtime-honest widening: hosts may omit the id despite the
+         * field type. */
+        const resultToolCallId = result.toolCallId as string | undefined;
         const request =
-          result.toolCallId != null
-            ? dispatchRequestById.get(result.toolCallId)
+          resultToolCallId != null
+            ? dispatchRequestById.get(resultToolCallId)
             : undefined;
         if (
           request == null ||
@@ -3027,9 +3050,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               // the eager path sends `agentContext.agentId` — this must
               // match it at the top level too.
               agentId: this.executingAgentId,
-              configurable: config.configurable as
-                  | Record<string, unknown>
-                  | undefined,
+              configurable: stripRunBreakerScope(
+                config.configurable as Record<string, unknown> | undefined
+              ),
               metadata: config.metadata as
                   | Record<string, unknown>
                   | undefined,
@@ -3771,8 +3794,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      */
     const breakerSignal = this.getBreakerSignal?.();
     const composedSignal = composeAbortSignals(config.signal, breakerSignal);
-    if (composedSignal !== config.signal) {
-      config = { ...config, signal: composedSignal };
+    /** Immutable batch scope, captured with the signal BEFORE hooks: tools
+     * that spawn runs (subagents) bind their child to this controller, so a
+     * reset during a PreToolUse hook cannot hand them the new run's one. */
+    const batchRunScope = this.getRunScope?.();
+    if (composedSignal !== config.signal || batchRunScope != null) {
+      config = {
+        ...config,
+        signal: composedSignal,
+        ...(batchRunScope != null && {
+          configurable: {
+            ...config.configurable,
+            [RUN_BREAKER_SCOPE_CONFIG_KEY]: batchRunScope,
+          },
+        }),
+      };
     }
     /** Already-tripped-at-entry: a parallel sibling's breach failed the run
      * before this batch was scheduled. Rethrow before hooks, direct

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -474,6 +474,52 @@ describe('SubagentExecutor', () => {
     ).rejects.toBeInstanceOf(StreamLimitExceededError);
   });
 
+  it('trips the breaker controller captured at execution start, not the current one', async () => {
+    const oldRun = new AbortController();
+    const newRun = new AbortController();
+    let current = oldRun;
+    let releaseChild: (() => void) | undefined;
+    const executor = createExecutor({
+      breakerScope: { controller: () => current },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(
+              () =>
+                new Promise((_resolve, reject) => {
+                  releaseChild = (): void =>
+                    reject(
+                      new StreamLimitExceededError({
+                        kind: 'tool_call_args',
+                        limit: 10,
+                        observed: 11,
+                        toolName: 'db_query',
+                      })
+                    );
+                })
+            ),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const pending = executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+    while (releaseChild == null) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    /** The failed run's reset installs a fresh controller while the child
+     * is still settling; the straggler's trip must land on the controller
+     * captured when its execution started. */
+    current = newRun;
+    releaseChild();
+    await expect(pending).rejects.toBeInstanceOf(StreamLimitExceededError);
+    expect(oldRun.signal.aborted).toBe(true);
+    expect(newRun.signal.aborted).toBe(false);
+  });
+
   it('threads run-level streamLimits into every child graph input', async () => {
     const childGraphInputs: StandardGraphInput[] = [];
     const noopFactory = makeNoopGraphFactory();

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -474,6 +474,42 @@ describe('SubagentExecutor', () => {
     ).rejects.toBeInstanceOf(StreamLimitExceededError);
   });
 
+  it('binds the child to the batch-captured controller, not the live scope', async () => {
+    const batchBreaker = new AbortController();
+    const liveBreaker = new AbortController();
+    const executor = createExecutor({
+      breakerScope: { controller: () => liveBreaker },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockRejectedValue(
+              new StreamLimitExceededError({
+                kind: 'tool_call_args',
+                limit: 10,
+                observed: 11,
+                toolName: 'db_query',
+              })
+            ),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    /** `breaker` is the controller the parent TOOL BATCH captured before
+     * PreToolUse hooks; a reset during those hooks replaced the live
+     * scope, and the child must not revive on — or trip — the new run's
+     * controller. */
+    await expect(
+      executor.execute({
+        description: 'Do something',
+        subagentType: 'researcher',
+        breaker: batchBreaker,
+      })
+    ).rejects.toBeInstanceOf(StreamLimitExceededError);
+    expect(batchBreaker.signal.aborted).toBe(true);
+    expect(liveBreaker.signal.aborted).toBe(false);
+  });
+
   it('trips the breaker controller captured at execution start, not the current one', async () => {
     const oldRun = new AbortController();
     const newRun = new AbortController();

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -451,6 +451,27 @@ describe('SubagentExecutor', () => {
     expect(result.messages).toEqual([]);
   });
 
+  it('threads run-level streamLimits into every child graph input', async () => {
+    const childGraphInputs: StandardGraphInput[] = [];
+    const noopFactory = makeNoopGraphFactory();
+    const executor = createExecutor({
+      streamLimits: { maxToolCallArgBytes: 1234, maxDeltaEventsPerTurn: 9 },
+      createChildGraph: (input: StandardGraphInput): StandardGraph => {
+        childGraphInputs.push(input);
+        return noopFactory();
+      },
+    });
+    await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+    expect(childGraphInputs).toHaveLength(1);
+    expect(childGraphInputs[0].streamLimits).toEqual({
+      maxToolCallArgBytes: 1234,
+      maxDeltaEventsPerTurn: 9,
+    });
+  });
+
   it('executes child graph and returns filtered content', async () => {
     const { factory, clearHeavyState } = makeStubGraphFactory({
       messages: [

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../subagent';
 import { sanitizeForwardedSubagentUpdateData } from '../subagent/SubagentExecutor';
 import { Constants, Providers, GraphEvents, StepTypes } from '@/common';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { AgentContext } from '@/agents/AgentContext';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { HandlerRegistry } from '@/events';
@@ -449,6 +450,28 @@ describe('SubagentExecutor', () => {
     });
     expect(result.content).toContain('Maximum subagent nesting depth');
     expect(result.messages).toEqual([]);
+  });
+
+  it('rethrows a child stream-limit trip instead of converting it to a tool result', async () => {
+    const executor = createExecutor({
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockRejectedValue(
+              new StreamLimitExceededError({
+                kind: 'tool_call_args',
+                limit: 10,
+                observed: 11,
+                toolName: 'db_query',
+              })
+            ),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    await expect(
+      executor.execute({ description: 'Do something', subagentType: 'researcher' })
+    ).rejects.toBeInstanceOf(StreamLimitExceededError);
   });
 
   it('threads run-level streamLimits into every child graph input', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -6,7 +6,10 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import * as events from '@/utils/events';
-import { StreamLimitExceededError } from '@/llm/streamLimits';
+import {
+  StreamLimitExceededError,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
+} from '@/llm/streamLimits';
 import { GraphEvents } from '@/common';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
@@ -317,6 +320,48 @@ describe('ToolNode breaker signal composition', () => {
       })
     ).rejects.toBe(trip);
     expect(toolExecuteCalls).toHaveLength(0);
+  });
+
+  it('stamps the batch-entry run scope into tool configs and strips it from host batches', async () => {
+    const scope = Object.freeze({ epoch: 3, controller: new AbortController() });
+    let seenScope: unknown;
+    const capture = {
+      name: 'capture_scope',
+      description: 'captures the batch scope from its config',
+      invoke: async (
+        _params: unknown,
+        config?: { configurable?: Record<string, unknown> }
+      ): Promise<string> => {
+        seenScope = config?.configurable?.[RUN_BREAKER_SCOPE_CONFIG_KEY];
+        return 'ok';
+      },
+    } as unknown as StructuredToolInterface;
+    const node = new ToolNode({
+      tools: [capture],
+      getRunScope: () => scope,
+    });
+
+    await node.invoke({
+      messages: [createToolCallMessage('call_1', 'capture_scope')],
+    });
+    expect(seenScope).toBe(scope);
+
+    /** Host batch requests spread `configurable` into their own run
+     * configs — the scope must not leak there. */
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const eventNode = new ToolNode({
+      tools: [],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      getRunScope: () => scope,
+    });
+    await eventNode.invoke({
+      messages: [createToolCallMessage('call_1', 'remote_tool')],
+    });
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(
+      toolExecuteCalls[0].configurable?.[RUN_BREAKER_SCOPE_CONFIG_KEY]
+    ).toBeUndefined();
   });
 
   it('sends a breaker-composed signal on ON_TOOL_EXECUTE batch requests', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -33,6 +33,20 @@ function createToolCallMessage(id: string, name: string): AIMessage {
   return new AIMessage({ content: '', tool_calls: [{ id, name, args: {} }] });
 }
 
+/** A minimal tool whose invoke ignores the abort signal entirely — unlike
+ * langchain `tool()` Runnables, which race the signal and reject with its
+ * reason the moment a trip fires mid-execution. */
+function createSignalBlindTool(
+  name: string,
+  fn: () => Promise<string>
+): StructuredToolInterface {
+  return {
+    name,
+    description: `signal-blind ${name}`,
+    invoke: fn,
+  } as unknown as StructuredToolInterface;
+}
+
 function installToolExecuteResponder(): {
   toolExecuteCalls: t.ToolExecuteBatchRequest[];
   } {
@@ -149,6 +163,89 @@ describe('ToolNode breaker signal composition', () => {
       })
     ).rejects.toBe(trip);
     expect(toolRan).toBe(false);
+  });
+
+  it('stops regular siblings when an interrupting tool trips the breaker', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    let sideEffectRan = false;
+    /** Plain tool objects, NOT langchain `tool()`: Runnable invokes race
+     * the composed signal and reject with its reason the instant the trip
+     * fires, which would mask the stage boundary this test targets. The
+     * exposure is exactly tools that ignore cancellation. */
+    const tripper = createSignalBlindTool('ask_question', async () => {
+      breaker.abort(trip);
+      return 'completed normally across the trip';
+    });
+    const sideEffect = createSignalBlindTool('send_email', async () => {
+      sideEffectRan = true;
+      return 'sent';
+    });
+    const node = new ToolNode({
+      tools: [tripper, sideEffect],
+      interruptingToolNames: new Set(['ask_question']),
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'ask_question', args: {} },
+              { id: 'call_2', name: 'send_email', args: {} },
+            ],
+          }),
+        ],
+      })
+    ).rejects.toBe(trip);
+    expect(sideEffectRan).toBe(false);
+  });
+
+  it('stops event dispatch when a direct tool trips the breaker mid-batch', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const tripper = createSignalBlindTool('direct_tripper', async () => {
+      breaker.abort(trip);
+      return 'completed normally across the trip';
+    });
+    const node = new ToolNode({
+      tools: [tripper],
+      eventDrivenMode: true,
+      directToolNames: new Set(['direct_tripper']),
+      toolCallStepIds: new Map([
+        ['call_1', 'step_1'],
+        ['call_2', 'step_2'],
+      ]),
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'direct_tripper', args: {} },
+              { id: 'call_2', name: 'remote_tool', args: {} },
+            ],
+          }),
+        ],
+      })
+    ).rejects.toBe(trip);
+    expect(toolExecuteCalls).toHaveLength(0);
   });
 
   it('sends a breaker-composed signal on ON_TOOL_EXECUTE batch requests', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -6,6 +6,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import * as events from '@/utils/events';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { GraphEvents } from '@/common';
 import { ToolNode } from '../ToolNode';
 
@@ -114,6 +115,40 @@ describe('ToolNode breaker signal composition', () => {
     );
 
     expect(observed()).toBe(caller.signal);
+  });
+
+  it('rejects the batch at entry when the breaker has already tripped', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    breaker.abort(trip);
+    let toolRan = false;
+    const sideEffect = tool(
+      async () => {
+        toolRan = true;
+        return 'ran';
+      },
+      {
+        name: 'side_effect',
+        description: 'must never run on a failed run',
+        schema: z.object({}),
+      }
+    ) as unknown as StructuredToolInterface;
+    const node = new ToolNode({
+      tools: [sideEffect],
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [createToolCallMessage('call_1', 'side_effect')],
+      })
+    ).rejects.toBe(trip);
+    expect(toolRan).toBe(false);
   });
 
   it('sends a breaker-composed signal on ON_TOOL_EXECUTE batch requests', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -8,6 +8,7 @@ import type * as t from '@/types';
 import * as events from '@/utils/events';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { GraphEvents } from '@/common';
+import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
 
 function createSignalCaptureTool(name: string): {
@@ -243,6 +244,76 @@ describe('ToolNode breaker signal composition', () => {
             ],
           }),
         ],
+      })
+    ).rejects.toBe(trip);
+    expect(toolExecuteCalls).toHaveLength(0);
+  });
+
+  it('stops a direct tool when the breaker trips during its PreToolUse hook', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    let toolRan = false;
+    const sideEffect = createSignalBlindTool('send_email', async () => {
+      toolRan = true;
+      return 'sent';
+    });
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async () => {
+          breaker.abort(trip);
+          return { decision: 'allow' };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [sideEffect],
+      hookRegistry: registry,
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [createToolCallMessage('call_1', 'send_email')],
+      })
+    ).rejects.toBe(trip);
+    expect(toolRan).toBe(false);
+  });
+
+  it('stops the host batch when the breaker trips during approval hooks', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async () => {
+          breaker.abort(trip);
+          return { decision: 'allow' };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [createToolCallMessage('call_1', 'remote_tool')],
       })
     ).rejects.toBe(trip);
     expect(toolExecuteCalls).toHaveLength(0);

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { GraphEvents } from '@/common';
+import { ToolNode } from '../ToolNode';
+
+function createSignalCaptureTool(name: string): {
+  tool: StructuredToolInterface;
+  observed: () => AbortSignal | undefined;
+} {
+  let signal: AbortSignal | undefined;
+  const captureTool = tool(
+    async (_input, config) => {
+      signal = (config as RunnableConfig | undefined)?.signal;
+      return 'captured';
+    },
+    {
+      name,
+      description: 'captures the abort signal its runtime receives',
+      schema: z.object({}),
+    }
+  ) as unknown as StructuredToolInterface;
+  return { tool: captureTool, observed: () => signal };
+}
+
+function createToolCallMessage(id: string, name: string): AIMessage {
+  return new AIMessage({ content: '', tool_calls: [{ id, name, args: {} }] });
+}
+
+function installToolExecuteResponder(): {
+  toolExecuteCalls: t.ToolExecuteBatchRequest[];
+  } {
+  const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+  jest
+    .spyOn(events, 'safeDispatchCustomEvent')
+    .mockImplementation(async (event, data): Promise<void> => {
+      if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+        return;
+      }
+      const batch = data as t.ToolExecuteBatchRequest;
+      toolExecuteCalls.push(batch);
+      batch.resolve(
+        batch.toolCalls.map((call) => ({
+          toolCallId: call.id,
+          status: 'success' as const,
+          content: `ok ${call.name}`,
+        }))
+      );
+    });
+  return { toolExecuteCalls };
+}
+
+describe('ToolNode breaker signal composition', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('exposes the run breaker to direct tool runtimes', async () => {
+    const breaker = new AbortController();
+    const { tool: capture, observed } = createSignalCaptureTool('capture');
+    const node = new ToolNode({
+      tools: [capture],
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    const result = (await node.invoke({
+      messages: [createToolCallMessage('call_1', 'capture')],
+    })) as { messages: ToolMessage[] };
+
+    expect(result.messages[0].content).toBe('captured');
+    const signal = observed();
+    expect(signal).toBeDefined();
+    expect(signal?.aborted).toBe(false);
+
+    breaker.abort(new Error('stream limit breach'));
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('composes the breaker with the caller signal instead of replacing it', async () => {
+    const breaker = new AbortController();
+    const caller = new AbortController();
+    const { tool: capture, observed } = createSignalCaptureTool('capture');
+    const node = new ToolNode({
+      tools: [capture],
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await node.invoke(
+      { messages: [createToolCallMessage('call_1', 'capture')] },
+      { signal: caller.signal }
+    );
+
+    const signal = observed();
+    expect(signal).toBeDefined();
+    expect(signal?.aborted).toBe(false);
+
+    caller.abort(new Error('caller cancelled'));
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('leaves the caller signal untouched when no breaker accessor is set', async () => {
+    const caller = new AbortController();
+    const { tool: capture, observed } = createSignalCaptureTool('capture');
+    const node = new ToolNode({ tools: [capture] });
+
+    await node.invoke(
+      { messages: [createToolCallMessage('call_1', 'capture')] },
+      { signal: caller.signal }
+    );
+
+    expect(observed()).toBe(caller.signal);
+  });
+
+  it('sends a breaker-composed signal on ON_TOOL_EXECUTE batch requests', async () => {
+    const breaker = new AbortController();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const node = new ToolNode({
+      tools: [],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await node.invoke({
+      messages: [createToolCallMessage('call_1', 'remote_tool')],
+    });
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    const { signal } = toolExecuteCalls[0];
+    expect(signal).toBeDefined();
+    expect(signal?.aborted).toBe(false);
+
+    breaker.abort(new Error('stream limit breach'));
+    expect(signal?.aborted).toBe(true);
+  });
+});

--- a/src/tools/__tests__/ToolNode.streamLimits.test.ts
+++ b/src/tools/__tests__/ToolNode.streamLimits.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `StreamLimitExceededError` must pass through ToolNode's tool-error
+ * conversion like a `GraphInterrupt`: a child run (subagent) that trips a
+ * stream circuit breaker is a safety abort, and converting it into an error
+ * ToolMessage would let the parent keep generating after the limit fired.
+ */
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
+import { ToolNode } from '@/tools/ToolNode';
+
+const stateWith = (name: string): { messages: AIMessage[] } => ({
+  messages: [
+    new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'call_1', name, args: { command: 'x' } }],
+    }),
+  ],
+});
+
+describe('ToolNode stream-limit passthrough', () => {
+  it('rethrows StreamLimitExceededError instead of converting it to a ToolMessage', async () => {
+    const limitBoom = tool(
+      async () => {
+        throw new StreamLimitExceededError({
+          kind: 'tool_call_args',
+          limit: 10,
+          observed: 11,
+          toolName: 'db_query',
+        });
+      },
+      {
+        name: 'limitBoom',
+        description: 'tool that trips a stream limit',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const node = new ToolNode({ tools: [limitBoom] });
+    await expect(
+      node.invoke(stateWith('limitBoom'), {
+        configurable: { run_id: 'limit-run' },
+      })
+    ).rejects.toBeInstanceOf(StreamLimitExceededError);
+  });
+
+  it('still converts ordinary tool errors to error ToolMessages', async () => {
+    const plainBoom = tool(
+      async () => {
+        throw new Error('ordinary failure');
+      },
+      {
+        name: 'plainBoom',
+        description: 'tool that throws a normal error',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    const node = new ToolNode({ tools: [plainBoom] });
+    const result = (await node.invoke(stateWith('plainBoom'), {
+      configurable: { run_id: 'plain-run' },
+    })) as { messages: Array<{ content: unknown; status?: string }> };
+    expect(result.messages).toHaveLength(1);
+    expect(String(result.messages[0].content)).toContain('ordinary failure');
+  });
+});

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -28,6 +28,7 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
 import { Constants, GraphEvents, Callback, StepTypes } from '@/common';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
@@ -537,6 +538,16 @@ export class SubagentExecutor {
         });
       }
       childGraph.clearHeavyState();
+      /**
+       * A tripped stream circuit breaker is a safety abort, not a recoverable
+       * subagent failure: converting it into a tool result would let the
+       * parent keep generating (or spawn another child) after the limit
+       * fired. Rethrown here and passed through ToolNode's error conversion,
+       * so the parent run rejects with the child's limit error.
+       */
+      if (error instanceof StreamLimitExceededError) {
+        throw error;
+      }
       return {
         content: `Subagent error: ${errorMessage}`,
         messages: [],

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -264,6 +264,12 @@ export type SubagentExecutorOptions = {
 export class SubagentExecutor {
   private readonly configs: Map<string, ResolvedSubagentConfig>;
   private readonly parentSignal?: AbortSignal;
+  /** Aborted when a child trips a stream circuit breaker: parallel sibling
+   * subagents run concurrently on the parent's signal, and rejecting the
+   * batch alone would leave their provider requests streaming after the
+   * safety abort. One-way by design — a tripped breaker ends the run, so no
+   * later child of this executor should start either. */
+  private readonly childRunAbort = new AbortController();
   private readonly hookRegistry?: HookRegistry;
   private readonly parentRunId: string;
   private readonly parentAgentId?: string;
@@ -295,6 +301,17 @@ export class SubagentExecutor {
     } else if (rawRegistry != null) {
       this.resolveParentHandlerRegistry = (): HandlerRegistry => rawRegistry;
     }
+  }
+
+  /** One signal that fires on the parent's abort or the executor's own
+   * breaker abort, collapsed to a single signal when possible (mirrors
+   * `composeAbortSignals` in Graph.ts). */
+  private resolveChildSignal(): AbortSignal {
+    const child = this.childRunAbort.signal;
+    if (this.parentSignal == null || this.parentSignal === child) {
+      return child;
+    }
+    return AbortSignal.any([this.parentSignal, child]);
   }
 
   /** Snapshot of the parent's registry at the moment a subagent is dispatched. */
@@ -381,7 +398,7 @@ export class SubagentExecutor {
     const hostUsageSink = this.usageSink;
     const childGraph = this.createChildGraph({
       runId: childRunId,
-      signal: this.parentSignal,
+      signal: this.resolveChildSignal(),
       agents: [childInputs],
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
@@ -514,7 +531,7 @@ export class SubagentExecutor {
         { messages: [new HumanMessage(description)] },
         {
           recursionLimit: maxTurns * RECURSION_MULTIPLIER,
-          signal: this.parentSignal,
+          signal: this.resolveChildSignal(),
           callbacks,
           runName: `subagent:${subagentType}`,
           configurable: {
@@ -546,6 +563,10 @@ export class SubagentExecutor {
        * so the parent run rejects with the child's limit error.
        */
       if (error instanceof StreamLimitExceededError) {
+        /** Stop concurrently running sibling subagents before failing the
+         * batch; they stream on the composed child signal and would
+         * otherwise keep consuming provider quota after the safety abort. */
+        this.childRunAbort.abort(error);
         throw error;
       }
       return {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -217,13 +217,14 @@ export type SubagentExecutorOptions = {
   parentSignal?: AbortSignal;
   /** Run-scoped breaker abort shared by every executor of one graph, so a
    * child tripping a stream limit stops subagents running under OTHER
-   * parallel agent nodes too. Accessors rather than a captured controller:
-   * the graph recreates its controller per run, and children must always
-   * compose against the current one. Absent (tests, minimal hosts), the
-   * executor falls back to its own private controller. */
+   * parallel agent nodes too. An accessor rather than a captured controller:
+   * the graph recreates its controller per run, and each execution must
+   * bind to the controller current when it STARTS — signal and trip target
+   * together, so a straggler from a failed run can neither revive on nor
+   * circuit-break a later run's controller. Absent (tests, minimal hosts),
+   * the executor falls back to its own private controller. */
   breakerScope?: {
-    signal: () => AbortSignal;
-    trip: (reason: unknown) => void;
+    controller: () => AbortController;
   };
   hookRegistry?: HookRegistry;
   parentRunId: string;
@@ -316,24 +317,21 @@ export class SubagentExecutor {
     }
   }
 
-  /** One signal that fires on the parent's abort or the breaker-scope abort,
-   * collapsed to a single signal when possible (mirrors
-   * `composeAbortSignals` in Graph.ts). The scope signal is read per spawn
+  /** The breaker controller current for this execution — read per spawn
    * because the graph recreates its controller each run. */
-  private resolveChildSignal(): AbortSignal {
-    const child = this.breakerScope?.signal() ?? this.childRunAbort.signal;
+  private resolveBreakerController(): AbortController {
+    return this.breakerScope?.controller() ?? this.childRunAbort;
+  }
+
+  /** One signal that fires on the parent's abort or the breaker abort,
+   * collapsed to a single signal when possible (mirrors
+   * `composeAbortSignals` in Graph.ts). */
+  private composeChildSignal(breaker: AbortController): AbortSignal {
+    const child = breaker.signal;
     if (this.parentSignal == null || this.parentSignal === child) {
       return child;
     }
     return AbortSignal.any([this.parentSignal, child]);
-  }
-
-  private tripBreakerScope(reason: unknown): void {
-    if (this.breakerScope != null) {
-      this.breakerScope.trip(reason);
-      return;
-    }
-    this.childRunAbort.abort(reason);
   }
 
   /** Snapshot of the parent's registry at the moment a subagent is dispatched. */
@@ -344,11 +342,13 @@ export class SubagentExecutor {
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
     const { description, subagentType, threadId, parentToolCallId } = params;
     /** Captured ONCE per execution: a failed run's graph reset replaces the
-     * breaker controller, and a straggling execution that re-resolved the
-     * signal later (e.g. after a slow start-update handler) would read the
-     * NEW run's un-aborted controller and revive old-run work. Binding to
-     * the controller active at execution start keeps old work cancelled. */
-    const childSignal = this.resolveChildSignal();
+     * breaker controller, and a straggling execution that re-resolved it
+     * later (e.g. after a slow start-update handler) would read the NEW
+     * run's un-aborted controller — reviving old-run work, or worse,
+     * tripping the new run's breaker from an old child's stream-limit
+     * breach. Signal and trip target both bind to this capture. */
+    const childBreaker = this.resolveBreakerController();
+    const childSignal = this.composeChildSignal(childBreaker);
     const config = this.configs.get(subagentType);
 
     if (!config) {
@@ -573,9 +573,11 @@ export class SubagentExecutor {
        * this executor and, via the graph-scoped breaker, under other
        * parallel agent nodes — stream on the composed child signal, and
        * awaiting forwarding.drain() first would let them consume provider
-       * quota for that entire interval. */
+       * quota for that entire interval. Trips the ENTRY-captured controller:
+       * after a reset, a straggler must break its own dead run, not the
+       * current one. */
       if (error instanceof StreamLimitExceededError) {
-        this.tripBreakerScope(error);
+        childBreaker.abort(error);
       }
       const errorMessage = truncateErrorMessage(error);
       if (forwarding) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -215,6 +215,16 @@ export type ChildGraphFactory = (input: StandardGraphInput) => StandardGraph;
 export type SubagentExecutorOptions = {
   configs: Map<string, ResolvedSubagentConfig>;
   parentSignal?: AbortSignal;
+  /** Run-scoped breaker abort shared by every executor of one graph, so a
+   * child tripping a stream limit stops subagents running under OTHER
+   * parallel agent nodes too. Accessors rather than a captured controller:
+   * the graph recreates its controller per run, and children must always
+   * compose against the current one. Absent (tests, minimal hosts), the
+   * executor falls back to its own private controller. */
+  breakerScope?: {
+    signal: () => AbortSignal;
+    trip: (reason: unknown) => void;
+  };
   hookRegistry?: HookRegistry;
   parentRunId: string;
   parentAgentId?: string;
@@ -268,8 +278,10 @@ export class SubagentExecutor {
    * subagents run concurrently on the parent's signal, and rejecting the
    * batch alone would leave their provider requests streaming after the
    * safety abort. One-way by design — a tripped breaker ends the run, so no
-   * later child of this executor should start either. */
+   * later child of this executor should start either. Fallback for hosts
+   * that do not supply the graph's shared `breakerScope`. */
   private readonly childRunAbort = new AbortController();
+  private readonly breakerScope?: SubagentExecutorOptions['breakerScope'];
   private readonly hookRegistry?: HookRegistry;
   private readonly parentRunId: string;
   private readonly parentAgentId?: string;
@@ -286,6 +298,7 @@ export class SubagentExecutor {
   constructor(options: SubagentExecutorOptions) {
     this.configs = options.configs;
     this.parentSignal = options.parentSignal;
+    this.breakerScope = options.breakerScope;
     this.hookRegistry = options.hookRegistry;
     this.parentRunId = options.parentRunId;
     this.parentAgentId = options.parentAgentId;
@@ -303,15 +316,24 @@ export class SubagentExecutor {
     }
   }
 
-  /** One signal that fires on the parent's abort or the executor's own
-   * breaker abort, collapsed to a single signal when possible (mirrors
-   * `composeAbortSignals` in Graph.ts). */
+  /** One signal that fires on the parent's abort or the breaker-scope abort,
+   * collapsed to a single signal when possible (mirrors
+   * `composeAbortSignals` in Graph.ts). The scope signal is read per spawn
+   * because the graph recreates its controller each run. */
   private resolveChildSignal(): AbortSignal {
-    const child = this.childRunAbort.signal;
+    const child = this.breakerScope?.signal() ?? this.childRunAbort.signal;
     if (this.parentSignal == null || this.parentSignal === child) {
       return child;
     }
     return AbortSignal.any([this.parentSignal, child]);
+  }
+
+  private tripBreakerScope(reason: unknown): void {
+    if (this.breakerScope != null) {
+      this.breakerScope.trip(reason);
+      return;
+    }
+    this.childRunAbort.abort(reason);
   }
 
   /** Snapshot of the parent's registry at the moment a subagent is dispatched. */
@@ -541,6 +563,14 @@ export class SubagentExecutor {
         }
       );
     } catch (error) {
+      /** Aborted before any observational work below: parallel siblings — in
+       * this executor and, via the graph-scoped breaker, under other
+       * parallel agent nodes — stream on the composed child signal, and
+       * awaiting forwarding.drain() first would let them consume provider
+       * quota for that entire interval. */
+      if (error instanceof StreamLimitExceededError) {
+        this.tripBreakerScope(error);
+      }
       const errorMessage = truncateErrorMessage(error);
       if (forwarding) {
         await forwarding.drain();
@@ -563,10 +593,6 @@ export class SubagentExecutor {
        * so the parent run rejects with the child's limit error.
        */
       if (error instanceof StreamLimitExceededError) {
-        /** Stop concurrently running sibling subagents before failing the
-         * batch; they stream on the composed child signal and would
-         * otherwise keep consuming provider quota after the safety abort. */
-        this.childRunAbort.abort(error);
         throw error;
       }
       return {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -343,6 +343,12 @@ export class SubagentExecutor {
 
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
     const { description, subagentType, threadId, parentToolCallId } = params;
+    /** Captured ONCE per execution: a failed run's graph reset replaces the
+     * breaker controller, and a straggling execution that re-resolved the
+     * signal later (e.g. after a slow start-update handler) would read the
+     * NEW run's un-aborted controller and revive old-run work. Binding to
+     * the controller active at execution start keeps old work cancelled. */
+    const childSignal = this.resolveChildSignal();
     const config = this.configs.get(subagentType);
 
     if (!config) {
@@ -420,7 +426,7 @@ export class SubagentExecutor {
     const hostUsageSink = this.usageSink;
     const childGraph = this.createChildGraph({
       runId: childRunId,
-      signal: this.resolveChildSignal(),
+      signal: childSignal,
       agents: [childInputs],
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
@@ -553,7 +559,7 @@ export class SubagentExecutor {
         { messages: [new HumanMessage(description)] },
         {
           recursionLimit: maxTurns * RECURSION_MULTIPLIER,
-          signal: this.resolveChildSignal(),
+          signal: childSignal,
           callbacks,
           runName: `subagent:${subagentType}`,
           configurable: {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -28,7 +28,10 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
 import { Constants, GraphEvents, Callback, StepTypes } from '@/common';
-import { StreamLimitExceededError } from '@/llm/streamLimits';
+import {
+  StreamLimitExceededError,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
+} from '@/llm/streamLimits';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
@@ -158,6 +161,14 @@ export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
   threadId?: string;
+  /**
+   * Breaker controller captured at the parent TOOL BATCH's entry, before
+   * PreToolUse hooks. Preferred over the live scope accessor: a graph reset
+   * during a hook would otherwise bind this child to the NEW run's
+   * controller — reviving it on a fresh signal and letting its trips cancel
+   * unrelated work.
+   */
+  breaker?: AbortController;
   /**
    * Parent-side `tool_call_id` of the `subagent` tool invocation that
    * triggered this execution. Surfaced on {@link SubagentUpdateEvent} so
@@ -341,13 +352,14 @@ export class SubagentExecutor {
 
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
     const { description, subagentType, threadId, parentToolCallId } = params;
-    /** Captured ONCE per execution: a failed run's graph reset replaces the
-     * breaker controller, and a straggling execution that re-resolved it
-     * later (e.g. after a slow start-update handler) would read the NEW
-     * run's un-aborted controller — reviving old-run work, or worse,
-     * tripping the new run's breaker from an old child's stream-limit
-     * breach. Signal and trip target both bind to this capture. */
-    const childBreaker = this.resolveBreakerController();
+    /** Captured ONCE per execution, preferring the controller the parent
+     * tool batch captured at ITS entry (before PreToolUse hooks): a failed
+     * run's graph reset replaces the live controller, and resolving it here
+     * — after the hook awaits — would bind this child to the NEW run's
+     * un-aborted controller: reviving old-run work, or worse, tripping the
+     * new run's breaker from an old child's stream-limit breach. Signal and
+     * trip target both bind to this capture. */
+    const childBreaker = params.breaker ?? this.resolveBreakerController();
     const childSignal = this.composeChildSignal(childBreaker);
     const config = this.configs.get(subagentType);
 
@@ -1034,7 +1046,10 @@ function sanitizeChildConfigurable(
 function isLangGraphRuntimeConfigKey(key: string): boolean {
   return (
     key.startsWith(LANGGRAPH_RUNTIME_CONFIG_PREFIX) ||
-    LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key)
+    LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key) ||
+    /** The parent batch's breaker scope must not leak into the child
+     * workflow's configurable — children own separate controllers. */
+    key === RUN_BREAKER_SCOPE_CONFIG_KEY
   );
 }
 

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -219,6 +219,15 @@ export type SubagentExecutorOptions = {
   parentAgentId?: string;
   langfuse?: StandardGraphInput['langfuse'];
   tokenCounter?: TokenCounter;
+  /**
+   * Run-level stream circuit breakers, forwarded into every child graph so
+   * a host raising, lowering, or disabling the limits governs subagents too.
+   * Child model calls run through `attemptInvoke`'s local stream handler
+   * (children have no registered dispatcher), which enforces the child
+   * graph's own resolved limits; without this the child would silently
+   * revert to the defaults.
+   */
+  streamLimits?: StandardGraphInput['streamLimits'];
   /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
   /**
@@ -259,6 +268,7 @@ export class SubagentExecutor {
   private readonly parentAgentId?: string;
   private readonly langfuse?: StandardGraphInput['langfuse'];
   private readonly tokenCounter?: TokenCounter;
+  private readonly streamLimits?: StandardGraphInput['streamLimits'];
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
   private readonly usageSink?: SubagentUsageSink;
@@ -274,6 +284,7 @@ export class SubagentExecutor {
     this.parentAgentId = options.parentAgentId;
     this.langfuse = options.langfuse;
     this.tokenCounter = options.tokenCounter;
+    this.streamLimits = options.streamLimits;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
     this.usageSink = options.usageSink;
@@ -373,6 +384,7 @@ export class SubagentExecutor {
       agents: [childInputs],
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
+      streamLimits: this.streamLimits,
       subagentScope: true,
       /**
        * Forwarded so the child graph's own `SubagentExecutor` (created in

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -32,6 +32,7 @@ import type {
 } from '@/types/stream';
 import type {
   TokenCounter,
+  StreamLimits,
   StreamPreemption,
   TokenBudgetBreakdown,
 } from '@/types/run';
@@ -357,6 +358,12 @@ export type StandardGraphInput = {
    * this field.
    */
   preemption?: StreamPreemption;
+  /**
+   * Stream circuit breakers, forwarded from `RunConfig.streamLimits` and
+   * resolved once at graph construction. Enforced by the stream handler on
+   * every streamed chunk event. See {@link StreamLimits}.
+   */
+  streamLimits?: StreamLimits;
 };
 
 export type GraphEdge = {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -28,7 +28,13 @@ export type BaseGraphConfig = {
 };
 export type LegacyGraphConfig = BaseGraphConfig & {
   type?: 'standard';
-} & Omit<g.StandardGraphInput, 'provider' | 'clientOptions' | 'agents'> &
+} & Omit<
+    g.StandardGraphInput,
+    /** `streamLimits` is excluded because legacy graphs receive limits only
+     * via the top-level `RunConfig.streamLimits`; accepting the field here
+     * would type-check but be silently ignored by `createLegacyGraph`. */
+    'provider' | 'clientOptions' | 'agents' | 'streamLimits'
+  > &
   Omit<g.AgentInputs, 'provider' | 'clientOptions' | 'agentId'>;
 
 /* Supervised graph (opt-in) */

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -190,6 +190,17 @@ export interface StreamLimits {
    */
   maxToolCallArgBytes?: number;
   /**
+   * Per-tool overrides for `maxToolCallArgBytes`, keyed by the model-facing
+   * tool name. A matching entry replaces the global cap for that tool's
+   * calls (`0` disables the guard for that tool only). Tools that
+   * legitimately stream whole documents as arguments (e.g. file creation)
+   * can run with a higher cap without loosening every other tool's guard.
+   * Calls whose tool name has not yet arrived on the stream use the global
+   * cap; providers send the name in the first chunk, so this only matters
+   * for malformed streams.
+   */
+  maxToolCallArgBytesByTool?: Record<string, number>;
+  /**
    * Max streamed chunk events a single model generation (turn) may emit
    * before the run is aborted. Defense in depth against looping or
    * duplicated provider streams that a byte limit cannot see (e.g. endless

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -174,6 +174,30 @@ export type PreemptStats = {
   emptyBoundaries: number;
 };
 
+/**
+ * Circuit breakers for pathological model streams. A malformed generation
+ * can stream a single tool call's arguments for many minutes while they
+ * never become executable (observed live: one 149,923-char SQL argument
+ * streamed for 26 minutes before the 64k output-token ceiling ended the
+ * run). When a limit trips, the run aborts with a `StreamLimitExceededError`
+ * and the in-flight provider request is torn down mid-stream.
+ */
+export interface StreamLimits {
+  /**
+   * Max cumulative UTF-8 bytes a single streamed tool call's arguments may
+   * reach before the run is aborted. Defaults to
+   * `DEFAULT_MAX_TOOL_CALL_ARG_BYTES` (64 KiB); `0` disables the guard.
+   */
+  maxToolCallArgBytes?: number;
+  /**
+   * Max streamed chunk events a single model generation (turn) may emit
+   * before the run is aborted. Defense in depth against looping or
+   * duplicated provider streams that a byte limit cannot see (e.g. endless
+   * empty chunks). Disabled by default; `0` also disables.
+   */
+  maxDeltaEventsPerTurn?: number;
+}
+
 export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
@@ -213,6 +237,13 @@ export type RunConfig = {
    * tool boundary.
    */
   preemption?: StreamPreemption;
+  /**
+   * Circuit breakers for pathological model streams (runaway tool-call
+   * argument generation, looping delta streams). Omit for defaults: the
+   * tool-call argument byte cap is ON by default, the per-turn event cap is
+   * opt-in. See {@link StreamLimits}.
+   */
+  streamLimits?: StreamLimits;
   returnContent?: boolean;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -3,6 +3,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { MessageContentComplex, ToolErrorData } from './stream';
 import type { HumanInTheLoopConfig } from './hitl';
 import type { LangfuseConfig } from './graph';
@@ -266,6 +267,13 @@ export type ToolNodeOptions = {
    * trips elsewhere in the run.
    */
   getBreakerSignal?: () => AbortSignal | undefined;
+  /**
+   * Returns the owning graph's immutable run scope. Read once per batch,
+   * BEFORE hooks, and threaded to tools that spawn runs (subagents) so a
+   * reset during a hook cannot rebind their children to a newer run's
+   * controller.
+   */
+  getRunScope?: () => RunBreakerScope;
 };
 
 export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -259,6 +259,13 @@ export type ToolNodeOptions = {
    * `resolveLocalExecutionTools`.
    */
   fileCheckpointer?: LocalFileCheckpointer;
+  /**
+   * Returns the owning graph's run-scoped breaker signal. Read once per
+   * `run()` invocation and composed into the batch config's `signal`, so
+   * every tool execution in the batch aborts when a stream circuit breaker
+   * trips elsewhere in the run.
+   */
+  getBreakerSignal?: () => AbortSignal | undefined;
 };
 
 export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;
@@ -523,6 +530,12 @@ export type ToolExecuteBatchRequest = {
   configurable?: Record<string, unknown>;
   /** Runtime metadata from RunnableConfig (includes thread_id, run_id, provider, etc.) */
   metadata?: Record<string, unknown>;
+  /**
+   * Aborts when the run is cancelled or its stream circuit breaker trips.
+   * Handlers SHOULD forward this to their tool executions so in-flight work
+   * stops consuming quota once the run is already failing.
+   */
+  signal?: AbortSignal;
   /** Promise resolver - handler calls this with ALL results */
   resolve: (results: ToolExecuteResult[]) => void;
   /** Promise rejector - handler calls this on fatal error */

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -73,3 +73,22 @@ export function unescapeObject(obj: unknown, key?: string): unknown {
   }
   return obj;
 }
+
+/**
+ * One signal that fires when either input fires. `AbortSignal.any` is skipped
+ * when the inputs collapse to a single signal — the composite is a fresh
+ * object per call, and the common cases (one channel, or the host reusing the
+ * same controller for both) don't need one.
+ */
+export function composeAbortSignals(
+  a: AbortSignal | undefined,
+  b: AbortSignal | undefined
+): AbortSignal | undefined {
+  if (a == null || a === b) {
+    return b;
+  }
+  if (b == null) {
+    return a;
+  }
+  return AbortSignal.any([a, b]);
+}


### PR DESCRIPTION
## Summary

Production incident: a model streamed a single malformed tool-call argument (a SQL query with 5,708 quoted table names) to 149,923 characters over 26m26s, never completing it, until the 64k output-token ceiling ended the run (~$2.56, ~40 events/sec of sustained stream traffic). Nothing bounded a single tool call's streamed argument growth mid-flight: the truncation guard (#280) fires only after the stop signal, and the eager divergence breaker (#368) addresses correctness, not size.

This adds circuit breakers at the point where streamed tool-call chunks enter the graph, and a run-wide abort that stops parallel branches, tools, subagents, and summarization once any breaker trips.

## Configuration

New `RunConfig.streamLimits` (threaded to the graph like `preemption`, resolved once at construction):

- `maxToolCallArgBytes`: max cumulative UTF-8 bytes a single streamed tool call's arguments may reach. **Default ON at 64 KiB** (`DEFAULT_MAX_TOOL_CALL_ARG_BYTES`); `0`/negative/`Infinity` disables, `NaN` falls back to the default.
- `maxToolCallArgBytesByTool`: per-tool overrides keyed by model-facing tool name (e.g. raise `create_file` while keeping the global default). Resolved from the call's accumulated name at check time; prototype-safe lookup; `0` disables per tool. Works with the global cap disabled.
- `maxDeltaEventsPerTurn`: max streamed chunk events per model generation. Defense in depth for pathologies a byte cap cannot see, e.g. a provider stream looping on empty chunks. **Opt-in (default off)**.

On breach the SDK throws `StreamLimitExceededError` (exported; carries `kind`, `limit`, `observed`, `toolName`) out of the run's `streamEvents` loop, which cancels the stream reader and langgraph aborts the in-flight provider call. The error is non-retryable by design: it rethrows past provider fallbacks and summarization recovery, so a succeeding fallback can never resolve a run that must reject.

## Enforcement

One shared accounting primitive (`enforceStreamLimitsForWireChunk`) covers all five dispatch paths: the registered stream handler, both producer loops in `attemptInvoke`, the replay-skip arm, and the summarization `onChunk` handler. Charging is claim-based per chunk object and generation (producer/consumer sides balance a signed credit), so the same emission is counted exactly once no matter which path sees it first.

Byte tallies are keyed per generation (`checkpoint_ns|node|step|attempt`, so fallback attempts never inherit a failed primary's bytes) and per call through a namespaced identity system: index, id, and batch-position identities with alias registration and guarded adoption, covering every identifier transition adapters exhibit (drop/add id or index, empty-string placeholder ids, name fragments, id-correlated parsed calls, cumulative seal restatements from the OpenAI Responses/Bedrock/Google adapters). Ambiguous identifier-less continuations in parallel batches charge every live candidate under each candidate's own per-tool limit; a sole live call keeps its budget continuous.

## Run-wide halt

A run-scoped `breakerAbort` controller is composed into every model invocation, tool batch, subagent child, and summarization attempt. The lifecycle is pinned by four invariants:

- captured at entry (model node, summarize node, ToolNode batch, subagent execute), so resets can never rebind in-flight work to a fresh controller
- already-tripped rejection at entry plus rechecks after every await window (pre-invoke, hook boundaries, interrupt-group boundary, host batch dispatch, eager dispatch, fallback loop), so providers, tools, and host handlers that ignore abort signals cannot start new work on a failed run
- replaced unconditionally at run start, never mid-run or in cleanup; stream-limit accounting also survives `clearHeavyState` so straggling attempts stay bound to their original budgets
- consumer-side trips are epoch-gated (`STREAM_LIMIT_EPOCH_KEY` stamped per attempt): a straggler from a failed run can neither trip nor consult the controller serving a newer run, and its stale events are dropped before content or eager handling

All three `attemptInvoke` drain loops also check the composed signal per yielded chunk, so a cancellation-ignoring adapter stops consuming the provider stream within one chunk of a trip. `ToolExecuteBatchRequest` gains an optional `signal` hosts can forward to their tool executions.

## Perf notes

- Byte guard: one `Map` get (+ one set on first chunk of a call) and one `Buffer.byteLength` over just the new chunk per event. No re-scan of accumulated args.
- Claim accounting only engages when a chunk carries tool payloads or the event cap is on; fully disabled guards skip all bookkeeping (no generation keys, no WeakMap entries).
- Breaker checks are single aborted-flag reads per site; signal composition collapses to the lone signal when only one channel is present.

## Incident impact

With the 64 KiB default, the incident run would have aborted after ~16k output tokens instead of 64k: roughly 1/4 of the cost and wall time, with a clear error instead of 26 minutes of silence.

## Tests

101 tests across the dedicated breaker suites:

- `src/llm/streamLimits.test.ts`: resolution semantics, accumulation, UTF-8 and split-surrogate byte counting, identity keys and aliases.
- `src/__tests__/stream.streamLimits.test.ts`: real `ChatModelStreamHandler` end-to-end; default trip, per-tool overrides, parallel budgets, seal shapes, parsed-call correlation, ambiguous sparse deltas, epoch gating, disabled-path zero allocation.
- `src/summarization/chunkHandler.test.ts`: summary-stream enforcement, producer/consumer claim pairing, breach trips.
- `src/tools/__tests__/ToolNode.breakerSignal.test.ts`: batch signal composition, entry rejection, stage rechecks (signal-blind tools).
- `src/graphs/__tests__/Graph.breakerLifecycle.test.ts`: per-run controller replacement, entry rejection, accounting survival through cleanup.

Plus breaker/limits regression tests added to the eager-execution, summarize-node, subagent, and invoke suites. Full sweep passes (2,259 tests; only key-gated live provider specs excluded locally).
