### PR TITLE
fix(stream): keep Anthropic citations that arrive without text

### DIFF
--- a/src/aggregator.test.ts
+++ b/src/aggregator.test.ts
@@ -1085,3 +1085,130 @@ describe('ContentAggregator multi-entry deltas', () => {
     });
   });
 });
+
+describe('ContentAggregator citation deltas', () => {
+  const citation = (url: string, cited_text: string) => ({
+    type: 'web_search_result_location',
+    url,
+    title: 'Example',
+    cited_text,
+    encrypted_index: 'enc',
+  });
+
+  /**
+   * Anthropic emits a search turn's citations as their own `citations_delta`,
+   * which `_makeMessageChunkFromAnthropicEvent` normalizes into a `text` part
+   * carrying `citations` and **no** `text` key.
+   */
+  const citationDelta = (id: string, ...citations: unknown[]) => ({
+    event: GraphEvents.ON_MESSAGE_DELTA,
+    data: {
+      id,
+      delta: { content: [{ type: ContentTypes.TEXT, citations }] },
+    } as t.MessageDeltaEvent,
+  });
+
+  const textDelta = (id: string, text: string) => ({
+    event: GraphEvents.ON_MESSAGE_DELTA,
+    data: {
+      id,
+      delta: { content: [{ type: ContentTypes.TEXT, text }] },
+    } as t.MessageDeltaEvent,
+  });
+
+  it('keeps citations that arrive without accompanying text', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_citations'),
+    });
+
+    aggregateContent(textDelta('step_citations', 'Answer.'));
+    aggregateContent(
+      citationDelta('step_citations', citation('https://a.example', 'quoted a'))
+    );
+
+    expect(contentParts[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Answer.',
+      citations: [citation('https://a.example', 'quoted a')],
+    });
+  });
+
+  it('accumulates citations across successive deltas', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_multi'),
+    });
+
+    aggregateContent(textDelta('step_multi', 'Part one. '));
+    aggregateContent(
+      citationDelta('step_multi', citation('https://a.example', 'quoted a'))
+    );
+    aggregateContent(textDelta('step_multi', 'Part two.'));
+    aggregateContent(
+      citationDelta('step_multi', citation('https://b.example', 'quoted b'))
+    );
+
+    expect(contentParts[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Part one. Part two.',
+      citations: [
+        citation('https://a.example', 'quoted a'),
+        citation('https://b.example', 'quoted b'),
+      ],
+    });
+  });
+
+  it('leaves parts without citations untouched', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_plain'),
+    });
+
+    aggregateContent(textDelta('step_plain', 'Hello '));
+    aggregateContent(textDelta('step_plain', 'world.'));
+
+    expect(contentParts[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Hello world.',
+    });
+    expect(contentParts[0]).not.toHaveProperty('citations');
+  });
+
+  it('preserves tool_call_ids when a citations-only delta follows', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: createRunStep('step_tool_ids'),
+    });
+
+    aggregateContent({
+      event: GraphEvents.ON_MESSAGE_DELTA,
+      data: {
+        id: 'step_tool_ids',
+        delta: {
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              text: 'Answer.',
+              tool_call_ids: ['call_1'],
+            },
+          ],
+        },
+      } as t.MessageDeltaEvent,
+    });
+    aggregateContent(
+      citationDelta('step_tool_ids', citation('https://a.example', 'quoted a'))
+    );
+
+    expect(contentParts[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Answer.',
+      tool_call_ids: ['call_1'],
+      citations: [citation('https://a.example', 'quoted a')],
+    });
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2299,20 +2299,44 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       return;
     }
 
