### PR TITLE
🧬 test: Harden Circular Dependency Checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Build package
         run: npm run build:dev
 
+      - name: Test circular dependency checker
+        run: npm run test:circular-deps
+
       - name: Check circular dependencies
         run: npm run check:circular-deps
 

--- a/config/circular-deps.mjs
+++ b/config/circular-deps.mjs
@@ -5,12 +5,20 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { packageEntries } from './package-entries.mjs';
 
 const root = path.resolve(fileURLToPath(import.meta.url), '../..');
-const minimumModuleCount = 100;
+
 /**
- * The public type barrels contain pre-existing declaration-only cycles. Runtime
- * edges are enforced now; type edges can be enabled after that graph is untangled.
+ * Type-only cycles in the public barrels predate this check. Runtime edges are
+ * enforced now; the exclusion remains explicit until the type graph is
+ * untangled in a dedicated change.
  */
-const includeTypeEdges = false;
+export const agentsTarget = Object.freeze({
+  name: '@librechat/agents',
+  entries: Object.values(packageEntries).map((entry) => path.join(root, entry)),
+  alias: { '@': path.join(root, 'src') },
+  internalPrefixes: ['@/'],
+  minModules: 100,
+  typeEdges: false,
+});
 
 /** Collect every type-only dependency specifier from a parsed TypeScript AST. */
 const collectTypeSpecifiers = (node, specifiers) => {
@@ -44,7 +52,7 @@ const collectTypeSpecifiers = (node, specifiers) => {
   }
 };
 
-/** Materialize type-only imports so Rolldown checks the declaration graph too. */
+/** Materialize type-only imports when a target opts into declaration edges. */
 const typeEdgesPlugin = (parseAst) => ({
   name: 'type-edges',
   transform(code, id) {
@@ -69,9 +77,12 @@ const typeEdgesPlugin = (parseAst) => ({
   },
 });
 
-async function loadRolldown() {
+/** Load the exact Rolldown installation resolved from tsdown. */
+export async function loadRolldown() {
   const packageRequire = createRequire(path.join(root, 'package.json'));
-  const tsdownRequire = createRequire(packageRequire.resolve('tsdown'));
+  const tsdownRequire = createRequire(
+    packageRequire.resolve('tsdown/package.json')
+  );
   const { rolldown } = await import(
     pathToFileURL(tsdownRequire.resolve('rolldown')).href
   );
@@ -85,77 +96,153 @@ async function loadRolldown() {
 const stripAnsi = (message) => message.replace(/\u001B\[[0-9;]*m/g, '');
 const relativize = (message) =>
   stripAnsi(message).replaceAll(root + path.sep, '');
+const errorMessage = (error) =>
+  error instanceof Error ? error.message : String(error);
+const uniqueSorted = (values) => [...new Set(values)].sort();
+const unresolvedCodes = new Set(['UNRESOLVED_IMPORT', 'RESOLVE_ERROR']);
 
-async function scan({ rolldown, parseAst }) {
+const getNestedErrors = (error) => {
+  if (
+    error === null ||
+    typeof error !== 'object' ||
+    !Array.isArray(error.errors)
+  ) {
+    return [];
+  }
+  return error.errors;
+};
+
+const isInternal = (id, target) =>
+  id.startsWith('.') ||
+  path.isAbsolute(id) ||
+  target.internalPrefixes.some((prefix) => id.startsWith(prefix));
+const isUnresolvedFirstParty = (diagnostic, target) =>
+  unresolvedCodes.has(diagnostic?.code) &&
+  (typeof diagnostic.exporter !== 'string' ||
+    isInternal(diagnostic.exporter, target));
+
+export async function scan(engine, target = agentsTarget) {
   const cycles = [];
   const unresolved = [];
-  const isInternal = (id) =>
-    id.startsWith('.') || path.isAbsolute(id) || id.startsWith('@/');
+  const moduleIds = new Set();
+  const graphCounterPlugin = {
+    name: 'resolved-module-counter',
+    async resolveId(source, importer) {
+      const resolved = await this.resolve(source, importer, { skipSelf: true });
+      if (resolved && !resolved.external && path.isAbsolute(resolved.id)) {
+        moduleIds.add(resolved.id);
+      }
+      return resolved;
+    },
+  };
 
   try {
-    const build = await rolldown({
-      input: Object.values(packageEntries).map((entry) =>
-        path.join(root, entry)
-      ),
+    const build = await engine.rolldown({
+      input: target.entries,
       platform: 'node',
-      resolve: { alias: { '@': path.join(root, 'src') } },
-      external: (id) => !isInternal(id),
-      plugins: includeTypeEdges ? [typeEdgesPlugin(parseAst)] : [],
+      resolve: { alias: target.alias },
+      external: (id) => !isInternal(id, target),
+      plugins: [
+        ...(target.typeEdges ? [typeEdgesPlugin(engine.parseAst)] : []),
+        graphCounterPlugin,
+      ],
       checks: { circularDependency: true },
       onLog(_level, log) {
         if (log.code === 'CIRCULAR_DEPENDENCY') {
           cycles.push(relativize(log.message));
-        } else if (log.code === 'UNRESOLVED_IMPORT') {
+        } else if (isUnresolvedFirstParty(log, target)) {
           unresolved.push(relativize(log.message));
         }
       },
     });
-    const { output } = await build.generate({ format: 'cjs' });
-    const modules = output.reduce(
-      (sum, chunk) => sum + (chunk.moduleIds?.length ?? 0),
-      0
-    );
-    await build.close();
-    return { cycles, unresolved, modules, error: null };
+
+    try {
+      await build.generate({ format: 'cjs' });
+      return {
+        target,
+        cycles: uniqueSorted(cycles),
+        unresolved: uniqueSorted(unresolved),
+        modules: moduleIds.size,
+        error: null,
+      };
+    } finally {
+      await build.close();
+    }
   } catch (error) {
-    return { cycles, unresolved, modules: 0, error };
+    const unresolvedErrors = getNestedErrors(error)
+      .filter((nestedError) => isUnresolvedFirstParty(nestedError, target))
+      .map((nestedError) => relativize(errorMessage(nestedError)));
+    return {
+      target,
+      cycles: uniqueSorted(cycles),
+      unresolved: uniqueSorted([...unresolved, ...unresolvedErrors]),
+      modules: 0,
+      error,
+    };
   }
 }
 
-function report({ cycles, unresolved, modules, error }) {
+export function getProblems({ target, cycles, unresolved, modules, error }) {
   const problems = [];
   if (error) {
-    problems.push(`build failed: ${relativize(error.message)}`);
+    problems.push(`build failed: ${relativize(errorMessage(error))}`);
   }
   problems.push(...cycles);
   problems.push(
     ...unresolved.map((message) => `unresolved first-party import: ${message}`)
   );
-  if (!error && modules < minimumModuleCount) {
+  if (!error && modules < target.minModules) {
     problems.push(
-      `graph has ${modules} modules, below the ${minimumModuleCount} floor; the scan is no longer resolving the full package`
+      `graph has ${modules} modules, below the ${target.minModules} floor; the scan is no longer resolving the full package`
     );
   }
+  return problems;
+}
 
+export function report(result) {
+  const { target, modules } = result;
+  const problems = getProblems(result);
   if (problems.length === 0) {
-    const scope = includeTypeEdges
+    const scope = target.typeEdges
       ? 'runtime + type edges'
       : 'runtime edges only, type edges grandfathered';
     console.log(
-      `✓ @librechat/agents: no circular dependencies (${modules} modules, ${scope})`
+      `✓ ${target.name}: no circular dependencies (${modules} modules, ${scope})`
     );
     return true;
   }
 
-  console.error('✗ @librechat/agents:');
+  console.error(`✗ ${target.name}:`);
   for (const problem of problems) {
     console.error(`    ${problem}`);
   }
   return false;
 }
 
-const passed = report(await scan(await loadRolldown()));
-if (!passed) {
-  console.error('\nCircular dependency check failed.');
-  process.exit(1);
+export async function main() {
+  let result;
+  try {
+    result = await scan(await loadRolldown());
+  } catch (error) {
+    result = {
+      target: agentsTarget,
+      cycles: [],
+      unresolved: [],
+      modules: 0,
+      error,
+    };
+  }
+
+  const passed = report(result);
+  if (!passed) {
+    console.error('\nCircular dependency check failed.');
+  }
+  return passed;
+}
+
+const isDirectRun =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun && !(await main())) {
+  process.exitCode = 1;
 }

--- a/config/circular-deps.test.mjs
+++ b/config/circular-deps.test.mjs
@@ -1,0 +1,157 @@
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import test, { after, before } from 'node:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+
+import {
+  agentsTarget,
+  getProblems,
+  loadRolldown,
+  scan,
+} from './circular-deps.mjs';
+import { packageEntries } from './package-entries.mjs';
+import tsdownConfig from '../tsdown.config.mjs';
+
+let engine;
+const fixtureRoots = [];
+
+before(async () => {
+  engine = await loadRolldown();
+});
+
+after(async () => {
+  await Promise.all(
+    fixtureRoots.map((fixtureRoot) =>
+      rm(fixtureRoot, { recursive: true, force: true })
+    )
+  );
+});
+
+async function createTarget(files, options = {}) {
+  const fixtureRoot = await mkdtemp(
+    path.join(os.tmpdir(), 'agents-circular-deps-')
+  );
+  fixtureRoots.push(fixtureRoot);
+
+  await Promise.all(
+    Object.entries(files).map(async ([file, source]) => {
+      const filePath = path.join(fixtureRoot, file);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, source, 'utf8');
+    })
+  );
+
+  return {
+    name: 'fixture',
+    entries: [path.join(fixtureRoot, 'entry.ts')],
+    alias: { '@': fixtureRoot },
+    internalPrefixes: ['@/'],
+    minModules: options.minModules ?? 1,
+    typeEdges: false,
+  };
+}
+
+test('the package build and checker share all public entries', () => {
+  assert.equal(Object.keys(packageEntries).length, 13);
+  assert.equal(tsdownConfig.length, 2);
+  for (const config of tsdownConfig) {
+    assert.equal(config.entry, packageEntries);
+    assert.equal(config.inputOptions.checks.circularDependency, true);
+  }
+  assert.equal(agentsTarget.minModules, 100);
+  assert.equal(agentsTarget.typeEdges, false);
+  assert.deepEqual(
+    agentsTarget.entries,
+    Object.values(packageEntries).map((entry) =>
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', entry)
+    )
+  );
+});
+
+test('reports a runtime dependency cycle', async () => {
+  const target = await createTarget({
+    'entry.ts':
+      "import { right } from './right';\nexport const left = right + 1;\n",
+    'right.ts':
+      "import { left } from './entry';\nexport const right = left + 1;\n",
+  });
+
+  const result = await scan(engine, target);
+
+  assert.equal(result.error, null);
+  assert.equal(result.cycles.length, 1);
+  assert.match(result.cycles[0], /Circular dependency/);
+});
+
+test('reports unresolved relative and aliased first-party imports', async () => {
+  for (const specifier of ['./missing', '@/missing']) {
+    const target = await createTarget({
+      'entry.ts': `import { missing } from '${specifier}';\nexport const value = missing;\n`,
+    });
+
+    const result = await scan(engine, target);
+
+    assert.equal(result.unresolved.length, 1);
+    assert.match(
+      getProblems(result).join('\n'),
+      /unresolved first-party import/
+    );
+  }
+});
+
+test('reports syntax errors as build failures', async () => {
+  const target = await createTarget({
+    'entry.ts': 'export const = ;\n',
+  });
+
+  const result = await scan(engine, target);
+
+  assert.notEqual(result.error, null);
+  assert.match(getProblems(result).join('\n'), /build failed/);
+});
+
+test('fails when the resolved module graph drops below its floor', async () => {
+  const target = await createTarget(
+    { 'entry.ts': 'export const value = 1;\n' },
+    { minModules: 2 }
+  );
+
+  const result = await scan(engine, target);
+
+  assert.equal(result.error, null);
+  assert.equal(result.modules, 1);
+  assert.match(getProblems(result).join('\n'), /below the 2 floor/);
+});
+
+test('counts resolved runtime modules even when tree-shaking removes them', async () => {
+  const target = await createTarget(
+    {
+      'entry.ts': "import './unused';\nexport const value = 1;\n",
+      'unused.ts': 'export const unused = 2;\n',
+    },
+    { minModules: 2 }
+  );
+
+  const result = await scan(engine, target);
+
+  assert.equal(result.error, null);
+  assert.equal(result.modules, 2);
+  assert.deepEqual(getProblems(result), []);
+});
+
+test('keeps grandfathered type-only edges out of the runtime graph', async () => {
+  const target = await createTarget({
+    'entry.ts':
+      "import type { Right } from './right';\nexport type Left = { right: Right };\nexport const value = 1;\n",
+    'right.ts':
+      "import type { Left } from './entry';\nexport type Right = { left: Left };\n",
+  });
+
+  const result = await scan(engine, target);
+
+  assert.equal(result.error, null);
+  assert.deepEqual(result.cycles, []);
+  assert.equal(result.modules, 1);
+});

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",
     "check:circular-deps": "node config/circular-deps.mjs",
+    "test:circular-deps": "node --test config/circular-deps.test.mjs",
     "sort-imports": "node scripts/sort-imports.ts",
     "sort-imports:check": "node scripts/sort-imports.ts --check",
     "start": "node dist/esm/main.js",


### PR DESCRIPTION
## Summary

I hardened the structured circular-dependency checker added in #398 so failures are deterministic, testable, and tied to the exact graph the package build resolves.

- Reused the exact Rolldown installation bundled through `tsdown` and the shared 13-entry package manifest.
- Counted resolved first-party modules before tree shaking and enforced a conservative 100-module resolution floor.
- Failed explicitly on runtime cycles, unresolved relative or `@/` imports, syntax/build errors, and unexpected graph shrinkage.
- Kept type-only dependency edges explicitly grandfathered until the existing declaration-barrel cycles are untangled separately.
- Added seven real Rolldown fixtures covering acyclic graphs, cycles, unresolved imports, syntax failures, graph shrinkage, tree-shaken modules, and type-only cycles.
- Added the checker test suite to CI while retaining the build-time Rolldown diagnostic as defense in depth.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm run test:circular-deps` (7/7 passed)
- `npm run check:circular-deps` (180 runtime modules, no cycles or unresolved imports)
- `npm run build:dev`
- `npx tsc --noEmit`
- Prettier, Node syntax checks, and `git diff --check`

### **Test Configuration**:

- Node.js 24
- npm 10.5.2
- Rolldown resolved through `tsdown@0.22.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
