### PR TITLE
🖼️ fix: Reject Unresolved Bedrock Image URLs

### DIFF
--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -1,6 +1,9 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-import { convertToConverseMessages } from './message_inputs';
+import {
+  convertToConverseMessages,
+  UnresolvedBedrockImageUrlError,
+} from './message_inputs';
 import { toLangChainContent } from '@/messages/langchain';
 
 /**
@@ -31,6 +34,30 @@ const assistantContent = (result: ConverseResult): ConverseBlock[] => {
   const msg = result.converseMessages.find((m) => m.role === 'assistant');
   return (msg?.content ?? []) as ConverseBlock[];
 };
+
+describe('convertToConverseMessages — unresolved image URLs', () => {
+  it('rejects HTTPS image URLs before attempting base64 decoding', () => {
+    const atobSpy = jest.spyOn(globalThis, 'atob');
+    const messages: BaseMessage[] = [
+      new HumanMessage([
+        { type: 'text', text: 'Describe this image.' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://files.example.test/unavailable-image.png' },
+        },
+      ]),
+    ];
+
+    try {
+      expect(() => convertToConverseMessages(messages)).toThrow(
+        UnresolvedBedrockImageUrlError
+      );
+      expect(atobSpy).not.toHaveBeenCalled();
+    } finally {
+      atobSpy.mockRestore();
+    }
+  });
+});
 
 describe('convertToConverseMessages — Anthropic tool replay', () => {
   it('deduplicates raw tool_use blocks and unwraps tool_result content', () => {

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -184,10 +184,35 @@ export function concatenateLangchainReasoningBlocks(
   return result;
 }
 
-/**
- * Extract image info from a base64 string or URL.
- */
+const BEDROCK_UNRESOLVED_IMAGE_URL = 'BEDROCK_UNRESOLVED_IMAGE_URL';
+
+/** Raised before invoking Bedrock when image bytes could not be restored. */
+export class UnresolvedBedrockImageUrlError extends Error {
+  readonly code = BEDROCK_UNRESOLVED_IMAGE_URL;
+
+  constructor() {
+    super(
+      'Bedrock requires image bytes, but an image resource could not be restored. Reattach the image and try again.'
+    );
+    this.name = 'UnresolvedBedrockImageUrlError';
+  }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/** Extract image info from base64 image content. */
 export function extractImageInfo(base64: string): BedrockContentBlock {
+  if (isHttpUrl(base64)) {
+    throw new UnresolvedBedrockImageUrlError();
+  }
+
   // Extract the format from the base64 string
   const formatMatch = base64.match(/^data:image\/(\w+);base64,/);
   let format: 'gif' | 'jpeg' | 'png' | 'webp' | undefined;


### PR DESCRIPTION
I prevented unresolved HTTPS image URLs from reaching Bedrock's base64 decoder, addressing AI-1681 and the confirmed `InvalidCharacterError` failure mode.

- Reject HTTP and HTTPS image URLs with a typed, actionable preflight error.
- Preserve data-URL and raw-base64 image handling.
- Verify that remote URLs never invoke `atob()`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest src/llm/bedrock/utils/message_inputs.test.ts --runInBand` (26 tests passed).
- Ran targeted ESLint for the changed formatter and test.
- Ran `git diff --check`.
- Attempted `npx tsc --noEmit`; the repository currently fails on the pre-existing missing `socks-proxy-agent` dependency in `src/utils/proxy.ts` and `src/utils/proxy.test.ts`.

### **Test Configuration**:

- Node.js 24.3.0
- Target branch: `release/v3.3.12`
- Provider path: Amazon Bedrock Converse image formatting

## Checklist

- [x] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local targeted unit tests pass with my changes