### PR TITLE
⏪ revert: Defer The `.d.ts` Alias Rewrite, Restore Packaging Fixes (v3.5.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"
@@ -10,69 +10,69 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/main.mjs",
-      "require": "./dist/cjs/main.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/main.cjs"
     },
     "./openai": {
+      "types": "./dist/types/openai/index.d.ts",
       "import": "./dist/esm/openai/index.mjs",
-      "require": "./dist/cjs/openai/index.cjs",
-      "types": "./dist/types/openai/index.d.ts"
+      "require": "./dist/cjs/openai/index.cjs"
     },
     "./responses": {
+      "types": "./dist/types/responses/index.d.ts",
       "import": "./dist/esm/responses/index.mjs",
-      "require": "./dist/cjs/responses/index.cjs",
-      "types": "./dist/types/responses/index.d.ts"
+      "require": "./dist/cjs/responses/index.cjs"
     },
     "./langchain": {
+      "types": "./dist/types/langchain/index.d.ts",
       "import": "./dist/esm/langchain/index.mjs",
-      "require": "./dist/cjs/langchain/index.cjs",
-      "types": "./dist/types/langchain/index.d.ts"
+      "require": "./dist/cjs/langchain/index.cjs"
     },
     "./langchain/language_models/chat_models": {
+      "types": "./dist/types/langchain/language_models/chat_models.d.ts",
       "import": "./dist/esm/langchain/language_models/chat_models.mjs",
-      "require": "./dist/cjs/langchain/language_models/chat_models.cjs",
-      "types": "./dist/types/langchain/language_models/chat_models.d.ts"
+      "require": "./dist/cjs/langchain/language_models/chat_models.cjs"
     },
     "./langchain/messages": {
+      "types": "./dist/types/langchain/messages.d.ts",
       "import": "./dist/esm/langchain/messages.mjs",
-      "require": "./dist/cjs/langchain/messages.cjs",
-      "types": "./dist/types/langchain/messages.d.ts"
+      "require": "./dist/cjs/langchain/messages.cjs"
     },
     "./langchain/messages/tool": {
+      "types": "./dist/types/langchain/messages/tool.d.ts",
       "import": "./dist/esm/langchain/messages/tool.mjs",
-      "require": "./dist/cjs/langchain/messages/tool.cjs",
-      "types": "./dist/types/langchain/messages/tool.d.ts"
+      "require": "./dist/cjs/langchain/messages/tool.cjs"
     },
     "./langchain/google-common": {
+      "types": "./dist/types/langchain/google-common.d.ts",
       "import": "./dist/esm/langchain/google-common.mjs",
-      "require": "./dist/cjs/langchain/google-common.cjs",
-      "types": "./dist/types/langchain/google-common.d.ts"
+      "require": "./dist/cjs/langchain/google-common.cjs"
     },
     "./langchain/openai": {
+      "types": "./dist/types/langchain/openai.d.ts",
       "import": "./dist/esm/langchain/openai.mjs",
-      "require": "./dist/cjs/langchain/openai.cjs",
-      "types": "./dist/types/langchain/openai.d.ts"
+      "require": "./dist/cjs/langchain/openai.cjs"
     },
     "./langchain/prompts": {
+      "types": "./dist/types/langchain/prompts.d.ts",
       "import": "./dist/esm/langchain/prompts.mjs",
-      "require": "./dist/cjs/langchain/prompts.cjs",
-      "types": "./dist/types/langchain/prompts.d.ts"
+      "require": "./dist/cjs/langchain/prompts.cjs"
     },
     "./langchain/runnables": {
+      "types": "./dist/types/langchain/runnables.d.ts",
       "import": "./dist/esm/langchain/runnables.mjs",
-      "require": "./dist/cjs/langchain/runnables.cjs",
-      "types": "./dist/types/langchain/runnables.d.ts"
+      "require": "./dist/cjs/langchain/runnables.cjs"
     },
     "./langchain/tools": {
+      "types": "./dist/types/langchain/tools.d.ts",
       "import": "./dist/esm/langchain/tools.mjs",
-      "require": "./dist/cjs/langchain/tools.cjs",
-      "types": "./dist/types/langchain/tools.d.ts"
+      "require": "./dist/cjs/langchain/tools.cjs"
     },
     "./langchain/utils/env": {
+      "types": "./dist/types/langchain/utils/env.d.ts",
       "import": "./dist/esm/langchain/utils/env.mjs",
-      "require": "./dist/cjs/langchain/utils/env.cjs",
-      "types": "./dist/types/langchain/utils/env.d.ts"
+      "require": "./dist/cjs/langchain/utils/env.cjs"
     }
   },
   "typesVersions": {
@@ -125,7 +125,7 @@
   "scripts": {
     "prepare": "node husky-setup.js",
     "prepublishOnly": "npm run build",
-    "build": "tsdown && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "build": "tsdown && tsc -p tsconfig.build.json",
     "build:dev": "tsdown",
     "check:circular-deps": "node config/circular-deps.mjs",
     "test:circular-deps": "node --test config/circular-deps.test.mjs",
@@ -273,10 +273,6 @@
     "@anthropic-ai/sandbox-runtime": {
       "optional": true
     }
-  },
-  "imports": {
-    "@/*": "./src/*",
-    "~/*": "./*"
   },
   "devDependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.67",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,10 +12,12 @@
   "exclude": [
     "**/*.test.ts",
     "**/*.spec.ts",
+    "**/__tests__/**",
     "node_modules",
     "dist",
     "src/proto/**/*",
     "src/scripts/**/*",
-    "src/specs/**/*"
+    "src/specs/**/*",
+    "src/test/**/*"
   ]
 }