+    const incomingText =
+      ContentTypes.TEXT in contentPart && typeof contentPart.text === 'string'
+        ? contentPart.text
+        : undefined;
+    /**
+     * Anthropic emits a search turn's citations as their own `citations_delta`,
+     * which arrives here as a text part carrying `citations` and no `text`.
+     */
+    const { citations } = contentPart as {
+      citations?: t.MessageDeltaUpdate['citations'];
+    };
+    const incomingCitations = Array.isArray(citations) ? citations : undefined;
+
     if (
       partType.startsWith(ContentTypes.TEXT) &&
-      ContentTypes.TEXT in contentPart &&
-      typeof contentPart.text === 'string'
+      (incomingText !== undefined || incomingCitations !== undefined)
     ) {
       // TODO: update this!!
       const currentContent = contentParts[index] as t.MessageDeltaUpdate;
       const update: t.MessageDeltaUpdate = {
         type: ContentTypes.TEXT,
-        text: (currentContent.text || '') + contentPart.text,
+        text: (currentContent.text || '') + (incomingText ?? ''),
       };
 
       if (contentPart.tool_call_ids) {
         update.tool_call_ids = contentPart.tool_call_ids;
+      } else if (incomingText === undefined && currentContent.tool_call_ids) {
+        /** A citations-only delta must not drop ids already accumulated */
+        update.tool_call_ids = currentContent.tool_call_ids;
+      }
+
+      if (incomingCitations !== undefined) {
+        update.citations =
+          currentContent.citations !== undefined
+            ? [...currentContent.citations, ...incomingCitations]
+            : [...incomingCitations];
+      } else if (currentContent.citations !== undefined) {
+        update.citations = currentContent.citations;
       }
       contentParts[index] = update;
     } else if (

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -8,6 +8,7 @@ import type {
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type { LLMResult, Generation } from '@langchain/core/outputs';
 import type { Command } from '@langchain/langgraph';
+import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicContentBlock } from '@/llm/anthropic/types';
 import type { AssistantTextPhase } from '@/types/assistantPhase';
 import type { SummarizeCompleteEvent } from '@/types/summarize';
@@ -285,6 +286,8 @@ export type MessageDeltaUpdate = {
   type: ContentTypes.TEXT;
   text: string;
   tool_call_ids?: string[];
+  /** Provider-supplied source citations, accumulated across deltas. */
+  citations?: Anthropic.TextCitation[];
 };
 export type ReasoningDeltaUpdate = { type: ContentTypes.THINK; think: string };
 


### PR DESCRIPTION
## Problem

`createContentAggregator` drops every Anthropic citation, because the producer and the consumer inside this repo disagree about the shape of a citations delta.

**Producer** — `_makeMessageChunkFromAnthropicEvent` normalizes a `citations_delta` into a **`text` part that carries `citations` and no `text` key** ([`src/llm/anthropic/utils/message_outputs.ts#L184-L206`](https://github.com/danny-avila/agents/blob/main/src/llm/anthropic/utils/message_outputs.ts#L184-L206)):

```ts
const contentBlock: Record<string, unknown> = { ...data.delta };
if ('citation' in contentBlock) {
  contentBlock.citations = [contentBlock.citation];
  delete contentBlock.citation;
}
...
content: [{ index: data.index, ...contentBlock, type: 'text' }],
```

So the aggregator receives `{ index, type: 'text', citations: [...] }`.

**Consumer** — `updateContent` requires `text` to be a string before it will merge a text part ([`src/stream.ts#L2302-L2306`](https://github.com/danny-avila/agents/blob/main/src/stream.ts#L2302-L2306)):

```ts
if (
  partType.startsWith(ContentTypes.TEXT) &&
  ContentTypes.TEXT in contentPart &&
  typeof contentPart.text === 'string'
) {
```

A citations-only delta fails that guard, matches no other branch in the chain, and falls through to the end of `updateContent` without being stored. The `citations` are discarded silently — no warning, no error. What survives is the bare `{ type: 'text' }` stub created at line 2293.

The net effect: **when Anthropic web search is enabled, the model's citations never reach the aggregated content.** Anthropic sends one `citations_delta` per cited passage, so the whole set is lost, and downstream consumers have no way to tell "the model cited nothing" apart from "the citations were dropped in transit".

## Fix

Accept a text delta that carries `citations` even when it has no `text`, and accumulate citations across deltas (Anthropic emits one citation per delta).

Two details worth calling out, both covered by tests:

- **`tool_call_ids` are carried forward** only when the delta has no `text` key. Without that, a citations-only delta arriving after a text part would blank ids that had already accumulated. Deltas that *do* carry `text` keep the existing behaviour exactly, including an explicit empty-string `text`.
- **Nothing is allocated on the no-citation path.** `update.citations` is only ever touched when citations are actually present, so the ordinary streaming-text path is unchanged.

`MessageDeltaUpdate` gains an optional `citations` field, typed as `Anthropic.TextCitation[]` — reusing the SDK type rather than introducing a new one. If another provider ever routes citations through this path, that's the place to widen to a union.

## Tests

Four cases added to `src/aggregator.test.ts`:

| Test | Guards |
|---|---|
| keeps citations that arrive without accompanying text | the bug itself |
| accumulates citations across successive deltas | one-citation-per-delta from Anthropic |
| leaves parts without citations untouched | no regression on ordinary text |
| preserves `tool_call_ids` when a citations-only delta follows | the carry-forward detail above |

All four fail on `main` except the regression guard, which passes before and after — as it should.

## Verification

Full suite, before and after, `jest --testPathIgnorePatterns=title.memory-leak.test.ts`:

```
main     Test Suites: 3 failed, 20 skipped, 214 passed, 217 of 237 total
         Tests:       12 failed, 98 skipped, 4149 passed, 4259 total

branch   Test Suites: 3 failed, 20 skipped, 214 passed, 217 of 237 total
         Tests:       12 failed, 98 skipped, 4153 passed, 4263 total
```

Identical, `+4` passing — the four new tests. The 12 failures are pre-existing on `main` (VertexAI thought-signature specs) and unrelated to this change.

`tsc --noEmit -p tsconfig.json` exits 0. `eslint` on the touched files reports no new problems (one pre-existing warning at `src/stream.ts:1828`). `sort-imports:check` is unchanged at 33/453, with neither touched file in the list.

## How this was found

Measuring whether an assistant actually reads a given web page, driving LibreChat headlessly against Anthropic with `web_search_20250305`. The searches were firing and the answers were plainly grounded in fresh pages, but zero citations were ever persisted. Instrumenting the running aggregator showed the delta arriving as `{"index","type","citations"}` — no `text` key — and being dropped at the guard above.

The equivalent change has been running on our deployment since 2026-08-12, applied as a patch over the `librechat-dev` image. On the first run afterwards, a workload whose all-time citation count had been 0 recorded 93 citations, each with its `cited_text`, with no change to any non-citation turn.

I'd much rather delete that patch and depend on a release. Happy to adjust naming, typing, or test placement to whatever you prefer.
