### PR TITLE
⬆️ chore: Bump @langchain/core To 1.2.8 And @langchain/openai To 1.5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
         "@langchain/anthropic": "1.5.2",
         "@langchain/aws": "^1.4.2",
-        "@langchain/core": "^1.2.8",
+        "@langchain/core": "1.2.8",
         "@langchain/deepseek": "^1.1.3",
         "@langchain/google-common": "2.2.0",
         "@langchain/google-gauth": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
         "@langchain/anthropic": "1.5.2",
         "@langchain/aws": "^1.4.2",
-        "@langchain/core": "^1.2.3",
+        "@langchain/core": "^1.2.8",
         "@langchain/deepseek": "^1.1.3",
         "@langchain/google-common": "2.2.0",
         "@langchain/google-gauth": "2.2.0",
@@ -21,7 +21,7 @@
         "@langchain/google-vertexai": "2.2.0",
         "@langchain/langgraph": "1.4.8",
         "@langchain/mistralai": "^1.2.0",
-        "@langchain/openai": "1.5.5",
+        "@langchain/openai": "1.5.8",
         "@langchain/textsplitters": "^1.0.1",
         "@langchain/xai": "^1.4.3",
         "@langfuse/core": "^5.4.1",
@@ -2144,9 +2144,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-F+L5SsciykwDl7eDxacnhDTcWe1IF6jetzfkvI5PPfq6ogWHO7xcjU90SGh/3lqbbS0tgun+qF01KIqxawrCsA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-ppi2UaCYKqM4LEY8NWQ/JZ0Of0MAngHRvclceVeEQklcD/M6QKanlHPWblDnLO2m4vz7987b1Z4r33Ps6lf/ig==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.5.tgz",
-      "integrity": "sha512-wX7dwb9z4nf5FHXlIl/X2mk08pzonvRHCt1D4+s1zXLP0duYDC95j7dulPIQJ6fmhbyYQc9Ki8mEhY/D1lB8kw==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.8.tgz",
+      "integrity": "sha512-BKzIgWYSXQ03V9F9u46vC12vZjHy8wyOt8H7VUrTWt6VdwSnnxXmjeEUEIkLjpU/bqVkGzHLXGCSMEHYbDSi5Q==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
@@ -2375,7 +2375,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.2"
+        "@langchain/core": "^1.2.8"
       }
     },
     "node_modules/@langchain/openai/node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
     "@langchain/anthropic": "1.5.2",
     "@langchain/aws": "^1.4.2",
