### PR TITLE
🐛 fix: Isolate The `ON_RUN_STEP_CLOSED` Handler Dispatch

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/agents/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/agents/node_modules

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2024,12 +2024,36 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       GraphEvents.ON_RUN_STEP_CLOSED
     );
     if (handler) {
-      await handler.handle(
-        GraphEvents.ON_RUN_STEP_CLOSED,
-        closedEvent,
-        options?.metadata,
-        this
-      );
+      /**
+       * Isolated, unlike the other dual-dispatch sites, because this one
+       * reports state that is already committed: the step was stamped
+       * terminal and untracked above, and nothing a failed delivery can do
+       * will undo that. Propagating instead costs two things.
+       *
+       * First, it fails an entire run over an observational event —
+       * `closeOpenMessageStep` awaits this inside the stream loop on every
+       * CHAT_MODEL_END, where a rejection sets `streamThrew` and fires the
+       * StopFailure hooks for a response that was fully delivered.
+       *
+       * Second, and worse, it skips the secondary custom-event dispatch
+       * below. That channel exists precisely as the fallback for when the
+       * primary path does not deliver, so letting the primary's failure
+       * suppress it removes the redundancy exactly when it is needed.
+       *
+       * `closeUnfinishedRunSteps` and `dispatchRunStep` already wrap their
+       * own calls for the same reason; this closes the gap inside, which
+       * those wrappers cannot reach.
+       */
+      try {
+        await handler.handle(
+          GraphEvents.ON_RUN_STEP_CLOSED,
+          closedEvent,
+          options?.metadata,
+          this
+        );
+      } catch (_e) {
+        /** Host delivery failure must not fail the run or block the echo */
+      }
       this.handlerDispatchedStepIds.add(stepId);
     }
     const unmarkHandlerDispatchedEvent = handler

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -1,8 +1,24 @@
 // src/graphs/__tests__/Graph.closeRunStep.test.ts
+import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch';
 import type * as t from '@/types';
 import { GraphEvents, StepTypes, Providers } from '@/common';
 import { HandlerRegistry } from '@/events';
 import { StandardGraph } from '../Graph';
+
+/** The secondary dual-dispatch channel needs a real callback manager to run
+ *  for real, which these unit graphs do not have; mocking the SDK entry point
+ *  lets the tests observe whether it was reached. */
+jest.mock('@langchain/core/callbacks/dispatch', () => ({
+  dispatchCustomEvent: jest.fn(),
+}));
+
+const dispatchCustomEventMock = dispatchCustomEvent as jest.MockedFunction<
+  typeof dispatchCustomEvent
+>;
+
+beforeEach(() => {
+  dispatchCustomEventMock.mockClear();
+});
 
 const makeAgent = (agentId: string): t.AgentInputs => ({
   agentId,
@@ -284,6 +300,105 @@ describe('StandardGraph.closeUnfinishedRunSteps', () => {
       expect(step.status).toBe('cancelled');
       expect(step.cancelled_at).toBe(5_000);
     }
+  });
+
+  describe('host handler isolation', () => {
+    function createThrowingGraph(): {
+      graph: StandardGraph;
+      seen: string[];
+      } {
+      const graph = new StandardGraph({
+        runId: 'run_1',
+        agents: [makeAgent('agent')],
+      });
+      const seen: string[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_RUN_STEP_CLOSED, {
+        handle: (_event, data): void => {
+          seen.push((data as t.RunStepClosedEvent).id);
+          throw new Error('host handler blew up');
+        },
+      });
+      graph.handlerRegistry = registry;
+      return { graph, seen };
+    }
+
+    /**
+     * The step is stamped terminal before dispatch, so a delivery failure
+     * reports on state that is already committed. Propagating would fail the
+     * whole run over an observational event — `closeOpenMessageStep` awaits
+     * this inside the stream loop on every CHAT_MODEL_END.
+     */
+    it('does not propagate a throwing host handler', async () => {
+      const { graph, seen } = createThrowingGraph();
+      const step = seedStep(graph, 'step_a');
+
+      await expect(
+        graph.closeRunStep('step_a', 'completed', { at: 2_000 })
+      ).resolves.toBe(true);
+
+      expect(seen).toEqual(['step_a']);
+      expect(step.status).toBe('completed');
+      expect(step.completed_at).toBe(2_000);
+    });
+
+    /**
+     * The hot path from `run.ts`: a rejection here sets `streamThrew` and
+     * fires the StopFailure hooks for a response that fully delivered.
+     */
+    it('does not fail the stream loop when closing the open message step', async () => {
+      const { graph, seen } = createThrowingGraph();
+      const step = seedStep(graph, 'step_msg');
+      graph.openMessageStepByAgent.set('', 'step_msg');
+
+      await expect(
+        graph.closeOpenMessageStep(undefined, 3_000)
+      ).resolves.toBeUndefined();
+
+      expect(seen).toEqual(['step_msg']);
+      expect(step.status).toBe('completed');
+    });
+
+    /**
+     * The secondary channel is the documented fallback for when the primary
+     * dispatch does not deliver, so a throwing primary must not suppress it —
+     * that would remove the redundancy exactly when it is needed.
+     */
+    it('still dispatches the secondary custom event after the handler throws', async () => {
+      const { graph } = createThrowingGraph();
+      seedStep(graph, 'step_b');
+      graph.config = { configurable: { thread_id: 'test' } };
+
+      await graph.closeRunStep('step_b', 'failed', { at: 4_000 });
+
+      expect(dispatchCustomEventMock).toHaveBeenCalledTimes(1);
+      expect(dispatchCustomEventMock).toHaveBeenCalledWith(
+        GraphEvents.ON_RUN_STEP_CLOSED,
+        expect.objectContaining({
+          id: 'step_b',
+          status: 'failed',
+          closed_at: 4_000,
+        }),
+        graph.config
+      );
+    });
+
+    /** A terminal status stays immutable even when delivery failed. */
+    it('keeps the close authoritative despite the delivery failure', async () => {
+      const { graph, seen } = createThrowingGraph();
+      const step = seedStep(graph, 'step_c');
+
+      await graph.closeRunStep('step_c', 'cancelled', { at: 5_000 });
+      const second = await graph.closeRunStep('step_c', 'completed', {
+        at: 6_000,
+      });
+
+      expect(second).toBe(false);
+      expect(seen).toEqual(['step_c']);
+      expect(step.status).toBe('cancelled');
+      expect(step.cancelled_at).toBe(5_000);
+      expect(step.completed_at).toBeUndefined();
+    });
   });
 });
 

--- a/src/graphs/__tests__/Graph.closeRunStep.test.ts
+++ b/src/graphs/__tests__/Graph.closeRunStep.test.ts
@@ -1,24 +1,10 @@
 // src/graphs/__tests__/Graph.closeRunStep.test.ts
-import { dispatchCustomEvent } from '@langchain/core/callbacks/dispatch';
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import { CallbackManager } from '@langchain/core/callbacks/manager';
 import type * as t from '@/types';
 import { GraphEvents, StepTypes, Providers } from '@/common';
 import { HandlerRegistry } from '@/events';
 import { StandardGraph } from '../Graph';
-
-/** The secondary dual-dispatch channel needs a real callback manager to run
- *  for real, which these unit graphs do not have; mocking the SDK entry point
- *  lets the tests observe whether it was reached. */
-jest.mock('@langchain/core/callbacks/dispatch', () => ({
-  dispatchCustomEvent: jest.fn(),
-}));
-
-const dispatchCustomEventMock = dispatchCustomEvent as jest.MockedFunction<
-  typeof dispatchCustomEvent
->;
-
-beforeEach(() => {
-  dispatchCustomEventMock.mockClear();
-});
 
 const makeAgent = (agentId: string): t.AgentInputs => ({
   agentId,
@@ -367,20 +353,38 @@ describe('StandardGraph.closeUnfinishedRunSteps', () => {
     it('still dispatches the secondary custom event after the handler throws', async () => {
       const { graph } = createThrowingGraph();
       seedStep(graph, 'step_b');
-      graph.config = { configurable: { thread_id: 'test' } };
+      /**
+       * A real subscriber on the real dispatch path. Asserting that
+       * `dispatchCustomEvent` was merely called would still pass if the
+       * config or the callback propagation dropped the event — the exact
+       * failure this test exists to catch — so the assertion is that a
+       * handler actually received it.
+       *
+       * The manager needs a parent run id: `dispatchCustomEvent` reads it
+       * from `getParentRunId()`, not from the config, and silently skips the
+       * dispatch when there is none.
+       */
+      const received: Array<{ name: string; payload: unknown }> = [];
+      const callbacks = new CallbackManager('parent-run-1');
+      callbacks.addHandler(
+        BaseCallbackHandler.fromMethods({
+          handleCustomEvent(name: string, payload: unknown): void {
+            received.push({ name, payload });
+          },
+        }),
+        true,
+      );
+      graph.config = { configurable: { thread_id: 'test' }, callbacks };
 
       await graph.closeRunStep('step_b', 'failed', { at: 4_000 });
 
-      expect(dispatchCustomEventMock).toHaveBeenCalledTimes(1);
-      expect(dispatchCustomEventMock).toHaveBeenCalledWith(
-        GraphEvents.ON_RUN_STEP_CLOSED,
-        expect.objectContaining({
-          id: 'step_b',
-          status: 'failed',
-          closed_at: 4_000,
-        }),
-        graph.config
-      );
+      expect(received).toHaveLength(1);
+      expect(received[0].name).toBe(GraphEvents.ON_RUN_STEP_CLOSED);
+      expect(received[0].payload).toMatchObject({
+        id: 'step_b',
+        status: 'failed',
+        closed_at: 4_000,
+      });
     });
 
     /** A terminal status stays immutable even when delivery failed. */

--- a/src/run.ts
+++ b/src/run.ts
@@ -826,12 +826,23 @@ export class Run<_T extends t.BaseGraphState> {
              * The producer stamped `completed_at` before dispatch. Carrying it
              * through keeps the recorded duration the tool's, not the host
              * handler's — this runs after an arbitrarily slow handler resolves.
+             *
+             * Isolated because this is a `finally`: a throw here would
+             * REPLACE an in-flight error from the handler above, so the
+             * host's original failure would be reported as whatever went
+             * wrong during closure instead. Closing is best-effort at this
+             * point either way — the end-of-run sweep still stamps any step
+             * this misses.
              */
-            await this.Graph.recordStepCompletion(completion.stepId, {
-              toolCallId: completion.toolCallId,
-              metadata,
-              at: completion.completedAt,
-            });
+            try {
+              await this.Graph.recordStepCompletion(completion.stepId, {
+                toolCallId: completion.toolCallId,
+                metadata,
+                at: completion.completedAt,
+              });
+            } catch (_e) {
+              /** Never mask the handler's error with a closure failure */
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Third finding from the structured review of the v3.6.0 run-step lifecycle work (siblings: #421, merged). `closeRunStep` awaited the host's closed-event handler with no guard:

```ts
if (handler) {
  await handler.handle(GraphEvents.ON_RUN_STEP_CLOSED, closedEvent, options?.metadata, this);
  this.handlerDispatchedStepIds.add(stepId);
}
```

By the time that line runs the step is already stamped terminal and untracked — the event **reports state that is committed**, and nothing a failed delivery does can undo it. Propagating cost two things.

**It failed whole runs over an observational event.** `closeOpenMessageStep` awaits this inside the stream loop on every `CHAT_MODEL_END` (`run.ts:1268`, un-isolated). A host handler that throws on an unexpected payload rejected there → `processStream`'s catch → `streamThrew = true` → the run reported failed and `StopFailure` hooks ran, for a response that had fully delivered.

**And it silently disabled the fallback.** The secondary `safeDispatchCustomEvent` sits directly below and never runs if the primary throws. That channel is documented as the redundancy for when the primary path does not deliver — so the primary's failure removed it exactly when it was needed.

`closeUnfinishedRunSteps` and `dispatchRunStep` already wrap their own `closeRunStep` calls for precisely this reason ("one host handler throwing must not strand the remaining steps"). The gap was *inside* `closeRunStep`, where those wrappers cannot reach.

### Scope

Deliberately limited to the closed event. `ON_RUN_STEP` uses the same dual-dispatch shape and stays un-isolated: a host that cannot record a step which is *about to produce content* has a defensible claim to fail the run, and the state there is not yet committed. Widening that is a separate judgement call, not a bug fix.

The second change isolates the `recordStepCompletion` call in `createCustomEventCallback`'s `finally`. A throw there **replaced** an in-flight error from the handler above, so a host's original failure surfaced as whatever went wrong during closure instead. The closed-handler fix removes its main trigger, so this is belt-and-braces — but a `finally` that can throw is a debugging hazard regardless of cause, and closure is best-effort there anyway since the end-of-run sweep still stamps whatever it misses.

## Testing

Four regression tests in `Graph.closeRunStep.test.ts`, **all four verified failing against the previous code** (stash the `Graph.ts` change, re-run):

| Test | Pins |
| --- | --- |
| does not propagate a throwing host handler | the core contract; step still stamped, `closeRunStep` still returns `true` |
| does not fail the stream loop when closing the open message step | the `run.ts` hot path that made this fail whole runs |
| still dispatches the secondary custom event after the handler throws | the fallback channel, the consequence I consider worst |
| keeps the close authoritative despite the delivery failure | terminal status stays immutable; a later close still returns `false` |

The secondary-dispatch test mocks `@langchain/core/callbacks/dispatch`, since these unit graphs have no real callback manager for `dispatchCustomEvent` to reach.

Suites: `src/graphs`, `src/specs/run-step-timestamps.test.ts`, `src/specs/custom-event-await.test.ts`, `src/tools/__tests__/SubagentExecutor.test.ts` — **239/239 passed**. Broader `src/specs` — **593 passed, 3 failed**, all three in `durability-checkpoint.integration.test.ts` and all from `MongoMemoryServer` failing to download its mongod binary (`DownloadError` on `fastdl.mongodb.org`) in this sandbox; environmental, unrelated to the diff, passes in CI. `npx tsc --noEmit` clean, eslint clean on all touched files.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_014vLhxCFMYkCaTsoFTiAjJ5)_