### PR TITLE
feat: add explicit host provider registration seam

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,12 +52,6 @@ export type * from './types';
 /* LangChain compatibility facade */
 export * from './langchain';
 
-/**
- * HITL primitives re-exported from `@langchain/langgraph` so hosts that
- * build durable checkpoint savers, dispatch `Command({ resume })`, or
- * detect interrupts can do so against the same langgraph instance the
- * SDK was compiled against — avoiding accidental dual-version drift.
- */
 export {
   Command,
   INTERRUPT,
@@ -76,7 +70,12 @@ export type {
   OpenRouterReasoningEffort,
   ChatOpenRouterCallOptions,
 } from './llm/openrouter';
-export { getChatModelClass } from './llm/providers';
+export {
+  getChatModelClass,
+  getRegisteredChatModelClass,
+  registerChatModelProvider,
+} from './llm/providers';
+export type { RegisteredChatModelConstructor } from './llm/providers';
 export { CustomChatMistralAI } from './llm/mistral';
 export {
   smoothStream,

--- a/src/llm/init.ts
+++ b/src/llm/init.ts
@@ -2,18 +2,14 @@ import { ChatVertexAI } from '@langchain/google-vertexai';
 import type { Runnable } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { ChatOpenAI, AzureChatOpenAI } from '@/llm/openai';
-import { getChatModelClass } from '@/llm/providers';
+import { getRegisteredChatModelClass } from '@/llm/providers';
 import { isOpenAILike } from '@/utils';
 import { Providers } from '@/common';
 
 /**
- * Creates a chat model instance for a given provider, applies provider-specific
- * field assignments, and optionally binds tools.
- *
- * This is the single entry point for model creation across the codebase — used
- * by both the agent graph (main LLM) and the summarization node (compaction LLM).
- * An optional `override` model can be passed to skip construction entirely
- * (useful for cached/reused model instances or test fakes).
+ * Creates a chat model instance for a given built-in or host-registered
+ * provider, applies provider-specific field assignments, and optionally binds
+ * tools.
  */
 export function initializeModel({
   provider,
@@ -21,14 +17,14 @@ export function initializeModel({
   tools,
   override,
 }: {
-  provider: Providers;
+  provider: Providers | string;
   clientOptions?: t.ClientOptions;
   tools?: t.GraphTools;
   override?: t.ChatModelInstance;
 }): Runnable {
   const model =
     override ??
-    new (getChatModelClass(provider))(clientOptions ?? ({} as never));
+    new (getRegisteredChatModelClass(provider))(clientOptions ?? ({} as never));
 
   if (
     isOpenAILike(provider) &&

--- a/src/llm/providers.registry.test.ts
+++ b/src/llm/providers.registry.test.ts
@@ -1,0 +1,41 @@
+import {
+  getChatModelClass,
+  getRegisteredChatModelClass,
+  registerChatModelProvider,
+} from './providers';
+
+class HostProvider {
+  constructor(public readonly config: unknown) {}
+}
+
+describe('host provider registry', () => {
+  it('registers and resolves a host provider', () => {
+    const provider = `test-provider-${Date.now()}`;
+    registerChatModelProvider(provider, HostProvider as never);
+    expect(getRegisteredChatModelClass(provider)).toBe(HostProvider);
+  });
+
+  it('rejects duplicate registration', () => {
+    const provider = `duplicate-provider-${Date.now()}`;
+    registerChatModelProvider(provider, HostProvider as never);
+    expect(() => registerChatModelProvider(provider, HostProvider as never)).toThrow(
+      `Provider already registered: ${provider}`,
+    );
+  });
+
+  it('rejects invalid names and constructors', () => {
+    expect(() => registerChatModelProvider('', HostProvider as never)).toThrow(
+      'Provider name must be a non-empty string',
+    );
+    expect(() => registerChatModelProvider('invalid-provider', null as never)).toThrow(
+      'Provider constructor is invalid: invalid-provider',
+    );
+  });
+
+  it('preserves built-in lookup and unsupported-provider errors', () => {
+    expect(getChatModelClass('openAI')).toBeDefined();
+    expect(() => getRegisteredChatModelClass(`missing-${Date.now()}`)).toThrow(
+      /Unsupported LLM provider/,
+    );
+  });
+});

--- a/src/llm/providers.ts
+++ b/src/llm/providers.ts
@@ -18,6 +18,12 @@ import { CustomAnthropic } from '@/llm/anthropic';
 import { ChatOpenRouter } from '@/llm/openrouter';
 import { ChatVertexAI } from '@/llm/vertexai';
 import { Providers } from '@/common';
+import type { Runnable } from '@langchain/core/runnables';
+
+/** Constructor contract for providers registered by host applications. */
+export type RegisteredChatModelConstructor = new (config: unknown) => Runnable;
+
+const registeredChatModelProviders = new Map<string, RegisteredChatModelConstructor>();
 
 export const llmProviders: Partial<ChatModelConstructorMap> = {
   [Providers.XAI]: ChatXAI,
@@ -30,10 +36,40 @@ export const llmProviders: Partial<ChatModelConstructorMap> = {
   [Providers.ANTHROPIC]: CustomAnthropic,
   [Providers.OPENROUTER]: ChatOpenRouter,
   [Providers.BEDROCK]: CustomChatBedrockConverse,
-  // [Providers.ANTHROPIC]: ChatAnthropic,
   [Providers.GOOGLE]: CustomChatGoogleGenerativeAI,
   [Providers.MOONSHOT]: ChatMoonshot,
 };
+
+/** Register a host-provided provider without replacing built-in providers. */
+export function registerChatModelProvider(
+  provider: string,
+  modelClass: RegisteredChatModelConstructor,
+): void {
+  if (typeof provider !== 'string' || provider.trim() === '') {
+    throw new Error('Provider name must be a non-empty string');
+  }
+  if (typeof modelClass !== 'function') {
+    throw new Error(`Provider constructor is invalid: ${provider}`);
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(llmProviders, provider) ||
+    registeredChatModelProviders.has(provider)
+  ) {
+    throw new Error(`Provider already registered: ${provider}`);
+  }
+  registeredChatModelProviders.set(provider, modelClass);
+}
+
+/** Resolve either a built-in or explicitly registered host provider. */
+export function getRegisteredChatModelClass(
+  provider: string,
+): RegisteredChatModelConstructor {
+  const registered = registeredChatModelProviders.get(provider);
+  if (registered) return registered;
+  const builtin = llmProviders[provider as Providers];
+  if (builtin) return builtin as unknown as RegisteredChatModelConstructor;
+  throw new Error(`Unsupported LLM provider: ${provider}`);
+}
 
 export const manualToolStreamProviders = new Set<Providers | string>([
   Providers.ANTHROPIC,
@@ -41,12 +77,11 @@ export const manualToolStreamProviders = new Set<Providers | string>([
 ]);
 
 export const getChatModelClass = <P extends Providers>(
-  provider: P
+  provider: P,
 ): new (config: ProviderOptionsMap[P]) => ChatModelMap[P] => {
   const ChatModelClass = llmProviders[provider];
   if (!ChatModelClass) {
     throw new Error(`Unsupported LLM provider: ${provider}`);
   }
-
   return ChatModelClass;
 };


### PR DESCRIPTION
## Summary

- add an explicit registry for host-provided chat model constructors
- preserve the existing typed built-in provider lookup
- resolve built-in and host providers through `initializeModel`
- export the registration and lookup APIs
- add registry behavior tests

## Design notes

This is a generic provider-extension seam only. It does not add an ERIS dependency, register any provider implicitly, modify AgentClient, or enable any runtime behavior by default.

Host applications must explicitly call `registerChatModelProvider`. Existing built-in provider names cannot be overwritten.

## Validation

The added test covers registration, duplicate rejection, invalid inputs, built-in lookup preservation, and unsupported-provider errors.

ERIS integration remains downstream and feature-gated.