### PR TITLE
v3.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.4.6",
+      "version": "3.4.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
Version bump so the Gemini 3.7 Flash prefill fix actually reaches consumers.

## Why this is needed

#412 merged as `f93660fb`, but it did not publish. `Publish Package` gates on a version change:

```
PACKAGE_VERSION=$(node -p "require('./package.json').version")
PUBLISHED_VERSION=$(npm view @librechat/agents version 2>/dev/null || echo "0.0.0")
if [ "$PACKAGE_VERSION" = "$PUBLISHED_VERSION" ]; then
  echo "No version change, skipping publish"
```

`main` was still at `3.4.6` and npm's latest is `3.4.6`, so the run triggered by the merge skipped. `3.4.7` releases `f93660fb`.

## Contents

`3.4.6...3.4.7` is exactly #412 — `gemini-3.7-flash` added to `NO_PREFILL_GEMINI_MODELS` so a trailing `model`-role turn is dropped instead of returning HTTP 400. Patch bump per semver: one bugfix, no API change.

Diff is the same shape as the `v3.4.6` bump — `package.json` version plus the matching `package-lock.json` fields (`version` and `packages[""].version`), via `npm version 3.4.7 --no-git-tag-version`. No tag on this branch; `v3.4.x` tags point at the bump commit on `main`, so tagging follows the merge as usual.

## Downstream

danny-avila/LibreChat#14818 (Gemini 3.7 Flash support) is blocked on this. It pins `@librechat/agents` at `^3.4.6` in both `api/package.json` and `packages/api/package.json`, so until `3.4.7` is on npm, LibreChat would advertise `gemini-3.7-flash` while editing an assistant reply and resubmitting still 400s. Once this publishes I'll bump the LibreChat lock.

## Verification

Confirmed the fix is present on this branch (`common.ts:671`) and `src/llm/google/utils/common.test.ts` passes (11 tests).