### PR TITLE
🐛 fix: Close A Self-Limited Child's Steps As `failed`, Not `cancelled`

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -161,6 +161,7 @@ import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
 import { shouldTriggerSummarization } from '@/summarization';
+import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
 import { messagesStateReducer } from '@/messages/reducer';
@@ -168,7 +169,6 @@ import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
 import { handleToolCalls } from '@/tools/handlers';
-import { isRunStepResumeState } from '@/tools/runStepResume';
 import { isThinkingEnabled } from '@/llm/request';
 import { resolveMaxSeals } from '@/llm/preempt';
 import { initializeModel } from '@/llm/init';
@@ -1800,9 +1800,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       version: 1,
       revision: this.runStepStateRevision,
       nextIndex: this.nextContentIndex,
-      toolCallSteps: [...this.toolCallStepIds].map(
-        ([toolCallId, stepId]) => ({ toolCallId, stepId })
-      ),
+      toolCallSteps: [...this.toolCallStepIds].map(([toolCallId, stepId]) => ({
+        toolCallId,
+        stepId,
+      })),
       steps,
     };
   }
@@ -1836,10 +1837,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         this.pendingToolCallsByStep.set(runStep.id, pending);
       }
       if (entry.latestCompletionAt != null) {
-        this.latestCompletionByStep.set(
-          runStep.id,
-          entry.latestCompletionAt
-        );
+        this.latestCompletionByStep.set(runStep.id, entry.latestCompletionAt);
       }
       if (entry.openMessageStep) {
         this.openMessageStepByAgent.set(runStep.agentId ?? '', runStep.id);
@@ -1964,10 +1962,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /**
    * Closes a run step: stamps its terminal status + timestamp on the stored
    * `RunStep` and emits `ON_RUN_STEP_CLOSED`. First close wins — later calls
-   * are no-ops — except a `restamp` close, which lets a `completed`
-   * TOOL_CALLS step refresh `completed_at` when a late-registered parallel
-   * tool call finishes after the step already closed (the eager-execution
-   * race). `cancelled`/`failed` are immutable once stamped.
+   * are no-ops with no exceptions; every terminal status is immutable once
+   * stamped. (A `restamp` option once let a completed TOOL_CALLS step
+   * refresh `completed_at` for the eager-execution race, but that race is
+   * unreachable — each step registers its calls before any completion can
+   * reference it — and the mechanism was removed.)
    */
   async closeRunStep(
     stepId: string,
@@ -4990,10 +4989,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       .addNode(agentNode, (state, config) =>
         invokeWithRunStepState(state, config, () => callModel(state, config))
       )
-      .addNode(
-        toolNode,
-        callTools
-      )
+      .addNode(toolNode, callTools)
       .addNode(
         summarizeNode,
         createSummarizeNode({

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -814,6 +814,85 @@ describe('SubagentExecutor', () => {
     ).rejects.toBeInstanceOf(StreamLimitExceededError);
   });
 
+  it('closes child steps as \'failed\' when the child trips its own stream limit', async () => {
+    /**
+     * The closure sweep runs AFTER the catch block self-aborts the child
+     * breaker, so deriving the status from the live signal relabels the
+     * child's own limit failure as an intentional stop — while the parent
+     * stamps 'failed' for the same incident. The status must come from the
+     * pre-error snapshot.
+     */
+    const closeUnfinishedRunSteps = jest.fn();
+    const executor = createExecutor({
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockRejectedValue(
+              new StreamLimitExceededError({
+                kind: 'tool_call_args',
+                limit: 10,
+                observed: 11,
+                toolName: 'db_query',
+              })
+            ),
+          }),
+          closeUnfinishedRunSteps,
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    await expect(
+      executor.execute({
+        description: 'Do something',
+        subagentType: 'researcher',
+      })
+    ).rejects.toBeInstanceOf(StreamLimitExceededError);
+    expect(closeUnfinishedRunSteps).toHaveBeenCalledWith(
+      'failed',
+      expect.any(Number)
+    );
+  });
+
+  it('closes child steps as \'cancelled\' when the abort preceded the error', async () => {
+    /** The counterpart bound: a child that dies BECAUSE it was already
+     * aborted (caller abort, sibling breaker trip) is an intentional stop,
+     * and must keep reading as 'cancelled' under the snapshot. */
+    const closeUnfinishedRunSteps = jest.fn();
+    const batchBreaker = new AbortController();
+    let releaseChild: (() => void) | undefined;
+    const executor = createExecutor({
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(
+              () =>
+                new Promise((_resolve, reject) => {
+                  releaseChild = (): void =>
+                    reject(new Error('aborted mid-flight'));
+                })
+            ),
+          }),
+          closeUnfinishedRunSteps,
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const pending = executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+      breaker: batchBreaker,
+    });
+    while (releaseChild == null) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    batchBreaker.abort();
+    releaseChild();
+    const result = await pending;
+    expect(result.content).toContain('Subagent error');
+    expect(closeUnfinishedRunSteps).toHaveBeenCalledWith(
+      'cancelled',
+      expect.any(Number)
+    );
+  });
+
   it('binds the child to the batch-captured controller, not the live scope', async () => {
     const batchBreaker = new AbortController();
     const liveBreaker = new AbortController();
@@ -1625,9 +1704,7 @@ describe('SubagentExecutor', () => {
       agentInputs: {
         ...makeChildInputs('selected-agent'),
         codeSessionKey,
-        initialSessions: new Map([
-          [Constants.EXECUTE_CODE, seededSession],
-        ]),
+        initialSessions: new Map([[Constants.EXECUTE_CODE, seededSession]]),
       },
     });
     const childSessions: ToolSessionMap = new Map();

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -87,7 +87,6 @@ import type {
 import type { GraphFactory } from '@/graphs/graphFactory';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
-import { stripRunStepResumeState } from '@/tools/runStepResume';
 import {
   getSubagentApprovalExecutionScope,
   SubagentDefinitionBindingError,
@@ -125,6 +124,7 @@ import {
   createChildGraphPlan,
   isGraphSubagentConfig,
 } from './childGraphConfig';
+import { stripRunStepResumeState } from '@/tools/runStepResume';
 import { seedAgentInitialSessions } from '@/utils/toolSessions';
 import { stableStringify } from '@/tools/eagerEventExecution';
 import { composeAbortSignals } from '@/utils/misc';
@@ -2450,6 +2450,18 @@ export class SubagentExecutor {
     } catch (error) {
       /** Stamped at failure, not after the error-envelope work below. */
       const childTerminalAt = Date.now();
+      /**
+       * Captured at catch entry, BEFORE the self-abort below flips it. The
+       * closure sweep distinguishes "stopped on purpose" from "died of this
+       * error" by whether the child was already aborted when the error
+       * arrived — reading the signal after `childBreaker.abort(error)` would
+       * relabel the child's own stream-limit failure as an intentional stop
+       * (`cancelled`), while the parent stamps `failed` for the same
+       * incident. A trip that arrived from a parallel sibling has already
+       * aborted the composed signal by this point, so it still reads as
+       * `cancelled` here.
+       */
+      const abortedBeforeError = childSignal.aborted;
       if (isGraphInterrupt(error)) {
         const activeChildRun = execution.activeRun;
         if (activeChildRun != null) {
@@ -2488,11 +2500,13 @@ export class SubagentExecutor {
       /**
        * `cancelled` vs `failed` mirrors `Run.resolveSweepStatus`: an aborted
        * child was stopped on purpose (caller abort, or a breaker trip from a
-       * parallel sibling), anything else died of an unexpected error.
+       * parallel sibling), anything else died of an unexpected error. Uses
+       * the pre-error snapshot, not the live signal — the self-abort above
+       * has already tripped it for the child's own limit error.
        */
       await this.closeChildRunSteps(
         childGraph,
-        childSignal.aborted ? 'cancelled' : 'failed',
+        abortedBeforeError ? 'cancelled' : 'failed',
         childTerminalAt
       );
       if (forwarding) {


### PR DESCRIPTION
## Summary

Follow-up to #417, from a structured review of the v3.6.0 run-step lifecycle work. Two commits: a status-mislabel fix and a stale-contract doc removal.

### The fix (`aa26ef46`)

A child subagent that trips **its own** stream limit had its run steps closed as `cancelled`. The catch block self-aborts the child breaker *before* the closure sweep reads the composed signal:

```ts
if (error instanceof StreamLimitExceededError) {
  childBreaker.abort(error);        // flips childSignal.aborted
}
await this.closeChildRunSteps(
  childGraph,
  childSignal.aborted ? 'cancelled' : 'failed',   // reads it after → always 'cancelled'
  childTerminalAt
);
```

So the child's own failure reported as an intentional stop — while the parent, whose `resolveSweepStatus` this code is documented to mirror, stamps `failed` for the same incident. One error, contradictory terminal statuses; and in the LibreChat UI that consumes these statuses (#14871/#14873), a genuine limit failure renders as a user cancellation.

The status now derives from a snapshot of `childSignal.aborted` captured at catch entry, before the self-abort. The intentional cases are preserved: a trip arriving from a parallel sibling (or a caller abort) has already aborted the composed signal by the time the error lands, so those still read `cancelled`.

### The docs commit (`c5b7287a`)

`closeRunStep`'s JSDoc promised a `restamp` close that refreshes a completed TOOL_CALLS step's `completed_at` in the eager-execution race — but `RunStepCloseOptions` carries no such option and the implementation unconditionally refuses any second close; the mechanism was dropped as unreachable in the PR that introduced the doc. Removed so nobody designs around behavior that never happens.

## Testing

Two new tests in `SubagentExecutor.test.ts` pin both bounds:

- **`closes child steps as 'failed' when the child trips its own stream limit`** — fails against the previous code with exactly the mislabel (`Expected: "failed" / Received: "cancelled"`), verified by stashing the fix and re-running.
- **`closes child steps as 'cancelled' when the abort preceded the error`** — the batch breaker aborts mid-flight before the child rejects; the intentional-stop path keeps reading `cancelled` under the snapshot.

Full file suite: **109/109**. `npx tsc --noEmit` clean; eslint/prettier/import-sort clean via the commit hooks.

Related issues filed from the same review, not addressed here: AI-1811 (closed-handler dispatch isolation), AI-1812 (`AgentSession` closeStep duplication), AI-1813 (non-streaming final-step race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5)_