### PR TITLE
feat: support batched user questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "supervised": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/supervised.ts --provider anthropic --name Jo --location \"New York, NY\"",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:live:handoffs": "RUN_HANDOFF_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/agent-handoffs.live.test.ts --runInBand",
+    "test:live:ask-user-questions": "RUN_ASK_USER_QUESTIONS_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/ask-user-questions.live.test.ts --runInBand",
     "test:memory": "NODE_OPTIONS='--expose-gc' npx jest src/specs/title.memory-leak.test.ts",
     "test:all": "npm test -- --testPathIgnorePatterns=title.memory-leak.test.ts && npm run test:memory",
     "reinstall": "npm run clean && npm ci && rm -rf ./dist && npm run build",

--- a/src/hitl/askUserQuestions.ts
+++ b/src/hitl/askUserQuestions.ts
@@ -9,7 +9,7 @@ import type {
 import {
   ASK_USER_QUESTION_ID_PATTERN,
   MAX_ASK_USER_QUESTIONS,
-} from '@/types/hitl';
+} from './askUserQuestionsInterrupt';
 
 function validateQuestions(
   questions: readonly AskUserQuestionBatchItem[]

--- a/src/hitl/askUserQuestions.ts
+++ b/src/hitl/askUserQuestions.ts
@@ -6,9 +6,10 @@ import type {
   AskUserQuestionsRequest,
   AskUserQuestionsResolution,
 } from '@/types/hitl';
-
-/** Maximum questions supported by one batched clarification interaction. */
-export const MAX_ASK_USER_QUESTIONS = 4;
+import {
+  ASK_USER_QUESTION_ID_PATTERN,
+  MAX_ASK_USER_QUESTIONS,
+} from '@/types/hitl';
 
 function validateQuestions(
   questions: readonly AskUserQuestionBatchItem[]
@@ -24,9 +25,9 @@ function validateQuestions(
 
   const ids = new Set<string>();
   for (const question of questions) {
-    if (question.id.trim() === '') {
+    if (!ASK_USER_QUESTION_ID_PATTERN.test(question.id)) {
       throw new Error(
-        'askUserQuestions requires every question to have an id.'
+        'askUserQuestions requires each question id to match [A-Za-z][A-Za-z0-9_-]{0,63}.'
       );
     }
     if (ids.has(question.id)) {
@@ -37,6 +38,40 @@ function validateQuestions(
     ids.add(question.id);
   }
   return questions[0];
+}
+
+interface AskUserQuestionsResolutionCandidate {
+  answers?: unknown;
+}
+
+function validateResolution(
+  value: unknown,
+  questions: readonly AskUserQuestionBatchItem[]
+): AskUserQuestionsResolution {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError('askUserQuestions requires an answers object.');
+  }
+  const answers = (value as AskUserQuestionsResolutionCandidate).answers;
+  if (
+    typeof answers !== 'object' ||
+    answers === null ||
+    Array.isArray(answers)
+  ) {
+    throw new TypeError('askUserQuestions requires an answers object.');
+  }
+
+  const validated: Record<string, string> = {};
+  for (const question of questions) {
+    const descriptor = Object.getOwnPropertyDescriptor(answers, question.id);
+    const answer: unknown = descriptor?.value;
+    if (descriptor == null || typeof answer !== 'string') {
+      throw new TypeError(
+        `askUserQuestions requires a string answer for question id "${question.id}".`
+      );
+    }
+    validated[question.id] = answer;
+  }
+  return { answers: validated };
 }
 
 /**
@@ -78,8 +113,8 @@ export function askUserQuestions(
       options.toolCallId !== '' && { tool_call_id: options.toolCallId }),
   };
 
-  return interrupt<
-    AskUserQuestionsInterruptPayload,
-    AskUserQuestionsResolution
-  >(payload);
+  const resolution = interrupt<AskUserQuestionsInterruptPayload, unknown>(
+    payload
+  );
+  return validateResolution(resolution, request.questions);
 }

--- a/src/hitl/askUserQuestions.ts
+++ b/src/hitl/askUserQuestions.ts
@@ -1,0 +1,85 @@
+import { interrupt } from '@langchain/langgraph';
+import type {
+  AskUserQuestionBatchItem,
+  AskUserQuestionRequest,
+  AskUserQuestionsInterruptPayload,
+  AskUserQuestionsRequest,
+  AskUserQuestionsResolution,
+} from '@/types/hitl';
+
+/** Maximum questions supported by one batched clarification interaction. */
+export const MAX_ASK_USER_QUESTIONS = 4;
+
+function validateQuestions(
+  questions: readonly AskUserQuestionBatchItem[]
+): AskUserQuestionBatchItem {
+  if (questions.length === 0) {
+    throw new RangeError('askUserQuestions requires at least one question.');
+  }
+  if (questions.length > MAX_ASK_USER_QUESTIONS) {
+    throw new RangeError(
+      `askUserQuestions accepts at most ${MAX_ASK_USER_QUESTIONS} questions.`
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const question of questions) {
+    if (question.id.trim() === '') {
+      throw new Error(
+        'askUserQuestions requires every question to have an id.'
+      );
+    }
+    if (ids.has(question.id)) {
+      throw new Error(
+        `askUserQuestions requires unique question ids; received "${question.id}" more than once.`
+      );
+    }
+    ids.add(question.id);
+  }
+  return questions[0];
+}
+
+/**
+ * Suspend once to collect answers to several related questions. The first
+ * question is also included in the legacy `question` field so existing hosts
+ * can render a useful fallback during a staged rollout.
+ *
+ * Question ids must be non-empty and unique within the batch. The helper
+ * accepts at most four questions so hosts can render the interaction as one
+ * focused decision surface rather than an unbounded form.
+ *
+ * @example
+ * ```ts
+ * const { answers } = askUserQuestions({
+ *   questions: [
+ *     { id: 'environment', question: 'Which environment?' },
+ *     { id: 'region', question: 'Which region?' },
+ *   ],
+ * });
+ * return `Deploy to ${answers.environment} in ${answers.region}`;
+ * ```
+ */
+export function askUserQuestions(
+  request: AskUserQuestionsRequest,
+  options?: { toolCallId?: string }
+): AskUserQuestionsResolution {
+  const first = validateQuestions(request.questions);
+  const fallback: AskUserQuestionRequest = {
+    question: first.question,
+    ...(first.description != null && { description: first.description }),
+    ...(first.options != null && { options: first.options }),
+    ...(first.multiSelect != null && { multiSelect: first.multiSelect }),
+  };
+  const payload: AskUserQuestionsInterruptPayload = {
+    type: 'ask_user_question',
+    question: fallback,
+    questions: request.questions,
+    ...(options?.toolCallId != null &&
+      options.toolCallId !== '' && { tool_call_id: options.toolCallId }),
+  };
+
+  return interrupt<
+    AskUserQuestionsInterruptPayload,
+    AskUserQuestionsResolution
+  >(payload);
+}

--- a/src/hitl/askUserQuestions.ts
+++ b/src/hitl/askUserQuestions.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/types/hitl';
 import {
   ASK_USER_QUESTION_ID_PATTERN,
+  isAskUserQuestionRequest,
   MAX_ASK_USER_QUESTIONS,
 } from './askUserQuestionsInterrupt';
 
@@ -25,6 +26,11 @@ function validateQuestions(
 
   const ids = new Set<string>();
   for (const question of questions) {
+    if (!isAskUserQuestionRequest(question)) {
+      throw new TypeError(
+        'askUserQuestions requires each question and option to have valid string fields.'
+      );
+    }
     if (!ASK_USER_QUESTION_ID_PATTERN.test(question.id)) {
       throw new Error(
         'askUserQuestions requires each question id to match [A-Za-z][A-Za-z0-9_-]{0,63}.'

--- a/src/hitl/askUserQuestionsInterrupt.ts
+++ b/src/hitl/askUserQuestionsInterrupt.ts
@@ -1,0 +1,115 @@
+import type {
+  AskUserQuestionBatchItem,
+  AskUserQuestionOption,
+  AskUserQuestionRequest,
+  AskUserQuestionsInterruptPayload,
+} from '@/types/hitl';
+import { isAskUserQuestionInterrupt } from '@/types/hitl';
+
+/** Maximum questions supported by one batched clarification interaction. */
+export const MAX_ASK_USER_QUESTIONS = 4;
+
+/** Safe identifier format for answer-map keys in a batched question. */
+export const ASK_USER_QUESTION_ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+
+interface AskUserQuestionOptionCandidate {
+  label?: unknown;
+  value?: unknown;
+}
+
+interface AskUserQuestionCandidate {
+  question?: unknown;
+  description?: unknown;
+  options?: unknown;
+  multiSelect?: unknown;
+}
+
+interface AskUserQuestionBatchItemCandidate extends AskUserQuestionCandidate {
+  id?: unknown;
+  header?: unknown;
+}
+
+function isAskUserQuestionOption(
+  value: unknown
+): value is AskUserQuestionOption {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const option = value as AskUserQuestionOptionCandidate;
+  return typeof option.label === 'string' && typeof option.value === 'string';
+}
+
+function isAskUserQuestionOptions(
+  value: unknown
+): value is AskUserQuestionOption[] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  for (let index = 0; index < value.length; index++) {
+    if (!Object.hasOwn(value, index) || !isAskUserQuestionOption(value[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isAskUserQuestionRequest(
+  value: unknown
+): value is AskUserQuestionRequest {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const question = value as AskUserQuestionCandidate;
+  return (
+    typeof question.question === 'string' &&
+    (question.description === undefined ||
+      typeof question.description === 'string') &&
+    (question.options === undefined ||
+      isAskUserQuestionOptions(question.options)) &&
+    (question.multiSelect === undefined ||
+      typeof question.multiSelect === 'boolean')
+  );
+}
+
+function isAskUserQuestionBatchItem(
+  value: unknown
+): value is AskUserQuestionBatchItem {
+  if (!isAskUserQuestionRequest(value)) {
+    return false;
+  }
+  const question = value as AskUserQuestionBatchItemCandidate;
+  return (
+    typeof question.id === 'string' &&
+    ASK_USER_QUESTION_ID_PATTERN.test(question.id) &&
+    (question.header === undefined || typeof question.header === 'string')
+  );
+}
+
+/**
+ * Type guard for the batched form of an `ask_user_question` interrupt. Hosts
+ * use this to select the multi-question UI and `AskUserQuestionsResolution`.
+ */
+export function isAskUserQuestionsInterrupt(
+  payload: unknown
+): payload is AskUserQuestionsInterruptPayload {
+  if (
+    !isAskUserQuestionInterrupt(payload) ||
+    !isAskUserQuestionRequest(payload.question) ||
+    (payload.tool_call_id !== undefined &&
+      typeof payload.tool_call_id !== 'string') ||
+    !Array.isArray(payload.questions) ||
+    payload.questions.length === 0 ||
+    payload.questions.length > MAX_ASK_USER_QUESTIONS
+  ) {
+    return false;
+  }
+
+  const ids = new Set<string>();
+  for (const question of payload.questions) {
+    if (!isAskUserQuestionBatchItem(question) || ids.has(question.id)) {
+      return false;
+    }
+    ids.add(question.id);
+  }
+  return true;
+}

--- a/src/hitl/askUserQuestionsInterrupt.ts
+++ b/src/hitl/askUserQuestionsInterrupt.ts
@@ -53,7 +53,7 @@ function isAskUserQuestionOptions(
   return true;
 }
 
-function isAskUserQuestionRequest(
+export function isAskUserQuestionRequest(
   value: unknown
 ): value is AskUserQuestionRequest {
   if (typeof value !== 'object' || value === null) {

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { askUserQuestion } from './askUserQuestion';
+export { askUserQuestions, MAX_ASK_USER_QUESTIONS } from './askUserQuestions';

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -5,4 +5,4 @@
  */
 
 export { askUserQuestion } from './askUserQuestion';
-export { askUserQuestions, MAX_ASK_USER_QUESTIONS } from './askUserQuestions';
+export { askUserQuestions } from './askUserQuestions';

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -7,6 +7,7 @@
 export { askUserQuestion } from './askUserQuestion';
 export { askUserQuestions } from './askUserQuestions';
 export {
+  ASK_USER_QUESTION_ID_PATTERN,
   isAskUserQuestionsInterrupt,
   MAX_ASK_USER_QUESTIONS,
 } from './askUserQuestionsInterrupt';

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -9,4 +9,4 @@ export { askUserQuestions } from './askUserQuestions';
 export {
   isAskUserQuestionsInterrupt,
   MAX_ASK_USER_QUESTIONS,
-} from '@/types/hitl';
+} from './askUserQuestionsInterrupt';

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -6,4 +6,7 @@
 
 export { askUserQuestion } from './askUserQuestion';
 export { askUserQuestions } from './askUserQuestions';
-export { isAskUserQuestionsInterrupt } from '@/types/hitl';
+export {
+  isAskUserQuestionsInterrupt,
+  MAX_ASK_USER_QUESTIONS,
+} from '@/types/hitl';

--- a/src/hitl/index.ts
+++ b/src/hitl/index.ts
@@ -6,3 +6,4 @@
 
 export { askUserQuestion } from './askUserQuestion';
 export { askUserQuestions } from './askUserQuestions';
+export { isAskUserQuestionsInterrupt } from '@/types/hitl';

--- a/src/specs/ask-user-questions.live.test.ts
+++ b/src/specs/ask-user-questions.live.test.ts
@@ -42,9 +42,13 @@ const questionSchema = z.object({
     .max(3),
   multiSelect: z.boolean(),
 });
+const askUserQuestionsSchema = z.object({
+  questions: z.array(questionSchema).length(2),
+});
+type AskUserQuestionsInput = z.infer<typeof askUserQuestionsSchema>;
 
 const askTool = tool(
-  async (input: t.AskUserQuestionsRequest, config) => {
+  async (input: AskUserQuestionsInput, config) => {
     const resolution = askUserQuestions(input, {
       toolCallId: config.toolCall?.id,
     });
@@ -54,7 +58,7 @@ const askTool = tool(
     name: 'ask_user_question',
     description:
       'Ask the user one to four related questions in one interaction. Put every question in this single tool call.',
-    schema: z.object({ questions: z.array(questionSchema).length(2) }),
+    schema: askUserQuestionsSchema,
   }
 );
 

--- a/src/specs/ask-user-questions.live.test.ts
+++ b/src/specs/ask-user-questions.live.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Live proof that Anthropic can produce one tool call containing several
+ * questions, pause once, and continue from one keyed batch resolution.
+ *
+ * Run with:
+ * RUN_ASK_USER_QUESTIONS_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- ask-user-questions.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig(
+  process.env.DOTENV_CONFIG_PATH != null
+    ? { path: process.env.DOTENV_CONFIG_PATH }
+    : undefined
+);
+
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { MemorySaver } from '@langchain/langgraph';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { askUserQuestions } from '@/hitl';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_ASK_USER_QUESTIONS_LIVE_TESTS === '1' &&
+  process.env.ANTHROPIC_API_KEY != null &&
+  process.env.ANTHROPIC_API_KEY !== '';
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+const modelName =
+  process.env.ANTHROPIC_BATCH_QUESTIONS_LIVE_MODEL ?? 'claude-sonnet-5';
+
+const questionSchema = z.object({
+  id: z.enum(['metric', 'window']),
+  header: z.string().max(20),
+  question: z.string(),
+  options: z
+    .array(z.object({ label: z.string().max(120), value: z.string() }))
+    .min(2)
+    .max(3),
+  multiSelect: z.boolean(),
+});
+
+const askTool = tool(
+  async (input: t.AskUserQuestionsRequest, config) => {
+    const resolution = askUserQuestions(input, {
+      toolCallId: config.toolCall?.id,
+    });
+    return JSON.stringify(resolution);
+  },
+  {
+    name: 'ask_user_question',
+    description:
+      'Ask the user one to four related questions in one interaction. Put every question in this single tool call.',
+    schema: z.object({ questions: z.array(questionSchema).length(2) }),
+  }
+);
+
+type LiveStreamConfig = Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+};
+
+function streamConfig(threadId: string): LiveStreamConfig {
+  return {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2',
+  };
+}
+
+function messageText(message: BaseMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  if (!Array.isArray(message.content)) {
+    return '';
+  }
+  return message.content
+    .map((part) =>
+      typeof part === 'object' &&
+      'text' in part &&
+      typeof part.text === 'string'
+        ? part.text
+        : ''
+    )
+    .join('');
+}
+
+describeIfLive('askUserQuestions live Anthropic integration', () => {
+  jest.setTimeout(120_000);
+
+  it('uses one batched call and continues after one composite answer', async () => {
+    const nonce = `batch-questions-${Date.now()}`;
+    const saver = new MemorySaver();
+    const run = await Run.create<t.IState>({
+      runId: `${nonce}-run`,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'clarifier',
+            provider: Providers.ANTHROPIC,
+            clientOptions: {
+              modelName,
+              apiKey: process.env.ANTHROPIC_API_KEY,
+              maxTokens: 512,
+              streaming: true,
+            },
+            instructions: `You are testing a batched clarification tool.
+On the first turn, call ask_user_question exactly once. In that one call, ask exactly two questions:
+- id "metric": whether to analyze "workload" or "website"
+- id "window": whether to analyze "24h" or "7d"
+Do not emit two tool calls and do not answer in prose before the tool result.
+After the tool returns, reply exactly: LIVE_BATCH_OK metric=<metric>; window=<window>`,
+            maxContextTokens: 8000,
+            graphTools: [askTool],
+          },
+        ],
+        compileOptions: { checkpointer: saver },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      interruptingToolNames: ['ask_user_question'],
+    });
+    const config = streamConfig(`${nonce}-thread`);
+
+    await run.processStream(
+      {
+        messages: [
+          new HumanMessage(
+            'Clarify both dimensions before doing any analysis.'
+          ),
+        ],
+      },
+      config
+    );
+
+    const pending = run.getInterrupt();
+    expect(pending?.payload.type).toBe('ask_user_question');
+    if (pending?.payload.type !== 'ask_user_question') {
+      throw new Error('expected ask_user_question interrupt');
+    }
+    expect(pending.payload.questions).toHaveLength(2);
+    expect(pending.payload.questions?.map(({ id }) => id)).toEqual([
+      'metric',
+      'window',
+    ]);
+
+    await run.resume<t.AskUserQuestionsResolution>(
+      { answers: { metric: 'workload', window: '7d' } },
+      config
+    );
+
+    expect(run.getInterrupt()).toBeUndefined();
+    const messages = run.getRunMessages() ?? [];
+    const askCalls = messages.flatMap((message) => {
+      if (message.getType() !== 'ai') {
+        return [];
+      }
+      return ((message as AIMessage).tool_calls ?? []).filter(
+        ({ name }) => name === 'ask_user_question'
+      );
+    });
+    expect(askCalls).toHaveLength(1);
+    expect(askCalls[0].args).toMatchObject({
+      questions: expect.arrayContaining([
+        expect.objectContaining({ id: 'metric' }),
+        expect.objectContaining({ id: 'window' }),
+      ]),
+    });
+
+    const finalText = messages
+      .filter((message) => message.getType() === 'ai')
+      .map(messageText)
+      .join('\n');
+    expect(finalText).toContain('LIVE_BATCH_OK metric=workload; window=7d');
+  });
+});

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -53,10 +53,14 @@ const questionSchema = z.object({
     .array(z.object({ label: z.string(), value: z.string() }))
     .optional(),
 });
+const askUserQuestionsSchema = z.object({
+  questions: z.array(questionSchema).min(1).max(MAX_ASK_USER_QUESTIONS),
+});
+type AskUserQuestionsInput = z.infer<typeof askUserQuestionsSchema>;
 
 function buildGraph(): CompiledMessagesGraph {
   const askTool = tool(
-    async (input: t.AskUserQuestionsRequest, config) => {
+    async (input: AskUserQuestionsInput, config) => {
       const resolution = askUserQuestions(input, {
         toolCallId: config.toolCall?.id,
       });
@@ -65,7 +69,7 @@ function buildGraph(): CompiledMessagesGraph {
     {
       name: 'ask_user_question',
       description: 'Ask several related questions in one interaction.',
-      schema: z.object({ questions: z.array(questionSchema).min(1).max(4) }),
+      schema: askUserQuestionsSchema,
     }
   ) as unknown as StructuredToolInterface;
   const node = new ToolNode({

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -14,6 +14,7 @@ import {
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
+  ASK_USER_QUESTION_ID_PATTERN,
   askUserQuestions,
   isAskUserQuestionsInterrupt,
   MAX_ASK_USER_QUESTIONS,
@@ -43,7 +44,7 @@ const questions = [
 ] satisfies t.AskUserQuestionBatchItem[];
 
 const questionSchema = z.object({
-  id: z.string(),
+  id: z.string().regex(ASK_USER_QUESTION_ID_PATTERN),
   header: z.string().optional(),
   question: z.string(),
   options: z

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, expect, it } from '@jest/globals';
+import {
+  END,
+  START,
+  Command,
+  StateGraph,
+  MemorySaver,
+  isInterrupted,
+  MessagesAnnotation,
+} from '@langchain/langgraph';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import { askUserQuestions, MAX_ASK_USER_QUESTIONS } from '@/hitl';
+import { isAskUserQuestionsInterrupt } from '@/types/hitl';
+import { ToolNode } from '@/tools/ToolNode';
+
+type MessagesUpdate = { messages: BaseMessage[] };
+type CompiledMessagesGraph = Runnable<unknown, MessagesUpdate> & {
+  invoke(input: unknown, config?: RunnableConfig): Promise<unknown>;
+};
+
+const questions = [
+  {
+    id: 'metric',
+    header: 'Metric',
+    question: 'Which performance cost should be analyzed?',
+    options: [
+      { label: 'ClickHouse workload', value: 'workload' },
+      { label: 'Website experience', value: 'website' },
+    ],
+  },
+  {
+    id: 'window',
+    header: 'Window',
+    question: 'Which time window should be used?',
+    options: [
+      { label: 'Last 24 hours', value: '24h' },
+      { label: 'Last 7 days', value: '7d' },
+    ],
+  },
+] satisfies t.AskUserQuestionBatchItem[];
+
+const questionSchema = z.object({
+  id: z.string(),
+  header: z.string().optional(),
+  question: z.string(),
+  options: z
+    .array(z.object({ label: z.string(), value: z.string() }))
+    .optional(),
+});
+
+function buildGraph(): CompiledMessagesGraph {
+  const askTool = tool(
+    async (input: t.AskUserQuestionsRequest, config) => {
+      const resolution = askUserQuestions(input, {
+        toolCallId: config.toolCall?.id,
+      });
+      return JSON.stringify(resolution);
+    },
+    {
+      name: 'ask_user_question',
+      description: 'Ask several related questions in one interaction.',
+      schema: z.object({ questions: z.array(questionSchema).min(1).max(4) }),
+    }
+  ) as unknown as StructuredToolInterface;
+  const node = new ToolNode({
+    tools: [askTool],
+    directToolNames: new Set(['ask_user_question']),
+    interruptingToolNames: new Set(['ask_user_question']),
+  });
+
+  return new StateGraph(MessagesAnnotation)
+    .addNode(
+      'agent',
+      (): MessagesUpdate => ({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'batched-ask-call',
+                name: 'ask_user_question',
+                args: { questions },
+              },
+            ],
+          }),
+        ],
+      })
+    )
+    .addNode('tools', node)
+    .addEdge(START, 'agent')
+    .addEdge('agent', 'tools')
+    .addEdge('tools', END)
+    .compile({
+      checkpointer: new MemorySaver(),
+    }) as unknown as CompiledMessagesGraph;
+}
+
+describe('askUserQuestions', () => {
+  it('pauses once for a batch and resumes with keyed answers', async () => {
+    const graph = buildGraph();
+    const config = { configurable: { thread_id: 'batched-questions' } };
+
+    const first = await graph.invoke({ messages: [] }, config);
+    expect(isInterrupted<t.HumanInterruptPayload>(first)).toBe(true);
+    if (!isInterrupted<t.HumanInterruptPayload>(first)) {
+      throw new Error('expected batched question interrupt');
+    }
+    expect(first.__interrupt__).toHaveLength(1);
+    const payload = first.__interrupt__[0].value;
+    expect(isAskUserQuestionsInterrupt(payload)).toBe(true);
+    expect(payload).toMatchObject({
+      type: 'ask_user_question',
+      tool_call_id: 'batched-ask-call',
+      question: { question: questions[0].question },
+      questions,
+    });
+
+    const answers: t.AskUserQuestionsResolution = {
+      answers: { metric: 'workload', window: '7d' },
+    };
+    const second = (await graph.invoke(
+      new Command({ resume: answers }),
+      config
+    )) as MessagesUpdate;
+    const result = second.messages.find(
+      (message): message is ToolMessage =>
+        message.getType() === 'tool' &&
+        (message as ToolMessage).name === 'ask_user_question'
+    );
+    expect(result).toBeDefined();
+    expect(JSON.parse(String(result!.content))).toEqual(answers);
+  });
+
+  it('rejects duplicate question ids before raising an interrupt', () => {
+    const request: t.AskUserQuestionsRequest = {
+      questions: [questions[0], { ...questions[1], id: questions[0].id }],
+    };
+
+    expect(() => askUserQuestions(request)).toThrow(
+      'requires unique question ids'
+    );
+  });
+
+  it('distinguishes singular ask payloads from batched payloads', () => {
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+      })
+    ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: [],
+      })
+    ).toBe(false);
+  });
+
+  it('rejects empty question ids before raising an interrupt', () => {
+    const request: t.AskUserQuestionsRequest = {
+      questions: [{ ...questions[0], id: '  ' }],
+    };
+
+    expect(() => askUserQuestions(request)).toThrow(
+      'requires every question to have an id'
+    );
+  });
+
+  it('rejects batches larger than four questions', () => {
+    expect(MAX_ASK_USER_QUESTIONS).toBe(4);
+    const request: t.AskUserQuestionsRequest = {
+      questions: [
+        questions[0],
+        questions[1],
+        { ...questions[0], id: 'third' },
+        { ...questions[0], id: 'fourth' },
+        { ...questions[0], id: 'fifth' },
+      ],
+    };
+
+    expect(() => askUserQuestions(request)).toThrow(
+      'accepts at most 4 questions'
+    );
+  });
+});

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -15,11 +15,8 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { askUserQuestions } from '@/hitl';
-import {
-  isAskUserQuestionsInterrupt,
-  MAX_ASK_USER_QUESTIONS,
-} from '@/types/hitl';
+import { askUserQuestions, isAskUserQuestionsInterrupt } from '@/hitl';
+import { MAX_ASK_USER_QUESTIONS } from '@/types/hitl';
 import { ToolNode } from '@/tools/ToolNode';
 
 type MessagesUpdate = { messages: BaseMessage[] };

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -15,8 +15,11 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { askUserQuestions, isAskUserQuestionsInterrupt } from '@/hitl';
-import { MAX_ASK_USER_QUESTIONS } from '@/types/hitl';
+import {
+  askUserQuestions,
+  isAskUserQuestionsInterrupt,
+  MAX_ASK_USER_QUESTIONS,
+} from '@/hitl';
 import { ToolNode } from '@/tools/ToolNode';
 
 type MessagesUpdate = { messages: BaseMessage[] };

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import { describe, expect, it } from '@jest/globals';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import {
   END,
   START,
@@ -12,8 +12,6 @@ import {
   MessagesAnnotation,
 } from '@langchain/langgraph';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
-import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
   askUserQuestions,
@@ -23,10 +21,6 @@ import {
 import { ToolNode } from '@/tools/ToolNode';
 
 type MessagesUpdate = { messages: BaseMessage[] };
-type CompiledMessagesGraph = Runnable<unknown, MessagesUpdate> & {
-  invoke(input: unknown, config?: RunnableConfig): Promise<unknown>;
-};
-
 const questions = [
   {
     id: 'metric',
@@ -61,7 +55,7 @@ const askUserQuestionsSchema = z.object({
 });
 type AskUserQuestionsInput = z.infer<typeof askUserQuestionsSchema>;
 
-function buildGraph(): CompiledMessagesGraph {
+function buildGraph() {
   const askTool = tool(
     async (input: AskUserQuestionsInput, config) => {
       const resolution = askUserQuestions(input, {
@@ -74,7 +68,7 @@ function buildGraph(): CompiledMessagesGraph {
       description: 'Ask several related questions in one interaction.',
       schema: askUserQuestionsSchema,
     }
-  ) as unknown as StructuredToolInterface;
+  );
   const node = new ToolNode({
     tools: [askTool],
     directToolNames: new Set(['ask_user_question']),
@@ -105,7 +99,7 @@ function buildGraph(): CompiledMessagesGraph {
     .addEdge('tools', END)
     .compile({
       checkpointer: new MemorySaver(),
-    }) as unknown as CompiledMessagesGraph;
+    });
 }
 
 describe('askUserQuestions', () => {
@@ -155,6 +149,9 @@ describe('askUserQuestions', () => {
   });
 
   it('distinguishes singular ask payloads from batched payloads', () => {
+    const sparseOptions: unknown[] = [];
+    sparseOptions.length = 2;
+
     expect(
       isAskUserQuestionsInterrupt({
         type: 'ask_user_question',
@@ -204,6 +201,19 @@ describe('askUserQuestions', () => {
             id: 'choice',
             question: 'Choose?',
             options: [{ label: 'Missing value' }],
+          },
+        ],
+      })
+    ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: [
+          {
+            id: 'choice',
+            question: 'Choose?',
+            options: sparseOptions,
           },
         ],
       })

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -15,8 +15,11 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { askUserQuestions, MAX_ASK_USER_QUESTIONS } from '@/hitl';
-import { isAskUserQuestionsInterrupt } from '@/types/hitl';
+import { askUserQuestions } from '@/hitl';
+import {
+  isAskUserQuestionsInterrupt,
+  MAX_ASK_USER_QUESTIONS,
+} from '@/types/hitl';
 import { ToolNode } from '@/tools/ToolNode';
 
 type MessagesUpdate = { messages: BaseMessage[] };
@@ -165,6 +168,67 @@ describe('askUserQuestions', () => {
         questions: [],
       })
     ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: [null],
+      })
+    ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: [{ id: '__proto__', question: 'Unsafe key?' }],
+      })
+    ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: Array.from(
+          { length: MAX_ASK_USER_QUESTIONS + 1 },
+          (_, index) => ({
+            id: `question-${index}`,
+            question: `Question ${index}?`,
+          })
+        ),
+      })
+    ).toBe(false);
+    expect(
+      isAskUserQuestionsInterrupt({
+        type: 'ask_user_question',
+        question: { question: 'Proceed?' },
+        questions: [
+          {
+            id: 'choice',
+            question: 'Choose?',
+            options: [{ label: 'Missing value' }],
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('returns a tool error when a resumed batch omits an answer', async () => {
+    const graph = buildGraph();
+    const config = { configurable: { thread_id: 'incomplete-answers' } };
+
+    await graph.invoke({ messages: [] }, config);
+    const resumed = (await graph.invoke(
+      new Command({ resume: { answers: { metric: 'workload' } } }),
+      config
+    )) as MessagesUpdate;
+    const result = resumed.messages.find(
+      (message): message is ToolMessage =>
+        message.getType() === 'tool' &&
+        (message as ToolMessage).name === 'ask_user_question'
+    );
+
+    expect(result?.status).toBe('error');
+    expect(String(result?.content)).toContain(
+      'requires a string answer for question id "window"'
+    );
   });
 
   it('rejects empty question ids before raising an interrupt', () => {
@@ -173,7 +237,17 @@ describe('askUserQuestions', () => {
     };
 
     expect(() => askUserQuestions(request)).toThrow(
-      'requires every question to have an id'
+      'requires each question id to match'
+    );
+  });
+
+  it('rejects unsafe answer-map keys before raising an interrupt', () => {
+    const request: t.AskUserQuestionsRequest = {
+      questions: [{ ...questions[0], id: '__proto__' }],
+    };
+
+    expect(() => askUserQuestions(request)).toThrow(
+      'requires each question id to match'
     );
   });
 

--- a/src/specs/ask-user-questions.test.ts
+++ b/src/specs/ask-user-questions.test.ts
@@ -261,6 +261,18 @@ describe('askUserQuestions', () => {
     );
   });
 
+  it('rejects sparse option arrays before raising an interrupt', () => {
+    const sparseOptions: t.AskUserQuestionOption[] = [];
+    sparseOptions.length = 2;
+    const request: t.AskUserQuestionsRequest = {
+      questions: [{ ...questions[0], options: sparseOptions }],
+    };
+
+    expect(() => askUserQuestions(request)).toThrow(
+      'requires each question and option to have valid string fields'
+    );
+  });
+
   it('rejects batches larger than four questions', () => {
     expect(MAX_ASK_USER_QUESTIONS).toBe(4);
     const request: t.AskUserQuestionsRequest = {

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -175,7 +175,7 @@ export interface AskUserQuestionBatchItem extends AskUserQuestionRequest {
 
 /** Input shape for one tool call that asks one to four questions together. */
 export interface AskUserQuestionsRequest {
-  questions: [AskUserQuestionBatchItem, ...AskUserQuestionBatchItem[]];
+  questions: AskUserQuestionBatchItem[];
 }
 
 /**

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -165,15 +165,37 @@ export interface AskUserQuestionRequest {
   multiSelect?: boolean;
 }
 
+/** One independently answerable question in a batched question request. */
+export interface AskUserQuestionBatchItem extends AskUserQuestionRequest {
+  /** Non-empty, batch-unique key used to correlate the answer on resume. */
+  id: string;
+  /** Optional short heading rendered above the question. */
+  header?: string;
+}
+
+/** Input shape for one tool call that asks one to four questions together. */
+export interface AskUserQuestionsRequest {
+  questions: [AskUserQuestionBatchItem, ...AskUserQuestionBatchItem[]];
+}
+
 /**
  * Structured payload the SDK passes to `interrupt()` when an agent (or
  * a custom node) needs to ask the user a clarifying question. Mirrors
- * Claude Code's `AskUserQuestion` semantic. Resume value:
- * `AskUserQuestionResolution`.
+ * Claude Code's `AskUserQuestion` semantic. Resume value is
+ * `AskUserQuestionResolution` for a single question, or
+ * `AskUserQuestionsResolution` when `questions` is present.
  */
 export interface AskUserQuestionInterruptPayload {
   type: 'ask_user_question';
+  /**
+   * Single-question request, or the first question as a compatibility
+   * fallback when `questions` contains a batch. This lets existing hosts show
+   * a useful preview during a staged rollout, but they must support `questions`
+   * and `AskUserQuestionsResolution` before enabling a batched tool schema.
+   */
   question: AskUserQuestionRequest;
+  /** One to four questions collected by one `ask_user_question` tool call. */
+  questions?: AskUserQuestionsRequest['questions'];
   /**
    * The `tool_call_id` of the ask-tool call that raised this interrupt,
    * when the tool body supplied it (see `askUserQuestion`'s `options`).
@@ -182,6 +204,12 @@ export interface AskUserQuestionInterruptPayload {
    * mislabels cards when a model emits several ask calls in one turn.
    */
   tool_call_id?: string;
+}
+
+/** Batch-specialized ask payload for hosts that render several questions. */
+export interface AskUserQuestionsInterruptPayload
+  extends AskUserQuestionInterruptPayload {
+  questions: AskUserQuestionsRequest['questions'];
 }
 
 /**
@@ -205,6 +233,12 @@ export interface AskUserQuestionResolution {
    * host docs for what your downstream consumer expects.
    */
   answer: string;
+}
+
+/** Resume value for a batched `ask_user_question` interrupt. */
+export interface AskUserQuestionsResolution {
+  /** Human answers keyed by each `AskUserQuestionBatchItem.id`. */
+  answers: Record<string, string>;
 }
 
 /**
@@ -236,6 +270,20 @@ export function isAskUserQuestionInterrupt(
     typeof payload === 'object' &&
     payload !== null &&
     (payload as { type?: unknown }).type === 'ask_user_question'
+  );
+}
+
+/**
+ * Type guard for the batched form of an `ask_user_question` interrupt. Hosts
+ * use this to select the multi-question UI and `AskUserQuestionsResolution`.
+ */
+export function isAskUserQuestionsInterrupt(
+  payload: unknown
+): payload is AskUserQuestionsInterruptPayload {
+  return (
+    isAskUserQuestionInterrupt(payload) &&
+    Array.isArray(payload.questions) &&
+    payload.questions.length > 0
   );
 }
 

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -173,12 +173,6 @@ export interface AskUserQuestionBatchItem extends AskUserQuestionRequest {
   header?: string;
 }
 
-/** Maximum questions supported by one batched clarification interaction. */
-export const MAX_ASK_USER_QUESTIONS = 4;
-
-/** Safe identifier format for answer-map keys in a batched question. */
-export const ASK_USER_QUESTION_ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
-
 /** Input shape for one tool call that asks one to four questions together. */
 export interface AskUserQuestionsRequest {
   questions: AskUserQuestionBatchItem[];
@@ -277,108 +271,6 @@ export function isAskUserQuestionInterrupt(
     payload !== null &&
     (payload as { type?: unknown }).type === 'ask_user_question'
   );
-}
-
-interface AskUserQuestionOptionCandidate {
-  label?: unknown;
-  value?: unknown;
-}
-
-interface AskUserQuestionCandidate {
-  question?: unknown;
-  description?: unknown;
-  options?: unknown;
-  multiSelect?: unknown;
-}
-
-interface AskUserQuestionBatchItemCandidate extends AskUserQuestionCandidate {
-  id?: unknown;
-  header?: unknown;
-}
-
-function isAskUserQuestionOption(
-  value: unknown
-): value is AskUserQuestionOption {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const option = value as AskUserQuestionOptionCandidate;
-  return typeof option.label === 'string' && typeof option.value === 'string';
-}
-
-function isAskUserQuestionOptions(
-  value: unknown
-): value is AskUserQuestionOption[] {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  for (let index = 0; index < value.length; index++) {
-    if (!Object.hasOwn(value, index) || !isAskUserQuestionOption(value[index])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function isAskUserQuestionRequest(
-  value: unknown
-): value is AskUserQuestionRequest {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const question = value as AskUserQuestionCandidate;
-  return (
-    typeof question.question === 'string' &&
-    (question.description === undefined ||
-      typeof question.description === 'string') &&
-    (question.options === undefined ||
-      isAskUserQuestionOptions(question.options)) &&
-    (question.multiSelect === undefined ||
-      typeof question.multiSelect === 'boolean')
-  );
-}
-
-function isAskUserQuestionBatchItem(
-  value: unknown
-): value is AskUserQuestionBatchItem {
-  if (!isAskUserQuestionRequest(value)) {
-    return false;
-  }
-  const question = value as AskUserQuestionBatchItemCandidate;
-  return (
-    typeof question.id === 'string' &&
-    ASK_USER_QUESTION_ID_PATTERN.test(question.id) &&
-    (question.header === undefined || typeof question.header === 'string')
-  );
-}
-
-/**
- * Type guard for the batched form of an `ask_user_question` interrupt. Hosts
- * use this to select the multi-question UI and `AskUserQuestionsResolution`.
- */
-export function isAskUserQuestionsInterrupt(
-  payload: unknown
-): payload is AskUserQuestionsInterruptPayload {
-  if (
-    !isAskUserQuestionInterrupt(payload) ||
-    !isAskUserQuestionRequest(payload.question) ||
-    (payload.tool_call_id !== undefined &&
-      typeof payload.tool_call_id !== 'string') ||
-    !Array.isArray(payload.questions) ||
-    payload.questions.length === 0 ||
-    payload.questions.length > MAX_ASK_USER_QUESTIONS
-  ) {
-    return false;
-  }
-
-  const ids = new Set<string>();
-  for (const question of payload.questions) {
-    if (!isAskUserQuestionBatchItem(question) || ids.has(question.id)) {
-      return false;
-    }
-    ids.add(question.id);
-  }
-  return true;
 }
 
 /**

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -167,11 +167,17 @@ export interface AskUserQuestionRequest {
 
 /** One independently answerable question in a batched question request. */
 export interface AskUserQuestionBatchItem extends AskUserQuestionRequest {
-  /** Non-empty, batch-unique key used to correlate the answer on resume. */
+  /** Batch-unique identifier (`[A-Za-z][A-Za-z0-9_-]{0,63}`). */
   id: string;
   /** Optional short heading rendered above the question. */
   header?: string;
 }
+
+/** Maximum questions supported by one batched clarification interaction. */
+export const MAX_ASK_USER_QUESTIONS = 4;
+
+/** Safe identifier format for answer-map keys in a batched question. */
+export const ASK_USER_QUESTION_ID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
 
 /** Input shape for one tool call that asks one to four questions together. */
 export interface AskUserQuestionsRequest {
@@ -273,6 +279,66 @@ export function isAskUserQuestionInterrupt(
   );
 }
 
+interface AskUserQuestionOptionCandidate {
+  label?: unknown;
+  value?: unknown;
+}
+
+interface AskUserQuestionCandidate {
+  question?: unknown;
+  description?: unknown;
+  options?: unknown;
+  multiSelect?: unknown;
+}
+
+interface AskUserQuestionBatchItemCandidate extends AskUserQuestionCandidate {
+  id?: unknown;
+  header?: unknown;
+}
+
+function isAskUserQuestionOption(
+  value: unknown
+): value is AskUserQuestionOption {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const option = value as AskUserQuestionOptionCandidate;
+  return typeof option.label === 'string' && typeof option.value === 'string';
+}
+
+function isAskUserQuestionRequest(
+  value: unknown
+): value is AskUserQuestionRequest {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const question = value as AskUserQuestionCandidate;
+  return (
+    typeof question.question === 'string' &&
+    (question.description === undefined ||
+      typeof question.description === 'string') &&
+    (question.options === undefined ||
+      (Array.isArray(question.options) &&
+        question.options.every(isAskUserQuestionOption))) &&
+    (question.multiSelect === undefined ||
+      typeof question.multiSelect === 'boolean')
+  );
+}
+
+function isAskUserQuestionBatchItem(
+  value: unknown
+): value is AskUserQuestionBatchItem {
+  if (!isAskUserQuestionRequest(value)) {
+    return false;
+  }
+  const question = value as AskUserQuestionBatchItemCandidate;
+  return (
+    typeof question.id === 'string' &&
+    ASK_USER_QUESTION_ID_PATTERN.test(question.id) &&
+    (question.header === undefined || typeof question.header === 'string')
+  );
+}
+
 /**
  * Type guard for the batched form of an `ask_user_question` interrupt. Hosts
  * use this to select the multi-question UI and `AskUserQuestionsResolution`.
@@ -280,11 +346,26 @@ export function isAskUserQuestionInterrupt(
 export function isAskUserQuestionsInterrupt(
   payload: unknown
 ): payload is AskUserQuestionsInterruptPayload {
-  return (
-    isAskUserQuestionInterrupt(payload) &&
-    Array.isArray(payload.questions) &&
-    payload.questions.length > 0
-  );
+  if (
+    !isAskUserQuestionInterrupt(payload) ||
+    !isAskUserQuestionRequest(payload.question) ||
+    (payload.tool_call_id !== undefined &&
+      typeof payload.tool_call_id !== 'string') ||
+    !Array.isArray(payload.questions) ||
+    payload.questions.length === 0 ||
+    payload.questions.length > MAX_ASK_USER_QUESTIONS
+  ) {
+    return false;
+  }
+
+  const ids = new Set<string>();
+  for (const question of payload.questions) {
+    if (!isAskUserQuestionBatchItem(question) || ids.has(question.id)) {
+      return false;
+    }
+    ids.add(question.id);
+  }
+  return true;
 }
 
 /**

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -306,6 +306,20 @@ function isAskUserQuestionOption(
   return typeof option.label === 'string' && typeof option.value === 'string';
 }
 
+function isAskUserQuestionOptions(
+  value: unknown
+): value is AskUserQuestionOption[] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  for (let index = 0; index < value.length; index++) {
+    if (!Object.hasOwn(value, index) || !isAskUserQuestionOption(value[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isAskUserQuestionRequest(
   value: unknown
 ): value is AskUserQuestionRequest {
@@ -318,8 +332,7 @@ function isAskUserQuestionRequest(
     (question.description === undefined ||
       typeof question.description === 'string') &&
     (question.options === undefined ||
-      (Array.isArray(question.options) &&
-        question.options.every(isAskUserQuestionOption))) &&
+      isAskUserQuestionOptions(question.options)) &&
     (question.multiSelect === undefined ||
       typeof question.multiSelect === 'boolean')
   );


### PR DESCRIPTION
## Summary

- add an `askUserQuestions()` HITL helper that raises one composite interrupt for one to four questions
- add keyed batch request, payload, resolution, guard, and maximum-size contracts while preserving the existing singular payload
- validate non-empty, unique question IDs and retain the first question as a staged-rollout preview for singular hosts
- add deterministic pause/resume coverage and a gated real-Anthropic integration test

## Why

Models can emit one tool call containing several clarification questions, but the SDK only exposed a singular question and answer contract. Hosts therefore had no safe way to render and resume a composite interaction, while multiple sibling interrupt calls are replay-sensitive under LangGraph. This adds the Claude Code-style single-call `questions[]` path without disabling general parallel tool calling.

Hosts must support `payload.questions` and return `AskUserQuestionsResolution` before enabling a batched tool schema; existing singular `askUserQuestion()` behavior is unchanged.

## Validation

- `npx eslint` on the changed TypeScript files
- `npx tsc --noEmit`
- 37 focused HITL, sibling replay, and Langfuse callback tests
- `npm run build`
- live `claude-sonnet-5` test using a real Anthropic request: one tool call with two keyed questions, one interrupt, one composite resume, and the expected final response
