### PR TITLE
fix: Prevent unsafe token sentinels from overflowing context

### DIFF
--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -72,6 +72,32 @@ describe('createTokenCounter with different encodings', () => {
     expect(count).toBeGreaterThan(0);
   });
 
+  test('claude correction keeps proxy-backed tool history safely measurable', async () => {
+    let getCalls = 0;
+    const args = new Proxy(
+      { query: 'select * from reports' },
+      {
+        get(target, property, receiver) {
+          getCalls++;
+          return Reflect.get(target, property, receiver);
+        },
+      }
+    );
+    const message = {
+      content: '',
+      tool_calls: [{ id: 'proxy-call', name: 'query', args }],
+      getType: () => 'ai',
+    } as unknown as AIMessage;
+    const counter = await createTokenCounter('claude');
+
+    const count = counter(message);
+
+    expect(Number.isSafeInteger(count)).toBe(true);
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(1_000);
+    expect(getCalls).toBe(0);
+  });
+
   test('o200k_base encoding produces valid token counts', async () => {
     const counter = await createTokenCounter('o200k_base');
     const msg = new HumanMessage('Hello, world!');
@@ -109,6 +135,22 @@ describe('getTokenCountForMessage', () => {
 
     expect(Math.max(...callbackLengths)).toBe(200_000);
     expect(count).toBe(600_003);
+  });
+
+  test.each([
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER,
+    Number.MAX_SAFE_INTEGER + 1,
+    Number.POSITIVE_INFINITY,
+    Number.NaN,
+  ])('rejects an unsafe tokenizer result of %s', (unsafeCount) => {
+    expect(() =>
+      getTokenCountForMessage(
+        new HumanMessage('unsafe count'),
+        () => unsafeCount
+      )
+    ).toThrow(UnsafeTokenMeasurementError);
   });
 
   test('bounds direct string tool args before tokenization and charges omitted characters', () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -13,6 +13,7 @@ import {
   estimateImageBlockTokens,
   estimateDocumentBlockTokens,
   estimateTimedMediaBlockTokens,
+  UnsafeTokenMeasurementError,
 } from '@/utils/tokens';
 
 /** Builds a minimal PNG data URI whose IHDR encodes the given dimensions. */
@@ -153,10 +154,13 @@ describe('getTokenCountForMessage', () => {
     );
 
     expect(Math.max(...callbackLengths)).toBeLessThanOrEqual(200_000);
-    expect(count).toBeGreaterThan(payload.length);
+    // A traversal-work sentinel is unknown size, not real context usage.
+    // The provider-input projection will compact the value before invoke.
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(Number.MAX_SAFE_INTEGER);
   });
 
-  test('fails closed when prototype traps throw', () => {
+  test('counts an opaque proxy argument as its bounded provider-safe placeholder', () => {
     let prototypeCalls = 0;
     const args = new Proxy(
       { safe: true },
@@ -171,11 +175,11 @@ describe('getTokenCountForMessage', () => {
     expect(hasUnsafeStructuredSerialization(args)).toBe(true);
     expect(
       getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
-    ).toBe(Number.MAX_SAFE_INTEGER);
+    ).toBeLessThan(Number.MAX_SAFE_INTEGER);
     expect(prototypeCalls).toBeLessThanOrEqual(2);
   });
 
-  test('fails closed without recursing through self-referential prototype proxies', () => {
+  test('does not recurse through self-referential prototype proxies', () => {
     let prototypeCalls = 0;
     const args: Record<string, unknown> = new Proxy<Record<string, unknown>>(
       {},
@@ -190,11 +194,11 @@ describe('getTokenCountForMessage', () => {
     expect(hasUnsafeStructuredSerialization(args)).toBe(true);
     expect(
       getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
-    ).toBe(Number.MAX_SAFE_INTEGER);
+    ).toBeLessThan(Number.MAX_SAFE_INTEGER);
     expect(prototypeCalls).toBeLessThanOrEqual(2);
   });
 
-  test('fails closed when descriptor and own-key proxy traps throw', () => {
+  test('uses bounded placeholders when descriptor and own-key proxy traps throw', () => {
     const descriptorProxy = new Proxy(
       {},
       {
@@ -219,11 +223,11 @@ describe('getTokenCountForMessage', () => {
           messageWithToolArgs(args),
           (text) => text.length
         )
-      ).toBe(Number.MAX_SAFE_INTEGER);
+      ).toBeLessThan(Number.MAX_SAFE_INTEGER);
     }
   });
 
-  test('fails closed on get traps and revoked proxies without invoking them', () => {
+  test('does not invoke get traps or revoked proxies while measuring arguments', () => {
     let getCalls = 0;
     const getProxy = new Proxy(
       {},
@@ -250,12 +254,12 @@ describe('getTokenCountForMessage', () => {
           messageWithToolArgs(args),
           (text) => text.length
         )
-      ).toBe(Number.MAX_SAFE_INTEGER);
+      ).toBeLessThan(Number.MAX_SAFE_INTEGER);
     }
     expect(getCalls).toBe(0);
   });
 
-  test('fails closed on proxied content blocks without invoking their traps', () => {
+  test('reports a typed terminal error for a proxied content block', () => {
     let getCalls = 0;
     const contentBlock = new Proxy(
       { type: 'text', text: 'safe' },
@@ -271,9 +275,18 @@ describe('getTokenCountForMessage', () => {
       getType: () => 'tool',
     } as unknown as ToolMessage;
 
-    expect(getTokenCountForMessage(message, (text) => text.length)).toBe(
-      Number.MAX_SAFE_INTEGER
+    expect(() => getTokenCountForMessage(message, (text) => text.length)).toThrow(
+      UnsafeTokenMeasurementError
     );
+    try {
+      getTokenCountForMessage(message, (text) => text.length);
+    } catch (error) {
+      expect(JSON.parse((error as Error).message)).toEqual({
+        type: 'unsafe_token_measurement',
+        reason: 'content_proxy',
+        path: 'content[0]',
+      });
+    }
     expect(getCalls).toBe(0);
   });
 
@@ -292,8 +305,30 @@ describe('getTokenCountForMessage', () => {
     expect(hasUnsafeStructuredSerialization(args)).toBe(true);
     expect(
       getTokenCountForMessage(messageWithToolArgs(args), (text) => text.length)
-    ).toBe(Number.MAX_SAFE_INTEGER);
+    ).toBeLessThan(Number.MAX_SAFE_INTEGER);
     expect(accessorCalls).toBe(0);
+  });
+
+  test('counts safely serializable proxy tool-call history without invoking getters', () => {
+    let getCalls = 0;
+    const args = new Proxy(
+      { query: 'select * from reports' },
+      {
+        get(target, property, receiver) {
+          getCalls++;
+          return Reflect.get(target, property, receiver);
+        },
+      }
+    );
+
+    const count = getTokenCountForMessage(
+      messageWithToolArgs(args),
+      (text) => text.length
+    );
+
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    expect(getCalls).toBe(0);
   });
 
   test('counts tool_calls-only names and arguments', () => {
@@ -334,7 +369,8 @@ describe('getTokenCountForMessage', () => {
 
     const count = getTokenCountForMessage(message, (text) => text.length);
 
-    expect(count).toBeGreaterThanOrEqual(Number.MAX_SAFE_INTEGER);
+    expect(count).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    expect(count).toBeGreaterThan(0);
     expect(toJSONCalls).toBe(0);
   });
 

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -332,6 +332,73 @@ describe('getTokenCountForMessage', () => {
     expect(getCalls).toBe(0);
   });
 
+  test('reports typed errors for unsafe message and metadata branches', () => {
+    let getterCalls = 0;
+    const messageProxy = new Proxy(new HumanMessage('secret payload'), {
+      get() {
+        getterCalls++;
+        throw new Error('message read denied');
+      },
+    });
+    const metadataProxy = new Proxy(
+      {},
+      {
+        get() {
+          getterCalls++;
+          throw new Error('metadata read denied');
+        },
+      }
+    );
+    const accessorMetadata = {};
+    Object.defineProperty(accessorMetadata, 'type', {
+      get() {
+        getterCalls++;
+        return 'computer_call_output';
+      },
+    });
+    const cases = [
+      {
+        message: messageProxy,
+        reason: 'message_proxy',
+        path: 'message',
+      },
+      {
+        message: {
+          content: '',
+          additional_kwargs: metadataProxy,
+          getType: () => 'tool',
+        } as unknown as ToolMessage,
+        reason: 'metadata_proxy',
+        path: 'additional_kwargs',
+      },
+      {
+        message: {
+          content: '',
+          additional_kwargs: accessorMetadata,
+          getType: () => 'tool',
+        } as unknown as ToolMessage,
+        reason: 'metadata_accessor',
+        path: 'additional_kwargs.type',
+      },
+    ];
+
+    for (const testCase of cases) {
+      try {
+        getTokenCountForMessage(testCase.message, (text) => text.length);
+        throw new Error('Expected token measurement to fail');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnsafeTokenMeasurementError);
+        expect(JSON.parse((error as Error).message)).toEqual({
+          type: 'unsafe_token_measurement',
+          reason: testCase.reason,
+          path: testCase.path,
+        });
+        expect((error as Error).message).not.toContain('secret payload');
+      }
+    }
+    expect(getterCalls).toBe(0);
+  });
+
   test('detects inherited accessors without invoking them', () => {
     let accessorCalls = 0;
     const prototype = {};

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -14,7 +14,8 @@ export type UnsafeTokenMeasurementReason =
   | 'message_proxy'
   | 'content_proxy'
   | 'metadata_proxy'
-  | 'metadata_accessor';
+  | 'metadata_accessor'
+  | 'invalid_count';
 
 export class UnsafeTokenMeasurementError extends Error {
   readonly type = 'unsafe_token_measurement';
@@ -39,6 +40,20 @@ export class UnsafeTokenMeasurementError extends Error {
     this.reason = reason;
     this.path = path;
   }
+}
+
+function ensureSafeTokenMeasurement(value: number, path: string): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw new UnsafeTokenMeasurementError({
+      reason: 'invalid_count',
+      path,
+    });
+  }
+  return value;
 }
 
 /** Anthropic minimum image token cost. */
@@ -875,7 +890,10 @@ function getBoundedTextTokenCount(
     value.length > MAX_STRUCTURED_TOKENIZATION_CHARS
       ? value.slice(0, MAX_STRUCTURED_TOKENIZATION_CHARS)
       : value;
-  const previewTokens = getTokenCount(preview);
+  const previewTokens = ensureSafeTokenMeasurement(
+    getTokenCount(preview),
+    'tokenizer'
+  );
   const omittedChars = value.length - preview.length;
   if (omittedChars <= 0) {
     return previewTokens;
@@ -894,7 +912,10 @@ function getBoundedStructuredTokenCount(
     value,
     MAX_STRUCTURED_TOKENIZATION_CHARS
   );
-  const previewTokens = getTokenCount(serialized.content);
+  const previewTokens = ensureSafeTokenMeasurement(
+    getTokenCount(serialized.content),
+    'tokenizer'
+  );
   if (!serialized.truncated) {
     return previewTokens;
   }
@@ -1125,9 +1146,7 @@ export function getTokenCountForMessage(
   } else {
     processValue(message.content, 'content');
   }
-  if (numTokens >= Number.MAX_SAFE_INTEGER) {
-    return Number.MAX_SAFE_INTEGER;
-  }
+  ensureSafeTokenMeasurement(numTokens, 'content');
   const messageRole = (message as BaseMessage & { role?: unknown }).role;
   if (messageType === 'ai' || messageRole === 'assistant') {
     const toolCalls = (message as AIMessage).tool_calls ?? [];
@@ -1188,7 +1207,7 @@ export function getTokenCountForMessage(
       }
     }
   }
-  return Math.min(Number.MAX_SAFE_INTEGER, numTokens);
+  return ensureSafeTokenMeasurement(numTokens, 'message');
 }
 
 /**
@@ -1243,7 +1262,10 @@ export const createTokenCounter = async (
   const isClaude = encoding === 'claude';
   return (message: BaseMessage): number => {
     const count = getTokenCountForMessage(message, countTokens, encoding);
-    return isClaude ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION) : count;
+    const correctedCount = isClaude
+      ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION)
+      : count;
+    return ensureSafeTokenMeasurement(correctedCount, 'message');
   };
 };
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -10,6 +10,37 @@ import { ContentTypes } from '@/common/enum';
 
 export type EncodingName = 'o200k_base' | 'claude';
 
+export type UnsafeTokenMeasurementReason =
+  | 'message_proxy'
+  | 'content_proxy'
+  | 'metadata_proxy'
+  | 'metadata_accessor';
+
+export class UnsafeTokenMeasurementError extends Error {
+  readonly type = 'unsafe_token_measurement';
+  readonly reason: UnsafeTokenMeasurementReason;
+  readonly path: string;
+
+  constructor({
+    reason,
+    path,
+  }: {
+    reason: UnsafeTokenMeasurementReason;
+    path: string;
+  }) {
+    super(
+      JSON.stringify({
+        type: 'unsafe_token_measurement',
+        reason,
+        path,
+      })
+    );
+    this.name = 'UnsafeTokenMeasurementError';
+    this.reason = reason;
+    this.path = path;
+  }
+}
+
 /** Anthropic minimum image token cost. */
 const ANTHROPIC_IMAGE_MIN_TOKENS = 1024;
 /** Anthropic divisor: tokens = width × height / 750. */
@@ -859,9 +890,6 @@ function getBoundedStructuredTokenCount(
   value: unknown,
   getTokenCount: (text: string) => number
 ): number {
-  if (hasUnsafeStructuredSerialization(value)) {
-    return Number.MAX_SAFE_INTEGER;
-  }
   const serialized = serializeStructuredValueBounded(
     value,
     MAX_STRUCTURED_TOKENIZATION_CHARS
@@ -870,8 +898,14 @@ function getBoundedStructuredTokenCount(
   if (!serialized.truncated) {
     return previewTokens;
   }
-  if (!Number.isSafeInteger(serialized.originalChars)) {
-    return Number.MAX_SAFE_INTEGER;
+  // The bounded serializer uses MAX_SAFE_INTEGER as its unknown-size sentinel.
+  // Do not extrapolate from it: use its bounded preview and let the provider
+  // input projection preserve the same bounded behavior before invocation.
+  if (
+    !Number.isSafeInteger(serialized.originalChars) ||
+    serialized.originalChars >= Number.MAX_SAFE_INTEGER
+  ) {
+    return previewTokens;
   }
 
   const omittedChars = Math.max(
@@ -893,7 +927,10 @@ export function getTokenCountForMessage(
   const countText = (text: string): number =>
     getBoundedTextTokenCount(text, getTokenCount);
   if (isProxy(message)) {
-    return Number.MAX_SAFE_INTEGER;
+    throw new UnsafeTokenMeasurementError({
+      reason: 'message_proxy',
+      path: 'message',
+    });
   }
 
   type ContentBlock = Record<string, unknown> & {
@@ -907,19 +944,22 @@ export function getTokenCountForMessage(
   };
   const representedToolCallIds = new Set<string>();
 
-  const processValue = (value: unknown): void => {
+  const processValue = (value: unknown, path: string): void => {
     if (value != null && typeof value === 'object' && isProxy(value)) {
-      numTokens = Number.MAX_SAFE_INTEGER;
-      return;
+      throw new UnsafeTokenMeasurementError({
+        reason: 'content_proxy',
+        path,
+      });
     }
     if (Array.isArray(value)) {
-      for (const raw of value) {
+      for (let index = 0; index < value.length; index++) {
+        const raw = value[index];
         if (
           typeof raw === 'string' ||
           typeof raw === 'number' ||
           typeof raw === 'boolean'
         ) {
-          processValue(raw);
+          processValue(raw, `${path}[${index}]`);
           continue;
         }
         const item = raw as ContentBlock | null | undefined;
@@ -927,8 +967,10 @@ export function getTokenCountForMessage(
           continue;
         }
         if (isProxy(item)) {
-          numTokens = Number.MAX_SAFE_INTEGER;
-          return;
+          throw new UnsafeTokenMeasurementError({
+            reason: 'content_proxy',
+            path: `${path}[${index}]`,
+          });
         }
         if (typeof item.type !== 'string') {
           numTokens += getBoundedStructuredTokenCount(item, countText);
@@ -1010,7 +1052,7 @@ export function getTokenCountForMessage(
           }
           const output = item.tool_call.output;
           if (output != null) {
-            processValue(output);
+            processValue(output, `${path}[${index}].tool_call.output`);
           }
           continue;
         }
@@ -1021,7 +1063,7 @@ export function getTokenCountForMessage(
           continue;
         }
 
-        processValue(nestedValue);
+        processValue(nestedValue, `${path}[${index}].${item.type}`);
       }
     } else if (typeof value === 'string') {
       numTokens += countText(value);
@@ -1040,7 +1082,10 @@ export function getTokenCountForMessage(
       ? rawAdditionalKwargs
       : undefined;
   if (additionalKwargs != null && isProxy(additionalKwargs)) {
-    return Number.MAX_SAFE_INTEGER;
+    throw new UnsafeTokenMeasurementError({
+      reason: 'metadata_proxy',
+      path: 'additional_kwargs',
+    });
   }
   let additionalType: PropertyDescriptor | undefined;
   try {
@@ -1049,10 +1094,16 @@ export function getTokenCountForMessage(
         ? Object.getOwnPropertyDescriptor(additionalKwargs, 'type')
         : undefined;
   } catch {
-    return Number.MAX_SAFE_INTEGER;
+    throw new UnsafeTokenMeasurementError({
+      reason: 'metadata_accessor',
+      path: 'additional_kwargs.type',
+    });
   }
   if (additionalType != null && !('value' in additionalType)) {
-    return Number.MAX_SAFE_INTEGER;
+    throw new UnsafeTokenMeasurementError({
+      reason: 'metadata_accessor',
+      path: 'additional_kwargs.type',
+    });
   }
 
   let numTokens = tokensPerMessage;
@@ -1072,7 +1123,7 @@ export function getTokenCountForMessage(
       ) * IMAGE_TOKEN_SAFETY_MARGIN
     );
   } else {
-    processValue(message.content);
+    processValue(message.content, 'content');
   }
   if (numTokens >= Number.MAX_SAFE_INTEGER) {
     return Number.MAX_SAFE_INTEGER;
@@ -1081,11 +1132,17 @@ export function getTokenCountForMessage(
   if (messageType === 'ai' || messageRole === 'assistant') {
     const toolCalls = (message as AIMessage).tool_calls ?? [];
     if (isProxy(toolCalls)) {
-      return Number.MAX_SAFE_INTEGER;
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_proxy',
+        path: 'tool_calls',
+      });
     }
     for (const toolCall of toolCalls) {
       if (isProxy(toolCall)) {
-        return Number.MAX_SAFE_INTEGER;
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_proxy',
+          path: 'tool_calls',
+        });
       }
       if (
         typeof toolCall.id === 'string' &&
@@ -1111,11 +1168,17 @@ export function getTokenCountForMessage(
           ? Object.getOwnPropertyDescriptor(additionalKwargs, 'function_call')
           : undefined;
     } catch {
-      return Number.MAX_SAFE_INTEGER;
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_accessor',
+        path: 'additional_kwargs.function_call',
+      });
     }
     if (legacyFunctionCall != null) {
       if (!('value' in legacyFunctionCall)) {
-        return Number.MAX_SAFE_INTEGER;
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_accessor',
+          path: 'additional_kwargs.function_call',
+        });
       }
       if (legacyFunctionCall.value != null) {
         numTokens += getBoundedStructuredTokenCount(


### PR DESCRIPTION
## Summary

- treat the bounded serializer's unknown-size sentinel as unknown rather than real token usage
- count proxy-backed structured tool-call arguments through their bounded provider-safe representation without invoking getters
- reject invalid, non-safe, sentinel, aggregate-overflow, and post-Claude-correction token measurements
- report genuinely unmeasurable message, content, and metadata branches as machine-readable `unsafe_token_measurement` errors
- add regression coverage for proxy traps, accessors, traversal limits, Claude correction, diagnostics, and safe proxy tool-call history

## Root cause

`serializeStructuredValueBounded` uses `Number.MAX_SAFE_INTEGER` to signal that exact serialized length is unknown after a defensive inspection or traversal limit. Token accounting extrapolated from that marker as though it were a real character count. Claude's 1.1 correction then surfaced the sentinel as roughly 9.9 quadrillion tokens and caused a false context overflow before any provider call.

## Impact

Unsafe inspection sentinels no longer become fabricated context usage. Supported structured proxy histories remain bounded and countable, while branches that cannot be safely inspected fail distinctly from genuine context-window overflows and identify only the offending path. A final invariant prevents future estimators or provider corrections from leaking unsafe counts through this API.

## Validation

- `npx jest src/specs/tokens.test.ts src/graphs/__tests__/Graph.contextOverflow.test.ts --runInBand` — 94 tests passed
- `npx tsc --noEmit`
- `npm run build`
- `npm run sort-imports:check` — changed files pass; repository check reports 17 pre-existing unrelated files