### PR TITLE
🛰️ feat: Add Detached Subagent Task Control

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1312,6 +1312,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   subagentUsageSink?: t.SubagentUsageSink;
   /** See {@link t.StandardGraphInput.subagentScope}. */
   subagentScope: boolean;
+  /** See {@link t.StandardGraphInput.subagentTasks}. */
+  subagentTasks: t.SubagentTaskConfig | undefined;
   /** See {@link t.StandardGraphInput.subagentExecutionContext}. */
   private readonly subagentExecutionContext?: t.SubagentExecutionContext;
   /** See {@link t.StandardGraphInput.preemption}. */
@@ -1445,6 +1447,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       indexTokenCountMap,
       calibrationRatio,
       subagentUsageSink,
+      subagentTasks,
       subagentScope,
       subagentExecutionContext,
       preemption,
@@ -1469,6 +1472,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.signal = signal;
     this.langfuse = langfuse;
     this.subagentUsageSink = subagentUsageSink;
+    this.subagentTasks = subagentTasks;
     this.subagentScope = subagentScope === true;
     this.subagentExecutionContext = subagentExecutionContext;
     this.preemption = preemption;
@@ -1695,8 +1699,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * budget is taken by {@link claimPreemptSeal} once the accumulated chunk is
    * known to be safe, so a chunk that cannot seal never spends budget.
    *
