### PR TITLE
🔭 refactor: Activity Label Langfuse Traces

### DIFF
--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -14,6 +14,7 @@ const CHAIN_OBSERVATION_TYPE = 'chain';
 const TOOL_OBSERVATION_TYPE = 'tool';
 const AGENT_TRACE_TAG = 'agent';
 const TITLE_TRACE_TAG = 'title';
+const ACTIVITY_PHASE_TRACE_TAG = 'activity-phase';
 const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
 const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
 const OBSERVATION_METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
@@ -473,14 +474,17 @@ function shapeRootObservationType(span: MutableSpan): void {
   if (isGenerationSpan(span)) {
     return;
   }
+  if (
+    hasTraceTag(span, TITLE_TRACE_TAG) ||
+    hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG)
+  ) {
+    span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+      CHAIN_OBSERVATION_TYPE;
+    return;
+  }
   if (hasTraceTag(span, AGENT_TRACE_TAG)) {
     span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
       ROOT_OBSERVATION_TYPE;
-    return;
-  }
-  if (hasTraceTag(span, TITLE_TRACE_TAG)) {
-    span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
-      CHAIN_OBSERVATION_TYPE;
   }
 }
 
@@ -497,9 +501,10 @@ function shapeRootObservationType(span: MutableSpan): void {
  * - Agent nodes become `agent` observations, while tool-dispatch nodes become
  *   stable `chain` observations whose input is scoped to the pending calls.
  *   Individual child calls remain `tool` observations (items 3 & 4).
- * - Agent trace roots become `agent` observations and title trace roots become
- *   `chain` observations. Root and trace input/output are reduced to the user
- *   question and assistant response when chat messages are available (item 2).
+ * - Agent trace roots become `agent` observations, while title and activity
+ *   summary roots become `chain` observations. Root and trace input/output are
+ *   reduced to the user question and assistant response when chat messages are
+ *   available (item 2).
  */
 export function shapeLangfuseSpan(span: ReadableSpan): void {
   const mutable = span as MutableSpan;

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -15,6 +15,7 @@ const TOOL_OBSERVATION_TYPE = 'tool';
 const AGENT_TRACE_TAG = 'agent';
 const TITLE_TRACE_TAG = 'title';
 const ACTIVITY_PHASE_TRACE_TAG = 'activity-phase';
+const ACTIVITY_PHASE_ROOT_NAME = 'summarize-activity-phase';
 const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
 const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
 const OBSERVATION_METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
@@ -476,7 +477,8 @@ function shapeRootObservationType(span: MutableSpan): void {
   }
   if (
     hasTraceTag(span, TITLE_TRACE_TAG) ||
-    hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG)
+    (span.name === ACTIVITY_PHASE_ROOT_NAME &&
+      hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG))
   ) {
     span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
       CHAIN_OBSERVATION_TYPE;

--- a/src/run.ts
+++ b/src/run.ts
@@ -93,6 +93,9 @@ export const defaultOmitOptions = new Set([
   'additionalModelRequestFields',
 ]);
 
+const ACTIVITY_LABEL_TRACE_NAME = 'LibreChat Activity Label';
+const ACTIVITY_PHASE_TRACE_NAME = 'LibreChat Activity Phase';
+
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_AGENT_UPDATE,
   GraphEvents.ON_RUN_STEP,
@@ -1866,22 +1869,15 @@ export class Run<_T extends t.BaseGraphState> {
         ? undefined
         : (requestedContext ??
           this.Graph.agentContexts.get(this.Graph.defaultAgentId));
-    const traceMetadata = createLangfuseTraceMetadata({
-      messageId: 'activity-label-' + this.id,
-      agentName: labelContext?.name,
-    });
-    const labelRunName = getLangfuseTraceName(
-      traceMetadata,
-      'LibreChat Activity Label'
-    );
-
     /** Shallow-cloned: activity labels run once per tool batch, and writing
      *  the Langfuse handler back onto a host-reused `chainOptions` would
      *  accumulate duplicate callbacks across batches. */
     const labelChainOptions = {
       ...(chainOptions ?? {}),
     } as Partial<RunnableConfig> & {
-      configurable?: Record<string, unknown>;
+      configurable?: Record<string, unknown> & {
+        requestBody?: { parentMessageId?: unknown };
+      };
     };
     const labelUserId =
       typeof labelChainOptions.configurable?.user_id === 'string'
@@ -1891,6 +1887,32 @@ export class Run<_T extends t.BaseGraphState> {
       typeof labelChainOptions.configurable?.thread_id === 'string'
         ? (labelChainOptions.configurable.thread_id as string)
         : undefined;
+    const labelIndex = labelSeq - 1;
+    const labelParentMessageId =
+      labelChainOptions.configurable?.requestBody?.parentMessageId;
+    const labelMetadata: Record<string, unknown> = {
+      sourceRunId: this.id,
+      responseId: this.id,
+      activityIndex: labelIndex,
+      ...(typeof labelParentMessageId === 'string'
+        ? { parentMessageId: labelParentMessageId }
+        : {}),
+      ...(agentId == null ? {} : { agentId }),
+      ...(labelContext?.name == null ? {} : { agentName: labelContext.name }),
+    };
+    const traceMetadata = {
+      ...createLangfuseTraceMetadata({
+        messageId: 'activity-label-' + this.id,
+        parentMessageId: labelParentMessageId,
+        agentId,
+        agentName: labelContext?.name,
+      }),
+      sourceRunId: this.id,
+      responseId: this.id,
+      activityIndex: String(labelIndex),
+    };
+    const labelRunName = labelChainOptions.runName ?? ACTIVITY_LABEL_TRACE_NAME;
+    const labelTags = ['librechat', 'activity-label'];
     const labelLangfuseConfig = resolveLangfuseConfig(
       this.langfuse,
       labelContext?.langfuse
@@ -1934,14 +1956,14 @@ export class Run<_T extends t.BaseGraphState> {
         userId: labelUserId,
         sessionId: labelSessionId,
         traceMetadata,
-        tags: ['librechat', 'activity-label'],
+        tags: labelTags,
         traceIdSeed:
           labelLangfuseConfig?.deterministicTraceId === true
             ? labelTraceSeed
             : undefined,
         runId: labelScopeRunId,
         toolOutputTracing: labelRuntimeScope.toolOutputTracing,
-        traceName: labelChainOptions.runName ?? labelRunName,
+        traceName: labelRunName,
       });
     }
     if (labelLangfuseHandler != null) {
@@ -2027,7 +2049,12 @@ export class Run<_T extends t.BaseGraphState> {
     const invokeConfig = Object.assign({}, labelChainOptions, {
       run_id: labelRunId,
       runId: labelRunId,
-      runName: labelChainOptions.runName ?? labelRunName,
+      runName: labelRunName,
+      tags: [...new Set([...(labelChainOptions.tags ?? []), ...labelTags])],
+      metadata: {
+        ...(labelChainOptions.metadata ?? {}),
+        ...labelMetadata,
+      },
     }) as Partial<RunnableConfig>;
 
     const invokeLabel = (
@@ -2038,9 +2065,9 @@ export class Run<_T extends t.BaseGraphState> {
           langfuse: labelLangfuseConfig,
           userId: labelUserId,
           sessionId: labelSessionId,
-          traceName: runtimeConfig.runName ?? labelRunName,
+          traceName: labelRunName,
           traceMetadata,
-          tags: ['librechat', 'activity-label'],
+          tags: labelTags,
         },
         () =>
           model.invoke(
@@ -2124,7 +2151,7 @@ export class Run<_T extends t.BaseGraphState> {
 
   /**
    * Generates one parent summary for two or more logical activities. The
-   * summary model is traced as a dedicated activity-phase agent root in the
+   * summary model is traced as a dedicated activity-phase chain root in the
    * conversation session, with the model callback recorded as its generation
    * child. No session id means no phase trace, avoiding orphan observations.
    */
@@ -2289,11 +2316,8 @@ export class Run<_T extends t.BaseGraphState> {
         : { contributingAgentIds: contributingAgentIds.join(',') }),
       ...(closingTextPhase == null ? {} : { closingTextPhase }),
     };
-    const phaseRunName = getLangfuseTraceName(
-      traceMetadata,
-      'LibreChat Activity Phase'
-    );
-    const phaseTraceName = phaseChainOptions.runName ?? phaseRunName;
+    const phaseTraceName =
+      phaseChainOptions.runName ?? ACTIVITY_PHASE_TRACE_NAME;
     const phaseTags = [
       'librechat',
       'activity-phase',

--- a/src/run.ts
+++ b/src/run.ts
@@ -1890,6 +1890,16 @@ export class Run<_T extends t.BaseGraphState> {
     const labelIndex = labelSeq - 1;
     const labelParentMessageId =
       labelChainOptions.configurable?.requestBody?.parentMessageId;
+    /** An omitted `agentId` is attributable only when exactly one context
+     *  exists. Multi-agent callers remain unattributed instead of being
+     *  incorrectly assigned to the graph's default agent. */
+    const labelAgentId =
+      agentId ??
+      (this.Graph?.agentContexts.size === 1
+        ? this.Graph.defaultAgentId
+        : undefined);
+    const labelAgentName =
+      labelAgentId == null ? undefined : labelContext?.name;
     const labelMetadata: Record<string, unknown> = {
       sourceRunId: this.id,
       responseId: this.id,
@@ -1897,15 +1907,15 @@ export class Run<_T extends t.BaseGraphState> {
       ...(typeof labelParentMessageId === 'string'
         ? { parentMessageId: labelParentMessageId }
         : {}),
-      ...(agentId == null ? {} : { agentId }),
-      ...(labelContext?.name == null ? {} : { agentName: labelContext.name }),
+      ...(labelAgentId == null ? {} : { agentId: labelAgentId }),
+      ...(labelAgentName == null ? {} : { agentName: labelAgentName }),
     };
     const traceMetadata = {
       ...createLangfuseTraceMetadata({
         messageId: 'activity-label-' + this.id,
         parentMessageId: labelParentMessageId,
-        agentId,
-        agentName: labelContext?.name,
+        agentId: labelAgentId,
+        agentName: labelAgentName,
       }),
       sourceRunId: this.id,
       responseId: this.id,

--- a/src/specs/activity-label-observability.live.test.ts
+++ b/src/specs/activity-label-observability.live.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Live provider + Langfuse export verification for activity-label traces.
+ *
+ * Run with:
+ * RUN_ACTIVITY_LABEL_LANGFUSE_LIVE=1 OPENAI_API_KEY=... \
+ * LANGFUSE_PUBLIC_KEY=... LANGFUSE_SECRET_KEY=... LANGFUSE_BASE_URL=... \
+ * LANGFUSE_FORCE_FLUSH_ON_DISPOSE=true \
+ * npm test -- activity-label-observability.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+type LangfuseMetadata = {
+  sourceRunId?: string;
+  responseId?: string;
+  activityIndex?: string | number;
+  phaseIndex?: string | number;
+  activityCount?: string | number;
+};
+
+type LangfuseObservation = {
+  id: string;
+  parentObservationId?: string | null;
+  type: string;
+  name: string;
+  model?: string | null;
+  usage?: { input?: number; output?: number; total?: number };
+};
+
+type LangfuseTrace = {
+  id: string;
+  name: string;
+  tags?: string[];
+  metadata?: LangfuseMetadata;
+  observations?: LangfuseObservation[];
+};
+
+type LangfuseTraceList = {
+  data: LangfuseTrace[];
+};
+
+const shouldRunLive =
+  process.env.RUN_ACTIVITY_LABEL_LANGFUSE_LIVE === '1' &&
+  (process.env.OPENAI_API_KEY ?? '') !== '' &&
+  (process.env.LANGFUSE_PUBLIC_KEY ?? '') !== '' &&
+  (process.env.LANGFUSE_SECRET_KEY ?? '') !== '' &&
+  (process.env.LANGFUSE_BASE_URL ?? '') !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+
+function langfuseHeaders(): HeadersInit {
+  const credentials = Buffer.from(
+    `${process.env.LANGFUSE_PUBLIC_KEY}:${process.env.LANGFUSE_SECRET_KEY}`
+  ).toString('base64');
+  return { Authorization: `Basic ${credentials}` };
+}
+
+async function requestLangfuse(path: string): Promise<Response> {
+  const baseUrl = process.env.LANGFUSE_BASE_URL?.replace(/\/$/, '');
+  return fetch(`${baseUrl}${path}`, {
+    headers: langfuseHeaders(),
+  });
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await requestLangfuse(path);
+  if (!response.ok) {
+    throw new Error(`Langfuse request failed: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function getJsonIfPresent<T>(path: string): Promise<T | undefined> {
+  const response = await requestLangfuse(path);
+  if (response.status === 404) {
+    return undefined;
+  }
+  if (!response.ok) {
+    throw new Error(`Langfuse request failed: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function findExportedTraces(
+  sourceRunId: string,
+  fromTimestamp: string
+): Promise<{ label: LangfuseTrace; phase: LangfuseTrace }> {
+  const query = new URLSearchParams({
+    limit: '100',
+    fromTimestamp,
+  });
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const list = await getJson<LangfuseTraceList>(
+      `/api/public/traces?${query.toString()}`
+    );
+    const candidates = list.data.filter(
+      (trace) => trace.metadata?.sourceRunId === sourceRunId
+    );
+    const labelSummary = candidates.find(
+      (trace) => trace.tags?.includes('activity-label') === true
+    );
+    const phaseSummary = candidates.find(
+      (trace) => trace.tags?.includes('activity-phase') === true
+    );
+    if (labelSummary != null && phaseSummary != null) {
+      const [label, phase] = await Promise.all([
+        getJsonIfPresent<LangfuseTrace>(
+          `/api/public/traces/${labelSummary.id}`
+        ),
+        getJsonIfPresent<LangfuseTrace>(
+          `/api/public/traces/${phaseSummary.id}`
+        ),
+      ]);
+      if (label != null && phase != null) {
+        const labelReady =
+          label.observations?.some(
+            (observation) => observation.type === 'GENERATION'
+          ) === true;
+        const phaseRootReady =
+          phase.observations?.some(
+            (observation) =>
+              observation.parentObservationId == null &&
+              observation.type === 'CHAIN'
+          ) === true;
+        const phaseGenerationReady =
+          phase.observations?.some(
+            (observation) => observation.type === 'GENERATION'
+          ) === true;
+        if (labelReady && phaseRootReady && phaseGenerationReady) {
+          return { label, phase };
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  }
+  throw new Error(`Timed out waiting for activity traces from ${sourceRunId}`);
+}
+
+describeIfLive('activity label Langfuse export (live)', () => {
+  jest.setTimeout(120_000);
+
+  it('exports stable, correlated traces with correct observation types', async () => {
+    const startedAt = new Date(Date.now() - 5000).toISOString();
+    const sourceRunId = `activity-label-live-${Date.now()}`;
+    const sessionId = `${sourceRunId}-session`;
+    const model = process.env.ACTIVITY_LABEL_LIVE_MODEL ?? 'gpt-4.1-mini';
+    const run = await Run.create({
+      runId: sourceRunId,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'activity-label-live-agent',
+            name: 'Volatile Agent Display Name',
+            provider: Providers.OPENAI,
+            clientOptions: {
+              apiKey: process.env.OPENAI_API_KEY,
+              model,
+            },
+            tools: [],
+          },
+        ],
+      },
+    });
+    if (run.Graph != null) {
+      run.Graph.messages = [
+        new HumanMessage('Verify activity-label Langfuse trace semantics'),
+      ];
+    }
+    const chainOptions = {
+      configurable: {
+        thread_id: sessionId,
+        user_id: 'activity-label-live-user',
+        requestBody: { parentMessageId: 'activity-label-live-parent' },
+      },
+    };
+
+    await run.generateActivityLabel({
+      provider: Providers.OPENAI,
+      agentId: 'activity-label-live-agent',
+      clientOptions: {
+        apiKey: process.env.OPENAI_API_KEY,
+        model,
+      },
+      entries: [
+        {
+          toolName: 'inspect_runtime',
+          toolInput: { target: 'trace-shape' },
+          toolOutput: { status: 'verified' },
+          status: 'success',
+        },
+      ],
+      chainOptions,
+    });
+    await run.generateActivityPhaseLabel({
+      provider: Providers.OPENAI,
+      clientOptions: {
+        apiKey: process.env.OPENAI_API_KEY,
+        model,
+      },
+      activities: [
+        { label: 'Inspected the activity-label trace shape' },
+        { label: 'Verified stable correlation metadata' },
+      ],
+      sourceRunId,
+      responseId: sourceRunId,
+      phaseIndex: 0,
+      chainOptions,
+    });
+
+    const { label, phase } = await findExportedTraces(sourceRunId, startedAt);
+    expect(label).toMatchObject({
+      name: 'LibreChat Activity Label',
+      metadata: {
+        sourceRunId,
+        responseId: sourceRunId,
+        activityIndex: 0,
+      },
+    });
+    expect(phase).toMatchObject({
+      name: 'LibreChat Activity Phase',
+      metadata: {
+        sourceRunId,
+        responseId: sourceRunId,
+        phaseIndex: 0,
+        activityCount: 2,
+      },
+    });
+
+    const labelGeneration = label.observations?.find(
+      (observation) => observation.type === 'GENERATION'
+    );
+    expect(labelGeneration).toMatchObject({
+      parentObservationId: null,
+      name: 'llm',
+      model: expect.stringContaining(model),
+    });
+    expect(labelGeneration?.usage?.total).toBeGreaterThan(0);
+
+    const phaseRoot = phase.observations?.find(
+      (observation) => observation.parentObservationId == null
+    );
+    expect(phaseRoot).toMatchObject({
+      type: 'CHAIN',
+      name: 'summarize-activity-phase',
+    });
+    const phaseGeneration = phase.observations?.find(
+      (observation) => observation.type === 'GENERATION'
+    );
+    expect(phaseGeneration).toMatchObject({
+      parentObservationId: phaseRoot?.id,
+      name: 'llm',
+      model: expect.stringContaining(model),
+    });
+    expect(phaseGeneration?.usage?.total).toBeGreaterThan(0);
+  });
+});

--- a/src/specs/activity-label-observability.test.ts
+++ b/src/specs/activity-label-observability.test.ts
@@ -1,0 +1,168 @@
+import { CallbackHandler } from '@langfuse/langchain';
+import { propagateAttributes } from '@langfuse/tracing';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+const invoke = jest.fn();
+
+jest.mock('@/llm/init', () => ({
+  initializeModel: jest.fn(() => ({ invoke })),
+}));
+
+jest.mock('@langfuse/langchain', () => ({
+  CallbackHandler: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@langfuse/tracing', () => ({
+  ...jest.requireActual('@langfuse/tracing'),
+  propagateAttributes: jest.fn((_params, action: () => unknown) => action()),
+}));
+
+const MockedCallbackHandler = CallbackHandler as jest.MockedClass<
+  typeof CallbackHandler
+>;
+const MockedPropagateAttributes = propagateAttributes as jest.MockedFunction<
+  typeof propagateAttributes
+>;
+
+async function createRun(): Promise<Run<never>> {
+  const run = await Run.create({
+    runId: 'response-1',
+    graphConfig: {
+      type: 'standard',
+      agents: [
+        {
+          agentId: 'agent-1',
+          name: 'Changing Model Name',
+          provider: Providers.OPENAI,
+          clientOptions: { model: 'gpt-4.1-mini' },
+          tools: [],
+        },
+      ],
+    },
+  });
+  if (run.Graph != null) {
+    run.Graph.messages = [new HumanMessage('Why did the run fail?')];
+  }
+  return run;
+}
+
+describe('activity label observability', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    invoke.mockResolvedValue(new AIMessage('Resolved the failing run'));
+    process.env = {
+      ...originalEnv,
+      LANGFUSE_SECRET_KEY: 'sk-test',
+      LANGFUSE_PUBLIC_KEY: 'pk-test',
+      LANGFUSE_BASE_URL: 'https://langfuse.test',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses a stable trace name and source-run metadata for batch labels', async () => {
+    const run = await createRun();
+
+    await run.generateActivityLabel({
+      provider: Providers.OPENAI,
+      agentId: 'agent-1',
+      entries: [
+        {
+          toolName: 'inspect_status',
+          toolInput: { id: 'one' },
+          toolOutput: { fixed: true },
+          status: 'success',
+        },
+      ],
+      chainOptions: {
+        configurable: {
+          thread_id: 'thread-1',
+          user_id: 'user-1',
+          requestBody: { parentMessageId: 'parent-1' },
+        },
+      },
+    });
+
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+    expect(MockedCallbackHandler.mock.calls[0][0]).toMatchObject({
+      traceMetadata: {
+        messageId: 'activity-label-response-1',
+        parentMessageId: 'parent-1',
+        agentId: 'agent-1',
+        agentName: 'Changing Model Name',
+        sourceRunId: 'response-1',
+        responseId: 'response-1',
+        activityIndex: '0',
+      },
+      tags: ['librechat', 'activity-label'],
+    });
+    expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
+      traceName: 'LibreChat Activity Label',
+      metadata: {
+        sourceRunId: 'response-1',
+        responseId: 'response-1',
+        activityIndex: '0',
+      },
+    });
+    expect(invoke.mock.calls[0][1]).toMatchObject({
+      runName: 'LibreChat Activity Label',
+      tags: ['librechat', 'activity-label'],
+      metadata: {
+        sourceRunId: 'response-1',
+        responseId: 'response-1',
+        activityIndex: 0,
+        parentMessageId: 'parent-1',
+        agentId: 'agent-1',
+        agentName: 'Changing Model Name',
+      },
+    });
+  });
+
+  it('uses a stable trace name for phase summaries', async () => {
+    const run = await createRun();
+
+    await run.generateActivityPhaseLabel({
+      provider: Providers.OPENAI,
+      activities: [
+        { label: 'Inspected session refresh behavior' },
+        { label: 'Fixed refresh token validation' },
+      ],
+      sourceRunId: 'response-1',
+      responseId: 'response-1',
+      phaseIndex: 0,
+      chainOptions: {
+        configurable: {
+          thread_id: 'thread-1',
+          user_id: 'user-1',
+          requestBody: { parentMessageId: 'parent-1' },
+        },
+      },
+    });
+
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+    expect(MockedCallbackHandler.mock.calls[0][0]).toMatchObject({
+      tags: ['librechat', 'activity-phase', 'agent-run-summary', 'agent'],
+      traceMetadata: {
+        sourceRunId: 'response-1',
+        responseId: 'response-1',
+        phaseIndex: '0',
+        activityCount: '2',
+      },
+    });
+    expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
+      traceName: 'LibreChat Activity Phase',
+      metadata: {
+        sourceRunId: 'response-1',
+        responseId: 'response-1',
+        phaseIndex: '0',
+        activityCount: '2',
+      },
+    });
+  });
+});

--- a/src/specs/activity-label-observability.test.ts
+++ b/src/specs/activity-label-observability.test.ts
@@ -71,7 +71,6 @@ describe('activity label observability', () => {
 
     await run.generateActivityLabel({
       provider: Providers.OPENAI,
-      agentId: 'agent-1',
       entries: [
         {
           toolName: 'inspect_status',

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -486,6 +486,27 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[TRACE_OUTPUT]).toBe('Conversation title');
   });
 
+  it('marks activity-phase roots as chains even when tagged as agent work', () => {
+    const span = createSpan('summarize-activity-phase', {
+      [TRACE_TAGS]: JSON.stringify([
+        'librechat',
+        'activity-phase',
+        'agent-run-summary',
+        'agent',
+      ]),
+      [INPUT]: 'What changed?',
+      [OUTPUT]: 'Reconciled the implementation and verified the fix',
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
+    expect(span.attributes[TRACE_INPUT]).toBe('What changed?');
+    expect(span.attributes[TRACE_OUTPUT]).toBe(
+      'Reconciled the implementation and verified the fix'
+    );
+  });
+
   it('does not classify untagged root spans as agents', () => {
     const span = createSpan('Custom root', { [INPUT]: 'input' });
 

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -507,6 +507,17 @@ describe('shapeLangfuseSpan', () => {
     );
   });
 
+  it('does not treat a user-supplied activity-phase tag as an operation type', () => {
+    const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent', 'activity-phase']),
+      [INPUT]: 'Run an ordinary agent',
+    });
+
+    shapeLangfuseSpan(span);
+
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
+  });
+
   it('does not classify untagged root spans as agents', () => {
     const span = createSpan('Custom root', { [INPUT]: 'input' });
 


### PR DESCRIPTION
## Summary

I improved Langfuse observability for LibreChat activity labels and activity-phase summaries so traces remain stable, correctly typed, and directly correlatable with their source agent run.

- Stabilized default trace names as `LibreChat Activity Label` and `LibreChat Activity Phase` while preserving explicit `runName` overrides.
- Added `sourceRunId`, `responseId`, activity indexes, parent message context, and resolved agent context to activity-label trace and generation metadata.
- Classified activity-phase summary roots as `CHAIN` observations with their model call retained as the child `GENERATION`.
- Added focused unit coverage for names, metadata propagation, tags, and root observation shaping.
- Added a gated live OpenAI-to-Langfuse contract test that waits for the complete exported observation tree and verifies model usage.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran 38 focused activity-label, activity-phase, and Langfuse shaping tests successfully.
- Ran the gated live test with an OpenAI provider call and the Langfuse development project; verified both exported traces, correlation metadata, observation hierarchy, resolved model, and nonzero token usage.
- Ran ESLint over every changed source and test file with no errors or new warnings.
- Ran `git diff --check` successfully.
- Confirmed the repository-wide import-sort failures and two `src/run.ts` lint warnings already exist on `origin/main`.

### **Test Configuration**:

- Node.js local workspace runtime
- OpenAI `gpt-4.1-mini`
- Langfuse development project
- Jest run in band with Node VM modules enabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
