### PR TITLE
🌊 feat: Universal Adaptive Stream Smoother

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.13",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.3.13",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.3.13",
+  "version": "3.4.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,14 @@ export type {
   ChatOpenRouterCallOptions,
 } from './llm/openrouter';
 export { getChatModelClass } from './llm/providers';
+export { CustomChatMistralAI } from './llm/mistral';
+export {
+  smoothStream,
+  resolveStreamDelay,
+  DEFAULT_STREAM_DELAY,
+  computeAdaptivePieceSize,
+} from './llm/stream/smoother';
+export type { SmoothItem, SmoothPiece } from './llm/stream/smoother';
 export { FakeChatModel, createFakeStreamingLLM } from './llm/fake';
 export { initializeModel } from './llm/init';
 export { attemptInvoke, tryFallbackProviders } from './llm/invoke';

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -21,20 +21,16 @@ import type {
   AnthropicRequestOptions,
   AnthropicMessageStreamEvent,
 } from '@/llm/anthropic/types';
+import type { SmoothItem } from '@/llm/stream/smoother';
 import type { AnthropicUsageData } from './utils/message_outputs';
 import {
   _convertMessagesToAnthropicPayload,
   stripUnsupportedAssistantPrefill,
 } from './utils/message_inputs';
 import { _makeMessageChunkFromAnthropicEvent } from './utils/message_outputs';
+import { smoothStream, resolveStreamDelay, isSignalAborted } from '@/llm/stream/smoother';
 import { convertAnthropicStream } from './utils/stream_events';
 import { handleToolChoice } from './utils/tools';
-
-const DEFAULT_STREAM_DELAY = 25;
-const MAX_STREAM_QUEUE_CHUNKS = 256;
-const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
-const STREAM_CHUNK_MIN_SIZE = 4;
-const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
 
 type StreamTokenType = 'string' | 'input' | 'content';
 
@@ -268,83 +264,6 @@ function getSamplingParams({
   };
 }
 
