### PR TITLE
🌱 fix: Seed Sessions Into Subagent Graphs

### DIFF
--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1613,13 +1613,15 @@ describe('SubagentExecutor', () => {
   });
 
   it('combines member session seeds inside a selected graph child', async () => {
-    const makeSession = (id: string) => ({
-      session_id: `${id}-storage`,
+    const makeSession = (storageSessionId: string, includeFileSession = true) => ({
+      session_id: storageSessionId,
       files: [
         {
-          id,
-          name: `${id}.txt`,
-          storage_session_id: `${id}-storage`,
+          id: 'shared-file-id',
+          name: `${storageSessionId}.txt`,
+          ...(includeFileSession
+            ? { storage_session_id: storageSessionId }
+            : {}),
         },
       ],
       lastUpdated: 1,
@@ -1627,13 +1629,13 @@ describe('SubagentExecutor', () => {
     const first = {
       ...makeChildInputs('first'),
       initialSessions: new Map([
-        [Constants.EXECUTE_CODE, makeSession('first-file')],
+        [Constants.EXECUTE_CODE, makeSession('first-storage')],
       ]),
     };
     const second = {
       ...makeChildInputs('second'),
       initialSessions: new Map([
-        [Constants.EXECUTE_CODE, makeSession('second-file')],
+        [Constants.EXECUTE_CODE, makeSession('second-storage', false)],
       ]),
     };
     const graphConfig: GraphSubagentConfig = {
@@ -1651,8 +1653,11 @@ describe('SubagentExecutor', () => {
       expect(
         childSessions
           .get(Constants.EXECUTE_CODE)
-          ?.files?.map((file) => file.id)
-      ).toEqual(['first-file', 'second-file']);
+          ?.files?.map((file) => [file.id, file.storage_session_id])
+      ).toEqual([
+        ['shared-file-id', 'first-storage'],
+        ['shared-file-id', 'second-storage'],
+      ]);
       return {
         messages: [new AIMessage('done')],
         subagentResult: { agentId: 'second' },

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -10,6 +10,7 @@ import type {
   StandardGraphInput,
   SubagentUpdateEvent,
   SubagentUsageEvent,
+  ToolSessionMap,
   ToolExecuteBatchRequest,
   ToolExecuteResult,
 } from '@/types';
@@ -1534,6 +1535,248 @@ describe('SubagentExecutor', () => {
     expect(observedChildInputs).toBeDefined();
     expect(observedChildInputs!.subagentConfigs).toBeUndefined();
     expect(observedChildInputs!.maxSubagentDepth).toBeUndefined();
+  });
+
+  it('seeds only the selected single-agent child before its first invocation', async () => {
+    const selectedSession = {
+      session_id: 'selected-storage',
+      files: [
+        {
+          id: 'selected-file',
+          name: 'selected.txt',
+          storage_session_id: 'selected-storage',
+        },
+      ],
+      lastUpdated: 1,
+    };
+    const siblingSession = {
+      session_id: 'sibling-storage',
+      files: [
+        {
+          id: 'sibling-file',
+          name: 'sibling.txt',
+          storage_session_id: 'sibling-storage',
+        },
+      ],
+      lastUpdated: 1,
+    };
+    const selected = makeConfig('selected', {
+      agentInputs: {
+        ...makeChildInputs('selected-agent'),
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, selectedSession],
+        ]),
+      },
+    });
+    const sibling = makeConfig('sibling', {
+      agentInputs: {
+        ...makeChildInputs('sibling-agent'),
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, siblingSession],
+        ]),
+      },
+    });
+    const childSessions: ToolSessionMap = new Map();
+    const invoke = jest.fn(async () => {
+      expect(childSessions.get(Constants.EXECUTE_CODE)).toEqual(
+        selectedSession
+      );
+      expect(childSessions.get(Constants.EXECUTE_CODE)).not.toBe(
+        selectedSession
+      );
+      return { messages: [new AIMessage('done')] };
+    });
+    const executor = createExecutor({
+      configs: new Map([
+        [selected.type, selected],
+        [sibling.type, sibling],
+      ]),
+      createChildGraph: (): StandardGraph =>
+        ({
+          sessions: childSessions,
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    await executor.execute({
+      description: 'Use the selected file.',
+      subagentType: selected.type,
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(
+      childSessions
+        .get(Constants.EXECUTE_CODE)
+        ?.files?.some((file) => file.id === 'sibling-file')
+    ).toBe(false);
+  });
+
+  it('combines member session seeds inside a selected graph child', async () => {
+    const makeSession = (id: string) => ({
+      session_id: `${id}-storage`,
+      files: [
+        {
+          id,
+          name: `${id}.txt`,
+          storage_session_id: `${id}-storage`,
+        },
+      ],
+      lastUpdated: 1,
+    });
+    const first = {
+      ...makeChildInputs('first'),
+      initialSessions: new Map([
+        [Constants.EXECUTE_CODE, makeSession('first-file')],
+      ]),
+    };
+    const second = {
+      ...makeChildInputs('second'),
+      initialSessions: new Map([
+        [Constants.EXECUTE_CODE, makeSession('second-file')],
+      ]),
+    };
+    const graphConfig: GraphSubagentConfig = {
+      kind: 'graph',
+      type: 'graph-team',
+      name: 'Graph Team',
+      description: 'Runs a graph.',
+      agents: [first, second],
+      edges: [{ from: 'first', to: 'second', edgeType: 'direct' }],
+      entryAgentId: 'first',
+      resultAgentId: 'second',
+    };
+    const childSessions: ToolSessionMap = new Map();
+    const invoke = jest.fn(async () => {
+      expect(
+        childSessions
+          .get(Constants.EXECUTE_CODE)
+          ?.files?.map((file) => file.id)
+      ).toEqual(['first-file', 'second-file']);
+      return {
+        messages: [new AIMessage('done')],
+        subagentResult: { agentId: 'second' },
+      };
+    });
+    const childGraph = {
+      sessions: childSessions,
+      createWorkflow: () => ({ invoke }),
+      clearHeavyState: jest.fn(),
+    } as unknown as StandardGraph;
+    const executor = createExecutor({
+      configs: new Map([[graphConfig.type, graphConfig]]),
+      createChildGraphByKind: () => childGraph,
+    });
+
+    await executor.execute({
+      description: 'Use both files.',
+      subagentType: graphConfig.type,
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the child session across an in-memory HITL resume', async () => {
+    const seededSession = {
+      session_id: 'seed-storage',
+      files: [
+        {
+          id: 'seed-file',
+          name: 'seed.txt',
+          storage_session_id: 'seed-storage',
+        },
+      ],
+      lastUpdated: 1,
+    };
+    const hitlConfig = makeConfig('hitl-child', {
+      agentInputs: {
+        ...makeChildInputs('hitl-child'),
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, seededSession],
+        ]),
+      },
+    });
+    const childSessions: ToolSessionMap = new Map();
+    const childInterrupt = new GraphInterrupt([
+      {
+        id: 'approval-1',
+        value: {
+          type: 'tool_approval',
+          action_requests: [],
+          review_configs: [],
+        },
+      },
+    ]);
+    const invoke = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        const session = childSessions.get(Constants.EXECUTE_CODE)!;
+        childSessions.set(Constants.EXECUTE_CODE, {
+          ...session,
+          session_id: 'live-execution',
+          files: [
+            ...(session.files ?? []),
+            {
+              id: 'generated-file',
+              name: 'generated.txt',
+              storage_session_id: 'live-execution',
+            },
+          ],
+        });
+        throw childInterrupt;
+      })
+      .mockImplementationOnce(async () => {
+        expect(childSessions.get(Constants.EXECUTE_CODE)).toMatchObject({
+          session_id: 'live-execution',
+          files: [{ id: 'seed-file' }, { id: 'generated-file' }],
+        });
+        return { messages: [new AIMessage('resumed')] };
+      });
+    const executor = createExecutor({
+      configs: new Map([[hitlConfig.type, hitlConfig]]),
+      humanInTheLoop: { enabled: true },
+      checkpointer: new MemorySaver(),
+      createChildGraph: (): StandardGraph =>
+        ({
+          sessions: childSessions,
+          createWorkflow: () => ({
+            getState: jest.fn().mockResolvedValue({
+              values: {},
+              next: [],
+              tasks: [],
+            }),
+            invoke,
+          }),
+          getChildCheckpointThreadIds: jest.fn(() => []),
+          createSubagentResumeState: jest.fn(() => ({
+            toolCallSteps: [],
+            toolSessions: [],
+            toolNodes: [],
+            eagerToolUsage: [],
+            eagerToolSuppressions: [],
+          })),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const params = {
+      description: 'Pause and resume.',
+      subagentType: hitlConfig.type,
+      threadId: 'durable-parent',
+      parentToolCallId: 'call-hitl',
+    };
+
+    await expect(executor.execute(params)).rejects.toBeInstanceOf(
+      GraphInterrupt
+    );
+    const result = await executor.execute({
+      ...params,
+      parentConfigurable: {
+        __pregel_resume_map: { 'approval-1': [] },
+      },
+    });
+
+    expect(result.content).toBe('resumed');
+    expect(invoke).toHaveBeenCalledTimes(2);
   });
 
   describe('parentConfigurable inheritance', () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -60,6 +60,7 @@ import type {
   ToolApprovalInterruptPayload,
   ToolExecuteBatchRequest,
   ToolCallDelta,
+  ToolSessionContext,
   TokenCounter,
   ToolApprovalDecision,
   ToolApprovalDecisionMap,
@@ -144,6 +145,66 @@ const SUBAGENT_CONFIG_CHANGED_MESSAGE =
   'Subagent error: Subagent configuration changed since this execution was paused.';
 const SUBAGENT_INVOCATION_CHANGED_MESSAGE =
   'Subagent error: Subagent invocation changed for this execution.';
+
+function cloneToolSessionContext(
+  context: ToolSessionContext
+): ToolSessionContext {
+  return {
+    ...context,
+    ...(context.files == null
+      ? {}
+      : { files: context.files.map((file) => ({ ...file })) }),
+  };
+}
+
+function seedChildGraphSessions(
+  childGraph: StandardGraph,
+  agents: AgentInputs[]
+): void {
+  const seenFilesByTool = new Map<string, Set<string>>();
+  for (const agent of agents) {
+    if (agent.initialSessions == null) {
+      continue;
+    }
+    for (const [toolName, context] of agent.initialSessions) {
+      const existing = childGraph.sessions.get(toolName);
+      if (existing == null) {
+        const cloned = cloneToolSessionContext(context);
+        childGraph.sessions.set(toolName, cloned);
+        seenFilesByTool.set(
+          toolName,
+          new Set(
+            cloned.files?.map(
+              (file) => `${file.storage_session_id ?? ''}\0${file.id}`
+            ) ?? []
+          )
+        );
+        continue;
+      }
+      if (context.files == null || context.files.length === 0) {
+        continue;
+      }
+      const seenFiles =
+        seenFilesByTool.get(toolName) ??
+        new Set(
+          existing.files?.map(
+            (file) => `${file.storage_session_id ?? ''}\0${file.id}`
+          ) ?? []
+        );
+      const files = existing.files == null ? [] : [...existing.files];
+      for (const file of context.files) {
+        const key = `${file.storage_session_id ?? ''}\0${file.id}`;
+        if (seenFiles.has(key)) {
+          continue;
+        }
+        seenFiles.add(key);
+        files.push({ ...file });
+      }
+      seenFilesByTool.set(toolName, seenFiles);
+      childGraph.sessions.set(toolName, { ...existing, files });
+    }
+  }
+}
 
 async function dispatchObservationalSubagentUpdate(
   handler: EventHandler,
@@ -2131,6 +2192,9 @@ export class SubagentExecutor {
       });
     }
     childGraph ??= this.createChildGraph(childGraphInput);
+    if (cachedChildRun == null) {
+      seedChildGraphSessions(childGraph, childPlan.agents);
+    }
     let forwarding: ForwarderCallback | undefined;
     if (forwardingEnabled) {
       forwarding = this.createForwarderCallback({

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -153,7 +153,13 @@ function cloneToolSessionContext(
     ...context,
     ...(context.files == null
       ? {}
-      : { files: context.files.map((file) => ({ ...file })) }),
+      : {
+        files: context.files.map((file) => ({
+          ...file,
+          storage_session_id:
+              file.storage_session_id ?? context.session_id,
+        })),
+      }),
   };
 }
 
@@ -188,17 +194,20 @@ function seedChildGraphSessions(
         seenFilesByTool.get(toolName) ??
         new Set(
           existing.files?.map(
-            (file) => `${file.storage_session_id ?? ''}\0${file.id}`
+            (file) =>
+              `${file.storage_session_id ?? existing.session_id}\0${file.id}`
           ) ?? []
         );
       const files = existing.files == null ? [] : [...existing.files];
       for (const file of context.files) {
-        const key = `${file.storage_session_id ?? ''}\0${file.id}`;
+        const storageSessionId =
+          file.storage_session_id ?? context.session_id;
+        const key = `${storageSessionId}\0${file.id}`;
         if (seenFiles.has(key)) {
           continue;
         }
         seenFiles.add(key);
-        files.push({ ...file });
+        files.push({ ...file, storage_session_id: storageSessionId });
       }
       seenFilesByTool.set(toolName, seenFiles);
       childGraph.sessions.set(toolName, { ...existing, files });

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -19,6 +19,7 @@ import type {
 } from '@/types/summarize';
 import type {
   ToolMap,
+  ToolSessionMap,
   ToolEndEvent,
   GenericTool,
   LCTool,
@@ -848,6 +849,13 @@ export interface AgentInputs {
   subagentConfigs?: SubagentConfigEntry[];
   /** Maximum subagent nesting depth. Default 1 means top-level agents can spawn subagents but subagents cannot nest further. */
   maxSubagentDepth?: number;
+  /**
+   * Initial tool-session state owned by this agent when it runs as a
+   * subagent. The executor copies these sessions into the isolated child
+   * graph before its first invocation. Top-level runs continue to use
+   * `RunConfig.initialSessions`.
+   */
+  initialSessions?: ToolSessionMap;
   /**
    * Host-supplied tool instances that must execute IN-PROCESS inside the graph's
    * ToolNode even when the run is event-driven (`toolDefinitions` non-empty). Each


### PR DESCRIPTION
## Summary

I fixed primed code-file session propagation for isolated subagent child graphs and preserved child session state across graph members and HITL resume.

- Added an optional per-agent `initialSessions` contract for eager and lazily resolved subagent inputs.
- Seeded newly created child graph session maps before workflow creation and first invocation.
- Deep-copied session contexts and file references so parent and sibling graphs cannot share mutable session state.
- Combined and deduplicated session files from members of a selected graph subagent.
- Skipped reseeding active child graphs so HITL resume retains live execution sessions and generated files.
- Added regression coverage for single-agent isolation, graph-member merging, and in-memory HITL resume.

Fixes #402.
Linear: [AI-1738](https://linear.app/clickhouse/issue/AI-1738/seed-primed-code-file-sessions-into-subagent-child-graphs)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest SubagentExecutor Graph.subagentResumeState --runInBand` (155 tests passed).
- Ran `npx tsc --noEmit`.
- Ran scoped ESLint for all changed TypeScript files.
- Ran `git diff --check`.

### **Test Configuration**:

- macOS
- Node.js with the repository's existing dependencies
- Jest with `ts-jest`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where the lifecycle is non-obvious
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
