### PR TITLE
🧵 fix: Preserve Streamed Subagent Result Text

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -998,6 +998,7 @@ export abstract class Graph<
 
 export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   overrideModel?: t.ChatModel;
+  private subagentModelOverride?: t.ChatModel;
   /** Optional compile options passed into workflow.compile() */
   compileOptions?: t.CompileOptions | undefined;
   /** Whether the workflow was actually compiled with a checkpointer. */
@@ -1320,6 +1321,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super.clearHeavyState();
     this.messages = [];
     this.overrideModel = undefined;
+    this.subagentModelOverride = undefined;
     /** Stream-limit accounting (argument tallies, event counts, charge
      * credits) deliberately SURVIVES cleanup: this runs in `processStream`'s
      * finally, which an ordinary parallel-branch failure reaches while
@@ -1942,6 +1944,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sleep,
       toolCalls,
     });
+  }
+
+  /** Explicitly overrides the model used by isolated descendant subagent graphs. */
+  setSubagentModelOverride(model: t.ChatModel): void {
+    this.subagentModelOverride = model;
   }
 
   getUsageMetadata(
@@ -4057,6 +4064,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
+            if (this.subagentModelOverride != null) {
+              childGraph.overrideModel = this.subagentModelOverride;
+              childGraph.setSubagentModelOverride(this.subagentModelOverride);
+            }
             const toolHandlerRegistry = createToolHandlerRegistry(
               getParentHandlerRegistry()
             );

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -21,6 +21,7 @@ import * as providers from '@/llm/providers';
 import { Run } from '@/run';
 
 const CHILD_RESPONSE = 'Research result: Paris is the capital of France.';
+const OVERRIDDEN_CHILD_RESPONSE = 'Deterministic child override result.';
 
 const callerConfig: Partial<RunnableConfig> & {
   version: 'v1' | 'v2';
@@ -224,6 +225,49 @@ describe('Subagent Integration', () => {
       (t) => 'name' in t && t.name === Constants.SUBAGENT
     );
     expect(subagentTool).toBeDefined();
+  });
+
+  it('only applies an explicitly configured subagent model override', async () => {
+    const invokeSubagent = async (
+      overrideSubagents: boolean
+    ): Promise<string> => {
+      const run = await Run.create<t.IState>({
+        runId: `subagent-model-override-${overrideSubagents}-${Date.now()}`,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgent()],
+        },
+        returnContent: true,
+        skipCleanup: true,
+      });
+      const graph = run.Graph as StandardGraph;
+      const model = new FakeListChatModel({
+        responses: [OVERRIDDEN_CHILD_RESPONSE],
+      });
+      graph.overrideModel = model;
+      if (overrideSubagents) {
+        graph.setSubagentModelOverride(model);
+      }
+
+      const context = graph.agentContexts.get('parent');
+      const subagentTool = (context?.graphTools as t.GenericTool[]).find(
+        (tool) => 'name' in tool && tool.name === Constants.SUBAGENT
+      );
+      expect(subagentTool).toBeDefined();
+
+      return String(
+        await subagentTool!.invoke(
+          {
+            description: 'What is the capital of France?',
+            subagent_type: 'researcher',
+          },
+          callerConfig
+        )
+      );
+    };
+
+    await expect(invokeSubagent(false)).resolves.toBe(CHILD_RESPONSE);
+    await expect(invokeSubagent(true)).resolves.toBe(OVERRIDDEN_CHILD_RESPONSE);
   });
 
   it('inherits eager event-tool settings into self-spawn child graphs', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -67,6 +67,25 @@ describe('filterSubagentResult', () => {
     expect(filterSubagentResult(messages)).toBe('First part.\nSecond part.');
   });
 
+  it('prefers final text_delta blocks over earlier AI text', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          { type: 'tool_use', id: 'call_1', name: 'search', input: {} },
+        ],
+      }),
+      new ToolMessage({ content: 'result', tool_call_id: 'call_1' }),
+      new AIMessage({
+        content: [
+          { type: 'text_delta', text: 'Streamed ' },
+          { type: 'text_delta', text: 'result.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Streamed result.');
+  });
+
   it('strips tool_use blocks from array content', () => {
     const messages: BaseMessage[] = [
       new AIMessage({
@@ -470,7 +489,10 @@ describe('SubagentExecutor', () => {
         }) as unknown as StandardGraph,
     });
     await expect(
-      executor.execute({ description: 'Do something', subagentType: 'researcher' })
+      executor.execute({
+        description: 'Do something',
+        subagentType: 'researcher',
+      })
     ).rejects.toBeInstanceOf(StreamLimitExceededError);
   });
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -78,12 +78,37 @@ describe('filterSubagentResult', () => {
       new ToolMessage({ content: 'result', tool_call_id: 'call_1' }),
       new AIMessage({
         content: [
-          { type: 'text_delta', text: 'Streamed ' },
-          { type: 'text_delta', text: 'result.' },
+          { type: 'text_delta', index: 0, text: 'Streamed ' },
+          { type: 'text_delta', index: 0, text: 'result.' },
         ],
       }),
     ];
     expect(filterSubagentResult(messages)).toBe('Streamed result.');
+  });
+
+  it('keeps annotation-only text blocks within a text_delta sequence', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'text_delta', index: 0, text: 'Cited ' },
+          { type: 'text', index: 0, citations: [{ url: 'source' }] },
+          { type: 'text_delta', index: 0, text: 'answer.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Cited answer.');
+  });
+
+  it('separates text_delta blocks with different indexes', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'text_delta', index: 0, text: 'First.' },
+          { type: 'text_delta', index: 1, text: 'Second.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('First.\nSecond.');
   });
 
   it('strips tool_use blocks from array content', () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -27,17 +27,24 @@ import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
-import { Constants, GraphEvents, Callback, StepTypes } from '@/common';
 import {
   StreamLimitExceededError,
   RUN_BREAKER_SCOPE_CONFIG_KEY,
 } from '@/llm/streamLimits';
+import {
+  ContentTypes,
+  Constants,
+  GraphEvents,
+  Callback,
+  StepTypes,
+} from '@/common';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
 const ERROR_MESSAGE_MAX_CHARS = 200;
 const MAX_PENDING_SUBAGENT_UPDATES = 64;
+const TEXT_DELTA_CONTENT_TYPE = `${ContentTypes.TEXT}_delta`;
 
 const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
   additionalContexts: [] as string[],
@@ -119,7 +126,10 @@ type SanitizedStepCompleted =
     };
 
 type SanitizedProcessedToolCall = Partial<
-  Pick<ProcessedToolCall, 'args' | 'id' | 'name' | 'output' | 'progress' | 'outcome'>
+  Pick<
+    ProcessedToolCall,
+    'args' | 'id' | 'name' | 'output' | 'progress' | 'outcome'
+  >
 >;
 
 type SanitizedRunStepCompleted = {
@@ -1401,6 +1411,8 @@ export function summarizeEvent(eventName: string, data: unknown): string {
  * pure tool_use (e.g. the subagent hit `maxTurns` mid-tool-call), the walk
  * continues to earlier AIMessages so partial progress is salvaged — this
  * matches Claude Code's behavior in `agentToolUtils.finalizeAgentTool`.
+ * Consecutive streamed text-delta blocks are coalesced without adding
+ * whitespace; complete text blocks remain newline-separated.
  * Returns "Task completed" only when no AIMessage in the history contains
  * any text.
  */
@@ -1422,13 +1434,44 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
     }
 
     const textParts: string[] = [];
+    let textDeltaParts: string[] = [];
+    const flushTextDeltaParts = (): void => {
+      if (textDeltaParts.length === 0) {
+        return;
+      }
+      textParts.push(textDeltaParts.join(''));
+      textDeltaParts = [];
+    };
     for (const block of content) {
       if (typeof block === 'string') {
-        textParts.push(block);
-      } else if ('type' in block && block.type === 'text' && 'text' in block) {
-        textParts.push(block.text as string);
+        flushTextDeltaParts();
+        if (block !== '') {
+          textParts.push(block);
+        }
+        continue;
+      }
+
+      const type =
+        'type' in block && typeof block.type === 'string' ? block.type : '';
+      const isTextDelta = type === TEXT_DELTA_CONTENT_TYPE;
+      const isText = type === ContentTypes.TEXT || isTextDelta;
+      const text =
+        isText && 'text' in block && typeof block.text === 'string'
+          ? block.text
+          : '';
+      if (isTextDelta) {
+        if (text !== '') {
+          textDeltaParts.push(text);
+        }
+        continue;
+      }
+
+      flushTextDeltaParts();
+      if (text !== '') {
+        textParts.push(text);
       }
     }
+    flushTextDeltaParts();
 
     if (textParts.length > 0) {
       return textParts.join('\n');

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1411,8 +1411,9 @@ export function summarizeEvent(eventName: string, data: unknown): string {
  * pure tool_use (e.g. the subagent hit `maxTurns` mid-tool-call), the walk
  * continues to earlier AIMessages so partial progress is salvaged — this
  * matches Claude Code's behavior in `agentToolUtils.finalizeAgentTool`.
- * Consecutive streamed text-delta blocks are coalesced without adding
- * whitespace; complete text blocks remain newline-separated.
+ * Consecutive streamed text-delta blocks with the same provider index are
+ * coalesced without adding whitespace. Annotation-only text blocks are
+ * ignored; complete text blocks and distinct delta indexes remain separated.
  * Returns "Task completed" only when no AIMessage in the history contains
  * any text.
  */
@@ -1435,12 +1436,14 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
 
     const textParts: string[] = [];
     let textDeltaParts: string[] = [];
+    let textDeltaIndex: string | number | undefined;
     const flushTextDeltaParts = (): void => {
       if (textDeltaParts.length === 0) {
         return;
       }
       textParts.push(textDeltaParts.join(''));
       textDeltaParts = [];
+      textDeltaIndex = undefined;
     };
     for (const block of content) {
       if (typeof block === 'string') {
@@ -1460,9 +1463,27 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
           ? block.text
           : '';
       if (isTextDelta) {
-        if (text !== '') {
-          textDeltaParts.push(text);
+        if (text === '') {
+          continue;
         }
+        const index =
+          'index' in block &&
+          (typeof block.index === 'string' || typeof block.index === 'number')
+            ? block.index
+            : undefined;
+        if (
+          textDeltaIndex != null &&
+          index != null &&
+          index !== textDeltaIndex
+        ) {
+          flushTextDeltaParts();
+        }
+        textDeltaIndex ??= index;
+        textDeltaParts.push(text);
+        continue;
+      }
+
+      if (type === ContentTypes.TEXT && text === '') {
         continue;
       }
 


### PR DESCRIPTION
## Summary

I fixed isolated subagent result extraction so canonical `text_delta` content is returned instead of stale earlier assistant text or `Task completed`.

- Recognized canonical `text_delta` blocks alongside complete `text` blocks.
- Coalesced consecutive delta fragments without inserting whitespace between streamed tokens.
- Preserved newline separation for complete text blocks and the existing earlier-message fallback.
- Added regression coverage for a stale pre-tool response followed by a final answer represented only by text deltas.
- Avoided buffering forwarded `ON_MESSAGE_DELTA` events, keeping final graph messages as the source of truth and avoiding duplicate state or mixed preamble/final output.
- Added an explicit descendant model override for full-stack test harnesses while leaving production subagent model selection unchanged by default.
- Verified the packed SDK through deterministic and real-Anthropic LibreChat Playwright flows.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/specs/subagent.test.ts src/tools/__tests__/SubagentExecutor.test.ts --runInBand` (95 passed)
- `npx jest langfuse deterministic-trace-id --runInBand` (164 passed)
- `npx tsc --noEmit`
- `npx eslint src/graphs/Graph.ts src/specs/subagent.test.ts src/tools/subagent/SubagentExecutor.ts src/tools/__tests__/SubagentExecutor.test.ts`
- `npm run build`
- Exercised isolated subagent execution against Anthropic, OpenAI, Google, and Bedrock credentials from the local provider environment.
- Packed the branch and installed it into LibreChat for a deterministic streamed-`text_delta` Playwright regression (1 passed).
- Ran the dependent LibreChat real-provider Playwright test against Anthropic (1 passed).

### **Test Configuration**:

- Node.js 24.16.0
- macOS arm64
- Playwright Chromium

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
