### PR TITLE
fix: read Keenable page text from snippet, not description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4312,9 +4312,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4332,9 +4329,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4352,9 +4346,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4372,9 +4363,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4392,9 +4380,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4412,9 +4397,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5440,9 +5422,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5457,9 +5436,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5474,9 +5450,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5491,9 +5464,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5508,9 +5478,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5525,9 +5492,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5542,9 +5506,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5559,9 +5520,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5576,9 +5534,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5593,9 +5548,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4312,6 +4312,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4329,6 +4332,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4346,6 +4352,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4363,6 +4372,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4380,6 +4392,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4397,6 +4412,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5422,6 +5440,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5436,6 +5457,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5450,6 +5474,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5464,6 +5491,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5478,6 +5508,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5492,6 +5525,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5506,6 +5542,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5520,6 +5559,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5534,6 +5576,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5548,6 +5593,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/tools/search/keenable-search.ts
+++ b/src/tools/search/keenable-search.ts
@@ -23,10 +23,13 @@ const SNIPPET_MAX_LENGTH = 500;
 
 /** Keenable sends both `description` and `snippet` on every result: `snippet`
  * carries the page text and `description` is the page's meta description, which
- * is empty for most pages. `??` is deliberately not used here, since the empty
- * string is present rather than nullish and would win. */
+ * is empty for most pages. Either field can arrive as an empty string, so the
+ * pick is on emptiness rather than nullishness: a `??` chain would keep an empty
+ * `snippet` over a `description` that does carry text. */
 function toSnippet(result: t.KeenableSearchResult): string {
-  const text = result.snippet ?? result.description ?? '';
+  const snippet = result.snippet ?? '';
+  const description = result.description ?? '';
+  const text = snippet !== '' ? snippet : description;
   return text.replace(/\s+/g, ' ').trim().slice(0, SNIPPET_MAX_LENGTH);
 }
 

--- a/src/tools/search/keenable-search.ts
+++ b/src/tools/search/keenable-search.ts
@@ -16,6 +16,20 @@ const KEENABLE_DATE_RANGES: Record<DATE_RANGE, string> = {
   [DATE_RANGE.PAST_YEAR]: '1y',
 };
 
+/** Characters of page text kept per result. Keenable returns the whole page on
+ * every search result, an order of magnitude more than the other providers here
+ * return, which would crowd out the reranker and the LLM output budget. */
+const SNIPPET_MAX_LENGTH = 500;
+
+/** Keenable sends both `description` and `snippet` on every result: `snippet`
+ * carries the page text and `description` is the page's meta description, which
+ * is empty for most pages. `??` is deliberately not used here, since the empty
+ * string is present rather than nullish and would win. */
+function toSnippet(result: t.KeenableSearchResult): string {
+  const text = result.snippet ?? result.description ?? '';
+  return text.replace(/\s+/g, ' ').trim().slice(0, SNIPPET_MAX_LENGTH);
+}
+
 export const createKeenableAPI = (
   apiKey?: string,
   apiUrl?: string,
@@ -84,7 +98,7 @@ export const createKeenableAPI = (
       const organic: t.OrganicResult[] = rawResults.map((result) => ({
         title: result.title ?? '',
         link: result.url ?? '',
-        snippet: result.description ?? result.snippet ?? '',
+        snippet: toSnippet(result),
         date: result.published_at,
       }));
 

--- a/src/tools/search/keenable.test.ts
+++ b/src/tools/search/keenable.test.ts
@@ -101,6 +101,28 @@ describe('Keenable search API', () => {
     ]);
   });
 
+  it('falls back to the description when the snippet is present but empty', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'Empty snippet',
+            url: 'https://example.com/empty',
+            description: 'The meta description carries the text here.',
+            snippet: '',
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.organic?.[0].snippet).toBe(
+      'The meta description carries the text here.'
+    );
+  });
+
   it('caps the page text Keenable returns on every result', async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {

--- a/src/tools/search/keenable.test.ts
+++ b/src/tools/search/keenable.test.ts
@@ -12,13 +12,14 @@ const sampleResponse = {
       {
         title: 'TypeScript Best Practices 2026',
         url: 'https://example.com/ts',
-        description: 'A comprehensive guide to TypeScript.',
+        description: '',
+        snippet: 'A comprehensive guide\n\nto TypeScript.',
         published_at: '2026-01-15T10:30:00Z',
       },
       {
         title: 'Second result',
         url: 'https://example.com/second',
-        snippet: 'Snippet fallback when description is absent.',
+        description: 'Description fallback when snippet is absent.',
       },
     ],
   },
@@ -78,7 +79,7 @@ describe('Keenable search API', () => {
     );
   });
 
-  it('maps results into organic sources (description and snippet fallback)', async () => {
+  it('maps results into organic sources, reading page text from snippet', async () => {
     mockedAxios.post.mockResolvedValueOnce(sampleResponse);
 
     const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
@@ -94,10 +95,30 @@ describe('Keenable search API', () => {
       {
         title: 'Second result',
         link: 'https://example.com/second',
-        snippet: 'Snippet fallback when description is absent.',
+        snippet: 'Description fallback when snippet is absent.',
         date: undefined,
       },
     ]);
+  });
+
+  it('caps the page text Keenable returns on every result', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            title: 'Long page',
+            url: 'https://example.com/long',
+            description: '',
+            snippet: 'word '.repeat(400),
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.organic?.[0].snippet).toHaveLength(500);
   });
 
   it('applies the site filter and limits results client-side', async () => {


### PR DESCRIPTION
`result.description ?? result.snippet` never reaches the fallback: Keenable sends `description` on every result and it is the page's meta description, empty for most pages, so `??` keeps the empty string and organic sources come back with no text.

Reads `snippet` first now, capped at 500 chars since Keenable returns whole pages rather than an excerpt. The old test passed because its fixture had a populated `description`, a shape the API never returns.
