### PR TITLE
📡 chore: Replace Reo-Census With Reova Telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "nanoid": "^3.3.7",
         "okapibm25": "^1.4.1",
         "openai": "^6.46.0",
-        "reo-census": "^1.2.10",
+        "reova": "^0.4.1",
         "socks-proxy-agent": "^8.0.5",
         "uuid": "^11.1.1"
       },
@@ -11022,14 +11022,14 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reo-census": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/reo-census/-/reo-census-1.2.10.tgz",
-      "integrity": "sha512-Wr/cNvk1S2EMNUwLISWtO3VgSaoaKRsaAwc/t7TMPmSu1i4LhyS/mEHhQg9PhiK3bpAqSUqI5dY8riqAukXuyA==",
+    "node_modules/reova": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/reova/-/reova-0.4.1.tgz",
+      "integrity": "sha512-9TNaquUZIeT+2SYAy5on/ZTCTF+cWFJNeZ1ugV1K2HdepeswSzGRl+pBghuXqr0ur4tWfaxkvW5etPX0e7mQNg==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@librechat/agents",
   "version": "3.4.0",
+  "reova": {
+    "enabled": true,
+    "endpoint": "https://telemetry.reo.dev/data"
+  },
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",
@@ -248,7 +252,7 @@
     "nanoid": "^3.3.7",
     "okapibm25": "^1.4.1",
     "openai": "^6.46.0",
-    "reo-census": "^1.2.10",
+    "reova": "^0.4.1",
     "socks-proxy-agent": "^8.0.5",
     "uuid": "^11.1.1"
   },


### PR DESCRIPTION
I replaced `reo-census` with the current `reova` install-analytics package and preserved the existing Reo telemetry destination through explicit package configuration.

- Remove `reo-census@^1.2.10` from the published dependency graph.
- Add `reova@^0.4.1` and configure package-level opt-in with the existing `https://telemetry.reo.dev/data` endpoint.
- Regenerate the npm lockfile so the published package installs only `reova`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm install --ignore-scripts --no-audit --no-fund --prefer-offline`
- `npm run build`
- `npx tsc --noEmit`
- `npx eslint src/` (0 errors; existing warnings remain)
- `npx jest src/graphs/__tests__/composition.smoke.test.ts --runInBand`
- `REOVA_ANALYTICS=false REOVA_VERBOSE=true node node_modules/reova/index.js`

### **Test Configuration**:

- Node/npm from the local agents development environment
- `reova@0.4.1`
- Telemetry disabled during the install-script smoke test

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes