### PR TITLE
📦 perf: Shrink Published Package 60% And Fix Consumer Type Resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.4.7",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"
@@ -111,14 +111,21 @@
   },
   "files": [
     "dist",
-    "src",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
+    "!src/**/*.spec.ts",
+    "!src/**/__tests__/**",
+    "!src/specs/**",
+    "!src/scripts/**",
+    "!src/proto/**",
+    "!src/test/**",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "prepare": "node husky-setup.js",
     "prepublishOnly": "npm run build",
-    "build": "tsdown && tsc -p tsconfig.build.json",
+    "build": "tsdown && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:dev": "tsdown",
     "check:circular-deps": "node config/circular-deps.mjs",
     "test:circular-deps": "node --test config/circular-deps.test.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "target": "ESNext",
     "skipLibCheck": true,
+    "isolatedModules": true,
     "strict": true,
     "types": ["node", "jest"],
     "allowSyntheticDefaultImports": true,

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -14,6 +14,16 @@ const shared = {
   // Mirror Rollup's `preserveModules: true` — one output file per source module,
   // preserving the src-relative paths the package.json exports map points at.
   unbundle: true,
+  outputOptions: {
+    // Maps resolve against the `src/**/*.ts` the package ships, so inlining
+    // `sourcesContent` would publish the same source a third time (once raw,
+    // once per format). Stack traces still map to real source without it.
+    sourcemapExcludeSources: true,
+    // JSDoc is the editor-hover payload of `dist/types`, not of the runtime
+    // JS — stripping it here leaves the `.d.ts` docs untouched. `annotation`
+    // must stay so `@__PURE__` survives for consumer tree-shaking.
+    comments: { legal: true, annotation: true, jsdoc: false },
+  },
   // Force `.mjs`/`.cjs` regardless of package `type`, matching the previous
   // Rollup `entryFileNames` and the paths in the exports map.
   fixedExtension: true,


### PR DESCRIPTION
## Summary

The published tarball shipped the same source text **three times** — the raw `src/` tree, plus a full `sourcesContent` copy inlined into every ESM map and again into every CJS map. Only ~5 MB of the 23.4 MB unpacked package was code a consumer actually runs.

| | before | after | |
|---|---|---|---|
| unpacked | 23.4 MB | **9.4 MB** | −60% |
| tarball | 5.49 MB | **2.08 MB** | −62% |
| files | 1462 | **1119** | −343 |
| publint errors | 15 | **0** | |

Bumped to `3.5.0` — minor rather than patch, because files are removed from the published artifact.

## What was in there

`src/` was 9.58 MB of the package, and only **161 of its 552 files** are referenced by any sourcemap. The other 391 were 241 test files, 89 demo scripts, and 1.24 MB of fixtures: a 431 KB WAV, a 358 KB HTML capture, a 74 KB PDF resume, and a hotdog JPEG. None of it is reachable — the exports map already makes `./src/*` an `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Debugging is preserved

This was the deciding constraint, and it rules out the obvious "just drop the maps" fix. Four options, measured:

| strategy | total | debuggable |
|---|---|---|
| current | 22.30 MB | ✅ |
| drop maps + `src/` | 4.95 MB | ❌ |
| keep `sourcesContent`, drop `src/` | 12.73 MB | ✅ |
| **strip `sourcesContent`, ship referenced `src/`** | **9.70 MB** | ✅ |

The last one wins because the source ships **once** instead of twice (each format's maps embed their own copy today). Maps still point at the shipped `src/**/*.ts`, verified end-to-end against a packed tarball:

```
TypeError: Cannot read properties of undefined (reading 'indexTokenCountMap')
    at Run.create (/…/package/src/run.ts:653:16)
```

## Type resolution bug

All **218 `@/…` specifiers across 105 shipped `.d.ts` files** were unresolvable for consumers — Node's `imports` field only maps `#`-prefixed specifiers, so `"@/*": "./src/*"` is a no-op for both Node and TypeScript. Confirmed with TypeScript's own resolver against the packed tarball:

```
@/common                   UNRESOLVED ❌
@/graphs                   UNRESOLVED ❌
(control) ./types/run      RESOLVED ✅
```

Large parts of the public type surface were silently degrading. `tsc-alias` now rewrites them; 218 → 0.

## Type-only imports

Investigated as asked — **it saves zero bytes.** Building twice from identical sources, once with all 74 offending value-imports converted to `import type`, produced byte-identical JS (4,434,562 bytes both times). `unbundle: true` still builds the full module graph, so rolldown already elides type-only bindings after type-stripping.

Worth knowing: **`verbatimModuleSyntax` actively hurts here** — it breaks the build today (rolldown `MISSING_EXPORT`), and even after fixing all violations it *inflates* output and pulls `@langchain/langgraph/prebuilt` and `@anthropic-ai/sdk` into modules that don't need them. Not adopted.

Added `isolatedModules: true` instead (0 errors today) as the safe half of that flag.

## Packaging correctness (second commit)

`publint` reported **15 errors**. All 13 `exports` entries listed `types` **last**, and conditions are order-sensitive — so TypeScript only reached declarations by falling through `import`/`require`. `attw` flagged every entry point with `FallbackCondition` and degraded `bundler` resolution across the board.

The `imports` map declared `"@/*"` and `"~/*"`, but Node ignores any `imports` key not starting with `#` — it resolved nothing. Nothing reads it: jest builds its mapper from `tsconfig.compilerOptions.paths`, tsdown has its own `alias`, and `dist/` has no `@/` specifiers after the `tsc-alias` pass.

```
publint errors  15 -> 0
attw bundler    fallback -> green (all 13 entries)
```

Two `attw` problems remain and are **pre-existing**, not introduced here: types masquerade as ESM under `node16`-from-CJS (needs a `.d.cts` emit), and relative specifiers in `.d.ts` are extensionless under `node16`-from-ESM. Both need a dual declaration build — I tried `tsc-alias --resolve-full-paths` and it can't help, since there are no `.js` files in `dist/types` to resolve against. Worth its own PR.

## Changes

- **`tsdown.config.mjs`** — `sourcemapExcludeSources: true`; strip JSDoc from runtime JS only. `.d.ts` hover docs (1646 blocks) and `@__PURE__` annotations (318) both verified preserved.
- **`package.json`** — narrow `files` to the source maps actually reference; add `tsc-alias` to `build`; bump to `3.5.0`.
- **`tsconfig.json`** — `isolatedModules: true`.
- **`package.json`** — `types` first in all 13 `exports` entries; delete the dead `imports` map.
- **`tsconfig.build.json`** — exclude `__tests__/` and `src/test/`, which were shipping 3 orphan declarations.

## Verification

- Build clean; no circular dependencies (185 modules)
- `tsc --noEmit` clean, including with `isolatedModules`
- Full suite: 4179 passed, re-run after removing the `imports` map — **identical to a clean tree at HEAD**. The 12 failures are pre-existing missing-credential/403 errors in live provider specs
- `publint` 0 errors; `attw` `bundler` green on all 13 entry points
- Source mapping and type resolution both verified against an actual packed-and-extracted tarball

## Audit

A 39-agent audit measured the recoverable total at **14.0 MB**; this PR banks **13.98 MB** of it. Every remaining package-axis item was ≤5 KB. It also killed a tempting wrong answer: "drop `src/` entirely, keep `sourcesContent`" was measured as a **+2.99 MB regression** against this branch, since inlining source once per format costs 6.21 MB to delete 3.22 MB.

## Deliberately not included

An audit of the dependency tree (the larger bandwidth cost — ~299 MB installed) produced candidates that mostly **failed** adversarial verification: inflated figures, missed breakage, and in one case a security regression. Two look genuinely promising and deserve their own PR with real testing:

- `@opentelemetry/sdk-node` is imported nowhere while pulling 154 packages / 78.9 MB. `@opentelemetry/api` and `@opentelemetry/sdk-trace-base` are used but undeclared (as are `node-fetch` and `@google/generative-ai`)
- `@langchain/openai` is pinned exact, yielding multiple copies in consumer trees

Sizing that honestly: it's **−79 MB (−30.8%)** for a greenfield consumer, but only **−11.9 MB (−0.9%)** for LibreChat, which declares `@opentelemetry/sdk-node` itself at two other `^0.x` ranges. The real win there is install/CI time — 32,905 fewer files and 154 fewer packages to resolve — not disk.

Also deferred: `@typescript-eslint/consistent-type-imports` is absent despite AGENTS.md mandating standalone `import type` (146 violations). Since it changes zero bytes, it belongs in its own PR rather than adding an 80-file diff here.