### PR TITLE
🧵 feat: Continue Detached Subagent Threads

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4854,6 +4854,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const input = rawInput as {
             description?: string;
             subagent_type?: string;
+            subagent_thread_id?: string;
             run_in_background?: boolean;
           };
           const description =
@@ -4863,6 +4864,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               : DEFAULT_SUBAGENT_DESCRIPTION;
           const subagentType =
             typeof input.subagent_type === 'string' ? input.subagent_type : '';
+          const subagentThreadId =
+            typeof input.subagent_thread_id === 'string' &&
+            input.subagent_thread_id.trim() !== ''
+              ? input.subagent_thread_id.trim()
+              : undefined;
           const threadId = config.configurable?.thread_id as string | undefined;
           /** Surface the parent call id so child checkpoints, interrupts, and
            * update events remain correlated across replay and resume. */
@@ -4905,12 +4911,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               | undefined,
           };
           if (input.run_in_background === true) {
-            return executor.executeInBackground(executeParams);
+            return executor.executeInBackground({
+              ...executeParams,
+              ...(subagentThreadId == null
+                ? {}
+                : { subagentThreadId }),
+            });
+          }
+          if (subagentThreadId != null) {
+            return JSON.stringify({
+              status: 'rejected',
+              tool: Constants.SUBAGENT,
+              message:
+                'Child-thread continuation requires run_in_background.',
+            });
           }
           const result = await executor.execute(executeParams);
           return result.content;
         }, buildSubagentToolParams(executableConfigs, {
           background: this.subagentTasks != null,
+          threadContinuation:
+            this.subagentTasks?.store.supportsThreadContinuation === true,
         }));
         const replayableSubagentTool = subagentTool as typeof subagentTool &
           ReplayableSubagentTool;