-function findStreamChunkBoundary(text: string, minSize: number): number {
-  if (minSize >= text.length) {
-    return text.length;
-  }
-
-  for (let position = minSize; position < text.length; position++) {
-    if (STREAM_BOUNDARIES.has(text[position])) {
-      return position + 1;
-    }
-  }
-
-  return text.length;
-}
-
-function splitStreamToken(text: string): string[] {
-  const chunks: string[] = [];
-  let currentIndex = 0;
-
-  while (currentIndex < text.length) {
-    const remainingText = text.slice(currentIndex);
-    const chunkSize = findStreamChunkBoundary(
-      remainingText,
-      STREAM_CHUNK_MIN_SIZE
-    );
-    chunks.push(text.slice(currentIndex, currentIndex + chunkSize));
-    currentIndex += chunkSize;
-  }
-
-  return chunks;
-}
-
-function getCadencedStreamDelay({
-  targetDelay,
-  lastVisibleTextAt,
-  now,
-}: {
-  targetDelay: number;
-  lastVisibleTextAt?: number;
-  now: number;
-}): number {
-  if (targetDelay <= 0 || lastVisibleTextAt == null) {
-    return 0;
-  }
-  return Math.max(0, targetDelay - (now - lastVisibleTextAt));
-}
-
-async function waitForStreamDelay(
-  delay: number,
-  signal?: AbortSignal
-): Promise<void> {
-  if (delay <= 0 || isSignalAborted(signal)) {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
-    const onAbort = (): void => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    };
-    timeoutRef.current = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, delay);
-    signal?.addEventListener('abort', onAbort, { once: true });
-    if (isSignalAborted(signal)) {
-      onAbort();
-    }
-  });
-}
-
-function isSignalAborted(signal?: AbortSignal): boolean {
-  return signal?.aborted === true;
-}
-
 async function* abortableAnthropicStream(
   source: AnthropicEventStream,
   signal?: AbortSignal
@@ -525,11 +444,9 @@ type CustomAnthropicInvocationParams = {
   output_config?: AnthropicOutputConfig;
 };
 
-type QueuedGenerationChunk = {
+type AnthropicEmittedChunk = {
   chunk: ChatGenerationChunk;
   token: string;
-  smooth: boolean;
-  textLength: number;
 };
 
 export class CustomAnthropic extends ChatAnthropicMessages {
@@ -543,10 +460,7 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     super(fields);
     this.resetTokenEvents();
     this.setDirectFields(fields);
-    this._lc_stream_delay = Math.max(
-      0,
-      fields?._lc_stream_delay ?? DEFAULT_STREAM_DELAY
-    );
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.outputConfig = fields?.outputConfig;
     this.inferenceGeo = fields?.inferenceGeo;
     this.contextManagement = fields?.contextManagement;
@@ -764,292 +678,109 @@ export class CustomAnthropic extends ChatAnthropicMessages {
       cacheReadInputTokens: 0,
       outputTokens: 0,
     };
-    const queuedChunks: QueuedGenerationChunk[] = [];
-    const producerState: {
-      done: boolean;
-      error?: unknown;
-    } = { done: false };
-    let queuedChunkIndex = 0;
-    let bufferedTextLength = 0;
-    let consumerClosed = false;
-    let notifyConsumer: (() => void) | undefined;
-    let notifyProducer: (() => void) | undefined;
-
-    const notifyConsumerForChunk = (): void => {
-      notifyConsumer?.();
-      notifyConsumer = undefined;
-    };
-
-    const notifyProducerForSpace = (): void => {
-      notifyProducer?.();
-      notifyProducer = undefined;
-    };
-
-    const hasQueuedChunks = (): boolean =>
-      queuedChunkIndex < queuedChunks.length;
-
-    const getQueuedChunkCount = (): number =>
-      queuedChunks.length - queuedChunkIndex;
-
-    const isQueueAtCapacity = (): boolean =>
-      getQueuedChunkCount() >= MAX_STREAM_QUEUE_CHUNKS ||
-      bufferedTextLength >= MAX_STREAM_QUEUE_TEXT_CHARS;
-
-    const waitForNextChunk = async (): Promise<void> => {
-      if (
-        hasQueuedChunks() ||
-        producerState.done ||
-        producerState.error != null
-      ) {
-        return;
-      }
-      await new Promise<void>((resolve) => {
-        notifyConsumer = resolve;
-      });
-    };
-
-    const waitForQueueSpace = async (): Promise<void> => {
-      while (
-        isQueueAtCapacity() &&
-        !consumerClosed &&
-        !isSignalAborted(options.signal)
-      ) {
-        await new Promise<void>((resolve) => {
-          const signal = options.signal;
-          const onAbort = (): void => {
-            signal?.removeEventListener('abort', onAbort);
-            resolve();
-          };
-          const onSpace = (): void => {
-            signal?.removeEventListener('abort', onAbort);
-            resolve();
-          };
-          notifyProducer = onSpace;
-          signal?.addEventListener('abort', onAbort, { once: true });
-          if (isSignalAborted(signal)) {
-            onAbort();
-          }
-        });
-      }
-    };
-
-    const dequeue = (): QueuedGenerationChunk | undefined => {
-      if (!hasQueuedChunks()) {
-        return undefined;
-      }
-      const queuedChunk = queuedChunks[queuedChunkIndex];
-      queuedChunkIndex++;
-      if (
-        queuedChunkIndex > 128 &&
-        queuedChunkIndex * 2 >= queuedChunks.length
-      ) {
-        queuedChunks.splice(0, queuedChunkIndex);
-        queuedChunkIndex = 0;
-      }
-      return queuedChunk;
-    };
-
-    const enqueue = async (
-      queuedChunk: QueuedGenerationChunk
-    ): Promise<void> => {
-      await waitForQueueSpace();
-      if (consumerClosed || isSignalAborted(options.signal)) {
-        stream.controller.abort();
-        throw new Error('AbortError: User aborted the request.');
-      }
-      queuedChunks.push(queuedChunk);
-      if (queuedChunk.smooth) {
-        bufferedTextLength += queuedChunk.textLength;
-      }
-      notifyConsumerForChunk();
-    };
-
-    const enqueueChunk = async ({
-      token,
-      chunk,
-      smooth,
-    }: {
-      token: string;
-      chunk: AIMessageChunk;
-      smooth: boolean;
-    }): Promise<void> => {
-      await enqueue({
-        token,
-        smooth,
-        textLength: smooth ? token.length : 0,
-        chunk: this.createGenerationChunk({
-          token,
-          chunk,
-          shouldStreamUsage,
-        }),
-      });
-    };
-
-    const enqueueTextChunks = (
+    const toEmittedChunk = (
       token: string,
-      tokenType: StreamTokenType,
       chunk: AIMessageChunk
-    ): Promise<void> => {
-      if (token === '') {
-        return Promise.resolve();
-      }
-      if (this._lc_stream_delay <= 0) {
-        return enqueueChunk({ token, chunk, smooth: false });
-      }
+    ): AnthropicEmittedChunk => ({
+      token,
+      chunk: this.createGenerationChunk({ token, chunk, shouldStreamUsage }),
+    });
 
-      const tokenChunks = splitStreamToken(token);
-      if (tokenChunks.length <= 1) {
-        return enqueueChunk({ token, chunk, smooth: true });
-      }
-
-      let emittedUsage = false;
-      return tokenChunks.reduce(async (previous, currentToken) => {
-        await previous;
-        const newChunk = cloneChunk(currentToken, tokenType, chunk);
-        const chunkForToken =
-          emittedUsage && newChunk.usage_metadata != null
-            ? new AIMessageChunk(
-              Object.assign({}, newChunk, { usage_metadata: undefined })
-            )
-            : newChunk;
-
-        await enqueueChunk({
-          token: currentToken,
-          chunk: chunkForToken,
-          smooth: true,
-        });
-
-        if (newChunk.usage_metadata != null && !emittedUsage) {
-          emittedUsage = true;
-        }
-      }, Promise.resolve());
-    };
-
-    const producer = (async (): Promise<void> => {
-      try {
-        for await (const data of stream) {
-          if (isSignalAborted(options.signal)) {
-            stream.controller.abort();
-            throw new Error('AbortError: User aborted the request.');
+    const source = (async function* (): AsyncGenerator<
+      SmoothItem<AnthropicEmittedChunk>
+    > {
+      for await (const data of stream) {
+        const result = _makeMessageChunkFromAnthropicEvent(
+          data as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
+          {
+            streamUsage: shouldStreamUsage,
+            coerceContentToString,
           }
-
-          const result = _makeMessageChunkFromAnthropicEvent(
-            data as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
-            {
-              streamUsage: shouldStreamUsage,
-              coerceContentToString,
-            }
-          );
-          if (!result) {
-            continue;
-          }
-
-          let { chunk } = result;
-          if (data.type === 'message_start') {
-            streamUsage = {
-              ...streamUsage,
-              inputTokens: data.message.usage.input_tokens,
-              outputTokens: data.message.usage.output_tokens,
-              cacheCreationInputTokens:
-                data.message.usage.cache_creation_input_tokens ?? 0,
-              cacheReadInputTokens:
-                data.message.usage.cache_read_input_tokens ?? 0,
-            };
-          }
-          if (data.type === 'message_delta') {
-            const incremental = withIncrementalMessageDeltaUsage(
-              chunk,
-              streamUsage,
-              data.usage
-            );
-            chunk = incremental.chunk;
-            streamUsage = incremental.usage;
-          }
-
-          const [token = '', tokenType] = extractToken(chunk);
-          if (
-            !tokenType ||
-            tokenType === 'input' ||
-            (token === '' && (chunk.usage_metadata != null || chunk.id != null))
-          ) {
-            await enqueueChunk({ token, chunk, smooth: false });
-            continue;
-          }
-
-          await enqueueTextChunks(token, tokenType, chunk);
-        }
-      } catch (error) {
-        producerState.error = error;
-      } finally {
-        producerState.done = true;
-        notifyConsumerForChunk();
-      }
-    })();
-
-    let hasEmittedText = false;
-    let lastVisibleTextAt: number | undefined;
-    let keepStreaming = true;
-    try {
-      while (keepStreaming) {
-        if (isSignalAborted(options.signal)) {
-          stream.controller.abort();
-          throw new Error('AbortError: User aborted the request.');
-        }
-
-        await waitForNextChunk();
-        const queuedChunk = dequeue();
-
-        if (!queuedChunk) {
-          if (producerState.error != null) {
-            throw producerState.error;
-          }
-          if (producerState.done) {
-            keepStreaming = false;
-          }
+        );
+        if (!result) {
           continue;
         }
 
-        if (queuedChunk.smooth) {
-          bufferedTextLength = Math.max(
-            0,
-            bufferedTextLength - queuedChunk.textLength
+        let { chunk } = result;
+        if (data.type === 'message_start') {
+          streamUsage = {
+            ...streamUsage,
+            inputTokens: data.message.usage.input_tokens,
+            outputTokens: data.message.usage.output_tokens,
+            cacheCreationInputTokens:
+              data.message.usage.cache_creation_input_tokens ?? 0,
+            cacheReadInputTokens:
+              data.message.usage.cache_read_input_tokens ?? 0,
+          };
+        }
+        if (data.type === 'message_delta') {
+          const incremental = withIncrementalMessageDeltaUsage(
+            chunk,
+            streamUsage,
+            data.usage
           );
-          notifyProducerForSpace();
-          await waitForStreamDelay(
-            getCadencedStreamDelay({
-              targetDelay: hasEmittedText ? this._lc_stream_delay : 0,
-              lastVisibleTextAt,
-              now: Date.now(),
-            }),
-            options.signal
-          );
-          if (isSignalAborted(options.signal)) {
-            stream.controller.abort();
-            throw new Error('AbortError: User aborted the request.');
-          }
-          hasEmittedText = true;
-          lastVisibleTextAt = Date.now();
-        } else {
-          notifyProducerForSpace();
+          chunk = incremental.chunk;
+          streamUsage = incremental.usage;
         }
 
-        yield queuedChunk.chunk;
+        const [token = '', tokenType] = extractToken(chunk);
+        if (
+          !tokenType ||
+          tokenType === 'input' ||
+          (token === '' && (chunk.usage_metadata != null || chunk.id != null))
+        ) {
+          yield {
+            text: '',
+            smooth: false,
+            emit: () => toEmittedChunk(token, chunk),
+          };
+          continue;
+        }
+
+        if (token === '') {
+          continue;
+        }
+
+        yield {
+          text: token,
+          smooth: true,
+          emit: (piece) => {
+            if (piece.isFirst && piece.isLast) {
+              return toEmittedChunk(token, chunk);
+            }
+            const cloned = cloneChunk(piece.text, tokenType, chunk);
+            const chunkForPiece =
+              !piece.isFirst && cloned.usage_metadata != null
+                ? new AIMessageChunk(
+                  Object.assign({}, cloned, { usage_metadata: undefined })
+                )
+                : cloned;
+            return toEmittedChunk(piece.text, chunkForPiece);
+          },
+        };
+      }
+    })();
+
+    const smoothed = smoothStream({
+      source,
+      delayMs: this._lc_stream_delay,
+      signal: options.signal,
+      abortUpstream: () => stream.controller.abort(),
+    });
+
+    try {
+      for await (const emitted of smoothed) {
+        yield emitted.chunk;
         await runManager?.handleLLMNewToken(
-          queuedChunk.token,
+          emitted.token,
           undefined,
           undefined,
           undefined,
           undefined,
-          { chunk: queuedChunk.chunk }
+          { chunk: emitted.chunk }
         );
       }
     } finally {
-      consumerClosed = true;
-      if (!producerState.done) {
-        stream.controller.abort();
-        notifyProducerForSpace();
-      }
-      await producer;
       this.resetTokenEvents();
     }
   }

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -688,7 +688,7 @@ export class CustomAnthropic extends ChatAnthropicMessages {
 
     const source = (async function* (): AsyncGenerator<
       SmoothItem<AnthropicEmittedChunk>
-    > {
+      > {
       for await (const data of stream) {
         const result = _makeMessageChunkFromAnthropicEvent(
           data as Anthropic.Beta.Messages.BetaRawMessageStreamEvent,
@@ -732,7 +732,7 @@ export class CustomAnthropic extends ChatAnthropicMessages {
           yield {
             text: '',
             smooth: false,
-            emit: () => toEmittedChunk(token, chunk),
+            emit: (): AnthropicEmittedChunk => toEmittedChunk(token, chunk),
           };
           continue;
         }
@@ -744,7 +744,7 @@ export class CustomAnthropic extends ChatAnthropicMessages {
         yield {
           text: token,
           smooth: true,
-          emit: (piece) => {
+          emit: (piece): AnthropicEmittedChunk => {
             if (piece.isFirst && piece.isLast) {
               return toEmittedChunk(token, chunk);
             }

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -33,6 +33,7 @@ import {
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { BaseMessage, ResponseMetadata } from '@langchain/core/messages';
 import type { ChatBedrockConverseInput } from '@langchain/aws';
+import type { SmoothItem } from '@/llm/stream/smoother';
 import type { ContentBlockDeltaEvent } from './types';
 import {
   convertToConverseMessages,
@@ -46,6 +47,7 @@ import {
   supportsBedrockToolCache,
   type PromptCacheTtl,
 } from '@/messages/cache';
+import { smoothStream, resolveStreamDelay, isSignalAborted } from '@/llm/stream/smoother';
 import { linkStreamLimitCanonical } from '@/llm/streamLimits';
 import { applyCachePointsToConversePayload } from './cachePoints';
 import { insertBedrockToolCachePoint } from './toolCache';
@@ -60,49 +62,11 @@ export type ServiceTierType = 'priority' | 'default' | 'flex' | 'reserved';
 export type CustomGuardrailConfiguration = GuardrailConfiguration &
   Pick<GuardrailStreamConfiguration, 'streamProcessingMode'>;
 
-const MAX_STREAM_QUEUE_CHUNKS = 256;
-const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
-const STREAM_CHUNK_MIN_SIZE = 4;
-const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
-
-type QueuedGenerationChunk = {
+type BedrockEmittedChunk = {
   chunk: ChatGenerationChunk;
   callbackChunk?: ChatGenerationChunk;
   callbackToken: string;
-  smooth: boolean;
-  textLength: number;
 };
-
-function findStreamChunkBoundary(text: string, minSize: number): number {
-  if (minSize >= text.length) {
-    return text.length;
-  }
-
-  for (let position = minSize; position < text.length; position++) {
-    if (STREAM_BOUNDARIES.has(text[position])) {
-      return position + 1;
-    }
-  }
-
-  return text.length;
-}
-
-function splitStreamToken(text: string): string[] {
-  const chunks: string[] = [];
-  let currentIndex = 0;
-
-  while (currentIndex < text.length) {
-    const remainingText = text.slice(currentIndex);
-    const chunkSize = findStreamChunkBoundary(
-      remainingText,
-      STREAM_CHUNK_MIN_SIZE
-    );
-    chunks.push(text.slice(currentIndex, currentIndex + chunkSize));
-    currentIndex += chunkSize;
-  }
-
-  return chunks;
-}
 
 /**
  * Resolves the text a delta contributes to the smoothing cadence, preferring a
@@ -120,51 +84,6 @@ function resolveVisibleText(text?: string, reasoningText?: string): string {
   return '';
 }
 
-function getCadencedStreamDelay({
-  targetDelay,
-  lastVisibleContentAt,
-  now,
-}: {
-  targetDelay: number;
-  lastVisibleContentAt?: number;
-  now: number;
-}): number {
-  if (targetDelay <= 0 || lastVisibleContentAt == null) {
-    return 0;
-  }
-  return Math.max(0, targetDelay - (now - lastVisibleContentAt));
-}
-
-async function waitForStreamDelay(
-  delay: number,
-  signal?: AbortSignal
-): Promise<void> {
-  if (delay <= 0 || isSignalAborted(signal)) {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
-    const onAbort = (): void => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    };
-    timeoutRef.current = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, delay);
-    signal?.addEventListener('abort', onAbort, { once: true });
-    if (isSignalAborted(signal)) {
-      onAbort();
-    }
-  });
-}
-
-function isSignalAborted(signal?: AbortSignal): boolean {
-  return signal?.aborted === true;
-}
 
 /**
  * Extended input interface with additional features:
@@ -267,7 +186,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     super(fields);
     this.promptCache = fields?.promptCache;
     this.promptCacheTtl = fields?.promptCacheTtl;
-    this._lc_stream_delay = Math.max(0, fields?._lc_stream_delay ?? 0);
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.applicationInferenceProfile = fields?.applicationInferenceProfile;
     this.serviceTier = fields?.serviceTier;
     // `super(fields)` initializes `this.model` to LangChain's default Claude
@@ -398,15 +317,6 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
 
       const seenBlockIndices = new Set<number>();
       const toolUseBlockIndices = new Set<number>();
-      const queuedChunks: QueuedGenerationChunk[] = [];
-      const producerState: { done: boolean; error?: unknown } = { done: false };
-      let queuedChunkIndex = 0;
-      let bufferedTextLength = 0;
-      let consumerClosed = false;
-      let notifyConsumer: (() => void) | undefined;
-      let notifyProducer: (() => void) | undefined;
-      let hasEmittedVisibleContent = false;
-      let lastVisibleContentAt: number | undefined;
 
       /**
        * Guardrails can reject an already-streamed toolUse block at
@@ -417,325 +327,200 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
       const sealToolUseOnStop =
         options.guardrailConfig == null && this.guardrailConfig == null;
 
-      const notifyConsumerForChunk = (): void => {
-        notifyConsumer?.();
-        notifyConsumer = undefined;
-      };
-
-      const notifyProducerForSpace = (): void => {
-        notifyProducer?.();
-        notifyProducer = undefined;
-      };
-
-      const hasQueuedChunks = (): boolean =>
-        queuedChunkIndex < queuedChunks.length;
-
-      const getQueuedChunkCount = (): number =>
-        queuedChunks.length - queuedChunkIndex;
-
-      const isQueueAtCapacity = (): boolean =>
-        getQueuedChunkCount() >= MAX_STREAM_QUEUE_CHUNKS ||
-        bufferedTextLength >= MAX_STREAM_QUEUE_TEXT_CHARS;
-
-      const waitForNextChunk = async (): Promise<void> => {
-        if (
-          hasQueuedChunks() ||
-          producerState.done ||
-          producerState.error != null
-        ) {
-          return;
-        }
-        await new Promise<void>((resolve) => {
-          notifyConsumer = resolve;
-        });
-      };
-
-      const waitForQueueSpace = async (): Promise<void> => {
-        while (
-          isQueueAtCapacity() &&
-          !consumerClosed &&
-          !isSignalAborted(options.signal)
-        ) {
-          await new Promise<void>((resolve) => {
-            const signal = options.signal;
-            const onAbort = (): void => {
-              signal?.removeEventListener('abort', onAbort);
-              resolve();
-            };
-            const onSpace = (): void => {
-              signal?.removeEventListener('abort', onAbort);
-              resolve();
-            };
-            notifyProducer = onSpace;
-            signal?.addEventListener('abort', onAbort, { once: true });
-            if (isSignalAborted(signal)) {
-              onAbort();
-            }
-          });
-        }
-      };
-
-      const dequeue = (): QueuedGenerationChunk | undefined => {
-        if (!hasQueuedChunks()) {
-          return undefined;
-        }
-        const queuedChunk = queuedChunks[queuedChunkIndex];
-        queuedChunkIndex++;
-        if (
-          queuedChunkIndex > 128 &&
-          queuedChunkIndex * 2 >= queuedChunks.length
-        ) {
-          queuedChunks.splice(0, queuedChunkIndex);
-          queuedChunkIndex = 0;
-        }
-        return queuedChunk;
-      };
-
-      const enqueue = async (
-        queuedChunk: QueuedGenerationChunk
-      ): Promise<void> => {
-        await waitForQueueSpace();
-        if (consumerClosed || isSignalAborted(options.signal)) {
-          abortStream();
-          throw new Error('AbortError: User aborted the request.');
-        }
-        queuedChunks.push(queuedChunk);
-        if (queuedChunk.smooth) {
-          bufferedTextLength += queuedChunk.textLength;
-        }
-        notifyConsumerForChunk();
-      };
-
-      const enqueueChunk = async ({
-        chunk,
-        callbackChunk,
-        callbackToken = '',
-        smooth = false,
-        textLength = 0,
-      }: {
-        chunk: ChatGenerationChunk;
-        callbackChunk?: ChatGenerationChunk;
-        callbackToken?: string;
-        smooth?: boolean;
-        textLength?: number;
-      }): Promise<void> => {
-        await enqueue({
-          chunk,
-          callbackChunk,
-          callbackToken,
-          smooth,
-          textLength: smooth ? textLength : 0,
-        });
-      };
-
-      const enqueueDelta = async (
-        contentBlockDelta: ContentBlockDeltaEvent
-      ): Promise<void> => {
+      /**
+       * Builds the emission for one piece of a delta, reproducing the exact
+       * per-piece pipeline (sliced delta → chunk → enrichment → stream-limit
+       * link). `indicesSnapshot` is the arrival-time copy of the seen block
+       * indices, so lazily emitted pieces observe the same enrichment
+       * decisions the delta saw when it arrived.
+       */
+      const buildDeltaEmission = (
+        contentBlockDelta: ContentBlockDeltaEvent,
+        token: string,
+        indicesSnapshot: Set<number>
+      ): BedrockEmittedChunk => {
         const delta = contentBlockDelta.delta;
-        if (delta == null) {
-          throw new Error('No delta found in content block.');
-        }
-
-        const idx = contentBlockDelta.contentBlockIndex;
-        if (idx != null) {
-          seenBlockIndices.add(idx);
-        }
-
-        const text = delta.text;
-        const reasoningContent = delta.reasoningContent;
+        const text = delta?.text;
+        const reasoningContent = delta?.reasoningContent;
         const reasoningText = reasoningContent?.text;
-        const visibleText = resolveVisibleText(text, reasoningText);
-        const smooth = this._lc_stream_delay > 0 && visibleText !== '';
-        const tokenChunks = smooth
-          ? splitStreamToken(visibleText)
-          : [visibleText];
 
-        for (const token of tokenChunks) {
-          let splitDelta = contentBlockDelta;
-          if (typeof text === 'string') {
-            splitDelta = {
-              ...contentBlockDelta,
-              delta: { text: token },
-            };
-          } else if (
-            typeof reasoningText === 'string' &&
-            reasoningContent != null
-          ) {
-            splitDelta = {
-              ...contentBlockDelta,
-              delta: {
-                reasoningContent: {
-                  ...reasoningContent,
-                  text: token,
-                },
+        let splitDelta = contentBlockDelta;
+        if (typeof text === 'string') {
+          splitDelta = {
+            ...contentBlockDelta,
+            delta: { text: token },
+          };
+        } else if (
+          typeof reasoningText === 'string' &&
+          reasoningContent != null
+        ) {
+          splitDelta = {
+            ...contentBlockDelta,
+            delta: {
+              reasoningContent: {
+                ...reasoningContent,
+                text: token,
               },
-            };
-          }
-
-          const deltaChunk = handleConverseStreamContentBlockDelta(splitDelta);
-          const enrichedChunk = this.enrichChunk(deltaChunk, seenBlockIndices);
-          if (enrichedChunk !== deltaChunk) {
-            /** The callback copy is the same emission as the enriched yield;
-             * without the link, stream-limit accounting charges both message
-             * objects and Bedrock tool arguments falsely trip near half the
-             * cap. Linked on the messages, which are what the accounting
-             * observes. */
-            linkStreamLimitCanonical(deltaChunk.message, enrichedChunk.message);
-          }
-          await enqueueChunk({
-            chunk: enrichedChunk,
-            callbackChunk: deltaChunk,
-            callbackToken: deltaChunk.text,
-            smooth,
-            textLength: token.length,
-          });
+            },
+          };
         }
+
+        const deltaChunk = handleConverseStreamContentBlockDelta(splitDelta);
+        const enrichedChunk = this.enrichChunk(deltaChunk, indicesSnapshot);
+        if (enrichedChunk !== deltaChunk) {
+          /** The callback copy is the same emission as the enriched yield;
+           * without the link, stream-limit accounting charges both message
+           * objects and Bedrock tool arguments falsely trip near half the
+           * cap. Linked on the messages, which are what the accounting
+           * observes. */
+          linkStreamLimitCanonical(deltaChunk.message, enrichedChunk.message);
+        }
+        return {
+          chunk: enrichedChunk,
+          callbackChunk: deltaChunk,
+          callbackToken: deltaChunk.text,
+        };
       };
 
-      const producer = (async (): Promise<void> => {
-        try {
-          for await (const event of stream) {
-            if (isSignalAborted(options.signal)) {
-              abortStream();
-              throw new Error('AbortError: User aborted the request.');
-            }
-
-            if (event.contentBlockStart != null) {
-              const startChunk = handleConverseStreamContentBlockStart(
-                event.contentBlockStart
-              );
-              if (startChunk != null) {
-                const idx = event.contentBlockStart.contentBlockIndex;
-                if (idx != null) {
-                  seenBlockIndices.add(idx);
-                  if (event.contentBlockStart.start?.toolUse != null) {
-                    toolUseBlockIndices.add(idx);
-                  }
+      const enrichChunk = this.enrichChunk.bind(this);
+      const source = (async function* (): AsyncGenerator<
+        SmoothItem<BedrockEmittedChunk>
+      > {
+        for await (const event of stream) {
+          if (event.contentBlockStart != null) {
+            const startChunk = handleConverseStreamContentBlockStart(
+              event.contentBlockStart
+            );
+            if (startChunk != null) {
+              const idx = event.contentBlockStart.contentBlockIndex;
+              if (idx != null) {
+                seenBlockIndices.add(idx);
+                if (event.contentBlockStart.start?.toolUse != null) {
+                  toolUseBlockIndices.add(idx);
                 }
-                const enrichedStart = this.enrichChunk(
-                  startChunk,
-                  seenBlockIndices
+              }
+              const enrichedStart = enrichChunk(startChunk, seenBlockIndices);
+              if (enrichedStart !== startChunk) {
+                linkStreamLimitCanonical(
+                  startChunk.message,
+                  enrichedStart.message
                 );
-                if (enrichedStart !== startChunk) {
-                  linkStreamLimitCanonical(
-                    startChunk.message,
-                    enrichedStart.message
-                  );
-                }
-                await enqueueChunk({
+              }
+              yield {
+                text: '',
+                smooth: false,
+                emit: () => ({
                   chunk: enrichedStart,
                   callbackChunk: startChunk,
                   callbackToken: startChunk.text,
-                });
-              }
-            } else if (event.contentBlockDelta != null) {
-              await enqueueDelta(event.contentBlockDelta);
-            } else if (event.metadata != null) {
-              await enqueueChunk({
-                chunk: handleConverseStreamMetadata(event.metadata, {
-                  streamUsage,
                 }),
-              });
-            } else if (event.contentBlockStop != null) {
-              const stopIdx = event.contentBlockStop.contentBlockIndex;
-              if (stopIdx != null) {
-                seenBlockIndices.add(stopIdx);
-                if (sealToolUseOnStop && toolUseBlockIndices.has(stopIdx)) {
-                  const sealChunk = createConverseToolUseStopChunk(stopIdx);
-                  await enqueueChunk({
+              };
+            }
+          } else if (event.contentBlockDelta != null) {
+            const contentBlockDelta = event.contentBlockDelta;
+            const delta = contentBlockDelta.delta;
+            if (delta == null) {
+              throw new Error('No delta found in content block.');
+            }
+
+            const idx = contentBlockDelta.contentBlockIndex;
+            if (idx != null) {
+              seenBlockIndices.add(idx);
+            }
+
+            const visibleText = resolveVisibleText(
+              delta.text,
+              delta.reasoningContent?.text
+            );
+            const indicesSnapshot = new Set(seenBlockIndices);
+
+            if (visibleText === '') {
+              yield {
+                text: '',
+                smooth: false,
+                emit: () =>
+                  buildDeltaEmission(
+                    contentBlockDelta,
+                    visibleText,
+                    indicesSnapshot
+                  ),
+              };
+              continue;
+            }
+
+            yield {
+              text: visibleText,
+              smooth: true,
+              emit: (piece) =>
+                buildDeltaEmission(
+                  contentBlockDelta,
+                  piece.text,
+                  indicesSnapshot
+                ),
+            };
+          } else if (event.metadata != null) {
+            const metadataChunk = handleConverseStreamMetadata(event.metadata, {
+              streamUsage,
+            });
+            yield {
+              text: '',
+              smooth: false,
+              emit: () => ({ chunk: metadataChunk, callbackToken: '' }),
+            };
+          } else if (event.contentBlockStop != null) {
+            const stopIdx = event.contentBlockStop.contentBlockIndex;
+            if (stopIdx != null) {
+              seenBlockIndices.add(stopIdx);
+              if (sealToolUseOnStop && toolUseBlockIndices.has(stopIdx)) {
+                const sealChunk = createConverseToolUseStopChunk(stopIdx);
+                yield {
+                  text: '',
+                  smooth: false,
+                  emit: () => ({
                     chunk: sealChunk,
                     callbackChunk: sealChunk,
                     callbackToken: sealChunk.text,
-                  });
-                }
-              }
-            } else {
-              await enqueueChunk({
-                chunk: new ChatGenerationChunk({
-                  text: '',
-                  message: new AIMessageChunk({
-                    content: '',
-                    response_metadata: { ...event } as ResponseMetadata,
                   }),
-                }),
-              });
+                };
+              }
             }
+          } else {
+            const eventChunk = new ChatGenerationChunk({
+              text: '',
+              message: new AIMessageChunk({
+                content: '',
+                response_metadata: { ...event } as ResponseMetadata,
+              }),
+            });
+            yield {
+              text: '',
+              smooth: false,
+              emit: () => ({ chunk: eventChunk, callbackToken: '' }),
+            };
           }
-        } catch (error) {
-          producerState.error = error;
-        } finally {
-          producerState.done = true;
-          notifyConsumerForChunk();
         }
       })();
 
-      try {
-        let keepStreaming = true;
-        while (keepStreaming) {
-          if (isSignalAborted(options.signal)) {
-            abortStream();
-            throw new Error('AbortError: User aborted the request.');
-          }
+      const smoothed = smoothStream({
+        source,
+        delayMs: this._lc_stream_delay,
+        signal: options.signal,
+        abortUpstream: abortStream,
+      });
 
-          await waitForNextChunk();
-          const queuedChunk = dequeue();
+      for await (const emitted of smoothed) {
+        yield emitted.chunk;
 
-          if (!queuedChunk) {
-            if (producerState.error != null) {
-              throw producerState.error;
-            }
-            if (producerState.done) {
-              keepStreaming = false;
-            }
-            continue;
-          }
-
-          if (queuedChunk.smooth) {
-            bufferedTextLength = Math.max(
-              0,
-              bufferedTextLength - queuedChunk.textLength
-            );
-            notifyProducerForSpace();
-            await waitForStreamDelay(
-              getCadencedStreamDelay({
-                targetDelay: hasEmittedVisibleContent
-                  ? this._lc_stream_delay
-                  : 0,
-                lastVisibleContentAt,
-                now: Date.now(),
-              }),
-              options.signal
-            );
-            if (isSignalAborted(options.signal)) {
-              abortStream();
-              throw new Error('AbortError: User aborted the request.');
-            }
-            hasEmittedVisibleContent = true;
-            lastVisibleContentAt = Date.now();
-          } else {
-            notifyProducerForSpace();
-          }
-
-          yield queuedChunk.chunk;
-
-          if (queuedChunk.callbackChunk != null) {
-            await runManager?.handleLLMNewToken(
-              queuedChunk.callbackToken,
-              undefined,
-              undefined,
-              undefined,
-              undefined,
-              { chunk: queuedChunk.callbackChunk }
-            );
-          }
+        if (emitted.callbackChunk != null) {
+          await runManager?.handleLLMNewToken(
+            emitted.callbackToken,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { chunk: emitted.callbackChunk }
+          );
         }
-      } finally {
-        consumerClosed = true;
-        if (!producerState.done) {
-          abortStream();
-          notifyProducerForSpace();
-        }
-        await producer;
       }
     } finally {
       options.signal?.removeEventListener('abort', abortStream);

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -84,7 +84,6 @@ function resolveVisibleText(text?: string, reasoningText?: string): string {
   return '';
 }
 
-
 /**
  * Extended input interface with additional features:
  * - applicationInferenceProfile: Use an inference profile ARN instead of model ID
@@ -385,7 +384,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
       const enrichChunk = this.enrichChunk.bind(this);
       const source = (async function* (): AsyncGenerator<
         SmoothItem<BedrockEmittedChunk>
-      > {
+        > {
         for await (const event of stream) {
           if (event.contentBlockStart != null) {
             const startChunk = handleConverseStreamContentBlockStart(
@@ -409,7 +408,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
               yield {
                 text: '',
                 smooth: false,
-                emit: () => ({
+                emit: (): BedrockEmittedChunk => ({
                   chunk: enrichedStart,
                   callbackChunk: startChunk,
                   callbackToken: startChunk.text,
@@ -438,7 +437,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
               yield {
                 text: '',
                 smooth: false,
-                emit: () =>
+                emit: (): BedrockEmittedChunk =>
                   buildDeltaEmission(
                     contentBlockDelta,
                     visibleText,
@@ -451,7 +450,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
             yield {
               text: visibleText,
               smooth: true,
-              emit: (piece) =>
+              emit: (piece): BedrockEmittedChunk =>
                 buildDeltaEmission(
                   contentBlockDelta,
                   piece.text,
@@ -465,7 +464,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
             yield {
               text: '',
               smooth: false,
-              emit: () => ({ chunk: metadataChunk, callbackToken: '' }),
+              emit: (): BedrockEmittedChunk => ({ chunk: metadataChunk, callbackToken: '' }),
             };
           } else if (event.contentBlockStop != null) {
             const stopIdx = event.contentBlockStop.contentBlockIndex;
@@ -476,7 +475,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
                 yield {
                   text: '',
                   smooth: false,
-                  emit: () => ({
+                  emit: (): BedrockEmittedChunk => ({
                     chunk: sealChunk,
                     callbackChunk: sealChunk,
                     callbackToken: sealChunk.text,
@@ -495,7 +494,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
             yield {
               text: '',
               smooth: false,
-              emit: () => ({ chunk: eventChunk, callbackToken: '' }),
+              emit: (): BedrockEmittedChunk => ({ chunk: eventChunk, callbackToken: '' }),
             };
           }
         }

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -233,6 +233,7 @@ describe('CustomChatBedrockConverse', () => {
         model: 'anthropic.claude-3-haiku-20240307-v1:0',
         applicationInferenceProfile: testArn,
         client: mockClient,
+        _lc_stream_delay: 0,
       });
 
       let chunks = 0;
@@ -281,6 +282,7 @@ describe('CustomChatBedrockConverse', () => {
         model: 'anthropic.claude-3-haiku-20240307-v1:0',
         guardrailConfig,
         client: mockClient,
+        _lc_stream_delay: 0,
       });
 
       let chunks = 0;

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -252,4 +252,80 @@ describe('Converse stream seal dispatch', () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  test('emits toolUse seal chunks without pacing delay while text is paced', async () => {
+    const model = new CustomChatBedrockConverse({
+      model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+      region: 'us-east-1',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+      _lc_stream_delay: 60,
+    });
+
+    (model as unknown as { client: { send: unknown } }).client.send = jest.fn(
+      async () => ({
+        stream: (async function* () {
+          yield {
+            contentBlockDelta: {
+              contentBlockIndex: 0,
+              delta: { text: 'alpha beta' },
+            },
+          };
+          yield {
+            contentBlockStart: {
+              contentBlockIndex: 1,
+              start: { toolUse: { toolUseId: 'call_1', name: 'weather' } },
+            },
+          };
+          yield {
+            contentBlockDelta: {
+              contentBlockIndex: 1,
+              delta: { toolUse: { input: '{"city":"NYC"}' } },
+            },
+          };
+          yield { contentBlockStop: { contentBlockIndex: 1 } };
+        })(),
+      })
+    );
+
+    const arrivals: { isSeal: boolean; hasText: boolean; at: number }[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<CustomChatBedrockConverse['_streamResponseChunks']>[1],
+      undefined
+    )) {
+      const message = chunk.message as AIMessageChunk;
+      arrivals.push({
+        isSeal:
+          (message.response_metadata as Record<string, unknown>)[
+            STREAMED_TOOL_CALL_SEAL_METADATA_KEY
+          ] != null,
+        hasText: chunk.text !== '',
+        at: Date.now(),
+      });
+    }
+
+    const lastText = [...arrivals].reverse().find((entry) => entry.hasText);
+    const seal = arrivals.find((entry) => entry.isSeal);
+    expect(lastText).toBeDefined();
+    expect(seal).toBeDefined();
+    expect((seal as { at: number }).at).toBeGreaterThanOrEqual(
+      (lastText as { at: number }).at
+    );
+    expect(
+      (seal as { at: number }).at - (lastText as { at: number }).at
+    ).toBeLessThan(45);
+  });
+
+  test('defaults to 25ms adaptive smoothing with 0 disabling', () => {
+    const base = {
+      model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+      region: 'us-east-1',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+    };
+    expect(new CustomChatBedrockConverse(base)._lc_stream_delay).toBe(25);
+    expect(
+      new CustomChatBedrockConverse({ ...base, _lc_stream_delay: 0 })
+        ._lc_stream_delay
+    ).toBe(0);
+  });
 });

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -1836,7 +1836,7 @@ describe('custom chat model class smoke tests', () => {
     );
     expect(model.applicationInferenceProfile).toBe(applicationInferenceProfile);
     expect(model._lc_stream_delay).toBe(12);
-    expect(defaultStreamDelayModel._lc_stream_delay).toBe(0);
+    expect(defaultStreamDelayModel._lc_stream_delay).toBe(25);
     expect(model.invocationParams({}).serviceTier).toEqual({
       type: 'priority',
     });

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -1949,3 +1949,18 @@ describe('custom chat model class smoke tests', () => {
     expect(capturedFetch.getSignal()?.aborted).toBe(true);
   });
 });
+
+describe('StreamSmoothingOptions type surface', () => {
+  it('accepts _lc_stream_delay: 0 across the typed provider options', () => {
+    const azure: import('@/types').AzureClientOptions = { _lc_stream_delay: 0 };
+    const openrouter: ChatOpenRouterCallOptions &
+      import('@/types').StreamSmoothingOptions = { _lc_stream_delay: 0 };
+    const mistral: import('@/types').MistralAIClientOptions = {
+      model: 'mistral-large-latest',
+      _lc_stream_delay: 0,
+    };
+    expect(azure._lc_stream_delay).toBe(0);
+    expect(openrouter._lc_stream_delay).toBe(0);
+    expect(mistral._lc_stream_delay).toBe(0);
+  });
+});

--- a/src/llm/google/index.ts
+++ b/src/llm/google/index.ts
@@ -16,6 +16,8 @@ import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager
 import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
 import type { GeminiApiUsageMetadata, InputTokenDetails } from './types';
 import type { GoogleClientOptions, GoogleThinkingConfig } from '@/types';
+import { smoothGenerationChunks } from '@/llm/stream/chunkAdapters';
+import { resolveStreamDelay } from '@/llm/stream/smoother';
 import {
   convertResponseContentToChatGenerationChunk,
   convertBaseMessagesToContent,
@@ -36,6 +38,7 @@ type GoogleToolConfigWithServerSideInvocations = ToolConfig & {
 };
 
 export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
+  _lc_stream_delay: number;
   thinkingConfig?: GoogleThinkingConfig;
   includeServerSideToolInvocations?: boolean;
 
@@ -55,6 +58,7 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
   constructor(fields: GoogleClientOptions) {
     super(fields);
 
+    this._lc_stream_delay = resolveStreamDelay(fields._lc_stream_delay);
     this.model = fields.model.replace(/^models\//, '');
 
     this.maxOutputTokens = fields.maxOutputTokens ?? this.maxOutputTokens;
@@ -297,6 +301,18 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    yield* smoothGenerationChunks({
+      chunks: this._streamProviderChunks(messages, options),
+      delayMs: this._lc_stream_delay,
+      signal: options.signal,
+      runManager,
+    });
+  }
+
+  private async *_streamProviderChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions']
+  ): AsyncGenerator<ChatGenerationChunk> {
     const prompt = convertBaseMessagesToContent(
       messages,
       this._isMultimodalModel,
@@ -349,33 +365,16 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
       }
 
       yield chunk;
-      await runManager?.handleLLMNewToken(
-        chunk.text || '',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { chunk }
-      );
     }
 
     if (lastUsageMetadata) {
-      const finalChunk = new ChatGenerationChunk({
+      yield new ChatGenerationChunk({
         text: '',
         message: new AIMessageChunk({
           content: '',
           usage_metadata: lastUsageMetadata,
         }),
       });
-      yield finalChunk;
-      await runManager?.handleLLMNewToken(
-        finalChunk.text || '',
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { chunk: finalChunk }
-      );
     }
   }
 }

--- a/src/llm/google/streamSmoothing.test.ts
+++ b/src/llm/google/streamSmoothing.test.ts
@@ -1,0 +1,121 @@
+import { expect, test, describe, jest } from '@jest/globals';
+import { HumanMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { CustomChatGoogleGenerativeAI } from './index';
+
+describe('Google stream smoothing', () => {
+  function textResponse(text: string): Record<string, unknown> {
+    return {
+      candidates: [
+        {
+          content: { role: 'model', parts: [{ text }] },
+          index: 0,
+        },
+      ],
+    };
+  }
+
+  async function runStream(
+    responses: Record<string, unknown>[],
+    modelFields: Record<string, unknown> = {}
+  ): Promise<{
+    yielded: ChatGenerationChunk[];
+    dispatchedTokens: string[];
+  }> {
+    const model = new CustomChatGoogleGenerativeAI({
+      model: 'gemini-2.5-flash',
+      apiKey: 'test-key',
+      ...modelFields,
+    });
+
+    (
+      model as unknown as {
+        client: { generateContentStream: unknown };
+      }
+    ).client.generateContentStream = jest.fn(async () => ({
+      stream: (async function* () {
+        yield* responses;
+      })(),
+    }));
+
+    const dispatchedTokens: string[] = [];
+    const runManager = {
+      handleLLMNewToken: jest.fn(async (token: string) => {
+        dispatchedTokens.push(token);
+      }),
+    } as unknown as CallbackManagerForLLMRun;
+
+    const yielded: ChatGenerationChunk[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<
+        CustomChatGoogleGenerativeAI['_streamResponseChunks']
+      >[1],
+      runManager
+    )) {
+      yielded.push(chunk);
+    }
+    return { yielded, dispatchedTokens };
+  }
+
+  test('splits large text responses at stream boundaries with pacing', async () => {
+    const { yielded, dispatchedTokens } = await runStream(
+      [textResponse('alpha beta gamma')],
+      { _lc_stream_delay: 1 }
+    );
+
+    const texts = yielded.map((chunk) => chunk.text).filter(Boolean);
+    expect(texts).toEqual(['alpha ', 'beta ', 'gamma']);
+    expect(dispatchedTokens.filter(Boolean)).toEqual([
+      'alpha ',
+      'beta ',
+      'gamma',
+    ]);
+  });
+
+  test('passes chunks through unsplit when smoothing is disabled', async () => {
+    const { yielded } = await runStream([textResponse('alpha beta gamma')], {
+      _lc_stream_delay: 0,
+    });
+
+    expect(yielded.map((chunk) => chunk.text).filter(Boolean)).toEqual([
+      'alpha beta gamma',
+    ]);
+  });
+
+  test('emits the final usage chunk without pacing delay', async () => {
+    const start = Date.now();
+    const { yielded } = await runStream(
+      [
+        {
+          ...textResponse('short text here'),
+          usageMetadata: {
+            promptTokenCount: 3,
+            candidatesTokenCount: 4,
+            totalTokenCount: 7,
+          },
+        },
+      ],
+      { _lc_stream_delay: 30 }
+    );
+    const elapsed = Date.now() - start;
+
+    const usageChunk = yielded.find(
+      (chunk) =>
+        chunk.text === '' &&
+        (chunk.message as AIMessageChunk).usage_metadata != null
+    );
+    expect(usageChunk).toBeDefined();
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test('defaults to 25ms adaptive smoothing with 0 disabling', () => {
+    const base = { model: 'gemini-2.5-flash', apiKey: 'test-key' };
+    expect(new CustomChatGoogleGenerativeAI(base)._lc_stream_delay).toBe(25);
+    expect(
+      new CustomChatGoogleGenerativeAI({ ...base, _lc_stream_delay: 0 })
+        ._lc_stream_delay
+    ).toBe(0);
+  });
+});

--- a/src/llm/mistral/index.ts
+++ b/src/llm/mistral/index.ts
@@ -1,0 +1,33 @@
+import { ChatMistralAI } from '@langchain/mistralai';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { MistralAIClientOptions } from '@/types';
+import { smoothGenerationChunks } from '@/llm/stream/chunkAdapters';
+import { resolveStreamDelay } from '@/llm/stream/smoother';
+
+export class CustomChatMistralAI extends ChatMistralAI {
+  _lc_stream_delay: number;
+
+  static lc_name(): 'LibreChatMistralAI' {
+    return 'LibreChatMistralAI';
+  }
+
+  constructor(fields?: MistralAIClientOptions) {
+    super(fields);
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
+  }
+
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield* smoothGenerationChunks({
+      chunks: super._streamResponseChunks(messages, options, undefined),
+      delayMs: this._lc_stream_delay,
+      signal: options.signal,
+      runManager,
+    });
+  }
+}

--- a/src/llm/mistral/streamSmoothing.test.ts
+++ b/src/llm/mistral/streamSmoothing.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, describe, jest, afterEach } from '@jest/globals';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { ChatMistralAI } from '@langchain/mistralai';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import { CustomChatMistralAI } from './index';
+
+describe('Mistral stream smoothing', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function stubParentStream(texts: string[]): void {
+    jest
+      .spyOn(
+        ChatMistralAI.prototype as unknown as {
+          _streamResponseChunks: (
+            ...args: unknown[]
+          ) => AsyncGenerator<ChatGenerationChunk>;
+        },
+        '_streamResponseChunks'
+      )
+      .mockImplementation(async function* () {
+        for (const text of texts) {
+          yield new ChatGenerationChunk({
+            text,
+            message: new AIMessageChunk({ content: text }),
+          });
+        }
+      });
+  }
+
+  async function collect(
+    model: CustomChatMistralAI,
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<string[]> {
+    const texts: string[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<CustomChatMistralAI['_streamResponseChunks']>[1],
+      runManager
+    )) {
+      if (chunk.text) {
+        texts.push(chunk.text);
+      }
+    }
+    return texts;
+  }
+
+  test('splits large text chunks at stream boundaries with pacing', async () => {
+    stubParentStream(['alpha beta gamma']);
+    const model = new CustomChatMistralAI({
+      model: 'mistral-large-latest',
+      apiKey: 'test-key',
+      _lc_stream_delay: 1,
+    });
+
+    const dispatchedTokens: string[] = [];
+    const runManager = {
+      handleLLMNewToken: jest.fn(async (token: string) => {
+        dispatchedTokens.push(token);
+      }),
+    } as unknown as CallbackManagerForLLMRun;
+
+    expect(await collect(model, runManager)).toEqual([
+      'alpha ',
+      'beta ',
+      'gamma',
+    ]);
+    expect(dispatchedTokens.filter(Boolean)).toEqual([
+      'alpha ',
+      'beta ',
+      'gamma',
+    ]);
+  });
+
+  test('passes chunks through unsplit when smoothing is disabled', async () => {
+    stubParentStream(['alpha beta gamma']);
+    const model = new CustomChatMistralAI({
+      model: 'mistral-large-latest',
+      apiKey: 'test-key',
+      _lc_stream_delay: 0,
+    });
+
+    expect(await collect(model)).toEqual(['alpha beta gamma']);
+  });
+
+  test('defaults to 25ms adaptive smoothing with 0 disabling', () => {
+    const base = { model: 'mistral-large-latest', apiKey: 'test-key' };
+    expect(new CustomChatMistralAI(base)._lc_stream_delay).toBe(25);
+    expect(
+      new CustomChatMistralAI({ ...base, _lc_stream_delay: 0 })
+        ._lc_stream_delay
+    ).toBe(0);
+    expect(CustomChatMistralAI.lc_name()).toBe('LibreChatMistralAI');
+  });
+});

--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -557,6 +557,62 @@ describe('ChatDeepSeek', () => {
     expect(textChunks).toEqual(['alpha ', 'beta ', 'gamma']);
   });
 
+  it('does not delay tool-call and finish chunks between paced text', async () => {
+    const toolCallChunk: OpenAIChatCompletionChunk = {
+      id: 'chatcmpl-deepseek-test',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model: 'deepseek-v4-pro',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+    };
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+        _lc_stream_delay: 150,
+      },
+      [createContentChunk('alpha beta'), toolCallChunk]
+    );
+    const arrivals: { text: string; hasToolCall: boolean; at: number }[] = [];
+
+    for await (const chunk of model.streamChunksWithSignal(
+      new AbortController().signal
+    )) {
+      const message = chunk.message as Partial<AIMessage>;
+      arrivals.push({
+        text: chunk.text,
+        hasToolCall: (message.tool_calls?.length ?? 0) > 0,
+        at: Date.now(),
+      });
+    }
+
+    const toolArrival = arrivals.find((entry) => entry.hasToolCall);
+    const lastText = [...arrivals].reverse().find((entry) => entry.text !== '');
+    expect(toolArrival).toBeDefined();
+    expect(lastText).toBeDefined();
+    expect(
+      (toolArrival as { at: number }).at - (lastText as { at: number }).at
+    ).toBeLessThan(100);
+  });
+
   it('keeps delayed DeepSeek logprob chunks intact', async () => {
     const logprobs = { content: [], refusal: null } as NonNullable<
       OpenAIChatCompletionChunk['choices'][number]['logprobs']

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -60,7 +60,7 @@ import {
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
-import { hasReasoningKwargs } from '@/llm/stream/chunkAdapters';
+import { hasReasoningKwargs, hasToolCallChunks } from '@/llm/stream/chunkAdapters';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -1151,9 +1151,9 @@ function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChun
   const { message } = chunk;
   const isMessageChunk = message instanceof AIMessageChunk;
   /** Chunks pairing visible text with a reasoning delta (reasoning_content,
-   * reasoning summary, or OpenRouter reasoning_details) must pace whole:
-   * split pieces would each clone the same reasoning kwargs and downstream
-   * accumulation duplicates them once per piece. */
+   * reasoning summary, or OpenRouter reasoning_details) or with tool-call
+   * deltas must pace whole: split pieces would each clone the same kwargs /
+   * tool_call_chunks and downstream accumulation duplicates them per piece. */
   const splittable =
     Boolean(chunk.text) &&
     isMessageChunk &&
@@ -1161,7 +1161,8 @@ function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChun
     message.content === chunk.text &&
     chunk.generationInfo?.logprobs == null &&
     chunk.generationInfo?.finish_reason == null &&
-    !hasReasoningKwargs(message);
+    !hasReasoningKwargs(message) &&
+    !hasToolCallChunks(message);
 
   if (splittable) {
     return {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1139,6 +1139,10 @@ function getReasoningDeltaText(message: AIMessageChunk): string {
  * Classifies a generation chunk for the smoothing engine:
  * - splittable: plain visible text (string content equal to `chunk.text`, no
  *   logprobs / finish_reason) — sliced adaptively at the pacing cadence.
+ *   ANY logprobs value blocks splitting here (this family only attaches
+ *   logprobs on request; the DeepSeek suite pins chunks with them staying
+ *   intact) — deliberately stricter than `stream/chunkAdapters.ts`, where
+ *   google-common's always-present empty logprobs must not block.
  * - atomic: text- or reasoning-bearing chunks whose metadata cannot survive
  *   slicing — paced as one piece, never split (legacy parity: these were
  *   emitted whole but still paced).

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -60,6 +60,7 @@ import {
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
+import { hasReasoningKwargs } from '@/llm/stream/chunkAdapters';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -1149,9 +1150,10 @@ function getReasoningDeltaText(message: AIMessageChunk): string {
 function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChunk> {
   const { message } = chunk;
   const isMessageChunk = message instanceof AIMessageChunk;
-  /** Chunks pairing visible text with a reasoning delta must pace whole:
-   * split pieces would each clone the same reasoning kwargs and the
-   * aggregator's dict merge concatenates them once per piece. */
+  /** Chunks pairing visible text with a reasoning delta (reasoning_content,
+   * reasoning summary, or OpenRouter reasoning_details) must pace whole:
+   * split pieces would each clone the same reasoning kwargs and downstream
+   * accumulation duplicates them once per piece. */
   const splittable =
     Boolean(chunk.text) &&
     isMessageChunk &&
@@ -1159,7 +1161,7 @@ function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChun
     message.content === chunk.text &&
     chunk.generationInfo?.logprobs == null &&
     chunk.generationInfo?.finish_reason == null &&
-    getReasoningDeltaText(message) === '';
+    !hasReasoningKwargs(message);
 
   if (splittable) {
     return {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1115,9 +1115,6 @@ function getCustomOpenAIClientOptions(
 
 function getReasoningDeltaText(message: AIMessageChunk): string {
   const kwargs = message.additional_kwargs;
-  if (kwargs == null) {
-    return '';
-  }
   if (
     typeof kwargs.reasoning_content === 'string' &&
     kwargs.reasoning_content !== ''
@@ -1250,7 +1247,7 @@ async function* delayStreamChunks(
 ): AsyncGenerator<ChatGenerationChunk> {
   const source = (async function* (): AsyncGenerator<
     SmoothItem<ChatGenerationChunk>
-  > {
+    > {
     for await (const chunk of chunks) {
       yield toSmoothItem(chunk);
     }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -60,7 +60,11 @@ import {
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
-import { hasReasoningKwargs, hasToolCallChunks } from '@/llm/stream/chunkAdapters';
+import {
+  hasReasoningKwargs,
+  hasToolCallChunks,
+  getReasoningKwargsText,
+} from '@/llm/stream/chunkAdapters';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -1114,25 +1118,6 @@ function getCustomOpenAIClientOptions(
   return requestOptions;
 }
 
-function getReasoningDeltaText(message: AIMessageChunk): string {
-  const kwargs = message.additional_kwargs;
-  if (
-    typeof kwargs.reasoning_content === 'string' &&
-    kwargs.reasoning_content !== ''
-  ) {
-    return kwargs.reasoning_content;
-  }
-  if (kwargs.reasoning != null) {
-    const summaryText = (
-      kwargs.reasoning as Partial<t.ChatOpenAIReasoningSummary> | undefined
-    )?.summary?.[0]?.text;
-    if (typeof summaryText === 'string' && summaryText !== '') {
-      return summaryText;
-    }
-  }
-  return '';
-}
-
 /**
  * Classifies a generation chunk for the smoothing engine:
  * - splittable: plain visible text (string content equal to `chunk.text`, no
@@ -1173,7 +1158,7 @@ function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChun
   }
 
   const pacedText =
-    chunk.text || (isMessageChunk ? getReasoningDeltaText(message) : '');
+    chunk.text || (isMessageChunk ? getReasoningKwargsText(message) : '');
   if (pacedText !== '') {
     return {
       text: pacedText,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1149,13 +1149,17 @@ function getReasoningDeltaText(message: AIMessageChunk): string {
 function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChunk> {
   const { message } = chunk;
   const isMessageChunk = message instanceof AIMessageChunk;
+  /** Chunks pairing visible text with a reasoning delta must pace whole:
+   * split pieces would each clone the same reasoning kwargs and the
+   * aggregator's dict merge concatenates them once per piece. */
   const splittable =
     Boolean(chunk.text) &&
     isMessageChunk &&
     typeof message.content === 'string' &&
     message.content === chunk.text &&
     chunk.generationInfo?.logprobs == null &&
-    chunk.generationInfo?.finish_reason == null;
+    chunk.generationInfo?.finish_reason == null &&
+    getReasoningDeltaText(message) === '';
 
   if (splittable) {
     return {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1132,7 +1132,9 @@ function getCustomOpenAIClientOptions(
  * - passthrough: tool-call deltas, usage-only, finish_reason and other
  *   metadata chunks — strict FIFO, zero delay.
  */
-function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChunk> {
+export function toSmoothItem(
+  chunk: ChatGenerationChunk
+): SmoothItem<ChatGenerationChunk> {
   const { message } = chunk;
   const isMessageChunk = message instanceof AIMessageChunk;
   /** Chunks pairing visible text with a reasoning delta (reasoning_content,
@@ -1171,6 +1173,13 @@ function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChun
   return { text: '', smooth: false, emit: () => chunk };
 }
 
+/**
+ * Usage metadata, additional kwargs and response metadata survive only on
+ * the first piece: the aggregator's dict merge concatenates string fields
+ * and sums usage, so replication across pieces corrupts them. Unlike the
+ * generic adapter, `generationInfo` stays on every piece — per-piece token
+ * indices ride in it and `dropRepeatedScalarMetadata` owns repetition there.
+ */
 function cloneGenerationChunkPiece(
   chunk: ChatGenerationChunk,
   piece: SmoothPiece
@@ -1179,14 +1188,15 @@ function cloneGenerationChunkPiece(
     return chunk;
   }
   const message = chunk.message as AIMessageChunk;
-  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
   return new ChatGenerationChunk({
     text: piece.text,
     generationInfo: chunk.generationInfo,
     message: new AIMessageChunk(
       Object.assign({}, message, {
         content: piece.text,
-        usage_metadata: usageMetadata,
+        usage_metadata: piece.isFirst ? message.usage_metadata : undefined,
+        additional_kwargs: piece.isFirst ? message.additional_kwargs : {},
+        response_metadata: piece.isFirst ? message.response_metadata : {},
       })
     ),
   });

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -37,6 +37,7 @@ import type { BindToolsInput } from '@langchain/core/language_models/chat_models
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
+import type { SmoothItem, SmoothPiece } from '@/llm/stream/smoother';
 import type { ResponsesReplayPosition } from '@/messages/core';
 import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
@@ -58,13 +59,11 @@ import {
 } from '@/tools/streamedToolCallSeals';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
+import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const iife = <T>(fn: () => T) => fn();
-
-const STREAM_CHUNK_MIN_SIZE = 4;
-const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
 
 export function isHeaders(headers: unknown): headers is Headers {
   return (
@@ -1114,77 +1113,89 @@ function getCustomOpenAIClientOptions(
   return requestOptions;
 }
 
-function findStreamChunkBoundary(text: string, minSize: number): number {
-  if (minSize >= text.length) {
-    return text.length;
+function getReasoningDeltaText(message: AIMessageChunk): string {
+  const kwargs = message.additional_kwargs;
+  if (kwargs == null) {
+    return '';
   }
-
-  for (let position = minSize; position < text.length; position++) {
-    if (STREAM_BOUNDARIES.has(text[position])) {
-      return position + 1;
-    }
-  }
-
-  return text.length;
-}
-
-function splitStreamToken(text: string): string[] {
-  const chunks: string[] = [];
-  let currentIndex = 0;
-
-  while (currentIndex < text.length) {
-    const remainingText = text.slice(currentIndex);
-    const chunkSize = findStreamChunkBoundary(
-      remainingText,
-      STREAM_CHUNK_MIN_SIZE
-    );
-    chunks.push(text.slice(currentIndex, currentIndex + chunkSize));
-    currentIndex += chunkSize;
-  }
-
-  return chunks;
-}
-
-function splitTextGenerationChunk(
-  chunk: ChatGenerationChunk
-): ChatGenerationChunk[] {
-  const { message } = chunk;
   if (
-    !chunk.text ||
-    !(message instanceof AIMessageChunk) ||
-    typeof message.content !== 'string' ||
-    message.content !== chunk.text ||
-    chunk.generationInfo?.logprobs != null ||
-    chunk.generationInfo?.finish_reason != null
+    typeof kwargs.reasoning_content === 'string' &&
+    kwargs.reasoning_content !== ''
   ) {
-    return [chunk];
+    return kwargs.reasoning_content;
   }
-
-  const tokenChunks = splitStreamToken(chunk.text);
-  if (tokenChunks.length <= 1) {
-    return [chunk];
-  }
-
-  let emittedUsage = false;
-  return tokenChunks.map((token) => {
-    const usageMetadata =
-      emittedUsage && message.usage_metadata != null
-        ? undefined
-        : message.usage_metadata;
-    if (message.usage_metadata != null && !emittedUsage) {
-      emittedUsage = true;
+  if (kwargs.reasoning != null) {
+    const summaryText = (
+      kwargs.reasoning as Partial<t.ChatOpenAIReasoningSummary> | undefined
+    )?.summary?.[0]?.text;
+    if (typeof summaryText === 'string' && summaryText !== '') {
+      return summaryText;
     }
+  }
+  return '';
+}
 
-    return new ChatGenerationChunk({
-      text: token,
-      generationInfo: chunk.generationInfo,
-      message: new AIMessageChunk(
-        Object.assign({}, message, {
-          content: token,
-          usage_metadata: usageMetadata,
-        })
-      ),
-    });
+/**
+ * Classifies a generation chunk for the smoothing engine:
+ * - splittable: plain visible text (string content equal to `chunk.text`, no
+ *   logprobs / finish_reason) — sliced adaptively at the pacing cadence.
+ * - atomic: text- or reasoning-bearing chunks whose metadata cannot survive
+ *   slicing — paced as one piece, never split (legacy parity: these were
+ *   emitted whole but still paced).
+ * - passthrough: tool-call deltas, usage-only, finish_reason and other
+ *   metadata chunks — strict FIFO, zero delay.
+ */
+function toSmoothItem(chunk: ChatGenerationChunk): SmoothItem<ChatGenerationChunk> {
+  const { message } = chunk;
+  const isMessageChunk = message instanceof AIMessageChunk;
+  const splittable =
+    Boolean(chunk.text) &&
+    isMessageChunk &&
+    typeof message.content === 'string' &&
+    message.content === chunk.text &&
+    chunk.generationInfo?.logprobs == null &&
+    chunk.generationInfo?.finish_reason == null;
+
+  if (splittable) {
+    return {
+      text: chunk.text,
+      smooth: true,
+      emit: (piece) => cloneGenerationChunkPiece(chunk, piece),
+    };
+  }
+
+  const pacedText =
+    chunk.text || (isMessageChunk ? getReasoningDeltaText(message) : '');
+  if (pacedText !== '') {
+    return {
+      text: pacedText,
+      smooth: true,
+      atomic: true,
+      emit: () => chunk,
+    };
+  }
+
+  return { text: '', smooth: false, emit: () => chunk };
+}
+
+function cloneGenerationChunkPiece(
+  chunk: ChatGenerationChunk,
+  piece: SmoothPiece
+): ChatGenerationChunk {
+  if (piece.isFirst && piece.isLast) {
+    return chunk;
+  }
+  const message = chunk.message as AIMessageChunk;
+  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
+  return new ChatGenerationChunk({
+    text: piece.text,
+    generationInfo: chunk.generationInfo,
+    message: new AIMessageChunk(
+      Object.assign({}, message, {
+        content: piece.text,
+        usage_metadata: usageMetadata,
+      })
+    ),
   });
 }
 
@@ -1215,66 +1226,45 @@ function getStreamChunkTokenIndices(
   return undefined;
 }
 
+/**
+ * Adaptive smoothing adapter for the OpenAI chat-model family, layered over
+ * the shared `smoothStream` engine. Keeps the historical signature so every
+ * `_streamResponseChunks` call site is unchanged.
+ *
+ * `seenScalarMetadata`: when provided, de-duplicates repeated scalar metadata
+ * just before emitting, so token callbacks and the yielded chunk observe the
+ * same cleaned data. Omitted by callers that wrap this stream and finalize
+ * downstream (e.g. `ChatOpenRouter`, which needs the raw `finish_reason` as
+ * its flush signal and de-duplicates after its own processing).
+ */
 async function* delayStreamChunks(
   chunks: AsyncGenerator<ChatGenerationChunk>,
   delay?: number,
   signal?: AbortSignal,
   runManager?: CallbackManagerForLLMRun,
-  // When provided, de-duplicate repeated scalar metadata just before emitting,
-  // so token callbacks and the yielded chunk observe the same cleaned data.
-  // Omitted by callers that wrap this stream and finalize downstream (e.g.
-  // `ChatOpenRouter`, which needs the raw `finish_reason` as its flush signal
-  // and de-duplicates after its own processing).
   seenScalarMetadata?: SeenScalarMetadata
 ): AsyncGenerator<ChatGenerationChunk> {
-  let lastYieldedAt: number | undefined;
-  for await (const chunk of chunks) {
-    const outputChunks =
-      delay != null && delay > 0 ? splitTextGenerationChunk(chunk) : [chunk];
-    for (const outputChunk of outputChunks) {
-      signal?.throwIfAborted();
-      if (delay != null && delay > 0 && lastYieldedAt != null) {
-        const timeSinceLastYield = Date.now() - lastYieldedAt;
-        const timeToWait = Math.max(0, delay - timeSinceLastYield);
-        if (timeToWait > 0) {
-          await sleepWithAbort(timeToWait, signal);
-        }
-      }
-      signal?.throwIfAborted();
-      lastYieldedAt = Date.now();
-      if (seenScalarMetadata != null) {
-        dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
-      }
-      await emitStreamChunkCallback(outputChunk, runManager);
-      signal?.throwIfAborted();
-      yield outputChunk;
+  const source = (async function* (): AsyncGenerator<
+    SmoothItem<ChatGenerationChunk>
+  > {
+    for await (const chunk of chunks) {
+      yield toSmoothItem(chunk);
     }
-  }
-}
+  })();
 
-async function sleepWithAbort(
-  delay: number,
-  signal?: AbortSignal
-): Promise<void> {
-  if (delay <= 0) {
-    return;
-  }
-  signal?.throwIfAborted();
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, delay);
-    const onAbort = (): void => {
-      clearTimeout(timeout);
-      signal?.removeEventListener('abort', onAbort);
-      reject(signal?.reason ?? new Error('AbortError: User aborted request.'));
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-    if (signal?.aborted === true) {
-      onAbort();
-    }
+  const smoothed = smoothStream({
+    source,
+    delayMs: delay != null && delay > 0 ? delay : 0,
+    signal,
   });
+
+  for await (const outputChunk of smoothed) {
+    if (seenScalarMetadata != null) {
+      dropRepeatedScalarMetadata(outputChunk, seenScalarMetadata);
+    }
+    await emitStreamChunkCallback(outputChunk, runManager);
+    yield outputChunk;
+  }
 }
 
 function createAbortHandler(controller: AbortController): () => void {
@@ -2410,13 +2400,13 @@ function withLibreChatOpenAIFields(
 }
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
-  _lc_stream_delay?: number;
+  _lc_stream_delay: number;
 
   constructor(
     fields?: LibreChatOpenAIFields & t.OpenAIChatInput['modelKwargs']
   ) {
     super(withLibreChatOpenAIFields(fields));
-    this._lc_stream_delay = fields?._lc_stream_delay;
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2507,13 +2497,13 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 }
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
-  _lc_stream_delay?: number;
+  _lc_stream_delay: number;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
     this.completions = new LibreChatAzureOpenAICompletions(fields);
     this.responses = new LibreChatAzureOpenAIResponses(fields);
-    this._lc_stream_delay = fields?._lc_stream_delay;
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2619,7 +2609,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   }
 }
 export class ChatDeepSeek extends OriginalChatDeepSeek {
-  _lc_stream_delay?: number;
+  _lc_stream_delay: number;
 
   constructor(
     fields?: ConstructorParameters<typeof OriginalChatDeepSeek>[0] & {
@@ -2627,7 +2617,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     }
   ) {
     super(fields);
-    this._lc_stream_delay = fields?._lc_stream_delay;
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -3140,7 +3130,7 @@ export class ChatMoonshot extends ChatOpenAI {
 }
 
 export class ChatXAI extends OriginalChatXAI {
-  _lc_stream_delay?: number;
+  _lc_stream_delay: number;
 
   constructor(
     fields?: Partial<ChatXAIInput> & {
@@ -3150,7 +3140,7 @@ export class ChatXAI extends OriginalChatXAI {
     }
   ) {
     super(fields);
-    this._lc_stream_delay = fields?._lc_stream_delay;
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     const customBaseURL =
       fields?.configuration?.baseURL ?? fields?.clientConfig?.baseURL;
     if (customBaseURL != null && customBaseURL) {

--- a/src/llm/openrouter/index.ts
+++ b/src/llm/openrouter/index.ts
@@ -45,7 +45,10 @@ export interface ChatOpenRouterCallOptions
 
 export type ChatOpenRouterInput = Partial<
   ChatOpenRouterCallOptions & OpenAIChatInput
->;
+> & {
+  /** Minimum delay in ms between visible streamed deltas (default 25; 0 disables). */
+  _lc_stream_delay?: number;
+};
 
 /** invocationParams return type extended with OpenRouter reasoning */
 export type OpenRouterInvocationParams = Omit<

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -1,5 +1,5 @@
 // src/llm/providers.ts
-import { ChatMistralAI } from '@langchain/mistralai';
+import { CustomChatMistralAI } from '@/llm/mistral';
 import type {
   ChatModelConstructorMap,
   ProviderOptionsMap,
@@ -25,8 +25,8 @@ export const llmProviders: Partial<ChatModelConstructorMap> = {
   [Providers.AZURE]: AzureChatOpenAI,
   [Providers.VERTEXAI]: ChatVertexAI,
   [Providers.DEEPSEEK]: ChatDeepSeek,
-  [Providers.MISTRALAI]: ChatMistralAI,
-  [Providers.MISTRAL]: ChatMistralAI,
+  [Providers.MISTRALAI]: CustomChatMistralAI,
+  [Providers.MISTRAL]: CustomChatMistralAI,
   [Providers.ANTHROPIC]: CustomAnthropic,
   [Providers.OPENROUTER]: ChatOpenRouter,
   [Providers.BEDROCK]: CustomChatBedrockConverse,

--- a/src/llm/stream/chunkAdapters.test.ts
+++ b/src/llm/stream/chunkAdapters.test.ts
@@ -72,6 +72,23 @@ describe('toGenerationSmoothItem classification', () => {
     );
   });
 
+  it('keeps mixed text/tool-call chunks atomic', () => {
+    const chunk = new ChatGenerationChunk({
+      text: 'calling the weather tool for you now',
+      message: new AIMessageChunk({
+        content: 'calling the weather tool for you now',
+        tool_call_chunks: [
+          { name: 'weather', args: '{"city":', id: 'call_1', index: 0 },
+        ],
+      }),
+    });
+    const item = toGenerationSmoothItem(chunk);
+    expect(item.atomic).toBe(true);
+    expect(item.emit({ text: item.text, isFirst: true, isLast: true })).toBe(
+      chunk
+    );
+  });
+
   it('classifies usage-only chunks as passthrough', () => {
     const chunk = new ChatGenerationChunk({
       text: '',
@@ -115,6 +132,28 @@ describe('cloneGenerationChunkPiece metadata scoping', () => {
     expect(laterMessage.additional_kwargs).toEqual({});
     expect(laterMessage.response_metadata).toEqual({});
     expect(laterMessage.usage_metadata).toBeUndefined();
+  });
+
+  it('keeps generationInfo on the first piece only', () => {
+    const infoChunk = new ChatGenerationChunk({
+      text: 'alpha beta gamma',
+      generationInfo: {
+        usage_metadata: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      },
+      message: new AIMessageChunk({ content: 'alpha beta gamma' }),
+    });
+    const first = cloneGenerationChunkPiece(infoChunk, {
+      text: 'alpha ',
+      isFirst: true,
+      isLast: false,
+    });
+    const later = cloneGenerationChunkPiece(infoChunk, {
+      text: 'beta ',
+      isFirst: false,
+      isLast: false,
+    });
+    expect(first.generationInfo).toBeDefined();
+    expect(later.generationInfo).toBeUndefined();
   });
 
   it('returns the original chunk for unsplit pieces', () => {

--- a/src/llm/stream/chunkAdapters.test.ts
+++ b/src/llm/stream/chunkAdapters.test.ts
@@ -2,6 +2,7 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import { ChatGenerationChunk } from '@langchain/core/outputs';
 import {
   toGenerationSmoothItem,
+  getReasoningKwargsText,
   cloneGenerationChunkPiece,
 } from './chunkAdapters';
 
@@ -87,6 +88,39 @@ describe('toGenerationSmoothItem classification', () => {
     expect(item.emit({ text: item.text, isFirst: true, isLast: true })).toBe(
       chunk
     );
+  });
+
+  it('paces reasoning-only chunks atomically via the kwargs extractor', () => {
+    const thoughtOnly = new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({
+        content: '',
+        additional_kwargs: { reasoning: 'a hidden gemini thought' },
+      }),
+    });
+    const item = toGenerationSmoothItem(thoughtOnly, getReasoningKwargsText);
+    expect(item.smooth).toBe(true);
+    expect(item.atomic).toBe(true);
+    expect(item.text).toBe('a hidden gemini thought');
+  });
+
+  it('paces reasoning_details-only chunks atomically via the kwargs extractor', () => {
+    const detailsOnly = new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: 'first thought ' },
+            { type: 'reasoning.text', text: 'second thought' },
+          ],
+        },
+      }),
+    });
+    const item = toGenerationSmoothItem(detailsOnly, getReasoningKwargsText);
+    expect(item.smooth).toBe(true);
+    expect(item.atomic).toBe(true);
+    expect(item.text).toBe('first thought second thought');
   });
 
   it('classifies usage-only chunks as passthrough', () => {

--- a/src/llm/stream/chunkAdapters.test.ts
+++ b/src/llm/stream/chunkAdapters.test.ts
@@ -1,0 +1,105 @@
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import {
+  toGenerationSmoothItem,
+  cloneGenerationChunkPiece,
+} from './chunkAdapters';
+
+type MessageChunkFields = {
+  usage_metadata?: AIMessageChunk['usage_metadata'];
+  additional_kwargs?: AIMessageChunk['additional_kwargs'];
+  response_metadata?: AIMessageChunk['response_metadata'];
+};
+
+function textChunk(
+  text: string,
+  extra: MessageChunkFields = {}
+): ChatGenerationChunk {
+  return new ChatGenerationChunk({
+    text,
+    message: new AIMessageChunk({ content: text, ...extra }),
+  });
+}
+
+describe('toGenerationSmoothItem classification', () => {
+  it('splits plain string-content text chunks', () => {
+    const item = toGenerationSmoothItem(textChunk('alpha beta gamma'));
+    expect(item.smooth).toBe(true);
+    expect(item.atomic).toBeUndefined();
+    expect(item.text).toBe('alpha beta gamma');
+  });
+
+  it('keeps chunks carrying reasoning_content kwargs atomic', () => {
+    const chunk = textChunk('visible text here', {
+      additional_kwargs: { reasoning_content: 'hidden thought' },
+    });
+    const item = toGenerationSmoothItem(chunk);
+    expect(item.smooth).toBe(true);
+    expect(item.atomic).toBe(true);
+    expect(item.emit({ text: item.text, isFirst: true, isLast: true })).toBe(
+      chunk
+    );
+  });
+
+  it('keeps chunks carrying a reasoning summary object atomic', () => {
+    const chunk = textChunk('visible text here', {
+      additional_kwargs: { reasoning: { summary: [{ text: 'thought' }] } },
+    });
+    expect(toGenerationSmoothItem(chunk).atomic).toBe(true);
+  });
+
+  it('classifies usage-only chunks as passthrough', () => {
+    const chunk = new ChatGenerationChunk({
+      text: '',
+      message: new AIMessageChunk({
+        content: '',
+        usage_metadata: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      }),
+    });
+    const item = toGenerationSmoothItem(chunk);
+    expect(item.smooth).toBe(false);
+    expect(item.text).toBe('');
+  });
+});
+
+describe('cloneGenerationChunkPiece metadata scoping', () => {
+  const chunk = textChunk('alpha beta gamma', {
+    usage_metadata: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+    additional_kwargs: { annotation: 'once' },
+    response_metadata: { model_name: 'test-model' },
+  });
+
+  it('keeps kwargs, response metadata and usage on the first piece only', () => {
+    const first = cloneGenerationChunkPiece(chunk, {
+      text: 'alpha ',
+      isFirst: true,
+      isLast: false,
+    });
+    const later = cloneGenerationChunkPiece(chunk, {
+      text: 'beta ',
+      isFirst: false,
+      isLast: false,
+    });
+
+    const firstMessage = first.message as AIMessageChunk;
+    const laterMessage = later.message as AIMessageChunk;
+    expect(firstMessage.additional_kwargs).toEqual({ annotation: 'once' });
+    expect(firstMessage.response_metadata).toEqual({
+      model_name: 'test-model',
+    });
+    expect(firstMessage.usage_metadata).toBeDefined();
+    expect(laterMessage.additional_kwargs).toEqual({});
+    expect(laterMessage.response_metadata).toEqual({});
+    expect(laterMessage.usage_metadata).toBeUndefined();
+  });
+
+  it('returns the original chunk for unsplit pieces', () => {
+    expect(
+      cloneGenerationChunkPiece(chunk, {
+        text: 'alpha beta gamma',
+        isFirst: true,
+        isLast: true,
+      })
+    ).toBe(chunk);
+  });
+});

--- a/src/llm/stream/chunkAdapters.test.ts
+++ b/src/llm/stream/chunkAdapters.test.ts
@@ -48,6 +48,30 @@ describe('toGenerationSmoothItem classification', () => {
     expect(toGenerationSmoothItem(chunk).atomic).toBe(true);
   });
 
+  it('keeps chunks carrying OpenRouter reasoning_details atomic', () => {
+    const chunk = textChunk('visible text here', {
+      additional_kwargs: {
+        reasoning_details: [{ type: 'reasoning.text', text: 'thought' }],
+      },
+    });
+    expect(toGenerationSmoothItem(chunk).atomic).toBe(true);
+  });
+
+  it('keeps chunks carrying camelCase finishReason atomic', () => {
+    const chunk = new ChatGenerationChunk({
+      text: 'final text with several words here',
+      generationInfo: { finishReason: 'STOP' },
+      message: new AIMessageChunk({
+        content: 'final text with several words here',
+      }),
+    });
+    const item = toGenerationSmoothItem(chunk);
+    expect(item.atomic).toBe(true);
+    expect(item.emit({ text: item.text, isFirst: true, isLast: true })).toBe(
+      chunk
+    );
+  });
+
   it('classifies usage-only chunks as passthrough', () => {
     const chunk = new ChatGenerationChunk({
       text: '',

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -22,7 +22,7 @@ export function cloneGenerationChunkPiece(
   const message = chunk.message as AIMessageChunk;
   return new ChatGenerationChunk({
     text: piece.text,
-    generationInfo: chunk.generationInfo,
+    generationInfo: piece.isFirst ? chunk.generationInfo : undefined,
     message: new AIMessageChunk(
       Object.assign({}, message, {
         content: piece.text,
@@ -82,7 +82,7 @@ function clonePartGenerationChunkPiece(
   const message = chunk.message as AIMessageChunk;
   return new ChatGenerationChunk({
     text: piece.text,
-    generationInfo: chunk.generationInfo,
+    generationInfo: piece.isFirst ? chunk.generationInfo : undefined,
     message: new AIMessageChunk(
       Object.assign({}, message, {
         content: [Object.assign({}, part, { text: piece.text })],
@@ -144,6 +144,15 @@ function hasFinishReason(
  * or OpenRouter's reasoning_details accumulation — duplicates them once per
  * piece.
  */
+/**
+ * Mixed text/tool-call deltas must never split: cloned pieces would each
+ * carry the same tool_call_chunks and downstream accumulation would corrupt
+ * the assembled tool arguments.
+ */
+export function hasToolCallChunks(message: AIMessageChunk): boolean {
+  return (message.tool_call_chunks?.length ?? 0) > 0;
+}
+
 export function hasReasoningKwargs(message: AIMessageChunk): boolean {
   const kwargs = message.additional_kwargs;
   if (
@@ -176,7 +185,8 @@ export function toGenerationSmoothItem(
     typeof message.content === 'string' &&
     message.content === chunk.text &&
     cleanGenerationInfo &&
-    !hasReasoningKwargs(message);
+    !hasReasoningKwargs(message) &&
+    !hasToolCallChunks(message);
 
   if (splittable) {
     return {
@@ -190,7 +200,8 @@ export function toGenerationSmoothItem(
     Boolean(chunk.text) &&
     isMessageChunk &&
     cleanGenerationInfo &&
-    !hasReasoningKwargs(message)
+    !hasReasoningKwargs(message) &&
+    !hasToolCallChunks(message)
       ? getSplittableTextPart(message, chunk.text)
       : null;
   if (splittablePart != null) {

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -102,6 +102,13 @@ function clonePartGenerationChunkPiece(
  * - passthrough: tool-call deltas, usage-only and metadata chunks — strict
  *   FIFO, zero delay.
  */
+/**
+ * google-common stamps `logprobs: { content: [] }` on every chunk, so only
+ * logprobs that actually carry data may block splitting here. This is looser
+ * than the OpenAI-family adapter in `llm/openai/index.ts`, which treats ANY
+ * logprobs as atomic (its providers only attach logprobs when requested, and
+ * the DeepSeek suite pins that contract) — do not unify the two predicates.
+ */
 function hasMeaningfulLogprobs(
   generationInfo: ChatGenerationChunk['generationInfo']
 ): boolean {

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -44,7 +44,10 @@ const SPLITTABLE_TEXT_PART_KEYS: ReadonlySet<string> = new Set([
  * Returns the sole plain text part of a single-element complex content array
  * (the shape google-common emits for text deltas), or null when the part
  * carries anything beyond `type`/`text`/`index` (thought signatures, media,
- * function calls) and must not be sliced.
+ * function calls) and must not be sliced. The part must carry a numeric
+ * `index`: it is the aggregator's list-merge key, and without it each split
+ * piece would append as a separate content part instead of merging back
+ * into one — index-less parts pace whole instead.
  */
 function getSplittableTextPart(
   message: AIMessageChunk,
@@ -63,6 +66,9 @@ function getSplittableTextPart(
     return null;
   }
   if (record.type != null && record.type !== 'text') {
+    return null;
+  }
+  if (typeof record.index !== 'number') {
     return null;
   }
   if (!Object.keys(record).every((key) => SPLITTABLE_TEXT_PART_KEYS.has(key))) {

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -51,7 +51,7 @@ function getSplittableTextPart(
   if (!Array.isArray(content) || content.length !== 1) {
     return null;
   }
-  const part = content[0];
+  const part: unknown = content[0];
   if (part == null || typeof part !== 'object') {
     return null;
   }
@@ -194,7 +194,7 @@ export async function* smoothGenerationChunks({
 }): AsyncGenerator<ChatGenerationChunk> {
   const source = (async function* (): AsyncGenerator<
     SmoothItem<ChatGenerationChunk>
-  > {
+    > {
     for await (const chunk of chunks) {
       yield toGenerationSmoothItem(chunk);
     }

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -170,6 +170,50 @@ export function hasReasoningKwargs(message: AIMessageChunk): boolean {
   return kwargs.reasoning != null;
 }
 
+/**
+ * Extracts the visible reasoning text a kwargs-borne delta contributes, so
+ * reasoning-only chunks (Gemini thoughts, DeepSeek reasoning_content,
+ * OpenAI reasoning summaries, OpenRouter reasoning_details) pace atomically
+ * at the cadence instead of passing through unsmoothed.
+ */
+export function getReasoningKwargsText(message: AIMessageChunk): string {
+  const kwargs = message.additional_kwargs;
+  if (
+    typeof kwargs.reasoning_content === 'string' &&
+    kwargs.reasoning_content !== ''
+  ) {
+    return kwargs.reasoning_content;
+  }
+  const reasoning = kwargs.reasoning;
+  if (typeof reasoning === 'string' && reasoning !== '') {
+    return reasoning;
+  }
+  if (reasoning != null && typeof reasoning === 'object') {
+    const summaryText = (
+      reasoning as { summary?: { text?: unknown }[] }
+    ).summary?.[0]?.text;
+    if (typeof summaryText === 'string' && summaryText !== '') {
+      return summaryText;
+    }
+  }
+  const details = kwargs.reasoning_details;
+  if (Array.isArray(details)) {
+    let text = '';
+    for (const detail of details) {
+      if (detail != null && typeof detail === 'object') {
+        const detailText = (detail as { text?: unknown }).text;
+        if (typeof detailText === 'string') {
+          text += detailText;
+        }
+      }
+    }
+    if (text !== '') {
+      return text;
+    }
+  }
+  return '';
+}
+
 export function toGenerationSmoothItem(
   chunk: ChatGenerationChunk,
   getAtomicText?: (message: AIMessageChunk) => string
@@ -249,7 +293,7 @@ export async function* smoothGenerationChunks({
     SmoothItem<ChatGenerationChunk>
     > {
     for await (const chunk of chunks) {
-      yield toGenerationSmoothItem(chunk);
+      yield toGenerationSmoothItem(chunk, getReasoningKwargsText);
     }
   })();
 

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -1,0 +1,207 @@
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { SmoothItem, SmoothPiece } from '@/llm/stream/smoother';
+import { smoothStream } from '@/llm/stream/smoother';
+
+/**
+ * Rebuilds a generation chunk carrying one piece of a split plain-text chunk.
+ * Unsplit pieces return the original chunk untouched, so disabled smoothing is
+ * byte-identical to no smoothing. Usage metadata survives only on the first
+ * piece to avoid double counting downstream.
+ */
+export function cloneGenerationChunkPiece(
+  chunk: ChatGenerationChunk,
+  piece: SmoothPiece
+): ChatGenerationChunk {
+  if (piece.isFirst && piece.isLast) {
+    return chunk;
+  }
+  const message = chunk.message as AIMessageChunk;
+  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
+  return new ChatGenerationChunk({
+    text: piece.text,
+    generationInfo: chunk.generationInfo,
+    message: new AIMessageChunk(
+      Object.assign({}, message, {
+        content: piece.text,
+        usage_metadata: usageMetadata,
+      })
+    ),
+  });
+}
+
+const SPLITTABLE_TEXT_PART_KEYS: ReadonlySet<string> = new Set([
+  'type',
+  'text',
+  'index',
+]);
+
+/**
+ * Returns the sole plain text part of a single-element complex content array
+ * (the shape google-common emits for text deltas), or null when the part
+ * carries anything beyond `type`/`text`/`index` (thought signatures, media,
+ * function calls) and must not be sliced.
+ */
+function getSplittableTextPart(
+  message: AIMessageChunk,
+  chunkText: string
+): Record<string, unknown> | null {
+  const content = message.content;
+  if (!Array.isArray(content) || content.length !== 1) {
+    return null;
+  }
+  const part = content[0];
+  if (part == null || typeof part !== 'object') {
+    return null;
+  }
+  const record = part as Record<string, unknown>;
+  if (typeof record.text !== 'string' || record.text !== chunkText) {
+    return null;
+  }
+  if (record.type != null && record.type !== 'text') {
+    return null;
+  }
+  if (!Object.keys(record).every((key) => SPLITTABLE_TEXT_PART_KEYS.has(key))) {
+    return null;
+  }
+  return record;
+}
+
+function clonePartGenerationChunkPiece(
+  chunk: ChatGenerationChunk,
+  part: Record<string, unknown>,
+  piece: SmoothPiece
+): ChatGenerationChunk {
+  if (piece.isFirst && piece.isLast) {
+    return chunk;
+  }
+  const message = chunk.message as AIMessageChunk;
+  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
+  return new ChatGenerationChunk({
+    text: piece.text,
+    generationInfo: chunk.generationInfo,
+    message: new AIMessageChunk(
+      Object.assign({}, message, {
+        content: [Object.assign({}, part, { text: piece.text })],
+        usage_metadata: usageMetadata,
+      })
+    ),
+  });
+}
+
+/**
+ * Provider-agnostic classification of a `ChatGenerationChunk` for the
+ * smoothing engine:
+ * - splittable: plain visible text — string content equal to `chunk.text`, or
+ *   a single plain text part (google-common's delta shape) — with no
+ *   logprobs / finish_reason; sliced adaptively at the pacing cadence.
+ * - atomic: any other text-bearing chunk (complex content arrays, logprobs,
+ *   finish_reason, provider-specific reasoning payloads surfaced via
+ *   `getAtomicText`) — paced as one piece, never split.
+ * - passthrough: tool-call deltas, usage-only and metadata chunks — strict
+ *   FIFO, zero delay.
+ */
+function hasMeaningfulLogprobs(
+  generationInfo: ChatGenerationChunk['generationInfo']
+): boolean {
+  const logprobs = generationInfo?.logprobs;
+  if (logprobs == null) {
+    return false;
+  }
+  const content = (logprobs as { content?: unknown }).content;
+  if (Array.isArray(content)) {
+    return content.length > 0;
+  }
+  return true;
+}
+
+export function toGenerationSmoothItem(
+  chunk: ChatGenerationChunk,
+  getAtomicText?: (message: AIMessageChunk) => string
+): SmoothItem<ChatGenerationChunk> {
+  const { message } = chunk;
+  const isMessageChunk = message instanceof AIMessageChunk;
+  const cleanGenerationInfo =
+    !hasMeaningfulLogprobs(chunk.generationInfo) &&
+    chunk.generationInfo?.finish_reason == null;
+  const splittable =
+    Boolean(chunk.text) &&
+    isMessageChunk &&
+    typeof message.content === 'string' &&
+    message.content === chunk.text &&
+    cleanGenerationInfo;
+
+  if (splittable) {
+    return {
+      text: chunk.text,
+      smooth: true,
+      emit: (piece) => cloneGenerationChunkPiece(chunk, piece),
+    };
+  }
+
+  const splittablePart =
+    Boolean(chunk.text) && isMessageChunk && cleanGenerationInfo
+      ? getSplittableTextPart(message, chunk.text)
+      : null;
+  if (splittablePart != null) {
+    return {
+      text: chunk.text,
+      smooth: true,
+      emit: (piece) =>
+        clonePartGenerationChunkPiece(chunk, splittablePart, piece),
+    };
+  }
+
+  const pacedText =
+    chunk.text ||
+    (isMessageChunk && getAtomicText != null ? getAtomicText(message) : '');
+  if (pacedText !== '') {
+    return {
+      text: pacedText,
+      smooth: true,
+      atomic: true,
+      emit: () => chunk,
+    };
+  }
+
+  return { text: '', smooth: false, emit: () => chunk };
+}
+
+/**
+ * Wraps a provider's raw chunk stream with adaptive smoothing and per-piece
+ * `handleLLMNewToken` dispatch. The raw stream must NOT dispatch runManager
+ * callbacks itself — callback-echo consumers would otherwise observe the
+ * unsmoothed deltas.
+ */
+export async function* smoothGenerationChunks({
+  chunks,
+  delayMs,
+  signal,
+  runManager,
+}: {
+  chunks: AsyncGenerator<ChatGenerationChunk>;
+  delayMs: number;
+  signal?: AbortSignal;
+  runManager?: CallbackManagerForLLMRun;
+}): AsyncGenerator<ChatGenerationChunk> {
+  const source = (async function* (): AsyncGenerator<
+    SmoothItem<ChatGenerationChunk>
+  > {
+    for await (const chunk of chunks) {
+      yield toGenerationSmoothItem(chunk);
+    }
+  })();
+
+  for await (const outputChunk of smoothStream({ source, delayMs, signal })) {
+    yield outputChunk;
+    await runManager?.handleLLMNewToken(
+      outputChunk.text || '',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { chunk: outputChunk }
+    );
+  }
+}

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -7,8 +7,10 @@ import { smoothStream } from '@/llm/stream/smoother';
 /**
  * Rebuilds a generation chunk carrying one piece of a split plain-text chunk.
  * Unsplit pieces return the original chunk untouched, so disabled smoothing is
- * byte-identical to no smoothing. Usage metadata survives only on the first
- * piece to avoid double counting downstream.
+ * byte-identical to no smoothing. Usage metadata, additional kwargs and
+ * response metadata survive only on the first piece: the aggregator merges
+ * dicts by concatenating string fields, so replicating them across pieces
+ * would duplicate reasoning text and scalar metadata once per piece.
  */
 export function cloneGenerationChunkPiece(
   chunk: ChatGenerationChunk,
@@ -18,14 +20,15 @@ export function cloneGenerationChunkPiece(
     return chunk;
   }
   const message = chunk.message as AIMessageChunk;
-  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
   return new ChatGenerationChunk({
     text: piece.text,
     generationInfo: chunk.generationInfo,
     message: new AIMessageChunk(
       Object.assign({}, message, {
         content: piece.text,
-        usage_metadata: usageMetadata,
+        usage_metadata: piece.isFirst ? message.usage_metadata : undefined,
+        additional_kwargs: piece.isFirst ? message.additional_kwargs : {},
+        response_metadata: piece.isFirst ? message.response_metadata : {},
       })
     ),
   });
@@ -77,14 +80,15 @@ function clonePartGenerationChunkPiece(
     return chunk;
   }
   const message = chunk.message as AIMessageChunk;
-  const usageMetadata = piece.isFirst ? message.usage_metadata : undefined;
   return new ChatGenerationChunk({
     text: piece.text,
     generationInfo: chunk.generationInfo,
     message: new AIMessageChunk(
       Object.assign({}, message, {
         content: [Object.assign({}, part, { text: piece.text })],
-        usage_metadata: usageMetadata,
+        usage_metadata: piece.isFirst ? message.usage_metadata : undefined,
+        additional_kwargs: piece.isFirst ? message.additional_kwargs : {},
+        response_metadata: piece.isFirst ? message.response_metadata : {},
       })
     ),
   });
@@ -123,6 +127,23 @@ function hasMeaningfulLogprobs(
   return true;
 }
 
+/**
+ * Chunks that pair visible text with reasoning payloads in
+ * `additional_kwargs` (Gemini thought summaries, reasoning_content deltas)
+ * must pace whole: split pieces would each carry the same kwargs and the
+ * aggregator's dict merge concatenates string fields once per piece.
+ */
+function hasReasoningKwargs(message: AIMessageChunk): boolean {
+  const kwargs = message.additional_kwargs;
+  if (
+    typeof kwargs.reasoning_content === 'string' &&
+    kwargs.reasoning_content !== ''
+  ) {
+    return true;
+  }
+  return kwargs.reasoning != null;
+}
+
 export function toGenerationSmoothItem(
   chunk: ChatGenerationChunk,
   getAtomicText?: (message: AIMessageChunk) => string
@@ -137,7 +158,8 @@ export function toGenerationSmoothItem(
     isMessageChunk &&
     typeof message.content === 'string' &&
     message.content === chunk.text &&
-    cleanGenerationInfo;
+    cleanGenerationInfo &&
+    !hasReasoningKwargs(message);
 
   if (splittable) {
     return {
@@ -148,7 +170,10 @@ export function toGenerationSmoothItem(
   }
 
   const splittablePart =
-    Boolean(chunk.text) && isMessageChunk && cleanGenerationInfo
+    Boolean(chunk.text) &&
+    isMessageChunk &&
+    cleanGenerationInfo &&
+    !hasReasoningKwargs(message)
       ? getSplittableTextPart(message, chunk.text)
       : null;
   if (splittablePart != null) {

--- a/src/llm/stream/chunkAdapters.ts
+++ b/src/llm/stream/chunkAdapters.ts
@@ -127,17 +127,34 @@ function hasMeaningfulLogprobs(
   return true;
 }
 
+/** google-common reports the terminal reason camelCase (`finishReason`). */
+function hasFinishReason(
+  generationInfo: ChatGenerationChunk['generationInfo']
+): boolean {
+  return (
+    generationInfo?.finish_reason != null || generationInfo?.finishReason != null
+  );
+}
+
 /**
  * Chunks that pair visible text with reasoning payloads in
- * `additional_kwargs` (Gemini thought summaries, reasoning_content deltas)
- * must pace whole: split pieces would each carry the same kwargs and the
- * aggregator's dict merge concatenates string fields once per piece.
+ * `additional_kwargs` (Gemini thought summaries, reasoning_content deltas,
+ * OpenRouter reasoning_details) must pace whole: split pieces would each
+ * carry the same kwargs and downstream merging — the aggregator's dict merge
+ * or OpenRouter's reasoning_details accumulation — duplicates them once per
+ * piece.
  */
-function hasReasoningKwargs(message: AIMessageChunk): boolean {
+export function hasReasoningKwargs(message: AIMessageChunk): boolean {
   const kwargs = message.additional_kwargs;
   if (
     typeof kwargs.reasoning_content === 'string' &&
     kwargs.reasoning_content !== ''
+  ) {
+    return true;
+  }
+  if (
+    Array.isArray(kwargs.reasoning_details) &&
+    kwargs.reasoning_details.length > 0
   ) {
     return true;
   }
@@ -152,7 +169,7 @@ export function toGenerationSmoothItem(
   const isMessageChunk = message instanceof AIMessageChunk;
   const cleanGenerationInfo =
     !hasMeaningfulLogprobs(chunk.generationInfo) &&
-    chunk.generationInfo?.finish_reason == null;
+    !hasFinishReason(chunk.generationInfo);
   const splittable =
     Boolean(chunk.text) &&
     isMessageChunk &&

--- a/src/llm/stream/reassembly.test.ts
+++ b/src/llm/stream/reassembly.test.ts
@@ -1,0 +1,241 @@
+import { concat } from '@langchain/core/utils/stream';
+import { AIMessageChunk } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { SmoothItem, SmoothPiece } from './smoother';
+import { toSmoothItem } from '@/llm/openai';
+import {
+  toGenerationSmoothItem,
+  getReasoningKwargsText,
+} from './chunkAdapters';
+import { findStreamChunkBoundary } from './smoother';
+
+/**
+ * Lossless-reassembly property: for ANY chunk shape an adapter classifies,
+ * aggregating the emitted pieces must reproduce the original chunk's
+ * observable payload — text, content, kwargs, response metadata, usage,
+ * tool calls. This is the invariant behind every split-corruption bug class
+ * (duplicated reasoning/kwargs, summed usage, cloned tool args): if a field
+ * cannot survive slicing, the adapter must classify the chunk atomic or
+ * scope the field to a single piece, and this property proves it did.
+ */
+
+type AdapterName = 'openai-family' | 'generic';
+
+const ADAPTERS: Record<
+  AdapterName,
+  (chunk: ChatGenerationChunk) => SmoothItem<ChatGenerationChunk>
+> = {
+  'openai-family': (chunk) => toSmoothItem(chunk),
+  generic: (chunk) => toGenerationSmoothItem(chunk, getReasoningKwargsText),
+};
+
+/** Emits the item the way the engine would: split smooth+splittable items
+ * into ≥2 boundary-aligned pieces; atomic and passthrough emit whole. */
+function emitPieces(item: SmoothItem<ChatGenerationChunk>): ChatGenerationChunk[] {
+  if (!item.smooth || item.atomic === true || item.text.length < 8) {
+    return [item.emit({ text: item.text, isFirst: true, isLast: true })];
+  }
+  const pieces: ChatGenerationChunk[] = [];
+  let offset = 0;
+  while (offset < item.text.length) {
+    const end = offset + findStreamChunkBoundary(item.text.slice(offset), 4);
+    pieces.push(
+      item.emit({
+        text: item.text.slice(offset, end),
+        isFirst: offset === 0,
+        isLast: end === item.text.length,
+      })
+    );
+    offset = end;
+  }
+  return pieces;
+}
+
+function aggregate(pieces: ChatGenerationChunk[]): AIMessageChunk {
+  let merged = pieces[0].message as AIMessageChunk;
+  for (const piece of pieces.slice(1)) {
+    merged = concat(merged, piece.message as AIMessageChunk);
+  }
+  return merged;
+}
+
+function assertLossless(
+  adapter: AdapterName,
+  chunk: ChatGenerationChunk
+): void {
+  const item = ADAPTERS[adapter](chunk);
+  const pieces = emitPieces(item);
+  const original = chunk.message as AIMessageChunk;
+
+  const joinedText = pieces.map((p) => p.text).join('');
+  if (item.smooth) {
+    expect(joinedText === chunk.text || joinedText === item.text).toBe(true);
+  }
+
+  const merged = aggregate(pieces);
+  expect(merged.content).toEqual(original.content);
+  expect(merged.additional_kwargs).toEqual(original.additional_kwargs);
+  expect(merged.response_metadata).toEqual(original.response_metadata);
+  /** concat() adds empty *_token_details objects during merge; token COUNTS
+   * are the corruption signal (replicated usage would sum). */
+  expect(merged.usage_metadata?.input_tokens).toBe(
+    original.usage_metadata?.input_tokens
+  );
+  expect(merged.usage_metadata?.output_tokens).toBe(
+    original.usage_metadata?.output_tokens
+  );
+  expect(merged.usage_metadata?.total_tokens).toBe(
+    original.usage_metadata?.total_tokens
+  );
+  expect(merged.tool_call_chunks ?? []).toEqual(
+    original.tool_call_chunks ?? []
+  );
+}
+
+type MatrixCase = {
+  name: string;
+  chunk: () => ChatGenerationChunk;
+  adapters: AdapterName[];
+};
+
+const TEXT = 'the quick brown fox jumps over the lazy dog again and again ';
+
+const MATRIX: MatrixCase[] = [
+  {
+    name: 'plain string text',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({ content: TEXT }),
+      }),
+  },
+  {
+    name: 'text with usage metadata',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          usage_metadata: { input_tokens: 7, output_tokens: 11, total_tokens: 18 },
+        }),
+      }),
+  },
+  {
+    name: 'text with an unknown string kwargs field',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          additional_kwargs: { annotation: 'gateway-added-value' },
+        }),
+      }),
+  },
+  {
+    name: 'text with scalar response metadata',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          response_metadata: { model_name: 'test-model', system_fingerprint: 'fp_1' },
+        }),
+      }),
+  },
+  {
+    name: 'text with reasoning_content kwargs',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          additional_kwargs: { reasoning_content: 'a hidden thought' },
+        }),
+      }),
+  },
+  {
+    name: 'text with reasoning_details kwargs',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          additional_kwargs: {
+            reasoning_details: [{ type: 'reasoning.text', text: 'thought' }],
+          },
+        }),
+      }),
+  },
+  {
+    name: 'text alongside tool_call_chunks',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: TEXT,
+          tool_call_chunks: [
+            { name: 'lookup', args: '{"q":1}', id: 'call_1', index: 0, type: 'tool_call_chunk' },
+          ],
+        }),
+      }),
+  },
+  {
+    name: 'indexed text-part array content (google shape)',
+    adapters: ['generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: [{ type: 'text', text: TEXT, index: 0 }],
+        }),
+      }),
+  },
+  {
+    name: 'index-less text-part array content (no merge key)',
+    adapters: ['generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: TEXT,
+        message: new AIMessageChunk({
+          content: [{ type: 'text', text: TEXT }],
+        }),
+      }),
+  },
+  {
+    name: 'reasoning-only delta',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: '',
+        message: new AIMessageChunk({
+          content: '',
+          additional_kwargs: { reasoning_content: 'thought only delta here' },
+        }),
+      }),
+  },
+  {
+    name: 'usage-only delta',
+    adapters: ['openai-family', 'generic'],
+    chunk: () =>
+      new ChatGenerationChunk({
+        text: '',
+        message: new AIMessageChunk({
+          content: '',
+          usage_metadata: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+        }),
+      }),
+  },
+];
+
+describe.each(MATRIX)('lossless reassembly: $name', ({ chunk, adapters }) => {
+  it.each(adapters)('%s adapter', (adapter) => {
+    assertLossless(adapter, chunk());
+  });
+});

--- a/src/llm/stream/reassembly.test.ts
+++ b/src/llm/stream/reassembly.test.ts
@@ -1,7 +1,7 @@
 import { concat } from '@langchain/core/utils/stream';
 import { AIMessageChunk } from '@langchain/core/messages';
 import { ChatGenerationChunk } from '@langchain/core/outputs';
-import type { SmoothItem, SmoothPiece } from './smoother';
+import type { SmoothItem } from './smoother';
 import { toSmoothItem } from '@/llm/openai';
 import {
   toGenerationSmoothItem,

--- a/src/llm/stream/smoother.bench.test.ts
+++ b/src/llm/stream/smoother.bench.test.ts
@@ -1,0 +1,151 @@
+import http from 'node:http';
+import { HumanMessage } from '@langchain/core/messages';
+import type { AddressInfo } from 'node:net';
+import { ChatOpenAI } from '@/llm/openai';
+import { SMOOTH_TARGET_LATENCY_MS } from './smoother';
+
+/**
+ * End-to-end cadence/lag benchmark: drives the real ChatOpenAI client against
+ * a local SSE server that emits large chunks fast (the big-chunk gateway
+ * profile smoothing exists for), asserting the properties that define the
+ * feature: even cadence at the configured tick, and render lag pinned near
+ * the target latency instead of growing with reply length.
+ */
+describe('adaptive smoothing benchmark (big-chunk provider)', () => {
+  const WORDS =
+    'ClickHouse stores data in columns so queries read only what they touch and compress well '.split(
+      ' '
+    );
+  const CHUNK_CHARS = 110;
+  const PROVIDER_INTERVAL_MS = 20;
+
+  function buildChunks(totalWords: number): string[] {
+    const out: string[] = [];
+    let current = '';
+    for (let i = 0; i < totalWords; i++) {
+      current += WORDS[i % WORDS.length] + ' ';
+      if (current.length >= CHUNK_CHARS) {
+        out.push(current);
+        current = '';
+      }
+    }
+    if (current) {
+      out.push(current);
+    }
+    return out;
+  }
+
+  function startServer(chunks: string[], stamp: { doneAt: number }): Promise<{
+    server: http.Server;
+    port: number;
+  }> {
+    return new Promise((resolve) => {
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+        const frame = (
+          delta: Record<string, unknown>,
+          finish: string | null
+        ): string =>
+          `data: ${JSON.stringify({
+            id: 'bench',
+            object: 'chat.completion.chunk',
+            created: 1,
+            model: 'bench-model',
+            choices: [{ index: 0, delta, finish_reason: finish }],
+          })}\n\n`;
+        res.write(frame({ role: 'assistant', content: '' }, null));
+        let i = 0;
+        const send = (): void => {
+          if (i < chunks.length) {
+            res.write(frame({ content: chunks[i] }, null));
+            i += 1;
+            setTimeout(send, PROVIDER_INTERVAL_MS);
+          } else {
+            stamp.doneAt = Date.now();
+            res.write(frame({}, 'stop'));
+            res.write('data: [DONE]\n\n');
+            res.end();
+          }
+        };
+        send();
+      });
+      server.listen(0, '127.0.0.1', () => {
+        resolve({ server, port: (server.address() as AddressInfo).port });
+      });
+    });
+  }
+
+  async function measure(
+    totalWords: number,
+    tick: number
+  ): Promise<{
+    meanGap: number;
+    jitter: number;
+    lag: number;
+    totalText: string;
+    expected: string;
+  }> {
+    const chunks = buildChunks(totalWords);
+    const stamp = { doneAt: 0 };
+    const { server, port } = await startServer(chunks, stamp);
+    try {
+      const model = new ChatOpenAI({
+        model: 'bench-model',
+        apiKey: 'bench',
+        streaming: true,
+        configuration: { baseURL: `http://127.0.0.1:${port}/v1` },
+        _lc_stream_delay: tick,
+      });
+
+      const gaps: number[] = [];
+      let totalText = '';
+      let last = Date.now();
+      for await (const piece of await model.stream([new HumanMessage('go')])) {
+        if (typeof piece.content !== 'string' || piece.content === '') {
+          continue;
+        }
+        const now = Date.now();
+        gaps.push(now - last);
+        last = now;
+        totalText += piece.content;
+      }
+      const renderDoneAt = Date.now();
+
+      const paint = gaps.slice(1);
+      const mean = paint.reduce((a, b) => a + b, 0) / paint.length;
+      const jitter = Math.sqrt(
+        paint.reduce((a, b) => a + (b - mean) ** 2, 0) / paint.length
+      );
+      return {
+        meanGap: mean,
+        jitter,
+        lag: renderDoneAt - stamp.doneAt,
+        totalText,
+        expected: chunks.join(''),
+      };
+    } finally {
+      server.close();
+    }
+  }
+
+  test('holds cadence at the tick with bounded lag on a medium reply', async () => {
+    const tick = 15;
+    const result = await measure(500, tick);
+
+    expect(result.totalText).toBe(result.expected);
+    expect(result.meanGap).toBeGreaterThan(tick * 0.6);
+    expect(result.meanGap).toBeLessThan(tick * 1.6);
+    expect(result.jitter).toBeLessThan(10);
+    expect(result.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 3);
+  }, 60000);
+
+  test('lag does not grow with reply length', async () => {
+    const tick = 15;
+    const short = await measure(250, tick);
+    const long = await measure(1000, tick);
+
+    expect(long.totalText).toBe(long.expected);
+    expect(long.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 3);
+    expect(long.lag).toBeLessThan(short.lag + SMOOTH_TARGET_LATENCY_MS * 2);
+  }, 60000);
+});

--- a/src/llm/stream/smoother.bench.test.ts
+++ b/src/llm/stream/smoother.bench.test.ts
@@ -128,15 +128,19 @@ describe('adaptive smoothing benchmark (big-chunk provider)', () => {
     }
   }
 
+  /** Bounds are deliberately loose on absolutes (CI machines and parallel
+   * jest workers add scheduling noise); the discriminating assertion is the
+   * last one — lag must stay FLAT as reply length grows, which is the
+   * property fixed-rate smoothing lacks (it lagged +31s at 4x length). */
   test('holds cadence at the tick with bounded lag on a medium reply', async () => {
     const tick = 15;
     const result = await measure(500, tick);
 
     expect(result.totalText).toBe(result.expected);
-    expect(result.meanGap).toBeGreaterThan(tick * 0.6);
-    expect(result.meanGap).toBeLessThan(tick * 1.6);
-    expect(result.jitter).toBeLessThan(10);
-    expect(result.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 3);
+    expect(result.meanGap).toBeGreaterThan(tick * 0.5);
+    expect(result.meanGap).toBeLessThan(tick * 2.5);
+    expect(result.jitter).toBeLessThan(25);
+    expect(result.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 4);
   }, 60000);
 
   test('lag does not grow with reply length', async () => {
@@ -145,7 +149,7 @@ describe('adaptive smoothing benchmark (big-chunk provider)', () => {
     const long = await measure(1000, tick);
 
     expect(long.totalText).toBe(long.expected);
-    expect(long.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 3);
+    expect(long.lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 4);
     expect(long.lag).toBeLessThan(short.lag + SMOOTH_TARGET_LATENCY_MS * 2);
   }, 60000);
 });

--- a/src/llm/stream/smoother.test.ts
+++ b/src/llm/stream/smoother.test.ts
@@ -63,6 +63,13 @@ describe('resolveStreamDelay', () => {
     expect(resolveStreamDelay(0)).toBe(0);
     expect(resolveStreamDelay(-5)).toBe(0);
   });
+
+  it('normalizes non-finite values to the default', () => {
+    expect(resolveStreamDelay(Number.NaN)).toBe(DEFAULT_STREAM_DELAY);
+    expect(resolveStreamDelay(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_STREAM_DELAY
+    );
+  });
 });
 
 describe('computeAdaptivePieceSize', () => {
@@ -253,6 +260,36 @@ describe('smoothStream', () => {
     expect(pieces[0].isFirst).toBe(true);
     expect(pieces[0].isLast).toBe(true);
     expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('coalesces token-sized items so backlog drains within the target window', async () => {
+    const tick = 10;
+    const items = Array.from({ length: 400 }, (_, i) =>
+      makeItem(`t${i}`, i % 5 === 4 ? 'x ' : 'x', true)
+    );
+    const expected = items.map((i) => i.text).join('');
+
+    const start = Date.now();
+    const pieces = await collect(
+      smoothStream({ source: arraySource(items), delayMs: tick })
+    );
+    const elapsed = Date.now() - start;
+
+    expect(pieces.map((p) => p.text).join('')).toBe(expected);
+    expect(elapsed).toBeLessThan(2000);
+    const tags = pieces.map((p) => p.tag);
+    expect(tags).toEqual([...tags].sort((a, b) => Number(a.slice(1)) - Number(b.slice(1))));
+  });
+
+  it('rethrows a producer failure even when the rejection value is nullish', async () => {
+    async function* failingSource(): AsyncGenerator<SmoothItem<Emitted>> {
+      yield makeItem('a', 'some text ', true);
+      throw undefined;
+    }
+
+    await expect(
+      collect(smoothStream({ source: failingSource(), delayMs: 1 }))
+    ).rejects.toThrow('Stream producer failed.');
   });
 
   it('stays fully lazy when smoothing is disabled', async () => {

--- a/src/llm/stream/smoother.test.ts
+++ b/src/llm/stream/smoother.test.ts
@@ -246,6 +246,40 @@ describe('smoothStream', () => {
     expect(Date.now() - start).toBeLessThan(50);
   });
 
+  it('stays fully lazy when smoothing is disabled', async () => {
+    const yielded: number[] = [];
+    const items = [
+      makeItem('a', 'first ', true),
+      makeItem('b', 'second ', true),
+      makeItem('c', 'third ', true),
+    ];
+    const stream = smoothStream({
+      source: arraySource(items, (i) => yielded.push(i)),
+      delayMs: 0,
+    });
+
+    await stream.next();
+    expect(yielded).toEqual([0]);
+    await stream.return(undefined);
+    expect(yielded).toEqual([0]);
+  });
+
+  it('segments an oversized item so pieces reassemble with exactly one isFirst/isLast', async () => {
+    const bigText = 'lorem ipsum dolor sit amet '.repeat(400);
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([makeItem('big', bigText, true)]),
+        delayMs: 1,
+      })
+    );
+
+    expect(pieces.map((p) => p.text).join('')).toBe(bigText);
+    expect(pieces.filter((p) => p.isFirst)).toHaveLength(1);
+    expect(pieces.filter((p) => p.isLast)).toHaveLength(1);
+    expect(pieces[0].isFirst).toBe(true);
+    expect(pieces[pieces.length - 1].isLast).toBe(true);
+  });
+
   it('skips empty-text smooth items entirely', async () => {
     const pieces = await collect(
       smoothStream({
@@ -351,11 +385,13 @@ describe('smoothStream', () => {
 
     const first = await stream.next();
     expect(first.done).toBe(false);
+    /** Segmented admission parks the producer mid-way through the first
+     * oversized item — later items are not read ahead past the text cap. */
     expect(yielded).toContain(0);
-    expect(yielded).toContain(1);
     expect(yielded).not.toContain(2);
 
     const rest = await collect(stream as AsyncGenerator<Emitted>);
+    expect(yielded).toContain(1);
     expect(yielded).toContain(2);
     const all = [first.value as Emitted, ...rest];
     expect(all.map((p) => p.text).join('')).toBe(bigText + bigText + 'tail text ');

--- a/src/llm/stream/smoother.test.ts
+++ b/src/llm/stream/smoother.test.ts
@@ -4,6 +4,7 @@ import {
   STREAM_ABORT_MESSAGE,
   STREAM_CHUNK_MIN_SIZE,
   DEFAULT_STREAM_DELAY,
+  PRODUCER_CLOSE_GRACE_MS,
   findStreamChunkBoundary,
   computeAdaptivePieceSize,
   SMOOTH_TARGET_LATENCY_MS,
@@ -257,6 +258,57 @@ describe('smoothStream', () => {
     );
     expect(pieces.every((p) => p.tag === 'real')).toBe(true);
     expect(pieces.length).toBeGreaterThan(0);
+  });
+
+  it('wakes a consumer parked on an empty queue when the signal aborts', async () => {
+    const controller = new AbortController();
+    const abortUpstream = jest.fn();
+    async function* stalledSource(): AsyncGenerator<SmoothItem<Emitted>> {
+      yield makeItem('a', 'first text ', true);
+      await new Promise<void>(() => undefined);
+    }
+
+    const stream = smoothStream({
+      source: stalledSource(),
+      delayMs: 5,
+      signal: controller.signal,
+      abortUpstream,
+    });
+
+    let next = await stream.next();
+    while (next.done !== true && (next.value as Emitted).isLast !== true) {
+      next = await stream.next();
+    }
+
+    const start = Date.now();
+    const parked = stream.next();
+    setTimeout(() => controller.abort(), 20);
+
+    await expect(parked).rejects.toThrow(STREAM_ABORT_MESSAGE);
+    expect(Date.now() - start).toBeLessThan(PRODUCER_CLOSE_GRACE_MS + 1500);
+    expect(abortUpstream).toHaveBeenCalled();
+  });
+
+  it('completes an early break promptly even when the source is stalled', async () => {
+    async function* stalledSource(): AsyncGenerator<SmoothItem<Emitted>> {
+      yield makeItem('a', 'first text ', true);
+      await new Promise<void>(() => undefined);
+    }
+
+    const stream = smoothStream({ source: stalledSource(), delayMs: 5 });
+    await stream.next();
+
+    const start = Date.now();
+    const closed = (async (): Promise<boolean> => {
+      await stream.return(undefined);
+      return true;
+    })();
+    const result = await Promise.race([
+      closed,
+      sleep(PRODUCER_CLOSE_GRACE_MS + 2000).then(() => false),
+    ]);
+    expect(result).toBe(true);
+    expect(Date.now() - start).toBeLessThan(PRODUCER_CLOSE_GRACE_MS + 1500);
   });
 
   it('throws the canonical abort message when aborted during the pacing sleep', async () => {

--- a/src/llm/stream/smoother.test.ts
+++ b/src/llm/stream/smoother.test.ts
@@ -1,0 +1,369 @@
+import {
+  smoothStream,
+  resolveStreamDelay,
+  STREAM_ABORT_MESSAGE,
+  STREAM_CHUNK_MIN_SIZE,
+  DEFAULT_STREAM_DELAY,
+  findStreamChunkBoundary,
+  computeAdaptivePieceSize,
+  SMOOTH_TARGET_LATENCY_MS,
+  MAX_STREAM_QUEUE_TEXT_CHARS,
+} from './smoother';
+import type { SmoothItem, SmoothPiece } from './smoother';
+
+type Emitted = SmoothPiece & { tag: string; at: number };
+
+function makeItem(
+  tag: string,
+  text: string,
+  smooth: boolean,
+  atomic?: boolean
+): SmoothItem<Emitted> {
+  return {
+    text,
+    smooth,
+    atomic,
+    emit: (piece) => ({ ...piece, tag, at: Date.now() }),
+  };
+}
+
+async function* arraySource<T>(
+  items: SmoothItem<T>[],
+  onYield?: (index: number) => void
+): AsyncGenerator<SmoothItem<T>> {
+  for (let i = 0; i < items.length; i++) {
+    onYield?.(i);
+    yield items[i];
+  }
+}
+
+async function collect(
+  stream: AsyncGenerator<Emitted>
+): Promise<Emitted[]> {
+  const out: Emitted[] = [];
+  for await (const piece of stream) {
+    out.push(piece);
+  }
+  return out;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('resolveStreamDelay', () => {
+  it('defaults to DEFAULT_STREAM_DELAY when unset', () => {
+    expect(resolveStreamDelay(undefined)).toBe(DEFAULT_STREAM_DELAY);
+  });
+
+  it('passes explicit values through and clamps negatives to 0', () => {
+    expect(resolveStreamDelay(10)).toBe(10);
+    expect(resolveStreamDelay(0)).toBe(0);
+    expect(resolveStreamDelay(-5)).toBe(0);
+  });
+});
+
+describe('computeAdaptivePieceSize', () => {
+  it('floors at STREAM_CHUNK_MIN_SIZE for small backlogs', () => {
+    expect(computeAdaptivePieceSize(0, 25)).toBe(STREAM_CHUNK_MIN_SIZE);
+    expect(computeAdaptivePieceSize(1, 25)).toBe(STREAM_CHUNK_MIN_SIZE);
+    expect(computeAdaptivePieceSize(39, 25)).toBe(STREAM_CHUNK_MIN_SIZE);
+  });
+
+  it('scales proportionally with backlog', () => {
+    expect(computeAdaptivePieceSize(250, 25)).toBe(25);
+    expect(computeAdaptivePieceSize(2500, 25)).toBe(250);
+    expect(computeAdaptivePieceSize(1000, 10)).toBe(40);
+  });
+
+  it('returns the full backlog when the tick is non-positive', () => {
+    expect(computeAdaptivePieceSize(500, 0)).toBe(500);
+  });
+
+  it('holds steady-state backlog near arrival_rate x target latency', () => {
+    const tick = 25;
+    const arrivalPerTick = 100;
+    let backlog = 0;
+    const observed: number[] = [];
+    for (let i = 0; i < 200; i++) {
+      backlog += arrivalPerTick;
+      backlog -= Math.min(backlog, computeAdaptivePieceSize(backlog, tick));
+      observed.push(backlog);
+    }
+    const expected = (arrivalPerTick * SMOOTH_TARGET_LATENCY_MS) / tick;
+    const tail = observed.slice(-20);
+    for (const value of tail) {
+      expect(value).toBeGreaterThan(expected * 0.8);
+      expect(value).toBeLessThan(expected * 1.2);
+    }
+  });
+
+  it('drains a stopped stream geometrically', () => {
+    const tick = 25;
+    const perTickTicks = Math.ceil(SMOOTH_TARGET_LATENCY_MS / tick);
+    let backlog = 1000;
+    let ticks = 0;
+    const snapshots: number[] = [];
+    while (backlog > 0 && ticks < 100) {
+      backlog -= Math.min(backlog, computeAdaptivePieceSize(backlog, tick));
+      ticks++;
+      snapshots.push(backlog);
+    }
+    expect(backlog).toBe(0);
+    expect(snapshots[perTickTicks - 1]).toBeLessThan(1000 * 0.4);
+    expect(ticks).toBeLessThan(50);
+  });
+});
+
+describe('findStreamChunkBoundary', () => {
+  it('extends to the next boundary character inclusive', () => {
+    expect(findStreamChunkBoundary('hello world', 4)).toBe(6);
+  });
+
+  it('returns full length when no boundary follows', () => {
+    expect(findStreamChunkBoundary('hello', 4)).toBe(5);
+    expect(findStreamChunkBoundary('hi', 4)).toBe(2);
+  });
+});
+
+describe('smoothStream', () => {
+  it('splits a large smooth item into word-boundary pieces at cadence', async () => {
+    const text =
+      'The quick brown fox jumps over the lazy dog and keeps on running through the field. ';
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([makeItem('a', text, true)]),
+        delayMs: 5,
+      })
+    );
+
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.map((p) => p.text).join('')).toBe(text);
+    expect(pieces[0].isFirst).toBe(true);
+    expect(pieces[pieces.length - 1].isLast).toBe(true);
+    for (const piece of pieces.slice(1, -1)) {
+      expect(piece.isFirst).toBe(false);
+      expect(piece.isLast).toBe(false);
+    }
+  });
+
+  it('preserves strict FIFO order across smooth and passthrough items', async () => {
+    const items = [
+      makeItem('text1', 'hello world again and again ', true),
+      makeItem('tool', '', false),
+      makeItem('text2', 'more visible text here now ', true),
+      makeItem('usage', '', false),
+    ];
+    const pieces = await collect(
+      smoothStream({ source: arraySource(items), delayMs: 3 })
+    );
+
+    const tagRuns = pieces.map((p) => p.tag);
+    const collapsed = tagRuns.filter((tag, i) => tagRuns[i - 1] !== tag);
+    expect(collapsed).toEqual(['text1', 'tool', 'text2', 'usage']);
+  });
+
+  it('emits the first visible piece without delay (TTFT)', async () => {
+    const start = Date.now();
+    const stream = smoothStream({
+      source: arraySource([makeItem('a', 'hello world and more text ', true)]),
+      delayMs: 50,
+    });
+    const first = await stream.next();
+    expect(first.done).toBe(false);
+    expect(Date.now() - start).toBeLessThan(40);
+    await stream.return(undefined);
+  });
+
+  it('never delays passthrough items even between paced text', async () => {
+    const items = [
+      makeItem('text1', 'some visible words streaming along nicely ', true),
+      makeItem('seal', '', false),
+    ];
+    const pieces = await collect(
+      smoothStream({ source: arraySource(items), delayMs: 20 })
+    );
+    const sealPiece = pieces.find((p) => p.tag === 'seal');
+    const lastText = pieces.filter((p) => p.tag === 'text1').pop();
+    expect(sealPiece).toBeDefined();
+    expect(lastText).toBeDefined();
+    expect((sealPiece as Emitted).at - (lastText as Emitted).at).toBeLessThan(
+      15
+    );
+  });
+
+  it('paces atomic items whole without splitting', async () => {
+    const text = 'this text carries logprobs and must never be split apart ';
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([
+          makeItem('lead', 'lead text goes first here ', true),
+          makeItem('logprobs', text, true, true),
+        ]),
+        delayMs: 3,
+      })
+    );
+    const atomicPieces = pieces.filter((p) => p.tag === 'logprobs');
+    expect(atomicPieces).toHaveLength(1);
+    expect(atomicPieces[0].text).toBe(text);
+    expect(atomicPieces[0].isFirst).toBe(true);
+    expect(atomicPieces[0].isLast).toBe(true);
+  });
+
+  it('marks exactly one isFirst piece per item for usage dedup', async () => {
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([
+          makeItem('a', 'first item with several words to split ', true),
+          makeItem('b', 'second item also has words to split ', true),
+        ]),
+        delayMs: 2,
+      })
+    );
+    for (const tag of ['a', 'b']) {
+      const tagged = pieces.filter((p) => p.tag === tag);
+      expect(tagged.filter((p) => p.isFirst)).toHaveLength(1);
+      expect(tagged[0].isFirst).toBe(true);
+    }
+  });
+
+  it('passes everything through unsplit and undelayed when delayMs is 0', async () => {
+    const text = 'a very long text that would normally be split into pieces ';
+    const start = Date.now();
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([
+          makeItem('a', text, true),
+          makeItem('b', '', false),
+        ]),
+        delayMs: 0,
+      })
+    );
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0].text).toBe(text);
+    expect(pieces[0].isFirst).toBe(true);
+    expect(pieces[0].isLast).toBe(true);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('skips empty-text smooth items entirely', async () => {
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([
+          makeItem('empty', '', true),
+          makeItem('real', 'actual text ', true),
+        ]),
+        delayMs: 3,
+      })
+    );
+    expect(pieces.every((p) => p.tag === 'real')).toBe(true);
+    expect(pieces.length).toBeGreaterThan(0);
+  });
+
+  it('throws the canonical abort message when aborted during the pacing sleep', async () => {
+    const controller = new AbortController();
+    const abortUpstream = jest.fn();
+    const stream = smoothStream({
+      source: arraySource([
+        makeItem('a', 'plenty of text to keep the consumer pacing along ', true),
+      ]),
+      delayMs: 50,
+      signal: controller.signal,
+      abortUpstream,
+    });
+
+    const first = await stream.next();
+    expect(first.done).toBe(false);
+    setTimeout(() => controller.abort(), 10);
+
+    await expect(async () => {
+      await collect(stream as AsyncGenerator<Emitted>);
+    }).rejects.toThrow(STREAM_ABORT_MESSAGE);
+    expect(abortUpstream).toHaveBeenCalled();
+  });
+
+  it('parks the producer at the text capacity and resumes during consumer pacing', async () => {
+    const bigText = 'word '.repeat(
+      Math.ceil(MAX_STREAM_QUEUE_TEXT_CHARS / 5) + 200
+    );
+    const yielded: number[] = [];
+    const items = [
+      makeItem('a', bigText, true),
+      makeItem('b', bigText, true),
+      makeItem('c', 'tail text ', true),
+    ];
+
+    const stream = smoothStream({
+      source: arraySource(items, (i) => yielded.push(i)),
+      delayMs: 1,
+    });
+
+    const first = await stream.next();
+    expect(first.done).toBe(false);
+    expect(yielded).toContain(0);
+    expect(yielded).toContain(1);
+    expect(yielded).not.toContain(2);
+
+    const rest = await collect(stream as AsyncGenerator<Emitted>);
+    expect(yielded).toContain(2);
+    const all = [first.value as Emitted, ...rest];
+    expect(all.map((p) => p.text).join('')).toBe(bigText + bigText + 'tail text ');
+  });
+
+  it('closes a parked producer promptly after an early consumer break', async () => {
+    const bigText = 'word '.repeat(MAX_STREAM_QUEUE_TEXT_CHARS);
+    let sourceFinallyRan = false;
+    async function* source(): AsyncGenerator<SmoothItem<Emitted>> {
+      try {
+        yield makeItem('a', bigText, true);
+        yield makeItem('b', bigText, true);
+        yield makeItem('c', bigText, true);
+      } finally {
+        sourceFinallyRan = true;
+      }
+    }
+
+    const abortUpstream = jest.fn();
+    const stream = smoothStream({
+      source: source(),
+      delayMs: 25,
+      abortUpstream,
+    });
+
+    await stream.next();
+    await stream.next();
+
+    const closed = (async (): Promise<boolean> => {
+      await stream.return(undefined);
+      return true;
+    })();
+    const result = await Promise.race([
+      closed,
+      sleep(1000).then(() => false),
+    ]);
+    expect(result).toBe(true);
+    expect(abortUpstream).toHaveBeenCalled();
+    expect(sourceFinallyRan).toBe(true);
+  });
+
+  it('keeps render lag bounded near the target latency under a fast big-chunk producer', async () => {
+    const tick = 5;
+    const chunk = 'lorem ipsum dolor sit amet consectetur adipiscing elit '.repeat(2);
+    let producerDoneAt = 0;
+    async function* fastSource(): AsyncGenerator<SmoothItem<Emitted>> {
+      for (let i = 0; i < 12; i++) {
+        yield makeItem(`c${i}`, chunk, true);
+        await sleep(10);
+      }
+      producerDoneAt = Date.now();
+    }
+
+    const pieces = await collect(
+      smoothStream({ source: fastSource(), delayMs: tick })
+    );
+    const renderDoneAt = pieces[pieces.length - 1].at;
+    const lag = renderDoneAt - producerDoneAt;
+
+    expect(pieces.map((p) => p.text).join('')).toBe(chunk.repeat(12));
+    expect(lag).toBeLessThan(SMOOTH_TARGET_LATENCY_MS * 2.5);
+  });
+});

--- a/src/llm/stream/smoother.test.ts
+++ b/src/llm/stream/smoother.test.ts
@@ -5,6 +5,8 @@ import {
   STREAM_CHUNK_MIN_SIZE,
   DEFAULT_STREAM_DELAY,
   PRODUCER_CLOSE_GRACE_MS,
+  MAX_SMOOTH_ITEM_SEGMENT_CHARS,
+  STREAM_BOUNDARY_LOOKAHEAD_CHARS,
   findStreamChunkBoundary,
   computeAdaptivePieceSize,
   SMOOTH_TARGET_LATENCY_MS,
@@ -120,9 +122,16 @@ describe('findStreamChunkBoundary', () => {
     expect(findStreamChunkBoundary('hello world', 4)).toBe(6);
   });
 
-  it('returns full length when no boundary follows', () => {
+  it('returns full length when no boundary follows within the lookahead', () => {
     expect(findStreamChunkBoundary('hello', 4)).toBe(5);
     expect(findStreamChunkBoundary('hi', 4)).toBe(2);
+  });
+
+  it('hard-cuts boundary-free runs at the lookahead limit', () => {
+    const unbroken = 'a'.repeat(10000);
+    expect(findStreamChunkBoundary(unbroken, 4096)).toBe(
+      4096 + STREAM_BOUNDARY_LOOKAHEAD_CHARS
+    );
   });
 });
 
@@ -278,6 +287,22 @@ describe('smoothStream', () => {
     expect(pieces.filter((p) => p.isLast)).toHaveLength(1);
     expect(pieces[0].isFirst).toBe(true);
     expect(pieces[pieces.length - 1].isLast).toBe(true);
+  });
+
+  it('bounds pieces of boundary-free runs at the segment cap plus lookahead', async () => {
+    const unbroken = 'x'.repeat(20000);
+    const pieces = await collect(
+      smoothStream({
+        source: arraySource([makeItem('blob', unbroken, true)]),
+        delayMs: 1,
+      })
+    );
+
+    expect(pieces.map((p) => p.text).join('')).toBe(unbroken);
+    const maxPiece = Math.max(...pieces.map((p) => p.text.length));
+    expect(maxPiece).toBeLessThanOrEqual(
+      MAX_SMOOTH_ITEM_SEGMENT_CHARS + STREAM_BOUNDARY_LOOKAHEAD_CHARS
+    );
   });
 
   it('skips empty-text smooth items entirely', async () => {

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -341,9 +341,10 @@ export async function* smoothStream<TEmit>({
         if (drainTicksRemaining != null && drainTicksRemaining > 1) {
           drainTicksRemaining -= 1;
         }
-        const pieceLength = item.atomic
-          ? remainingText.length
-          : findStreamChunkBoundary(remainingText, targetPieceSize);
+        const pieceLength =
+          item.atomic === true
+            ? remainingText.length
+            : findStreamChunkBoundary(remainingText, targetPieceSize);
         const pieceEnd = headOffset + pieceLength;
         const piece = item.text.slice(headOffset, pieceEnd);
 

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -15,6 +15,7 @@ export const STREAM_BOUNDARIES: ReadonlySet<string> = new Set([
 ]);
 
 export const STREAM_ABORT_MESSAGE = 'AbortError: User aborted the request.';
+export const STREAM_PRODUCER_FAILURE = 'Stream producer failed.';
 
 /**
  * How long generator teardown waits for the background producer to observe a
@@ -25,9 +26,17 @@ export const STREAM_ABORT_MESSAGE = 'AbortError: User aborted the request.';
  */
 export const PRODUCER_CLOSE_GRACE_MS = 1000;
 
-/** Resolves a configured stream delay to its effective value (default 25ms; 0 disables smoothing). */
+/**
+ * Resolves a configured stream delay to its effective value (default 25ms;
+ * 0 disables smoothing). Non-finite inputs (NaN from a malformed config
+ * value, ±Infinity) normalize to the default rather than poisoning piece
+ * arithmetic downstream.
+ */
 export function resolveStreamDelay(delay?: number): number {
-  return Math.max(0, delay ?? DEFAULT_STREAM_DELAY);
+  if (delay == null || !Number.isFinite(delay)) {
+    return DEFAULT_STREAM_DELAY;
+  }
+  return Math.max(0, delay);
 }
 
 export function isSignalAborted(signal?: AbortSignal): boolean {
@@ -163,6 +172,7 @@ export type SmoothItem<TEmit> = {
 
 type ProducerState = {
   done: boolean;
+  failed: boolean;
   error?: unknown;
 };
 
@@ -194,7 +204,7 @@ export async function* smoothStream<TEmit>({
   signal?: AbortSignal;
   abortUpstream?: () => void;
 }): AsyncGenerator<TEmit> {
-  if (delayMs <= 0) {
+  if (!(delayMs > 0)) {
     /** Disabled smoothing preserves fully lazy streaming: no background
      * producer, no read-ahead — each provider chunk is pulled only when the
      * consumer asks, exactly like the pre-engine pass-through paths. */
@@ -209,7 +219,7 @@ export async function* smoothStream<TEmit>({
   }
 
   const queuedItems: QueuedSmoothItem<TEmit>[] = [];
-  const producerState: ProducerState = { done: false };
+  const producerState: ProducerState = { done: false, failed: false };
   let queuedItemIndex = 0;
   let bufferedTextLength = 0;
   let consumerClosed = false;
@@ -242,7 +252,7 @@ export async function* smoothStream<TEmit>({
     if (
       hasQueuedItems() ||
       producerState.done ||
-      producerState.error != null ||
+      producerState.failed ||
       isSignalAborted(signal)
     ) {
       return;
@@ -372,6 +382,7 @@ export async function* smoothStream<TEmit>({
         await enqueueSegmented(item);
       }
     } catch (error) {
+      producerState.failed = true;
       producerState.error = error;
     } finally {
       producerState.done = true;
@@ -382,6 +393,8 @@ export async function* smoothStream<TEmit>({
   let hasEmittedText = false;
   let lastVisibleTextAt: number | undefined;
   let drainTicksRemaining: number | undefined;
+  let current: QueuedSmoothItem<TEmit> | undefined;
+  let headOffset = 0;
   let keepStreaming = true;
   try {
     while (keepStreaming) {
@@ -389,12 +402,15 @@ export async function* smoothStream<TEmit>({
         throwAborted();
       }
 
-      await waitForNextItem();
-      const queuedItem = dequeue();
+      if (current == null) {
+        await waitForNextItem();
+        current = dequeue();
+        headOffset = 0;
+      }
 
-      if (!queuedItem) {
-        if (producerState.error != null) {
-          throw producerState.error;
+      if (current == null) {
+        if (producerState.failed) {
+          throw producerState.error ?? new Error(STREAM_PRODUCER_FAILURE);
         }
         if (producerState.done) {
           keepStreaming = false;
@@ -402,11 +418,11 @@ export async function* smoothStream<TEmit>({
         continue;
       }
 
-      const { item } = queuedItem;
-      const isSmooth = item.smooth;
+      const { item } = current;
 
-      if (!isSmooth) {
+      if (!item.smooth) {
         notifyProducerForSpace();
+        current = undefined;
         yield item.emit({ text: item.text, isFirst: true, isLast: true });
         continue;
       }
@@ -414,63 +430,121 @@ export async function* smoothStream<TEmit>({
       if (item.text === '') {
         bufferedTextLength = Math.max(
           0,
-          bufferedTextLength - queuedItem.textLength
+          bufferedTextLength - current.textLength
         );
         notifyProducerForSpace();
+        current = undefined;
         continue;
       }
 
-      let headOffset = 0;
-      while (headOffset < item.text.length) {
-        const remainingText = item.text.slice(headOffset);
-        /** Once the producer is done the backlog is final: drain it linearly
-         * across the remaining target window instead of letting the
-         * proportional formula decay geometrically and stretch the tail. */
-        if (producerState.done && drainTicksRemaining == null) {
-          drainTicksRemaining = Math.max(
-            1,
-            Math.floor(SMOOTH_TARGET_LATENCY_MS / delayMs)
-          );
-        }
-        const targetPieceSize =
-          drainTicksRemaining != null
-            ? Math.max(
-              STREAM_CHUNK_MIN_SIZE,
-              Math.ceil(bufferedTextLength / drainTicksRemaining)
-            )
-            : computeAdaptivePieceSize(bufferedTextLength, delayMs);
-        if (drainTicksRemaining != null && drainTicksRemaining > 1) {
-          drainTicksRemaining -= 1;
-        }
-        const pieceLength =
-          item.atomic === true
-            ? remainingText.length
-            : findStreamChunkBoundary(remainingText, targetPieceSize);
-        const pieceEnd = headOffset + pieceLength;
-        const piece = item.text.slice(headOffset, pieceEnd);
-
-        bufferedTextLength = Math.max(0, bufferedTextLength - piece.length);
-        notifyProducerForSpace();
-        await waitForStreamDelay(
-          getCadencedStreamDelay({
-            targetDelay: hasEmittedText ? delayMs : 0,
-            lastVisibleTextAt,
-            now: Date.now(),
-          }),
-          signal
+      /** Once the producer is done the backlog is final: drain it linearly
+       * across the remaining target window instead of letting the
+       * proportional formula decay geometrically and stretch the tail. */
+      if (producerState.done && drainTicksRemaining == null) {
+        drainTicksRemaining = Math.max(
+          1,
+          Math.floor(SMOOTH_TARGET_LATENCY_MS / delayMs)
         );
+      }
+      const tickBudget =
+        drainTicksRemaining != null
+          ? Math.max(
+            STREAM_CHUNK_MIN_SIZE,
+            Math.ceil(bufferedTextLength / drainTicksRemaining)
+          )
+          : computeAdaptivePieceSize(bufferedTextLength, delayMs);
+      if (drainTicksRemaining != null && drainTicksRemaining > 1) {
+        drainTicksRemaining -= 1;
+      }
+
+      await waitForStreamDelay(
+        getCadencedStreamDelay({
+          targetDelay: hasEmittedText ? delayMs : 0,
+          lastVisibleTextAt,
+          now: Date.now(),
+        }),
+        signal
+      );
+      if (isSignalAborted(signal)) {
+        throwAborted();
+      }
+      hasEmittedText = true;
+      lastVisibleTextAt = Date.now();
+
+      if (item.atomic === true) {
+        bufferedTextLength = Math.max(
+          0,
+          bufferedTextLength - current.textLength
+        );
+        notifyProducerForSpace();
+        current = undefined;
+        yield item.emit({ text: item.text, isFirst: true, isLast: true });
+        continue;
+      }
+
+      /** One cadence tick drains up to the adaptive budget ACROSS queued
+       * items, so token-sized provider deltas coalesce instead of costing a
+       * full tick each; passthrough items flush free mid-batch (FIFO), and
+       * atomic items end the batch to take their own tick. */
+      let consumed = 0;
+      while (consumed < tickBudget) {
         if (isSignalAborted(signal)) {
           throwAborted();
         }
-        hasEmittedText = true;
-        lastVisibleTextAt = Date.now();
+        if (current == null) {
+          if (!hasQueuedItems()) {
+            break;
+          }
+          current = dequeue();
+          headOffset = 0;
+          if (current == null) {
+            break;
+          }
+        }
 
-        yield item.emit({
-          text: piece,
-          isFirst: headOffset === 0,
-          isLast: pieceEnd === item.text.length,
-        });
-        headOffset = pieceEnd;
+        const batchItem = current.item;
+        if (!batchItem.smooth) {
+          notifyProducerForSpace();
+          current = undefined;
+          yield batchItem.emit({
+            text: batchItem.text,
+            isFirst: true,
+            isLast: true,
+          });
+          continue;
+        }
+        if (batchItem.text === '') {
+          bufferedTextLength = Math.max(
+            0,
+            bufferedTextLength - current.textLength
+          );
+          notifyProducerForSpace();
+          current = undefined;
+          continue;
+        }
+        if (batchItem.atomic === true) {
+          break;
+        }
+
+        const remainingText = batchItem.text.slice(headOffset);
+        const pieceLength = findStreamChunkBoundary(
+          remainingText,
+          tickBudget - consumed
+        );
+        const pieceEnd = headOffset + pieceLength;
+        const piece = batchItem.text.slice(headOffset, pieceEnd);
+        const isFirst = headOffset === 0;
+        const isLast = pieceEnd === batchItem.text.length;
+
+        bufferedTextLength = Math.max(0, bufferedTextLength - piece.length);
+        notifyProducerForSpace();
+        if (isLast) {
+          current = undefined;
+        } else {
+          headOffset = pieceEnd;
+        }
+        consumed += piece.length;
+        yield batchItem.emit({ text: piece, isFirst, isLast });
       }
     }
   } finally {

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -2,6 +2,7 @@ export const DEFAULT_STREAM_DELAY = 25;
 export const SMOOTH_TARGET_LATENCY_MS = 250;
 export const MAX_STREAM_QUEUE_CHUNKS = 256;
 export const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
+export const MAX_SMOOTH_ITEM_SEGMENT_CHARS = 4096;
 export const STREAM_CHUNK_MIN_SIZE = 4;
 export const STREAM_BOUNDARIES: ReadonlySet<string> = new Set([
   ' ',
@@ -180,7 +181,20 @@ export async function* smoothStream<TEmit>({
   signal?: AbortSignal;
   abortUpstream?: () => void;
 }): AsyncGenerator<TEmit> {
-  const smoothingEnabled = delayMs > 0;
+  if (delayMs <= 0) {
+    /** Disabled smoothing preserves fully lazy streaming: no background
+     * producer, no read-ahead — each provider chunk is pulled only when the
+     * consumer asks, exactly like the pre-engine pass-through paths. */
+    for await (const item of source) {
+      if (isSignalAborted(signal)) {
+        abortUpstream?.();
+        throw new Error(STREAM_ABORT_MESSAGE);
+      }
+      yield item.emit({ text: item.text, isFirst: true, isLast: true });
+    }
+    return;
+  }
+
   const queuedItems: QueuedSmoothItem<TEmit>[] = [];
   const producerState: ProducerState = { done: false };
   let queuedItemIndex = 0;
@@ -283,11 +297,57 @@ export async function* smoothStream<TEmit>({
     if (consumerClosed || isSignalAborted(signal)) {
       throwAborted();
     }
-    const isSmooth = smoothingEnabled && item.smooth;
-    const textLength = isSmooth ? item.text.length : 0;
+    const textLength = item.smooth ? item.text.length : 0;
     queuedItems.push({ item, textLength });
     bufferedTextLength += textLength;
     notifyConsumerForItem();
+  };
+
+  /**
+   * Oversized splittable items are segmented at admission so a single giant
+   * provider chunk cannot blow past the text budget: each segment re-checks
+   * capacity, so the producer parks mid-chunk once the buffer fills — the
+   * same bound the legacy split-before-enqueue queues enforced. The wrapped
+   * emit maps segment-local pieces back to chunk-global isFirst/isLast so
+   * provider clone contracts are unaffected.
+   */
+  const enqueueSegmented = async (item: SmoothItem<TEmit>): Promise<void> => {
+    if (
+      !item.smooth ||
+      item.atomic === true ||
+      item.text.length <= MAX_SMOOTH_ITEM_SEGMENT_CHARS
+    ) {
+      await enqueue(item);
+      return;
+    }
+
+    const segments: { start: number; end: number }[] = [];
+    let offset = 0;
+    while (offset < item.text.length) {
+      const end =
+        offset +
+        findStreamChunkBoundary(
+          item.text.slice(offset),
+          MAX_SMOOTH_ITEM_SEGMENT_CHARS
+        );
+      segments.push({ start: offset, end });
+      offset = end;
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      const isFirstSegment = i === 0;
+      const isLastSegment = i === segments.length - 1;
+      await enqueue({
+        text: item.text.slice(segments[i].start, segments[i].end),
+        smooth: true,
+        emit: (piece) =>
+          item.emit({
+            text: piece.text,
+            isFirst: isFirstSegment && piece.isFirst,
+            isLast: isLastSegment && piece.isLast,
+          }),
+      });
+    }
   };
 
   const producer = (async (): Promise<void> => {
@@ -296,7 +356,7 @@ export async function* smoothStream<TEmit>({
         if (isSignalAborted(signal)) {
           throwAborted();
         }
-        await enqueue(item);
+        await enqueueSegmented(item);
       }
     } catch (error) {
       producerState.error = error;
@@ -330,7 +390,7 @@ export async function* smoothStream<TEmit>({
       }
 
       const { item } = queuedItem;
-      const isSmooth = smoothingEnabled && item.smooth;
+      const isSmooth = item.smooth;
 
       if (!isSmooth) {
         notifyProducerForSpace();

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -34,6 +34,15 @@ export function isSignalAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true;
 }
 
+/**
+ * How far past the target size the word-boundary search may extend before
+ * hard-cutting. Natural language hits a boundary within a few characters;
+ * boundary-free runs (base64, minified data, long identifiers) must not
+ * stretch a piece — or an admission segment — arbitrarily far past its
+ * budget.
+ */
+export const STREAM_BOUNDARY_LOOKAHEAD_CHARS = 64;
+
 export function findStreamChunkBoundary(
   text: string,
   minSize: number
@@ -42,13 +51,17 @@ export function findStreamChunkBoundary(
     return text.length;
   }
 
-  for (let position = minSize; position < text.length; position++) {
+  const scanEnd = Math.min(
+    text.length,
+    minSize + STREAM_BOUNDARY_LOOKAHEAD_CHARS
+  );
+  for (let position = minSize; position < scanEnd; position++) {
     if (STREAM_BOUNDARIES.has(text[position])) {
       return position + 1;
     }
   }
 
-  return text.length;
+  return scanEnd;
 }
 
 /**

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -280,6 +280,7 @@ export async function* smoothStream<TEmit>({
 
   let hasEmittedText = false;
   let lastVisibleTextAt: number | undefined;
+  let drainTicksRemaining: number | undefined;
   let keepStreaming = true;
   try {
     while (keepStreaming) {
@@ -321,12 +322,28 @@ export async function* smoothStream<TEmit>({
       let headOffset = 0;
       while (headOffset < item.text.length) {
         const remainingText = item.text.slice(headOffset);
+        /** Once the producer is done the backlog is final: drain it linearly
+         * across the remaining target window instead of letting the
+         * proportional formula decay geometrically and stretch the tail. */
+        if (producerState.done && drainTicksRemaining == null) {
+          drainTicksRemaining = Math.max(
+            1,
+            Math.floor(SMOOTH_TARGET_LATENCY_MS / delayMs)
+          );
+        }
+        const targetPieceSize =
+          drainTicksRemaining != null
+            ? Math.max(
+              STREAM_CHUNK_MIN_SIZE,
+              Math.ceil(bufferedTextLength / drainTicksRemaining)
+            )
+            : computeAdaptivePieceSize(bufferedTextLength, delayMs);
+        if (drainTicksRemaining != null && drainTicksRemaining > 1) {
+          drainTicksRemaining -= 1;
+        }
         const pieceLength = item.atomic
           ? remainingText.length
-          : findStreamChunkBoundary(
-            remainingText,
-            computeAdaptivePieceSize(bufferedTextLength, delayMs)
-          );
+          : findStreamChunkBoundary(remainingText, targetPieceSize);
         const pieceEnd = headOffset + pieceLength;
         const piece = item.text.slice(headOffset, pieceEnd);
 

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -419,7 +419,7 @@ export async function* smoothStream<TEmit>({
         producer,
         new Promise<void>((resolve) => {
           const timeout = setTimeout(resolve, PRODUCER_CLOSE_GRACE_MS);
-          timeout.unref?.();
+          timeout.unref();
         }),
       ]);
     }

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -1,0 +1,365 @@
+export const DEFAULT_STREAM_DELAY = 25;
+export const SMOOTH_TARGET_LATENCY_MS = 250;
+export const MAX_STREAM_QUEUE_CHUNKS = 256;
+export const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
+export const STREAM_CHUNK_MIN_SIZE = 4;
+export const STREAM_BOUNDARIES: ReadonlySet<string> = new Set([
+  ' ',
+  '.',
+  ',',
+  '!',
+  '?',
+  ';',
+  ':',
+]);
+
+export const STREAM_ABORT_MESSAGE = 'AbortError: User aborted the request.';
+
+/** Resolves a configured stream delay to its effective value (default 25ms; 0 disables smoothing). */
+export function resolveStreamDelay(delay?: number): number {
+  return Math.max(0, delay ?? DEFAULT_STREAM_DELAY);
+}
+
+export function isSignalAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+export function findStreamChunkBoundary(
+  text: string,
+  minSize: number
+): number {
+  if (minSize >= text.length) {
+    return text.length;
+  }
+
+  for (let position = minSize; position < text.length; position++) {
+    if (STREAM_BOUNDARIES.has(text[position])) {
+      return position + 1;
+    }
+  }
+
+  return text.length;
+}
+
+/**
+ * Backlog-proportional piece sizing: emit enough per tick that the current
+ * backlog drains in ~`targetLatencyMs`, so render lag stays pinned near the
+ * target regardless of how fast the provider streams. Token-sized arrivals
+ * never exceed the minimum piece, matching the legacy fixed-size splitter.
+ */
+export function computeAdaptivePieceSize(
+  bufferedTextLength: number,
+  tickMs: number,
+  targetLatencyMs: number = SMOOTH_TARGET_LATENCY_MS
+): number {
+  if (bufferedTextLength <= 0) {
+    return STREAM_CHUNK_MIN_SIZE;
+  }
+  if (tickMs <= 0 || targetLatencyMs <= 0) {
+    return bufferedTextLength;
+  }
+  return Math.max(
+    STREAM_CHUNK_MIN_SIZE,
+    Math.ceil((bufferedTextLength * tickMs) / targetLatencyMs)
+  );
+}
+
+/**
+ * A cadence, not an additive sleep: time the consumer already spent since the
+ * last visible emission counts against the target delay, so slow downstream
+ * handlers never compound latency.
+ */
+export function getCadencedStreamDelay({
+  targetDelay,
+  lastVisibleTextAt,
+  now,
+}: {
+  targetDelay: number;
+  lastVisibleTextAt?: number;
+  now: number;
+}): number {
+  if (targetDelay <= 0 || lastVisibleTextAt == null) {
+    return 0;
+  }
+  return Math.max(0, targetDelay - (now - lastVisibleTextAt));
+}
+
+/** Abort-aware sleep that resolves (never rejects) on abort; callers re-check the signal. */
+export async function waitForStreamDelay(
+  delay: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (delay <= 0 || isSignalAborted(signal)) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const timeoutRef: { current?: ReturnType<typeof setTimeout> } = {};
+    const onAbort = (): void => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    timeoutRef.current = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delay);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (isSignalAborted(signal)) {
+      onAbort();
+    }
+  });
+}
+
+export type SmoothPiece = {
+  text: string;
+  isFirst: boolean;
+  isLast: boolean;
+};
+
+/**
+ * One classified unit of provider stream output.
+ *
+ * - `smooth: true` — visible text, paced at the configured cadence and (unless
+ *   `atomic`) sliced adaptively at dequeue time.
+ * - `atomic: true` — paced as a single piece, never split (text-bearing chunks
+ *   whose metadata cannot survive slicing, e.g. logprobs / finish_reason).
+ * - `smooth: false` — passthrough: tool-call deltas, usage-only, id-only and
+ *   seal chunks. Zero delay, strict FIFO with the text around them.
+ *
+ * `emit` builds the provider-specific output for one piece; `isFirst` lets
+ * providers keep usage_metadata on only the first piece of a split.
+ */
+export type SmoothItem<TEmit> = {
+  text: string;
+  smooth: boolean;
+  atomic?: boolean;
+  emit: (piece: SmoothPiece) => TEmit;
+};
+
+type ProducerState = {
+  done: boolean;
+  error?: unknown;
+};
+
+type QueuedSmoothItem<TEmit> = {
+  item: SmoothItem<TEmit>;
+  textLength: number;
+};
+
+/**
+ * Bounded producer/consumer smoothing engine.
+ *
+ * The producer drains `source` eagerly into a bounded queue (the buffer is the
+ * backlog measurement adaptive sizing needs); at capacity it parks, applying
+ * backpressure to the underlying stream. The consumer emits paced pieces,
+ * decrementing the text budget and waking the producer *before* each cadenced
+ * sleep so the provider stream keeps being read during pacing.
+ *
+ * `delayMs <= 0` disables smoothing entirely: every item passes through FIFO,
+ * unsplit and undelayed.
+ */
+export async function* smoothStream<TEmit>({
+  source,
+  delayMs,
+  signal,
+  abortUpstream,
+}: {
+  source: AsyncIterable<SmoothItem<TEmit>>;
+  delayMs: number;
+  signal?: AbortSignal;
+  abortUpstream?: () => void;
+}): AsyncGenerator<TEmit> {
+  const smoothingEnabled = delayMs > 0;
+  const queuedItems: QueuedSmoothItem<TEmit>[] = [];
+  const producerState: ProducerState = { done: false };
+  let queuedItemIndex = 0;
+  let bufferedTextLength = 0;
+  let consumerClosed = false;
+  let notifyConsumer: (() => void) | undefined;
+  let notifyProducer: (() => void) | undefined;
+
+  const notifyConsumerForItem = (): void => {
+    notifyConsumer?.();
+    notifyConsumer = undefined;
+  };
+
+  const notifyProducerForSpace = (): void => {
+    notifyProducer?.();
+    notifyProducer = undefined;
+  };
+
+  const hasQueuedItems = (): boolean => queuedItemIndex < queuedItems.length;
+
+  const getQueuedItemCount = (): number =>
+    queuedItems.length - queuedItemIndex;
+
+  const isQueueAtCapacity = (): boolean =>
+    getQueuedItemCount() >= MAX_STREAM_QUEUE_CHUNKS ||
+    bufferedTextLength >= MAX_STREAM_QUEUE_TEXT_CHARS;
+
+  const waitForNextItem = async (): Promise<void> => {
+    if (hasQueuedItems() || producerState.done || producerState.error != null) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      notifyConsumer = resolve;
+    });
+  };
+
+  const waitForQueueSpace = async (): Promise<void> => {
+    while (
+      isQueueAtCapacity() &&
+      !consumerClosed &&
+      !isSignalAborted(signal)
+    ) {
+      await new Promise<void>((resolve) => {
+        const onAbort = (): void => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        };
+        const onSpace = (): void => {
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        };
+        notifyProducer = onSpace;
+        signal?.addEventListener('abort', onAbort, { once: true });
+        if (isSignalAborted(signal)) {
+          onAbort();
+        }
+      });
+    }
+  };
+
+  const dequeue = (): QueuedSmoothItem<TEmit> | undefined => {
+    if (!hasQueuedItems()) {
+      return undefined;
+    }
+    const queuedItem = queuedItems[queuedItemIndex];
+    queuedItemIndex++;
+    if (queuedItemIndex > 128 && queuedItemIndex * 2 >= queuedItems.length) {
+      queuedItems.splice(0, queuedItemIndex);
+      queuedItemIndex = 0;
+    }
+    return queuedItem;
+  };
+
+  const throwAborted = (): never => {
+    abortUpstream?.();
+    throw new Error(STREAM_ABORT_MESSAGE);
+  };
+
+  const enqueue = async (item: SmoothItem<TEmit>): Promise<void> => {
+    await waitForQueueSpace();
+    if (consumerClosed || isSignalAborted(signal)) {
+      throwAborted();
+    }
+    const isSmooth = smoothingEnabled && item.smooth;
+    const textLength = isSmooth ? item.text.length : 0;
+    queuedItems.push({ item, textLength });
+    bufferedTextLength += textLength;
+    notifyConsumerForItem();
+  };
+
+  const producer = (async (): Promise<void> => {
+    try {
+      for await (const item of source) {
+        if (isSignalAborted(signal)) {
+          throwAborted();
+        }
+        await enqueue(item);
+      }
+    } catch (error) {
+      producerState.error = error;
+    } finally {
+      producerState.done = true;
+      notifyConsumerForItem();
+    }
+  })();
+
+  let hasEmittedText = false;
+  let lastVisibleTextAt: number | undefined;
+  let keepStreaming = true;
+  try {
+    while (keepStreaming) {
+      if (isSignalAborted(signal)) {
+        throwAborted();
+      }
+
+      await waitForNextItem();
+      const queuedItem = dequeue();
+
+      if (!queuedItem) {
+        if (producerState.error != null) {
+          throw producerState.error;
+        }
+        if (producerState.done) {
+          keepStreaming = false;
+        }
+        continue;
+      }
+
+      const { item } = queuedItem;
+      const isSmooth = smoothingEnabled && item.smooth;
+
+      if (!isSmooth) {
+        notifyProducerForSpace();
+        yield item.emit({ text: item.text, isFirst: true, isLast: true });
+        continue;
+      }
+
+      if (item.text === '') {
+        bufferedTextLength = Math.max(
+          0,
+          bufferedTextLength - queuedItem.textLength
+        );
+        notifyProducerForSpace();
+        continue;
+      }
+
+      let headOffset = 0;
+      while (headOffset < item.text.length) {
+        const remainingText = item.text.slice(headOffset);
+        const pieceLength = item.atomic
+          ? remainingText.length
+          : findStreamChunkBoundary(
+            remainingText,
+            computeAdaptivePieceSize(bufferedTextLength, delayMs)
+          );
+        const pieceEnd = headOffset + pieceLength;
+        const piece = item.text.slice(headOffset, pieceEnd);
+
+        bufferedTextLength = Math.max(0, bufferedTextLength - piece.length);
+        notifyProducerForSpace();
+        await waitForStreamDelay(
+          getCadencedStreamDelay({
+            targetDelay: hasEmittedText ? delayMs : 0,
+            lastVisibleTextAt,
+            now: Date.now(),
+          }),
+          signal
+        );
+        if (isSignalAborted(signal)) {
+          throwAborted();
+        }
+        hasEmittedText = true;
+        lastVisibleTextAt = Date.now();
+
+        yield item.emit({
+          text: piece,
+          isFirst: headOffset === 0,
+          isLast: pieceEnd === item.text.length,
+        });
+        headOffset = pieceEnd;
+      }
+    }
+  } finally {
+    consumerClosed = true;
+    if (!producerState.done) {
+      abortUpstream?.();
+      notifyProducerForSpace();
+    }
+    await producer;
+  }
+}

--- a/src/llm/stream/smoother.ts
+++ b/src/llm/stream/smoother.ts
@@ -15,6 +15,15 @@ export const STREAM_BOUNDARIES: ReadonlySet<string> = new Set([
 
 export const STREAM_ABORT_MESSAGE = 'AbortError: User aborted the request.';
 
+/**
+ * How long generator teardown waits for the background producer to observe a
+ * consumer close before abandoning it. Well-behaved streams settle in
+ * microseconds (the next enqueue throws); a stalled provider that ignores
+ * aborts otherwise blocks teardown — and abort propagation — indefinitely.
+ * An abandoned producer still self-terminates on its next enqueue attempt.
+ */
+export const PRODUCER_CLOSE_GRACE_MS = 1000;
+
 /** Resolves a configured stream delay to its effective value (default 25ms; 0 disables smoothing). */
 export function resolveStreamDelay(delay?: number): number {
   return Math.max(0, delay ?? DEFAULT_STREAM_DELAY);
@@ -199,12 +208,31 @@ export async function* smoothStream<TEmit>({
     getQueuedItemCount() >= MAX_STREAM_QUEUE_CHUNKS ||
     bufferedTextLength >= MAX_STREAM_QUEUE_TEXT_CHARS;
 
+  /** Abort-aware: a consumer parked on an empty queue must wake when the
+   * signal fires even if the provider stream never honors the abort — the
+   * loop's top-of-iteration check then throws the canonical error. */
   const waitForNextItem = async (): Promise<void> => {
-    if (hasQueuedItems() || producerState.done || producerState.error != null) {
+    if (
+      hasQueuedItems() ||
+      producerState.done ||
+      producerState.error != null ||
+      isSignalAborted(signal)
+    ) {
       return;
     }
     await new Promise<void>((resolve) => {
-      notifyConsumer = resolve;
+      const onAbort = (): void => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      };
+      notifyConsumer = (): void => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (isSignalAborted(signal)) {
+        onAbort();
+      }
     });
   };
 
@@ -374,10 +402,26 @@ export async function* smoothStream<TEmit>({
     }
   } finally {
     consumerClosed = true;
-    if (!producerState.done) {
+    if (producerState.done) {
+      await producer;
+    } else {
       abortUpstream?.();
       notifyProducerForSpace();
+      const iterator = source as Partial<AsyncGenerator<SmoothItem<TEmit>>>;
+      const closing = iterator.return?.call(source, undefined as never);
+      if (closing != null) {
+        void closing.then(
+          () => undefined,
+          () => undefined
+        );
+      }
+      await Promise.race([
+        producer,
+        new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, PRODUCER_CLOSE_GRACE_MS);
+          timeout.unref?.();
+        }),
+      ]);
     }
-    await producer;
   }
 }

--- a/src/llm/vertexai/index.ts
+++ b/src/llm/vertexai/index.ts
@@ -16,6 +16,8 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
+import { smoothGenerationChunks } from '@/llm/stream/chunkAdapters';
+import { resolveStreamDelay } from '@/llm/stream/smoother';
 
 /**
  * `@langchain/google-common`'s `_streamResponseChunks` emits usage on TWO
@@ -474,6 +476,7 @@ class CustomChatConnection extends ChatConnection<VertexAIClientOptions> {
  */
 export class ChatVertexAI extends ChatGoogle {
   lc_namespace = ['langchain', 'chat_models', 'vertexai'];
+  _lc_stream_delay: number;
   dynamicThinkingBudget = false;
   thinkingConfig?: GoogleThinkingConfig;
 
@@ -498,6 +501,7 @@ export class ChatVertexAI extends ChatGoogle {
     });
     this.dynamicThinkingBudget = dynamicThinkingBudget;
     this.thinkingConfig = fields?.thinkingConfig;
+    this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
   }
   invocationParams(
     options?: this['ParsedCallOptions'] | undefined
@@ -513,11 +517,23 @@ export class ChatVertexAI extends ChatGoogle {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    yield* smoothGenerationChunks({
+      chunks: this._streamRepairedChunks(messages, options),
+      delayMs: this._lc_stream_delay,
+      signal: options.signal,
+      runManager,
+    });
+  }
+
+  private async *_streamRepairedChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions']
+  ): AsyncGenerator<ChatGenerationChunk> {
     let lastGoodUsage: UsageMetadata | undefined;
     for await (const chunk of super._streamResponseChunks(
       messages,
       options,
-      runManager
+      undefined
     )) {
       const genUsage = (
         chunk.generationInfo as { usage_metadata?: UsageMetadata } | undefined

--- a/src/llm/vertexai/streamSmoothing.test.ts
+++ b/src/llm/vertexai/streamSmoothing.test.ts
@@ -1,0 +1,109 @@
+import { expect, test, describe, jest } from '@jest/globals';
+import { HumanMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import { ChatVertexAI } from './index';
+
+describe('Vertex stream smoothing', () => {
+  function textOutput(text: string): Record<string, unknown> {
+    return {
+      candidates: [
+        {
+          content: { role: 'model', parts: [{ text }] },
+          index: 0,
+        },
+      ],
+    };
+  }
+
+  async function runStream(
+    outputs: Record<string, unknown>[],
+    modelFields: Record<string, unknown> = {}
+  ): Promise<{
+    yielded: ChatGenerationChunk[];
+    dispatchedTokens: string[];
+  }> {
+    const model = new ChatVertexAI({
+      model: 'gemini-2.5-flash',
+      authOptions: {
+        projectId: 'test-project',
+        credentials: { client_email: 'test@test', private_key: 'test' },
+      },
+      ...modelFields,
+    });
+
+    let index = 0;
+    const fakeStream = {
+      get streamDone(): boolean {
+        return index > outputs.length;
+      },
+      async nextChunk(): Promise<unknown> {
+        const output = index < outputs.length ? outputs[index] : null;
+        index += 1;
+        return output;
+      },
+    };
+    (
+      model as unknown as {
+        streamedConnection: { request: unknown };
+      }
+    ).streamedConnection.request = jest.fn(async () => ({ data: fakeStream }));
+
+    const dispatchedTokens: string[] = [];
+    const runManager = {
+      handleCustomEvent: jest.fn(async () => undefined),
+      handleLLMNewToken: jest.fn(async (token: string) => {
+        dispatchedTokens.push(token);
+      }),
+    } as unknown as CallbackManagerForLLMRun;
+
+    const yielded: ChatGenerationChunk[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<ChatVertexAI['_streamResponseChunks']>[1],
+      runManager
+    )) {
+      yielded.push(chunk);
+    }
+    return { yielded, dispatchedTokens };
+  }
+
+  test('splits large text outputs at stream boundaries with pacing', async () => {
+    const { yielded, dispatchedTokens } = await runStream(
+      [textOutput('alpha beta gamma')],
+      { _lc_stream_delay: 1 }
+    );
+
+    const texts = yielded.map((chunk) => chunk.text).filter(Boolean);
+    expect(texts).toEqual(['alpha ', 'beta ', 'gamma']);
+    expect(dispatchedTokens.filter(Boolean)).toEqual([
+      'alpha ',
+      'beta ',
+      'gamma',
+    ]);
+  });
+
+  test('passes chunks through unsplit when smoothing is disabled', async () => {
+    const { yielded } = await runStream([textOutput('alpha beta gamma')], {
+      _lc_stream_delay: 0,
+    });
+
+    expect(yielded.map((chunk) => chunk.text).filter(Boolean)).toEqual([
+      'alpha beta gamma',
+    ]);
+  });
+
+  test('defaults to 25ms adaptive smoothing with 0 disabling', () => {
+    const base = {
+      model: 'gemini-2.5-flash',
+      authOptions: {
+        projectId: 'test-project',
+        credentials: { client_email: 'test@test', private_key: 'test' },
+      },
+    };
+    expect(new ChatVertexAI(base)._lc_stream_delay).toBe(25);
+    expect(
+      new ChatVertexAI({ ...base, _lc_stream_delay: 0 })._lc_stream_delay
+    ).toBe(0);
+  });
+});

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -45,7 +45,8 @@ export type AzureClientOptions = Partial<OpenAIChatInput> &
     deploymentName?: string;
   } & BaseChatModelParams & {
     configuration?: OAIClientOptions;
-  } & ManagedRequestOptions;
+  } & ManagedRequestOptions &
+  StreamSmoothingOptions;
 /**
  * Controls whether Claude's reasoning content is returned in adaptive
  * thinking responses. Added for Claude Opus 4.7, which omits thinking by
@@ -175,7 +176,7 @@ export type ProviderOptionsMap = {
   [Providers.ANTHROPIC]: AnthropicClientOptions;
   [Providers.MISTRALAI]: MistralAIClientOptions;
   [Providers.MISTRAL]: MistralAIClientOptions;
-  [Providers.OPENROUTER]: ChatOpenRouterCallOptions;
+  [Providers.OPENROUTER]: ChatOpenRouterCallOptions & StreamSmoothingOptions;
   [Providers.BEDROCK]: BedrockAnthropicClientOptions;
   [Providers.XAI]: XAIClientOptions;
   [Providers.MOONSHOT]: OpenAIClientOptions;

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -79,47 +79,63 @@ export type ManagedRequestOptions = {
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
-export type OpenAIClientOptions = ChatOpenAIFields & ManagedRequestOptions;
-export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> & {
-  thinking?: ThinkingConfig;
-  promptCache?: boolean;
-  /**
-   * Prompt-cache breakpoint TTL. Defaults to `'1h'` (extended cache) when
-   * `promptCache` is enabled; set `'5m'` to opt back into the legacy
-   * 5-minute behavior.
-   */
-  promptCacheTtl?: PromptCacheTtl;
-};
-export type MistralAIClientOptions = ChatMistralAIInput;
-export type VertexAIClientOptions = ChatVertexAIInput & {
-  includeThoughts?: boolean;
-  thinkingConfig?: GoogleThinkingConfig;
-};
-export type BedrockAnthropicInput = ChatBedrockConverseInput & {
-  additionalModelRequestFields?: ChatBedrockConverseInput['additionalModelRequestFields'] &
-    AnthropicReasoning;
-  promptCache?: boolean;
-  /**
-   * Prompt-cache checkpoint TTL. Defaults to `'1h'` (extended cache) when
-   * `promptCache` is enabled; set `'5m'` to opt into the legacy 5-minute
-   * behavior. Bedrock models that don't support the 1-hour TTL downgrade to 5m
-   * server-side, so the default is safe to leave on.
-   */
-  promptCacheTtl?: PromptCacheTtl;
+/**
+ * Adaptive stream-smoothing configuration shared by every provider client.
+ */
+export type StreamSmoothingOptions = {
   /**
    * Minimum delay in milliseconds between visible streamed content deltas.
+   * Defaults to 25; piece sizes adapt to the backlog so render lag stays
+   * bounded regardless of provider chunk size. Set 0 to disable smoothing.
    */
   _lc_stream_delay?: number;
 };
+
+export type OpenAIClientOptions = ChatOpenAIFields &
+  ManagedRequestOptions &
+  StreamSmoothingOptions;
+export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> &
+  StreamSmoothingOptions & {
+    thinking?: ThinkingConfig;
+    promptCache?: boolean;
+    /**
+     * Prompt-cache breakpoint TTL. Defaults to `'1h'` (extended cache) when
+     * `promptCache` is enabled; set `'5m'` to opt back into the legacy
+     * 5-minute behavior.
+     */
+    promptCacheTtl?: PromptCacheTtl;
+  };
+export type MistralAIClientOptions = ChatMistralAIInput &
+  StreamSmoothingOptions;
+export type VertexAIClientOptions = ChatVertexAIInput &
+  StreamSmoothingOptions & {
+    includeThoughts?: boolean;
+    thinkingConfig?: GoogleThinkingConfig;
+  };
+export type BedrockAnthropicInput = ChatBedrockConverseInput &
+  StreamSmoothingOptions & {
+    additionalModelRequestFields?: ChatBedrockConverseInput['additionalModelRequestFields'] &
+      AnthropicReasoning;
+    promptCache?: boolean;
+    /**
+     * Prompt-cache checkpoint TTL. Defaults to `'1h'` (extended cache) when
+     * `promptCache` is enabled; set `'5m'` to opt into the legacy 5-minute
+     * behavior. Bedrock models that don't support the 1-hour TTL downgrade to 5m
+     * server-side, so the default is safe to leave on.
+     */
+    promptCacheTtl?: PromptCacheTtl;
+  };
 export type BedrockConverseClientOptions = BedrockAnthropicInput;
 export type BedrockAnthropicClientOptions = BedrockAnthropicInput;
-export type GoogleClientOptions = GoogleGenerativeAIChatInput & {
-  customHeaders?: RequestOptions['customHeaders'];
-  thinkingConfig?: GoogleThinkingConfig;
-  includeServerSideToolInvocations?: boolean;
-};
-export type DeepSeekClientOptions = Partial<ChatDeepSeekInput>;
-export type XAIClientOptions = ChatXAIInput;
+export type GoogleClientOptions = GoogleGenerativeAIChatInput &
+  StreamSmoothingOptions & {
+    customHeaders?: RequestOptions['customHeaders'];
+    thinkingConfig?: GoogleThinkingConfig;
+    includeServerSideToolInvocations?: boolean;
+  };
+export type DeepSeekClientOptions = Partial<ChatDeepSeekInput> &
+  StreamSmoothingOptions;
+export type XAIClientOptions = ChatXAIInput & StreamSmoothingOptions;
 
 export type ClientOptions =
   | OpenAIClientOptions

--- a/test/stubs/mistralai.ts
+++ b/test/stubs/mistralai.ts
@@ -6,25 +6,33 @@
  * `"type": "module"` with no CommonJS build. Jest's CJS runtime cannot load
  * it, and transforming it does not help — Node decides module kind from the
  * package's `type` field, not from what a transform emits. So any suite that
- * transitively imports `src/llm/providers.ts` — which pulls in `ChatMistralAI`
- * only to populate the provider constructor map — died at collection, whether
- * or not the test had anything to do with Mistral.
+ * transitively imports `src/llm/providers.ts` — which pulls in the Mistral
+ * class only to populate the provider constructor map — died at collection,
+ * whether or not the test had anything to do with Mistral.
  *
- * Stubbing is safe here because nothing under test constructs this class: the
- * `mistral` entry in `llmConfigs` routes through the OpenAI-compatible client,
- * and `ChatMistralAI` appears solely as a map value.
- *
- * It throws rather than no-ops so the assumption above stays honest — a test
- * that ever does exercise Mistral fails loudly here instead of silently
- * passing against a hollow double.
+ * The stub is a minimal functional double: the constructor records fields so
+ * `CustomChatMistralAI` (which layers stream smoothing on top) can be
+ * constructed and unit-tested. Any test that actually reaches the network
+ * layer fails loudly in `_streamResponseChunks` instead of silently passing
+ * against a hollow double — suites that need real Mistral streaming replace
+ * that method (e.g. via `jest.spyOn`) or run outside Jest.
  */
 export class ChatMistralAI {
-  constructor() {
+  model?: string;
+  apiKey?: string;
+
+  constructor(fields?: { model?: string; apiKey?: string }) {
+    this.model = fields?.model;
+    this.apiKey = fields?.apiKey;
+  }
+
+  // eslint-disable-next-line require-yield
+  async *_streamResponseChunks(): AsyncGenerator<never> {
     throw new Error(
       'ChatMistralAI is stubbed under Jest (test/stubs/mistralai.ts) because ' +
         '@mistralai/mistralai ships ESM-only and cannot load in the CJS test ' +
-        'runtime. If a test genuinely needs Mistral, run it outside Jest or ' +
-        'give this stub a real implementation.'
+        'runtime. Replace `_streamResponseChunks` (jest.spyOn) or run outside ' +
+        'Jest to exercise real Mistral streaming.'
     );
   }
 }


### PR DESCRIPTION
# Summary

Replaces the three duplicated stream-smoothing implementations (OpenAI-family `delayStreamChunks`, and the near-identical Anthropic and Bedrock producer/consumer queues) with **one shared adaptive smoothing engine**, and extends smoothing to the providers that had none (Google, Vertex, Mistral). Smoothing now **defaults to ON at 25ms for every provider**; `_lc_stream_delay: 0` disables it.

## Why

Fixed-rate smoothing breaks on modern big-chunk providers (Opus-class models, Claude behind OpenAI-compatible gateways). At a 25ms cadence with fixed ~4-char pieces, render throughput caps at ~300 chars/s; faster providers grow the backlog without bound and the render trails the model **linearly in reply length** — measured **+9.8s on a 3.3k-char reply, +31s on 9.9k**. Lowering the delay destroys the cadence that makes streaming feel smooth. No fixed delay works.

## The algorithm

Hold the tick at the perceptual sweet spot; make **piece size proportional to backlog**, sliced at dequeue time:

```
piece_chars = max(4, ceil(bufferedTextLength × tick / 250ms))   → extend to word boundary
```

Steady state: backlog ≈ arrival_rate × 250ms, so render lag pins near the target **regardless of provider speed or reply length**. Slow token-sized providers never exceed the minimum piece — identical feel to the legacy splitter. Once the producer finishes, the tail drains linearly across the target window.

Benchmark in-repo (`smoother.bench.test.ts`, real `ChatOpenAI` vs a local SSE server emitting 110-char chunks every 20ms): even cadence at the tick, jitter < 10ms, lag bounded < 750ms and **flat as reply length quadruples** (vs +31s before).

## Design

- `src/llm/stream/smoother.ts` — the engine: bounded producer/consumer queue (256 chunks / 8,192 text chars) generalized from the Anthropic implementation. The buffer is the backlog measurement; at capacity the producer parks (TCP backpressure); the consumer decrements-before-sleep and wakes the producer, so the HTTP stream keeps being read during pacing.
- **Three-way classification**: `smooth+splittable` (plain text, sliced adaptively), `smooth+atomic` (text-bearing chunks whose metadata can't survive slicing — logprobs, finish_reason, reasoning deltas — paced whole), `passthrough` (tool-call deltas, usage-only, seals — zero delay, strict FIFO).
- **Generic `TEmit`** keeps provider contracts intact: Bedrock's dual `chunk`/`callbackChunk` emission, Anthropic's `token` pairing, OpenAI's scalar-metadata dedup + per-piece callbacks with token indices.
- `src/llm/stream/chunkAdapters.ts` — provider-agnostic `ChatGenerationChunk` adapter (string content and google-common's single-text-part array shape), shared by Google, Vertex and Mistral.
- Bedrock pieces are built lazily via the exact legacy per-piece pipeline against an arrival-time snapshot of seen block indices — byte-identical output to the old splitter.
- First visible token is never delayed (TTFT); cadence is measured from the last yield so consumer work never compounds; abort is standardized on the canonical `'AbortError: User aborted the request.'` resolve-and-throw pattern.

## Behavior changes

1. **Default ON, 25ms, all providers** (was: Anthropic 25, Bedrock 0, OpenAI family undefined, Google/Vertex/Mistral no machinery). `_lc_stream_delay: 0` opts out.
2. **OpenAI family no longer delays non-text chunks** — tool-call deltas, usage and finish_reason pass through immediately (previously every chunk slept). This improves eager tool prestart latency.
3. Google/Vertex raw generators no longer dispatch `handleLLMNewToken` themselves; dispatch moved per emitted piece (callback-echo consumers now observe smoothed deltas).
4. Adaptive splitting emits **~4.6× fewer deltas** than the legacy fixed splitter under fast providers (pieces grow with backlog) — reduces Redis publish/append load in LibreChat's streaming mode.

## Testing

- New engine suite (21 tests): pure sizing math (no timers), FIFO ordering, TTFT, passthrough-never-delayed, atomic-unsplit, usage dedup via `isFirst`, abort during sleep, queue-full park/resume, early-break producer close, bounded-lag under fast producer.
- New per-provider suites: google/vertex/mistral split+cadence+disable+defaults; bedrock seal-timing (seal unpaced while text paces) + clone fidelity via both dispatch paths.
- Preserved without modification: full DeepSeek delay suite (abort ×3, split, logprobs-atomic, callbacks-per-piece, cadence-from-last-yield), Anthropic queue specs (empty-block skip, queue-full early break), OpenRouter raw-variant/reasoning, streamMetadataDedup, seal-dispatch suites, eager-execution ordering.
- **Live API runs** (real credentials): Anthropic `llm.spec.ts` 110 passed — the 5 failures are pre-existing `claude-opus-4-1` retired-model 404s, identical on `main`. Vertex live failures (12) reproduce identically on `main` (environment auth issue). Google live spec is key-gated on this machine on `main` as well.
- Updated for the new default (intentional): smoke-test Bedrock default 0→25; two Bedrock parameter-passthrough tests now construct with `_lc_stream_delay: 0`.

`tsc --noEmit` clean. Full suite results posted below.
