### PR TITLE
🧹 fix: Close Subagent Child-Graph Run Steps

### DIFF
--- a/src/specs/subagent-step-closure.test.ts
+++ b/src/specs/subagent-step-closure.test.ts
@@ -1,0 +1,210 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+} from '@/index';
+import * as providers from '@/llm/providers';
+import { Run } from '@/run';
+
+const CHILD_RESPONSE = 'Research result: Paris is the capital of France.';
+
+const callerConfig: Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} = {
+  configurable: { thread_id: 'subagent-step-closure-thread' },
+  streamMode: 'values',
+  version: 'v2' as const,
+};
+
+const createParentAgent = (): t.AgentInputs => ({
+  agentId: 'parent',
+  provider: Providers.OPENAI,
+  clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+  instructions: 'You are a supervisor. Delegate research using the subagent.',
+  maxContextTokens: 8000,
+  subagentConfigs: [
+    {
+      type: 'researcher',
+      name: 'Research Agent',
+      description: 'Researches and summarizes information',
+      agentInputs: {
+        agentId: 'researcher',
+        provider: Providers.OPENAI,
+        clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+        instructions: 'You are a research agent. Answer concisely.',
+        maxContextTokens: 8000,
+      },
+    },
+  ],
+});
+
+const subagentToolCall: ToolCall = {
+  id: 'call_subagent_1',
+  name: Constants.SUBAGENT,
+  args: {
+    description: 'What is the capital of France?',
+    subagent_type: 'researcher',
+  },
+  type: 'tool_call',
+};
+
+type CapturedUpdate = {
+  phase: t.SubagentUpdatePhase;
+  data?: unknown;
+};
+
+type UpdateCapture = {
+  updates: CapturedUpdate[];
+  handlers: Record<string, t.EventHandler>;
+};
+
+/**
+ * Collects the child-run lifecycle envelopes the executor forwards to the
+ * parent. Child run steps only reach a host through these, so they are the
+ * only place a subagent's closure is observable.
+ */
+function createUpdateCapture(): UpdateCapture {
+  const updates: CapturedUpdate[] = [];
+  const handlers: Record<string, t.EventHandler> = {
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.ON_SUBAGENT_UPDATE]: {
+      handle: (_event: string, data: t.StreamEventData): void => {
+        const update = data as unknown as t.SubagentUpdateEvent;
+        updates.push({ phase: update.phase, data: update.data });
+      },
+    },
+  };
+  return { updates, handlers };
+}
+
+describe('Subagent child-graph run step closure', () => {
+  jest.setTimeout(30000);
+
+  let getChatModelClassSpy: jest.SpyInstance;
+  const originalGetChatModelClass = providers.getChatModelClass;
+
+  beforeEach(() => {
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: [CHILD_RESPONSE] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('closes the child run steps it opened when the subagent completes', async () => {
+    const { updates, handlers } = createUpdateCapture();
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-closure-${Date.now()}`,
+      graphConfig: { type: 'standard', agents: [createParentAgent()] },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: handlers,
+    });
+
+    run.Graph?.overrideTestModel(
+      ['Delegating this research.', `Based on the research: ${CHILD_RESPONSE}`],
+      10,
+      [subagentToolCall]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      callerConfig
+    );
+
+    const opened = updates.filter((update) => update.phase === 'run_step');
+    const closed = updates.filter(
+      (update) => update.phase === 'run_step_closed'
+    );
+
+    expect(opened.length).toBeGreaterThan(0);
+    expect(closed.length).toBeGreaterThan(0);
+    expect(
+      closed.every(
+        (update) =>
+          (update.data as { status?: string } | undefined)?.status ===
+          'completed'
+      )
+    ).toBe(true);
+  });
+
+  it('closes the child run steps as cancelled when the caller aborts mid-child', async () => {
+    const updates: CapturedUpdate[] = [];
+    const controller = new AbortController();
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-closure-abort-${Date.now()}`,
+      graphConfig: { type: 'standard', agents: [createParentAgent()] },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.ON_SUBAGENT_UPDATE]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            const update = data as unknown as t.SubagentUpdateEvent;
+            updates.push({ phase: update.phase, data: update.data });
+            /** The child has opened a step — abort while it is still open. */
+            if (update.phase === 'run_step') {
+              controller.abort();
+            }
+          },
+        },
+      },
+    });
+
+    run.Graph?.overrideTestModel(
+      ['Delegating this research.', `Based on the research: ${CHILD_RESPONSE}`],
+      25,
+      [subagentToolCall]
+    );
+
+    await run
+      .processStream(
+        { messages: [new HumanMessage('What is the capital of France?')] },
+        {
+          ...callerConfig,
+          configurable: { thread_id: 'subagent-step-closure-abort' },
+          signal: controller.signal,
+        }
+      )
+      .catch(() => {
+        /** The abort is the point; the rejection shape is not under test. */
+      });
+
+    const closed = updates.filter(
+      (update) => update.phase === 'run_step_closed'
+    );
+    expect(closed.length).toBeGreaterThan(0);
+    expect(
+      closed.every(
+        (update) =>
+          (update.data as { status?: string } | undefined)?.status ===
+          'cancelled'
+      )
+    ).toBe(true);
+  });
+});

