### PR TITLE
🧮 fix: Count Long Plain Text in Bounded Chunks

### DIFF
--- a/src/specs/context-accuracy.live.test.ts
+++ b/src/specs/context-accuracy.live.test.ts
@@ -12,12 +12,18 @@
  * BEDROCK_AWS_* creds; Bedrock's AWS SDK needs
  * NODE_OPTIONS='--experimental-vm-modules' under jest.
  */
+/* eslint-disable no-console */
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
 
 import { z } from 'zod';
+import Anthropic from '@anthropic-ai/sdk';
 import { tool } from '@langchain/core/tools';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
 import { describe, expect, it, jest } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -27,10 +33,14 @@ import { GraphEvents, Providers } from '@/common';
 import { ModelEndHandler } from '@/events';
 import { Run } from '@/run';
 
+function hasEnv(name: string): boolean {
+  const value = process.env[name];
+  return value != null && value !== '';
+}
+
 const shouldRunLive =
   process.env.RUN_CONTEXT_USAGE_LIVE_TESTS === '1' &&
-  process.env.ANTHROPIC_API_KEY != null &&
-  process.env.ANTHROPIC_API_KEY !== '';
+  hasEnv('ANTHROPIC_API_KEY');
 
 const describeIfLive = shouldRunLive ? describe : describe.skip;
 const modelName =
