### PR TITLE
🏁 feat: Run Step Lifecycle Timestamps and Closure Events

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -15,6 +15,8 @@ export enum GraphEvents {
   ON_RUN_STEP_DELTA = 'on_run_step_delta',
   /** [Custom] Completed event for run steps (tool calls) */
   ON_RUN_STEP_COMPLETED = 'on_run_step_completed',
+  /** [Custom] Terminal signal for a run step: closed with status + timestamps */
+  ON_RUN_STEP_CLOSED = 'on_run_step_closed',
   /** [Custom] Delta events for messages */
   ON_MESSAGE_DELTA = 'on_message_delta',
   /** [Custom] Reasoning Delta events for messages */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1921,15 +1921,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   async recordStepCompletion(
     stepId: string,
-    toolCallId?: string,
-    metadata?: Record<string, unknown>
+    options?: t.RecordStepCompletionOptions
   ): Promise<void> {
     if (!stepId) {
       return;
     }
+    const { toolCallId, metadata, at } = options ?? {};
     const pending = this.pendingToolCallsByStep.get(stepId);
     if (pending == null) {
-      await this.closeRunStep(stepId, 'completed', { metadata });
+      await this.closeRunStep(stepId, 'completed', { metadata, at });
       return;
     }
     const removed =
@@ -1941,6 +1941,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
     await this.closeRunStep(stepId, 'completed', {
       metadata,
+      at,
       restamp: removed,
     });
   }
@@ -4929,6 +4930,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               nodeConfig?: RunnableConfig
             ) => {
               const resolvedConfig = nodeConfig ?? this.config;
+              const completedAt = Date.now();
               const runStep = this.getRunStep(stepId);
               const handler = this.handlerRegistry?.getHandler(
                 GraphEvents.ON_RUN_STEP_COMPLETED
@@ -4941,18 +4943,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       ...result,
                       id: stepId,
                       index: runStep?.index ?? 0,
-                      completed_at: Date.now(),
+                      completed_at: completedAt,
                     },
                   },
                   resolvedConfig?.configurable,
                   this
                 );
               }
-              await this.recordStepCompletion(
-                stepId,
-                undefined,
-                resolvedConfig?.metadata
-              );
+              await this.recordStepCompletion(stepId, {
+                metadata: resolvedConfig?.metadata,
+                at: completedAt,
+              });
             },
           },
           generateStepId: (stepKey: string) => this.generateStepId(stepKey),
@@ -5185,6 +5186,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return false;
     }
 
+    const completedAt = Date.now();
     const tool_call: t.ProcessedToolCall = {
       id: data.id,
       name: name || '',
@@ -5212,13 +5214,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           index: runStep.index,
           type: 'tool_call',
           tool_call,
-          completed_at: Date.now(),
+          completed_at: completedAt,
         } as t.ToolCompleteEvent,
       },
       metadata,
       graph
     );
-    await graph.recordStepCompletion(stepId, data.id, metadata);
+    await graph.recordStepCompletion(stepId, {
+      toolCallId: data.id,
+      metadata,
+      at: completedAt,
+    });
     return true;
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1794,15 +1794,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   ): Promise<void> {
     const agentKey = runStep.agentId ?? '';
     const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
-    if (openMessageStepId != null && openMessageStepId !== runStep.id) {
-      await this.closeRunStep(openMessageStepId, 'completed', { metadata });
-    }
+    /**
+     * Reserve the content index and register the step SYNCHRONOUSLY, before
+     * awaiting the predecessor's closure. Parallel agent lanes dispatch
+     * successors concurrently: if both yielded here first, they would push
+     * with the same `contentData.length` and `contentIndexMap` would resolve
+     * one step id to the other lane's entry, so later deltas and completions
+     * would mutate the wrong agent's step. Assigning the index at push time
+     * also supersedes whatever the caller computed before this await point.
+     */
+    runStep.index = this.contentData.length;
     this.contentData.push(runStep);
     this.contentIndexMap.set(runStep.id, runStep.index);
     if (trackAsOpenMessageStep && runStep.type === StepTypes.MESSAGE_CREATION) {
       this.openMessageStepByAgent.set(agentKey, runStep.id);
     } else {
       this.openMessageStepByAgent.delete(agentKey);
+    }
+    /**
+     * Awaited after registration but before the caller dispatches this step's
+     * ON_RUN_STEP, so the predecessor's CLOSED event still precedes the
+     * successor's start event.
+     */
+    if (openMessageStepId != null && openMessageStepId !== runStep.id) {
+      await this.closeRunStep(openMessageStepId, 'completed', { metadata });
     }
   }
 
@@ -1953,7 +1968,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * successor-close does no work here.
    */
   async closeOpenMessageStep(
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
+    /** Model-end time captured before host handlers ran, so a slow usage sink
+     *  cannot inflate the step's measured duration. */
+    at?: number
   ): Promise<void> {
     if (this.openMessageStepByAgent.size === 0) {
       return;
@@ -1963,7 +1981,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (openStepId == null) {
       return;
     }
-    await this.closeRunStep(openStepId, 'completed', { metadata });
+    await this.closeRunStep(openStepId, 'completed', { metadata, at });
   }
 
   /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1780,7 +1780,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   protected async trackDispatchedRunStep(
     runStep: t.RunStep,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
+    /**
+     * Summarization steps are typed MESSAGE_CREATION but own an explicit
+     * completion, and their model call emits `CHAT_MODEL_END` well before the
+     * summary is assembled. Tracking one as the lane's open step would let
+     * model-end publish an authoritative `completed` closure early — the
+     * measured duration would exclude the remaining work and a later
+     * post-model failure could no longer change the status. They close
+     * through `recordStepCompletion` instead.
+     */
+    trackAsOpenMessageStep: boolean = true
   ): Promise<void> {
     const agentKey = runStep.agentId ?? '';
     const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
@@ -1789,7 +1799,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
     this.contentData.push(runStep);
     this.contentIndexMap.set(runStep.id, runStep.index);
-    if (runStep.type === StepTypes.MESSAGE_CREATION) {
+    if (trackAsOpenMessageStep && runStep.type === StepTypes.MESSAGE_CREATION) {
       this.openMessageStepByAgent.set(agentKey, runStep.id);
     } else {
       this.openMessageStepByAgent.delete(agentKey);
@@ -1838,6 +1848,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       runStep.failed_at = closedAt;
     }
 
+    /**
+     * A restamp corrects the stored `completed_at` for a parallel tool call
+     * that completed after its step already closed. The terminal event stays
+     * single-shot — re-emitting would break the exactly-once contract and
+     * double-count downstream (duplicate session `step.finished`, doubled
+     * step analytics).
+     */
+    if (isTerminal) {
+      this.untrackRunStep(runStep);
+      return true;
+    }
+
     const closedEvent: t.RunStepClosedEvent = {
       id: stepId,
       index: runStep.index,
@@ -1878,7 +1900,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       ? this.markHandlerDispatchedEvent(GraphEvents.ON_RUN_STEP_CLOSED, stepId)
       : undefined;
     try {
-      if (options?.registryOnly !== true && this.config) {
+      if (this.config) {
         await safeDispatchCustomEvent(
           GraphEvents.ON_RUN_STEP_CLOSED,
           closedEvent,
@@ -1945,8 +1967,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /**
    * End-of-run sweep: closes every step that never reached a terminal
-   * status. Runs after the LangGraph stream has ended, so dispatch is
-   * registry-only — the custom-event channel is already dead there.
+   * status. Dual-dispatches like any other close — the custom-event channel
+   * is usually already torn down here and `safeDispatchCustomEvent` reports
+   * that quietly, but callback-only subscribers still receive the terminal
+   * signal whenever it is alive.
    */
   async closeUnfinishedRunSteps(
     status: Exclude<t.RunStepStatus, 'in_progress'>,
@@ -1957,10 +1981,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (runStep.status != null && runStep.status !== 'in_progress') {
         continue;
       }
-      await this.closeRunStep(runStep.id, status, {
-        at: closedAt,
-        registryOnly: true,
-      });
+      /**
+       * Isolated per step: one host handler throwing must not strand the
+       * remaining steps `in_progress` with no terminal event. The step is
+       * stamped before dispatch either way, so a thrown handler still leaves
+       * consistent state behind.
+       */
+      try {
+        await this.closeRunStep(runStep.id, status, { at: closedAt });
+      } catch (_e) {
+        /** Delivery failure for one step must not halt the sweep */
+      }
     }
     this.pendingToolCallsByStep.clear();
     this.openMessageStepByAgent.clear();
@@ -4857,7 +4888,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               runStep.status ??= 'in_progress';
               await this.trackDispatchedRunStep(
                 runStep,
-                resolvedConfig?.metadata
+                resolvedConfig?.metadata,
+                false
               );
 
               const handler = this.handlerRegistry?.getHandler(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -742,6 +742,10 @@ export abstract class Graph<
   stepKeyIds: Map<string, string[]> = new Map<string, string[]>();
   contentIndexMap: Map<string, number> = new Map();
   toolCallStepIds: Map<string, string> = new Map();
+  /** Step ID -> tool call IDs whose completions have not yet arrived. */
+  pendingToolCallsByStep: Map<string, Set<string>> = new Map();
+  /** Agent key ('' for single-agent) -> currently open MESSAGE_CREATION step ID. */
+  openMessageStepByAgent: Map<string, string> = new Map();
   /**
    * Step IDs dispatched through the handler registry during this run.
    * Event echo suppression is tracked separately so repeated deltas for
@@ -858,6 +862,8 @@ export abstract class Graph<
     this.contentIndexMap = new Map();
     this.stepKeyIds = new Map();
     this.toolCallStepIds.clear();
+    this.pendingToolCallsByStep.clear();
+    this.openMessageStepByAgent.clear();
     this.messageIdsByStepKey = new Map();
     this.messageStepHasTextDeltas = new Set();
     this.reasoningStepHasDeltas = new Set();
@@ -932,6 +938,24 @@ export abstract class Graph<
     for (const usageCount of this.eagerEventToolUsageCountsByAgentId.values()) {
       usageCount.clear();
     }
+  }
+
+  /**
+   * Tracks a tool call whose completion must arrive before its step can be
+   * considered finished. Registered wherever `toolCallStepIds` gains entries,
+   * except cross-process subagent resume restoration, where pending state
+   * cannot be faithfully rebuilt and closes fall back to completions/sweep.
+   */
+  registerPendingToolCall(toolCallId: string, stepId: string): void {
+    if (!toolCallId || !stepId) {
+      return;
+    }
+    let pending = this.pendingToolCallsByStep.get(stepId);
+    if (!pending) {
+      pending = new Set();
+      this.pendingToolCallsByStep.set(stepId, pending);
+    }
+    pending.add(toolCallId);
   }
 
   markHandlerDispatchedEvent(eventName: string, stepId: string): () => void {
@@ -1441,6 +1465,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * a stale reference on 2nd+ processStream calls.
      */
     this.toolCallStepIds.clear();
+    this.pendingToolCallsByStep.clear();
+    this.openMessageStepByAgent.clear();
     this.runProducedAiMessageIds.clear();
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
@@ -1702,6 +1728,194 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return this.contentData[index];
     }
     return undefined;
+  }
+
+  /** Derives the same lane key `dispatchRunStep` stamps as `runStep.agentId`. */
+  protected getStepAgentKey(metadata?: Record<string, unknown>): string {
+    if (!metadata) {
+      return '';
+    }
+    try {
+      const agentContext = this.getAgentContext(metadata);
+      if (this.isMultiAgentGraph() && agentContext.agentId) {
+        return agentContext.agentId;
+      }
+    } catch (_e) {
+      /** No agent context — single-agent lane */
+    }
+    return '';
+  }
+
+  private untrackRunStep(stepId: string): void {
+    this.pendingToolCallsByStep.delete(stepId);
+    for (const [agentKey, openStepId] of this.openMessageStepByAgent) {
+      if (openStepId === stepId) {
+        this.openMessageStepByAgent.delete(agentKey);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Closes a run step: stamps its terminal status + timestamp on the stored
+   * `RunStep` and emits `ON_RUN_STEP_CLOSED`. First close wins — later calls
+   * are no-ops — except a `restamp` close, which lets a `completed`
+   * TOOL_CALLS step refresh `completed_at` when a late-registered parallel
+   * tool call finishes after the step already closed (the eager-execution
+   * race). `cancelled`/`failed` are immutable once stamped.
+   */
+  async closeRunStep(
+    stepId: string,
+    status: Exclude<t.RunStepStatus, 'in_progress'>,
+    at?: number,
+    options?: t.RunStepCloseOptions
+  ): Promise<boolean> {
+    if (!stepId) {
+      return false;
+    }
+    const runStep = this.getRunStep(stepId);
+    if (!runStep) {
+      return false;
+    }
+    const isTerminal =
+      runStep.status != null && runStep.status !== 'in_progress';
+    const canRestamp =
+      options?.restamp === true &&
+      status === 'completed' &&
+      runStep.status === 'completed' &&
+      runStep.type === StepTypes.TOOL_CALLS;
+    if (isTerminal && !canRestamp) {
+      this.untrackRunStep(stepId);
+      return false;
+    }
+
+    const closedAt = at ?? Date.now();
+    runStep.status = status;
+    if (status === 'completed') {
+      runStep.completed_at = closedAt;
+    } else if (status === 'cancelled') {
+      runStep.cancelled_at = closedAt;
+    } else {
+      runStep.failed_at = closedAt;
+    }
+
+    const closedEvent: t.RunStepClosedEvent = {
+      id: stepId,
+      index: runStep.index,
+      type: runStep.type,
+      status,
+      closed_at: closedAt,
+    };
+    if (runStep.created_at != null) {
+      closedEvent.created_at = runStep.created_at;
+    }
+    if (runStep.runId != null) {
+      closedEvent.runId = runStep.runId;
+    }
+    if (runStep.agentId != null) {
+      closedEvent.agentId = runStep.agentId;
+    }
+    if (runStep.groupId != null) {
+      closedEvent.groupId = runStep.groupId;
+    }
+    if (runStep.stepIndex != null) {
+      closedEvent.stepIndex = runStep.stepIndex;
+    }
+    this.untrackRunStep(stepId);
+
+    const handler = this.handlerRegistry?.getHandler(
+      GraphEvents.ON_RUN_STEP_CLOSED
+    );
+    if (handler) {
+      await handler.handle(
+        GraphEvents.ON_RUN_STEP_CLOSED,
+        closedEvent,
+        options?.metadata,
+        this
+      );
+      this.handlerDispatchedStepIds.add(stepId);
+    }
+    const unmarkHandlerDispatchedEvent = handler
+      ? this.markHandlerDispatchedEvent(GraphEvents.ON_RUN_STEP_CLOSED, stepId)
+      : undefined;
+    try {
+      if (options?.registryOnly !== true && this.config) {
+        await safeDispatchCustomEvent(
+          GraphEvents.ON_RUN_STEP_CLOSED,
+          closedEvent,
+          this.config
+        );
+      }
+    } finally {
+      unmarkHandlerDispatchedEvent?.();
+    }
+    return true;
+  }
+
+  /**
+   * Observes one `ON_RUN_STEP_COMPLETED` for a step and closes the step when
+   * no registered tool calls remain pending. Steps without pending tracking
+   * (summaries, cross-process resume) close on their first completion; the
+   * terminal-status guard in `closeRunStep` absorbs duplicate echoes.
+   */
+  async recordStepCompletion(
+    stepId: string,
+    toolCallId?: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    if (!stepId) {
+      return;
+    }
+    const pending = this.pendingToolCallsByStep.get(stepId);
+    if (pending == null) {
+      await this.closeRunStep(stepId, 'completed', undefined, { metadata });
+      return;
+    }
+    const removed =
+      toolCallId != null && toolCallId !== ''
+        ? pending.delete(toolCallId)
+        : false;
+    if (pending.size > 0) {
+      return;
+    }
+    await this.closeRunStep(stepId, 'completed', undefined, {
+      metadata,
+      restamp: removed,
+    });
+  }
+
+  /** Closes the tracked open MESSAGE_CREATION step for the event's agent lane. */
+  async closeOpenMessageStep(
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    const agentKey = this.getStepAgentKey(metadata);
+    const openStepId = this.openMessageStepByAgent.get(agentKey);
+    if (openStepId == null) {
+      return;
+    }
+    await this.closeRunStep(openStepId, 'completed', undefined, { metadata });
+  }
+
+  /**
+   * End-of-run sweep: closes every step that never reached a terminal
+   * status. Runs after the LangGraph stream has ended, so dispatch is
+   * registry-only — the custom-event channel is already dead there.
+   */
+  async closeUnfinishedRunSteps(
+    status: Exclude<t.RunStepStatus, 'in_progress'>,
+    at?: number
+  ): Promise<void> {
+    const closedAt = at ?? Date.now();
+    for (const runStep of this.contentData) {
+      if (runStep.status != null && runStep.status !== 'in_progress') {
+        continue;
+      }
+      await this.closeRunStep(runStep.id, status, closedAt, {
+        registryOnly: true,
+      });
+    }
+    this.pendingToolCallsByStep.clear();
+    this.openMessageStepByAgent.clear();
   }
 
   getAgentContext(metadata: Record<string, unknown> | undefined): AgentContext {
@@ -4591,8 +4805,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   runStep.groupId = groupId;
                 }
               }
+              runStep.created_at ??= Date.now();
+              runStep.status ??= 'in_progress';
+              const agentKey = runStep.agentId ?? '';
+              const openMessageStepId =
+                this.openMessageStepByAgent.get(agentKey);
+              if (
+                openMessageStepId != null &&
+                openMessageStepId !== runStep.id
+              ) {
+                await this.closeRunStep(
+                  openMessageStepId,
+                  'completed',
+                  undefined,
+                  { metadata: resolvedConfig?.metadata }
+                );
+              }
               this.contentData.push(runStep);
               this.contentIndexMap.set(runStep.id, runStep.index);
+              if (runStep.type === StepTypes.MESSAGE_CREATION) {
+                this.openMessageStepByAgent.set(agentKey, runStep.id);
+              } else {
+                this.openMessageStepByAgent.delete(agentKey);
+              }
 
               const handler = this.handlerRegistry?.getHandler(
                 GraphEvents.ON_RUN_STEP
@@ -4643,12 +4878,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       ...result,
                       id: stepId,
                       index: runStep?.index ?? 0,
+                      completed_at: Date.now(),
                     },
                   },
                   resolvedConfig?.configurable,
                   this
                 );
               }
+              await this.recordStepCompletion(
+                stepId,
+                undefined,
+                resolvedConfig?.metadata
+              );
             },
           },
           generateStepId: (stepKey: string) => this.generateStepId(stepKey),
@@ -4763,6 +5004,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           continue;
         }
         this.toolCallStepIds.set(toolCallId, stepId);
+        this.registerPendingToolCall(toolCallId, stepId);
       }
     }
 
@@ -4773,6 +5015,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       index: this.contentData.length,
       stepDetails,
       usage: null,
+      created_at: Date.now(),
+      status: 'in_progress',
     };
 
     const runId = this.runId ?? '';
@@ -4798,8 +5042,26 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
     }
 
