### PR TITLE
🧵 fix: Harden Subagent Thread Contracts

### DIFF
--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1083,6 +1083,70 @@ describe('SubagentExecutor', () => {
     expect(store.list('owner:conversation')).toEqual([]);
   });
 
+  it('reports an unavailable child thread without misclassifying it as capacity', () => {
+    class RejectingContinuationStore extends ContinuationTaskStore {
+      override start(
+        request: SubagentTaskStartRequest
+      ): SubagentTaskStartResult {
+        if (request.threadId === 'missing-child') {
+          return { accepted: false, reason: 'thread_unavailable' };
+        }
+        return super.start(request);
+      }
+    }
+    const store = new RejectingContinuationStore();
+    const result = JSON.parse(
+      createExecutor({
+        taskConfig: { store, scopeId: 'owner:conversation' },
+      }).executeInBackground({
+        description: 'Continue this child.',
+        subagentType: 'researcher',
+        subagentThreadId: 'missing-child',
+        parentToolCallId: 'call_missing_continuation',
+      })
+    ) as { status: string; message: string };
+
+    expect(result).toMatchObject({
+      status: 'rejected',
+      message:
+        'The requested subagent thread is unavailable in this parent scope. Start a new subagent thread or choose one created by this parent for the same subagent type.',
+    });
+    expect(store.list('owner:conversation')).toEqual([]);
+  });
+
+  it('cancels a continuation task when its host omits the required thread ID', async () => {
+    class InvalidContinuationStore extends ContinuationTaskStore {
+      override start(
+        request: SubagentTaskStartRequest
+      ): SubagentTaskStartResult {
+        const started = super.start(request);
+        return started.accepted
+          ? { ...started, task: { ...started.task, threadId: undefined } }
+          : started;
+      }
+    }
+    const store = new InvalidContinuationStore();
+    const result = JSON.parse(
+      createExecutor({
+        taskConfig: { store, scopeId: 'owner:conversation' },
+      }).executeInBackground({
+        description: 'Start this child.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_missing_host_thread',
+      })
+    ) as { status: string; message: string };
+
+    expect(result).toMatchObject({
+      status: 'rejected',
+      message:
+        'The host accepted the subagent task without assigning its required thread ID.',
+    });
+    await Promise.resolve();
+    expect(store.list('owner:conversation')).toEqual([
+      expect.objectContaining({ status: 'cancelled' }),
+    ]);
+  });
+
   it('returns error for unknown subagent type', async () => {
     const executor = createExecutor();
     const result = await executor.execute({

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1148,6 +1148,14 @@ export class SubagentExecutor {
         ),
     });
     if (!started.accepted) {
+      if (started.reason === 'thread_unavailable') {
+        return JSON.stringify({
+          status: 'rejected',
+          tool: Constants.SUBAGENT,
+          message:
+            'The requested subagent thread is unavailable in this parent scope. Start a new subagent thread or choose one created by this parent for the same subagent type.',
+        });
+      }
       if (started.reason === 'conflict') {
         return JSON.stringify({
           status: 'rejected',
@@ -1163,10 +1171,27 @@ export class SubagentExecutor {
           'Too many background subagent tasks are already running in this scope or process. Poll or cancel an existing task, or run this call in the foreground.',
       });
     }
+    const startedThreadId = started.task.threadId?.trim();
+    if (
+      this.taskConfig.store.supportsThreadContinuation === true &&
+      (startedThreadId == null || startedThreadId === '')
+    ) {
+      this.taskConfig.store.control(
+        this.taskConfig.scopeId,
+        started.task.taskId,
+        { action: 'cancel' }
+      );
+      return JSON.stringify({
+        status: 'rejected',
+        tool: Constants.SUBAGENT,
+        message:
+          'The host accepted the subagent task without assigning its required thread ID.',
+      });
+    }
     return JSON.stringify({
       background_task_id: started.task.taskId,
       ...(this.taskConfig.store.supportsThreadContinuation === true
-        ? { subagent_thread_id: started.task.threadId }
+        ? { subagent_thread_id: startedThreadId }
         : {}),
       tool: Constants.SUBAGENT,
       subagent_type: params.subagentType,

--- a/src/types/subagentTasks.ts
+++ b/src/types/subagentTasks.ts
@@ -29,8 +29,12 @@ export interface SubagentTaskProgress {
 export interface SubagentTaskSnapshot {
   /** Handle for this child-thread execution lease within its trusted scope. */
   taskId: string;
-  /** Stable logical child-thread identity shared by fresh execution leases. */
-  threadId: string;
+  /**
+   * Stable logical thread identity shared by fresh execution leases. Required
+   * from stores that advertise `supportsThreadContinuation`; optional for
+   * legacy/process-local stores that do not expose a durable conversation.
+   */
+  threadId?: string;
   subagentType: string;
   status: SubagentTaskStatus;
   createdAt: number;
@@ -119,6 +123,7 @@ export type SubagentTaskStartResult =
       task: SubagentTaskSnapshot;
     }
   | { accepted: false; reason: 'capacity' }
+  | { accepted: false; reason: 'thread_unavailable' }
   | {
       accepted: false;
       reason: 'conflict';


### PR DESCRIPTION
## Summary

I hardened the detached subagent thread contract before publishing the next SDK version. This follows up on two late inline findings from #427 and keeps thread identity host-neutral while preserving compatibility with existing process-local task stores.

- Keep threadId optional on the base task snapshot so stores that do not advertise continuation remain source-compatible.
- Require continuation-capable stores to return a non-empty thread ID and cancel a task that violates that capability contract.
- Add an explicit thread_unavailable start rejection so unknown, stale, or unauthorized selectors are not misreported as capacity failures.
- Return a clear model-facing recovery message without distinguishing missing from unauthorized threads.
- Add focused regression coverage for both rejection paths.

Related to #394.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- npm test -- --runInBand src/tools/__tests__/SubagentExecutor.test.ts src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts (133 passed)
- npm exec -- tsc --noEmit -p tsconfig.json
- npm exec -- eslint src/types/subagentTasks.ts src/tools/subagent/SubagentExecutor.ts src/tools/__tests__/SubagentExecutor.test.ts
- node scripts/sort-imports.ts --check src/types/subagentTasks.ts src/tools/subagent/SubagentExecutor.ts src/tools/__tests__/SubagentExecutor.test.ts
- npm run build

### **Test Configuration**:

- Node.js 24-compatible local workspace
- Exact base: 27d806342242e07a0ef4f108e5f98f2f4c1f630d

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes