### PR TITLE
🪢 feat: Support Custom Headers On Langfuse Exports

### DIFF
--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -175,6 +175,44 @@ export function resolveToolOutputTracingConfig(
   };
 }
 
+/**
+ * Merges header maps case-insensitively, keeping the override's casing.
+ *
+ * A plain spread would keep both `X-Proxy-Token` and `x-proxy-token`, and
+ * filling a fetch `Headers` from that record *appends* rather than replaces —
+ * the exporter would send one comma-joined `run-token, agent-token` value, so
+ * the agent override never cleanly wins and a gateway sees a malformed
+ * credential. Matches the case-insensitive identity already used for the
+ * destination key.
+ */
+function mergeAdditionalHeaders(
+  base?: Record<string, string>,
+  override?: Record<string, string>
+): Record<string, string> | undefined {
+  if (base == null && override == null) {
+    return undefined;
+  }
+
+  const merged: Record<string, string> = { ...base };
+  if (override == null) {
+    return merged;
+  }
+
+  const baseKeyByLower = new Map<string, string>(
+    Object.keys(merged).map((key) => [key.toLowerCase(), key])
+  );
+  for (const [key, value] of Object.entries(override)) {
+    const lower = key.toLowerCase();
+    const existingKey = baseKeyByLower.get(lower);
+    if (existingKey != null && existingKey !== key) {
+      delete merged[existingKey];
+    }
+    merged[key] = value;
+    baseKeyByLower.set(lower, key);
+  }
+  return merged;
+}
+
 export function resolveLangfuseConfig(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
@@ -208,14 +246,10 @@ export function resolveLangfuseConfig(
         ...agentLangfuse.metadata,
       }
       : undefined;
-  const additionalHeaders =
-    runLangfuse.additionalHeaders != null ||
-    agentLangfuse.additionalHeaders != null
-      ? {
-        ...runLangfuse.additionalHeaders,
-        ...agentLangfuse.additionalHeaders,
-      }
-      : undefined;
+  const additionalHeaders = mergeAdditionalHeaders(
+    runLangfuse.additionalHeaders,
+    agentLangfuse.additionalHeaders
+  );
   const librechatTraceAttributes =
     runLangfuse.librechatTraceAttributes != null ||
     agentLangfuse.librechatTraceAttributes != null

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -208,6 +208,14 @@ export function resolveLangfuseConfig(
         ...agentLangfuse.metadata,
       }
       : undefined;
+  const additionalHeaders =
+    runLangfuse.additionalHeaders != null ||
+    agentLangfuse.additionalHeaders != null
+      ? {
+        ...runLangfuse.additionalHeaders,
+        ...agentLangfuse.additionalHeaders,
+      }
+      : undefined;
   const librechatTraceAttributes =
     runLangfuse.librechatTraceAttributes != null ||
     agentLangfuse.librechatTraceAttributes != null
@@ -230,6 +238,7 @@ export function resolveLangfuseConfig(
     ...runLangfuse,
     ...agentLangfuse,
     ...(metadata != null ? { metadata } : {}),
+    ...(additionalHeaders != null ? { additionalHeaders } : {}),
     ...(librechatTraceAttributes != null ? { librechatTraceAttributes } : {}),
     ...(tags != null ? { tags } : {}),
     ...(toolNodeTracing != null ? { toolNodeTracing } : {}),

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -59,6 +59,12 @@ function resolveLangfuseEnvironment(
   return undefined;
 }
 
+function hasAdditionalHeaders(
+  headers?: Record<string, string>
+): headers is Record<string, string> {
+  return headers != null && Object.keys(headers).length > 0;
+}
+
 export function getLangfuseSpanProcessorParams(
   langfuse?: t.LangfuseConfig
 ): LangfuseSpanProcessorParams | undefined {
@@ -66,6 +72,9 @@ export function getLangfuseSpanProcessorParams(
     return undefined;
   }
   const environment = resolveLangfuseEnvironment(langfuse);
+  const additionalHeaders = hasAdditionalHeaders(langfuse?.additionalHeaders)
+    ? { additionalHeaders: langfuse.additionalHeaders }
+    : {};
   if (hasLangfuseConfigCredentials(langfuse)) {
     return {
       publicKey: langfuse.publicKey,
@@ -75,6 +84,7 @@ export function getLangfuseSpanProcessorParams(
       ...(langfuse.mediaUploadEnabled != null
         ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
         : {}),
+      ...additionalHeaders,
     };
   }
   if (hasLangfuseEnvConfig()) {
@@ -90,6 +100,7 @@ export function getLangfuseSpanProcessorParams(
       ...(langfuse?.mediaUploadEnabled != null
         ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
         : {}),
+      ...additionalHeaders,
     };
   }
   if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
@@ -101,6 +112,7 @@ export function getLangfuseSpanProcessorParams(
       ...(langfuse.mediaUploadEnabled != null
         ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
         : {}),
+      ...additionalHeaders,
     };
   }
   return undefined;
@@ -113,11 +125,36 @@ function hashCacheKeyValue(value: string | undefined): string | undefined {
 }
 
 /**
+ * Order- and case-insensitive digest of the custom headers sent to a
+ * destination, so header maps that differ only in key order or header-name
+ * casing resolve to one destination instead of duplicating its exporter.
+ * Hashed because these values are credentials (proxy tokens, gateway keys).
+ * Absent and empty both yield `undefined`, keeping keys stable for the
+ * overwhelmingly common no-headers case.
+ */
+function hashAdditionalHeaders(
+  headers: Record<string, string> | undefined
+): string | undefined {
+  if (!hasAdditionalHeaders(headers)) {
+    return undefined;
+  }
+  const normalized = Object.entries(headers)
+    .map(([name, value]) => JSON.stringify([name.trim().toLowerCase(), value]))
+    .sort();
+  return hashCacheKeyValue(normalized.join('\n'));
+}
+
+/**
  * Identity of an export destination (project credentials + endpoint +
- * environment) only. Processor-level policies like `toolOutputTracing` are
- * deliberately excluded: two spans exporting to the same project under
- * different redaction settings still share a destination and may parent one
- * another.
+ * environment + custom headers) only. Processor-level policies like
+ * `toolOutputTracing` are deliberately excluded: two spans exporting to the
+ * same project under different redaction settings still share a destination
+ * and may parent one another.
+ *
+ * Custom headers are included because a gateway may route on them, making two
+ * otherwise-identical configs different projects. Treating them as part of the
+ * destination keeps a run from inheriting a parent span bound elsewhere, and
+ * keeps a rotated proxy credential from reusing the stale exporter.
  */
 export function getLangfuseDestinationKey(
   params: LangfuseSpanProcessorParams
@@ -127,6 +164,7 @@ export function getLangfuseDestinationKey(
     secretKeyHash: hashCacheKeyValue(params.secretKey),
     baseUrl: params.baseUrl,
     environment: params.environment,
+    additionalHeadersHash: hashAdditionalHeaders(params.additionalHeaders),
   });
 }
 

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -84,4 +84,109 @@ describe('Langfuse span registry', () => {
       resolveLangfuseDestinationKey(tenantConfig({ enabled: false }))
     ).toBeUndefined();
   });
+
+  it('passes custom headers to the Langfuse span processor params', () => {
+    expect(
+      getLangfuseSpanProcessorParams(
+        tenantConfig({ additionalHeaders: { 'CF-Access-Client-Id': 'proxy' } })
+      )
+    ).toEqual(
+      expect.objectContaining({
+        additionalHeaders: { 'CF-Access-Client-Id': 'proxy' },
+      })
+    );
+  });
+
+  it('passes custom headers alongside env credentials', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_BASEURL;
+
+    expect(
+      getLangfuseSpanProcessorParams({
+        additionalHeaders: { 'X-Proxy-Token': 'env-branch' },
+      })
+    ).toEqual(
+      expect.objectContaining({
+        publicKey: 'pk-env',
+        secretKey: 'sk-env',
+        additionalHeaders: { 'X-Proxy-Token': 'env-branch' },
+      })
+    );
+
+    expect(
+      getLangfuseSpanProcessorParams({
+        baseUrl: 'https://langfuse.self-hosted',
+        additionalHeaders: { 'X-Proxy-Token': 'baseurl-branch' },
+      })
+    ).toEqual(
+      expect.objectContaining({
+        baseUrl: 'https://langfuse.self-hosted',
+        additionalHeaders: { 'X-Proxy-Token': 'baseurl-branch' },
+      })
+    );
+  });
+
+  it('omits custom headers from the params when none are configured', () => {
+    expect(getLangfuseSpanProcessorParams(tenantConfig())).not.toHaveProperty(
+      'additionalHeaders'
+    );
+    expect(
+      getLangfuseSpanProcessorParams(tenantConfig({ additionalHeaders: {} }))
+    ).not.toHaveProperty('additionalHeaders');
+  });
+
+  it('separates destinations by custom headers', () => {
+    const base = resolveLangfuseDestinationKey(tenantConfig());
+    const proxied = resolveLangfuseDestinationKey(
+      tenantConfig({ additionalHeaders: { 'X-Proxy-Token': 'first' } })
+    );
+    expect(proxied).not.toBe(base);
+    expect(
+      resolveLangfuseDestinationKey(
+        tenantConfig({ additionalHeaders: { 'X-Proxy-Token': 'rotated' } })
+      )
+    ).not.toBe(proxied);
+    expect(
+      resolveLangfuseDestinationKey(
+        tenantConfig({ additionalHeaders: { 'X-Tenant': 'first' } })
+      )
+    ).not.toBe(proxied);
+  });
+
+  it('keeps one destination across header key order, casing, and empty maps', () => {
+    const base = resolveLangfuseDestinationKey(tenantConfig());
+    expect(
+      resolveLangfuseDestinationKey(tenantConfig({ additionalHeaders: {} }))
+    ).toBe(base);
+
+    const ordered = resolveLangfuseDestinationKey(
+      tenantConfig({
+        additionalHeaders: { 'X-Alpha': 'a', 'X-Beta': 'b' },
+      })
+    );
+    expect(
+      resolveLangfuseDestinationKey(
+        tenantConfig({
+          additionalHeaders: { 'X-Beta': 'b', 'X-Alpha': 'a' },
+        })
+      )
+    ).toBe(ordered);
+    expect(
+      resolveLangfuseDestinationKey(
+        tenantConfig({
+          additionalHeaders: { 'x-alpha': 'a', 'x-beta': 'b' },
+        })
+      )
+    ).toBe(ordered);
+  });
+
+  it('keeps header values out of the destination key', () => {
+    const key = resolveLangfuseDestinationKey(
+      tenantConfig({ additionalHeaders: { 'X-Proxy-Token': 'super-secret' } })
+    );
+    expect(key).toBeDefined();
+    expect(key).not.toContain('super-secret');
+  });
 });

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -1555,6 +1555,48 @@ describe('Langfuse tool output tracing redaction', () => {
     });
   });
 
