### PR TITLE
🔐 fix: Seal Responses Reasoning Items Per Item On Interrupt

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -43,6 +43,7 @@ import type { SeenScalarMetadata } from './streamMetadata';
 import type { HeaderValue, HeadersLike } from './types';
 import type { PromptCacheTtl } from '@/messages/cache';
 import {
+  OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY,
   OPENAI_RESPONSES_REPLAY_POSITIONS_KEY,
   projectOpenAIResponsesToolMessageContent,
   projectToolStreamContentForProvider,
@@ -606,6 +607,85 @@ function isResponsesReplayOutputItem(item: unknown): boolean {
   );
 }
 
+type ResponsesReasoningSlot = {
+  encrypted_content?: string;
+  id?: string;
+  status?: string;
+};
+
+function getResponsesReasoningSlot(
+  reasoning: unknown
+): ResponsesReasoningSlot | undefined {
+  return typeof reasoning === 'object' && reasoning != null
+    ? (reasoning as ResponsesReasoningSlot)
+    : undefined;
+}
+
+function isSealedReasoningSlot(
+  slot: ResponsesReasoningSlot | undefined
+): slot is ResponsesReasoningSlot & { encrypted_content: string } {
+  return (
+    typeof slot?.encrypted_content === 'string' &&
+    slot.encrypted_content.length > 0
+  );
+}
+
+function resolveActiveReasoningItemId(
+  incoming: ResponsesReasoningSlot | undefined,
+  carried: unknown
+): string | undefined {
+  if (typeof incoming?.id === 'string' && incoming.id.length > 0) {
+    return incoming.id;
+  }
+  return typeof carried === 'string' ? carried : undefined;
+}
+
+/**
+ * A single `additional_kwargs.reasoning` slot has to stand in for a turn that
+ * can emit many reasoning items, and the chunk merge folds it field by field:
+ * `encrypted_content` and `status` are strings, so they concatenate, while
+ * `id` takes whichever item arrived last. An interrupted turn replays from
+ * that slot, handing the provider one item id welded to every item's
+ * ciphertext — rejected as "Encrypted content could not be decrypted or
+ * parsed". Keep the slot describing whichever item most recently sealed, so
+ * the id, its ciphertext, and its status always come from the same item.
+ *
+ * `activeItemId` tracks the item currently streaming, which is the one a
+ * terminal `encrypted_content` belongs to: the slot's own id has already been
+ * pinned back to the last sealed item by an earlier merge.
+ */
+function resealReasoningItemBoundary(
+  combined: AIMessageChunk,
+  accumulated: ResponsesReasoningSlot | undefined,
+  incoming: ResponsesReasoningSlot | undefined,
+  activeItemId: string | undefined
+): void {
+  const merged = getResponsesReasoningSlot(
+    combined.additional_kwargs.reasoning
+  );
+  if (merged == null || incoming == null) {
+    return;
+  }
+  if (isSealedReasoningSlot(incoming)) {
+    combined.additional_kwargs.reasoning = {
+      ...merged,
+      id: activeItemId ?? merged.id,
+      encrypted_content: incoming.encrypted_content,
+      status: incoming.status,
+    };
+    return;
+  }
+  if (!isSealedReasoningSlot(accumulated)) {
+    return;
+  }
+  combined.additional_kwargs.reasoning = {
+    ...merged,
+    id: accumulated.id,
+    encrypted_content: accumulated.encrypted_content,
+    status: accumulated.status,
+  };
+}
+
 /**
  * LangChain's Responses converter places the authoritative terminal output in
  * response_metadata.output. Its chunk merge has no way to delete provisional
@@ -619,10 +699,26 @@ class ResponsesReplayAIMessageChunk extends AIMessageChunk {
   }
 
   override concat(chunk: AIMessageChunk): this {
+    const accumulated = getResponsesReasoningSlot(
+      this.additional_kwargs.reasoning
+    );
+    const incoming = getResponsesReasoningSlot(
+      chunk.additional_kwargs.reasoning
+    );
+    const activeItemId = resolveActiveReasoningItemId(
+      incoming,
+      this.additional_kwargs[OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY]
+    );
     const combined = super.concat(chunk);
+    resealReasoningItemBoundary(combined, accumulated, incoming, activeItemId);
+    if (activeItemId != null) {
+      combined.additional_kwargs[OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY] =
+        activeItemId;
+    }
     if (!Array.isArray(chunk.response_metadata.output)) {
       return combined;
     }
+    delete combined.additional_kwargs[OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY];
     delete combined.additional_kwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY];
     const toolOutputs = combined.additional_kwargs.tool_outputs;
     if (!Array.isArray(toolOutputs)) {

--- a/src/llm/openai/reasoning-replay.spec.ts
+++ b/src/llm/openai/reasoning-replay.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * An interrupted Responses turn never receives `response.completed`, so it has
+ * no authoritative `response_metadata.output` to replay from. The only record
+ * of its reasoning is the `additional_kwargs.reasoning` slot, which chunk
+ * concatenation merges field-by-field. That slot holds one item, but a turn
+ * can emit many: without a per-item boundary the merge welds every item's
+ * `encrypted_content` into a single blob and pairs it with the last item's id,
+ * which the provider rejects with "Encrypted content could not be decrypted or
+ * parsed."
+ */
+import { concat } from '@langchain/core/utils/stream';
+import { convertMessagesToResponsesInput } from '@langchain/openai';
+import { HumanMessage } from '@langchain/core/messages';
+import type { OpenAIClient } from '@langchain/openai';
+import type { AIMessageChunk } from '@langchain/core/messages';
+import { ChatOpenAI } from '@/llm/openai';
+
+type StreamingResponsesDelegate = {
+  completionWithRetry: (
+    request: OpenAIClient.Responses.ResponseCreateParamsStreaming
+  ) => Promise<
+    AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent> | undefined
+  >;
+};
+
+type ReasoningItemFixture = {
+  id: string;
+  encryptedContent?: string;
+};
+
+const ENCRYPTED_CONTENT_BY_ID = new Map([
+  ['rs_first', 'ENCRYPTED_FIRST'],
+  ['rs_second', 'ENCRYPTED_SECOND'],
+  ['rs_third', 'ENCRYPTED_THIRD'],
+]);
+
+function* interruptedReasoningEvents(
+  items: readonly ReasoningItemFixture[]
+): Generator<OpenAIClient.Responses.ResponseStreamEvent> {
+  let sequence = 0;
+  let outputIndex = 0;
+  for (const item of items) {
+    yield {
+      type: 'response.output_item.added',
+      sequence_number: sequence++,
+      output_index: outputIndex,
+      item: {
+        id: item.id,
+        type: 'reasoning',
+        status: 'in_progress',
+        summary: [],
+      },
+    } as OpenAIClient.Responses.ResponseStreamEvent;
+    if (item.encryptedContent == null) {
+      outputIndex++;
+      continue;
+    }
+    yield {
+      type: 'response.output_item.done',
+      sequence_number: sequence++,
+      output_index: outputIndex,
+      item: {
+        id: item.id,
+        type: 'reasoning',
+        status: 'completed',
+        summary: [],
+        encrypted_content: item.encryptedContent,
+      },
+    } as OpenAIClient.Responses.ResponseStreamEvent;
+    outputIndex++;
+  }
+  yield {
+    type: 'response.output_item.added',
+    sequence_number: sequence++,
+    output_index: outputIndex,
+    item: {
+      id: 'msg_interrupted',
+      type: 'message',
+      role: 'assistant',
+      status: 'in_progress',
+      content: [],
+    },
+  } as OpenAIClient.Responses.ResponseStreamEvent;
+  yield {
+    type: 'response.output_text.delta',
+    sequence_number: sequence++,
+    output_index: outputIndex,
+    content_index: 0,
+    item_id: 'msg_interrupted',
+    delta: 'Partial answer.',
+    logprobs: [],
+  } as OpenAIClient.Responses.ResponseStreamEvent;
+  /** The user interrupted here: no `response.completed`, no terminal output. */
+}
+
+async function streamInterruptedTurn(
+  items: readonly ReasoningItemFixture[]
+): Promise<AIMessageChunk> {
+  const model = new ChatOpenAI({
+    model: 'gpt-5.6',
+    apiKey: 'test-key',
+    useResponsesApi: true,
+  });
+  const responses = (
+    model as unknown as { responses: StreamingResponsesDelegate }
+  ).responses;
+  responses.completionWithRetry = async () =>
+    (async function* () {
+      yield* interruptedReasoningEvents(items);
+    })();
+
+  let aggregate: AIMessageChunk | undefined;
+  for await (const chunk of await model.stream([
+    new HumanMessage('tell me a long story'),
+  ])) {
+    aggregate = aggregate == null ? chunk : concat(aggregate, chunk);
+  }
+  if (aggregate == null) {
+    throw new Error('Expected the interrupted stream to yield chunks');
+  }
+  return aggregate;
+}
+
+function replayedReasoningItems(
+  message: AIMessageChunk
+): OpenAIClient.Responses.ResponseReasoningItem[] {
+  return convertMessagesToResponsesInput({
+    messages: [message],
+    model: 'gpt-5.6',
+    zdrEnabled: false,
+  }).filter(
+    (item): item is OpenAIClient.Responses.ResponseReasoningItem =>
+      item.type === 'reasoning'
+  );
+}
+
+describe('interrupted Responses reasoning replay', () => {
+  it.each([
+    [
+      'every reasoning item completed before the interrupt',
+      [
+        { id: 'rs_first', encryptedContent: 'ENCRYPTED_FIRST' },
+        { id: 'rs_second', encryptedContent: 'ENCRYPTED_SECOND' },
+        { id: 'rs_third', encryptedContent: 'ENCRYPTED_THIRD' },
+      ],
+      'rs_third',
+    ],
+    [
+      'the interrupt landed inside a later reasoning item',
+      [
+        { id: 'rs_first', encryptedContent: 'ENCRYPTED_FIRST' },
+        { id: 'rs_second', encryptedContent: 'ENCRYPTED_SECOND' },
+        { id: 'rs_third' },
+      ],
+      'rs_second',
+    ],
+    [
+      'the interrupt landed inside the second reasoning item',
+      [
+        { id: 'rs_first', encryptedContent: 'ENCRYPTED_FIRST' },
+        { id: 'rs_second' },
+      ],
+      'rs_first',
+    ],
+  ] as [string, ReasoningItemFixture[], string][])(
+    'replays the last sealed item intact when %s',
+    async (_label, items, expectedSealedId) => {
+      const message = await streamInterruptedTurn(items);
+      const replayed = replayedReasoningItems(message);
+
+      const encrypted = replayed.filter(
+        (item) => item.encrypted_content != null
+      );
+      expect(encrypted).toHaveLength(1);
+      expect(encrypted[0].id).toBe(expectedSealedId);
+      expect(encrypted[0].encrypted_content).toBe(
+        ENCRYPTED_CONTENT_BY_ID.get(expectedSealedId)
+      );
+
+      /** Ids the provider cannot resolve must never ride along bare. */
+      for (const item of replayed) {
+        expect(item.encrypted_content).toBe(
+          ENCRYPTED_CONTENT_BY_ID.get(item.id)
+        );
+      }
+    }
+  );
+
+  it('keeps the replayed status a single provider-legal value', async () => {
+    const message = await streamInterruptedTurn([
+      { id: 'rs_first', encryptedContent: 'ENCRYPTED_FIRST' },
+      { id: 'rs_second', encryptedContent: 'ENCRYPTED_SECOND' },
+      { id: 'rs_third', encryptedContent: 'ENCRYPTED_THIRD' },
+    ]);
+
+    for (const item of replayedReasoningItems(message)) {
+      if (item.status == null) {
+        continue;
+      }
+      expect(['completed', 'in_progress', 'incomplete']).toContain(item.status);
+    }
+  });
+
+  it('still replays reasoning when the turn emitted a single item', async () => {
+    const message = await streamInterruptedTurn([
+      { id: 'rs_first', encryptedContent: 'ENCRYPTED_FIRST' },
+    ]);
+
+    const replayed = replayedReasoningItems(message);
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0].id).toBe('rs_first');
+    expect(replayed[0].encrypted_content).toBe('ENCRYPTED_FIRST');
+  });
+});

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -671,6 +671,10 @@ type ResponsesReplayProjection = 'fallback' | 'native';
 export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
   '__openai_responses_replay_positions__';
 
+/** Reasoning item currently streaming, so a terminal ciphertext seals against its own id. */
+export const OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY =
+  '__openai_responses_active_reasoning_id__';
+
 export type ResponsesReplayPosition = {
   contentIndex?: number;
   itemId: string;
@@ -1813,6 +1817,7 @@ function projectPreemptedOpenAIResponsesMessage(
   }
   delete additionalKwargs.tool_outputs;
   delete additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY];
+  delete additionalKwargs[OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY];
   delete additionalKwargs.__openai_function_call_ids__;
   delete additionalKwargs.__openai_custom_tool_call_ids__;
 

--- a/src/specs/preemptSeal.test.ts
+++ b/src/specs/preemptSeal.test.ts
@@ -675,4 +675,133 @@ describe('cooperative seal (end-to-end via Run)', () => {
     expect(resumedInput).not.toContain('rs_interrupted');
     expect(run.getHaltReason()).toBeUndefined();
   });
+
+  /**
+   * A reasoning turn can seal one item and be interrupted inside the next.
+   * Both items share the single `additional_kwargs.reasoning` slot, so the
+   * merge used to hand the steered request the second item's id carrying the
+   * first item's ciphertext — accepted by every local guard and rejected by
+   * the provider as "Encrypted content could not be decrypted or parsed".
+   */
+  it('steers a multi-item reasoning turn without welding ciphertexts together', async () => {
+    const run = await createSealRun({
+      runId: 'seal-openai-responses-multi-reasoning',
+      hook: async () => ({
+        injectedMessages: [
+          { role: 'user' as const, content: 'what inspired you', source: 'steer' },
+        ],
+      }),
+      responses: [],
+    });
+    const model = new ChatOpenAI({
+      model: 'gpt-5.6',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = (
+      model as unknown as { responses: StreamingResponsesDelegate }
+    ).responses;
+    const requests: OpenAIClient.Responses.ResponseCreateParamsStreaming[] = [];
+    responses.completionWithRetry = async (request) => {
+      requests.push(request);
+      const invocation = requests.length;
+      return (async function* () {
+        if (invocation !== 1) {
+          yield {
+            type: 'response.output_text.delta',
+            sequence_number: 0,
+            output_index: 0,
+            content_index: 0,
+            item_id: 'msg_resumed',
+            delta: RESUMED_RESPONSE,
+            logprobs: [],
+          } as OpenAIClient.Responses.ResponseStreamEvent;
+          return;
+        }
+        yield {
+          type: 'response.output_item.added',
+          sequence_number: 0,
+          output_index: 0,
+          item: {
+            id: 'rs_sealed',
+            type: 'reasoning',
+            status: 'in_progress',
+            summary: [],
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.done',
+          sequence_number: 1,
+          output_index: 0,
+          item: {
+            id: 'rs_sealed',
+            type: 'reasoning',
+            status: 'completed',
+            summary: [],
+            encrypted_content: 'CIPHERTEXT_SEALED',
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.added',
+          sequence_number: 2,
+          output_index: 1,
+          item: {
+            id: 'rs_inflight',
+            type: 'reasoning',
+            status: 'in_progress',
+            summary: [],
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_item.added',
+          sequence_number: 3,
+          output_index: 2,
+          item: {
+            id: 'msg_interrupted',
+            type: 'message',
+            role: 'assistant',
+            status: 'in_progress',
+            content: [],
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+        yield {
+          type: 'response.output_text.delta',
+          sequence_number: 4,
+          output_index: 2,
+          content_index: 0,
+          item_id: 'msg_interrupted',
+          delta: 'Partial answer.',
+          logprobs: [],
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+    };
+    run.Graph!.overrideModel = model;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    expect(requests).toHaveLength(2);
+    const resumedInput = requests[1].input;
+    if (resumedInput == null || typeof resumedInput === 'string') {
+      throw new Error('Expected a structured Responses input on resume');
+    }
+    const replayedReasoning = resumedInput.filter(
+      (item): item is OpenAIClient.Responses.ResponseReasoningItem =>
+        typeof item === 'object' && item.type === 'reasoning'
+    );
+
+    expect(replayedReasoning).not.toHaveLength(0);
+    for (const item of replayedReasoning) {
+      if (item.encrypted_content == null) {
+        continue;
+      }
+      expect(item.id).toBe('rs_sealed');
+      expect(item.encrypted_content).toBe('CIPHERTEXT_SEALED');
+    }
+    /** The interrupted item never completed, so its id is unresolvable. */
+    expect(JSON.stringify(resumedInput)).not.toContain('rs_inflight');
+    expect(run.getHaltReason()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Interrupting a `gpt-5.6` turn that emitted **more than one reasoning item** makes the **next** request fail with:

```
400 The encrypted content for item rs_... could not be verified.
Reason: Encrypted content could not be decrypted or parsed.
```

**Verified live against `gpt-5.6-terra`** — reproduced and then fixed end to end (details below).

## When this fires

A single Responses turn emits multiple reasoning items whenever a **server-side tool** interleaves with reasoning — `web_search`, `code_interpreter`, `image_generation`. Live, one `web_search` request produced ~10 reasoning items in one turn:

```
added:reasoning:rs_…be64  → done:reasoning:rs_…be64
added:web_search_call:ws_…c063 → done:web_search_call:ws_…c063
added:reasoning:rs_…c7de  → done:reasoning:rs_…c7de
… (repeats) …
added:message:msg_…fffe  → *** interrupt lands here ***
```

A plain no-tool turn emits a single reasoning item (confirmed live) and is unaffected, no matter how long the answer is. Multiple *summary parts* within one item are also fine — it is multiple **items** that break.

## Root cause

An interrupted turn never receives `response.completed`, so it has no authoritative `response_metadata.output` and replays from the single `additional_kwargs.reasoning` slot instead.

That one slot has to stand in for a turn that can emit **many** reasoning items, and the chunk merge folds it field by field:

| field | merge result across N items |
|---|---|
| `id` | last wins |
| `status` | concatenated — `"completedcompleted…"` |
| `encrypted_content` | concatenated — every item's ciphertext welded together |

The replay then hands the provider one item id paired with a blob that is not that item's ciphertext. Live, the welded blob measured **27,012 chars** against ~1,700 for a single item.

Completed turns are unaffected: the authoritative terminal output wins over the slot. Claude models are unaffected: Anthropic stores `encrypted_content` per content block and assigns rather than appends.

The nastiest shape is an interrupt landing *inside* the second item — `status` stays a single legal `'completed'` while `encrypted_content` still belongs to the first item. That passes every local guard including `hasReplayableEncryptedReasoning`; only the provider catches it.

## Fix

- Track the reasoning item currently streaming so a terminal `encrypted_content` seals against **its own** id.
- Keep the slot describing whichever item most recently sealed, so `id`, ciphertext, and `status` always come from the same item.
- Items that never completed no longer replay a bare, unresolvable id.

## Live verification

Real `gpt-5.6-terra`, `store: false`, `include: ['reasoning.encrypted_content']`, `web_search` bound, interrupted mid-answer, then the accumulated message replayed to a real follow-up request:

| | accumulated `encrypted_content` | replay result |
|---|---|---|
| before | 27,012 chars (many items welded) | `400 … could not be verified` — **reported error reproduced** |
| after | 3,428 chars (one intact item) | **accepted**, model answered normally |

## Tests

`src/llm/openai/reasoning-replay.spec.ts` (new) drives the real stream pipeline across three interrupt shapes and asserts exactly one intact item replays, paired with its own id.

`src/specs/preemptSeal.test.ts` gains an end-to-end interrupt-then-steer case that inspects the actual resumed provider payload.

Both were verified to fail without the fix — the steer test sends `rs_inflight` carrying `rs_sealed`'s ciphertext.

Full suite: 4225 passing. The only failures (`anthropic`/`google`/`vertexai` `llm.spec.ts`) fail identically on `main` — credential-gated live tests.

## Not fixed upstream

Checked against latest published, not our pins (we are on `@langchain/openai@1.5.5` / `@langchain/core@1.2.3`):

| package | latest | relevant behavior |
|---|---|---|
| `@langchain/openai` | 1.5.8 | still returns `null` for `response.output_item.done` on a reasoning item, so our own `convertDroppedResponsesReplayOutput` fallback is what writes `encrypted_content` into the slot |
| `@langchain/core` | 1.2.8 | chunk merge still string-concatenates |

A dependency bump does not address this, and upstream never sees the field, so the per-item boundary belongs here.
