### PR TITLE
🧭 fix: Restore Run Steps Across Process Resumes

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -16,6 +16,7 @@ import type {
   BaseMessage,
   MessageContent,
 } from '@langchain/core/messages';
+import type { BaseChannel, OverwriteValue } from '@langchain/langgraph';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
   ReplayableSubagentTool,
@@ -167,6 +168,7 @@ import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
 import { handleToolCalls } from '@/tools/handlers';
+import { isRunStepResumeState } from '@/tools/runStepResume';
 import { isThinkingEnabled } from '@/llm/request';
 import { resolveMaxSeals } from '@/llm/preempt';
 import { initializeModel } from '@/llm/init';
@@ -673,11 +675,36 @@ function getDispatchableFinalReasoningContent({
   return responseReasoningContent;
 }
 
+function createEmptyRunStepResumeState(): t.RunStepResumeState {
+  return {
+    version: 1,
+    revision: 0,
+    nextIndex: 0,
+    toolCallSteps: [],
+    steps: [],
+  };
+}
+
+type RunStepStateChannel = BaseChannel<
+  t.RunStepResumeState,
+  t.RunStepResumeState | OverwriteValue<t.RunStepResumeState>
+>;
+
+function buildRunStepStateAnnotation(): RunStepStateChannel {
+  return Annotation<t.RunStepResumeState>({
+    reducer: (current, update) =>
+      update.revision >= current.revision ? update : current,
+    default: createEmptyRunStepResumeState,
+  });
+}
+
 export abstract class Graph<
   T extends t.BaseGraphState = t.BaseGraphState,
   _TNodeName extends string = string,
 > {
   abstract resetValues(keepContent?: boolean, checkpointScope?: string): void;
+  abstract createRunStepResumeState(): t.RunStepResumeState;
+  abstract restoreRunStepResumeState(state?: t.RunStepResumeState): void;
   restoreCheckpointMessages(
     _messages: BaseMessage[],
     _pendingMessages?: BaseMessage[]
@@ -739,6 +766,8 @@ export abstract class Graph<
   prelimMessageIdsByStepKey: Map<string, string> = new Map();
   config: RunnableConfig | undefined;
   contentData: t.RunStep[] = [];
+  protected nextContentIndex = 0;
+  protected runStepStateRevision = 0;
   stepKeyIds: Map<string, string[]> = new Map<string, string[]>();
   contentIndexMap: Map<string, number> = new Map();
   toolCallStepIds: Map<string, string> = new Map();
@@ -866,6 +895,8 @@ export abstract class Graph<
     this.signal = undefined;
     this.callerSignal = undefined;
     this.contentData = [];
+    this.nextContentIndex = 0;
+    this.runStepStateRevision = 0;
     this.contentIndexMap = new Map();
     this.stepKeyIds = new Map();
     this.toolCallStepIds.clear();
@@ -950,15 +981,18 @@ export abstract class Graph<
 
   /**
    * Tracks a tool call whose completion must arrive before its step can be
-   * considered finished. Registered wherever `toolCallStepIds` gains entries,
-   * except cross-process subagent resume restoration, where pending state
-   * cannot be faithfully rebuilt and closes fall back to completions/sweep.
+   * considered finished. Registered wherever `toolCallStepIds` gains entries.
    */
   registerPendingToolCall(toolCallId: string, stepId: string): void {
     if (!toolCallId || !stepId) {
       return;
     }
-    this.getPendingToolCallSet(stepId).add(toolCallId);
+    const pending = this.getPendingToolCallSet(stepId);
+    const size = pending.size;
+    pending.add(toolCallId);
+    if (pending.size !== size) {
+      this.runStepStateRevision += 1;
+    }
   }
 
   /** Lazily creates a step's pending-completions set; callers registering a
@@ -1063,6 +1097,7 @@ export abstract class Graph<
         ),
       ],
       eagerToolSuppressions: [...this.eagerEventToolSuppressions],
+      runStepState: this.createRunStepResumeState(),
       ...(this._toolOutputRegistry == null
         ? {}
         : {
@@ -1099,6 +1134,7 @@ export abstract class Graph<
       throw new Error('Cannot restore disabled tool output references.');
     }
 
+    this.restoreRunStepResumeState(state.runStepState);
     this.toolCallStepIds.clear();
     for (const { toolCallId, stepId } of state.toolCallSteps) {
       this.toolCallStepIds.set(toolCallId, stepId);
@@ -1469,6 +1505,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.config = resetIfNotEmpty(this.config, undefined);
     if (keepContent !== true) {
       this.contentData = resetIfNotEmpty(this.contentData, []);
+      this.nextContentIndex = 0;
+      this.runStepStateRevision = 0;
       this.contentIndexMap = resetIfNotEmpty(this.contentIndexMap, new Map());
     }
     this.stepKeyIds = resetIfNotEmpty(this.stepKeyIds, new Map());
@@ -1737,6 +1775,78 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /* Run Step Processing */
 
+  createRunStepResumeState(): t.RunStepResumeState {
+    const steps: t.RunStepResumeEntry[] = [];
+    for (const runStep of this.contentData) {
+      if (runStep.status != null && runStep.status !== 'in_progress') {
+        continue;
+      }
+      const agentKey = runStep.agentId ?? '';
+      steps.push({
+        step: structuredClone(runStep),
+        pendingToolCallIds: [
+          ...(this.pendingToolCallsByStep.get(runStep.id) ?? []),
+        ],
+        ...(this.latestCompletionByStep.has(runStep.id)
+          ? {
+            latestCompletionAt: this.latestCompletionByStep.get(runStep.id),
+          }
+          : {}),
+        openMessageStep:
+          this.openMessageStepByAgent.get(agentKey) === runStep.id,
+      });
+    }
+    return {
+      version: 1,
+      revision: this.runStepStateRevision,
+      nextIndex: this.nextContentIndex,
+      toolCallSteps: [...this.toolCallStepIds].map(
+        ([toolCallId, stepId]) => ({ toolCallId, stepId })
+      ),
+      steps,
+    };
+  }
+
+  restoreRunStepResumeState(state?: t.RunStepResumeState): void {
+    if (
+      !isRunStepResumeState(state) ||
+      this.contentData.length > 0 ||
+      this.runStepStateRevision > 0
+    ) {
+      return;
+    }
+
+    this.nextContentIndex = state.nextIndex;
+    this.runStepStateRevision = state.revision;
+    for (const { toolCallId, stepId } of state.toolCallSteps) {
+      this.toolCallStepIds.set(toolCallId, stepId);
+    }
+    for (const entry of state.steps) {
+      const runStep = structuredClone(entry.step);
+      runStep.status = 'in_progress';
+      this.nextContentIndex = Math.max(
+        this.nextContentIndex,
+        runStep.index + 1
+      );
+      const position = this.contentData.length;
+      this.contentData.push(runStep);
+      this.contentIndexMap.set(runStep.id, position);
+      if (entry.pendingToolCallIds.length > 0) {
+        const pending = new Set(entry.pendingToolCallIds);
+        this.pendingToolCallsByStep.set(runStep.id, pending);
+      }
+      if (entry.latestCompletionAt != null) {
+        this.latestCompletionByStep.set(
+          runStep.id,
+          entry.latestCompletionAt
+        );
+      }
+      if (entry.openMessageStep) {
+        this.openMessageStepByAgent.set(runStep.agentId ?? '', runStep.id);
+      }
+    }
+  }
+
   getRunStep(stepId: string): t.RunStep | undefined {
     const index = this.contentIndexMap.get(stepId);
     if (index !== undefined) {
@@ -1813,9 +1923,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * would mutate the wrong agent's step. Assigning the index at push time
      * also supersedes whatever the caller computed before this await point.
      */
-    runStep.index = this.contentData.length;
+    runStep.index = Math.max(this.nextContentIndex, this.contentData.length);
+    this.nextContentIndex = runStep.index + 1;
+    const position = this.contentData.length;
     this.contentData.push(runStep);
-    this.contentIndexMap.set(runStep.id, runStep.index);
+    this.contentIndexMap.set(runStep.id, position);
     if (trackAsOpenMessageStep && runStep.type === StepTypes.MESSAGE_CREATION) {
       this.openMessageStepByAgent.set(agentKey, runStep.id);
     } else {
@@ -1846,6 +1958,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * absorb the latency of an arbitrarily slow predecessor handler.
      */
     runStep.created_at = Date.now();
+    this.runStepStateRevision += 1;
   }
 
   /**
@@ -1906,6 +2019,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       closedEvent.stepIndex = runStep.stepIndex;
     }
     this.untrackRunStep(runStep);
+    this.runStepStateRevision += 1;
 
     const handler = this.handlerRegistry?.getHandler(
       GraphEvents.ON_RUN_STEP_CLOSED
@@ -1950,10 +2064,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return;
     }
     const { toolCallId, metadata, at } = options ?? {};
+    let lifecycleChanged = false;
     if (at != null) {
       const latest = this.latestCompletionByStep.get(stepId);
       if (latest == null || at > latest) {
         this.latestCompletionByStep.set(stepId, at);
+        lifecycleChanged = true;
       }
     }
     const closeAt = this.latestCompletionByStep.get(stepId) ?? at;
@@ -1963,9 +2079,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return;
     }
     if (toolCallId != null && toolCallId !== '') {
-      pending.delete(toolCallId);
+      lifecycleChanged = pending.delete(toolCallId) || lifecycleChanged;
     }
     if (pending.size > 0) {
+      if (lifecycleChanged) {
+        this.runStepStateRevision += 1;
+      }
       return;
     }
     await this.closeRunStep(stepId, 'completed', { metadata, at: closeAt });
@@ -2418,6 +2537,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         fileCheckpointer: this.getOrCreateFileCheckpointer(),
         getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
         getRunScope: (): RunBreakerScope => this.runScope,
+        restoreRunStepResumeState: (state, config): void => {
+          this.config = config;
+          this.restoreRunStepResumeState(state);
+        },
+        createRunStepResumeState: (): t.RunStepResumeState =>
+          this.createRunStepResumeState(),
         errorHandler: (data, metadata): Promise<boolean> =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
@@ -2484,6 +2609,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       fileCheckpointer: this.getOrCreateFileCheckpointer(),
       getBreakerSignal: (): AbortSignal => this.breakerAbort.signal,
       getRunScope: (): RunBreakerScope => this.runScope,
+      restoreRunStepResumeState: (state, config): void => {
+        this.config = config;
+        this.restoreRunStepResumeState(state);
+      },
+      createRunStepResumeState: (): t.RunStepResumeState =>
+        this.createRunStepResumeState(),
     });
     this.registerCompiledToolNode(node);
     return node;
@@ -4573,6 +4704,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     };
   }
 
+  protected createRunStepStateAnnotation(): RunStepStateChannel {
+    return buildRunStepStateAnnotation();
+  }
+
   createAgentNode(agentId: string): t.CompiledAgentWorfklow {
     const getConfig = (): RunnableConfig | undefined => this.config;
     const agentContext = this.agentContexts.get(agentId);
@@ -4781,6 +4916,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const agentNode = `${AGENT}${agentId}` as const;
     const toolNode = `${TOOLS}${agentId}` as const;
     const summarizeNode = `${SUMMARIZE}${agentId}` as const;
+    const callModel = this.createCallModel(agentId);
+    const callTools = this.initializeTools({
+      currentTools: agentContext.tools,
+      currentToolMap: agentContext.toolMap,
+      agentContext,
+    });
+    const invokeWithRunStepState = async (
+      state: t.AgentSubgraphState,
+      config: RunnableConfig | undefined,
+      invoke: () => Promise<Partial<t.AgentSubgraphState>>
+    ): Promise<Partial<t.AgentSubgraphState>> => {
+      this.config = config;
+      this.restoreRunStepResumeState(state.runStepState);
+      const result = await invoke();
+      return { ...result, runStepState: this.createRunStepResumeState() };
+    };
 
     const routeMessage = (
       state: t.AgentSubgraphState,
@@ -4817,6 +4968,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ) => b,
         default: () => undefined,
       }),
+      runStepState: this.createRunStepStateAnnotation(),
     });
 
     const readChargeCredits = ():
@@ -4835,14 +4987,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     };
 
     const workflow = new StateGraph(StateAnnotation)
-      .addNode(agentNode, this.createCallModel(agentId))
+      .addNode(agentNode, (state, config) =>
+        invokeWithRunStepState(state, config, () => callModel(state, config))
+      )
       .addNode(
         toolNode,
-        this.initializeTools({
-          currentTools: agentContext.tools,
-          currentToolMap: agentContext.toolMap,
-          agentContext,
-        })
+        callTools
       )
       .addNode(
         summarizeNode,
@@ -5021,6 +5171,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         },
         default: () => [],
       }),
+      runStepState: this.createRunStepStateAnnotation(),
     });
     const workflow = new StateGraph(StateAnnotation)
       .addNode(
@@ -5097,6 +5248,32 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   ): Promise<string> {
     if (!this.config) {
       throw new Error('No config provided');
+    }
+
+    if (stepDetails.type === StepTypes.TOOL_CALLS && stepDetails.tool_calls) {
+      let replayStepId: string | undefined;
+      let reusesOpenStep = stepDetails.tool_calls.length > 0;
+      for (const toolCall of stepDetails.tool_calls) {
+        const toolCallId = toolCall.id ?? '';
+        const mappedStepId = this.toolCallStepIds.get(toolCallId);
+        if (!toolCallId || mappedStepId == null) {
+          reusesOpenStep = false;
+          continue;
+        }
+        replayStepId ??= mappedStepId;
+        if (mappedStepId !== replayStepId) {
+          reusesOpenStep = false;
+        }
+      }
+      const replayStep =
+        replayStepId == null ? undefined : this.getRunStep(replayStepId);
+      if (
+        reusesOpenStep &&
+        replayStep != null &&
+        (replayStep.status == null || replayStep.status === 'in_progress')
+      ) {
+        return replayStep.id;
+      }
     }
 
     const [stepId, stepIndex] = this.generateStepId(stepKey);

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1036,6 +1036,7 @@ export class MultiAgentGraph extends StandardGraph {
         reducer: (_current, update) => update,
         default: () => undefined,
       }),
+      runStepState: this.createRunStepStateAnnotation(),
     });
 
     const builder = new StateGraph(StateAnnotation);

--- a/src/run.ts
+++ b/src/run.ts
@@ -30,6 +30,10 @@ import {
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from '@/tools/subagent/SubagentReplay';
 import {
+  getRunStepResumeState,
+  stripRunStepResumeState,
+} from '@/tools/runStepResume';
+import {
   ACTIVITY_PHASE_LABEL_PROMPT,
   ACTIVITY_LABEL_PROMPT,
   buildActivityLabelPrompt,
@@ -174,7 +178,9 @@ function isLangGraphResumeMapForInterrupt(
 }
 
 function getInterruptHookSessionId(payload: unknown): string | undefined {
-  const publicPayload = stripSubagentResumeManifest(payload);
+  const publicPayload = stripSubagentResumeManifest(
+    stripRunStepResumeState(payload)
+  );
   if (
     publicPayload == null ||
     typeof publicPayload !== 'object' ||
@@ -194,11 +200,15 @@ type InterruptStateSnapshot = {
   values?: { messages?: BaseMessage[] };
   tasks?: Array<{
     interrupts?: Array<{ id?: string; value?: unknown }>;
+    state?: RunnableConfig | InterruptStateSnapshot;
   }>;
 };
 
 type WorkflowWithStateHistory = {
-  getState?(config: RunnableConfig): Promise<InterruptStateSnapshot>;
+  getState?(
+    config: RunnableConfig,
+    options?: { subgraphs?: boolean }
+  ): Promise<InterruptStateSnapshot>;
   getStateHistory?(
     config: RunnableConfig
   ): AsyncIterableIterator<InterruptStateSnapshot>;
@@ -214,6 +224,17 @@ function getFirstPersistedInterrupt(
         pendingInterrupt.id.length > 0
       ) {
         return { id: pendingInterrupt.id, value: pendingInterrupt.value };
+      }
+    }
+    const nestedState = task.state;
+    if (
+      nestedState != null &&
+      'tasks' in nestedState &&
+      Array.isArray(nestedState.tasks)
+    ) {
+      const nestedInterrupt = getFirstPersistedInterrupt(nestedState);
+      if (nestedInterrupt != null) {
+        return nestedInterrupt;
       }
     }
   }
@@ -966,6 +987,12 @@ export class Run<_T extends t.BaseGraphState> {
       delete config.configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
       delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
     }
+    if (isResume) {
+      await this.restoreInterruptFromCheckpoint(
+        config,
+        (inputs as Command).update
+      );
+    }
 
     /**
      * Cancellation can arrive either at graph construction or per-call through
@@ -1520,7 +1547,9 @@ export class Run<_T extends t.BaseGraphState> {
     }
     return {
       ...this._interrupt,
-      payload: stripSubagentResumeManifest(this._interrupt.payload),
+      payload: stripSubagentResumeManifest(
+        stripRunStepResumeState(this._interrupt.payload)
+      ),
     } as t.RunInterruptResult<TPayload>;
   }
 
@@ -1639,7 +1668,7 @@ export class Run<_T extends t.BaseGraphState> {
     await this.restoreInterruptFromCheckpoint(callerConfig, resumeUpdate);
     const interrupt = this._interrupt;
     const resumeManifest = requireValidSubagentResumeManifest(
-      interrupt?.payload
+      stripRunStepResumeState(interrupt?.payload)
     );
     const resumeConfigurable = { ...callerConfig.configurable };
     delete resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
@@ -1726,7 +1755,7 @@ export class Run<_T extends t.BaseGraphState> {
     callerConfig: t.RunStreamConfig,
     resumeUpdate?: ResumeCommandUpdate
   ): Promise<void> {
-    if (this._interrupt != null || this.humanInTheLoop?.enabled !== true) {
+    if (this._interrupt != null || !this.hasCheckpointer) {
       return;
     }
     const workflow = this.graphRunnable as
@@ -1736,11 +1765,16 @@ export class Run<_T extends t.BaseGraphState> {
       return;
     }
 
-    const snapshot = await workflow.getState(callerConfig as RunnableConfig);
+    const snapshot = await workflow.getState(callerConfig as RunnableConfig, {
+      subgraphs: true,
+    });
     const persistedInterrupt = getFirstPersistedInterrupt(snapshot);
     if (persistedInterrupt == null) {
       return;
     }
+    this.Graph?.restoreRunStepResumeState(
+      getRunStepResumeState(persistedInterrupt.value)
+    );
     const persistedMessages = getPersistedMessages(snapshot);
     if (persistedMessages != null) {
       const resumeMessages = getResumeUpdateMessages(resumeUpdate);
@@ -2678,8 +2712,8 @@ function findActivityPhaseTraceInput(
     const message = messages[i];
     if (
       message.getType() !== 'human' ||
-      message.additional_kwargs?.role === 'system' ||
-      message.additional_kwargs?.isMeta === true
+      message.additional_kwargs.role === 'system' ||
+      message.additional_kwargs.isMeta === true
     ) {
       continue;
     }

--- a/src/specs/run-step-timestamps.test.ts
+++ b/src/specs/run-step-timestamps.test.ts
@@ -411,4 +411,95 @@ describe('run step timestamps', () => {
       expect(step.status).toBe('completed');
     }
   });
+
+  it('rehydrates and closes open steps when HITL resumes in a fresh process', async () => {
+    const { sequence, handlers } = createRecorder();
+    const saver = new MemorySaver();
+    const createRun = async (resume: boolean): Promise<Run<t.IState>> => {
+      const run = await Run.create<t.IState>({
+        runId: 'test-run-step-timestamps-cross-process',
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            {
+              agentId: 'timestamps-cross-process-agent',
+              provider: Providers.OPENAI,
+              clientOptions: {
+                model: 'gpt-4o-mini',
+                streaming: true,
+                streamUsage: false,
+              },
+              instructions: 'You are a helpful assistant.',
+              maxContextTokens: 8000,
+              graphTools: [askTool],
+            },
+          ],
+          compileOptions: { checkpointer: saver },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: handlers,
+      });
+      run.Graph!.overrideModel = new FakeChatModel(
+        resume
+          ? { responses: ['done after resume'] }
+          : {
+            responses: ['asking the user'],
+            toolCalls: [
+              {
+                name: 'ask_user_question',
+                args: { question: 'pick one' },
+                id: 'call_ask_cross_process',
+                type: 'tool_call',
+              },
+            ],
+          }
+      );
+      return run;
+    };
+
+    const streamConfig = createStreamConfig(
+      'run-step-timestamps-cross-process'
+    );
+    const firstRun = await createRun(false);
+    await firstRun.processStream(
+      { messages: [new HumanMessage('go')] },
+      streamConfig
+    );
+
+    const openStep = firstRun.Graph?.contentData.find(
+      (step) => step.type === StepTypes.TOOL_CALLS
+    ) as t.RunStep;
+    expect(firstRun.getInterrupt()?.payload).toMatchObject({
+      type: 'ask_user_question',
+    });
+    expect(openStep.status).toBe('in_progress');
+    expect(getClosed(sequence).map((event) => event.id)).not.toContain(
+      openStep.id
+    );
+
+    const resumedRun = await createRun(true);
+    await resumedRun.resume({ answer: 'blue' }, streamConfig);
+
+    const restoredStep = resumedRun.Graph?.getRunStep(openStep.id);
+    expect(restoredStep).toMatchObject({
+      id: openStep.id,
+      index: openStep.index,
+      created_at: openStep.created_at,
+      status: 'completed',
+    });
+    expect(
+      getSteps(sequence).filter((step) => step.id === openStep.id)
+    ).toHaveLength(1);
+    expect(
+      getClosed(sequence).filter((event) => event.id === openStep.id)
+    ).toEqual([
+      expect.objectContaining({
+        id: openStep.id,
+        index: openStep.index,
+        created_at: openStep.created_at,
+        status: 'completed',
+      }),
+    ]);
+  });
 });

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -62,6 +62,7 @@ import {
   SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_REPLAY_CONTROLLER,
 } from '@/tools/subagent/SubagentReplay';
+import { attachRunStepResumeState } from '@/tools/runStepResume';
 import {
   INTENT_ARG,
   readOutcomeFields,
@@ -818,11 +819,45 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     fileCheckpointer,
     getBreakerSignal,
     getRunScope,
+    restoreRunStepResumeState,
+    createRunStepResumeState,
   }: t.ToolNodeConstructorParams) {
     super({
       name: name ?? TOOL_NODE_RUN_NAME,
       tags,
-      func: (input, config) => this.run(input, config),
+      func: async (input, config) => {
+        const state = input as T & Pick<t.BaseGraphState, 'runStepState'>;
+        restoreRunStepResumeState?.(state.runStepState, config);
+        let result: T;
+        try {
+          result = await this.run(input, config);
+        } catch (error) {
+          if (!isGraphInterrupt(error) || createRunStepResumeState == null) {
+            throw error;
+          }
+          const resumeState = createRunStepResumeState();
+          throw new GraphInterrupt(
+            error.interrupts.map((pendingInterrupt) => ({
+              ...pendingInterrupt,
+              value: attachRunStepResumeState(
+                pendingInterrupt.value,
+                resumeState
+              ),
+            }))
+          );
+        }
+        if (createRunStepResumeState == null) {
+          return result;
+        }
+        const runStepState = createRunStepResumeState();
+        if (Array.isArray(result)) {
+          return [...result, { runStepState }] as T;
+        }
+        return {
+          ...result,
+          runStepState,
+        };
+      },
     });
     this.trace = trace ?? this.trace;
     this.runLangfuse = runLangfuse;

--- a/src/tools/__tests__/SubagentReplay.test.ts
+++ b/src/tools/__tests__/SubagentReplay.test.ts
@@ -4,6 +4,12 @@ import {
   requireValidSubagentResumeManifest,
   stripSubagentResumeManifest,
 } from '@/tools/subagent/SubagentReplay';
+import {
+  attachRunStepResumeState,
+  getRunStepResumeState,
+  stripRunStepResumeState,
+} from '@/tools/runStepResume';
+import type { RunStepResumeState } from '@/types';
 
 describe('SubagentReplay manifest', () => {
   const execution = {
@@ -82,6 +88,32 @@ describe('SubagentReplay manifest', () => {
       type: 'tool_approval',
       visible: true,
     });
+  });
+
+  it('composes with private run-step state without changing the public payload', () => {
+    const manifest = { version: 1 as const, executions: [execution] };
+    const runStepState: RunStepResumeState = {
+      version: 1,
+      revision: 1,
+      nextIndex: 0,
+      toolCallSteps: [],
+      steps: [],
+    };
+    const visiblePayload = {
+      type: 'tool_approval',
+      subagent: { parent_tool_call_id: 'call_parent' },
+    };
+    const payload = attachSubagentResumeManifest(
+      attachRunStepResumeState(visiblePayload, runStepState),
+      manifest
+    );
+    const manifestPayload = stripRunStepResumeState(payload);
+
+    expect(getRunStepResumeState(payload)).toEqual(runStepState);
+    expect(getSubagentResumeManifest(manifestPayload)).toEqual(manifest);
+    expect(stripSubagentResumeManifest(manifestPayload)).toEqual(
+      visiblePayload
+    );
   });
 
   it('accepts legacy executions without a bound subagent type', () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1146,7 +1146,12 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
         },
       ],
     };
-    const getState = jest.fn(async (_config: RunnableConfig) => persistedState);
+    const getState = jest.fn(
+      async (
+        _config: RunnableConfig,
+        _options?: { subgraphs?: boolean }
+      ) => persistedState
+    );
     run.graphRunnable = { getState } as unknown as t.CompiledStateWorkflow;
     const processSpy = jest
       .spyOn(run, 'processStream')
@@ -1159,7 +1164,7 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
 
     await run.resume(decision, callerConfig);
 
-    expect(getState).toHaveBeenCalledWith(callerConfig);
+    expect(getState).toHaveBeenCalledWith(callerConfig, { subgraphs: true });
     const command = processSpy.mock.calls[0]?.[0] as Command;
     expect(command.resume).toEqual({ 'persisted-interrupt': decision });
     expect(processSpy.mock.calls[0]?.[1].configurable).toMatchObject({

--- a/src/tools/runStepResume.ts
+++ b/src/tools/runStepResume.ts
@@ -95,7 +95,7 @@ function isRunStepResumePayload(value: unknown): value is RunStepResumePayload {
 export function attachRunStepResumeState(
   payload: unknown,
   state: RunStepResumeState
-): unknown {
+): object {
   const publicPayload = isRunStepResumePayload(payload)
     ? payload[RUN_STEP_RESUME_PAYLOAD_KEY]
     : payload;

--- a/src/tools/runStepResume.ts
+++ b/src/tools/runStepResume.ts
@@ -1,0 +1,121 @@
+import type { RunStepResumeEntry, RunStepResumeState } from '@/types';
+
+const RUN_STEP_RESUME_STATE_KEY = '__librechat_run_step_resume_state';
+const RUN_STEP_RESUME_PAYLOAD_KEY = '__librechat_run_step_resume_payload';
+const RUN_STEP_RESUME_WRAPPER_KEY = '__librechat_run_step_resume_wrapper';
+
+type RunStepResumePayload = {
+  [RUN_STEP_RESUME_STATE_KEY]: RunStepResumeState;
+  [RUN_STEP_RESUME_PAYLOAD_KEY]: unknown;
+  [RUN_STEP_RESUME_WRAPPER_KEY]: 1;
+};
+
+export function isRunStepResumeState(
+  value: unknown
+): value is RunStepResumeState {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const state = value as Partial<RunStepResumeState>;
+  if (
+    state.version !== 1 ||
+    !Number.isSafeInteger(state.revision) ||
+    (state.revision ?? -1) < 0 ||
+    !Number.isSafeInteger(state.nextIndex) ||
+    (state.nextIndex ?? -1) < 0 ||
+    !Array.isArray(state.toolCallSteps) ||
+    !Array.isArray(state.steps)
+  ) {
+    return false;
+  }
+  const toolCallSteps = new Map<string, string>();
+  for (const reference of state.toolCallSteps as unknown[]) {
+    if (reference == null || typeof reference !== 'object') {
+      return false;
+    }
+    const { toolCallId, stepId } = reference as {
+      toolCallId?: unknown;
+      stepId?: unknown;
+    };
+    if (
+      typeof toolCallId !== 'string' ||
+      toolCallId === '' ||
+      typeof stepId !== 'string' ||
+      stepId === '' ||
+      toolCallSteps.has(toolCallId)
+    ) {
+      return false;
+    }
+    toolCallSteps.set(toolCallId, stepId);
+  }
+  const stepIds = new Set<string>();
+  for (const value of state.steps as unknown[]) {
+    if (value == null || typeof value !== 'object') {
+      return false;
+    }
+    const entry = value as Partial<RunStepResumeEntry>;
+    const step = entry.step;
+    if (
+      step == null ||
+      typeof step.id !== 'string' ||
+      step.id === '' ||
+      !Number.isSafeInteger(step.index) ||
+      step.index < 0 ||
+      !Array.isArray(entry.pendingToolCallIds) ||
+      entry.pendingToolCallIds.some(
+        (toolCallId) => typeof toolCallId !== 'string' || toolCallId === ''
+      ) ||
+      (entry.latestCompletionAt != null &&
+        !Number.isFinite(entry.latestCompletionAt)) ||
+      typeof entry.openMessageStep !== 'boolean' ||
+      entry.pendingToolCallIds.some(
+        (toolCallId) => toolCallSteps.get(toolCallId) !== step.id
+      ) ||
+      stepIds.has(step.id)
+    ) {
+      return false;
+    }
+    stepIds.add(step.id);
+  }
+  return true;
+}
+
+function isRunStepResumePayload(value: unknown): value is RunStepResumePayload {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const payload = value as Partial<RunStepResumePayload>;
+  return (
+    payload[RUN_STEP_RESUME_WRAPPER_KEY] === 1 &&
+    Object.prototype.hasOwnProperty.call(value, RUN_STEP_RESUME_PAYLOAD_KEY) &&
+    isRunStepResumeState(payload[RUN_STEP_RESUME_STATE_KEY])
+  );
+}
+
+export function attachRunStepResumeState(
+  payload: unknown,
+  state: RunStepResumeState
+): unknown {
+  const publicPayload = isRunStepResumePayload(payload)
+    ? payload[RUN_STEP_RESUME_PAYLOAD_KEY]
+    : payload;
+  return {
+    [RUN_STEP_RESUME_WRAPPER_KEY]: 1,
+    [RUN_STEP_RESUME_PAYLOAD_KEY]: publicPayload,
+    [RUN_STEP_RESUME_STATE_KEY]: state,
+  } satisfies RunStepResumePayload;
+}
+
+export function getRunStepResumeState(
+  payload: unknown
+): RunStepResumeState | undefined {
+  return isRunStepResumePayload(payload)
+    ? payload[RUN_STEP_RESUME_STATE_KEY]
+    : undefined;
+}
+
+export function stripRunStepResumeState(payload: unknown): unknown {
+  return isRunStepResumePayload(payload)
+    ? payload[RUN_STEP_RESUME_PAYLOAD_KEY]
+    : payload;
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -87,6 +87,7 @@ import type {
 import type { GraphFactory } from '@/graphs/graphFactory';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
+import { stripRunStepResumeState } from '@/tools/runStepResume';
 import {
   getSubagentApprovalExecutionScope,
   SubagentDefinitionBindingError,
@@ -654,11 +655,11 @@ function addSubagentScope(
   resumeManifest?: SubagentResumeManifest
 ): Interrupt[] {
   return interrupts.map((childInterrupt) => {
-    let payload = childInterrupt.value;
+    let payload = stripRunStepResumeState(childInterrupt.value);
     if (isToolApprovalPayload(payload)) {
       payload = {
-        ...childInterrupt.value,
-        subagent: childInterrupt.value.subagent ?? scope,
+        ...payload,
+        subagent: payload.subagent ?? scope,
       };
     }
     return {

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -2,7 +2,11 @@ import type { ToolCall, ToolMessage } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolOutputReferenceState } from '@/tools/toolOutputReferences';
 import type { ToolApprovalReplaySnapshot } from '@/hooks';
-import type { ToolSessionContext } from '@/types';
+import type { RunStepResumeState, ToolSessionContext } from '@/types';
+import {
+  isRunStepResumeState,
+  stripRunStepResumeState,
+} from '@/tools/runStepResume';
 
 export const SUBAGENT_RESUME_MANIFEST_CONFIG_KEY =
   '__librechat_subagent_resume_manifest';
@@ -57,6 +61,7 @@ export interface SubagentGraphResumeState {
   toolNodes: SubagentToolNodeResumeState[];
   eagerToolUsage: SubagentEagerToolUsageState[];
   eagerToolSuppressions: string[];
+  runStepState?: RunStepResumeState;
   toolOutputReferences?: ToolOutputReferenceState;
 }
 
@@ -291,6 +296,8 @@ function isGraphResumeState(value: unknown): value is SubagentGraphResumeState {
     !state.eagerToolUsage.every(isEagerToolUsageState) ||
     !Array.isArray(state.eagerToolSuppressions) ||
     !state.eagerToolSuppressions.every(isString) ||
+    (state.runStepState != null &&
+      !isRunStepResumeState(state.runStepState)) ||
     (state.toolOutputReferences != null &&
       !isToolOutputReferenceState(state.toolOutputReferences))
   ) {
@@ -412,6 +419,7 @@ function isSubagentResumeManifest(
 export function getSubagentResumeManifest(
   payload: unknown
 ): SubagentResumeManifest | undefined {
+  payload = stripRunStepResumeState(payload);
   if (payload == null || typeof payload !== 'object') {
     return undefined;
   }
@@ -512,6 +520,7 @@ export function attachSubagentResumeManifest(
 }
 
 export function stripSubagentResumeManifest(payload: unknown): unknown {
+  payload = stripRunStepResumeState(payload);
   if (isWrappedSubagentResumePayload(payload)) {
     return payload[SUBAGENT_RESUME_WRAPPED_PAYLOAD_KEY];
   }

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -4,6 +4,8 @@ import type { ToolOutputReferenceState } from '@/tools/toolOutputReferences';
 import type { ToolApprovalReplaySnapshot } from '@/hooks';
 import type { RunStepResumeState, ToolSessionContext } from '@/types';
 import {
+  attachRunStepResumeState,
+  getRunStepResumeState,
   isRunStepResumeState,
   stripRunStepResumeState,
 } from '@/tools/runStepResume';
@@ -497,6 +499,16 @@ export function attachSubagentResumeManifest(
   payload: unknown,
   manifest: SubagentResumeManifest
 ): object {
+  const runStepState = getRunStepResumeState(payload);
+  if (runStepState != null) {
+    return attachRunStepResumeState(
+      attachSubagentResumeManifest(
+        stripRunStepResumeState(payload),
+        manifest
+      ),
+      runStepState
+    );
+  }
   if (
     isWrappedSubagentResumePayload(payload) ||
     isInlineSubagentResumePayload(payload)

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   RunStep,
   RunStepDeltaEvent,
+  RunStepResumeState,
   RunStepClosedEvent,
   MessageDeltaEvent,
   ReasoningDeltaEvent,
@@ -76,6 +77,7 @@ export type SystemCallbacks = {
 
 export type BaseGraphState = {
   messages: BaseMessage[];
+  runStepState?: RunStepResumeState;
 };
 
 export type AgentSubgraphState = BaseGraphState & {

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -103,6 +103,23 @@ export type RunStep = {
   // };
 };
 
+/** Minimal durable lifecycle state needed to continue open run steps. */
+export interface RunStepResumeEntry {
+  step: RunStep;
+  pendingToolCallIds: string[];
+  latestCompletionAt?: number;
+  openMessageStep: boolean;
+}
+
+/** SDK-private state persisted in LangGraph checkpoints for process-safe resume. */
+export interface RunStepResumeState {
+  version: 1;
+  revision: number;
+  nextIndex: number;
+  toolCallSteps: Array<{ toolCallId: string; stepId: string }>;
+  steps: RunStepResumeEntry[];
+}
+
 /**
  * Represents a run step delta i.e. any changed fields on a run step during
  * streaming.

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,10 +1,17 @@
 // src/types/tools.ts
 import type { StructuredToolInterface } from '@langchain/core/tools';
-import type { RunnableToolLike } from '@langchain/core/runnables';
+import type {
+  RunnableConfig,
+  RunnableToolLike,
+} from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type { RunBreakerScope } from '@/llm/streamLimits';
-import type { MessageContentComplex, ToolErrorData } from './stream';
+import type {
+  MessageContentComplex,
+  RunStepResumeState,
+  ToolErrorData,
+} from './stream';
 import type { HumanInTheLoopConfig } from './hitl';
 import type { LangfuseConfig } from './graph';
 import type { HookRegistry } from '@/hooks';
@@ -276,6 +283,13 @@ export type ToolNodeOptions = {
    * controller.
    */
   getRunScope?: () => RunBreakerScope;
+  /** SDK-owned checkpoint bridge for open run-step lifecycle state. */
+  restoreRunStepResumeState?: (
+    state?: RunStepResumeState,
+    config?: RunnableConfig
+  ) => void;
+  /** SDK-owned checkpoint snapshot for open run-step lifecycle state. */
+  createRunStepResumeState?: () => RunStepResumeState;
 };
 
 export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;


### PR DESCRIPTION
## Summary

I fixed AI-1797 by making open run-step lifecycle state durable across process boundaries so fresh SDK instances can resume checkpointed runs without leaving orphaned `in_progress` steps.

- Persist versioned run-step state through standard, multi-agent, and subagent LangGraph checkpoints.
- Rehydrate original step IDs, indices, timestamps, pending tool-call membership, and message-step ownership before resume execution.
- Preserve completed sibling tool mappings so replayed tool batches remain idempotent.
- Keep checkpoint metadata private by wrapping persisted interrupt payloads and stripping the wrapper from the public SDK surface.
- Restore nested subgraph interrupt state when `Run.resume` rebuilds a run on a fresh process.
- Add regression coverage proving the original step closes exactly once after a cross-process resume.
- Preserve Langfuse ParentCommand, GraphInterrupt, and observation-shaping behavior.

Related: AI-1797

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I rebased the changes onto the latest `origin/main` and ran focused lifecycle, HITL, subagent, and tracing validation.

- `npm run build`
- `npx tsc --noEmit`
- `npx eslint src/graphs/Graph.ts src/graphs/MultiAgentGraph.ts src/run.ts src/specs/run-step-timestamps.test.ts src/tools/ToolNode.ts src/tools/__tests__/hitl.test.ts src/tools/subagent/SubagentReplay.ts src/tools/runStepResume.ts src/types/graph.ts src/types/stream.ts src/types/tools.ts`
- `npx jest src/specs/run-step-timestamps.test.ts src/graphs/__tests__/Graph.closeRunStep.test.ts src/specs/tool-error-resume.test.ts src/graphs/__tests__/Graph.subagentResumeState.test.ts src/tools/__tests__/SubagentReplay.test.ts src/tools/__tests__/hitl.test.ts langfuse deterministic-trace-id --runInBand`

### **Test Configuration**:

- Node.js: workspace runtime
- Test suites: 17 passed
- Tests: 284 passed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes