### PR TITLE
🏷️ feat: Add Activity Phase Label Support

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -62,6 +62,7 @@ import {
   isSyntheticProviderContextMessage,
   getMessageId,
   getMessageCreationContentMetadata,
+  splitAssistantTextContentByPhase,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
   DEFAULT_RETAIN_RECENT_TURNS,
@@ -567,15 +568,24 @@ async function dispatchTextMessageContent({
     }
     return true;
   }
-  const stepId = await dispatchMessageCreationStep({
-    graph,
-    stepKey,
-    messageId,
-    content,
-    contentType: ContentTypes.TEXT,
-    metadata,
-  });
-  await graph.dispatchMessageDelta(stepId, { content }, metadata);
+  const contentGroups = Array.isArray(content)
+    ? splitAssistantTextContentByPhase(content)
+    : [content];
+  for (const contentGroup of contentGroups) {
+    const stepId = await dispatchMessageCreationStep({
+      graph,
+      stepKey,
+      messageId,
+      content: contentGroup,
+      contentType: ContentTypes.TEXT,
+      metadata,
+    });
+    await graph.dispatchMessageDelta(
+      stepId,
+      { content: contentGroup },
+      metadata
+    );
+  }
   return true;
 }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -61,6 +61,7 @@ import {
   supportsBedrockToolCache,
   isSyntheticProviderContextMessage,
   getMessageId,
+  getMessageCreationContentMetadata,
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
   DEFAULT_RETAIN_RECENT_TURNS,
@@ -507,18 +508,25 @@ async function dispatchMessageCreationStep({
   graph,
   stepKey,
   messageId,
+  content,
+  contentType,
   metadata,
 }: {
   graph: Graph<t.BaseGraphState>;
   stepKey: string;
   messageId: string;
+  content?: string | t.MessageContentComplex[];
+  contentType?: ContentTypes.TEXT | ContentTypes.THINK;
   metadata: Record<string, unknown>;
 }): Promise<string> {
   await graph.dispatchRunStep(
     stepKey,
     {
       type: StepTypes.MESSAGE_CREATION,
-      message_creation: { message_id: messageId },
+      message_creation: {
+        message_id: messageId,
+        ...getMessageCreationContentMetadata(content, contentType),
+      },
     },
     metadata
   );
@@ -548,6 +556,7 @@ async function dispatchTextMessageContent({
         graph,
         stepKey,
         messageId,
+        content: [contentPart],
         metadata,
       });
       await graph.dispatchMessageDelta(
@@ -562,6 +571,8 @@ async function dispatchTextMessageContent({
     graph,
     stepKey,
     messageId,
+    content,
+    contentType: ContentTypes.TEXT,
     metadata,
   });
   await graph.dispatchMessageDelta(stepId, { content }, metadata);
@@ -599,7 +610,10 @@ async function dispatchReasoningContent({
     stepKey,
     {
       type: StepTypes.MESSAGE_CREATION,
-      message_creation: { message_id: messageId },
+      message_creation: {
+        message_id: messageId,
+        content_type: ContentTypes.THINK,
+      },
     },
     metadata
   );

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -275,6 +275,63 @@ describe('StandardGraph final response reasoning fallback', () => {
     streamUsage: false,
   };
 
+  it('starts a new message step when streamed assistant phases change', async () => {
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'separate-streamed-assistant-phases',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({
+        content: [
+          { type: 'text', text: 'Checking the session.', phase: 'commentary' },
+        ] as never,
+      }),
+      new AIMessageChunk({
+        content: [
+          { type: 'text', text: 'The session is fixed.', phase: 'final_answer' },
+        ] as never,
+      }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('fix the session')] },
+      config
+    );
+
+    expect(new Set(messageDeltas.map((delta) => delta.id)).size).toBe(2);
+    expect(contentParts).toEqual([
+      { type: 'text', text: 'Checking the session.' },
+      { type: 'text', text: 'The session is fixed.' },
+    ]);
+    expect(
+      run.Graph.getRunSteps()
+        .filter((step) => step.stepDetails.type === StepTypes.MESSAGE_CREATION)
+        .map((step) =>
+          step.stepDetails.type === StepTypes.MESSAGE_CREATION
+            ? step.stepDetails.message_creation.phase
+            : undefined
+        )
+    ).toEqual(['commentary', 'final_answer']);
+  });
+
   it('emits reasoning_content from invoke-only final responses', async () => {
     const reasoningText = 'Need to inspect the Home Assistant tool state.';
     const reasoningDeltas: t.ReasoningDeltaEvent[] = [];

--- a/src/messages/assistantPhase.test.ts
+++ b/src/messages/assistantPhase.test.ts
@@ -1,0 +1,42 @@
+import {
+  getAssistantTextPhase,
+  getMessageCreationContentMetadata,
+} from './assistantPhase';
+import { ContentTypes } from '@/common';
+
+describe('assistant phase metadata', () => {
+  it('reads provider-native Open Responses phase metadata', () => {
+    const part = {
+      type: ContentTypes.TEXT,
+      text: '',
+      phase: 'commentary' as const,
+    };
+
+    expect(getAssistantTextPhase(part)).toBe('commentary');
+    expect(getMessageCreationContentMetadata([part])).toEqual({
+      content_type: ContentTypes.TEXT,
+      phase: 'commentary',
+    });
+  });
+
+  it('reads LangChain standard-content extras', () => {
+    const part = {
+      type: ContentTypes.TEXT,
+      text: '',
+      extras: { phase: 'final_answer' as const },
+    };
+
+    expect(getMessageCreationContentMetadata([part])).toEqual({
+      content_type: ContentTypes.TEXT,
+      phase: 'final_answer',
+    });
+  });
+
+  it('announces reasoning without inventing a text phase', () => {
+    expect(
+      getMessageCreationContentMetadata([
+        { type: ContentTypes.THINK, think: 'checking' },
+      ])
+    ).toEqual({ content_type: ContentTypes.THINK });
+  });
+});

--- a/src/messages/assistantPhase.test.ts
+++ b/src/messages/assistantPhase.test.ts
@@ -1,6 +1,7 @@
 import {
   getAssistantTextPhase,
   getMessageCreationContentMetadata,
+  splitAssistantTextContentByPhase,
 } from './assistantPhase';
 import { ContentTypes } from '@/common';
 
@@ -38,5 +39,37 @@ describe('assistant phase metadata', () => {
         { type: ContentTypes.THINK, think: 'checking' },
       ])
     ).toEqual({ content_type: ContentTypes.THINK });
+  });
+
+  it('preserves every provider phase in a multi-block text chunk', () => {
+    const commentary = {
+      type: ContentTypes.TEXT,
+      text: 'I will inspect the session path.',
+      phase: 'commentary' as const,
+    };
+    const moreCommentary = {
+      type: ContentTypes.TEXT,
+      text: 'The refresh branch is stale.',
+      phase: 'commentary' as const,
+    };
+    const finalAnswer = {
+      type: ContentTypes.TEXT,
+      text: 'The refresh path is fixed.',
+      phase: 'final_answer' as const,
+    };
+
+    const groups = splitAssistantTextContentByPhase([
+      commentary,
+      moreCommentary,
+      finalAnswer,
+    ]);
+
+    expect(groups).toEqual([[commentary, moreCommentary], [finalAnswer]]);
+    expect(
+      groups.map((group) => getMessageCreationContentMetadata(group))
+    ).toEqual([
+      { content_type: ContentTypes.TEXT, phase: 'commentary' },
+      { content_type: ContentTypes.TEXT, phase: 'final_answer' },
+    ]);
   });
 });

--- a/src/messages/assistantPhase.ts
+++ b/src/messages/assistantPhase.ts
@@ -21,6 +21,31 @@ export function getAssistantTextPhase(
   );
 }
 
+/**
+ * Keeps provider-authored text phases in distinct message-creation steps.
+ * Open Responses may return commentary and final-answer blocks in one chunk;
+ * collapsing the array into one step would assign the first block's phase to
+ * every block and hide the boundary that closes an activity phase.
+ */
+export function splitAssistantTextContentByPhase(
+  content: MessageContentComplex[]
+): MessageContentComplex[][] {
+  const groups: MessageContentComplex[][] = [];
+  for (const contentPart of content) {
+    const phase = getAssistantTextPhase(contentPart);
+    const currentGroup = groups.at(-1);
+    if (
+      currentGroup == null ||
+      getAssistantTextPhase(currentGroup[0]) !== phase
+    ) {
+      groups.push([contentPart]);
+      continue;
+    }
+    currentGroup.push(contentPart);
+  }
+  return groups;
+}
+
 function isTextPart(contentPart: MessageContentComplex): boolean {
   return contentPart.type?.startsWith(ContentTypes.TEXT) ?? false;
 }

--- a/src/messages/assistantPhase.ts
+++ b/src/messages/assistantPhase.ts
@@ -1,0 +1,66 @@
+import type { AssistantTextPhase } from '@/types/assistantPhase';
+import type { MessageContentComplex } from '@/types/stream';
+import { ContentTypes } from '@/common';
+
+export type MessageCreationContentMetadata = {
+  content_type?: ContentTypes.TEXT | ContentTypes.THINK;
+  phase?: AssistantTextPhase;
+};
+
+function toAssistantTextPhase(value: unknown): AssistantTextPhase | undefined {
+  return value === 'commentary' || value === 'final_answer' ? value : undefined;
+}
+
+/** Reads both provider-native and LangChain standard-content phase fields. */
+export function getAssistantTextPhase(
+  contentPart: MessageContentComplex
+): AssistantTextPhase | undefined {
+  return (
+    toAssistantTextPhase(contentPart.phase) ??
+    toAssistantTextPhase(contentPart.extras?.phase)
+  );
+}
+
+function isTextPart(contentPart: MessageContentComplex): boolean {
+  return contentPart.type?.startsWith(ContentTypes.TEXT) ?? false;
+}
+
+function isReasoningPart(contentPart: MessageContentComplex): boolean {
+  return (
+    contentPart.type === ContentTypes.THINK ||
+    (contentPart.type?.startsWith(ContentTypes.THINKING) ?? false) ||
+    (contentPart.type?.startsWith(ContentTypes.REASONING) ?? false) ||
+    (contentPart.type?.startsWith(ContentTypes.REASONING_CONTENT) ?? false) ||
+    contentPart.type === 'redacted_thinking'
+  );
+}
+
+/**
+ * Derives additive message-creation metadata before a content delta is
+ * dispatched. The fallback covers string-only providers whose semantic lane
+ * is tracked by the stream handler rather than represented on a block.
+ */
+export function getMessageCreationContentMetadata(
+  content: string | MessageContentComplex[] | undefined,
+  fallbackContentType?: ContentTypes.TEXT | ContentTypes.THINK
+): MessageCreationContentMetadata {
+  if (!Array.isArray(content)) {
+    return fallbackContentType == null
+      ? {}
+      : { content_type: fallbackContentType };
+  }
+  const textPart = content.find(isTextPart);
+  if (textPart != null) {
+    const phase = getAssistantTextPhase(textPart);
+    return {
+      content_type: ContentTypes.TEXT,
+      ...(phase == null ? {} : { phase }),
+    };
+  }
+  if (content.some(isReasoningPart)) {
+    return { content_type: ContentTypes.THINK };
+  }
+  return fallbackContentType == null
+    ? {}
+    : { content_type: fallbackContentType };
+}

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -14,3 +14,4 @@ export * from './contextPruning';
 export * from './contextPruningSettings';
 export * from './reducer';
 export * from './recency';
+export * from './assistantPhase';

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -1,5 +1,8 @@
+import type {
+  ActivityLabelToolEntry,
+  ActivityPhaseEntry,
+} from '@/types/activityLabel';
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
-import type { ActivityLabelToolEntry } from '@/types/activityLabel';
 import { shouldRedactTool } from '@/langfuseToolOutputTracing';
 
 /**
@@ -24,6 +27,26 @@ Examples:
 - Fixed failing auth middleware tests
 - Read project config and dependency manifests
 - Attempted database migration, hit permission errors`;
+
+/** Default system prompt for a run-wide parent activity phase. */
+export const ACTIVITY_PHASE_LABEL_PROMPT = `Summarize what this phase of an agent run accomplished. The result appears as the header of one collapsed parent group containing several activities.
+
+Rules:
+- One line, 8 to 18 words, past tense
+- Lead with the concrete outcome and name the most distinctive subject
+- Synthesize the phase; do not enumerate, count, or restate individual activities
+- Describe failures plainly when they are the phase's material outcome
+- Never mention tool names, calls, arguments, reasoning, commentary, or activity counts
+- Output only the summary — no quotes, no trailing punctuation, no preamble
+
+Examples:
+- Reconciled authentication behavior and fixed the failing session refresh path
+- Compared deployment options and documented the safest production rollout
+- Investigated database latency but could not confirm the suspected index regression
+
+Bad examples:
+- Used three tools to inspect files and run tests
+- Searched code, read configuration, and updated middleware`;
 
 /** Truncates a serialized value for the label prompt. */
 export function truncateForLabel(value: string, maxLength: number): string {
@@ -105,6 +128,10 @@ const PREVIOUS_LABEL_LIMIT = 200;
  *  produce one, and the cap keeps a 200-call programmatic batch from
  *  building an enormous prompt out of per-field-bounded pieces. */
 const MAX_PROMPT_ENTRIES = 12;
+const MAX_PHASE_ACTIVITIES = 12;
+const MAX_PHASE_CONTEXT = 3;
+const MAX_PHASE_TOOL_ENTRIES = 6;
+export const ACTIVITY_PHASE_LABEL_MAX_LENGTH = 160;
 
 export type BuildActivityLabelPromptParams = {
   entries: ActivityLabelToolEntry[];
@@ -239,4 +266,126 @@ export function buildActivityLabelPrompt({
    *  output as "the header of a collapsed activity group". */
   sections.push('Header:');
   return sections.join('\n\n');
+}
+
+export type BuildActivityPhaseLabelPromptParams = {
+  activities: ActivityPhaseEntry[];
+  charLimit: number;
+  assistantContext?: string[];
+  redaction?: ResolvedLangfuseToolOutputTracingConfig;
+};
+
+/**
+ * Builds bounded, redaction-aware evidence for a parent activity phase.
+ * Committed child labels are preferred; raw tool/reasoning evidence is only
+ * used when no child label exists.
+ */
+export function buildActivityPhaseLabelPrompt({
+  activities,
+  charLimit,
+  assistantContext,
+  redaction,
+}: BuildActivityPhaseLabelPromptParams): string {
+  const freeFormSuppressed =
+    redaction != null &&
+    (redaction.enabled === false || redaction.redactedToolNames.size > 0);
+  const sections: string[] = [];
+  if (
+    !freeFormSuppressed &&
+    assistantContext != null &&
+    assistantContext.length > 0
+  ) {
+    const context = assistantContext
+      .slice(-MAX_PHASE_CONTEXT)
+      .map((text) =>
+        truncateForLabel(text.replace(/\s+/g, ' ').trim(), charLimit)
+      )
+      .filter((text) => text.length > 0);
+    if (context.length > 0) {
+      sections.push(
+        'Intermediate assistant context (do not quote or restate):\n' +
+          context.map((text) => `- ${text}`).join('\n')
+      );
+    }
+  }
+
+  const activityLines = activities
+    .slice(0, MAX_PHASE_ACTIVITIES)
+    .map((activity, index) => {
+      if (
+        !freeFormSuppressed &&
+        activity.label != null &&
+        activity.label.trim() !== ''
+      ) {
+        return `${index + 1}. ${truncateForLabel(activity.label.replace(/\s+/g, ' ').trim(), charLimit)}`;
+      }
+
+      const evidence: string[] = [];
+      if (
+        !freeFormSuppressed &&
+        activity.thinkingExcerpts != null &&
+        activity.thinkingExcerpts.length > 0
+      ) {
+        evidence.push(
+          ...activity.thinkingExcerpts
+            .slice(0, MAX_THINKING_EXCERPTS)
+            .map((excerpt) =>
+              truncateForLabel(excerpt.replace(/\s+/g, ' ').trim(), charLimit)
+            )
+            .filter((excerpt) => excerpt.length > 0)
+            .map((excerpt) => `context=${excerpt}`)
+        );
+      }
+      if (activity.entries != null && activity.entries.length > 0) {
+        evidence.push(
+          ...activity.entries.slice(0, MAX_PHASE_TOOL_ENTRIES).map((entry) => {
+            const entryRedacted =
+              redaction != null && shouldRedactTool(entry.toolName, redaction);
+            const input = truncateForLabel(
+              serializeForLabel(entry.toolInput, charLimit),
+              charLimit
+            );
+            let outcome: string;
+            if (entryRedacted) {
+              outcome = redaction.redactionText;
+            } else if (entry.status === 'error') {
+              outcome = `ERROR: ${truncateForLabel(
+                entry.error ?? 'unknown error',
+                charLimit
+              )}`;
+            } else {
+              outcome = truncateForLabel(
+                serializeForLabel(entry.toolOutput, charLimit),
+                charLimit
+              );
+            }
+            return `${entry.toolName}(${input}) → ${outcome}`;
+          })
+        );
+      }
+      const status = activity.status === 'error' ? 'failed' : 'completed';
+      return `${index + 1}. ${status}${evidence.length > 0 ? `: ${evidence.join('; ')}` : ''}`;
+    });
+
+  if (activities.length > MAX_PHASE_ACTIVITIES) {
+    activityLines.push(
+      `${MAX_PHASE_ACTIVITIES + 1}. …and ${activities.length - MAX_PHASE_ACTIVITIES} more activities`
+    );
+  }
+  sections.push(
+    'Activities in this phase (synthesize; do not restate):\n' +
+      activityLines.join('\n')
+  );
+  sections.push('Phase summary:');
+  return sections.join('\n\n');
+}
+
+/** Normalizes a model result for safe single-row persistence and display. */
+export function normalizeActivityPhaseLabel(label: string): string {
+  const normalized = label
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .replace(/[.!?]+$/g, '');
+  return truncateForLabel(normalized, ACTIVITY_PHASE_LABEL_MAX_LENGTH);
 }

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -312,12 +312,18 @@ export function buildActivityPhaseLabelPrompt({
   const activityLines = activities
     .slice(0, MAX_PHASE_ACTIVITIES)
     .map((activity, index) => {
+      const status =
+        activity.status === 'error'
+          ? 'failed'
+          : activity.status === 'partial'
+            ? 'partial'
+            : 'completed';
       if (
         !freeFormSuppressed &&
         activity.label != null &&
         activity.label.trim() !== ''
       ) {
-        return `${index + 1}. ${truncateForLabel(activity.label.replace(/\s+/g, ' ').trim(), charLimit)}`;
+        return `${index + 1}. ${status}: ${truncateForLabel(activity.label.replace(/\s+/g, ' ').trim(), charLimit)}`;
       }
 
       const evidence: string[] = [];
@@ -363,7 +369,6 @@ export function buildActivityPhaseLabelPrompt({
           })
         );
       }
-      const status = activity.status === 'error' ? 'failed' : 'completed';
       return `${index + 1}. ${status}${evidence.length > 0 ? `: ${evidence.join('; ')}` : ''}`;
     });
 

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -270,6 +270,7 @@ export function buildActivityLabelPrompt({
 
 export type BuildActivityPhaseLabelPromptParams = {
   activities: ActivityPhaseEntry[];
+  totalActivityCount?: number;
   charLimit: number;
   assistantContext?: string[];
   redaction?: ResolvedLangfuseToolOutputTracingConfig;
@@ -282,6 +283,7 @@ export type BuildActivityPhaseLabelPromptParams = {
  */
 export function buildActivityPhaseLabelPrompt({
   activities,
+  totalActivityCount,
   charLimit,
   assistantContext,
   redaction,
@@ -372,9 +374,10 @@ export function buildActivityPhaseLabelPrompt({
       return `${index + 1}. ${status}${evidence.length > 0 ? `: ${evidence.join('; ')}` : ''}`;
     });
 
-  if (activities.length > MAX_PHASE_ACTIVITIES) {
+  const activityCount = Math.max(activities.length, totalActivityCount ?? 0);
+  if (activityCount > MAX_PHASE_ACTIVITIES) {
     activityLines.push(
-      `${MAX_PHASE_ACTIVITIES + 1}. …and ${activities.length - MAX_PHASE_ACTIVITIES} more activities`
+      `${MAX_PHASE_ACTIVITIES + 1}. …and ${activityCount - MAX_PHASE_ACTIVITIES} more activities`
     );
   }
   sections.push(

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -314,6 +314,7 @@ export function buildActivityPhaseLabelPrompt({
     }
   }
 
+  let hasDescribableEvidence = false;
   const activityLines = activities
     .slice(0, MAX_PHASE_ACTIVITIES)
     .map((activity, index) => {
@@ -328,6 +329,7 @@ export function buildActivityPhaseLabelPrompt({
         activity.label != null &&
         activity.label.trim() !== ''
       ) {
+        hasDescribableEvidence = true;
         return `${index + 1}. ${status}: ${truncateForLabel(activity.label.replace(/\s+/g, ' ').trim(), charLimit)}`;
       }
 
@@ -374,8 +376,15 @@ export function buildActivityPhaseLabelPrompt({
           })
         );
       }
+      if (evidence.length > 0) {
+        hasDescribableEvidence = true;
+      }
       return `${index + 1}. ${status}${evidence.length > 0 ? `: ${evidence.join('; ')}` : ''}`;
     });
+
+  if (!hasDescribableEvidence) {
+    return '';
+  }
 
   const activityCount = Math.max(activities.length, totalActivityCount ?? 0);
   if (activityCount > MAX_PHASE_ACTIVITIES) {

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -314,12 +314,12 @@ export function buildActivityPhaseLabelPrompt({
   const activityLines = activities
     .slice(0, MAX_PHASE_ACTIVITIES)
     .map((activity, index) => {
-      const status =
-        activity.status === 'error'
-          ? 'failed'
-          : activity.status === 'partial'
-            ? 'partial'
-            : 'completed';
+      let status = 'completed';
+      if (activity.status === 'error') {
+        status = 'failed';
+      } else if (activity.status === 'partial') {
+        status = 'partial';
+      }
       if (
         !freeFormSuppressed &&
         activity.label != null &&

--- a/src/prompts/activityLabel.ts
+++ b/src/prompts/activityLabel.ts
@@ -48,6 +48,9 @@ Bad examples:
 - Used three tools to inspect files and run tests
 - Searched code, read configuration, and updated middleware`;
 
+/** Hard ceiling across every activity/context section in one phase request. */
+export const ACTIVITY_PHASE_PROMPT_MAX_LENGTH = 12_000;
+
 /** Truncates a serialized value for the label prompt. */
 export function truncateForLabel(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
@@ -384,8 +387,15 @@ export function buildActivityPhaseLabelPrompt({
     'Activities in this phase (synthesize; do not restate):\n' +
       activityLines.join('\n')
   );
-  sections.push('Phase summary:');
-  return sections.join('\n\n');
+  const terminalCue = '\n\nPhase summary:';
+  const evidence = sections.join('\n\n');
+  const prompt = evidence + terminalCue;
+  if (prompt.length <= ACTIVITY_PHASE_PROMPT_MAX_LENGTH) {
+    return prompt;
+  }
+  const evidenceLimit =
+    ACTIVITY_PHASE_PROMPT_MAX_LENGTH - terminalCue.length - 1;
+  return `${evidence.slice(0, evidenceLimit).trimEnd()}…${terminalCue}`;
 }
 
 /** Normalizes a model result for safe single-row persistence and display. */

--- a/src/run.ts
+++ b/src/run.ts
@@ -2119,6 +2119,7 @@ export class Run<_T extends t.BaseGraphState> {
     provider,
     clientOptions,
     activities,
+    totalActivityCount,
     assistantContext,
     closingTextPhase,
     prompt,
@@ -2220,6 +2221,7 @@ export class Run<_T extends t.BaseGraphState> {
 
     const userPrompt = buildActivityPhaseLabelPrompt({
       activities,
+      totalActivityCount,
       charLimit,
       assistantContext,
       redaction,
@@ -2342,7 +2344,7 @@ export class Run<_T extends t.BaseGraphState> {
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
       responseId: phaseMessageId,
       phaseIndex: resolvedPhaseIndex,
-      activityCount: activities.length,
+      activityCount: Math.max(activities.length, totalActivityCount ?? 0),
       status,
       contributingAgentIds,
       ...(closingTextPhase == null ? {} : { closingTextPhase }),

--- a/src/run.ts
+++ b/src/run.ts
@@ -2228,7 +2228,9 @@ export class Run<_T extends t.BaseGraphState> {
     const phaseChainOptions = {
       ...(chainOptions ?? {}),
     } as Partial<RunnableConfig> & {
-      configurable?: Record<string, unknown>;
+      configurable?: Record<string, unknown> & {
+        requestBody?: { parentMessageId?: unknown };
+      };
     };
     const phaseUserId =
       typeof phaseChainOptions.configurable?.user_id === 'string'
@@ -2243,6 +2245,8 @@ export class Run<_T extends t.BaseGraphState> {
       responseId ?? `activity-phase-${this.id}-${resolvedPhaseIndex}`;
     const phaseAgentId = this.Graph?.defaultAgentId;
     const phaseAgentName = phaseContext?.name;
+    const phaseParentMessageId =
+      phaseChainOptions.configurable?.requestBody?.parentMessageId;
     const phaseMetadata: Record<string, unknown> = {
       sourceRunId: sourceRunId ?? this.id,
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
@@ -2251,6 +2255,9 @@ export class Run<_T extends t.BaseGraphState> {
       activityCount: Math.max(activities.length, totalActivityCount ?? 0),
       status,
       contributingAgentIds,
+      ...(typeof phaseParentMessageId === 'string'
+        ? { parentMessageId: phaseParentMessageId }
+        : {}),
       ...(phaseAgentId == null ? {} : { agentId: phaseAgentId }),
       ...(phaseAgentName == null ? {} : { agentName: phaseAgentName }),
       ...(closingTextPhase == null ? {} : { closingTextPhase }),
@@ -2258,6 +2265,7 @@ export class Run<_T extends t.BaseGraphState> {
     const traceMetadata = {
       ...createLangfuseTraceMetadata({
         messageId: phaseMessageId,
+        parentMessageId: phaseParentMessageId,
         agentId: phaseAgentId,
         agentName: phaseAgentName,
       }),
@@ -2300,8 +2308,8 @@ export class Run<_T extends t.BaseGraphState> {
     });
     let phaseLangfuseHandler: CallbackEntry | undefined;
     const sourceUserText =
-      findActivityPhaseTraceInput(this.Graph?.getRunMessages() ?? []) ??
-      this.activityPhaseTraceInput;
+      this.activityPhaseTraceInput ??
+      findActivityPhaseTraceInput(this.Graph?.getRunMessages() ?? []);
     if (phaseSessionId != null && sourceUserText != null) {
       phaseLangfuseHandler = createLangfuseHandler({
         langfuse: phaseLangfuseConfig,
@@ -2463,7 +2471,8 @@ function findActivityPhaseTraceInput(
     const message = messages[i];
     if (
       message.getType() !== 'human' ||
-      message.additional_kwargs?.role === 'system'
+      message.additional_kwargs?.role === 'system' ||
+      message.additional_kwargs?.isMeta === true
     ) {
       continue;
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -2111,7 +2111,7 @@ export class Run<_T extends t.BaseGraphState> {
 
   /**
    * Generates one parent summary for two or more logical activities. The
-   * summary model is traced as a dedicated `activity-phase` agent root in the
+   * summary model is traced as a dedicated activity-phase chain root in the
    * conversation session, with the model callback recorded as its generation
    * child. No session id means no phase trace, avoiding orphan observations.
    */
@@ -2126,6 +2126,7 @@ export class Run<_T extends t.BaseGraphState> {
     chainOptions,
     traceSeed,
     sourceRunId,
+    sourceTraceId,
     responseId,
     phaseIndex,
     status = 'completed',
@@ -2338,6 +2339,7 @@ export class Run<_T extends t.BaseGraphState> {
     };
     const phaseMetadata: Record<string, unknown> = {
       sourceRunId: sourceRunId ?? this.id,
+      ...(sourceTraceId == null ? {} : { sourceTraceId }),
       responseId: phaseMessageId,
       phaseIndex: resolvedPhaseIndex,
       activityCount: activities.length,
@@ -2387,7 +2389,7 @@ export class Run<_T extends t.BaseGraphState> {
             },
             () =>
               startActiveObservation(
-                'activity-phase',
+                'summarize-activity-phase',
                 async (phaseObservation) => {
                   phaseObservation.update({
                     input: userPrompt,
@@ -2411,7 +2413,7 @@ export class Run<_T extends t.BaseGraphState> {
                     throw error;
                   }
                 },
-                { asType: 'agent' }
+                { asType: 'chain' }
               )
           )
         );

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,16 +5,17 @@ import { RunnableLambda } from '@langchain/core/runnables';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import {
-  BaseMessage,
-  HumanMessage,
-  SystemMessage,
-} from '@langchain/core/messages';
-import {
   Command,
   INTERRUPT,
   MemorySaver,
   isInterrupted,
 } from '@langchain/langgraph';
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
 import type { StringPromptValue } from '@langchain/core/prompt_values';
 import type { MessageContentComplex } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -251,6 +252,8 @@ export class Run<_T extends t.BaseGraphState> {
   private activityLabelSeq = 0;
   /** Per-run sequence for parent activity-phase trace and invocation ids. */
   private activityPhaseLabelSeq = 0;
+  /** Latest user turn used to keep detached phase roots conversation-shaped. */
+  private activityPhaseTraceInput?: string;
   /** Distinguishes sibling forks started from the same explicit checkpoint. */
   private checkpointForkSeq = 0;
   private _haltedReason: string | undefined;
@@ -831,6 +834,11 @@ export class Run<_T extends t.BaseGraphState> {
      */
     const isResume = inputs instanceof Command;
     const stateInputs = isResume ? undefined : (inputs as t.IState);
+    if (stateInputs != null) {
+      this.activityPhaseTraceInput = findActivityPhaseTraceInput(
+        stateInputs.messages
+      );
+    }
 
     /**
      * Every honored seal costs one extra superstep, so a preemption-enabled
@@ -1570,9 +1578,12 @@ export class Run<_T extends t.BaseGraphState> {
     }
     const persistedMessages = getPersistedMessages(snapshot);
     if (persistedMessages != null) {
-      this.Graph?.restoreCheckpointMessages(
-        persistedMessages,
-        getResumeUpdateMessages(resumeUpdate)
+      const resumeMessages = getResumeUpdateMessages(resumeUpdate);
+      this.Graph?.restoreCheckpointMessages(persistedMessages, resumeMessages);
+      this.activityPhaseTraceInput = findActivityPhaseTraceInput(
+        resumeMessages == null
+          ? persistedMessages
+          : [...persistedMessages, ...resumeMessages]
       );
     }
 
@@ -2204,22 +2215,6 @@ export class Run<_T extends t.BaseGraphState> {
       };
     }
 
-    const freeFormSuppressed =
-      redaction != null &&
-      (redaction.enabled === false || redaction.redactedToolNames.size > 0);
-    const hasDescribableEvidence = activities.some(
-      (activity) =>
-        (!freeFormSuppressed &&
-          ((activity.label?.trim().length ?? 0) > 0 ||
-            activity.thinkingExcerpts?.some(
-              (excerpt) => excerpt.trim().length > 0
-            ) === true)) ||
-        (activity.entries?.length ?? 0) > 0
-    );
-    if (!hasDescribableEvidence) {
-      return {};
-    }
-
     const userPrompt = buildActivityPhaseLabelPrompt({
       activities,
       totalActivityCount,
@@ -2227,6 +2222,9 @@ export class Run<_T extends t.BaseGraphState> {
       assistantContext,
       redaction,
     });
+    if (userPrompt === '') {
+      return {};
+    }
     const phaseChainOptions = {
       ...(chainOptions ?? {}),
     } as Partial<RunnableConfig> & {
@@ -2243,6 +2241,8 @@ export class Run<_T extends t.BaseGraphState> {
     const resolvedPhaseIndex = phaseIndex ?? phaseSeq - 1;
     const phaseMessageId =
       responseId ?? `activity-phase-${this.id}-${resolvedPhaseIndex}`;
+    const phaseAgentId = this.Graph?.defaultAgentId;
+    const phaseAgentName = phaseContext?.name;
     const phaseMetadata: Record<string, unknown> = {
       sourceRunId: sourceRunId ?? this.id,
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
@@ -2251,10 +2251,16 @@ export class Run<_T extends t.BaseGraphState> {
       activityCount: Math.max(activities.length, totalActivityCount ?? 0),
       status,
       contributingAgentIds,
+      ...(phaseAgentId == null ? {} : { agentId: phaseAgentId }),
+      ...(phaseAgentName == null ? {} : { agentName: phaseAgentName }),
       ...(closingTextPhase == null ? {} : { closingTextPhase }),
     };
     const traceMetadata = {
-      ...createLangfuseTraceMetadata({ messageId: phaseMessageId }),
+      ...createLangfuseTraceMetadata({
+        messageId: phaseMessageId,
+        agentId: phaseAgentId,
+        agentName: phaseAgentName,
+      }),
       sourceRunId: String(phaseMetadata.sourceRunId),
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
       responseId: phaseMessageId,
@@ -2293,7 +2299,10 @@ export class Run<_T extends t.BaseGraphState> {
       runId: phaseScopeRunId,
     });
     let phaseLangfuseHandler: CallbackEntry | undefined;
-    if (phaseSessionId != null) {
+    const sourceUserText =
+      findActivityPhaseTraceInput(this.Graph?.getRunMessages() ?? []) ??
+      this.activityPhaseTraceInput;
+    if (phaseSessionId != null && sourceUserText != null) {
       phaseLangfuseHandler = createLangfuseHandler({
         langfuse: phaseLangfuseConfig,
         userId: phaseUserId,
@@ -2394,17 +2403,19 @@ export class Run<_T extends t.BaseGraphState> {
     };
     const phaseRunnable = new RunnableLambda({
       func: async (
-        _input: string,
+        _input: { messages: BaseMessage[] },
         runtimeConfig?: Partial<RunnableConfig>
-      ): Promise<{ label?: string }> => {
+      ): Promise<{ label?: string; messages: BaseMessage[] }> => {
         const response = await invokeWithCallbackFallback(runtimeConfig ?? {});
         const label = extractPhaseLabel(response);
-        return label.length > 0 ? { label } : {};
+        return label.length > 0
+          ? { label, messages: [new AIMessage(label)] }
+          : { messages: [] };
       },
     }).withConfig({ runName: 'summarize-activity-phase' });
 
     try {
-      return await withLangfuseRuntimeScope(phaseRuntimeScope, () =>
+      const result = await withLangfuseRuntimeScope(phaseRuntimeScope, () =>
         withLangfuseAttributes(
           {
             langfuse: phaseLangfuseConfig,
@@ -2414,9 +2425,19 @@ export class Run<_T extends t.BaseGraphState> {
             traceMetadata,
             tags: phaseTags,
           },
-          () => phaseRunnable.invoke(userPrompt, invokeConfig)
+          () =>
+            phaseRunnable.invoke(
+              {
+                messages:
+                  sourceUserText == null
+                    ? []
+                    : [new HumanMessage(sourceUserText)],
+              },
+              invokeConfig
+            )
         )
       );
+      return result.label == null ? {} : { label: result.label };
     } finally {
       await disposeLangfuseHandler(phaseLangfuseHandler);
     }
@@ -2430,6 +2451,25 @@ function findLastMessageOfType(
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].getType() === type) {
       return messages[i];
+    }
+  }
+  return undefined;
+}
+
+function findActivityPhaseTraceInput(
+  messages: BaseMessage[]
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (
+      message.getType() !== 'human' ||
+      message.additional_kwargs?.role === 'system'
+    ) {
+      continue;
+    }
+    const input = extractPromptText(message).trim();
+    if (input !== '') {
+      return input;
     }
   }
   return undefined;

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,10 +2,8 @@
 import { nanoid } from 'nanoid';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
-import { startActiveObservation } from '@langfuse/tracing';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
-import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import {
   BaseMessage,
   HumanMessage,
@@ -2138,6 +2136,9 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     const phaseSeq = ++this.activityPhaseLabelSeq;
+    const hasUnattributedActivity = activities.some(
+      (activity) => activity.agentId == null
+    );
     const contributingAgentIds = [
       ...new Set([
         ...(agentIds ?? []),
@@ -2170,7 +2171,7 @@ export class Run<_T extends t.BaseGraphState> {
       ? resolveToolOutputTracingConfig(this.langfuse, phaseContext?.langfuse)
       : undefined;
     const redactionContexts =
-      contributingAgentIds.length > 0
+      contributingAgentIds.length > 0 && !hasUnattributedActivity
         ? contributingAgentIds.flatMap((agentId) => {
           const context = agentContexts?.get(agentId);
           return context == null ? [] : [context];
@@ -2242,13 +2243,40 @@ export class Run<_T extends t.BaseGraphState> {
     const resolvedPhaseIndex = phaseIndex ?? phaseSeq - 1;
     const phaseMessageId =
       responseId ?? `activity-phase-${this.id}-${resolvedPhaseIndex}`;
-    const traceMetadata = createLangfuseTraceMetadata({
-      messageId: phaseMessageId,
-    });
+    const phaseMetadata: Record<string, unknown> = {
+      sourceRunId: sourceRunId ?? this.id,
+      ...(sourceTraceId == null ? {} : { sourceTraceId }),
+      responseId: phaseMessageId,
+      phaseIndex: resolvedPhaseIndex,
+      activityCount: Math.max(activities.length, totalActivityCount ?? 0),
+      status,
+      contributingAgentIds,
+      ...(closingTextPhase == null ? {} : { closingTextPhase }),
+    };
+    const traceMetadata = {
+      ...createLangfuseTraceMetadata({ messageId: phaseMessageId }),
+      sourceRunId: String(phaseMetadata.sourceRunId),
+      ...(sourceTraceId == null ? {} : { sourceTraceId }),
+      responseId: phaseMessageId,
+      phaseIndex: String(resolvedPhaseIndex),
+      activityCount: String(phaseMetadata.activityCount),
+      status,
+      ...(contributingAgentIds.length === 0
+        ? {}
+        : { contributingAgentIds: contributingAgentIds.join(',') }),
+      ...(closingTextPhase == null ? {} : { closingTextPhase }),
+    };
     const phaseRunName = getLangfuseTraceName(
       traceMetadata,
       'LibreChat Activity Phase'
     );
+    const phaseTraceName = phaseChainOptions.runName ?? phaseRunName;
+    const phaseTags = [
+      'librechat',
+      'activity-phase',
+      'agent-run-summary',
+      'agent',
+    ];
     initializeLangfuseTracing(phaseLangfuseConfig);
 
     const inheritedTraceSeed = getTraceIdSeed();
@@ -2271,14 +2299,14 @@ export class Run<_T extends t.BaseGraphState> {
         userId: phaseUserId,
         sessionId: phaseSessionId,
         traceMetadata,
-        tags: ['librechat', 'activity-phase', 'agent-run-summary'],
+        tags: phaseTags,
         traceIdSeed:
           phaseLangfuseConfig?.deterministicTraceId === true
             ? phaseTraceSeed
             : undefined,
         runId: phaseScopeRunId,
         toolOutputTracing: phaseRuntimeScope.toolOutputTracing,
-        traceName: phaseChainOptions.runName ?? phaseRunName,
+        traceName: phaseTraceName,
       });
     }
     if (phaseLangfuseHandler != null) {
@@ -2299,7 +2327,12 @@ export class Run<_T extends t.BaseGraphState> {
     const invokeConfig = Object.assign({}, phaseChainOptions, {
       run_id: phaseRunId,
       runId: phaseRunId,
-      runName: phaseChainOptions.runName ?? phaseRunName,
+      runName: 'summarize-activity-phase',
+      tags: [...new Set([...(phaseChainOptions.tags ?? []), ...phaseTags])],
+      metadata: {
+        ...(phaseChainOptions.metadata ?? {}),
+        ...phaseMetadata,
+      },
     }) as Partial<RunnableConfig>;
     const invokeModel = (
       runtimeConfig: Partial<RunnableConfig>
@@ -2311,12 +2344,14 @@ export class Run<_T extends t.BaseGraphState> {
         ],
         runtimeConfig
       );
-    const invokeWithCallbackFallback = async (): Promise<unknown> => {
+    const invokeWithCallbackFallback = async (
+      runtimeConfig: Partial<RunnableConfig>
+    ): Promise<unknown> => {
       try {
-        return await invokeModel(invokeConfig);
+        return await invokeModel(runtimeConfig);
       } catch (error) {
         const aborted =
-          (phaseChainOptions as { signal?: AbortSignal }).signal?.aborted ===
+          (runtimeConfig as { signal?: AbortSignal }).signal?.aborted ===
             true || (error as Error | null)?.name === 'AbortError';
         const callbackFailure = /callback|tracer|event.?stream/i.test(
           String(
@@ -2329,25 +2364,15 @@ export class Run<_T extends t.BaseGraphState> {
           throw error;
         }
         const langfuseHandler = findCallback(
-          invokeConfig.callbacks,
+          runtimeConfig.callbacks,
           isLangfuseCallbackHandler
         );
-        const { callbacks: _callbacks, ...rest } = invokeConfig;
+        const { callbacks: _callbacks, ...rest } = runtimeConfig;
         const safeConfig = Object.assign({}, rest, {
           callbacks: langfuseHandler ? [langfuseHandler] : [],
         });
         return invokeModel(safeConfig as Partial<RunnableConfig>);
       }
-    };
-    const phaseMetadata: Record<string, unknown> = {
-      sourceRunId: sourceRunId ?? this.id,
-      ...(sourceTraceId == null ? {} : { sourceTraceId }),
-      responseId: phaseMessageId,
-      phaseIndex: resolvedPhaseIndex,
-      activityCount: Math.max(activities.length, totalActivityCount ?? 0),
-      status,
-      contributingAgentIds,
-      ...(closingTextPhase == null ? {} : { closingTextPhase }),
     };
     const extractPhaseLabel = (response: unknown): string => {
       const content = (response as { content?: unknown } | null)?.content;
@@ -2367,59 +2392,31 @@ export class Run<_T extends t.BaseGraphState> {
           .join('')
       );
     };
+    const phaseRunnable = new RunnableLambda({
+      func: async (
+        _input: string,
+        runtimeConfig?: Partial<RunnableConfig>
+      ): Promise<{ label?: string }> => {
+        const response = await invokeWithCallbackFallback(runtimeConfig ?? {});
+        const label = extractPhaseLabel(response);
+        return label.length > 0 ? { label } : {};
+      },
+    }).withConfig({ runName: 'summarize-activity-phase' });
 
     try {
-      return await withLangfuseRuntimeScope(phaseRuntimeScope, async () => {
-        const invokePhase = async (): Promise<{ label?: string }> => {
-          const response = await invokeWithCallbackFallback();
-          const label = extractPhaseLabel(response);
-          return label.length > 0 ? { label } : {};
-        };
-        if (phaseLangfuseHandler == null) {
-          return invokePhase();
-        }
-        const detachedContext = otelTrace.deleteSpan(otelContext.active());
-        return otelContext.with(detachedContext, () =>
-          withLangfuseAttributes(
-            {
-              langfuse: phaseLangfuseConfig,
-              userId: phaseUserId,
-              sessionId: phaseSessionId,
-              traceName: phaseChainOptions.runName ?? phaseRunName,
-              traceMetadata,
-              tags: ['librechat', 'activity-phase', 'agent-run-summary'],
-            },
-            () =>
-              startActiveObservation(
-                'summarize-activity-phase',
-                async (phaseObservation) => {
-                  phaseObservation.update({
-                    input: userPrompt,
-                    metadata: phaseMetadata,
-                  });
-                  try {
-                    const result = await invokePhase();
-                    phaseObservation.update({
-                      output: result.label,
-                      metadata: phaseMetadata,
-                    });
-                    return result;
-                  } catch (error) {
-                    phaseObservation.update({
-                      level: 'ERROR',
-                      statusMessage: String(
-                        (error as Error | null)?.message ?? error
-                      ),
-                      metadata: { ...phaseMetadata, status: 'failed' },
-                    });
-                    throw error;
-                  }
-                },
-                { asType: 'chain' }
-              )
-          )
-        );
-      });
+      return await withLangfuseRuntimeScope(phaseRuntimeScope, () =>
+        withLangfuseAttributes(
+          {
+            langfuse: phaseLangfuseConfig,
+            userId: phaseUserId,
+            sessionId: phaseSessionId,
+            traceName: phaseTraceName,
+            traceMetadata,
+            tags: phaseTags,
+          },
+          () => phaseRunnable.invoke(userPrompt, invokeConfig)
+        )
+      );
     } finally {
       await disposeLangfuseHandler(phaseLangfuseHandler);
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -2494,14 +2494,13 @@ function extractPromptText(message: BaseMessage): string {
   }
   const parts: string[] = [];
   for (const block of content) {
+    const textBlock = block as { type?: unknown; text?: unknown } | null;
     if (
-      typeof block === 'object' &&
-      'type' in block &&
-      block.type === 'text' &&
-      'text' in block &&
-      typeof block.text === 'string'
+      textBlock != null &&
+      (textBlock.type === 'text' || textBlock.type === 'input_text') &&
+      typeof textBlock.text === 'string'
     ) {
-      parts.push(block.text);
+      parts.push(textBlock.text);
     }
   }
   return parts.join('\n');

--- a/src/run.ts
+++ b/src/run.ts
@@ -2109,7 +2109,7 @@ export class Run<_T extends t.BaseGraphState> {
 
   /**
    * Generates one parent summary for two or more logical activities. The
-   * summary model is traced as a dedicated activity-phase chain root in the
+   * summary model is traced as a dedicated activity-phase agent root in the
    * conversation session, with the model callback recorded as its generation
    * child. No session id means no phase trace, avoiding orphan observations.
    */

--- a/src/run.ts
+++ b/src/run.ts
@@ -2154,6 +2154,9 @@ export class Run<_T extends t.BaseGraphState> {
     const hasUnattributedActivity = activities.some(
       (activity) => activity.agentId == null
     );
+    const hasOmittedActivitiesWithoutAgentIds =
+      agentIds == null &&
+      (totalActivityCount ?? activities.length) > activities.length;
     const contributingAgentIds = [
       ...new Set([
         ...(agentIds ?? []),
@@ -2186,7 +2189,9 @@ export class Run<_T extends t.BaseGraphState> {
       ? resolveToolOutputTracingConfig(this.langfuse, phaseContext?.langfuse)
       : undefined;
     const redactionContexts =
-      contributingAgentIds.length > 0 && !hasUnattributedActivity
+      contributingAgentIds.length > 0 &&
+      !hasUnattributedActivity &&
+      !hasOmittedActivitiesWithoutAgentIds
         ? contributingAgentIds.flatMap((agentId) => {
           const context = agentContexts?.get(agentId);
           return context == null ? [] : [context];

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,8 +2,10 @@
 import { nanoid } from 'nanoid';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
+import { startActiveObservation } from '@langfuse/tracing';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import {
   BaseMessage,
   HumanMessage,
@@ -29,6 +31,13 @@ import {
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from '@/tools/subagent/SubagentReplay';
 import {
+  ACTIVITY_PHASE_LABEL_PROMPT,
+  ACTIVITY_LABEL_PROMPT,
+  buildActivityLabelPrompt,
+  buildActivityPhaseLabelPrompt,
+  normalizeActivityPhaseLabel,
+} from '@/prompts/activityLabel';
+import {
   createLangfuseTraceMetadata,
   createLangfuseHandler,
   disposeLangfuseHandler,
@@ -45,10 +54,6 @@ import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
-import {
-  ACTIVITY_LABEL_PROMPT,
-  buildActivityLabelPrompt,
-} from '@/prompts/activityLabel';
 import {
   Callback,
   GraphEvents,
@@ -246,6 +251,8 @@ export class Run<_T extends t.BaseGraphState> {
   private _interrupt: t.RunInterruptResult<unknown> | undefined;
   /** Per-run sequence for batch-unique activity-label trace-seed fallbacks. */
   private activityLabelSeq = 0;
+  /** Per-run sequence for parent activity-phase trace and invocation ids. */
+  private activityPhaseLabelSeq = 0;
   /** Distinguishes sibling forks started from the same explicit checkpoint. */
   private checkpointForkSeq = 0;
   private _haltedReason: string | undefined;
@@ -1815,6 +1822,7 @@ export class Run<_T extends t.BaseGraphState> {
     entries,
     thinkingExcerpts,
     lastAssistantText,
+    lastAssistantPhase,
     previousLabels,
     prompt,
     charLimit = 600,
@@ -1988,7 +1996,8 @@ export class Run<_T extends t.BaseGraphState> {
       entries,
       charLimit,
       thinkingExcerpts,
-      lastAssistantText,
+      lastAssistantText:
+        lastAssistantPhase === 'final_answer' ? undefined : lastAssistantText,
       previousLabels,
       redaction,
     });
@@ -2097,6 +2106,318 @@ export class Run<_T extends t.BaseGraphState> {
       return label.length > 0 ? { label } : {};
     } finally {
       await disposeLangfuseHandler(labelLangfuseHandler);
+    }
+  }
+
+  /**
+   * Generates one parent summary for two or more logical activities. The
+   * summary model is traced as a dedicated `activity-phase` agent root in the
+   * conversation session, with the model callback recorded as its generation
+   * child. No session id means no phase trace, avoiding orphan observations.
+   */
+  async generateActivityPhaseLabel({
+    provider,
+    clientOptions,
+    activities,
+    assistantContext,
+    closingTextPhase,
+    prompt,
+    charLimit = 600,
+    chainOptions,
+    traceSeed,
+    sourceRunId,
+    responseId,
+    phaseIndex,
+    status = 'completed',
+    agentIds,
+  }: t.RunActivityPhaseLabelOptions): Promise<{ label?: string }> {
+    if (activities.length < 2) {
+      return {};
+    }
+
+    const phaseSeq = ++this.activityPhaseLabelSeq;
+    const contributingAgentIds = [
+      ...new Set([
+        ...(agentIds ?? []),
+        ...activities.flatMap((activity) =>
+          activity.agentId == null ? [] : [activity.agentId]
+        ),
+      ]),
+    ];
+    const agentContexts = this.Graph?.agentContexts;
+    if (
+      contributingAgentIds.some(
+        (agentId) => agentContexts?.get(agentId) == null
+      )
+    ) {
+      return {};
+    }
+    const phaseContext =
+      this.Graph == null
+        ? undefined
+        : this.Graph.agentContexts.get(this.Graph.defaultAgentId);
+    const phaseLangfuseConfig = resolveLangfuseConfig(
+      this.langfuse,
+      phaseContext?.langfuse
+    );
+
+    let redaction = hasToolOutputTracingConfig(
+      this.langfuse,
+      phaseContext?.langfuse
+    )
+      ? resolveToolOutputTracingConfig(this.langfuse, phaseContext?.langfuse)
+      : undefined;
+    const redactionContexts =
+      contributingAgentIds.length > 0
+        ? contributingAgentIds.flatMap((agentId) => {
+          const context = agentContexts?.get(agentId);
+          return context == null ? [] : [context];
+        })
+        : Array.from(agentContexts?.values() ?? []);
+    for (const context of redactionContexts) {
+      if (!hasToolOutputTracingConfig(this.langfuse, context.langfuse)) {
+        continue;
+      }
+      const candidate = resolveToolOutputTracingConfig(
+        this.langfuse,
+        context.langfuse
+      );
+      if (redaction == null) {
+        redaction = candidate;
+        continue;
+      }
+      redaction = {
+        enabled: redaction.enabled === false ? false : candidate.enabled,
+        redactedToolNames: new Set([
+          ...redaction.redactedToolNames,
+          ...candidate.redactedToolNames,
+        ]),
+        redactedToolNameMatchMode:
+          redaction.redactedToolNameMatchMode === 'partial' ||
+          candidate.redactedToolNameMatchMode === 'partial'
+            ? 'partial'
+            : 'exact',
+        redactionText: redaction.redactionText,
+      };
+    }
+
+    const freeFormSuppressed =
+      redaction != null &&
+      (redaction.enabled === false || redaction.redactedToolNames.size > 0);
+    const hasDescribableEvidence = activities.some(
+      (activity) =>
+        (!freeFormSuppressed &&
+          ((activity.label?.trim().length ?? 0) > 0 ||
+            activity.thinkingExcerpts?.some(
+              (excerpt) => excerpt.trim().length > 0
+            ) === true)) ||
+        (activity.entries?.length ?? 0) > 0
+    );
+    if (!hasDescribableEvidence) {
+      return {};
+    }
+
+    const userPrompt = buildActivityPhaseLabelPrompt({
+      activities,
+      charLimit,
+      assistantContext,
+      redaction,
+    });
+    const phaseChainOptions = {
+      ...(chainOptions ?? {}),
+    } as Partial<RunnableConfig> & {
+      configurable?: Record<string, unknown>;
+    };
+    const phaseUserId =
+      typeof phaseChainOptions.configurable?.user_id === 'string'
+        ? phaseChainOptions.configurable.user_id
+        : undefined;
+    const phaseSessionId =
+      typeof phaseChainOptions.configurable?.thread_id === 'string'
+        ? phaseChainOptions.configurable.thread_id
+        : undefined;
+    const resolvedPhaseIndex = phaseIndex ?? phaseSeq - 1;
+    const phaseMessageId =
+      responseId ?? `activity-phase-${this.id}-${resolvedPhaseIndex}`;
+    const traceMetadata = createLangfuseTraceMetadata({
+      messageId: phaseMessageId,
+    });
+    const phaseRunName = getLangfuseTraceName(
+      traceMetadata,
+      'LibreChat Activity Phase'
+    );
+    initializeLangfuseTracing(phaseLangfuseConfig);
+
+    const inheritedTraceSeed = getTraceIdSeed();
+    const phaseTraceSeed =
+      phaseLangfuseConfig?.deterministicTraceId === true ||
+      inheritedTraceSeed != null
+        ? (traceSeed ?? `activity-phase-${this.id}-${resolvedPhaseIndex}`)
+        : undefined;
+    const phaseScopeRunId = `activity-phase:${this.id}:${phaseSeq}:${nanoid()}`;
+    const phaseRuntimeScope = resolveLangfuseRuntimeScope({
+      runLangfuse: this.langfuse,
+      langfuseOverlay: phaseContext?.langfuse,
+      traceIdSeed: phaseTraceSeed,
+      runId: phaseScopeRunId,
+    });
+    let phaseLangfuseHandler: CallbackEntry | undefined;
+    if (phaseSessionId != null) {
+      phaseLangfuseHandler = createLangfuseHandler({
+        langfuse: phaseLangfuseConfig,
+        userId: phaseUserId,
+        sessionId: phaseSessionId,
+        traceMetadata,
+        tags: ['librechat', 'activity-phase', 'agent-run-summary'],
+        traceIdSeed:
+          phaseLangfuseConfig?.deterministicTraceId === true
+            ? phaseTraceSeed
+            : undefined,
+        runId: phaseScopeRunId,
+        toolOutputTracing: phaseRuntimeScope.toolOutputTracing,
+        traceName: phaseChainOptions.runName ?? phaseRunName,
+      });
+    }
+    if (phaseLangfuseHandler != null) {
+      phaseChainOptions.callbacks = appendCallbacks(
+        phaseChainOptions.callbacks,
+        [phaseLangfuseHandler]
+      );
+    }
+
+    const model = initializeModel({
+      provider,
+      clientOptions: {
+        ...(clientOptions ?? {}),
+        streaming: false,
+      } as t.ClientOptions,
+    }) as t.ChatModelInstance;
+    const phaseRunId = `${this.id}-activity-phase-${phaseSeq}`;
+    const invokeConfig = Object.assign({}, phaseChainOptions, {
+      run_id: phaseRunId,
+      runId: phaseRunId,
+      runName: phaseChainOptions.runName ?? phaseRunName,
+    }) as Partial<RunnableConfig>;
+    const invokeModel = (
+      runtimeConfig: Partial<RunnableConfig>
+    ): Promise<unknown> =>
+      model.invoke(
+        [
+          new SystemMessage(prompt ?? ACTIVITY_PHASE_LABEL_PROMPT),
+          new HumanMessage(userPrompt),
+        ],
+        runtimeConfig
+      );
+    const invokeWithCallbackFallback = async (): Promise<unknown> => {
+      try {
+        return await invokeModel(invokeConfig);
+      } catch (error) {
+        const aborted =
+          (phaseChainOptions as { signal?: AbortSignal }).signal?.aborted ===
+            true || (error as Error | null)?.name === 'AbortError';
+        const callbackFailure = /callback|tracer|event.?stream/i.test(
+          String(
+            (error as Error | null)?.stack ??
+              (error as Error | null)?.message ??
+              ''
+          )
+        );
+        if (aborted || !callbackFailure) {
+          throw error;
+        }
+        const langfuseHandler = findCallback(
+          invokeConfig.callbacks,
+          isLangfuseCallbackHandler
+        );
+        const { callbacks: _callbacks, ...rest } = invokeConfig;
+        const safeConfig = Object.assign({}, rest, {
+          callbacks: langfuseHandler ? [langfuseHandler] : [],
+        });
+        return invokeModel(safeConfig as Partial<RunnableConfig>);
+      }
+    };
+    const phaseMetadata: Record<string, unknown> = {
+      sourceRunId: sourceRunId ?? this.id,
+      responseId: phaseMessageId,
+      phaseIndex: resolvedPhaseIndex,
+      activityCount: activities.length,
+      status,
+      contributingAgentIds,
+      ...(closingTextPhase == null ? {} : { closingTextPhase }),
+    };
+    const extractPhaseLabel = (response: unknown): string => {
+      const content = (response as { content?: unknown } | null)?.content;
+      if (typeof content === 'string') {
+        return normalizeActivityPhaseLabel(content);
+      }
+      if (!Array.isArray(content)) {
+        return '';
+      }
+      return normalizeActivityPhaseLabel(
+        content
+          .map((block) =>
+            typeof block === 'string'
+              ? block
+              : ((block as { text?: string }).text ?? '')
+          )
+          .join('')
+      );
+    };
+
+    try {
+      return await withLangfuseRuntimeScope(phaseRuntimeScope, async () => {
+        const invokePhase = async (): Promise<{ label?: string }> => {
+          const response = await invokeWithCallbackFallback();
+          const label = extractPhaseLabel(response);
+          return label.length > 0 ? { label } : {};
+        };
+        if (phaseLangfuseHandler == null) {
+          return invokePhase();
+        }
+        const detachedContext = otelTrace.deleteSpan(otelContext.active());
+        return otelContext.with(detachedContext, () =>
+          withLangfuseAttributes(
+            {
+              langfuse: phaseLangfuseConfig,
+              userId: phaseUserId,
+              sessionId: phaseSessionId,
+              traceName: phaseChainOptions.runName ?? phaseRunName,
+              traceMetadata,
+              tags: ['librechat', 'activity-phase', 'agent-run-summary'],
+            },
+            () =>
+              startActiveObservation(
+                'activity-phase',
+                async (phaseObservation) => {
+                  phaseObservation.update({
+                    input: userPrompt,
+                    metadata: phaseMetadata,
+                  });
+                  try {
+                    const result = await invokePhase();
+                    phaseObservation.update({
+                      output: result.label,
+                      metadata: phaseMetadata,
+                    });
+                    return result;
+                  } catch (error) {
+                    phaseObservation.update({
+                      level: 'ERROR',
+                      statusMessage: String(
+                        (error as Error | null)?.message ?? error
+                      ),
+                      metadata: { ...phaseMetadata, status: 'failed' },
+                    });
+                    throw error;
+                  }
+                },
+                { asType: 'agent' }
+              )
+          )
+        );
+      });
+    } finally {
+      await disposeLangfuseHandler(phaseLangfuseHandler);
     }
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -61,6 +61,7 @@ import {
 } from '@/common';
 import {
   appendCallbacks,
+  filterCallbacks,
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
@@ -2103,9 +2104,12 @@ export class Run<_T extends t.BaseGraphState> {
           invokeConfig.callbacks,
           isLangfuseCallbackHandler
         );
-        const { callbacks: _cb, ...rest } = invokeConfig;
+        const { callbacks, ...rest } = invokeConfig;
         const safeConfig = Object.assign({}, rest, {
-          callbacks: langfuseHandler ? [langfuseHandler] : [],
+          callbacks: filterCallbacks(
+            callbacks,
+            (callback) => callback === langfuseHandler
+          ),
         });
         response = await withLangfuseRuntimeScope(labelRuntimeScope, () =>
           invokeLabel(safeConfig as Partial<RunnableConfig>)
@@ -2384,9 +2388,12 @@ export class Run<_T extends t.BaseGraphState> {
           runtimeConfig.callbacks,
           isLangfuseCallbackHandler
         );
-        const { callbacks: _callbacks, ...rest } = runtimeConfig;
+        const { callbacks, ...rest } = runtimeConfig;
         const safeConfig = Object.assign({}, rest, {
-          callbacks: langfuseHandler ? [langfuseHandler] : [],
+          callbacks: filterCallbacks(
+            callbacks,
+            (callback) => callback === langfuseHandler
+          ),
         });
         return invokeModel(safeConfig as Partial<RunnableConfig>);
       }

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -260,6 +260,24 @@ describe('buildActivityPhaseLabelPrompt', () => {
     expect(prompt).not.toContain(entries[0].toolName);
   });
 
+  it('preserves partial outcomes when a committed child label is available', () => {
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: [
+        {
+          label: 'Checked the deployment and found one unhealthy replica',
+          status: 'partial',
+        },
+        { label: 'Recovered the remaining replicas', status: 'success' },
+      ],
+      charLimit: 600,
+    });
+
+    expect(prompt).toContain(
+      'partial: Checked the deployment and found one unhealthy replica'
+    );
+    expect(prompt).toContain('completed: Recovered the remaining replicas');
+  });
+
   it('uses raw fallback while applying the strict redaction policy', () => {
     const prompt = buildActivityPhaseLabelPrompt({
       activities: [

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -1,6 +1,10 @@
 import type { ActivityLabelToolEntry } from '@/types/activityLabel';
+import {
+  buildActivityLabelPrompt,
+  buildActivityPhaseLabelPrompt,
+  normalizeActivityPhaseLabel,
+} from '@/prompts/activityLabel';
 import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
-import { buildActivityLabelPrompt } from '@/prompts/activityLabel';
 import { resolveToolOutputTracingConfig } from '@/langfuseConfig';
 
 const entries: ActivityLabelToolEntry[] = [
@@ -233,5 +237,57 @@ describe('buildActivityLabelPrompt redaction', () => {
     expect(prompt).toContain('PUBLIC_SEARCH_RESULTS');
     expect(prompt).not.toContain('SECRET_CONNECTION_STRING_LEAK');
     expect(prompt).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+});
+
+describe('buildActivityPhaseLabelPrompt', () => {
+  it('prefers committed child labels and includes bounded commentary', () => {
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: [
+        {
+          label: 'Inspected session middleware behavior',
+          entries: [entries[0]],
+        },
+        { label: 'Fixed refresh token validation' },
+      ],
+      assistantContext: ['I am checking the auth path before changing it.'],
+      charLimit: 600,
+    });
+
+    expect(prompt).toContain('Inspected session middleware behavior');
+    expect(prompt).toContain('Fixed refresh token validation');
+    expect(prompt).toContain('I am checking the auth path');
+    expect(prompt).not.toContain(entries[0].toolName);
+  });
+
+  it('uses raw fallback while applying the strict redaction policy', () => {
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: [
+        {
+          thinkingExcerpts: ['Secret result quoted in reasoning'],
+          entries,
+        },
+        { status: 'error', entries: [entries[0]] },
+      ],
+      assistantContext: ['Secret result quoted in commentary'],
+      charLimit: 600,
+      redaction: {
+        enabled: true,
+        redactedToolNames: new Set([entries[0].toolName]),
+        redactedToolNameMatchMode: 'exact',
+        redactionText: '[REDACTED]',
+      },
+    });
+
+    expect(prompt).toContain('[REDACTED]');
+    expect(prompt).not.toContain('Secret result');
+    expect(prompt).not.toContain(String(entries[0].toolOutput));
+  });
+
+  it('normalizes phase summaries to one bounded row', () => {
+    expect(normalizeActivityPhaseLabel('"Fixed auth\nrefresh handling."')).toBe(
+      'Fixed auth refresh handling'
+    );
+    expect(normalizeActivityPhaseLabel('x'.repeat(300))).toHaveLength(160);
   });
 });

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -278,6 +278,18 @@ describe('buildActivityPhaseLabelPrompt', () => {
     expect(prompt).toContain('completed: Recovered the remaining replicas');
   });
 
+  it('reports omitted activities from the host total without retaining their evidence', () => {
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: Array.from({ length: 12 }, (_, index) => ({
+        label: `Completed activity ${index + 1}`,
+      })),
+      totalActivityCount: 20,
+      charLimit: 600,
+    });
+
+    expect(prompt).toContain('…and 8 more activities');
+  });
+
   it('uses raw fallback while applying the strict redaction policy', () => {
     const prompt = buildActivityPhaseLabelPrompt({
       activities: [

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -1,5 +1,6 @@
 import type { ActivityLabelToolEntry } from '@/types/activityLabel';
 import {
+  ACTIVITY_PHASE_PROMPT_MAX_LENGTH,
   buildActivityLabelPrompt,
   buildActivityPhaseLabelPrompt,
   normalizeActivityPhaseLabel,
@@ -312,6 +313,29 @@ describe('buildActivityPhaseLabelPrompt', () => {
     expect(prompt).toContain('[REDACTED]');
     expect(prompt).not.toContain('Secret result');
     expect(prompt).not.toContain(String(entries[0].toolOutput));
+  });
+
+  it('caps aggregate phase evidence while preserving the terminal cue', () => {
+    const oversized = 'x'.repeat(600);
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: Array.from({ length: 12 }, (_, activityIndex) => ({
+        thinkingExcerpts: Array.from(
+          { length: 4 },
+          (_, excerptIndex) => `${activityIndex}-${excerptIndex}-${oversized}`
+        ),
+        entries: Array.from({ length: 6 }, (_, entryIndex) => ({
+          toolName: `tool_${activityIndex}_${entryIndex}`,
+          toolInput: oversized,
+          toolOutput: oversized,
+          status: 'success' as const,
+        })),
+      })),
+      assistantContext: [oversized, oversized],
+      charLimit: 600,
+    });
+
+    expect(prompt.length).toBeLessThanOrEqual(ACTIVITY_PHASE_PROMPT_MAX_LENGTH);
+    expect(prompt.endsWith('\n\nPhase summary:')).toBe(true);
   });
 
   it('normalizes phase summaries to one bounded row', () => {

--- a/src/specs/activity-label-prompt.test.ts
+++ b/src/specs/activity-label-prompt.test.ts
@@ -291,6 +291,18 @@ describe('buildActivityPhaseLabelPrompt', () => {
     expect(prompt).toContain('…and 8 more activities');
   });
 
+  it('rejects status-only retained activities when evidence exists only beyond the cap', () => {
+    const prompt = buildActivityPhaseLabelPrompt({
+      activities: [
+        ...Array.from({ length: 12 }, () => ({ status: 'success' as const })),
+        { label: 'This evidence is outside the retained activity window' },
+      ],
+      charLimit: 600,
+    });
+
+    expect(prompt).toBe('');
+  });
+
   it('uses raw fallback while applying the strict redaction policy', () => {
     const prompt = buildActivityPhaseLabelPrompt({
       activities: [

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -1,6 +1,6 @@
-import { AIMessage } from '@langchain/core/messages';
-import { Providers } from '@/common';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
+import { Providers } from '@/common';
 import { Run } from '@/run';
 
 const invoke = jest.fn();
@@ -17,6 +17,7 @@ async function createRun(): Promise<Run<never>> {
       agents: [
         {
           agentId: 'agent-1',
+          name: 'Phase Agent',
           provider: Providers.OPENAI,
           clientOptions: { model: 'gpt-4.1-mini' },
           tools: [],
@@ -48,6 +49,13 @@ describe('generateActivityPhaseLabel', () => {
 
   it('summarizes two activities and normalizes the persisted row', async () => {
     const run = await createRun();
+    if (run.Graph != null) {
+      run.Graph.messages = [
+        new HumanMessage('Why is session refresh failing?'),
+      ];
+    }
+    const handleChainStart = jest.fn();
+    const handleChainEnd = jest.fn();
 
     await expect(
       run.generateActivityPhaseLabel({
@@ -59,7 +67,7 @@ describe('generateActivityPhaseLabel', () => {
         assistantContext: ['I am checking the auth path.'],
         closingTextPhase: 'final_answer',
         chainOptions: {
-          callbacks: [{ handleChainStart: jest.fn() }],
+          callbacks: [{ handleChainStart, handleChainEnd }],
         },
       })
     ).resolves.toEqual({
@@ -73,9 +81,13 @@ describe('generateActivityPhaseLabel', () => {
     expect(String(messages[1].content)).toContain(
       'Fixed refresh token validation'
     );
+    expect(String(messages[1].content)).not.toContain(
+      'Why is session refresh failing?'
+    );
     const modelConfig = invoke.mock.calls[0][1] as {
       callbacks?: { getParentRunId?: () => string | undefined };
       tags?: string[];
+      metadata?: Record<string, unknown>;
     };
     expect(modelConfig.callbacks?.getParentRunId?.()).toEqual(
       expect.any(String)
@@ -83,6 +95,45 @@ describe('generateActivityPhaseLabel', () => {
     expect(modelConfig.tags).toEqual(
       expect.arrayContaining(['activity-phase', 'agent'])
     );
+    expect(modelConfig.metadata).toEqual(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        agentName: 'Phase Agent',
+      })
+    );
+    expect(handleChainStart.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: 'Why is session refresh failing?',
+          }),
+        ]),
+      })
+    );
+    expect(handleChainEnd.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: 'Fixed session refresh handling and verified auth tests',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('does not call the model when retained activities have no evidence', async () => {
+    const run = await createRun();
+
+    await expect(
+      run.generateActivityPhaseLabel({
+        provider: Providers.OPENAI,
+        activities: [
+          ...Array.from({ length: 12 }, () => ({ status: 'success' as const })),
+          { label: 'Evidence beyond the prompt cap' },
+        ],
+      })
+    ).resolves.toEqual({});
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it('applies every agent redaction policy when any activity is unattributed', async () => {

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -52,6 +52,14 @@ describe('generateActivityPhaseLabel', () => {
     if (run.Graph != null) {
       run.Graph.messages = [
         new HumanMessage('Why is session refresh failing?'),
+        new HumanMessage({
+          content: 'Internal routing instructions',
+          additional_kwargs: {
+            role: 'user',
+            isMeta: true,
+            source: 'routing',
+          },
+        }),
       ];
     }
     const handleChainStart = jest.fn();
@@ -68,6 +76,9 @@ describe('generateActivityPhaseLabel', () => {
         closingTextPhase: 'final_answer',
         chainOptions: {
           callbacks: [{ handleChainStart, handleChainEnd }],
+          configurable: {
+            requestBody: { parentMessageId: 'parent-message-1' },
+          },
         },
       })
     ).resolves.toEqual({
@@ -99,6 +110,7 @@ describe('generateActivityPhaseLabel', () => {
       expect.objectContaining({
         agentId: 'agent-1',
         agentName: 'Phase Agent',
+        parentMessageId: 'parent-message-1',
       })
     );
     expect(handleChainStart.mock.calls[0]?.[1]).toEqual(
@@ -109,6 +121,9 @@ describe('generateActivityPhaseLabel', () => {
           }),
         ]),
       })
+    );
+    expect(JSON.stringify(handleChainStart.mock.calls[0]?.[1])).not.toContain(
+      'Internal routing instructions'
     );
     expect(handleChainEnd.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -58,6 +58,9 @@ describe('generateActivityPhaseLabel', () => {
         ],
         assistantContext: ['I am checking the auth path.'],
         closingTextPhase: 'final_answer',
+        chainOptions: {
+          callbacks: [{ handleChainStart: jest.fn() }],
+        },
       })
     ).resolves.toEqual({
       label: 'Fixed session refresh handling and verified auth tests',

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -158,6 +158,41 @@ describe('generateActivityPhaseLabel', () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
+  it('preserves the phase parent when retrying without a failing callback', async () => {
+    invoke.mockRejectedValueOnce(new Error('event stream callback failed'));
+    const run = await createRun();
+
+    await expect(
+      run.generateActivityPhaseLabel({
+        provider: Providers.OPENAI,
+        activities: [
+          { label: 'Inspected session refresh middleware' },
+          { label: 'Fixed refresh token validation' },
+        ],
+        chainOptions: {
+          callbacks: [{ handleChainStart: jest.fn() }],
+        },
+      })
+    ).resolves.toEqual({
+      label: 'Fixed session refresh handling and verified auth tests',
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    const firstCallbacks = invoke.mock.calls[0][1].callbacks as {
+      getParentRunId: () => string | undefined;
+      handlers: unknown[];
+    };
+    const retryCallbacks = invoke.mock.calls[1][1].callbacks as {
+      getParentRunId: () => string | undefined;
+      handlers: unknown[];
+    };
+    expect(firstCallbacks.getParentRunId()).toEqual(expect.any(String));
+    expect(retryCallbacks.getParentRunId()).toBe(
+      firstCallbacks.getParentRunId()
+    );
+    expect(retryCallbacks.handlers).toHaveLength(0);
+  });
+
   it('applies every agent redaction policy when any activity is unattributed', async () => {
     const run = await Run.create({
       runId: 'mixed-attribution-phase-run',

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -242,4 +242,65 @@ describe('generateActivityPhaseLabel', () => {
       LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
     );
   });
+
+  it('applies every policy when omitted activities have no complete agent list', async () => {
+    const run = await Run.create({
+      runId: 'omitted-attribution-phase-run',
+      graphConfig: {
+        type: 'multi-agent',
+        agents: [
+          {
+            agentId: 'agent-1',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4.1-mini' },
+            tools: [],
+          },
+          {
+            agentId: 'agent-2',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4.1-mini' },
+            tools: [],
+            langfuse: {
+              toolOutputTracing: { redactedToolNames: ['secret_tool'] },
+            },
+          },
+        ],
+        edges: [],
+      },
+    });
+
+    await run.generateActivityPhaseLabel({
+      provider: Providers.OPENAI,
+      activities: [
+        {
+          agentId: 'agent-1',
+          entries: [
+            {
+              toolName: 'public_lookup',
+              toolInput: { id: 'one' },
+              toolOutput: 'public-one',
+              status: 'success',
+            },
+          ],
+        },
+        {
+          agentId: 'agent-1',
+          entries: [
+            {
+              toolName: 'public_lookup',
+              toolInput: { id: 'two' },
+              toolOutput: 'public-two',
+              status: 'success',
+            },
+          ],
+        },
+      ],
+      totalActivityCount: 3,
+      assistantContext: ['OMITTED_AGENT_SECRET'],
+    });
+
+    const messages = invoke.mock.calls[0][0] as AIMessage[];
+    expect(String(messages[1].content)).not.toContain('OMITTED_AGENT_SECRET');
+    expect(String(messages[1].content)).toContain('public-one');
+  });
 });

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -1,0 +1,73 @@
+import { AIMessage } from '@langchain/core/messages';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+const invoke = jest.fn();
+
+jest.mock('@/llm/init', () => ({
+  initializeModel: jest.fn(() => ({ invoke })),
+}));
+
+async function createRun(): Promise<Run<never>> {
+  return Run.create({
+    runId: 'phase-run',
+    graphConfig: {
+      type: 'standard',
+      agents: [
+        {
+          agentId: 'agent-1',
+          provider: Providers.OPENAI,
+          clientOptions: { model: 'gpt-4.1-mini' },
+          tools: [],
+        },
+      ],
+    },
+  });
+}
+
+describe('generateActivityPhaseLabel', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(
+      new AIMessage('"Fixed session refresh handling and verified auth tests."')
+    );
+  });
+
+  it('does not spend a model call on one logical activity', async () => {
+    const run = await createRun();
+
+    await expect(
+      run.generateActivityPhaseLabel({
+        provider: Providers.OPENAI,
+        activities: [{ label: 'Inspected session refresh middleware' }],
+      })
+    ).resolves.toEqual({});
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('summarizes two activities and normalizes the persisted row', async () => {
+    const run = await createRun();
+
+    await expect(
+      run.generateActivityPhaseLabel({
+        provider: Providers.OPENAI,
+        activities: [
+          { label: 'Inspected session refresh middleware' },
+          { label: 'Fixed refresh token validation' },
+        ],
+        assistantContext: ['I am checking the auth path.'],
+        closingTextPhase: 'final_answer',
+      })
+    ).resolves.toEqual({
+      label: 'Fixed session refresh handling and verified auth tests',
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    const messages = invoke.mock.calls[0][0] as AIMessage[];
+    expect(String(messages[1].content)).toContain(
+      'Inspected session refresh middleware'
+    );
+    expect(String(messages[1].content)).toContain(
+      'Fixed refresh token validation'
+    );
+  });
+});

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -71,10 +71,12 @@ describe('generateActivityPhaseLabel', () => {
       'Fixed refresh token validation'
     );
     const modelConfig = invoke.mock.calls[0][1] as {
-      callbacks?: { parentRunId?: string };
+      callbacks?: { getParentRunId?: () => string | undefined };
       tags?: string[];
     };
-    expect(modelConfig.callbacks?.parentRunId).toEqual(expect.any(String));
+    expect(modelConfig.callbacks?.getParentRunId?.()).toEqual(
+      expect.any(String)
+    );
     expect(modelConfig.tags).toEqual(
       expect.arrayContaining(['activity-phase', 'agent'])
     );
@@ -84,7 +86,7 @@ describe('generateActivityPhaseLabel', () => {
     const run = await Run.create({
       runId: 'mixed-attribution-phase-run',
       graphConfig: {
-        type: 'standard',
+        type: 'multi-agent',
         agents: [
           {
             agentId: 'agent-1',
@@ -102,6 +104,7 @@ describe('generateActivityPhaseLabel', () => {
             },
           },
         ],
+        edges: [],
       },
     });
 

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -51,7 +51,14 @@ describe('generateActivityPhaseLabel', () => {
     const run = await createRun();
     if (run.Graph != null) {
       run.Graph.messages = [
-        new HumanMessage('Why is session refresh failing?'),
+        new HumanMessage({
+          content: [
+            {
+              type: 'input_text',
+              text: 'Why is session refresh failing?',
+            } as never,
+          ],
+        }),
         new HumanMessage({
           content: 'Internal routing instructions',
           additional_kwargs: {

--- a/src/specs/activity-phase-label.test.ts
+++ b/src/specs/activity-phase-label.test.ts
@@ -1,5 +1,6 @@
 import { AIMessage } from '@langchain/core/messages';
 import { Providers } from '@/common';
+import { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT } from '@/langfuseToolOutputTracing';
 import { Run } from '@/run';
 
 const invoke = jest.fn();
@@ -68,6 +69,63 @@ describe('generateActivityPhaseLabel', () => {
     );
     expect(String(messages[1].content)).toContain(
       'Fixed refresh token validation'
+    );
+    const modelConfig = invoke.mock.calls[0][1] as {
+      callbacks?: { parentRunId?: string };
+      tags?: string[];
+    };
+    expect(modelConfig.callbacks?.parentRunId).toEqual(expect.any(String));
+    expect(modelConfig.tags).toEqual(
+      expect.arrayContaining(['activity-phase', 'agent'])
+    );
+  });
+
+  it('applies every agent redaction policy when any activity is unattributed', async () => {
+    const run = await Run.create({
+      runId: 'mixed-attribution-phase-run',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'agent-1',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4.1-mini' },
+            tools: [],
+          },
+          {
+            agentId: 'agent-2',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4.1-mini' },
+            tools: [],
+            langfuse: {
+              toolOutputTracing: { redactedToolNames: ['secret_tool'] },
+            },
+          },
+        ],
+      },
+    });
+
+    await run.generateActivityPhaseLabel({
+      provider: Providers.OPENAI,
+      activities: [
+        { agentId: 'agent-1', label: 'Inspected public session behavior' },
+        {
+          entries: [
+            {
+              toolName: 'secret_tool',
+              toolInput: { key: 'public-key' },
+              toolOutput: 'STRICT_AGENT_SECRET',
+              status: 'success',
+            },
+          ],
+        },
+      ],
+    });
+
+    const messages = invoke.mock.calls[0][0] as AIMessage[];
+    expect(String(messages[1].content)).not.toContain('STRICT_AGENT_SECRET');
+    expect(String(messages[1].content)).toContain(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
     );
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -51,7 +51,10 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
-import { getMessageCreationContentMetadata } from '@/messages/assistantPhase';
+import {
+  getMessageCreationContentMetadata,
+  splitAssistantTextContentByPhase,
+} from '@/messages/assistantPhase';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { composeAbortSignals } from '@/utils/misc';
@@ -1818,6 +1821,26 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     if (hasGoogleServerSideToolContent) {
       return;
+    }
+
+    if (Array.isArray(content) && content.every(isTextContentPart)) {
+      const contentGroups = splitAssistantTextContentByPhase(content);
+      if (contentGroups.length > 1) {
+        for (const contentGroup of contentGroups) {
+          const currentStepId = await dispatchMessageCreationStep({
+            graph,
+            stepKey,
+            content: contentGroup,
+            metadata,
+          });
+          await graph.dispatchMessageDelta(
+            currentStepId,
+            { content: contentGroup },
+            metadata
+          );
+        }
+        return;
+      }
     }
 
     const message_id = getMessageId(stepKey, graph) ?? '';

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1825,7 +1825,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     if (Array.isArray(content) && content.every(isTextContentPart)) {
       const contentGroups = splitAssistantTextContentByPhase(content);
-      const currentStepId = graph.stepKeyIds.get(stepKey)?.at(-1);
+      const currentStepId = graph.stepKeyIds?.get(stepKey)?.at(-1);
       const currentStep =
         currentStepId == null ? undefined : graph.getRunStep(currentStepId);
       const currentPhase =

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -33,6 +33,10 @@ import {
   LOCAL_CODING_BUNDLE_NAMES,
 } from '@/common';
 import {
+  getMessageCreationContentMetadata,
+  splitAssistantTextContentByPhase,
+} from '@/messages/assistantPhase';
+import {
   buildToolExecutionRequestPlan,
   coerceRecordArgs,
   normalizeError,
@@ -51,10 +55,6 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
-import {
-  getMessageCreationContentMetadata,
-  splitAssistantTextContentByPhase,
-} from '@/messages/assistantPhase';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { composeAbortSignals } from '@/utils/misc';
@@ -1825,7 +1825,21 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     if (Array.isArray(content) && content.every(isTextContentPart)) {
       const contentGroups = splitAssistantTextContentByPhase(content);
-      if (contentGroups.length > 1) {
+      const currentStepId = graph.stepKeyIds.get(stepKey)?.at(-1);
+      const currentStep =
+        currentStepId == null ? undefined : graph.getRunStep(currentStepId);
+      const currentPhase =
+        currentStep?.stepDetails.type === StepTypes.MESSAGE_CREATION
+          ? currentStep.stepDetails.message_creation.phase
+          : undefined;
+      const nextPhase = getMessageCreationContentMetadata(
+        contentGroups[0]
+      ).phase;
+      const phaseChanged =
+        currentPhase != null &&
+        nextPhase != null &&
+        currentPhase !== nextPhase;
+      if (contentGroups.length > 1 || phaseChanged) {
         for (const contentGroup of contentGroups) {
           const currentStepId = await dispatchMessageCreationStep({
             graph,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,8 +3,19 @@ import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type { ChatOpenAIReasoningSummary } from '@langchain/openai';
 import type { AIMessageChunk } from '@langchain/core/messages';
 import type { AgentContext } from '@/agents/AgentContext';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
+import {
+  claimStreamLimitCharge,
+  combineCompleteToolCalls,
+  enforceCompleteToolCallArgLimit,
+  enforceStreamedToolCallArgLimit,
+  enforceStreamDeltaEventLimit,
+  requiresStreamLimitAccounting,
+  StreamLimitExceededError,
+  STREAM_LIMIT_EPOCH_KEY,
+} from '@/llm/streamLimits';
 import {
   getStreamedToolCallSeal,
   getStreamedToolCallAdapter,
@@ -39,18 +50,8 @@ import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
-import type { RunBreakerScope } from '@/llm/streamLimits';
-import {
-  claimStreamLimitCharge,
-  combineCompleteToolCalls,
-  enforceCompleteToolCallArgLimit,
-  enforceStreamedToolCallArgLimit,
-  enforceStreamDeltaEventLimit,
-  requiresStreamLimitAccounting,
-  StreamLimitExceededError,
-  STREAM_LIMIT_EPOCH_KEY,
-} from '@/llm/streamLimits';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
+import { getMessageCreationContentMetadata } from '@/messages/assistantPhase';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { composeAbortSignals } from '@/utils/misc';
@@ -521,10 +522,14 @@ function shouldStartFreshMessageStepAfterGoogleServerSideTool({
 async function dispatchMessageCreationStep({
   graph,
   stepKey,
+  content,
+  contentType,
   metadata,
 }: {
   graph: StandardGraph;
   stepKey: string;
+  content?: string | t.MessageContentComplex[];
+  contentType?: ContentTypes.TEXT | ContentTypes.THINK;
   metadata?: Record<string, unknown>;
 }): Promise<string> {
   const messageId = getMessageId(stepKey, graph, true) ?? '';
@@ -534,6 +539,7 @@ async function dispatchMessageCreationStep({
       type: StepTypes.MESSAGE_CREATION,
       message_creation: {
         message_id: messageId,
+        ...getMessageCreationContentMetadata(content, contentType),
       },
     },
     metadata
@@ -555,6 +561,7 @@ async function dispatchMessageContentParts({
     const currentStepId = await dispatchMessageCreationStep({
       graph,
       stepKey,
+      content: [contentPart],
       metadata,
     });
     if (isGoogleServerSideToolContentPart(contentPart)) {
@@ -587,6 +594,8 @@ async function dispatchReasoningContentParts({
   const currentStepId = await dispatchMessageCreationStep({
     graph,
     stepKey,
+    content,
+    contentType: ContentTypes.THINK,
     metadata,
   });
   await graph.dispatchReasoningDelta(
@@ -1813,12 +1822,17 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     const message_id = getMessageId(stepKey, graph) ?? '';
     if (message_id) {
+      const fallbackContentType =
+        agentContext.currentTokenType === ContentTypes.TEXT
+          ? ContentTypes.TEXT
+          : ContentTypes.THINK;
       await graph.dispatchRunStep(
         stepKey,
         {
           type: StepTypes.MESSAGE_CREATION,
           message_creation: {
             message_id,
+            ...getMessageCreationContentMetadata(content, fallbackContentType),
           },
         },
         metadata
@@ -1835,7 +1849,12 @@ export class ChatModelStreamHandler implements t.EventHandler {
         content,
       })
     ) {
-      stepId = await dispatchMessageCreationStep({ graph, stepKey, metadata });
+      stepId = await dispatchMessageCreationStep({
+        graph,
+        stepKey,
+        content,
+        metadata,
+      });
       runStep = graph.getRunStep(stepId);
     }
     if (!runStep) {
@@ -1906,6 +1925,7 @@ hasToolCallChunks: ${hasToolCallChunks}
               type: StepTypes.MESSAGE_CREATION,
               message_creation: {
                 message_id,
+                content_type: ContentTypes.TEXT,
               },
             },
             metadata

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -3138,6 +3138,54 @@ describe('summarizeEvent', () => {
 });
 
 describe('sanitizeForwardedSubagentUpdateData', () => {
+  it('preserves bounded assistant phase metadata on message-creation steps', () => {
+    const sanitized = sanitizeForwardedSubagentUpdateData(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'step_1',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: {
+            message_id: 'message_1',
+            content_type: 'text',
+            phase: 'commentary',
+            futureSecret: 'nested-secret',
+          },
+        },
+      }
+    );
+
+    expect(sanitized).toEqual({
+      id: 'step_1',
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: {
+          message_id: 'message_1',
+          content_type: 'text',
+          phase: 'commentary',
+        },
+      },
+    });
+
+    expect(
+      sanitizeForwardedSubagentUpdateData(GraphEvents.ON_RUN_STEP, {
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: {
+            message_id: 'message_2',
+            content_type: 'image',
+            phase: 'internal',
+          },
+        },
+      })
+    ).toEqual({
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'message_2' },
+      },
+    });
+  });
+
   it('uses an allowlist for run step payloads', () => {
     const sanitized = sanitizeForwardedSubagentUpdateData(
       GraphEvents.ON_RUN_STEP,

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -40,6 +40,7 @@ import type {
   HumanInTheLoopConfig,
   InjectedMessage,
   MessageDeltaEvent,
+  MessageCreationDetails,
   ProcessedToolCall,
   ReasoningDeltaEvent,
   RunStep,
@@ -208,9 +209,7 @@ type SanitizedRunStep = Partial<
 type SanitizedStepDetails =
   | {
       type: StepTypes.MESSAGE_CREATION;
-      message_creation?: {
-        message_id?: string;
-      };
+      message_creation?: Partial<MessageCreationDetails['message_creation']>;
     }
   | {
       type: StepTypes.TOOL_CALLS;
@@ -3182,7 +3181,11 @@ function sanitizeStepDetails(
     return undefined;
   }
   const rawDetails = stepDetails as {
-    message_creation?: { message_id?: unknown };
+    message_creation?: {
+      message_id?: unknown;
+      content_type?: unknown;
+      phase?: unknown;
+    };
     tool_calls?: unknown[];
     type?: unknown;
   };
@@ -3190,9 +3193,27 @@ function sanitizeStepDetails(
     const sanitized: SanitizedStepDetails = {
       type: StepTypes.MESSAGE_CREATION,
     };
-    const messageId = rawDetails.message_creation?.message_id;
-    if (typeof messageId === 'string') {
-      sanitized.message_creation = { message_id: messageId };
+    const rawMessageCreation = rawDetails.message_creation;
+    const messageId = rawMessageCreation?.message_id;
+    const contentType = rawMessageCreation?.content_type;
+    const phase = rawMessageCreation?.phase;
+    if (
+      typeof messageId === 'string' ||
+      contentType === ContentTypes.TEXT ||
+      contentType === ContentTypes.THINK ||
+      phase === 'commentary' ||
+      phase === 'final_answer'
+    ) {
+      sanitized.message_creation = {
+        ...(typeof messageId === 'string' ? { message_id: messageId } : {}),
+        ...(contentType === ContentTypes.TEXT ||
+        contentType === ContentTypes.THINK
+          ? { content_type: contentType }
+          : {}),
+        ...(phase === 'commentary' || phase === 'final_answer'
+          ? { phase }
+          : {}),
+      };
     }
     return sanitized;
   }

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -1,4 +1,5 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { AssistantTextPhase } from '@/types/assistantPhase';
 import type { ClientOptions } from '@/types/llm';
 import type { Providers } from '@/common';
 
@@ -39,6 +40,11 @@ export type RunActivityLabelOptions = {
   /** Assistant's last text before the block (~200 chars), as intent context. */
   lastAssistantText?: string;
   /**
+   * Provider-authored semantic phase for `lastAssistantText`. Hosts can use
+   * this to pass commentary as intent while excluding final-answer text.
+   */
+  lastAssistantPhase?: AssistantTextPhase;
+  /**
    * Headers already committed for earlier batches in this run (run order,
    * most recent last). Continuity context: the prompt shows them so the new
    * header extends the run's story instead of restating a line already on
@@ -60,4 +66,59 @@ export type RunActivityLabelOptions = {
    * a per-run sequence keeps batches from collapsing into one trace.
    */
   traceSeed?: string;
+};
+
+/** One logical activity contributing to a run-wide phase summary. */
+export type ActivityPhaseEntry = {
+  /** Already committed child activity label, preferred over raw evidence. */
+  label?: string;
+  /** Raw fallback for a child label that was disabled, pending, or dropped. */
+  entries?: ActivityLabelToolEntry[];
+  /** Standalone or tool-attached reasoning excerpts for this activity. */
+  thinkingExcerpts?: string[];
+  /** Agent lane that produced the activity. */
+  agentId?: string;
+  /** Failed activities remain useful evidence and still count. */
+  status?: 'success' | 'error';
+};
+
+/** Options for `Run.generateActivityPhaseLabel`. */
+export type RunActivityPhaseLabelOptions = {
+  provider: Providers;
+  clientOptions?: ClientOptions;
+  /**
+   * Logical activities in run order. The SDK requires at least two so hosts
+   * cannot accidentally spend a model call summarizing a single activity.
+   */
+  activities: ActivityPhaseEntry[];
+  /**
+   * Bounded assistant commentary emitted inside the phase. Human messages
+   * must not be supplied through this low-scrutiny summarization path.
+   */
+  assistantContext?: string[];
+  /** Semantic phase of the text boundary that closed the activity phase. */
+  closingTextPhase?: AssistantTextPhase;
+  /** Override for the dedicated phase-label system prompt. */
+  prompt?: string;
+  /** Per-evidence serialization cap for the prompt. Default 600. */
+  charLimit?: number;
+  /** LangChain runnable config carrier (signal, callbacks, thread/user ids). */
+  chainOptions?: Partial<RunnableConfig> & {
+    configurable?: Record<string, unknown>;
+  };
+  /** Deterministic seed for this phase label trace. */
+  traceSeed?: string;
+  /** Stable source run identifier recorded on the phase observation. */
+  sourceRunId?: string;
+  /** Host response/message identifier recorded on the phase observation. */
+  responseId?: string;
+  /** Zero-based index of the phase within the source run. */
+  phaseIndex?: number;
+  /** Completion state recorded on the phase observation. */
+  status?: 'completed' | 'failed';
+  /**
+   * Contributing agents. Their Langfuse redaction policies are combined into
+   * the strictest union before any phase evidence enters the model or trace.
+   */
+  agentIds?: string[];
 };

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -79,7 +79,7 @@ export type ActivityPhaseEntry = {
   /** Agent lane that produced the activity. */
   agentId?: string;
   /** Failed activities remain useful evidence and still count. */
-  status?: 'success' | 'error';
+  status?: 'success' | 'partial' | 'error';
 };
 
 /** Options for `Run.generateActivityPhaseLabel`. */
@@ -110,12 +110,14 @@ export type RunActivityPhaseLabelOptions = {
   traceSeed?: string;
   /** Stable source run identifier recorded on the phase observation. */
   sourceRunId?: string;
+  /** Source Langfuse trace id for linking this detached summary trace. */
+  sourceTraceId?: string;
   /** Host response/message identifier recorded on the phase observation. */
   responseId?: string;
   /** Zero-based index of the phase within the source run. */
   phaseIndex?: number;
   /** Completion state recorded on the phase observation. */
-  status?: 'completed' | 'failed';
+  status?: 'completed' | 'partial' | 'failed';
   /**
    * Contributing agents. Their Langfuse redaction policies are combined into
    * the strictest union before any phase evidence enters the model or trace.

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -91,6 +91,8 @@ export type RunActivityPhaseLabelOptions = {
    * cannot accidentally spend a model call summarizing a single activity.
    */
   activities: ActivityPhaseEntry[];
+  /** Full count when the host retained only bounded prompt evidence. */
+  totalActivityCount?: number;
   /**
    * Bounded assistant commentary emitted inside the phase. Human messages
    * must not be supplied through this low-scrutiny summarization path.

--- a/src/types/assistantPhase.ts
+++ b/src/types/assistantPhase.ts
@@ -1,0 +1,6 @@
+/**
+ * Semantic phase attached to assistant text by Open Responses-compatible
+ * providers. Commentary is intermediate agent narration; final_answer marks
+ * the user-facing answer that closes the preceding activity phase.
+ */
+export type AssistantTextPhase = 'commentary' | 'final_answer';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,4 @@ export * from './stream';
 export * from './tools';
 export * from './summarize';
 export * from './activityLabel';
+export * from './assistantPhase';

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -9,6 +9,7 @@ import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type { LLMResult, Generation } from '@langchain/core/outputs';
 import type { Command } from '@langchain/langgraph';
 import type { AnthropicContentBlock } from '@/llm/anthropic/types';
+import type { AssistantTextPhase } from '@/types/assistantPhase';
 import type { SummarizeCompleteEvent } from '@/types/summarize';
 import type { ToolEndEvent } from '@/types/tools';
 import { StepTypes, ContentTypes, GraphEvents } from '@/common/enum';
@@ -119,6 +120,10 @@ export type MessageCreationDetails = {
   type: StepTypes.MESSAGE_CREATION;
   message_creation: {
     message_id: string;
+    /** Content lane announced before its first delta. */
+    content_type?: ContentTypes.TEXT | ContentTypes.THINK;
+    /** Provider-authored assistant text phase, when available. */
+    phase?: AssistantTextPhase;
   };
 };
 
@@ -415,6 +420,10 @@ export type MessageContentComplex = (
       type?: never;
     })
 ) & {
+  /** Open Responses-compatible semantic phase for assistant text. */
+  phase?: AssistantTextPhase;
+  /** LangChain standard-content form of provider-specific block fields. */
+  extras?: { phase?: AssistantTextPhase } & Record<string, unknown>;
   tool_call_ids?: string[];
   // Optional agentId for parallel execution attribution
   agentId?: string;

--- a/src/utils/callbacks.ts
+++ b/src/utils/callbacks.ts
@@ -37,3 +37,24 @@ export function findCallback(
   const handlers = Array.isArray(callbacks) ? callbacks : callbacks.handlers;
   return handlers.find(predicate);
 }
+
+export function filterCallbacks(
+  callbacks: Callbacks | undefined,
+  predicate: (callback: CallbackEntry) => boolean
+): Callbacks {
+  if (callbacks == null) {
+    return [];
+  }
+
+  if (Array.isArray(callbacks)) {
+    return callbacks.filter(predicate);
+  }
+
+  const filtered = callbacks.copy();
+  for (const handler of [...filtered.handlers]) {
+    if (!predicate(handler)) {
+      filtered.removeHandler(handler);
+    }
+  }
+  return filtered;
+}


### PR DESCRIPTION
## Summary

I added the SDK surface and provider-phase semantics for run-wide activity phase summaries.

- Expose Open Responses `commentary` and `final_answer` metadata on message-creation steps, including multi-block chunks that cross a phase boundary.
- Generate one bounded parent label for two or more logical activities with strict multi-agent redaction, including incomplete attribution.
- Preserve typed commentary as child-label intent while excluding final-answer text.
- Trace each summary as a session-bound `summarize-activity-phase` agent observation with a tracked generation child and source AgentRun metadata.
- Cap the complete evidence prompt at 12,000 characters while preserving the full activity count for observability.
- Preserve existing activity-label behavior and avoid adding an SDK-owned transport event.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

GitHub Actions passes on exact head `cd96b913`: lint, typecheck, circular-dependency checks, integration tests, all four unit shards, and Anthropic, OpenAI, Bedrock, and local summarization lanes. Earlier focused assistant-phase, prompt, trace-shaping, and phase-label suites passed locally; the final exact-head regressions are covered by the green CI matrix.

### **Test Configuration**:

- Node.js 24 on GitHub-hosted Ubuntu runners
- Focused phase metadata, prompt budgeting, normalization, attribution/redaction, callback-parent, and Responses input coverage

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local focused unit tests pass with my changes
