### PR TITLE
🪢 feat: Resume HITL Approvals Inside Subagents

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -61,14 +61,6 @@ import {
   removePredecessorHandoffCue,
 } from '@/messages';
 import {
-  attemptInvoke,
-  tryFallbackProviders,
-  getFallbackErrorContext,
-  getFallbackOverflowCandidates,
-  projectMessagesForProvider,
-  resolveServingModelId,
-} from '@/llm/invoke';
-import {
   resetIfNotEmpty,
   isAnthropicLike,
   isOpenAILike,
@@ -79,6 +71,21 @@ import {
   joinKeys,
   sleep,
 } from '@/utils';
+import {
+  attemptInvoke,
+  tryFallbackProviders,
+  getFallbackErrorContext,
+  getFallbackOverflowCandidates,
+  projectMessagesForProvider,
+  resolveServingModelId,
+} from '@/llm/invoke';
+import {
+  resolveStreamLimits,
+  StreamLimitExceededError,
+  sweepStaleStreamLimitEntries,
+  STREAM_LIMIT_EPOCH_KEY,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
+} from '@/llm/streamLimits';
 import {
   Constants,
   GraphNodeKeys,
@@ -122,13 +129,6 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import {
-  resolveStreamLimits,
-  StreamLimitExceededError,
-  sweepStaleStreamLimitEntries,
-  STREAM_LIMIT_EPOCH_KEY,
-  RUN_BREAKER_SCOPE_CONFIG_KEY,
-} from '@/llm/streamLimits';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
@@ -853,6 +853,10 @@ export abstract class Graph<
       node.clearDirectPathTurns();
     }
     this._compiledToolNodes.clear();
+    for (const executor of this._subagentExecutors) {
+      executor.clearHeavyState();
+    }
+    this._subagentExecutors.clear();
     this.sessions.clear();
   }
 
@@ -908,6 +912,10 @@ export abstract class Graph<
     this._compiledToolNodes.add(node);
   }
 
+  protected registerSubagentExecutor(executor: SubagentExecutor): void {
+    this._subagentExecutors.add(executor);
+  }
+
   /**
    * Returns the shared `ToolOutputReferenceRegistry` for this run,
    * constructing it on first access. Returns `undefined` when the
@@ -958,6 +966,7 @@ export abstract class Graph<
   private _compiledToolNodes: Set<{
     clearDirectPathTurns(): void;
   }> = new Set();
+  private _subagentExecutors = new Set<SubagentExecutor>();
   public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
     // Return the cached instance unconditionally if one exists. The
     // toolExecution check below decides whether to *create* a new
@@ -1058,8 +1067,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * generation key + chunk index (see `resolveGenerationKey`). Per-run
    * accumulation state, cleared by both reset paths.
    */
-  streamedToolCallArgTallies: Map<string, StreamedToolCallArgTally> =
-    new Map();
+  streamedToolCallArgTallies: Map<string, StreamedToolCallArgTally> = new Map();
   /** Streamed chunk events per model generation, keyed by generation key. */
   streamDeltaEventCounts: Map<string, StreamDeltaEventTally> = new Map();
   /** Per-chunk-object, per-generation charge balances (lazily created; see
@@ -1798,6 +1806,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       runLangfuse: this.langfuse,
       agentLangfuse: agentContext?.langfuse,
     });
+    const interruptingToolNames = new Set(this.interruptingToolNames ?? []);
+    if (
+      this.humanInTheLoop?.enabled === true &&
+      (agentContext?.subagentConfigs?.length ?? 0) > 0
+    ) {
+      interruptingToolNames.add(Constants.SUBAGENT);
+    }
+    const effectiveInterruptingToolNames =
+      interruptingToolNames.size > 0 ? interruptingToolNames : undefined;
 
     if (eventDrivenMode) {
       const schemaTools = createSchemaOnlyTools(toolDefinitions);
@@ -1849,11 +1866,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         eagerEventToolSuppressions: this.eagerEventToolSuppressions,
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
-        interruptingToolNames:
-          this.interruptingToolNames != null &&
-          this.interruptingToolNames.length > 0
-            ? new Set(this.interruptingToolNames)
-            : undefined,
+        interruptingToolNames: effectiveInterruptingToolNames,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
@@ -1916,11 +1929,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessions: this.sessions,
       toolExecution: this.toolExecution,
       codeSessionToolNames: this.codeSessionToolNames,
-      interruptingToolNames:
-        this.interruptingToolNames != null &&
-        this.interruptingToolNames.length > 0
-          ? new Set(this.interruptingToolNames)
-          : undefined,
+      interruptingToolNames: effectiveInterruptingToolNames,
       hookRegistry: this.hookRegistry,
       humanInTheLoop: this.humanInTheLoop,
       maxContextTokens: agentContext?.maxContextTokens,
@@ -3377,7 +3386,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * would start new provider work after the run-wide breaker fired.
          * Rethrow the breaker's own stream-limit reason instead. */
         {
-          const trippedReason = this.resolveTrippedBreakerReason(attemptBreaker.signal);
+          const trippedReason = this.resolveTrippedBreakerReason(
+            attemptBreaker.signal
+          );
           if (trippedReason != null) {
             throw trippedReason;
           }
@@ -3624,7 +3635,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           }
           {
             /** Same sibling-abort translation guard as the primary catch. */
-            const trippedReason = this.resolveTrippedBreakerReason(attemptBreaker.signal);
+            const trippedReason = this.resolveTrippedBreakerReason(
+              attemptBreaker.signal
+            );
             if (trippedReason != null) {
               throw trippedReason;
             }
@@ -4061,6 +4074,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           tokenCounter: agentContext.tokenCounter,
           usageSink: this.subagentUsageSink,
           streamLimits: this.streamLimits,
+          humanInTheLoop: this.humanInTheLoop,
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
@@ -4072,12 +4086,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               getParentHandlerRegistry()
             );
             childGraph.hookRegistry = this.hookRegistry;
-            /**
-             * Do not propagate `humanInTheLoop` into the child graph yet:
-             * nested subagent interrupts need a stable child checkpoint and
-             * resume bridge. Child hooks still fire; `ask` decisions fail
-             * closed inside the subagent until that flow is implemented.
-             */
+            childGraph.humanInTheLoop = this.humanInTheLoop;
+            if (this.humanInTheLoop?.enabled === true) {
+              childGraph.compileOptions = {
+                checkpointer: this.compileOptions?.checkpointer,
+              };
+            }
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
             childGraph.codeSessionToolNames = this.codeSessionToolNames;
@@ -4099,6 +4113,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             return childGraph;
           },
         });
+        this.registerSubagentExecutor(executor);
 
         const subagentTool = tool(async (rawInput, config) => {
           const input = rawInput as {
@@ -4113,20 +4128,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const subagentType =
             typeof input.subagent_type === 'string' ? input.subagent_type : '';
           const threadId = config.configurable?.thread_id as string | undefined;
-          /**
-           * When the tool is dispatched from an LLM's `tool_call`, LangChain
-           * threads the originating `ToolCall` onto the RunnableConfig as
-           * `config.toolCall` (see `ToolRunnableConfig` in
-           * `@langchain/core/tools` — internal but stable since ≥0.3.x).
-           * Surfacing its id lets hosts correlate `SubagentUpdateEvent`s
-           * back to the parent's `tool_call_id` deterministically — no
-           * temporal heuristics needed. If a future LangChain version
-           * changes the threading, the type-guarded read falls back to
-           * `undefined` and the correlation degrades gracefully.
-           */
-          const toolCall = (config as { toolCall?: { id?: string } }).toolCall;
-          const parentToolCallId =
-            typeof toolCall?.id === 'string' ? toolCall.id : undefined;
+          /** Surface the parent call id so child checkpoints, interrupts, and
+           * update events remain correlated across replay and resume. */
+          const toolRuntime = config as {
+            toolCallId?: string;
+            toolCall?: { id?: string };
+          };
+          const toolCall = toolRuntime.toolCall;
+          let parentToolCallId: string | undefined;
+          if (
+            typeof toolRuntime.toolCallId === 'string' &&
+            toolRuntime.toolCallId !== ''
+          ) {
+            parentToolCallId = toolRuntime.toolCallId;
+          } else if (typeof toolCall?.id === 'string' && toolCall.id !== '') {
+            parentToolCallId = toolCall.id;
+          }
           /** The parent tool batch's entry-captured scope (stamped by
            * ToolNode before PreToolUse hooks) — binds this child to the
            * run that dispatched it, not to whatever controller a reset

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -638,6 +638,10 @@ export abstract class Graph<
   _TNodeName extends string = string,
 > {
   abstract resetValues(keepContent?: boolean, checkpointScope?: string): void;
+  restoreCheckpointMessages(
+    _messages: BaseMessage[],
+    _pendingMessages?: BaseMessage[]
+  ): void {}
   abstract initializeTools({
     currentTools,
     currentToolMap,
@@ -1149,6 +1153,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /** Whether the workflow was actually compiled with a checkpointer. */
   hasCompiledCheckpointer: boolean = false;
   messages: BaseMessage[] = [];
+  /** Whether a rebuilt resume seeded the message baseline from its checkpoint. */
+  private hasRestoredCheckpointMessages = false;
   /** Cached run messages preserved before clearHeavyState() so getRunMessages() works after cleanup. */
   private cachedRunMessages?: BaseMessage[];
   /** Per-agent discovery snapshots preserved before contexts are reset on cleanup. */
@@ -1359,6 +1365,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   resetValues(keepContent?: boolean, checkpointScope?: string): void {
     this.resetSubagentCheckpointThreadIds();
     this.messages = [];
+    this.hasRestoredCheckpointMessages = false;
     this.cachedRunMessages = undefined;
     this.cachedDiscoveredTools = undefined;
     this.config = resetIfNotEmpty(this.config, undefined);
@@ -1453,6 +1460,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.originalToolContentCheckpointScope = hasScopedCheckpoint
       ? checkpointScope
       : undefined;
+  }
+
+  /** Seeds the sidecar message view that checkpoint restoration bypasses. */
+  override restoreCheckpointMessages(
+    messages: BaseMessage[],
+    pendingMessages?: BaseMessage[]
+  ): void {
+    if (this.messages.length > 0) {
+      return;
+    }
+    this.messages =
+      pendingMessages == null
+        ? [...messages]
+        : messagesStateReducer(messages, pendingMessages);
+    this.startIndex = this.messages.length;
+    this.hasRestoredCheckpointMessages = true;
+    this.cachedRunMessages = undefined;
   }
 
   override clearHeavyState(): void {
@@ -4569,7 +4593,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {
-          if (!this.messages.length) {
+          if (!this.messages.length && !this.hasRestoredCheckpointMessages) {
             this.startIndex = a.length + b.length;
           }
           const result = messagesStateReducer(a, b);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -924,6 +924,16 @@ export abstract class Graph<
     this._subagentExecutors.add(executor);
   }
 
+  getChildCheckpointThreadIds(): string[] {
+    const threadIds = new Set<string>();
+    for (const executor of this._subagentExecutors) {
+      for (const threadId of executor.getChildCheckpointThreadIds()) {
+        threadIds.add(threadId);
+      }
+    }
+    return [...threadIds];
+  }
+
   /**
    * Returns the shared `ToolOutputReferenceRegistry` for this run,
    * constructing it on first access. Returns `undefined` when the

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -929,6 +929,12 @@ export abstract class Graph<
     this._subagentExecutors.add(executor);
   }
 
+  protected resetSubagentCheckpointThreadIds(): void {
+    for (const executor of this._subagentExecutors) {
+      executor.resetCheckpointThreadIds();
+    }
+  }
+
   getChildCheckpointThreadIds(): string[] {
     const threadIds = new Set<string>();
     for (const executor of this._subagentExecutors) {
@@ -1351,6 +1357,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /* Init */
 
   resetValues(keepContent?: boolean, checkpointScope?: string): void {
+    this.resetSubagentCheckpointThreadIds();
     this.messages = [];
     this.cachedRunMessages = undefined;
     this.cachedDiscoveredTools = undefined;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -853,15 +853,18 @@ export abstract class Graph<
     // Flush each compiled ToolNode's direct-path turn cache so it
     // doesn't leak across Runs (Codex P2 #33). The cache survives
     // `run()` re-entry by design (resume-stable), but end-of-Run
-    // is the right point to reset it.
+    // is the right point to reset it. Retain the registrations because
+    // the compiled workflow can be reused for later Runs; compilation
+    // will not register these instances again.
     for (const node of this._compiledToolNodes) {
       node.clearDirectPathTurns();
     }
-    this._compiledToolNodes.clear();
+    // Subagent executors are likewise compiled once and reused. Clear
+    // their per-Run state without dropping the registrations needed by
+    // subsequent cleanup cycles.
     for (const executor of this._subagentExecutors) {
       executor.clearHeavyState();
     }
-    this._subagentExecutors.clear();
     this.sessions.clear();
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -23,6 +23,10 @@ import type {
   StreamedToolCallArgTally,
   StreamDeltaEventTally,
 } from '@/llm/streamLimits';
+import type {
+  ReplayableSubagentTool,
+  SettledSubagentToolOutput,
+} from '@/tools/subagent/SubagentReplay';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
 import type { HookRegistry } from '@/hooks';
@@ -133,6 +137,7 @@ import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache'
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
+import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
 import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
@@ -4075,6 +4080,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           usageSink: this.subagentUsageSink,
           streamLimits: this.streamLimits,
           humanInTheLoop: this.humanInTheLoop,
+          checkpointer: this.compileOptions?.checkpointer,
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
@@ -4169,6 +4175,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           });
           return result.content;
         }, buildSubagentToolParams(resolvedConfigs));
+        const replayableSubagentTool = subagentTool as typeof subagentTool &
+          ReplayableSubagentTool;
+        replayableSubagentTool[SUBAGENT_REPLAY_CONTROLLER] = {
+          getSettledOutput: (
+            call,
+            config
+          ): Promise<SettledSubagentToolOutput | undefined> =>
+            executor.getSettledToolOutput(call, config),
+          persistSettledOutput: (call, config, output): Promise<void> =>
+            executor.persistSettledToolOutput(call, config, output),
+        };
 
         if (!agentContext.graphTools) {
           agentContext.graphTools = [];

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -18,15 +18,18 @@ import type {
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
+  ReplayableSubagentTool,
+  SubagentGraphResumeState,
+  SubagentResumeManifest,
+  SubagentToolNodeResumeState,
+  SettledSubagentToolOutput,
+} from '@/tools/subagent/SubagentReplay';
+import type {
   ResolvedStreamLimits,
   RunBreakerScope,
   StreamedToolCallArgTally,
   StreamDeltaEventTally,
 } from '@/llm/streamLimits';
-import type {
-  ReplayableSubagentTool,
-  SettledSubagentToolOutput,
-} from '@/tools/subagent/SubagentReplay';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
 import type { HookRegistry } from '@/hooks';
@@ -916,6 +919,8 @@ export abstract class Graph<
    */
   protected registerCompiledToolNode(node: {
     clearDirectPathTurns(): void;
+    createSubagentResumeState(): SubagentToolNodeResumeState;
+    restoreSubagentResumeState(state: SubagentToolNodeResumeState): void;
   }): void {
     this._compiledToolNodes.add(node);
   }
@@ -932,6 +937,111 @@ export abstract class Graph<
       }
     }
     return [...threadIds];
+  }
+
+  createSubagentResumeState(runId: string): SubagentGraphResumeState {
+    return {
+      toolCallSteps: [...this.toolCallStepIds].map(([toolCallId, stepId]) => ({
+        toolCallId,
+        stepId,
+      })),
+      toolSessions: [...this.sessions].map(([toolName, context]) => ({
+        toolName,
+        context: {
+          ...context,
+          ...(context.files == null
+            ? {}
+            : { files: context.files.map((file) => ({ ...file })) }),
+        },
+      })),
+      toolNodes: [...this._compiledToolNodes].map((node) =>
+        node.createSubagentResumeState()
+      ),
+      eagerToolUsage: [
+        {
+          agentId: '',
+          toolUsageCounts: [...this.eagerEventToolUsageCount].map(
+            ([toolName, count]) => ({ toolName, count })
+          ),
+        },
+        ...[...this.eagerEventToolUsageCountsByAgentId].map(
+          ([agentId, usageCounts]) => ({
+            agentId,
+            toolUsageCounts: [...usageCounts].map(([toolName, count]) => ({
+              toolName,
+              count,
+            })),
+          })
+        ),
+      ],
+      eagerToolSuppressions: [...this.eagerEventToolSuppressions],
+      ...(this._toolOutputRegistry == null
+        ? {}
+        : {
+          toolOutputReferences: this._toolOutputRegistry.snapshotState(runId),
+        }),
+    };
+  }
+
+  restoreSubagentResumeState(
+    state: SubagentGraphResumeState,
+    runId: string
+  ): void {
+    const toolNodesByKey = new Map(
+      [...this._compiledToolNodes].map((node) => {
+        const nodeState = node.createSubagentResumeState();
+        return [nodeState.stateKey, node] as const;
+      })
+    );
+    if (toolNodesByKey.size !== state.toolNodes.length) {
+      throw new Error('Cannot restore changed subagent tool topology.');
+    }
+    for (const nodeState of state.toolNodes) {
+      if (!toolNodesByKey.has(nodeState.stateKey)) {
+        throw new Error(
+          `Cannot restore subagent tool state for "${nodeState.stateKey}".`
+        );
+      }
+    }
+    const registry =
+      state.toolOutputReferences == null
+        ? undefined
+        : this.getOrCreateToolOutputRegistry();
+    if (state.toolOutputReferences != null && registry == null) {
+      throw new Error('Cannot restore disabled tool output references.');
+    }
+
+    this.toolCallStepIds.clear();
+    for (const { toolCallId, stepId } of state.toolCallSteps) {
+      this.toolCallStepIds.set(toolCallId, stepId);
+    }
+    this.sessions.clear();
+    for (const { toolName, context } of state.toolSessions) {
+      this.sessions.set(toolName, {
+        ...context,
+        ...(context.files == null
+          ? {}
+          : { files: context.files.map((file) => ({ ...file })) }),
+      });
+    }
+    for (const nodeState of state.toolNodes) {
+      const node = toolNodesByKey.get(nodeState.stateKey)!;
+      node.restoreSubagentResumeState(nodeState);
+    }
+    this.clearEagerEventToolUsageCounts();
+    for (const usageState of state.eagerToolUsage) {
+      const usageCounts = this.getEagerEventToolUsageCount(usageState.agentId);
+      for (const { toolName, count } of usageState.toolUsageCounts) {
+        usageCounts.set(toolName, count);
+      }
+    }
+    this.eagerEventToolSuppressions.clear();
+    for (const toolName of state.eagerToolSuppressions) {
+      this.eagerEventToolSuppressions.add(toolName);
+    }
+    if (state.toolOutputReferences != null && registry != null) {
+      registry.restoreState(runId, state.toolOutputReferences);
+    }
   }
 
   /**
@@ -983,6 +1093,8 @@ export abstract class Graph<
    */
   private _compiledToolNodes: Set<{
     clearDirectPathTurns(): void;
+    createSubagentResumeState(): SubagentToolNodeResumeState;
+    restoreSubagentResumeState(state: SubagentToolNodeResumeState): void;
   }> = new Set();
   private _subagentExecutors = new Set<SubagentExecutor>();
   public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
@@ -4191,6 +4303,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const replayableSubagentTool = subagentTool as typeof subagentTool &
           ReplayableSubagentTool;
         replayableSubagentTool[SUBAGENT_REPLAY_CONTROLLER] = {
+          getResumeManifest: (
+            parentToolCallIds
+          ): Promise<SubagentResumeManifest | undefined> =>
+            executor.getResumeManifest(parentToolCallIds),
           getSettledOutput: (
             call,
             config

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -27,7 +27,10 @@ const makeTrip = (): StreamLimitExceededError =>
 
 type CompiledRegistrationInternals = {
   _compiledToolNodes: Set<{ clearDirectPathTurns(): void }>;
-  _subagentExecutors: Set<{ clearHeavyState(): void }>;
+  _subagentExecutors: Set<{
+    clearHeavyState(): void;
+    resetCheckpointThreadIds(): void;
+  }>;
 };
 
 describe('run breaker lifecycle', () => {
@@ -36,8 +39,12 @@ describe('run breaker lifecycle', () => {
     const internals = graph as unknown as CompiledRegistrationInternals;
     const clearDirectPathTurns = jest.fn();
     const clearSubagentState = jest.fn();
+    const resetCheckpointThreadIds = jest.fn();
     internals._compiledToolNodes.add({ clearDirectPathTurns });
-    internals._subagentExecutors.add({ clearHeavyState: clearSubagentState });
+    internals._subagentExecutors.add({
+      clearHeavyState: clearSubagentState,
+      resetCheckpointThreadIds,
+    });
 
     graph.clearHeavyState();
     graph.clearHeavyState();
@@ -46,6 +53,21 @@ describe('run breaker lifecycle', () => {
     expect(clearSubagentState).toHaveBeenCalledTimes(2);
     expect(internals._compiledToolNodes.size).toBe(1);
     expect(internals._subagentExecutors.size).toBe(1);
+  });
+
+  it('resets subagent checkpoint ownership at each fresh run start', () => {
+    const graph = makeGraph();
+    const internals = graph as unknown as CompiledRegistrationInternals;
+    const resetCheckpointThreadIds = jest.fn();
+    internals._subagentExecutors.add({
+      clearHeavyState: jest.fn(),
+      resetCheckpointThreadIds,
+    });
+
+    graph.resetValues();
+    graph.resetValues();
+
+    expect(resetCheckpointThreadIds).toHaveBeenCalledTimes(2);
   });
 
   it('replaces the breaker at every run start, even when un-aborted', () => {

--- a/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
+++ b/src/graphs/__tests__/Graph.breakerLifecycle.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
-import { Providers } from '@/common';
 import { StandardGraph } from '../Graph';
+import { Providers } from '@/common';
 
 const makeAgent = (agentId: string): t.AgentInputs => ({
   agentId,
@@ -25,7 +25,29 @@ const makeTrip = (): StreamLimitExceededError =>
     toolName: 'db_query',
   });
 
+type CompiledRegistrationInternals = {
+  _compiledToolNodes: Set<{ clearDirectPathTurns(): void }>;
+  _subagentExecutors: Set<{ clearHeavyState(): void }>;
+};
+
 describe('run breaker lifecycle', () => {
+  it('retains compiled cleanup registrations across graph reuse', () => {
+    const graph = makeGraph();
+    const internals = graph as unknown as CompiledRegistrationInternals;
+    const clearDirectPathTurns = jest.fn();
+    const clearSubagentState = jest.fn();
+    internals._compiledToolNodes.add({ clearDirectPathTurns });
+    internals._subagentExecutors.add({ clearHeavyState: clearSubagentState });
+
+    graph.clearHeavyState();
+    graph.clearHeavyState();
+
+    expect(clearDirectPathTurns).toHaveBeenCalledTimes(2);
+    expect(clearSubagentState).toHaveBeenCalledTimes(2);
+    expect(internals._compiledToolNodes.size).toBe(1);
+    expect(internals._subagentExecutors.size).toBe(1);
+  });
+
   it('replaces the breaker at every run start, even when un-aborted', () => {
     const graph = makeGraph();
     const previous = graph.breakerAbort;
@@ -115,9 +137,7 @@ describe('run breaker lifecycle', () => {
           model: model as unknown as t.ChatModel,
           messages: [new HumanMessage('hi')],
           provider: Providers.OPENAI,
-          context: graph as Parameters<
-            typeof attemptInvoke
-          >[0]['context'],
+          context: graph as Parameters<typeof attemptInvoke>[0]['context'],
           onChunk: () => {
             /* producer loop enforcement is under test */
           },
@@ -225,10 +245,7 @@ describe('run breaker lifecycle', () => {
     /** With a live breaker the entry guard must not fire; the node then
      * fails later, on the missing config, proving it got past the guard. */
     await expect(
-      node(
-        { messages: [] } as unknown as t.AgentSubgraphState,
-        undefined
-      )
+      node({ messages: [] } as unknown as t.AgentSubgraphState, undefined)
     ).rejects.toThrow('No config provided');
   });
 });

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -1338,7 +1338,7 @@ describe('context overflow recovery', () => {
     if (agentContext == null) {
       throw new Error('Expected default agent context');
     }
-    expect(run.Graph.compileOptions?.checkpointer).toBeUndefined();
+    expect(run.Graph.compileOptions?.checkpointer).toBeInstanceOf(MemorySaver);
     expect(run.Graph.hasCompiledCheckpointer).toBe(true);
     run.Graph.resetValues(undefined, 'checkpoint-scope');
     agentContext.preserveOriginalToolContent(new Map([[2, 'full output']]));

--- a/src/graphs/__tests__/Graph.subagentResumeState.test.ts
+++ b/src/graphs/__tests__/Graph.subagentResumeState.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from '@jest/globals';
+import type { SubagentToolNodeResumeState } from '@/tools/subagent/SubagentReplay';
+import { StandardGraph } from '../Graph';
+import { Providers } from '@/common';
+
+type ResumeToolNode = {
+  createSubagentResumeState(): SubagentToolNodeResumeState;
+  restoreSubagentResumeState(state: SubagentToolNodeResumeState): void;
+};
+
+const makeGraph = (runId: string): StandardGraph =>
+  new StandardGraph({
+    runId,
+    agents: [
+      {
+        agentId: 'child-agent',
+        provider: Providers.OPENAI,
+        instructions: 'Test child state restoration.',
+      },
+    ],
+  });
+
+const initializeToolNode = (graph: StandardGraph): ResumeToolNode => {
+  const agentContext = graph.agentContexts.get('child-agent');
+  return graph.initializeTools({
+    currentTools: [],
+    agentContext,
+  }) as unknown as ResumeToolNode;
+};
+
+describe('subagent graph resume state', () => {
+  it('restores tool identity, turns, references, and sessions into a branch', () => {
+    const source = makeGraph('source');
+    source.toolOutputReferences = { enabled: true };
+    const sourceNode = initializeToolNode(source);
+    source.toolCallStepIds.set('call_tool', 'step_tool');
+    source.sessions.set('execute_code', {
+      session_id: 'sandbox-session',
+      lastUpdated: 42,
+    });
+    source
+      .getOrCreateToolOutputRegistry()
+      ?.set('source-scope', 'tool0turn0', 'raw output');
+    source.getEagerEventToolUsageCount('child-agent').set('calculator', 3);
+    source.eagerEventToolSuppressions.add('unstable_search');
+    const sourceNodeState = sourceNode.createSubagentResumeState();
+    sourceNode.restoreSubagentResumeState({
+      ...sourceNodeState,
+      toolUsageCounts: [{ toolName: 'calculator', count: 3 }],
+      directPathTurns: [{ toolCallId: 'call_tool', turn: 2 }],
+    });
+
+    const target = makeGraph('target');
+    target.toolOutputReferences = { enabled: true };
+    const targetNode = initializeToolNode(target);
+    target.restoreSubagentResumeState(
+      source.createSubagentResumeState('source-scope'),
+      'target-scope'
+    );
+
+    expect(target.toolCallStepIds.get('call_tool')).toBe('step_tool');
+    expect(target.sessions.get('execute_code')).toMatchObject({
+      session_id: 'sandbox-session',
+      lastUpdated: 42,
+    });
+    expect(
+      target.getOrCreateToolOutputRegistry()?.get('target-scope', 'tool0turn0')
+    ).toBe('raw output');
+    expect(targetNode.createSubagentResumeState()).toMatchObject({
+      toolUsageCounts: [{ toolName: 'calculator', count: 3 }],
+      directPathTurns: [{ toolCallId: 'call_tool', turn: 2 }],
+    });
+    expect(
+      target.getEagerEventToolUsageCount('child-agent').get('calculator')
+    ).toBe(3);
+    expect(target.eagerEventToolSuppressions).toEqual(
+      new Set(['unstable_search'])
+    );
+  });
+});

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -1,5 +1,14 @@
 // src/hooks/HookRegistry.ts
-import type { HookEvent, HookMatcher, AggregatedHookResult } from './types';
+import type {
+  HookEvent,
+  HookMatcher,
+  ToolApprovalReplayKey,
+  AggregatedHookResult,
+} from './types';
+
+function serializeApprovalKey(key: ToolApprovalReplayKey): string {
+  return JSON.stringify([key.executionScope, key.agentId, key.toolUseId]);
+}
 
 /**
  * Internal matcher storage type.
@@ -203,14 +212,16 @@ export class HookRegistry {
 
   getPendingToolApproval(
     sessionId: string,
-    toolUseId: string
+    key: ToolApprovalReplayKey
   ): AggregatedHookResult | undefined {
-    return this.pendingToolApprovals.get(sessionId)?.get(toolUseId);
+    return this.pendingToolApprovals
+      .get(sessionId)
+      ?.get(serializeApprovalKey(key));
   }
 
   setPendingToolApproval(
     sessionId: string,
-    toolUseId: string,
+    key: ToolApprovalReplayKey,
     result: AggregatedHookResult
   ): void {
     let pending = this.pendingToolApprovals.get(sessionId);
@@ -218,15 +229,18 @@ export class HookRegistry {
       pending = new Map();
       this.pendingToolApprovals.set(sessionId, pending);
     }
-    pending.set(toolUseId, result);
+    pending.set(serializeApprovalKey(key), result);
   }
 
-  clearPendingToolApproval(sessionId: string, toolUseId: string): void {
+  clearPendingToolApproval(
+    sessionId: string,
+    key: ToolApprovalReplayKey
+  ): void {
     const pending = this.pendingToolApprovals.get(sessionId);
     if (pending == null) {
       return;
     }
-    pending.delete(toolUseId);
+    pending.delete(serializeApprovalKey(key));
     if (pending.size === 0) {
       this.pendingToolApprovals.delete(sessionId);
     }

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -97,7 +97,7 @@ export class HookRegistry {
    * O(1) insertion in hot paths, no spread-on-write.
    */
   private readonly haltSignals: Map<string, HookHaltSignal> = new Map();
-  /** One-shot approval results retained until the matching resume is consumed. */
+  /** One-shot hook contributions retained until approval is consumed. */
   private readonly pendingToolApprovals = new Map<
     string,
     Map<string, AggregatedHookResult>

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -1,5 +1,5 @@
 // src/hooks/HookRegistry.ts
-import type { HookEvent, HookMatcher } from './types';
+import type { HookEvent, HookMatcher, AggregatedHookResult } from './types';
 
 /**
  * Internal matcher storage type.
@@ -71,6 +71,11 @@ export class HookRegistry {
    * O(1) insertion in hot paths, no spread-on-write.
    */
   private readonly haltSignals: Map<string, HookHaltSignal> = new Map();
+  /** One-shot approval results retained until the matching resume is consumed. */
+  private readonly pendingToolApprovals = new Map<
+    string,
+    Map<string, AggregatedHookResult>
+  >();
 
   /**
    * Register a matcher for the lifetime of this registry (= one Run).
@@ -160,6 +165,7 @@ export class HookRegistry {
    */
   clearSession(sessionId: string): void {
     this.sessions.delete(sessionId);
+    this.pendingToolApprovals.delete(sessionId);
   }
 
   /** Copies session-scoped policy into a rebuilt or branched Run. */
@@ -168,17 +174,61 @@ export class HookRegistry {
       return;
     }
     const source = this.sessions.get(sourceSessionId);
-    if (source == null) {
-      return;
-    }
-    const target = this.ensureSessionBucket(targetSessionId);
-    for (const event of Object.keys(source) as HookEvent[]) {
-      const targetList = ensureList(target, event);
-      for (const matcher of readList(source, event)) {
-        if (!targetList.includes(matcher)) {
-          targetList.push(matcher);
+    if (source != null) {
+      const target = this.ensureSessionBucket(targetSessionId);
+      for (const event of Object.keys(source) as HookEvent[]) {
+        const targetList = ensureList(target, event);
+        for (const matcher of readList(source, event)) {
+          if (!targetList.includes(matcher)) {
+            targetList.push(matcher);
+          }
         }
       }
+    }
+    const pending = this.pendingToolApprovals.get(sourceSessionId);
+    if (pending == null) {
+      return;
+    }
+    let targetPending = this.pendingToolApprovals.get(targetSessionId);
+    if (targetPending == null) {
+      targetPending = new Map();
+      this.pendingToolApprovals.set(targetSessionId, targetPending);
+    }
+    for (const [toolUseId, result] of pending) {
+      if (!targetPending.has(toolUseId)) {
+        targetPending.set(toolUseId, result);
+      }
+    }
+  }
+
+  getPendingToolApproval(
+    sessionId: string,
+    toolUseId: string
+  ): AggregatedHookResult | undefined {
+    return this.pendingToolApprovals.get(sessionId)?.get(toolUseId);
+  }
+
+  setPendingToolApproval(
+    sessionId: string,
+    toolUseId: string,
+    result: AggregatedHookResult
+  ): void {
+    let pending = this.pendingToolApprovals.get(sessionId);
+    if (pending == null) {
+      pending = new Map();
+      this.pendingToolApprovals.set(sessionId, pending);
+    }
+    pending.set(toolUseId, result);
+  }
+
+  clearPendingToolApproval(sessionId: string, toolUseId: string): void {
+    const pending = this.pendingToolApprovals.get(sessionId);
+    if (pending == null) {
+      return;
+    }
+    pending.delete(toolUseId);
+    if (pending.size === 0) {
+      this.pendingToolApprovals.delete(sessionId);
     }
   }
 

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -162,6 +162,34 @@ export class HookRegistry {
     this.sessions.delete(sessionId);
   }
 
+  /** Moves session-scoped policy state to a rebuilt Run's session ID. */
+  migrateSession(sourceSessionId: string, targetSessionId: string): void {
+    if (sourceSessionId === targetSessionId) {
+      return;
+    }
+    const source = this.sessions.get(sourceSessionId);
+    const target = this.sessions.get(targetSessionId);
+    if (source != null && target == null) {
+      this.sessions.set(targetSessionId, source);
+    } else if (source != null && target != null) {
+      for (const event of Object.keys(source) as HookEvent[]) {
+        const targetList = ensureList(target, event);
+        for (const matcher of readList(source, event)) {
+          if (!targetList.includes(matcher)) {
+            targetList.push(matcher);
+          }
+        }
+      }
+    }
+    this.sessions.delete(sourceSessionId);
+
+    const sourceHalt = this.haltSignals.get(sourceSessionId);
+    if (sourceHalt != null && !this.haltSignals.has(targetSessionId)) {
+      this.haltSignals.set(targetSessionId, sourceHalt);
+    }
+    this.haltSignals.delete(sourceSessionId);
+  }
+
   /**
    * Raise a halt signal scoped to `sessionId` (= the run id the hook
    * fired under). The SDK's run loop polls for this between stream

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -3,11 +3,28 @@ import type {
   HookEvent,
   HookMatcher,
   ToolApprovalReplayKey,
+  ToolApprovalReplaySnapshot,
   AggregatedHookResult,
 } from './types';
 
 function serializeApprovalKey(key: ToolApprovalReplayKey): string {
   return JSON.stringify([key.executionScope, key.agentId, key.toolUseId]);
+}
+
+function deserializeApprovalKey(value: string): ToolApprovalReplayKey | null {
+  const parsed: unknown = JSON.parse(value);
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== 3 ||
+    parsed.some((part) => typeof part !== 'string')
+  ) {
+    return null;
+  }
+  return {
+    executionScope: parsed[0],
+    agentId: parsed[1],
+    toolUseId: parsed[2],
+  };
 }
 
 /**
@@ -244,6 +261,49 @@ export class HookRegistry {
     if (pending.size === 0) {
       this.pendingToolApprovals.delete(sessionId);
     }
+  }
+
+  snapshotPendingToolApprovals(
+    sessionId: string,
+    executionScope: string
+  ): ToolApprovalReplaySnapshot[] {
+    const pending = this.pendingToolApprovals.get(sessionId);
+    if (pending == null) {
+      return [];
+    }
+    const snapshots: ToolApprovalReplaySnapshot[] = [];
+    for (const [serializedKey, result] of pending) {
+      const key = deserializeApprovalKey(serializedKey);
+      if (key == null || key.executionScope !== executionScope) {
+        continue;
+      }
+      snapshots.push({ key, result });
+    }
+    return snapshots;
+  }
+
+  restorePendingToolApprovals(
+    sessionId: string,
+    executionScope: string,
+    snapshots: ReadonlyArray<ToolApprovalReplaySnapshot>
+  ): void {
+    const restored = new Map<string, AggregatedHookResult>();
+    for (const [serializedKey, result] of this.pendingToolApprovals.get(
+      sessionId
+    ) ?? []) {
+      const key = deserializeApprovalKey(serializedKey);
+      if (key?.executionScope !== executionScope) {
+        restored.set(serializedKey, result);
+      }
+    }
+    for (const snapshot of snapshots) {
+      restored.set(serializeApprovalKey(snapshot.key), snapshot.result);
+    }
+    if (restored.size === 0) {
+      this.pendingToolApprovals.delete(sessionId);
+      return;
+    }
+    this.pendingToolApprovals.set(sessionId, restored);
   }
 
   /**

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -284,7 +284,7 @@ export class HookRegistry {
 
   restorePendingToolApprovals(
     sessionId: string,
-    executionScope: string,
+    targetExecutionScope: string,
     snapshots: ReadonlyArray<ToolApprovalReplaySnapshot>
   ): void {
     const restored = new Map<string, AggregatedHookResult>();
@@ -292,12 +292,18 @@ export class HookRegistry {
       sessionId
     ) ?? []) {
       const key = deserializeApprovalKey(serializedKey);
-      if (key?.executionScope !== executionScope) {
+      if (key?.executionScope !== targetExecutionScope) {
         restored.set(serializedKey, result);
       }
     }
     for (const snapshot of snapshots) {
-      restored.set(serializeApprovalKey(snapshot.key), snapshot.result);
+      restored.set(
+        serializeApprovalKey({
+          ...snapshot.key,
+          executionScope: targetExecutionScope,
+        }),
+        snapshot.result
+      );
     }
     if (restored.size === 0) {
       this.pendingToolApprovals.delete(sessionId);

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -162,32 +162,24 @@ export class HookRegistry {
     this.sessions.delete(sessionId);
   }
 
-  /** Moves session-scoped policy state to a rebuilt Run's session ID. */
-  migrateSession(sourceSessionId: string, targetSessionId: string): void {
+  /** Copies session-scoped policy into a rebuilt or branched Run. */
+  copySession(sourceSessionId: string, targetSessionId: string): void {
     if (sourceSessionId === targetSessionId) {
       return;
     }
     const source = this.sessions.get(sourceSessionId);
-    const target = this.sessions.get(targetSessionId);
-    if (source != null && target == null) {
-      this.sessions.set(targetSessionId, source);
-    } else if (source != null && target != null) {
-      for (const event of Object.keys(source) as HookEvent[]) {
-        const targetList = ensureList(target, event);
-        for (const matcher of readList(source, event)) {
-          if (!targetList.includes(matcher)) {
-            targetList.push(matcher);
-          }
+    if (source == null) {
+      return;
+    }
+    const target = this.ensureSessionBucket(targetSessionId);
+    for (const event of Object.keys(source) as HookEvent[]) {
+      const targetList = ensureList(target, event);
+      for (const matcher of readList(source, event)) {
+        if (!targetList.includes(matcher)) {
+          targetList.push(matcher);
         }
       }
     }
-    this.sessions.delete(sourceSessionId);
-
-    const sourceHalt = this.haltSignals.get(sourceSessionId);
-    if (sourceHalt != null && !this.haltSignals.has(targetSessionId)) {
-      this.haltSignals.set(targetSessionId, sourceHalt);
-    }
-    this.haltSignals.delete(sourceSessionId);
   }
 
   /**

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -164,6 +164,23 @@ describe('HookRegistry', () => {
       expect(registry.hasHookFor('PreToolUse', 'run-a')).toBe(true);
       expect(registry.hasHookFor('PreToolUse', 'run-b')).toBe(false);
     });
+
+    it('copies session policy without consuming the source or sibling branches', () => {
+      const registry = new HookRegistry();
+      const matcher = makePreToolUseMatcher('subagent');
+      registry.registerSession('source', 'PreToolUse', matcher);
+
+      registry.copySession('source', 'branch-a');
+      registry.copySession('source', 'branch-b');
+
+      expect(registry.getMatchers('PreToolUse', 'source')).toEqual([matcher]);
+      expect(registry.getMatchers('PreToolUse', 'branch-a')).toEqual([matcher]);
+      expect(registry.getMatchers('PreToolUse', 'branch-b')).toEqual([matcher]);
+
+      registry.clearSession('branch-a');
+      expect(registry.getMatchers('PreToolUse', 'source')).toEqual([matcher]);
+      expect(registry.getMatchers('PreToolUse', 'branch-b')).toEqual([matcher]);
+    });
   });
 
   describe('session isolation under parallel registration', () => {

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -191,23 +191,35 @@ describe('HookRegistry', () => {
         injectedMessages: [],
         errors: [],
       };
-      registry.setPendingToolApproval('source', 'call_1', approval);
+      const key = {
+        executionScope: 'child-a',
+        agentId: 'researcher',
+        toolUseId: 'call_1',
+      };
+      const siblingKey = { ...key, executionScope: 'child-b' };
+      registry.setPendingToolApproval('source', key, approval);
+      registry.setPendingToolApproval('source', siblingKey, {
+        ...approval,
+        reason: 'review sibling',
+      });
 
       registry.copySession('source', 'branch');
 
-      expect(registry.getPendingToolApproval('source', 'call_1')).toBe(
-        approval
-      );
-      expect(registry.getPendingToolApproval('branch', 'call_1')).toBe(
-        approval
-      );
+      expect(registry.getPendingToolApproval('source', key)).toBe(approval);
+      expect(registry.getPendingToolApproval('branch', key)).toBe(approval);
+      expect(
+        registry.getPendingToolApproval('branch', siblingKey)?.reason
+      ).toBe('review sibling');
+      registry.clearPendingToolApproval('branch', key);
+      expect(registry.getPendingToolApproval('branch', key)).toBeUndefined();
+      expect(
+        registry.getPendingToolApproval('branch', siblingKey)?.reason
+      ).toBe('review sibling');
       registry.clearSession('branch');
       expect(
-        registry.getPendingToolApproval('branch', 'call_1')
+        registry.getPendingToolApproval('branch', siblingKey)
       ).toBeUndefined();
-      expect(registry.getPendingToolApproval('source', 'call_1')).toBe(
-        approval
-      );
+      expect(registry.getPendingToolApproval('source', key)).toBe(approval);
     });
   });
 

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -246,6 +246,19 @@ describe('HookRegistry', () => {
       expect(
         registry.getPendingToolApproval('restored', siblingKey)
       ).toBeUndefined();
+
+      const branchKey = { ...key, executionScope: 'child-a-attempt-2' };
+      registry.restorePendingToolApprovals(
+        'restored',
+        branchKey.executionScope,
+        checkpointSnapshot
+      );
+      expect(registry.getPendingToolApproval('restored', branchKey)).toBe(
+        approval
+      );
+      expect(registry.getPendingToolApproval('restored', key)).toBe(approval);
+      registry.clearPendingToolApproval('restored', branchKey);
+      expect(registry.getPendingToolApproval('restored', key)).toBe(approval);
     });
   });
 

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -181,6 +181,34 @@ describe('HookRegistry', () => {
       expect(registry.getMatchers('PreToolUse', 'source')).toEqual([matcher]);
       expect(registry.getMatchers('PreToolUse', 'branch-b')).toEqual([matcher]);
     });
+
+    it('copies pending one-shot approvals and clears them with the target session', () => {
+      const registry = new HookRegistry();
+      const approval = {
+        decision: 'ask' as const,
+        reason: 'review tool',
+        additionalContexts: [],
+        injectedMessages: [],
+        errors: [],
+      };
+      registry.setPendingToolApproval('source', 'call_1', approval);
+
+      registry.copySession('source', 'branch');
+
+      expect(registry.getPendingToolApproval('source', 'call_1')).toBe(
+        approval
+      );
+      expect(registry.getPendingToolApproval('branch', 'call_1')).toBe(
+        approval
+      );
+      registry.clearSession('branch');
+      expect(
+        registry.getPendingToolApproval('branch', 'call_1')
+      ).toBeUndefined();
+      expect(registry.getPendingToolApproval('source', 'call_1')).toBe(
+        approval
+      );
+    });
   });
 
   describe('session isolation under parallel registration', () => {

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -215,11 +215,37 @@ describe('HookRegistry', () => {
       expect(
         registry.getPendingToolApproval('branch', siblingKey)?.reason
       ).toBe('review sibling');
+      const checkpointSnapshot = registry.snapshotPendingToolApprovals(
+        'source',
+        'child-a'
+      );
+      expect(checkpointSnapshot).toEqual([{ key, result: approval }]);
       registry.clearSession('branch');
       expect(
         registry.getPendingToolApproval('branch', siblingKey)
       ).toBeUndefined();
       expect(registry.getPendingToolApproval('source', key)).toBe(approval);
+      registry.setPendingToolApproval('restored', key, {
+        ...approval,
+        reason: 'stale approval',
+      });
+      registry.setPendingToolApproval('restored', siblingKey, {
+        ...approval,
+        reason: 'preserved sibling',
+      });
+      registry.restorePendingToolApprovals(
+        'restored',
+        'child-a',
+        checkpointSnapshot
+      );
+      expect(registry.getPendingToolApproval('restored', key)).toBe(approval);
+      expect(
+        registry.getPendingToolApproval('restored', siblingKey)?.reason
+      ).toBe('preserved sibling');
+      registry.restorePendingToolApprovals('restored', 'child-b', []);
+      expect(
+        registry.getPendingToolApproval('restored', siblingKey)
+      ).toBeUndefined();
     });
   });
 

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -788,10 +788,9 @@ describe('executeHooks', () => {
         },
       };
 
-      const first = await executeHooks(options);
+      await executeHooks(options);
       const replay = await executeHooks(options);
 
-      expect(first).toBe(replay);
       expect(replay).toMatchObject({
         decision: 'ask',
         reason: 'review once',
@@ -812,6 +811,117 @@ describe('executeHooks', () => {
       const afterDecision = await executeHooks(options);
       expect(afterDecision.decision).toBeUndefined();
       expect(calls).toBe(1);
+    });
+
+    it('replays only one-shot contributions while rerunning ordinary hooks', async () => {
+      const registry = new HookRegistry();
+      let onceCalls = 0;
+      let ordinaryCalls = 0;
+      let ordinaryDecision: 'allow' | 'deny' = 'allow';
+      registry.registerSession('run-1', 'PreToolUse', {
+        once: true,
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            onceCalls += 1;
+            return {
+              decision: 'ask',
+              reason: 'review once',
+              additionalContext: 'once-context',
+            };
+          },
+        ],
+      });
+      registry.registerSession('run-1', 'PreToolUse', {
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            ordinaryCalls += 1;
+            return {
+              decision: ordinaryDecision,
+              reason: `ordinary-${ordinaryDecision}`,
+              additionalContext: `ordinary-${ordinaryCalls}`,
+            };
+          },
+        ],
+      });
+      const options = {
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+        onceReplayKey: {
+          executionScope: 'child-a',
+          agentId: 'researcher',
+          toolUseId: 'call_1',
+        },
+      };
+
+      const first = await executeHooks(options);
+      ordinaryDecision = 'deny';
+      const replay = await executeHooks(options);
+
+      expect(first.decision).toBe('ask');
+      expect(replay).toMatchObject({
+        decision: 'deny',
+        reason: 'ordinary-deny',
+        additionalContexts: ['once-context', 'ordinary-2'],
+      });
+      expect(onceCalls).toBe(1);
+      expect(ordinaryCalls).toBe(2);
+      expect(
+        registry.getPendingToolApproval('run-1', options.onceReplayKey)
+      ).toBeUndefined();
+    });
+
+    it('retains a consumed one-shot rewrite when an ordinary hook asks', async () => {
+      const registry = new HookRegistry();
+      let onceCalls = 0;
+      let ordinaryCalls = 0;
+      registry.registerSession('run-1', 'PreToolUse', {
+        once: true,
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            onceCalls += 1;
+            return {
+              decision: 'allow',
+              updatedInput: { command: 'sanitized' },
+            };
+          },
+        ],
+      });
+      registry.registerSession('run-1', 'PreToolUse', {
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            ordinaryCalls += 1;
+            return { decision: 'ask', reason: 'ordinary approval' };
+          },
+        ],
+      });
+      const options = {
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+        onceReplayKey: {
+          executionScope: 'child-a',
+          agentId: 'researcher',
+          toolUseId: 'call_1',
+        },
+      };
+
+      const first = await executeHooks(options);
+      const replay = await executeHooks(options);
+
+      expect(first).toMatchObject({
+        decision: 'ask',
+        updatedInput: { command: 'sanitized' },
+      });
+      expect(replay).toMatchObject({
+        decision: 'ask',
+        reason: 'ordinary approval',
+        updatedInput: { command: 'sanitized' },
+      });
+      expect(onceCalls).toBe(1);
+      expect(ordinaryCalls).toBe(2);
     });
 
     it('removes the matcher after a successful fire', async () => {

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -764,6 +764,43 @@ describe('executeHooks', () => {
   });
 
   describe('once: true self-removal', () => {
+    it('replays a one-shot approval until the tool decision is consumed', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      registry.registerSession('run-1', 'PreToolUse', {
+        once: true,
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            calls += 1;
+            return { decision: 'ask', reason: 'review once' };
+          },
+        ],
+      });
+      const options = {
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+        onceReplayKey: 'call_1',
+      };
+
+      const first = await executeHooks(options);
+      const replay = await executeHooks(options);
+
+      expect(first).toBe(replay);
+      expect(replay).toMatchObject({
+        decision: 'ask',
+        reason: 'review once',
+      });
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
+
+      registry.clearPendingToolApproval('run-1', 'call_1');
+      const afterDecision = await executeHooks(options);
+      expect(afterDecision.decision).toBeUndefined();
+      expect(calls).toBe(1);
+    });
+
     it('removes the matcher after a successful fire', async () => {
       const registry = new HookRegistry();
       let calls = 0;

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -781,7 +781,11 @@ describe('executeHooks', () => {
         input: preToolUseInput('Bash'),
         matchQuery: 'Bash',
         sessionId: 'run-1',
-        onceReplayKey: 'call_1',
+        onceReplayKey: {
+          executionScope: 'child-a',
+          agentId: 'researcher',
+          toolUseId: 'call_1',
+        },
       };
 
       const first = await executeHooks(options);
@@ -795,7 +799,16 @@ describe('executeHooks', () => {
       expect(calls).toBe(1);
       expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
 
-      registry.clearPendingToolApproval('run-1', 'call_1');
+      const sibling = await executeHooks({
+        ...options,
+        onceReplayKey: {
+          ...options.onceReplayKey,
+          executionScope: 'child-b',
+        },
+      });
+      expect(sibling.decision).toBeUndefined();
+
+      registry.clearPendingToolApproval('run-1', options.onceReplayKey);
       const afterDecision = await executeHooks(options);
       expect(afterDecision.decision).toBeUndefined();
       expect(calls).toBe(1);

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -28,6 +28,8 @@ export interface ExecuteHooksOptions {
   sessionId?: string;
   /** Query string matched against each matcher's pattern (tool name, etc.). */
   matchQuery?: string;
+  /** Stable tool-call key for replaying a consumed one-shot approval. */
+  onceReplayKey?: string;
   /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
   signal?: AbortSignal;
   /** Default per-hook timeout; overridden by `matcher.timeout` when present. */
@@ -301,12 +303,16 @@ function applyAllowedDecisions(
   agg.allowedDecisions = output.allowedDecisions;
 }
 
-function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
-  const agg = freshResult();
+function fold(outcomes: readonly HookOutcome[]): {
+  aggregated: AggregatedHookResult;
+  onceMatcherAsked: boolean;
+} {
+  const aggregated = freshResult();
+  let onceMatcherAsked = false;
   for (const outcome of outcomes) {
     if (outcome.error !== null) {
       if (outcome.matcher.internal !== true) {
-        agg.errors.push(outcome.error);
+        aggregated.errors.push(outcome.error);
       }
       continue;
     }
@@ -323,15 +329,22 @@ function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
     if (output.async === true) {
       continue;
     }
-    applyContext(agg, output);
-    applyInjectedMessages(agg, output);
-    applyStopFlag(agg, output);
-    applyDecision(agg, output);
-    applyUpdatedInput(agg, output);
-    applyUpdatedOutput(agg, output);
-    applyAllowedDecisions(agg, output);
+    if (
+      outcome.matcher.once === true &&
+      'decision' in output &&
+      output.decision === 'ask'
+    ) {
+      onceMatcherAsked = true;
+    }
+    applyContext(aggregated, output);
+    applyInjectedMessages(aggregated, output);
+    applyStopFlag(aggregated, output);
+    applyDecision(aggregated, output);
+    applyUpdatedInput(aggregated, output);
+    applyUpdatedOutput(aggregated, output);
+    applyAllowedDecisions(aggregated, output);
   }
-  return agg;
+  return { aggregated, onceMatcherAsked };
 }
 
 /**
@@ -396,11 +409,18 @@ export async function executeHooks(
     input,
     sessionId,
     matchQuery,
+    onceReplayKey,
     signal,
     timeoutMs = DEFAULT_HOOK_TIMEOUT_MS,
     logger,
   } = opts;
   const event = input.hook_event_name;
+  if (event === 'PreToolUse' && sessionId != null && onceReplayKey != null) {
+    const pending = registry.getPendingToolApproval(sessionId, onceReplayKey);
+    if (pending != null) {
+      return pending;
+    }
+  }
   const matchers = registry.getMatchers(event, sessionId);
   if (matchers.length === 0) {
     return freshResult();
@@ -429,7 +449,16 @@ export async function executeHooks(
 
   const outcomes = (await Promise.all(tasks)).flat();
   reportErrors(outcomes, event, logger);
-  const aggregated = fold(outcomes);
+  const { aggregated, onceMatcherAsked } = fold(outcomes);
+  if (
+    event === 'PreToolUse' &&
+    aggregated.decision === 'ask' &&
+    onceMatcherAsked &&
+    sessionId != null &&
+    onceReplayKey != null
+  ) {
+    registry.setPendingToolApproval(sessionId, onceReplayKey, aggregated);
+  }
   /**
    * Centralized `preventContinuation` propagation: when any hook (across
    * any callsite — RunStart, PreToolUse, PostToolBatch, SubagentStop,

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -31,6 +31,8 @@ export interface ExecuteHooksOptions {
   matchQuery?: string;
   /** Stable tool-call key for replaying consumed one-shot contributions. */
   onceReplayKey?: ToolApprovalReplayKey;
+  /** Storage scope for replay state when it must outlive or branch from the hook session. */
+  onceReplaySessionId?: string;
   /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
   signal?: AbortSignal;
   /** Default per-hook timeout; overridden by `matcher.timeout` when present. */
@@ -480,14 +482,16 @@ export async function executeHooks(
     sessionId,
     matchQuery,
     onceReplayKey,
+    onceReplaySessionId,
     signal,
     timeoutMs = DEFAULT_HOOK_TIMEOUT_MS,
     logger,
   } = opts;
   const event = input.hook_event_name;
+  const replaySessionId = onceReplaySessionId ?? sessionId;
   const pendingApproval =
-    event === 'PreToolUse' && sessionId != null && onceReplayKey != null
-      ? registry.getPendingToolApproval(sessionId, onceReplayKey)
+    event === 'PreToolUse' && replaySessionId != null && onceReplayKey != null
+      ? registry.getPendingToolApproval(replaySessionId, onceReplayKey)
       : undefined;
   const matchers = registry.getMatchers(event, sessionId);
   if (matchers.length === 0) {
@@ -523,11 +527,11 @@ export async function executeHooks(
     event === 'PreToolUse' &&
     aggregated.decision === 'ask' &&
     onceReplayContribution != null &&
-    sessionId != null &&
+    replaySessionId != null &&
     onceReplayKey != null
   ) {
     registry.setPendingToolApproval(
-      sessionId,
+      replaySessionId,
       onceReplayKey,
       createPendingApprovalReplay(
         aggregated,
@@ -539,10 +543,10 @@ export async function executeHooks(
     event === 'PreToolUse' &&
     aggregated.decision !== 'ask' &&
     pendingApproval != null &&
-    sessionId != null &&
+    replaySessionId != null &&
     onceReplayKey != null
   ) {
-    registry.clearPendingToolApproval(sessionId, onceReplayKey);
+    registry.clearPendingToolApproval(replaySessionId, onceReplayKey);
   }
   /**
    * Centralized `preventContinuation` propagation: when any hook (across

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -29,7 +29,7 @@ export interface ExecuteHooksOptions {
   sessionId?: string;
   /** Query string matched against each matcher's pattern (tool name, etc.). */
   matchQuery?: string;
-  /** Stable tool-call key for replaying a consumed one-shot approval. */
+  /** Stable tool-call key for replaying consumed one-shot contributions. */
   onceReplayKey?: ToolApprovalReplayKey;
   /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
   signal?: AbortSignal;
@@ -304,13 +304,76 @@ function applyAllowedDecisions(
   agg.allowedDecisions = output.allowedDecisions;
 }
 
+function applyAggregatedResult(
+  target: AggregatedHookResult,
+  source: AggregatedHookResult
+): void {
+  target.additionalContexts.push(...source.additionalContexts);
+  target.injectedMessages.push(...source.injectedMessages);
+  target.errors.push(...source.errors);
+  if (source.decision != null) {
+    applyToolDecision(target, source.decision, source.reason);
+  }
+  if (source.stopDecision != null) {
+    applyStopDecision(target, source.stopDecision, source.reason);
+  }
+  if (source.updatedInput != null) {
+    target.updatedInput = source.updatedInput;
+  }
+  if (source.updatedOutput !== undefined) {
+    target.updatedOutput = source.updatedOutput;
+  }
+  if (source.allowedDecisions != null) {
+    target.allowedDecisions = source.allowedDecisions;
+  }
+  if (source.preventContinuation === true) {
+    target.preventContinuation = true;
+    target.stopReason ??= source.stopReason;
+  }
+}
+
+function combineAggregatedResults(
+  first: AggregatedHookResult | undefined,
+  second: AggregatedHookResult
+): AggregatedHookResult {
+  if (first == null) {
+    return second;
+  }
+  const combined = freshResult();
+  applyAggregatedResult(combined, first);
+  applyAggregatedResult(combined, second);
+  return combined;
+}
+
+function createPendingApprovalReplay(
+  approvalResult: AggregatedHookResult,
+  pendingApproval: AggregatedHookResult | undefined,
+  onceContribution: AggregatedHookResult
+): AggregatedHookResult {
+  const replay = freshResult();
+  if (pendingApproval != null) {
+    applyAggregatedResult(replay, pendingApproval);
+  }
+  applyAggregatedResult(replay, onceContribution);
+  replay.decision = 'ask';
+  replay.reason = approvalResult.reason;
+  if (approvalResult.allowedDecisions == null) {
+    delete replay.allowedDecisions;
+  } else {
+    replay.allowedDecisions = approvalResult.allowedDecisions;
+  }
+  return replay;
+}
+
 function fold(outcomes: readonly HookOutcome[]): {
   aggregated: AggregatedHookResult;
-  onceMatcherAsked: boolean;
+  onceReplayContribution?: AggregatedHookResult;
 } {
   const aggregated = freshResult();
-  let onceMatcherAsked = false;
+  const onceContribution = freshResult();
+  let hasOnceContribution = false;
   for (const outcome of outcomes) {
+    const isOnceMatcher = outcome.matcher.once === true;
     if (outcome.error !== null) {
       if (outcome.matcher.internal !== true) {
         aggregated.errors.push(outcome.error);
@@ -330,22 +393,28 @@ function fold(outcomes: readonly HookOutcome[]): {
     if (output.async === true) {
       continue;
     }
-    if (
-      outcome.matcher.once === true &&
-      'decision' in output &&
-      output.decision === 'ask'
-    ) {
-      onceMatcherAsked = true;
+    const targets = isOnceMatcher
+      ? [aggregated, onceContribution]
+      : [aggregated];
+    if (isOnceMatcher) {
+      hasOnceContribution = true;
     }
-    applyContext(aggregated, output);
-    applyInjectedMessages(aggregated, output);
-    applyStopFlag(aggregated, output);
-    applyDecision(aggregated, output);
-    applyUpdatedInput(aggregated, output);
-    applyUpdatedOutput(aggregated, output);
-    applyAllowedDecisions(aggregated, output);
+    for (const target of targets) {
+      applyContext(target, output);
+      applyInjectedMessages(target, output);
+      applyStopFlag(target, output);
+      applyDecision(target, output);
+      applyUpdatedInput(target, output);
+      applyUpdatedOutput(target, output);
+      applyAllowedDecisions(target, output);
+    }
   }
-  return { aggregated, onceMatcherAsked };
+  return {
+    aggregated,
+    ...(hasOnceContribution
+      ? { onceReplayContribution: onceContribution }
+      : {}),
+  };
 }
 
 /**
@@ -416,15 +485,13 @@ export async function executeHooks(
     logger,
   } = opts;
   const event = input.hook_event_name;
-  if (event === 'PreToolUse' && sessionId != null && onceReplayKey != null) {
-    const pending = registry.getPendingToolApproval(sessionId, onceReplayKey);
-    if (pending != null) {
-      return pending;
-    }
-  }
+  const pendingApproval =
+    event === 'PreToolUse' && sessionId != null && onceReplayKey != null
+      ? registry.getPendingToolApproval(sessionId, onceReplayKey)
+      : undefined;
   const matchers = registry.getMatchers(event, sessionId);
   if (matchers.length === 0) {
-    return freshResult();
+    return pendingApproval ?? freshResult();
   }
 
   // --- SYNC CRITICAL SECTION: once-matcher removal must complete before any await ---
@@ -445,20 +512,37 @@ export async function executeHooks(
   }
   // --- END SYNC CRITICAL SECTION ---
   if (tasks.length === 0) {
-    return freshResult();
+    return pendingApproval ?? freshResult();
   }
 
   const outcomes = (await Promise.all(tasks)).flat();
   reportErrors(outcomes, event, logger);
-  const { aggregated, onceMatcherAsked } = fold(outcomes);
+  const { aggregated: liveResult, onceReplayContribution } = fold(outcomes);
+  const aggregated = combineAggregatedResults(pendingApproval, liveResult);
   if (
     event === 'PreToolUse' &&
     aggregated.decision === 'ask' &&
-    onceMatcherAsked &&
+    onceReplayContribution != null &&
     sessionId != null &&
     onceReplayKey != null
   ) {
-    registry.setPendingToolApproval(sessionId, onceReplayKey, aggregated);
+    registry.setPendingToolApproval(
+      sessionId,
+      onceReplayKey,
+      createPendingApprovalReplay(
+        aggregated,
+        pendingApproval,
+        onceReplayContribution
+      )
+    );
+  } else if (
+    event === 'PreToolUse' &&
+    aggregated.decision !== 'ask' &&
+    pendingApproval != null &&
+    sessionId != null &&
+    onceReplayKey != null
+  ) {
+    registry.clearPendingToolApproval(sessionId, onceReplayKey);
   }
   /**
    * Centralized `preventContinuation` propagation: when any hook (across

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -8,6 +8,7 @@ import type {
   ToolDecision,
   StopDecision,
   HookCallback,
+  ToolApprovalReplayKey,
   AggregatedHookResult,
 } from './types';
 import type { HookRegistry } from './HookRegistry';
@@ -29,7 +30,7 @@ export interface ExecuteHooksOptions {
   /** Query string matched against each matcher's pattern (tool name, etc.). */
   matchQuery?: string;
   /** Stable tool-call key for replaying a consumed one-shot approval. */
-  onceReplayKey?: string;
+  onceReplayKey?: ToolApprovalReplayKey;
   /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
   signal?: AbortSignal;
   /** Default per-hook timeout; overridden by `matcher.timeout` when present. */

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -57,6 +57,7 @@ export type {
   ToolDecision,
   StopDecision,
   ToolApprovalReplayKey,
+  ToolApprovalReplaySnapshot,
   AggregatedHookResult,
   RunStartHookInput,
   UserPromptSubmitHookInput,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -42,7 +42,7 @@ export type {
   WorkspacePolicyConfig,
   PathExtractor,
 } from './createWorkspacePolicyHook';
-export { HOOK_EVENTS } from './types';
+export { HOOK_EVENTS, TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY } from './types';
 export type {
   HookEvent,
   HookInput,
@@ -56,6 +56,7 @@ export type {
   BaseHookOutput,
   ToolDecision,
   StopDecision,
+  ToolApprovalReplayKey,
   AggregatedHookResult,
   RunStartHookInput,
   UserPromptSubmitHookInput,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -27,6 +27,9 @@ export const HOOK_EVENTS = [
   'PostCompact',
 ] as const;
 
+export const TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY =
+  '__librechat_tool_approval_execution_scope';
+
 export type HookEvent = (typeof HOOK_EVENTS)[number];
 
 /** Tool-gating decision; executeHooks folds with `deny > ask > allow` precedence. */
@@ -391,6 +394,13 @@ export interface PreToolUseHookOutput extends BaseHookOutput {
    * registration order, same precedence rules as `updatedInput`.
    */
   allowedDecisions?: ReadonlyArray<'approve' | 'reject' | 'edit' | 'respond'>;
+}
+
+/** Stable identity for replaying a consumed one-shot tool approval. */
+export interface ToolApprovalReplayKey {
+  executionScope: string;
+  agentId: string;
+  toolUseId: string;
 }
 
 export interface PostToolUseHookOutput extends BaseHookOutput {

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -403,6 +403,12 @@ export interface ToolApprovalReplayKey {
   toolUseId: string;
 }
 
+/** Checkpoint-safe copy of a pending tool approval replay. */
+export interface ToolApprovalReplaySnapshot {
+  key: ToolApprovalReplayKey;
+  result: AggregatedHookResult;
+}
+
 export interface PostToolUseHookOutput extends BaseHookOutput {
   /**
    * Replacement tool output. Flows through the aggregated result so the

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -403,7 +403,7 @@ export interface ToolApprovalReplayKey {
   toolUseId: string;
 }
 
-/** Checkpoint-safe copy of a pending tool approval replay. */
+/** Checkpoint-safe copy of a consumed one-shot approval contribution. */
 export interface ToolApprovalReplaySnapshot {
   key: ToolApprovalReplayKey;
   result: AggregatedHookResult;

--- a/src/run.ts
+++ b/src/run.ts
@@ -571,6 +571,10 @@ export class Run<_T extends t.BaseGraphState> {
     return this.Graph.getRunMessages();
   }
 
+  getChildCheckpointThreadIds(): string[] {
+    return this.Graph?.getChildCheckpointThreadIds() ?? [];
+  }
+
   /**
    * Returns a defensive snapshot of tools discovered by the current run.
    * Pass an agent id for that context, or omit it for the ordered union across

--- a/src/run.ts
+++ b/src/run.ts
@@ -128,14 +128,16 @@ function isLangGraphResumeMapForInterrupt(
 }
 
 function getInterruptHookSessionId(payload: unknown): string | undefined {
+  const publicPayload = stripSubagentResumeManifest(payload);
   if (
-    payload == null ||
-    typeof payload !== 'object' ||
-    (payload as { type?: unknown }).type !== 'tool_approval'
+    publicPayload == null ||
+    typeof publicPayload !== 'object' ||
+    (publicPayload as { type?: unknown }).type !== 'tool_approval'
   ) {
     return undefined;
   }
-  const sessionId = (payload as { hook_session_id?: unknown }).hook_session_id;
+  const sessionId = (publicPayload as { hook_session_id?: unknown })
+    .hook_session_id;
   return typeof sessionId === 'string' && sessionId.length > 0
     ? sessionId
     : undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,6 +20,12 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
+  requireValidSubagentResumeManifest,
+  stripSubagentResumeManifest,
+  SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
+  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
+} from '@/tools/subagent/SubagentReplay';
+import {
   createLangfuseTraceMetadata,
   createLangfuseHandler,
   disposeLangfuseHandler,
@@ -27,11 +33,6 @@ import {
   isLangfuseCallbackHandler,
   withLangfuseAttributes,
 } from '@/langfuse';
-import {
-  requireValidSubagentResumeManifest,
-  stripSubagentResumeManifest,
-  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
-} from '@/tools/subagent/SubagentReplay';
 import {
   hasToolOutputTracingConfig,
   resolveLangfuseConfig,
@@ -798,6 +799,7 @@ export class Run<_T extends t.BaseGraphState> {
       configurable: { ...callerConfig.configurable },
     };
     if (!isResume) {
+      delete config.configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
       delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
     }
 
@@ -1412,7 +1414,9 @@ export class Run<_T extends t.BaseGraphState> {
       interrupt?.payload
     );
     const resumeConfigurable = { ...callerConfig.configurable };
+    delete resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
     delete resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
+    resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY] = nanoid();
     if (resumeManifest != null) {
       resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] = resumeManifest;
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -244,8 +244,6 @@ export class Run<_T extends t.BaseGraphState> {
       /** Default to legacy graph for 'standard' or undefined type */
       this.graphRunnable = this.createLegacyGraph(config.graphConfig);
       if (this.Graph) {
-        this.Graph.compileOptions =
-          config.graphConfig.compileOptions ?? this.Graph.compileOptions;
         this.Graph.handlerRegistry = handlerRegistry;
       }
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,18 +4,19 @@ import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
-import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import {
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
 import {
   Command,
   INTERRUPT,
   MemorySaver,
   isInterrupted,
 } from '@langchain/langgraph';
-import type {
-  MessageContentComplex,
-  BaseMessage,
-} from '@langchain/core/messages';
 import type { StringPromptValue } from '@langchain/core/prompt_values';
+import type { MessageContentComplex } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
@@ -145,6 +146,7 @@ function getInterruptHookSessionId(payload: unknown): string | undefined {
 
 type InterruptStateSnapshot = {
   config?: RunnableConfig;
+  values?: { messages?: BaseMessage[] };
   tasks?: Array<{
     interrupts?: Array<{ id?: string; value?: unknown }>;
   }>;
@@ -171,6 +173,36 @@ function getFirstPersistedInterrupt(
     }
   }
   return undefined;
+}
+
+function getPersistedMessages(
+  snapshot: InterruptStateSnapshot
+): BaseMessage[] | undefined {
+  const messages = snapshot.values?.messages;
+  if (!Array.isArray(messages) || !messages.every(BaseMessage.isInstance)) {
+    return undefined;
+  }
+  return messages;
+}
+
+type ResumeCommandUpdate = ConstructorParameters<typeof Command>[0]['update'];
+
+function getResumeUpdateMessages(
+  update: ResumeCommandUpdate
+): BaseMessage[] | undefined {
+  if (update == null) {
+    return undefined;
+  }
+  const messages = Array.isArray(update)
+    ? update.find(([key]) => key === 'messages')?.[1]
+    : update.messages;
+  if (BaseMessage.isInstance(messages)) {
+    return [messages];
+  }
+  if (!Array.isArray(messages) || !messages.every(BaseMessage.isInstance)) {
+    return undefined;
+  }
+  return messages;
 }
 
 export class Run<_T extends t.BaseGraphState> {
@@ -1382,7 +1414,10 @@ export class Run<_T extends t.BaseGraphState> {
       'update' | 'goto'
     >
   ): Promise<MessageContentComplex[] | undefined> {
-    const resumeConfig = await this.resolveInterruptResumeConfig(callerConfig);
+    const resumeConfig = await this.resolveInterruptResumeConfig(
+      callerConfig,
+      commandOptions?.update
+    );
     const interruptId = this._interrupt?.interruptId;
     const scopedResume =
       typeof interruptId === 'string' &&
@@ -1408,9 +1443,10 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   private async resolveInterruptResumeConfig(
-    callerConfig: t.RunStreamConfig
+    callerConfig: t.RunStreamConfig,
+    resumeUpdate?: ResumeCommandUpdate
   ): Promise<t.RunStreamConfig> {
-    await this.restoreInterruptFromCheckpoint(callerConfig);
+    await this.restoreInterruptFromCheckpoint(callerConfig, resumeUpdate);
     const interrupt = this._interrupt;
     const resumeManifest = requireValidSubagentResumeManifest(
       interrupt?.payload
@@ -1497,7 +1533,8 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   private async restoreInterruptFromCheckpoint(
-    callerConfig: t.RunStreamConfig
+    callerConfig: t.RunStreamConfig,
+    resumeUpdate?: ResumeCommandUpdate
   ): Promise<void> {
     if (this._interrupt != null || this.humanInTheLoop?.enabled !== true) {
       return;
@@ -1513,6 +1550,13 @@ export class Run<_T extends t.BaseGraphState> {
     const persistedInterrupt = getFirstPersistedInterrupt(snapshot);
     if (persistedInterrupt == null) {
       return;
+    }
+    const persistedMessages = getPersistedMessages(snapshot);
+    if (persistedMessages != null) {
+      this.Graph?.restoreCheckpointMessages(
+        persistedMessages,
+        getResumeUpdateMessages(resumeUpdate)
+      );
     }
 
     const checkpointConfigurable = snapshot.config?.configurable;

--- a/src/run.ts
+++ b/src/run.ts
@@ -124,15 +124,32 @@ function isLangGraphResumeMapForInterrupt(
 type InterruptStateSnapshot = {
   config?: RunnableConfig;
   tasks?: Array<{
-    interrupts?: Array<{ id?: string }>;
+    interrupts?: Array<{ id?: string; value?: unknown }>;
   }>;
 };
 
 type WorkflowWithStateHistory = {
+  getState?(config: RunnableConfig): Promise<InterruptStateSnapshot>;
   getStateHistory?(
     config: RunnableConfig
   ): AsyncIterableIterator<InterruptStateSnapshot>;
 };
+
+function getFirstPersistedInterrupt(
+  snapshot: InterruptStateSnapshot
+): { id: string; value: unknown } | undefined {
+  for (const task of snapshot.tasks ?? []) {
+    for (const pendingInterrupt of task.interrupts ?? []) {
+      if (
+        typeof pendingInterrupt.id === 'string' &&
+        pendingInterrupt.id.length > 0
+      ) {
+        return { id: pendingInterrupt.id, value: pendingInterrupt.value };
+      }
+    }
+  }
+  return undefined;
+}
 
 export class Run<_T extends t.BaseGraphState> {
   id: string;
@@ -1331,6 +1348,7 @@ export class Run<_T extends t.BaseGraphState> {
       'update' | 'goto'
     >
   ): Promise<MessageContentComplex[] | undefined> {
+    const resumeConfig = await this.resolveInterruptResumeConfig(callerConfig);
     const interruptId = this._interrupt?.interruptId;
     const scopedResume =
       typeof interruptId === 'string' &&
@@ -1338,7 +1356,6 @@ export class Run<_T extends t.BaseGraphState> {
       !isLangGraphResumeMapForInterrupt(resumeValue, interruptId)
         ? { [interruptId]: resumeValue }
         : resumeValue;
-    const resumeConfig = await this.resolveInterruptResumeConfig(callerConfig);
     // langgraph 1.4.5 applies resume + state update + reroute in one superstep
     // (single checkpoint). `update`/`goto` are omitted unless the caller sets them.
     return this.processStream(
@@ -1359,6 +1376,7 @@ export class Run<_T extends t.BaseGraphState> {
   private async resolveInterruptResumeConfig(
     callerConfig: t.RunStreamConfig
   ): Promise<t.RunStreamConfig> {
+    await this.restoreInterruptFromCheckpoint(callerConfig);
     const interrupt = this._interrupt;
     const interruptId = interrupt?.interruptId;
     const workflow = this.graphRunnable as
@@ -1424,6 +1442,38 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     return callerConfig;
+  }
+
+  private async restoreInterruptFromCheckpoint(
+    callerConfig: t.RunStreamConfig
+  ): Promise<void> {
+    if (this._interrupt != null || this.humanInTheLoop?.enabled !== true) {
+      return;
+    }
+    const workflow = this.graphRunnable as
+      | (t.CompiledStateWorkflow & WorkflowWithStateHistory)
+      | undefined;
+    if (typeof workflow?.getState !== 'function') {
+      return;
+    }
+
+    const snapshot = await workflow.getState(callerConfig as RunnableConfig);
+    const persistedInterrupt = getFirstPersistedInterrupt(snapshot);
+    if (persistedInterrupt == null) {
+      return;
+    }
+
+    const checkpointConfigurable = snapshot.config?.configurable;
+    const checkpointId = checkpointConfigurable?.checkpoint_id;
+    const checkpointNs = checkpointConfigurable?.checkpoint_ns;
+    const threadId = callerConfig.configurable?.thread_id;
+    this._interrupt = {
+      interruptId: persistedInterrupt.id,
+      payload: persistedInterrupt.value,
+      ...(typeof threadId === 'string' ? { threadId } : {}),
+      ...(typeof checkpointId === 'string' ? { checkpointId } : {}),
+      ...(typeof checkpointNs === 'string' ? { checkpointNs } : {}),
+    };
   }
 
   private createSystemCallback<K extends keyof t.ClientCallbacks>(

--- a/src/run.ts
+++ b/src/run.ts
@@ -28,6 +28,11 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
+  requireValidSubagentResumeManifest,
+  stripSubagentResumeManifest,
+  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
+} from '@/tools/subagent/SubagentReplay';
+import {
   hasToolOutputTracingConfig,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
@@ -792,6 +797,9 @@ export class Run<_T extends t.BaseGraphState> {
       recursionLimit,
       configurable: { ...callerConfig.configurable },
     };
+    if (!isResume) {
+      delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
+    }
 
     /**
      * Cancellation can arrive either at graph construction or per-call through
@@ -1281,7 +1289,13 @@ export class Run<_T extends t.BaseGraphState> {
   getInterrupt<TPayload = t.HumanInterruptPayload>():
     | t.RunInterruptResult<TPayload>
     | undefined {
-    return this._interrupt as t.RunInterruptResult<TPayload> | undefined;
+    if (this._interrupt == null) {
+      return undefined;
+    }
+    return {
+      ...this._interrupt,
+      payload: stripSubagentResumeManifest(this._interrupt.payload),
+    } as t.RunInterruptResult<TPayload>;
   }
 
   /**
@@ -1394,6 +1408,18 @@ export class Run<_T extends t.BaseGraphState> {
   ): Promise<t.RunStreamConfig> {
     await this.restoreInterruptFromCheckpoint(callerConfig);
     const interrupt = this._interrupt;
+    const resumeManifest = requireValidSubagentResumeManifest(
+      interrupt?.payload
+    );
+    const resumeConfigurable = { ...callerConfig.configurable };
+    delete resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
+    if (resumeManifest != null) {
+      resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] = resumeManifest;
+    }
+    const manifestConfig = {
+      ...callerConfig,
+      configurable: resumeConfigurable,
+    };
     const hookSessionId = getInterruptHookSessionId(interrupt?.payload);
     if (hookSessionId != null) {
       this.hookRegistry?.copySession(hookSessionId, this.id);
@@ -1405,9 +1431,9 @@ export class Run<_T extends t.BaseGraphState> {
     const stateHistory = workflow?.getStateHistory;
     if (interrupt?.checkpointId != null && interrupt.checkpointId.length > 0) {
       return {
-        ...callerConfig,
+        ...manifestConfig,
         configurable: {
-          ...callerConfig.configurable,
+          ...manifestConfig.configurable,
           checkpoint_id: interrupt.checkpointId,
           ...(typeof interrupt.checkpointNs === 'string'
             ? { checkpoint_ns: interrupt.checkpointNs }
@@ -1421,12 +1447,12 @@ export class Run<_T extends t.BaseGraphState> {
       interruptId.length === 0 ||
       typeof stateHistory !== 'function'
     ) {
-      return callerConfig;
+      return manifestConfig;
     }
 
     for await (const snapshot of stateHistory.call(
       this.graphRunnable,
-      callerConfig as RunnableConfig
+      manifestConfig as RunnableConfig
     )) {
       const hasMatchingInterrupt =
         snapshot.tasks?.some(
@@ -1449,9 +1475,9 @@ export class Run<_T extends t.BaseGraphState> {
           ...(typeof checkpointNs === 'string' ? { checkpointNs } : {}),
         };
         return {
-          ...callerConfig,
+          ...manifestConfig,
           configurable: {
-            ...callerConfig.configurable,
+            ...manifestConfig.configurable,
             checkpoint_id: checkpointId,
             ...(typeof checkpointNs === 'string'
               ? { checkpoint_ns: checkpointNs }
@@ -1461,7 +1487,7 @@ export class Run<_T extends t.BaseGraphState> {
       }
     }
 
-    return callerConfig;
+    return manifestConfig;
   }
 
   private async restoreInterruptFromCheckpoint(

--- a/src/run.ts
+++ b/src/run.ts
@@ -121,6 +121,20 @@ function isLangGraphResumeMapForInterrupt(
   return Object.prototype.hasOwnProperty.call(value, interruptId);
 }
 
+function getInterruptHookSessionId(payload: unknown): string | undefined {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    (payload as { type?: unknown }).type !== 'tool_approval'
+  ) {
+    return undefined;
+  }
+  const sessionId = (payload as { hook_session_id?: unknown }).hook_session_id;
+  return typeof sessionId === 'string' && sessionId.length > 0
+    ? sessionId
+    : undefined;
+}
+
 type InterruptStateSnapshot = {
   config?: RunnableConfig;
   tasks?: Array<{
@@ -1376,6 +1390,10 @@ export class Run<_T extends t.BaseGraphState> {
   ): Promise<t.RunStreamConfig> {
     await this.restoreInterruptFromCheckpoint(callerConfig);
     const interrupt = this._interrupt;
+    const hookSessionId = getInterruptHookSessionId(interrupt?.payload);
+    if (hookSessionId != null) {
+      this.hookRegistry?.copySession(hookSessionId, this.id);
+    }
     const interruptId = interrupt?.interruptId;
     const workflow = this.graphRunnable as
       | (t.CompiledStateWorkflow & WorkflowWithStateHistory)

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -934,6 +934,30 @@ export class AgentSession {
     });
   }
 
+  private async recordChildCheckpointThreads(params: {
+    source: 'run' | 'resume';
+    runId: string;
+    run: Run<t.IState>;
+  }): Promise<void> {
+    if (!this.checkpointing.enabled || this.store == null) {
+      return;
+    }
+    const recordedThreadIds = new Set(
+      this.store.getCheckpoints().map((checkpoint) => checkpoint.data.threadId)
+    );
+    for (const threadId of params.run.getChildCheckpointThreadIds()) {
+      if (recordedThreadIds.has(threadId)) {
+        continue;
+      }
+      recordedThreadIds.add(threadId);
+      await this.store.appendCheckpoint({
+        source: params.source,
+        runId: params.runId,
+        threadId,
+      });
+    }
+  }
+
   private getCheckpointThreadIds(): string[] {
     const threadIds = new Set<string>([this.threadId]);
     for (const checkpoint of this.store?.getCheckpoints() ?? []) {
@@ -1006,6 +1030,7 @@ export class AgentSession {
     const sessionState = createSessionRunState(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
+    let run: Run<t.IState> | undefined;
     try {
       const runConfig: t.RunConfig = {
         ...this.runConfig,
@@ -1024,7 +1049,7 @@ export class AgentSession {
           ...handlerResult.handlers,
         },
       };
-      const run = await Run.create<t.IState>(runConfig);
+      run = await Run.create<t.IState>(runConfig);
       let messages = inputMessages;
       if (!useCheckpointState && sessionState.messages.length > 0) {
         messages = sessionState.messages;
@@ -1070,6 +1095,11 @@ export class AgentSession {
         checkpointId: interrupt?.checkpointId,
         checkpointNs: interrupt?.checkpointNs,
       });
+      await this.recordChildCheckpointThreads({
+        source: 'run',
+        runId,
+        run,
+      });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
       );
@@ -1099,6 +1129,13 @@ export class AgentSession {
         threadId,
         config: callerConfig,
       });
+      if (run != null) {
+        await this.recordChildCheckpointThreads({
+          source: 'run',
+          runId,
+          run,
+        });
+      }
       throw error;
     }
   }
@@ -1348,8 +1385,9 @@ export class AgentSession {
     const sessionState = createSessionRunState(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
+    let run: Run<t.IState> | undefined;
     try {
-      const run = await Run.create<t.IState>({
+      run = await Run.create<t.IState>({
         ...this.runConfig,
         runId,
         graphConfig: applyCheckpointingToGraphConfig(
@@ -1400,6 +1438,11 @@ export class AgentSession {
         checkpointId: interrupt?.checkpointId,
         checkpointNs: interrupt?.checkpointNs,
       });
+      await this.recordChildCheckpointThreads({
+        source: 'resume',
+        runId,
+        run,
+      });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
       );
@@ -1425,6 +1468,13 @@ export class AgentSession {
         threadId,
         config: callerConfig,
       });
+      if (run != null) {
+        await this.recordChildCheckpointThreads({
+          source: 'resume',
+          runId,
+          run,
+        });
+      }
       throw error;
     }
   }

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -25,6 +25,9 @@ type MockRun = {
   >;
   getInterrupt: jest.MockedFunction<Run<t.IState>['getInterrupt']>;
   getHaltReason: jest.MockedFunction<Run<t.IState>['getHaltReason']>;
+  getChildCheckpointThreadIds: jest.MockedFunction<
+    Run<t.IState>['getChildCheckpointThreadIds']
+  >;
 };
 
 function createMockRun(outputText = 'ok'): MockRun {
@@ -45,6 +48,7 @@ function createMockRun(outputText = 'ok'): MockRun {
     getCalibrationRatio: jest.fn(() => 1),
     getInterrupt: jest.fn(() => undefined),
     getHaltReason: jest.fn(() => undefined),
+    getChildCheckpointThreadIds: jest.fn(() => []),
   };
 }
 
@@ -1117,6 +1121,55 @@ describe('JsonlSessionStore', () => {
       source: 'reset',
       reason: 'branch',
     });
+  });
+
+  it('records and resets child checkpoint threads owned by a run', async () => {
+    const checkpointer = new MemorySaver();
+    const childThreadId = 'subagent:owned-child';
+    const mockRun = createMockRun('child result');
+    mockRun.getChildCheckpointThreadIds.mockReturnValue([childThreadId]);
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: childThreadId,
+      id: 'checkpoint_child',
+    });
+
+    await session.run('fresh turn', { runId: 'run_with_child' });
+
+    expect(
+      session.getSessionStore()?.getCheckpoints(childThreadId).at(-1)?.data
+    ).toMatchObject({
+      source: 'run',
+      runId: 'run_with_child',
+      threadId: childThreadId,
+    });
+    const firstMessage = session
+      .getSessionStore()
+      ?.getPath()
+      .find((entry) => entry.type === 'message');
+    await session.branch(firstMessage?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: childThreadId },
+    });
+    expect(tuple).toBeUndefined();
+    expect(
+      session.getSessionStore()?.getCheckpoints(childThreadId).at(-1)?.data
+    ).toMatchObject({ source: 'reset', reason: 'branch' });
   });
 
   it('keeps checkpoint state when branching to the active JSONL leaf', async () => {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -574,6 +574,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * the Run ends.
    */
   private directPathTurns: Map<string, number> = new Map();
+  /** Terminal outputs from interrupting siblings that must survive a
+   * LangGraph replay of the containing ToolNode. */
+  private settledInterruptingOutputs = new Map<string, BaseMessage | Command>();
   /** Tool registry for filtering (lazy computation of programmatic maps) */
   private toolRegistry?: t.LCToolRegistry;
   /** Cached programmatic tools (computed once on first PTC call) */
@@ -931,16 +934,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Flush the per-Run direct-path turn cache. Called by the Graph at
-   * end-of-Run via `clearHeavyState`. The map intentionally survives
-   * `run()` re-entry so an interrupt + resume reuses the original
-   * slot (Codex P2 #30), but it would otherwise grow linearly with
-   * tool calls and could collide across Runs if a provider reused
-   * call IDs (Codex P2 #33). Hosts can also call this directly if
+   * Flush per-Run direct replay state. Called by the Graph at end-of-Run via
+   * `clearHeavyState`. The state intentionally survives `run()` re-entry so
+   * interrupt + resume keeps both original turn slots and terminal sibling
+   * outputs, but it would otherwise grow linearly and could collide across
+   * Runs if a provider reused call IDs. Hosts can also call this directly if
    * they reuse a ToolNode across batches outside of a Graph.
    */
   clearDirectPathTurns(): void {
     this.directPathTurns.clear();
+    this.settledInterruptingOutputs.clear();
   }
 
   /**
@@ -3680,16 +3683,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * call throws a `GraphInterrupt`, the `await` below rejects and unwinds the
    * whole ToolNode *before* any non-interrupting sibling has started — so a
    * sibling with real side effects (send_email, billing) never executes on
-   * the first pass. On the resume pass LangGraph re-runs the batch from the
-   * top; the interrupting tool resolves with the host's answer instead of
-   * throwing, and the siblings execute for the FIRST time, exactly once.
+   * the first pass. Terminal interrupting siblings are cached by call id, so
+   * LangGraph replay reuses their complete lifecycle output instead of
+   * repeating model calls, hooks, or side effects.
    *
    * Without this ordering, a flat `Promise.all` starts every sibling
    * concurrently, so a non-idempotent sibling can complete its side effect
    * before the interrupt unwinds and then run a SECOND time on resume — the
-   * duplicate side effect this method exists to prevent. Interrupting tools
-   * are expected to be side-effect-free (they only suspend), so running them
-   * as a group and re-running them on resume is harmless.
+   * duplicate side effect this method exists to prevent. A tool that actually
+   * suspends re-enters until it reaches a terminal result; siblings that
+   * already settled do not re-enter.
    *
    * `batchIndices[i]` is `directCalls[i]`'s position within the parent
    * ToolNode batch (used for `{{tool<i>turn<n>}}` registration); it is
@@ -3706,11 +3709,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const runOne = (
       call: ToolCall,
       position: number
-    ): Promise<BaseMessage | Command> =>
-      this.runDirectToolWithLifecycleHooks(call, config, {
+    ): Promise<BaseMessage | Command> => {
+      const cachedOutput =
+        typeof call.id === 'string'
+          ? this.settledInterruptingOutputs.get(call.id)
+          : undefined;
+      if (cachedOutput != null) {
+        return Promise.resolve(cachedOutput);
+      }
+      return this.runDirectToolWithLifecycleHooks(call, config, {
         ...baseContext,
         batchIndex: batchIndices[position],
       });
+    };
 
     const interrupting = this.interruptingToolNames;
     const hasInterrupting =
@@ -3753,7 +3764,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
         continue;
       }
-      outputs[interruptingPositions[i]] = result.value;
+      const position = interruptingPositions[i];
+      outputs[position] = result.value;
+      const callId = directCalls[position].id;
+      if (typeof callId === 'string' && callId !== '') {
+        this.settledInterruptingOutputs.set(callId, result.value);
+      }
     }
     if (hasInterruptingError) {
       throw interruptingError;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -25,8 +25,8 @@ import type {
   ToolRuntime,
   StructuredToolInterface,
 } from '@langchain/core/tools';
-import type { BaseMessage } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
+import type { BaseMessage } from '@langchain/core/messages';
 import type {
   ToolOutputResolveView,
   PreResolvedArgsMap,
@@ -39,6 +39,7 @@ import type {
   AggregatedHookResult,
   PostToolBatchEntry,
 } from '@/hooks';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
@@ -74,16 +75,15 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import {
+  StreamLimitExceededError,
+  RUN_BREAKER_SCOPE_CONFIG_KEY,
+} from '@/llm/streamLimits';
+import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
-import type { RunBreakerScope } from '@/llm/streamLimits';
-import {
-  StreamLimitExceededError,
-  RUN_BREAKER_SCOPE_CONFIG_KEY,
-} from '@/llm/streamLimits';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
  * hosts spread `configurable` into their own run configs. */
@@ -3051,7 +3051,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               // match it at the top level too.
               agentId: this.executingAgentId,
               configurable: stripRunBreakerScope(
-                config.configurable as Record<string, unknown> | undefined
+                  config.configurable as Record<string, unknown> | undefined
               ),
               metadata: config.metadata as
                   | Record<string, unknown>
@@ -3732,14 +3732,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
 
-    // Interrupting group first. A GraphInterrupt here propagates out of the
-    // `await` before any regular sibling is dispatched below.
-    const interruptingOutputs = await Promise.all(
+    // Interrupting group first. Wait for every sibling to settle before
+    // propagating an interrupt so approved subagents cannot keep running in
+    // the background while the parent exposes the next pending approval.
+    const interruptingResults = await Promise.allSettled(
       interruptingPositions.map((i) => runOne(directCalls[i], i))
     );
-    interruptingPositions.forEach((i, k) => {
-      outputs[i] = interruptingOutputs[k];
-    });
+    let hasInterruptingError = false;
+    let interruptingError: unknown;
+    for (let i = 0; i < interruptingResults.length; i++) {
+      const result = interruptingResults[i];
+      if (result.status === 'rejected') {
+        if (!hasInterruptingError) {
+          hasInterruptingError = true;
+          interruptingError = result.reason;
+        }
+        continue;
+      }
+      outputs[interruptingPositions[i]] = result.value;
+    }
+    if (hasInterruptingError) {
+      throw interruptingError;
+    }
 
     /** The breaker can trip while the interrupting group is awaited — e.g.
      * a tool that ignores cancellation and completes normally. Recheck
@@ -3999,9 +4013,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         : (aiMessage.invalid_tool_calls ?? []).filter(
           (call) =>
             call.id != null &&
-            call.id !== '' &&
-            !toolMessageIds.has(call.id) &&
-            !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+              call.id !== '' &&
+              !toolMessageIds.has(call.id) &&
+              !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
         );
       invalidCallResults = attributableInvalidCalls.map(
         (call) =>
@@ -4240,7 +4254,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
         // Append accumulated additionalContexts as a single
         // HumanMessage so the next model turn sees them. Codex P2 #39.
-        const promotedPrefix = promotedAiMessage != null ? [promotedAiMessage] : [];
+        const promotedPrefix =
+          promotedAiMessage != null ? [promotedAiMessage] : [];
         outputs =
           directAdditionalContexts.length > 0
             ? [
@@ -4301,8 +4316,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         isCommand(output)
           ? patchCommandUpdateForPromotedInvalidCalls(
             output,
-            promotedAiMessage!,
-            invalidCallResults
+              promotedAiMessage!,
+              invalidCallResults
           )
           : output
       );
@@ -4498,8 +4513,7 @@ function sanitizeInvalidToolUseBlocks(
     /** `name` normalizes with the SAME fallback the promoted `tool_calls`
      *  entry uses — a nameless block would fail provider validation on its
      *  own even with a valid input. */
-    const nameIsValid =
-      typeof toolUse.name === 'string' && toolUse.name !== '';
+    const nameIsValid = typeof toolUse.name === 'string' && toolUse.name !== '';
     if (inputIsObject && nameIsValid) {
       return block;
     }
@@ -4571,9 +4585,7 @@ function patchCommandUpdateForPromotedInvalidCalls(
     if (!isAIMessage(msg) || msg.id !== promoted.id) {
       return msg;
     }
-    const existingIds = new Set(
-      (msg.tool_calls ?? []).map((call) => call.id)
-    );
+    const existingIds = new Set((msg.tool_calls ?? []).map((call) => call.id));
     const promotedEntries = invalidResults
       .filter((result) => !existingIds.has(result.tool_call_id))
       .map((result) => ({

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -352,10 +352,14 @@ type AskEntry = {
  * needs `interrupt()` plus the AsyncLocalStorage anchoring shim).
  */
 function buildToolApprovalInterruptPayload(
-  askEntries: ReadonlyArray<AskEntry>
+  askEntries: ReadonlyArray<AskEntry>,
+  hookSessionId?: string
 ): t.ToolApprovalInterruptPayload {
   return {
     type: 'tool_approval',
+    ...(hookSessionId == null || hookSessionId === ''
+      ? {}
+      : { hook_session_id: hookSessionId }),
     action_requests: askEntries.map(({ entry, reason }) => {
       const request: t.ToolApprovalRequest = {
         tool_call_id: entry.call.id!,
@@ -1770,7 +1774,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             reason: preResult.reason,
             allowedDecisions: preResult.allowedDecisions,
           };
-          const payload = buildToolApprovalInterruptPayload([askEntry]);
+          const payload = buildToolApprovalInterruptPayload([askEntry], runId);
           const resumeValue = AsyncLocalStorageProviderSingleton.runWithConfig(
             config,
             () =>
@@ -2768,7 +2772,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * are pure — see `humanInTheLoop` docs).
        */
       if (askEntries.length > 0) {
-        const payload = buildToolApprovalInterruptPayload(askEntries);
+        const payload = buildToolApprovalInterruptPayload(askEntries, runId);
 
         /**
          * `interrupt()` reads the current `RunnableConfig` from

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -38,6 +38,7 @@ import type {
   HookRegistry,
   AggregatedHookResult,
   PostToolBatchEntry,
+  ToolApprovalReplayKey,
 } from '@/hooks';
 import type { ReplayableSubagentTool } from '@/tools/subagent/SubagentReplay';
 import type { RunBreakerScope } from '@/llm/streamLimits';
@@ -101,7 +102,31 @@ function stripRunBreakerScope(
 import { convertInjectedMessages } from '@/messages/injected';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { RunnableCallable, composeAbortSignals } from '@/utils';
-import { executeHooks } from '@/hooks';
+import {
+  executeHooks,
+  TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY,
+} from '@/hooks';
+
+function createToolApprovalReplayKey(
+  config: RunnableConfig,
+  agentId: string,
+  toolUseId: string
+): ToolApprovalReplayKey {
+  const configuredScope =
+    config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY];
+  const threadId = config.configurable?.thread_id;
+  let executionScope = '';
+  if (typeof configuredScope === 'string') {
+    executionScope = configuredScope;
+  } else if (typeof threadId === 'string') {
+    executionScope = threadId;
+  }
+  return {
+    executionScope,
+    agentId,
+    toolUseId,
+  };
+}
 
 /**
  * Per-call batch context for `runTool`. Bundles every optional
@@ -1597,12 +1622,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return output;
     };
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
+    const threadId = config.configurable?.thread_id as string | undefined;
     const hookRegistry = this.hookRegistry;
     const hasPreHook = hookRegistry?.hasHookFor('PreToolUse', runId) === true;
-    const pendingApproval =
+    const approvalReplayKey =
       call.id == null
         ? undefined
-        : hookRegistry?.getPendingToolApproval(runId, call.id);
+        : createToolApprovalReplayKey(
+          config,
+          this.executingAgentId ?? this.agentId ?? '',
+          call.id
+        );
+    const pendingApproval =
+      approvalReplayKey == null
+        ? undefined
+        : hookRegistry?.getPendingToolApproval(runId, approvalReplayKey);
     const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
@@ -1618,7 +1652,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return output instanceof ToolMessage ? persistOutput(output) : output;
     }
 
-    const threadId = config.configurable?.thread_id as string | undefined;
     const registryRunId =
       batchContext.batchScopeId ??
       (config.configurable?.run_id as string | undefined);
@@ -1705,7 +1738,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           },
           sessionId: runId,
           matchQuery: call.name,
-          onceReplayKey: call.id,
+          onceReplayKey: approvalReplayKey,
         }).catch(() => undefined));
 
       if (preResult != null) {
@@ -1793,7 +1826,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
               >(payload)
           );
-          hookRegistry.clearPendingToolApproval(runId, call.id!);
+          hookRegistry.clearPendingToolApproval(runId, approvalReplayKey!);
           const decisionByCallId = normalizeApprovalDecisions(
             [call.id!],
             resumeValue
@@ -2528,7 +2561,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const hasPendingApproval = preToolCalls.some(
       (entry) =>
         entry.call.id != null &&
-        hookRegistry?.getPendingToolApproval(runId, entry.call.id) != null
+        hookRegistry?.getPendingToolApproval(
+          runId,
+          createToolApprovalReplayKey(
+            config,
+            this.executingAgentId ?? this.agentId ?? '',
+            entry.call.id
+          )
+        ) != null
     );
     if (
       hookRegistry != null &&
@@ -2563,10 +2603,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const preResults = await Promise.all(
         preToolCalls.map((entry) => {
           const toolUseId = entry.call.id;
-          const pending =
+          const approvalReplayKey =
             toolUseId == null
               ? undefined
-              : hookRegistry.getPendingToolApproval(runId, toolUseId);
+              : createToolApprovalReplayKey(
+                config,
+                this.executingAgentId ?? this.agentId ?? '',
+                toolUseId
+              );
+          const pending =
+            approvalReplayKey == null
+              ? undefined
+              : hookRegistry.getPendingToolApproval(runId, approvalReplayKey);
           if (pending != null) {
             return pending;
           }
@@ -2586,7 +2634,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             sessionId: runId,
             matchQuery: entry.call.name,
-            onceReplayKey: toolUseId,
+            onceReplayKey: approvalReplayKey,
           }).catch((): AggregatedHookResult => HOOK_FALLBACK);
         })
       );
@@ -2833,7 +2881,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
 
         for (const { entry } of askEntries) {
-          hookRegistry.clearPendingToolApproval(runId, entry.call.id!);
+          hookRegistry.clearPendingToolApproval(
+            runId,
+            createToolApprovalReplayKey(
+              config,
+              this.executingAgentId ?? this.agentId ?? '',
+              entry.call.id!
+            )
+          );
         }
 
         const decisionByCallId = normalizeApprovalDecisions(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -147,6 +147,8 @@ type RunToolBatchContext<T = unknown> = {
    * contract for hosts relying on it for policy / recovery guidance.
    */
   additionalContextsSink?: string[];
+  /** Stable identity of the assistant tool-call batch across HITL replay. */
+  replayBatchKey?: string;
   /**
    * Graph state the ToolNode was invoked with, threaded from `run()`
    * so `tool.invoke` can forward it as langgraph 1.4's `runtime.state`
@@ -587,7 +589,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * the fresh batch needs for hook-context injection and completion events. */
   private settledInterruptingResults = new Map<
     string,
-    SettledDirectToolResult
+    Map<string, SettledDirectToolResult>
   >();
   /** Tool registry for filtering (lazy computation of programmatic maps) */
   private toolRegistry?: t.LCToolRegistry;
@@ -1559,14 +1561,25 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return settledOutput.output;
     }
     const replayAdditionalContexts: string[] = [];
-    const persistOutput = async (output: ToolMessage): Promise<ToolMessage> => {
+    const persistOutput = async (
+      output: ToolMessage,
+      terminalArgs?: Record<string, unknown>
+    ): Promise<ToolMessage> => {
       const refMeta = output.additional_kwargs as
         | t.ToolMessageRefMetadata
         | undefined;
+      if (
+        terminalArgs != null &&
+        call.id != null &&
+        batchContext.resolvedArgsByCallId != null
+      ) {
+        batchContext.resolvedArgsByCallId.set(call.id, terminalArgs);
+      }
       const resolvedArgs =
-        call.id == null
+        terminalArgs ??
+        (call.id == null
           ? undefined
-          : batchContext.resolvedArgsByCallId?.get(call.id);
+          : batchContext.resolvedArgsByCallId?.get(call.id));
       const referenceContent =
         this.toolOutputRegistry == null || refMeta?._refKey == null
           ? undefined
@@ -1703,14 +1716,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
 
         if (preResult.decision === 'deny') {
-          return this.blockDirectCall({
-            call,
-            resolvedArgs,
-            reason: preResult.reason ?? 'Blocked by hook',
-            hookRegistry,
-            runId,
-            threadId,
-          });
+          return persistOutput(
+            this.blockDirectCall({
+              call,
+              resolvedArgs,
+              reason: preResult.reason ?? 'Blocked by hook',
+              hookRegistry,
+              runId,
+              threadId,
+            }),
+            effectiveCall.args as Record<string, unknown>
+          );
         }
 
         if (preResult.decision === 'ask') {
@@ -1721,14 +1737,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               preResult.reason,
               call.name
             );
-            return this.blockDirectCall({
-              call,
-              resolvedArgs,
-              reason,
-              hookRegistry,
-              runId,
-              threadId,
-            });
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason,
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
           }
 
           // Raise a single-tool tool_approval interrupt. LangGraph
@@ -1777,25 +1796,32 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 declaredType as t.ToolApprovalDecisionType
               ))
           ) {
-            return this.blockDirectCall({
-              call,
-              resolvedArgs,
-              reason: `Decision "${typeof declaredType === 'string' ? declaredType : '<missing>'}" not in allowedDecisions [${preResult.allowedDecisions.join(', ')}] — failing closed`,
-              hookRegistry,
-              runId,
-              threadId,
-            });
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason: `Decision "${typeof declaredType === 'string' ? declaredType : '<missing>'}" not in allowedDecisions [${preResult.allowedDecisions.join(', ')}] — failing closed`,
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
           }
 
           if (decision.type === 'reject') {
-            return this.blockDirectCall({
-              call,
-              resolvedArgs,
-              reason: decision.reason ?? preResult.reason ?? 'Rejected by user',
-              hookRegistry,
-              runId,
-              threadId,
-            });
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason:
+                  decision.reason ?? preResult.reason ?? 'Rejected by user',
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
           }
 
           if (decision.type === 'respond') {
@@ -1812,12 +1838,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 threadId,
               });
             }
-            return new ToolMessage({
-              status: 'success',
-              content: responseText,
-              name: call.name,
-              tool_call_id: call.id ?? '',
-            });
+            return persistOutput(
+              new ToolMessage({
+                status: 'success',
+                content: responseText,
+                name: call.name,
+                tool_call_id: call.id ?? '',
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
           }
 
           if (decision.type === 'edit') {
@@ -1836,13 +1865,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               typeof updatedInput !== 'object' ||
               Array.isArray(updatedInput)
             ) {
-              return new ToolMessage({
-                status: 'error',
-                content:
-                  'Decision "edit" missing object updatedInput — failing closed.',
-                name: call.name,
-                tool_call_id: call.id ?? '',
-              });
+              return persistOutput(
+                new ToolMessage({
+                  status: 'error',
+                  content:
+                    'Decision "edit" missing object updatedInput — failing closed.',
+                  name: call.name,
+                  tool_call_id: call.id ?? '',
+                }),
+                effectiveCall.args as Record<string, unknown>
+              );
             }
             effectiveCall = {
               ...call,
@@ -3781,6 +3813,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     baseContext: Omit<RunToolBatchContext<T>, 'batchIndex'>
   ): Promise<(BaseMessage | Command)[]> {
+    const settledBatchResults =
+      baseContext.replayBatchKey == null
+        ? undefined
+        : this.settledInterruptingResults.get(baseContext.replayBatchKey);
     const restoreResult = (
       call: ToolCall,
       result: SettledDirectToolResult
@@ -3801,7 +3837,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     ): Promise<SettledDirectToolResult> => {
       const cachedResult =
         typeof call.id === 'string'
-          ? this.settledInterruptingResults.get(call.id)
+          ? settledBatchResults?.get(call.id)
           : undefined;
       if (cachedResult != null) {
         return restoreResult(call, cachedResult);
@@ -3870,8 +3906,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const position = interruptingPositions[i];
       outputs[position] = result.value.output;
       const callId = directCalls[position].id;
-      if (typeof callId === 'string' && callId !== '') {
-        this.settledInterruptingResults.set(callId, result.value);
+      if (
+        baseContext.replayBatchKey != null &&
+        typeof callId === 'string' &&
+        callId !== ''
+      ) {
+        const batchResults =
+          this.settledInterruptingResults.get(baseContext.replayBatchKey) ??
+          new Map<string, SettledDirectToolResult>();
+        batchResults.set(callId, result.value);
+        this.settledInterruptingResults.set(
+          baseContext.replayBatchKey,
+          batchResults
+        );
       }
     }
     if (hasInterruptingError) {
@@ -3982,6 +4029,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
     const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
+    let replayBatchKey: string | undefined;
     /** Hoisted from the messages-state branch so the Command tail can carry
      *  the promotion into handoff updates (same-id state copies there would
      *  otherwise overwrite the replacement message). */
@@ -4063,10 +4111,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
 
       let aiMessage: AIMessage | undefined;
+      let aiMessageIndex = -1;
       for (let i = messages.length - 1; i >= 0; i--) {
         const message = messages[i];
         if (isAIMessage(message)) {
           aiMessage = message;
+          aiMessageIndex = i;
           break;
         }
       }
@@ -4074,6 +4124,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (aiMessage == null || !isAIMessage(aiMessage)) {
         throw new Error('ToolNode only accepts AIMessages as input.');
       }
+      replayBatchKey = JSON.stringify([
+        incomingRunId ?? null,
+        aiMessage.id ?? null,
+        aiMessageIndex,
+        messages.length,
+      ]);
 
       if (this.loadRuntimeTools) {
         const { tools, toolMap } = this.loadRuntimeTools(
@@ -4293,6 +4349,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 errorOwnership,
                 preBatchSnapshot,
                 additionalContextsSink: directAdditionalContexts,
+                replayBatchKey,
                 runInput: input as T,
               }
             )
@@ -4365,6 +4422,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             errorOwnership,
             preBatchSnapshot,
             additionalContextsSink: directAdditionalContexts,
+            replayBatchKey,
             runInput: input as T,
           }
         );
@@ -4421,6 +4479,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
 
     if (!outputs.some(isCommand)) {
+      if (replayBatchKey != null) {
+        this.settledInterruptingResults.delete(replayBatchKey);
+      }
       return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
     }
 
@@ -4561,6 +4622,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       combinedOutputs.push(parentCommand);
     }
 
+    if (replayBatchKey != null) {
+      this.settledInterruptingResults.delete(replayBatchKey);
+    }
     return combinedOutputs as T;
   }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1496,9 +1496,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    *       `blockDirectCall`, `respond` returns the host-supplied
    *       `responseText` as a synthetic success ToolMessage,
    *       `edit` re-runs with edited args. LangGraph re-enters
-   *       ToolNode.run from the start on resume; the hook fires
-   *       again and the resume value distinguishes "first ask" from
-   *       "second pass with decision".
+   *       ToolNode.run from the start on resume. Reusable hooks fire
+   *       again; a consumed one-shot hook replays its pending approval
+   *       result. In both cases `interrupt()` consumes the resume value.
    *     • When HITL is off: collapses to a fail-closed deny (matches
    *       the rest of the SDK's HITL-disabled default). One-time
    *       warning logged so hosts notice the gap.
@@ -1599,13 +1599,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const hookRegistry = this.hookRegistry;
     const hasPreHook = hookRegistry?.hasHookFor('PreToolUse', runId) === true;
+    const pendingApproval =
+      call.id == null
+        ? undefined
+        : hookRegistry?.getPendingToolApproval(runId, call.id);
     const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
     if (
       hookRegistry == null ||
-      (!hasPreHook && !hasPostHook && !hasFailureHook)
+      (!hasPreHook &&
+        pendingApproval == null &&
+        !hasPostHook &&
+        !hasFailureHook)
     ) {
       const output = await this.runTool(call, config, batchContext);
       return output instanceof ToolMessage ? persistOutput(output) : output;
@@ -1679,24 +1686,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
 
     let effectiveCall = call;
-    if (hasPreHook) {
-      const preResult = await executeHooks({
-        registry: hookRegistry,
-        input: {
-          hook_event_name: 'PreToolUse',
-          runId,
-          threadId,
-          agentId: this.agentId,
-          executingAgentId: this.executingAgentId,
-          toolName: call.name,
-          toolInput: resolvedArgs,
-          toolUseId: call.id ?? '',
-          stepId,
-          turn,
-        },
-        sessionId: runId,
-        matchQuery: call.name,
-      }).catch(() => undefined);
+    if (hasPreHook || pendingApproval != null) {
+      const preResult =
+        pendingApproval ??
+        (await executeHooks({
+          registry: hookRegistry,
+          input: {
+            hook_event_name: 'PreToolUse',
+            runId,
+            threadId,
+            agentId: this.agentId,
+            executingAgentId: this.executingAgentId,
+            toolName: call.name,
+            toolInput: resolvedArgs,
+            toolUseId: call.id ?? '',
+            stepId,
+            turn,
+          },
+          sessionId: runId,
+          matchQuery: call.name,
+          onceReplayKey: call.id,
+        }).catch(() => undefined));
 
       if (preResult != null) {
         // Forward any additionalContext strings hooks returned into
@@ -1757,14 +1767,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // Raise a single-tool tool_approval interrupt. LangGraph
           // throws on the first execution (host gets the interrupt)
           // and returns the resume value on re-entry. Because direct
-          // tools re-enter the entire ToolNode.run on resume, the
-          // PreToolUse hook fires AGAIN — which is fine: the hook is
-          // expected to be deterministic, and the resume value is what
-          // distinguishes "first call asking" from "second call after
-          // approve/reject". We anchor `interrupt()` against the
+          // tools re-enter the entire ToolNode.run on resume. Reusable
+          // hooks fire again; a consumed one-shot hook instead replays
+          // the pending approval. We anchor `interrupt()` against the
           // node's RunnableConfig the same way `dispatchToolEvents`
-          // does (ToolNode disables LangSmith tracing, so the
-          // AsyncLocalStorage frame must be re-established here).
+          // does. A one-shot hook's pending aggregate reconstructs this
+          // same ask entry without dispatching the consumed hook again.
+          // ToolNode disables LangSmith tracing, so the AsyncLocalStorage
+          // frame must be re-established here.
           const askEntry: AskEntry = {
             entry: {
               call: effectiveCall,
@@ -1783,6 +1793,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
               >(payload)
           );
+          hookRegistry.clearPendingToolApproval(runId, call.id!);
           const decisionByCallId = normalizeApprovalDecisions(
             [call.id!],
             resumeValue
@@ -2513,13 +2524,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       errors: [] as string[],
     });
 
-    if (this.hookRegistry?.hasHookFor('PreToolUse', runId) === true) {
-      /**
-       * Capture as a non-null local so the inner `blockEntry` closure
-       * doesn't lose narrowing on `this.hookRegistry` and we don't have
-       * to defensively `?.` it across every reference inside.
-       */
-      const hookRegistry = this.hookRegistry;
+    const hookRegistry = this.hookRegistry;
+    const hasPendingApproval = preToolCalls.some(
+      (entry) =>
+        entry.call.id != null &&
+        hookRegistry?.getPendingToolApproval(runId, entry.call.id) != null
+    );
+    if (
+      hookRegistry != null &&
+      (hookRegistry.hasHookFor('PreToolUse', runId) || hasPendingApproval)
+    ) {
       /**
        * Pull each call's prestarted eager record BEFORE awaiting the hooks:
        * an async deny must never race the eager host promise into emitting a
@@ -2547,8 +2561,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       }
       const preResults = await Promise.all(
-        preToolCalls.map((entry) =>
-          executeHooks({
+        preToolCalls.map((entry) => {
+          const toolUseId = entry.call.id;
+          const pending =
+            toolUseId == null
+              ? undefined
+              : hookRegistry.getPendingToolApproval(runId, toolUseId);
+          if (pending != null) {
+            return pending;
+          }
+          return executeHooks({
             registry: hookRegistry,
             input: {
               hook_event_name: 'PreToolUse',
@@ -2564,8 +2586,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             sessionId: runId,
             matchQuery: entry.call.name,
-          }).catch((): AggregatedHookResult => HOOK_FALLBACK)
-        )
+            onceReplayKey: toolUseId,
+          }).catch((): AggregatedHookResult => HOOK_FALLBACK);
+        })
       );
 
       type PendingEntry = (typeof preToolCalls)[number];
@@ -2785,9 +2808,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * pauses, gathers human input, and resumes the run with one
        * decision per request. On resume LangGraph re-executes this node
        * from the start; `interrupt()` then returns the resume value
-       * instead of throwing, so the loop above re-runs and the same
-       * `askEntries` list is rebuilt deterministically (assuming hooks
-       * are pure — see `humanInTheLoop` docs).
+       * instead of throwing. Reusable hooks rebuild their entries, while
+       * consumed one-shot hooks replay their pending approval aggregate.
        */
       if (askEntries.length > 0) {
         const payload = buildToolApprovalInterruptPayload(askEntries, runId);
@@ -2809,6 +2831,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
             >(payload)
         );
+
+        for (const { entry } of askEntries) {
+          hookRegistry.clearPendingToolApproval(runId, entry.call.id!);
+        }
 
         const decisionByCallId = normalizeApprovalDecisions(
           askEntries.map(({ entry }) => entry.call.id!),

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -39,6 +39,7 @@ import type {
   AggregatedHookResult,
   PostToolBatchEntry,
 } from '@/hooks';
+import type { ReplayableSubagentTool } from '@/tools/subagent/SubagentReplay';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
 import {
@@ -83,6 +84,7 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
+import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
@@ -1504,6 +1506,69 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     batchContext: RunToolBatchContext<T> = {}
   ): Promise<BaseMessage | Command> {
+    const replayController = (
+      this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
+    )?.[SUBAGENT_REPLAY_CONTROLLER];
+    const settledOutput = await replayController?.getSettledOutput(
+      call,
+      config
+    );
+    if (settledOutput != null) {
+      if (
+        batchContext.additionalContextsSink != null &&
+        settledOutput.additionalContexts.length > 0
+      ) {
+        batchContext.additionalContextsSink.push(
+          ...settledOutput.additionalContexts
+        );
+      }
+      if (
+        batchContext.resolvedArgsByCallId != null &&
+        call.id != null &&
+        settledOutput.resolvedArgs != null
+      ) {
+        batchContext.resolvedArgsByCallId.set(
+          call.id,
+          settledOutput.resolvedArgs
+        );
+      }
+      const refMeta = settledOutput.output.additional_kwargs as
+        | t.ToolMessageRefMetadata
+        | undefined;
+      if (
+        this.toolOutputRegistry != null &&
+        refMeta?._refKey != null &&
+        settledOutput.referenceContent != null
+      ) {
+        this.toolOutputRegistry.set(
+          refMeta._refScope,
+          refMeta._refKey,
+          settledOutput.referenceContent
+        );
+      }
+      return settledOutput.output;
+    }
+    const replayAdditionalContexts: string[] = [];
+    const persistOutput = async (output: ToolMessage): Promise<ToolMessage> => {
+      const refMeta = output.additional_kwargs as
+        | t.ToolMessageRefMetadata
+        | undefined;
+      const resolvedArgs =
+        call.id == null
+          ? undefined
+          : batchContext.resolvedArgsByCallId?.get(call.id);
+      const referenceContent =
+        this.toolOutputRegistry == null || refMeta?._refKey == null
+          ? undefined
+          : this.toolOutputRegistry.get(refMeta._refScope, refMeta._refKey);
+      await replayController?.persistSettledOutput(call, config, {
+        output,
+        additionalContexts: replayAdditionalContexts,
+        ...(resolvedArgs == null ? {} : { resolvedArgs }),
+        ...(referenceContent == null ? {} : { referenceContent }),
+      });
+      return output;
+    };
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const hookRegistry = this.hookRegistry;
     const hasPreHook = hookRegistry?.hasHookFor('PreToolUse', runId) === true;
@@ -1515,7 +1580,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       hookRegistry == null ||
       (!hasPreHook && !hasPostHook && !hasFailureHook)
     ) {
-      return this.runTool(call, config, batchContext);
+      const output = await this.runTool(call, config, batchContext);
+      return output instanceof ToolMessage ? persistOutput(output) : output;
     }
 
     const threadId = config.configurable?.thread_id as string | undefined;
@@ -1610,11 +1676,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // the per-batch sink so the caller materializes them as a
         // HumanMessage for the next model turn — same shape as the
         // event-driven path's `injected[]`. Codex P2 #39.
-        if (
-          batchContext.additionalContextsSink != null &&
-          preResult.additionalContexts.length > 0
-        ) {
-          batchContext.additionalContextsSink.push(
+        if (preResult.additionalContexts.length > 0) {
+          replayAdditionalContexts.push(...preResult.additionalContexts);
+          batchContext.additionalContextsSink?.push(
             ...preResult.additionalContexts
           );
         }
@@ -1842,14 +1906,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }).catch(() => undefined);
       if (
         failureResult != null &&
-        batchContext.additionalContextsSink != null &&
         failureResult.additionalContexts.length > 0
       ) {
-        batchContext.additionalContextsSink.push(
+        replayAdditionalContexts.push(...failureResult.additionalContexts);
+        batchContext.additionalContextsSink?.push(
           ...failureResult.additionalContexts
         );
       }
-      return output;
+      return persistOutput(output);
     }
 
     if (output.status !== 'error' && hasPostHook) {
@@ -1874,12 +1938,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
       // Forward additionalContexts from the PostToolUse hook into
       // the per-batch sink (Codex P2 #39).
-      if (
-        postResult != null &&
-        batchContext.additionalContextsSink != null &&
-        postResult.additionalContexts.length > 0
-      ) {
-        batchContext.additionalContextsSink.push(
+      if (postResult != null && postResult.additionalContexts.length > 0) {
+        replayAdditionalContexts.push(...postResult.additionalContexts);
+        batchContext.additionalContextsSink?.push(
           ...postResult.additionalContexts
         );
       }
@@ -1891,7 +1952,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               'PostToolUse updatedOutput for a computer call must be a valid screenshot URL or screenshot content block.'
             );
           }
-          return cloneToolMessageWithContent(output, postResult.updatedOutput);
+          return persistOutput(
+            cloneToolMessageWithContent(output, postResult.updatedOutput)
+          );
         }
         // Keep the tool-output registry in sync with what the model
         // actually sees. Without this, `runTool` already registered
@@ -1921,11 +1984,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             replaced.registryContent
           );
         }
-        return cloneToolMessageWithContent(output, replaced.content);
+        return persistOutput(
+          cloneToolMessageWithContent(output, replaced.content)
+        );
       }
     }
 
-    return output;
+    return persistOutput(output);
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -58,6 +58,11 @@ import {
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
+  attachSubagentResumeManifest,
+  SUBAGENT_PARENT_BATCH_CONFIG_KEY,
+  SUBAGENT_REPLAY_CONTROLLER,
+} from '@/tools/subagent/SubagentReplay';
+import {
   INTENT_ARG,
   readOutcomeFields,
   resolveToolOutcome,
@@ -69,10 +74,6 @@ import {
   resolveRuntimeSessionHint,
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
-import {
-  attachSubagentResumeManifest,
-  SUBAGENT_REPLAY_CONTROLLER,
-} from '@/tools/subagent/SubagentReplay';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
@@ -1598,9 +1599,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const replayController = (
       this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
     )?.[SUBAGENT_REPLAY_CONTROLLER];
+    const replayConfig =
+      replayController == null || batchContext.replayBatchKey == null
+        ? config
+        : {
+          ...config,
+          configurable: {
+            ...config.configurable,
+            [SUBAGENT_PARENT_BATCH_CONFIG_KEY]: batchContext.replayBatchKey,
+          },
+        };
     const settledOutput = await replayController?.getSettledOutput(
       call,
-      config
+      replayConfig
     );
     if (settledOutput != null) {
       if (
@@ -1661,7 +1672,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.toolOutputRegistry == null || refMeta?._refKey == null
           ? undefined
           : this.toolOutputRegistry.get(refMeta._refScope, refMeta._refKey);
-      await replayController?.persistSettledOutput(call, config, {
+      await replayController?.persistSettledOutput(call, replayConfig, {
         output,
         additionalContexts: replayAdditionalContexts,
         ...(resolvedArgs == null ? {} : { resolvedArgs }),
@@ -1703,7 +1714,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         !hasPostHook &&
         !hasFailureHook)
     ) {
-      const output = await this.runTool(call, config, batchContext);
+      const output = await this.runTool(call, replayConfig, batchContext);
       return output instanceof ToolMessage ? persistOutput(output) : output;
     }
 
@@ -1968,7 +1979,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             return persistOutput(
               new ToolMessage({
                 status: 'success',
-                content: responseText,
+                content: truncateToolResultContent(
+                  responseText,
+                  this.maxToolResultChars
+                ),
                 name: call.name,
                 tool_call_id: call.id ?? '',
               }),
@@ -2050,7 +2064,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
     }
 
-    const output = await this.runTool(effectiveCall, config, {
+    const output = await this.runTool(effectiveCall, replayConfig, {
       ...batchContext,
       usageCount,
     });

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -370,6 +370,38 @@ function describeOfferedShape(value: unknown): string {
   return typeof value;
 }
 
+type AssistantBatch = {
+  message: AIMessage;
+  index: number;
+  messageCount: number;
+};
+
+function findAssistantBatch(
+  messages: BaseMessage[]
+): AssistantBatch | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (isAIMessage(message)) {
+      return { message, index: i, messageCount: messages.length };
+    }
+  }
+  return undefined;
+}
+
+function getAssistantBatchReplayKey(
+  batch: AssistantBatch,
+  runId: string | undefined,
+  threadId: string | undefined
+): string {
+  return JSON.stringify([
+    runId ?? null,
+    threadId ?? null,
+    batch.message.id ?? null,
+    batch.index,
+    batch.messageCount,
+  ]);
+}
+
 /**
  * Per-entry record collected during PreToolUse hook handling for tool
  * calls that need human approval. Carries everything
@@ -4263,6 +4295,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * every subsequent registry call on this batch.
      */
     const incomingRunId = config.configurable?.run_id as string | undefined;
+    const incomingThreadId = config.configurable?.thread_id as
+      | string
+      | undefined;
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
     const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
@@ -4294,6 +4329,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // Mirror langgraph's prebuilt ToolNode: the Send-input state is
       // the input minus the `lg_tool_call` envelope key.
       const { lg_tool_call: _sendToolCall, ...sendState } = input;
+      const sendMessages = (sendState as { messages?: unknown }).messages;
+      const sendAssistantBatch = Array.isArray(sendMessages)
+        ? findAssistantBatch(sendMessages as BaseMessage[])
+        : undefined;
+      const sendReplayBatchKey =
+        sendAssistantBatch == null
+          ? undefined
+          : getAssistantBatchReplayKey(
+            sendAssistantBatch,
+            incomingRunId,
+            incomingThreadId
+          );
       const sendOutput = await this.runDirectToolWithLifecycleHooks(
         input.lg_tool_call,
         config,
@@ -4304,6 +4351,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           resolvedArgsByCallId,
           errorOwnership,
           additionalContextsSink: directAdditionalContexts,
+          replayBatchKey: sendReplayBatchKey,
           runInput: sendState as T,
         }
       );
@@ -4347,26 +4395,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           .map((msg) => (msg as ToolMessage).tool_call_id)
       );
 
-      let aiMessage: AIMessage | undefined;
-      let aiMessageIndex = -1;
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const message = messages[i];
-        if (isAIMessage(message)) {
-          aiMessage = message;
-          aiMessageIndex = i;
-          break;
-        }
-      }
-
-      if (aiMessage == null || !isAIMessage(aiMessage)) {
+      const assistantBatch = findAssistantBatch(messages);
+      if (assistantBatch == null) {
         throw new Error('ToolNode only accepts AIMessages as input.');
       }
-      replayBatchKey = JSON.stringify([
-        incomingRunId ?? null,
-        aiMessage.id ?? null,
-        aiMessageIndex,
-        messages.length,
-      ]);
+      const aiMessage = assistantBatch.message;
+      replayBatchKey = getAssistantBatchReplayKey(
+        assistantBatch,
+        incomingRunId,
+        incomingThreadId
+      );
 
       if (this.loadRuntimeTools) {
         const { tools, toolMap } = this.loadRuntimeTools(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -136,6 +136,17 @@ function createToolApprovalReplayKey(
   };
 }
 
+function getToolApprovalReplaySessionId(
+  config: RunnableConfig,
+  hookSessionId: string
+): string {
+  const configuredScope =
+    config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY];
+  return typeof configuredScope === 'string' && configuredScope.length > 0
+    ? configuredScope
+    : hookSessionId;
+}
+
 /**
  * Per-call batch context for `runTool`. Bundles every optional
  * batch-scoped value the method needs so the signature stays at
@@ -1670,10 +1681,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           this.executingAgentId ?? this.agentId ?? '',
           call.id
         );
+    const approvalReplaySessionId = getToolApprovalReplaySessionId(
+      config,
+      runId
+    );
     const pendingApproval =
       approvalReplayKey == null
         ? undefined
-        : hookRegistry?.getPendingToolApproval(runId, approvalReplayKey);
+        : hookRegistry?.getPendingToolApproval(
+          approvalReplaySessionId,
+          approvalReplayKey
+        );
     const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
@@ -1774,6 +1792,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         sessionId: runId,
         matchQuery: call.name,
         onceReplayKey: approvalReplayKey,
+        onceReplaySessionId: approvalReplaySessionId,
       }).catch(() => undefined);
 
       if (preResult != null) {
@@ -1880,7 +1899,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
               >(payload)
           );
-          hookRegistry.clearPendingToolApproval(runId, approvalReplayKey);
+          hookRegistry.clearPendingToolApproval(
+            approvalReplaySessionId,
+            approvalReplayKey
+          );
           const decisionByCallId = normalizeApprovalDecisions(
             [toolCallId],
             resumeValue
@@ -2612,11 +2634,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     });
 
     const hookRegistry = this.hookRegistry;
+    const approvalReplaySessionId = getToolApprovalReplaySessionId(
+      config,
+      runId
+    );
     const hasPendingApproval = preToolCalls.some(
       (entry) =>
         entry.call.id != null &&
         hookRegistry?.getPendingToolApproval(
-          runId,
+          approvalReplaySessionId,
           createToolApprovalReplayKey(
             config,
             this.executingAgentId ?? this.agentId ?? '',
@@ -2665,13 +2691,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 this.executingAgentId ?? this.agentId ?? '',
                 toolUseId
               );
-          const pending =
-            approvalReplayKey == null
-              ? undefined
-              : hookRegistry.getPendingToolApproval(runId, approvalReplayKey);
-          if (pending != null) {
-            return pending;
-          }
           return executeHooks({
             registry: hookRegistry,
             input: {
@@ -2689,6 +2708,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             sessionId: runId,
             matchQuery: entry.call.name,
             onceReplayKey: approvalReplayKey,
+            onceReplaySessionId: approvalReplaySessionId,
           }).catch((): AggregatedHookResult => HOOK_FALLBACK);
         })
       );
@@ -2936,7 +2956,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         for (const { entry } of askEntries) {
           hookRegistry.clearPendingToolApproval(
-            runId,
+            approvalReplaySessionId,
             createToolApprovalReplayKey(
               config,
               this.executingAgentId ?? this.agentId ?? '',
@@ -4117,15 +4137,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           throw new GraphInterrupt(
             interruptingError.interrupts.map((pendingInterrupt) => ({
               ...pendingInterrupt,
-              value:
-                pendingInterrupt.value != null &&
-                typeof pendingInterrupt.value === 'object' &&
-                !Array.isArray(pendingInterrupt.value)
-                  ? attachSubagentResumeManifest(
-                    pendingInterrupt.value,
-                    manifest
-                  )
-                  : pendingInterrupt.value,
+              value: attachSubagentResumeManifest(
+                pendingInterrupt.value,
+                manifest
+              ),
             }))
           );
         }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -158,6 +158,12 @@ type RunToolBatchContext<T = unknown> = {
   errorOwnership?: ToolErrorOwnership;
 };
 
+type SettledDirectToolResult = {
+  output: BaseMessage | Command;
+  additionalContexts: string[];
+  resolvedArgs?: Record<string, unknown>;
+};
+
 /**
  * Batch-local record of who owns each failed call's completion event.
  *
@@ -576,9 +582,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * the Run ends.
    */
   private directPathTurns: Map<string, number> = new Map();
-  /** Terminal outputs from interrupting siblings that must survive a
-   * LangGraph replay of the containing ToolNode. */
-  private settledInterruptingOutputs = new Map<string, BaseMessage | Command>();
+  /** Terminal results from interrupting siblings that must survive a
+   * LangGraph replay of the containing ToolNode. Includes the sidecar data
+   * the fresh batch needs for hook-context injection and completion events. */
+  private settledInterruptingResults = new Map<
+    string,
+    SettledDirectToolResult
+  >();
   /** Tool registry for filtering (lazy computation of programmatic maps) */
   private toolRegistry?: t.LCToolRegistry;
   /** Cached programmatic tools (computed once on first PTC call) */
@@ -945,7 +955,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   clearDirectPathTurns(): void {
     this.directPathTurns.clear();
-    this.settledInterruptingOutputs.clear();
+    this.settledInterruptingResults.clear();
   }
 
   /**
@@ -3771,20 +3781,45 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     baseContext: Omit<RunToolBatchContext<T>, 'batchIndex'>
   ): Promise<(BaseMessage | Command)[]> {
-    const runOne = (
+    const restoreResult = (
+      call: ToolCall,
+      result: SettledDirectToolResult
+    ): SettledDirectToolResult => {
+      baseContext.additionalContextsSink?.push(...result.additionalContexts);
+      if (
+        call.id != null &&
+        result.resolvedArgs != null &&
+        baseContext.resolvedArgsByCallId != null
+      ) {
+        baseContext.resolvedArgsByCallId.set(call.id, result.resolvedArgs);
+      }
+      return result;
+    };
+    const runOne = async (
       call: ToolCall,
       position: number
-    ): Promise<BaseMessage | Command> => {
-      const cachedOutput =
+    ): Promise<SettledDirectToolResult> => {
+      const cachedResult =
         typeof call.id === 'string'
-          ? this.settledInterruptingOutputs.get(call.id)
+          ? this.settledInterruptingResults.get(call.id)
           : undefined;
-      if (cachedOutput != null) {
-        return Promise.resolve(cachedOutput);
+      if (cachedResult != null) {
+        return restoreResult(call, cachedResult);
       }
-      return this.runDirectToolWithLifecycleHooks(call, config, {
+      const additionalContexts: string[] = [];
+      const output = await this.runDirectToolWithLifecycleHooks(call, config, {
         ...baseContext,
         batchIndex: batchIndices[position],
+        additionalContextsSink: additionalContexts,
+      });
+      const resolvedArgs =
+        call.id == null
+          ? undefined
+          : baseContext.resolvedArgsByCallId?.get(call.id);
+      return restoreResult(call, {
+        output,
+        additionalContexts,
+        ...(resolvedArgs == null ? {} : { resolvedArgs }),
       });
     };
 
@@ -3794,7 +3829,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       directCalls.some((call) => interrupting.has(call.name));
 
     if (!hasInterrupting) {
-      return Promise.all(directCalls.map((call, i) => runOne(call, i)));
+      const results = await Promise.all(
+        directCalls.map((call, i) => runOne(call, i))
+      );
+      return results.map((result) => result.output);
     }
 
     const outputs: (BaseMessage | Command)[] = new Array(directCalls.length);
@@ -3830,10 +3868,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
       const position = interruptingPositions[i];
-      outputs[position] = result.value;
+      outputs[position] = result.value.output;
       const callId = directCalls[position].id;
       if (typeof callId === 'string' && callId !== '') {
-        this.settledInterruptingOutputs.set(callId, result.value);
+        this.settledInterruptingResults.set(callId, result.value);
       }
     }
     if (hasInterruptingError) {
@@ -3850,7 +3888,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       regularPositions.map((i) => runOne(directCalls[i], i))
     );
     regularPositions.forEach((i, k) => {
-      outputs[i] = regularOutputs[k];
+      outputs[i] = regularOutputs[k].output;
     });
 
     return outputs;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -12,6 +12,7 @@ import {
   END,
   Send,
   Command,
+  GraphInterrupt,
   isCommand,
   interrupt,
   isGraphInterrupt,
@@ -35,12 +36,16 @@ import type {
   ResolveOptions,
 } from '@/tools/toolOutputReferences';
 import type {
+  ReplayableSubagentTool,
+  SubagentResumeManifest,
+  SubagentToolNodeResumeState,
+} from '@/tools/subagent/SubagentReplay';
+import type {
   HookRegistry,
   AggregatedHookResult,
   PostToolBatchEntry,
   ToolApprovalReplayKey,
 } from '@/hooks';
-import type { ReplayableSubagentTool } from '@/tools/subagent/SubagentReplay';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
 import {
@@ -65,6 +70,10 @@ import {
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
 import {
+  attachSubagentResumeManifest,
+  SUBAGENT_REPLAY_CONTROLLER,
+} from '@/tools/subagent/SubagentReplay';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -85,7 +94,6 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
-import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
@@ -1021,6 +1029,35 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   public getToolUsageCounts(): ReadonlyMap<string, number> {
     return new Map(this.toolUsageCount); // Return a copy
+  }
+
+  createSubagentResumeState(): SubagentToolNodeResumeState {
+    return {
+      stateKey: JSON.stringify([
+        this.executingAgentId ?? '',
+        this.agentId ?? '',
+        this.name,
+      ]),
+      toolUsageCounts: [...this.toolUsageCount].map(([toolName, count]) => ({
+        toolName,
+        count,
+      })),
+      directPathTurns: [...this.directPathTurns].map(([toolCallId, turn]) => ({
+        toolCallId,
+        turn,
+      })),
+    };
+  }
+
+  restoreSubagentResumeState(state: SubagentToolNodeResumeState): void {
+    this.toolUsageCount.clear();
+    for (const { toolName, count } of state.toolUsageCounts) {
+      this.toolUsageCount.set(toolName, count);
+    }
+    this.directPathTurns.clear();
+    for (const { toolCallId, turn } of state.directPathTurns) {
+      this.directPathTurns.set(toolCallId, turn);
+    }
   }
 
   private recordToolUsageTurn(
@@ -4025,6 +4062,57 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
     if (hasInterruptingError) {
+      if (isGraphInterrupt(interruptingError)) {
+        const controllers = new Set<
+          NonNullable<ReplayableSubagentTool[typeof SUBAGENT_REPLAY_CONTROLLER]>
+        >();
+        const parentToolCallIds = new Set<string>();
+        for (const call of directCalls) {
+          const controller = (
+            this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
+          )?.[SUBAGENT_REPLAY_CONTROLLER];
+          if (controller?.getResumeManifest != null) {
+            controllers.add(controller);
+          }
+          if (call.id != null && call.id !== '') {
+            parentToolCallIds.add(call.id);
+          }
+        }
+        const executionsByParentCall = new Map<
+          string,
+          SubagentResumeManifest['executions'][number]
+        >();
+        for (const controller of controllers) {
+          const manifest =
+            await controller.getResumeManifest?.(parentToolCallIds);
+          if (manifest != null) {
+            for (const execution of manifest.executions) {
+              executionsByParentCall.set(execution.parentToolCallId, execution);
+            }
+          }
+        }
+        const executions = [...executionsByParentCall.values()];
+        if (executions.length > 0) {
+          const manifest: SubagentResumeManifest = {
+            version: 1,
+            executions,
+          };
+          throw new GraphInterrupt(
+            interruptingError.interrupts.map((pendingInterrupt) => ({
+              ...pendingInterrupt,
+              value:
+                pendingInterrupt.value != null &&
+                typeof pendingInterrupt.value === 'object' &&
+                !Array.isArray(pendingInterrupt.value)
+                  ? attachSubagentResumeManifest(
+                    pendingInterrupt.value,
+                    manifest
+                  )
+                  : pendingInterrupt.value,
+            }))
+          );
+        }
+      }
       throw interruptingError;
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1663,7 +1663,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const hookRegistry = this.hookRegistry;
     const hasPreHook = hookRegistry?.hasHookFor('PreToolUse', runId) === true;
     const approvalReplayKey =
-      call.id == null
+      call.id == null || call.id === ''
         ? undefined
         : createToolApprovalReplayKey(
           config,
@@ -1757,26 +1757,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     let effectiveCall = call;
     if (hasPreHook || pendingApproval != null) {
-      const preResult =
-        pendingApproval ??
-        (await executeHooks({
-          registry: hookRegistry,
-          input: {
-            hook_event_name: 'PreToolUse',
-            runId,
-            threadId,
-            agentId: this.agentId,
-            executingAgentId: this.executingAgentId,
-            toolName: call.name,
-            toolInput: resolvedArgs,
-            toolUseId: call.id ?? '',
-            stepId,
-            turn,
-          },
-          sessionId: runId,
-          matchQuery: call.name,
-          onceReplayKey: approvalReplayKey,
-        }).catch(() => undefined));
+      const preResult = await executeHooks({
+        registry: hookRegistry,
+        input: {
+          hook_event_name: 'PreToolUse',
+          runId,
+          threadId,
+          agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
+          toolName: call.name,
+          toolInput: resolvedArgs,
+          toolUseId: call.id ?? '',
+          stepId,
+          turn,
+        },
+        sessionId: runId,
+        matchQuery: call.name,
+        onceReplayKey: approvalReplayKey,
+      }).catch(() => undefined);
 
       if (preResult != null) {
         // Forward any additionalContext strings hooks returned into
@@ -1833,6 +1831,25 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               effectiveCall.args as Record<string, unknown>
             );
           }
+          const toolCallId = call.id;
+          if (
+            toolCallId == null ||
+            toolCallId === '' ||
+            approvalReplayKey == null
+          ) {
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason:
+                  'Tool approval requires a non-empty tool call ID — failing closed',
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
+          }
 
           // Raise a single-tool tool_approval interrupt. LangGraph
           // throws on the first execution (host gets the interrupt)
@@ -1841,7 +1858,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // hooks fire again; a consumed one-shot hook instead replays
           // the pending approval. We anchor `interrupt()` against the
           // node's RunnableConfig the same way `dispatchToolEvents`
-          // does. A one-shot hook's pending aggregate reconstructs this
+          // does. A one-shot hook's pending contribution reconstructs this
           // same ask entry without dispatching the consumed hook again.
           // ToolNode disables LangSmith tracing, so the AsyncLocalStorage
           // frame must be re-established here.
@@ -1863,12 +1880,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
               >(payload)
           );
-          hookRegistry.clearPendingToolApproval(runId, approvalReplayKey!);
+          hookRegistry.clearPendingToolApproval(runId, approvalReplayKey);
           const decisionByCallId = normalizeApprovalDecisions(
-            [call.id!],
+            [toolCallId],
             resumeValue
           );
-          const decision = decisionByCallId.get(call.id!) ?? {
+          const decision = decisionByCallId.get(toolCallId) ?? {
             type: 'reject' as const,
             reason: 'No decision provided for tool approval',
           };

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1832,15 +1832,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             const responseText = (decision as { responseText?: unknown })
               .responseText;
             if (typeof responseText !== 'string') {
-              return this.blockDirectCall({
-                call,
-                resolvedArgs,
-                reason:
-                  'Approval payload `respond` was missing a string `responseText`',
-                hookRegistry,
-                runId,
-                threadId,
-              });
+              return persistOutput(
+                this.blockDirectCall({
+                  call,
+                  resolvedArgs,
+                  reason:
+                    'Approval payload `respond` was missing a string `responseText`',
+                  hookRegistry,
+                  runId,
+                  threadId,
+                }),
+                effectiveCall.args as Record<string, unknown>
+              );
             }
             return persistOutput(
               new ToolMessage({
@@ -1885,6 +1888,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               args: updatedInput as Record<string, unknown>,
             };
             // fall through to executing the edited call
+          }
+          if (declaredType !== 'approve' && declaredType !== 'edit') {
+            const unknownType =
+              typeof declaredType === 'string' ? declaredType : '<missing>';
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason: `Unknown approval decision type "${unknownType}" — failing closed`,
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
           }
           // 'approve' (or 'edit' after applying edits) → fall through
         }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3738,6 +3738,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const interruptingResults = await Promise.allSettled(
       interruptingPositions.map((i) => runOne(directCalls[i], i))
     );
+    /** A sibling may have tripped the run-wide breaker while another raised
+     * a GraphInterrupt. Safety failures take precedence over approval pauses
+     * regardless of input order. */
+    this.throwIfBreakerTripped(config);
     let hasInterruptingError = false;
     let interruptingError: unknown;
     for (let i = 0; i < interruptingResults.length; i++) {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,5 +1,5 @@
-import { GraphInterrupt } from '@langchain/langgraph';
 import { describe, it, expect, beforeEach } from '@jest/globals';
+import { GraphInterrupt, MemorySaver } from '@langchain/langgraph';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type {
@@ -511,6 +511,129 @@ describe('SubagentExecutor', () => {
     expect(result.content).toContain('requires a parent tool call ID');
     expect(result.messages).toEqual([]);
     expect(createChildGraph).not.toHaveBeenCalled();
+  });
+
+  it('persists terminal replay outcomes without an active child workflow', async () => {
+    const checkpointer = new MemorySaver();
+    const hookRegistry = new HookRegistry();
+    hookRegistry.registerSession('original-run', 'PreToolUse', {
+      hooks: [async (): Promise<Record<string, never>> => ({})],
+    });
+    const initialExecutor = createExecutor({
+      checkpointer,
+      hookRegistry,
+      humanInTheLoop: { enabled: true },
+      parentRunId: 'original-run',
+    });
+    const call = {
+      id: 'call_terminal',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'blocked before execution',
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call' as const,
+    };
+    const originalConfig = {
+      configurable: {
+        thread_id: 'durable-parent',
+        checkpoint_id: 'parent-fork',
+        run_id: 'original-run',
+      },
+    };
+    const settled = {
+      output: new ToolMessage({
+        content: 'Blocked: policy',
+        status: 'error' as const,
+        name: Constants.SUBAGENT,
+        tool_call_id: call.id,
+      }),
+      additionalContexts: ['persisted context'],
+      resolvedArgs: { description: 'rewritten' },
+    };
+
+    await initialExecutor.persistSettledToolOutput(
+      call,
+      originalConfig,
+      settled
+    );
+
+    const rebuiltExecutor = createExecutor({
+      checkpointer,
+      hookRegistry,
+      humanInTheLoop: { enabled: true },
+      parentRunId: 'rebuilt-run',
+    });
+    const restored = await rebuiltExecutor.getSettledToolOutput(call, {
+      configurable: {
+        ...originalConfig.configurable,
+        run_id: 'rebuilt-run',
+      },
+    });
+
+    expect(restored?.output.content).toBe('Blocked: policy');
+    expect(restored?.additionalContexts).toEqual(['persisted context']);
+    expect(restored?.resolvedArgs).toEqual({ description: 'rewritten' });
+    expect(hookRegistry.hasHookFor('PreToolUse', 'original-run')).toBe(false);
+    expect(hookRegistry.hasHookFor('PreToolUse', 'rebuilt-run')).toBe(true);
+  });
+
+  it('persists an ordinary child error after the active workflow is released', async () => {
+    const checkpointer = new MemorySaver();
+    const invoke = jest.fn().mockRejectedValue(new Error('child failed'));
+    const executor = createExecutor({
+      checkpointer,
+      humanInTheLoop: { enabled: true },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({
+            getState: jest.fn().mockResolvedValue({
+              values: {},
+              next: ['child-agent'],
+              tasks: [],
+            }),
+            invoke,
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const call = {
+      id: 'call_error',
+      name: Constants.SUBAGENT,
+      args: { description: 'fail', subagent_type: 'researcher' },
+      type: 'tool_call' as const,
+    };
+    const runnableConfig = {
+      configurable: {
+        thread_id: 'durable-parent',
+        checkpoint_id: 'parent-fork',
+        run_id: 'original-run',
+      },
+    };
+    const result = await executor.execute({
+      description: 'fail',
+      subagentType: 'researcher',
+      threadId: 'durable-parent',
+      parentToolCallId: call.id,
+      parentConfigurable: runnableConfig.configurable,
+    });
+    expect(result.content).toBe('Subagent error: child failed');
+
+    await executor.persistSettledToolOutput(call, runnableConfig, {
+      output: new ToolMessage({
+        content: result.content,
+        name: Constants.SUBAGENT,
+        tool_call_id: call.id,
+      }),
+      additionalContexts: [],
+    });
+
+    const restored = await createExecutor({
+      checkpointer,
+      humanInTheLoop: { enabled: true },
+    }).getSettledToolOutput(call, runnableConfig);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(restored?.output.content).toBe('Subagent error: child failed');
   });
 
   it('preserves an existing nested approval scope', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -20,6 +20,7 @@ import {
   summarizeEvent,
 } from '../subagent';
 import { sanitizeForwardedSubagentUpdateData } from '../subagent/SubagentExecutor';
+import { SUBAGENT_PARENT_BATCH_CONFIG_KEY } from '../subagent/SubagentReplay';
 import { Constants, Providers, GraphEvents, StepTypes } from '@/common';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { AgentContext } from '@/agents/AgentContext';
@@ -1618,6 +1619,7 @@ describe('SubagentExecutor', () => {
           checkpoint_id: 'parent-checkpoint-id',
           checkpoint_map: { parent: 'checkpoint' },
           checkpoint_ns: 'parent-checkpoint-ns',
+          [SUBAGENT_PARENT_BATCH_CONFIG_KEY]: 'assistant-batch',
           requestBody: { messageId: 'msg-1' },
           thread_id: 'parent-thread',
           user: { id: 'user_abc' },
@@ -1634,6 +1636,7 @@ describe('SubagentExecutor', () => {
       expect(configurable.checkpoint_id).toBeUndefined();
       expect(configurable.checkpoint_map).toBeUndefined();
       expect(configurable.checkpoint_ns).toBeUndefined();
+      expect(configurable[SUBAGENT_PARENT_BATCH_CONFIG_KEY]).toBeUndefined();
       expect(configurable.requestBody).toEqual({ messageId: 'msg-1' });
       expect(configurable.thread_id).toBe('parent-thread');
       expect(configurable.user).toEqual({ id: 'user_abc' });
@@ -1697,6 +1700,62 @@ describe('SubagentExecutor', () => {
       expect(childThreadIds[0]).toMatch(/^subagent:/);
       expect(childThreadIds[1]).toMatch(/^subagent:/);
       expect(childThreadIds[0]).not.toBe(childThreadIds[1]);
+    });
+
+    it('isolates reused tool-call IDs across assistant batches', async () => {
+      const invokedThreadIds: string[] = [];
+      const executor = createExecutor({
+        humanInTheLoop: { enabled: true },
+        createChildGraph: (): StandardGraph =>
+          ({
+            createWorkflow: () => ({
+              getState: jest.fn().mockResolvedValue({
+                values: {},
+                next: [],
+                tasks: [],
+              }),
+              invoke: jest
+                .fn()
+                .mockImplementation(
+                  async (
+                    _input: unknown,
+                    invokeConfig: Record<string, unknown>
+                  ): Promise<{ messages: BaseMessage[] }> => {
+                    invokedThreadIds.push(
+                      (invokeConfig.configurable as Record<string, unknown>)
+                        .thread_id as string
+                    );
+                    return { messages: [new AIMessage('done')] };
+                  }
+                ),
+            }),
+            clearHeavyState: jest.fn(),
+          }) as unknown as StandardGraph,
+      });
+      const common = {
+        description: 'task',
+        subagentType: 'researcher',
+        threadId: 'parent-thread',
+        parentToolCallId: 'call_reused',
+      };
+
+      await executor.execute({
+        ...common,
+        parentConfigurable: {
+          thread_id: 'parent-thread',
+          [SUBAGENT_PARENT_BATCH_CONFIG_KEY]: 'assistant-batch-1',
+        },
+      });
+      await executor.execute({
+        ...common,
+        parentConfigurable: {
+          thread_id: 'parent-thread',
+          [SUBAGENT_PARENT_BATCH_CONFIG_KEY]: 'assistant-batch-2',
+        },
+      });
+
+      expect(invokedThreadIds).toHaveLength(2);
+      expect(invokedThreadIds[0]).not.toBe(invokedThreadIds[1]);
     });
 
     it('keeps ambiguous parent agent and tool-call components collision-free', async () => {
@@ -1781,6 +1840,9 @@ describe('SubagentExecutor', () => {
 
       expect(beforeCleanup).toHaveLength(1);
       expect(executor.getChildCheckpointThreadIds()).toEqual(beforeCleanup);
+
+      executor.resetCheckpointThreadIds();
+      expect(executor.getChildCheckpointThreadIds()).toEqual([]);
     });
 
     it('includes checkpoint threads from active descendant graphs', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,3 +1,4 @@
+import { GraphInterrupt } from '@langchain/langgraph';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
@@ -349,8 +350,7 @@ describe('buildChildInputs', () => {
     /**
      * Self-spawn: `resolveSubagentConfigs` fills `agentInputs` as a shallow
      * spread of the parent's `_sourceInputs`, so the parent-scoped direct
-     * tool would leak into a checkpointer-less child graph and fail with
-     * `No checkpointer set` — must be scrubbed.
+     * tool would leak into the child implicitly — it must be scrubbed.
      */
     const selfConfig: ResolvedSubagentConfig = {
       type: 'self',
@@ -365,9 +365,8 @@ describe('buildChildInputs', () => {
 
     /**
      * Explicit child config: a host that deliberately attaches its own
-     * in-process direct tools to a child keeps them (Codex #289 P2 —
-     * interrupt-capable tools still fail in children, but non-interrupting
-     * direct tools are legitimate there).
+     * in-process direct tools to a child keeps them (Codex #289 P2). With
+     * HITL enabled, interrupt-capable child tools use the shared checkpointer.
      */
     const explicitConfig: ResolvedSubagentConfig = {
       type: 'researcher',
@@ -494,6 +493,59 @@ describe('SubagentExecutor', () => {
     });
     expect(result.content).toContain('Maximum subagent nesting depth');
     expect(result.messages).toEqual([]);
+  });
+
+  it('preserves an existing nested approval scope', async () => {
+    const nestedScope = {
+      run_id: 'grandchild-run',
+      agent_id: 'grandchild-agent',
+      subagent_type: 'grandchild',
+      parent_tool_call_id: 'call_grandchild',
+    };
+    const nestedInterrupt = new GraphInterrupt([
+      {
+        id: 'nested-interrupt',
+        value: {
+          type: 'tool_approval',
+          action_requests: [],
+          review_configs: [],
+          subagent: nestedScope,
+        },
+      },
+    ]);
+    const executor = createExecutor({
+      humanInTheLoop: { enabled: true },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({
+            getState: jest.fn().mockResolvedValue({
+              values: {},
+              next: ['agent'],
+              tasks: [],
+            }),
+            invoke: jest.fn().mockRejectedValue(nestedInterrupt),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    let received: GraphInterrupt | undefined;
+    try {
+      await executor.execute({
+        description: 'Delegate again',
+        subagentType: 'researcher',
+        threadId: 'durable-thread',
+        parentToolCallId: 'call_child',
+      });
+    } catch (error) {
+      if (error instanceof GraphInterrupt) {
+        received = error;
+      }
+    }
+
+    expect(received?.interrupts[0].value).toMatchObject({
+      subagent: nestedScope,
+    });
   });
 
   it('rethrows a child stream-limit trip instead of converting it to a tool result', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1841,10 +1841,7 @@ describe('SubagentExecutor', () => {
         string,
         unknown
       >;
-      expect(Object.keys(configurable)).toEqual([
-        '__librechat_tool_approval_execution_scope',
-        'thread_id',
-      ]);
+      expect(Object.keys(configurable)).toEqual(['thread_id']);
     });
   });
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1783,6 +1783,51 @@ describe('SubagentExecutor', () => {
       expect(executor.getChildCheckpointThreadIds()).toEqual(beforeCleanup);
     });
 
+    it('includes checkpoint threads from active descendant graphs', async () => {
+      const grandchildThreadId = 'subagent:grandchild';
+      const executor = createExecutor({
+        checkpointer: new MemorySaver(),
+        humanInTheLoop: { enabled: true },
+        createChildGraph: (): StandardGraph =>
+          ({
+            createWorkflow: () => ({
+              getState: jest.fn().mockResolvedValue({
+                values: {},
+                next: ['child-agent'],
+                tasks: [],
+              }),
+              invoke: jest.fn().mockRejectedValue(
+                new GraphInterrupt([
+                  {
+                    id: 'grandchild-interrupt',
+                    value: {
+                      type: 'tool_approval',
+                      action_requests: [],
+                      review_configs: [],
+                    },
+                  },
+                ])
+              ),
+            }),
+            getChildCheckpointThreadIds: jest.fn(() => [grandchildThreadId]),
+            clearHeavyState: jest.fn(),
+          }) as unknown as StandardGraph,
+      });
+
+      await expect(
+        executor.execute({
+          description: 'nested task',
+          subagentType: 'researcher',
+          threadId: 'parent',
+          parentToolCallId: 'call_child',
+        })
+      ).rejects.toBeInstanceOf(GraphInterrupt);
+
+      expect(executor.getChildCheckpointThreadIds()).toEqual(
+        expect.arrayContaining([grandchildThreadId])
+      );
+    });
+
     it('does not require parentConfigurable (back-compat with hosts that omit it)', async () => {
       const { factory, getInvokeConfig } = makeCapturingGraphFactory();
       const executor = createExecutor({ createChildGraph: factory });

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1484,6 +1484,66 @@ describe('SubagentExecutor', () => {
       expect(configurable.user).toEqual({ id: 'user_abc' });
     });
 
+    it('isolates child checkpoints created from different parent forks', async () => {
+      const invokedConfigs: Record<string, unknown>[] = [];
+      const invoke = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _input: unknown,
+            config: Record<string, unknown>
+          ): Promise<{ messages: BaseMessage[] }> => {
+            invokedConfigs.push(config);
+            return { messages: [new AIMessage('done')] };
+          }
+        );
+      const executor = createExecutor({
+        humanInTheLoop: { enabled: true },
+        createChildGraph: (): StandardGraph =>
+          ({
+            createWorkflow: () => ({
+              getState: jest.fn().mockResolvedValue({
+                values: {},
+                next: [],
+                tasks: [],
+              }),
+              invoke,
+            }),
+            clearHeavyState: jest.fn(),
+          }) as unknown as StandardGraph,
+      });
+      const common = {
+        description: 'task',
+        subagentType: 'researcher',
+        threadId: 'parent-thread',
+        parentToolCallId: 'call_shared',
+      };
+
+      await executor.execute({
+        ...common,
+        parentConfigurable: {
+          thread_id: 'parent-thread',
+          checkpoint_id: 'fork-a',
+        },
+      });
+      await executor.execute({
+        ...common,
+        parentConfigurable: {
+          thread_id: 'parent-thread',
+          checkpoint_id: 'fork-b',
+        },
+      });
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      const childThreadIds = invokedConfigs.map(
+        (config) =>
+          (config.configurable as Record<string, unknown>).thread_id as string
+      );
+      expect(childThreadIds[0]).toContain('_sub_fork-a_');
+      expect(childThreadIds[1]).toContain('_sub_fork-b_');
+      expect(childThreadIds[0]).not.toBe(childThreadIds[1]);
+    });
+
     it('does not require parentConfigurable (back-compat with hosts that omit it)', async () => {
       const { factory, getInvokeConfig } = makeCapturingGraphFactory();
       const executor = createExecutor({ createChildGraph: factory });
@@ -1570,6 +1630,67 @@ describe('SubagentExecutor', () => {
       const input = capturedStop as Record<string, unknown>;
       expect(input.hook_event_name).toBe('SubagentStop');
       expect(input.agentType).toBe('researcher');
+    });
+
+    it('finishes missing child lifecycle after recovering a completed checkpoint', async () => {
+      const stopHook = jest.fn().mockResolvedValue({});
+      const hookRegistry = new HookRegistry();
+      hookRegistry.register('SubagentStop', { hooks: [stopHook] });
+      const updates: SubagentUpdateEvent[] = [];
+      const handlerRegistry = new HandlerRegistry();
+      handlerRegistry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          updates.push(data as SubagentUpdateEvent);
+        },
+      });
+      const invoke = jest.fn();
+      const updateState = jest.fn().mockResolvedValue({});
+      const executor = createExecutor({
+        humanInTheLoop: { enabled: true },
+        hookRegistry,
+        parentHandlerRegistry: handlerRegistry,
+        createChildGraph: (): StandardGraph =>
+          ({
+            createWorkflow: () => ({
+              getState: jest.fn().mockResolvedValue({
+                values: { messages: [new AIMessage('persisted result')] },
+                next: [],
+                tasks: [],
+              }),
+              invoke,
+              updateState,
+            }),
+            clearHeavyState: jest.fn(),
+          }) as unknown as StandardGraph,
+      });
+
+      const result = await executor.execute({
+        description: 'recover me',
+        subagentType: 'researcher',
+        threadId: 'durable-thread',
+        parentToolCallId: 'call_recovered',
+      });
+
+      expect(result.content).toBe('persisted result');
+      expect(invoke).not.toHaveBeenCalled();
+      expect(stopHook).toHaveBeenCalledTimes(1);
+      expect(updates.filter((update) => update.phase === 'stop')).toHaveLength(
+        1
+      );
+      expect(updateState).toHaveBeenCalledTimes(1);
+      expect(updateState.mock.calls[0][1]).toMatchObject({
+        messages: [
+          {
+            additional_kwargs: {
+              __librechat_subagent_checkpoint: {
+                version: 1,
+                parentToolCallId: 'call_recovered',
+                lifecycleComplete: true,
+              },
+            },
+          },
+        ],
+      });
     });
 
     it('SubagentStart deny blocks execution', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -574,7 +574,7 @@ describe('SubagentExecutor', () => {
     expect(restored?.output.content).toBe('Blocked: policy');
     expect(restored?.additionalContexts).toEqual(['persisted context']);
     expect(restored?.resolvedArgs).toEqual({ description: 'rewritten' });
-    expect(hookRegistry.hasHookFor('PreToolUse', 'original-run')).toBe(false);
+    expect(hookRegistry.hasHookFor('PreToolUse', 'original-run')).toBe(true);
     expect(hookRegistry.hasHookFor('PreToolUse', 'rebuilt-run')).toBe(true);
   });
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1841,8 +1841,10 @@ describe('SubagentExecutor', () => {
         string,
         unknown
       >;
-      // Only thread_id (childRunId fallback) is set when no parent context is supplied.
-      expect(Object.keys(configurable)).toEqual(['thread_id']);
+      expect(Object.keys(configurable)).toEqual([
+        '__librechat_tool_approval_execution_scope',
+        'thread_id',
+      ]);
     });
   });
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -495,6 +495,24 @@ describe('SubagentExecutor', () => {
     expect(result.messages).toEqual([]);
   });
 
+  it('fails closed when resumable execution has no parent tool call ID', async () => {
+    const createChildGraph = jest.fn(makeNoopGraphFactory());
+    const executor = createExecutor({
+      humanInTheLoop: { enabled: true },
+      createChildGraph,
+    });
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+      threadId: 'durable-thread',
+    });
+
+    expect(result.content).toContain('requires a parent tool call ID');
+    expect(result.messages).toEqual([]);
+    expect(createChildGraph).not.toHaveBeenCalled();
+  });
+
   it('preserves an existing nested approval scope', async () => {
     const nestedScope = {
       run_id: 'grandchild-run',

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -636,6 +636,38 @@ describe('SubagentExecutor', () => {
     expect(restored?.output.content).toBe('Subagent error: child failed');
   });
 
+  it('continues a recovered in-progress child without reseeding its task', async () => {
+    const invoke = jest.fn().mockResolvedValue({
+      messages: [new AIMessage('continued')],
+    });
+    const executor = createExecutor({
+      checkpointer: new MemorySaver(),
+      humanInTheLoop: { enabled: true },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({
+            getState: jest.fn().mockResolvedValue({
+              values: {},
+              next: ['child-agent'],
+              tasks: [],
+            }),
+            invoke,
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const result = await executor.execute({
+      description: 'Do not duplicate this task',
+      subagentType: 'researcher',
+      threadId: 'durable-parent',
+      parentToolCallId: 'call_in_progress',
+    });
+
+    expect(result.content).toBe('continued');
+    expect(invoke).toHaveBeenCalledWith(null, expect.any(Object));
+  });
+
   it('preserves an existing nested approval scope', async () => {
     const nestedScope = {
       run_id: 'grandchild-run',
@@ -1662,9 +1694,93 @@ describe('SubagentExecutor', () => {
         (config) =>
           (config.configurable as Record<string, unknown>).thread_id as string
       );
-      expect(childThreadIds[0]).toContain('_sub_fork-a_');
-      expect(childThreadIds[1]).toContain('_sub_fork-b_');
+      expect(childThreadIds[0]).toMatch(/^subagent:/);
+      expect(childThreadIds[1]).toMatch(/^subagent:/);
       expect(childThreadIds[0]).not.toBe(childThreadIds[1]);
+    });
+
+    it('keeps ambiguous parent agent and tool-call components collision-free', async () => {
+      const invokedThreadIds: string[] = [];
+      const createChildGraph = (): StandardGraph =>
+        ({
+          createWorkflow: () => ({
+            getState: jest.fn().mockResolvedValue({
+              values: {},
+              next: [],
+              tasks: [],
+            }),
+            invoke: jest
+              .fn()
+              .mockImplementation(
+                async (
+                  _input: unknown,
+                  invokeConfig: Record<string, unknown>
+                ): Promise<{ messages: BaseMessage[] }> => {
+                  invokedThreadIds.push(
+                    (invokeConfig.configurable as Record<string, unknown>)
+                      .thread_id as string
+                  );
+                  return { messages: [new AIMessage('done')] };
+                }
+              ),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+      const common = {
+        description: 'task',
+        subagentType: 'researcher',
+        threadId: 'parent',
+        parentConfigurable: { thread_id: 'parent' },
+      };
+
+      await createExecutor({
+        checkpointer: new MemorySaver(),
+        humanInTheLoop: { enabled: true },
+        parentAgentId: 'a_b',
+        createChildGraph,
+      }).execute({ ...common, parentToolCallId: 'c' });
+      await createExecutor({
+        checkpointer: new MemorySaver(),
+        humanInTheLoop: { enabled: true },
+        parentAgentId: 'a',
+        createChildGraph,
+      }).execute({ ...common, parentToolCallId: 'b_c' });
+
+      expect(invokedThreadIds).toHaveLength(2);
+      expect(invokedThreadIds[0]).not.toBe(invokedThreadIds[1]);
+    });
+
+    it('retains owned child checkpoint threads after heavy-state cleanup', async () => {
+      const executor = createExecutor({
+        checkpointer: new MemorySaver(),
+        humanInTheLoop: { enabled: true },
+        createChildGraph: (): StandardGraph =>
+          ({
+            createWorkflow: () => ({
+              getState: jest.fn().mockResolvedValue({
+                values: {},
+                next: [],
+                tasks: [],
+              }),
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('done')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          }) as unknown as StandardGraph,
+      });
+
+      await executor.execute({
+        description: 'task',
+        subagentType: 'researcher',
+        threadId: 'parent',
+        parentToolCallId: 'call_owned',
+      });
+      const beforeCleanup = executor.getChildCheckpointThreadIds();
+      executor.clearHeavyState();
+
+      expect(beforeCleanup).toHaveLength(1);
+      expect(executor.getChildCheckpointThreadIds()).toEqual(beforeCleanup);
     });
 
     it('does not require parentConfigurable (back-compat with hosts that omit it)', async () => {

--- a/src/tools/__tests__/SubagentReplay.test.ts
+++ b/src/tools/__tests__/SubagentReplay.test.ts
@@ -9,6 +9,7 @@ describe('SubagentReplay manifest', () => {
   const execution = {
     parentToolCallId: 'call_parent',
     childRunId: 'child-run',
+    approvalExecutionScope: 'child-approval-scope',
     checkpoints: [
       {
         threadId: 'child-thread',
@@ -52,7 +53,7 @@ describe('SubagentReplay manifest', () => {
     approvalReplays: [
       {
         key: {
-          executionScope: 'child-run',
+          executionScope: 'child-approval-scope',
           agentId: 'child-agent',
           toolUseId: 'call_tool',
         },
@@ -80,6 +81,22 @@ describe('SubagentReplay manifest', () => {
       visible: true,
     });
   });
+
+  it.each([
+    ['string', 'approve this child'],
+    ['number', 42],
+    ['null', null],
+    ['array', ['approve', { call: 1 }]],
+  ])(
+    'round-trips a private manifest around a %s interrupt payload',
+    (_label, visiblePayload) => {
+      const manifest = { version: 1 as const, executions: [execution] };
+      const payload = attachSubagentResumeManifest(visiblePayload, manifest);
+
+      expect(getSubagentResumeManifest(payload)).toEqual(manifest);
+      expect(stripSubagentResumeManifest(payload)).toEqual(visiblePayload);
+    }
+  );
 
   it('rejects ambiguous or cross-execution replay data', () => {
     const mismatchedScope = {

--- a/src/tools/__tests__/SubagentReplay.test.ts
+++ b/src/tools/__tests__/SubagentReplay.test.ts
@@ -1,0 +1,205 @@
+import {
+  getSubagentResumeManifest,
+  attachSubagentResumeManifest,
+  requireValidSubagentResumeManifest,
+  stripSubagentResumeManifest,
+} from '@/tools/subagent/SubagentReplay';
+
+describe('SubagentReplay manifest', () => {
+  const execution = {
+    parentToolCallId: 'call_parent',
+    childRunId: 'child-run',
+    checkpoints: [
+      {
+        threadId: 'child-thread',
+        checkpointId: 'checkpoint-root',
+        checkpointNs: '',
+      },
+      {
+        threadId: 'child-thread',
+        checkpointId: 'checkpoint-agent',
+        checkpointNs: 'agent:task',
+      },
+    ],
+    graphState: {
+      toolCallSteps: [{ toolCallId: 'call_tool', stepId: 'step_tool' }],
+      toolSessions: [
+        {
+          toolName: 'execute_code',
+          context: { session_id: 'session', lastUpdated: 1 },
+        },
+      ],
+      toolNodes: [
+        {
+          stateKey: 'child-agent',
+          toolUsageCounts: [{ toolName: 'calculator', count: 1 }],
+          directPathTurns: [{ toolCallId: 'call_tool', turn: 0 }],
+        },
+      ],
+      eagerToolUsage: [
+        {
+          agentId: 'child-agent',
+          toolUsageCounts: [{ toolName: 'calculator', count: 1 }],
+        },
+      ],
+      eagerToolSuppressions: ['unstable_search'],
+      toolOutputReferences: {
+        entries: [{ key: 'tool0turn0', value: '42' }],
+        turnCounter: 1,
+        warnedNonStringTools: [],
+      },
+    },
+    approvalReplays: [
+      {
+        key: {
+          executionScope: 'child-run',
+          agentId: 'child-agent',
+          toolUseId: 'call_tool',
+        },
+        result: {
+          decision: 'ask' as const,
+          reason: 'review tool',
+          additionalContexts: [],
+          injectedMessages: [],
+          errors: [],
+        },
+      },
+    ],
+  };
+
+  it('round-trips a private manifest without exposing it publicly', () => {
+    const manifest = { version: 1 as const, executions: [execution] };
+    const payload = attachSubagentResumeManifest(
+      { type: 'tool_approval', visible: true },
+      manifest
+    );
+
+    expect(getSubagentResumeManifest(payload)).toEqual(manifest);
+    expect(stripSubagentResumeManifest(payload)).toEqual({
+      type: 'tool_approval',
+      visible: true,
+    });
+  });
+
+  it('rejects ambiguous or cross-execution replay data', () => {
+    const mismatchedScope = {
+      ...execution,
+      approvalReplays: [
+        {
+          ...execution.approvalReplays[0],
+          key: {
+            ...execution.approvalReplays[0].key,
+            executionScope: 'different-child',
+          },
+        },
+      ],
+    };
+    const duplicateParent = {
+      version: 1 as const,
+      executions: [execution, { ...execution }],
+    };
+    const duplicateToolCall = {
+      ...execution,
+      graphState: {
+        ...execution.graphState,
+        toolCallSteps: [
+          ...execution.graphState.toolCallSteps,
+          { ...execution.graphState.toolCallSteps[0] },
+        ],
+      },
+    };
+
+    expect(
+      getSubagentResumeManifest(
+        attachSubagentResumeManifest(
+          { type: 'tool_approval' },
+          { version: 1, executions: [mismatchedScope] }
+        )
+      )
+    ).toBeUndefined();
+    expect(
+      getSubagentResumeManifest(
+        attachSubagentResumeManifest({ type: 'tool_approval' }, duplicateParent)
+      )
+    ).toBeUndefined();
+    expect(
+      getSubagentResumeManifest(
+        attachSubagentResumeManifest(
+          { type: 'tool_approval' },
+          { version: 1, executions: [duplicateToolCall] }
+        )
+      )
+    ).toBeUndefined();
+  });
+
+  it('fails closed for malformed nested references', () => {
+    const malformed = {
+      __librechat_subagent_resume_manifest: {
+        version: 1,
+        executions: [{ ...execution, checkpoints: [null] }],
+      },
+    };
+    expect(getSubagentResumeManifest(malformed)).toBeUndefined();
+    expect(() => requireValidSubagentResumeManifest(malformed)).toThrow(
+      'Invalid subagent resume manifest.'
+    );
+    expect(
+      getSubagentResumeManifest({
+        __librechat_subagent_resume_manifest: {
+          version: 1,
+          executions: [
+            {
+              ...execution,
+              graphState: {
+                ...execution.graphState,
+                toolCallSteps: [null],
+              },
+            },
+          ],
+        },
+      })
+    ).toBeUndefined();
+  });
+
+  it('rejects duplicate checkpoint namespaces and approval replay keys', () => {
+    const duplicateCheckpointNamespace = {
+      ...execution,
+      checkpoints: [execution.checkpoints[0], { ...execution.checkpoints[0] }],
+    };
+    const duplicateApprovalReplay = {
+      ...execution,
+      approvalReplays: [
+        execution.approvalReplays[0],
+        { ...execution.approvalReplays[0] },
+      ],
+    };
+
+    for (const invalidExecution of [
+      duplicateCheckpointNamespace,
+      duplicateApprovalReplay,
+    ]) {
+      expect(
+        getSubagentResumeManifest(
+          attachSubagentResumeManifest(
+            { type: 'tool_approval' },
+            { version: 1, executions: [invalidExecution] }
+          )
+        )
+      ).toBeUndefined();
+    }
+  });
+
+  it('rejects cyclic descendant manifests', () => {
+    const cyclic: {
+      version: number;
+      executions: Array<typeof execution & { descendant?: object }>;
+    } = { version: 1, executions: [{ ...execution }] };
+    cyclic.executions[0].descendant = cyclic;
+
+    expect(
+      getSubagentResumeManifest({
+        __librechat_subagent_resume_manifest: cyclic,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/tools/__tests__/SubagentReplay.test.ts
+++ b/src/tools/__tests__/SubagentReplay.test.ts
@@ -98,6 +98,84 @@ describe('SubagentReplay manifest', () => {
     }
   );
 
+  it.each([
+    ['Map', new Map([['decision', 'approve']])],
+    ['Set', new Set(['approve'])],
+    ['RegExp', /^approve$/i],
+  ])(
+    'round-trips a private manifest around a %s interrupt payload',
+    (_label, visiblePayload) => {
+      const manifest = { version: 1 as const, executions: [execution] };
+      const payload = attachSubagentResumeManifest(visiblePayload, manifest);
+
+      expect(getSubagentResumeManifest(payload)).toEqual(manifest);
+      expect(stripSubagentResumeManifest(payload)).toBe(visiblePayload);
+    }
+  );
+
+  it.each([
+    {
+      __librechat_subagent_resume_manifest: { visible: true },
+      value: 'manifest collision',
+    },
+    {
+      __librechat_subagent_resume_wrapper: 1,
+      __librechat_subagent_resume_payload: 'visible nested value',
+      value: 'wrapper collision',
+    },
+  ])(
+    'preserves a custom payload containing private transport keys',
+    (value) => {
+      const manifest = { version: 1 as const, executions: [execution] };
+      const payload = attachSubagentResumeManifest(value, manifest);
+
+      expect(stripSubagentResumeManifest(value)).toBe(value);
+      expect(getSubagentResumeManifest(payload)).toEqual(manifest);
+      expect(stripSubagentResumeManifest(payload)).toBe(value);
+    }
+  );
+
+  it('updates the manifest on an existing inline payload', () => {
+    const firstManifest = { version: 1 as const, executions: [execution] };
+    const nextManifest = {
+      version: 1 as const,
+      executions: [{ ...execution, childRunId: 'next-inline-child-run' }],
+    };
+    const firstPayload = attachSubagentResumeManifest(
+      { type: 'tool_approval', visible: true },
+      firstManifest
+    );
+    const nextPayload = attachSubagentResumeManifest(
+      firstPayload,
+      nextManifest
+    );
+
+    expect(getSubagentResumeManifest(nextPayload)).toEqual(nextManifest);
+    expect(stripSubagentResumeManifest(nextPayload)).toEqual({
+      type: 'tool_approval',
+      visible: true,
+    });
+  });
+
+  it('updates the manifest on an existing private wrapper', () => {
+    const firstManifest = { version: 1 as const, executions: [execution] };
+    const nextManifest = {
+      version: 1 as const,
+      executions: [{ ...execution, childRunId: 'next-child-run' }],
+    };
+    const firstPayload = attachSubagentResumeManifest(
+      'visible payload',
+      firstManifest
+    );
+    const nextPayload = attachSubagentResumeManifest(
+      firstPayload,
+      nextManifest
+    );
+
+    expect(getSubagentResumeManifest(nextPayload)).toEqual(nextManifest);
+    expect(stripSubagentResumeManifest(nextPayload)).toBe('visible payload');
+  });
+
   it('rejects ambiguous or cross-execution replay data', () => {
     const mismatchedScope = {
       ...execution,

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -1,15 +1,16 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
+import { GraphInterrupt } from '@langchain/langgraph';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
-import * as events from '@/utils/events';
 import {
   StreamLimitExceededError,
   RUN_BREAKER_SCOPE_CONFIG_KEY,
 } from '@/llm/streamLimits';
+import * as events from '@/utils/events';
 import { GraphEvents } from '@/common';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
@@ -212,6 +213,42 @@ describe('ToolNode breaker signal composition', () => {
     expect(sideEffectRan).toBe(false);
   });
 
+  it('prioritizes a sibling breaker trip over an approval interrupt', async () => {
+    const breaker = new AbortController();
+    const trip = new StreamLimitExceededError({
+      kind: 'tool_call_args',
+      limit: 10,
+      observed: 11,
+      toolName: 'db_query',
+    });
+    const approval = createSignalBlindTool('ask_question', async () => {
+      throw new GraphInterrupt([]);
+    });
+    const tripper = createSignalBlindTool('tripping_child', async () => {
+      breaker.abort(trip);
+      return 'tripped';
+    });
+    const node = new ToolNode({
+      tools: [approval, tripper],
+      interruptingToolNames: new Set(['ask_question', 'tripping_child']),
+      getBreakerSignal: () => breaker.signal,
+    });
+
+    await expect(
+      node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'ask_question', args: {} },
+              { id: 'call_2', name: 'tripping_child', args: {} },
+            ],
+          }),
+        ],
+      })
+    ).rejects.toBe(trip);
+  });
+
   it('stops event dispatch when a direct tool trips the breaker mid-batch', async () => {
     const breaker = new AbortController();
     const trip = new StreamLimitExceededError({
@@ -323,7 +360,10 @@ describe('ToolNode breaker signal composition', () => {
   });
 
   it('stamps the batch-entry run scope into tool configs and strips it from host batches', async () => {
-    const scope = Object.freeze({ epoch: 3, controller: new AbortController() });
+    const scope = Object.freeze({
+      epoch: 3,
+      controller: new AbortController(),
+    });
     let seenScope: unknown;
     const capture = {
       name: 'capture_scope',

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -5,12 +5,17 @@ import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type {
+  ReplayableSubagentTool,
+  SettledSubagentToolOutput,
+} from '@/tools/subagent/SubagentReplay';
 import type { PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
 import {
   StreamLimitExceededError,
   RUN_BREAKER_SCOPE_CONFIG_KEY,
 } from '@/llm/streamLimits';
+import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import * as events from '@/utils/events';
 import { GraphEvents } from '@/common';
 import { HookRegistry } from '@/hooks';
@@ -325,6 +330,89 @@ describe('ToolNode breaker signal composition', () => {
     expect(terminalCompletion?.result?.tool_call?.args).toContain(
       '"rewritten":true'
     );
+
+    await node.invoke({
+      messages: [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_terminal',
+              name: 'terminal_child',
+              args: { laterTurn: true },
+              type: 'tool_call',
+            },
+          ],
+        }),
+      ],
+    });
+    expect(terminalRuns).toBe(2);
+    expect(terminalPreHooks).toBe(2);
+  });
+
+  it('persists a hook-terminal outcome before a sibling interrupts', async () => {
+    const persistedOutputs: SettledSubagentToolOutput[] = [];
+    const terminal = createSignalBlindTool('terminal_child', async () => {
+      throw new Error('denied tool must not execute');
+    }) as StructuredToolInterface & ReplayableSubagentTool;
+    terminal[SUBAGENT_REPLAY_CONTROLLER] = {
+      getSettledOutput: async () => undefined,
+      persistSettledOutput: async (_call, _config, settled): Promise<void> => {
+        persistedOutputs.push(settled);
+      },
+    };
+    const approval = createSignalBlindTool('approval_child', async () => {
+      throw new GraphInterrupt([
+        { id: 'approval-interrupt', value: { type: 'approval' } },
+      ]);
+    });
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> =>
+          input.toolName === 'terminal_child'
+            ? { decision: 'deny', reason: 'blocked by policy' }
+            : {},
+      ],
+    });
+    const node = new ToolNode({
+      tools: [terminal, approval],
+      hookRegistry,
+      interruptingToolNames: new Set(['terminal_child', 'approval_child']),
+    });
+
+    await expect(
+      node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_terminal',
+                name: 'terminal_child',
+                args: {},
+                type: 'tool_call',
+              },
+              {
+                id: 'call_approval',
+                name: 'approval_child',
+                args: {},
+                type: 'tool_call',
+              },
+            ],
+          }),
+        ],
+      })
+    ).rejects.toBeInstanceOf(GraphInterrupt);
+
+    expect(persistedOutputs).toHaveLength(1);
+    expect(persistedOutputs[0]).toMatchObject({
+      output: {
+        content: 'Blocked: blocked by policy',
+        status: 'error',
+        tool_call_id: 'call_terminal',
+      },
+    });
   });
 
   it('stops event dispatch when a direct tool trips the breaker mid-batch', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -5,6 +5,7 @@ import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
 import {
   StreamLimitExceededError,
@@ -251,18 +252,55 @@ describe('ToolNode breaker signal composition', () => {
 
   it('reuses terminal interrupting sibling outputs across replay', async () => {
     let terminalRuns = 0;
+    let terminalPreHooks = 0;
+    let approvalRuns = 0;
+    const completions: Array<{
+      result?: { tool_call?: { id?: string; args?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as (typeof completions)[number]);
+        }
+        return true;
+      });
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => {
+          if (input.toolName !== 'terminal_child') {
+            return {};
+          }
+          terminalPreHooks += 1;
+          return {
+            additionalContext: 'cached terminal context',
+            updatedInput: { rewritten: true },
+          };
+        },
+      ],
+    });
     const terminal = createSignalBlindTool('terminal_child', async () => {
       terminalRuns += 1;
       return 'completed';
     });
     const approval = createSignalBlindTool('approval_child', async () => {
-      throw new GraphInterrupt([
-        { id: 'approval-interrupt', value: { type: 'approval' } },
-      ]);
+      approvalRuns += 1;
+      if (approvalRuns === 1) {
+        throw new GraphInterrupt([
+          { id: 'approval-interrupt', value: { type: 'approval' } },
+        ]);
+      }
+      return 'approved';
     });
     const node = new ToolNode({
       tools: [terminal, approval],
       interruptingToolNames: new Set(['terminal_child', 'approval_child']),
+      hookRegistry,
+      toolCallStepIds: new Map([
+        ['call_terminal', 'step_terminal'],
+        ['call_approval', 'step_approval'],
+      ]),
     });
     const input = {
       messages: [
@@ -277,8 +315,16 @@ describe('ToolNode breaker signal composition', () => {
     };
 
     await expect(node.invoke(input)).rejects.toBeInstanceOf(GraphInterrupt);
-    await expect(node.invoke(input)).rejects.toBeInstanceOf(GraphInterrupt);
+    const replayResult = await node.invoke(input);
     expect(terminalRuns).toBe(1);
+    expect(terminalPreHooks).toBe(1);
+    expect(JSON.stringify(replayResult)).toContain('cached terminal context');
+    const terminalCompletion = completions.find(
+      (completion) => completion.result?.tool_call?.id === 'call_terminal'
+    );
+    expect(terminalCompletion?.result?.tool_call?.args).toContain(
+      '"rewritten":true'
+    );
   });
 
   it('stops event dispatch when a direct tool trips the breaker mid-batch', async () => {

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -249,6 +249,38 @@ describe('ToolNode breaker signal composition', () => {
     ).rejects.toBe(trip);
   });
 
+  it('reuses terminal interrupting sibling outputs across replay', async () => {
+    let terminalRuns = 0;
+    const terminal = createSignalBlindTool('terminal_child', async () => {
+      terminalRuns += 1;
+      return 'completed';
+    });
+    const approval = createSignalBlindTool('approval_child', async () => {
+      throw new GraphInterrupt([
+        { id: 'approval-interrupt', value: { type: 'approval' } },
+      ]);
+    });
+    const node = new ToolNode({
+      tools: [terminal, approval],
+      interruptingToolNames: new Set(['terminal_child', 'approval_child']),
+    });
+    const input = {
+      messages: [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'call_terminal', name: 'terminal_child', args: {} },
+            { id: 'call_approval', name: 'approval_child', args: {} },
+          ],
+        }),
+      ],
+    };
+
+    await expect(node.invoke(input)).rejects.toBeInstanceOf(GraphInterrupt);
+    await expect(node.invoke(input)).rejects.toBeInstanceOf(GraphInterrupt);
+    expect(terminalRuns).toBe(1);
+  });
+
   it('stops event dispatch when a direct tool trips the breaker mid-batch', async () => {
     const breaker = new AbortController();
     const trip = new StreamLimitExceededError({

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -42,7 +42,7 @@ import { ToolNode } from '../ToolNode';
  */
 
 function aiCall(
-  callId: string,
+  callId: string | undefined,
   name: string,
   args: Record<string, unknown>
 ): AIMessage {
@@ -59,7 +59,11 @@ type CompiledMessagesGraph = Runnable<unknown, { messages: BaseMessage[] }> & {
 
 function buildGraph(
   toolNode: ToolNode,
-  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>
+  toolCalls: Array<{
+    id: string | undefined;
+    name: string;
+    args: Record<string, unknown>;
+  }>
 ): CompiledMessagesGraph {
   let agentInvocations = 0;
   const builder = new StateGraph(MessagesAnnotation)
@@ -137,6 +141,112 @@ describe('direct-path HITL: resume scope', () => {
     );
     expect(toolMessage?.status).toBe('error');
     expect(String(toolMessage?.content)).toContain('rejected once');
+  });
+
+  it('fails closed when an id-less direct call requires approval', async () => {
+    const sideEffect = jest.fn(() => 'must not execute');
+    const directTool = tool(async () => sideEffect(), {
+      name: 'echo',
+      description: 'id-less approval tool',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review id-less call',
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildGraph(node, [
+      { id: undefined, name: 'echo', args: { command: 'go' } },
+    ]);
+
+    const result = await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'thread-id-less-approval' } }
+    );
+
+    expect(isInterrupted(result)).toBe(false);
+    expect(sideEffect).not.toHaveBeenCalled();
+    const messages = (result as { messages: ToolMessage[] }).messages;
+    const toolMessage = messages.find(
+      (message) => message instanceof ToolMessage
+    );
+    expect(toolMessage?.status).toBe('error');
+    expect(String(toolMessage?.content)).toContain(
+      'requires a non-empty tool call ID'
+    );
+  });
+
+  it('reruns ordinary hooks while replaying a consumed one-shot approval', async () => {
+    const sideEffect = jest.fn(() => 'must not execute');
+    const directTool = tool(async () => sideEffect(), {
+      name: 'echo',
+      description: 'mixed replay hook tool',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    let onceCalls = 0;
+    let ordinaryCalls = 0;
+    registry.register('PreToolUse', {
+      once: true,
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          onceCalls += 1;
+          return { decision: 'ask', reason: 'review once' };
+        },
+      ],
+    });
+    registry.register('PreToolUse', {
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          ordinaryCalls += 1;
+          return ordinaryCalls === 1
+            ? { decision: 'allow' }
+            : { decision: 'deny', reason: 'policy changed on resume' };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildGraph(node, [
+      { id: 'call_mixed_hooks', name: 'echo', args: { command: 'go' } },
+    ]);
+    const config = { configurable: { thread_id: 'thread-mixed-hooks' } };
+
+    const first = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted(first)).toBe(true);
+    const resumed = await graph.invoke(
+      new Command({ resume: [{ type: 'approve' }] }),
+      config
+    );
+
+    expect(onceCalls).toBe(1);
+    expect(ordinaryCalls).toBe(2);
+    expect(sideEffect).not.toHaveBeenCalled();
+    const messages = (resumed as { messages: ToolMessage[] }).messages;
+    const toolMessage = messages.find(
+      (message) => message instanceof ToolMessage
+    );
+    expect(toolMessage?.status).toBe('error');
+    expect(String(toolMessage?.content)).toContain('policy changed on resume');
   });
 
   it('re-executes the direct tool body on resume when interrupt() fires from the direct path', async () => {

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -7,6 +7,7 @@ import {
   START,
   StateGraph,
   MemorySaver,
+  GraphInterrupt,
   isInterrupted,
   MessagesAnnotation,
   Command,
@@ -21,7 +22,11 @@ import type {
 } from '@/tools/subagent/SubagentReplay';
 import type { PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
-import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
+import {
+  getSubagentResumeManifest,
+  stripSubagentResumeManifest,
+  SUBAGENT_REPLAY_CONTROLLER,
+} from '@/tools/subagent/SubagentReplay';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
 
@@ -90,6 +95,78 @@ function buildGraph(
 describe('direct-path HITL: resume scope', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('persists a resume manifest beside a primitive child interrupt', async () => {
+    const directTool = tool(
+      async () => {
+        throw new GraphInterrupt([
+          { id: 'primitive-interrupt', value: 'confirm child' },
+        ]);
+      },
+      {
+        name: 'subagent',
+        description: 'primitive interrupt subagent',
+        schema: z.object({ description: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const manifest = {
+      version: 1 as const,
+      executions: [
+        {
+          parentToolCallId: 'call_primitive',
+          childRunId: 'child-run',
+          approvalExecutionScope: 'child-approval-attempt',
+          checkpoints: [
+            {
+              threadId: 'child-thread',
+              checkpointId: 'child-checkpoint',
+              checkpointNs: '',
+            },
+          ],
+          graphState: {
+            toolCallSteps: [],
+            toolSessions: [],
+            toolNodes: [],
+            eagerToolUsage: [],
+            eagerToolSuppressions: [],
+          },
+          approvalReplays: [],
+        },
+      ],
+    };
+    const replayableTool = directTool as StructuredToolInterface &
+      ReplayableSubagentTool;
+    replayableTool[SUBAGENT_REPLAY_CONTROLLER] = {
+      getResumeManifest: async () => manifest,
+      getSettledOutput: async () => undefined,
+      persistSettledOutput: async () => {},
+    };
+    const node = new ToolNode({
+      tools: [directTool],
+      directToolNames: new Set(['subagent']),
+      interruptingToolNames: new Set(['subagent']),
+    });
+    const graph = buildGraph(node, [
+      {
+        id: 'call_primitive',
+        name: 'subagent',
+        args: { description: 'pause with primitive data' },
+      },
+    ]);
+
+    const interrupted = await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'parent-thread' } }
+    );
+
+    expect(isInterrupted(interrupted)).toBe(true);
+    if (!isInterrupted(interrupted)) {
+      throw new Error('expected primitive child interrupt');
+    }
+    const internalPayload = interrupted.__interrupt__[0].value;
+    expect(getSubagentResumeManifest(internalPayload)).toEqual(manifest);
+    expect(stripSubagentResumeManifest(internalPayload)).toBe('confirm child');
   });
 
   it('preserves a one-shot approval until a reject decision is applied', async () => {

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -321,6 +321,67 @@ describe('direct-path HITL: resume scope', () => {
     expect(invokedBatchKeys).toEqual(replayConfigKeys);
   });
 
+  it('stamps the assistant batch into Send-input subagent configs', async () => {
+    const invokedBatchKeys: unknown[] = [];
+    const directTool = tool(
+      async (_input, config) => {
+        invokedBatchKeys.push(
+          config.configurable?.[SUBAGENT_PARENT_BATCH_CONFIG_KEY]
+        );
+        return 'done';
+      },
+      {
+        name: 'subagent',
+        description: 'replayable direct tool',
+        schema: z.object({ description: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const replayConfigKeys: unknown[] = [];
+    const replayableTool = directTool as StructuredToolInterface &
+      ReplayableSubagentTool;
+    replayableTool[SUBAGENT_REPLAY_CONTROLLER] = {
+      getSettledOutput: async (_call, config) => {
+        replayConfigKeys.push(
+          config.configurable?.[SUBAGENT_PARENT_BATCH_CONFIG_KEY]
+        );
+        return undefined;
+      },
+      persistSettledOutput: async () => {},
+    };
+    const node = new ToolNode({
+      tools: [directTool],
+      directToolNames: new Set(['subagent']),
+    });
+    const toolCall = {
+      id: 'call_send',
+      name: 'subagent',
+      args: { description: 'send task' },
+    };
+
+    await node.invoke(
+      {
+        messages: [
+          new AIMessage({
+            id: 'assistant-send',
+            content: '',
+            tool_calls: [toolCall],
+          }),
+        ],
+        lg_tool_call: toolCall,
+      },
+      {
+        configurable: {
+          run_id: 'run-send',
+          thread_id: 'thread-send',
+        },
+      }
+    );
+
+    expect(replayConfigKeys).toHaveLength(1);
+    expect(replayConfigKeys[0]).toBeDefined();
+    expect(invokedBatchKeys).toEqual(replayConfigKeys);
+  });
+
   it('fails closed when an id-less direct call requires approval', async () => {
     const sideEffect = jest.fn(() => 'must not execute');
     const directTool = tool(async () => sideEffect(), {

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -25,6 +25,7 @@ import type * as t from '@/types';
 import {
   getSubagentResumeManifest,
   stripSubagentResumeManifest,
+  SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_REPLAY_CONTROLLER,
 } from '@/tools/subagent/SubagentReplay';
 import { HookRegistry } from '@/hooks';
@@ -218,6 +219,106 @@ describe('direct-path HITL: resume scope', () => {
     );
     expect(toolMessage?.status).toBe('error');
     expect(String(toolMessage?.content)).toContain('rejected once');
+  });
+
+  it('truncates direct respond decisions before returning them', async () => {
+    const executeTool = jest.fn(async () => 'must not execute');
+    const directTool = tool(executeTool, {
+      name: 'echo',
+      description: 'approval response tool',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [async (): Promise<PreToolUseHookOutput> => ({ decision: 'ask' })],
+    });
+    const node = new ToolNode({
+      tools: [directTool],
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      humanInTheLoop: { enabled: true },
+      maxToolResultChars: 50,
+    });
+    const graph = buildGraph(node, [
+      { id: 'call_respond', name: 'echo', args: { command: 'go' } },
+    ]);
+    const config = { configurable: { thread_id: 'thread-respond-truncate' } };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted(interrupted)).toBe(true);
+
+    const oversized = 'A'.repeat(200);
+    const resumed = await graph.invoke(
+      new Command({
+        resume: [{ type: 'respond', responseText: oversized }],
+      }),
+      config
+    );
+
+    const messages = (resumed as { messages: ToolMessage[] }).messages;
+    const toolMessage = messages.find(
+      (message) => message instanceof ToolMessage
+    );
+    expect(String(toolMessage?.content).length).toBeLessThan(oversized.length);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it('stamps distinct assistant batches into subagent replay configs', async () => {
+    const invokedBatchKeys: unknown[] = [];
+    const directTool = tool(
+      async (_input, config) => {
+        invokedBatchKeys.push(
+          config.configurable?.[SUBAGENT_PARENT_BATCH_CONFIG_KEY]
+        );
+        return 'done';
+      },
+      {
+        name: 'subagent',
+        description: 'replayable direct tool',
+        schema: z.object({ description: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const replayConfigKeys: unknown[] = [];
+    const replayableTool = directTool as StructuredToolInterface &
+      ReplayableSubagentTool;
+    replayableTool[SUBAGENT_REPLAY_CONTROLLER] = {
+      getSettledOutput: async (_call, config) => {
+        replayConfigKeys.push(
+          config.configurable?.[SUBAGENT_PARENT_BATCH_CONFIG_KEY]
+        );
+        return undefined;
+      },
+      persistSettledOutput: async () => {},
+    };
+    const node = new ToolNode({
+      tools: [directTool],
+      directToolNames: new Set(['subagent']),
+    });
+    const config = {
+      configurable: { run_id: 'run-shared', thread_id: 'thread-shared' },
+    };
+    const input = (assistantMessageId: string): { messages: AIMessage[] } => ({
+      messages: [
+        new AIMessage({
+          id: assistantMessageId,
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_reused',
+              name: 'subagent',
+              args: { description: assistantMessageId },
+            },
+          ],
+        }),
+      ],
+    });
+
+    await node.invoke(input('assistant-1'), config);
+    await node.invoke(input('assistant-2'), config);
+
+    expect(replayConfigKeys).toHaveLength(2);
+    expect(replayConfigKeys[0]).not.toBe(replayConfigKeys[1]);
+    expect(invokedBatchKeys).toEqual(replayConfigKeys);
   });
 
   it('fails closed when an id-less direct call requires approval', async () => {

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -13,9 +13,15 @@ import {
 } from '@langchain/langgraph';
 import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  ReplayableSubagentTool,
+  SettledSubagentToolOutput,
+} from '@/tools/subagent/SubagentReplay';
 import type { PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
+import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
 
@@ -373,6 +379,84 @@ describe('direct-path HITL: resume scope', () => {
       );
       expect(String(toolMsg.content)).not.toContain('should-not-execute');
     });
+  });
+
+  describe('untrusted resume decisions', () => {
+    it.each([
+      [
+        { type: 'respond' },
+        'Approval payload `respond` was missing a string `responseText`',
+      ],
+      [
+        { type: 'aproved' },
+        'Unknown approval decision type "aproved" — failing closed',
+      ],
+    ])(
+      'blocks and persists malformed direct decision %#',
+      async (rawDecision, expectedError) => {
+        const executeTool = jest.fn(async () => 'should-not-execute');
+        const directTool = tool(executeTool, {
+          name: 'subagent',
+          description: 'replayable direct tool',
+          schema: z.object({ description: z.string() }),
+        }) as unknown as StructuredToolInterface;
+        const persistSettledOutput = jest.fn(
+          async (
+            _call: ToolCall,
+            _config: RunnableConfig,
+            _settled: SettledSubagentToolOutput
+          ): Promise<void> => {}
+        );
+        const replayableTool = directTool as StructuredToolInterface &
+          ReplayableSubagentTool;
+        replayableTool[SUBAGENT_REPLAY_CONTROLLER] = {
+          getSettledOutput: async () => undefined,
+          persistSettledOutput,
+        };
+        const registry = new HookRegistry();
+        registry.register('PreToolUse', {
+          hooks: [
+            async (): Promise<PreToolUseHookOutput> => ({ decision: 'ask' }),
+          ],
+        });
+        const node = new ToolNode({
+          tools: [directTool],
+          hookRegistry: registry,
+          directToolNames: new Set(['subagent']),
+          humanInTheLoop: { enabled: true },
+        });
+        const graph = buildGraph(node, [
+          {
+            id: 'call_malformed',
+            name: 'subagent',
+            args: { description: 'inspect' },
+          },
+        ]);
+        const config = {
+          configurable: { thread_id: `thread-malformed-${rawDecision.type}` },
+        };
+
+        await graph.invoke({ messages: [] }, config);
+        const resumed = await graph.invoke(
+          new Command({
+            resume: [rawDecision as unknown as t.ToolApprovalDecision],
+          }),
+          config
+        );
+
+        const messages = (resumed as { messages: ToolMessage[] }).messages;
+        const toolMessage = messages.find(
+          (message) => message instanceof ToolMessage
+        );
+        expect(toolMessage?.status).toBe('error');
+        expect(String(toolMessage?.content)).toContain(expectedError);
+        expect(executeTool).not.toHaveBeenCalled();
+        expect(persistSettledOutput).toHaveBeenCalledTimes(1);
+        expect(persistSettledOutput.mock.calls[0]?.[2].output.status).toBe(
+          'error'
+        );
+      }
+    );
   });
 
   describe('usage counter stability across resume (Codex P2 #30)', () => {

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -88,6 +88,57 @@ describe('direct-path HITL: resume scope', () => {
     jest.restoreAllMocks();
   });
 
+  it('preserves a one-shot approval until a reject decision is applied', async () => {
+    const sideEffect = jest.fn(() => 'must not execute');
+    const directTool = tool(async () => sideEffect(), {
+      name: 'echo',
+      description: 'one-shot approval tool',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    let hookInvocations = 0;
+    registry.register('PreToolUse', {
+      once: true,
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          hookInvocations += 1;
+          return { decision: 'ask', reason: 'review once' };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildGraph(node, [
+      { id: 'call_once', name: 'echo', args: { command: 'go' } },
+    ]);
+    const config = { configurable: { thread_id: 'thread-once-reject' } };
+
+    const first = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+
+    const resumed = await graph.invoke(
+      new Command({
+        resume: [{ type: 'reject', reason: 'rejected once' }],
+      }),
+      config
+    );
+
+    expect(hookInvocations).toBe(1);
+    expect(sideEffect).not.toHaveBeenCalled();
+    const messages = (resumed as { messages: ToolMessage[] }).messages;
+    const toolMessage = messages.find(
+      (message) => message instanceof ToolMessage
+    );
+    expect(toolMessage?.status).toBe('error');
+    expect(String(toolMessage?.content)).toContain('rejected once');
+  });
+
   it('re-executes the direct tool body on resume when interrupt() fires from the direct path', async () => {
     const sideEffect = jest.fn(() => 'EXECUTED');
     const directTool = tool(async () => sideEffect(), {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -33,8 +33,8 @@ import type {
 } from '@/hooks';
 import type * as t from '@/types';
 import { Providers as providers, GraphEvents } from '@/common';
-import * as events from '@/utils/events';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
+import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
 import { ToolNode } from '../ToolNode';
 
@@ -1088,6 +1088,76 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     const cmd2 = spy.mock.calls[1]?.[0] as Command;
     expect(cmd2.update).toBeUndefined();
     expect(cmd2.goto).toEqual([]);
+  });
+
+  it('Run.resume restores a persisted interrupt before scoping a rebuilt resume', async () => {
+    const { Run } = await import('@/run');
+    const { Providers } = await import('@/common');
+
+    const run = await Run.create<t.IState>({
+      runId: 'hitl-rebuilt-scope',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: Providers.OPENAI,
+            clientOptions: {
+              modelName: 'gpt-4o-mini',
+              apiKey: 'test-key',
+            },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      humanInTheLoop: { enabled: true },
+    });
+    const persistedState = {
+      config: {
+        configurable: {
+          thread_id: 'durable-thread',
+          checkpoint_id: 'interrupted-checkpoint',
+          checkpoint_ns: '',
+        },
+      },
+      tasks: [
+        {
+          interrupts: [
+            {
+              id: 'persisted-interrupt',
+              value: { type: 'tool_approval' },
+            },
+          ],
+        },
+      ],
+    };
+    const getState = jest.fn(async (_config: RunnableConfig) => persistedState);
+    run.graphRunnable = { getState } as unknown as t.CompiledStateWorkflow;
+    const processSpy = jest
+      .spyOn(run, 'processStream')
+      .mockResolvedValue(undefined);
+    const callerConfig = {
+      version: 'v2' as const,
+      configurable: { thread_id: 'durable-thread' },
+    };
+    const decision = [{ type: 'approve' as const }];
+
+    await run.resume(decision, callerConfig);
+
+    expect(getState).toHaveBeenCalledWith(callerConfig);
+    const command = processSpy.mock.calls[0]?.[0] as Command;
+    expect(command.resume).toEqual({ 'persisted-interrupt': decision });
+    expect(processSpy.mock.calls[0]?.[1].configurable).toMatchObject({
+      thread_id: 'durable-thread',
+      checkpoint_id: 'interrupted-checkpoint',
+      checkpoint_ns: '',
+    });
+    expect(run.getInterrupt()).toMatchObject({
+      interruptId: 'persisted-interrupt',
+      threadId: 'durable-thread',
+      payload: { type: 'tool_approval' },
+    });
   });
 
   it('re-exports langgraph HITL primitives from the SDK barrel for host use', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -32,7 +32,7 @@ import type {
   UserPromptSubmitHookOutput,
 } from '@/hooks';
 import type * as t from '@/types';
-import { Providers as providers, GraphEvents } from '@/common';
+import { Constants, Providers as providers, GraphEvents } from '@/common';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
@@ -1094,6 +1094,16 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     const { Run } = await import('@/run');
     const { Providers } = await import('@/common');
 
+    const registry = new HookRegistry();
+    const persistedMatcher = {
+      hooks: [async (): Promise<PreToolUseHookOutput> => ({ decision: 'ask' })],
+    };
+    registry.registerSession(
+      'persisted-hook-session',
+      'PreToolUse',
+      persistedMatcher
+    );
+
     const run = await Run.create<t.IState>({
       runId: 'hitl-rebuilt-scope',
       graphConfig: {
@@ -1111,6 +1121,7 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
           },
         ],
       },
+      hooks: registry,
       humanInTheLoop: { enabled: true },
     });
     const persistedState = {
@@ -1126,7 +1137,10 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
           interrupts: [
             {
               id: 'persisted-interrupt',
-              value: { type: 'tool_approval' },
+              value: {
+                type: 'tool_approval',
+                hook_session_id: 'persisted-hook-session',
+              },
             },
           ],
         },
@@ -1156,8 +1170,17 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     expect(run.getInterrupt()).toMatchObject({
       interruptId: 'persisted-interrupt',
       threadId: 'durable-thread',
-      payload: { type: 'tool_approval' },
+      payload: {
+        type: 'tool_approval',
+        hook_session_id: 'persisted-hook-session',
+      },
     });
+    expect(
+      registry.getMatchers('PreToolUse', 'persisted-hook-session')
+    ).toEqual([persistedMatcher]);
+    expect(registry.getMatchers('PreToolUse', run.id)).toEqual([
+      persistedMatcher,
+    ]);
   });
 
   it('re-exports langgraph HITL primitives from the SDK barrel for host use', async () => {
@@ -2365,6 +2388,10 @@ describe('Codex review fixes', () => {
      * MUST still be present — the regression was that finally cleared
      * it, leaving the resume to bypass the policy entirely. */
     expect(run.getInterrupt()).toBeDefined();
+    expect(run.getInterrupt()?.payload).toMatchObject({
+      type: 'tool_approval',
+      hook_session_id: runId,
+    });
     expect(preCallCount).toBe(1);
     expect(registry.hasHookFor('PreToolUse', runId)).toBe(true);
     expect(dispatchCalls).toBe(0);
@@ -2378,6 +2405,63 @@ describe('Codex review fixes', () => {
     /** After natural completion, session matchers ARE cleared so the
      * next run on this registry starts clean. */
     expect(registry.hasHookFor('PreToolUse', runId)).toBe(false);
+  });
+
+  it('persists the parent hook session when a direct subagent approval interrupts', async () => {
+    const runId = 'parent-subagent-policy';
+    const executeSubagent = jest.fn(async () => 'child result');
+    const subagentTool = tool(executeSubagent, {
+      name: Constants.SUBAGENT,
+      description: 'execute a child agent',
+      schema: z.object({
+        description: z.string(),
+        subagent_type: z.string(),
+      }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    registry.registerSession(runId, 'PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'approve child delegation',
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [subagentTool],
+      hookRegistry: registry,
+      directToolNames: new Set([Constants.SUBAGENT]),
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_subagent',
+        name: Constants.SUBAGENT,
+        args: { description: 'inspect logs', subagent_type: 'researcher' },
+      },
+    ]);
+
+    const interrupted = await graph.invoke(
+      { messages: [] },
+      {
+        configurable: {
+          thread_id: 'parent-subagent-thread',
+          run_id: runId,
+        },
+      }
+    );
+
+    if (!isInterrupted<t.ToolApprovalInterruptPayload>(interrupted)) {
+      throw new Error('expected a subagent approval interrupt');
+    }
+    expect(interrupted.__interrupt__[0].value).toMatchObject({
+      type: 'tool_approval',
+      hook_session_id: runId,
+      action_requests: [
+        { tool_call_id: 'call_subagent', name: Constants.SUBAGENT },
+      ],
+    });
+    expect(executeSubagent).not.toHaveBeenCalled();
   });
 
   it('denied tool in a deny+ask batch dispatches ON_RUN_STEP_COMPLETED exactly once across interrupt + resume', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -2287,6 +2287,81 @@ describe('Codex review fixes', () => {
     jest.restoreAllMocks();
   });
 
+  it('reruns live hooks while replaying a consumed event-tool approval', async () => {
+    let dispatchCalls = 0;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        dispatchCalls += 1;
+        const request = data as {
+          resolve: (results: t.ToolExecuteResult[]) => void;
+        };
+        request.resolve([
+          { toolCallId: 'call_event', content: 'ran', status: 'success' },
+        ]);
+      });
+
+    const registry = new HookRegistry();
+    let onceCalls = 0;
+    let liveCalls = 0;
+    registry.register('PreToolUse', {
+      once: true,
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          onceCalls += 1;
+          return { decision: 'ask', reason: 'review once' };
+        },
+      ],
+    });
+    registry.register('PreToolUse', {
+      pattern: '^echo$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          liveCalls += 1;
+          return liveCalls === 1
+            ? { decision: 'allow' }
+            : { decision: 'deny', reason: 'policy changed before resume' };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo')],
+      eventDrivenMode: true,
+      agentId: 'agent-event-replay',
+      toolCallStepIds: new Map([['call_event', 'step_event']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'call_event', name: 'echo', args: { command: 'run' } },
+    ]);
+    const config = {
+      configurable: { thread_id: 'thread-event-hook-replay' },
+    };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted(interrupted)).toBe(true);
+    const resumed = await graph.invoke(
+      new Command({ resume: [{ type: 'approve' }] }),
+      config
+    );
+
+    expect(onceCalls).toBe(1);
+    expect(liveCalls).toBe(2);
+    expect(dispatchCalls).toBe(0);
+    const messages = (resumed as { messages: ToolMessage[] }).messages;
+    const result = messages.find(
+      (message) =>
+        message instanceof ToolMessage && message.tool_call_id === 'call_event'
+    );
+    expect(result?.status).toBe('error');
+    expect(String(result?.content)).toContain('policy changed before resume');
+  });
+
   it('preserves session-scoped hooks across HITL interrupt so the policy still fires on resume', async () => {
     let dispatchCalls = 0;
     jest

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1015,13 +1015,13 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
           },
         ],
         // Caller compileOptions without a checkpointer: HITL adds a MemorySaver
-        // fallback to the compiled graph, but the constructor restores this raw
-        // metadata (no checkpointer) onto Graph.compileOptions.
+        // fallback while preserving the caller's remaining compile options.
         compileOptions: { interruptBefore: [] },
       },
       humanInTheLoop: { enabled: true },
     });
-    expect(run.Graph?.compileOptions?.checkpointer).toBeUndefined();
+    expect(run.Graph?.compileOptions?.checkpointer).toBeInstanceOf(MemorySaver);
+    expect(run.Graph?.compileOptions?.interruptBefore).toEqual([]);
 
     const graph = new StateGraph(MessagesAnnotation)
       .addNode('noop', (): MessagesUpdate => ({ messages: [] }))

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -821,7 +821,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(serializedUpdates).not.toContain('checkpoint_');
   });
 
-  it('preserves a session-scoped child approval after rebuilding Run', async () => {
+  it('isolates rebuilt sibling approvals and preserves child run identity', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
         return HitlChildFakeChatModel;
@@ -832,6 +832,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const checkpointer = new MemorySaver();
     const registry = new HookRegistry();
     const executedTools: string[] = [];
+    const updates: t.SubagentUpdateEvent[] = [];
     let approvalHookCalls = 0;
     const runId = `subagent-rebuild-hitl-${Date.now()}`;
     registry.registerSession(`${runId}-initial`, 'PreToolUse', {
@@ -858,6 +859,11 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
               content: '42',
             }))
           );
+        },
+      },
+      [GraphEvents.ON_SUBAGENT_UPDATE]: {
+        handle: (_event, data): void => {
+          updates.push(data as t.SubagentUpdateEvent);
         },
       },
     };
@@ -891,23 +897,54 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       subagent: { parent_tool_call_id: tc.id },
     });
     expect(approvalHookCalls).toBe(1);
-
-    const rebuiltRun = await createRun(`${runId}-rebuilt`);
-    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    const sourceChildRunId =
+      persistedInterrupt?.payload.type === 'tool_approval'
+        ? persistedInterrupt.payload.subagent?.run_id
+        : undefined;
+    expect(sourceChildRunId).toBeDefined();
+    const branchConfig = {
+      ...callerConfig,
+      configurable: {
+        ...callerConfig.configurable,
+        checkpoint_id: persistedInterrupt?.checkpointId,
+        checkpoint_ns: persistedInterrupt?.checkpointNs ?? '',
+      },
+    };
+    const approvedRun = await createRun(`${runId}-approved`);
+    const rejectedRun = await createRun(`${runId}-rejected`);
+    approvedRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    rejectedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     const warningSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation((): void => undefined);
     try {
-      await rebuiltRun.resume(
+      await approvedRun.resume([{ type: 'approve' }], branchConfig);
+      await rejectedRun.resume(
         [{ type: 'reject', reason: 'deny after restart' }],
-        callerConfig
+        branchConfig
       );
     } finally {
       warningSpy.mockRestore();
     }
 
-    expect(rebuiltRun.getInterrupt()).toBeUndefined();
-    expect(executedTools).toEqual([]);
+    expect(approvedRun.getInterrupt()).toBeUndefined();
+    expect(rejectedRun.getInterrupt()).toBeUndefined();
+    expect(executedTools).toEqual(['calculator']);
     expect(approvalHookCalls).toBe(1);
+    const approvedChildThreads = approvedRun.getChildCheckpointThreadIds();
+    const rejectedChildThreads = rejectedRun.getChildCheckpointThreadIds();
+    expect(approvedChildThreads).toHaveLength(1);
+    expect(rejectedChildThreads).toHaveLength(1);
+    expect(approvedChildThreads[0]).not.toBe(rejectedChildThreads[0]);
+    expect(
+      updates
+        .filter((event) => event.parentToolCallId === tc.id)
+        .map((event) => event.subagentRunId)
+    ).toEqual(expect.arrayContaining([sourceChildRunId]));
+    expect(
+      updates
+        .filter((event) => event.parentToolCallId === tc.id)
+        .every((event) => event.subagentRunId === sourceChildRunId)
+    ).toBe(true);
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1,5 +1,7 @@
-import { MemorySaver } from '@langchain/langgraph';
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
 import { HumanMessage } from '@langchain/core/messages';
+import { MemorySaver, interrupt } from '@langchain/langgraph';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
@@ -27,6 +29,7 @@ import { FakeChatModel } from '@/llm/fake';
 import { Run } from '@/run';
 
 const CHILD_RESPONSE = 'Hook test child response.';
+const PRIMITIVE_INTERRUPT_TOOL_NAME = 'confirm_child';
 
 const calculatorDef: t.LCTool = {
   name: 'calculator',
@@ -123,6 +126,30 @@ function createParentAgentWithChildTool(): t.AgentInputs {
           instructions: 'Use calculator for arithmetic, then answer concisely.',
           maxContextTokens: 8000,
           toolDefinitions: [calculatorDef],
+        },
+      },
+    ],
+  };
+}
+
+function createParentAgentWithPrimitiveInterruptTool(
+  primitiveInterruptTool: t.GenericTool
+): t.AgentInputs {
+  const parent = createParentAgent();
+  const child = parent.subagentConfigs?.[0];
+  const childAgent = child?.agentInputs;
+  if (child == null || childAgent == null) {
+    throw new Error('Expected a child agent configuration.');
+  }
+  return {
+    ...parent,
+    subagentConfigs: [
+      {
+        ...child,
+        agentInputs: {
+          ...childAgent,
+          instructions: 'Request confirmation, then answer concisely.',
+          graphTools: [primitiveInterruptTool],
         },
       },
     ],
@@ -231,6 +258,42 @@ class HitlChildFakeChatModel extends FakeChatModel {
       tools,
     } as Parameters<FakeChatModel['withConfig']>[0];
     return this.withConfig(config);
+  }
+}
+
+class PrimitiveInterruptFakeChatModel extends FakeChatModel {
+  constructor(_options: object) {
+    super({ responses: [CHILD_RESPONSE], sleep: 1 });
+  }
+
+  _streamResponseChunks(
+    messages: Parameters<FakeChatModel['_streamResponseChunks']>[0],
+    options: Parameters<FakeChatModel['_streamResponseChunks']>[1],
+    runManager?: Parameters<FakeChatModel['_streamResponseChunks']>[2]
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    const hasToolResult = messages.some(
+      (message) => message._getType() === 'tool'
+    );
+    return new FakeChatModel({
+      responses: [hasToolResult ? CHILD_RESPONSE : 'Requesting confirmation.'],
+      sleep: 1,
+      toolCalls: hasToolResult
+        ? []
+        : [
+          {
+            name: PRIMITIVE_INTERRUPT_TOOL_NAME,
+            args: {},
+            id: 'call_child_primitive_interrupt',
+            type: 'tool_call',
+          },
+        ],
+    })._streamResponseChunks(messages, options, runManager);
+  }
+
+  bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
+    return this.withConfig({ tools } as Parameters<
+      FakeChatModel['withConfig']
+    >[0]);
   }
 }
 
@@ -999,6 +1062,81 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(serializedUpdates).not.toContain('checkpoint_');
   });
 
+  it('resumes a primitive child interrupt through a rebuilt Run', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return PrimitiveInterruptFakeChatModel;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const checkpointer = new MemorySaver();
+    const resumedValues: string[] = [];
+    const primitiveInterruptTool = tool(
+      async () => {
+        const resumeValue = interrupt<string, string>('confirm child');
+        resumedValues.push(resumeValue);
+        return `confirmed:${resumeValue}`;
+      },
+      {
+        name: PRIMITIVE_INTERRUPT_TOOL_NAME,
+        description: 'Pause for primitive confirmation.',
+        schema: z.object({}),
+      }
+    );
+    const createRun = (currentRunId: string): Promise<Run<t.IState>> =>
+      Run.create<t.IState>({
+        runId: currentRunId,
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            createParentAgentWithPrimitiveInterruptTool(primitiveInterruptTool),
+          ],
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+        humanInTheLoop: { enabled: true },
+      });
+    const runId = `primitive-subagent-rebuild-${Date.now()}`;
+    const parentCall = makeSubagentToolCall('call_primitive_rebuild');
+    const initialRun = await createRun(`${runId}-initial`);
+    initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
+      parentCall,
+    ]);
+
+    await initialRun.processStream(
+      { messages: [new HumanMessage('confirm inside the child')] },
+      callerConfig
+    );
+    const paused = initialRun.getInterrupt<string>();
+    expect(paused?.payload).toBe('confirm child');
+    expect(JSON.stringify(paused)).not.toContain(
+      '__librechat_subagent_resume_manifest'
+    );
+    if (paused?.checkpointId == null) {
+      throw new Error('Expected a persisted parent checkpoint.');
+    }
+
+    const rebuiltRun = await createRun(`${runId}-rebuilt`);
+    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    await rebuiltRun.resume<string>('approved after restart', {
+      ...callerConfig,
+      configurable: {
+        ...callerConfig.configurable,
+        checkpoint_id: paused.checkpointId,
+        checkpoint_ns: paused.checkpointNs ?? '',
+      },
+    });
+
+    expect(rebuiltRun.getInterrupt()).toBeUndefined();
+    expect(resumedValues).toEqual(['approved after restart']);
+  });
+
   it('forks every resume from the paused child snapshot', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
@@ -1095,28 +1233,77 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const sharedRebuiltRunId = `${runId}-same-rebuilt-id`;
     const approvedRun = await createRun(sharedRebuiltRunId);
     const rejectedRun = await createRun(sharedRebuiltRunId);
-    const restoreApprovalSpy = jest.spyOn(
-      registry,
-      'restorePendingToolApprovals'
-    );
+    let armRestoredCheckpointBarrier = false;
+    let blockNextRestoredCheckpointRead = false;
+    const originalRestorePendingToolApprovals =
+      registry.restorePendingToolApprovals.bind(registry);
+    const restoreApprovalSpy = jest
+      .spyOn(registry, 'restorePendingToolApprovals')
+      .mockImplementation((sessionId, targetExecutionScope, snapshots) => {
+        originalRestorePendingToolApprovals(
+          sessionId,
+          targetExecutionScope,
+          snapshots
+        );
+        if (armRestoredCheckpointBarrier) {
+          armRestoredCheckpointBarrier = false;
+          blockNextRestoredCheckpointRead = true;
+        }
+      });
+    let markCheckpointReadBlocked = (): void => undefined;
+    const checkpointReadBlocked = new Promise<void>((resolve) => {
+      markCheckpointReadBlocked = resolve;
+    });
+    let releaseBlockedCheckpointRead = (): void => undefined;
+    const blockedCheckpointReadRelease = new Promise<void>((resolve) => {
+      releaseBlockedCheckpointRead = resolve;
+    });
+    const originalGetTuple = checkpointer.getTuple.bind(checkpointer);
+    const checkpointReadSpy = jest
+      .spyOn(checkpointer, 'getTuple')
+      .mockImplementation(async (config) => {
+        const tuple = await originalGetTuple(config);
+        const configurable = config.configurable;
+        const threadId = configurable?.thread_id;
+        if (
+          blockNextRestoredCheckpointRead &&
+          typeof threadId === 'string' &&
+          threadId.startsWith('subagent:') &&
+          configurable?.checkpoint_id == null
+        ) {
+          blockNextRestoredCheckpointRead = false;
+          markCheckpointReadBlocked();
+          await blockedCheckpointReadRelease;
+        }
+        return tuple;
+      });
     earlyApprovedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     approvedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     rejectedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     const warningSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation((): void => undefined);
+    let rejectedResume: Promise<t.MessageContentComplex[] | undefined> | null =
+      null;
     try {
       await earlyApprovedRun.resume([{ type: 'approve' }], branchConfig);
       await initialRun.resume([{ type: 'approve' }], callerConfig);
-      await approvedRun.resume([{ type: 'approve' }], branchConfig);
-      await rejectedRun.resume(
+      armRestoredCheckpointBarrier = true;
+      rejectedResume = rejectedRun.resume(
         [{ type: 'reject', reason: 'deny after restart' }],
         branchConfig
       );
+      await checkpointReadBlocked;
+      await approvedRun.resume([{ type: 'approve' }], branchConfig);
+      releaseBlockedCheckpointRead();
+      await rejectedResume;
       expect(warningSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('toolCallStepIds missing entry')
       );
     } finally {
+      releaseBlockedCheckpointRead();
+      await rejectedResume?.catch(() => undefined);
+      checkpointReadSpy.mockRestore();
       warningSpy.mockRestore();
     }
 

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1,3 +1,4 @@
+import { MemorySaver } from '@langchain/langgraph';
 import { HumanMessage } from '@langchain/core/messages';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type { ToolCall } from '@langchain/core/messages/tool';
@@ -47,14 +48,17 @@ const callerConfig = {
 
 const originalGetChatModelClass = providers.getChatModelClass;
 
-function makeSubagentToolCall(): ToolCall {
+function makeSubagentToolCall(
+  id = `call_sub_${Date.now()}`,
+  description = 'Test task for hook verification'
+): ToolCall {
   return {
     name: Constants.SUBAGENT,
     args: {
-      description: 'Test task for hook verification',
+      description,
       subagent_type: 'researcher',
     },
-    id: `call_sub_${Date.now()}`,
+    id,
     type: 'tool_call',
   };
 }
@@ -115,6 +119,34 @@ function createCalculatorToolCall(): ToolCall {
     id: 'call_child_calculator',
     type: 'tool_call',
   };
+}
+
+class HitlChildFakeChatModel extends FakeChatModel {
+  constructor(_options: object) {
+    super({ responses: [CHILD_RESPONSE], sleep: 1 });
+  }
+
+  _streamResponseChunks(
+    messages: Parameters<FakeChatModel['_streamResponseChunks']>[0],
+    options: Parameters<FakeChatModel['_streamResponseChunks']>[1],
+    runManager?: Parameters<FakeChatModel['_streamResponseChunks']>[2]
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    const hasToolResult = messages.some(
+      (message) => message._getType() === 'tool'
+    );
+    return new FakeChatModel({
+      responses: [hasToolResult ? CHILD_RESPONSE : 'Using calculator.'],
+      sleep: 1,
+      toolCalls: hasToolResult ? [] : [createCalculatorToolCall()],
+    })._streamResponseChunks(messages, options, runManager);
+  }
+
+  bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
+    const config = {
+      tools,
+    } as Parameters<FakeChatModel['withConfig']>[0];
+    return this.withConfig(config);
+  }
 }
 
 async function createSubagentRun(
@@ -489,53 +521,185 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(dispatchAgentIds).toEqual(['hook-parent']);
   });
 
-  it('child subagent tool ask hooks fail closed instead of starting unsupported nested HITL', async () => {
+  it.each([
+    {
+      label: 'approve',
+      resumeDecision: { type: 'approve' } as const,
+      shouldExecute: true,
+      deniedReason: undefined,
+    },
+    {
+      label: 'reject',
+      resumeDecision: {
+        type: 'reject',
+        reason: 'host rejected child tool',
+      } as const,
+      shouldExecute: false,
+      deniedReason: 'host rejected child tool',
+    },
+    {
+      label: 'deny',
+      resumeDecision: undefined,
+      shouldExecute: false,
+      deniedReason: 'policy denied child tool',
+    },
+  ])(
+    'handles a child subagent tool $label through the parent Run',
+    async ({ resumeDecision, shouldExecute, deniedReason }) => {
+      getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return HitlChildFakeChatModel;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+
+      const registry = new HookRegistry();
+      const deniedTools: string[] = [];
+      const executedTools: string[] = [];
+      let calculatorPreToolCalls = 0;
+      let calculatorPostToolCalls = 0;
+
+      const preHook: HookCallback<'PreToolUse'> = async (
+        input
+      ): Promise<PreToolUseHookOutput> => {
+        if (input.toolName === 'calculator') {
+          calculatorPreToolCalls += 1;
+          if (resumeDecision == null) {
+            return {
+              decision: 'deny',
+              reason: 'policy denied child tool',
+            };
+          }
+          return { decision: 'ask', reason: 'review calculator' };
+        }
+        return { decision: 'allow' };
+      };
+      registry.register('PreToolUse', { hooks: [preHook] });
+      registry.register('PostToolUse', {
+        hooks: [
+          async (input): Promise<PostToolUseHookOutput> => {
+            if (input.toolName === 'calculator') {
+              calculatorPostToolCalls += 1;
+            }
+            return {};
+          },
+        ],
+      });
+
+      const deniedHook: HookCallback<'PermissionDenied'> = async (
+        input
+      ): Promise<PermissionDeniedHookOutput> => {
+        deniedTools.push(
+          `${input.agentId ?? '-'}:${input.toolName}:${input.reason}`
+        );
+        return {};
+      };
+      registry.register('PermissionDenied', { hooks: [deniedHook] });
+
+      const customHandlers: Record<string, t.EventHandler> = {
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.ON_TOOL_EXECUTE]: {
+          handle: (_event, rawData): void => {
+            const request = rawData as t.ToolExecuteBatchRequest;
+            executedTools.push(...request.toolCalls.map((call) => call.name));
+            const results: t.ToolExecuteResult[] = request.toolCalls.map(
+              (call) => ({
+                toolCallId: call.id,
+                status: 'success',
+                content: '42',
+              })
+            );
+            request.resolve(results);
+          },
+        },
+      };
+
+      const run = await Run.create<t.IState>({
+        runId: `subagent-tool-ask-${Date.now()}`,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgentWithChildTool()],
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+
+      const tc = makeSubagentToolCall();
+      run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+      await run.processStream(
+        { messages: [new HumanMessage('calculate something')] },
+        callerConfig
+      );
+
+      if (resumeDecision == null) {
+        expect(run.getInterrupt()).toBeUndefined();
+        expect(calculatorPreToolCalls).toBe(1);
+        expect(executedTools).not.toContain('calculator');
+        expect(deniedTools).toEqual([
+          `researcher-child:calculator:${deniedReason}`,
+        ]);
+        return;
+      }
+
+      const pending = run.getInterrupt();
+      expect(pending?.payload).toMatchObject({
+        type: 'tool_approval',
+        subagent: {
+          agent_id: 'researcher-child',
+          parent_tool_call_id: tc.id,
+          subagent_type: 'researcher',
+        },
+      });
+      expect(executedTools).not.toContain('calculator');
+
+      await run.resume([resumeDecision], callerConfig);
+
+      expect(run.getInterrupt()).toBeUndefined();
+      expect(calculatorPreToolCalls).toBe(2);
+      expect(
+        executedTools.filter((name) => name === 'calculator')
+      ).toHaveLength(shouldExecute ? 1 : 0);
+      expect(calculatorPostToolCalls).toBe(shouldExecute ? 1 : 0);
+      expect(deniedTools).toEqual(
+        shouldExecute ? [] : [`researcher-child:calculator:${deniedReason}`]
+      );
+    }
+  );
+
+  it('resumes approvals across multiple subagents and keeps updates sanitized', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
-        return class extends FakeChatModel {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          constructor(_options: any) {
-            super({
-              responses: ['Using calculator.', CHILD_RESPONSE],
-              sleep: 1,
-              toolCalls: [createCalculatorToolCall()],
-            });
-          }
-          bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
-            const config = {
-              tools,
-            } as Parameters<FakeChatModel['withConfig']>[0];
-            return this.withConfig(config);
-          }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any;
+        return HitlChildFakeChatModel;
       }
       return originalGetChatModelClass(provider);
     }) as typeof providers.getChatModelClass);
 
     const registry = new HookRegistry();
-    const deniedTools: string[] = [];
-    const executedTools: string[] = [];
+    const deniedToolIds: string[] = [];
+    const executedToolIds: string[] = [];
+    const updates: t.SubagentUpdateEvent[] = [];
 
-    const preHook: HookCallback<'PreToolUse'> = async (
-      input
-    ): Promise<PreToolUseHookOutput> => {
-      if (input.toolName === 'calculator') {
-        return { decision: 'ask', reason: 'review calculator' };
-      }
-      return { decision: 'allow' };
-    };
-    registry.register('PreToolUse', { hooks: [preHook] });
-
-    const deniedHook: HookCallback<'PermissionDenied'> = async (
-      input
-    ): Promise<PermissionDeniedHookOutput> => {
-      deniedTools.push(
-        `${input.agentId ?? '-'}:${input.toolName}:${input.reason}`
-      );
-      return {};
-    };
-    registry.register('PermissionDenied', { hooks: [deniedHook] });
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> =>
+          input.toolName === 'calculator'
+            ? { decision: 'ask', reason: 'review child calculator' }
+            : { decision: 'allow' },
+      ],
+    });
+    registry.register('PermissionDenied', {
+      hooks: [
+        async (input): Promise<PermissionDeniedHookOutput> => {
+          deniedToolIds.push(input.toolUseId);
+          return {};
+        },
+      ],
+    });
 
     const customHandlers: Record<string, t.EventHandler> = {
       [GraphEvents.TOOL_END]: new ToolEndHandler(),
@@ -543,21 +707,25 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       [GraphEvents.ON_TOOL_EXECUTE]: {
         handle: (_event, rawData): void => {
           const request = rawData as t.ToolExecuteBatchRequest;
-          executedTools.push(...request.toolCalls.map((call) => call.name));
-          const results: t.ToolExecuteResult[] = request.toolCalls.map(
-            (call) => ({
+          executedToolIds.push(...request.toolCalls.map((call) => call.id));
+          request.resolve(
+            request.toolCalls.map((call) => ({
               toolCallId: call.id,
-              status: 'success',
+              status: 'success' as const,
               content: '42',
-            })
+            }))
           );
-          request.resolve(results);
+        },
+      },
+      [GraphEvents.ON_SUBAGENT_UPDATE]: {
+        handle: (_event, data): void => {
+          updates.push(data as t.SubagentUpdateEvent);
         },
       },
     };
 
     const run = await Run.create<t.IState>({
-      runId: `subagent-tool-ask-${Date.now()}`,
+      runId: `subagent-multi-hitl-${Date.now()}`,
       graphConfig: {
         type: 'standard',
         agents: [createParentAgentWithChildTool()],
@@ -568,19 +736,155 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       hooks: registry,
       humanInTheLoop: { enabled: true },
     });
-
-    const tc = makeSubagentToolCall();
-    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+    const first = makeSubagentToolCall(
+      'call_sub_first',
+      'Run the first calculation'
+    );
+    const second = makeSubagentToolCall(
+      'call_sub_second',
+      'Run the second calculation'
+    );
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
+      first,
+      second,
+    ]);
+    const multiCallerConfig = {
+      ...callerConfig,
+      configurable: {
+        thread_id: 'multi-subagent-hitl-thread',
+        access_token: 'must-not-leak',
+        requestBody: { currentTaskInput: 'must-not-leak-task' },
+        userMCPAuthMap: { private: { token: 'must-not-leak-mcp' } },
+      },
+    };
 
     await run.processStream(
-      { messages: [new HumanMessage('calculate something')] },
-      callerConfig
+      { messages: [new HumanMessage('calculate twice')] },
+      multiCallerConfig
+    );
+    expect(run.getInterrupt()?.payload).toMatchObject({
+      type: 'tool_approval',
+      subagent: { parent_tool_call_id: first.id },
+    });
+    expect(updates.some((event) => event.parentToolCallId === second.id)).toBe(
+      true
+    );
+
+    await run.resume([{ type: 'approve' }], multiCallerConfig);
+    expect(run.getInterrupt()?.payload).toMatchObject({
+      type: 'tool_approval',
+      subagent: { parent_tool_call_id: second.id },
+    });
+
+    await run.resume(
+      [{ type: 'reject', reason: 'reject second child' }],
+      multiCallerConfig
     );
 
     expect(run.getInterrupt()).toBeUndefined();
-    expect(deniedTools).toContain(
-      'researcher-child:calculator:review calculator'
+    expect(executedToolIds).toHaveLength(1);
+    expect(deniedToolIds).toHaveLength(1);
+    const firstPhases = updates
+      .filter((event) => event.parentToolCallId === first.id)
+      .map((event) => event.phase);
+    const secondPhases = updates
+      .filter((event) => event.parentToolCallId === second.id)
+      .map((event) => event.phase);
+    expect(firstPhases[0]).toBe('start');
+    expect(firstPhases[firstPhases.length - 1]).toBe('stop');
+    expect(secondPhases[0]).toBe('start');
+    expect(secondPhases[secondPhases.length - 1]).toBe('stop');
+    const serializedUpdates = JSON.stringify(updates);
+    expect(serializedUpdates).not.toContain('must-not-leak');
+    expect(serializedUpdates).not.toContain('currentTaskInput');
+    expect(serializedUpdates).not.toContain('userMCPAuthMap');
+    expect(serializedUpdates).not.toContain('checkpoint_');
+  });
+
+  it('resumes a child approval after rebuilding Run with the same checkpointer', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return HitlChildFakeChatModel;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const checkpointer = new MemorySaver();
+    const registry = new HookRegistry();
+    const executedTools: string[] = [];
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> =>
+          input.toolName === 'calculator'
+            ? { decision: 'ask', reason: 'review calculator' }
+            : { decision: 'allow' },
+      ],
+    });
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          executedTools.push(...request.toolCalls.map((call) => call.name));
+          request.resolve(
+            request.toolCalls.map((call) => ({
+              toolCallId: call.id,
+              status: 'success' as const,
+              content: '42',
+            }))
+          );
+        },
+      },
+    };
+    const runId = `subagent-rebuild-hitl-${Date.now()}`;
+    const createRun = (): Promise<Run<t.IState>> =>
+      Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgentWithChildTool()],
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+    const tc = makeSubagentToolCall('call_sub_rebuild');
+    const initialRun = await createRun();
+    initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
+      tc,
+    ]);
+
+    await initialRun.processStream(
+      { messages: [new HumanMessage('calculate after restart')] },
+      callerConfig
     );
-    expect(executedTools).not.toContain('calculator');
+    const persistedInterrupt = initialRun.getInterrupt();
+    expect(persistedInterrupt?.payload).toMatchObject({
+      type: 'tool_approval',
+      subagent: { parent_tool_call_id: tc.id },
+    });
+
+    const rebuiltRun = await createRun();
+    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    const warningSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => undefined);
+    try {
+      await rebuiltRun.resume(
+        {
+          [persistedInterrupt!.interruptId]: [{ type: 'approve' }],
+        },
+        callerConfig
+      );
+    } finally {
+      warningSpy.mockRestore();
+    }
+
+    expect(rebuiltRun.getInterrupt()).toBeUndefined();
+    expect(executedTools).toEqual(['calculator']);
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -740,6 +740,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       graphConfig: {
         type: 'standard',
         agents: [createParentAgentWithChildTool()],
+        compileOptions: { interruptBefore: [] },
       },
       returnContent: true,
       skipCleanup: true,

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1095,6 +1095,10 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const sharedRebuiltRunId = `${runId}-same-rebuilt-id`;
     const approvedRun = await createRun(sharedRebuiltRunId);
     const rejectedRun = await createRun(sharedRebuiltRunId);
+    const restoreApprovalSpy = jest.spyOn(
+      registry,
+      'restorePendingToolApprovals'
+    );
     earlyApprovedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     approvedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     rejectedRun.Graph!.overrideTestModel(['Final answer.'], 1);
@@ -1122,6 +1126,10 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(rejectedRun.getInterrupt()).toBeUndefined();
     expect(executedTools).toEqual(['calculator', 'calculator', 'calculator']);
     expect(approvalHookCalls).toBe(1);
+    const restoredApprovalScopes = new Set(
+      restoreApprovalSpy.mock.calls.map(([, executionScope]) => executionScope)
+    );
+    expect(restoredApprovalScopes.size).toBeGreaterThanOrEqual(4);
     const initialChildThreads = initialRun.getChildCheckpointThreadIds();
     const earlyApprovedChildThreads =
       earlyApprovedRun.getChildCheckpointThreadIds();

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1124,17 +1124,37 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
 
     const rebuiltRun = await createRun(`${runId}-rebuilt`);
     rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
-    await rebuiltRun.resume<string>('approved after restart', {
-      ...callerConfig,
-      configurable: {
-        ...callerConfig.configurable,
-        checkpoint_id: paused.checkpointId,
-        checkpoint_ns: paused.checkpointNs ?? '',
+    const injected = new HumanMessage('host edit on resume');
+    const rebuiltContent = await rebuiltRun.resume<string>(
+      'approved after restart',
+      {
+        ...callerConfig,
+        configurable: {
+          ...callerConfig.configurable,
+          checkpoint_id: paused.checkpointId,
+          checkpoint_ns: paused.checkpointNs ?? '',
+        },
       },
-    });
+      undefined,
+      { update: { messages: [injected] } }
+    );
 
     expect(rebuiltRun.getInterrupt()).toBeUndefined();
     expect(resumedValues).toEqual(['approved after restart']);
+    expect(JSON.stringify(rebuiltContent)).toContain('Final answer.');
+    expect(JSON.stringify(rebuiltContent)).not.toContain('host edit on resume');
+    expect(
+      rebuiltRun
+        .getRunMessages()
+        ?.some(
+          (message) =>
+            message._getType() === 'ai' &&
+            JSON.stringify(message.content).includes('Final answer.')
+        )
+    ).toBe(true);
+    expect(
+      rebuiltRun.getRunMessages()?.some((message) => message.id === injected.id)
+    ).toBe(false);
   });
 
   it('forks every resume from the paused child snapshot', async () => {

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -832,13 +832,16 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const checkpointer = new MemorySaver();
     const registry = new HookRegistry();
     const executedTools: string[] = [];
+    let approvalHookCalls = 0;
     const runId = `subagent-rebuild-hitl-${Date.now()}`;
     registry.registerSession(`${runId}-initial`, 'PreToolUse', {
+      once: true,
+      pattern: '^calculator$',
       hooks: [
-        async (input): Promise<PreToolUseHookOutput> =>
-          input.toolName === 'calculator'
-            ? { decision: 'ask', reason: 'review calculator' }
-            : { decision: 'allow' },
+        async (): Promise<PreToolUseHookOutput> => {
+          approvalHookCalls += 1;
+          return { decision: 'ask', reason: 'review calculator' };
+        },
       ],
     });
     const customHandlers: Record<string, t.EventHandler> = {
@@ -887,6 +890,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       type: 'tool_approval',
       subagent: { parent_tool_call_id: tc.id },
     });
+    expect(approvalHookCalls).toBe(1);
 
     const rebuiltRun = await createRun(`${runId}-rebuilt`);
     rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
@@ -904,5 +908,6 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
 
     expect(rebuiltRun.getInterrupt()).toBeUndefined();
     expect(executedTools).toEqual([]);
+    expect(approvalHookCalls).toBe(1);
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1092,8 +1092,9 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       },
     };
     const earlyApprovedRun = await createRun(`${runId}-early-approved`);
-    const approvedRun = await createRun(`${runId}-approved`);
-    const rejectedRun = await createRun(`${runId}-rejected`);
+    const sharedRebuiltRunId = `${runId}-same-rebuilt-id`;
+    const approvedRun = await createRun(sharedRebuiltRunId);
+    const rejectedRun = await createRun(sharedRebuiltRunId);
     earlyApprovedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     approvedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     rejectedRun.Graph!.overrideTestModel(['Final answer.'], 1);

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -40,6 +40,23 @@ const calculatorDef: t.LCTool = {
   },
 };
 
+const referenceToolDefs: t.LCTool[] = [
+  {
+    name: 'produce_value',
+    description: 'Produce a value for a later tool.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: 'consume_value',
+    description: 'Consume a value from an earlier tool.',
+    parameters: {
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+    },
+  },
+];
+
 const callerConfig = {
   configurable: { thread_id: 'hook-test-thread' },
   streamMode: 'values' as const,
@@ -112,6 +129,74 @@ function createParentAgentWithChildTool(): t.AgentInputs {
   };
 }
 
+function createParentAgentWithNestedChildTool(): t.AgentInputs {
+  return {
+    agentId: 'nested-hook-parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'parent-model', apiKey: 'test-key' },
+    instructions: 'Delegate nested calculations.',
+    maxContextTokens: 8000,
+    maxSubagentDepth: 2,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Researcher',
+        description: 'Delegates calculations',
+        allowNested: true,
+        agentInputs: {
+          agentId: 'nested-researcher-child',
+          provider: Providers.OPENAI,
+          clientOptions: {
+            modelName: 'nested-child-model',
+            apiKey: 'test-key',
+          },
+          instructions: 'Delegate arithmetic to the calculator worker.',
+          maxContextTokens: 8000,
+          subagentConfigs: [
+            {
+              type: 'calculator-worker',
+              name: 'Calculator Worker',
+              description: 'Runs calculator tools',
+              agentInputs: {
+                agentId: 'calculator-grandchild',
+                provider: Providers.OPENAI,
+                clientOptions: {
+                  modelName: 'grandchild-model',
+                  apiKey: 'test-key',
+                },
+                instructions: 'Use calculator, then answer.',
+                maxContextTokens: 8000,
+                toolDefinitions: [calculatorDef],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function createParentAgentWithReferenceTools(): t.AgentInputs {
+  const parent = createParentAgentWithChildTool();
+  const child = parent.subagentConfigs?.[0];
+  const childAgent = child?.agentInputs;
+  if (child == null || childAgent == null) {
+    throw new Error('Expected a child agent configuration.');
+  }
+  return {
+    ...parent,
+    subagentConfigs: [
+      {
+        ...child,
+        agentInputs: {
+          ...childAgent,
+          toolDefinitions: referenceToolDefs,
+        },
+      },
+    ],
+  };
+}
+
 function createCalculatorToolCall(): ToolCall {
   return {
     name: 'calculator',
@@ -146,6 +231,99 @@ class HitlChildFakeChatModel extends FakeChatModel {
       tools,
     } as Parameters<FakeChatModel['withConfig']>[0];
     return this.withConfig(config);
+  }
+}
+
+class NestedHitlFakeChatModel extends FakeChatModel {
+  private readonly nestedChild: boolean;
+
+  constructor(options: { modelName?: string }) {
+    super({ responses: [CHILD_RESPONSE], sleep: 1 });
+    this.nestedChild = options.modelName === 'nested-child-model';
+  }
+
+  _streamResponseChunks(
+    messages: Parameters<FakeChatModel['_streamResponseChunks']>[0],
+    options: Parameters<FakeChatModel['_streamResponseChunks']>[1],
+    runManager?: Parameters<FakeChatModel['_streamResponseChunks']>[2]
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    const hasToolResult = messages.some(
+      (message) => message._getType() === 'tool'
+    );
+    let toolCalls: ToolCall[] = [];
+    if (!hasToolResult && this.nestedChild) {
+      toolCalls = [
+        {
+          name: Constants.SUBAGENT,
+          args: {
+            description: 'Calculate the result',
+            subagent_type: 'calculator-worker',
+          },
+          id: 'call_nested_calculator_worker',
+          type: 'tool_call',
+        },
+      ];
+    } else if (!hasToolResult) {
+      toolCalls = [createCalculatorToolCall()];
+    }
+    return new FakeChatModel({
+      responses: [hasToolResult ? CHILD_RESPONSE : 'Delegating calculation.'],
+      sleep: 1,
+      toolCalls,
+    })._streamResponseChunks(messages, options, runManager);
+  }
+
+  bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
+    return this.withConfig({ tools } as Parameters<
+      FakeChatModel['withConfig']
+    >[0]);
+  }
+}
+
+class ReferenceHitlFakeChatModel extends FakeChatModel {
+  constructor(_options: object) {
+    super({ responses: [CHILD_RESPONSE], sleep: 1 });
+  }
+
+  _streamResponseChunks(
+    messages: Parameters<FakeChatModel['_streamResponseChunks']>[0],
+    options: Parameters<FakeChatModel['_streamResponseChunks']>[1],
+    runManager?: Parameters<FakeChatModel['_streamResponseChunks']>[2]
+  ): ReturnType<FakeChatModel['_streamResponseChunks']> {
+    const toolResultCount = messages.filter(
+      (message) => message._getType() === 'tool'
+    ).length;
+    let toolCalls: ToolCall[] = [];
+    if (toolResultCount === 0) {
+      toolCalls = [
+        {
+          name: 'produce_value',
+          args: {},
+          id: 'call_produce_value',
+          type: 'tool_call',
+        },
+      ];
+    } else if (toolResultCount === 1) {
+      toolCalls = [
+        {
+          name: 'consume_value',
+          args: { value: '{{tool0turn0}}' },
+          id: 'call_consume_value',
+          type: 'tool_call',
+        },
+      ];
+    }
+    return new FakeChatModel({
+      responses: [toolCalls.length > 0 ? 'Using a tool.' : CHILD_RESPONSE],
+      sleep: 1,
+      toolCalls,
+    })._streamResponseChunks(messages, options, runManager);
+  }
+
+  bindTools(tools: unknown): ReturnType<FakeChatModel['withConfig']> {
+    return this.withConfig({ tools } as Parameters<
+      FakeChatModel['withConfig']
+    >[0]);
   }
 }
 
@@ -821,7 +999,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(serializedUpdates).not.toContain('checkpoint_');
   });
 
-  it('isolates rebuilt sibling approvals and preserves child run identity', async () => {
+  it('forks every resume from the paused child snapshot', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
         return HitlChildFakeChatModel;
@@ -896,6 +1074,9 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       type: 'tool_approval',
       subagent: { parent_tool_call_id: tc.id },
     });
+    expect(JSON.stringify(persistedInterrupt)).not.toContain(
+      '__librechat_subagent_resume_manifest'
+    );
     expect(approvalHookCalls).toBe(1);
     const sourceChildRunId =
       persistedInterrupt?.payload.type === 'tool_approval'
@@ -910,32 +1091,50 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         checkpoint_ns: persistedInterrupt?.checkpointNs ?? '',
       },
     };
+    const earlyApprovedRun = await createRun(`${runId}-early-approved`);
     const approvedRun = await createRun(`${runId}-approved`);
     const rejectedRun = await createRun(`${runId}-rejected`);
+    earlyApprovedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     approvedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     rejectedRun.Graph!.overrideTestModel(['Final answer.'], 1);
     const warningSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation((): void => undefined);
     try {
+      await earlyApprovedRun.resume([{ type: 'approve' }], branchConfig);
+      await initialRun.resume([{ type: 'approve' }], callerConfig);
       await approvedRun.resume([{ type: 'approve' }], branchConfig);
       await rejectedRun.resume(
         [{ type: 'reject', reason: 'deny after restart' }],
         branchConfig
       );
+      expect(warningSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('toolCallStepIds missing entry')
+      );
     } finally {
       warningSpy.mockRestore();
     }
 
+    expect(earlyApprovedRun.getInterrupt()).toBeUndefined();
+    expect(initialRun.getInterrupt()).toBeUndefined();
     expect(approvedRun.getInterrupt()).toBeUndefined();
     expect(rejectedRun.getInterrupt()).toBeUndefined();
-    expect(executedTools).toEqual(['calculator']);
+    expect(executedTools).toEqual(['calculator', 'calculator', 'calculator']);
     expect(approvalHookCalls).toBe(1);
+    const initialChildThreads = initialRun.getChildCheckpointThreadIds();
+    const earlyApprovedChildThreads =
+      earlyApprovedRun.getChildCheckpointThreadIds();
     const approvedChildThreads = approvedRun.getChildCheckpointThreadIds();
     const rejectedChildThreads = rejectedRun.getChildCheckpointThreadIds();
+    expect(initialChildThreads).toHaveLength(2);
+    expect(earlyApprovedChildThreads).toHaveLength(1);
     expect(approvedChildThreads).toHaveLength(1);
     expect(rejectedChildThreads).toHaveLength(1);
     expect(approvedChildThreads[0]).not.toBe(rejectedChildThreads[0]);
+    expect(earlyApprovedChildThreads[0]).not.toBe(approvedChildThreads[0]);
+    expect(earlyApprovedChildThreads[0]).not.toBe(rejectedChildThreads[0]);
+    expect(initialChildThreads).not.toContain(approvedChildThreads[0]);
+    expect(initialChildThreads).not.toContain(rejectedChildThreads[0]);
     expect(
       updates
         .filter((event) => event.parentToolCallId === tc.id)
@@ -946,5 +1145,204 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         .filter((event) => event.parentToolCallId === tc.id)
         .every((event) => event.subagentRunId === sourceChildRunId)
     ).toBe(true);
+  });
+
+  it('forks nested resumes from each checkpoint in the manifest chain', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return NestedHitlFakeChatModel;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const checkpointer = new MemorySaver();
+    const registry = new HookRegistry();
+    const executedTools: string[] = [];
+    const baseRunId = `nested-subagent-rebuild-${Date.now()}`;
+    registry.registerSession(`${baseRunId}-initial`, 'PreToolUse', {
+      once: true,
+      pattern: '^calculator$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review nested calculator',
+        }),
+      ],
+    });
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          executedTools.push(...request.toolCalls.map((call) => call.name));
+          request.resolve(
+            request.toolCalls.map((call) => ({
+              toolCallId: call.id,
+              status: 'success' as const,
+              content: '42',
+            }))
+          );
+        },
+      },
+    };
+    const createRun = (runId: string): Promise<Run<t.IState>> =>
+      Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgentWithNestedChildTool()],
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+    const parentCall = makeSubagentToolCall(
+      'call_nested_researcher',
+      'Delegate a nested calculation'
+    );
+    const initialRun = await createRun(`${baseRunId}-initial`);
+    initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
+      parentCall,
+    ]);
+
+    await initialRun.processStream(
+      { messages: [new HumanMessage('calculate through two agents')] },
+      callerConfig
+    );
+    const paused = initialRun.getInterrupt();
+    expect(paused?.payload).toMatchObject({
+      type: 'tool_approval',
+      subagent: {
+        agent_id: 'calculator-grandchild',
+        parent_tool_call_id: 'call_nested_calculator_worker',
+      },
+    });
+    const oldParentCheckpoint = {
+      ...callerConfig,
+      configurable: {
+        ...callerConfig.configurable,
+        checkpoint_id: paused?.checkpointId,
+        checkpoint_ns: paused?.checkpointNs ?? '',
+      },
+    };
+    const rebuiltRun = await createRun(`${baseRunId}-rebuilt`);
+    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    const warningSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => undefined);
+    try {
+      await initialRun.resume([{ type: 'approve' }], callerConfig);
+      await rebuiltRun.resume(
+        [{ type: 'reject', reason: 'reject stale nested branch' }],
+        oldParentCheckpoint
+      );
+      expect(warningSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('toolCallStepIds missing entry')
+      );
+    } finally {
+      warningSpy.mockRestore();
+    }
+
+    expect(initialRun.getInterrupt()).toBeUndefined();
+    expect(rebuiltRun.getInterrupt()).toBeUndefined();
+    expect(executedTools).toEqual(['calculator']);
+    expect(initialRun.getChildCheckpointThreadIds().length).toBeGreaterThan(2);
+    expect(rebuiltRun.getChildCheckpointThreadIds().length).toBeGreaterThan(1);
+  });
+
+  it('restores child tool-output references into rebuilt branches', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return ReferenceHitlFakeChatModel;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const referenceValue = 'checkpoint-scoped producer output';
+    const consumedValues: unknown[] = [];
+    const checkpointer = new MemorySaver();
+    const registry = new HookRegistry();
+    const baseRunId = `subagent-reference-rebuild-${Date.now()}`;
+    registry.registerSession(`${baseRunId}-initial`, 'PreToolUse', {
+      once: true,
+      pattern: '^consume_value$',
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review referenced input',
+        }),
+      ],
+    });
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          request.resolve(
+            request.toolCalls.map((call) => {
+              if (call.name === 'consume_value') {
+                consumedValues.push(call.args.value);
+              }
+              return {
+                toolCallId: call.id,
+                status: 'success' as const,
+                content:
+                  call.name === 'produce_value' ? referenceValue : 'consumed',
+              };
+            })
+          );
+        },
+      },
+    };
+    const createRun = (runId: string): Promise<Run<t.IState>> =>
+      Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgentWithReferenceTools()],
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+        toolOutputReferences: { enabled: true },
+      });
+    const parentCall = makeSubagentToolCall('call_reference_researcher');
+    const initialRun = await createRun(`${baseRunId}-initial`);
+    initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
+      parentCall,
+    ]);
+
+    await initialRun.processStream(
+      { messages: [new HumanMessage('produce and consume a value')] },
+      callerConfig
+    );
+    const paused = initialRun.getInterrupt();
+    expect(paused?.payload).toMatchObject({
+      type: 'tool_approval',
+      action_requests: [
+        { tool_call_id: 'call_consume_value', name: 'consume_value' },
+      ],
+    });
+    const rebuiltRun = await createRun(`${baseRunId}-rebuilt`);
+    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    await rebuiltRun.resume([{ type: 'approve' }], {
+      ...callerConfig,
+      configurable: {
+        ...callerConfig.configurable,
+        checkpoint_id: paused?.checkpointId,
+        checkpoint_ns: paused?.checkpointNs ?? '',
+      },
+    });
+
+    expect(rebuiltRun.getInterrupt()).toBeUndefined();
+    expect(consumedValues).toEqual([referenceValue]);
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -683,6 +683,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const deniedToolIds: string[] = [];
     const executedToolIds: string[] = [];
     const updates: t.SubagentUpdateEvent[] = [];
+    const completedSubagentCalls: string[] = [];
 
     registry.register('PreToolUse', {
       hooks: [
@@ -690,6 +691,16 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
           input.toolName === 'calculator'
             ? { decision: 'ask', reason: 'review child calculator' }
             : { decision: 'allow' },
+      ],
+    });
+    registry.register('PostToolUse', {
+      hooks: [
+        async (input): Promise<PostToolUseHookOutput> => {
+          if (input.toolName === Constants.SUBAGENT) {
+            completedSubagentCalls.push(input.toolUseId);
+          }
+          return {};
+        },
       ],
     });
     registry.register('PermissionDenied', {
@@ -784,6 +795,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(run.getInterrupt()).toBeUndefined();
     expect(executedToolIds).toHaveLength(1);
     expect(deniedToolIds).toHaveLength(1);
+    expect(completedSubagentCalls).toEqual([first.id, second.id]);
     const firstPhases = updates
       .filter((event) => event.parentToolCallId === first.id)
       .map((event) => event.phase);
@@ -838,9 +850,9 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       },
     };
     const runId = `subagent-rebuild-hitl-${Date.now()}`;
-    const createRun = (): Promise<Run<t.IState>> =>
+    const createRun = (currentRunId: string): Promise<Run<t.IState>> =>
       Run.create<t.IState>({
-        runId,
+        runId: currentRunId,
         graphConfig: {
           type: 'standard',
           agents: [createParentAgentWithChildTool()],
@@ -853,7 +865,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         humanInTheLoop: { enabled: true },
       });
     const tc = makeSubagentToolCall('call_sub_rebuild');
-    const initialRun = await createRun();
+    const initialRun = await createRun(`${runId}-initial`);
     initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
       tc,
     ]);
@@ -868,18 +880,13 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       subagent: { parent_tool_call_id: tc.id },
     });
 
-    const rebuiltRun = await createRun();
+    const rebuiltRun = await createRun(`${runId}-rebuilt`);
     rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
     const warningSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation((): void => undefined);
     try {
-      await rebuiltRun.resume(
-        {
-          [persistedInterrupt!.interruptId]: [{ type: 'approve' }],
-        },
-        callerConfig
-      );
+      await rebuiltRun.resume([{ type: 'approve' }], callerConfig);
     } finally {
       warningSpy.mockRestore();
     }

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -821,7 +821,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(serializedUpdates).not.toContain('checkpoint_');
   });
 
-  it('resumes a child approval after rebuilding Run with the same checkpointer', async () => {
+  it('preserves a session-scoped child approval after rebuilding Run', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
         return HitlChildFakeChatModel;
@@ -832,7 +832,8 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const checkpointer = new MemorySaver();
     const registry = new HookRegistry();
     const executedTools: string[] = [];
-    registry.register('PreToolUse', {
+    const runId = `subagent-rebuild-hitl-${Date.now()}`;
+    registry.registerSession(`${runId}-initial`, 'PreToolUse', {
       hooks: [
         async (input): Promise<PreToolUseHookOutput> =>
           input.toolName === 'calculator'
@@ -857,7 +858,6 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         },
       },
     };
-    const runId = `subagent-rebuild-hitl-${Date.now()}`;
     const createRun = (currentRunId: string): Promise<Run<t.IState>> =>
       Run.create<t.IState>({
         runId: currentRunId,
@@ -894,12 +894,15 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       .spyOn(console, 'warn')
       .mockImplementation((): void => undefined);
     try {
-      await rebuiltRun.resume([{ type: 'approve' }], callerConfig);
+      await rebuiltRun.resume(
+        [{ type: 'reject', reason: 'deny after restart' }],
+        callerConfig
+      );
     } finally {
       warningSpy.mockRestore();
     }
 
     expect(rebuiltRun.getInterrupt()).toBeUndefined();
-    expect(executedTools).toEqual(['calculator']);
+    expect(executedTools).toEqual([]);
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -698,6 +698,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         async (input): Promise<PostToolUseHookOutput> => {
           if (input.toolName === Constants.SUBAGENT) {
             completedSubagentCalls.push(input.toolUseId);
+            return { additionalContext: `context:${input.toolUseId}` };
           }
           return {};
         },
@@ -735,19 +736,23 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       },
     };
 
-    const run = await Run.create<t.IState>({
-      runId: `subagent-multi-hitl-${Date.now()}`,
-      graphConfig: {
-        type: 'standard',
-        agents: [createParentAgentWithChildTool()],
-        compileOptions: { interruptBefore: [] },
-      },
-      returnContent: true,
-      skipCleanup: true,
-      customHandlers,
-      hooks: registry,
-      humanInTheLoop: { enabled: true },
-    });
+    const checkpointer = new MemorySaver();
+    const baseRunId = `subagent-multi-hitl-${Date.now()}`;
+    const createRun = (runId: string): Promise<Run<t.IState>> =>
+      Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          agents: [createParentAgentWithChildTool()],
+          compileOptions: { checkpointer, interruptBefore: [] },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+    const run = await createRun(`${baseRunId}-initial`);
     const first = makeSubagentToolCall(
       'call_sub_first',
       'Run the first calculation'
@@ -788,12 +793,14 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       subagent: { parent_tool_call_id: second.id },
     });
 
-    await run.resume(
+    const rebuiltRun = await createRun(`${baseRunId}-rebuilt`);
+    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+    await rebuiltRun.resume(
       [{ type: 'reject', reason: 'reject second child' }],
       multiCallerConfig
     );
 
-    expect(run.getInterrupt()).toBeUndefined();
+    expect(rebuiltRun.getInterrupt()).toBeUndefined();
     expect(executedToolIds).toHaveLength(1);
     expect(deniedToolIds).toHaveLength(1);
     expect(completedSubagentCalls).toEqual([first.id, second.id]);

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -265,8 +265,10 @@ describe('ToolOutputReferenceRegistry', () => {
         intent: 'x {{tool0turn0}}',
       });
       expect(
-        view.resolve({ intent: 'x {{tool0turn0}}' }, { substituteIntentKey: true })
-          .resolved
+        view.resolve(
+          { intent: 'x {{tool0turn0}}' },
+          { substituteIntentKey: true }
+        ).resolved
       ).toEqual({ intent: 'x STORED' });
     });
 
@@ -282,6 +284,21 @@ describe('ToolOutputReferenceRegistry', () => {
   });
 
   describe('snapshot', () => {
+    it('restores entries and counters under a new run scope', () => {
+      const source = new ToolOutputReferenceRegistry();
+      source.set('source', 'tool0turn0', 'A');
+      expect(source.nextTurn('source')).toBe(0);
+      expect(source.claimWarnOnce('source', 'calculator')).toBe(true);
+
+      const restored = new ToolOutputReferenceRegistry();
+      restored.restoreState('branch', source.snapshotState('source'));
+
+      expect(restored.get('branch', 'tool0turn0')).toBe('A');
+      expect(restored.nextTurn('branch')).toBe(1);
+      expect(restored.claimWarnOnce('branch', 'calculator')).toBe(false);
+      expect(restored.get('source', 'tool0turn0')).toBeUndefined();
+    });
+
     it('resolves against the captured state and ignores later mutations', () => {
       const reg = new ToolOutputReferenceRegistry();
       reg.set('r', 'tool0turn0', 'OLD');

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -507,6 +507,17 @@ export class SubagentExecutor {
       };
     }
 
+    if (
+      this.humanInTheLoop?.enabled === true &&
+      (parentToolCallId == null || parentToolCallId === '')
+    ) {
+      return {
+        content:
+          'Error: Resumable subagent execution requires a parent tool call ID.',
+        messages: [],
+      };
+    }
+
     const executionSuffix = parentToolCallId ?? nanoid(8);
     const durableParentId = threadId ?? this.parentRunId;
     const childRunId = `${this.parentRunId}_sub_${executionSuffix}`;

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -188,6 +188,7 @@ type ActiveChildRun = {
 
 const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
 const LANGGRAPH_RESUME_MAP_CONFIG_KEY = '__pregel_resume_map';
+const LANGGRAPH_SCRATCHPAD_CONFIG_KEY = '__pregel_scratchpad';
 const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
   'checkpoint_id',
   'checkpoint_map',
@@ -211,20 +212,53 @@ function addSubagentScope(
   return interrupts.map((childInterrupt) => ({
     ...childInterrupt,
     value: isToolApprovalPayload(childInterrupt.value)
-      ? { ...childInterrupt.value, subagent: scope }
+      ? {
+        ...childInterrupt.value,
+        subagent: childInterrupt.value.subagent ?? scope,
+      }
       : childInterrupt.value,
   }));
 }
 
 type ToolApprovalResumeValue = ToolApprovalDecision[] | ToolApprovalDecisionMap;
 
+function isToolApprovalDecisionMap(
+  value: object
+): value is ToolApprovalDecisionMap {
+  return (
+    !Array.isArray(value) &&
+    Object.values(value).every(
+      (decision) =>
+        decision != null &&
+        typeof decision === 'object' &&
+        typeof (decision as { type?: unknown }).type === 'string'
+    )
+  );
+}
+
 function getChildResumeMap(
   pendingInterrupts: Interrupt[],
   parentConfigurable: Record<string, unknown> | undefined
 ): Record<string, ToolApprovalResumeValue> | undefined {
-  const resumeMap = parentConfigurable?.[LANGGRAPH_RESUME_MAP_CONFIG_KEY];
+  const scratchpad = parentConfigurable?.[LANGGRAPH_SCRATCHPAD_CONFIG_KEY] as
+    | { nullResume?: unknown; resume?: unknown[] }
+    | undefined;
+  const scratchpadResume =
+    scratchpad?.resume?.length === 1
+      ? scratchpad.resume[0]
+      : scratchpad?.nullResume;
+  const resumeMap =
+    parentConfigurable?.[LANGGRAPH_RESUME_MAP_CONFIG_KEY] ?? scratchpadResume;
   if (resumeMap == null || typeof resumeMap !== 'object') {
     return undefined;
+  }
+
+  const pendingInterruptId =
+    pendingInterrupts.length === 1 ? pendingInterrupts[0].id : undefined;
+  if (Array.isArray(resumeMap)) {
+    return typeof pendingInterruptId === 'string'
+      ? { [pendingInterruptId]: resumeMap }
+      : undefined;
   }
 
   const parentResumeMap = resumeMap as Record<string, ToolApprovalResumeValue>;
@@ -238,7 +272,16 @@ function getChildResumeMap(
       childResumeMap[interruptId] = parentResumeMap[interruptId];
     }
   }
-  return Object.keys(childResumeMap).length > 0 ? childResumeMap : undefined;
+  if (Object.keys(childResumeMap).length > 0) {
+    return childResumeMap;
+  }
+  if (
+    typeof pendingInterruptId === 'string' &&
+    isToolApprovalDecisionMap(resumeMap)
+  ) {
+    return { [pendingInterruptId]: resumeMap };
+  }
+  return undefined;
 }
 
 function getPersistedInterrupts(snapshot: StateSnapshot): Interrupt[] {
@@ -293,8 +336,10 @@ export type SubagentExecuteParams = {
    *
    * Inheritance details (verified empirically against LangGraph):
    *   - host-set keys propagate as-is into the child's tool dispatches;
-   *   - with nested HITL enabled, `thread_id` is replaced with the stable
-   *     child run id so parent and child checkpoints cannot collide;
+   *   - with nested HITL enabled, `thread_id` is replaced with a stable
+   *     child checkpoint id derived from the parent's durable thread id,
+   *     parent agent id, and spawning tool call id so parent and child
+   *     checkpoints cannot collide or drift when a host rebuilds the Run;
    *     parent-scoped hook lookup remains keyed by the inherited `run_id`;
    *   - `parent_run_id` propagates when the host put it on parent's
    *     configurable;
@@ -503,7 +548,9 @@ export class SubagentExecutor {
     }
 
     const executionSuffix = parentToolCallId ?? nanoid(8);
+    const durableParentId = threadId ?? this.parentRunId;
     const childRunId = `${this.parentRunId}_sub_${executionSuffix}`;
+    const childThreadId = `${durableParentId}_sub_${this.parentAgentId ?? 'agent'}_${executionSuffix}`;
     const childAgentId =
       config.agentInputs.agentId ||
       `${this.parentAgentId ?? 'agent'}_sub_${executionSuffix}`;
@@ -639,10 +686,11 @@ export class SubagentExecutor {
       const callbacks: Callbacks = callbackHandlers;
       /**
        * Inherit the parent's host `configurable` while binding LangGraph's
-       * checkpoint identity to the stable child run id. The parent thread id
-       * cannot be reused here: parent and child share one checkpointer when
-       * nested HITL is enabled, and root checkpoint namespaces are normalized
-       * by LangGraph, so a shared `thread_id` would collide with the parent.
+       * checkpoint identity to a stable child id derived from the durable
+       * parent thread. The parent thread id cannot be reused here: parent and
+       * child share one checkpointer when nested HITL is enabled, and root
+       * checkpoint namespaces are normalized by LangGraph, so a shared
+       * `thread_id` would collide with the parent.
        *
        * `run_id` still propagates as the parent run id, which is the key used
        * for session-scoped hook lookup. Child hook inputs therefore retain
@@ -660,7 +708,7 @@ export class SubagentExecutor {
           ...inheritedConfigurable,
           thread_id:
             this.humanInTheLoop?.enabled === true
-              ? childRunId
+              ? childThreadId
               : (inheritedConfigurable.thread_id ?? childRunId),
         },
       };
@@ -1790,11 +1838,10 @@ export function buildChildInputs(
      * Host-supplied direct tools are scrubbed from INHERITED configs only.
      * A self-spawn config's `agentInputs` is a shallow spread of the parent's
      * `_sourceInputs`, so without this a parent-scoped graph tool (e.g. an
-     * interrupt-raising ask_user_question, which needs the parent's
-     * checkpointer — child graphs compile without one) would silently leak
-     * into the child and deterministically throw `No checkpointer set`. An
-     * EXPLICIT child config that lists its own `graphTools` is a deliberate
-     * host choice and keeps them (Codex #289 P2).
+     * interrupt-raising ask_user_question) would silently become available to
+     * the child. An EXPLICIT child config that lists its own `graphTools` is a
+     * deliberate host choice and keeps them (Codex #289 P2); with HITL enabled,
+     * those tools use the shared checkpointer and can pause and resume safely.
      */
     graphTools: config.self === true ? undefined : agentInputs.graphTools,
   };

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,7 +1,12 @@
 import { nanoid } from 'nanoid';
-import { HumanMessage } from '@langchain/core/messages';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import {
   Command,
   GraphInterrupt,
@@ -9,11 +14,16 @@ import {
   isGraphInterrupt,
   isInterrupted,
 } from '@langchain/langgraph';
-import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
+import type {
+  Interrupt,
+  StateSnapshot,
+  BaseCheckpointSaver,
+} from '@langchain/langgraph';
 import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
-import type { Interrupt, StateSnapshot } from '@langchain/langgraph';
 import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
   AgentInputs,
   BaseGraphState,
@@ -40,6 +50,7 @@ import type {
   ToolApprovalDecisionMap,
 } from '@/types';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
+import type { SettledSubagentToolOutput } from './SubagentReplay';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
@@ -178,12 +189,40 @@ type ForwarderCallback = {
 
 type StatefulCompiledWorkflow = CompiledStateWorkflow & {
   getState(config: RunnableConfig): Promise<StateSnapshot>;
+  updateState?(
+    config: RunnableConfig,
+    values: Record<string, unknown>,
+    asNode?: string
+  ): Promise<RunnableConfig>;
 };
 
 type ActiveChildRun = {
   graph: StandardGraph;
   workflow: StatefulCompiledWorkflow;
   pendingInterrupts: Interrupt[];
+  invokeConfig?: RunnableConfig;
+  childAgentId: string;
+};
+
+type PersistedToolOutput = {
+  content: ToolMessage['content'];
+  toolCallId: string;
+  id?: string;
+  name?: string;
+  status?: 'success' | 'error';
+  additionalKwargs: ToolMessage['additional_kwargs'];
+  responseMetadata: ToolMessage['response_metadata'];
+  metadata?: Record<string, unknown>;
+  additionalContexts: string[];
+  resolvedArgs?: Record<string, unknown>;
+  referenceContent?: string;
+};
+
+type SubagentCheckpointMarker = {
+  version: 1;
+  parentToolCallId: string;
+  lifecycleComplete: true;
+  settledOutput?: PersistedToolOutput;
 };
 
 const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
@@ -193,6 +232,183 @@ const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
   'checkpoint_map',
   'checkpoint_ns',
 ]);
+const SUBAGENT_CHECKPOINT_MARKER_KEY = '__librechat_subagent_checkpoint';
+
+function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<BaseCheckpointSaver>;
+  return (
+    typeof candidate.getTuple === 'function' &&
+    typeof candidate.list === 'function' &&
+    typeof candidate.put === 'function' &&
+    typeof candidate.putWrites === 'function' &&
+    typeof candidate.deleteThread === 'function'
+  );
+}
+
+function isSubagentCheckpointMarker(
+  value: unknown
+): value is SubagentCheckpointMarker {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const marker = value as Partial<SubagentCheckpointMarker>;
+  return (
+    marker.version === 1 &&
+    marker.lifecycleComplete === true &&
+    typeof marker.parentToolCallId === 'string' &&
+    (marker.settledOutput == null ||
+      isPersistedToolOutput(marker.settledOutput))
+  );
+}
+
+function isPersistedToolOutput(value: unknown): value is PersistedToolOutput {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const output = value as {
+    content?: unknown;
+    toolCallId?: unknown;
+    status?: unknown;
+    additionalKwargs?: unknown;
+    responseMetadata?: unknown;
+    additionalContexts?: unknown;
+    resolvedArgs?: unknown;
+    referenceContent?: unknown;
+  };
+  const contentIsValid =
+    typeof output.content === 'string' || Array.isArray(output.content);
+  const statusIsValid =
+    output.status == null ||
+    output.status === 'success' ||
+    output.status === 'error';
+  const contextsAreValid =
+    Array.isArray(output.additionalContexts) &&
+    output.additionalContexts.every((context) => typeof context === 'string');
+  const resolvedArgsAreValid =
+    output.resolvedArgs == null ||
+    (typeof output.resolvedArgs === 'object' &&
+      !Array.isArray(output.resolvedArgs));
+  return (
+    contentIsValid &&
+    typeof output.toolCallId === 'string' &&
+    output.additionalKwargs != null &&
+    typeof output.additionalKwargs === 'object' &&
+    output.responseMetadata != null &&
+    typeof output.responseMetadata === 'object' &&
+    statusIsValid &&
+    contextsAreValid &&
+    resolvedArgsAreValid &&
+    (output.referenceContent == null ||
+      typeof output.referenceContent === 'string')
+  );
+}
+
+function getSubagentCheckpointMarker(
+  messages: BaseMessage[],
+  parentToolCallId: string
+): SubagentCheckpointMarker | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const marker =
+      messages[i].additional_kwargs[SUBAGENT_CHECKPOINT_MARKER_KEY];
+    if (
+      isSubagentCheckpointMarker(marker) &&
+      marker.parentToolCallId === parentToolCallId
+    ) {
+      return marker;
+    }
+  }
+  return undefined;
+}
+
+function isSubagentCheckpointMarkerMessage(message: BaseMessage): boolean {
+  return isSubagentCheckpointMarker(
+    message.additional_kwargs[SUBAGENT_CHECKPOINT_MARKER_KEY]
+  );
+}
+
+function createSubagentCheckpointMarkerMessage(
+  marker: SubagentCheckpointMarker
+): AIMessage {
+  return new AIMessage({
+    content: '',
+    additional_kwargs: { [SUBAGENT_CHECKPOINT_MARKER_KEY]: marker },
+  });
+}
+
+function getCheckpointMessages(value: unknown): BaseMessage[] {
+  return Array.isArray(value) ? value.filter(BaseMessage.isInstance) : [];
+}
+
+function serializeToolOutput(
+  settled: SettledSubagentToolOutput
+): PersistedToolOutput {
+  const { output } = settled;
+  return {
+    content: output.content,
+    toolCallId: output.tool_call_id,
+    ...(output.id == null ? {} : { id: output.id }),
+    ...(output.name == null ? {} : { name: output.name }),
+    ...(output.status == null ? {} : { status: output.status }),
+    additionalKwargs: output.additional_kwargs,
+    responseMetadata: output.response_metadata,
+    ...(output.metadata == null ? {} : { metadata: output.metadata }),
+    additionalContexts: settled.additionalContexts,
+    ...(settled.resolvedArgs == null
+      ? {}
+      : { resolvedArgs: settled.resolvedArgs }),
+    ...(settled.referenceContent == null
+      ? {}
+      : { referenceContent: settled.referenceContent }),
+  };
+}
+
+function deserializeToolOutput(
+  output: PersistedToolOutput
+): SettledSubagentToolOutput {
+  return {
+    output: new ToolMessage({
+      content: output.content,
+      tool_call_id: output.toolCallId,
+      ...(output.id == null ? {} : { id: output.id }),
+      ...(output.name == null ? {} : { name: output.name }),
+      ...(output.status == null ? {} : { status: output.status }),
+      additional_kwargs: output.additionalKwargs,
+      response_metadata: output.responseMetadata,
+      ...(output.metadata == null ? {} : { metadata: output.metadata }),
+    }),
+    additionalContexts: output.additionalContexts,
+    ...(output.resolvedArgs == null
+      ? {}
+      : { resolvedArgs: output.resolvedArgs }),
+    ...(output.referenceContent == null
+      ? {}
+      : { referenceContent: output.referenceContent }),
+  };
+}
+
+function getParentCheckpointFork(
+  configurable: Record<string, unknown> | undefined
+): string {
+  const checkpointId = configurable?.checkpoint_id;
+  return typeof checkpointId === 'string' && checkpointId.length > 0
+    ? checkpointId
+    : 'root';
+}
+
+function getChildThreadId(args: {
+  parentRunId: string;
+  parentAgentId?: string;
+  threadId?: string;
+  parentToolCallId: string;
+  parentConfigurable?: Record<string, unknown>;
+}): string {
+  const durableParentId = args.threadId ?? args.parentRunId;
+  const parentFork = getParentCheckpointFork(args.parentConfigurable);
+  return `${durableParentId}_sub_${parentFork}_${args.parentAgentId ?? 'agent'}_${args.parentToolCallId}`;
+}
 
 function isToolApprovalPayload(
   value: unknown
@@ -261,9 +477,13 @@ function getPersistedMessages(
     return undefined;
   }
   const values = snapshot.values as { messages?: BaseMessage[] };
-  return Array.isArray(values.messages) && values.messages.length > 0
-    ? values.messages
-    : undefined;
+  if (!Array.isArray(values.messages) || values.messages.length === 0) {
+    return undefined;
+  }
+  const messages = values.messages.filter(
+    (message) => !isSubagentCheckpointMarkerMessage(message)
+  );
+  return messages.length > 0 ? messages : undefined;
 }
 
 export type SubagentExecuteParams = {
@@ -298,8 +518,9 @@ export type SubagentExecuteParams = {
    *   - host-set keys propagate as-is into the child's tool dispatches;
    *   - with nested HITL enabled, `thread_id` is replaced with a stable
    *     child checkpoint id derived from the parent's durable thread id,
-   *     parent agent id, and spawning tool call id so parent and child
-   *     checkpoints cannot collide or drift when a host rebuilds the Run;
+   *     checkpoint fork, parent agent id, and spawning tool call id so parent
+   *     and child checkpoints cannot collide, sibling parent forks stay
+   *     isolated, and reconstruction returns to the same child checkpoint;
    *     parent-scoped hook lookup remains keyed by the inherited `run_id`;
    *   - `parent_run_id` propagates when the host put it on parent's
    *     configurable;
@@ -361,6 +582,10 @@ export type SubagentExecutorOptions = {
    */
   streamLimits?: StandardGraphInput['streamLimits'];
   humanInTheLoop?: HumanInTheLoopConfig;
+  /** Shared durable saver used to recover outer tool lifecycle results before
+   * parent hooks re-enter after a process rebuild. Narrowed structurally at
+   * construction because graph compile options also permit framework flags. */
+  checkpointer?: unknown;
   /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
   /**
@@ -411,6 +636,7 @@ export class SubagentExecutor {
   private readonly tokenCounter?: TokenCounter;
   private readonly streamLimits?: StandardGraphInput['streamLimits'];
   private readonly humanInTheLoop?: HumanInTheLoopConfig;
+  private readonly checkpointer?: BaseCheckpointSaver;
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
   private readonly usageSink?: SubagentUsageSink;
@@ -436,6 +662,9 @@ export class SubagentExecutor {
     this.tokenCounter = options.tokenCounter;
     this.streamLimits = options.streamLimits;
     this.humanInTheLoop = options.humanInTheLoop;
+    this.checkpointer = isCheckpointSaver(options.checkpointer)
+      ? options.checkpointer
+      : undefined;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
     this.usageSink = options.usageSink;
@@ -479,6 +708,102 @@ export class SubagentExecutor {
     this.completedChildRuns.clear();
   }
 
+  async getSettledToolOutput(
+    call: ToolCall,
+    config: RunnableConfig
+  ): Promise<SettledSubagentToolOutput | undefined> {
+    const parentToolCallId = call.id;
+    if (
+      this.humanInTheLoop?.enabled !== true ||
+      this.checkpointer == null ||
+      parentToolCallId == null ||
+      parentToolCallId === ''
+    ) {
+      return undefined;
+    }
+    const parentConfigurable = config.configurable as
+      | Record<string, unknown>
+      | undefined;
+    const threadId = parentConfigurable?.thread_id;
+    const childThreadId = getChildThreadId({
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      threadId: typeof threadId === 'string' ? threadId : undefined,
+      parentToolCallId,
+      parentConfigurable,
+    });
+    const checkpoint = await this.checkpointer.getTuple({
+      configurable: { thread_id: childThreadId },
+    });
+    const messages = getCheckpointMessages(
+      checkpoint?.checkpoint.channel_values.messages
+    );
+    const marker = getSubagentCheckpointMarker(messages, parentToolCallId);
+    return marker?.settledOutput == null
+      ? undefined
+      : deserializeToolOutput(marker.settledOutput);
+  }
+
+  async persistSettledToolOutput(
+    call: ToolCall,
+    config: RunnableConfig,
+    settled: SettledSubagentToolOutput
+  ): Promise<void> {
+    const parentToolCallId = call.id;
+    if (parentToolCallId == null || parentToolCallId === '') {
+      return;
+    }
+    const parentConfigurable = config.configurable as
+      | Record<string, unknown>
+      | undefined;
+    const threadId = parentConfigurable?.thread_id;
+    const childThreadId = getChildThreadId({
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      threadId: typeof threadId === 'string' ? threadId : undefined,
+      parentToolCallId,
+      parentConfigurable,
+    });
+    const activeChildRun = this.activeChildRuns.get(childThreadId);
+    if (activeChildRun == null) {
+      return;
+    }
+    await this.persistChildCheckpointMarker(
+      activeChildRun,
+      parentToolCallId,
+      serializeToolOutput(settled)
+    );
+    this.activeChildRuns.delete(childThreadId);
+  }
+
+  private async persistChildCheckpointMarker(
+    activeChildRun: ActiveChildRun,
+    parentToolCallId: string,
+    settledOutput?: PersistedToolOutput
+  ): Promise<void> {
+    if (
+      this.humanInTheLoop?.enabled !== true ||
+      activeChildRun.workflow.updateState == null ||
+      activeChildRun.invokeConfig == null
+    ) {
+      return;
+    }
+    await activeChildRun.workflow.updateState(
+      activeChildRun.invokeConfig,
+      {
+        messages: [
+          createSubagentCheckpointMarkerMessage({
+            version: 1,
+            parentToolCallId,
+            lifecycleComplete: true,
+            ...(settledOutput == null ? {} : { settledOutput }),
+          }),
+        ],
+      },
+      activeChildRun.childAgentId
+    );
+  }
+
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
     const { description, subagentType, threadId, parentToolCallId } = params;
     /** Captured ONCE per execution, preferring the controller the parent
@@ -519,13 +844,20 @@ export class SubagentExecutor {
     }
 
     const executionSuffix = parentToolCallId ?? nanoid(8);
-    const durableParentId = threadId ?? this.parentRunId;
     const childRunId = `${this.parentRunId}_sub_${executionSuffix}`;
-    const childThreadId = `${durableParentId}_sub_${this.parentAgentId ?? 'agent'}_${executionSuffix}`;
+    const childThreadId = getChildThreadId({
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      threadId,
+      parentToolCallId: executionSuffix,
+      parentConfigurable: params.parentConfigurable,
+    });
+    const childExecutionKey = childThreadId;
     const childAgentId =
       config.agentInputs.agentId ||
       `${this.parentAgentId ?? 'agent'}_sub_${executionSuffix}`;
-    const completedChildResult = this.completedChildResults.get(childRunId);
+    const completedChildResult =
+      this.completedChildResults.get(childExecutionKey);
     if (completedChildResult != null) {
       return completedChildResult;
     }
@@ -552,7 +884,7 @@ export class SubagentExecutor {
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
     const hostUsageSink = this.usageSink;
-    const cachedChildRun = this.activeChildRuns.get(childRunId);
+    const cachedChildRun = this.activeChildRuns.get(childExecutionKey);
     const childGraph =
       cachedChildRun?.graph ??
       this.createChildGraph({
@@ -598,10 +930,11 @@ export class SubagentExecutor {
       });
     }
     const forwarder = forwarding?.handler;
-    let childAlreadyStarted = this.startedChildRuns.has(childRunId);
-    const childAlreadyCompleted = this.completedChildRuns.has(childRunId);
+    let childAlreadyStarted = this.startedChildRuns.has(childExecutionKey);
+    let childAlreadyCompleted = this.completedChildRuns.has(childExecutionKey);
 
-    let result: { messages: BaseMessage[] };
+    let result: { messages: BaseMessage[] } | undefined;
+    let recoveredComplete = false;
     try {
       const workflow = (cachedChildRun?.workflow ??
         childGraph.createWorkflow()) as StatefulCompiledWorkflow;
@@ -609,9 +942,10 @@ export class SubagentExecutor {
         graph: childGraph,
         workflow,
         pendingInterrupts: [],
+        childAgentId,
       };
       if (cachedChildRun == null) {
-        this.activeChildRuns.set(childRunId, activeChildRun);
+        this.activeChildRuns.set(childExecutionKey, activeChildRun);
       }
       /**
        * When `parentHandlerRegistry` is provided (forwarding mode), attach a
@@ -658,10 +992,10 @@ export class SubagentExecutor {
       /**
        * Inherit the parent's host `configurable` while binding LangGraph's
        * checkpoint identity to a stable child id derived from the durable
-       * parent thread. The parent thread id cannot be reused here: parent and
-       * child share one checkpointer when nested HITL is enabled, and root
-       * checkpoint namespaces are normalized by LangGraph, so a shared
-       * `thread_id` would collide with the parent.
+       * parent thread and checkpoint fork. The parent thread id cannot be
+       * reused here: parent and child share one checkpointer when nested HITL
+       * is enabled, and root checkpoint namespaces are normalized by
+       * LangGraph, so a shared `thread_id` would collide with the parent.
        *
        * `run_id` still propagates as the parent run id, which is the key used
        * for session-scoped hook lookup. Child hook inputs therefore retain
@@ -683,6 +1017,7 @@ export class SubagentExecutor {
               : (inheritedConfigurable.thread_id ?? childRunId),
         },
       };
+      activeChildRun.invokeConfig = childInvokeConfig;
       if (cachedChildRun == null && this.humanInTheLoop?.enabled === true) {
         /** Rehydrate child-owned interrupt state when a host rebuilds Run
          * around the same durable checkpointer after a process boundary. */
@@ -690,107 +1025,111 @@ export class SubagentExecutor {
         const persistedInterrupts = getPersistedInterrupts(persistedState);
         if (persistedInterrupts.length > 0) {
           activeChildRun.pendingInterrupts = persistedInterrupts;
-          this.startedChildRuns.add(childRunId);
+          this.startedChildRuns.add(childExecutionKey);
           childAlreadyStarted = true;
         } else if (persistedState.next.length === 0) {
           const persistedMessages = getPersistedMessages(persistedState);
           if (persistedMessages != null) {
-            const persistedResult = {
-              content: filterSubagentResult(persistedMessages),
-              messages: persistedMessages,
+            const snapshotValues = persistedState.values as {
+              messages?: unknown;
             };
-            this.startedChildRuns.add(childRunId);
-            this.completedChildRuns.add(childRunId);
-            this.completedChildResults.set(childRunId, persistedResult);
-            childGraph.clearHeavyState();
-            this.activeChildRuns.delete(childRunId);
-            return persistedResult;
+            const marker = getSubagentCheckpointMarker(
+              getCheckpointMessages(snapshotValues.messages),
+              executionSuffix
+            );
+            result = { messages: persistedMessages };
+            recoveredComplete = true;
+            childAlreadyStarted = true;
+            childAlreadyCompleted = marker?.lifecycleComplete === true;
+            this.startedChildRuns.add(childExecutionKey);
           }
         }
       }
-      const childResumeMap = getChildResumeMap(
-        activeChildRun.pendingInterrupts,
-        params.parentConfigurable
-      );
-      if (
-        activeChildRun.pendingInterrupts.length > 0 &&
-        childResumeMap == null
-      ) {
-        throw new GraphInterrupt(activeChildRun.pendingInterrupts);
-      }
-      const childInput =
-        childResumeMap == null
-          ? { messages: [new HumanMessage(description)] }
-          : new Command({ resume: childResumeMap });
-
-      if (
-        !childAlreadyStarted &&
-        this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) ===
-          true
-      ) {
-        const hookResult = await executeHooks({
-          registry: this.hookRegistry,
-          input: {
-            hook_event_name: 'SubagentStart',
-            runId: this.parentRunId,
-            threadId,
-            parentAgentId: this.parentAgentId,
-            agentId: childAgentId,
-            agentType: subagentType,
-            inputs: [new HumanMessage(description)],
-          },
-          sessionId: this.parentRunId,
-          matchQuery: subagentType,
-        }).catch((): AggregatedHookResult => HOOK_FALLBACK);
-
-        if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
-          childGraph.clearHeavyState();
-          this.activeChildRuns.delete(childRunId);
-          return {
-            content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
-            messages: [],
-          };
+      if (!recoveredComplete) {
+        const childResumeMap = getChildResumeMap(
+          activeChildRun.pendingInterrupts,
+          params.parentConfigurable
+        );
+        if (
+          activeChildRun.pendingInterrupts.length > 0 &&
+          childResumeMap == null
+        ) {
+          throw new GraphInterrupt(activeChildRun.pendingInterrupts);
         }
-      }
-      this.startedChildRuns.add(childRunId);
+        const childInput =
+          childResumeMap == null
+            ? { messages: [new HumanMessage(description)] }
+            : new Command({ resume: childResumeMap });
 
-      if (forwarder && !childAlreadyStarted) {
-        await this.emitSubagentUpdate(parentRegistry!, {
-          childRunId,
-          subagentType,
-          subagentAgentId: childAgentId,
-          parentToolCallId,
-          phase: 'start',
-          label: `Subagent "${subagentType}" started`,
-        });
-      }
+        if (
+          !childAlreadyStarted &&
+          this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) ===
+            true
+        ) {
+          const hookResult = await executeHooks({
+            registry: this.hookRegistry,
+            input: {
+              hook_event_name: 'SubagentStart',
+              runId: this.parentRunId,
+              threadId,
+              parentAgentId: this.parentAgentId,
+              agentId: childAgentId,
+              agentType: subagentType,
+              inputs: [new HumanMessage(description)],
+            },
+            sessionId: this.parentRunId,
+            matchQuery: subagentType,
+          }).catch((): AggregatedHookResult => HOOK_FALLBACK);
 
-      let childResult: BaseGraphState;
-      if (this.humanInTheLoop?.enabled === true) {
-        /** Execute as an independently checkpointed root instead of inheriting
-         * the parent's Pregel namespace. Parent decisions are routed explicitly
-         * by interrupt id, so concurrent children keep isolated resume state. */
-        childResult = await AsyncLocalStorageProviderSingleton.runWithConfig(
-          childInvokeConfig,
-          (): Promise<BaseGraphState> =>
-            workflow.invoke(childInput as BaseGraphState, childInvokeConfig)
-        );
-      } else {
-        childResult = await workflow.invoke(
-          childInput as BaseGraphState,
-          childInvokeConfig
-        );
+          if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
+            childGraph.clearHeavyState();
+            this.activeChildRuns.delete(childExecutionKey);
+            return {
+              content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
+              messages: [],
+            };
+          }
+        }
+        this.startedChildRuns.add(childExecutionKey);
+
+        if (forwarder && !childAlreadyStarted) {
+          await this.emitSubagentUpdate(parentRegistry!, {
+            childRunId,
+            subagentType,
+            subagentAgentId: childAgentId,
+            parentToolCallId,
+            phase: 'start',
+            label: `Subagent "${subagentType}" started`,
+          });
+        }
+
+        let childResult: BaseGraphState;
+        if (this.humanInTheLoop?.enabled === true) {
+          /** Execute as an independently checkpointed root instead of inheriting
+           * the parent's Pregel namespace. Parent decisions are routed explicitly
+           * by interrupt id, so concurrent children keep isolated resume state. */
+          childResult = await AsyncLocalStorageProviderSingleton.runWithConfig(
+            childInvokeConfig,
+            (): Promise<BaseGraphState> =>
+              workflow.invoke(childInput as BaseGraphState, childInvokeConfig)
+          );
+        } else {
+          childResult = await workflow.invoke(
+            childInput as BaseGraphState,
+            childInvokeConfig
+          );
+        }
+        const childInterrupts = isInterrupted(childResult)
+          ? childResult[INTERRUPT]
+          : undefined;
+        if (childInterrupts != null && childInterrupts.length > 0) {
+          throw new GraphInterrupt(childInterrupts);
+        }
+        result = { messages: childResult.messages };
       }
-      const childInterrupts = isInterrupted(childResult)
-        ? childResult[INTERRUPT]
-        : undefined;
-      if (childInterrupts != null && childInterrupts.length > 0) {
-        throw new GraphInterrupt(childInterrupts);
-      }
-      result = { messages: childResult.messages };
     } catch (error) {
       if (isGraphInterrupt(error)) {
-        const activeChildRun = this.activeChildRuns.get(childRunId);
+        const activeChildRun = this.activeChildRuns.get(childExecutionKey);
         if (activeChildRun != null) {
           activeChildRun.pendingInterrupts = error.interrupts;
         }
@@ -828,7 +1167,7 @@ export class SubagentExecutor {
         });
       }
       childGraph.clearHeavyState();
-      this.activeChildRuns.delete(childRunId);
+      this.activeChildRuns.delete(childExecutionKey);
       /**
        * A tripped stream circuit breaker is a safety abort, not a recoverable
        * subagent failure: converting it into a tool result would let the
@@ -845,6 +1184,9 @@ export class SubagentExecutor {
       };
     }
 
+    if (result == null) {
+      throw new Error('Subagent completed without producing graph state.');
+    }
     const filteredContent = filterSubagentResult(result.messages);
 
     if (
@@ -885,16 +1227,24 @@ export class SubagentExecutor {
         label: `Subagent "${subagentType}" finished`,
       });
     }
-    this.completedChildRuns.add(childRunId);
+    if (!childAlreadyCompleted) {
+      const activeChildRun = this.activeChildRuns.get(childExecutionKey);
+      if (activeChildRun != null && parentToolCallId != null) {
+        await this.persistChildCheckpointMarker(
+          activeChildRun,
+          parentToolCallId
+        );
+      }
+    }
+    this.completedChildRuns.add(childExecutionKey);
 
     childGraph.clearHeavyState();
-    this.activeChildRuns.delete(childRunId);
 
     const completedResult = {
       content: filteredContent,
       messages: result.messages,
     };
-    this.completedChildResults.set(childRunId, completedResult);
+    this.completedChildResults.set(childExecutionKey, completedResult);
     return completedResult;
   }
 

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -55,11 +55,21 @@ import type {
   ToolApprovalDecision,
   ToolApprovalDecisionMap,
 } from '@/types';
+import type {
+  SubagentResumeExecution,
+  SubagentResumeManifest,
+  SubagentCheckpointReference,
+  SettledSubagentToolOutput,
+} from './SubagentReplay';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
-import type { SettledSubagentToolOutput } from './SubagentReplay';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
+import {
+  getSubagentResumeManifest,
+  attachSubagentResumeManifest,
+  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
+} from './SubagentReplay';
 import {
   StreamLimitExceededError,
   RUN_BREAKER_SCOPE_CONFIG_KEY,
@@ -252,6 +262,7 @@ type SubagentCheckpointMarker = {
 type ChildExecutionIdentity = {
   childRunId: string;
   childThreadId: string;
+  resumeExecution?: SubagentResumeExecution;
 };
 
 type ChildExecutionIdentityParams = {
@@ -424,6 +435,25 @@ function getTupleMessages(tuple: CheckpointTuple | undefined): BaseMessage[] {
   return getCheckpointMessages(tuple?.checkpoint.channel_values.messages);
 }
 
+function getCheckpointReference(
+  tuple: CheckpointTuple | undefined
+): SubagentCheckpointReference | undefined {
+  const configurable = tuple?.config.configurable;
+  const threadId = configurable?.thread_id;
+  const checkpointId = configurable?.checkpoint_id;
+  const checkpointNs = configurable?.checkpoint_ns ?? '';
+  if (
+    typeof threadId !== 'string' ||
+    threadId.length === 0 ||
+    typeof checkpointId !== 'string' ||
+    checkpointId.length === 0 ||
+    typeof checkpointNs !== 'string'
+  ) {
+    return undefined;
+  }
+  return { threadId, checkpointId, checkpointNs };
+}
+
 function serializeToolOutput(
   settled: SettledSubagentToolOutput
 ): PersistedToolOutput {
@@ -514,17 +544,24 @@ function isToolApprovalPayload(
 
 function addSubagentScope(
   interrupts: Interrupt[],
-  scope: NonNullable<ToolApprovalInterruptPayload['subagent']>
+  scope: NonNullable<ToolApprovalInterruptPayload['subagent']>,
+  resumeManifest?: SubagentResumeManifest
 ): Interrupt[] {
-  return interrupts.map((childInterrupt) => ({
-    ...childInterrupt,
-    value: isToolApprovalPayload(childInterrupt.value)
+  return interrupts.map((childInterrupt) => {
+    const payload = isToolApprovalPayload(childInterrupt.value)
       ? {
         ...childInterrupt.value,
         subagent: childInterrupt.value.subagent ?? scope,
       }
-      : childInterrupt.value,
-  }));
+      : childInterrupt.value;
+    return {
+      ...childInterrupt,
+      value:
+        resumeManifest == null || !isObjectLike(payload)
+          ? payload
+          : attachSubagentResumeManifest(payload, resumeManifest),
+    };
+  });
 }
 
 type ToolApprovalResumeValue = ToolApprovalDecision[] | ToolApprovalDecisionMap;
@@ -749,6 +786,10 @@ export class SubagentExecutor {
     string,
     SubagentExecuteResult
   >();
+  private readonly childExecutionIdentities = new Map<
+    string,
+    Pick<ChildExecutionIdentity, 'childRunId' | 'childThreadId'>
+  >();
   private readonly activeChildRuns = new Map<string, ActiveChildRun>();
   private replayCheckpointWorkflow?: ReplayCheckpointWorkflow;
   private readonly resolveParentHandlerRegistry?: () =>
@@ -826,6 +867,10 @@ export class SubagentExecutor {
       };
     }
 
+    const resumeManifest = getSubagentResumeManifest(params.parentConfigurable);
+    const resumeExecution = resumeManifest?.executions.find(
+      (execution) => execution.parentToolCallId === params.parentToolCallId
+    );
     const branchChildThreadId = getChildThreadId({
       parentRunId: this.parentRunId,
       parentAgentId: this.parentAgentId,
@@ -834,6 +879,30 @@ export class SubagentExecutor {
       parentConfigurable: params.parentConfigurable,
       branchId: this.parentRunId,
     });
+    if (resumeExecution != null) {
+      const configuredHookSessionId = params.parentConfigurable?.run_id;
+      const hookSessionId =
+        typeof configuredHookSessionId === 'string' &&
+        configuredHookSessionId.length > 0
+          ? configuredHookSessionId
+          : this.parentRunId;
+      this.hookRegistry?.restorePendingToolApprovals(
+        hookSessionId,
+        resumeExecution.childRunId,
+        resumeExecution.approvalReplays
+      );
+      await this.forkCheckpointSnapshot(
+        resumeExecution.checkpoints,
+        branchChildThreadId
+      );
+      this.checkpointThreadIds.add(branchChildThreadId);
+      return {
+        childRunId: resumeExecution.childRunId,
+        childThreadId: branchChildThreadId,
+        resumeExecution,
+      };
+    }
+
     const branchTuple = await this.checkpointer.getTuple({
       configurable: { thread_id: branchChildThreadId },
     });
@@ -862,7 +931,14 @@ export class SubagentExecutor {
       };
     }
 
-    await this.forkCheckpointThread(baseChildThreadId, branchChildThreadId);
+    const sourceCheckpoints =
+      await this.getLatestCheckpointSnapshot(baseChildThreadId);
+    if (sourceCheckpoints.length === 0) {
+      throw new Error(
+        `Cannot fork subagent checkpoint thread "${baseChildThreadId}" without a checkpoint ID.`
+      );
+    }
+    await this.forkCheckpointSnapshot(sourceCheckpoints, branchChildThreadId);
     this.checkpointThreadIds.add(branchChildThreadId);
     return {
       childRunId: persistedChildRunId,
@@ -870,67 +946,211 @@ export class SubagentExecutor {
     };
   }
 
-  /** Copies a complete checkpoint lineage, including pending task writes. */
-  private async forkCheckpointThread(
-    sourceThreadId: string,
+  /** Captures one exact checkpoint head per namespace for a child thread. */
+  private async getLatestCheckpointSnapshot(
+    threadId: string
+  ): Promise<SubagentCheckpointReference[]> {
+    if (this.checkpointer == null) {
+      return [];
+    }
+    const checkpointsByNamespace = new Map<
+      string,
+      SubagentCheckpointReference
+    >();
+    for await (const tuple of this.checkpointer.list({
+      configurable: { thread_id: threadId },
+    })) {
+      const checkpoint = getCheckpointReference(tuple);
+      const current =
+        checkpoint == null
+          ? undefined
+          : checkpointsByNamespace.get(checkpoint.checkpointNs);
+      if (
+        checkpoint != null &&
+        (current == null ||
+          checkpoint.checkpointId.localeCompare(current.checkpointId) > 0)
+      ) {
+        checkpointsByNamespace.set(checkpoint.checkpointNs, checkpoint);
+      }
+    }
+    return [...checkpointsByNamespace.values()].sort((left, right) =>
+      left.checkpointNs.localeCompare(right.checkpointNs)
+    );
+  }
+
+  /** Copies exact checkpoint lineages, including pending task writes. */
+  private async forkCheckpointSnapshot(
+    sources: ReadonlyArray<SubagentCheckpointReference>,
     targetThreadId: string
   ): Promise<void> {
-    if (this.checkpointer == null || sourceThreadId === targetThreadId) {
+    if (
+      this.checkpointer == null ||
+      sources.length === 0 ||
+      sources.every((source) => source.threadId === targetThreadId)
+    ) {
       return;
     }
-    const existing = await this.checkpointer.getTuple({
-      configurable: { thread_id: targetThreadId },
-    });
-    if (existing != null) {
-      return;
-    }
-
-    const tuples: CheckpointTuple[] = [];
-    for await (const tuple of this.checkpointer.list({
-      configurable: { thread_id: sourceThreadId },
-    })) {
-      tuples.push(tuple);
-    }
-    tuples.reverse();
-
-    for (const tuple of tuples) {
-      const checkpointNs =
-        getConfigurableString(tuple.config, 'checkpoint_ns') ?? '';
-      const parentCheckpointId = getConfigurableString(
-        tuple.parentConfig,
-        'checkpoint_id'
-      );
-      const storedConfig = await this.checkpointer.put(
-        {
-          configurable: {
-            thread_id: targetThreadId,
-            checkpoint_ns: checkpointNs,
-            ...(parentCheckpointId == null
-              ? {}
-              : { checkpoint_id: parentCheckpointId }),
-          },
+    for (const source of sources) {
+      const tuples: CheckpointTuple[] = [];
+      const visited = new Set<string>();
+      let tuple = await this.checkpointer.getTuple({
+        configurable: {
+          thread_id: source.threadId,
+          checkpoint_ns: source.checkpointNs,
+          checkpoint_id: source.checkpointId,
         },
-        copyCheckpoint(tuple.checkpoint),
-        tuple.metadata ?? {
-          source: 'fork',
-          step: -1,
-          parents: {},
-        },
-        tuple.checkpoint.channel_versions
-      );
-      const writesByTask = new Map<string, Array<[string, unknown]>>();
-      for (const [taskId, channel, value] of tuple.pendingWrites ?? []) {
-        let writes = writesByTask.get(taskId);
-        if (writes == null) {
-          writes = [];
-          writesByTask.set(taskId, writes);
+      });
+      if (tuple == null) {
+        throw new Error(
+          `Subagent checkpoint "${source.checkpointId}" is unavailable.`
+        );
+      }
+      for (;;) {
+        const reference = getCheckpointReference(tuple);
+        if (reference == null) {
+          throw new Error(
+            'Subagent checkpoint lineage contains an invalid tuple.'
+          );
         }
-        writes.push([channel, value]);
+        if (
+          reference.threadId !== source.threadId ||
+          reference.checkpointNs !== source.checkpointNs
+        ) {
+          throw new Error(
+            'Subagent checkpoint lineage escapes its source namespace.'
+          );
+        }
+        const lineageKey = JSON.stringify([
+          reference.threadId,
+          reference.checkpointNs,
+          reference.checkpointId,
+        ]);
+        if (visited.has(lineageKey)) {
+          throw new Error('Subagent checkpoint lineage contains a cycle.');
+        }
+        visited.add(lineageKey);
+        tuples.push(tuple);
+        if (tuple.parentConfig == null) {
+          break;
+        }
+        tuple = await this.checkpointer.getTuple(tuple.parentConfig);
+        if (tuple == null) {
+          throw new Error('Subagent checkpoint lineage is incomplete.');
+        }
       }
-      for (const [taskId, writes] of writesByTask) {
-        await this.checkpointer.putWrites(storedConfig, writes, taskId);
+      tuples.reverse();
+
+      for (const lineageTuple of tuples) {
+        const checkpointNs =
+          getConfigurableString(lineageTuple.config, 'checkpoint_ns') ?? '';
+        const parentCheckpointId = getConfigurableString(
+          lineageTuple.parentConfig,
+          'checkpoint_id'
+        );
+        const storedConfig = await this.checkpointer.put(
+          {
+            configurable: {
+              thread_id: targetThreadId,
+              checkpoint_ns: checkpointNs,
+              ...(parentCheckpointId == null
+                ? {}
+                : { checkpoint_id: parentCheckpointId }),
+            },
+          },
+          copyCheckpoint(lineageTuple.checkpoint),
+          lineageTuple.metadata ?? {
+            source: 'fork',
+            step: -1,
+            parents: {},
+          },
+          lineageTuple.checkpoint.channel_versions
+        );
+        const writesByTask = new Map<string, Array<[string, unknown]>>();
+        for (const [taskId, channel, value] of lineageTuple.pendingWrites ??
+          []) {
+          let writes = writesByTask.get(taskId);
+          if (writes == null) {
+            writes = [];
+            writesByTask.set(taskId, writes);
+          }
+          writes.push([channel, value]);
+        }
+        for (const [taskId, writes] of writesByTask) {
+          await this.checkpointer.putWrites(storedConfig, writes, taskId);
+        }
       }
     }
+  }
+
+  private async createResumeManifest(
+    parentToolCallIds?: ReadonlySet<string>
+  ): Promise<SubagentResumeManifest | undefined> {
+    if (this.checkpointer == null) {
+      return undefined;
+    }
+    const executions: SubagentResumeExecution[] = [];
+    for (const [parentToolCallId, identity] of this.childExecutionIdentities) {
+      if (
+        parentToolCallIds != null &&
+        !parentToolCallIds.has(parentToolCallId)
+      ) {
+        continue;
+      }
+      const checkpoints = await this.getLatestCheckpointSnapshot(
+        identity.childThreadId
+      );
+      if (checkpoints.length === 0) {
+        continue;
+      }
+      const activeChildRun = this.activeChildRuns.get(identity.childThreadId);
+      const configuredHookSessionId =
+        activeChildRun?.invokeConfig?.configurable?.run_id;
+      const hookSessionId =
+        typeof configuredHookSessionId === 'string' &&
+        configuredHookSessionId.length > 0
+          ? configuredHookSessionId
+          : this.parentRunId;
+      const approvalReplays =
+        this.hookRegistry?.snapshotPendingToolApprovals(
+          hookSessionId,
+          identity.childRunId
+        ) ?? [];
+      const descendant = activeChildRun?.pendingInterrupts
+        .map((pendingInterrupt) =>
+          getSubagentResumeManifest(pendingInterrupt.value)
+        )
+        .find((manifest) => manifest != null);
+      const graphState = activeChildRun?.graph.createSubagentResumeState(
+        hookSessionId
+      ) ?? {
+        toolCallSteps: [],
+        toolSessions: [],
+        toolNodes: [],
+        eagerToolUsage: [],
+        eagerToolSuppressions: [],
+      };
+      executions.push({
+        parentToolCallId,
+        childRunId: identity.childRunId,
+        checkpoints,
+        graphState,
+        approvalReplays,
+        ...(descendant == null ? {} : { descendant }),
+      });
+    }
+    if (executions.length === 0) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      executions,
+    };
+  }
+
+  getResumeManifest(
+    parentToolCallIds?: ReadonlySet<string>
+  ): Promise<SubagentResumeManifest | undefined> {
+    return this.createResumeManifest(parentToolCallIds);
   }
 
   getChildCheckpointThreadIds(): string[] {
@@ -965,6 +1185,7 @@ export class SubagentExecutor {
     }
     this.activeChildRuns.clear();
     this.completedChildResults.clear();
+    this.childExecutionIdentities.clear();
     this.startedChildRuns.clear();
     this.completedChildRuns.clear();
     this.replayCheckpointWorkflow = undefined;
@@ -987,10 +1208,15 @@ export class SubagentExecutor {
       | Record<string, unknown>
       | undefined;
     const threadId = parentConfigurable?.thread_id;
-    const { childThreadId } = await this.resolveChildExecutionIdentity({
-      threadId: typeof threadId === 'string' ? threadId : undefined,
-      parentToolCallId,
-      parentConfigurable,
+    const { childRunId, childThreadId } =
+      await this.resolveChildExecutionIdentity({
+        threadId: typeof threadId === 'string' ? threadId : undefined,
+        parentToolCallId,
+        parentConfigurable,
+      });
+    this.childExecutionIdentities.set(parentToolCallId, {
+      childRunId,
+      childThreadId,
     });
     this.checkpointThreadIds.add(childThreadId);
     const checkpoint = await this.checkpointer.getTuple({
@@ -1042,6 +1268,10 @@ export class SubagentExecutor {
         parentToolCallId,
         parentConfigurable,
       });
+    this.childExecutionIdentities.set(parentToolCallId, {
+      childRunId,
+      childThreadId,
+    });
     this.checkpointThreadIds.add(childThreadId);
     const activeChildRun = this.activeChildRuns.get(childThreadId);
     const persistedOutput = serializeToolOutput(settled);
@@ -1153,12 +1383,16 @@ export class SubagentExecutor {
     }
 
     const executionSuffix = parentToolCallId ?? nanoid(8);
-    const { childRunId, childThreadId } =
+    const { childRunId, childThreadId, resumeExecution } =
       await this.resolveChildExecutionIdentity({
         threadId,
         parentToolCallId: executionSuffix,
         parentConfigurable: params.parentConfigurable,
       });
+    this.childExecutionIdentities.set(executionSuffix, {
+      childRunId,
+      childThreadId,
+    });
     const childExecutionKey = childThreadId;
     const childAgentId =
       config.agentInputs.agentId ||
@@ -1225,7 +1459,6 @@ export class SubagentExecutor {
             (event): void | Promise<void> =>
               hostUsageSink({ ...event, runId: this.parentRunId }),
       });
-
     let forwarding: ForwarderCallback | undefined;
     if (forwardingEnabled) {
       forwarding = this.createForwarderCallback({
@@ -1318,6 +1551,12 @@ export class SubagentExecutor {
         inheritedConfigurable.run_id.length > 0
           ? inheritedConfigurable.run_id
           : this.parentRunId;
+      if (cachedChildRun == null && resumeExecution != null) {
+        childGraph.restoreSubagentResumeState(
+          resumeExecution.graphState,
+          currentHookSessionId
+        );
+      }
       const childInvokeConfig = {
         recursionLimit: maxTurns * RECURSION_MULTIPLIER,
         signal: childSignal,
@@ -1326,6 +1565,12 @@ export class SubagentExecutor {
         configurable: {
           ...inheritedConfigurable,
           [TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY]: childRunId,
+          ...(resumeExecution?.descendant == null
+            ? {}
+            : {
+              [SUBAGENT_RESUME_MANIFEST_CONFIG_KEY]:
+                  resumeExecution.descendant,
+            }),
           thread_id:
             this.humanInTheLoop?.enabled === true
               ? childThreadId
@@ -1472,14 +1717,22 @@ export class SubagentExecutor {
         if (activeChildRun != null) {
           activeChildRun.pendingInterrupts = error.interrupts;
         }
+        const resumeManifest =
+          activeChildRun == null || parentToolCallId == null
+            ? undefined
+            : await this.createResumeManifest();
         await forwarding?.drain();
         throw new GraphInterrupt(
-          addSubagentScope(error.interrupts, {
-            run_id: childRunId,
-            agent_id: childAgentId,
-            subagent_type: subagentType,
-            parent_tool_call_id: parentToolCallId,
-          })
+          addSubagentScope(
+            error.interrupts,
+            {
+              run_id: childRunId,
+              agent_id: childAgentId,
+              subagent_type: subagentType,
+              parent_tool_call_id: parentToolCallId,
+            },
+            resumeManifest
+          )
         );
       }
       /** Aborted before any observational work below: parallel siblings — in
@@ -1968,6 +2221,7 @@ function isLangGraphRuntimeConfigKey(key: string): boolean {
   return (
     key.startsWith(LANGGRAPH_RUNTIME_CONFIG_PREFIX) ||
     LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key) ||
+    key === SUBAGENT_RESUME_MANIFEST_CONFIG_KEY ||
     /** The parent batch's breaker scope must not leak into the child
      * workflow's configurable — children own separate controllers. */
     key === RUN_BREAKER_SCOPE_CONFIG_KEY

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -188,7 +188,6 @@ type ActiveChildRun = {
 
 const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
 const LANGGRAPH_RESUME_MAP_CONFIG_KEY = '__pregel_resume_map';
-const LANGGRAPH_SCRATCHPAD_CONFIG_KEY = '__pregel_scratchpad';
 const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
   'checkpoint_id',
   'checkpoint_map',
@@ -222,43 +221,13 @@ function addSubagentScope(
 
 type ToolApprovalResumeValue = ToolApprovalDecision[] | ToolApprovalDecisionMap;
 
-function isToolApprovalDecisionMap(
-  value: object
-): value is ToolApprovalDecisionMap {
-  return (
-    !Array.isArray(value) &&
-    Object.values(value).every(
-      (decision) =>
-        decision != null &&
-        typeof decision === 'object' &&
-        typeof (decision as { type?: unknown }).type === 'string'
-    )
-  );
-}
-
 function getChildResumeMap(
   pendingInterrupts: Interrupt[],
   parentConfigurable: Record<string, unknown> | undefined
 ): Record<string, ToolApprovalResumeValue> | undefined {
-  const scratchpad = parentConfigurable?.[LANGGRAPH_SCRATCHPAD_CONFIG_KEY] as
-    | { nullResume?: unknown; resume?: unknown[] }
-    | undefined;
-  const scratchpadResume =
-    scratchpad?.resume?.length === 1
-      ? scratchpad.resume[0]
-      : scratchpad?.nullResume;
-  const resumeMap =
-    parentConfigurable?.[LANGGRAPH_RESUME_MAP_CONFIG_KEY] ?? scratchpadResume;
+  const resumeMap = parentConfigurable?.[LANGGRAPH_RESUME_MAP_CONFIG_KEY];
   if (resumeMap == null || typeof resumeMap !== 'object') {
     return undefined;
-  }
-
-  const pendingInterruptId =
-    pendingInterrupts.length === 1 ? pendingInterrupts[0].id : undefined;
-  if (Array.isArray(resumeMap)) {
-    return typeof pendingInterruptId === 'string'
-      ? { [pendingInterruptId]: resumeMap }
-      : undefined;
   }
 
   const parentResumeMap = resumeMap as Record<string, ToolApprovalResumeValue>;
@@ -272,16 +241,7 @@ function getChildResumeMap(
       childResumeMap[interruptId] = parentResumeMap[interruptId];
     }
   }
-  if (Object.keys(childResumeMap).length > 0) {
-    return childResumeMap;
-  }
-  if (
-    typeof pendingInterruptId === 'string' &&
-    isToolApprovalDecisionMap(resumeMap)
-  ) {
-    return { [pendingInterruptId]: resumeMap };
-  }
-  return undefined;
+  return Object.keys(childResumeMap).length > 0 ? childResumeMap : undefined;
 }
 
 function getPersistedInterrupts(snapshot: StateSnapshot): Interrupt[] {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -15,12 +15,14 @@ import {
   MessagesAnnotation,
   START,
   StateGraph,
+  copyCheckpoint,
   isGraphInterrupt,
   isInterrupted,
 } from '@langchain/langgraph';
 import type {
   Interrupt,
   StateSnapshot,
+  CheckpointTuple,
   BaseCheckpointSaver,
 } from '@langchain/langgraph';
 import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
@@ -69,7 +71,10 @@ import {
   Callback,
   StepTypes,
 } from '@/common';
-import { executeHooks } from '@/hooks';
+import {
+  executeHooks,
+  TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY,
+} from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
@@ -218,6 +223,7 @@ type ActiveChildRun = {
   pendingInterrupts: Interrupt[];
   invokeConfig?: RunnableConfig;
   childAgentId: string;
+  childRunId: string;
 };
 
 type PersistedToolOutput = {
@@ -239,7 +245,19 @@ type SubagentCheckpointMarker = {
   parentToolCallId: string;
   lifecycleComplete: true;
   hookSessionId?: string;
+  childRunId?: string;
   settledOutput?: PersistedToolOutput;
+};
+
+type ChildExecutionIdentity = {
+  childRunId: string;
+  childThreadId: string;
+};
+
+type ChildExecutionIdentityParams = {
+  threadId?: string;
+  parentToolCallId: string;
+  parentConfigurable?: Record<string, unknown>;
 };
 
 const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
@@ -251,6 +269,7 @@ const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
 ]);
 const SUBAGENT_CHECKPOINT_MARKER_KEY = '__librechat_subagent_checkpoint';
 const SUBAGENT_HOOK_SESSION_KEY = '__librechat_subagent_hook_session';
+const SUBAGENT_RUN_ID_KEY = '__librechat_subagent_run_id';
 const SUBAGENT_REPLAY_NODE = 'subagent-replay';
 
 function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
@@ -280,6 +299,7 @@ function isSubagentCheckpointMarker(
     typeof marker.parentToolCallId === 'string' &&
     (marker.hookSessionId == null ||
       typeof marker.hookSessionId === 'string') &&
+    (marker.childRunId == null || typeof marker.childRunId === 'string') &&
     (marker.settledOutput == null ||
       isPersistedToolOutput(marker.settledOutput))
   );
@@ -354,6 +374,25 @@ function getSubagentHookSessionId(messages: BaseMessage[]): string | undefined {
   return undefined;
 }
 
+function getSubagentRunId(messages: BaseMessage[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const runId = messages[i].additional_kwargs[SUBAGENT_RUN_ID_KEY];
+    if (typeof runId === 'string' && runId.length > 0) {
+      return runId;
+    }
+    const marker =
+      messages[i].additional_kwargs[SUBAGENT_CHECKPOINT_MARKER_KEY];
+    if (
+      isSubagentCheckpointMarker(marker) &&
+      marker.childRunId != null &&
+      marker.childRunId.length > 0
+    ) {
+      return marker.childRunId;
+    }
+  }
+  return undefined;
+}
+
 function isSubagentCheckpointMarkerMessage(message: BaseMessage): boolean {
   return isSubagentCheckpointMarker(
     message.additional_kwargs[SUBAGENT_CHECKPOINT_MARKER_KEY]
@@ -371,6 +410,18 @@ function createSubagentCheckpointMarkerMessage(
 
 function getCheckpointMessages(value: unknown): BaseMessage[] {
   return Array.isArray(value) ? value.filter(BaseMessage.isInstance) : [];
+}
+
+function getConfigurableString(
+  config: RunnableConfig | undefined,
+  key: string
+): string | undefined {
+  const value = config?.configurable?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getTupleMessages(tuple: CheckpointTuple | undefined): BaseMessage[] {
+  return getCheckpointMessages(tuple?.checkpoint.channel_values.messages);
 }
 
 function serializeToolOutput(
@@ -435,16 +486,20 @@ function getChildThreadId(args: {
   threadId?: string;
   parentToolCallId: string;
   parentConfigurable?: Record<string, unknown>;
+  branchId?: string;
 }): string {
   const durableParentId = args.threadId ?? args.parentRunId;
   const parentFork = getParentCheckpointFork(args.parentConfigurable);
-  const identity = JSON.stringify([
+  const identity = [
     durableParentId,
     parentFork,
     args.parentAgentId ?? 'agent',
     args.parentToolCallId,
-  ]);
-  return `subagent:${Buffer.from(identity).toString('base64url')}`;
+  ];
+  if (args.branchId != null) {
+    identity.push(args.branchId);
+  }
+  return `subagent:${Buffer.from(JSON.stringify(identity)).toString('base64url')}`;
 }
 
 function isToolApprovalPayload(
@@ -747,6 +802,137 @@ export class SubagentExecutor {
     return this.resolveParentHandlerRegistry?.();
   }
 
+  /**
+   * Keeps the original child thread as an immutable resume source once a
+   * different parent Run reconstructs it. Each rebuilt parent gets a private
+   * checkpoint fork, while the persisted child run ID remains stable for
+   * activity and usage correlation across the interrupt boundary.
+   */
+  private async resolveChildExecutionIdentity(
+    params: ChildExecutionIdentityParams
+  ): Promise<ChildExecutionIdentity> {
+    const currentChildRunId = `${this.parentRunId}_sub_${params.parentToolCallId}`;
+    const baseChildThreadId = getChildThreadId({
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      threadId: params.threadId,
+      parentToolCallId: params.parentToolCallId,
+      parentConfigurable: params.parentConfigurable,
+    });
+    if (this.humanInTheLoop?.enabled !== true || this.checkpointer == null) {
+      return {
+        childRunId: currentChildRunId,
+        childThreadId: baseChildThreadId,
+      };
+    }
+
+    const branchChildThreadId = getChildThreadId({
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      threadId: params.threadId,
+      parentToolCallId: params.parentToolCallId,
+      parentConfigurable: params.parentConfigurable,
+      branchId: this.parentRunId,
+    });
+    const branchTuple = await this.checkpointer.getTuple({
+      configurable: { thread_id: branchChildThreadId },
+    });
+    if (branchTuple != null) {
+      this.checkpointThreadIds.add(branchChildThreadId);
+      return {
+        childRunId:
+          getSubagentRunId(getTupleMessages(branchTuple)) ?? currentChildRunId,
+        childThreadId: branchChildThreadId,
+      };
+    }
+
+    const baseTuple = await this.checkpointer.getTuple({
+      configurable: { thread_id: baseChildThreadId },
+    });
+    const persistedChildRunId = getSubagentRunId(getTupleMessages(baseTuple));
+    if (
+      baseTuple == null ||
+      persistedChildRunId == null ||
+      persistedChildRunId === currentChildRunId
+    ) {
+      this.checkpointThreadIds.add(baseChildThreadId);
+      return {
+        childRunId: persistedChildRunId ?? currentChildRunId,
+        childThreadId: baseChildThreadId,
+      };
+    }
+
+    await this.forkCheckpointThread(baseChildThreadId, branchChildThreadId);
+    this.checkpointThreadIds.add(branchChildThreadId);
+    return {
+      childRunId: persistedChildRunId,
+      childThreadId: branchChildThreadId,
+    };
+  }
+
+  /** Copies a complete checkpoint lineage, including pending task writes. */
+  private async forkCheckpointThread(
+    sourceThreadId: string,
+    targetThreadId: string
+  ): Promise<void> {
+    if (this.checkpointer == null || sourceThreadId === targetThreadId) {
+      return;
+    }
+    const existing = await this.checkpointer.getTuple({
+      configurable: { thread_id: targetThreadId },
+    });
+    if (existing != null) {
+      return;
+    }
+
+    const tuples: CheckpointTuple[] = [];
+    for await (const tuple of this.checkpointer.list({
+      configurable: { thread_id: sourceThreadId },
+    })) {
+      tuples.push(tuple);
+    }
+    tuples.reverse();
+
+    for (const tuple of tuples) {
+      const checkpointNs =
+        getConfigurableString(tuple.config, 'checkpoint_ns') ?? '';
+      const parentCheckpointId = getConfigurableString(
+        tuple.parentConfig,
+        'checkpoint_id'
+      );
+      const storedConfig = await this.checkpointer.put(
+        {
+          configurable: {
+            thread_id: targetThreadId,
+            checkpoint_ns: checkpointNs,
+            ...(parentCheckpointId == null
+              ? {}
+              : { checkpoint_id: parentCheckpointId }),
+          },
+        },
+        copyCheckpoint(tuple.checkpoint),
+        tuple.metadata ?? {
+          source: 'fork',
+          step: -1,
+          parents: {},
+        },
+        tuple.checkpoint.channel_versions
+      );
+      const writesByTask = new Map<string, Array<[string, unknown]>>();
+      for (const [taskId, channel, value] of tuple.pendingWrites ?? []) {
+        let writes = writesByTask.get(taskId);
+        if (writes == null) {
+          writes = [];
+          writesByTask.set(taskId, writes);
+        }
+        writes.push([channel, value]);
+      }
+      for (const [taskId, writes] of writesByTask) {
+        await this.checkpointer.putWrites(storedConfig, writes, taskId);
+      }
+    }
+  }
+
   getChildCheckpointThreadIds(): string[] {
     const threadIds = new Set(this.checkpointThreadIds);
     for (const activeChildRun of this.activeChildRuns.values()) {
@@ -801,9 +987,7 @@ export class SubagentExecutor {
       | Record<string, unknown>
       | undefined;
     const threadId = parentConfigurable?.thread_id;
-    const childThreadId = getChildThreadId({
-      parentRunId: this.parentRunId,
-      parentAgentId: this.parentAgentId,
+    const { childThreadId } = await this.resolveChildExecutionIdentity({
       threadId: typeof threadId === 'string' ? threadId : undefined,
       parentToolCallId,
       parentConfigurable,
@@ -852,13 +1036,12 @@ export class SubagentExecutor {
       | Record<string, unknown>
       | undefined;
     const threadId = parentConfigurable?.thread_id;
-    const childThreadId = getChildThreadId({
-      parentRunId: this.parentRunId,
-      parentAgentId: this.parentAgentId,
-      threadId: typeof threadId === 'string' ? threadId : undefined,
-      parentToolCallId,
-      parentConfigurable,
-    });
+    const { childRunId, childThreadId } =
+      await this.resolveChildExecutionIdentity({
+        threadId: typeof threadId === 'string' ? threadId : undefined,
+        parentToolCallId,
+        parentConfigurable,
+      });
     this.checkpointThreadIds.add(childThreadId);
     const activeChildRun = this.activeChildRuns.get(childThreadId);
     const persistedOutput = serializeToolOutput(settled);
@@ -887,6 +1070,7 @@ export class SubagentExecutor {
               typeof parentConfigurable?.run_id === 'string'
                 ? parentConfigurable.run_id
                 : this.parentRunId,
+            childRunId,
             settledOutput: persistedOutput,
           }),
         ],
@@ -920,6 +1104,7 @@ export class SubagentExecutor {
               'string'
                 ? activeChildRun.invokeConfig.configurable.run_id
                 : this.parentRunId,
+            childRunId: activeChildRun.childRunId,
             ...(settledOutput == null ? {} : { settledOutput }),
           }),
         ],
@@ -968,17 +1153,12 @@ export class SubagentExecutor {
     }
 
     const executionSuffix = parentToolCallId ?? nanoid(8);
-    const childRunId = `${this.parentRunId}_sub_${executionSuffix}`;
-    const childThreadId = getChildThreadId({
-      parentRunId: this.parentRunId,
-      parentAgentId: this.parentAgentId,
-      threadId,
-      parentToolCallId: executionSuffix,
-      parentConfigurable: params.parentConfigurable,
-    });
-    if (this.humanInTheLoop?.enabled === true && this.checkpointer != null) {
-      this.checkpointThreadIds.add(childThreadId);
-    }
+    const { childRunId, childThreadId } =
+      await this.resolveChildExecutionIdentity({
+        threadId,
+        parentToolCallId: executionSuffix,
+        parentConfigurable: params.parentConfigurable,
+      });
     const childExecutionKey = childThreadId;
     const childAgentId =
       config.agentInputs.agentId ||
@@ -1071,6 +1251,7 @@ export class SubagentExecutor {
         workflow,
         pendingInterrupts: [],
         childAgentId,
+        childRunId,
       };
       if (cachedChildRun == null) {
         this.activeChildRuns.set(childExecutionKey, activeChildRun);
@@ -1144,6 +1325,7 @@ export class SubagentExecutor {
         runName: `subagent:${subagentType}`,
         configurable: {
           ...inheritedConfigurable,
+          [TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY]: childRunId,
           thread_id:
             this.humanInTheLoop?.enabled === true
               ? childThreadId
@@ -1214,6 +1396,7 @@ export class SubagentExecutor {
                 content: description,
                 additional_kwargs: {
                   [SUBAGENT_HOOK_SESSION_KEY]: currentHookSessionId,
+                  [SUBAGENT_RUN_ID_KEY]: childRunId,
                 },
               }),
             ],

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,11 +1,24 @@
 import { nanoid } from 'nanoid';
 import { HumanMessage } from '@langchain/core/messages';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import {
+  Command,
+  GraphInterrupt,
+  INTERRUPT,
+  isGraphInterrupt,
+  isInterrupted,
+} from '@langchain/langgraph';
 import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
 import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
+import type { Interrupt, StateSnapshot } from '@langchain/langgraph';
 import type { Callbacks } from '@langchain/core/callbacks/manager';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
   AgentInputs,
+  BaseGraphState,
+  CompiledStateWorkflow,
+  HumanInTheLoopConfig,
   InjectedMessage,
   MessageDeltaEvent,
   ProcessedToolCall,
@@ -19,9 +32,12 @@ import type {
   SubagentUpdateEvent,
   SubagentUpdatePhase,
   SubagentUsageSink,
+  ToolApprovalInterruptPayload,
   ToolExecuteBatchRequest,
   ToolCallDelta,
   TokenCounter,
+  ToolApprovalDecision,
+  ToolApprovalDecisionMap,
 } from '@/types';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
@@ -160,12 +176,92 @@ type ForwarderCallback = {
   drain: () => Promise<void>;
 };
 
+type StatefulCompiledWorkflow = CompiledStateWorkflow & {
+  getState(config: RunnableConfig): Promise<StateSnapshot>;
+};
+
+type ActiveChildRun = {
+  graph: StandardGraph;
+  workflow: StatefulCompiledWorkflow;
+  pendingInterrupts: Interrupt[];
+};
+
 const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
+const LANGGRAPH_RESUME_MAP_CONFIG_KEY = '__pregel_resume_map';
 const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
   'checkpoint_id',
   'checkpoint_map',
   'checkpoint_ns',
 ]);
+
+function isToolApprovalPayload(
+  value: unknown
+): value is ToolApprovalInterruptPayload {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'tool_approval'
+  );
+}
+
+function addSubagentScope(
+  interrupts: Interrupt[],
+  scope: NonNullable<ToolApprovalInterruptPayload['subagent']>
+): Interrupt[] {
+  return interrupts.map((childInterrupt) => ({
+    ...childInterrupt,
+    value: isToolApprovalPayload(childInterrupt.value)
+      ? { ...childInterrupt.value, subagent: scope }
+      : childInterrupt.value,
+  }));
+}
+
+type ToolApprovalResumeValue = ToolApprovalDecision[] | ToolApprovalDecisionMap;
+
+function getChildResumeMap(
+  pendingInterrupts: Interrupt[],
+  parentConfigurable: Record<string, unknown> | undefined
+): Record<string, ToolApprovalResumeValue> | undefined {
+  const resumeMap = parentConfigurable?.[LANGGRAPH_RESUME_MAP_CONFIG_KEY];
+  if (resumeMap == null || typeof resumeMap !== 'object') {
+    return undefined;
+  }
+
+  const parentResumeMap = resumeMap as Record<string, ToolApprovalResumeValue>;
+  const childResumeMap: Record<string, ToolApprovalResumeValue> = {};
+  for (const childInterrupt of pendingInterrupts) {
+    const interruptId = childInterrupt.id;
+    if (
+      typeof interruptId === 'string' &&
+      Object.prototype.hasOwnProperty.call(parentResumeMap, interruptId)
+    ) {
+      childResumeMap[interruptId] = parentResumeMap[interruptId];
+    }
+  }
+  return Object.keys(childResumeMap).length > 0 ? childResumeMap : undefined;
+}
+
+function getPersistedInterrupts(snapshot: StateSnapshot): Interrupt[] {
+  const interrupts: Interrupt[] = [];
+  for (const task of snapshot.tasks) {
+    for (const pendingInterrupt of task.interrupts) {
+      interrupts.push(pendingInterrupt);
+    }
+  }
+  return interrupts;
+}
+
+function getPersistedMessages(
+  snapshot: StateSnapshot
+): BaseMessage[] | undefined {
+  if (snapshot.values == null || typeof snapshot.values !== 'object') {
+    return undefined;
+  }
+  const values = snapshot.values as { messages?: BaseMessage[] };
+  return Array.isArray(values.messages) && values.messages.length > 0
+    ? values.messages
+    : undefined;
+}
 
 export type SubagentExecuteParams = {
   description: string;
@@ -197,11 +293,9 @@ export type SubagentExecuteParams = {
    *
    * Inheritance details (verified empirically against LangGraph):
    *   - host-set keys propagate as-is into the child's tool dispatches;
-   *   - `thread_id` propagates (with `childRunId` as a fallback when
-   *     parent did not supply one) — matches the "subagent is part of
-   *     the same conversation" mental model and aligns with the
-   *     `sessionId: this.parentRunId` convention this executor already
-   *     uses for `SubagentStart` / `SubagentStop` hooks;
+   *   - with nested HITL enabled, `thread_id` is replaced with the stable
+   *     child run id so parent and child checkpoints cannot collide;
+   *     parent-scoped hook lookup remains keyed by the inherited `run_id`;
    *   - `parent_run_id` propagates when the host put it on parent's
    *     configurable;
    *   - `run_id` is *overwritten by the LangGraph runtime* at child
@@ -261,6 +355,7 @@ export type SubagentExecutorOptions = {
    * revert to the defaults.
    */
   streamLimits?: StandardGraphInput['streamLimits'];
+  humanInTheLoop?: HumanInTheLoopConfig;
   /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
   /**
@@ -310,9 +405,17 @@ export class SubagentExecutor {
   private readonly langfuse?: StandardGraphInput['langfuse'];
   private readonly tokenCounter?: TokenCounter;
   private readonly streamLimits?: StandardGraphInput['streamLimits'];
+  private readonly humanInTheLoop?: HumanInTheLoopConfig;
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
   private readonly usageSink?: SubagentUsageSink;
+  private readonly startedChildRuns = new Set<string>();
+  private readonly completedChildRuns = new Set<string>();
+  private readonly completedChildResults = new Map<
+    string,
+    SubagentExecuteResult
+  >();
+  private readonly activeChildRuns = new Map<string, ActiveChildRun>();
   private readonly resolveParentHandlerRegistry?: () =>
     | HandlerRegistry
     | undefined;
@@ -327,6 +430,7 @@ export class SubagentExecutor {
     this.langfuse = options.langfuse;
     this.tokenCounter = options.tokenCounter;
     this.streamLimits = options.streamLimits;
+    this.humanInTheLoop = options.humanInTheLoop;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
     this.usageSink = options.usageSink;
@@ -360,6 +464,16 @@ export class SubagentExecutor {
     return this.resolveParentHandlerRegistry?.();
   }
 
+  clearHeavyState(): void {
+    for (const activeChildRun of this.activeChildRuns.values()) {
+      activeChildRun.graph.clearHeavyState();
+    }
+    this.activeChildRuns.clear();
+    this.completedChildResults.clear();
+    this.startedChildRuns.clear();
+    this.completedChildRuns.clear();
+  }
+
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
     const { description, subagentType, threadId, parentToolCallId } = params;
     /** Captured ONCE per execution, preferring the controller the parent
@@ -388,39 +502,14 @@ export class SubagentExecutor {
       };
     }
 
+    const executionSuffix = parentToolCallId ?? nanoid(8);
+    const childRunId = `${this.parentRunId}_sub_${executionSuffix}`;
     const childAgentId =
       config.agentInputs.agentId ||
-      `${this.parentAgentId ?? 'agent'}_sub_${nanoid(8)}`;
-
-    if (
-      this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) === true
-    ) {
-      const hookResult = await executeHooks({
-        registry: this.hookRegistry,
-        input: {
-          hook_event_name: 'SubagentStart',
-          runId: this.parentRunId,
-          threadId,
-          parentAgentId: this.parentAgentId,
-          agentId: childAgentId,
-          agentType: subagentType,
-          inputs: [new HumanMessage(description)],
-        },
-        sessionId: this.parentRunId,
-        matchQuery: subagentType,
-      }).catch((): AggregatedHookResult => HOOK_FALLBACK);
-
-      /**
-       * `ask` is treated identically to `deny` in the subagent context:
-       * subagents are non-interactive, so there is no prompt path for `ask`.
-       * Both decisions block execution and return a "Blocked" tool result.
-       */
-      if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
-        return {
-          content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
-          messages: [],
-        };
-      }
+      `${this.parentAgentId ?? 'agent'}_sub_${executionSuffix}`;
+    const completedChildResult = this.completedChildResults.get(childRunId);
+    if (completedChildResult != null) {
+      return completedChildResult;
     }
 
     const parentRegistry = this.getParentHandlerRegistry();
@@ -442,41 +531,43 @@ export class SubagentExecutor {
       this.maxDepth,
       /* keepToolDefinitions */ hasToolExecuteHandler
     );
-    const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
     const hostUsageSink = this.usageSink;
-    const childGraph = this.createChildGraph({
-      runId: childRunId,
-      signal: childSignal,
-      agents: [childInputs],
-      langfuse: this.langfuse,
-      tokenCounter: this.tokenCounter,
-      streamLimits: this.streamLimits,
-      subagentScope: true,
-      /**
-       * Forwarded so the child graph's own `SubagentExecutor` (created in
-       * its `createAgentNode` when `allowNested` keeps subagentConfigs)
-       * reports nested-child usage through the same host sink. Each nesting
-       * level attaches its own capture callback — `workflow.invoke` replaces
-       * the inherited callback chain, so a single top-level handler would
-       * never see grandchild model calls.
-       *
-       * The wrapper rewrites `runId` to THIS executor's parent run: nested
-       * executors emit with their own `parentRunId` (a `*_sub_*` child id),
-       * and each wrapper layer rewrites upward, so by the time an event
-       * reaches the host sink its `runId` is the ROOT run — hosts keying
-       * billing by run id never see intermediate child run ids there
-       * (`subagentRunId` still identifies the emitting child).
-       */
-      subagentUsageSink:
-        hostUsageSink == null
-          ? undefined
-          : /** Returns the host sink's result so async sinks stay awaited
-             *  through every wrapper layer. */
-          (event): void | Promise<void> =>
-            hostUsageSink({ ...event, runId: this.parentRunId }),
-    });
+    const cachedChildRun = this.activeChildRuns.get(childRunId);
+    const childGraph =
+      cachedChildRun?.graph ??
+      this.createChildGraph({
+        runId: childRunId,
+        signal: childSignal,
+        agents: [childInputs],
+        langfuse: this.langfuse,
+        tokenCounter: this.tokenCounter,
+        streamLimits: this.streamLimits,
+        subagentScope: true,
+        /**
+         * Forwarded so the child graph's own `SubagentExecutor` (created in
+         * its `createAgentNode` when `allowNested` keeps subagentConfigs)
+         * reports nested-child usage through the same host sink. Each nesting
+         * level attaches its own capture callback — `workflow.invoke` replaces
+         * the inherited callback chain, so a single top-level handler would
+         * never see grandchild model calls.
+         *
+         * The wrapper rewrites `runId` to THIS executor's parent run: nested
+         * executors emit with their own `parentRunId` (a `*_sub_*` child id),
+         * and each wrapper layer rewrites upward, so by the time an event
+         * reaches the host sink its `runId` is the ROOT run — hosts keying
+         * billing by run id never see intermediate child run ids there
+         * (`subagentRunId` still identifies the emitting child).
+         */
+        subagentUsageSink:
+          hostUsageSink == null
+            ? undefined
+            : /** Returns the host sink's result so async sinks stay awaited
+               *  through every wrapper layer. */
+            (event): void | Promise<void> =>
+              hostUsageSink({ ...event, runId: this.parentRunId }),
+      });
 
     let forwarding: ForwarderCallback | undefined;
     if (forwardingEnabled) {
@@ -489,21 +580,21 @@ export class SubagentExecutor {
       });
     }
     const forwarder = forwarding?.handler;
-
-    if (forwarder) {
-      await this.emitSubagentUpdate(parentRegistry!, {
-        childRunId,
-        subagentType,
-        subagentAgentId: childAgentId,
-        parentToolCallId,
-        phase: 'start',
-        label: `Subagent "${subagentType}" started`,
-      });
-    }
+    let childAlreadyStarted = this.startedChildRuns.has(childRunId);
+    const childAlreadyCompleted = this.completedChildRuns.has(childRunId);
 
     let result: { messages: BaseMessage[] };
     try {
-      const workflow = childGraph.createWorkflow();
+      const workflow = (cachedChildRun?.workflow ??
+        childGraph.createWorkflow()) as StatefulCompiledWorkflow;
+      const activeChildRun = cachedChildRun ?? {
+        graph: childGraph,
+        workflow,
+        pendingInterrupts: [],
+      };
+      if (cachedChildRun == null) {
+        this.activeChildRuns.set(childRunId, activeChildRun);
+      }
       /**
        * When `parentHandlerRegistry` is provided (forwarding mode), attach a
        * lightweight callback that intercepts the child's `on_custom_event`
@@ -547,50 +638,153 @@ export class SubagentExecutor {
       }
       const callbacks: Callbacks = callbackHandlers;
       /**
-       * Inherit the parent's host `configurable` — host-set fields
-       * (`requestBody`, `user`, `userMCPAuthMap`, etc.) AND the run-
-       * identity fields (`run_id`, `parent_run_id`, `thread_id`) all
-       * propagate. LangGraph's own runtime keys are excluded because the
-       * child graph creates its own scratchpad/checkpoint/abort plumbing.
+       * Inherit the parent's host `configurable` while binding LangGraph's
+       * checkpoint identity to the stable child run id. The parent thread id
+       * cannot be reused here: parent and child share one checkpointer when
+       * nested HITL is enabled, and root checkpoint namespaces are normalized
+       * by LangGraph, so a shared `thread_id` would collide with the parent.
        *
-       * Run-identity propagation is intentional and matches the
-       * convention this executor itself already uses for `SubagentStart`
-       * / `SubagentStop` hooks (`sessionId: this.parentRunId`): the
-       * subagent runs under the parent's session scope, not its own.
-       * Forwarding `run_id` / `parent_run_id` / `thread_id` makes
-       * `ToolNode`'s hook lookups (`hasHookFor(eventName, runId)`),
-       * `ToolOutputReferenceRegistry` keying, and trace lineage all
-       * resolve to the parent's session for tools dispatched from the
-       * subagent — so `PreToolUse` / `PostToolUse` hooks the host
-       * registered against the parent's run fire for subagent tool
-       * calls too. "Same run" matches the user-perceptual mental model.
-       *
-       * `thread_id` falls back to `childRunId` only when the parent
-       * didn't supply one (legacy behavior preserved for hosts that
-       * never set thread_id).
-       *
-       * NOTE: a future revision will likely make this configurable per
-       * spawn type — e.g. a background / async subagent that runs after
-       * the parent's run completes wants isolation, not inheritance.
-       * For now the inheritance path matches LibreChat's primary use
-       * case (synchronous subagents within a single user turn).
+       * `run_id` still propagates as the parent run id, which is the key used
+       * for session-scoped hook lookup. Child hook inputs therefore retain
+       * the parent policy scope while their `threadId` truthfully identifies
+       * the independently checkpointed child execution.
        */
       const inheritedConfigurable: Record<string, unknown> =
         sanitizeChildConfigurable(params.parentConfigurable);
-      result = await workflow.invoke(
-        { messages: [new HumanMessage(description)] },
-        {
-          recursionLimit: maxTurns * RECURSION_MULTIPLIER,
-          signal: childSignal,
-          callbacks,
-          runName: `subagent:${subagentType}`,
-          configurable: {
-            thread_id: childRunId,
-            ...inheritedConfigurable,
-          },
+      const childInvokeConfig = {
+        recursionLimit: maxTurns * RECURSION_MULTIPLIER,
+        signal: childSignal,
+        callbacks,
+        runName: `subagent:${subagentType}`,
+        configurable: {
+          ...inheritedConfigurable,
+          thread_id:
+            this.humanInTheLoop?.enabled === true
+              ? childRunId
+              : (inheritedConfigurable.thread_id ?? childRunId),
+        },
+      };
+      if (cachedChildRun == null && this.humanInTheLoop?.enabled === true) {
+        /** Rehydrate child-owned interrupt state when a host rebuilds Run
+         * around the same durable checkpointer after a process boundary. */
+        const persistedState = await workflow.getState(childInvokeConfig);
+        const persistedInterrupts = getPersistedInterrupts(persistedState);
+        if (persistedInterrupts.length > 0) {
+          activeChildRun.pendingInterrupts = persistedInterrupts;
+          this.startedChildRuns.add(childRunId);
+          childAlreadyStarted = true;
+        } else if (persistedState.next.length === 0) {
+          const persistedMessages = getPersistedMessages(persistedState);
+          if (persistedMessages != null) {
+            const persistedResult = {
+              content: filterSubagentResult(persistedMessages),
+              messages: persistedMessages,
+            };
+            this.startedChildRuns.add(childRunId);
+            this.completedChildRuns.add(childRunId);
+            this.completedChildResults.set(childRunId, persistedResult);
+            childGraph.clearHeavyState();
+            this.activeChildRuns.delete(childRunId);
+            return persistedResult;
+          }
         }
+      }
+      const childResumeMap = getChildResumeMap(
+        activeChildRun.pendingInterrupts,
+        params.parentConfigurable
       );
+      if (
+        activeChildRun.pendingInterrupts.length > 0 &&
+        childResumeMap == null
+      ) {
+        throw new GraphInterrupt(activeChildRun.pendingInterrupts);
+      }
+      const childInput =
+        childResumeMap == null
+          ? { messages: [new HumanMessage(description)] }
+          : new Command({ resume: childResumeMap });
+
+      if (
+        !childAlreadyStarted &&
+        this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) ===
+          true
+      ) {
+        const hookResult = await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'SubagentStart',
+            runId: this.parentRunId,
+            threadId,
+            parentAgentId: this.parentAgentId,
+            agentId: childAgentId,
+            agentType: subagentType,
+            inputs: [new HumanMessage(description)],
+          },
+          sessionId: this.parentRunId,
+          matchQuery: subagentType,
+        }).catch((): AggregatedHookResult => HOOK_FALLBACK);
+
+        if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
+          childGraph.clearHeavyState();
+          this.activeChildRuns.delete(childRunId);
+          return {
+            content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
+            messages: [],
+          };
+        }
+      }
+      this.startedChildRuns.add(childRunId);
+
+      if (forwarder && !childAlreadyStarted) {
+        await this.emitSubagentUpdate(parentRegistry!, {
+          childRunId,
+          subagentType,
+          subagentAgentId: childAgentId,
+          parentToolCallId,
+          phase: 'start',
+          label: `Subagent "${subagentType}" started`,
+        });
+      }
+
+      let childResult: BaseGraphState;
+      if (this.humanInTheLoop?.enabled === true) {
+        /** Execute as an independently checkpointed root instead of inheriting
+         * the parent's Pregel namespace. Parent decisions are routed explicitly
+         * by interrupt id, so concurrent children keep isolated resume state. */
+        childResult = await AsyncLocalStorageProviderSingleton.runWithConfig(
+          childInvokeConfig,
+          (): Promise<BaseGraphState> =>
+            workflow.invoke(childInput as BaseGraphState, childInvokeConfig)
+        );
+      } else {
+        childResult = await workflow.invoke(
+          childInput as BaseGraphState,
+          childInvokeConfig
+        );
+      }
+      const childInterrupts = isInterrupted(childResult)
+        ? childResult[INTERRUPT]
+        : undefined;
+      if (childInterrupts != null && childInterrupts.length > 0) {
+        throw new GraphInterrupt(childInterrupts);
+      }
+      result = { messages: childResult.messages };
     } catch (error) {
+      if (isGraphInterrupt(error)) {
+        const activeChildRun = this.activeChildRuns.get(childRunId);
+        if (activeChildRun != null) {
+          activeChildRun.pendingInterrupts = error.interrupts;
+        }
+        await forwarding?.drain();
+        throw new GraphInterrupt(
+          addSubagentScope(error.interrupts, {
+            run_id: childRunId,
+            agent_id: childAgentId,
+            subagent_type: subagentType,
+            parent_tool_call_id: parentToolCallId,
+          })
+        );
+      }
       /** Aborted before any observational work below: parallel siblings — in
        * this executor and, via the graph-scoped breaker, under other
        * parallel agent nodes — stream on the composed child signal, and
@@ -615,6 +809,7 @@ export class SubagentExecutor {
         });
       }
       childGraph.clearHeavyState();
+      this.activeChildRuns.delete(childRunId);
       /**
        * A tripped stream circuit breaker is a safety abort, not a recoverable
        * subagent failure: converting it into a tool result would let the
@@ -634,6 +829,7 @@ export class SubagentExecutor {
     const filteredContent = filterSubagentResult(result.messages);
 
     if (
+      !childAlreadyCompleted &&
       this.hookRegistry?.hasHookFor('SubagentStop', this.parentRunId) === true
     ) {
       /**
@@ -659,7 +855,7 @@ export class SubagentExecutor {
       });
     }
 
-    if (forwarding) {
+    if (forwarding && !childAlreadyCompleted) {
       await forwarding.drain();
       await this.emitSubagentUpdate(parentRegistry!, {
         childRunId,
@@ -670,10 +866,17 @@ export class SubagentExecutor {
         label: `Subagent "${subagentType}" finished`,
       });
     }
+    this.completedChildRuns.add(childRunId);
 
     childGraph.clearHeavyState();
+    this.activeChildRuns.delete(childRunId);
 
-    return { content: filteredContent, messages: result.messages };
+    const completedResult = {
+      content: filteredContent,
+      messages: result.messages,
+    };
+    this.completedChildResults.set(childRunId, completedResult);
+    return completedResult;
   }
 
   /**

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -191,7 +191,11 @@ type ForwarderCallback = {
   drain: () => Promise<void>;
 };
 
-type StatefulCompiledWorkflow = CompiledStateWorkflow & {
+type StatefulCompiledWorkflow = Omit<CompiledStateWorkflow, 'invoke'> & {
+  invoke(
+    input: BaseGraphState | Command | null,
+    config?: RunnableConfig
+  ): Promise<BaseGraphState>;
   getState(config: RunnableConfig): Promise<StateSnapshot>;
   updateState?(
     config: RunnableConfig,
@@ -434,7 +438,13 @@ function getChildThreadId(args: {
 }): string {
   const durableParentId = args.threadId ?? args.parentRunId;
   const parentFork = getParentCheckpointFork(args.parentConfigurable);
-  return `${durableParentId}_sub_${parentFork}_${args.parentAgentId ?? 'agent'}_${args.parentToolCallId}`;
+  const identity = JSON.stringify([
+    durableParentId,
+    parentFork,
+    args.parentAgentId ?? 'agent',
+    args.parentToolCallId,
+  ]);
+  return `subagent:${Buffer.from(identity).toString('base64url')}`;
 }
 
 function isToolApprovalPayload(
@@ -677,6 +687,7 @@ export class SubagentExecutor {
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
   private readonly usageSink?: SubagentUsageSink;
+  private readonly checkpointThreadIds = new Set<string>();
   private readonly startedChildRuns = new Set<string>();
   private readonly completedChildRuns = new Set<string>();
   private readonly completedChildResults = new Map<
@@ -736,9 +747,24 @@ export class SubagentExecutor {
     return this.resolveParentHandlerRegistry?.();
   }
 
+  getChildCheckpointThreadIds(): string[] {
+    return [...this.checkpointThreadIds];
+  }
+
+  private clearChildGraph(graph: StandardGraph): void {
+    const checkpointGraph = graph as {
+      getChildCheckpointThreadIds?: () => string[];
+    };
+    for (const threadId of checkpointGraph.getChildCheckpointThreadIds?.() ??
+      []) {
+      this.checkpointThreadIds.add(threadId);
+    }
+    graph.clearHeavyState();
+  }
+
   clearHeavyState(): void {
     for (const activeChildRun of this.activeChildRuns.values()) {
-      activeChildRun.graph.clearHeavyState();
+      this.clearChildGraph(activeChildRun.graph);
     }
     this.activeChildRuns.clear();
     this.completedChildResults.clear();
@@ -771,6 +797,7 @@ export class SubagentExecutor {
       parentToolCallId,
       parentConfigurable,
     });
+    this.checkpointThreadIds.add(childThreadId);
     const checkpoint = await this.checkpointer.getTuple({
       configurable: { thread_id: childThreadId },
     });
@@ -821,6 +848,7 @@ export class SubagentExecutor {
       parentToolCallId,
       parentConfigurable,
     });
+    this.checkpointThreadIds.add(childThreadId);
     const activeChildRun = this.activeChildRuns.get(childThreadId);
     const persistedOutput = serializeToolOutput(settled);
     if (activeChildRun != null) {
@@ -829,7 +857,7 @@ export class SubagentExecutor {
         parentToolCallId,
         persistedOutput
       );
-      activeChildRun.graph.clearHeavyState();
+      this.clearChildGraph(activeChildRun.graph);
       this.activeChildRuns.delete(childThreadId);
       return;
     }
@@ -937,6 +965,9 @@ export class SubagentExecutor {
       parentToolCallId: executionSuffix,
       parentConfigurable: params.parentConfigurable,
     });
+    if (this.humanInTheLoop?.enabled === true && this.checkpointer != null) {
+      this.checkpointThreadIds.add(childThreadId);
+    }
     const childExecutionKey = childThreadId;
     const childAgentId =
       config.agentInputs.agentId ||
@@ -1020,6 +1051,7 @@ export class SubagentExecutor {
 
     let result: { messages: BaseMessage[] } | undefined;
     let recoveredComplete = false;
+    let recoveredInProgress = false;
     try {
       const workflow = (cachedChildRun?.workflow ??
         childGraph.createWorkflow()) as StatefulCompiledWorkflow;
@@ -1129,6 +1161,10 @@ export class SubagentExecutor {
           activeChildRun.pendingInterrupts = persistedInterrupts;
           this.startedChildRuns.add(childExecutionKey);
           childAlreadyStarted = true;
+        } else if (persistedState.next.length > 0) {
+          recoveredInProgress = true;
+          childAlreadyStarted = true;
+          this.startedChildRuns.add(childExecutionKey);
         } else if (persistedState.next.length === 0) {
           const persistedMessages = getPersistedMessages(persistedState);
           if (persistedMessages != null) {
@@ -1155,19 +1191,23 @@ export class SubagentExecutor {
         ) {
           throw new GraphInterrupt(activeChildRun.pendingInterrupts);
         }
-        const childInput =
-          childResumeMap == null
-            ? {
-              messages: [
-                new HumanMessage({
-                  content: description,
-                  additional_kwargs: {
-                    [SUBAGENT_HOOK_SESSION_KEY]: currentHookSessionId,
-                  },
-                }),
-              ],
-            }
-            : new Command({ resume: childResumeMap });
+        let childInput: BaseGraphState | Command | null;
+        if (childResumeMap != null) {
+          childInput = new Command({ resume: childResumeMap });
+        } else if (recoveredInProgress) {
+          childInput = null;
+        } else {
+          childInput = {
+            messages: [
+              new HumanMessage({
+                content: description,
+                additional_kwargs: {
+                  [SUBAGENT_HOOK_SESSION_KEY]: currentHookSessionId,
+                },
+              }),
+            ],
+          };
+        }
 
         if (
           !childAlreadyStarted &&
@@ -1190,7 +1230,7 @@ export class SubagentExecutor {
           }).catch((): AggregatedHookResult => HOOK_FALLBACK);
 
           if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
-            childGraph.clearHeavyState();
+            this.clearChildGraph(childGraph);
             this.activeChildRuns.delete(childExecutionKey);
             return {
               content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
@@ -1219,13 +1259,10 @@ export class SubagentExecutor {
           childResult = await AsyncLocalStorageProviderSingleton.runWithConfig(
             childInvokeConfig,
             (): Promise<BaseGraphState> =>
-              workflow.invoke(childInput as BaseGraphState, childInvokeConfig)
+              workflow.invoke(childInput, childInvokeConfig)
           );
         } else {
-          childResult = await workflow.invoke(
-            childInput as BaseGraphState,
-            childInvokeConfig
-          );
+          childResult = await workflow.invoke(childInput, childInvokeConfig);
         }
         const childInterrupts = isInterrupted(childResult)
           ? childResult[INTERRUPT]
@@ -1274,7 +1311,7 @@ export class SubagentExecutor {
           data: { message: errorMessage },
         });
       }
-      childGraph.clearHeavyState();
+      this.clearChildGraph(childGraph);
       this.activeChildRuns.delete(childExecutionKey);
       /**
        * A tripped stream circuit breaker is a safety abort, not a recoverable
@@ -1346,7 +1383,7 @@ export class SubagentExecutor {
     }
     this.completedChildRuns.add(childExecutionKey);
 
-    childGraph.clearHeavyState();
+    this.clearChildGraph(childGraph);
 
     const completedResult = {
       content: filteredContent,

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -786,7 +786,7 @@ export class SubagentExecutor {
       typeof currentHookSessionId === 'string' &&
       currentHookSessionId.length > 0
     ) {
-      this.hookRegistry?.migrateSession(
+      this.hookRegistry?.copySession(
         persistedHookSessionId,
         currentHookSessionId
       );
@@ -1119,7 +1119,7 @@ export class SubagentExecutor {
         const persistedHookSessionId =
           getSubagentHookSessionId(checkpointMessages);
         if (persistedHookSessionId != null) {
-          this.hookRegistry?.migrateSession(
+          this.hookRegistry?.copySession(
             persistedHookSessionId,
             currentHookSessionId
           );

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -68,6 +68,7 @@ import type { HandlerRegistry } from '@/events';
 import {
   getSubagentResumeManifest,
   attachSubagentResumeManifest,
+  SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from './SubagentReplay';
 import {
@@ -510,6 +511,16 @@ function getParentCheckpointFork(
     : 'root';
 }
 
+function getResumeAttemptId(
+  configurable: Record<string, unknown> | undefined,
+  fallback: string
+): string {
+  const attemptId = configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
+  return typeof attemptId === 'string' && attemptId.length > 0
+    ? attemptId
+    : fallback;
+}
+
 function getChildThreadId(args: {
   parentRunId: string;
   parentAgentId?: string;
@@ -877,7 +888,7 @@ export class SubagentExecutor {
       threadId: params.threadId,
       parentToolCallId: params.parentToolCallId,
       parentConfigurable: params.parentConfigurable,
-      branchId: this.parentRunId,
+      branchId: getResumeAttemptId(params.parentConfigurable, this.parentRunId),
     });
     if (resumeExecution != null) {
       await this.forkCheckpointSnapshot(
@@ -1546,6 +1557,10 @@ export class SubagentExecutor {
        */
       const inheritedConfigurable: Record<string, unknown> =
         sanitizeChildConfigurable(params.parentConfigurable);
+      const resumeAttemptId = getResumeAttemptId(
+        params.parentConfigurable,
+        this.parentRunId
+      );
       const currentHookSessionId =
         typeof inheritedConfigurable.run_id === 'string' &&
         inheritedConfigurable.run_id.length > 0
@@ -1570,6 +1585,7 @@ export class SubagentExecutor {
             : {
               [SUBAGENT_RESUME_MANIFEST_CONFIG_KEY]:
                   resumeExecution.descendant,
+              [SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY]: resumeAttemptId,
             }),
           thread_id:
             this.humanInTheLoop?.enabled === true
@@ -2221,6 +2237,7 @@ function isLangGraphRuntimeConfigKey(key: string): boolean {
   return (
     key.startsWith(LANGGRAPH_RUNTIME_CONFIG_PREFIX) ||
     LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key) ||
+    key === SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY ||
     key === SUBAGENT_RESUME_MANIFEST_CONFIG_KEY ||
     /** The parent batch's breaker scope must not leak into the child
      * workflow's configurable — children own separate controllers. */

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -880,6 +880,10 @@ export class SubagentExecutor {
       branchId: this.parentRunId,
     });
     if (resumeExecution != null) {
+      await this.forkCheckpointSnapshot(
+        resumeExecution.checkpoints,
+        branchChildThreadId
+      );
       const configuredHookSessionId = params.parentConfigurable?.run_id;
       const hookSessionId =
         typeof configuredHookSessionId === 'string' &&
@@ -890,10 +894,6 @@ export class SubagentExecutor {
         hookSessionId,
         resumeExecution.childRunId,
         resumeExecution.approvalReplays
-      );
-      await this.forkCheckpointSnapshot(
-        resumeExecution.checkpoints,
-        branchChildThreadId
       );
       this.checkpointThreadIds.add(branchChildThreadId);
       return {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -263,6 +263,7 @@ type SubagentCheckpointMarker = {
 type ChildExecutionIdentity = {
   childRunId: string;
   childThreadId: string;
+  approvalExecutionScope: string;
   resumeExecution?: SubagentResumeExecution;
 };
 
@@ -521,6 +522,15 @@ function getResumeAttemptId(
     : fallback;
 }
 
+function getApprovalExecutionScope(
+  childRunId: string,
+  resumeAttemptId: string
+): string {
+  return `subagent-approval:${Buffer.from(
+    JSON.stringify([childRunId, resumeAttemptId])
+  ).toString('base64url')}`;
+}
+
 function getChildThreadId(args: {
   parentRunId: string;
   parentAgentId?: string;
@@ -568,7 +578,7 @@ function addSubagentScope(
     return {
       ...childInterrupt,
       value:
-        resumeManifest == null || !isObjectLike(payload)
+        resumeManifest == null
           ? payload
           : attachSubagentResumeManifest(payload, resumeManifest),
     };
@@ -799,7 +809,10 @@ export class SubagentExecutor {
   >();
   private readonly childExecutionIdentities = new Map<
     string,
-    Pick<ChildExecutionIdentity, 'childRunId' | 'childThreadId'>
+    Pick<
+      ChildExecutionIdentity,
+      'childRunId' | 'childThreadId' | 'approvalExecutionScope'
+    >
   >();
   private readonly activeChildRuns = new Map<string, ActiveChildRun>();
   private replayCheckpointWorkflow?: ReplayCheckpointWorkflow;
@@ -864,6 +877,10 @@ export class SubagentExecutor {
     params: ChildExecutionIdentityParams
   ): Promise<ChildExecutionIdentity> {
     const currentChildRunId = `${this.parentRunId}_sub_${params.parentToolCallId}`;
+    const resumeAttemptId = getResumeAttemptId(
+      params.parentConfigurable,
+      this.parentRunId
+    );
     const baseChildThreadId = getChildThreadId({
       parentRunId: this.parentRunId,
       parentAgentId: this.parentAgentId,
@@ -875,6 +892,7 @@ export class SubagentExecutor {
       return {
         childRunId: currentChildRunId,
         childThreadId: baseChildThreadId,
+        approvalExecutionScope: currentChildRunId,
       };
     }
 
@@ -888,28 +906,27 @@ export class SubagentExecutor {
       threadId: params.threadId,
       parentToolCallId: params.parentToolCallId,
       parentConfigurable: params.parentConfigurable,
-      branchId: getResumeAttemptId(params.parentConfigurable, this.parentRunId),
+      branchId: resumeAttemptId,
     });
     if (resumeExecution != null) {
+      const approvalExecutionScope = getApprovalExecutionScope(
+        resumeExecution.childRunId,
+        resumeAttemptId
+      );
       await this.forkCheckpointSnapshot(
         resumeExecution.checkpoints,
         branchChildThreadId
       );
-      const configuredHookSessionId = params.parentConfigurable?.run_id;
-      const hookSessionId =
-        typeof configuredHookSessionId === 'string' &&
-        configuredHookSessionId.length > 0
-          ? configuredHookSessionId
-          : this.parentRunId;
       this.hookRegistry?.restorePendingToolApprovals(
-        hookSessionId,
-        resumeExecution.childRunId,
+        approvalExecutionScope,
+        approvalExecutionScope,
         resumeExecution.approvalReplays
       );
       this.checkpointThreadIds.add(branchChildThreadId);
       return {
         childRunId: resumeExecution.childRunId,
         childThreadId: branchChildThreadId,
+        approvalExecutionScope,
         resumeExecution,
       };
     }
@@ -918,11 +935,16 @@ export class SubagentExecutor {
       configurable: { thread_id: branchChildThreadId },
     });
     if (branchTuple != null) {
+      const childRunId =
+        getSubagentRunId(getTupleMessages(branchTuple)) ?? currentChildRunId;
       this.checkpointThreadIds.add(branchChildThreadId);
       return {
-        childRunId:
-          getSubagentRunId(getTupleMessages(branchTuple)) ?? currentChildRunId,
+        childRunId,
         childThreadId: branchChildThreadId,
+        approvalExecutionScope: getApprovalExecutionScope(
+          childRunId,
+          resumeAttemptId
+        ),
       };
     }
 
@@ -939,6 +961,10 @@ export class SubagentExecutor {
       return {
         childRunId: persistedChildRunId ?? currentChildRunId,
         childThreadId: baseChildThreadId,
+        approvalExecutionScope: getApprovalExecutionScope(
+          persistedChildRunId ?? currentChildRunId,
+          resumeAttemptId
+        ),
       };
     }
 
@@ -954,6 +980,10 @@ export class SubagentExecutor {
     return {
       childRunId: persistedChildRunId,
       childThreadId: branchChildThreadId,
+      approvalExecutionScope: getApprovalExecutionScope(
+        persistedChildRunId,
+        resumeAttemptId
+      ),
     };
   }
 
@@ -1123,8 +1153,8 @@ export class SubagentExecutor {
           : this.parentRunId;
       const approvalReplays =
         this.hookRegistry?.snapshotPendingToolApprovals(
-          hookSessionId,
-          identity.childRunId
+          identity.approvalExecutionScope,
+          identity.approvalExecutionScope
         ) ?? [];
       const descendant = activeChildRun?.pendingInterrupts
         .map((pendingInterrupt) =>
@@ -1143,6 +1173,7 @@ export class SubagentExecutor {
       executions.push({
         parentToolCallId,
         childRunId: identity.childRunId,
+        approvalExecutionScope: identity.approvalExecutionScope,
         checkpoints,
         graphState,
         approvalReplays,
@@ -1196,6 +1227,9 @@ export class SubagentExecutor {
     }
     this.activeChildRuns.clear();
     this.completedChildResults.clear();
+    for (const identity of this.childExecutionIdentities.values()) {
+      this.hookRegistry?.clearSession(identity.approvalExecutionScope);
+    }
     this.childExecutionIdentities.clear();
     this.startedChildRuns.clear();
     this.completedChildRuns.clear();
@@ -1219,7 +1253,7 @@ export class SubagentExecutor {
       | Record<string, unknown>
       | undefined;
     const threadId = parentConfigurable?.thread_id;
-    const { childRunId, childThreadId } =
+    const { childRunId, childThreadId, approvalExecutionScope } =
       await this.resolveChildExecutionIdentity({
         threadId: typeof threadId === 'string' ? threadId : undefined,
         parentToolCallId,
@@ -1228,6 +1262,7 @@ export class SubagentExecutor {
     this.childExecutionIdentities.set(parentToolCallId, {
       childRunId,
       childThreadId,
+      approvalExecutionScope,
     });
     this.checkpointThreadIds.add(childThreadId);
     const checkpoint = await this.checkpointer.getTuple({
@@ -1273,7 +1308,7 @@ export class SubagentExecutor {
       | Record<string, unknown>
       | undefined;
     const threadId = parentConfigurable?.thread_id;
-    const { childRunId, childThreadId } =
+    const { childRunId, childThreadId, approvalExecutionScope } =
       await this.resolveChildExecutionIdentity({
         threadId: typeof threadId === 'string' ? threadId : undefined,
         parentToolCallId,
@@ -1282,6 +1317,7 @@ export class SubagentExecutor {
     this.childExecutionIdentities.set(parentToolCallId, {
       childRunId,
       childThreadId,
+      approvalExecutionScope,
     });
     this.checkpointThreadIds.add(childThreadId);
     const activeChildRun = this.activeChildRuns.get(childThreadId);
@@ -1394,15 +1430,20 @@ export class SubagentExecutor {
     }
 
     const executionSuffix = parentToolCallId ?? nanoid(8);
-    const { childRunId, childThreadId, resumeExecution } =
-      await this.resolveChildExecutionIdentity({
-        threadId,
-        parentToolCallId: executionSuffix,
-        parentConfigurable: params.parentConfigurable,
-      });
+    const {
+      childRunId,
+      childThreadId,
+      approvalExecutionScope,
+      resumeExecution,
+    } = await this.resolveChildExecutionIdentity({
+      threadId,
+      parentToolCallId: executionSuffix,
+      parentConfigurable: params.parentConfigurable,
+    });
     this.childExecutionIdentities.set(executionSuffix, {
       childRunId,
       childThreadId,
+      approvalExecutionScope,
     });
     const childExecutionKey = childThreadId;
     const childAgentId =
@@ -1579,7 +1620,12 @@ export class SubagentExecutor {
         runName: `subagent:${subagentType}`,
         configurable: {
           ...inheritedConfigurable,
-          [TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY]: childRunId,
+          ...(this.humanInTheLoop?.enabled === true
+            ? {
+              [TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY]:
+                  approvalExecutionScope,
+            }
+            : {}),
           ...(resumeExecution?.descendant == null
             ? {}
             : {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -68,6 +68,7 @@ import type { HandlerRegistry } from '@/events';
 import {
   getSubagentResumeManifest,
   attachSubagentResumeManifest,
+  SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from './SubagentReplay';
@@ -541,11 +542,16 @@ function getChildThreadId(args: {
 }): string {
   const durableParentId = args.threadId ?? args.parentRunId;
   const parentFork = getParentCheckpointFork(args.parentConfigurable);
+  const parentBatch =
+    args.parentConfigurable?.[SUBAGENT_PARENT_BATCH_CONFIG_KEY];
   const identity = [
     durableParentId,
     parentFork,
     args.parentAgentId ?? 'agent',
     args.parentToolCallId,
+    typeof parentBatch === 'string' && parentBatch.length > 0
+      ? parentBatch
+      : 'batch',
   ];
   if (args.branchId != null) {
     identity.push(args.branchId);
@@ -1205,6 +1211,10 @@ export class SubagentExecutor {
       }
     }
     return [...threadIds];
+  }
+
+  resetCheckpointThreadIds(): void {
+    this.checkpointThreadIds.clear();
   }
 
   private getGraphChildCheckpointThreadIds(graph: StandardGraph): string[] {
@@ -2285,6 +2295,7 @@ function isLangGraphRuntimeConfigKey(key: string): boolean {
     LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key) ||
     key === SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY ||
     key === SUBAGENT_RESUME_MANIFEST_CONFIG_KEY ||
+    key === SUBAGENT_PARENT_BATCH_CONFIG_KEY ||
     /** The parent batch's breaker scope must not leak into the child
      * workflow's configurable — children own separate controllers. */
     key === RUN_BREAKER_SCOPE_CONFIG_KEY

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -748,15 +748,26 @@ export class SubagentExecutor {
   }
 
   getChildCheckpointThreadIds(): string[] {
-    return [...this.checkpointThreadIds];
+    const threadIds = new Set(this.checkpointThreadIds);
+    for (const activeChildRun of this.activeChildRuns.values()) {
+      for (const threadId of this.getGraphChildCheckpointThreadIds(
+        activeChildRun.graph
+      )) {
+        threadIds.add(threadId);
+      }
+    }
+    return [...threadIds];
   }
 
-  private clearChildGraph(graph: StandardGraph): void {
+  private getGraphChildCheckpointThreadIds(graph: StandardGraph): string[] {
     const checkpointGraph = graph as {
       getChildCheckpointThreadIds?: () => string[];
     };
-    for (const threadId of checkpointGraph.getChildCheckpointThreadIds?.() ??
-      []) {
+    return checkpointGraph.getChildCheckpointThreadIds?.() ?? [];
+  }
+
+  private clearChildGraph(graph: StandardGraph): void {
+    for (const threadId of this.getGraphChildCheckpointThreadIds(graph)) {
       this.checkpointThreadIds.add(threadId);
     }
     graph.clearHeavyState();

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -9,8 +9,12 @@ import {
 } from '@langchain/core/messages';
 import {
   Command,
+  END,
   GraphInterrupt,
   INTERRUPT,
+  MessagesAnnotation,
+  START,
+  StateGraph,
   isGraphInterrupt,
   isInterrupted,
 } from '@langchain/langgraph';
@@ -196,6 +200,14 @@ type StatefulCompiledWorkflow = CompiledStateWorkflow & {
   ): Promise<RunnableConfig>;
 };
 
+type ReplayCheckpointWorkflow = {
+  updateState(
+    config: RunnableConfig,
+    values: { messages: BaseMessage[] },
+    asNode: string
+  ): Promise<RunnableConfig>;
+};
+
 type ActiveChildRun = {
   graph: StandardGraph;
   workflow: StatefulCompiledWorkflow;
@@ -222,6 +234,7 @@ type SubagentCheckpointMarker = {
   version: 1;
   parentToolCallId: string;
   lifecycleComplete: true;
+  hookSessionId?: string;
   settledOutput?: PersistedToolOutput;
 };
 
@@ -233,6 +246,8 @@ const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
   'checkpoint_ns',
 ]);
 const SUBAGENT_CHECKPOINT_MARKER_KEY = '__librechat_subagent_checkpoint';
+const SUBAGENT_HOOK_SESSION_KEY = '__librechat_subagent_hook_session';
+const SUBAGENT_REPLAY_NODE = 'subagent-replay';
 
 function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
   if (value == null || typeof value !== 'object') {
@@ -259,6 +274,8 @@ function isSubagentCheckpointMarker(
     marker.version === 1 &&
     marker.lifecycleComplete === true &&
     typeof marker.parentToolCallId === 'string' &&
+    (marker.hookSessionId == null ||
+      typeof marker.hookSessionId === 'string') &&
     (marker.settledOutput == null ||
       isPersistedToolOutput(marker.settledOutput))
   );
@@ -318,6 +335,16 @@ function getSubagentCheckpointMarker(
       marker.parentToolCallId === parentToolCallId
     ) {
       return marker;
+    }
+  }
+  return undefined;
+}
+
+function getSubagentHookSessionId(messages: BaseMessage[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const sessionId = messages[i].additional_kwargs[SUBAGENT_HOOK_SESSION_KEY];
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      return sessionId;
     }
   }
   return undefined;
@@ -486,6 +513,16 @@ function getPersistedMessages(
   return messages.length > 0 ? messages : undefined;
 }
 
+function createReplayCheckpointWorkflow(
+  checkpointer: BaseCheckpointSaver
+): ReplayCheckpointWorkflow {
+  return new StateGraph(MessagesAnnotation)
+    .addNode(SUBAGENT_REPLAY_NODE, (state) => state)
+    .addEdge(START, SUBAGENT_REPLAY_NODE)
+    .addEdge(SUBAGENT_REPLAY_NODE, END)
+    .compile({ checkpointer }) as ReplayCheckpointWorkflow;
+}
+
 export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
@@ -647,6 +684,7 @@ export class SubagentExecutor {
     SubagentExecuteResult
   >();
   private readonly activeChildRuns = new Map<string, ActiveChildRun>();
+  private replayCheckpointWorkflow?: ReplayCheckpointWorkflow;
   private readonly resolveParentHandlerRegistry?: () =>
     | HandlerRegistry
     | undefined;
@@ -706,6 +744,7 @@ export class SubagentExecutor {
     this.completedChildResults.clear();
     this.startedChildRuns.clear();
     this.completedChildRuns.clear();
+    this.replayCheckpointWorkflow = undefined;
   }
 
   async getSettledToolOutput(
@@ -739,6 +778,19 @@ export class SubagentExecutor {
       checkpoint?.checkpoint.channel_values.messages
     );
     const marker = getSubagentCheckpointMarker(messages, parentToolCallId);
+    const persistedHookSessionId =
+      marker?.hookSessionId ?? getSubagentHookSessionId(messages);
+    const currentHookSessionId = parentConfigurable?.run_id;
+    if (
+      persistedHookSessionId != null &&
+      typeof currentHookSessionId === 'string' &&
+      currentHookSessionId.length > 0
+    ) {
+      this.hookRegistry?.migrateSession(
+        persistedHookSessionId,
+        currentHookSessionId
+      );
+    }
     return marker?.settledOutput == null
       ? undefined
       : deserializeToolOutput(marker.settledOutput);
@@ -750,7 +802,12 @@ export class SubagentExecutor {
     settled: SettledSubagentToolOutput
   ): Promise<void> {
     const parentToolCallId = call.id;
-    if (parentToolCallId == null || parentToolCallId === '') {
+    if (
+      this.humanInTheLoop?.enabled !== true ||
+      this.checkpointer == null ||
+      parentToolCallId == null ||
+      parentToolCallId === ''
+    ) {
       return;
     }
     const parentConfigurable = config.configurable as
@@ -765,15 +822,38 @@ export class SubagentExecutor {
       parentConfigurable,
     });
     const activeChildRun = this.activeChildRuns.get(childThreadId);
-    if (activeChildRun == null) {
+    const persistedOutput = serializeToolOutput(settled);
+    if (activeChildRun != null) {
+      await this.persistChildCheckpointMarker(
+        activeChildRun,
+        parentToolCallId,
+        persistedOutput
+      );
+      activeChildRun.graph.clearHeavyState();
+      this.activeChildRuns.delete(childThreadId);
       return;
     }
-    await this.persistChildCheckpointMarker(
-      activeChildRun,
-      parentToolCallId,
-      serializeToolOutput(settled)
+    this.replayCheckpointWorkflow ??= createReplayCheckpointWorkflow(
+      this.checkpointer
     );
-    this.activeChildRuns.delete(childThreadId);
+    await this.replayCheckpointWorkflow.updateState(
+      { configurable: { thread_id: childThreadId } },
+      {
+        messages: [
+          createSubagentCheckpointMarkerMessage({
+            version: 1,
+            parentToolCallId,
+            lifecycleComplete: true,
+            hookSessionId:
+              typeof parentConfigurable?.run_id === 'string'
+                ? parentConfigurable.run_id
+                : this.parentRunId,
+            settledOutput: persistedOutput,
+          }),
+        ],
+      },
+      SUBAGENT_REPLAY_NODE
+    );
   }
 
   private async persistChildCheckpointMarker(
@@ -796,6 +876,11 @@ export class SubagentExecutor {
             version: 1,
             parentToolCallId,
             lifecycleComplete: true,
+            hookSessionId:
+              typeof activeChildRun.invokeConfig.configurable?.run_id ===
+              'string'
+                ? activeChildRun.invokeConfig.configurable.run_id
+                : this.parentRunId,
             ...(settledOutput == null ? {} : { settledOutput }),
           }),
         ],
@@ -1004,6 +1089,11 @@ export class SubagentExecutor {
        */
       const inheritedConfigurable: Record<string, unknown> =
         sanitizeChildConfigurable(params.parentConfigurable);
+      const currentHookSessionId =
+        typeof inheritedConfigurable.run_id === 'string' &&
+        inheritedConfigurable.run_id.length > 0
+          ? inheritedConfigurable.run_id
+          : this.parentRunId;
       const childInvokeConfig = {
         recursionLimit: maxTurns * RECURSION_MULTIPLIER,
         signal: childSignal,
@@ -1022,6 +1112,18 @@ export class SubagentExecutor {
         /** Rehydrate child-owned interrupt state when a host rebuilds Run
          * around the same durable checkpointer after a process boundary. */
         const persistedState = await workflow.getState(childInvokeConfig);
+        const checkpointMessages = getCheckpointMessages(
+          (persistedState.values as { messages?: unknown } | undefined)
+            ?.messages
+        );
+        const persistedHookSessionId =
+          getSubagentHookSessionId(checkpointMessages);
+        if (persistedHookSessionId != null) {
+          this.hookRegistry?.migrateSession(
+            persistedHookSessionId,
+            currentHookSessionId
+          );
+        }
         const persistedInterrupts = getPersistedInterrupts(persistedState);
         if (persistedInterrupts.length > 0) {
           activeChildRun.pendingInterrupts = persistedInterrupts;
@@ -1030,11 +1132,8 @@ export class SubagentExecutor {
         } else if (persistedState.next.length === 0) {
           const persistedMessages = getPersistedMessages(persistedState);
           if (persistedMessages != null) {
-            const snapshotValues = persistedState.values as {
-              messages?: unknown;
-            };
             const marker = getSubagentCheckpointMarker(
-              getCheckpointMessages(snapshotValues.messages),
+              checkpointMessages,
               executionSuffix
             );
             result = { messages: persistedMessages };
@@ -1058,7 +1157,16 @@ export class SubagentExecutor {
         }
         const childInput =
           childResumeMap == null
-            ? { messages: [new HumanMessage(description)] }
+            ? {
+              messages: [
+                new HumanMessage({
+                  content: description,
+                  additional_kwargs: {
+                    [SUBAGENT_HOOK_SESSION_KEY]: currentHookSessionId,
+                  },
+                }),
+              ],
+            }
             : new Command({ resume: childResumeMap });
 
         if (

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -17,6 +17,11 @@ const SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY =
   '__librechat_subagent_resume_payload';
 const SUBAGENT_RESUME_WRAPPER_VERSION_KEY =
   '__librechat_subagent_resume_wrapper';
+const SUBAGENT_RESUME_PRIVATE_PAYLOAD_KEYS = [
+  SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY,
+  SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY,
+  SUBAGENT_RESUME_WRAPPER_VERSION_KEY,
+] as const;
 const MAX_RESUME_MANIFEST_DEPTH = 32;
 
 export interface SubagentCheckpointReference {
@@ -436,21 +441,56 @@ export function requireValidSubagentResumeManifest(
   return manifest;
 }
 
+function canAttachSubagentResumeManifestInline(
+  payload: unknown
+): payload is Record<string, unknown> {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload) ||
+    Object.getPrototypeOf(payload) !== Object.prototype
+  ) {
+    return false;
+  }
+  return SUBAGENT_RESUME_PRIVATE_PAYLOAD_KEYS.every(
+    (key) => !Object.prototype.hasOwnProperty.call(payload, key)
+  );
+}
+
+function isInlineSubagentResumePayload(
+  payload: unknown
+): payload is PayloadWithSubagentResumeManifest & Record<string, unknown> {
+  return (
+    payload != null &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    Object.getPrototypeOf(payload) === Object.prototype &&
+    !Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_WRAPPER_VERSION_KEY
+    ) &&
+    !Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY
+    ) &&
+    getSubagentResumeManifest(payload) != null
+  );
+}
+
 export function attachSubagentResumeManifest(
   payload: unknown,
   manifest: SubagentResumeManifest
 ): object {
-  if (isWrappedSubagentResumePayload(payload)) {
+  if (
+    isWrappedSubagentResumePayload(payload) ||
+    isInlineSubagentResumePayload(payload)
+  ) {
     return {
       ...payload,
       [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]: manifest,
     };
   }
-  if (
-    payload == null ||
-    typeof payload !== 'object' ||
-    Array.isArray(payload)
-  ) {
+  if (!canAttachSubagentResumeManifestInline(payload)) {
     return {
       [SUBAGENT_RESUME_WRAPPER_VERSION_KEY]: 1,
       [SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY]: payload,
@@ -470,10 +510,7 @@ export function stripSubagentResumeManifest(payload: unknown): unknown {
   if (
     payload == null ||
     typeof payload !== 'object' ||
-    !Object.prototype.hasOwnProperty.call(
-      payload,
-      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
-    )
+    getSubagentResumeManifest(payload) == null
   ) {
     return payload;
   }
@@ -487,21 +524,23 @@ export function stripSubagentResumeManifest(payload: unknown): unknown {
 function isWrappedSubagentResumePayload(
   payload: unknown
 ): payload is WrappedSubagentResumePayload {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload) ||
+    Object.getPrototypeOf(payload) !== Object.prototype ||
+    Object.keys(payload).length !== SUBAGENT_RESUME_PRIVATE_PAYLOAD_KEYS.length
+  ) {
+    return false;
+  }
+  const wrapper = payload as Partial<WrappedSubagentResumePayload>;
   return (
-    payload != null &&
-    typeof payload === 'object' &&
-    !Array.isArray(payload) &&
-    (payload as Partial<WrappedSubagentResumePayload>)[
-      SUBAGENT_RESUME_WRAPPER_VERSION_KEY
-    ] === 1 &&
+    wrapper[SUBAGENT_RESUME_WRAPPER_VERSION_KEY] === 1 &&
     Object.prototype.hasOwnProperty.call(
-      payload,
+      wrapper,
       SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY
     ) &&
-    Object.prototype.hasOwnProperty.call(
-      payload,
-      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
-    )
+    getSubagentResumeManifest(wrapper) != null
   );
 }
 

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -1,5 +1,452 @@
 import type { ToolCall, ToolMessage } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ToolOutputReferenceState } from '@/tools/toolOutputReferences';
+import type { ToolApprovalReplaySnapshot } from '@/hooks';
+import type { ToolSessionContext } from '@/types';
+
+export const SUBAGENT_RESUME_MANIFEST_CONFIG_KEY =
+  '__librechat_subagent_resume_manifest';
+
+const SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY =
+  '__librechat_subagent_resume_manifest';
+const MAX_RESUME_MANIFEST_DEPTH = 32;
+
+export interface SubagentCheckpointReference {
+  threadId: string;
+  checkpointId: string;
+  checkpointNs: string;
+}
+
+export interface SubagentToolCallStepReference {
+  toolCallId: string;
+  stepId: string;
+}
+
+export interface SubagentToolSessionReference {
+  toolName: string;
+  context: ToolSessionContext;
+}
+
+export interface SubagentToolNodeResumeState {
+  stateKey: string;
+  toolUsageCounts: Array<{ toolName: string; count: number }>;
+  directPathTurns: Array<{ toolCallId: string; turn: number }>;
+}
+
+export interface SubagentEagerToolUsageState {
+  agentId: string;
+  toolUsageCounts: Array<{ toolName: string; count: number }>;
+}
+
+export interface SubagentGraphResumeState {
+  toolCallSteps: SubagentToolCallStepReference[];
+  toolSessions: SubagentToolSessionReference[];
+  toolNodes: SubagentToolNodeResumeState[];
+  eagerToolUsage: SubagentEagerToolUsageState[];
+  eagerToolSuppressions: string[];
+  toolOutputReferences?: ToolOutputReferenceState;
+}
+
+/** Private checkpoint payload linking a parent pause to an exact child state. */
+export interface SubagentResumeExecution {
+  parentToolCallId: string;
+  childRunId: string;
+  checkpoints: SubagentCheckpointReference[];
+  graphState: SubagentGraphResumeState;
+  approvalReplays: ToolApprovalReplaySnapshot[];
+  descendant?: SubagentResumeManifest;
+}
+
+/** Private checkpoint payload linking a parent pause to every child state. */
+export interface SubagentResumeManifest {
+  version: 1;
+  executions: SubagentResumeExecution[];
+}
+
+type PayloadWithSubagentResumeManifest = {
+  [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]?: unknown;
+};
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isApprovalReplaySnapshot(
+  value: unknown
+): value is ToolApprovalReplaySnapshot {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const snapshot = value as Partial<ToolApprovalReplaySnapshot>;
+  const key = snapshot.key;
+  const result = snapshot.result;
+  return (
+    key != null &&
+    isString(key.executionScope) &&
+    typeof key.agentId === 'string' &&
+    isString(key.toolUseId) &&
+    result != null &&
+    result.decision === 'ask' &&
+    Array.isArray(result.additionalContexts) &&
+    Array.isArray(result.injectedMessages) &&
+    Array.isArray(result.errors)
+  );
+}
+
+function isCheckpointReference(
+  value: unknown
+): value is SubagentCheckpointReference {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const checkpoint = value as Partial<SubagentCheckpointReference>;
+  return (
+    isString(checkpoint.threadId) &&
+    isString(checkpoint.checkpointId) &&
+    typeof checkpoint.checkpointNs === 'string'
+  );
+}
+
+function isToolCallStepReference(
+  value: unknown
+): value is SubagentToolCallStepReference {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const reference = value as Partial<SubagentToolCallStepReference>;
+  return isString(reference.toolCallId) && isString(reference.stepId);
+}
+
+function isToolSessionReference(
+  value: unknown
+): value is SubagentToolSessionReference {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const reference = value as Partial<SubagentToolSessionReference>;
+  const context = reference.context;
+  return (
+    isString(reference.toolName) &&
+    context != null &&
+    typeof context === 'object' &&
+    isString(context.session_id) &&
+    Number.isFinite(context.lastUpdated) &&
+    (context.files == null || Array.isArray(context.files))
+  );
+}
+
+function isToolUsageCountReference(
+  value: unknown
+): value is SubagentToolNodeResumeState['toolUsageCounts'][number] {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const entry = value as Partial<
+    SubagentToolNodeResumeState['toolUsageCounts'][number]
+  >;
+  return isString(entry.toolName) && isNonnegativeInteger(entry.count);
+}
+
+function isDirectPathTurnReference(
+  value: unknown
+): value is SubagentToolNodeResumeState['directPathTurns'][number] {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const entry = value as Partial<
+    SubagentToolNodeResumeState['directPathTurns'][number]
+  >;
+  return isString(entry.toolCallId) && isNonnegativeInteger(entry.turn);
+}
+
+function isToolNodeResumeState(
+  value: unknown
+): value is SubagentToolNodeResumeState {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const state = value as Partial<SubagentToolNodeResumeState>;
+  if (
+    !isString(state.stateKey) ||
+    !Array.isArray(state.toolUsageCounts) ||
+    !Array.isArray(state.directPathTurns)
+  ) {
+    return false;
+  }
+  const validUsageCounts = state.toolUsageCounts.every(
+    isToolUsageCountReference
+  );
+  const validDirectTurns = state.directPathTurns.every(
+    isDirectPathTurnReference
+  );
+  if (!validUsageCounts || !validDirectTurns) {
+    return false;
+  }
+  const usageToolNames = new Set(
+    state.toolUsageCounts.map((entry) => entry.toolName)
+  );
+  const directToolCallIds = new Set(
+    state.directPathTurns.map((entry) => entry.toolCallId)
+  );
+  return (
+    usageToolNames.size === state.toolUsageCounts.length &&
+    directToolCallIds.size === state.directPathTurns.length
+  );
+}
+
+function isEagerToolUsageState(
+  value: unknown
+): value is SubagentEagerToolUsageState {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const state = value as Partial<SubagentEagerToolUsageState>;
+  if (
+    typeof state.agentId !== 'string' ||
+    !Array.isArray(state.toolUsageCounts) ||
+    !state.toolUsageCounts.every(isToolUsageCountReference)
+  ) {
+    return false;
+  }
+  const toolNames = new Set(
+    state.toolUsageCounts.map((entry) => entry.toolName)
+  );
+  return toolNames.size === state.toolUsageCounts.length;
+}
+
+function isToolOutputReferenceEntry(
+  value: unknown
+): value is ToolOutputReferenceState['entries'][number] {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const entry = value as Partial<ToolOutputReferenceState['entries'][number]>;
+  return isString(entry.key) && typeof entry.value === 'string';
+}
+
+function isToolOutputReferenceState(
+  value: unknown
+): value is ToolOutputReferenceState {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const state = value as Partial<ToolOutputReferenceState>;
+  if (
+    !Array.isArray(state.entries) ||
+    !state.entries.every(isToolOutputReferenceEntry) ||
+    !isNonnegativeInteger(state.turnCounter) ||
+    !Array.isArray(state.warnedNonStringTools) ||
+    !state.warnedNonStringTools.every(isString)
+  ) {
+    return false;
+  }
+  const entryKeys = new Set(state.entries.map((entry) => entry.key));
+  const warnedTools = new Set(state.warnedNonStringTools);
+  return (
+    entryKeys.size === state.entries.length &&
+    warnedTools.size === state.warnedNonStringTools.length
+  );
+}
+
+function isGraphResumeState(value: unknown): value is SubagentGraphResumeState {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const state = value as Partial<SubagentGraphResumeState>;
+  if (
+    !Array.isArray(state.toolCallSteps) ||
+    !state.toolCallSteps.every(isToolCallStepReference) ||
+    !Array.isArray(state.toolSessions) ||
+    !state.toolSessions.every(isToolSessionReference) ||
+    !Array.isArray(state.toolNodes) ||
+    !state.toolNodes.every(isToolNodeResumeState) ||
+    !Array.isArray(state.eagerToolUsage) ||
+    !state.eagerToolUsage.every(isEagerToolUsageState) ||
+    !Array.isArray(state.eagerToolSuppressions) ||
+    !state.eagerToolSuppressions.every(isString) ||
+    (state.toolOutputReferences != null &&
+      !isToolOutputReferenceState(state.toolOutputReferences))
+  ) {
+    return false;
+  }
+  const toolCallIds = new Set(
+    state.toolCallSteps.map((reference) => reference.toolCallId)
+  );
+  const toolNames = new Set(
+    state.toolSessions.map((reference) => reference.toolName)
+  );
+  const toolNodeKeys = new Set(state.toolNodes.map((node) => node.stateKey));
+  const eagerAgentIds = new Set(
+    state.eagerToolUsage.map((usage) => usage.agentId)
+  );
+  const eagerSuppressions = new Set(state.eagerToolSuppressions);
+  return (
+    toolCallIds.size === state.toolCallSteps.length &&
+    toolNames.size === state.toolSessions.length &&
+    toolNodeKeys.size === state.toolNodes.length &&
+    eagerAgentIds.size === state.eagerToolUsage.length &&
+    eagerSuppressions.size === state.eagerToolSuppressions.length
+  );
+}
+
+function isSubagentResumeExecution(
+  value: unknown,
+  seen: Set<object>,
+  depth: number
+): value is SubagentResumeExecution {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const execution = value as Partial<SubagentResumeExecution>;
+  const childRunId = execution.childRunId;
+  const checkpoints = execution.checkpoints;
+  const graphState = execution.graphState;
+  const approvalReplays = execution.approvalReplays;
+  if (
+    !isString(execution.parentToolCallId) ||
+    !isString(childRunId) ||
+    !Array.isArray(checkpoints) ||
+    checkpoints.length === 0 ||
+    !checkpoints.every(isCheckpointReference) ||
+    !isGraphResumeState(graphState) ||
+    !Array.isArray(approvalReplays)
+  ) {
+    return false;
+  }
+  const checkpointThreadId = checkpoints[0].threadId;
+  const checkpointNamespaces = new Set(
+    checkpoints.map((checkpoint) => checkpoint.checkpointNs)
+  );
+  const validApprovalReplays = approvalReplays.every(
+    (snapshot) =>
+      isApprovalReplaySnapshot(snapshot) &&
+      snapshot.key.executionScope === childRunId
+  );
+  if (!validApprovalReplays) {
+    return false;
+  }
+  const approvalKeys = new Set(
+    approvalReplays.map((snapshot) =>
+      JSON.stringify([
+        snapshot.key.executionScope,
+        snapshot.key.agentId,
+        snapshot.key.toolUseId,
+      ])
+    )
+  );
+  return (
+    checkpoints.every(
+      (checkpoint) => checkpoint.threadId === checkpointThreadId
+    ) &&
+    checkpointNamespaces.size === checkpoints.length &&
+    approvalKeys.size === approvalReplays.length &&
+    (execution.descendant == null ||
+      isSubagentResumeManifest(execution.descendant, seen, depth + 1))
+  );
+}
+
+function isSubagentResumeManifest(
+  value: unknown,
+  seen: Set<object> = new Set(),
+  depth = 0
+): value is SubagentResumeManifest {
+  if (
+    value == null ||
+    typeof value !== 'object' ||
+    depth > MAX_RESUME_MANIFEST_DEPTH ||
+    seen.has(value)
+  ) {
+    return false;
+  }
+  seen.add(value);
+  const manifest = value as Partial<SubagentResumeManifest>;
+  if (
+    manifest.version !== 1 ||
+    !Array.isArray(manifest.executions) ||
+    manifest.executions.length === 0 ||
+    !manifest.executions.every((execution) =>
+      isSubagentResumeExecution(execution, seen, depth)
+    )
+  ) {
+    return false;
+  }
+  const parentToolCallIds = new Set(
+    manifest.executions.map((execution) => execution.parentToolCallId)
+  );
+  return parentToolCallIds.size === manifest.executions.length;
+}
+
+export function getSubagentResumeManifest(
+  payload: unknown
+): SubagentResumeManifest | undefined {
+  if (payload == null || typeof payload !== 'object') {
+    return undefined;
+  }
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+    )
+  ) {
+    return undefined;
+  }
+  const manifest = (payload as PayloadWithSubagentResumeManifest)[
+    SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+  ];
+  return isSubagentResumeManifest(manifest) ? manifest : undefined;
+}
+
+export function requireValidSubagentResumeManifest(
+  payload: unknown
+): SubagentResumeManifest | undefined {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    !Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+    )
+  ) {
+    return undefined;
+  }
+  const manifest = getSubagentResumeManifest(payload);
+  if (manifest == null) {
+    throw new Error('Invalid subagent resume manifest.');
+  }
+  return manifest;
+}
+
+export function attachSubagentResumeManifest(
+  payload: object,
+  manifest: SubagentResumeManifest
+): object {
+  return {
+    ...payload,
+    [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]: manifest,
+  };
+}
+
+export function stripSubagentResumeManifest(payload: unknown): unknown {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    !Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+    )
+  ) {
+    return payload;
+  }
+  return Object.fromEntries(
+    Object.entries(payload).filter(
+      ([key]) => key !== SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+    )
+  );
+}
 
 export const SUBAGENT_REPLAY_CONTROLLER = Symbol.for(
   '@librechat/agents/subagent-replay-controller'
@@ -13,6 +460,9 @@ export type SettledSubagentToolOutput = {
 };
 
 export interface SubagentReplayController {
+  getResumeManifest?(
+    parentToolCallIds?: ReadonlySet<string>
+  ): Promise<SubagentResumeManifest | undefined>;
   getSettledOutput(
     call: ToolCall,
     config: RunnableConfig

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -6,6 +6,8 @@ import type { ToolSessionContext } from '@/types';
 
 export const SUBAGENT_RESUME_MANIFEST_CONFIG_KEY =
   '__librechat_subagent_resume_manifest';
+export const SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY =
+  '__librechat_subagent_resume_attempt';
 
 const SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY =
   '__librechat_subagent_resume_manifest';

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -11,6 +11,10 @@ export const SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY =
 
 const SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY =
   '__librechat_subagent_resume_manifest';
+const SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY =
+  '__librechat_subagent_resume_payload';
+const SUBAGENT_RESUME_WRAPPER_VERSION_KEY =
+  '__librechat_subagent_resume_wrapper';
 const MAX_RESUME_MANIFEST_DEPTH = 32;
 
 export interface SubagentCheckpointReference {
@@ -53,6 +57,7 @@ export interface SubagentGraphResumeState {
 export interface SubagentResumeExecution {
   parentToolCallId: string;
   childRunId: string;
+  approvalExecutionScope: string;
   checkpoints: SubagentCheckpointReference[];
   graphState: SubagentGraphResumeState;
   approvalReplays: ToolApprovalReplaySnapshot[];
@@ -67,6 +72,11 @@ export interface SubagentResumeManifest {
 
 type PayloadWithSubagentResumeManifest = {
   [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]?: unknown;
+};
+
+type WrappedSubagentResumePayload = PayloadWithSubagentResumeManifest & {
+  [SUBAGENT_RESUME_WRAPPER_VERSION_KEY]: 1;
+  [SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY]: unknown;
 };
 
 function isString(value: unknown): value is string {
@@ -305,12 +315,14 @@ function isSubagentResumeExecution(
   }
   const execution = value as Partial<SubagentResumeExecution>;
   const childRunId = execution.childRunId;
+  const approvalExecutionScope = execution.approvalExecutionScope;
   const checkpoints = execution.checkpoints;
   const graphState = execution.graphState;
   const approvalReplays = execution.approvalReplays;
   if (
     !isString(execution.parentToolCallId) ||
     !isString(childRunId) ||
+    !isString(approvalExecutionScope) ||
     !Array.isArray(checkpoints) ||
     checkpoints.length === 0 ||
     !checkpoints.every(isCheckpointReference) ||
@@ -326,7 +338,7 @@ function isSubagentResumeExecution(
   const validApprovalReplays = approvalReplays.every(
     (snapshot) =>
       isApprovalReplaySnapshot(snapshot) &&
-      snapshot.key.executionScope === childRunId
+      snapshot.key.executionScope === approvalExecutionScope
   );
   if (!validApprovalReplays) {
     return false;
@@ -423,9 +435,26 @@ export function requireValidSubagentResumeManifest(
 }
 
 export function attachSubagentResumeManifest(
-  payload: object,
+  payload: unknown,
   manifest: SubagentResumeManifest
 ): object {
+  if (isWrappedSubagentResumePayload(payload)) {
+    return {
+      ...payload,
+      [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]: manifest,
+    };
+  }
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload)
+  ) {
+    return {
+      [SUBAGENT_RESUME_WRAPPER_VERSION_KEY]: 1,
+      [SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY]: payload,
+      [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]: manifest,
+    };
+  }
   return {
     ...payload,
     [SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY]: manifest,
@@ -433,6 +462,9 @@ export function attachSubagentResumeManifest(
 }
 
 export function stripSubagentResumeManifest(payload: unknown): unknown {
+  if (isWrappedSubagentResumePayload(payload)) {
+    return payload[SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY];
+  }
   if (
     payload == null ||
     typeof payload !== 'object' ||
@@ -446,6 +478,27 @@ export function stripSubagentResumeManifest(payload: unknown): unknown {
   return Object.fromEntries(
     Object.entries(payload).filter(
       ([key]) => key !== SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
+    )
+  );
+}
+
+function isWrappedSubagentResumePayload(
+  payload: unknown
+): payload is WrappedSubagentResumePayload {
+  return (
+    payload != null &&
+    typeof payload === 'object' &&
+    !Array.isArray(payload) &&
+    (payload as Partial<WrappedSubagentResumePayload>)[
+      SUBAGENT_RESUME_WRAPPER_VERSION_KEY
+    ] === 1 &&
+    Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY
+    ) &&
+    Object.prototype.hasOwnProperty.call(
+      payload,
+      SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY
     )
   );
 }

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -8,6 +8,8 @@ export const SUBAGENT_RESUME_MANIFEST_CONFIG_KEY =
   '__librechat_subagent_resume_manifest';
 export const SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY =
   '__librechat_subagent_resume_attempt';
+export const SUBAGENT_PARENT_BATCH_CONFIG_KEY =
+  '__librechat_subagent_parent_batch';
 
 const SUBAGENT_RESUME_MANIFEST_PAYLOAD_KEY =
   '__librechat_subagent_resume_manifest';

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -1,0 +1,29 @@
+import type { ToolCall, ToolMessage } from '@langchain/core/messages/tool';
+import type { RunnableConfig } from '@langchain/core/runnables';
+
+export const SUBAGENT_REPLAY_CONTROLLER = Symbol.for(
+  '@librechat/agents/subagent-replay-controller'
+);
+
+export type SettledSubagentToolOutput = {
+  output: ToolMessage;
+  additionalContexts: string[];
+  resolvedArgs?: Record<string, unknown>;
+  referenceContent?: string;
+};
+
+export interface SubagentReplayController {
+  getSettledOutput(
+    call: ToolCall,
+    config: RunnableConfig
+  ): Promise<SettledSubagentToolOutput | undefined>;
+  persistSettledOutput(
+    call: ToolCall,
+    config: RunnableConfig,
+    settled: SettledSubagentToolOutput
+  ): Promise<void>;
+}
+
+export type ReplayableSubagentTool = {
+  [SUBAGENT_REPLAY_CONTROLLER]?: SubagentReplayController;
+};

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -41,7 +41,11 @@ function parseStringifiedArgsObject(
   }
   try {
     const parsed = JSON.parse(value) as unknown;
-    if (parsed != null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    if (
+      parsed != null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+    ) {
       return parsed as Record<string, unknown>;
     }
   } catch {
@@ -90,6 +94,12 @@ export type ToolOutputReferenceRegistryOptions = {
    */
   maxActiveRuns?: number;
 };
+
+export interface ToolOutputReferenceState {
+  entries: Array<{ key: string; value: string }>;
+  turnCounter: number;
+  warnedNonStringTools: string[];
+}
 
 /**
  * Result of resolving placeholders in tool args.
@@ -395,6 +405,35 @@ export class ToolOutputReferenceRegistry {
       resolve: <T>(args: T, options?: ResolveOptions): ResolveResult<T> =>
         this.resolveAgainst(entries, args, options),
     };
+  }
+
+  /** Captures the checkpoint-safe state needed to resume one run bucket. */
+  snapshotState(runId: string | undefined): ToolOutputReferenceState {
+    const bucket = this.runStates.get(this.keyFor(runId));
+    return {
+      entries: [...(bucket?.entries ?? EMPTY_ENTRIES)].map(([key, value]) => ({
+        key,
+        value,
+      })),
+      turnCounter: bucket?.turnCounter ?? 0,
+      warnedNonStringTools: [...(bucket?.warnedNonStringTools ?? [])],
+    };
+  }
+
+  /** Restores a checkpointed run bucket under the current resume scope. */
+  restoreState(
+    runId: string | undefined,
+    state: ToolOutputReferenceState
+  ): void {
+    this.releaseRun(runId);
+    const bucket = this.getOrCreate(runId);
+    for (const { key, value } of state.entries) {
+      this.set(runId, key, value);
+    }
+    bucket.turnCounter = state.turnCounter;
+    for (const toolName of state.warnedNonStringTools) {
+      bucket.warnedNonStringTools.add(toolName);
+    }
   }
 
   private resolveAgainst<T>(

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -659,11 +659,11 @@ export interface AgentInputs {
    * raise a LangGraph `interrupt()` (e.g. a tool built on `askUserQuestion()`) —
    * the host-side event handler runs outside the graph task, where `interrupt()`
    * throws. Do NOT also list these tools in `toolDefinitions` (they would be bound
-   * twice). NOT inherited by SELF-SPAWNED subagent children (their config is a
-   * shallow spread of the parent's inputs, and child graphs compile without a
-   * checkpointer, so an interrupt-capable tool could never pause there) —
-   * `buildChildInputs` scrubs the inherited copy; an EXPLICIT child config that
-   * lists its own `graphTools` keeps them.
+   * twice). NOT inherited by SELF-SPAWNED subagent children: `buildChildInputs`
+   * scrubs the shallow-spread parent copy so parent-scoped direct tools are not
+   * exposed to a child implicitly. An EXPLICIT child config that lists its own
+   * `graphTools` keeps them; with HITL enabled, those tools share the parent's
+   * checkpointer and may pause and resume inside the child graph.
    *
    * Deliberately `GenericTool[]`, not `GraphTools`: the wider union admits
    * schema-only shapes (OpenAI `BindToolsInput`, Google tool objects) that

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -101,6 +101,18 @@ export type ToolApprovalDecisionMap = Record<string, ToolApprovalDecision>;
  */
 export type HumanInterruptType = 'tool_approval' | 'ask_user_question';
 
+/** Identifies an interrupt that originated inside a checkpointed subagent. */
+export interface SubagentInterruptScope {
+  /** Stable child run id used as the child checkpoint thread id. */
+  run_id: string;
+  /** Child agent id that owns the interrupted tool call. */
+  agent_id: string;
+  /** Configured subagent type selected by the parent tool call. */
+  subagent_type: string;
+  /** Parent `subagent` tool call that launched this child. */
+  parent_tool_call_id?: string;
+}
+
 /**
  * Structured payload the SDK passes to `interrupt()` when one or more
  * pending tool calls require host approval. All `ask`-decision tool calls
@@ -114,6 +126,8 @@ export interface ToolApprovalInterruptPayload {
   type: 'tool_approval';
   action_requests: ToolApprovalRequest[];
   review_configs: ToolApprovalReviewConfig[];
+  /** Present when the approval request was bridged from a child graph. */
+  subagent?: SubagentInterruptScope;
 }
 
 /**

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -103,7 +103,7 @@ export type HumanInterruptType = 'tool_approval' | 'ask_user_question';
 
 /** Identifies an interrupt that originated inside a checkpointed subagent. */
 export interface SubagentInterruptScope {
-  /** Stable child run id used as the child checkpoint thread id. */
+  /** Child execution run id used by subagent update and usage events. */
   run_id: string;
   /** Child agent id that owns the interrupted tool call. */
   agent_id: string;

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -126,6 +126,8 @@ export interface ToolApprovalInterruptPayload {
   type: 'tool_approval';
   action_requests: ToolApprovalRequest[];
   review_configs: ToolApprovalReviewConfig[];
+  /** Hook-registry session whose policy raised this interrupt. */
+  hook_session_id?: string;
   /** Present when the approval request was bridged from a child graph. */
   subagent?: SubagentInterruptScope;
 }


### PR DESCRIPTION
I implemented resumable human approval for tools invoked inside subagents and replaced mutable child-thread replay with an immutable, checkpoint-scoped resume contract. This closes #188.

- Propagated parent HITL configuration and the effective shared checkpointer into child graphs.
- Persisted exact child checkpoint heads, stable child run identity, approval replay state, graph/tool sidecars, and recursive descendant manifests with each parent interrupt.
- Forked every resume attempt from the child snapshot selected by the parent checkpoint into an internally unique branch, including repeated public run IDs.
- Restored tool sessions, tool-call step identity, usage counters, eager-tool state, and tool-output references before continuing a rebuilt child.
- Preserved settled sibling outputs and lifecycle state so rebuilt ToolNodes do not repeat child work or hook side effects.
- Routed resume decisions by interrupt ID while keeping the innermost nested subagent scope visible to the host.
- Confined checkpoint lineage copies to their source namespace and failed closed for malformed manifests or incomplete lineage.
- Kept private resume metadata out of public interrupt payloads and fresh-run caller configuration.
- Covered original-first, rebuilt-first, concurrent sibling, repeated-run-ID, nested pause, one-shot approval, cleanup ownership, and tool-output-reference scenarios.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran the CI-equivalent Jest suite: 198 suites and 3,772 tests passed; 16 repository-excluded suites were skipped.
- Ran focused resume-manifest and subagent HITL suites after each review correction.
- Ran `npx tsc --noEmit`.
- Ran ESLint against every changed TypeScript file with zero warnings.
- Ran `npm run sort-imports:check` against every changed TypeScript file.
- Ran `npm run build`.

### **Test Configuration**:

- Node.js: v24.16.0
- Checkpointer: LangGraph `MemorySaver` for local, branched, nested, and rebuilt-Run integration coverage

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