--- a/src/specs/subagent-step-closure.test.ts
+++ b/src/specs/subagent-step-closure.test.ts
@@ -10,6 +10,7 @@ import {
   ToolEndHandler,
   ModelEndHandler,
 } from '@/index';
+import { HookRegistry } from '@/hooks/HookRegistry';
 import * as providers from '@/llm/providers';
 import { Run } from '@/run';
 
@@ -61,6 +62,20 @@ type CapturedUpdate = {
   data?: unknown;
 };
 
+/**
+ * Derived from the real factory so a change to the provider constructor
+ * signature breaks this stub instead of being absorbed by an `any`.
+ */
+type OpenAIModelClass = ReturnType<
+  typeof providers.getChatModelClass<Providers.OPENAI>
+>;
+
+class FakeOpenAIChatModel extends FakeListChatModel {
+  constructor(_config: ConstructorParameters<OpenAIModelClass>[0]) {
+    super({ responses: [CHILD_RESPONSE] });
+  }
+}
+
 type UpdateCapture = {
   updates: CapturedUpdate[];
   handlers: Record<string, t.EventHandler>;
@@ -97,13 +112,12 @@ describe('Subagent child-graph run step closure', () => {
       .spyOn(providers, 'getChatModelClass')
       .mockImplementation(((provider: Providers) => {
         if (provider === Providers.OPENAI) {
-          return class extends FakeListChatModel {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            constructor(_options: any) {
-              super({ responses: [CHILD_RESPONSE] });
-            }
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any;
+          /**
+           * A fake is not a `ChatOpenAI`, so the class identity cannot be
+           * satisfied structurally; the constructor contract above is what
+           * this test actually depends on.
+           */
+          return FakeOpenAIChatModel as unknown as OpenAIModelClass;
         }
         return originalGetChatModelClass(provider);
       }) as typeof providers.getChatModelClass);
@@ -206,5 +220,64 @@ describe('Subagent child-graph run step closure', () => {
           'cancelled'
       )
     ).toBe(true);
+  });
+
+  it('stamps closure at child termination, not after a slow stop hook', async () => {
+    const HOOK_DELAY_MS = 200;
+    const { updates, handlers } = createUpdateCapture();
+    const registry = new HookRegistry();
+    let hookFinishedAt = 0;
+
+    registry.register('SubagentStop', {
+      hooks: [
+        async (): Promise<Record<string, never>> => {
+          await new Promise((resolve) => setTimeout(resolve, HOOK_DELAY_MS));
+          hookFinishedAt = Date.now();
+          return {};
+        },
+      ],
+    });
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-closure-hook-${Date.now()}`,
+      graphConfig: { type: 'standard', agents: [createParentAgent()] },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: handlers,
+      hooks: registry,
+    });
+
+    run.Graph?.overrideTestModel(
+      ['Delegating this research.', `Based on the research: ${CHILD_RESPONSE}`],
+      10,
+      [subagentToolCall]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      {
+        ...callerConfig,
+        configurable: { thread_id: 'subagent-step-closure-hook' },
+      }
+    );
+
+    expect(hookFinishedAt).toBeGreaterThan(0);
+
+    const closedAts = updates
+      .filter((update) => update.phase === 'run_step_closed')
+      .map((update) => (update.data as { closed_at?: number }).closed_at);
+
+    expect(closedAts.length).toBeGreaterThan(0);
+    /**
+     * Sweeping after the awaited hook would push every stamp to at or beyond
+     * `hookFinishedAt`; the margin keeps the assertion honest without making
+     * it sensitive to scheduler jitter.
+     */
+    for (const closedAt of closedAts) {
+      expect(closedAt).toBeDefined();
+      expect(closedAt as number).toBeLessThan(
+        hookFinishedAt - HOOK_DELAY_MS / 2
+      );
+    }
   });
 });

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -46,6 +46,7 @@ import type {
   RunStep,
   RunStepDeltaEvent,
   RunStepClosedEvent,
+  RunStepStatus,
   StandardGraphInput,
   ExecutableSubagentConfigEntry,
   ResolvedSubagentConfig,
@@ -1610,6 +1611,30 @@ export class SubagentExecutor {
     graph.clearHeavyState();
   }
 
+  /**
+   * Terminal sweep for a child graph's run steps. `Run.processStream` sweeps
+   * only the graph it owns, and a child executes through `workflow.invoke()`
+   * outside that loop — so without this, a child's last message step (no
+   * successor step ever opens to close it) and every step of an aborted child
+   * stay `in_progress` forever, leaving hosts with unmatched starts.
+   *
+   * Must run BEFORE `forwarding.drain()`: closures reach the parent only as
+   * child custom events through the forwarder, which stops relaying once
+   * drained. Deliberately not called on the interrupt path — that mirrors the
+   * parent's `isAwaitingResume` guard, since a paused child resumes into the
+   * same steps and closing them here would strand the resumed run.
+   */
+  private async closeChildRunSteps(
+    graph: StandardGraph,
+    status: Exclude<RunStepStatus, 'in_progress'>
+  ): Promise<void> {
+    try {
+      await graph.closeUnfinishedRunSteps(status);
+    } catch (_e) {
+      /** A failed sweep must never mask the subagent's own outcome */
+    }
+  }
+
   clearHeavyState(): void {
     this.executions.clear((record) => {
       if (record.activeRun != null) {
@@ -2505,6 +2530,15 @@ export class SubagentExecutor {
         childBreaker.abort(error);
       }
       const errorMessage = truncateErrorMessage(error);
+      /**
+       * `cancelled` vs `failed` mirrors `Run.resolveSweepStatus`: an aborted
+       * child was stopped on purpose (caller abort, or a breaker trip from a
+       * parallel sibling), anything else died of an unexpected error.
+       */
+      await this.closeChildRunSteps(
+        childGraph,
+        childSignal.aborted ? 'cancelled' : 'failed'
+      );
       if (forwarding) {
         await forwarding.drain();
         await this.emitSubagentUpdate(parentRegistry!, {
@@ -2571,6 +2605,10 @@ export class SubagentExecutor {
       }).catch(() => {
         /* SubagentStop is observational — swallow errors */
       });
+    }
+
+    if (!childAlreadyCompleted) {
+      await this.closeChildRunSteps(childGraph, 'completed');
     }
 
     if (forwarding && !childAlreadyCompleted) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1620,16 +1620,28 @@ export class SubagentExecutor {
    *
    * Must run BEFORE `forwarding.drain()`: closures reach the parent only as
    * child custom events through the forwarder, which stops relaying once
-   * drained. Deliberately not called on the interrupt path — that mirrors the
-   * parent's `isAwaitingResume` guard, since a paused child resumes into the
-   * same steps and closing them here would strand the resumed run.
+   * drained.
+   *
+   * Deliberately not called on the interrupt path, mirroring the parent's
+   * `isAwaitingResume` guard: an in-process resume continues into these same
+   * steps, so closing them would strand the resumed run. A resume that
+   * crosses a process boundary is a known gap either way — the child rebuilds
+   * from `SubagentGraphResumeState`, which carries tool-call identity but not
+   * `contentData`, so pre-interrupt steps are unreachable from the new graph
+   * and stay open. That is the child-level instance of the same cross-process
+   * orphan the parent graph has, and it needs persisted lifecycle state to
+   * fix rather than a sweep here.
+   *
+   * `at` is the moment execution actually ended, threaded through so
+   * observational work between then and the sweep cannot inflate the stamps.
    */
   private async closeChildRunSteps(
     graph: StandardGraph,
-    status: Exclude<RunStepStatus, 'in_progress'>
+    status: Exclude<RunStepStatus, 'in_progress'>,
+    at?: number
   ): Promise<void> {
     try {
-      await graph.closeUnfinishedRunSteps(status);
+      await graph.closeUnfinishedRunSteps(status, at);
     } catch (_e) {
       /** A failed sweep must never mask the subagent's own outcome */
     }
@@ -2495,6 +2507,8 @@ export class SubagentExecutor {
         result = childResult;
       }
     } catch (error) {
+      /** Stamped at failure, not after the error-envelope work below. */
+      const childTerminalAt = Date.now();
       if (isGraphInterrupt(error)) {
         const activeChildRun = execution.activeRun;
         if (activeChildRun != null) {
@@ -2537,7 +2551,8 @@ export class SubagentExecutor {
        */
       await this.closeChildRunSteps(
         childGraph,
-        childSignal.aborted ? 'cancelled' : 'failed'
+        childSignal.aborted ? 'cancelled' : 'failed',
+        childTerminalAt
       );
       if (forwarding) {
         await forwarding.drain();
@@ -2570,6 +2585,14 @@ export class SubagentExecutor {
         messages: [],
       };
     }
+
+    /**
+     * Child execution ended here. Captured before the observational work
+     * below — an awaited `SubagentStop` hook, then the forwarder drain — so a
+     * slow hook cannot inflate the closure stamps with its own latency.
+     * Mirrors the parent's `terminalAt` capture in `Run.processStream`.
+     */
+    const childTerminalAt = Date.now();
 
     if (result == null) {
       throw new Error('Subagent completed without producing graph state.');
@@ -2608,7 +2631,7 @@ export class SubagentExecutor {
     }
 
     if (!childAlreadyCompleted) {
-      await this.closeChildRunSteps(childGraph, 'completed');
+      await this.closeChildRunSteps(childGraph, 'completed', childTerminalAt);
     }
 
     if (forwarding && !childAlreadyCompleted) {


### PR DESCRIPTION
## Summary

Follow-up to #409, which added run step lifecycle timestamps and the `on_run_step_closed` event. That work left a documented gap: the terminal sweep in `Run.processStream` walks only the graph the `Run` owns, and a subagent child graph executes through `workflow.invoke()` outside that loop. Nothing ever closed the steps a child opened.

I went in expecting an abort-only bug and wrote the regression test first. It showed the gap is wider than that — the child opened run steps and closed **zero** of them on the **success** path too. The cause is structural rather than abort-specific: a message step is normally closed when a successor step opens in the same agent lane, so a child's *last* message step has nothing to close it. Every subagent invocation was leaving steps open, not just aborted ones.

Consumers waiting on `on_run_step_closed` were therefore left with unmatched starts, and nested steps spin indefinitely in a host UI.

- Added a terminal sweep for the child graph on both executor exit paths: `completed` on success, and `cancelled`/`failed` on error — `cancelled` when the composed child signal aborted, mirroring `Run.resolveSweepStatus`.
- Both sweeps run **before** `forwarding.drain()`. Child closures reach the parent only as child custom events relayed by the forwarder, which stops relaying once drained.
- Closure timestamps are stamped at the moment execution ends (after the `try`/`catch` on success, at `catch` entry on failure) and threaded through to `closeUnfinishedRunSteps`, so an awaited `SubagentStop` hook or the forwarder drain cannot inflate them. Mirrors the parent's `terminalAt` capture.
- The interrupt path deliberately does **not** sweep, mirroring the parent's `isAwaitingResume` guard: an in-process resume continues into these same steps, so closing them would strand the resumed run.

No API changes; the sweep reuses the existing idempotent, first-close-wins `closeRunStep` funnel, so a redundant close is a no-op.

## Known gap

A resume that crosses a **process boundary** still orphans child steps. The child rebuilds from `SubagentGraphResumeState`, which carries tool-call identity but not `contentData`, so pre-interrupt steps are unreachable from the reconstructed graph and stay open.

This is the child-level instance of a limitation the parent graph already has — run-step lifecycle state is in-memory on the `Graph`, so any cross-process resume orphans whatever the original process opened. It was identified and explicitly deferred in #409, and the same fix shape covers both levels: persist open-step lifecycle state into the checkpoint, or reconcile host-side on resume. Not in scope here, and nothing regresses: before this PR, in-process resume had the same orphan, because nothing closed child steps at all.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

New spec `src/specs/subagent-step-closure.test.ts` asserts the child's forwarded `run_step_closed` envelopes, observed through `ON_SUBAGENT_UPDATE` — the only surface on which a child's step lifecycle is visible to a host. Three cases: completion, caller abort mid-child, and closure-stamp ordering against a slow stop hook.

All three are non-vacuous, each verified to fail against the behavior it pins:

- **Completion** fails with zero closures observed — this is how the wider-than-filed scope surfaced.
- **Abort** independently pins the `cancelled` branch: a child that finished before the abort landed would report `completed` and fail the assertion.
- **Stop-hook ordering** fails by ~100ms against the previous ordering, with the stamps landing after the hook completed rather than before it.

Ran `src/specs`, `src/tools/__tests__`, `src/graphs`, `src/session`, `src/summarization` and `src/hooks` — 2009 passed. `npx tsc --noEmit`, `npx eslint`, and the import-sort check are clean on both touched files.

One note for reviewers: `prettier` and this repo's eslint `indent` rule disagree on `SubagentExecutor.ts`. Running prettier over it reformats two untouched regions and introduces 11 lint errors, so I reverted those hunks — the diff here is only the intended ones.

### **Test Configuration**:

`npx jest src/specs src/tools/__tests__ src/graphs src/session src/summarization src/hooks`

`src/specs/durability-checkpoint.integration.test.ts` fails locally for want of a `mongod` binary; verified it fails identically with these changes stashed, so it is environmental. It passes in CI.

## Checklist

- [x] My code adheres to this project&#39;s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5)_