### PR TITLE
v3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
Publishes the merged per-agent execution-profile support required by [LibreChat#14848](https://github.com/danny-avila/LibreChat/pull/14848).

## Contents

`3.5.1...3.6.0` contains:

- #416 — trusted per-agent Code API profile/session routing across code, bash, PTC, handoffs, subagents, background execution, and tool search.
- #417 — closes subagent child-graph run steps correctly.

This is a minor bump because #416 adds optional public execution-context inputs while preserving existing defaults.

## Verification

- Both source PRs merged with green CI.
- `package.json` and both root version fields in `package-lock.json` are `3.6.0`.
- `npm pack --dry-run` succeeds and reports `@librechat/agents@3.6.0`.

Once this merges and the publish workflow completes, LibreChat#14848 can bump its manifest and lockfile and resolve its final release-order review thread.