### PR TITLE
🛟 fix: Propagate Responses Stream Errors

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -58,14 +58,14 @@ import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
-import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
-import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
-import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
 import {
   hasReasoningKwargs,
   hasToolCallChunks,
   getReasoningKwargsText,
 } from '@/llm/stream/chunkAdapters';
+import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import { smoothStream, resolveStreamDelay } from '@/llm/stream/smoother';
+import { INTENT_ARG, isIntentLabelProperty } from '@/tools/intentArg';
 import { dropRepeatedScalarMetadata } from './streamMetadata';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -919,6 +919,33 @@ function attachResponsesReplayPosition(
   chunk.message.lc_kwargs.additional_kwargs = additionalKwargs;
 }
 
+function getResponsesStreamError(
+  event: OpenAIClient.Responses.ResponseStreamEvent
+): Error | undefined {
+  if (event.type === 'error') {
+    return new OpenAIClient.APIError(
+      undefined,
+      event,
+      event.message,
+      undefined
+    );
+  }
+  if (event.type !== 'response.failed') {
+    return;
+  }
+  if (event.response.error != null) {
+    return new OpenAIClient.APIError(
+      undefined,
+      event.response.error,
+      event.response.error.message,
+      undefined
+    );
+  }
+  return new OpenAIClient.OpenAIError(
+    `Response ${event.response.id} failed without error details.`
+  );
+}
+
 async function* convertLibreChatResponsesStream(
   stream: AsyncIterable<OpenAIClient.Responses.ResponseStreamEvent>,
   options: ResponsesStreamChunkOptions,
@@ -929,6 +956,10 @@ async function* convertLibreChatResponsesStream(
   try {
     for await (const event of stream) {
       options.signal?.throwIfAborted();
+      const streamError = getResponsesStreamError(event);
+      if (streamError != null) {
+        throw streamError;
+      }
       const convertedChunk =
         convertResponsesDeltaToChatGenerationChunk(event) ??
         convertDroppedResponsesReplayOutput(event);

--- a/src/llm/openai/llm.spec.ts
+++ b/src/llm/openai/llm.spec.ts
@@ -1094,7 +1094,80 @@ describe('ChatOpenAICompletions streaming usage_metadata callback', () => {
   });
 });
 
-describe('ChatOpenAIResponses streaming callback dispatch', () => {
+describe('ChatOpenAIResponses streaming', () => {
+  it('propagates response.failed provider errors', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = responsesOf<ResponsesStreamDelegate>(model);
+    const providerError = {
+      type: 'service_unavailable_error',
+      code: 'server_is_overloaded',
+      message: 'Our servers are currently overloaded. Please try again later.',
+      param: null,
+    };
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          type: 'response.failed',
+          sequence_number: 0,
+          response: {
+            id: 'resp_failed',
+            status: 'failed',
+            error: providerError,
+          },
+        } as OpenAIClient.Responses.ResponseStreamEvent;
+      })();
+
+    const stream = responses._streamResponseChunks(
+      [new HumanMessage('test')],
+      {}
+    );
+
+    await expect(stream.next()).rejects.toMatchObject({
+      message: providerError.message,
+      error: providerError,
+      type: providerError.type,
+      code: providerError.code,
+      param: providerError.param,
+    });
+  });
+
+  it('propagates Responses error events', async () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5',
+      apiKey: 'test-key',
+      useResponsesApi: true,
+    });
+    const responses = responsesOf<ResponsesStreamDelegate>(model);
+    const errorEvent: OpenAIClient.Responses.ResponseErrorEvent = {
+      type: 'error',
+      sequence_number: 0,
+      code: 'server_error',
+      message: 'The provider terminated the stream.',
+      param: null,
+    };
+    responses.completionWithRetry = async () =>
+      (async function* () {
+        yield errorEvent;
+      })();
+
+    const stream = responses._streamResponseChunks(
+      [new HumanMessage('test')],
+      {}
+    );
+
+    await expect(stream.next()).rejects.toMatchObject({
+      message: errorEvent.message,
+      error: errorEvent,
+      type: errorEvent.type,
+      code: errorEvent.code,
+      param: errorEvent.param,
+    });
+  });
+
   it('emits the callback before a consumer stops at the yielded chunk', async () => {
     const model = new ChatOpenAI({
       model: 'gpt-5',


### PR DESCRIPTION
I fixed Responses API streaming failures so terminal provider errors propagate to callers instead of completing with an empty assistant message.

- Detect `response.failed` and `error` events before unsupported stream events are skipped.
- Preserve structured provider details through the existing OpenAI error path.
- Return an explicit failure when a failed response omits error details.
- Add regression coverage for both terminal error event formats.

Closes #429

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/llm/openai/llm.spec.ts --runInBand` — 59 tests passed.
- `npx jest langfuse deterministic-trace-id --runInBand` — 176 tests passed.
- `npx tsc --noEmit` — passed.
- `npx eslint src/llm/openai/index.ts` — passed.
- `git diff --check` — passed.

### **Test Configuration**:

- Node.js v24.16.0
- npm 11.16.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes