### PR TITLE
🪪 fix: Attribute Graph Subagent Member Updates

### DIFF
--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -2154,6 +2154,146 @@ describe('SubagentExecutor', () => {
       expect(phases[phases.length - 1]).toBe('stop');
     });
 
+    it('attributes graph updates to validated payload and step-local member identities', async () => {
+      const updates: SubagentUpdateEvent[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          updates.push(data as SubagentUpdateEvent);
+        },
+      });
+      const graphConfig: GraphSubagentConfig = {
+        kind: 'graph',
+        type: 'graph-team',
+        name: 'Graph Team',
+        description: 'Runs a graph.',
+        agents: [
+          makeChildInputs('entry'),
+          makeChildInputs('worker'),
+          makeChildInputs('result'),
+        ],
+        edges: [
+          { from: 'entry', to: 'worker', edgeType: 'direct' },
+          { from: 'worker', to: 'result', edgeType: 'direct' },
+        ],
+        entryAgentId: 'entry',
+        resultAgentId: 'result',
+      };
+      const graphFactory = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              const opts = options as { callbacks?: unknown[] };
+              const forwarder = (opts.callbacks ?? [])[0] as {
+                handleCustomEvent?: (
+                  eventName: string,
+                  data: unknown,
+                  runId: string,
+                  tags?: string[],
+                  metadata?: Record<string, unknown>
+                ) => Promise<void> | void;
+              };
+              const emit = async (
+                eventName: string,
+                data: unknown,
+                agentId: string
+              ): Promise<void> => {
+                await forwarder.handleCustomEvent?.(
+                  eventName,
+                  data,
+                  'child-run',
+                  [],
+                  { agentId }
+                );
+              };
+
+              await emit(
+                GraphEvents.ON_RUN_STEP,
+                {
+                  id: 'step_entry',
+                  type: StepTypes.MESSAGE_CREATION,
+                  agentId: 'entry',
+                },
+                'parent-agent'
+              );
+              await emit(
+                GraphEvents.ON_MESSAGE_DELTA,
+                { id: 'step_entry', delta: { content: 'entry' } },
+                'parent-agent'
+              );
+              await emit(
+                GraphEvents.ON_REASONING_DELTA,
+                { id: 'step_entry', delta: { content: [] } },
+                'parent-agent'
+              );
+              await emit(
+                GraphEvents.ON_RUN_STEP,
+                {
+                  id: 'step_worker',
+                  type: StepTypes.MESSAGE_CREATION,
+                  agentId: 'worker',
+                },
+                'entry'
+              );
+              await emit(
+                GraphEvents.ON_RUN_STEP,
+                {
+                  id: 'step_spoofed',
+                  type: StepTypes.MESSAGE_CREATION,
+                  agentId: 'unknown-member',
+                },
+                'worker'
+              );
+              await emit(
+                GraphEvents.ON_RUN_STEP_COMPLETED,
+                { result: { id: 'step_result', agentId: 'result' } },
+                'parent-agent'
+              );
+              await emit(
+                GraphEvents.ON_MESSAGE_DELTA,
+                { id: 'step_metadata', delta: { content: 'worker' } },
+                'worker'
+              );
+              return {
+                messages: [new AIMessage('ok')],
+                subagentResult: { agentId: 'result' },
+              };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+      const executor = createExecutor({
+        configs: new Map([[graphConfig.type, graphConfig]]),
+        createChildGraphByKind: graphFactory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Run the graph.',
+        subagentType: graphConfig.type,
+      });
+
+      const activity = updates.filter(
+        (update) => update.phase !== 'start' && update.phase !== 'stop'
+      );
+      expect(
+        activity.map(({ phase, memberAgentId }) => ({
+          phase,
+          memberAgentId,
+        }))
+      ).toEqual([
+        { phase: 'run_step', memberAgentId: 'entry' },
+        { phase: 'message_delta', memberAgentId: 'entry' },
+        { phase: 'reasoning_delta', memberAgentId: 'entry' },
+        { phase: 'run_step', memberAgentId: 'worker' },
+        { phase: 'run_step', memberAgentId: undefined },
+        { phase: 'run_step_completed', memberAgentId: 'result' },
+        { phase: 'message_delta', memberAgentId: 'worker' },
+      ]);
+      expect(updates[0].memberAgentId).toBeUndefined();
+      expect(updates[updates.length - 1].memberAgentId).toBeUndefined();
+    });
+
     it('keeps toolDefinitions on child when registry has ON_TOOL_EXECUTE handler', async () => {
       const registry = new HandlerRegistry();
       registry.register(GraphEvents.ON_TOOL_EXECUTE, {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2138,6 +2138,8 @@ export class SubagentExecutor {
         subagentType,
         subagentKind: childPlan.kind,
         subagentAgentId: childAgentId,
+        graphMemberInputs:
+          childPlan.kind === 'graph' ? childPlan.memberInputs : undefined,
         childRunId,
         parentToolCallId,
         executionContext: childExecutionContext,
@@ -2588,6 +2590,7 @@ export class SubagentExecutor {
     subagentType: string;
     subagentKind: 'agent' | 'graph';
     subagentAgentId: string;
+    graphMemberInputs?: ReadonlyMap<string, AgentInputs>;
     childRunId: string;
     parentToolCallId?: string;
     executionContext: SubagentExecutionContext;
@@ -2597,12 +2600,14 @@ export class SubagentExecutor {
       subagentType,
       subagentKind,
       subagentAgentId,
+      graphMemberInputs,
       childRunId,
       parentToolCallId,
       executionContext,
     } = args;
     const immediateParentRunId = this.parentRunId;
     const parentAgentId = this.parentAgentId;
+    const memberAgentIdByStepId = new Map<string, string>();
 
     const wrap = async (
       eventName: string,
@@ -2709,7 +2714,14 @@ export class SubagentExecutor {
         metadata?: Record<string, unknown>
       ): Promise<void> => {
         const memberAgentId =
-          asNonEmptyString(metadata?.agentId) ?? getEventAgentId(data);
+          graphMemberInputs == null
+            ? (asNonEmptyString(metadata?.agentId) ?? getEventAgentId(data))
+            : getGraphEventMemberAgentId({
+              data,
+              metadata,
+              memberInputs: graphMemberInputs,
+              memberAgentIdByStepId,
+            });
         if (eventName === GraphEvents.ON_TOOL_EXECUTE) {
           const toolHandler = parentRegistry.getHandler(
             GraphEvents.ON_TOOL_EXECUTE
@@ -2925,6 +2937,52 @@ function getEventAgentId(data: unknown): string | undefined {
   return (
     asNonEmptyString(event.agentId) ?? asNonEmptyString(event.result?.agentId)
   );
+}
+
+function getEventStepId(data: unknown): string | undefined {
+  if (data == null || typeof data !== 'object') {
+    return undefined;
+  }
+  const event = data as {
+    id?: unknown;
+    result?: { id?: unknown };
+  };
+  return asNonEmptyString(event.id) ?? asNonEmptyString(event.result?.id);
+}
+
+function getGraphEventMemberAgentId({
+  data,
+  metadata,
+  memberInputs,
+  memberAgentIdByStepId,
+}: {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  memberInputs: ReadonlyMap<string, AgentInputs>;
+  memberAgentIdByStepId: Map<string, string>;
+}): string | undefined {
+  const eventAgentId = getEventAgentId(data);
+  const stepId = getEventStepId(data);
+  if (eventAgentId != null) {
+    if (!memberInputs.has(eventAgentId)) {
+      return undefined;
+    }
+    if (stepId != null) {
+      memberAgentIdByStepId.set(stepId, eventAgentId);
+    }
+    return eventAgentId;
+  }
+
+  const stepMemberAgentId =
+    stepId == null ? undefined : memberAgentIdByStepId.get(stepId);
+  if (stepMemberAgentId != null) {
+    return stepMemberAgentId;
+  }
+
+  const metadataAgentId = asNonEmptyString(metadata?.agentId);
+  return metadataAgentId != null && memberInputs.has(metadataAgentId)
+    ? metadataAgentId
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
I fixed graph-subagent progress envelopes so each update identifies the active configured graph member without changing single-agent forwarding or usage accounting.

- Prefer the sanitized event payload member identity over inherited callback metadata for graph subagents.
- Validate payload and metadata identities against the configured graph member map.
- Track member identity by run-step ID so message and reasoning deltas retain the member that created their step.
- Omit unknown or spoofed graph-member identities instead of leaking them through progress envelopes.
- Preserve metadata fallback when an event has no payload or step-local member identity.
- Add regression coverage for entry, worker, result, delta, fallback, spoofing, and lifecycle behavior.

Closes #401.
Linear: [AI-1734](https://linear.app/clickhouse/issue/AI-1734/fix-graph-subagent-progress-envelopes-to-attribute-the-active-member)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx tsc --noEmit`.
- Ran ESLint on the changed source and test files.
- Ran `npx jest src/tools/__tests__/SubagentExecutor.test.ts --runInBand`: 102 tests passed.
- Ran `npx jest graph-subagent langfuse deterministic-trace-id --runInBand`: 170 tests passed and 2 opt-in live tests were skipped.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js with the repository's existing dependencies
- Jest in serial mode
- Branch based on current `origin/main`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes