### PR TITLE
📝 docs: Strengthen /mnt/data Persistence Steering in Sandbox Tool Guidance

### DIFF
--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -23,7 +23,7 @@ export const emptyOutputMessage =
   'stdout: Empty. Ensure you\'re writing output explicitly.\n';
 
 export const CODE_ARTIFACT_PATH_GUIDANCE =
-  'Persist handoff artifacts in `/mnt/data` with standard extensions (.json/.txt/.csv/.tsv/.log/.parquet/.png/.jpg/.pdf/.xlsx); failed executions do not register new files; `/tmp` and odd extensions are same-call scratch only, not later-call storage.';
+  'Anything a later call needs (data, helper scripts/modules, partial results) MUST be written under `/mnt/data` in the same call that produces it; `/tmp` never survives the call. `/mnt/data` keeps files with recognized extensions, covering common source, text, data, document, image, and archive formats (.py/.sh/.sql/.md/.json/.csv/.parquet/.png/.pdf/.zip and similar); extensionless or unusual extensions are not kept. Failed executions register nothing; fix the error and rerun before relying on new files.';
 
 export const BASH_SHELL_GUIDANCE =
   'Bash: multi-line files use heredoc/printf; run Python via python3 -c/heredoc, not bare Python.';

--- a/src/tools/__tests__/BashExecutor.test.ts
+++ b/src/tools/__tests__/BashExecutor.test.ts
@@ -24,9 +24,9 @@ describe('buildBashExecutionToolDescription', () => {
     expect(BashExecutionToolDescription).toContain('heredoc/printf');
     expect(BashExecutionToolDescription).toContain('not bare Python');
     expect(BashExecutionToolDescription).toContain(
-      'failed executions do not register new files'
+      'Failed executions register nothing'
     );
-    expect(BashExecutionToolDescription).toContain('not later-call storage');
+    expect(BashExecutionToolDescription).toContain('`/tmp` never survives the call');
   });
 
   it('appends the tool-output references guide when enabled', () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -51,10 +51,8 @@ describe('ProgrammaticToolCalling', () => {
       expect(description).toContain('raw=$(tool');
       expect(description).toContain('direct tool > file may be empty');
       expect(description).toContain('/mnt/data/sf.json');
-      expect(description).toContain(
-        'failed executions do not register new files'
-      );
-      expect(description).toContain('not later-call storage');
+      expect(description).toContain('Failed executions register nothing');
+      expect(description).toContain('`/tmp` never survives the call');
     });
   });
 


### PR DESCRIPTION
## Summary

A production session showed a model writing helper files to `/tmp` in one `bash_tool` call and reading them in the next, despite the guidance already documenting that `/tmp` is same-call scratch. The documentation existed but did not steer: the persistence rule sat in a trailing clause, the extension examples covered only ten data formats (.json/.txt/.csv/.tsv/.log/.parquet/.png/.jpg/.pdf/.xlsx), and everything else was dismissed as "odd extensions."

That narrow list is also wrong in a way that discourages the correct pattern. The code API's output-collection filter accepts all common source, text, data, document, image, and archive formats (~100 extensions including .py/.sh/.sql/.md), so writing a helper module to /mnt/data/lib.py and importing it in later calls works and is exactly what a model should do for multi-call workflows. The old wording implied it would not persist.

## Changes

`CODE_ARTIFACT_PATH_GUIDANCE` (interpolated into the code, bash, and PTC tool descriptions) now:
- Leads with the imperative rule: anything a later call needs must be written under `/mnt/data` in the same call that produces it; `/tmp` never survives the call.
- Gives representative extension examples grounded in the actual output filter (.py/.sh/.sql/.md/.json/.csv/.parquet/.png/.pdf/.zip and similar) and states the real rule: extensionless or unrecognized extensions are not kept.
- Keeps the failed-execution warning, phrased as an action: failed executions register nothing; fix and rerun.

The reactive output reminder (`appendTmpScratchReminder`) already fires on all three executor paths and is unchanged; this PR sharpens the plan-time text those reminders back up.

## Tests

Two literal-substring assertions updated to the new phrasing (`BashExecutor.test.ts`, `ProgrammaticToolCalling.test.ts`). Full `src/tools/__tests__` suite: 936 passed.