### PR DESCRIPTION
Follow-up to #414. Two things went wrong there: its head got stuck at the first commit, so the packaging-correctness fixes never merged — and the one change that *did* merge is the one that broke LibreChat.

The 60% size reduction is already live on npm and is untouched by this PR.

## Reverted: the `tsc-alias` pass

It was correct. It made 218 `@/…` specifiers across 105 shipped `.d.ts` files resolvable for the first time. But correctness here is a **latent-error-surfacing** change: those declarations previously degraded to `any`, so every structural mismatch against them silently passed.

On the 3.5.0 bump, [LibreChat#14830](https://github.com/danny-avila/LibreChat/pull/14830) sees **115 type errors** — 108 in tests, 7 in production source.

**None are regressions.** The declarations are semantically unchanged. Diffing all 214 `.d.ts` files with import specifiers normalized: **213 byte-identical**, and the 214th differs only by the same rewrite in inline `import('@/…')` form.

Roughly half the errors are **nominal-enum identity** — this package and `librechat-data-provider` each define `ContentTypes` and `Providers` with identical string values, and TypeScript treats them as distinct types. That produces errors that read as nonsense on their face:

```
Type 'ContentTypes.TEXT' is not assignable to
     type 'ContentTypes.TEXT | ContentTypes.THINK | undefined'
```

The rest is genuine drift — `data-provider`'s `Agents.RunStep` has diverged from ours (`tool_calls` is required there, optional here).

That cleanup is worth doing, but it shouldn't gate a packaging release. Reverting only this step restores 3.4.7's type-resolution behavior.

## Restored: the fixes lost when #414 merged short

`publint` reports **15 errors** against the published 3.5.0:

- All 13 `exports` entries list `types` **last**. Conditions are order-sensitive, so TypeScript only reaches the declarations by falling through `import`/`require` — `attw` flags every entry point with `FallbackCondition`.
- The `imports` map declares `@/*` and `~/*`, but Node ignores any `imports` key not starting with `#`. It resolves nothing. Verified nothing reads it: jest builds its mapper from `tsconfig.compilerOptions.paths`, and tsdown has its own `alias`.
- `tsconfig.build.json` excluded `*.test.ts`/`*.spec.ts` but not `__tests__/` or `src/test/`, shipping three orphan declarations.

## Result

| | npm 3.5.0 | this PR |
|---|---|---|
| unpacked | 9.4 MB | 9.4 MB |
| files | 1122 | **1119** |
| publint errors | 15 | **0** |
| attw `bundler` | fallback | **green** (13/13) |
| LibreChat typecheck | 115 errors | **0** |

## Verification

- Build clean; no circular dependencies (185 modules); `tsc --noEmit` clean; prettier clean
- `publint` 0 errors; `attw` `bundler` green on all 13 entry points
- `@/` specifiers back to 213, matching 3.4.7 behavior
- **LibreChat's `tsc --noEmit -p packages/api/tsconfig.json`: 115 → 0**, run against unmodified PR source with this exact artifact installed into an isolated `node_modules`

## Follow-ups

- [LibreChat#14830](https://github.com/danny-avila/LibreChat/pull/14830) needs its pin moved `^3.5.0` → `^3.5.1` once this publishes.
- Consider `npm deprecate @librechat/agents@3.5.0` pointing at 3.5.1 — anyone who installed it in the meantime has the broken-in-a-new-way types.
- The 115 LibreChat errors are real pre-existing debt and still worth fixing, after which this alias rewrite can land again. The nominal-enum half might be better solved on this side, by typing public enum fields as string-literal unions so both copies satisfy them.

> [!NOTE]
> The commit is unsigned — GPG was locked in the authoring environment and signing isn't enforced on `main`. Re-sign with `git commit --amend -S` before merging if you want history consistent.
