### PR TITLE
🚫 fix: Drop Model-Turn Prefill for Gemini 3.7 Flash

### DIFF
--- a/src/llm/google/utils/common.test.ts
+++ b/src/llm/google/utils/common.test.ts
@@ -116,9 +116,11 @@ describe('convertResponseContentToChatGenerationChunk seal metadata', () => {
 
 describe('rejectsModelTurnPrefill', () => {
   test('is true for models that reject a trailing model turn', () => {
+    expect(rejectsModelTurnPrefill('gemini-3.7-flash')).toBe(true);
     expect(rejectsModelTurnPrefill('gemini-3.6-flash')).toBe(true);
     expect(rejectsModelTurnPrefill('gemini-3.5-flash-lite')).toBe(true);
     expect(rejectsModelTurnPrefill('models/gemini-3.6-flash')).toBe(true);
+    expect(rejectsModelTurnPrefill('models/gemini-3.7-flash-latest')).toBe(true);
     expect(rejectsModelTurnPrefill('google/gemini-3.5-flash-lite-latest')).toBe(
       true
     );
@@ -145,6 +147,15 @@ describe('dropUnsupportedModelTurnPrefill', () => {
     const result = dropUnsupportedModelTurnPrefill(
       contents,
       'gemini-3.6-flash'
+    );
+    expect(result).toEqual([userTurn]);
+  });
+
+  test('drops a trailing model turn for Gemini 3.7 Flash', () => {
+    const contents: Content[] = [userTurn, modelTurn];
+    const result = dropUnsupportedModelTurnPrefill(
+      contents,
+      'gemini-3.7-flash'
     );
     expect(result).toEqual([userTurn]);
   });

--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -660,13 +660,15 @@ export function convertBaseMessagesToContent(
 
 /**
  * Gemini models that reject a request whose `contents` end with a `model`-role
- * turn (a "prefill"). Google enforces this on newer generations (Gemini 3.6
- * Flash, Gemini 3.5 Flash-Lite) while older/sibling models still accept a
- * trailing model turn, so the rule is model-scoped rather than version-wide.
- * Extend this list as Google applies the restriction to further models.
+ * turn (a "prefill"). Google enforces this on newer generations (Gemini 3.7
+ * Flash, Gemini 3.6 Flash, Gemini 3.5 Flash-Lite) while older/sibling models
+ * still accept a trailing model turn, so the rule is model-scoped rather than
+ * version-wide. Extend this list as Google applies the restriction to further
+ * models.
  * @see https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates
  */
 const NO_PREFILL_GEMINI_MODELS = [
+  'gemini-3.7-flash',
   'gemini-3.6-flash',
   'gemini-3.5-flash-lite',
 ] as const;


### PR DESCRIPTION
## Summary

Google's prefill restriction — a request whose `contents` end with a `model`-role turn returns HTTP 400 — applies to **Gemini 3.7 Flash** exactly as it does to Gemini 3.6 Flash and Gemini 3.5 Flash-Lite. `NO_PREFILL_GEMINI_MODELS` is model-enumerated, so 3.7 Flash was not covered and prefill flows would fail against it.

Adds `gemini-3.7-flash` to the list.

## Why it matters

A trailing `model` turn is produced by prefill flows — most commonly editing an assistant reply and resubmitting. Without this entry, those requests reach Gemini 3.7 Flash unmodified and return a 400 instead of being repaired the way they already are for 3.6 Flash.

Companion to danny-avila/LibreChat#14802, which adds first-class Gemini 3.7 Flash support on the LibreChat side. That change is independent of this one — LibreChat's model list, pricing, and Flash-family parameter handling do not depend on this fix, but prefill on 3.7 Flash stays broken until this ships.

## Changes

- `src/llm/google/utils/common.ts` — add `gemini-3.7-flash` to `NO_PREFILL_GEMINI_MODELS`; update the doc comment.
- `src/llm/google/utils/common.test.ts` — cover the model and its versioned aliases (`models/gemini-3.7-flash-latest`) in `rejectsModelTurnPrefill`, and add a `dropUnsupportedModelTurnPrefill` case.

## Testing

`npx jest src/llm/google/utils/common.test.ts` — 11 passed.

Verified the new assertions are real: reverting `common.ts` alone turns both new tests red (`rejectsModelTurnPrefill › is true for models that reject a trailing model turn` and `dropUnsupportedModelTurnPrefill › drops a trailing model turn for Gemini 3.7 Flash`).

`npx tsc --noEmit` — clean.

Note: `src/llm/google/llm.spec.ts` fails to run in my sandbox for want of a `GOOGLE_API_KEY` in the process env. Confirmed pre-existing — it fails identically at `origin/main` with this change reverted.

## Reference

- https://ai.google.dev/gemini-api/docs/latest-model#api-changes-and-parameter-updates