### PR TITLE
🩺 perf: Short-Circuit Agent Context Lookup In Step Dispatch

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4780,10 +4780,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       runStep.runId = runId;
     }
 
-    if (metadata) {
+    /**
+     * `agentId`/`groupId` are multi-agent-only, and `getAgentContext` signals a
+     * miss by throwing — so for a single-agent graph the lookup could only ever
+     * build and discard an Error while producing the same undefined fields.
+     * The constant-time check gates it out of the per-step dispatch path.
+     */
+    if (metadata && this.isMultiAgentGraph()) {
       try {
         const agentContext = this.getAgentContext(metadata);
-        if (this.isMultiAgentGraph() && agentContext.agentId) {
+        if (agentContext.agentId) {
           runStep.agentId = agentContext.agentId;
           const groupId = this.resolveParallelGroupId(
             agentContext.agentId,


### PR DESCRIPTION
## Summary

I reordered two conditions in `dispatchRunStep` so single-agent graphs stop paying for an agent-context lookup they can never use. `agentId` and `groupId` are multi-agent-only fields, but the lookup ran before the multi-agent test, and `getAgentContext` signals a miss by throwing — so every step dispatch in a single-agent graph could construct an `Error`, capture its stack, throw it, and discard it in the catch, all to produce fields that stay `undefined` either way. Stack capture is the expensive part, and this sits on the per-step path that runs for every message and every tool call.

- Moved the constant-time `isMultiAgentGraph()` check ahead of `getAgentContext()`, so single-agent graphs short-circuit before the lookup.
- Kept `agentContext.agentId` as the inner guard and left the `try`/`catch` in place for multi-agent graphs, where a metadata shape without a resolvable node is still a legitimate miss.
- Documented why the check has to come first, since the ordering looks arbitrary until you know the lookup throws.

Behavior is unchanged in both graph types: when `isMultiAgentGraph()` is `false` the old code already fell through without assigning either field.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the suites that exercise both sides of the branch — `MultiAgentGraph`, `src/graphs`, `src/summarization`, `agent-handoffs`, `parallel`, and the tool `handlers` tests — covering the multi-agent paths where the lookup still runs and assigns `agentId`/`groupId`, plus the single-agent paths that now skip it. 239 passed, 1 skipped. Also ran `npx tsc --noEmit` and `npx eslint src/graphs/Graph.ts` clean.

To verify the behavior directly, run a multi-agent graph with a handoff and confirm run steps still carry `agentId` and a `groupId` for parallel members, then run a single-agent graph and confirm steps carry neither.

### **Test Configuration**:

`npx jest MultiAgentGraph src/graphs src/tools/__tests__/handlers.test.ts src/summarization agent-handoffs parallel`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5)_