+    /**
+     * A successor step in the same agent lane marks the previous message
+     * step as finished — its CLOSED event must precede this step's
+     * ON_RUN_STEP so hosts observe a consistent open-step timeline.
+     */
+    const agentKey = runStep.agentId ?? '';
+    const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
+    if (openMessageStepId != null && openMessageStepId !== stepId) {
+      await this.closeRunStep(openMessageStepId, 'completed', undefined, {
+        metadata,
+      });
+    }
+
     this.contentData.push(runStep);
     this.contentIndexMap.set(stepId, runStep.index);
+    if (stepDetails.type === StepTypes.MESSAGE_CREATION) {
+      this.openMessageStepByAgent.set(agentKey, stepId);
+    } else {
+      this.openMessageStepByAgent.delete(agentKey);
+    }
 
     // Primary dispatch: handler registry (reliable, always works).
     // This mirrors how handleToolCallCompleted dispatches ON_RUN_STEP_COMPLETED
@@ -4904,11 +5166,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           index: runStep.index,
           type: 'tool_call',
           tool_call,
+          completed_at: Date.now(),
         } as t.ToolCompleteEvent,
       },
       metadata,
       graph
     );
+    await graph.recordStepCompletion(stepId, data.id, metadata);
     return true;
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -744,6 +744,13 @@ export abstract class Graph<
   toolCallStepIds: Map<string, string> = new Map();
   /** Step ID -> tool call IDs whose completions have not yet arrived. */
   pendingToolCallsByStep: Map<string, Set<string>> = new Map();
+  /**
+   * Step ID -> latest producer completion time seen for that step. Parallel
+   * calls sharing a step can settle out of producer order when their host
+   * handlers differ in latency, so the call that happens to drain the set is
+   * not necessarily the one that finished last.
+   */
+  latestCompletionByStep: Map<string, number> = new Map();
   /** Agent key ('' for single-agent) -> currently open MESSAGE_CREATION step ID. */
   openMessageStepByAgent: Map<string, string> = new Map();
   /**
@@ -863,6 +870,7 @@ export abstract class Graph<
     this.stepKeyIds = new Map();
     this.toolCallStepIds.clear();
     this.pendingToolCallsByStep.clear();
+    this.latestCompletionByStep.clear();
     this.openMessageStepByAgent.clear();
     this.messageIdsByStepKey = new Map();
     this.messageStepHasTextDeltas = new Set();
@@ -1472,6 +1480,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      */
     this.toolCallStepIds.clear();
     this.pendingToolCallsByStep.clear();
+    this.latestCompletionByStep.clear();
     this.openMessageStepByAgent.clear();
     this.runProducedAiMessageIds.clear();
     this.eagerEventToolExecutions.clear();
@@ -1764,6 +1773,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   private untrackRunStep(runStep: t.RunStep): void {
     this.pendingToolCallsByStep.delete(runStep.id);
+    this.latestCompletionByStep.delete(runStep.id);
     const agentKey = runStep.agentId ?? '';
     if (this.openMessageStepByAgent.get(agentKey) === runStep.id) {
       this.openMessageStepByAgent.delete(agentKey);
@@ -1829,6 +1839,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         /** Predecessor delivery must not abort the successor's lifecycle */
       }
     }
+    /**
+     * Stamped last, after the predecessor's closure has been delivered and
+     * immediately before the caller publishes this step's ON_RUN_STEP.
+     * `created_at` documents when the step was dispatched, so it must not
+     * absorb the latency of an arbitrarily slow predecessor handler.
+     */
+    runStep.created_at = Date.now();
   }
 
   /**
@@ -1933,9 +1950,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return;
     }
     const { toolCallId, metadata, at } = options ?? {};
+    if (at != null) {
+      const latest = this.latestCompletionByStep.get(stepId);
+      if (latest == null || at > latest) {
+        this.latestCompletionByStep.set(stepId, at);
+      }
+    }
+    const closeAt = this.latestCompletionByStep.get(stepId) ?? at;
     const pending = this.pendingToolCallsByStep.get(stepId);
     if (pending == null) {
-      await this.closeRunStep(stepId, 'completed', { metadata, at });
+      await this.closeRunStep(stepId, 'completed', { metadata, at: closeAt });
       return;
     }
     if (toolCallId != null && toolCallId !== '') {
@@ -1944,7 +1968,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (pending.size > 0) {
       return;
     }
-    await this.closeRunStep(stepId, 'completed', { metadata, at });
+    await this.closeRunStep(stepId, 'completed', { metadata, at: closeAt });
   }
 
   /**
@@ -1999,6 +2023,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
     }
     this.pendingToolCallsByStep.clear();
+    this.latestCompletionByStep.clear();
     this.openMessageStepByAgent.clear();
   }
 
@@ -4889,7 +4914,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   runStep.groupId = groupId;
                 }
               }
-              runStep.created_at ??= Date.now();
               runStep.status ??= 'in_progress';
               await this.trackDispatchedRunStep(
                 runStep,
@@ -5094,7 +5118,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       index: this.contentData.length,
       stepDetails,
       usage: null,
-      created_at: Date.now(),
       status: 'in_progress',
     };
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1817,7 +1817,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * successor's start event.
      */
     if (openMessageStepId != null && openMessageStepId !== runStep.id) {
-      await this.closeRunStep(openMessageStepId, 'completed', { metadata });
+      /**
+       * Isolated: this step is already registered in `contentData`, so a
+       * predecessor delivery failure rejecting here would abort the caller
+       * before it publishes this step's ON_RUN_STEP — leaving the sweep to
+       * emit a terminal event for a step that never announced a start.
+       */
+      try {
+        await this.closeRunStep(openMessageStepId, 'completed', { metadata });
+      } catch (_e) {
+        /** Predecessor delivery must not abort the successor's lifecycle */
+      }
     }
   }
 
@@ -1841,14 +1851,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (!runStep) {
       return false;
     }
-    const isTerminal =
-      runStep.status != null && runStep.status !== 'in_progress';
-    const canRestamp =
-      options?.restamp === true &&
-      status === 'completed' &&
-      runStep.status === 'completed' &&
-      runStep.type === StepTypes.TOOL_CALLS;
-    if (isTerminal && !canRestamp) {
+    if (runStep.status != null && runStep.status !== 'in_progress') {
       this.untrackRunStep(runStep);
       return false;
     }
@@ -1861,18 +1864,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       runStep.cancelled_at = closedAt;
     } else {
       runStep.failed_at = closedAt;
-    }
-
-    /**
-     * A restamp corrects the stored `completed_at` for a parallel tool call
-     * that completed after its step already closed. The terminal event stays
-     * single-shot — re-emitting would break the exactly-once contract and
-     * double-count downstream (duplicate session `step.finished`, doubled
-     * step analytics).
-     */
-    if (isTerminal) {
-      this.untrackRunStep(runStep);
-      return true;
     }
 
     const closedEvent: t.RunStepClosedEvent = {
@@ -1947,18 +1938,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       await this.closeRunStep(stepId, 'completed', { metadata, at });
       return;
     }
-    const removed =
-      toolCallId != null && toolCallId !== ''
-        ? pending.delete(toolCallId)
-        : false;
+    if (toolCallId != null && toolCallId !== '') {
+      pending.delete(toolCallId);
+    }
     if (pending.size > 0) {
       return;
     }
-    await this.closeRunStep(stepId, 'completed', {
-      metadata,
-      at,
-      restamp: removed,
-    });
+    await this.closeRunStep(stepId, 'completed', { metadata, at });
   }
 
   /**
@@ -4941,6 +4927,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               } finally {
                 unmarkHandlerDispatchedEvent?.();
               }
+            },
+            closeRunStep: async (
+              stepId: string,
+              status: Exclude<t.RunStepStatus, 'in_progress'>,
+              nodeConfig?: RunnableConfig
+            ) => {
+              await this.closeRunStep(stepId, status, {
+                metadata: (nodeConfig ?? this.config)?.metadata,
+              });
             },
             dispatchRunStepCompleted: async (
               stepId: string,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -950,12 +950,18 @@ export abstract class Graph<
     if (!toolCallId || !stepId) {
       return;
     }
+    this.getPendingToolCallSet(stepId).add(toolCallId);
+  }
+
+  /** Lazily creates a step's pending-completions set; callers registering a
+   *  batch hoist this lookup out of their per-call loop. */
+  protected getPendingToolCallSet(stepId: string): Set<string> {
     let pending = this.pendingToolCallsByStep.get(stepId);
     if (!pending) {
       pending = new Set();
       this.pendingToolCallsByStep.set(stepId, pending);
     }
-    pending.add(toolCallId);
+    return pending;
   }
 
   markHandlerDispatchedEvent(eventName: string, stepId: string): () => void {
@@ -1746,13 +1752,43 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return '';
   }
 
-  private untrackRunStep(stepId: string): void {
-    this.pendingToolCallsByStep.delete(stepId);
-    for (const [agentKey, openStepId] of this.openMessageStepByAgent) {
-      if (openStepId === stepId) {
-        this.openMessageStepByAgent.delete(agentKey);
-        break;
-      }
+  /**
+   * O(1) reverse lookup: both dispatch funnels key the open-message map by
+   * `runStep.agentId ?? ''`, so the entry is addressable without scanning.
+   */
+  private untrackRunStep(runStep: t.RunStep): void {
+    this.pendingToolCallsByStep.delete(runStep.id);
+    const agentKey = runStep.agentId ?? '';
+    if (this.openMessageStepByAgent.get(agentKey) === runStep.id) {
+      this.openMessageStepByAgent.delete(agentKey);
+    }
+  }
+
+  /**
+   * Shared step accounting for both dispatch funnels: a successor step in
+   * the same agent lane marks the previous message step as finished — its
+   * CLOSED event must precede the successor's ON_RUN_STEP so hosts observe
+   * a consistent open-step timeline — then the step is registered in the
+   * content maps and tracked as the lane's open message step when
+   * applicable.
+   */
+  protected async trackDispatchedRunStep(
+    runStep: t.RunStep,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    const agentKey = runStep.agentId ?? '';
+    const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
+    if (openMessageStepId != null && openMessageStepId !== runStep.id) {
+      await this.closeRunStep(openMessageStepId, 'completed', undefined, {
+        metadata,
+      });
+    }
+    this.contentData.push(runStep);
+    this.contentIndexMap.set(runStep.id, runStep.index);
+    if (runStep.type === StepTypes.MESSAGE_CREATION) {
+      this.openMessageStepByAgent.set(agentKey, runStep.id);
+    } else {
+      this.openMessageStepByAgent.delete(agentKey);
     }
   }
 
@@ -1785,7 +1821,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       runStep.status === 'completed' &&
       runStep.type === StepTypes.TOOL_CALLS;
     if (isTerminal && !canRestamp) {
-      this.untrackRunStep(stepId);
+      this.untrackRunStep(runStep);
       return false;
     }
 
@@ -1821,7 +1857,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (runStep.stepIndex != null) {
       closedEvent.stepIndex = runStep.stepIndex;
     }
-    this.untrackRunStep(stepId);
+    this.untrackRunStep(runStep);
 
     const handler = this.handlerRegistry?.getHandler(
       GraphEvents.ON_RUN_STEP_CLOSED
@@ -4807,27 +4843,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               }
               runStep.created_at ??= Date.now();
               runStep.status ??= 'in_progress';
-              const agentKey = runStep.agentId ?? '';
-              const openMessageStepId =
-                this.openMessageStepByAgent.get(agentKey);
-              if (
-                openMessageStepId != null &&
-                openMessageStepId !== runStep.id
-              ) {
-                await this.closeRunStep(
-                  openMessageStepId,
-                  'completed',
-                  undefined,
-                  { metadata: resolvedConfig?.metadata }
-                );
-              }
-              this.contentData.push(runStep);
-              this.contentIndexMap.set(runStep.id, runStep.index);
-              if (runStep.type === StepTypes.MESSAGE_CREATION) {
-                this.openMessageStepByAgent.set(agentKey, runStep.id);
-              } else {
-                this.openMessageStepByAgent.delete(agentKey);
-              }
+              await this.trackDispatchedRunStep(
+                runStep,
+                resolvedConfig?.metadata
+              );
 
               const handler = this.handlerRegistry?.getHandler(
                 GraphEvents.ON_RUN_STEP
@@ -4866,7 +4885,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               nodeConfig?: RunnableConfig
             ) => {
               const resolvedConfig = nodeConfig ?? this.config;
-              const runStep = this.contentData.find((s) => s.id === stepId);
+              const runStep = this.getRunStep(stepId);
               const handler = this.handlerRegistry?.getHandler(
                 GraphEvents.ON_RUN_STEP_COMPLETED
               );
@@ -4998,13 +5017,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
     const [stepId, stepIndex] = this.generateStepId(stepKey);
     if (stepDetails.type === StepTypes.TOOL_CALLS && stepDetails.tool_calls) {
+      let pendingToolCalls: Set<string> | undefined;
       for (const tool_call of stepDetails.tool_calls) {
         const toolCallId = tool_call.id ?? '';
         if (!toolCallId || this.toolCallStepIds.has(toolCallId)) {
           continue;
         }
         this.toolCallStepIds.set(toolCallId, stepId);
-        this.registerPendingToolCall(toolCallId, stepId);
+        pendingToolCalls ??= this.getPendingToolCallSet(stepId);
+        pendingToolCalls.add(toolCallId);
       }
     }
 
@@ -5042,26 +5063,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
     }
 
-    /**
-     * A successor step in the same agent lane marks the previous message
-     * step as finished — its CLOSED event must precede this step's
-     * ON_RUN_STEP so hosts observe a consistent open-step timeline.
-     */
-    const agentKey = runStep.agentId ?? '';
-    const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
-    if (openMessageStepId != null && openMessageStepId !== stepId) {
-      await this.closeRunStep(openMessageStepId, 'completed', undefined, {
-        metadata,
-      });
-    }
-
-    this.contentData.push(runStep);
-    this.contentIndexMap.set(stepId, runStep.index);
-    if (stepDetails.type === StepTypes.MESSAGE_CREATION) {
-      this.openMessageStepByAgent.set(agentKey, stepId);
-    } else {
-      this.openMessageStepByAgent.delete(agentKey);
-    }
+    await this.trackDispatchedRunStep(runStep, metadata);
 
     // Primary dispatch: handler registry (reliable, always works).
     // This mirrors how handleToolCallCompleted dispatches ON_RUN_STEP_COMPLETED

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1736,18 +1736,24 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return undefined;
   }
 
-  /** Derives the same lane key `dispatchRunStep` stamps as `runStep.agentId`. */
+  /**
+   * Derives the same lane key `dispatchRunStep` stamps as `runStep.agentId`.
+   * The multi-agent check gates the lookup because `getAgentContext` signals
+   * a miss by throwing: single-agent graphs key every step under `''`, so
+   * resolving the context could only ever produce a thrown-and-discarded
+   * Error on a per-model-call path.
+   */
   protected getStepAgentKey(metadata?: Record<string, unknown>): string {
-    if (!metadata) {
+    if (!metadata || !this.isMultiAgentGraph()) {
       return '';
     }
     try {
       const agentContext = this.getAgentContext(metadata);
-      if (this.isMultiAgentGraph() && agentContext.agentId) {
+      if (agentContext.agentId) {
         return agentContext.agentId;
       }
     } catch (_e) {
-      /** No agent context — single-agent lane */
+      /** No agent context — fall back to the default lane */
     }
     return '';
   }
@@ -1917,10 +1923,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     });
   }
 
-  /** Closes the tracked open MESSAGE_CREATION step for the event's agent lane. */
+  /**
+   * Closes the tracked open MESSAGE_CREATION step for the event's agent lane.
+   * Fires on every model end, so the empty-map check short-circuits ahead of
+   * resolving the lane key — a turn whose message step already closed through
+   * successor-close does no work here.
+   */
   async closeOpenMessageStep(
     metadata?: Record<string, unknown>
   ): Promise<void> {
+    if (this.openMessageStepByAgent.size === 0) {
+      return;
+    }
     const agentKey = this.getStepAgentKey(metadata);
     const openStepId = this.openMessageStepByAgent.get(agentKey);
     if (openStepId == null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1779,9 +1779,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const agentKey = runStep.agentId ?? '';
     const openMessageStepId = this.openMessageStepByAgent.get(agentKey);
     if (openMessageStepId != null && openMessageStepId !== runStep.id) {
-      await this.closeRunStep(openMessageStepId, 'completed', undefined, {
-        metadata,
-      });
+      await this.closeRunStep(openMessageStepId, 'completed', { metadata });
     }
     this.contentData.push(runStep);
     this.contentIndexMap.set(runStep.id, runStep.index);
@@ -1803,7 +1801,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   async closeRunStep(
     stepId: string,
     status: Exclude<t.RunStepStatus, 'in_progress'>,
-    at?: number,
     options?: t.RunStepCloseOptions
   ): Promise<boolean> {
     if (!stepId) {
@@ -1825,7 +1822,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return false;
     }
 
-    const closedAt = at ?? Date.now();
+    const closedAt = options?.at ?? Date.now();
     runStep.status = status;
     if (status === 'completed') {
       runStep.completed_at = closedAt;
@@ -1904,7 +1901,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
     const pending = this.pendingToolCallsByStep.get(stepId);
     if (pending == null) {
-      await this.closeRunStep(stepId, 'completed', undefined, { metadata });
+      await this.closeRunStep(stepId, 'completed', { metadata });
       return;
     }
     const removed =
@@ -1914,7 +1911,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (pending.size > 0) {
       return;
     }
-    await this.closeRunStep(stepId, 'completed', undefined, {
+    await this.closeRunStep(stepId, 'completed', {
       metadata,
       restamp: removed,
     });
@@ -1929,7 +1926,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     if (openStepId == null) {
       return;
     }
-    await this.closeRunStep(openStepId, 'completed', undefined, { metadata });
+    await this.closeRunStep(openStepId, 'completed', { metadata });
   }
 
   /**
@@ -1946,7 +1943,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (runStep.status != null && runStep.status !== 'in_progress') {
         continue;
       }
-      await this.closeRunStep(runStep.id, status, closedAt, {
+      await this.closeRunStep(runStep.id, status, {
+        at: closedAt,
         registryOnly: true,
       });
     }

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -62,7 +62,9 @@ describe('StandardGraph.closeRunStep', () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a');
 
-    const first = await graph.closeRunStep('step_a', 'completed', 2_000);
+    const first = await graph.closeRunStep('step_a', 'completed', {
+      at: 2_000,
+    });
     expect(first).toBe(true);
     expect(step.status).toBe('completed');
     expect(step.completed_at).toBe(2_000);
@@ -76,7 +78,9 @@ describe('StandardGraph.closeRunStep', () => {
       closed_at: 2_000,
     });
 
-    const second = await graph.closeRunStep('step_a', 'completed', 3_000);
+    const second = await graph.closeRunStep('step_a', 'completed', {
+      at: 3_000,
+    });
     expect(second).toBe(false);
     expect(step.completed_at).toBe(2_000);
     expect(closed).toHaveLength(1);
@@ -86,8 +90,9 @@ describe('StandardGraph.closeRunStep', () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
 
-    await graph.closeRunStep('step_a', 'cancelled', 2_000);
-    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+    await graph.closeRunStep('step_a', 'cancelled', { at: 2_000 });
+    const restamped = await graph.closeRunStep('step_a', 'completed', {
+      at: 3_000,
       restamp: true,
     });
     expect(restamped).toBe(false);
@@ -101,8 +106,9 @@ describe('StandardGraph.closeRunStep', () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
 
-    await graph.closeRunStep('step_a', 'completed', 2_000);
-    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+    await graph.closeRunStep('step_a', 'completed', { at: 2_000 });
+    const restamped = await graph.closeRunStep('step_a', 'completed', {
+      at: 3_000,
       restamp: true,
     });
     expect(restamped).toBe(true);
@@ -115,8 +121,9 @@ describe('StandardGraph.closeRunStep', () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a');
 
-    await graph.closeRunStep('step_a', 'completed', 2_000);
-    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+    await graph.closeRunStep('step_a', 'completed', { at: 2_000 });
+    const restamped = await graph.closeRunStep('step_a', 'completed', {
+      at: 3_000,
       restamp: true,
     });
     expect(restamped).toBe(false);
@@ -192,7 +199,7 @@ describe('StandardGraph.closeUnfinishedRunSteps', () => {
     const done = seedStep(graph, 'step_done', StepTypes.TOOL_CALLS);
     const openMessage = seedStep(graph, 'step_msg');
     const openTool = seedStep(graph, 'step_tool', StepTypes.TOOL_CALLS);
-    await graph.closeRunStep('step_done', 'completed', 2_000);
+    await graph.closeRunStep('step_done', 'completed', { at: 2_000 });
     closed.length = 0;
 
     await graph.closeUnfinishedRunSteps('cancelled', 5_000);

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -86,50 +86,36 @@ describe('StandardGraph.closeRunStep', () => {
     expect(closed).toHaveLength(1);
   });
 
-  it('keeps cancelled and failed immutable, even with restamp', async () => {
+  it('keeps a terminal status immutable across later close attempts', async () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
 
     await graph.closeRunStep('step_a', 'cancelled', { at: 2_000 });
-    const restamped = await graph.closeRunStep('step_a', 'completed', {
+    const reclosed = await graph.closeRunStep('step_a', 'completed', {
       at: 3_000,
-      restamp: true,
     });
-    expect(restamped).toBe(false);
+    expect(reclosed).toBe(false);
     expect(step.status).toBe('cancelled');
     expect(step.cancelled_at).toBe(2_000);
     expect(step.completed_at).toBeUndefined();
     expect(closed).toHaveLength(1);
   });
 
-  it('restamps a completed TOOL_CALLS step on a late completion', async () => {
+  it('keeps the stored stamp and the emitted event in agreement', async () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
 
     await graph.closeRunStep('step_a', 'completed', { at: 2_000 });
-    const restamped = await graph.closeRunStep('step_a', 'completed', {
+    const reclosed = await graph.closeRunStep('step_a', 'completed', {
       at: 3_000,
-      restamp: true,
     });
-    expect(restamped).toBe(true);
-    expect(step.completed_at).toBe(3_000);
-    /** The stamp moves, the terminal event stays single-shot. */
-    expect(closed).toHaveLength(1);
-    expect(closed[0].closed_at).toBe(2_000);
-  });
 
-  it('does not restamp completed MESSAGE_CREATION steps', async () => {
-    const { graph, closed } = createGraph();
-    const step = seedStep(graph, 'step_a');
-
-    await graph.closeRunStep('step_a', 'completed', { at: 2_000 });
-    const restamped = await graph.closeRunStep('step_a', 'completed', {
-      at: 3_000,
-      restamp: true,
-    });
-    expect(restamped).toBe(false);
+    /** No silent correction: RunStep.completed_at can never disagree with the
+     *  closed_at already delivered to subscribers. */
+    expect(reclosed).toBe(false);
     expect(step.completed_at).toBe(2_000);
     expect(closed).toHaveLength(1);
+    expect(closed[0].closed_at).toBe(2_000);
   });
 
   it('tolerates empty and unknown step ids', async () => {
@@ -177,19 +163,27 @@ describe('StandardGraph.recordStepCompletion', () => {
     expect(closed).toHaveLength(1);
   });
 
-  it('restamps when a late-registered call completes after the step closed', async () => {
+  it('leaves a closed step untouched if a late call registers and completes', async () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
     graph.registerPendingToolCall('call_1', 'step_a');
 
-    await graph.recordStepCompletion('step_a', { toolCallId: 'call_1' });
+    await graph.recordStepCompletion('step_a', {
+      toolCallId: 'call_1',
+      at: 2_000,
+    });
     expect(closed).toHaveLength(1);
-    const firstClosedAt = step.completed_at;
 
     graph.registerPendingToolCall('call_2', 'step_a');
-    await graph.recordStepCompletion('step_a', { toolCallId: 'call_2' });
+    await graph.recordStepCompletion('step_a', {
+      toolCallId: 'call_2',
+      at: 3_000,
+    });
+    /** First close wins outright — no second event and no divergence between
+     *  the stored stamp and what subscribers were told. */
     expect(closed).toHaveLength(1);
-    expect(step.completed_at).toBeGreaterThanOrEqual(firstClosedAt as number);
+    expect(step.completed_at).toBe(2_000);
+    expect(closed[0].closed_at).toBe(2_000);
   });
   it('uses the producer\'s completion timestamp when one is supplied', async () => {
     const { graph, closed } = createGraph();

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -147,11 +147,11 @@ describe('StandardGraph.recordStepCompletion', () => {
     graph.registerPendingToolCall('call_1', 'step_a');
     graph.registerPendingToolCall('call_2', 'step_a');
 
-    await graph.recordStepCompletion('step_a', 'call_1');
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_1' });
     expect(step.status).toBe('in_progress');
     expect(closed).toHaveLength(0);
 
-    await graph.recordStepCompletion('step_a', 'call_2');
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_2' });
     expect(step.status).toBe('completed');
     expect(typeof step.completed_at).toBe('number');
     expect(closed).toHaveLength(1);
@@ -172,8 +172,8 @@ describe('StandardGraph.recordStepCompletion', () => {
     seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
     graph.registerPendingToolCall('call_1', 'step_a');
 
-    await graph.recordStepCompletion('step_a', 'call_1');
-    await graph.recordStepCompletion('step_a', 'call_1');
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_1' });
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_1' });
     expect(closed).toHaveLength(1);
   });
 
@@ -182,14 +182,29 @@ describe('StandardGraph.recordStepCompletion', () => {
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
     graph.registerPendingToolCall('call_1', 'step_a');
 
-    await graph.recordStepCompletion('step_a', 'call_1');
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_1' });
     expect(closed).toHaveLength(1);
     const firstClosedAt = step.completed_at;
 
     graph.registerPendingToolCall('call_2', 'step_a');
-    await graph.recordStepCompletion('step_a', 'call_2');
+    await graph.recordStepCompletion('step_a', { toolCallId: 'call_2' });
     expect(closed).toHaveLength(1);
     expect(step.completed_at).toBeGreaterThanOrEqual(firstClosedAt as number);
+  });
+  it('uses the producer\'s completion timestamp when one is supplied', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+    graph.registerPendingToolCall('call_1', 'step_a');
+
+    await graph.recordStepCompletion('step_a', {
+      toolCallId: 'call_1',
+      at: 4_000,
+    });
+
+    /** A slow host handler must not inflate the recorded duration. */
+    expect(step.completed_at).toBe(4_000);
+    expect(closed).toHaveLength(1);
+    expect(closed[0].closed_at).toBe(4_000);
   });
 });
 

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -113,8 +113,9 @@ describe('StandardGraph.closeRunStep', () => {
     });
     expect(restamped).toBe(true);
     expect(step.completed_at).toBe(3_000);
-    expect(closed).toHaveLength(2);
-    expect(closed[1].closed_at).toBe(3_000);
+    /** The stamp moves, the terminal event stays single-shot. */
+    expect(closed).toHaveLength(1);
+    expect(closed[0].closed_at).toBe(2_000);
   });
 
   it('does not restamp completed MESSAGE_CREATION steps', async () => {
@@ -187,9 +188,8 @@ describe('StandardGraph.recordStepCompletion', () => {
 
     graph.registerPendingToolCall('call_2', 'step_a');
     await graph.recordStepCompletion('step_a', 'call_2');
-    expect(closed).toHaveLength(2);
+    expect(closed).toHaveLength(1);
     expect(step.completed_at).toBeGreaterThanOrEqual(firstClosedAt as number);
-    expect(closed[1].status).toBe('completed');
   });
 });
 
@@ -224,5 +224,34 @@ describe('StandardGraph.closeUnfinishedRunSteps', () => {
     expect(step.failed_at).toBe(5_000);
     expect(step.cancelled_at).toBeUndefined();
     expect(step.completed_at).toBeUndefined();
+  });
+  it('keeps sweeping when a closure handler throws', async () => {
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    const seen: string[] = [];
+    const registry = new HandlerRegistry();
+    registry.register(GraphEvents.ON_RUN_STEP_CLOSED, {
+      handle: (_event, data): void => {
+        const event = data as t.RunStepClosedEvent;
+        seen.push(event.id);
+        if (event.id === 'step_1') {
+          throw new Error('host handler blew up');
+        }
+      },
+    });
+    graph.handlerRegistry = registry;
+    const first = seedStep(graph, 'step_1');
+    const second = seedStep(graph, 'step_2');
+    const third = seedStep(graph, 'step_3');
+
+    await graph.closeUnfinishedRunSteps('cancelled', 5_000);
+
+    expect(seen).toEqual(['step_1', 'step_2', 'step_3']);
+    for (const step of [first, second, third]) {
+      expect(step.status).toBe('cancelled');
+      expect(step.cancelled_at).toBe(5_000);
+    }
   });
 });

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -185,6 +185,28 @@ describe('StandardGraph.recordStepCompletion', () => {
     expect(step.completed_at).toBe(2_000);
     expect(closed[0].closed_at).toBe(2_000);
   });
+  it('closes a multi-call step at the latest producer timestamp', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+    graph.registerPendingToolCall('call_1', 'step_a');
+    graph.registerPendingToolCall('call_2', 'step_a');
+
+    /** call_2 finished later, but its host handler was faster, so the
+     *  earlier-finishing call_1 is what drains the pending set. */
+    await graph.recordStepCompletion('step_a', {
+      toolCallId: 'call_2',
+      at: 5_000,
+    });
+    await graph.recordStepCompletion('step_a', {
+      toolCallId: 'call_1',
+      at: 4_000,
+    });
+
+    expect(step.completed_at).toBe(5_000);
+    expect(closed).toHaveLength(1);
+    expect(closed[0].closed_at).toBe(5_000);
+  });
+
   it('uses the producer\'s completion timestamp when one is supplied', async () => {
     const { graph, closed } = createGraph();
     const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
@@ -318,5 +340,46 @@ describe('StandardGraph.trackDispatchedRunStep', () => {
     expect(graph.contentData.filter((s) => s.id === 'next_a')).toHaveLength(1);
     const indexes = graph.contentData.map((step) => step.index);
     expect(new Set(indexes).size).toBe(indexes.length);
+  });
+  it('stamps created_at after the predecessor closure is delivered', async () => {
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    let predecessorClosedAt = 0;
+    const registry = new HandlerRegistry();
+    registry.register(GraphEvents.ON_RUN_STEP_CLOSED, {
+      handle: async (): Promise<void> => {
+        /** A slow predecessor handler must not be charged to the successor. */
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        predecessorClosedAt = Date.now();
+      },
+    });
+    graph.handlerRegistry = registry;
+
+    seedStep(graph, 'open_a');
+    graph.openMessageStepByAgent.set('', 'open_a');
+
+    const successor: t.RunStep = {
+      id: 'next_a',
+      type: StepTypes.MESSAGE_CREATION,
+      index: 0,
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'msg_next_a' },
+      },
+      usage: null,
+      status: 'in_progress',
+    };
+    await (
+      graph as unknown as {
+        trackDispatchedRunStep: (step: t.RunStep) => Promise<void>;
+      }
+    ).trackDispatchedRunStep.bind(graph)(successor);
+
+    expect(predecessorClosedAt).toBeGreaterThan(0);
+    expect(successor.created_at as number).toBeGreaterThanOrEqual(
+      predecessorClosedAt
+    );
   });
 });

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -270,3 +270,59 @@ describe('StandardGraph.closeUnfinishedRunSteps', () => {
     }
   });
 });
+
+describe('StandardGraph.trackDispatchedRunStep', () => {
+  it('reserves distinct content indexes when parallel lanes dispatch concurrently', async () => {
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    /** A host handler that yields — the window in which two lanes could
+     *  otherwise both read the same contentData.length. */
+    const registry = new HandlerRegistry();
+    registry.register(GraphEvents.ON_RUN_STEP_CLOSED, {
+      handle: async (): Promise<void> => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      },
+    });
+    graph.handlerRegistry = registry;
+
+    const openA = seedStep(graph, 'open_a');
+    openA.agentId = 'agent_a';
+    const openB = seedStep(graph, 'open_b');
+    openB.agentId = 'agent_b';
+    graph.openMessageStepByAgent.set('agent_a', 'open_a');
+    graph.openMessageStepByAgent.set('agent_b', 'open_b');
+
+    const makeSuccessor = (id: string, agentId: string): t.RunStep => ({
+      id,
+      agentId,
+      type: StepTypes.MESSAGE_CREATION,
+      /** Both lanes computed the same stale index before dispatching. */
+      index: graph.contentData.length,
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: `msg_${id}` },
+      },
+      usage: null,
+      created_at: 1_000,
+      status: 'in_progress',
+    });
+    const successorA = makeSuccessor('next_a', 'agent_a');
+    const successorB = makeSuccessor('next_b', 'agent_b');
+
+    const track = (
+      graph as unknown as {
+        trackDispatchedRunStep: (step: t.RunStep) => Promise<void>;
+      }
+    ).trackDispatchedRunStep.bind(graph);
+    await Promise.all([track(successorA), track(successorB)]);
+
+    expect(successorA.index).not.toBe(successorB.index);
+    expect(graph.getRunStep('next_a')).toBe(successorA);
+    expect(graph.getRunStep('next_b')).toBe(successorB);
+    expect(graph.contentData.filter((s) => s.id === 'next_a')).toHaveLength(1);
+    const indexes = graph.contentData.map((step) => step.index);
+    expect(new Set(indexes).size).toBe(indexes.length);
+  });
+});

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -1,0 +1,221 @@
+// src/graphs/__tests__/Graph.closeRunStep.test.ts
+import type * as t from '@/types';
+import { GraphEvents, StepTypes, Providers } from '@/common';
+import { HandlerRegistry } from '@/events';
+import { StandardGraph } from '../Graph';
+
+const makeAgent = (agentId: string): t.AgentInputs => ({
+  agentId,
+  provider: Providers.OPENAI,
+  instructions: `You are ${agentId}.`,
+});
+
+function createGraph(): {
+  graph: StandardGraph;
+  closed: t.RunStepClosedEvent[];
+  } {
+  const graph = new StandardGraph({
+    runId: 'run_1',
+    agents: [makeAgent('agent')],
+  });
+  const closed: t.RunStepClosedEvent[] = [];
+  const registry = new HandlerRegistry();
+  registry.register(GraphEvents.ON_RUN_STEP_CLOSED, {
+    handle: (_event, data): void => {
+      closed.push(data as t.RunStepClosedEvent);
+    },
+  });
+  graph.handlerRegistry = registry;
+  return { graph, closed };
+}
+
+function seedStep(
+  graph: StandardGraph,
+  id: string,
+  type: StepTypes = StepTypes.MESSAGE_CREATION
+): t.RunStep {
+  const index = graph.contentData.length;
+  const stepDetails: t.StepDetails =
+    type === StepTypes.TOOL_CALLS
+      ? { type: StepTypes.TOOL_CALLS, tool_calls: [] }
+      : {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: `msg_${id}` },
+      };
+  const step: t.RunStep = {
+    id,
+    type,
+    index,
+    stepIndex: index,
+    stepDetails,
+    usage: null,
+    created_at: 1_000,
+    status: 'in_progress',
+  };
+  graph.contentData.push(step);
+  graph.contentIndexMap.set(id, index);
+  return step;
+}
+
+describe('StandardGraph.closeRunStep', () => {
+  it('stamps the terminal status + timestamp and emits ON_RUN_STEP_CLOSED once', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a');
+
+    const first = await graph.closeRunStep('step_a', 'completed', 2_000);
+    expect(first).toBe(true);
+    expect(step.status).toBe('completed');
+    expect(step.completed_at).toBe(2_000);
+    expect(closed).toHaveLength(1);
+    expect(closed[0]).toMatchObject({
+      id: 'step_a',
+      index: 0,
+      type: StepTypes.MESSAGE_CREATION,
+      status: 'completed',
+      created_at: 1_000,
+      closed_at: 2_000,
+    });
+
+    const second = await graph.closeRunStep('step_a', 'completed', 3_000);
+    expect(second).toBe(false);
+    expect(step.completed_at).toBe(2_000);
+    expect(closed).toHaveLength(1);
+  });
+
+  it('keeps cancelled and failed immutable, even with restamp', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+
+    await graph.closeRunStep('step_a', 'cancelled', 2_000);
+    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+      restamp: true,
+    });
+    expect(restamped).toBe(false);
+    expect(step.status).toBe('cancelled');
+    expect(step.cancelled_at).toBe(2_000);
+    expect(step.completed_at).toBeUndefined();
+    expect(closed).toHaveLength(1);
+  });
+
+  it('restamps a completed TOOL_CALLS step on a late completion', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+
+    await graph.closeRunStep('step_a', 'completed', 2_000);
+    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+      restamp: true,
+    });
+    expect(restamped).toBe(true);
+    expect(step.completed_at).toBe(3_000);
+    expect(closed).toHaveLength(2);
+    expect(closed[1].closed_at).toBe(3_000);
+  });
+
+  it('does not restamp completed MESSAGE_CREATION steps', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a');
+
+    await graph.closeRunStep('step_a', 'completed', 2_000);
+    const restamped = await graph.closeRunStep('step_a', 'completed', 3_000, {
+      restamp: true,
+    });
+    expect(restamped).toBe(false);
+    expect(step.completed_at).toBe(2_000);
+    expect(closed).toHaveLength(1);
+  });
+
+  it('tolerates empty and unknown step ids', async () => {
+    const { graph, closed } = createGraph();
+    expect(await graph.closeRunStep('', 'completed')).toBe(false);
+    expect(await graph.closeRunStep('step_missing', 'completed')).toBe(false);
+    expect(closed).toHaveLength(0);
+  });
+});
+
+describe('StandardGraph.recordStepCompletion', () => {
+  it('closes a TOOL_CALLS step only after every registered call completes', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+    graph.registerPendingToolCall('call_1', 'step_a');
+    graph.registerPendingToolCall('call_2', 'step_a');
+
+    await graph.recordStepCompletion('step_a', 'call_1');
+    expect(step.status).toBe('in_progress');
+    expect(closed).toHaveLength(0);
+
+    await graph.recordStepCompletion('step_a', 'call_2');
+    expect(step.status).toBe('completed');
+    expect(typeof step.completed_at).toBe('number');
+    expect(closed).toHaveLength(1);
+    expect(closed[0].status).toBe('completed');
+  });
+
+  it('closes steps without pending tracking on the first completion', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a');
+
+    await graph.recordStepCompletion('step_a');
+    expect(step.status).toBe('completed');
+    expect(closed).toHaveLength(1);
+  });
+
+  it('absorbs duplicate completions without re-emitting', async () => {
+    const { graph, closed } = createGraph();
+    seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+    graph.registerPendingToolCall('call_1', 'step_a');
+
+    await graph.recordStepCompletion('step_a', 'call_1');
+    await graph.recordStepCompletion('step_a', 'call_1');
+    expect(closed).toHaveLength(1);
+  });
+
+  it('restamps when a late-registered call completes after the step closed', async () => {
+    const { graph, closed } = createGraph();
+    const step = seedStep(graph, 'step_a', StepTypes.TOOL_CALLS);
+    graph.registerPendingToolCall('call_1', 'step_a');
+
+    await graph.recordStepCompletion('step_a', 'call_1');
+    expect(closed).toHaveLength(1);
+    const firstClosedAt = step.completed_at;
+
+    graph.registerPendingToolCall('call_2', 'step_a');
+    await graph.recordStepCompletion('step_a', 'call_2');
+    expect(closed).toHaveLength(2);
+    expect(step.completed_at).toBeGreaterThanOrEqual(firstClosedAt as number);
+    expect(closed[1].status).toBe('completed');
+  });
+});
+
+describe('StandardGraph.closeUnfinishedRunSteps', () => {
+  it('closes only non-terminal steps with the sweep status', async () => {
+    const { graph, closed } = createGraph();
+    const done = seedStep(graph, 'step_done', StepTypes.TOOL_CALLS);
+    const openMessage = seedStep(graph, 'step_msg');
+    const openTool = seedStep(graph, 'step_tool', StepTypes.TOOL_CALLS);
+    await graph.closeRunStep('step_done', 'completed', 2_000);
+    closed.length = 0;
+
+    await graph.closeUnfinishedRunSteps('cancelled', 5_000);
+
+    expect(done.completed_at).toBe(2_000);
+    expect(openMessage.status).toBe('cancelled');
+    expect(openMessage.cancelled_at).toBe(5_000);
+    expect(openTool.status).toBe('cancelled');
+    expect(openTool.cancelled_at).toBe(5_000);
+    expect(closed.map((event) => event.id)).toEqual(['step_msg', 'step_tool']);
+    expect(closed.every((event) => event.status === 'cancelled')).toBe(true);
+    expect(graph.pendingToolCallsByStep.size).toBe(0);
+    expect(graph.openMessageStepByAgent.size).toBe(0);
+  });
+
+  it('stamps failed_at for failed sweeps', async () => {
+    const { graph } = createGraph();
+    const step = seedStep(graph, 'step_a');
+
+    await graph.closeUnfinishedRunSteps('failed', 5_000);
+    expect(step.status).toBe('failed');
+    expect(step.failed_at).toBe(5_000);
+    expect(step.cancelled_at).toBeUndefined();
+    expect(step.completed_at).toBeUndefined();
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -1180,6 +1180,13 @@ export class Run<_T extends t.BaseGraphState> {
           }
         }
 
+        /**
+         * Stamped before the handler runs: the close below happens after an
+         * arbitrarily slow host handler resolves, and the step's duration
+         * should end when the model did, not when the host finished with it.
+         */
+        const modelEndAt =
+          eventName === GraphEvents.CHAT_MODEL_END ? Date.now() : undefined;
         const handler = this.handlerRegistry?.getHandler(eventName);
         if (handler) {
           await handler.handle(eventName, data, metadata, this.Graph);
@@ -1192,7 +1199,7 @@ export class Run<_T extends t.BaseGraphState> {
          * silently drop the close.
          */
         if (eventName === GraphEvents.CHAT_MODEL_END && this.Graph != null) {
-          await this.Graph.closeOpenMessageStep(metadata);
+          await this.Graph.closeOpenMessageStep(metadata, modelEndAt);
         }
 
         /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -132,9 +132,9 @@ function getStepScopedEventId(data: unknown): string | undefined {
  * to the ids step closure needs. Returns undefined for malformed payloads and
  * the resume race's empty step id.
  */
-function getToolCompletionIds(
+function getToolCompletion(
   data: unknown
-): { stepId: string; toolCallId?: string } | undefined {
+): { stepId: string; toolCallId?: string; completedAt?: number } | undefined {
   if (data == null || typeof data !== 'object') {
     return undefined;
   }
@@ -142,14 +142,20 @@ function getToolCompletionIds(
   if (result == null || typeof result !== 'object') {
     return undefined;
   }
-  const candidate = result as { id?: unknown; tool_call?: { id?: unknown } };
+  const candidate = result as {
+    id?: unknown;
+    tool_call?: { id?: unknown };
+    completed_at?: unknown;
+  };
   if (typeof candidate.id !== 'string' || candidate.id === '') {
     return undefined;
   }
   const toolCallId = candidate.tool_call?.id;
+  const completedAt = candidate.completed_at;
   return {
     stepId: candidate.id,
     ...(typeof toolCallId === 'string' ? { toolCallId } : {}),
+    ...(typeof completedAt === 'number' ? { completedAt } : {}),
   };
 }
 
@@ -761,13 +767,18 @@ export class Run<_T extends t.BaseGraphState> {
           eventName === GraphEvents.ON_RUN_STEP_COMPLETED &&
           this.Graph != null
         ) {
-          const completion = getToolCompletionIds(data);
+          const completion = getToolCompletion(data);
           if (completion != null) {
-            await this.Graph.recordStepCompletion(
-              completion.stepId,
-              completion.toolCallId,
-              metadata
-            );
+            /**
+             * The producer stamped `completed_at` before dispatch. Carrying it
+             * through keeps the recorded duration the tool's, not the host
+             * handler's — this runs after an arbitrarily slow handler resolves.
+             */
+            await this.Graph.recordStepCompletion(completion.stepId, {
+              toolCallId: completion.toolCallId,
+              metadata,
+              at: completion.completedAt,
+            });
           }
         }
       }
@@ -1297,9 +1308,15 @@ export class Run<_T extends t.BaseGraphState> {
       );
     } catch (err) {
       streamThrew = true;
+      /**
+       * Corroborate cancellation against an actually-aborted signal. A
+       * provider SDK or host handler can reject with an `AbortError` while
+       * nothing was cancelled — that is an unexpected failure (it also fires
+       * `StopFailure`), and naming it `cancelled` would misreport abort
+       * forensics.
+       */
       streamAborted =
-        config.signal?.aborted === true ||
-        (err instanceof Error && err.name === 'AbortError');
+        config.signal?.aborted === true || this.Graph.signal?.aborted === true;
       if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
         const runMessages = this.Graph.getRunMessages() ?? [];
         await executeHooks({

--- a/src/run.ts
+++ b/src/run.ts
@@ -1112,6 +1112,13 @@ export class Run<_T extends t.BaseGraphState> {
      */
     let streamThrew = false;
     let streamAborted = false;
+    /**
+     * When the stream itself ended — captured before the post-stream work in
+     * the `finally` (Stop/StopFailure hooks, Langfuse disposal, which can
+     * force-flush) so a slow hook cannot inflate the terminal stamps that the
+     * sweep writes onto steps that were still open.
+     */
+    let terminalAt: number | undefined;
 
     const consumeStream = async (): Promise<void> => {
       /**
@@ -1230,6 +1237,8 @@ export class Run<_T extends t.BaseGraphState> {
         }
       }
 
+      terminalAt = Date.now();
+
       if (this._interrupt != null) {
         await this.resolveInterruptResumeConfig(config);
       }
@@ -1314,6 +1323,7 @@ export class Run<_T extends t.BaseGraphState> {
         )
       );
     } catch (err) {
+      terminalAt = Date.now();
       streamThrew = true;
       /**
        * Corroborate cancellation against an actually-aborted signal. A
@@ -1372,6 +1382,29 @@ export class Run<_T extends t.BaseGraphState> {
       await disposeLangfuseHandler(langfuseHandler);
 
       /**
+       * Terminal sweep: close every step that never reached a terminal
+       * status — `completed` on a natural end, `cancelled` on caller abort
+       * or hook halt, `failed` on an unexpected stream error. Skipped on a
+       * HITL pause, where the open steps continue after `resume()`.
+       *
+       * Runs BEFORE the callback teardown below, so a caller observing
+       * lifecycle events only through `RunnableConfig.callbacks` still
+       * receives these closures rather than being left with unmatched
+       * starts, and before `getContentParts()` so terminal stamps flow into
+       * content and session serialization.
+       */
+      if (!this.isAwaitingResume(streamThrew)) {
+        try {
+          await this.Graph.closeUnfinishedRunSteps(
+            this.resolveSweepStatus(streamThrew, streamAborted),
+            terminalAt
+          );
+        } catch {
+          /* the sweep must never mask the stream outcome */
+        }
+      }
+
+      /**
        * Break the reference chain that keeps heavy data alive via
        * LangGraph's internal `__pregel_scratchpad.currentTaskInput` →
        * `@langchain/core` `RunTree.extra[lc:child_config]` →
@@ -1400,24 +1433,6 @@ export class Run<_T extends t.BaseGraphState> {
           config.configurable = undefined;
         }
         config.callbacks = undefined;
-      }
-
-      /**
-       * Terminal sweep: close every step that never reached a terminal
-       * status — `completed` on a natural end, `cancelled` on caller abort
-       * or hook halt, `failed` on an unexpected stream error. Skipped on a
-       * HITL pause, where the open steps continue after `resume()`. Runs
-       * before `getContentParts()` so terminal stamps flow into content and
-       * session serialization.
-       */
-      if (!this.isAwaitingResume(streamThrew)) {
-        try {
-          await this.Graph.closeUnfinishedRunSteps(
-            this.resolveSweepStatus(streamThrew, streamAborted)
-          );
-        } catch {
-          /* the sweep must never mask the stream outcome */
-        }
       }
 
       const result = this.returnContent

--- a/src/run.ts
+++ b/src/run.ts
@@ -50,6 +50,12 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
+  appendCallbacks,
+  filterCallbacks,
+  findCallback,
+  type CallbackEntry,
+} from '@/utils/callbacks';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
@@ -59,12 +65,6 @@ import {
   TitleMethod,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
-import {
-  appendCallbacks,
-  filterCallbacks,
-  findCallback,
-  type CallbackEntry,
-} from '@/utils/callbacks';
 import {
   createCompletionTitleRunnable,
   createTitleRunnable,
@@ -98,6 +98,7 @@ const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_RUN_STEP,
   GraphEvents.ON_RUN_STEP_DELTA,
   GraphEvents.ON_RUN_STEP_COMPLETED,
+  GraphEvents.ON_RUN_STEP_CLOSED,
   GraphEvents.ON_MESSAGE_DELTA,
   GraphEvents.ON_REASONING_DELTA,
   GraphEvents.ON_TOOL_EXECUTE,
@@ -113,6 +114,7 @@ const CUSTOM_GRAPH_EVENTS = new Set<string>([
 const DIRECT_DISPATCHED_STEP_EVENTS = new Set<string>([
   GraphEvents.ON_RUN_STEP,
   GraphEvents.ON_RUN_STEP_DELTA,
+  GraphEvents.ON_RUN_STEP_CLOSED,
   GraphEvents.ON_MESSAGE_DELTA,
   GraphEvents.ON_REASONING_DELTA,
 ]);
@@ -703,20 +705,49 @@ export class Run<_T extends t.BaseGraphState> {
         return;
       }
       const handler = this.handlerRegistry?.getHandler(eventName);
-      if (handler && this.Graph) {
-        return await handler.handle(
-          eventName,
-          data as
-            | t.StreamEventData
-            | t.ModelEndData
-            | t.RunStep
-            | t.RunStepDeltaEvent
-            | t.MessageDeltaEvent
-            | t.ReasoningDeltaEvent
-            | { result: t.ToolEndEvent },
-          metadata,
-          this.Graph
-        );
+      /**
+       * Tool completions arriving over the custom-event channel are the only
+       * signal ToolNode (which holds no graph reference) emits — observe them
+       * here to drive step closure. Runs in `finally`, independent of handler
+       * registration, so an absent or throwing host handler cannot lose the
+       * close; duplicate callback echoes are absorbed by the terminal-status
+       * guard in `closeRunStep`.
+       */
+      try {
+        if (handler && this.Graph) {
+          return await handler.handle(
+            eventName,
+            data as
+              | t.StreamEventData
+              | t.ModelEndData
+              | t.RunStep
+              | t.RunStepDeltaEvent
+              | t.RunStepClosedEvent
+              | t.MessageDeltaEvent
+              | t.ReasoningDeltaEvent
+              | { result: t.ToolEndEvent },
+            metadata,
+            this.Graph
+          );
+        }
+      } finally {
+        if (
+          eventName === GraphEvents.ON_RUN_STEP_COMPLETED &&
+          this.Graph != null
+        ) {
+          const completed = (
+            data as
+              | { result?: { id?: string; tool_call?: { id?: string } } }
+              | undefined
+          )?.result;
+          if (completed?.id != null && completed.id !== '') {
+            await this.Graph.recordStepCompletion(
+              completed.id,
+              completed.tool_call?.id,
+              metadata
+            );
+          }
+        }
       }
     };
   }
@@ -729,6 +760,26 @@ export class Run<_T extends t.BaseGraphState> {
     return (
       this._interrupt != null && this._haltedReason == null && !streamThrew
     );
+  }
+
+  /**
+   * Terminal status for steps still open at end-of-run: `cancelled` for
+   * intentional stops (caller abort, hook halt), `failed` for unexpected
+   * stream errors, `completed` for a natural finish. Reads `_haltedReason`
+   * behind a method boundary on purpose — it is assigned inside the
+   * `consumeStream` closure, which control-flow narrowing cannot see.
+   */
+  private resolveSweepStatus(
+    streamThrew: boolean,
+    streamAborted: boolean
+  ): Exclude<t.RunStepStatus, 'in_progress'> {
+    if (streamThrew) {
+      return streamAborted ? 'cancelled' : 'failed';
+    }
+    if (this._haltedReason != null) {
+      return 'cancelled';
+    }
+    return 'completed';
   }
 
   private getStreamLangfuseConfig(
@@ -1027,6 +1078,7 @@ export class Run<_T extends t.BaseGraphState> {
      * preserving session hooks would leak them into the next run.
      */
     let streamThrew = false;
+    let streamAborted = false;
 
     const consumeStream = async (): Promise<void> => {
       /**
@@ -1098,6 +1150,16 @@ export class Run<_T extends t.BaseGraphState> {
         const handler = this.handlerRegistry?.getHandler(eventName);
         if (handler) {
           await handler.handle(eventName, data, metadata, this.Graph);
+        }
+
+        /**
+         * A finished model call ends its lane's open message step. Placed
+         * here — not in `ModelEndHandler` — because hosts replace the
+         * CHAT_MODEL_END handler with their own instance, which would
+         * silently drop the close.
+         */
+        if (eventName === GraphEvents.CHAT_MODEL_END && this.Graph != null) {
+          await this.Graph.closeOpenMessageStep(metadata);
         }
 
         /**
@@ -1213,6 +1275,9 @@ export class Run<_T extends t.BaseGraphState> {
       );
     } catch (err) {
       streamThrew = true;
+      streamAborted =
+        config.signal?.aborted === true ||
+        (err instanceof Error && err.name === 'AbortError');
       if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
         const runMessages = this.Graph.getRunMessages() ?? [];
         await executeHooks({
@@ -1289,6 +1354,24 @@ export class Run<_T extends t.BaseGraphState> {
           config.configurable = undefined;
         }
         config.callbacks = undefined;
+      }
+
+      /**
+       * Terminal sweep: close every step that never reached a terminal
+       * status — `completed` on a natural end, `cancelled` on caller abort
+       * or hook halt, `failed` on an unexpected stream error. Skipped on a
+       * HITL pause, where the open steps continue after `resume()`. Runs
+       * before `getContentParts()` so terminal stamps flow into content and
+       * session serialization.
+       */
+      if (!this.isAwaitingResume(streamThrew)) {
+        try {
+          await this.Graph.closeUnfinishedRunSteps(
+            this.resolveSweepStatus(streamThrew, streamAborted)
+          );
+        } catch {
+          /* the sweep must never mask the stream outcome */
+        }
       }
 
       const result = this.returnContent

--- a/src/run.ts
+++ b/src/run.ts
@@ -127,6 +127,32 @@ function getStepScopedEventId(data: unknown): string | undefined {
   return typeof candidate.id === 'string' ? candidate.id : undefined;
 }
 
+/**
+ * Narrows an ON_RUN_STEP_COMPLETED payload (`{ result: ToolCompleteEvent }`)
+ * to the ids step closure needs. Returns undefined for malformed payloads and
+ * the resume race's empty step id.
+ */
+function getToolCompletionIds(
+  data: unknown
+): { stepId: string; toolCallId?: string } | undefined {
+  if (data == null || typeof data !== 'object') {
+    return undefined;
+  }
+  const { result } = data as { result?: unknown };
+  if (result == null || typeof result !== 'object') {
+    return undefined;
+  }
+  const candidate = result as { id?: unknown; tool_call?: { id?: unknown } };
+  if (typeof candidate.id !== 'string' || candidate.id === '') {
+    return undefined;
+  }
+  const toolCallId = candidate.tool_call?.id;
+  return {
+    stepId: candidate.id,
+    ...(typeof toolCallId === 'string' ? { toolCallId } : {}),
+  };
+}
+
 function isLangGraphResumeMapForInterrupt(
   value: unknown,
   interruptId: string
@@ -735,15 +761,11 @@ export class Run<_T extends t.BaseGraphState> {
           eventName === GraphEvents.ON_RUN_STEP_COMPLETED &&
           this.Graph != null
         ) {
-          const completed = (
-            data as
-              | { result?: { id?: string; tool_call?: { id?: string } } }
-              | undefined
-          )?.result;
-          if (completed?.id != null && completed.id !== '') {
+          const completion = getToolCompletionIds(data);
+          if (completion != null) {
             await this.Graph.recordStepCompletion(
-              completed.id,
-              completed.tool_call?.id,
+              completion.stepId,
+              completion.toolCallId,
               metadata
             );
           }

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -697,6 +697,15 @@ function createManualCompactGraph(params: {
           runStep
         );
       },
+      closeRunStep: async (stepId, status): Promise<void> => {
+        const stepIndex = contentIndexMap.get(stepId);
+        const runStep =
+          stepIndex === undefined ? undefined : contentData[stepIndex];
+        if (runStep == null) {
+          return;
+        }
+        await closeStep(runStep, status, Date.now());
+      },
       dispatchRunStepCompleted: async (stepId, completed): Promise<void> => {
         const completedAt = Date.now();
         const stepIndex = contentIndexMap.get(stepId);

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -642,7 +642,9 @@ function createManualCompactGraph(params: {
       },
       dispatchRunStepCompleted: async (stepId, completed): Promise<void> => {
         const completedAt = Date.now();
-        const runStep = contentData.find((step) => step.id === stepId);
+        const stepIndex = contentIndexMap.get(stepId);
+        const runStep =
+          stepIndex === undefined ? undefined : contentData[stepIndex];
         const resultWithStep = {
           ...completed,
           id: stepId,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -616,13 +616,70 @@ function createManualCompactGraph(params: {
 }): {
   graph: Parameters<typeof createSummarizeNode>[0]['graph'];
   completedSummary?: t.SummaryContentBlock;
+  closeOpenSteps: (
+    status: Exclude<t.RunStepStatus, 'in_progress'>
+  ) => Promise<void>;
 } {
   const contentData: t.RunStep[] = [];
   const contentIndexMap = new Map<string, number>();
+  /** Stamps the terminal state and publishes the single terminal event. */
+  const closeStep = async (
+    runStep: t.RunStep,
+    status: Exclude<t.RunStepStatus, 'in_progress'>,
+    at: number
+  ): Promise<void> => {
+    if (runStep.status !== 'in_progress') {
+      return;
+    }
+    runStep.status = status;
+    if (status === 'completed') {
+      runStep.completed_at = at;
+    } else if (status === 'cancelled') {
+      runStep.cancelled_at = at;
+    } else {
+      runStep.failed_at = at;
+    }
+    const closedEvent: t.RunStepClosedEvent = {
+      id: runStep.id,
+      index: runStep.index,
+      type: runStep.type,
+      status,
+      closed_at: at,
+    };
+    if (runStep.created_at != null) {
+      closedEvent.created_at = runStep.created_at;
+    }
+    if (runStep.runId != null) {
+      closedEvent.runId = runStep.runId;
+    }
+    await params.customHandlers?.[GraphEvents.ON_RUN_STEP_CLOSED]?.handle(
+      GraphEvents.ON_RUN_STEP_CLOSED,
+      closedEvent
+    );
+  };
   const result: {
     graph: Parameters<typeof createSummarizeNode>[0]['graph'];
     completedSummary?: t.SummaryContentBlock;
+    closeOpenSteps: (
+      status: Exclude<t.RunStepStatus, 'in_progress'>
+    ) => Promise<void>;
   } = {
+    /**
+     * Terminal sweep for compaction, which runs outside `Run.processStream`
+     * and so has no stream-level equivalent: a summarization model that
+     * rejects, aborts, or trips a stream limit after the step was published
+     * would otherwise strand observers with a permanently open step.
+     */
+    closeOpenSteps: async (status): Promise<void> => {
+      const closedAt = Date.now();
+      for (const runStep of contentData) {
+        try {
+          await closeStep(runStep, status, closedAt);
+        } catch (_e) {
+          /** Delivery failure for one step must not halt the sweep */
+        }
+      }
+    },
     graph: {
       contentData,
       contentIndexMap,
@@ -659,28 +716,10 @@ function createManualCompactGraph(params: {
         ]?.handle(GraphEvents.ON_RUN_STEP_COMPLETED, {
           result: resultWithStep,
         } as unknown as Parameters<t.EventHandler['handle']>[1]);
-        if (runStep == null || runStep.status !== 'in_progress') {
+        if (runStep == null) {
           return;
         }
-        runStep.status = 'completed';
-        runStep.completed_at = completedAt;
-        const closedEvent: t.RunStepClosedEvent = {
-          id: stepId,
-          index: runStep.index,
-          type: runStep.type,
-          status: 'completed',
-          closed_at: completedAt,
-        };
-        if (runStep.created_at != null) {
-          closedEvent.created_at = runStep.created_at;
-        }
-        if (runStep.runId != null) {
-          closedEvent.runId = runStep.runId;
-        }
-        await params.customHandlers?.[GraphEvents.ON_RUN_STEP_CLOSED]?.handle(
-          GraphEvents.ON_RUN_STEP_CLOSED,
-          closedEvent
-        );
+        await closeStep(runStep, 'completed', completedAt);
       },
     },
   };
@@ -1330,19 +1369,31 @@ export class AgentSession {
         graph.graph.contentData.length,
       ],
     });
-    const summarizedState = await summarizeNode(
-      {
-        messages: sessionState.messages,
-        summarizationRequest: {
-          remainingContextTokens: agentContext.maxContextTokens ?? 0,
-          agentId: agentContext.agentId,
+    let summarizedState;
+    try {
+      summarizedState = await summarizeNode(
+        {
+          messages: sessionState.messages,
+          summarizationRequest: {
+            remainingContextTokens: agentContext.maxContextTokens ?? 0,
+            agentId: agentContext.agentId,
+          },
         },
-      },
-      {
-        configurable: { thread_id: this.threadId },
-        metadata: { run_id: compactRunId },
-      }
-    );
+        {
+          configurable: { thread_id: this.threadId },
+          metadata: { run_id: compactRunId },
+        }
+      );
+    } catch (error) {
+      const aborted =
+        error instanceof Error &&
+        (error.name === 'AbortError' || error.name === 'GraphBubbleUp');
+      await graph.closeOpenSteps(aborted ? 'cancelled' : 'failed').catch(() => {
+        /** the sweep must never mask the summarization failure */
+      });
+      throw error;
+    }
+    await graph.closeOpenSteps('completed');
     const completedSummaryText = getSummaryText(graph.completedSummary);
     const contextSummaryText = agentContext.getSummaryText();
     let summaryText = completedSummaryText;

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1385,10 +1385,14 @@ export class AgentSession {
         }
       );
     } catch (error) {
-      const aborted =
-        error instanceof Error &&
-        (error.name === 'AbortError' || error.name === 'GraphBubbleUp');
-      await graph.closeOpenSteps(aborted ? 'cancelled' : 'failed').catch(() => {
+      /**
+       * `failed`, not `cancelled`: manual compaction is invoked without a
+       * caller abort signal, so there is no cancellation source to
+       * corroborate against. An error that merely carries the `AbortError`
+       * name is an unexpected failure here, and it propagates to the caller
+       * either way.
+       */
+      await graph.closeOpenSteps('failed').catch(() => {
         /** the sweep must never mask the summarization failure */
       });
       throw error;

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -631,6 +631,8 @@ function createManualCompactGraph(params: {
       hookRegistry: params.hooks,
       streamLimits: resolveStreamLimits(params.streamLimits),
       dispatchRunStep: async (runStep): Promise<void> => {
+        runStep.created_at ??= Date.now();
+        runStep.status ??= 'in_progress';
         contentData.push(runStep);
         contentIndexMap.set(runStep.id, runStep.index);
         await params.customHandlers?.[GraphEvents.ON_RUN_STEP]?.handle(
@@ -639,11 +641,13 @@ function createManualCompactGraph(params: {
         );
       },
       dispatchRunStepCompleted: async (stepId, completed): Promise<void> => {
+        const completedAt = Date.now();
         const runStep = contentData.find((step) => step.id === stepId);
         const resultWithStep = {
           ...completed,
           id: stepId,
           index: runStep?.index ?? 0,
+          completed_at: completedAt,
         };
         if (completed.type === 'summary') {
           result.completedSummary = completed.summary;
@@ -653,6 +657,28 @@ function createManualCompactGraph(params: {
         ]?.handle(GraphEvents.ON_RUN_STEP_COMPLETED, {
           result: resultWithStep,
         } as unknown as Parameters<t.EventHandler['handle']>[1]);
+        if (runStep == null || runStep.status !== 'in_progress') {
+          return;
+        }
+        runStep.status = 'completed';
+        runStep.completed_at = completedAt;
+        const closedEvent: t.RunStepClosedEvent = {
+          id: stepId,
+          index: runStep.index,
+          type: runStep.type,
+          status: 'completed',
+          closed_at: completedAt,
+        };
+        if (runStep.created_at != null) {
+          closedEvent.created_at = runStep.created_at;
+        }
+        if (runStep.runId != null) {
+          closedEvent.runId = runStep.runId;
+        }
+        await params.customHandlers?.[GraphEvents.ON_RUN_STEP_CLOSED]?.handle(
+          GraphEvents.ON_RUN_STEP_CLOSED,
+          closedEvent
+        );
       },
     },
   };

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -5,13 +5,13 @@ import type {
   AgentSessionUsage,
 } from './types';
 import type * as t from '@/types';
-import { ModelEndHandler, ToolEndHandler } from '@/events';
-import { toJsonValue } from './messageSerialization';
 import {
   createContentAggregator,
   dispatchesChatModelStream,
   SDK_STREAM_DISPATCH,
 } from '@/stream';
+import { ModelEndHandler, ToolEndHandler } from '@/events';
+import { toJsonValue } from './messageSerialization';
 import { createTimestamp } from './ids';
 import { GraphEvents } from '@/common';
 
@@ -216,6 +216,18 @@ export function createRunHandlers(params: {
         if (isToolCompletion(completed.result)) {
           emitEvent(createEvent('tool.completed', completed));
         }
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_CLOSED]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        emitEvent(createEvent('step.finished', data as t.RunStepClosedEvent));
         await callUserHandler({
           userHandlers: params.userHandlers,
           event,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -225,6 +225,7 @@ export interface AgentSessionStreamEvent {
     | 'tool.started'
     | 'tool.delta'
     | 'tool.completed'
+    | 'step.finished'
     | 'usage.updated'
     | 'run.completed'
     | 'run.failed'

--- a/src/specs/run-step-timestamps.test.ts
+++ b/src/specs/run-step-timestamps.test.ts
@@ -1,0 +1,371 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import { MemorySaver, Command } from '@langchain/langgraph';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import { GraphEvents, StepTypes, Providers } from '@/common';
+import { FakeChatModel } from '@/llm/fake';
+import { askUserQuestion } from '@/hitl';
+import { Run } from '@/run';
+
+const askTool = tool(
+  async (input) => {
+    const { answer } = askUserQuestion(input as { question: string });
+    return answer;
+  },
+  {
+    name: 'ask_user_question',
+    description:
+      'Ask the user a clarifying question and wait for their answer.',
+    schema: z.object({ question: z.string() }),
+  }
+);
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const echoTool = tool(
+  async ({ input }: { input: string }) => `echo: ${input}`,
+  {
+    name: 'echoTool',
+    description: 'Echoes the input back',
+    schema: z.object({ input: z.string() }),
+  }
+);
+
+const toolCalls: ToolCall[] = [
+  {
+    name: 'echoTool',
+    args: { input: 'ping' },
+    id: 'call_timestamps_1',
+    type: 'tool_call',
+  },
+];
+
+const createStreamConfig = (
+  threadId: string,
+  signal?: AbortSignal
+): t.RunStreamConfig => ({
+  configurable: { thread_id: threadId },
+  version: 'v2',
+  ...(signal != null ? { signal } : {}),
+});
+
+type RecordedEvent = {
+  event: string;
+  data: unknown;
+  /** Lifecycle fields captured at receipt — dispatched RunStep objects are
+   *  shared references that later closes mutate in place. */
+  statusAtReceipt?: t.RunStepStatus;
+};
+
+function createRecorder(): {
+  sequence: RecordedEvent[];
+  handlers: Record<string, t.EventHandler>;
+  } {
+  const sequence: RecordedEvent[] = [];
+  const record = (event: string): t.EventHandler => ({
+    handle: (_event, data): void => {
+      sequence.push({
+        event,
+        data,
+        ...(event === GraphEvents.ON_RUN_STEP
+          ? { statusAtReceipt: (data as t.RunStep).status }
+          : {}),
+      });
+    },
+  });
+  return {
+    sequence,
+    handlers: {
+      [GraphEvents.ON_RUN_STEP]: record(GraphEvents.ON_RUN_STEP),
+      [GraphEvents.ON_RUN_STEP_COMPLETED]: record(
+        GraphEvents.ON_RUN_STEP_COMPLETED
+      ),
+      [GraphEvents.ON_RUN_STEP_CLOSED]: record(GraphEvents.ON_RUN_STEP_CLOSED),
+    },
+  };
+}
+
+function getSteps(sequence: RecordedEvent[]): t.RunStep[] {
+  return sequence
+    .filter((entry) => entry.event === GraphEvents.ON_RUN_STEP)
+    .map((entry) => entry.data as t.RunStep);
+}
+
+function getClosed(sequence: RecordedEvent[]): t.RunStepClosedEvent[] {
+  return sequence
+    .filter((entry) => entry.event === GraphEvents.ON_RUN_STEP_CLOSED)
+    .map((entry) => entry.data as t.RunStepClosedEvent);
+}
+
+describe('run step timestamps', () => {
+  jest.setTimeout(20000);
+
+  it('stamps starts and closes every step exactly once on a natural finish', async () => {
+    const { sequence, handlers } = createRecorder();
+    const run = await Run.create<t.IState>({
+      runId: 'test-run-step-timestamps',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        tools: [echoTool],
+        instructions: 'You are a helpful assistant.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: handlers,
+    });
+
+    run.Graph?.overrideTestModel(
+      ['Let me call the tool', 'The tool answered'],
+      2,
+      toolCalls
+    );
+    const started = Date.now();
+    await run.processStream(
+      { messages: [new HumanMessage('hello')] },
+      createStreamConfig('run-step-timestamps')
+    );
+
+    const steps = getSteps(sequence);
+    const closed = getClosed(sequence);
+    expect(steps.length).toBeGreaterThanOrEqual(3);
+    const stepReceipts = sequence.filter(
+      (entry) => entry.event === GraphEvents.ON_RUN_STEP
+    );
+    for (const receipt of stepReceipts) {
+      expect(receipt.statusAtReceipt).toBe('in_progress');
+    }
+    for (const step of steps) {
+      expect(typeof step.created_at).toBe('number');
+      expect(step.created_at as number).toBeGreaterThanOrEqual(started);
+    }
+
+    const stepIds = steps.map((step) => step.id);
+    expect(closed.map((event) => event.id).sort()).toEqual([...stepIds].sort());
+    for (const event of closed) {
+      expect(event.status).toBe('completed');
+      expect(event.closed_at).toBeGreaterThanOrEqual(
+        event.created_at as number
+      );
+    }
+
+    const toolStep = steps.find((step) => step.type === StepTypes.TOOL_CALLS);
+    expect(toolStep).toBeDefined();
+    const toolStepId = (toolStep as t.RunStep).id;
+    const toolCompletedIndex = sequence.findIndex(
+      (entry) =>
+        entry.event === GraphEvents.ON_RUN_STEP_COMPLETED &&
+        (entry.data as { result?: { id?: string } }).result?.id === toolStepId
+    );
+    const toolClosedIndex = sequence.findIndex(
+      (entry) =>
+        entry.event === GraphEvents.ON_RUN_STEP_CLOSED &&
+        (entry.data as t.RunStepClosedEvent).id === toolStepId
+    );
+    expect(toolCompletedIndex).toBeGreaterThanOrEqual(0);
+    expect(toolClosedIndex).toBeGreaterThan(toolCompletedIndex);
+
+    const firstMessageStepId = steps[0].id;
+    const toolStepIndex = sequence.findIndex(
+      (entry) =>
+        entry.event === GraphEvents.ON_RUN_STEP &&
+        (entry.data as t.RunStep).id === toolStepId
+    );
+    const firstMessageClosedIndex = sequence.findIndex(
+      (entry) =>
+        entry.event === GraphEvents.ON_RUN_STEP_CLOSED &&
+        (entry.data as t.RunStepClosedEvent).id === firstMessageStepId
+    );
+    expect(firstMessageClosedIndex).toBeGreaterThanOrEqual(0);
+    expect(firstMessageClosedIndex).toBeLessThan(toolStepIndex);
+
+    const completedEvent = sequence
+      .filter((entry) => entry.event === GraphEvents.ON_RUN_STEP_COMPLETED)
+      .map((entry) => (entry.data as { result: t.ToolCompleteEvent }).result)
+      .find((result) => result.id === toolStepId);
+    expect(typeof completedEvent?.completed_at).toBe('number');
+
+    for (const step of run.Graph?.contentData ?? []) {
+      expect(step.status).toBe('completed');
+      expect(typeof step.completed_at).toBe('number');
+    }
+  });
+
+  it('changes nothing for hosts that only register the legacy handlers', async () => {
+    const received: string[] = [];
+    const legacyHandler = (event: string): t.EventHandler => ({
+      handle: (): void => {
+        received.push(event);
+      },
+    });
+    const run = await Run.create<t.IState>({
+      runId: 'test-run-step-timestamps-legacy',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        tools: [echoTool],
+        instructions: 'You are a helpful assistant.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.ON_RUN_STEP]: legacyHandler(GraphEvents.ON_RUN_STEP),
+        [GraphEvents.ON_RUN_STEP_COMPLETED]: legacyHandler(
+          GraphEvents.ON_RUN_STEP_COMPLETED
+        ),
+        [GraphEvents.ON_MESSAGE_DELTA]: legacyHandler(
+          GraphEvents.ON_MESSAGE_DELTA
+        ),
+      },
+    });
+
+    run.Graph?.overrideTestModel(
+      ['Let me call the tool', 'The tool answered'],
+      2,
+      toolCalls
+    );
+    await run.processStream(
+      { messages: [new HumanMessage('hello')] },
+      createStreamConfig('run-step-timestamps-legacy')
+    );
+
+    expect(new Set(received)).toEqual(
+      new Set([
+        GraphEvents.ON_RUN_STEP,
+        GraphEvents.ON_RUN_STEP_COMPLETED,
+        GraphEvents.ON_MESSAGE_DELTA,
+      ])
+    );
+    for (const step of run.Graph?.contentData ?? []) {
+      expect(step.status).toBe('completed');
+    }
+  });
+
+  it('sweeps unfinished steps as cancelled when the caller aborts mid-stream', async () => {
+    const { sequence, handlers } = createRecorder();
+    const controller = new AbortController();
+    const run = await Run.create<t.IState>({
+      runId: 'test-run-step-timestamps-abort',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'You are a helpful assistant.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        ...handlers,
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (): void => {
+            controller.abort();
+          },
+        },
+      },
+    });
+
+    run.Graph?.overrideTestModel(
+      ['This response streams slowly enough to abort in flight'],
+      25
+    );
+    await expect(
+      run.processStream(
+        { messages: [new HumanMessage('hello')] },
+        createStreamConfig('run-step-timestamps-abort', controller.signal)
+      )
+    ).rejects.toThrow();
+
+    const closed = getClosed(sequence);
+    expect(closed.length).toBeGreaterThanOrEqual(1);
+    expect(closed.every((event) => event.status === 'cancelled')).toBe(true);
+    for (const step of run.Graph?.contentData ?? []) {
+      expect(step.status).toBe('cancelled');
+      expect(typeof step.cancelled_at).toBe('number');
+      expect(step.cancelled_at as number).toBeGreaterThanOrEqual(
+        step.created_at as number
+      );
+    }
+  });
+
+  it('keeps steps open across a HITL interrupt and closes them on resume with the original created_at', async () => {
+    jest.setTimeout(30000);
+    const { sequence, handlers } = createRecorder();
+    const saver = new MemorySaver();
+    const run = await Run.create<t.IState>({
+      runId: 'test-run-step-timestamps-hitl',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'timestamps-hitl-agent',
+            provider: Providers.OPENAI,
+            clientOptions: {
+              model: 'gpt-4o-mini',
+              streaming: true,
+              streamUsage: false,
+            },
+            instructions: 'You are a helpful assistant.',
+            maxContextTokens: 8000,
+            graphTools: [askTool],
+          },
+        ],
+        compileOptions: { checkpointer: saver },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: handlers,
+    });
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['asking the user', 'done after resume'],
+      toolCalls: [
+        {
+          name: 'ask_user_question',
+          args: { question: 'pick one' },
+          id: 'call_ask_timestamps',
+          type: 'tool_call',
+        },
+      ],
+    });
+
+    const streamConfig = createStreamConfig('run-step-timestamps-hitl');
+    await run.processStream(
+      { messages: [new HumanMessage('go')] },
+      streamConfig
+    );
+
+    expect(run.getInterrupt()).toBeDefined();
+    const toolStep = run.Graph?.contentData.find(
+      (step) => step.type === StepTypes.TOOL_CALLS
+    ) as t.RunStep;
+    expect(toolStep).toBeDefined();
+    expect(toolStep.status).toBe('in_progress');
+    const createdAt = toolStep.created_at;
+    expect(typeof createdAt).toBe('number');
+    expect(getClosed(sequence).map((event) => event.id)).not.toContain(
+      toolStep.id
+    );
+
+    await run.processStream(
+      new Command({ resume: { answer: 'blue' } }) as unknown as t.IState,
+      streamConfig
+    );
+
+    expect(toolStep.status).toBe('completed');
+    expect(toolStep.created_at).toBe(createdAt);
+    const closedForTool = getClosed(sequence).filter(
+      (event) => event.id === toolStep.id
+    );
+    expect(closedForTool).toHaveLength(1);
+    expect(closedForTool[0].closed_at).toBeGreaterThanOrEqual(
+      createdAt as number
+    );
+    for (const step of run.Graph?.contentData ?? []) {
+      expect(step.status).toBe('completed');
+    }
+  });
+});

--- a/src/specs/run-step-timestamps.test.ts
+++ b/src/specs/run-step-timestamps.test.ts
@@ -292,6 +292,49 @@ describe('run step timestamps', () => {
     }
   });
 
+  it('sweeps as failed when an AbortError surfaces with no signal aborted', async () => {
+    const { sequence, handlers } = createRecorder();
+    const run = await Run.create<t.IState>({
+      runId: 'test-run-step-timestamps-uncorroborated-abort',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'You are a helpful assistant.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        ...handlers,
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (): void => {
+            /** A provider/host rejection that merely borrows the name — no
+             *  caller or construction signal was ever aborted. */
+            const error = new Error('provider stream aborted internally');
+            error.name = 'AbortError';
+            throw error;
+          },
+        },
+      },
+    });
+
+    run.Graph?.overrideTestModel(['some streamed content'], 2);
+    await expect(
+      run.processStream(
+        { messages: [new HumanMessage('hello')] },
+        createStreamConfig('run-step-timestamps-uncorroborated-abort')
+      )
+    ).rejects.toThrow();
+
+    const closed = getClosed(sequence);
+    expect(closed.length).toBeGreaterThanOrEqual(1);
+    expect(closed.every((event) => event.status === 'failed')).toBe(true);
+    for (const step of run.Graph?.contentData ?? []) {
+      expect(step.status).toBe('failed');
+      expect(typeof step.failed_at).toBe('number');
+      expect(step.cancelled_at).toBeUndefined();
+    }
+  });
+
   it('keeps steps open across a HITL interrupt and closes them on resume with the original created_at', async () => {
     jest.setTimeout(30000);
     const { sequence, handlers } = createRecorder();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -924,6 +924,7 @@ async function dispatchEagerToolCompletions(args: {
               progress: 1,
               ...(outcome != null && { outcome }),
             } as t.ProcessedToolCall,
+            completed_at: Date.now(),
           },
         },
         graph.config
@@ -1836,9 +1837,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
         contentGroups[0]
       ).phase;
       const phaseChanged =
-        currentPhase != null &&
-        nextPhase != null &&
-        currentPhase !== nextPhase;
+        currentPhase != null && nextPhase != null && currentPhase !== nextPhase;
       if (contentGroups.length > 1 || phaseChanged) {
         for (const contentGroup of contentGroups) {
           const currentStepId = await dispatchMessageCreationStep({

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -908,6 +908,16 @@ interface CreateSummarizeNodeParams {
       result: t.StepCompleted,
       config?: RunnableConfig
     ) => Promise<void>;
+    /**
+     * Terminal close for a summary step that ends without a completion —
+     * an errored or empty summary would otherwise stay `in_progress` until
+     * the run-end sweep reported it as `completed`.
+     */
+    closeRunStep?: (
+      stepId: string,
+      status: Exclude<t.RunStepStatus, 'in_progress'>,
+      config?: RunnableConfig
+    ) => Promise<void>;
     /** The run's shared breaker signal, composed into every summarization
      * model attempt so a sibling branch tripping a stream limit also
      * cancels in-flight summaries. */
@@ -1342,6 +1352,7 @@ export function createSummarizeNode({
           runnableConfig
         );
       }
+      await graph.closeRunStep?.(stepId, 'failed', runnableConfig);
       return { summarizationRequest: undefined };
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2561,6 +2561,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             index: turn,
             type: 'tool_call' as const,
             tool_call,
+            completed_at: Date.now(),
           },
         },
         config
@@ -3965,6 +3966,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             progress: 1,
             ...(outcome != null && { outcome }),
           } as t.ProcessedToolCall,
+          completed_at: Date.now(),
         },
       },
       config

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1563,17 +1563,13 @@ describe('SubagentExecutor', () => {
     const selected = makeConfig('selected', {
       agentInputs: {
         ...makeChildInputs('selected-agent'),
-        initialSessions: new Map([
-          [Constants.EXECUTE_CODE, selectedSession],
-        ]),
+        initialSessions: new Map([[Constants.EXECUTE_CODE, selectedSession]]),
       },
     });
     const sibling = makeConfig('sibling', {
       agentInputs: {
         ...makeChildInputs('sibling-agent'),
-        initialSessions: new Map([
-          [Constants.EXECUTE_CODE, siblingSession],
-        ]),
+        initialSessions: new Map([[Constants.EXECUTE_CODE, siblingSession]]),
       },
     });
     const childSessions: ToolSessionMap = new Map();
@@ -1613,7 +1609,10 @@ describe('SubagentExecutor', () => {
   });
 
   it('combines member session seeds inside a selected graph child', async () => {
-    const makeSession = (storageSessionId: string, includeFileSession = true) => ({
+    const makeSession = (
+      storageSessionId: string,
+      includeFileSession = true
+    ) => ({
       session_id: storageSessionId,
       files: [
         {
@@ -1696,9 +1695,7 @@ describe('SubagentExecutor', () => {
     const hitlConfig = makeConfig('hitl-child', {
       agentInputs: {
         ...makeChildInputs('hitl-child'),
-        initialSessions: new Map([
-          [Constants.EXECUTE_CODE, seededSession],
-        ]),
+        initialSessions: new Map([[Constants.EXECUTE_CODE, seededSession]]),
       },
     });
     const childSessions: ToolSessionMap = new Map();
@@ -3623,6 +3620,51 @@ describe('sanitizeForwardedSubagentUpdateData', () => {
     expect(serialized).not.toContain('nested-secret');
     expect(serialized).not.toContain('access-secret');
     expect(serialized).not.toContain('refresh-secret');
+  });
+
+  it('forwards run step lifecycle stamps and closed events via allowlists', () => {
+    const sanitizedStep = sanitizeForwardedSubagentUpdateData(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'step_1',
+        type: StepTypes.MESSAGE_CREATION,
+        index: 0,
+        created_at: 1_000,
+        status: 'in_progress',
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'message_1' },
+        },
+      }
+    ) as { created_at?: number; status?: string };
+    expect(sanitizedStep.created_at).toBe(1_000);
+    expect(sanitizedStep.status).toBe('in_progress');
+
+    const sanitizedClosed = sanitizeForwardedSubagentUpdateData(
+      GraphEvents.ON_RUN_STEP_CLOSED,
+      {
+        id: 'step_1',
+        index: 0,
+        type: StepTypes.MESSAGE_CREATION,
+        status: 'completed',
+        created_at: 1_000,
+        closed_at: 2_000,
+        runId: 'run_1',
+        agentId: 'researcher',
+        futureSecret: 'top-level-secret',
+      }
+    );
+    expect(sanitizedClosed).toEqual({
+      id: 'step_1',
+      index: 0,
+      type: StepTypes.MESSAGE_CREATION,
+      status: 'completed',
+      created_at: 1_000,
+      closed_at: 2_000,
+      runId: 'run_1',
+      agentId: 'researcher',
+    });
+    expect(JSON.stringify(sanitizedClosed)).not.toContain('top-level-secret');
   });
 
   it('keeps completed tool output while stripping operational fields', () => {

--- a/src/tools/__tests__/handlers.test.ts
+++ b/src/tools/__tests__/handlers.test.ts
@@ -16,6 +16,7 @@ type MockGraph = {
   getRunStep: jest.Mock;
   dispatchRunStep: jest.Mock;
   dispatchRunStepDelta: jest.Mock;
+  registerPendingToolCall: jest.Mock;
   toolCallStepIds: Map<string, string>;
   messageStepHasToolCalls: Map<string, boolean>;
   messageIdsByStepKey: Map<string, string>;
@@ -40,6 +41,7 @@ function createMockGraph(overrides?: Partial<MockGraph>): MockGraph {
     dispatchRunStepDelta: jest
       .fn<() => Promise<void>>()
       .mockResolvedValue(undefined),
+    registerPendingToolCall: jest.fn<() => void>(),
     toolCallStepIds: new Map(),
     messageStepHasToolCalls: new Map(),
     messageIdsByStepKey: new Map(),

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -181,6 +181,7 @@ export const handleToolCalls = async (
       const isEmpty = !details.tool_calls || details.tool_calls.length === 0;
       if (isEmpty && prevStepId !== reusedChunkStepId) {
         graph.toolCallStepIds.set(toolCallId, prevStepId);
+        graph.registerPendingToolCall(toolCallId, prevStepId);
         reusedChunkStepId = prevStepId;
         continue;
       }

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -45,6 +45,7 @@ import type {
   ReasoningDeltaEvent,
   RunStep,
   RunStepDeltaEvent,
+  RunStepClosedEvent,
   StandardGraphInput,
   ExecutableSubagentConfigEntry,
   ResolvedSubagentConfig,
@@ -156,8 +157,7 @@ function cloneToolSessionContext(
       : {
         files: context.files.map((file) => ({
           ...file,
-          storage_session_id:
-              file.storage_session_id ?? context.session_id,
+          storage_session_id: file.storage_session_id ?? context.session_id,
         })),
       }),
   };
@@ -200,8 +200,7 @@ function seedChildGraphSessions(
         );
       const files = existing.files == null ? [] : [...existing.files];
       for (const file of context.files) {
-        const storageSessionId =
-          file.storage_session_id ?? context.session_id;
+        const storageSessionId = file.storage_session_id ?? context.session_id;
         const key = `${storageSessionId}\0${file.id}`;
         if (seenFiles.has(key)) {
           continue;
@@ -263,10 +262,12 @@ type SanitizedRunStep = Partial<
   Pick<
     RunStep,
     | 'agentId'
+    | 'created_at'
     | 'groupId'
     | 'id'
     | 'index'
     | 'runId'
+    | 'status'
     | 'stepIndex'
     | 'summary'
     | 'type'
@@ -275,6 +276,8 @@ type SanitizedRunStep = Partial<
 > & {
   stepDetails?: SanitizedStepDetails;
 };
+
+type SanitizedRunStepClosed = Partial<RunStepClosedEvent>;
 
 type SanitizedStepDetails =
   | {
@@ -313,6 +316,7 @@ type SanitizedStepCompleted =
       index?: number;
       type: 'tool_call';
       tool_call?: SanitizedProcessedToolCall;
+      completed_at?: number;
     }
   | {
       type: 'summary';
@@ -2825,6 +2829,10 @@ export class SubagentExecutor {
           scheduleWrap(eventName, 'run_step_completed', data, memberAgentId);
           return;
         }
+        if (eventName === GraphEvents.ON_RUN_STEP_CLOSED) {
+          scheduleWrap(eventName, 'run_step_closed', data, memberAgentId);
+          return;
+        }
         if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
           scheduleWrap(eventName, 'message_delta', data, memberAgentId);
           return;
@@ -3179,6 +3187,9 @@ export function sanitizeForwardedSubagentUpdateData(
   if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
     return sanitizeRunStepCompletedUpdateData(data);
   }
+  if (eventName === GraphEvents.ON_RUN_STEP_CLOSED) {
+    return sanitizeRunStepClosedUpdateData(data);
+  }
   if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
     return sanitizeMessageDeltaUpdateData(data);
   }
@@ -3230,10 +3241,12 @@ function sanitizeRunStepUpdateData(
   const step = data as Partial<RunStep>;
   const sanitized: SanitizedRunStep = {};
   assignString(sanitized, 'agentId', step.agentId);
+  assignNumber(sanitized, 'created_at', step.created_at);
   assignNumber(sanitized, 'groupId', step.groupId);
   assignString(sanitized, 'id', step.id);
   assignNumber(sanitized, 'index', step.index);
   assignString(sanitized, 'runId', step.runId);
+  assignString(sanitized, 'status', step.status);
   assignNumber(sanitized, 'stepIndex', step.stepIndex);
   assignString(sanitized, 'type', step.type);
   if (step.summary !== undefined) {
@@ -3243,6 +3256,27 @@ function sanitizeRunStepUpdateData(
     sanitized.usage = step.usage;
   }
   sanitized.stepDetails = sanitizeStepDetails(step.stepDetails);
+  return sanitized;
+}
+
+function sanitizeRunStepClosedUpdateData(
+  data: unknown
+): SanitizedRunStepClosed | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const event = data as Partial<RunStepClosedEvent>;
+  const sanitized: SanitizedRunStepClosed = {};
+  assignString(sanitized, 'agentId', event.agentId);
+  assignNumber(sanitized, 'closed_at', event.closed_at);
+  assignNumber(sanitized, 'created_at', event.created_at);
+  assignNumber(sanitized, 'groupId', event.groupId);
+  assignString(sanitized, 'id', event.id);
+  assignNumber(sanitized, 'index', event.index);
+  assignString(sanitized, 'runId', event.runId);
+  assignString(sanitized, 'status', event.status);
+  assignNumber(sanitized, 'stepIndex', event.stepIndex);
+  assignString(sanitized, 'type', event.type);
   return sanitized;
 }
 
@@ -3389,6 +3423,7 @@ function sanitizeStepCompleted(
     id?: unknown;
     index?: unknown;
     tool_call?: unknown;
+    completed_at?: unknown;
   };
   if (completed.type === 'summary') {
     return {
@@ -3402,6 +3437,7 @@ function sanitizeStepCompleted(
   const sanitized: SanitizedStepCompleted = { type: 'tool_call' };
   assignString(sanitized, 'id', completed.id);
   assignNumber(sanitized, 'index', completed.index);
+  assignNumber(sanitized, 'completed_at', completed.completed_at);
   sanitized.tool_call = sanitizeProcessedToolCall(completed.tool_call);
   return sanitized;
 }
@@ -3519,6 +3555,12 @@ export function summarizeEvent(eventName: string, data: unknown): string {
       return `Tool ${tool.name} complete`;
     }
     return 'Step complete';
+  }
+  if (eventName === GraphEvents.ON_RUN_STEP_CLOSED) {
+    const closed = data as { status?: string };
+    return closed.status != null && closed.status !== ''
+      ? `Step ${closed.status}`
+      : 'Step closed';
   }
   if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
     return 'Streaming…';

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -18,6 +18,13 @@ import type {
   SummarizeDeltaEvent,
 } from '@/types/summarize';
 import type {
+  RunStep,
+  RunStepDeltaEvent,
+  RunStepClosedEvent,
+  MessageDeltaEvent,
+  ReasoningDeltaEvent,
+} from '@/types/stream';
+import type {
   ToolMap,
   ToolSessionMap,
   ToolEndEvent,
@@ -25,12 +32,6 @@ import type {
   LCTool,
   ToolExecuteBatchRequest,
 } from '@/types/tools';
-import type {
-  RunStep,
-  RunStepDeltaEvent,
-  MessageDeltaEvent,
-  ReasoningDeltaEvent,
-} from '@/types/stream';
 import type {
   TokenCounter,
   StreamLimits,
@@ -134,6 +135,7 @@ export interface EventHandler {
       | ModelEndData
       | RunStep
       | RunStepDeltaEvent
+      | RunStepClosedEvent
       | MessageDeltaEvent
       | ReasoningDeltaEvent
       | SummarizeStartEvent
@@ -597,6 +599,7 @@ export type SubagentUpdatePhase =
   | 'run_step'
   | 'run_step_delta'
   | 'run_step_completed'
+  | 'run_step_closed'
   | 'message_delta'
   | 'reasoning_delta'
   | 'stop'

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -60,7 +60,13 @@ export type RunStep = {
   type: StepTypes;
   /** Epoch ms when the step was dispatched. */
   created_at?: number;
-  /** Lifecycle status; terminal values are stamped when the step closes. */
+  /**
+   * Lifecycle status; terminal values are stamped when the step closes.
+   * Invariant (enforced by `closeRunStep`, not the type, to stay wire-compatible
+   * with the OpenAI Assistants shape): a terminal status sets exactly one
+   * matching `*_at` field; first close wins and `cancelled`/`failed` are
+   * immutable once stamped.
+   */
   status?: RunStepStatus;
   /** Epoch ms when the step closed with status `completed`. */
   completed_at?: number;
@@ -133,6 +139,8 @@ export interface RunStepClosedEvent {
 }
 
 export type RunStepCloseOptions = {
+  /** Epoch ms for the terminal stamp; defaults to `Date.now()` at close time. */
+  at?: number;
   metadata?: Record<string, unknown>;
   /** Allow a completed TOOL_CALLS step to refresh `completed_at` on a late completion. */
   restamp?: boolean;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -153,12 +153,6 @@ export type RunStepCloseOptions = {
   /** Epoch ms for the terminal stamp; defaults to `Date.now()` at close time. */
   at?: number;
   metadata?: Record<string, unknown>;
-  /**
-   * Allow a completed TOOL_CALLS step to refresh `completed_at` for a late
-   * parallel completion. Updates the stored stamp only — the terminal event
-   * is never re-emitted.
-   */
-  restamp?: boolean;
 };
 
 export type StepDetails = MessageCreationDetails | ToolCallsDetails;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -142,10 +142,12 @@ export type RunStepCloseOptions = {
   /** Epoch ms for the terminal stamp; defaults to `Date.now()` at close time. */
   at?: number;
   metadata?: Record<string, unknown>;
-  /** Allow a completed TOOL_CALLS step to refresh `completed_at` on a late completion. */
+  /**
+   * Allow a completed TOOL_CALLS step to refresh `completed_at` for a late
+   * parallel completion. Updates the stored stamp only — the terminal event
+   * is never re-emitted.
+   */
   restamp?: boolean;
-  /** Skip the custom-event dispatch (end-of-run sweep after the stream closed). */
-  registryOnly?: boolean;
 };
 
 export type StepDetails = MessageCreationDetails | ToolCallsDetails;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -138,6 +138,17 @@ export interface RunStepClosedEvent {
   stepIndex?: number;
 }
 
+export type RecordStepCompletionOptions = {
+  /** The completing tool call, when the step tracks pending completions. */
+  toolCallId?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Producer-stamped completion time (epoch ms). Carried through so a slow
+   * host completion handler cannot inflate the recorded step duration.
+   */
+  at?: number;
+};
+
 export type RunStepCloseOptions = {
   /** Epoch ms for the terminal stamp; defaults to `Date.now()` at close time. */
   at?: number;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -50,20 +50,24 @@ start, stream and end are associated with slightly different data payload.
 Please see the documentation for EventData for more details. */
 export type EventName = string;
 
+export type RunStepStatus =
+  | 'in_progress'
+  | 'completed'
+  | 'cancelled'
+  | 'failed';
+
 export type RunStep = {
-  // id: string;
-  // object: 'thread.run.step'; // Updated from 'run.step' # missing
-  // created_at: number;
-  // run_id: string;
-  // assistant_id: string;
-  // thread_id: string;
   type: StepTypes;
-  // status: 'in_progress' | 'completed' | 'failed' | 'cancelled'; // Add other possible status values if needed
-  // cancelled_at: number | null;
-  // completed_at: number | null;
-  // expires_at: number;
-  // failed_at: number | null;
-  // last_error: string | null;
+  /** Epoch ms when the step was dispatched. */
+  created_at?: number;
+  /** Lifecycle status; terminal values are stamped when the step closes. */
+  status?: RunStepStatus;
+  /** Epoch ms when the step closed with status `completed`. */
+  completed_at?: number;
+  /** Epoch ms when the step closed with status `cancelled` (abort/halt). */
+  cancelled_at?: number;
+  /** Epoch ms when the step closed with status `failed`. */
+  failed_at?: number;
   id: string; // #new
   runId?: string; // #new
   agentId?: string; // #new - tracks which agent this step belongs to
@@ -106,6 +110,35 @@ export interface RunStepDeltaEvent {
    */
   delta: ToolCallDelta;
 }
+
+/**
+ * Terminal signal for a run step, emitted exactly once per step when it
+ * finishes (`completed`), is aborted/halted (`cancelled`), or the run errors
+ * (`failed`). The `id` is top-level so callback echoes dedupe like other
+ * step-scoped events.
+ */
+export interface RunStepClosedEvent {
+  id: string;
+  index: number;
+  type: StepTypes;
+  status: Exclude<RunStepStatus, 'in_progress'>;
+  /** Epoch ms when the step was dispatched, when known. */
+  created_at?: number;
+  /** Epoch ms when the step reached its terminal status. */
+  closed_at: number;
+  runId?: string;
+  agentId?: string;
+  groupId?: number;
+  stepIndex?: number;
+}
+
+export type RunStepCloseOptions = {
+  metadata?: Record<string, unknown>;
+  /** Allow a completed TOOL_CALLS step to refresh `completed_at` on a late completion. */
+  restamp?: boolean;
+  /** Skip the custom-event dispatch (end-of-run sweep after the stream closed). */
+  registryOnly?: boolean;
+};
 
 export type StepDetails = MessageCreationDetails | ToolCallsDetails;
 
@@ -179,6 +212,8 @@ export type ToolCompleteEvent = ToolCallCompleted & {
   /** The content index of the tool call */
   index: number;
   type: 'tool_call';
+  /** Epoch ms when this tool call's completion was dispatched. */
+  completed_at?: number;
 };
 
 export type ToolCallsDetails = {

--- a/src/utils/handlers.ts
+++ b/src/utils/handlers.ts
@@ -30,6 +30,10 @@ interface HandlerCallbacks {
     event: GraphEvents.ON_RUN_STEP_DELTA,
     data: t.StreamEventData
   ) => void;
+  onRunStepClosed?: (
+    event: GraphEvents.ON_RUN_STEP_CLOSED,
+    data: t.RunStepClosedEvent
+  ) => void;
   onMessageDelta?: (
     event: GraphEvents.ON_MESSAGE_DELTA,
     data: t.StreamEventData
@@ -85,6 +89,15 @@ export function createHandlers(callbacks?: HandlerCallbacks): {
       ): void => {
         aggregateContent({ event, data: data as t.RunStepDeltaEvent });
         callbacks?.onRunStepDelta?.(event, data);
+      },
+    },
+
+    [GraphEvents.ON_RUN_STEP_CLOSED]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_CLOSED,
+        data: t.StreamEventData
+      ): void => {
+        callbacks?.onRunStepClosed?.(event, data as t.RunStepClosedEvent);
       },
     },
 


### PR DESCRIPTION
## Summary

I added start and finish timestamps to every run step, plus a new `on_run_step_closed` event that fires exactly once per step when it completes, is cancelled by an abort or halt, or fails. This gives LibreChat the timing data it needs for per-step latency display, "time spent in tools" analytics, and abort forensics — a step that never finished now says so explicitly instead of being silently orphaned. Every change is additive: hosts that register nothing observe identical behavior, and the `RunStep` type already anticipated this with `created_at` / `completed_at` / `cancelled_at` / `failed_at` / `status` sitting commented out.

- Stamped `created_at` and `status: 'in_progress'` on every `RunStep`, so the existing `ON_RUN_STEP` event carries the start time with no new subscription required.
- Added `GraphEvents.ON_RUN_STEP_CLOSED` with a `RunStepClosedEvent` payload carrying `{ id, index, type, status, created_at, closed_at, runId, agentId, groupId, stepIndex }`, dual-dispatched through the handler registry and the custom-event channel exactly like `ON_RUN_STEP`.
- Introduced `closeRunStep` on `StandardGraph` as the single idempotent close funnel: it stamps the terminal status and matching timestamp on the stored step, emits the event once, and treats the first close as authoritative — a later close attempt never re-emits and never rewrites the stamp, so stored state can't diverge from what subscribers were told.
- Solved the parallel-tool-call problem with N-of-M counting: each step tracks the tool call ids whose completions it is still waiting on and closes on the last one, using the latest producer timestamp among them, so a step holding three parallel calls neither announces completion early nor records the wrong finish time when handlers settle out of order.
- Intercepted `ON_RUN_STEP_COMPLETED` centrally in the run loop's custom-event callback, which covers all three completion transports — including `ToolNode`, which holds no graph reference — without threading the graph through it.
- Closed message-creation steps, which have never had a terminal event, when a successor step opens in the same agent lane or when the model call ends. Summarization steps are excluded from that tracking and close through their own completion, since their model call ends well before the summary exists.
- Swept every still-open step at end of run: `completed` on a natural finish, `cancelled` on caller abort or hook halt, `failed` on an unexpected stream error, skipped entirely while a HITL interrupt is awaiting resume so paused steps stay open across the pause. Cancellation is determined from an actually-aborted signal rather than an error name.
- Sourced every timestamp at its true boundary — the producer's completion time, the model-end time captured before host handlers run, and the stream's terminal time captured before post-stream hooks — so slow host callbacks cannot inflate a step's measured duration.
- Reserved each step's content index synchronously at registration, so parallel agent lanes dispatching successors concurrently cannot collide on the same index.
- Added `completed_at` to `ToolCompleteEvent` so tool durations ride the completion event LibreChat already consumes.
- Forwarded the new event and lifecycle fields through the subagent sanitizer allowlists, so child-run steps are not silently dropped.
- Emitted a `step.finished` session event and added an `onRunStepClosed` callback to `createHandlers` for hosts using those layers.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I added two test files and extended two others, all runnable without API keys via the existing `overrideTestModel` fake-model harness.

`src/specs/run-step-timestamps.test.ts` drives a real `Run` through five end-to-end scenarios:
- A natural finish with a tool call, asserting every step reports `in_progress` with a numeric `created_at` at dispatch, every step id receives exactly one close with `closed_at >= created_at`, the tool step closes after its completion event, and the message step closes before the tool step opens.
- A host registering only the pre-existing handlers, asserting the delivered event set is unchanged — this is the non-breaking guarantee pinned behaviorally.
- A mid-stream `AbortController` abort, asserting `processStream` rejects and every open step is swept to `cancelled` with a `cancelled_at` stamp, which also proves registry dispatch still works after the stream is dead.
- An error merely named `AbortError` with no signal ever aborted, asserting those steps sweep to `failed` rather than `cancelled`.
- A HITL interrupt, asserting the pending tool step stays `in_progress` across the pause and closes on resume with its original `created_at` intact.

`src/graphs/__tests__/Graph.closeRunStep.test.ts` covers the state machine directly: idempotency and terminal immutability, agreement between the stored stamp and the emitted event, empty and unknown step ids, N-of-M counting, duplicate completion absorption, latest-producer-timestamp selection for multi-call steps, the sweep skipping already-terminal steps and continuing past a throwing handler, `created_at` being stamped only after the predecessor closure is delivered, and distinct index reservation when parallel lanes dispatch concurrently. That last test was verified to fail against the pre-fix ordering.

### **Test Configuration**:

Ran `npx jest` across the full suite, `npx tsc --noEmit`, `npx eslint src/`, and `npm run check:circular-deps`. All green. Four suites fail identically on an unmodified checkout in this environment for reasons unrelated to these changes — `llm.spec.ts` files needing provider credentials and `durability-checkpoint.integration.test.ts` needing a MongoDB binary the sandbox proxy blocks.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

## Known gaps

Two lifecycle gaps are documented in the review threads rather than fixed here, both pre-existing in scope:

- **Subagent child graphs** run through `workflow.invoke()` rather than `Run.processStream`, so their steps do not receive closures. Parent-run steps are unaffected, and this is no worse than `main`, where no step closes at all. Wants its own PR — the fix touches the executor's forwarder and its success/error/interrupt teardown paths.
- **Cross-process resume** cannot close a step opened before the process boundary, because checkpoint restoration replays messages only. Fixing it means persisting step lifecycle into the checkpoint, which is a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5