### PR TITLE
feat: route code execution per agent profile

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -4945,6 +4945,50 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.has('call_file')).toBe(false);
   });
 
+  it('does not prestart code execution for a custom agent session partition', async () => {
+    const graph = createGraph({
+      eagerEventToolExecution: { enabled: true },
+      getAgentContext: jest.fn(() => ({
+        provider: Providers.ANTHROPIC,
+        reasoningKey: 'reasoning',
+        toolDefinitions: [{ name: Constants.EXECUTE_CODE }],
+        graphTools: [],
+        agentId: 'stateful-agent',
+        codeSessionKey: 'execute_code:stateful:user-1',
+      })) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_TOOL_EXECUTE) {
+          toolExecuteCalls.push(data as t.ToolExecuteBatchRequest);
+        }
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_code',
+              name: Constants.EXECUTE_CODE,
+              args: { lang: 'python', code: 'print(1)' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_code')).toBe(false);
+  });
+
   it('does not prestart codeSessionToolNames tools even without excludeToolNames', async () => {
     // A declared session-writing host tool is side-effecting, so it must not be
     // eagerly prestarted even when the host didn't also list it in excludeToolNames.

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -63,6 +63,7 @@ export class AgentContext {
   ): AgentContext {
     const {
       agentId,
+      codeSessionKey,
       name,
       provider,
       clientOptions,
@@ -92,6 +93,7 @@ export class AgentContext {
 
     const agentContext = new AgentContext({
       agentId,
+      codeSessionKey,
       name: name ?? agentId,
       provider,
       clientOptions,
@@ -167,6 +169,8 @@ export class AgentContext {
 
   /** Agent identifier */
   agentId: string;
+  /** Partition for this agent's transient code session and file refs. */
+  codeSessionKey?: string;
   /** Human-readable name for this agent (used in handoff context). Falls back to agentId if not provided. */
   name?: string;
   /** Provider for this specific agent */
@@ -370,6 +374,7 @@ export class AgentContext {
 
   constructor({
     agentId,
+    codeSessionKey,
     name,
     provider,
     clientOptions,
@@ -394,6 +399,7 @@ export class AgentContext {
     maxToolResultChars,
   }: {
     agentId: string;
+    codeSessionKey?: string;
     name?: string;
     provider: Providers;
     clientOptions?: t.ClientOptions;
@@ -418,6 +424,7 @@ export class AgentContext {
     maxToolResultChars?: number;
   }) {
     this.agentId = agentId;
+    this.codeSessionKey = codeSessionKey;
     this.name = name;
     this.provider = provider;
     this.clientOptions = clientOptions;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2391,6 +2391,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentLangfuse: agentContext?.langfuse,
         eventDrivenMode: true,
         sessions: this.sessions,
+        codeSessionKey: agentContext?.codeSessionKey,
         toolDefinitions: toolDefMap,
         // `agentId` is the subagent-scope marker — set ONLY for child-run
         // graphs (hooks fire for child scopes too, via the inherited
@@ -2471,6 +2472,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       toolRegistry: agentContext?.toolRegistry,
       sessions: this.sessions,
+      codeSessionKey: agentContext?.codeSessionKey,
       toolExecution: this.toolExecution,
       codeSessionToolNames: this.codeSessionToolNames,
       interruptingToolNames: effectiveInterruptingToolNames,

--- a/src/run.ts
+++ b/src/run.ts
@@ -72,6 +72,7 @@ import {
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
+import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import { createGraph } from '@/graphs/createGraph';
 import { resolveMaxSeals } from '@/llm/preempt';
@@ -351,9 +352,25 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     if (config.initialSessions && this.Graph) {
-      for (const [key, value] of config.initialSessions) {
-        this.Graph.sessions.set(key, value);
-      }
+      const configuredAgents =
+        'agents' in config.graphConfig &&
+        Array.isArray(config.graphConfig.agents)
+          ? config.graphConfig.agents
+          : undefined;
+      const agents: Array<Pick<t.AgentInputs, 'codeSessionKey'>> =
+        configuredAgents ?? [
+          {
+            codeSessionKey:
+              'codeSessionKey' in config.graphConfig
+                ? config.graphConfig.codeSessionKey
+                : undefined,
+          },
+        ];
+      seedRunInitialSessions({
+        sessions: this.Graph.sessions,
+        initialSessions: config.initialSessions,
+        agents,
+      });
     }
 
     this.returnContent = config.returnContent ?? false;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -258,7 +258,8 @@ function toCodeEnvFile(file: t.FileRef, execSessionId: string): t.CodeEnvFile {
 
 function getCodeSessionContext(
   graph: StandardGraph,
-  name: string
+  name: string,
+  agentContext?: AgentContext
 ): t.ToolCallRequest['codeSessionContext'] | undefined {
   if (
     !CODE_EXECUTION_TOOLS.has(name) &&
@@ -269,9 +270,9 @@ function getCodeSessionContext(
     return undefined;
   }
 
-  const codeSession = graph.sessions.get(Constants.EXECUTE_CODE) as
-    | t.CodeSessionContext
-    | undefined;
+  const codeSession = graph.sessions.get(
+    agentContext?.codeSessionKey ?? Constants.EXECUTE_CODE
+  ) as t.CodeSessionContext | undefined;
   if (codeSession?.session_id == null || codeSession.session_id === '') {
     return undefined;
   }
@@ -748,7 +749,11 @@ function createEagerToolExecutionPlan(args: {
       name: toolCall.name,
       args: toolCall.args,
       stepId: graph.toolCallStepIds.get(toolCall.id!) ?? '',
-      codeSessionContext: getCodeSessionContext(graph, toolCall.name),
+      codeSessionContext: getCodeSessionContext(
+        graph,
+        toolCall.name,
+        agentContext
+      ),
     })),
     usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
   });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -169,7 +169,8 @@ function hasToolOutputReference(value: unknown): boolean {
 
 function isEagerExecutionExcludedTool(
   name: string,
-  graph: StandardGraph
+  graph: StandardGraph,
+  agentContext?: AgentContext
 ): boolean {
   if (name === '') {
     return false;
@@ -200,9 +201,21 @@ function isEagerExecutionExcludedTool(
   // args, ToolNode discards the eager result but the mutation has already
   // landed in the session workspace, corrupting later runs. Stateless mode
   // uses a throwaway VM per call, so eager prestart stays safe there.
+  if (!CODE_EXECUTION_TOOLS.has(name)) {
+    return false;
+  }
+  if (graph.toolExecution?.sandbox?.statefulSessions === true) {
+    return true;
+  }
+  // A non-default code-session partition is the trusted per-agent signal that
+  // this call must remain isolated from the graph-wide stateless session. The
+  // actual tool factory may route it to a durable backend, which the stream
+  // layer cannot inspect in event-driven mode. Conservatively avoid speculative
+  // execution for these calls so discarded eager results cannot mutate that
+  // agent's workspace.
   return (
-    graph.toolExecution?.sandbox?.statefulSessions === true &&
-    CODE_EXECUTION_TOOLS.has(name)
+    agentContext?.codeSessionKey != null &&
+    agentContext.codeSessionKey !== Constants.EXECUTE_CODE
   );
 }
 
@@ -717,7 +730,8 @@ function createEagerToolExecutionPlan(args: {
   // tool from `hasDirectToolCallInBatch`. Excluded calls fall through to normal
   // ToolNode execution; siblings may still eager-execute.
   const candidateToolCalls = unstartedToolCalls.filter(
-    (toolCall) => !isEagerExecutionExcludedTool(toolCall.name, graph)
+    (toolCall) =>
+      !isEagerExecutionExcludedTool(toolCall.name, graph, agentContext)
   );
   if (candidateToolCalls.length === 0) {
     return [];

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -299,22 +299,22 @@ function createBashExecutionTool(
         const runtimeEcho =
           result.runtime_session_id != null
             ? {
-                runtime_session_id: result.runtime_session_id,
-                runtime_status: result.runtime_status,
-              }
+              runtime_session_id: result.runtime_session_id,
+              runtime_status: result.runtime_status,
+            }
             : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
             ? {
-                session_id: result.session_id,
-                files: result.files,
-                ...runtimeEcho,
-              }
+              session_id: result.session_id,
+              files: result.files,
+              ...runtimeEcho,
+            }
             : {
-                session_id: result.session_id,
-                ...runtimeEcho,
-              }) satisfies t.CodeExecutionArtifact,
+              session_id: result.session_id,
+              ...runtimeEcho,
+            }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -12,9 +12,11 @@ import {
   emptyOutputMessage,
   buildCodeApiHttpErrorMessage,
   CodeApiRequestError,
+  buildCodeApiEndpoint,
   getCodeBaseURL,
   normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
+  selectRuntimeSessionHint,
 } from './CodeExecutor';
 import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
@@ -175,7 +177,10 @@ export const BashExecutionToolDefinition = {
 function createBashExecutionTool(
   params: t.BashExecutionToolParams | null = {}
 ): DynamicStructuredTool {
-  const execEndpoint = `${params?.baseUrl ?? getCodeBaseURL()}/exec`;
+  const execEndpoint = buildCodeApiEndpoint(
+    params?.baseUrl ?? getCodeBaseURL(),
+    'exec'
+  );
 
   return tool(
     async (rawInput, config) => {
@@ -221,8 +226,10 @@ function createBashExecutionTool(
         ...executionParams,
       };
 
-      const effectiveRuntimeSessionHint =
-        runtimeSessionHint ?? _runtime_session_hint;
+      const effectiveRuntimeSessionHint = selectRuntimeSessionHint(
+        runtimeSessionHint,
+        _runtime_session_hint
+      );
       if (
         statefulSessions === true &&
         executionProfile !== 'default' &&
@@ -292,22 +299,22 @@ function createBashExecutionTool(
         const runtimeEcho =
           result.runtime_session_id != null
             ? {
-              runtime_session_id: result.runtime_session_id,
-              runtime_status: result.runtime_status,
-            }
+                runtime_session_id: result.runtime_session_id,
+                runtime_status: result.runtime_status,
+              }
             : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
             ? {
-              session_id: result.session_id,
-              files: result.files,
-              ...runtimeEcho,
-            }
+                session_id: result.session_id,
+                files: result.files,
+                ...runtimeEcho,
+              }
             : {
-              session_id: result.session_id,
-              ...runtimeEcho,
-            }) satisfies t.CodeExecutionArtifact,
+                session_id: result.session_id,
+                ...runtimeEcho,
+              }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -8,6 +8,7 @@ import {
   appendFailedExecutionFileReminder,
   appendTmpScratchReminder,
   appendCodeSessionFileSummary,
+  addCodeApiExecutionProfileHeader,
   emptyOutputMessage,
   buildCodeApiHttpErrorMessage,
   CodeApiRequestError,
@@ -20,9 +21,6 @@ import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();
-
-const baseEndpoint = getCodeBaseURL();
-const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
 
 export const BashExecutionToolSchema = {
   type: 'object',
@@ -177,15 +175,21 @@ export const BashExecutionToolDefinition = {
 function createBashExecutionTool(
   params: t.BashExecutionToolParams | null = {}
 ): DynamicStructuredTool {
+  const execEndpoint = `${params?.baseUrl ?? getCodeBaseURL()}/exec`;
+
   return tool(
     async (rawInput, config) => {
-      /* `statefulSessions` is prompt-only — keep it out of the wire body. */
+      /* `statefulSessions` drives the prompt and gates runtime affinity hints;
+       * keep the flag itself out of the wire body. */
       const {
         authHeaders,
-        statefulSessions: _statefulSessions,
+        baseUrl: _baseUrl,
+        executionProfile,
+        runtimeSessionHint,
+        statefulSessions,
         ...executionParams
       } = params ?? {};
-      void _statefulSessions;
+      void _baseUrl;
       /* Drop any model-supplied `runtime_session_hint` from the raw args: the
        * hint must only come from ToolNode's injected `_runtime_session_hint`
        * (below), never from the tool call itself. */
@@ -217,11 +221,15 @@ function createBashExecutionTool(
         ...executionParams,
       };
 
+      const effectiveRuntimeSessionHint =
+        runtimeSessionHint ?? _runtime_session_hint;
       if (
-        typeof _runtime_session_hint === 'string' &&
-        _runtime_session_hint !== ''
+        statefulSessions === true &&
+        executionProfile !== 'default' &&
+        typeof effectiveRuntimeSessionHint === 'string' &&
+        effectiveRuntimeSessionHint !== ''
       ) {
-        postData.runtime_session_hint = _runtime_session_hint;
+        postData.runtime_session_hint = effectiveRuntimeSessionHint;
       }
 
       /* See `CodeExecutor.ts` for the rationale — `/files/<session_id>`
@@ -248,19 +256,22 @@ function createBashExecutionTool(
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            ...resolvedAuthHeaders,
+            ...addCodeApiExecutionProfileHeader(
+              resolvedAuthHeaders,
+              executionProfile
+            ),
           },
           body: JSON.stringify(postData),
         };
 
-        const proxyAgent = resolveFetchProxyAgent(EXEC_ENDPOINT);
+        const proxyAgent = resolveFetchProxyAgent(execEndpoint);
         if (proxyAgent) {
           fetchOptions.agent = proxyAgent;
         }
-        const response = await fetch(EXEC_ENDPOINT, fetchOptions);
+        const response = await fetch(execEndpoint, fetchOptions);
         if (!response.ok) {
           throw new CodeApiRequestError(
-            await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
+            await buildCodeApiHttpErrorMessage('POST', execEndpoint, response)
           );
         }
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -362,13 +362,17 @@ export function createBashProgrammaticToolCallingTool(
           );
         }
 
-        /* Stateful sessions: hint on the INITIAL request only (continuations
-         * bind via continuation_token). Wire-only in v1 — BashPTC keeps its
-         * stateless prompt. */
+        /* The hint rides the INITIAL request only; continuation_token binds
+         * later round-trips. Prefer trusted per-agent factory context over
+         * legacy ToolNode injection. Explicit default profiles always drop it.
+         * BashPTC keeps its stateless runtime prompt in v1. */
+        const selectedRuntimeSessionHint =
+          initParams.runtimeSessionHint ?? _runtime_session_hint;
         const runtimeSessionHint =
-          typeof _runtime_session_hint === 'string' &&
-          _runtime_session_hint !== ''
-            ? _runtime_session_hint
+          initParams.executionProfile !== 'default' &&
+          typeof selectedRuntimeSessionHint === 'string' &&
+          selectedRuntimeSessionHint !== ''
+            ? selectedRuntimeSessionHint
             : undefined;
 
         let response = await makeRequest(
@@ -385,7 +389,8 @@ export function createBashProgrammaticToolCallingTool(
               : {}),
           },
           proxy,
-          initParams.authHeaders
+          initParams.authHeaders,
+          initParams.executionProfile
         );
 
         // ====================================================================
@@ -425,7 +430,8 @@ export function createBashProgrammaticToolCallingTool(
               tool_results: toolResults,
             },
             proxy,
-            initParams.authHeaders
+            initParams.authHeaders,
+            initParams.executionProfile
           );
         }
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -8,8 +8,10 @@ import {
   CODE_ARTIFACT_PATH_GUIDANCE,
   appendFailedExecutionFileReminder,
   buildCodeApiExecutionErrorMessage,
+  buildCodeApiEndpoint,
   CodeApiRequestError,
   getCodeBaseURL,
+  selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
   clampCodeApiRunTimeoutMs,
@@ -296,7 +298,7 @@ export function createBashProgrammaticToolCallingTool(
   const maxRunTimeoutMs = resolveCodeApiRunTimeoutMs(initParams.runTimeoutMs);
   const proxy = initParams.proxy ?? process.env.PROXY;
   const debug = initParams.debug ?? process.env.BASH_PTC_DEBUG === 'true';
-  const EXEC_ENDPOINT = `${baseUrl}/exec/programmatic`;
+  const EXEC_ENDPOINT = buildCodeApiEndpoint(baseUrl, 'exec/programmatic');
 
   return tool(
     async (rawParams, config) => {
@@ -366,8 +368,10 @@ export function createBashProgrammaticToolCallingTool(
          * later round-trips. Prefer trusted per-agent factory context over
          * legacy ToolNode injection. Explicit default profiles always drop it.
          * BashPTC keeps its stateless runtime prompt in v1. */
-        const selectedRuntimeSessionHint =
-          initParams.runtimeSessionHint ?? _runtime_session_hint;
+        const selectedRuntimeSessionHint = selectRuntimeSessionHint(
+          initParams.runtimeSessionHint,
+          _runtime_session_hint
+        );
         const runtimeSessionHint =
           initParams.executionProfile !== 'default' &&
           typeof selectedRuntimeSessionHint === 'string' &&

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -108,8 +108,8 @@ export const CodeExecutionToolSchema = {
   required: ['lang', 'code'],
 } as const;
 
-const baseEndpoint = getCodeBaseURL();
-const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
+export const CODE_API_EXPECTED_PROFILE_HEADER =
+  'X-CodeAPI-Expected-Profile';
 
 type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
@@ -226,6 +226,19 @@ export async function resolveCodeApiAuthHeaders(
   return authHeaders;
 }
 
+export function addCodeApiExecutionProfileHeader(
+  headers: t.CodeApiAuthHeaderMap,
+  executionProfile?: t.CodeApiExecutionProfile
+): t.CodeApiAuthHeaderMap {
+  if (executionProfile == null) {
+    return headers;
+  }
+  return {
+    ...headers,
+    [CODE_API_EXPECTED_PROFILE_HEADER]: executionProfile,
+  };
+}
+
 export async function buildCodeApiHttpErrorMessage(
   _method: string,
   _endpoint: string,
@@ -333,16 +346,21 @@ export const CodeExecutionToolDefinition = {
 function createCodeExecutionTool(
   params: t.CodeExecutionToolParams | null = {}
 ): DynamicStructuredTool {
+  const execEndpoint = `${params?.baseUrl ?? getCodeBaseURL()}/exec`;
+
   return tool(
     async (rawInput, config) => {
-      /* `statefulSessions` is a prompt-only flag (drives the description);
-       * keep it out of the wire body. */
+      /* `statefulSessions` drives the description and gates trusted runtime
+       * affinity hints. Keep the flag itself out of the wire body. */
       const {
         authHeaders,
-        statefulSessions: _statefulSessions,
+        baseUrl: _baseUrl,
+        executionProfile,
+        runtimeSessionHint,
+        statefulSessions,
         ...executionParams
       } = params ?? {};
-      void _statefulSessions;
+      void _baseUrl;
       /* Drop any model-supplied `runtime_session_hint` from the raw args: the
        * hint is host-controlled and must only ever come from ToolNode's
        * injected `_runtime_session_hint` (below). Spreading `...rest` into
@@ -383,14 +401,18 @@ function createCodeExecutionTool(
         ...executionParams,
       };
 
-      /* Stateful sessions: forward the hint so the Code API can route this
-       * execution to a warm per-session runtime. Additive — stateless
-       * servers ignore the unknown field. */
+      /* Stateful sessions: prefer the per-agent factory hint, falling back to
+       * legacy ToolNode injection. Explicit default-profile tools always drop
+       * the hint so a mixed graph cannot promote them to the stateful path. */
+      const effectiveRuntimeSessionHint =
+        runtimeSessionHint ?? _runtime_session_hint;
       if (
-        typeof _runtime_session_hint === 'string' &&
-        _runtime_session_hint !== ''
+        statefulSessions === true &&
+        executionProfile !== 'default' &&
+        typeof effectiveRuntimeSessionHint === 'string' &&
+        effectiveRuntimeSessionHint !== ''
       ) {
-        postData.runtime_session_hint = _runtime_session_hint;
+        postData.runtime_session_hint = effectiveRuntimeSessionHint;
       }
 
       /* File injection: `_injected_files` from ToolNode (set when host
@@ -421,19 +443,22 @@ function createCodeExecutionTool(
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            ...resolvedAuthHeaders,
+            ...addCodeApiExecutionProfileHeader(
+              resolvedAuthHeaders,
+              executionProfile
+            ),
           },
           body: JSON.stringify(postData),
         };
 
-        const proxyAgent = resolveFetchProxyAgent(EXEC_ENDPOINT);
+        const proxyAgent = resolveFetchProxyAgent(execEndpoint);
         if (proxyAgent) {
           fetchOptions.agent = proxyAgent;
         }
-        const response = await fetch(EXEC_ENDPOINT, fetchOptions);
+        const response = await fetch(execEndpoint, fetchOptions);
         if (!response.ok) {
           throw new CodeApiRequestError(
-            await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
+            await buildCodeApiHttpErrorMessage('POST', execEndpoint, response)
           );
         }
 

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -19,6 +19,17 @@ export const getCodeBaseURL = (): string =>
   getEnvironmentVariable(EnvVar.CODE_BASEURL) ??
   Constants.OFFICIAL_CODE_BASEURL;
 
+export function buildCodeApiEndpoint(baseUrl: string, route: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}/${route.replace(/^\/+/, '')}`;
+}
+
+export function selectRuntimeSessionHint(
+  factoryHint?: string,
+  injectedHint?: string
+): string | undefined {
+  return factoryHint != null && factoryHint !== '' ? factoryHint : injectedHint;
+}
+
 export const emptyOutputMessage =
   'stdout: Empty. Ensure you\'re writing output explicitly.\n';
 
@@ -346,7 +357,10 @@ export const CodeExecutionToolDefinition = {
 function createCodeExecutionTool(
   params: t.CodeExecutionToolParams | null = {}
 ): DynamicStructuredTool {
-  const execEndpoint = `${params?.baseUrl ?? getCodeBaseURL()}/exec`;
+  const execEndpoint = buildCodeApiEndpoint(
+    params?.baseUrl ?? getCodeBaseURL(),
+    'exec'
+  );
 
   return tool(
     async (rawInput, config) => {
@@ -404,8 +418,10 @@ function createCodeExecutionTool(
       /* Stateful sessions: prefer the per-agent factory hint, falling back to
        * legacy ToolNode injection. Explicit default-profile tools always drop
        * the hint so a mixed graph cannot promote them to the stateful path. */
-      const effectiveRuntimeSessionHint =
-        runtimeSessionHint ?? _runtime_session_hint;
+      const effectiveRuntimeSessionHint = selectRuntimeSessionHint(
+        runtimeSessionHint,
+        _runtime_session_hint
+      );
       if (
         statefulSessions === true &&
         executionProfile !== 'default' &&
@@ -482,22 +498,22 @@ function createCodeExecutionTool(
         const runtimeEcho =
           result.runtime_session_id != null
             ? {
-              runtime_session_id: result.runtime_session_id,
-              runtime_status: result.runtime_status,
-            }
+                runtime_session_id: result.runtime_session_id,
+                runtime_status: result.runtime_status,
+              }
             : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
             ? {
-              session_id: result.session_id,
-              files: result.files,
-              ...runtimeEcho,
-            }
+                session_id: result.session_id,
+                files: result.files,
+                ...runtimeEcho,
+              }
             : {
-              session_id: result.session_id,
-              ...runtimeEcho,
-            }) satisfies t.CodeExecutionArtifact,
+                session_id: result.session_id,
+                ...runtimeEcho,
+              }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -498,22 +498,22 @@ function createCodeExecutionTool(
         const runtimeEcho =
           result.runtime_session_id != null
             ? {
-                runtime_session_id: result.runtime_session_id,
-                runtime_status: result.runtime_status,
-              }
+              runtime_session_id: result.runtime_session_id,
+              runtime_status: result.runtime_status,
+            }
             : {};
         return [
           appendCodeSessionFileSummary(outputWithReminder, result.files),
           (hasFiles
             ? {
-                session_id: result.session_id,
-                files: result.files,
-                ...runtimeEcho,
-              }
+              session_id: result.session_id,
+              files: result.files,
+              ...runtimeEcho,
+            }
             : {
-                session_id: result.session_id,
-                ...runtimeEcho,
-              }) satisfies t.CodeExecutionArtifact,
+              session_id: result.session_id,
+              ...runtimeEcho,
+            }) satisfies t.CodeExecutionArtifact,
         ];
       } catch (error) {
         const messageWithReminder = appendFailedExecutionFileReminder(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -7,6 +7,7 @@ import type { ProgrammaticToolCallingJsonSchema } from './ptcTimeout';
 import type * as t from '@/types';
 import {
   CODE_ARTIFACT_PATH_GUIDANCE,
+  addCodeApiExecutionProfileHeader,
   appendCodeSessionFileSummary,
   appendFailedExecutionFileReminder,
   buildCodeApiExecutionErrorMessage,
@@ -478,7 +479,8 @@ export async function makeRequest(
   endpoint: string,
   body: Record<string, unknown>,
   proxy?: string,
-  authHeaders?: t.CodeApiAuthHeaders
+  authHeaders?: t.CodeApiAuthHeaders,
+  executionProfile?: t.CodeApiExecutionProfile
 ): Promise<t.ProgrammaticExecutionResponse> {
   try {
     const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
@@ -487,7 +489,10 @@ export async function makeRequest(
       headers: {
         'Content-Type': 'application/json',
         'User-Agent': 'LibreChat/1.0',
-        ...resolvedAuthHeaders,
+        ...addCodeApiExecutionProfileHeader(
+          resolvedAuthHeaders,
+          executionProfile
+        ),
       },
       body: JSON.stringify(body),
     };
@@ -952,14 +957,17 @@ export function createProgrammaticToolCallingTool(
           );
         }
 
-        /* Stateful sessions: hint rides the INITIAL request only; the server
-         * binds continuation round-trips to the same runtime via the
-         * continuation_token. Additive — ignored by stateless servers. PTC
-         * keeps its stateless prompt in v1; only the wire hint plumbs here. */
+        /* The hint rides the INITIAL request only; continuation_token binds
+         * later round-trips. Prefer trusted per-agent factory context over
+         * legacy ToolNode injection. Explicit default profiles always drop it.
+         * PTC keeps its stateless runtime prompt in v1. */
+        const selectedRuntimeSessionHint =
+          initParams.runtimeSessionHint ?? _runtime_session_hint;
         const runtimeSessionHint =
-          typeof _runtime_session_hint === 'string' &&
-          _runtime_session_hint !== ''
-            ? _runtime_session_hint
+          initParams.executionProfile !== 'default' &&
+          typeof selectedRuntimeSessionHint === 'string' &&
+          selectedRuntimeSessionHint !== ''
+            ? selectedRuntimeSessionHint
             : undefined;
 
         let response = await makeRequest(
@@ -975,7 +983,8 @@ export function createProgrammaticToolCallingTool(
               : {}),
           },
           proxy,
-          initParams.authHeaders
+          initParams.authHeaders,
+          initParams.executionProfile
         );
 
         // ====================================================================
@@ -1012,7 +1021,8 @@ export function createProgrammaticToolCallingTool(
               tool_results: toolResults,
             },
             proxy,
-            initParams.authHeaders
+            initParams.authHeaders,
+            initParams.executionProfile
           );
         }
 

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -850,9 +850,9 @@ export function formatCompletedResponse(
       files: response.files,
       ...(response.runtime_session_id != null
         ? {
-            runtime_session_id: response.runtime_session_id,
-            runtime_status: response.runtime_status,
-          }
+          runtime_session_id: response.runtime_session_id,
+          runtime_status: response.runtime_status,
+        }
         : {}),
     } satisfies t.ProgrammaticExecutionArtifact,
   ];

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -13,11 +13,13 @@ import {
   buildCodeApiExecutionErrorMessage,
   buildCodeApiHttpErrorMessage,
   CodeApiRequestError,
+  buildCodeApiEndpoint,
   emptyOutputMessage,
   getCodeBaseURL,
   appendTmpScratchReminder,
   normalizeCodeApiRequestError,
   resolveCodeApiAuthHeaders,
+  selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
   clampCodeApiRunTimeoutMs,
@@ -848,9 +850,9 @@ export function formatCompletedResponse(
       files: response.files,
       ...(response.runtime_session_id != null
         ? {
-          runtime_session_id: response.runtime_session_id,
-          runtime_status: response.runtime_status,
-        }
+            runtime_session_id: response.runtime_session_id,
+            runtime_status: response.runtime_status,
+          }
         : {}),
     } satisfies t.ProgrammaticExecutionArtifact,
   ];
@@ -887,7 +889,7 @@ export function createProgrammaticToolCallingTool(
   const maxRunTimeoutMs = resolveCodeApiRunTimeoutMs(initParams.runTimeoutMs);
   const proxy = initParams.proxy ?? process.env.PROXY;
   const debug = initParams.debug ?? process.env.PTC_DEBUG === 'true';
-  const EXEC_ENDPOINT = `${baseUrl}/exec/programmatic`;
+  const EXEC_ENDPOINT = buildCodeApiEndpoint(baseUrl, 'exec/programmatic');
 
   return tool(
     async (rawParams, config) => {
@@ -961,8 +963,10 @@ export function createProgrammaticToolCallingTool(
          * later round-trips. Prefer trusted per-agent factory context over
          * legacy ToolNode injection. Explicit default profiles always drop it.
          * PTC keeps its stateless runtime prompt in v1. */
-        const selectedRuntimeSessionHint =
-          initParams.runtimeSessionHint ?? _runtime_session_hint;
+        const selectedRuntimeSessionHint = selectRuntimeSessionHint(
+          initParams.runtimeSessionHint,
+          _runtime_session_hint
+        );
         const runtimeSessionHint =
           initParams.executionProfile !== 'default' &&
           typeof selectedRuntimeSessionHint === 'string' &&

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -595,17 +595,18 @@ function fileIdentityKey(file: {
 
 function updateCodeSession(
   sessions: t.ToolSessionMap,
+  sessionKey: string,
   execSessionId: string,
   files: t.FileRefs | undefined
 ): void {
   const newFiles = files ?? [];
-  const existingSession = sessions.get(Constants.EXECUTE_CODE) as
+  const existingSession = sessions.get(sessionKey) as
     | t.CodeSessionContext
     | undefined;
   const existingFiles = existingSession?.files ?? [];
 
   if (newFiles.length === 0) {
-    sessions.set(Constants.EXECUTE_CODE, {
+    sessions.set(sessionKey, {
       session_id: execSessionId,
       files: existingFiles,
       lastUpdated: Date.now(),
@@ -643,7 +644,7 @@ function updateCodeSession(
     }
   }
 
-  sessions.set(Constants.EXECUTE_CODE, {
+  sessions.set(sessionKey, {
     session_id: execSessionId,
     files: [...filteredExisting, ...filesWithSession],
     lastUpdated: Date.now(),
@@ -694,6 +695,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private programmaticCache?: t.ProgrammaticCache;
   /** Reference to Graph's sessions map for automatic session injection */
   private sessions?: t.ToolSessionMap;
+  /** Partition within `sessions` owned by this agent's execution profile. */
+  private codeSessionKey: string;
   /** When true, dispatches ON_TOOL_EXECUTE events instead of invoking tools directly */
   private eventDrivenMode: boolean = false;
   /** Opt-in stream-layer prestart config for event-driven tools. */
@@ -794,6 +797,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     loadRuntimeTools,
     toolRegistry,
     sessions,
+    codeSessionKey,
     eventDrivenMode,
     eagerEventToolExecution,
     eagerEventToolExecutions,
@@ -834,6 +838,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       toolExecution,
     });
     this.sessions = sessions;
+    this.codeSessionKey = codeSessionKey ?? Constants.EXECUTE_CODE;
     this.eventDrivenMode = eventDrivenMode ?? false;
     this.eagerEventToolExecution = eagerEventToolExecution;
     this.eagerEventToolExecutions = eagerEventToolExecutions;
@@ -1328,7 +1333,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * `/files/<session_id>` fallback was removed from the executors.
        */
       if (this.participatesInCodeSession(call.name)) {
-        const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
+        const codeSession = this.sessions?.get(this.codeSessionKey) as
           | t.CodeSessionContext
           | undefined;
         const execSessionId = codeSession?.session_id;
@@ -2356,7 +2361,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return undefined;
     }
 
-    const codeSession = this.sessions.get(Constants.EXECUTE_CODE) as
+    const codeSession = this.sessions.get(this.codeSessionKey) as
       | t.CodeSessionContext
       | undefined;
     if (!codeSession) {
@@ -2439,7 +2444,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      updateCodeSession(this.sessions, execSessionId, artifact?.files);
+      updateCodeSession(
+        this.sessions,
+        this.codeSessionKey,
+        execSessionId,
+        artifact?.files
+      );
     }
   }
 
@@ -2502,7 +2512,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           | undefined;
         const execSessionId = artifact?.session_id;
         if (execSessionId != null && execSessionId !== '') {
-          updateCodeSession(this.sessions, execSessionId, artifact?.files);
+          updateCodeSession(
+            this.sessions,
+            this.codeSessionKey,
+            execSessionId,
+            artifact?.files
+          );
         }
       }
 

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -25,7 +25,7 @@ import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
-import { getCodeBaseURL } from './CodeExecutor';
+import { buildCodeApiEndpoint, getCodeBaseURL } from './CodeExecutor';
 import { Constants } from '@/common';
 
 config();
@@ -914,7 +914,7 @@ function createToolSearch(
   const schema = createToolSearchSchema(mode);
 
   const baseEndpoint = initParams.baseUrl ?? getCodeBaseURL();
-  const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
+  const EXEC_ENDPOINT = buildCodeApiEndpoint(baseEndpoint, 'exec');
 
   const deferredToolsListing = getDeferredToolsListing(
     initParams.toolRegistry,

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { RequestInit } from 'node-fetch';
 import type * as t from '@/types';
 import {
@@ -35,6 +36,7 @@ type FetchMock = jest.MockedFunction<
 type CodeApiRequestBody = {
   timeout?: number;
   continuation_token?: string;
+  runtime_session_hint?: string;
   tool_results?: t.PTCToolResult[];
 };
 
@@ -55,6 +57,11 @@ const fetchMock = fetch as unknown as FetchMock;
 function requestBodyAt(callIndex: number): CodeApiRequestBody {
   const init = fetchMock.mock.calls[callIndex]?.[1] as RequestInit;
   return JSON.parse(init.body as string) as CodeApiRequestBody;
+}
+
+function requestHeadersAt(callIndex: number): Record<string, string> {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as RequestInit;
+  return init.headers as Record<string, string>;
 }
 
 function timeoutSchemaForTest(toolSchema: unknown): TimeoutSchemaForTest {
@@ -200,6 +207,51 @@ describe('CodeAPI auth header injection', () => {
     ).not.toHaveProperty('authHeaders');
   });
 
+  it('routes direct code tools by trusted per-agent profile', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ session_id: 'session_123', stdout: '1\n' })
+    );
+    const defaultTool = createCodeExecutionTool({
+      baseUrl: 'https://code-default.example.com',
+      executionProfile: 'default',
+      statefulSessions: false,
+    });
+    const statefulTool = createCodeExecutionTool({
+      baseUrl: 'https://code-stateful.example.com',
+      executionProfile: 'stateful',
+      runtimeSessionHint: 'user-123',
+      statefulSessions: true,
+    });
+
+    await defaultTool.invoke(
+      { lang: 'py', code: 'print(1)' },
+      {
+        toolCall: { _runtime_session_hint: 'graph-wide-hint' },
+      } as unknown as RunnableConfig
+    );
+    await statefulTool.invoke(
+      { lang: 'py', code: 'print(1)' },
+      {
+        toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
+      } as unknown as RunnableConfig
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://code-default.example.com/exec'
+    );
+    expect(requestHeadersAt(0)).toEqual(
+      expect.objectContaining({ 'X-CodeAPI-Expected-Profile': 'default' })
+    );
+    expect(requestBodyAt(0)).not.toHaveProperty('runtime_session_hint');
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      'https://code-stateful.example.com/exec'
+    );
+    expect(requestHeadersAt(1)).toEqual(
+      expect.objectContaining({ 'X-CodeAPI-Expected-Profile': 'stateful' })
+    );
+    expect(requestBodyAt(1).runtime_session_hint).toBe('user-123');
+  });
+
   it('tolerates null params for direct code execution', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({ session_id: 'session_123', stdout: '1\n' })
@@ -232,6 +284,33 @@ describe('CodeAPI auth header injection', () => {
     expect(
       JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string)
     ).not.toHaveProperty('authHeaders');
+  });
+
+  it('routes bash tools by trusted per-agent profile', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ session_id: 'session_123', stdout: '1\n' })
+    );
+    const tool = createBashExecutionTool({
+      baseUrl: 'https://code-stateful.example.com',
+      executionProfile: 'stateful',
+      runtimeSessionHint: 'user-123',
+      statefulSessions: true,
+    });
+
+    await tool.invoke(
+      { command: 'echo 1' },
+      {
+        toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
+      } as unknown as RunnableConfig
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://code-stateful.example.com/exec'
+    );
+    expect(requestHeadersAt(0)).toEqual(
+      expect.objectContaining({ 'X-CodeAPI-Expected-Profile': 'stateful' })
+    );
+    expect(requestBodyAt(0).runtime_session_hint).toBe('user-123');
   });
 
   it('redacts the CodeAPI endpoint and response body on direct execution failures', async () => {
@@ -518,6 +597,8 @@ describe('CodeAPI auth header injection', () => {
 
     const tool = createProgrammaticToolCallingTool({
       authHeaders: () => ({ Authorization: 'Bearer ptc-token' }),
+      executionProfile: 'stateful',
+      runtimeSessionHint: 'user-123',
     });
 
     await tool.invoke(
@@ -538,10 +619,41 @@ describe('CodeAPI auth header injection', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer ptc-token',
+            'X-CodeAPI-Expected-Profile': 'stateful',
           }),
         })
       );
     }
+    expect(requestBodyAt(0).runtime_session_hint).toBe('user-123');
+    expect(requestBodyAt(1)).not.toHaveProperty('runtime_session_hint');
+  });
+
+  it('keeps explicit default PTC stateless despite a graph-wide hint', async () => {
+    const tool = createProgrammaticToolCallingTool({
+      baseUrl: 'https://code-default.example.com',
+      executionProfile: 'default',
+    });
+
+    await tool.invoke(
+      { code: 'result = await lookup_user()\nprint(result)' },
+      {
+        toolCall: {
+          name: 'programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+          _runtime_session_hint: 'graph-wide-hint',
+        },
+      }
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://code-default.example.com/exec/programmatic'
+    );
+    expect(requestHeadersAt(0)).toEqual(
+      expect.objectContaining({ 'X-CodeAPI-Expected-Profile': 'default' })
+    );
+    expect(requestBodyAt(0)).not.toHaveProperty('runtime_session_hint');
   });
 
   it('defaults programmatic timeout to the configured CodeAPI run cap', async () => {
@@ -659,6 +771,9 @@ describe('CodeAPI auth header injection', () => {
   it('forwards Authorization for bash programmatic requests', async () => {
     const tool = createBashProgrammaticToolCallingTool({
       authHeaders: { Authorization: 'Bearer bash-ptc-token' },
+      baseUrl: 'https://code-stateful.example.com',
+      executionProfile: 'stateful',
+      runtimeSessionHint: 'user-123',
     });
 
     await tool.invoke(
@@ -678,9 +793,14 @@ describe('CodeAPI auth header injection', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer bash-ptc-token',
+          'X-CodeAPI-Expected-Profile': 'stateful',
         }),
       })
     );
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://code-stateful.example.com/exec/programmatic'
+    );
+    expect(requestBodyAt(0).runtime_session_hint).toBe('user-123');
   });
 
   it('normalizes JSON-looking bash programmatic tool results before continuation', async () => {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -252,6 +252,37 @@ describe('CodeAPI auth header injection', () => {
     expect(requestBodyAt(1).runtime_session_hint).toBe('user-123');
   });
 
+  it('normalizes profile URLs and falls back from empty factory hints', async () => {
+    const codeTool = createCodeExecutionTool({
+      baseUrl: 'https://code-stateful.example.com/',
+      executionProfile: 'stateful',
+      runtimeSessionHint: '',
+      statefulSessions: true,
+    });
+    const bashTool = createBashExecutionTool({
+      baseUrl: 'https://code-stateful.example.com///',
+      executionProfile: 'stateful',
+      runtimeSessionHint: '',
+      statefulSessions: true,
+    });
+
+    await codeTool.invoke({ lang: 'py', code: 'print(1)' }, {
+      toolCall: { _runtime_session_hint: 'thread-fallback' },
+    } as unknown as RunnableConfig);
+    await bashTool.invoke({ command: 'echo 1' }, {
+      toolCall: { _runtime_session_hint: 'thread-fallback' },
+    } as unknown as RunnableConfig);
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://code-stateful.example.com/exec'
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      'https://code-stateful.example.com/exec'
+    );
+    expect(requestBodyAt(0).runtime_session_hint).toBe('thread-fallback');
+    expect(requestBodyAt(1).runtime_session_hint).toBe('thread-fallback');
+  });
+
   it('tolerates null params for direct code execution', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({ session_id: 'session_123', stdout: '1\n' })
@@ -655,6 +686,38 @@ describe('CodeAPI auth header injection', () => {
     );
     expect(requestBodyAt(0)).not.toHaveProperty('runtime_session_hint');
   });
+
+  it.each([
+    ['python', createProgrammaticToolCallingTool],
+    ['bash', createBashProgrammaticToolCallingTool],
+  ] as const)(
+    'normalizes %s PTC URLs and falls back from empty factory hints',
+    async (_name, createTool) => {
+      const tool = createTool({
+        baseUrl: 'https://code-stateful.example.com/',
+        executionProfile: 'stateful',
+        runtimeSessionHint: '',
+      });
+
+      await tool.invoke(
+        { code: 'print("ok")' },
+        {
+          toolCall: {
+            name: 'programmatic_code_execution',
+            args: {},
+            toolMap: toolMap(),
+            toolDefs,
+            _runtime_session_hint: 'thread-fallback',
+          },
+        }
+      );
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'https://code-stateful.example.com/exec/programmatic'
+      );
+      expect(requestBodyAt(0).runtime_session_hint).toBe('thread-fallback');
+    }
+  );
 
   it('defaults programmatic timeout to the configured CodeAPI run cap', async () => {
     const tool = createProgrammaticToolCallingTool({

--- a/src/tools/__tests__/CodeExecutor.stateful.test.ts
+++ b/src/tools/__tests__/CodeExecutor.stateful.test.ts
@@ -87,9 +87,17 @@ describe('CodeExecutor runtime_session_hint wire field', () => {
     return fetchCalls;
   }
 
-  it('sends runtime_session_hint when ToolNode injected it', async () => {
-    const calls = await run({ _runtime_session_hint: 'conv-42' });
+  it('sends runtime_session_hint when a stateful tool receives it', async () => {
+    const calls = await run(
+      { _runtime_session_hint: 'conv-42' },
+      { statefulSessions: true }
+    );
     expect(calls[0].runtime_session_hint).toBe('conv-42');
+  });
+
+  it('ignores an injected hint when the tool is stateless', async () => {
+    const calls = await run({ _runtime_session_hint: 'conv-42' });
+    expect('runtime_session_hint' in calls[0]).toBe(false);
   });
 
   it('omits runtime_session_hint when not injected', async () => {
@@ -103,7 +111,7 @@ describe('CodeExecutor runtime_session_hint wire field', () => {
   });
 
   it('strips a model-supplied runtime_session_hint from the raw args', async () => {
-    const codeTool = createCodeExecutionTool({});
+    const codeTool = createCodeExecutionTool({ statefulSessions: true });
     await codeTool.invoke(
       { lang: 'py', code: 'print(1)', runtime_session_hint: 'model-picked' },
       { toolCall: {} } as unknown as RunnableConfig
@@ -112,7 +120,7 @@ describe('CodeExecutor runtime_session_hint wire field', () => {
   });
 
   it('lets only the ToolNode-injected hint reach the wire, ignoring model args', async () => {
-    const codeTool = createCodeExecutionTool({});
+    const codeTool = createCodeExecutionTool({ statefulSessions: true });
     await codeTool.invoke(
       { lang: 'py', code: 'print(1)', runtime_session_hint: 'model-picked' },
       {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1608,6 +1608,53 @@ describe('SubagentExecutor', () => {
     ).toBe(false);
   });
 
+  it('remaps a selected child legacy code seed into its agent partition', async () => {
+    const codeSessionKey = 'execute_code:stateful:user-1';
+    const seededSession = {
+      session_id: 'selected-storage',
+      files: [
+        {
+          id: 'selected-file',
+          name: 'selected.txt',
+          storage_session_id: 'selected-storage',
+        },
+      ],
+      lastUpdated: 1,
+    };
+    const selected = makeConfig('selected-partition', {
+      agentInputs: {
+        ...makeChildInputs('selected-agent'),
+        codeSessionKey,
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, seededSession],
+        ]),
+      },
+    });
+    const childSessions: ToolSessionMap = new Map();
+    const invoke = jest.fn(async () => {
+      expect(childSessions.has(Constants.EXECUTE_CODE)).toBe(false);
+      expect(childSessions.get(codeSessionKey)).toEqual(seededSession);
+      expect(childSessions.get(codeSessionKey)).not.toBe(seededSession);
+      return { messages: [new AIMessage('done')] };
+    });
+    const executor = createExecutor({
+      configs: new Map([[selected.type, selected]]),
+      createChildGraph: (): StandardGraph =>
+        ({
+          sessions: childSessions,
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    await executor.execute({
+      description: 'Use the selected file.',
+      subagentType: selected.type,
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
   it('combines member session seeds inside a selected graph child', async () => {
     const makeSession = (
       storageSessionId: string,

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -125,6 +125,74 @@ describe('ToolNode code execution session management', () => {
       expect(capturedConfigs[0]._injected_files).toBeUndefined();
     });
 
+    it('isolates session injection and updates by the agent codeSessionKey', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const sessions: t.ToolSessionMap = new Map();
+      const statefulKey = 'execute_code:stateful:v1:user';
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'stateless-session',
+        files: [
+          {
+            id: 's1',
+            name: 'stateless.txt',
+            storage_session_id: 'stateless-storage',
+          },
+        ],
+        lastUpdated: Date.now(),
+      });
+      sessions.set(statefulKey, {
+        session_id: 'stateful-session',
+        files: [
+          {
+            id: 'w1',
+            name: 'stateful.txt',
+            storage_session_id: 'stateful-storage',
+          },
+        ],
+        lastUpdated: Date.now(),
+      });
+
+      const mockTool = createMockCodeTool({
+        capturedConfigs,
+        artifact: {
+          session_id: 'new-stateful-session',
+          files: [
+            {
+              id: 'w2',
+              name: 'new-stateful.txt',
+              storage_session_id: 'stateful-storage',
+            },
+          ],
+        },
+      });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        codeSessionKey: statefulKey,
+      });
+
+      await toolNode.invoke({
+        messages: [createAIMessageWithCodeCall('call_partitioned')],
+      });
+
+      expect(capturedConfigs[0].session_id).toBe('stateful-session');
+      expect(
+        (capturedConfigs[0]._injected_files as t.CodeEnvFile[]).map(
+          (file) => file.id
+        )
+      ).toEqual(['w1']);
+      expect(sessions.get(Constants.EXECUTE_CODE)?.session_id).toBe(
+        'stateless-session'
+      );
+      expect(sessions.get(statefulKey)?.session_id).toBe(
+        'new-stateful-session'
+      );
+      expect(sessions.get(statefulKey)?.files?.map((file) => file.id)).toEqual([
+        'w1',
+        'w2',
+      ]);
+    });
+
     it('does not inject session context when no session exists', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();
@@ -1162,6 +1230,65 @@ describe('ToolNode code execution session management', () => {
           },
         ],
       });
+    });
+
+    it('attaches only the selected profile partition to host file requests', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const statefulKey = 'execute_code:stateful:v1:user';
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'stateless-session',
+        files: [
+          {
+            id: 's1',
+            name: 'stateless.txt',
+            storage_session_id: 'stateless-storage',
+          },
+        ],
+        lastUpdated: Date.now(),
+      });
+      sessions.set(statefulKey, {
+        session_id: 'stateful-session',
+        files: [
+          {
+            id: 'w1',
+            name: 'stateful.txt',
+            storage_session_id: 'stateful-storage',
+          },
+        ],
+        lastUpdated: Date.now(),
+      });
+      const { capturedRequests } = captureBatchRequests();
+      const toolNode = new ToolNode({
+        tools: [createDummyTool(Constants.READ_FILE)],
+        sessions,
+        codeSessionKey: statefulKey,
+        eventDrivenMode: true,
+        toolCallStepIds: new Map([
+          ['call_partitioned_read', 'step_partitioned_read'],
+        ]),
+      });
+
+      await toolNode.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_partitioned_read',
+                name: Constants.READ_FILE,
+                args: { path: '/mnt/data/stateful.txt' },
+              },
+            ],
+          }),
+        ],
+      });
+
+      expect(capturedRequests[0].codeSessionContext?.session_id).toBe(
+        'stateful-session'
+      );
+      expect(
+        capturedRequests[0].codeSessionContext?.files?.map((file) => file.id)
+      ).toEqual(['w1']);
     });
 
     it('does not attach codeSessionContext to read_file when no session exists yet', async () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -62,7 +62,6 @@ import type {
   ToolApprovalInterruptPayload,
   ToolExecuteBatchRequest,
   ToolCallDelta,
-  ToolSessionContext,
   TokenCounter,
   ToolApprovalDecision,
   ToolApprovalDecisionMap,
@@ -125,6 +124,7 @@ import {
   createChildGraphPlan,
   isGraphSubagentConfig,
 } from './childGraphConfig';
+import { seedAgentInitialSessions } from '@/utils/toolSessions';
 import { stableStringify } from '@/tools/eagerEventExecution';
 import { composeAbortSignals } from '@/utils/misc';
 
@@ -148,71 +148,11 @@ const SUBAGENT_CONFIG_CHANGED_MESSAGE =
 const SUBAGENT_INVOCATION_CHANGED_MESSAGE =
   'Subagent error: Subagent invocation changed for this execution.';
 
-function cloneToolSessionContext(
-  context: ToolSessionContext
-): ToolSessionContext {
-  return {
-    ...context,
-    ...(context.files == null
-      ? {}
-      : {
-        files: context.files.map((file) => ({
-          ...file,
-          storage_session_id: file.storage_session_id ?? context.session_id,
-        })),
-      }),
-  };
-}
-
 function seedChildGraphSessions(
   childGraph: StandardGraph,
   agents: AgentInputs[]
 ): void {
-  const seenFilesByTool = new Map<string, Set<string>>();
-  for (const agent of agents) {
-    if (agent.initialSessions == null) {
-      continue;
-    }
-    for (const [toolName, context] of agent.initialSessions) {
-      const existing = childGraph.sessions.get(toolName);
-      if (existing == null) {
-        const cloned = cloneToolSessionContext(context);
-        childGraph.sessions.set(toolName, cloned);
-        seenFilesByTool.set(
-          toolName,
-          new Set(
-            cloned.files?.map(
-              (file) => `${file.storage_session_id ?? ''}\0${file.id}`
-            ) ?? []
-          )
-        );
-        continue;
-      }
-      if (context.files == null || context.files.length === 0) {
-        continue;
-      }
-      const seenFiles =
-        seenFilesByTool.get(toolName) ??
-        new Set(
-          existing.files?.map(
-            (file) =>
-              `${file.storage_session_id ?? existing.session_id}\0${file.id}`
-          ) ?? []
-        );
-      const files = existing.files == null ? [] : [...existing.files];
-      for (const file of context.files) {
-        const storageSessionId = file.storage_session_id ?? context.session_id;
-        const key = `${storageSessionId}\0${file.id}`;
-        if (seenFiles.has(key)) {
-          continue;
-        }
-        seenFiles.add(key);
-        files.push({ ...file, storage_session_id: storageSessionId });
-      }
-      seenFilesByTool.set(toolName, seenFiles);
-      childGraph.sessions.set(toolName, { ...existing, files });
-    }
-  }
+  seedAgentInitialSessions(childGraph.sessions, agents);
 }
 
 async function dispatchObservationalSubagentUpdate(

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -803,6 +803,12 @@ export interface LangfuseConfig {
 
 export interface AgentInputs {
   agentId: string;
+  /**
+   * Partition key for transient code-session ids and file refs. Agents with
+   * the same key share those refs; different execution profiles/scopes must
+   * use different keys. Defaults to the legacy shared `execute_code` slot.
+   */
+  codeSessionKey?: string;
   /** Human-readable name for the agent (used in handoff context). Defaults to agentId if not provided. */
   name?: string;
   toolEnd?: boolean;

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -807,6 +807,8 @@ export interface AgentInputs {
    * Partition key for transient code-session ids and file refs. Agents with
    * the same key share those refs; different execution profiles/scopes must
    * use different keys. Defaults to the legacy shared `execute_code` slot.
+   * Non-default partitions also disable speculative eager execution of code
+   * tools because their factory may target a durable backend.
    */
   codeSessionKey?: string;
   /** Human-readable name for the agent (used in handoff context). Defaults to agentId if not provided. */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -128,6 +128,8 @@ export type ToolNodeOptions = {
   toolRegistry?: LCToolRegistry;
   /** Reference to Graph's sessions map for automatic session injection */
   sessions?: ToolSessionMap;
+  /** Partition within `sessions` used by this agent's code tools. */
+  codeSessionKey?: string;
   /** When true, dispatches ON_TOOL_EXECUTE events instead of invoking tools directly */
   eventDrivenMode?: boolean;
   /** Tool definitions for event-driven mode (used for context, not invocation) */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -375,6 +375,19 @@ export type CodeEnvFile =
 export type CodeExecutionToolParams =
   | undefined
   | {
+      /** Trusted Code API endpoint selected by the host for this agent. */
+      baseUrl?: string;
+      /**
+       * Expected Code API execution profile. Sent as a request assertion so
+       * endpoint/configuration drift fails closed instead of silently using
+       * the wrong sandbox backend.
+       */
+      executionProfile?: CodeApiExecutionProfile;
+      /**
+       * Trusted warm-runtime affinity hint selected by the host for this
+       * agent invocation. This overrides the legacy ToolNode-injected hint.
+       */
+      runtimeSessionHint?: string;
       /** Execution session — see `CodeSessionContext.session_id`. */
       session_id?: string;
       user_id?: string;
@@ -382,15 +395,15 @@ export type CodeExecutionToolParams =
       /** Optional host-supplied Code API auth headers. */
       authHeaders?: CodeApiAuthHeaders;
       /**
-       * Advertise best-effort stateful sessions in the tool description
-       * (variables/files may persist between calls, may reset). Prompt text
-       * only, and it must be set here because the description is bound to the
-       * LLM at construction time. Pair it with the run-scoped
-       * `toolExecution.sandbox.statefulSessions` gate, which drives the wire
-       * hint — set both from one flag so the prompt and the backend agree.
+       * Advertise filesystem-tier stateful sessions in the tool description
+       * and allow a trusted runtime affinity hint onto the wire. Resolve this,
+       * `baseUrl`, `executionProfile`, and `runtimeSessionHint` together from
+       * the executing agent so the prompt and backend agree.
        */
       statefulSessions?: boolean;
     };
+
+export type CodeApiExecutionProfile = 'default' | 'stateful';
 
 export type CodeApiAuthHeaderMap = Record<string, string>;
 
@@ -1106,19 +1119,17 @@ export type CloudflareSandboxExecutionConfig = {
 
 export type SandboxExecutionConfig = {
   /**
-   * Opt into best-effort stateful runtime sessions on the remote Code API
-   * (its warm per-session MicroVM backend). This gate is run-scoped: it only
-   * controls the wire behavior (ToolNode injecting the session hint on
-   * execute_code/bash calls). The transport is otherwise unchanged.
+   * Legacy run-scoped opt-in for warm runtime hint injection. New hosts that
+   * need mixed execution profiles should resolve `statefulSessions`,
+   * `baseUrl`, `executionProfile`, and `runtimeSessionHint` on each executing
+   * agent's tool factories instead. Direct executors ignore this injected hint
+   * unless their own factory has `statefulSessions: true`.
    *
    * It does NOT change the model-facing tool description. Tool descriptions are
    * bound to the LLM at construction time (`createCodeExecutionTool` /
    * `createBashExecutionTool`), before this run config is applied inside the
    * graph, so they can only be adjusted via the tools' own `statefulSessions`
-   * factory param. Set BOTH from one flag (as LibreChat does): with this on but
-   * the factory param off, the backend runs statefully while the model is still
-   * told the environment is stateless (non-corrupting — the model just won't
-   * exploit persistence).
+   * factory param.
    */
   statefulSessions?: boolean;
   /**
@@ -1294,6 +1305,10 @@ export type BashProgrammaticToolCallingParams = ProgrammaticToolCallingParams;
 export type ProgrammaticToolCallingParams = {
   /** Code API base URL (or use CODE_BASEURL env var) */
   baseUrl?: string;
+  /** Expected Code API execution profile (host-controlled). */
+  executionProfile?: CodeApiExecutionProfile;
+  /** Trusted warm-runtime affinity hint for this agent invocation. */
+  runtimeSessionHint?: string;
   /** Safety limit for round-trips (default: 20) */
   maxRoundTrips?: number;
   /** Maximum per-sandbox-run timeout for PTC's legacy `timeout` field. */
@@ -1304,11 +1319,9 @@ export type ProgrammaticToolCallingParams = {
   debug?: boolean;
   /** Optional host-supplied Code API auth headers. */
   authHeaders?: CodeApiAuthHeaders;
-  /* No `statefulSessions` here: PTC is stateless in v1. The initial
-   * /exec/programmatic request still forwards a ToolNode-injected
-   * `_runtime_session_hint` when present, but there is no factory-level opt-in
-   * to advertise (it would be a no-op). Re-add with real behavior when PTC
-   * stateful prompting lands. */
+  /* No `statefulSessions` here: PTC keeps a stateless runtime prompt in v1.
+   * An explicit stateful execution profile may still use a warm filesystem;
+   * runtime/in-memory state never carries across calls. */
 };
 
 // ============================================================================

--- a/src/utils/__tests__/toolSessions.test.ts
+++ b/src/utils/__tests__/toolSessions.test.ts
@@ -106,4 +106,30 @@ describe('tool session partition seeding', () => {
       }),
     ]);
   });
+
+  it('keeps an explicit child partition seed instead of merging the legacy fallback', () => {
+    const key = 'execute_code:stateful:user-1';
+    const explicit = session('stateful-storage', 'stateful-input');
+    const sessions: t.ToolSessionMap = new Map();
+
+    seedAgentInitialSessions(sessions, [
+      {
+        codeSessionKey: key,
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, session('legacy-storage', 'legacy-input')],
+          [key, explicit],
+        ]),
+      },
+    ]);
+
+    expect(sessions.get(key)).toEqual({
+      ...explicit,
+      files: [
+        {
+          ...explicit.files![0],
+          storage_session_id: 'stateful-storage',
+        },
+      ],
+    });
+  });
 });

--- a/src/utils/__tests__/toolSessions.test.ts
+++ b/src/utils/__tests__/toolSessions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from '@jest/globals';
+import type * as t from '@/types';
+import {
+  seedAgentInitialSessions,
+  seedRunInitialSessions,
+} from '@/utils/toolSessions';
+import { Constants } from '@/common';
+
+function session(id: string, fileId: string): t.ToolSessionContext {
+  return {
+    session_id: id,
+    files: [{ id: fileId, name: `${fileId}.txt` }],
+    lastUpdated: 1,
+  };
+}
+
+describe('tool session partition seeding', () => {
+  it('copies a legacy run seed into each custom agent partition', () => {
+    const legacy = session('legacy-storage', 'input');
+    const sessions: t.ToolSessionMap = new Map();
+
+    seedRunInitialSessions({
+      sessions,
+      initialSessions: new Map([[Constants.EXECUTE_CODE, legacy]]),
+      agents: [
+        {},
+        { codeSessionKey: 'execute_code:stateful:user-1' },
+        { codeSessionKey: 'execute_code:stateful:agent-2' },
+      ],
+    });
+
+    expect([...sessions.keys()]).toEqual([
+      Constants.EXECUTE_CODE,
+      'execute_code:stateful:user-1',
+      'execute_code:stateful:agent-2',
+    ]);
+    expect(sessions.get('execute_code:stateful:user-1')).toEqual({
+      ...legacy,
+      files: [
+        {
+          ...legacy.files![0],
+          storage_session_id: 'legacy-storage',
+        },
+      ],
+    });
+    expect(sessions.get('execute_code:stateful:user-1')).not.toBe(legacy);
+    expect(sessions.get('execute_code:stateful:agent-2')).not.toBe(legacy);
+  });
+
+  it('keeps an explicit custom run seed instead of replacing it with legacy state', () => {
+    const key = 'execute_code:stateful:user-1';
+    const explicit = session('stateful-storage', 'stateful-input');
+    const sessions: t.ToolSessionMap = new Map();
+
+    seedRunInitialSessions({
+      sessions,
+      initialSessions: new Map([
+        [Constants.EXECUTE_CODE, session('legacy-storage', 'legacy-input')],
+        [key, explicit],
+      ]),
+      agents: [{ codeSessionKey: key }],
+    });
+
+    expect(sessions.get(key)).toEqual({
+      ...explicit,
+      files: [
+        {
+          ...explicit.files![0],
+          storage_session_id: 'stateful-storage',
+        },
+      ],
+    });
+  });
+
+  it('remaps child legacy seeds to their owning agent partitions', () => {
+    const firstKey = 'execute_code:stateful:user-1';
+    const secondKey = 'execute_code:stateful:agent-2';
+    const sessions: t.ToolSessionMap = new Map();
+
+    seedAgentInitialSessions(sessions, [
+      {
+        codeSessionKey: firstKey,
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, session('first-storage', 'first-input')],
+        ]),
+      },
+      {
+        codeSessionKey: secondKey,
+        initialSessions: new Map([
+          [Constants.EXECUTE_CODE, session('second-storage', 'second-input')],
+        ]),
+      },
+    ]);
+
+    expect(sessions.has(Constants.EXECUTE_CODE)).toBe(false);
+    expect(sessions.get(firstKey)?.files).toEqual([
+      expect.objectContaining({
+        id: 'first-input',
+        storage_session_id: 'first-storage',
+      }),
+    ]);
+    expect(sessions.get(secondKey)?.files).toEqual([
+      expect.objectContaining({
+        id: 'second-input',
+        storage_session_id: 'second-storage',
+      }),
+    ]);
+  });
+});

--- a/src/utils/toolSessions.ts
+++ b/src/utils/toolSessions.ts
@@ -11,12 +11,12 @@ function cloneToolSessionContext(
     ...(context.files == null
       ? {}
       : {
-          files: context.files.map((file) => ({
-            ...file,
+        files: context.files.map((file) => ({
+          ...file,
           storage_session_id:
             file.storage_session_id ?? context.session_id,
-          })),
-        }),
+        })),
+      }),
   };
 }
 

--- a/src/utils/toolSessions.ts
+++ b/src/utils/toolSessions.ts
@@ -1,0 +1,108 @@
+import type * as t from '@/types';
+import { Constants } from '@/common';
+
+type CodeSessionAgent = Pick<t.AgentInputs, 'codeSessionKey' | 'initialSessions'>;
+
+function cloneToolSessionContext(
+  context: t.ToolSessionContext
+): t.ToolSessionContext {
+  return {
+    ...context,
+    ...(context.files == null
+      ? {}
+      : {
+        files: context.files.map((file) => ({
+          ...file,
+          storage_session_id:
+            file.storage_session_id ?? context.session_id,
+        })),
+      }),
+  };
+}
+
+function mergeToolSessionContext(
+  sessions: t.ToolSessionMap,
+  key: string,
+  context: t.ToolSessionContext
+): void {
+  const existing = sessions.get(key);
+  if (existing == null) {
+    sessions.set(key, cloneToolSessionContext(context));
+    return;
+  }
+  if (context.files == null || context.files.length === 0) {
+    return;
+  }
+
+  const seenFiles = new Set(
+    existing.files?.map(
+      (file) =>
+        `${file.storage_session_id ?? existing.session_id}\0${file.id}`
+    ) ?? []
+  );
+  const files = existing.files == null ? [] : [...existing.files];
+  for (const file of context.files) {
+    const storageSessionId = file.storage_session_id ?? context.session_id;
+    const fileKey = `${storageSessionId}\0${file.id}`;
+    if (seenFiles.has(fileKey)) {
+      continue;
+    }
+    seenFiles.add(fileKey);
+    files.push({ ...file, storage_session_id: storageSessionId });
+  }
+  sessions.set(key, { ...existing, files });
+}
+
+/**
+ * Seeds a top-level graph while preserving the legacy run-wide session map.
+ * A legacy `execute_code` seed is copied into every custom agent partition
+ * unless the host already supplied an explicit seed for that partition.
+ */
+export function seedRunInitialSessions(args: {
+  sessions: t.ToolSessionMap;
+  initialSessions: t.ToolSessionMap;
+  agents: Iterable<Pick<t.AgentInputs, 'codeSessionKey'>>;
+}): void {
+  const { sessions, initialSessions, agents } = args;
+  for (const [key, context] of initialSessions) {
+    mergeToolSessionContext(sessions, key, context);
+  }
+
+  const legacyCodeSession = initialSessions.get(Constants.EXECUTE_CODE);
+  if (legacyCodeSession == null) {
+    return;
+  }
+  for (const agent of agents) {
+    const key = agent.codeSessionKey ?? Constants.EXECUTE_CODE;
+    if (
+      key === Constants.EXECUTE_CODE ||
+      initialSessions.has(key) ||
+      sessions.has(key)
+    ) {
+      continue;
+    }
+    sessions.set(key, cloneToolSessionContext(legacyCodeSession));
+  }
+}
+
+/**
+ * Seeds an isolated child graph from each selected agent. Legacy code-session
+ * entries are remapped to the owning agent's partition before they are merged.
+ */
+export function seedAgentInitialSessions(
+  sessions: t.ToolSessionMap,
+  agents: Iterable<CodeSessionAgent>
+): void {
+  for (const agent of agents) {
+    if (agent.initialSessions == null) {
+      continue;
+    }
+    for (const [toolName, context] of agent.initialSessions) {
+      const key =
+        toolName === Constants.EXECUTE_CODE
+          ? (agent.codeSessionKey ?? Constants.EXECUTE_CODE)
+          : toolName;
+      mergeToolSessionContext(sessions, key, context);
+    }
+  }
+}

--- a/src/utils/toolSessions.ts
+++ b/src/utils/toolSessions.ts
@@ -11,12 +11,12 @@ function cloneToolSessionContext(
     ...(context.files == null
       ? {}
       : {
-        files: context.files.map((file) => ({
-          ...file,
+          files: context.files.map((file) => ({
+            ...file,
           storage_session_id:
             file.storage_session_id ?? context.session_id,
-        })),
-      }),
+          })),
+        }),
   };
 }
 
@@ -97,11 +97,16 @@ export function seedAgentInitialSessions(
     if (agent.initialSessions == null) {
       continue;
     }
+    const codeSessionKey = agent.codeSessionKey ?? Constants.EXECUTE_CODE;
+    const hasExplicitCodeSession =
+      codeSessionKey !== Constants.EXECUTE_CODE &&
+      agent.initialSessions.has(codeSessionKey);
     for (const [toolName, context] of agent.initialSessions) {
+      if (toolName === Constants.EXECUTE_CODE && hasExplicitCodeSession) {
+        continue;
+      }
       const key =
-        toolName === Constants.EXECUTE_CODE
-          ? (agent.codeSessionKey ?? Constants.EXECUTE_CODE)
-          : toolName;
+        toolName === Constants.EXECUTE_CODE ? codeSessionKey : toolName;
       mergeToolSessionContext(sessions, key, context);
     }
   }


### PR DESCRIPTION
## Summary

- let Code, Bash, Python PTC, and Bash PTC select a trusted Code API base URL and expected execution profile per tool factory
- assert the selected profile with X-CodeAPI-Expected-Profile on initial and continuation requests
- prefer per-agent runtime affinity context and prevent explicit default-profile tools from inheriting graph-wide stateful hints
- partition Graph code-session IDs and file refs by a trusted per-agent key while preserving the legacy shared stateless partition
- apply the same partition to direct, event-driven, eager, handoff, and child-graph tool execution

## Why

This is the Agents transport and session-isolation layer for AI-1650: stateless agents use the default HTTP/libkrun profile, while stateful agents use the Lambda MicroVM profile, including mixed-agent graphs. Session refs from one profile are never injected into another.

## Dependencies

- ClickHouse/code-interpreter#51
- consumed by danny-avila/LibreChat#14848

## Validation

- npm run build
- 75 focused Code API transport and ToolNode session tests
- focused ESLint with zero errors
- exact-head CI running on the rebased branch