+  it('merges run and agent custom headers with the agent winning collisions', () => {
+    const resolved = resolveLangfuseConfig(
+      {
+        enabled: true,
+        publicKey: 'pk-run',
+        secretKey: 'sk-run',
+        additionalHeaders: {
+          'X-Proxy-Token': 'run-token',
+          'X-Shared': 'run',
+        },
+      },
+      {
+        additionalHeaders: {
+          'X-Shared': 'agent',
+          'X-Agent-Only': 'agent',
+        },
+      }
+    );
+
+    expect(resolved).toMatchObject({
+      additionalHeaders: {
+        'X-Proxy-Token': 'run-token',
+        'X-Shared': 'agent',
+        'X-Agent-Only': 'agent',
+      },
+    });
+  });
+
+  it('leaves custom headers untouched when only one side sets them', () => {
+    expect(
+      resolveLangfuseConfig(
+        { additionalHeaders: { 'X-Proxy-Token': 'run-token' } },
+        { publicKey: 'pk-agent' }
+      )
+    ).toMatchObject({
+      additionalHeaders: { 'X-Proxy-Token': 'run-token' },
+    });
+    expect(
+      resolveLangfuseConfig({ publicKey: 'pk-run' }, { publicKey: 'pk-agent' })
+    ).not.toHaveProperty('additionalHeaders');
+  });
+
   it('inherits deterministic trace ids when tenant config only supplies connection settings', () => {
     const resolved = resolveLangfuseConfig(
       {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -1583,6 +1583,25 @@ describe('Langfuse tool output tracing redaction', () => {
     });
   });
 
+  it('lets an agent header override a differently cased run header', () => {
+    const resolved = resolveLangfuseConfig(
+      {
+        additionalHeaders: {
+          'X-Proxy-Token': 'run-token',
+          'CF-Access-Client-Id': 'run-client',
+        },
+      },
+      { additionalHeaders: { 'x-proxy-token': 'agent-token' } }
+    );
+
+    /** Both casings surviving would make fetch send a combined
+     *  "run-token, agent-token" value instead of the agent's. */
+    expect(resolved?.additionalHeaders).toEqual({
+      'CF-Access-Client-Id': 'run-client',
+      'x-proxy-token': 'agent-token',
+    });
+  });
+
   it('leaves custom headers untouched when only one side sets them', () => {
     expect(
       resolveLangfuseConfig(

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -780,6 +780,17 @@ export interface LangfuseConfig {
    * payloads. Defaults to the Langfuse SDK behavior.
    */
   mediaUploadEnabled?: boolean;
+  /**
+   * Extra HTTP headers sent on every Langfuse export request (OTLP trace
+   * export and media uploads), for self-hosted instances behind an
+   * authenticating proxy or gateway.
+   *
+   * Deployment-level only: one exporter is shared by every span routed to a
+   * destination, so these cannot carry per-request or per-user identity.
+   * Headers participate in destination identity — see
+   * `getLangfuseDestinationKey`.
+   */
+  additionalHeaders?: Record<string, string>;
   metadata?: Record<string, string | number | boolean | null | undefined>;
   /**
    * Internal OTLP span attributes to attach to Langfuse observations before


### PR DESCRIPTION
## Summary

Self-hosted Langfuse instances sitting behind an authenticating proxy or API gateway (Cloudflare Access, oauth2-proxy, a corporate gateway wanting `X-Api-Key`) need extra HTTP headers on every export request. There was no way to supply them.

`@langfuse/otel` already accepts `additionalHeaders` and applies it to **both** export surfaces — the OTLP trace exporter and the `LangfuseAPIClient` behind media uploads — so this is purely a passthrough that was never wired up.

## Changes

- `LangfuseConfig.additionalHeaders?: Record<string, string>` (`src/types/graph.ts`)
- Passed through in every credential branch of `getLangfuseSpanProcessorParams` — explicit config credentials, env credentials, and the config-baseUrl-with-env-credentials branch. Omitted entirely when unset or empty, so params are unchanged for everyone not using this.
- Merged in `resolveLangfuseConfig` like the other map-valued fields, agent overriding run on key collisions.

## Why headers are part of destination identity

`getLangfuseDestinationKey` gains a header digest. This is the load-bearing decision in the PR:

- A gateway may **route** on these headers, so two configs identical in credentials and baseUrl can be different projects. Excluding headers from the key would let a span inherit an ambient parent bound to another destination — the exact cross-destination parenting the registry exists to prevent.
- `RoutingLangfuseSpanProcessor` caches processors by a key derived from the destination key. Excluding headers would mean a rotated proxy credential silently keeps exporting through the stale cached exporter.

The digest is order- and case-insensitive (header names are case-insensitive in HTTP), so header maps that differ only in key order or casing share one exporter instead of duplicating it. Absent and empty both yield `undefined`, keeping keys byte-identical to today for the no-headers case. Values are hashed, like `secretKey` already is — proxy tokens are credentials.

## Scope note

Deployment-level only, and documented as such on the field. One exporter is shared by every span routed to a destination, so these headers cannot carry per-request or per-user identity the way custom-endpoint headers can.

## Testing

- 10 new assertions across `langfuse-span-registry.test.ts` (passthrough in all three credential branches, omission when unset/empty, separation by header name and by rotated value, stability across key order / name casing / empty maps, and that raw header values never appear in the destination key) and `langfuse-tool-output-tracing.test.ts` (run/agent merge precedence, one-sided merge).
- All 5 Langfuse suites green: 96/96.
- `npx tsc --noEmit` and `npx eslint` clean.
- Pre-existing unrelated failures in `llm/{google,vertexai,anthropic}` and `Graph.reasoning` reproduce identically on a clean `main` checkout (they need provider credentials).

## Follow-up (not in this PR)

While tracing the params path I found that **`mediaUploadEnabled` is a phantom option**: it appears in neither the type definitions nor the runtime of `@langfuse/otel@5.4.1` (`grep -c mediaUploadEnabled dist/index.cjs` → 0). It survives type-checking only because conditional spreads bypass excess-property checks. Anything relying on it to suppress media upload — including LibreChat's central-media-disable path — is currently a no-op. Filing separately.