### PR TITLE
🧭 ci: Add Structured Circular Dependency Checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,14 +82,11 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Build and check for circular dependencies
-        run: |
-          output=$(npm run build:dev 2>&1)
-          echo "$output"
-          if echo "$output" | grep -qi "Circular depend"; then
-            echo "::error title=Circular dependency detected::The bundler reported a circular dependency. See the build output above."
-            exit 1
-          fi
+      - name: Build package
+        run: npm run build:dev
+
+      - name: Check circular dependencies
+        run: npm run check:circular-deps
 
   unit-tests:
     name: 'unit tests (shard ${{ matrix.shard }}/4)'

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -1,0 +1,161 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { packageEntries } from './package-entries.mjs';
+
+const root = path.resolve(fileURLToPath(import.meta.url), '../..');
+const minimumModuleCount = 100;
+/**
+ * The public type barrels contain pre-existing declaration-only cycles. Runtime
+ * edges are enforced now; type edges can be enabled after that graph is untangled.
+ */
+const includeTypeEdges = false;
+
+/** Collect every type-only dependency specifier from a parsed TypeScript AST. */
+const collectTypeSpecifiers = (node, specifiers) => {
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectTypeSpecifiers(item, specifiers);
+    }
+    return;
+  }
+
+  const typeOnly =
+    node.type === 'TSImportType' ||
+    (node.importKind ?? node.exportKind) === 'type' ||
+    (Array.isArray(node.specifiers) &&
+      node.specifiers.some((specifier) =>
+        ['type', 'typeof'].includes(
+          specifier.importKind ?? specifier.exportKind
+        )
+      ));
+  if (typeOnly && typeof node.source?.value === 'string') {
+    specifiers.add(node.source.value);
+  }
+
+  for (const value of Object.values(node)) {
+    if (value !== null && typeof value === 'object') {
+      collectTypeSpecifiers(value, specifiers);
+    }
+  }
+};
+
+/** Materialize type-only imports so Rolldown checks the declaration graph too. */
+const typeEdgesPlugin = (parseAst) => ({
+  name: 'type-edges',
+  transform(code, id) {
+    const extension = /\.([mc]?tsx?)(?:$|\?)/.exec(id)?.[1];
+    if (!extension) {
+      return null;
+    }
+
+    const { body } = parseAst(code, {
+      lang: extension.endsWith('x') ? 'tsx' : 'ts',
+    });
+    const specifiers = new Set();
+    collectTypeSpecifiers(body, specifiers);
+    if (specifiers.size === 0) {
+      return null;
+    }
+
+    const edges = [...specifiers]
+      .map((specifier) => `\nimport ${JSON.stringify(specifier)};`)
+      .join('');
+    return { code: code + edges, map: null };
+  },
+});
+
+async function loadRolldown() {
+  const packageRequire = createRequire(path.join(root, 'package.json'));
+  const tsdownRequire = createRequire(packageRequire.resolve('tsdown'));
+  const { rolldown } = await import(
+    pathToFileURL(tsdownRequire.resolve('rolldown')).href
+  );
+  const { parseAst } = await import(
+    pathToFileURL(tsdownRequire.resolve('rolldown/parseAst')).href
+  );
+  return { rolldown, parseAst };
+}
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (message) => message.replace(/\u001B\[[0-9;]*m/g, '');
+const relativize = (message) =>
+  stripAnsi(message).replaceAll(root + path.sep, '');
+
+async function scan({ rolldown, parseAst }) {
+  const cycles = [];
+  const unresolved = [];
+  const isInternal = (id) =>
+    id.startsWith('.') || path.isAbsolute(id) || id.startsWith('@/');
+
+  try {
+    const build = await rolldown({
+      input: Object.values(packageEntries).map((entry) =>
+        path.join(root, entry)
+      ),
+      platform: 'node',
+      resolve: { alias: { '@': path.join(root, 'src') } },
+      external: (id) => !isInternal(id),
+      plugins: includeTypeEdges ? [typeEdgesPlugin(parseAst)] : [],
+      checks: { circularDependency: true },
+      onLog(_level, log) {
+        if (log.code === 'CIRCULAR_DEPENDENCY') {
+          cycles.push(relativize(log.message));
+        } else if (log.code === 'UNRESOLVED_IMPORT') {
+          unresolved.push(relativize(log.message));
+        }
+      },
+    });
+    const { output } = await build.generate({ format: 'cjs' });
+    const modules = output.reduce(
+      (sum, chunk) => sum + (chunk.moduleIds?.length ?? 0),
+      0
+    );
+    await build.close();
+    return { cycles, unresolved, modules, error: null };
+  } catch (error) {
+    return { cycles, unresolved, modules: 0, error };
+  }
+}
+
+function report({ cycles, unresolved, modules, error }) {
+  const problems = [];
+  if (error) {
+    problems.push(`build failed: ${relativize(error.message)}`);
+  }
+  problems.push(...cycles);
+  problems.push(
+    ...unresolved.map((message) => `unresolved first-party import: ${message}`)
+  );
+  if (!error && modules < minimumModuleCount) {
+    problems.push(
+      `graph has ${modules} modules, below the ${minimumModuleCount} floor; the scan is no longer resolving the full package`
+    );
+  }
+
+  if (problems.length === 0) {
+    const scope = includeTypeEdges
+      ? 'runtime + type edges'
+      : 'runtime edges only, type edges grandfathered';
+    console.log(
+      `✓ @librechat/agents: no circular dependencies (${modules} modules, ${scope})`
+    );
+    return true;
+  }
+
+  console.error('✗ @librechat/agents:');
+  for (const problem of problems) {
+    console.error(`    ${problem}`);
+  }
+  return false;
+}
+
+const passed = report(await scan(await loadRolldown()));
+if (!passed) {
+  console.error('\nCircular dependency check failed.');
+  process.exit(1);
+}

--- a/config/package-entries.mjs
+++ b/config/package-entries.mjs
@@ -1,0 +1,16 @@
+export const packageEntries = Object.freeze({
+  main: 'src/index.ts',
+  'openai/index': 'src/openai/index.ts',
+  'responses/index': 'src/responses/index.ts',
+  'langchain/index': 'src/langchain/index.ts',
+  'langchain/google-common': 'src/langchain/google-common.ts',
+  'langchain/language_models/chat_models':
+    'src/langchain/language_models/chat_models.ts',
+  'langchain/messages': 'src/langchain/messages.ts',
+  'langchain/messages/tool': 'src/langchain/messages/tool.ts',
+  'langchain/openai': 'src/langchain/openai.ts',
+  'langchain/prompts': 'src/langchain/prompts.ts',
+  'langchain/runnables': 'src/langchain/runnables.ts',
+  'langchain/tools': 'src/langchain/tools.ts',
+  'langchain/utils/env': 'src/langchain/utils/env.ts',
+});

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "prepublishOnly": "npm run build",
     "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",
+    "check:circular-deps": "node config/circular-deps.mjs",
     "sort-imports": "node scripts/sort-imports.ts",
     "sort-imports:check": "node scripts/sort-imports.ts --check",
     "start": "node dist/esm/main.js",

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -1,25 +1,10 @@
 import { defineConfig } from 'tsdown';
 import { isAbsolute } from 'node:path';
 
-const entry = {
-  main: 'src/index.ts',
-  'openai/index': 'src/openai/index.ts',
-  'responses/index': 'src/responses/index.ts',
-  'langchain/index': 'src/langchain/index.ts',
-  'langchain/google-common': 'src/langchain/google-common.ts',
-  'langchain/language_models/chat_models':
-    'src/langchain/language_models/chat_models.ts',
-  'langchain/messages': 'src/langchain/messages.ts',
-  'langchain/messages/tool': 'src/langchain/messages/tool.ts',
-  'langchain/openai': 'src/langchain/openai.ts',
-  'langchain/prompts': 'src/langchain/prompts.ts',
-  'langchain/runnables': 'src/langchain/runnables.ts',
-  'langchain/tools': 'src/langchain/tools.ts',
-  'langchain/utils/env': 'src/langchain/utils/env.ts',
-};
+import { packageEntries } from './config/package-entries.mjs';
 
 const shared = {
-  entry,
+  entry: packageEntries,
   platform: 'node',
   // Declarations are emitted separately by `tsc -p tsconfig.build.json` (see the
   // `build` script); the source isn't isolatedDeclarations-clean, so oxc dts
@@ -33,8 +18,7 @@ const shared = {
   // Rollup `entryFileNames` and the paths in the exports map.
   fixedExtension: true,
   alias: { '@': './src' },
-  // CI greps the build output for "Circular depend" (validate.yml); rolldown's
-  // check is off by default, so enable it to keep that guard working.
+  // Keep local build diagnostics aligned with the dedicated graph check.
   inputOptions: { checks: { circularDependency: true } },
   // Match the prior Rollup build (`external: [/node_modules/]`): bundle nothing
   // third-party, compile only this package's own modules.


### PR DESCRIPTION
## Summary

I replaced the Agents SDK's build-output grep with a structured Rolldown dependency-graph check modeled on LibreChat's CI guard.

- Added a deterministic checker that fails on runtime cycles, unresolved first-party imports, build errors, and unexpectedly small module graphs.
- Shared all 13 published entry points between `tsdown` and the checker so their module coverage cannot drift.
- Preserved the real package build as a separate CI step and retained build-time circular-dependency diagnostics.
- Reported the current scope explicitly as runtime-only because the SDK has pre-existing declaration-only barrel cycles that require a dedicated cleanup.
- Reused Rolldown from the existing `tsdown` dependency without changing the dependency tree.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run check:circular-deps` — 181 runtime modules, zero cycles, zero unresolved imports
- `npm run build:dev`
- `npm run build`
- `npx tsc --noEmit`
- `npx prettier --check config/circular-deps.mjs config/package-entries.mjs tsdown.config.mjs .github/workflows/validate.yml package.json`
- `git diff --check`

### **Test Configuration**:

- Node.js 24.16
- npm 10.5.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local validation passes with my changes