@@ -105,7 +115,7 @@ const providerMatrix: Array<{
 }> = [
   {
     name: 'google',
-    enabled: !!process.env.GOOGLE_API_KEY,
+    enabled: hasEnv('GOOGLE_API_KEY'),
     llmConfig: {
       provider: Providers.GOOGLE,
       model: process.env.GOOGLE_CONTEXT_LIVE_MODEL ?? 'gemini-2.5-flash',
@@ -118,8 +128,8 @@ const providerMatrix: Array<{
   {
     name: 'bedrock',
     enabled:
-      !!process.env.BEDROCK_AWS_ACCESS_KEY_ID &&
-      !!process.env.BEDROCK_AWS_SECRET_ACCESS_KEY,
+      hasEnv('BEDROCK_AWS_ACCESS_KEY_ID') &&
+      hasEnv('BEDROCK_AWS_SECRET_ACCESS_KEY'),
     llmConfig: {
       provider: Providers.BEDROCK,
       model:
@@ -152,6 +162,61 @@ describeIfLive('Context accuracy live integration', () => {
 
   afterAll(() => {
     TokenEncoderManager.reset();
+  });
+
+  it('matches Anthropic count_tokens for issue-sized context across cache placement', async () => {
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+    const claudeCounter = await createTokenCounter('claude');
+    const phrase = 'The quick brown fox jumps over the lazy dog. ';
+    const instructions = phrase
+      .repeat(Math.ceil(118_315 / phrase.length))
+      .slice(0, 118_315);
+    const fileContext = phrase
+      .repeat(Math.ceil(361_473 / phrase.length))
+      .slice(0, 361_473);
+    const joinedInstructions = `${instructions}\n\n${fileContext}`;
+    const userPrompt = 'test';
+
+    const [joinedProviderCount, splitProviderCount] = await Promise.all([
+      client.messages.countTokens({
+        model: modelName,
+        system: joinedInstructions,
+        messages: [{ role: 'user', content: userPrompt }],
+      }),
+      client.messages.countTokens({
+        model: modelName,
+        system: instructions,
+        messages: [
+          { role: 'user', content: userPrompt },
+          { role: 'user', content: fileContext },
+        ],
+      }),
+    ]);
+    const joinedLocalCount =
+      claudeCounter(new SystemMessage(joinedInstructions)) +
+      claudeCounter(new HumanMessage(userPrompt));
+    const splitLocalCount =
+      claudeCounter(new SystemMessage(instructions)) +
+      claudeCounter(new HumanMessage(userPrompt)) +
+      claudeCounter(new HumanMessage(fileContext));
+    const joinedRatio = joinedLocalCount / joinedProviderCount.input_tokens;
+    const splitRatio = splitLocalCount / splitProviderCount.input_tokens;
+
+    console.log('[ctx-accuracy] long-context local/provider ratios:', {
+      joinedRatio,
+      splitRatio,
+      joinedLocalCount,
+      splitLocalCount,
+      joinedProviderCount: joinedProviderCount.input_tokens,
+      splitProviderCount: splitProviderCount.input_tokens,
+    });
+    expect(joinedRatio).toBeGreaterThan(0.8);
+    expect(joinedRatio).toBeLessThan(1.2);
+    expect(splitRatio).toBeGreaterThan(0.8);
+    expect(splitRatio).toBeLessThan(1.2);
+    expect(joinedProviderCount.input_tokens).toBe(
+      splitProviderCount.input_tokens
+    );
   });
 
   it('tracks provider counts through a cached tool loop and tightens with calibration', async () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -1,7 +1,10 @@
+import { Tokenizer } from 'ai-tokenizer';
+import * as claudeEncoding from 'ai-tokenizer/encoding/claude';
 import {
   AIMessage,
   ChatMessage,
   HumanMessage,
+  SystemMessage,
   ToolMessage,
 } from '@langchain/core/messages';
 import {
@@ -124,17 +127,83 @@ describe('getTokenCountForMessage', () => {
       getType: () => 'ai',
     }) as unknown as AIMessage;
 
-  test('bounds direct message strings before tokenization and charges omitted characters', () => {
-    const callbackLengths: number[] = [];
-    const content = 'x'.repeat(300_000);
+  test('counts long plain-text messages close to the real Claude tokenizer result', () => {
+    const tokenizer = new Tokenizer(claudeEncoding);
+    const phrase = 'The quick brown fox jumps over the lazy dog. ';
+    const content = phrase
+      .repeat(Math.ceil(361_473 / phrase.length))
+      .slice(0, 361_473);
+    const exactCount = tokenizer.count(content) + 3;
 
-    const count = getTokenCountForMessage(new HumanMessage(content), (text) => {
-      callbackLengths.push(text.length);
-      return text.length;
-    });
+    const count = getTokenCountForMessage(
+      new HumanMessage(content),
+      (text) => tokenizer.count(text),
+      'claude'
+    );
 
-    expect(Math.max(...callbackLengths)).toBe(200_000);
-    expect(count).toBe(600_003);
+    expect(count).toBeGreaterThanOrEqual(exactCount);
+    expect(count / exactCount).toBeLessThan(1.005);
+  });
+
+  test('counts a high-density suffix instead of extrapolating from low-density text', () => {
+    const tokenizer = new Tokenizer(claudeEncoding);
+    const phrase = 'The quick brown fox jumps over the lazy dog. ';
+    const prose = phrase
+      .repeat(Math.ceil(200_000 / phrase.length))
+      .slice(0, 200_000);
+    const content = `${prose}${'😀'.repeat(8_000)}`;
+    const exactCount = tokenizer.count(content) + 3;
+
+    const count = getTokenCountForMessage(
+      new HumanMessage(content),
+      (text) => tokenizer.count(text),
+      'claude'
+    );
+
+    expect(count).toBeGreaterThanOrEqual(exactCount);
+    expect(count / exactCount).toBeLessThan(1.005);
+  });
+
+  test('stays conservative when a chunk boundary changes tokenizer segmentation', () => {
+    const tokenizer = new Tokenizer(claudeEncoding);
+    const boundaryPrefix = '\n\n \n\n ';
+    const boundarySuffix = '😀é a0é0漢,\n0.AAaA,Aééé0\n.😀.A😀,.aéa';
+    const padding = 'word '
+      .repeat(2_000)
+      .slice(0, 8_192 - boundaryPrefix.length);
+    const content = `${padding}${boundaryPrefix}${boundarySuffix}`;
+    const exactCount = tokenizer.count(content) + 3;
+
+    const count = getTokenCountForMessage(
+      new HumanMessage(content),
+      (text) => tokenizer.count(text),
+      'claude'
+    );
+
+    expect(count).toBeGreaterThanOrEqual(exactCount);
+  });
+
+  test('keeps long instruction counts stable across prompt-cache placement', () => {
+    const tokenizer = new Tokenizer(claudeEncoding);
+    const phrase = 'The quick brown fox jumps over the lazy dog. ';
+    const stable = phrase
+      .repeat(Math.ceil(118_315 / phrase.length))
+      .slice(0, 118_315);
+    const dynamic = phrase
+      .repeat(Math.ceil(361_473 / phrase.length))
+      .slice(0, 361_473);
+    const count = (message: HumanMessage | SystemMessage): number =>
+      getTokenCountForMessage(
+        message,
+        (text) => tokenizer.count(text),
+        'claude'
+      );
+
+    const splitCount =
+      count(new SystemMessage(stable)) + count(new HumanMessage(dynamic));
+    const joinedCount = count(new SystemMessage(`${stable}\n\n${dynamic}`));
+
+    expect(Math.abs(splitCount - joinedCount)).toBeLessThanOrEqual(100);
   });
 
   test.each([
@@ -153,7 +222,7 @@ describe('getTokenCountForMessage', () => {
     ).toThrow(UnsafeTokenMeasurementError);
   });
 
-  test('bounds direct string tool args before tokenization and charges omitted characters', () => {
+  test('bounds tokenizer input while fully counting direct string tool args', () => {
     const callbackLengths: number[] = [];
     const args = 'x'.repeat(300_000);
 
@@ -162,7 +231,7 @@ describe('getTokenCountForMessage', () => {
       return text.length;
     });
 
-    expect(Math.max(...callbackLengths)).toBe(200_000);
+    expect(Math.max(...callbackLengths)).toBe(8_192);
     expect(count).toBeGreaterThan(args.length);
   });
 
@@ -317,9 +386,9 @@ describe('getTokenCountForMessage', () => {
       getType: () => 'tool',
     } as unknown as ToolMessage;
 
-    expect(() => getTokenCountForMessage(message, (text) => text.length)).toThrow(
-      UnsafeTokenMeasurementError
-    );
+    expect(() =>
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toThrow(UnsafeTokenMeasurementError);
     try {
       getTokenCountForMessage(message, (text) => text.length);
     } catch (error) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -120,6 +120,10 @@ const MAX_STRUCTURED_TOKENIZATION_CHARS = 200_000;
 /** One UTF-16 character can encode to several tokenizer pieces. */
 const MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR = 4;
 const MAX_STRUCTURED_SAFETY_INSPECTION_WORK = 10_000;
+/** Bounds BPE work per plain-text segment without omitting any text. */
+const MAX_TEXT_TOKENIZATION_CHARS = 8_192;
+/** Covers tokenizer segmentation changes on both sides of a chunk boundary. */
+const TEXT_TOKEN_CHUNK_BOUNDARY_SAFETY_TOKENS = 4;
 
 /**
  * Extracts image dimensions from the first bytes of a base64-encoded
@@ -886,22 +890,24 @@ function getBoundedTextTokenCount(
   value: string,
   getTokenCount: (text: string) => number
 ): number {
-  const preview =
-    value.length > MAX_STRUCTURED_TOKENIZATION_CHARS
-      ? value.slice(0, MAX_STRUCTURED_TOKENIZATION_CHARS)
-      : value;
-  const previewTokens = ensureSafeTokenMeasurement(
-    getTokenCount(preview),
-    'tokenizer'
-  );
-  const omittedChars = value.length - preview.length;
-  if (omittedChars <= 0) {
-    return previewTokens;
+  let numTokens = 0;
+  for (
+    let offset = 0;
+    offset < value.length;
+    offset += MAX_TEXT_TOKENIZATION_CHARS
+  ) {
+    const chunkTokens = ensureSafeTokenMeasurement(
+      getTokenCount(value.slice(offset, offset + MAX_TEXT_TOKENIZATION_CHARS)),
+      'tokenizer'
+    );
+    const boundaryTokens =
+      offset > 0 ? TEXT_TOKEN_CHUNK_BOUNDARY_SAFETY_TOKENS : 0;
+    numTokens = Math.min(
+      Number.MAX_SAFE_INTEGER,
+      numTokens + chunkTokens + boundaryTokens
+    );
   }
-  return Math.min(
-    Number.MAX_SAFE_INTEGER,
-    previewTokens + omittedChars * MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR
-  );
+  return numTokens;
 }
 
 function getBoundedStructuredTokenCount(


### PR DESCRIPTION
## Summary

I fixed long plain-text token counting so issue-sized LibreChat context is measured in bounded chunks without omitting content or applying an extreme per-character fallback. This addresses [LibreChat #14951](https://github.com/danny-avila/LibreChat/issues/14951).

- Count every plain-text segment using 8,192-character tokenizer chunks.
- Add a conservative four-token allowance at each chunk boundary to cover tokenizer segmentation changes.
- Preserve the existing bounded serializer and omitted-character safety behavior for structured values.
- Add real Claude-tokenizer regressions for 361,473-character File Context, mixed token-density text, chunk-boundary behavior, prompt-cache placement, and callback bounds.
- Validate issue-sized context against Anthropic's live `count_tokens` endpoint for cached and uncached placement shapes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran focused unit and integration tests, TypeScript validation, lint, and the package build. The live Anthropic test measured 117,291 provider tokens versus 117,608–117,610 locally, a conservative difference of approximately 0.27%.

### **Test Configuration**:

- Node.js with the repository's installed dependencies
- Anthropic live token counting using `RUN_CONTEXT_USAGE_LIVE_TESTS=1`
- Claude tokenizer from `ai-tokenizer`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