-    "@langchain/core": "^1.2.8",
+    "@langchain/core": "1.2.8",
     "@langchain/deepseek": "^1.1.3",
     "@langchain/google-common": "2.2.0",
     "@langchain/google-gauth": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "label:rescore": "node ./src/scripts/activity-labels/rescore.cjs"
   },
   "overrides": {
-    "@langchain/openai": "1.5.5",
+    "@langchain/openai": "$@langchain/openai",
     "@browserbasehq/stagehand": {
       "openai": "$openai"
     },
@@ -234,7 +234,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1075.0",
     "@langchain/anthropic": "1.5.2",
     "@langchain/aws": "^1.4.2",
-    "@langchain/core": "^1.2.3",
+    "@langchain/core": "^1.2.8",
     "@langchain/deepseek": "^1.1.3",
     "@langchain/google-common": "2.2.0",
     "@langchain/google-gauth": "2.2.0",
@@ -242,7 +242,7 @@
     "@langchain/google-vertexai": "2.2.0",
     "@langchain/langgraph": "1.4.8",
     "@langchain/mistralai": "^1.2.0",
-    "@langchain/openai": "1.5.5",
+    "@langchain/openai": "1.5.8",
     "@langchain/textsplitters": "^1.0.1",
     "@langchain/xai": "^1.4.3",
     "@langfuse/core": "^5.4.1",

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -1568,6 +1568,14 @@ describe('formatAgentMessages', () => {
     expect((result.messages[3] as ToolMessage).tool_call_id).toBe('call_2');
   });
 
+  /**
+   * Empty-string content rather than a forced `undefined`: `@langchain/core`
+   * 1.2.6 made `instanceof` structural, so a message whose `content` was
+   * overwritten with `undefined` stops registering as a `ToolMessage` and
+   * never reaches the merge. The constructor normalizes `undefined` to `[]`,
+   * so that state is no longer representable; `''` covers the same non-array
+   * branch through `stringifyToolMessageContent`.
+   */
   it('keeps absent tool content empty when merging Anthropic artifacts', () => {
     const toolMessage = new ToolMessage({
       content: '',
@@ -1576,11 +1584,6 @@ describe('formatAgentMessages', () => {
       artifact: {
         content: [{ type: ContentTypes.TEXT, text: 'artifact text' }],
       },
-    });
-    Object.defineProperty(toolMessage, 'content', {
-      value: undefined,
-      writable: true,
-      configurable: true,
     });
 
     const originalMessages = [
@@ -1604,7 +1607,7 @@ describe('formatAgentMessages', () => {
       { type: ContentTypes.TEXT, text: '' },
       { type: ContentTypes.TEXT, text: 'artifact text' },
     ]);
-    expect(toolMessage.content).toBeUndefined();
+    expect(toolMessage.content).toBe('');
     expect(formattedMessages).not.toBe(originalMessages);
   });
 


### PR DESCRIPTION
## What this does

| package | from | to |
|---|---|---|
| `@langchain/core` | `^1.2.3` | `1.2.8` (pinned) |
| `@langchain/openai` | `1.5.5` | `1.5.8` |

`@langchain/core` was the one LangChain package on a caret while `openai`, `anthropic`, and `langgraph` are pinned exactly — meaning it was free to move on any lockfile regen. Now pinned to match.

Also converts the `@langchain/openai` **override** from the literal `1.5.5` to a reference override `$@langchain/openai`. That override was a trap in waiting: bumping the direct dependency while the override stayed literal would have force-pinned every transitive copy back to 1.5.5. The reference form tracks the declared version and matches the `"uuid": "$uuid"` style already in the file, per AGENTS.md.

## What we get

- `openai@1.5.7` — includes `usage` in `response_metadata` when `system_fingerprint` is absent, which matters for our token accounting.
- `core@1.2.6` — `[Symbol.hasInstance]` via `.isInstance()`, fixing `z.instanceof()` when multiple copies of core are installed. Our topology duplicates core easily.
- `core@1.2.4` — coalesces nested tracer callbacks, relevant to our Langfuse span work.

These cannot be taken separately: the peer chain is `1.5.6 → core ^1.2.5`, `1.5.7 → ^1.2.6`, `1.5.8 → ^1.2.8`.

## The one behavior change, and why it is fine

`@langchain/core@1.2.6` makes `instanceof` **structural** — a message whose `content` is not a string or array no longer registers as that message class. This surfaced as one failing test, `formatAgentMessages › keeps absent tool content empty when merging Anthropic artifacts`, which built a `ToolMessage` and then forced `content` to `undefined` via `Object.defineProperty`.

That state is no longer reachable:

| path | result |
|---|---|
| `new ToolMessage({ content: undefined })` | normalizes to `[]`, `instanceof` **true** |
| `new ToolMessage({ content: null })` | normalizes to `[]`, `instanceof` **true** |
| `mapStoredMessagesToChatMessages` round-trip | `instanceof` **true**, content preserved |
| `load()` round-trip | `instanceof` **true**, content preserved |
| forced overwrite via `defineProperty` | `instanceof` false — **only** way to reach it |

Only `content` is validated; forcing `tool_call_id`, `name`, or `additional_kwargs` to `undefined` still passes. And no production path writes `undefined` into a message's own `content` — the v1 output-version clone in `messages/core.ts` sets `content: undefined` on **`lc_kwargs`** only, while `descriptors.content` always carries the real array, which is why both v0 and v1 preempt-seal paths pass untouched.

So the test was asserting a state the library no longer permits. It now uses empty-string content, which reaches the same non-array `stringifyToolMessageContent` branch through a shape that actually occurs.

## Verification

- `tsc --noEmit` clean
- `eslint src/` 0 errors (104 pre-existing warnings)
- `npm audit --omit=dev` 0 vulnerabilities
- dependencies fully deduped — single copy of each
- full suite **4219 passing**, failures exactly at `main`'s baseline: `anthropic`/`google`/`vertexai` `llm.spec.ts`, all credential-gated live tests

`smoother.test.ts`, `smoother.bench.test.ts`, and `langfuse-instrumentation.test.ts` fail under full-suite parallel load and pass in isolation (32/32 and 15/15). Load flakes, not regressions — worth knowing they are noisy under load.