--- a/src/langchain/messages.ts
+++ b/src/langchain/messages.ts
@@ -10,6 +10,8 @@ export {
   isAIMessage,
   isBaseMessage,
   isToolMessage,
+  mapChatMessagesToStoredMessages,
+  mapStoredMessagesToChatMessages,
 } from '@langchain/core/messages';
 
 export type {
@@ -17,5 +19,6 @@ export type {
   MessageContent,
   MessageContentText,
   MessageContentImageUrl,
+  StoredMessage,
   UsageMetadata,
 } from '@langchain/core/messages';

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -13,7 +13,7 @@ WHEN TO USE:
 - A specialized subagent is available for the task domain.
 
 WHAT HAPPENS:
-- A fresh agent or configured agent graph is created with the task description as its only input.
+- A fresh agent or configured agent graph is created with the task description as its only input, unless the host enables child-thread continuation and you provide a saved thread id.
 - The delegated agent or team runs to completion using isolated tools and context.
 - Only the single agent's final response or the graph's designated result-agent response is returned to you.
 
@@ -29,6 +29,9 @@ const SUBAGENT_TYPE_PROP_DESCRIPTION =
 
 const RUN_IN_BACKGROUND_PROP_DESCRIPTION =
   'Set true to start the subagent as a detached process-local task and return a background_task_id immediately. Poll the host background-task tool to collect its result. The task can outlive this turn but does not survive a process restart.';
+
+const SUBAGENT_THREAD_PROP_DESCRIPTION =
+  'Continue a host-owned child thread using a fresh execution lease. The saved thread must belong to this scope and subagent type. Only available with run_in_background.';
 
 export const SubagentToolSchema = {
   type: 'object',
@@ -59,7 +62,7 @@ export const SubagentToolDefinition: LCTool = {
  */
 export function buildSubagentToolParams(
   configs: SubagentConfig[],
-  options: { background?: boolean } = {}
+  options: { background?: boolean; threadContinuation?: boolean } = {}
 ): {
   name: string;
   schema: JsonSchemaType;
@@ -93,12 +96,25 @@ export function buildSubagentToolParams(
             },
           }
           : {}),
+        ...(options.background === true &&
+        options.threadContinuation === true
+          ? {
+            subagent_thread_id: {
+              type: 'string',
+              description: SUBAGENT_THREAD_PROP_DESCRIPTION,
+            },
+          }
+          : {}),
       },
       required: ['description', 'subagent_type'],
     },
     description: `${SubagentToolDescription}${
       options.background === true
         ? '\n\nBACKGROUND EXECUTION:\n- Set run_in_background to true when you do not need the result immediately. The call returns a background_task_id; use the host background-task tools to poll, steer, queue, interrupt, or cancel it.'
+        : ''
+    }${
+      options.background === true && options.threadContinuation === true
+        ? '\n- To continue a completed child later, set run_in_background and pass its subagent_thread_id. The host starts a fresh execution from saved history; it does not restore a completed runtime.'
         : ''
     }\n\nAvailable types:\n${typeDescriptions}`,
   };

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { GraphInterrupt, MemorySaver } from '@langchain/langgraph';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
@@ -8,6 +9,8 @@ import type {
   ResolvedSubagentConfig,
   ResolvedSingleAgentSubagentConfig,
   StandardGraphInput,
+  SubagentTaskStartRequest,
+  SubagentTaskStartResult,
   SubagentUpdateEvent,
   SubagentUsageEvent,
   ToolSessionMap,
@@ -28,6 +31,7 @@ import { sanitizeForwardedSubagentUpdateData } from '../subagent/SubagentExecuto
 import { SUBAGENT_PARENT_BATCH_CONFIG_KEY } from '../subagent/SubagentReplay';
 import { Constants, Providers, GraphEvents, StepTypes } from '@/common';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
+import { stableStringify } from '../eagerEventExecution';
 import { AgentContext } from '@/agents/AgentContext';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { HandlerRegistry } from '@/events';
@@ -439,6 +443,38 @@ describe('buildChildInputs', () => {
 describe('SubagentExecutor', () => {
   const config = makeConfig();
 
+  class ContinuationTaskStore extends InMemorySubagentTaskStore {
+    readonly supportsThreadContinuation = true;
+    readonly inputs: string[] = [];
+    readonly fingerprints: string[] = [];
+    readonly lineage: Array<{
+      parentRunId: string;
+      parentAgentId?: string;
+      parentToolCallId: string;
+      subagentKind: SubagentTaskStartRequest['subagentKind'];
+    }> = [];
+
+    start(request: SubagentTaskStartRequest): SubagentTaskStartResult {
+      this.inputs.push(request.input);
+      this.fingerprints.push(request.requestFingerprint ?? '');
+      this.lineage.push({
+        parentRunId: request.parentRunId,
+        ...(request.parentAgentId == null
+          ? {}
+          : { parentAgentId: request.parentAgentId }),
+        parentToolCallId: request.parentToolCallId,
+        subagentKind: request.subagentKind,
+      });
+      const threadId = request.threadId ?? 'new-child-thread';
+      return super.start({
+        ...request,
+        threadId,
+        run: (runtime) =>
+          request.run(runtime, [new HumanMessage('Saved child turn.')]),
+      });
+    }
+  }
+
   /**
    * Build a stub `createChildGraph` factory that returns a minimal
    * `StandardGraph`-shaped object whose `createWorkflow().invoke()`
@@ -654,6 +690,77 @@ describe('SubagentExecutor', () => {
     expect(
       store.claim('owner:conversation', response.background_task_id)
     ).toMatchObject({ status: 'completed', result: 'second answer' });
+  });
+
+  it('starts a fresh execution from a host-restored child thread', async () => {
+    const store = new ContinuationTaskStore();
+    const invoke = jest.fn().mockResolvedValue({
+      messages: [new AIMessage('continued answer')],
+    });
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Continue with the new evidence.',
+        subagentType: 'researcher',
+        subagentThreadId: 'child-thread',
+        parentToolCallId: 'call_continuation',
+      })
+    ) as {
+      background_task_id: string;
+      subagent_thread_id: string;
+    };
+
+    expect(response.subagent_thread_id).toBe('child-thread');
+    expect(store.inputs).toEqual(['Continue with the new evidence.']);
+    expect(store.lineage).toEqual([
+      {
+        parentRunId: 'test-run',
+        parentAgentId: 'parent-agent',
+        parentToolCallId: 'call_continuation',
+        subagentKind: 'agent',
+      },
+    ]);
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+    const childInput = invoke.mock.calls[0][0] as { messages: BaseMessage[] };
+    expect(childInput.messages.map((message) => message.content)).toEqual([
+      'Saved child turn.',
+      'Continue with the new evidence.',
+    ]);
+  });
+
+  it('preserves the legacy fingerprint when no child thread is selected', () => {
+    const store = new ContinuationTaskStore();
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+    });
+
+    executor.executeInBackground({
+      description: 'Legacy detached task.',
+      subagentType: 'researcher',
+      parentToolCallId: 'call_legacy_fingerprint',
+    });
+
+    expect(store.fingerprints).toEqual([
+      createHash('sha256')
+        .update(
+          stableStringify({
+            description: 'Legacy detached task.',
+            subagentType: 'researcher',
+          })
+        )
+        .digest('hex'),
+    ]);
   });
 
   it('drains interrupt and steer controls through child-safe hook boundaries', async () => {
@@ -895,6 +1002,38 @@ describe('SubagentExecutor', () => {
     });
   });
 
+  it('rejects a different child thread under the same parent tool call', () => {
+    const store = new ContinuationTaskStore();
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+    });
+    const first = JSON.parse(
+      executor.executeInBackground({
+        description: 'Continue the child.',
+        subagentType: 'researcher',
+        subagentThreadId: 'child-a',
+        parentToolCallId: 'call_thread_conflict',
+      })
+    ) as { background_task_id: string };
+    const conflict = JSON.parse(
+      executor.executeInBackground({
+        description: 'Continue the child.',
+        subagentType: 'researcher',
+        subagentThreadId: 'child-b',
+        parentToolCallId: 'call_thread_conflict',
+      })
+    ) as { status: string; message: string };
+
+    expect(conflict).toMatchObject({
+      status: 'rejected',
+      message:
+        'The same parent tool call ID was already used with different background subagent arguments.',
+    });
+    store.control('owner:conversation', first.background_task_id, {
+      action: 'cancel',
+    });
+  });
+
   it('fails closed when detached execution is unavailable or not attributable', () => {
     const disabled = JSON.parse(
       createExecutor().executeInBackground({
@@ -920,6 +1059,26 @@ describe('SubagentExecutor', () => {
     expect(unattributed).toMatchObject({
       status: 'rejected',
       message: 'Background subagent execution requires a parent tool call ID.',
+    });
+    expect(store.list('owner:conversation')).toEqual([]);
+  });
+
+  it('fails closed when the host cannot restore child threads', () => {
+    const store = new InMemorySubagentTaskStore();
+    const result = JSON.parse(
+      createExecutor({
+        taskConfig: { store, scopeId: 'owner:conversation' },
+      }).executeInBackground({
+        description: 'Continue this child.',
+        subagentType: 'researcher',
+        subagentThreadId: 'child-thread',
+        parentToolCallId: 'call_unsupported_continuation',
+      })
+    ) as { status: string; message: string };
+
+    expect(result).toMatchObject({
+      status: 'rejected',
+      message: 'Child-thread continuation is not enabled by this host.',
     });
     expect(store.list('owner:conversation')).toEqual([]);
   });

--- a/src/tools/__tests__/SubagentTool.test.ts
+++ b/src/tools/__tests__/SubagentTool.test.ts
@@ -143,11 +143,19 @@ describe('SubagentTool', () => {
       const background = buildSubagentToolParams(configs, {
         background: true,
       });
+      const continuable = buildSubagentToolParams(configs, {
+        background: true,
+        threadContinuation: true,
+      });
       const foregroundProperties = foreground.schema.properties as Record<
         string,
         Record<string, unknown>
       >;
       const backgroundProperties = background.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const continuableProperties = continuable.schema.properties as Record<
         string,
         Record<string, unknown>
       >;
@@ -157,7 +165,14 @@ describe('SubagentTool', () => {
       expect(backgroundProperties.run_in_background).toMatchObject({
         type: 'boolean',
       });
+      expect(backgroundProperties.subagent_thread_id).toBeUndefined();
       expect(background.description).toContain('BACKGROUND EXECUTION');
+      expect(continuableProperties.subagent_thread_id).toMatchObject({
+        type: 'string',
+      });
+      expect(continuable.description).toContain(
+        'fresh execution from saved history'
+      );
     });
 
     it('produces same schema as createSubagentToolDefinition', () => {

--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -50,6 +50,7 @@ type StoredTask = {
   idempotencyKey: string;
   requestFingerprint?: string;
   scopeId: string;
+  threadId: string;
   subagentType: string;
   status: SubagentTaskStatus;
   createdAt: number;
@@ -167,6 +168,7 @@ function toInjectedMessage(control: PendingControl): InjectedMessage {
 function snapshot(task: StoredTask): SubagentTaskSnapshot {
   return {
     taskId: task.id,
+    threadId: task.threadId,
     subagentType: task.subagentType,
     status: task.status,
     createdAt: task.createdAt,
@@ -251,13 +253,19 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       this.dropEmptyBucket(scopeId, bucket);
       return { accepted: false, reason: 'capacity' };
     }
+    const taskId = nanoid();
+    const requestedThreadId = request.threadId?.trim();
     const task: StoredTask = {
-      id: nanoid(),
+      id: taskId,
       idempotencyKey,
       ...(requestFingerprint == null || requestFingerprint === ''
         ? {}
         : { requestFingerprint }),
       scopeId,
+      threadId:
+        requestedThreadId != null && requestedThreadId !== ''
+          ? requestedThreadId
+          : taskId,
       subagentType: request.subagentType,
       status: 'running',
       createdAt: now,

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -623,10 +623,17 @@ function getSettlementFingerprint(output: PersistedToolOutput): string {
 
 function getBackgroundTaskFingerprint(
   description: string,
-  subagentType: string
+  subagentType: string,
+  threadId?: string
 ): string {
   return createHash('sha256')
-    .update(stableStringify({ description, subagentType }))
+    .update(
+      stableStringify({
+        description,
+        subagentType,
+        ...(threadId == null || threadId === '' ? {} : { threadId }),
+      })
+    )
     .digest('hex');
 }
 
@@ -758,6 +765,8 @@ function createReplayCheckpointWorkflow(
 export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
+  /** Saved logical child thread selected by the parent model. */
+  subagentThreadId?: string;
   threadId?: string;
   /** Signal attached to this specific parent tool invocation. */
   signal?: AbortSignal;
@@ -812,6 +821,8 @@ export type SubagentExecuteParams = {
   hookSessionId?: string;
   /** Process-local task controls consumed by the child graph. @internal */
   taskRuntime?: SubagentTaskRuntime;
+  /** Host-restored child transcript for a fresh continuation run. @internal */
+  initialMessages?: BaseMessage[];
 };
 
 export type SubagentExecuteResult = {
@@ -1071,6 +1082,19 @@ export class SubagentExecutor {
           'Background subagent execution requires a parent tool call ID.',
       });
     }
+    const subagentThreadId = params.subagentThreadId?.trim();
+    if (
+      subagentThreadId != null &&
+      subagentThreadId !== '' &&
+      this.taskConfig.store.supportsThreadContinuation !== true
+    ) {
+      return JSON.stringify({
+        status: 'rejected',
+        tool: Constants.SUBAGENT,
+        message:
+          'Child-thread continuation is not enabled by this host.',
+      });
+    }
     const detachedHandlers = new HandlerRegistry();
     const sourceHookSessionId =
       asNonEmptyString(params.parentConfigurable?.run_id) ??
@@ -1092,14 +1116,31 @@ export class SubagentExecutor {
         this.parentAgentId ?? '',
         parentToolCallId,
       ]),
+      parentRunId: this.parentRunId,
+      ...(this.parentAgentId == null
+        ? {}
+        : { parentAgentId: this.parentAgentId }),
+      parentToolCallId,
       requestFingerprint: getBackgroundTaskFingerprint(
         params.description,
-        params.subagentType
+        params.subagentType,
+        subagentThreadId
       ),
+      ...(subagentThreadId == null || subagentThreadId === ''
+        ? {}
+        : { threadId: subagentThreadId }),
+      input: params.description,
+      subagentKind:
+        'kind' in executableConfig && executableConfig.kind === 'graph'
+          ? 'graph'
+          : 'agent',
       subagentType: params.subagentType,
-      run: (runtime) =>
+      run: (runtime, initialMessages) =>
         this.executeDetached(
-          params,
+          {
+            ...params,
+            ...(initialMessages == null ? {} : { initialMessages }),
+          },
           runtime,
           detachedHandlers,
           taskHookRegistry,
@@ -1124,6 +1165,9 @@ export class SubagentExecutor {
     }
     return JSON.stringify({
       background_task_id: started.task.taskId,
+      ...(this.taskConfig.store.supportsThreadContinuation === true
+        ? { subagent_thread_id: started.task.threadId }
+        : {}),
       tool: Constants.SUBAGENT,
       subagent_type: params.subagentType,
       status: started.task.status,
@@ -2615,6 +2659,7 @@ export class SubagentExecutor {
         } else {
           childInput = {
             messages: [
+              ...(params.initialMessages ?? []),
               new HumanMessage({
                 content: description,
                 additional_kwargs: {

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -15,15 +15,24 @@ const start = (
     scopeId: string;
     idempotencyKey: string;
     requestFingerprint: string;
+    threadId: string;
     subagentType: string;
   }> = {}
 ) =>
   store.start({
     scopeId: overrides.scopeId ?? 'user:conversation',
     idempotencyKey: overrides.idempotencyKey ?? 'run:agent:call',
+    parentRunId: 'run',
+    parentAgentId: 'parent-agent',
+    parentToolCallId: 'call',
     ...(overrides.requestFingerprint == null
       ? {}
       : { requestFingerprint: overrides.requestFingerprint }),
+    ...(overrides.threadId == null
+      ? {}
+      : { threadId: overrides.threadId }),
+    input: 'Research the question.',
+    subagentKind: 'agent',
     subagentType: overrides.subagentType ?? 'researcher',
     run,
   });
@@ -50,6 +59,7 @@ describe('InMemorySubagentTaskStore', () => {
       throw new Error('Expected task dispatch to be accepted.');
     }
     expect(duplicate.task.taskId).toBe(first.task.taskId);
+    expect(first.task.threadId).toBe(first.task.taskId);
     expect(run).not.toHaveBeenCalled();
 
     await settle();
@@ -63,6 +73,23 @@ describe('InMemorySubagentTaskStore', () => {
     });
     expect(store.claim('user:conversation', first.task.taskId)).toMatchObject({
       status: 'claimed',
+    });
+  });
+
+  it('carries a host-owned thread identity without retaining its transcript', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const started = start(store, async () => ({ content: 'continued' }), {
+      threadId: 'child-thread',
+    });
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+
+    expect(started.task.threadId).toBe('child-thread');
+    await settle();
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      threadId: 'child-thread',
+      status: 'completed',
     });
   });
 

--- a/src/types/subagentTasks.ts
+++ b/src/types/subagentTasks.ts
@@ -27,8 +27,10 @@ export interface SubagentTaskProgress {
 }
 /** Read-only task metadata. Results are exposed only through `claim`. */
 export interface SubagentTaskSnapshot {
-  /** Handle for this child-conversation execution within its trusted scope. */
+  /** Handle for this child-thread execution lease within its trusted scope. */
   taskId: string;
+  /** Stable logical child-thread identity shared by fresh execution leases. */
+  threadId: string;
   subagentType: string;
   status: SubagentTaskStatus;
   createdAt: number;
@@ -77,15 +79,34 @@ export interface SubagentTaskRuntime {
 export interface SubagentTaskStartRequest {
   scopeId: string;
   idempotencyKey: string;
+  /** Host/SDK-owned parent run identity for durable lineage. */
+  parentRunId: string;
+  /** Executing parent agent, when the graph has a stable agent identity. */
+  parentAgentId?: string;
+  /** Provider tool-call identity that created this execution lease. */
+  parentToolCallId: string;
+  /**
+   * Untrusted child-thread selector supplied by the parent model. A
+   * continuation-capable store MUST validate ownership, scope, lineage, and
+   * `subagentType` before loading any saved messages.
+   */
+  threadId?: string;
+  /** Untrusted new user-turn text for host persistence and audit. */
+  input: string;
   /** Stable hash of model-writable inputs used to reject conflicting replays. */
   requestFingerprint?: string;
+  /** Execution shape selected from the host-provided subagent catalog. */
+  subagentKind: SubagentUpdateEvent['subagentKind'];
   subagentType: string;
   /**
    * Starts one ephemeral execution lease. The canonical child transcript is
    * returned so a host-owned store may persist it for a later fresh run;
    * retaining a graph/checkpoint after terminal completion is unnecessary.
    */
-  run(runtime: SubagentTaskRuntime): Promise<{
+  run(
+    runtime: SubagentTaskRuntime,
+    initialMessages?: BaseMessage[]
+  ): Promise<{
     content: string;
     messages?: BaseMessage[];
   }>;
@@ -107,10 +128,17 @@ export type SubagentTaskStartResult =
 /**
  * Host-replaceable store contract used by the SDK's subagent tool. The store
  * should normally outlive individual `Run` instances. Durable hosts may
- * persist the transcript returned by `run` under the task/conversation
+ * persist the transcript returned by `run` under the task/thread
  * lineage and start a fresh execution for a later turn.
  */
 export interface SubagentTaskStore {
+  /**
+   * True only when `start` authorizes an existing `threadId`, loads its
+   * saved transcript, and supplies that transcript to `run`. The flag exposes
+   * the model-facing continuation field, so a store must fail closed for an
+   * unknown or unauthorized id rather than starting an empty child.
+   */
+  readonly supportsThreadContinuation?: boolean;
   start(request: SubagentTaskStartRequest): SubagentTaskStartResult;
   get(scopeId: string, taskId: string): SubagentTaskSnapshot | undefined;
   list(scopeId: string): SubagentTaskSnapshot[];


### PR DESCRIPTION
## Summary

I added a durable child-thread identity on top of detached subagent execution so hosts can continue a completed child in a fresh execution without retaining its graph or checkpoint.

- Separate the stable `subagent_thread_id` from each ephemeral `background_task_id`.
- Expose continuation only when the host store explicitly declares support.
- Require continuation-capable stores to authorize ownership, scope, lineage, and subagent type before restoring history.
- Pass the new user-turn text, parent lineage, execution shape, and canonical `BaseMessage` transcript through the host store contract for durable thread persistence.
- Reject unsupported or foreground continuation requests instead of silently starting an empty child.
- Include the child-thread selector in replay fingerprints to prevent conflicting idempotent replays.
- Preserve the bounded process-local default store without claiming restart durability.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran TypeScript compilation with `npm exec -- tsc --noEmit -p tsconfig.json`.
- Ran 147 focused subagent task, tool schema, and executor tests.
- Ran targeted ESLint across every changed source and test file.
- Ran `npm run build` for ESM, CJS, and declaration output.
- Ran `git diff --check`.

### Test Configuration

- Node.js 24-compatible repository toolchain
- Jest in band with experimental VM modules

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes