### PR TITLE
feat(langfuse): forward media upload policy

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -84,6 +84,7 @@ function getLangfuseProcessorCacheKey(
 ): string {
   return JSON.stringify({
     destinationKey,
+    mediaUploadEnabled: langfuse?.mediaUploadEnabled,
     toolOutputTracing: langfuse?.toolOutputTracing,
   });
 }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -72,6 +72,9 @@ export function getLangfuseSpanProcessorParams(
       secretKey: langfuse.secretKey,
       ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
       ...(isPresent(environment) ? { environment } : {}),
+      ...(langfuse.mediaUploadEnabled != null
+        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
+        : {}),
     };
   }
   if (hasLangfuseEnvConfig()) {
@@ -84,6 +87,9 @@ export function getLangfuseSpanProcessorParams(
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       ...(isPresent(baseUrl) ? { baseUrl } : {}),
       ...(isPresent(environment) ? { environment } : {}),
+      ...(langfuse?.mediaUploadEnabled != null
+        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
+        : {}),
     };
   }
   if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
@@ -92,6 +98,9 @@ export function getLangfuseSpanProcessorParams(
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       baseUrl: langfuse.baseUrl,
       ...(isPresent(environment) ? { environment } : {}),
+      ...(langfuse.mediaUploadEnabled != null
+        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
+        : {}),
     };
   }
   return undefined;

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -320,6 +320,32 @@ describe('Langfuse instrumentation', () => {
     });
   });
 
+  it('does not reuse processors across different media upload policies', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-media',
+      secretKey: 'sk-media',
+      baseUrl: 'https://langfuse.media',
+      mediaUploadEnabled: false,
+    });
+    initializeLangfuseTracing({
+      publicKey: 'pk-media',
+      secretKey: 'sk-media',
+      baseUrl: 'https://langfuse.media',
+      mediaUploadEnabled: true,
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(2);
+    expect(mockLangfuseSpanProcessor).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ mediaUploadEnabled: false })
+    );
+    expect(mockLangfuseSpanProcessor).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ mediaUploadEnabled: true })
+    );
+  });
+
   it('reuses the isolated provider after initialization', async () => {
     process.env.LANGFUSE_SECRET_KEY = 'sk-test';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -1,6 +1,7 @@
 import type { Span } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
+  getLangfuseSpanProcessorParams,
   getLangfuseManagedSpanDestination,
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
@@ -41,7 +42,23 @@ describe('Langfuse span registry', () => {
     const redacting = resolveLangfuseDestinationKey(
       tenantConfig({ toolOutputTracing: { enabled: false } })
     );
+    const mediaDisabled = resolveLangfuseDestinationKey(
+      tenantConfig({ mediaUploadEnabled: false })
+    );
     expect(redacting).toBe(base);
+    expect(mediaDisabled).toBe(base);
+  });
+
+  it('passes media upload policy to the Langfuse span processor params', () => {
+    expect(
+      getLangfuseSpanProcessorParams(
+        tenantConfig({ mediaUploadEnabled: false })
+      )
+    ).toEqual(
+      expect.objectContaining({
+        mediaUploadEnabled: false,
+      })
+    );
   });
 
   it('separates destinations by credentials, endpoint, and environment', () => {

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -1162,7 +1162,7 @@ const hasBedrock = hasEveryEnv(requiredBedrockEnv);
 
 const hasOpenAI = hasEnv('OPENAI_API_KEY');
 (hasOpenAI ? describe : describe.skip)('OpenAI Summarization E2E', () => {
-  jest.setTimeout(120_000);
+  jest.setTimeout(240_000);
 
   const agentProvider = Providers.OPENAI;
   const streamConfig = {
@@ -1190,6 +1190,9 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
         agentProvider,
         summarizationProvider: Providers.OPENAI,
         summarizationModel: 'gpt-4.1-mini',
+        llmConfigOverride: {
+          model: 'gpt-4.1-mini',
+        },
         maxContextTokens: maxTokens,
         instructions:
           'You are a helpful math tutor. Use the calculator tool for ALL computations. Keep responses concise.',
@@ -1320,7 +1323,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
       `  OpenAI summary: "${getSummaryText(completePayload.summary).substring(0, 200)}…"`
     );
     console.log(`  Final messages: ${conversationHistory.length}`);
-  }, 120_000);
+  }, 240_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -571,6 +571,11 @@ export interface LangfuseConfig {
    * `default` environment.
    */
   environment?: string;
+  /**
+   * Whether the Langfuse span processor should detect and upload base64 media
+   * payloads. Defaults to the Langfuse SDK behavior.
+   */
+  mediaUploadEnabled?: boolean;
   metadata?: Record<string, string | number | boolean | null | undefined>;
   /**
    * Internal OTLP span attributes to attach to Langfuse observations before


### PR DESCRIPTION
## Summary
- expose `mediaUploadEnabled` on run/agent Langfuse config
- forward it to `LangfuseSpanProcessor` params
- keep separate cached processors when media upload policy differs

## Validation
- `npm test -- --runInBand src/specs/langfuse-span-registry.test.ts src/specs/langfuse-instrumentation.test.ts`
- `npm run build` reached existing unrelated type errors in provider code