### PR TITLE
v3.3.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.11",
+      "version": "3.3.12",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## v3.3.12

I bumped `@librechat/agents` to `v3.3.12` and included every change merged since `v3.3.11`.

Patch release:

- [📝 docs: Strengthen /mnt/data Persistence Steering in Sandbox Tool Guidance](https://github.com/danny-avila/agents/pull/382) — strengthens plan-time guidance so persistent artifacts and helper files are written under `/mnt/data`, while clarifying which outputs survive and that failed executions register nothing
- [🩹 fix: Guard Optional input_tokens_details in Responses Cache-Write Extraction](https://github.com/danny-avila/agents/pull/380) — prevents OpenAI-compatible providers that omit `input_tokens_details` from crashing cache-write usage extraction
- [🔌 feat(search): Allow Callers to Inject an HTTP(s) Agent for Outbound Requests](https://github.com/danny-avila/agents/pull/377) — lets hosts inject HTTP and HTTPS agents across search, scraping, and reranking requests without changing default behavior
- [fix(tools): match proxy agent to the PROXY scheme and honour NO_PROXY](https://github.com/danny-avila/agents/pull/379) — selects the proxy agent by scheme and respects `NO_PROXY` across code-execution tool requests
- [🚦 feat: Circuit-Break Runaway Streamed Tool-Call Arguments](https://github.com/danny-avila/agents/pull/381) — adds run-scoped streamed tool-call limits and aborts parallel model, tool, subagent, and summarization work when a circuit breaker trips

**Full Changelog**: https://github.com/danny-avila/agents/compare/v3.3.11...v3.3.12

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Verified `package.json` and both root version fields in `package-lock.json` resolve to `3.3.12`.
- Ran `npm run build` successfully after installing the dependencies pinned by the lockfile.
- Confirmed the committed diff contains only the intended version changes in `package.json` and `package-lock.json`.

### **Test Configuration**:

- Node.js `v24.16.0`
- npm `11.16.0`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
