### PR TITLE
feat(search): add You.com as a search provider

### DIFF
--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -5,6 +5,7 @@ import { getAttribution, createDefaultLogger } from './utils';
 import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
 import { createCrwAPI } from './crw-search';
+import { createYouAPI } from './you-search';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -499,6 +500,9 @@ export const createSearchAPI = (
     crwApiKey,
     crwApiUrl,
     crwSearchOptions,
+    youApiKey,
+    youApiUrl,
+    youSearchOptions,
     httpAgent,
     httpsAgent,
   } = config;
@@ -527,9 +531,15 @@ export const createSearchAPI = (
       httpAgent: httpAgent ?? crwSearchOptions?.httpAgent,
       httpsAgent: httpsAgent ?? crwSearchOptions?.httpsAgent,
     });
+  } else if (searchProvider.toLowerCase() === 'you') {
+    return createYouAPI(youApiKey, youApiUrl, {
+      ...youSearchOptions,
+      httpAgent: httpAgent ?? youSearchOptions?.httpAgent,
+      httpsAgent: httpsAgent ?? youSearchOptions?.httpsAgent,
+    });
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', 'keenable', or 'crw'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', 'keenable', 'crw', or 'you'`
     );
   }
 };

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -448,6 +448,9 @@ export const createSearchTool = (
     crwApiUrl,
     crwSearchOptions,
     crwScraperOptions,
+    youApiKey,
+    youApiUrl,
+    youSearchOptions,
     scraperTimeout,
     jinaApiKey,
     jinaApiUrl,
@@ -479,7 +482,11 @@ export const createSearchTool = (
     news: newsSchema,
   };
 
-  if (searchProvider === 'serper' || searchProvider === 'tavily') {
+  if (
+    searchProvider === 'serper' ||
+    searchProvider === 'tavily' ||
+    searchProvider === 'you'
+  ) {
     schemaProperties.country = countrySchema;
   }
 
@@ -503,6 +510,9 @@ export const createSearchTool = (
     crwApiKey,
     crwApiUrl,
     crwSearchOptions,
+    youApiKey,
+    youApiUrl,
+    youSearchOptions,
     httpAgent,
     httpsAgent,
   });

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -25,7 +25,8 @@ export type SearchProvider =
   | 'searxng'
   | 'tavily'
   | 'keenable'
-  | 'crw';
+  | 'crw'
+  | 'you';
 export type ScraperProvider =
   | 'firecrawl'
   | 'serper'
@@ -196,6 +197,43 @@ export interface SearchConfig extends HttpAgentConfig {
   crwApiKey?: string;
   crwApiUrl?: string;
   crwSearchOptions?: CrwSearchOptions;
+  youApiKey?: string;
+  youApiUrl?: string;
+  youSearchOptions?: YouSearchOptions;
+}
+
+export interface YouSearchOptions extends HttpAgentConfig {
+  maxResults?: number;
+  /** Sent as the User-Agent alongside the You.com attribution token. Defaults
+   * to "LibreChat". */
+  attributionTitle?: string;
+  timeout?: number;
+}
+
+export interface YouSearchParams {
+  query: string;
+  count: number;
+  freshness?: string;
+  country?: string;
+  safesearch?: string;
+}
+
+export interface YouSearchResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  /** Extracted passages from the page body. Web hits carry these; news hits
+   * carry only `description`. */
+  snippets?: string[];
+  page_age?: string;
+  thumbnail_url?: string;
+}
+
+export interface YouSearchResponse {
+  results?: {
+    web?: YouSearchResult[];
+    news?: YouSearchResult[];
+  };
 }
 
 export interface KeenableSearchOptions extends HttpAgentConfig {

--- a/src/tools/search/you-search.ts
+++ b/src/tools/search/you-search.ts
@@ -1,0 +1,137 @@
+import axios from 'axios';
+import type * as t from './types';
+import { DATE_RANGE } from './schema';
+
+const DEFAULT_YOU_TIMEOUT = 15000;
+
+/** Authenticated and keyless endpoints. You.com works without an API key by
+ * falling back to the public agents endpoint; a key lifts rate limits and
+ * unlocks the full Search API surface. The keyless endpoint rejects an
+ * `X-API-Key` header, so the endpoint and the headers are always chosen
+ * together — never send a stale key to the public path. */
+const YOU_DEFAULT_API_URL = 'https://api.you.com/v1/search';
+const YOU_PUBLIC_API_URL = 'https://api.you.com/v1/agents/search';
+/** You.com's `freshness` filter has no sub-day granularity, so PAST_HOUR
+ * widens to the narrowest bucket it does support. */
+const YOU_DATE_RANGES: Record<DATE_RANGE, string> = {
+  [DATE_RANGE.PAST_HOUR]: 'day',
+  [DATE_RANGE.PAST_24_HOURS]: 'day',
+  [DATE_RANGE.PAST_WEEK]: 'week',
+  [DATE_RANGE.PAST_MONTH]: 'month',
+  [DATE_RANGE.PAST_YEAR]: 'year',
+};
+const YOU_SAFE_SEARCH = ['off', 'moderate', 'strict'] as const;
+/** `count` is applied per response section, and the API caps it at 100. */
+const YOU_MAX_COUNT = 100;
+
+/** Web hits carry several extracted passages from the page body; news hits
+ * carry only a meta description. Prefer the passages when present. */
+const resolveSnippet = (result: t.YouSearchResult): string => {
+  const snippets = Array.isArray(result.snippets)
+    ? result.snippets.filter((snippet) => snippet.trim() !== '')
+    : [];
+  if (snippets.length > 0) {
+    return snippets.join('\n');
+  }
+  return result.description ?? '';
+};
+
+export const createYouAPI = (
+  apiKey?: string,
+  apiUrl?: string,
+  options?: t.YouSearchOptions
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  const resolvedKey = apiKey ?? process.env.YDC_API_KEY;
+  const hasKey = resolvedKey != null && resolvedKey !== '';
+  const timeout = options?.timeout ?? DEFAULT_YOU_TIMEOUT;
+  const resolvedUrl =
+    apiUrl ??
+    process.env.YDC_API_URL ??
+    (hasKey ? YOU_DEFAULT_API_URL : YOU_PUBLIC_API_URL);
+
+  /** Constant for the provider's lifetime. The User-Agent identifies the host
+   * application to You.com and is the only attribution signal available on the
+   * keyless endpoint, where there is no key to tie usage to. The API key is
+   * sent only when present, and only to the authenticated endpoint. */
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'User-Agent': `${options?.attributionTitle ?? 'LibreChat'} youdotcom-integration/danny-avila-agents`,
+  };
+  if (hasKey) {
+    headers['X-API-Key'] = resolvedKey;
+  }
+
+  const getSources = async ({
+    query,
+    date,
+    country,
+    safeSearch,
+    numResults = 8,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    const maxResults = Math.min(
+      Math.max(1, options?.maxResults ?? numResults),
+      YOU_MAX_COUNT
+    );
+
+    try {
+      const params: t.YouSearchParams = { query, count: maxResults };
+      if (date != null) {
+        params.freshness = YOU_DATE_RANGES[date];
+      }
+      if (country != null && country !== '') {
+        params.country = country.toUpperCase();
+      }
+      if (safeSearch != null) {
+        params.safesearch = YOU_SAFE_SEARCH[safeSearch] ?? 'moderate';
+      }
+
+      const response = await axios.get<t.YouSearchResponse>(resolvedUrl, {
+        headers,
+        params,
+        timeout,
+        httpAgent: options?.httpAgent,
+        httpsAgent: options?.httpsAgent,
+      });
+
+      const sections = response.data.results ?? {};
+      const webResults = Array.isArray(sections.web) ? sections.web : [];
+      const newsResults = Array.isArray(sections.news) ? sections.news : [];
+
+      const organic: t.OrganicResult[] = webResults
+        .slice(0, maxResults)
+        .map((result, index) => ({
+          position: index + 1,
+          title: result.title ?? '',
+          link: result.url ?? '',
+          snippet: resolveSnippet(result),
+          date: result.page_age,
+        }));
+
+      const topStories: t.TopStoryResult[] = newsResults
+        .slice(0, maxResults)
+        .map((result) => ({
+          title: result.title ?? '',
+          link: result.url ?? '',
+          date: result.page_age,
+          imageUrl: result.thumbnail_url,
+        }));
+
+      return { success: true, data: { organic, topStories } };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `You.com API request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/you.test.ts
+++ b/src/tools/search/you.test.ts
@@ -1,0 +1,310 @@
+import axios from 'axios';
+import { createSearchAPI } from './search';
+import { DATE_RANGE } from './schema';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const YOU_PUBLIC_URL = 'https://api.you.com/v1/agents/search';
+const YOU_KEYED_URL = 'https://api.you.com/v1/search';
+
+const sampleResponse = {
+  data: {
+    results: {
+      web: [
+        {
+          title: 'TypeScript Best Practices 2026',
+          url: 'https://example.com/ts',
+          description: 'A comprehensive guide to TypeScript.',
+          snippets: ['First passage.', 'Second passage.'],
+          page_age: '2026-01-15T10:30:00Z',
+        },
+        {
+          title: 'Second result',
+          url: 'https://example.com/second',
+          description: 'Description fallback when snippets are absent.',
+        },
+      ],
+      news: [
+        {
+          title: 'TypeScript 8 released',
+          url: 'https://news.example.com/ts8',
+          description: 'The release landed today.',
+          page_age: '2026-01-16T09:00:00Z',
+          thumbnail_url: 'https://news.example.com/ts8.jpg',
+        },
+      ],
+    },
+  },
+};
+
+describe('You.com search API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.YDC_API_KEY;
+    delete process.env.YDC_API_URL;
+  });
+
+  it('returns an error for empty queries without calling the API', async () => {
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({ success: false, error: 'Query cannot be empty' });
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it('hits the public endpoint and omits the API key header when keyless', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      YOU_PUBLIC_URL,
+      expect.objectContaining({
+        params: expect.objectContaining({ query: 'typescript' }),
+      })
+    );
+    const headers = mockedAxios.get.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers['X-API-Key']).toBeUndefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('hits the authenticated endpoint and sends the API key when a key is set', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'you',
+      youApiKey: 'secret-key',
+    });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      YOU_KEYED_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'secret-key' }),
+      })
+    );
+  });
+
+  it('reads the key from YDC_API_KEY when no explicit key is passed', async () => {
+    process.env.YDC_API_KEY = 'env-key';
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      YOU_KEYED_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'env-key' }),
+      })
+    );
+  });
+
+  it.each([
+    ['keyless', undefined],
+    ['keyed', 'secret-key'],
+  ])(
+    'identifies the host application on the %s endpoint',
+    async (_label, key) => {
+      mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+      const searchAPI = createSearchAPI({
+        searchProvider: 'you',
+        youApiKey: key,
+      });
+      await searchAPI.getSources({ query: 'typescript' });
+
+      const headers = mockedAxios.get.mock.calls[0][1]?.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['User-Agent']).toBe(
+        'LibreChat youdotcom-integration/danny-avila-agents'
+      );
+    }
+  );
+
+  it('honours a custom attribution title', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'you',
+      youSearchOptions: { attributionTitle: 'MyApp' },
+    });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    const headers = mockedAxios.get.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers['User-Agent']).toBe(
+      'MyApp youdotcom-integration/danny-avila-agents'
+    );
+  });
+
+  it('joins extracted passages and falls back to the description', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.organic).toEqual([
+      {
+        position: 1,
+        title: 'TypeScript Best Practices 2026',
+        link: 'https://example.com/ts',
+        snippet: 'First passage.\nSecond passage.',
+        date: '2026-01-15T10:30:00Z',
+      },
+      {
+        position: 2,
+        title: 'Second result',
+        link: 'https://example.com/second',
+        snippet: 'Description fallback when snippets are absent.',
+        date: undefined,
+      },
+    ]);
+  });
+
+  it('maps the news section into top stories', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.topStories).toEqual([
+      {
+        title: 'TypeScript 8 released',
+        link: 'https://news.example.com/ts8',
+        date: '2026-01-16T09:00:00Z',
+        imageUrl: 'https://news.example.com/ts8.jpg',
+      },
+    ]);
+  });
+
+  it('returns empty sections when the response carries no results', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: {} });
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result).toEqual({
+      success: true,
+      data: { organic: [], topStories: [] },
+    });
+  });
+
+  it('caps the requested count and applies it per section', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        results: {
+          web: [{ url: '1' }, { url: '2' }, { url: '3' }],
+          news: [{ url: 'n1' }, { url: 'n2' }],
+        },
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'you',
+      youSearchOptions: { maxResults: 2 },
+    });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ count: 2 }),
+      })
+    );
+    expect(result.data?.organic).toHaveLength(2);
+    expect(result.data?.topStories).toHaveLength(2);
+  });
+
+  it('clamps the count to the API maximum', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'you',
+      youSearchOptions: { maxResults: 500 },
+    });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ count: 100 }),
+      })
+    );
+  });
+
+  it.each([
+    [DATE_RANGE.PAST_HOUR, 'day'],
+    [DATE_RANGE.PAST_24_HOURS, 'day'],
+    [DATE_RANGE.PAST_WEEK, 'week'],
+    [DATE_RANGE.PAST_MONTH, 'month'],
+    [DATE_RANGE.PAST_YEAR, 'year'],
+  ])('maps date range %s to freshness %s', async (date, freshness) => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    await searchAPI.getSources({ query: 'typescript', date });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ freshness }),
+      })
+    );
+  });
+
+  it('upper-cases the country code and maps safe search', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    await searchAPI.getSources({
+      query: 'typescript',
+      country: 'de',
+      safeSearch: 2,
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          country: 'DE',
+          safesearch: 'strict',
+        }),
+      })
+    );
+  });
+
+  it('surfaces request failures as a structured error', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({ searchProvider: 'you' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('You.com API request failed: Network error');
+  });
+
+  it('respects an explicit API URL override', async () => {
+    mockedAxios.get.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'you',
+      youApiUrl: 'https://proxy.internal/v1/search',
+    });
+    await searchAPI.getSources({ query: 'typescript' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://proxy.internal/v1/search',
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
Adds You.com as a first-class search provider, modeled on the existing Keenable provider (#285).

You.com runs its own web index and returns several extracted passages per hit rather than a single meta description, so sources arrive with usable context before the scraping/reranking pipeline runs. The rest of the pipeline (scraping, reranking, highlights, formatting) is reused unchanged.

## What's here

- **`you-search.ts`** — `createYouAPI`. Maps You.com's `results.web` into `organic` and `results.news` into `topStories`.
- **`types.ts`** — `'you'` added to the `SearchProvider` union; `YouSearchOptions` plus param/result/response types.
- **`search.ts` / `tool.ts`** — wired into `createSearchAPI` and `createSearchTool`.
- **`you.test.ts`** — 20 tests.

No new dependency; axios is already used by every provider here.

## Keyless by default

With no key the provider hits the public agents endpoint; a key switches it to the authenticated Search API, which is where the higher limits and the full parameter surface live.

| | Endpoint | Auth |
|---|---|---|
| No key | `https://api.you.com/v1/agents/search` | none — free tier |
| `YDC_API_KEY` set | `https://api.you.com/v1/search` | `X-API-Key` |

The endpoint and the headers are always resolved together, because the keyless endpoint rejects an `X-API-Key` header — a stale key must never reach it. Both cases are pinned by tests.

Every request carries a `User-Agent` identifying the host application (`LibreChat youdotcom-integration/danny-avila-agents`, overridable via `youSearchOptions.attributionTitle`). It's the only attribution signal available on the keyless endpoint, since there's no key to tie usage to — the same role `X-Keenable-Title` plays for Keenable. Happy to drop it if you'd rather providers stayed anonymous.

## Parameter mapping

- **`date`** → `freshness`. You.com has no sub-day bucket, so `PAST_HOUR` widens to `day`; the rest map exactly (`d→day`, `w→week`, `m→month`, `y→year`).
- **`country`** → `country`, upper-cased (You.com expects `DE`, the tool schema emits `de`). `you` is added to the set of providers that get `countrySchema`, alongside serper and tavily.
- **`safeSearch`** → `safesearch`, `0|1|2 → off|moderate|strict`.
- **`numResults`** → `count`. Worth flagging: You.com applies `count` **per response section**, so a `count=5` request can return 5 web + 5 news. Each section is sliced back to the requested count on our side so `numResults` keeps its usual meaning. Clamped to the API maximum of 100.

## Validation

- `jest src/tools/search` — **207 passed, 12 suites** (20 of them new).
- `tsc -p tsconfig.build.json` — clean.
- `eslint` on the changed files — clean. (`prettier --check` flags `tool.ts`, but that's pre-existing on `main` at the `effectiveTavilySearchOptions` block, untouched here.)

Live-tested against the real API on both paths through `createSearchAPI`, 3 results each:

```
--- keyless (no key) ---     organic=3 topStories=3
--- keyed (YDC_API_KEY) ---  organic=3 topStories=3
```

…including a news-bearing query to exercise the `news → topStories` mapping, and a non-news query where `topStories` is correctly empty.

## Scope

Search provider only — no scraper. Firecrawl/Serper/Tavily/CRW/Keenable already cover that slot, and keeping this single-purpose keeps the diff near the size of the Keenable provider PR rather than a combined one.

LibreChat-side config (the `SearchProviders` enum, schema, and auth wiring) is a separate follow-up once this is released, same as #285 → danny-avila/LibreChat#14194.