-   * Subagent scopes never seal: a steer targets the top-level conversation,
-   * and a child run must finish so its parent sees a complete result.
+   * Ordinary subagent scopes never receive `preemption`. A detached child may
+   * receive a dedicated parent-control preemption source, in which case the
+   * same provider-safe seal path is intentionally reused inside that child.
    */
   /** Internal seal preconditions only — no host callback, no side effects. */
   private canClaimPreemptSeal(): boolean {
@@ -1710,7 +1715,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const runId =
       (this.config?.configurable?.run_id as string | undefined) ?? this.runId;
     return (
-      !this.subagentScope &&
       this.preemption != null &&
       !this.preemptSealInFlight &&
       this.preemptSealBudgetUsed < resolveMaxSeals(this.preemption.maxSeals) &&
@@ -4769,19 +4773,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
         const getParentHandlerRegistry = (): HandlerRegistry | undefined =>
           this.handlerRegistry ?? this.parentToolHandlerRegistry;
-        const createConfiguredChildGraph: GraphFactory = (request) => {
-          const childGraph = this.graphFactory(request);
-          if (this.subagentModelOverride != null) {
-            childGraph.overrideModel = this.subagentModelOverride;
-            childGraph.setSubagentModelOverride(this.subagentModelOverride);
-          }
-          const childHandlerRegistry = createChildHandlerRegistry(
-            getParentHandlerRegistry()
-          );
-          // Pure execution-ordering hint (unlike `humanInTheLoop`). It only
-          // reorders tools already in the child's direct group; it does not
-          // force a schema-only event tool onto the direct execution path.
-          applyGraphRuntimeConfig(childGraph, {
+        const snapshotChildGraphFactory = (
+          parentHandlerRegistry: HandlerRegistry | undefined
+        ): GraphFactory => {
+          const graphFactory = this.graphFactory;
+          const subagentModelOverride = this.subagentModelOverride;
+          const runtimeConfig = {
             hookRegistry: this.hookRegistry,
             humanInTheLoop: this.humanInTheLoop,
             toolOutputReferences: this.toolOutputReferences,
@@ -4789,18 +4786,33 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             codeSessionToolNames: this.codeSessionToolNames,
             interruptingToolNames: this.interruptingToolNames,
             toolExecution: this.toolExecution,
-          });
-          if (this.humanInTheLoop?.enabled === true) {
-            childGraph.compileOptions = {
-              checkpointer: this.compileOptions?.checkpointer,
-            };
-          }
-          childGraph.parentToolHandlerRegistry = childHandlerRegistry;
-          childGraph.eventToolExecutionAvailable =
-            childHandlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
-            null;
-          return childGraph;
+          };
+          const checkpointer = this.compileOptions?.checkpointer;
+          return (request): StandardGraph => {
+            const childGraph = graphFactory(request);
+            if (subagentModelOverride != null) {
+              childGraph.overrideModel = subagentModelOverride;
+              childGraph.setSubagentModelOverride(subagentModelOverride);
+            }
+            const childHandlerRegistry = createChildHandlerRegistry(
+              parentHandlerRegistry
+            );
+            // Pure execution-ordering hint (unlike `humanInTheLoop`). It only
+            // reorders tools already in the child's direct group; it does not
+            // force a schema-only event tool onto the direct execution path.
+            applyGraphRuntimeConfig(childGraph, runtimeConfig);
+            if (runtimeConfig.humanInTheLoop?.enabled === true) {
+              childGraph.compileOptions = { checkpointer };
+            }
+            childGraph.parentToolHandlerRegistry = childHandlerRegistry;
+            childGraph.eventToolExecutionAvailable =
+              childHandlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
+              null;
+            return childGraph;
+          };
         };
+        const createConfiguredChildGraph: GraphFactory = (request) =>
+          snapshotChildGraphFactory(getParentHandlerRegistry())(request);
         const executor = new SubagentExecutor({
           configs: new Map(
             executableConfigs.map((config) => [config.type, config])
@@ -4820,6 +4832,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           langfuse: this.langfuse,
           tokenCounter: agentContext.tokenCounter,
           usageSink: this.subagentUsageSink,
+          taskConfig: this.subagentTasks,
           streamLimits: this.streamLimits,
           humanInTheLoop: this.humanInTheLoop,
           checkpointer: this.compileOptions?.checkpointer,
@@ -4830,6 +4843,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               input,
             }),
           createChildGraphByKind: createConfiguredChildGraph,
+          createDetachedChildGraphFactory: (
+            parentHandlerRegistry
+          ): GraphFactory =>
+            snapshotChildGraphFactory(parentHandlerRegistry),
         });
         this.registerSubagentExecutor(executor);
 
@@ -4837,6 +4854,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const input = rawInput as {
             description?: string;
             subagent_type?: string;
+            run_in_background?: boolean;
           };
           const description =
             typeof input.description === 'string' &&
@@ -4869,7 +4887,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const batchScope = config.configurable?.[
             RUN_BREAKER_SCOPE_CONFIG_KEY
           ] as RunBreakerScope | undefined;
-          const result = await executor.execute({
+          const executeParams = {
             description,
             subagentType,
             threadId,
@@ -4885,9 +4903,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             parentConfigurable: config.configurable as
               | Record<string, unknown>
               | undefined,
-          });
+          };
+          if (input.run_in_background === true) {
+            return executor.executeInBackground(executeParams);
+          }
+          const result = await executor.execute(executeParams);
           return result.content;
-        }, buildSubagentToolParams(executableConfigs));
+        }, buildSubagentToolParams(executableConfigs, {
+          background: this.subagentTasks != null,
+        }));
         const replayableSubagentTool = subagentTool as typeof subagentTool &
           ReplayableSubagentTool;
         replayableSubagentTool[SUBAGENT_REPLAY_CONTROLLER] = {

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -6,6 +6,7 @@ import type {
   ToolApprovalReplaySnapshot,
   AggregatedHookResult,
 } from './types';
+import { HOOK_EVENTS } from './types';
 
 function serializeApprovalKey(key: ToolApprovalReplayKey): string {
   return JSON.stringify([key.executionScope, key.agentId, key.toolUseId]);
@@ -225,6 +226,23 @@ export class HookRegistry {
         targetPending.set(toolUseId, result);
       }
     }
+  }
+
+  /**
+   * Takes an isolated policy snapshot for work that may outlive the source
+   * run. Global and source-session matchers become global to the returned
+   * task-local registry, so parent cleanup and one-shot hook consumption
+   * cannot mutate the detached child (or vice versa). Runtime halt signals
+   * and pending approvals are intentionally not copied.
+   */
+  forkSession(sourceSessionId: string): HookRegistry {
+    const fork = new HookRegistry();
+    for (const event of HOOK_EVENTS) {
+      for (const matcher of this.getMatchers(event, sourceSessionId)) {
+        fork.register(event, matcher);
+      }
+    }
+    return fork;
   }
 
   getPendingToolApproval(

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -182,6 +182,26 @@ describe('HookRegistry', () => {
       expect(registry.getMatchers('PreToolUse', 'branch-b')).toEqual([matcher]);
     });
 
+    it('forks an isolated snapshot of global and session policy', () => {
+      const registry = new HookRegistry();
+      const global = makePreToolUseMatcher('global');
+      const session = makePreToolUseMatcher('session');
+      registry.register('PreToolUse', global);
+      registry.registerSession('source', 'PreToolUse', session);
+
+      const fork = registry.forkSession('source');
+      registry.clearSession('source');
+      registry.removeMatcher('PreToolUse', global);
+
+      expect(fork.getMatchers('PreToolUse', 'detached')).toEqual([
+        global,
+        session,
+      ]);
+      expect(fork.removeMatcher('PreToolUse', session)).toBe(true);
+      expect(fork.getMatchers('PreToolUse', 'detached')).toEqual([global]);
+      expect(registry.getMatchers('PreToolUse', 'source')).toEqual([]);
+    });
+
     it('copies pending one-shot approvals and clears them with the target session', () => {
       const registry = new HookRegistry();
       const approval = {

--- a/src/run.ts
+++ b/src/run.ts
@@ -296,6 +296,7 @@ export class Run<_T extends t.BaseGraphState> {
   private subagentUsageSink?: t.SubagentUsageSink;
   private preemption?: t.StreamPreemption;
   private streamLimits?: t.StreamLimits;
+  private subagentTasks?: t.SubagentTaskConfig;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -363,6 +364,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.interruptingToolNames = config.interruptingToolNames;
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
+    this.subagentTasks = config.subagentTasks;
     this.preemption = config.preemption;
     this.streamLimits = config.streamLimits;
 
@@ -455,6 +457,7 @@ export class Run<_T extends t.BaseGraphState> {
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
         subagentUsageSink: this.subagentUsageSink,
+        subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
       },
@@ -493,6 +496,7 @@ export class Run<_T extends t.BaseGraphState> {
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
         subagentUsageSink: this.subagentUsageSink,
+        subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
       },

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -27,6 +27,9 @@ const DESCRIPTION_PROP_DESCRIPTION =
 const SUBAGENT_TYPE_PROP_DESCRIPTION =
   'Which subagent type to delegate to. Must be one of the available types.';
 
+const RUN_IN_BACKGROUND_PROP_DESCRIPTION =
+  'Set true to start the subagent as a detached process-local task and return a background_task_id immediately. Poll the host background-task tool to collect its result. The task can outlive this turn but does not survive a process restart.';
+
 export const SubagentToolSchema = {
   type: 'object',
   properties: {
@@ -54,7 +57,10 @@ export const SubagentToolDefinition: LCTool = {
  * Used by `Graph.createAgentNode()` when constructing the runtime tool instance.
  * Extends `SubagentToolSchema` by populating `subagent_type.enum` dynamically.
  */
-export function buildSubagentToolParams(configs: SubagentConfig[]): {
+export function buildSubagentToolParams(
+  configs: SubagentConfig[],
+  options: { background?: boolean } = {}
+): {
   name: string;
   schema: JsonSchemaType;
   description: string;
@@ -79,10 +85,22 @@ export function buildSubagentToolParams(configs: SubagentConfig[]): {
           enum: types,
           description: `${SUBAGENT_TYPE_PROP_DESCRIPTION} Available: ${types.join(', ')}.`,
         },
+        ...(options.background === true
+          ? {
+            run_in_background: {
+              type: 'boolean',
+              description: RUN_IN_BACKGROUND_PROP_DESCRIPTION,
+            },
+          }
+          : {}),
       },
       required: ['description', 'subagent_type'],
     },
-    description: `${SubagentToolDescription}\n\nAvailable types:\n${typeDescriptions}`,
+    description: `${SubagentToolDescription}${
+      options.background === true
+        ? '\n\nBACKGROUND EXECUTION:\n- Set run_in_background to true when you do not need the result immediately. The call returns a background_task_id; use the host background-task tools to poll, steer, queue, interrupt, or cancel it.'
+        : ''
+    }\n\nAvailable types:\n${typeDescriptions}`,
   };
 }
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -517,13 +517,15 @@ describe('SubagentExecutor', () => {
     });
     const invoke = jest.fn(() => invocation);
     const clearHeavyState = jest.fn();
+    let detachedGraph: StandardGraph | undefined;
     const createDetachedChildGraphFactory = jest.fn(
-      () =>
-        (): StandardGraph =>
-          ({
-            createWorkflow: () => ({ invoke }),
-            clearHeavyState,
-          }) as unknown as StandardGraph
+      () => (): StandardGraph => {
+        detachedGraph = {
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState,
+        } as unknown as StandardGraph;
+        return detachedGraph;
+      }
     );
     const fallbackFactory = jest.fn(
       (): StandardGraph =>
@@ -554,11 +556,20 @@ describe('SubagentExecutor', () => {
     expect(response.status).toBe('running');
     expect(createDetachedChildGraphFactory).toHaveBeenCalledTimes(1);
     const taskHookSessionId = `test-run:subagent-task:${response.background_task_id}`;
-    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(true);
+    await waitForTask(
+      store,
+      response.background_task_id,
+      () => invoke.mock.calls.length > 0
+    );
+    const taskHookRegistry = detachedGraph?.hookRegistry;
+    expect(taskHookRegistry).toBeDefined();
+    expect(taskHookRegistry).not.toBe(hookRegistry);
+    expect(taskHookRegistry?.hasHookFor('PreToolUse', taskHookSessionId)).toBe(
+      true
+    );
     hookRegistry.clearSession('test-run');
-    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(true);
-    await waitForTask(store, response.background_task_id, () =>
-      invoke.mock.calls.length > 0
+    expect(taskHookRegistry?.hasHookFor('PreToolUse', taskHookSessionId)).toBe(
+      true
     );
     executor.clearHeavyState();
     finish({ messages: [new AIMessage('detached result')] });
@@ -576,7 +587,7 @@ describe('SubagentExecutor', () => {
     ).toMatchObject({ status: 'claimed' });
     expect(fallbackFactory).not.toHaveBeenCalled();
     expect(clearHeavyState).toHaveBeenCalled();
-    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(false);
+    expect(hookRegistry.hasHookFor('PreToolUse', 'test-run')).toBe(false);
   });
 
   it('continues the same detached child for a queued parent message', async () => {
@@ -611,8 +622,10 @@ describe('SubagentExecutor', () => {
         parentToolCallId: 'call_queued',
       })
     ) as { background_task_id: string };
-    await waitForTask(store, response.background_task_id, () =>
-      invoke.mock.calls.length > 0
+    await waitForTask(
+      store,
+      response.background_task_id,
+      () => invoke.mock.calls.length > 0
     );
 
     expect(
@@ -645,7 +658,8 @@ describe('SubagentExecutor', () => {
 
   it('drains interrupt and steer controls through child-safe hook boundaries', async () => {
     const store = new InMemorySubagentTaskStore();
-    const hookRegistry = new HookRegistry();
+    let taskHookRegistry: HookRegistry | undefined;
+    let childGraph: StandardGraph | undefined;
     let release = (): void => undefined;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
@@ -657,10 +671,14 @@ describe('SubagentExecutor', () => {
         runnableConfig: { configurable?: Record<string, unknown> }
       ): Promise<{ messages: BaseMessage[] }> => {
         await gate;
+        taskHookRegistry = childGraph?.hookRegistry;
         const runId = runnableConfig.configurable?.run_id as string;
         expect(childInput?.preemption?.shouldPreempt()).toBe(true);
+        if (taskHookRegistry == null) {
+          throw new Error('Expected a task-local hook registry.');
+        }
         const interrupted = await executeHooks({
-          registry: hookRegistry,
+          registry: taskHookRegistry,
           input: {
             hook_event_name: 'PreemptBoundary',
             runId,
@@ -671,7 +689,7 @@ describe('SubagentExecutor', () => {
           sessionId: runId,
         });
         const steered = await executeHooks({
-          registry: hookRegistry,
+          registry: taskHookRegistry,
           input: {
             hook_event_name: 'PostToolBatch',
             runId,
@@ -693,14 +711,14 @@ describe('SubagentExecutor', () => {
       }
     );
     const executor = createExecutor({
-      hookRegistry,
       taskConfig: { store, scopeId: 'owner:conversation' },
       createChildGraph: (input): StandardGraph => {
         childInput = input;
-        return {
+        childGraph = {
           createWorkflow: () => ({ invoke }),
           clearHeavyState: jest.fn(),
         } as unknown as StandardGraph;
+        return childGraph;
       },
     });
     const response = JSON.parse(
@@ -710,8 +728,10 @@ describe('SubagentExecutor', () => {
         parentToolCallId: 'call_controlled',
       })
     ) as { background_task_id: string };
-    await waitForTask(store, response.background_task_id, () =>
-      invoke.mock.calls.length > 0
+    await waitForTask(
+      store,
+      response.background_task_id,
+      () => invoke.mock.calls.length > 0
     );
 
     store.control('owner:conversation', response.background_task_id, {
@@ -734,6 +754,66 @@ describe('SubagentExecutor', () => {
     ).toMatchObject({
       status: 'completed',
       result: 'Summarize immediately.|Include the primary source.',
+    });
+  });
+
+  it('marks ordinary detached child failures as task errors', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: makeThrowingGraphFactory(new Error('provider failed')),
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Try the provider.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_failure',
+      })
+    ) as { background_task_id: string };
+
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'error'
+    );
+
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'error', error: 'provider failed' });
+  });
+
+  it('reserves recursion headroom for every detached preemption seal', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const invoke = jest.fn().mockResolvedValue({
+      messages: [new AIMessage('done')],
+    });
+    const executor = createExecutor({
+      configs: new Map([
+        [config.type, makeConfig(config.type, { maxTurns: 2 })],
+      ]),
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Finish after interrupts.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_recursion_headroom',
+      })
+    ) as { background_task_id: string };
+
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(invoke.mock.calls[0][1]).toMatchObject({
+      recursionLimit: 2 * 3 + 32,
     });
   });
 
@@ -764,8 +844,10 @@ describe('SubagentExecutor', () => {
         parentToolCallId: 'call_cancelled',
       })
     ) as { background_task_id: string };
-    await waitForTask(store, response.background_task_id, () =>
-      invoke.mock.calls.length > 0
+    await waitForTask(
+      store,
+      response.background_task_id,
+      () => invoke.mock.calls.length > 0
     );
 
     expect(
@@ -778,9 +860,9 @@ describe('SubagentExecutor', () => {
       response.background_task_id,
       (status) => status === 'cancelled'
     );
-    expect(store.get('owner:conversation', response.background_task_id)).toMatchObject(
-      { status: 'cancelled' }
-    );
+    expect(
+      store.get('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'cancelled' });
   });
 
   it('rejects changed arguments replayed under the same parent tool call', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -17,6 +17,7 @@ import type {
 import type { StandardGraph } from '@/graphs/Graph';
 import {
   SubagentExecutor,
+  InMemorySubagentTaskStore,
   filterGraphSubagentResult,
   filterSubagentResult,
   resolveSubagentConfigs,
@@ -30,6 +31,7 @@ import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { AgentContext } from '@/agents/AgentContext';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { HandlerRegistry } from '@/events';
+import { executeHooks } from '@/hooks';
 
 jest.setTimeout(15000);
 
@@ -491,6 +493,354 @@ describe('SubagentExecutor', () => {
       ...overrides,
     });
   }
+
+  async function waitForTask(
+    store: InMemorySubagentTaskStore,
+    taskId: string,
+    predicate: (status: string) => boolean
+  ): Promise<void> {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const task = store.get('owner:conversation', taskId);
+      if (task != null && predicate(task.status)) {
+        return;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error(`Timed out waiting for background task ${taskId}.`);
+  }
+
+  it('runs a detached child past parent cleanup and exposes its result once', async () => {
+    const store = new InMemorySubagentTaskStore();
+    let finish = (_value: { messages: BaseMessage[] }): void => undefined;
+    const invocation = new Promise<{ messages: BaseMessage[] }>((resolve) => {
+      finish = resolve;
+    });
+    const invoke = jest.fn(() => invocation);
+    const clearHeavyState = jest.fn();
+    const createDetachedChildGraphFactory = jest.fn(
+      () =>
+        (): StandardGraph =>
+          ({
+            createWorkflow: () => ({ invoke }),
+            clearHeavyState,
+          }) as unknown as StandardGraph
+    );
+    const fallbackFactory = jest.fn(
+      (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState,
+        }) as unknown as StandardGraph
+    );
+    const hookRegistry = new HookRegistry();
+    hookRegistry.registerSession('test-run', 'PreToolUse', {
+      hooks: [async (): Promise<Record<string, never>> => ({})],
+    });
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: fallbackFactory,
+      createDetachedChildGraphFactory,
+      hookRegistry,
+    });
+
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Research independently.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_background',
+      })
+    ) as { background_task_id: string; status: string };
+
+    expect(response.status).toBe('running');
+    expect(createDetachedChildGraphFactory).toHaveBeenCalledTimes(1);
+    const taskHookSessionId = `test-run:subagent-task:${response.background_task_id}`;
+    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(true);
+    hookRegistry.clearSession('test-run');
+    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(true);
+    await waitForTask(store, response.background_task_id, () =>
+      invoke.mock.calls.length > 0
+    );
+    executor.clearHeavyState();
+    finish({ messages: [new AIMessage('detached result')] });
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'completed', result: 'detached result' });
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'claimed' });
+    expect(fallbackFactory).not.toHaveBeenCalled();
+    expect(clearHeavyState).toHaveBeenCalled();
+    expect(hookRegistry.hasHookFor('PreToolUse', taskHookSessionId)).toBe(false);
+  });
+
+  it('continues the same detached child for a queued parent message', async () => {
+    const store = new InMemorySubagentTaskStore();
+    let finishFirst = (_value: { messages: BaseMessage[] }): void => undefined;
+    const firstInvocation = new Promise<{ messages: BaseMessage[] }>(
+      (resolve) => {
+        finishFirst = resolve;
+      }
+    );
+    const invoke = jest
+      .fn()
+      .mockImplementationOnce(() => firstInvocation)
+      .mockResolvedValueOnce({ messages: [new AIMessage('second answer')] });
+    const resetValues = jest.fn();
+    let childInput: StandardGraphInput | undefined;
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (input): StandardGraph => {
+        childInput = input;
+        return {
+          createWorkflow: () => ({ invoke }),
+          resetValues,
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Start the analysis.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_queued',
+      })
+    ) as { background_task_id: string };
+    await waitForTask(store, response.background_task_id, () =>
+      invoke.mock.calls.length > 0
+    );
+
+    expect(
+      store.control('owner:conversation', response.background_task_id, {
+        action: 'queue',
+        message: 'Now compare both sources.',
+      })
+    ).toMatchObject({ status: 'accepted' });
+    finishFirst({ messages: [new AIMessage('first answer')] });
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    const continuation = invoke.mock.calls[1][0] as {
+      messages: BaseMessage[];
+    };
+    expect(continuation.messages.at(-1)).toBeInstanceOf(HumanMessage);
+    expect(continuation.messages.at(-1)?.content).toBe(
+      'Now compare both sources.'
+    );
+    expect(resetValues).toHaveBeenCalledWith(true);
+    expect(childInput?.preemption).toBeDefined();
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'completed', result: 'second answer' });
+  });
+
+  it('drains interrupt and steer controls through child-safe hook boundaries', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const hookRegistry = new HookRegistry();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let childInput: StandardGraphInput | undefined;
+    const invoke = jest.fn(
+      async (
+        _input: unknown,
+        runnableConfig: { configurable?: Record<string, unknown> }
+      ): Promise<{ messages: BaseMessage[] }> => {
+        await gate;
+        const runId = runnableConfig.configurable?.run_id as string;
+        expect(childInput?.preemption?.shouldPreempt()).toBe(true);
+        const interrupted = await executeHooks({
+          registry: hookRegistry,
+          input: {
+            hook_event_name: 'PreemptBoundary',
+            runId,
+            agentId: 'child-agent',
+            executingAgentId: 'child-agent',
+            sealCount: 1,
+          },
+          sessionId: runId,
+        });
+        const steered = await executeHooks({
+          registry: hookRegistry,
+          input: {
+            hook_event_name: 'PostToolBatch',
+            runId,
+            agentId: 'child-agent',
+            executingAgentId: 'child-agent',
+            entries: [],
+          },
+          sessionId: runId,
+        });
+        const messages = [
+          ...interrupted.injectedMessages,
+          ...steered.injectedMessages,
+        ];
+        return {
+          messages: [
+            new AIMessage(messages.map((message) => message.content).join('|')),
+          ],
+        };
+      }
+    );
+    const executor = createExecutor({
+      hookRegistry,
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (input): StandardGraph => {
+        childInput = input;
+        return {
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Work until redirected.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_controlled',
+      })
+    ) as { background_task_id: string };
+    await waitForTask(store, response.background_task_id, () =>
+      invoke.mock.calls.length > 0
+    );
+
+    store.control('owner:conversation', response.background_task_id, {
+      action: 'interrupt',
+      message: 'Summarize immediately.',
+    });
+    store.control('owner:conversation', response.background_task_id, {
+      action: 'steer',
+      message: 'Include the primary source.',
+    });
+    release();
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({
+      status: 'completed',
+      result: 'Summarize immediately.|Include the primary source.',
+    });
+  });
+
+  it('cancels a detached child through its dedicated abort signal', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const invoke = jest.fn(
+      (_input: unknown, runnableConfig: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          runnableConfig.signal?.addEventListener(
+            'abort',
+            () => reject(runnableConfig.signal?.reason),
+            { once: true }
+          );
+        })
+    );
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Wait until cancelled.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_cancelled',
+      })
+    ) as { background_task_id: string };
+    await waitForTask(store, response.background_task_id, () =>
+      invoke.mock.calls.length > 0
+    );
+
+    expect(
+      store.control('owner:conversation', response.background_task_id, {
+        action: 'cancel',
+      })
+    ).toMatchObject({ status: 'cancelled' });
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'cancelled'
+    );
+    expect(store.get('owner:conversation', response.background_task_id)).toMatchObject(
+      { status: 'cancelled' }
+    );
+  });
+
+  it('rejects changed arguments replayed under the same parent tool call', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+    });
+    const first = JSON.parse(
+      executor.executeInBackground({
+        description: 'Original task.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_conflict',
+      })
+    ) as { background_task_id: string };
+    const conflict = JSON.parse(
+      executor.executeInBackground({
+        description: 'Changed task.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_conflict',
+      })
+    ) as { status: string; message: string };
+
+    expect(conflict).toMatchObject({
+      status: 'rejected',
+      message:
+        'The same parent tool call ID was already used with different background subagent arguments.',
+    });
+    store.control('owner:conversation', first.background_task_id, {
+      action: 'cancel',
+    });
+  });
+
+  it('fails closed when detached execution is unavailable or not attributable', () => {
+    const disabled = JSON.parse(
+      createExecutor().executeInBackground({
+        description: 'Do not run.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_disabled',
+      })
+    ) as { status: string; message: string };
+    const store = new InMemorySubagentTaskStore();
+    const unattributed = JSON.parse(
+      createExecutor({
+        taskConfig: { store, scopeId: 'owner:conversation' },
+      }).executeInBackground({
+        description: 'Do not run.',
+        subagentType: 'researcher',
+      })
+    ) as { status: string; message: string };
+
+    expect(disabled).toMatchObject({
+      status: 'rejected',
+      message: 'Background subagent execution is not enabled for this run.',
+    });
+    expect(unattributed).toMatchObject({
+      status: 'rejected',
+      message: 'Background subagent execution requires a parent tool call ID.',
+    });
+    expect(store.list('owner:conversation')).toEqual([]);
+  });
 
   it('returns error for unknown subagent type', async () => {
     const executor = createExecutor();

--- a/src/tools/__tests__/SubagentTool.test.ts
+++ b/src/tools/__tests__/SubagentTool.test.ts
@@ -138,6 +138,28 @@ describe('SubagentTool', () => {
       expect(params.description).toContain('"coder" (Coding Agent)');
     });
 
+    it('only advertises detached execution when the host enables it', () => {
+      const foreground = buildSubagentToolParams(configs);
+      const background = buildSubagentToolParams(configs, {
+        background: true,
+      });
+      const foregroundProperties = foreground.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const backgroundProperties = background.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(foregroundProperties.run_in_background).toBeUndefined();
+      expect(foreground.description).not.toContain('BACKGROUND EXECUTION');
+      expect(backgroundProperties.run_in_background).toMatchObject({
+        type: 'boolean',
+      });
+      expect(background.description).toContain('BACKGROUND EXECUTION');
+    });
+
     it('produces same schema as createSubagentToolDefinition', () => {
       const params = buildSubagentToolParams(configs);
       const def = createSubagentToolDefinition(configs);

--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -1,0 +1,622 @@
+import { nanoid } from 'nanoid';
+import type {
+  InjectedMessage,
+  SubagentTaskBoundary,
+  SubagentTaskClaim,
+  SubagentTaskControlCommand,
+  SubagentTaskControlResult,
+  SubagentTaskProgress,
+  SubagentTaskRuntime,
+  SubagentTaskSnapshot,
+  SubagentTaskStartRequest,
+  SubagentTaskStartResult,
+  SubagentTaskStatus,
+  SubagentTaskStore,
+  SubagentUpdateEvent,
+} from '@/types';
+
+const DEFAULT_COMPLETED_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_MAX_ERROR_CHARS = 4 * 1024;
+const DEFAULT_MAX_MESSAGE_CHARS = 64 * 1024;
+const DEFAULT_TASK_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_CONTROLS = 32;
+const DEFAULT_MAX_RESULT_CHARS = 100_000;
+const DEFAULT_MAX_RUNNING_PER_SCOPE = 10;
+const DEFAULT_MAX_RUNNING_TOTAL = 100;
+const DEFAULT_MAX_TASKS_PER_SCOPE = 200;
+const DEFAULT_MAX_TASKS_TOTAL = 2_000;
+
+export interface InMemorySubagentTaskStoreOptions {
+  completedTtlMs?: number;
+  maxControlMessageChars?: number;
+  maxControlsPerTask?: number;
+  maxErrorChars?: number;
+  maxResultChars?: number;
+  maxRunningPerScope?: number;
+  maxRunningTotal?: number;
+  maxTasksPerScope?: number;
+  maxTasksTotal?: number;
+  taskTimeoutMs?: number;
+}
+
+type PendingControl = {
+  id: string;
+  action: 'steer' | 'queue' | 'interrupt';
+  message: string;
+};
+
+type StoredTask = {
+  id: string;
+  idempotencyKey: string;
+  requestFingerprint?: string;
+  scopeId: string;
+  subagentType: string;
+  status: SubagentTaskStatus;
+  createdAt: number;
+  updatedAt: number;
+  controller: AbortController;
+  controls: PendingControl[];
+  progressEvents: number;
+  resultClaimed: boolean;
+  acceptingControls: boolean;
+  result?: string;
+  error?: string;
+  progress?: SubagentTaskProgress;
+  expiry?: ReturnType<typeof setTimeout>;
+  timeout?: ReturnType<typeof setTimeout>;
+};
+
+type TaskBucket = {
+  tasks: Map<string, StoredTask>;
+  taskIdByIdempotencyKey: Map<string, string>;
+};
+
+type ResolvedOptions = Required<InMemorySubagentTaskStoreOptions>;
+
+function resolvePositiveInteger(
+  value: number | undefined,
+  fallback: number
+): number {
+  return Number.isSafeInteger(value) && value != null && value > 0
+    ? value
+    : fallback;
+}
+
+function resolveOptions(
+  options: InMemorySubagentTaskStoreOptions
+): ResolvedOptions {
+  const maxTasksPerScope = resolvePositiveInteger(
+    options.maxTasksPerScope,
+    DEFAULT_MAX_TASKS_PER_SCOPE
+  );
+  const maxTasksTotal = resolvePositiveInteger(
+    options.maxTasksTotal,
+    DEFAULT_MAX_TASKS_TOTAL
+  );
+  return {
+    completedTtlMs: resolvePositiveInteger(
+      options.completedTtlMs,
+      DEFAULT_COMPLETED_TTL_MS
+    ),
+    maxControlMessageChars: resolvePositiveInteger(
+      options.maxControlMessageChars,
+      DEFAULT_MAX_MESSAGE_CHARS
+    ),
+    maxControlsPerTask: resolvePositiveInteger(
+      options.maxControlsPerTask,
+      DEFAULT_MAX_CONTROLS
+    ),
+    maxErrorChars: resolvePositiveInteger(
+      options.maxErrorChars,
+      DEFAULT_MAX_ERROR_CHARS
+    ),
+    maxResultChars: resolvePositiveInteger(
+      options.maxResultChars,
+      DEFAULT_MAX_RESULT_CHARS
+    ),
+    maxRunningPerScope: Math.min(
+      resolvePositiveInteger(
+        options.maxRunningPerScope,
+        DEFAULT_MAX_RUNNING_PER_SCOPE
+      ),
+      maxTasksPerScope
+    ),
+    maxRunningTotal: Math.min(
+      resolvePositiveInteger(
+        options.maxRunningTotal,
+        DEFAULT_MAX_RUNNING_TOTAL
+      ),
+      maxTasksTotal
+    ),
+    maxTasksPerScope,
+    maxTasksTotal,
+    taskTimeoutMs: resolvePositiveInteger(
+      options.taskTimeoutMs,
+      DEFAULT_TASK_TIMEOUT_MS
+    ),
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+  return 'Detached subagent task failed.';
+}
+
+function truncateMiddle(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  const marker = '\n…[truncated]…\n';
+  const available = Math.max(0, maxChars - marker.length);
+  const head = Math.ceil(available / 2);
+  return `${value.slice(0, head)}${marker}${value.slice(
+    value.length - (available - head)
+  )}`;
+}
+
+function toInjectedMessage(control: PendingControl): InjectedMessage {
+  return {
+    role: 'user',
+    content: control.message,
+    source: 'steer',
+  };
+}
+
+function snapshot(task: StoredTask): SubagentTaskSnapshot {
+  return {
+    taskId: task.id,
+    subagentType: task.subagentType,
+    status: task.status,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    resultAvailable:
+      task.status === 'completed' &&
+      task.result != null &&
+      !task.resultClaimed,
+    resultClaimed: task.resultClaimed,
+    pendingControls: task.controls.length,
+    ...(task.progress == null ? {} : { progress: { ...task.progress } }),
+    ...(task.error == null ? {} : { error: task.error }),
+  };
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Detached subagent task cancelled.');
+}
+
+/**
+ * Bounded process-local task ownership for detached subagents. Hosts may
+ * replace this store without changing the executor; this default deliberately
+ * makes no restart or cross-replica durability claim.
+ */
+export class InMemorySubagentTaskStore implements SubagentTaskStore {
+  private readonly buckets = new Map<string, TaskBucket>();
+  private readonly options: ResolvedOptions;
+  private runningTasks = 0;
+  private totalTasks = 0;
+
+  constructor(options: InMemorySubagentTaskStoreOptions = {}) {
+    this.options = resolveOptions(options);
+  }
+
+  start(request: SubagentTaskStartRequest): SubagentTaskStartResult {
+    const scopeId = request.scopeId.trim();
+    const idempotencyKey = request.idempotencyKey.trim();
+    const requestFingerprint = request.requestFingerprint?.trim();
+    if (scopeId === '' || idempotencyKey === '') {
+      throw new Error('Subagent task scope and idempotency key are required.');
+    }
+    const now = Date.now();
+    const bucket = this.getBucket(scopeId);
+    this.sweepBucket(bucket, now);
+    const existingId = bucket.taskIdByIdempotencyKey.get(idempotencyKey);
+    if (existingId != null) {
+      const existing = bucket.tasks.get(existingId);
+      if (existing != null) {
+        if (
+          requestFingerprint != null &&
+          requestFingerprint !== '' &&
+          existing.requestFingerprint != null &&
+          existing.requestFingerprint !== requestFingerprint
+        ) {
+          return {
+            accepted: false,
+            reason: 'conflict',
+            task: snapshot(existing),
+          };
+        }
+        return { accepted: true, isNew: false, task: snapshot(existing) };
+      }
+      bucket.taskIdByIdempotencyKey.delete(idempotencyKey);
+    }
+    let running = 0;
+    for (const task of bucket.tasks.values()) {
+      if (task.status === 'running') {
+        running += 1;
+      }
+    }
+    if (
+      running >= this.options.maxRunningPerScope ||
+      this.runningTasks >= this.options.maxRunningTotal
+    ) {
+      this.dropEmptyBucket(scopeId, bucket);
+      return { accepted: false, reason: 'capacity' };
+    }
+    if (!this.makeRoom(bucket) || !this.makeGlobalRoom()) {
+      this.dropEmptyBucket(scopeId, bucket);
+      return { accepted: false, reason: 'capacity' };
+    }
+    const task: StoredTask = {
+      id: nanoid(),
+      idempotencyKey,
+      ...(requestFingerprint == null || requestFingerprint === ''
+        ? {}
+        : { requestFingerprint }),
+      scopeId,
+      subagentType: request.subagentType,
+      status: 'running',
+      createdAt: now,
+      updatedAt: now,
+      controller: new AbortController(),
+      controls: [],
+      progressEvents: 0,
+      resultClaimed: false,
+      acceptingControls: true,
+    };
+    this.buckets.set(scopeId, bucket);
+    bucket.tasks.set(task.id, task);
+    bucket.taskIdByIdempotencyKey.set(idempotencyKey, task.id);
+    this.runningTasks += 1;
+    this.totalTasks += 1;
+    task.timeout = setTimeout(() => {
+      this.finishWithError(
+        task,
+        'error',
+        new Error('Detached subagent task timed out.')
+      );
+    }, this.options.taskTimeoutMs);
+    task.timeout.unref();
+    const runtime = this.createRuntime(task);
+    void Promise.resolve()
+      .then(() => request.run(runtime))
+      .then(
+        (result) => {
+          if (task.status !== 'running') {
+            return;
+          }
+          if (task.controller.signal.aborted) {
+            this.finishWithError(
+              task,
+              'cancelled',
+              abortReason(task.controller.signal)
+            );
+            return;
+          }
+          task.status = 'completed';
+          task.acceptingControls = false;
+          task.controls.length = 0;
+          task.result = truncateMiddle(
+            result.content,
+            this.options.maxResultChars
+          );
+          task.updatedAt = Date.now();
+          this.runningTasks -= 1;
+          this.scheduleExpiry(task);
+        },
+        (error: unknown) => {
+          const status = task.controller.signal.aborted
+            ? 'cancelled'
+            : 'error';
+          this.finishWithError(task, status, error);
+        }
+      );
+    return { accepted: true, isNew: true, task: snapshot(task) };
+  }
+
+  get(scopeId: string, taskId: string): SubagentTaskSnapshot | undefined {
+    const task = this.find(scopeId, taskId);
+    return task == null ? undefined : snapshot(task);
+  }
+
+  list(scopeId: string): SubagentTaskSnapshot[] {
+    const bucket = this.buckets.get(scopeId.trim());
+    if (bucket == null) {
+      return [];
+    }
+    this.sweepBucket(bucket, Date.now());
+    return [...bucket.tasks.values()]
+      .sort((left, right) => left.createdAt - right.createdAt)
+      .map(snapshot);
+  }
+
+  claim(scopeId: string, taskId: string): SubagentTaskClaim {
+    const task = this.find(scopeId, taskId);
+    if (task == null) {
+      return { status: 'not_found' };
+    }
+    if (task.status === 'running') {
+      return { status: 'running', task: snapshot(task) };
+    }
+    if (task.resultClaimed) {
+      return { status: 'claimed', task: snapshot(task) };
+    }
+    task.resultClaimed = true;
+    task.updatedAt = Date.now();
+    const taskSnapshot = snapshot(task);
+    this.scheduleExpiry(task);
+    if (task.status === 'completed') {
+      const result = task.result ?? '';
+      task.result = undefined;
+      return { status: 'completed', task: taskSnapshot, result };
+    }
+    const error = task.error ?? 'Detached subagent task did not complete.';
+    return { status: task.status, task: taskSnapshot, error };
+  }
+
+  control(
+    scopeId: string,
+    taskId: string,
+    command: SubagentTaskControlCommand
+  ): SubagentTaskControlResult {
+    const task = this.find(scopeId, taskId);
+    if (task == null) {
+      return { status: 'not_found' };
+    }
+    if (command.action === 'cancel') {
+      if (task.status !== 'running') {
+        return { status: 'not_running', task: snapshot(task) };
+      }
+      this.finishWithError(
+        task,
+        'cancelled',
+        new Error('Detached subagent task cancelled by its parent.')
+      );
+      return { status: 'cancelled', task: snapshot(task) };
+    }
+    if (task.status !== 'running' || !task.acceptingControls) {
+      return { status: 'not_running', task: snapshot(task) };
+    }
+    if (command.action === 'cancel_message') {
+      const index = task.controls.findIndex(
+        (control) => control.id === command.controlId
+      );
+      if (index < 0) {
+        return { status: 'control_not_found', task: snapshot(task) };
+      }
+      task.controls.splice(index, 1);
+      task.updatedAt = Date.now();
+      return { status: 'accepted', task: snapshot(task) };
+    }
+    const message = command.message.trim();
+    if (message === '') {
+      return { status: 'invalid', message: 'A non-empty message is required.' };
+    }
+    if (message.length > this.options.maxControlMessageChars) {
+      return {
+        status: 'invalid',
+        message: `Message exceeds ${this.options.maxControlMessageChars} characters.`,
+      };
+    }
+    if (task.controls.length >= this.options.maxControlsPerTask) {
+      return {
+        status: 'invalid',
+        message: `Task already has ${this.options.maxControlsPerTask} pending messages.`,
+      };
+    }
+    const control: PendingControl = {
+      id: nanoid(),
+      action: command.action,
+      message,
+    };
+    task.controls.push(control);
+    task.updatedAt = Date.now();
+    return {
+      status: 'accepted',
+      task: snapshot(task),
+      controlId: control.id,
+    };
+  }
+
+  private getBucket(scopeId: string): TaskBucket {
+    let bucket = this.buckets.get(scopeId);
+    if (bucket == null) {
+      bucket = {
+        tasks: new Map(),
+        taskIdByIdempotencyKey: new Map(),
+      };
+      this.buckets.set(scopeId, bucket);
+    }
+    return bucket;
+  }
+
+  private find(scopeId: string, taskId: string): StoredTask | undefined {
+    const bucket = this.buckets.get(scopeId.trim());
+    if (bucket == null) {
+      return undefined;
+    }
+    this.sweepBucket(bucket, Date.now());
+    return bucket.tasks.get(taskId);
+  }
+
+  private makeRoom(bucket: TaskBucket): boolean {
+    if (bucket.tasks.size < this.options.maxTasksPerScope) {
+      return true;
+    }
+    const terminal = [...bucket.tasks.values()]
+      .filter((task) => task.status !== 'running')
+      .sort((left, right) => left.updatedAt - right.updatedAt);
+    let removeCount = bucket.tasks.size - this.options.maxTasksPerScope + 1;
+    for (const task of terminal) {
+      if (removeCount <= 0) {
+        break;
+      }
+      this.removeTask(task);
+      removeCount -= 1;
+    }
+    return bucket.tasks.size < this.options.maxTasksPerScope;
+  }
+
+  private makeGlobalRoom(): boolean {
+    if (this.totalTasks < this.options.maxTasksTotal) {
+      return true;
+    }
+    const terminal = [...this.buckets.values()]
+      .flatMap((bucket) => [...bucket.tasks.values()])
+      .filter((task) => task.status !== 'running')
+      .sort((left, right) => left.updatedAt - right.updatedAt);
+    let removeCount = this.totalTasks - this.options.maxTasksTotal + 1;
+    for (const task of terminal) {
+      if (removeCount <= 0) {
+        break;
+      }
+      this.removeTask(task);
+      removeCount -= 1;
+    }
+    return this.totalTasks < this.options.maxTasksTotal;
+  }
+
+  private sweepBucket(bucket: TaskBucket, now: number): void {
+    for (const task of bucket.tasks.values()) {
+      if (
+        task.status !== 'running' &&
+        now - task.updatedAt > this.options.completedTtlMs
+      ) {
+        this.removeTask(task);
+      }
+    }
+  }
+
+  private removeTask(task: StoredTask): void {
+    const bucket = this.buckets.get(task.scopeId);
+    if (bucket?.tasks.get(task.id) !== task) {
+      return;
+    }
+    bucket.tasks.delete(task.id);
+    this.totalTasks -= 1;
+    if (
+      bucket.taskIdByIdempotencyKey.get(task.idempotencyKey) === task.id
+    ) {
+      bucket.taskIdByIdempotencyKey.delete(task.idempotencyKey);
+    }
+    if (bucket.tasks.size === 0) {
+      this.buckets.delete(task.scopeId);
+    }
+    this.clearTaskExpiry(task);
+    this.clearTaskTimeout(task);
+  }
+
+  private dropEmptyBucket(scopeId: string, bucket: TaskBucket): void {
+    if (bucket.tasks.size === 0 && this.buckets.get(scopeId) === bucket) {
+      this.buckets.delete(scopeId);
+    }
+  }
+
+  private scheduleExpiry(task: StoredTask): void {
+    this.clearTaskTimeout(task);
+    this.clearTaskExpiry(task);
+    task.expiry = setTimeout(() => {
+      this.removeTask(task);
+    }, this.options.completedTtlMs);
+    task.expiry.unref();
+  }
+
+  private clearTaskExpiry(task: StoredTask): void {
+    if (task.expiry == null) {
+      return;
+    }
+    clearTimeout(task.expiry);
+    task.expiry = undefined;
+  }
+
+  private clearTaskTimeout(task: StoredTask): void {
+    if (task.timeout == null) {
+      return;
+    }
+    clearTimeout(task.timeout);
+    task.timeout = undefined;
+  }
+
+  private finishWithError(
+    task: StoredTask,
+    status: 'error' | 'cancelled',
+    error: unknown
+  ): void {
+    if (task.status !== 'running') {
+      return;
+    }
+    const message = truncateMiddle(
+      toErrorMessage(error),
+      this.options.maxErrorChars
+    );
+    const resolved = new Error(message);
+    task.status = status;
+    this.runningTasks -= 1;
+    task.acceptingControls = false;
+    task.controls.length = 0;
+    task.error = message;
+    task.updatedAt = Date.now();
+    this.scheduleExpiry(task);
+    task.controller.abort(resolved);
+  }
+
+  private createRuntime(task: StoredTask): SubagentTaskRuntime {
+    const take = (
+      accept: (control: PendingControl) => boolean
+    ): InjectedMessage[] => {
+      if (task.status !== 'running') {
+        return [];
+      }
+      const selected: PendingControl[] = [];
+      const retained: PendingControl[] = [];
+      for (const control of task.controls) {
+        (accept(control) ? selected : retained).push(control);
+      }
+      task.controls = retained;
+      if (selected.length > 0) {
+        task.updatedAt = Date.now();
+      }
+      return selected.map(toInjectedMessage);
+    };
+    return {
+      taskId: task.id,
+      signal: task.controller.signal,
+      shouldPreempt: (): boolean =>
+        task.status === 'running' &&
+        task.controls.some((control) => control.action === 'interrupt'),
+      drain: (boundary: SubagentTaskBoundary): InjectedMessage[] => {
+        if (boundary === 'preempt') {
+          return take((control) => control.action === 'interrupt');
+        }
+        if (boundary === 'tool') {
+          return take((control) => control.action !== 'queue');
+        }
+        return take(() => true);
+      },
+      closeTurn: (): { closed: boolean; messages: InjectedMessage[] } => {
+        const messages = take(() => true);
+        if (messages.length > 0) {
+          return { closed: false, messages };
+        }
+        task.acceptingControls = false;
+        return { closed: true, messages: [] };
+      },
+      reportProgress: (event: SubagentUpdateEvent): void => {
+        if (task.status !== 'running') {
+          return;
+        }
+        task.progressEvents += 1;
+        task.updatedAt = Date.now();
+        task.progress = {
+          phase: event.phase,
+          at: task.updatedAt,
+          eventCount: task.progressEvents,
+          ...(event.label == null ? {} : { label: event.label }),
+        };
+      },
+    };
+  }
+}

--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -172,9 +172,7 @@ function snapshot(task: StoredTask): SubagentTaskSnapshot {
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
     resultAvailable:
-      task.status === 'completed' &&
-      task.result != null &&
-      !task.resultClaimed,
+      task.status === 'completed' && task.result != null && !task.resultClaimed,
     resultClaimed: task.resultClaimed,
     pendingControls: task.controls.length,
     ...(task.progress == null ? {} : { progress: { ...task.progress } }),
@@ -189,9 +187,12 @@ function abortReason(signal: AbortSignal): Error {
 }
 
 /**
- * Bounded process-local task ownership for detached subagents. Hosts may
- * replace this store without changing the executor; this default deliberately
- * makes no restart or cross-replica durability claim.
+ * Bounded process-local task ownership for detached subagents. Terminal tasks
+ * keep only a bounded claimable result: the child graph, checkpoint, and full
+ * transcript are released. Hosts that need later child-chat continuation may
+ * replace this store and persist the canonical messages returned by `run`.
+ * This default deliberately makes no restart or cross-replica durability
+ * claim.
  */
 export class InMemorySubagentTaskStore implements SubagentTaskStore {
   private readonly buckets = new Map<string, TaskBucket>();
@@ -282,10 +283,15 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     task.timeout.unref();
     const runtime = this.createRuntime(task);
     void Promise.resolve()
-      .then(() => request.run(runtime))
+      .then(() => {
+        if (task.status !== 'running' || task.controller.signal.aborted) {
+          return undefined;
+        }
+        return request.run(runtime);
+      })
       .then(
         (result) => {
-          if (task.status !== 'running') {
+          if (task.status !== 'running' || result == null) {
             return;
           }
           if (task.controller.signal.aborted) {
@@ -308,9 +314,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
           this.scheduleExpiry(task);
         },
         (error: unknown) => {
-          const status = task.controller.signal.aborted
-            ? 'cancelled'
-            : 'error';
+          const status = task.controller.signal.aborted ? 'cancelled' : 'error';
           this.finishWithError(task, status, error);
         }
       );
@@ -497,9 +501,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     }
     bucket.tasks.delete(task.id);
     this.totalTasks -= 1;
-    if (
-      bucket.taskIdByIdempotencyKey.get(task.idempotencyKey) === task.id
-    ) {
+    if (bucket.taskIdByIdempotencyKey.get(task.idempotencyKey) === task.id) {
       bucket.taskIdByIdempotencyKey.delete(task.idempotencyKey);
     }
     if (bucket.tasks.size === 0) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -76,18 +76,17 @@ import type {
   SubagentExecutionRecord,
 } from './SubagentExecutionRegistry';
 import type {
-  AggregatedHookResult,
-  HookRegistry,
-  PostToolBatchHookOutput,
-  PreemptBoundaryHookOutput,
-  ToolApprovalReplaySnapshot,
-} from '@/hooks';
-import type {
   SubagentResumeExecution,
   SubagentResumeManifest,
   SubagentCheckpointReference,
   SettledSubagentToolOutput,
 } from './SubagentReplay';
+import type {
+  AggregatedHookResult,
+  PostToolBatchHookOutput,
+  PreemptBoundaryHookOutput,
+  ToolApprovalReplaySnapshot,
+} from '@/hooks';
 import type { GraphFactory } from '@/graphs/graphFactory';
 import type { StandardGraph } from '@/graphs/Graph';
 import {
@@ -105,6 +104,11 @@ import {
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from './SubagentReplay';
 import {
+  executeHooks,
+  HookRegistry,
+  TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY,
+} from '@/hooks';
+import {
   StreamLimitExceededError,
   RUN_BREAKER_SCOPE_CONFIG_KEY,
 } from '@/llm/streamLimits';
@@ -119,10 +123,6 @@ import {
   Callback,
   StepTypes,
 } from '@/common';
-import {
-  executeHooks,
-  TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY,
-} from '@/hooks';
 import {
   createChildGraphPlan,
   isGraphSubagentConfig,
@@ -817,7 +817,16 @@ export type SubagentExecuteParams = {
 export type SubagentExecuteResult = {
   content: string;
   messages: BaseMessage[];
+  /** Tagged internal failure; foreground callers retain the legacy content. */
+  error?: string;
 };
+
+function createSubagentFailure(
+  content: string,
+  error = content
+): SubagentExecuteResult {
+  return { content, messages: [], error };
+}
 
 /**
  * Factory that constructs a child graph for subagent execution. Injected
@@ -1058,10 +1067,16 @@ export class SubagentExecutor {
     if (parentToolCallId == null || parentToolCallId === '') {
       return JSON.stringify({
         status: 'rejected',
-        message: 'Background subagent execution requires a parent tool call ID.',
+        message:
+          'Background subagent execution requires a parent tool call ID.',
       });
     }
     const detachedHandlers = new HandlerRegistry();
+    const sourceHookSessionId =
+      asNonEmptyString(params.parentConfigurable?.run_id) ??
+      this.executionContext.hookSessionId;
+    const taskHookRegistry =
+      this.hookRegistry?.forkSession(sourceHookSessionId) ?? new HookRegistry();
     const toolHandler = this.getParentHandlerRegistry()?.getHandler(
       GraphEvents.ON_TOOL_EXECUTE
     );
@@ -1070,9 +1085,6 @@ export class SubagentExecutor {
     }
     const detachedGraphFactory =
       this.createDetachedChildGraphFactory?.(detachedHandlers);
-    const sourceHookSessionId =
-      asNonEmptyString(params.parentConfigurable?.run_id) ??
-      this.executionContext.hookSessionId;
     const started = this.taskConfig.store.start({
       scopeId: this.taskConfig.scopeId,
       idempotencyKey: JSON.stringify([
@@ -1090,6 +1102,7 @@ export class SubagentExecutor {
           params,
           runtime,
           detachedHandlers,
+          taskHookRegistry,
           detachedGraphFactory
         ),
     });
@@ -1106,24 +1119,15 @@ export class SubagentExecutor {
         status: 'rejected',
         tool: Constants.SUBAGENT,
         message:
-          'Too many background subagent tasks are already running in this scope. Poll or cancel an existing task, or run this call in the foreground.',
+          'Too many background subagent tasks are already running in this scope or process. Poll or cancel an existing task, or run this call in the foreground.',
       });
-    }
-    if (started.isNew) {
-      this.hookRegistry?.copySession(
-        sourceHookSessionId,
-        getBackgroundTaskHookSessionId(
-          sourceHookSessionId,
-          started.task.taskId
-        )
-      );
     }
     return JSON.stringify({
       background_task_id: started.task.taskId,
       tool: Constants.SUBAGENT,
       subagent_type: params.subagentType,
       status: started.task.status,
-      message: `Started subagent "${params.subagentType}" in the background. Poll the host background-task tool with background_task_id "${started.task.taskId}" to check progress or collect its result.`,
+      message: `${started.isNew ? 'Started' : 'Reused'} subagent "${params.subagentType}" background task. Poll the host background-task tool with background_task_id "${started.task.taskId}" to check progress or collect its result.`,
     });
   }
 
@@ -1131,6 +1135,7 @@ export class SubagentExecutor {
     params: SubagentExecuteParams,
     runtime: SubagentTaskRuntime,
     detachedHandlers: HandlerRegistry,
+    taskHookRegistry: HookRegistry,
     detachedGraphFactory?: GraphFactory
   ): Promise<SubagentExecuteResult> {
     const sourceHookSessionId =
@@ -1141,25 +1146,22 @@ export class SubagentExecutor {
       runtime.taskId
     );
     const unregisterHooks: Array<() => void> = [];
-    if (this.hookRegistry != null) {
-      this.hookRegistry.copySession(sourceHookSessionId, taskHookSessionId);
-      unregisterHooks.push(
-        this.hookRegistry.registerSession(taskHookSessionId, 'PostToolBatch', {
-          hooks: [
-            (): PostToolBatchHookOutput => ({
-              injectedMessages: runtime.drain('tool'),
-            }),
-          ],
-        }),
-        this.hookRegistry.registerSession(taskHookSessionId, 'PreemptBoundary', {
-          hooks: [
-            (): PreemptBoundaryHookOutput => ({
-              injectedMessages: runtime.drain('preempt'),
-            }),
-          ],
-        })
-      );
-    }
+    unregisterHooks.push(
+      taskHookRegistry.registerSession(taskHookSessionId, 'PostToolBatch', {
+        hooks: [
+          (): PostToolBatchHookOutput => ({
+            injectedMessages: runtime.drain('tool'),
+          }),
+        ],
+      }),
+      taskHookRegistry.registerSession(taskHookSessionId, 'PreemptBoundary', {
+        hooks: [
+          (): PreemptBoundaryHookOutput => ({
+            injectedMessages: runtime.drain('preempt'),
+          }),
+        ],
+      })
+    );
 
     detachedHandlers.register(GraphEvents.ON_SUBAGENT_UPDATE, {
       handle: (_event, data): void => {
@@ -1170,7 +1172,7 @@ export class SubagentExecutor {
     const detached = new SubagentExecutor({
       configs: this.configs,
       parentSignal: runtime.signal,
-      hookRegistry: this.hookRegistry,
+      hookRegistry: taskHookRegistry,
       parentHandlerRegistry: detachedHandlers,
       parentRunId: this.parentRunId,
       parentAgentId: this.parentAgentId,
@@ -1208,13 +1210,16 @@ export class SubagentExecutor {
           ? runtime.signal.reason
           : new Error('Detached subagent task cancelled.');
       }
+      if (result.error != null) {
+        throw new Error(result.error);
+      }
       return result;
     } finally {
       detached.clearHeavyState();
       for (const unregister of unregisterHooks) {
         unregister();
       }
-      this.hookRegistry?.clearSession(taskHookSessionId);
+      taskHookRegistry.clearSession(taskHookSessionId);
     }
   }
 
@@ -2179,36 +2184,38 @@ export class SubagentExecutor {
     const executableConfig = this.configs.get(params.subagentType);
     if (executableConfig == null) {
       const available = [...this.configs.keys()].join(', ');
-      return Promise.resolve({
-        content: `Error: Unknown subagent type "${params.subagentType}". Available types: ${available}`,
-        messages: [],
-      });
+      return Promise.resolve(
+        createSubagentFailure(
+          `Error: Unknown subagent type "${params.subagentType}". Available types: ${available}`
+        )
+      );
     }
     if (this.maxDepth <= 0) {
-      return Promise.resolve({
-        content: 'Error: Maximum subagent nesting depth exceeded.',
-        messages: [],
-      });
+      return Promise.resolve(
+        createSubagentFailure(
+          'Error: Maximum subagent nesting depth exceeded.'
+        )
+      );
     }
     if (
       isGraphSubagentConfig(executableConfig) &&
       this.humanInTheLoop?.enabled === true
     ) {
-      return Promise.resolve({
-        content:
-          'Error: Human-in-the-loop execution is not yet supported for graph subagents.',
-        messages: [],
-      });
+      return Promise.resolve(
+        createSubagentFailure(
+          'Error: Human-in-the-loop execution is not yet supported for graph subagents.'
+        )
+      );
     }
     if (
       this.humanInTheLoop?.enabled === true &&
       (params.parentToolCallId == null || params.parentToolCallId === '')
     ) {
-      return Promise.resolve({
-        content:
-          'Error: Resumable subagent execution requires a parent tool call ID.',
-        messages: [],
-      });
+      return Promise.resolve(
+        createSubagentFailure(
+          'Error: Resumable subagent execution requires a parent tool call ID.'
+        )
+      );
     }
     const execution = this.executions.open({
       threadId: params.threadId,
@@ -2228,16 +2235,14 @@ export class SubagentExecutor {
       );
     } catch (error) {
       if (error instanceof SubagentDefinitionBindingError) {
-        return Promise.resolve({
-          content: SUBAGENT_CONFIG_CHANGED_MESSAGE,
-          messages: [],
-        });
+        return Promise.resolve(
+          createSubagentFailure(SUBAGENT_CONFIG_CHANGED_MESSAGE)
+        );
       }
       if (error instanceof SubagentInvocationBindingError) {
-        return Promise.resolve({
-          content: SUBAGENT_INVOCATION_CHANGED_MESSAGE,
-          messages: [],
-        });
+        return Promise.resolve(
+          createSubagentFailure(SUBAGENT_INVOCATION_CHANGED_MESSAGE)
+        );
       }
       throw error;
     }
@@ -2269,10 +2274,7 @@ export class SubagentExecutor {
       )
     ) {
       this.executions.remove(execution);
-      return {
-        content: SUBAGENT_CONFIG_CHANGED_MESSAGE,
-        messages: [],
-      };
+      return createSubagentFailure(SUBAGENT_CONFIG_CHANGED_MESSAGE);
     }
     let identity: SubagentExecutionIdentity;
     try {
@@ -2282,10 +2284,7 @@ export class SubagentExecutor {
       if (error instanceof StreamLimitExceededError) {
         throw error;
       }
-      return {
-        content: SUBAGENT_RESOLUTION_ERROR_MESSAGE,
-        messages: [],
-      };
+      return createSubagentFailure(SUBAGENT_RESOLUTION_ERROR_MESSAGE);
     }
     const { childRunId, childThreadId, approvalExecutionScope } = identity;
     const bound = this.bindExecutionDefinition(
@@ -2299,7 +2298,7 @@ export class SubagentExecutor {
       'effective'
     );
     if (!bound) {
-      return { content: SUBAGENT_CONFIG_CHANGED_MESSAGE, messages: [] };
+      return createSubagentFailure(SUBAGENT_CONFIG_CHANGED_MESSAGE);
     }
     const completedChildResult = execution.completedResult;
     if (completedChildResult != null) {
@@ -2320,10 +2319,7 @@ export class SubagentExecutor {
       if (error instanceof StreamLimitExceededError) {
         throw error;
       }
-      return {
-        content: SUBAGENT_RESOLUTION_ERROR_MESSAGE,
-        messages: [],
-      };
+      return createSubagentFailure(SUBAGENT_RESOLUTION_ERROR_MESSAGE);
     }
 
     const parentRegistry = this.getParentHandlerRegistry();
@@ -2372,7 +2368,8 @@ export class SubagentExecutor {
     const memberRecursionLimit = maxTurns * SUBAGENT_RECURSION_MULTIPLIER;
     const recursionLimit =
       memberRecursionLimit *
-      (childPlan.kind === 'graph' ? childPlan.agents.length : 1);
+        (childPlan.kind === 'graph' ? childPlan.agents.length : 1) +
+      (params.taskRuntime == null ? 0 : MAX_BACKGROUND_SUBAGENT_SEALS);
 
     const hostUsageSink = this.usageSink;
     let subagentUsageSink: SubagentUsageSink | undefined;
@@ -2415,11 +2412,9 @@ export class SubagentExecutor {
     let childGraph = cachedChildRun?.graph;
     if (childGraph == null && childPlan.kind === 'graph') {
       if (this.createChildGraphByKind == null) {
-        return {
-          content:
-            'Error: Graph subagent execution requires a polymorphic child graph factory.',
-          messages: [],
-        };
+        return createSubagentFailure(
+          'Error: Graph subagent execution requires a polymorphic child graph factory.'
+        );
       }
       childGraph = this.createChildGraphByKind({
         kind: 'multi-agent',
@@ -2432,6 +2427,9 @@ export class SubagentExecutor {
       });
     }
     childGraph ??= this.createChildGraph(childGraphInput);
+    if (params.taskRuntime != null) {
+      childGraph.hookRegistry = this.hookRegistry;
+    }
     if (cachedChildRun == null) {
       seedChildGraphSessions(childGraph, childPlan.agents);
     }
@@ -2804,10 +2802,10 @@ export class SubagentExecutor {
       if (error instanceof StreamLimitExceededError) {
         throw error;
       }
-      return {
-        content: `Subagent error: ${errorMessage}`,
-        messages: [],
-      };
+      return createSubagentFailure(
+        `Subagent error: ${errorMessage}`,
+        errorMessage
+      );
     }
 
     /**

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -52,6 +52,8 @@ import type {
   ResolvedSubagentConfig,
   ResolvedSubagentConfigEntry,
   SubagentExecutionContext,
+  SubagentTaskConfig,
+  SubagentTaskRuntime,
   SubagentResolveConfigurable,
   SubagentResolveRequestContext,
   SubagentResolveUserContext,
@@ -74,19 +76,20 @@ import type {
   SubagentExecutionRecord,
 } from './SubagentExecutionRegistry';
 import type {
+  AggregatedHookResult,
+  HookRegistry,
+  PostToolBatchHookOutput,
+  PreemptBoundaryHookOutput,
+  ToolApprovalReplaySnapshot,
+} from '@/hooks';
+import type {
   SubagentResumeExecution,
   SubagentResumeManifest,
   SubagentCheckpointReference,
   SettledSubagentToolOutput,
 } from './SubagentReplay';
-import type {
-  AggregatedHookResult,
-  HookRegistry,
-  ToolApprovalReplaySnapshot,
-} from '@/hooks';
 import type { GraphFactory } from '@/graphs/graphFactory';
 import type { StandardGraph } from '@/graphs/Graph';
-import type { HandlerRegistry } from '@/events';
 import {
   getSubagentApprovalExecutionScope,
   SubagentDefinitionBindingError,
@@ -127,7 +130,9 @@ import {
 import { stripRunStepResumeState } from '@/tools/runStepResume';
 import { seedAgentInitialSessions } from '@/utils/toolSessions';
 import { stableStringify } from '@/tools/eagerEventExecution';
+import { convertInjectedMessages } from '@/messages/injected';
 import { composeAbortSignals } from '@/utils/misc';
+import { HandlerRegistry } from '@/events';
 
 export {
   buildChildInputs,
@@ -140,6 +145,7 @@ export {
 
 const ERROR_MESSAGE_MAX_CHARS = 200;
 const MAX_QUEUED_SUBAGENT_UPDATES = 64;
+const MAX_BACKGROUND_SUBAGENT_SEALS = 32;
 const SUBAGENT_UPDATE_HANDLER_TIMEOUT_MS = 5_000;
 const TEXT_DELTA_CONTENT_TYPE = `${ContentTypes.TEXT}_delta`;
 const SUBAGENT_RESOLUTION_ERROR_MESSAGE =
@@ -615,6 +621,22 @@ function getSettlementFingerprint(output: PersistedToolOutput): string {
   return createHash('sha256').update(stableStringify(output)).digest('hex');
 }
 
+function getBackgroundTaskFingerprint(
+  description: string,
+  subagentType: string
+): string {
+  return createHash('sha256')
+    .update(stableStringify({ description, subagentType }))
+    .digest('hex');
+}
+
+function getBackgroundTaskHookSessionId(
+  sourceHookSessionId: string,
+  taskId: string
+): string {
+  return `${sourceHookSessionId}:subagent-task:${taskId}`;
+}
+
 function deserializeToolOutput(
   output: PersistedToolOutput
 ): SettledSubagentToolOutput {
@@ -786,6 +808,10 @@ export type SubagentExecuteParams = {
    * rather than sharing parent's host context.
    */
   parentConfigurable?: Record<string, unknown>;
+  /** Dedicated hook session used by a detached task. @internal */
+  hookSessionId?: string;
+  /** Process-local task controls consumed by the child graph. @internal */
+  taskRuntime?: SubagentTaskRuntime;
 };
 
 export type SubagentExecuteResult = {
@@ -849,6 +875,13 @@ export type SubagentExecutorOptions = {
    * factory remains required for source compatibility. */
   createChildGraphByKind?: GraphFactory;
   /**
+   * Captures a child-graph factory and its run-scoped host dependencies
+   * synchronously, before a detached task can outlive parent cleanup.
+   */
+  createDetachedChildGraphFactory?: (
+    parentHandlerRegistry: HandlerRegistry
+  ) => GraphFactory;
+  /**
    * Parent's event handler registry. When provided, child-graph events are
    * forwarded through this registry so hosts can:
    *   (a) execute event-driven tools (`ON_TOOL_EXECUTE` routed to parent's handler),
@@ -870,6 +903,8 @@ export type SubagentExecutorOptions = {
    * nested subagents report through the same sink.
    */
   usageSink?: SubagentUsageSink;
+  /** Host-owned process-local task namespace for detached execution. */
+  taskConfig?: SubagentTaskConfig;
 };
 
 type DurableExecutionRecord = SubagentExecutionRecord<
@@ -902,7 +937,11 @@ export class SubagentExecutor {
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
   private readonly createChildGraphByKind?: GraphFactory;
+  private readonly createDetachedChildGraphFactory?: (
+    parentHandlerRegistry: HandlerRegistry
+  ) => GraphFactory;
   private readonly usageSink?: SubagentUsageSink;
+  private readonly taskConfig?: SubagentTaskConfig;
   private readonly executions: SubagentExecutionRegistry<
     SubagentExecuteResult,
     ResolvedSubagentConfig,
@@ -943,7 +982,10 @@ export class SubagentExecutor {
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
     this.createChildGraphByKind = options.createChildGraphByKind;
+    this.createDetachedChildGraphFactory =
+      options.createDetachedChildGraphFactory;
     this.usageSink = options.usageSink;
+    this.taskConfig = options.taskConfig;
     const rawRegistry = options.parentHandlerRegistry;
     if (typeof rawRegistry === 'function') {
       this.resolveParentHandlerRegistry = rawRegistry;
@@ -977,6 +1019,203 @@ export class SubagentExecutor {
   /** Snapshot of the parent's registry at the moment a subagent is dispatched. */
   private getParentHandlerRegistry(): HandlerRegistry | undefined {
     return this.resolveParentHandlerRegistry?.();
+  }
+
+  /**
+   * Starts one independently-owned executor behind the configured task store.
+   * The parent ToolNode receives the handle synchronously; the detached clone
+   * is not registered on the parent graph, so end-of-turn cleanup cannot
+   * invalidate or clear a child that intentionally outlives that turn.
+   */
+  executeInBackground(params: SubagentExecuteParams): string {
+    if (this.taskConfig == null) {
+      return JSON.stringify({
+        status: 'rejected',
+        message: 'Background subagent execution is not enabled for this run.',
+      });
+    }
+    const executableConfig = this.configs.get(params.subagentType);
+    if (executableConfig == null) {
+      return JSON.stringify({
+        status: 'rejected',
+        message: `Unknown subagent type "${params.subagentType}".`,
+      });
+    }
+    if (this.maxDepth <= 0) {
+      return JSON.stringify({
+        status: 'rejected',
+        message: 'Maximum subagent nesting depth exceeded.',
+      });
+    }
+    if (this.humanInTheLoop?.enabled === true) {
+      return JSON.stringify({
+        status: 'rejected',
+        message:
+          'Background subagent execution does not support human-in-the-loop pauses.',
+      });
+    }
+    const parentToolCallId = params.parentToolCallId?.trim();
+    if (parentToolCallId == null || parentToolCallId === '') {
+      return JSON.stringify({
+        status: 'rejected',
+        message: 'Background subagent execution requires a parent tool call ID.',
+      });
+    }
+    const detachedHandlers = new HandlerRegistry();
+    const toolHandler = this.getParentHandlerRegistry()?.getHandler(
+      GraphEvents.ON_TOOL_EXECUTE
+    );
+    if (toolHandler != null) {
+      detachedHandlers.register(GraphEvents.ON_TOOL_EXECUTE, toolHandler);
+    }
+    const detachedGraphFactory =
+      this.createDetachedChildGraphFactory?.(detachedHandlers);
+    const sourceHookSessionId =
+      asNonEmptyString(params.parentConfigurable?.run_id) ??
+      this.executionContext.hookSessionId;
+    const started = this.taskConfig.store.start({
+      scopeId: this.taskConfig.scopeId,
+      idempotencyKey: JSON.stringify([
+        this.parentRunId,
+        this.parentAgentId ?? '',
+        parentToolCallId,
+      ]),
+      requestFingerprint: getBackgroundTaskFingerprint(
+        params.description,
+        params.subagentType
+      ),
+      subagentType: params.subagentType,
+      run: (runtime) =>
+        this.executeDetached(
+          params,
+          runtime,
+          detachedHandlers,
+          detachedGraphFactory
+        ),
+    });
+    if (!started.accepted) {
+      if (started.reason === 'conflict') {
+        return JSON.stringify({
+          status: 'rejected',
+          tool: Constants.SUBAGENT,
+          message:
+            'The same parent tool call ID was already used with different background subagent arguments.',
+        });
+      }
+      return JSON.stringify({
+        status: 'rejected',
+        tool: Constants.SUBAGENT,
+        message:
+          'Too many background subagent tasks are already running in this scope. Poll or cancel an existing task, or run this call in the foreground.',
+      });
+    }
+    if (started.isNew) {
+      this.hookRegistry?.copySession(
+        sourceHookSessionId,
+        getBackgroundTaskHookSessionId(
+          sourceHookSessionId,
+          started.task.taskId
+        )
+      );
+    }
+    return JSON.stringify({
+      background_task_id: started.task.taskId,
+      tool: Constants.SUBAGENT,
+      subagent_type: params.subagentType,
+      status: started.task.status,
+      message: `Started subagent "${params.subagentType}" in the background. Poll the host background-task tool with background_task_id "${started.task.taskId}" to check progress or collect its result.`,
+    });
+  }
+
+  private async executeDetached(
+    params: SubagentExecuteParams,
+    runtime: SubagentTaskRuntime,
+    detachedHandlers: HandlerRegistry,
+    detachedGraphFactory?: GraphFactory
+  ): Promise<SubagentExecuteResult> {
+    const sourceHookSessionId =
+      asNonEmptyString(params.parentConfigurable?.run_id) ??
+      this.executionContext.hookSessionId;
+    const taskHookSessionId = getBackgroundTaskHookSessionId(
+      sourceHookSessionId,
+      runtime.taskId
+    );
+    const unregisterHooks: Array<() => void> = [];
+    if (this.hookRegistry != null) {
+      this.hookRegistry.copySession(sourceHookSessionId, taskHookSessionId);
+      unregisterHooks.push(
+        this.hookRegistry.registerSession(taskHookSessionId, 'PostToolBatch', {
+          hooks: [
+            (): PostToolBatchHookOutput => ({
+              injectedMessages: runtime.drain('tool'),
+            }),
+          ],
+        }),
+        this.hookRegistry.registerSession(taskHookSessionId, 'PreemptBoundary', {
+          hooks: [
+            (): PreemptBoundaryHookOutput => ({
+              injectedMessages: runtime.drain('preempt'),
+            }),
+          ],
+        })
+      );
+    }
+
+    detachedHandlers.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+      handle: (_event, data): void => {
+        runtime.reportProgress(data as SubagentUpdateEvent);
+      },
+    });
+
+    const detached = new SubagentExecutor({
+      configs: this.configs,
+      parentSignal: runtime.signal,
+      hookRegistry: this.hookRegistry,
+      parentHandlerRegistry: detachedHandlers,
+      parentRunId: this.parentRunId,
+      parentAgentId: this.parentAgentId,
+      executionContext: {
+        ...this.executionContext,
+        hookSessionId: taskHookSessionId,
+      },
+      langfuse: this.langfuse,
+      tokenCounter: this.tokenCounter,
+      usageSink: this.usageSink,
+      streamLimits: this.streamLimits,
+      maxDepth: this.maxDepth,
+      createChildGraph:
+        detachedGraphFactory == null
+          ? this.createChildGraph
+          : (input): StandardGraph =>
+            detachedGraphFactory({ kind: 'standard', input }),
+      createChildGraphByKind:
+        detachedGraphFactory ?? this.createChildGraphByKind,
+    });
+    try {
+      const result = await detached.execute({
+        ...params,
+        signal: undefined,
+        breaker: undefined,
+        hookSessionId: taskHookSessionId,
+        taskRuntime: runtime,
+        parentConfigurable: {
+          ...params.parentConfigurable,
+          run_id: taskHookSessionId,
+        },
+      });
+      if (runtime.signal.aborted) {
+        throw runtime.signal.reason instanceof Error
+          ? runtime.signal.reason
+          : new Error('Detached subagent task cancelled.');
+      }
+      return result;
+    } finally {
+      detached.clearHeavyState();
+      for (const unregister of unregisterHooks) {
+        unregister();
+      }
+      this.hookRegistry?.clearSession(taskHookSessionId);
+    }
   }
 
   private bindExecutionDefinition(
@@ -2109,6 +2348,7 @@ export class SubagentExecutor {
     });
     const childAgentId = childPlan.subjectAgentId;
     const currentHookSessionId =
+      asNonEmptyString(params.hookSessionId) ??
       asNonEmptyString(params.parentConfigurable?.run_id) ??
       this.executionContext.hookSessionId;
     const childExecutionContext: SubagentExecutionContext = {
@@ -2162,6 +2402,15 @@ export class SubagentExecutor {
        * never see grandchild model calls.
        */
       subagentUsageSink,
+      ...(params.taskRuntime == null
+        ? {}
+        : {
+          preemption: {
+            shouldPreempt: (): boolean =>
+              params.taskRuntime?.shouldPreempt() === true,
+            maxSeals: MAX_BACKGROUND_SUBAGENT_SEALS,
+          },
+        }),
     };
     let childGraph = cachedChildRun?.graph;
     if (childGraph == null && childPlan.kind === 'graph') {
@@ -2426,26 +2675,46 @@ export class SubagentExecutor {
           });
         }
 
-        let childResult: MultiAgentGraphState;
-        if (this.humanInTheLoop?.enabled === true) {
-          /** Execute as an independently checkpointed root instead of inheriting
-           * the parent's Pregel namespace. Parent decisions are routed explicitly
-           * by interrupt id, so concurrent children keep isolated resume state. */
-          childResult = await AsyncLocalStorageProviderSingleton.runWithConfig(
-            childInvokeConfig,
-            (): Promise<MultiAgentGraphState> =>
-              workflow.invoke(childInput, childInvokeConfig)
-          );
-        } else {
-          childResult = await workflow.invoke(childInput, childInvokeConfig);
+        for (;;) {
+          let childResult: MultiAgentGraphState;
+          if (this.humanInTheLoop?.enabled === true) {
+            /** Execute as an independently checkpointed root instead of inheriting
+             * the parent's Pregel namespace. Parent decisions are routed explicitly
+             * by interrupt id, so concurrent children keep isolated resume state. */
+            childResult =
+              await AsyncLocalStorageProviderSingleton.runWithConfig(
+                childInvokeConfig,
+                (): Promise<MultiAgentGraphState> =>
+                  workflow.invoke(childInput, childInvokeConfig)
+              );
+          } else {
+            childResult = await workflow.invoke(childInput, childInvokeConfig);
+          }
+          const childInterrupts = isInterrupted(childResult)
+            ? childResult[INTERRUPT]
+            : undefined;
+          if (childInterrupts != null && childInterrupts.length > 0) {
+            throw new GraphInterrupt(childInterrupts);
+          }
+          result = childResult;
+          const continuation = params.taskRuntime?.closeTurn();
+          if (continuation == null || continuation.closed) {
+            break;
+          }
+          /**
+           * A queued control becomes the next user turn inside the same
+           * detached task. Reset graph sidecars while carrying the complete
+           * child transcript forward, preserving one task/trace identity and
+           * avoiding a second subagent lifecycle or duplicate billing path.
+           */
+          childGraph.resetValues(true);
+          childInput = {
+            messages: [
+              ...childResult.messages,
+              ...convertInjectedMessages(continuation.messages),
+            ],
+          };
         }
-        const childInterrupts = isInterrupted(childResult)
-          ? childResult[INTERRUPT]
-          : undefined;
-        if (childInterrupts != null && childInterrupts.length > 0) {
-          throw new GraphInterrupt(childInterrupts);
-        }
-        result = childResult;
       }
     } catch (error) {
       /** Stamped at failure, not after the error-envelope work below. */

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -79,9 +79,32 @@ describe('InMemorySubagentTaskStore', () => {
     await settle();
   });
 
+  it('does not launch work cancelled before its dispatch microtask', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const run = jest.fn(async () => ({ content: 'should not run' }));
+    const started = start(store, run);
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'cancel',
+      })
+    ).toMatchObject({ status: 'cancelled' });
+    await settle();
+
+    expect(run).not.toHaveBeenCalled();
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'cancelled',
+    });
+  });
+
   it('keeps scopes isolated and enforces running capacity', async () => {
     const store = new InMemorySubagentTaskStore({ maxRunningPerScope: 1 });
-    const never = async (runtime: SubagentTaskRuntime): Promise<{ content: string }> =>
+    const never = async (
+      runtime: SubagentTaskRuntime
+    ): Promise<{ content: string }> =>
       new Promise((_resolve, reject) => {
         runtime.signal.addEventListener(
           'abort',
@@ -101,7 +124,9 @@ describe('InMemorySubagentTaskStore', () => {
     if (!first.accepted || !anotherScope.accepted) {
       throw new Error('Expected tasks to be accepted.');
     }
-    expect(store.get('other-user:conversation', first.task.taskId)).toBeUndefined();
+    expect(
+      store.get('other-user:conversation', first.task.taskId)
+    ).toBeUndefined();
     expect(
       store.control('user:conversation', first.task.taskId, {
         action: 'cancel',
@@ -117,7 +142,9 @@ describe('InMemorySubagentTaskStore', () => {
 
   it('enforces total capacity across independent scopes', async () => {
     const store = new InMemorySubagentTaskStore({ maxRunningTotal: 1 });
-    const never = async (runtime: SubagentTaskRuntime): Promise<{ content: string }> =>
+    const never = async (
+      runtime: SubagentTaskRuntime
+    ): Promise<{ content: string }> =>
       new Promise((_resolve, reject) => {
         runtime.signal.addEventListener(
           'abort',
@@ -192,9 +219,9 @@ describe('InMemorySubagentTaskStore', () => {
     expect(interrupt).toMatchObject({ status: 'accepted' });
     expect(steer).toMatchObject({ status: 'accepted' });
     expect(runtime?.shouldPreempt()).toBe(true);
-    expect(runtime?.drain('preempt').map((message) => message.content)).toEqual([
-      'Stop searching and summarize now.',
-    ]);
+    expect(runtime?.drain('preempt').map((message) => message.content)).toEqual(
+      ['Stop searching and summarize now.']
+    );
     expect(runtime?.shouldPreempt()).toBe(false);
     expect(runtime?.drain('tool').map((message) => message.content)).toEqual([
       'Also check the primary source.',

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import type { SubagentTaskRuntime } from '@/types';
+import { InMemorySubagentTaskStore } from '@/tools/subagent/InMemorySubagentTaskStore';
+
+const settle = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const start = (
+  store: InMemorySubagentTaskStore,
+  run: (runtime: SubagentTaskRuntime) => Promise<{ content: string }>,
+  overrides: Partial<{
+    scopeId: string;
+    idempotencyKey: string;
+    requestFingerprint: string;
+    subagentType: string;
+  }> = {}
+) =>
+  store.start({
+    scopeId: overrides.scopeId ?? 'user:conversation',
+    idempotencyKey: overrides.idempotencyKey ?? 'run:agent:call',
+    ...(overrides.requestFingerprint == null
+      ? {}
+      : { requestFingerprint: overrides.requestFingerprint }),
+    subagentType: overrides.subagentType ?? 'researcher',
+    run,
+  });
+
+describe('InMemorySubagentTaskStore', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns a handle immediately, coalesces replays, and claims once', async () => {
+    const store = new InMemorySubagentTaskStore();
+    let finish = (_result: { content: string }): void => undefined;
+    const result = new Promise<{ content: string }>((resolve) => {
+      finish = resolve;
+    });
+    const run = jest.fn(() => result);
+
+    const first = start(store, run);
+    const duplicate = start(store, run);
+
+    expect(first).toMatchObject({ accepted: true, isNew: true });
+    expect(duplicate).toMatchObject({ accepted: true, isNew: false });
+    if (!first.accepted || !duplicate.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    expect(duplicate.task.taskId).toBe(first.task.taskId);
+    expect(run).not.toHaveBeenCalled();
+
+    await settle();
+    expect(run).toHaveBeenCalledTimes(1);
+    finish({ content: 'finished research' });
+    await settle();
+
+    expect(store.claim('user:conversation', first.task.taskId)).toMatchObject({
+      status: 'completed',
+      result: 'finished research',
+    });
+    expect(store.claim('user:conversation', first.task.taskId)).toMatchObject({
+      status: 'claimed',
+    });
+  });
+
+  it('rejects a conflicting replay of the same operation', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const run = async (): Promise<{ content: string }> => ({ content: 'ok' });
+    const first = start(store, run, { requestFingerprint: 'fingerprint-a' });
+    const conflict = start(store, run, {
+      requestFingerprint: 'fingerprint-b',
+    });
+
+    expect(first).toMatchObject({ accepted: true, isNew: true });
+    expect(conflict).toMatchObject({ accepted: false, reason: 'conflict' });
+    await settle();
+  });
+
+  it('keeps scopes isolated and enforces running capacity', async () => {
+    const store = new InMemorySubagentTaskStore({ maxRunningPerScope: 1 });
+    const never = async (runtime: SubagentTaskRuntime): Promise<{ content: string }> =>
+      new Promise((_resolve, reject) => {
+        runtime.signal.addEventListener(
+          'abort',
+          () => reject(runtime.signal.reason),
+          { once: true }
+        );
+      });
+    const first = start(store, never);
+    const saturated = start(store, never, { idempotencyKey: 'another-call' });
+    const anotherScope = start(store, never, {
+      scopeId: 'other-user:conversation',
+      idempotencyKey: 'another-call',
+    });
+
+    expect(saturated).toEqual({ accepted: false, reason: 'capacity' });
+    expect(anotherScope.accepted).toBe(true);
+    if (!first.accepted || !anotherScope.accepted) {
+      throw new Error('Expected tasks to be accepted.');
+    }
+    expect(store.get('other-user:conversation', first.task.taskId)).toBeUndefined();
+    expect(
+      store.control('user:conversation', first.task.taskId, {
+        action: 'cancel',
+      })
+    ).toMatchObject({ status: 'cancelled' });
+    expect(
+      store.control('other-user:conversation', anotherScope.task.taskId, {
+        action: 'cancel',
+      })
+    ).toMatchObject({ status: 'cancelled' });
+    await settle();
+  });
+
+  it('enforces total capacity across independent scopes', async () => {
+    const store = new InMemorySubagentTaskStore({ maxRunningTotal: 1 });
+    const never = async (runtime: SubagentTaskRuntime): Promise<{ content: string }> =>
+      new Promise((_resolve, reject) => {
+        runtime.signal.addEventListener(
+          'abort',
+          () => reject(runtime.signal.reason),
+          { once: true }
+        );
+      });
+    const first = start(store, never);
+    const saturated = start(store, never, {
+      scopeId: 'other-user:conversation',
+      idempotencyKey: 'other-call',
+    });
+
+    expect(saturated).toEqual({ accepted: false, reason: 'capacity' });
+    if (!first.accepted) {
+      throw new Error('Expected first task to be accepted.');
+    }
+    store.control('user:conversation', first.task.taskId, {
+      action: 'cancel',
+    });
+    await settle();
+  });
+
+  it('evicts the oldest terminal task to honor the total retained-task bound', async () => {
+    const store = new InMemorySubagentTaskStore({
+      maxRunningTotal: 2,
+      maxTasksTotal: 1,
+    });
+    const first = start(store, async () => ({ content: 'first' }));
+    if (!first.accepted) {
+      throw new Error('Expected first task to be accepted.');
+    }
+    await settle();
+    const second = start(store, async () => ({ content: 'second' }), {
+      scopeId: 'other-user:conversation',
+      idempotencyKey: 'other-call',
+    });
+
+    expect(second).toMatchObject({ accepted: true, isNew: true });
+    expect(store.get('user:conversation', first.task.taskId)).toBeUndefined();
+    await settle();
+  });
+
+  it('drains interrupt, steer, and queued messages at their intended boundaries', async () => {
+    const store = new InMemorySubagentTaskStore();
+    let runtime: SubagentTaskRuntime | undefined;
+    let finish = (_result: { content: string }): void => undefined;
+    const result = new Promise<{ content: string }>((resolve) => {
+      finish = resolve;
+    });
+    const started = start(store, async (taskRuntime) => {
+      runtime = taskRuntime;
+      return result;
+    });
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+
+    const interrupt = store.control('user:conversation', started.task.taskId, {
+      action: 'interrupt',
+      message: 'Stop searching and summarize now.',
+    });
+    const steer = store.control('user:conversation', started.task.taskId, {
+      action: 'steer',
+      message: 'Also check the primary source.',
+    });
+    store.control('user:conversation', started.task.taskId, {
+      action: 'queue',
+      message: 'After this turn, compare both results.',
+    });
+    expect(interrupt).toMatchObject({ status: 'accepted' });
+    expect(steer).toMatchObject({ status: 'accepted' });
+    expect(runtime?.shouldPreempt()).toBe(true);
+    expect(runtime?.drain('preempt').map((message) => message.content)).toEqual([
+      'Stop searching and summarize now.',
+    ]);
+    expect(runtime?.shouldPreempt()).toBe(false);
+    expect(runtime?.drain('tool').map((message) => message.content)).toEqual([
+      'Also check the primary source.',
+    ]);
+    expect(runtime?.closeTurn()).toEqual({
+      closed: false,
+      messages: [
+        {
+          role: 'user',
+          content: 'After this turn, compare both results.',
+          source: 'steer',
+        },
+      ],
+    });
+    expect(runtime?.closeTurn()).toEqual({ closed: true, messages: [] });
+
+    finish({ content: 'done' });
+    await settle();
+  });
+
+  it('cancels a pending message before it drains', async () => {
+    const store = new InMemorySubagentTaskStore();
+    let runtime: SubagentTaskRuntime | undefined;
+    const started = start(
+      store,
+      async (taskRuntime) =>
+        new Promise((_resolve, reject) => {
+          runtime = taskRuntime;
+          taskRuntime.signal.addEventListener(
+            'abort',
+            () => reject(taskRuntime.signal.reason),
+            { once: true }
+          );
+        })
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+    const queued = store.control('user:conversation', started.task.taskId, {
+      action: 'steer',
+      message: 'This should not be delivered.',
+    });
+    if (queued.status !== 'accepted' || queued.controlId == null) {
+      throw new Error('Expected a cancellable control receipt.');
+    }
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'cancel_message',
+        controlId: queued.controlId,
+      })
+    ).toMatchObject({ status: 'accepted' });
+    expect(runtime?.drain('tool')).toEqual([]);
+    store.control('user:conversation', started.task.taskId, {
+      action: 'cancel',
+    });
+    await settle();
+  });
+
+  it('times out a non-cooperative task and frees its running slot', async () => {
+    jest.useFakeTimers();
+    const store = new InMemorySubagentTaskStore({
+      maxRunningPerScope: 1,
+      taskTimeoutMs: 100,
+    });
+    const started = start(
+      store,
+      async () => new Promise<{ content: string }>(() => undefined)
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await jest.advanceTimersByTimeAsync(101);
+
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'error',
+      error: 'Detached subagent task timed out.',
+    });
+    expect(
+      start(store, async () => ({ content: 'replacement' }), {
+        idempotencyKey: 'replacement-call',
+      })
+    ).toMatchObject({ accepted: true, isNew: true });
+  });
+});

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -17,3 +17,5 @@ export type {
   SubagentExecutorOptions,
   ChildGraphFactory,
 } from './SubagentExecutor';
+export { InMemorySubagentTaskStore } from './InMemorySubagentTaskStore';
+export type { InMemorySubagentTaskStoreOptions } from './InMemorySubagentTaskStore';

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -40,6 +40,7 @@ import type {
   TokenBudgetBreakdown,
 } from '@/types/run';
 import type { Providers, Callback, GraphNodeKeys } from '@/common';
+import type { SubagentTaskConfig } from '@/types/subagentTasks';
 import type { StandardGraph, MultiAgentGraph } from '@/graphs';
 import type { ClientOptions } from '@/types/llm';
 
@@ -353,6 +354,12 @@ export type StandardGraphInput = {
    */
   subagentUsageSink?: SubagentUsageSink;
   /**
+   * Optional host-owned process-local task namespace for detached subagents.
+   * Presence enables `run_in_background` on the subagent tool. Child graphs
+   * do not inherit it, keeping background nesting disabled for the MVP.
+   */
+  subagentTasks?: SubagentTaskConfig;
+  /**
    * True when this graph IS a subagent child run (set by `SubagentExecutor`
    * when it constructs the child graph). Drives the hook-input `agentId`
    * subagent-scope marker: hook dispatches from this graph's tool nodes
@@ -363,10 +370,10 @@ export type StandardGraphInput = {
    */
   subagentScope?: boolean;
   /**
-   * Cooperative preemption, forwarded from `RunConfig.preemption`. Only ever
-   * set on the top-level graph: a steer targets the conversation, so subagent
-   * children must run to completion and `buildChildInputs` does not propagate
-   * this field.
+   * Cooperative preemption, forwarded from `RunConfig.preemption`. Ordinary
+   * child graphs do not inherit it. Detached subagent tasks may receive their
+   * own internal parent-control source so an interrupt can reuse the same
+   * provider-safe sealing path without targeting the top-level conversation.
    */
   preemption?: StreamPreemption;
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './messages';
 export * from './run';
 export * from './skill';
 export * from './stream';
+export * from './subagentTasks';
 export * from './tools';
 export * from './summarize';
 export * from './activityLabel';

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -10,6 +10,7 @@ import type {
   ToolOutputReferencesConfig,
   EagerEventToolExecutionConfig,
 } from '@/types/tools';
+import type { SubagentTaskConfig } from '@/types/subagentTasks';
 import type { HumanInTheLoopConfig } from '@/types/hitl';
 import type { HookRegistry } from '@/hooks';
 import type * as s from '@/types/stream';
@@ -234,6 +235,11 @@ export type RunConfig = {
    * the registered `CHAT_MODEL_END` handler as usual.
    */
   subagentUsageSink?: g.SubagentUsageSink;
+  /**
+   * Trusted process-local task namespace for detached subagent execution.
+   * Omit to preserve foreground-only subagent behavior.
+   */
+  subagentTasks?: SubagentTaskConfig;
   /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle
    * points in `processStream` (RunStart, UserPromptSubmit, Stop,

--- a/src/types/subagentTasks.ts
+++ b/src/types/subagentTasks.ts
@@ -1,0 +1,114 @@
+import type { SubagentUpdateEvent } from './graph';
+import type { InjectedMessage } from './tools';
+
+/** Terminal and in-flight states for a detached subagent task. */
+export type SubagentTaskStatus =
+  | 'running'
+  | 'completed'
+  | 'error'
+  | 'cancelled';
+
+/** Where a pending parent message may enter the child run. */
+export type SubagentTaskBoundary = 'preempt' | 'tool' | 'turn';
+
+/** Parent-to-child control operations accepted while a task is running. */
+export type SubagentTaskControlCommand =
+  | { action: 'steer' | 'queue' | 'interrupt'; message: string }
+  | { action: 'cancel' }
+  | { action: 'cancel_message'; controlId: string };
+
+/** Small, payload-free progress view safe to retain between parent turns. */
+export interface SubagentTaskProgress {
+  phase: SubagentUpdateEvent['phase'];
+  at: number;
+  eventCount: number;
+  label?: string;
+}
+/** Read-only task metadata. Results are exposed only through `claim`. */
+export interface SubagentTaskSnapshot {
+  taskId: string;
+  subagentType: string;
+  status: SubagentTaskStatus;
+  createdAt: number;
+  updatedAt: number;
+  resultAvailable: boolean;
+  resultClaimed: boolean;
+  pendingControls: number;
+  progress?: SubagentTaskProgress;
+  error?: string;
+}
+
+export type SubagentTaskClaim =
+  | { status: 'running'; task: SubagentTaskSnapshot }
+  | { status: 'completed'; task: SubagentTaskSnapshot; result: string }
+  | { status: 'error'; task: SubagentTaskSnapshot; error: string }
+  | { status: 'cancelled'; task: SubagentTaskSnapshot; error: string }
+  | { status: 'claimed'; task: SubagentTaskSnapshot }
+  | { status: 'not_found' };
+
+export type SubagentTaskControlResult =
+  | {
+      status: 'accepted';
+      task: SubagentTaskSnapshot;
+      controlId?: string;
+    }
+  | { status: 'cancelled'; task: SubagentTaskSnapshot }
+  | { status: 'not_running'; task: SubagentTaskSnapshot }
+  | { status: 'not_found' }
+  | { status: 'control_not_found'; task: SubagentTaskSnapshot }
+  | { status: 'invalid'; message: string };
+
+/**
+ * Child-side view supplied to one detached execution. It intentionally owns
+ * only cancellation, bounded message drains, and payload-free progress — no
+ * request/response object or host transport can leak into retained task state.
+ */
+export interface SubagentTaskRuntime {
+  readonly taskId: string;
+  readonly signal: AbortSignal;
+  shouldPreempt(): boolean;
+  drain(boundary: SubagentTaskBoundary): InjectedMessage[];
+  closeTurn(): { closed: boolean; messages: InjectedMessage[] };
+  reportProgress(event: SubagentUpdateEvent): void;
+}
+
+export interface SubagentTaskStartRequest {
+  scopeId: string;
+  idempotencyKey: string;
+  /** Stable hash of model-writable inputs used to reject conflicting replays. */
+  requestFingerprint?: string;
+  subagentType: string;
+  run(runtime: SubagentTaskRuntime): Promise<{ content: string }>;
+}
+
+export type SubagentTaskStartResult =
+  | {
+      accepted: true;
+      isNew: boolean;
+      task: SubagentTaskSnapshot;
+    }
+  | { accepted: false; reason: 'capacity' }
+  | {
+      accepted: false;
+      reason: 'conflict';
+      task: SubagentTaskSnapshot;
+    };
+
+/** Host-replaceable store contract used by the SDK's subagent tool. */
+export interface SubagentTaskStore {
+  start(request: SubagentTaskStartRequest): SubagentTaskStartResult;
+  get(scopeId: string, taskId: string): SubagentTaskSnapshot | undefined;
+  list(scopeId: string): SubagentTaskSnapshot[];
+  claim(scopeId: string, taskId: string): SubagentTaskClaim;
+  control(
+    scopeId: string,
+    taskId: string,
+    command: SubagentTaskControlCommand
+  ): SubagentTaskControlResult;
+}
+
+/** Trusted, host-selected task namespace. It is never model-writable. */
+export interface SubagentTaskConfig {
+  store: SubagentTaskStore;
+  scopeId: string;
+}

--- a/src/types/subagentTasks.ts
+++ b/src/types/subagentTasks.ts
@@ -1,3 +1,4 @@
+import type { BaseMessage } from '@langchain/core/messages';
 import type { SubagentUpdateEvent } from './graph';
 import type { InjectedMessage } from './tools';
 
@@ -26,6 +27,7 @@ export interface SubagentTaskProgress {
 }
 /** Read-only task metadata. Results are exposed only through `claim`. */
 export interface SubagentTaskSnapshot {
+  /** Handle for this child-conversation execution within its trusted scope. */
   taskId: string;
   subagentType: string;
   status: SubagentTaskStatus;
@@ -78,7 +80,15 @@ export interface SubagentTaskStartRequest {
   /** Stable hash of model-writable inputs used to reject conflicting replays. */
   requestFingerprint?: string;
   subagentType: string;
-  run(runtime: SubagentTaskRuntime): Promise<{ content: string }>;
+  /**
+   * Starts one ephemeral execution lease. The canonical child transcript is
+   * returned so a host-owned store may persist it for a later fresh run;
+   * retaining a graph/checkpoint after terminal completion is unnecessary.
+   */
+  run(runtime: SubagentTaskRuntime): Promise<{
+    content: string;
+    messages?: BaseMessage[];
+  }>;
 }
 
 export type SubagentTaskStartResult =
@@ -94,7 +104,12 @@ export type SubagentTaskStartResult =
       task: SubagentTaskSnapshot;
     };
 
-/** Host-replaceable store contract used by the SDK's subagent tool. */
+/**
+ * Host-replaceable store contract used by the SDK's subagent tool. The store
+ * should normally outlive individual `Run` instances. Durable hosts may
+ * persist the transcript returned by `run` under the task/conversation
+ * lineage and start a fresh execution for a later turn.
+ */
 export interface SubagentTaskStore {
   start(request: SubagentTaskStartRequest): SubagentTaskStartResult;
   get(scopeId: string, taskId: string): SubagentTaskSnapshot | undefined;


### PR DESCRIPTION
## Summary

I added an opt-in, process-local background execution seam for subagents so a parent can launch a child conversation, continue immediately, then poll, steer, queue, interrupt, cancel, or collect the child result through a host-owned task store. This advances [AI-1708](https://linear.app/clickhouse/issue/AI-1708/agent-to-subagent-steering-queueing-and-interrupts) and [AI-1735](https://linear.app/clickhouse/issue/AI-1735/run-subagents-as-detached-background-tasks); restart and replica durability remain the explicit [AI-1737](https://linear.app/clickhouse/issue/AI-1737/make-background-subagent-execution-restart-and-replica-safe) follow-up.

- Added trusted `RunConfig.subagentTasks` configuration and only exposed `run_in_background` when the host enables it.
- Added a bounded `InMemorySubagentTaskStore` with trusted scope isolation, global and per-scope capacity, timeout/TTL cleanup, replay fingerprints, payload bounds, one-time result claims, and stable task handles.
- Added parent controls for cooperative steer, queued follow-up turns, provider-safe interrupt seals, queued-message cancellation, and hard task cancellation.
- Treated detached work as an ephemeral execution lease: terminal completion clears graph/checkpoint state, while the canonical child transcript is returned to a host-owned store for efficient later continuation as a fresh run.
- Snapshotted child graph runtime configuration, tool handlers, and hook policy into an isolated task-local registry before dispatch so parent cleanup and one-shot hooks cannot alter detached execution.
- Kept ordinary foreground subagents unchanged and disabled background nesting, HITL pauses, and cross-process durability in this slice. The existing default delegation depth of 1 prevents recursive background fan-out.
- Added regression coverage for lifecycle isolation, replay conflicts, capacity, control boundaries, continuation turns, cancellation races, honest failure state, recursion headroom, and opt-in schema behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npm exec -- tsc --noEmit -p tsconfig.json`
- `npm test -- --runInBand src/hooks/__tests__/HookRegistry.test.ts src/tools/subagent src/tools/__tests__/SubagentExecutor.test.ts src/tools/__tests__/SubagentTool.test.ts src/specs/preemptSeal.test.ts src/graphs/__tests__/Graph.preemptSignal.test.ts` (290 passing)
- `npm run build`
- ESLint with zero warnings on every changed TypeScript file
- Import sorting check on every changed file

### **Test Configuration**:

- Node.js 24-compatible local workspace
- Exact base: `5202a514cb1b0593612b54caef6ad1bdfaa7991e` (`origin/main`, `v3.6.3`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that the feature works
- [x] Local unit tests pass with my changes