### PR TITLE
🪆 feat: Langfuse Runtime Span Names and Nested Label Traces

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -33,3 +33,12 @@ export const PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS = 120_000;
  * the stream config; a preemption-enabled run adds its seal budget on top.
  */
 export const DEFAULT_RECURSION_LIMIT = 50;
+
+/** Stable runtime names used for agent workflow observations. */
+export const STANDARD_GRAPH_RUN_NAME = 'StandardGraph';
+export const MULTI_AGENT_GRAPH_RUN_NAME = 'MultiAgentGraph';
+export const AGENT_MODEL_CALL_RUN_NAME = 'AgentModelCall';
+export const ACTIVITY_LABEL_RUN_NAME = 'ActivityLabel';
+export const REASONING_LABEL_RUN_NAME = 'ReasoningLabel';
+export const ACTIVITY_PHASE_RUN_NAME = 'ActivityPhase';
+export const ACTIVITY_PHASE_LABEL_RUN_NAME = 'ActivityPhaseLabel';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -35,10 +35,10 @@ export const PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS = 120_000;
 export const DEFAULT_RECURSION_LIMIT = 50;
 
 /** Stable runtime names used for agent workflow observations. */
-export const STANDARD_GRAPH_RUN_NAME = 'StandardGraph';
+export const STANDARD_GRAPH_RUN_NAME = 'AgentGraph';
 export const MULTI_AGENT_GRAPH_RUN_NAME = 'MultiAgentGraph';
 export const AGENT_MODEL_CALL_RUN_NAME = 'AgentModelCall';
-export const ACTIVITY_LABEL_RUN_NAME = 'ActivityLabel';
+export const ACTIVITY_LABEL_RUN_NAME = 'StepLabel';
 export const REASONING_LABEL_RUN_NAME = 'ReasoningLabel';
-export const ACTIVITY_PHASE_RUN_NAME = 'ActivityPhase';
-export const ACTIVITY_PHASE_LABEL_RUN_NAME = 'ActivityPhaseLabel';
+export const ACTIVITY_PHASE_RUN_NAME = 'MultiStepLabel';
+export const ACTIVITY_PHASE_LABEL_RUN_NAME = 'MultiStepLabelGeneration';

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -75,6 +75,17 @@ import {
   removePredecessorHandoffCue,
 } from '@/messages';
 import {
+  Constants,
+  GraphNodeKeys,
+  ContentTypes,
+  GraphEvents,
+  Providers,
+  StepTypes,
+  STANDARD_GRAPH_RUN_NAME,
+  AGENT_MODEL_CALL_RUN_NAME,
+  PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
+} from '@/common';
+import {
   resetIfNotEmpty,
   isAnthropicLike,
   isOpenAILike,
@@ -106,15 +117,6 @@ import {
   isGraphSubagentConfig,
   normalizeSubagentConfigEntries,
 } from '@/tools/subagent';
-import {
-  Constants,
-  GraphNodeKeys,
-  ContentTypes,
-  GraphEvents,
-  Providers,
-  StepTypes,
-  PREEMPT_BOUNDARY_HOOK_TIMEOUT_MS,
-} from '@/common';
 import {
   createLangfuseHandler,
   createLangfuseTraceMetadata,
@@ -1290,6 +1292,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * by the stream handler and every graph-level scope of that execution.
    */
   readonly langfuseScopeRunId: string;
+  /** Opaque key for parenting post-processing observations to this run. */
+  readonly langfuseTraceAnchor: object = {};
   /**
    * Boundary between historical messages (loaded from conversation state)
    * and messages produced during the current run.  Set once in the state
@@ -2913,7 +2917,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         });
 
       if (agentContext.systemRunnable) {
-        model = agentContext.systemRunnable.pipe(model as Runnable);
+        model = agentContext.systemRunnable
+          .pipe(model as Runnable)
+          .withConfig({ runName: AGENT_MODEL_CALL_RUN_NAME });
       }
 
       if (agentContext.tokenCalculationPromise) {
@@ -4010,6 +4016,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           tags: ['librechat', 'agent'],
           traceIdSeed:
             langfuse?.deterministicTraceId === true ? this.runId : undefined,
+          traceAnchor: this.langfuseTraceAnchor,
           runId: this.langfuseScopeRunId,
           toolOutputTracing: hasToolOutputTracingConfig(
             this.langfuse,
@@ -4052,6 +4059,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           resolveLangfuseRuntimeScope({
             runLangfuse: this.langfuse,
             langfuseOverlay: agentContext.langfuse,
+            traceAnchor: this.langfuseTraceAnchor,
             runId: this.langfuseScopeRunId,
             agentId,
           }),
@@ -4845,94 +4853,98 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           createChildGraphByKind: createConfiguredChildGraph,
           createDetachedChildGraphFactory: (
             parentHandlerRegistry
-          ): GraphFactory =>
-            snapshotChildGraphFactory(parentHandlerRegistry),
+          ): GraphFactory => snapshotChildGraphFactory(parentHandlerRegistry),
         });
         this.registerSubagentExecutor(executor);
 
-        const subagentTool = tool(async (rawInput, config) => {
-          const input = rawInput as {
-            description?: string;
-            subagent_type?: string;
-            subagent_thread_id?: string;
-            run_in_background?: boolean;
-          };
-          const description =
-            typeof input.description === 'string' &&
-            input.description.trim().length > 0
-              ? input.description
-              : DEFAULT_SUBAGENT_DESCRIPTION;
-          const subagentType =
-            typeof input.subagent_type === 'string' ? input.subagent_type : '';
-          const subagentThreadId =
-            typeof input.subagent_thread_id === 'string' &&
-            input.subagent_thread_id.trim() !== ''
-              ? input.subagent_thread_id.trim()
-              : undefined;
-          const threadId = config.configurable?.thread_id as string | undefined;
-          /** Surface the parent call id so child checkpoints, interrupts, and
-           * update events remain correlated across replay and resume. */
-          const toolRuntime = config as {
-            toolCallId?: string;
-            toolCall?: { id?: string };
-          };
-          const toolCall = toolRuntime.toolCall;
-          let parentToolCallId: string | undefined;
-          if (
-            typeof toolRuntime.toolCallId === 'string' &&
-            toolRuntime.toolCallId !== ''
-          ) {
-            parentToolCallId = toolRuntime.toolCallId;
-          } else if (typeof toolCall?.id === 'string' && toolCall.id !== '') {
-            parentToolCallId = toolCall.id;
-          }
-          /** The parent tool batch's entry-captured scope (stamped by
-           * ToolNode before PreToolUse hooks) — binds this child to the
-           * run that dispatched it, not to whatever controller a reset
-           * installed while the hooks were awaited. */
-          const batchScope = config.configurable?.[
-            RUN_BREAKER_SCOPE_CONFIG_KEY
-          ] as RunBreakerScope | undefined;
-          const executeParams = {
-            description,
-            subagentType,
-            threadId,
-            signal: config.signal,
-            parentToolCallId,
-            breaker: batchScope?.controller,
-            /**
-             * Forward the parent's `configurable` so host-set fields
-             * (`requestBody`, `user`, etc.) propagate into the child
-             * workflow. The executor scrubs run-identity fields before
-             * forwarding — see `SubagentExecuteParams.parentConfigurable`.
-             */
-            parentConfigurable: config.configurable as
-              | Record<string, unknown>
-              | undefined,
-          };
-          if (input.run_in_background === true) {
-            return executor.executeInBackground({
-              ...executeParams,
-              ...(subagentThreadId == null
-                ? {}
-                : { subagentThreadId }),
-            });
-          }
-          if (subagentThreadId != null) {
-            return JSON.stringify({
-              status: 'rejected',
-              tool: Constants.SUBAGENT,
-              message:
-                'Child-thread continuation requires run_in_background.',
-            });
-          }
-          const result = await executor.execute(executeParams);
-          return result.content;
-        }, buildSubagentToolParams(executableConfigs, {
-          background: this.subagentTasks != null,
-          threadContinuation:
-            this.subagentTasks?.store.supportsThreadContinuation === true,
-        }));
+        const subagentTool = tool(
+          async (rawInput, config) => {
+            const input = rawInput as {
+              description?: string;
+              subagent_type?: string;
+              subagent_thread_id?: string;
+              run_in_background?: boolean;
+            };
+            const description =
+              typeof input.description === 'string' &&
+              input.description.trim().length > 0
+                ? input.description
+                : DEFAULT_SUBAGENT_DESCRIPTION;
+            const subagentType =
+              typeof input.subagent_type === 'string'
+                ? input.subagent_type
+                : '';
+            const subagentThreadId =
+              typeof input.subagent_thread_id === 'string' &&
+              input.subagent_thread_id.trim() !== ''
+                ? input.subagent_thread_id.trim()
+                : undefined;
+            const threadId = config.configurable?.thread_id as
+              | string
+              | undefined;
+            /** Surface the parent call id so child checkpoints, interrupts, and
+             * update events remain correlated across replay and resume. */
+            const toolRuntime = config as {
+              toolCallId?: string;
+              toolCall?: { id?: string };
+            };
+            const toolCall = toolRuntime.toolCall;
+            let parentToolCallId: string | undefined;
+            if (
+              typeof toolRuntime.toolCallId === 'string' &&
+              toolRuntime.toolCallId !== ''
+            ) {
+              parentToolCallId = toolRuntime.toolCallId;
+            } else if (typeof toolCall?.id === 'string' && toolCall.id !== '') {
+              parentToolCallId = toolCall.id;
+            }
+            /** The parent tool batch's entry-captured scope (stamped by
+             * ToolNode before PreToolUse hooks) — binds this child to the
+             * run that dispatched it, not to whatever controller a reset
+             * installed while the hooks were awaited. */
+            const batchScope = config.configurable?.[
+              RUN_BREAKER_SCOPE_CONFIG_KEY
+            ] as RunBreakerScope | undefined;
+            const executeParams = {
+              description,
+              subagentType,
+              threadId,
+              signal: config.signal,
+              parentToolCallId,
+              breaker: batchScope?.controller,
+              /**
+               * Forward the parent's `configurable` so host-set fields
+               * (`requestBody`, `user`, etc.) propagate into the child
+               * workflow. The executor scrubs run-identity fields before
+               * forwarding — see `SubagentExecuteParams.parentConfigurable`.
+               */
+              parentConfigurable: config.configurable as
+                | Record<string, unknown>
+                | undefined,
+            };
+            if (input.run_in_background === true) {
+              return executor.executeInBackground({
+                ...executeParams,
+                ...(subagentThreadId == null ? {} : { subagentThreadId }),
+              });
+            }
+            if (subagentThreadId != null) {
+              return JSON.stringify({
+                status: 'rejected',
+                tool: Constants.SUBAGENT,
+                message:
+                  'Child-thread continuation requires run_in_background.',
+              });
+            }
+            const result = await executor.execute(executeParams);
+            return result.content;
+          },
+          buildSubagentToolParams(executableConfigs, {
+            background: this.subagentTasks != null,
+            threadContinuation:
+              this.subagentTasks?.store.supportsThreadContinuation === true,
+          })
+        );
         const replayableSubagentTool = subagentTool as typeof subagentTool &
           ReplayableSubagentTool;
         replayableSubagentTool[SUBAGENT_REPLAY_CONTROLLER] = {
@@ -5218,7 +5230,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       .addEdge(summarizeNode, agentNode)
       .addEdge(toolNode, agentContext.toolEnd ? END : agentNode);
 
-    return workflow.compile();
+    return workflow.compile().withConfig({ runName: STANDARD_GRAPH_RUN_NAME });
   }
 
   createWorkflow(): t.CompiledStateWorkflow {
@@ -5251,7 +5263,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // LangGraph compile() types are overly strict for opt-in options
       .compile(this.compileOptions as unknown as never);
 
-    return workflow;
+    return workflow.withConfig({ runName: STANDARD_GRAPH_RUN_NAME });
   }
 
   /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4017,6 +4017,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           traceIdSeed:
             langfuse?.deterministicTraceId === true ? this.runId : undefined,
           traceAnchor: this.langfuseTraceAnchor,
+          agentId,
           runId: this.langfuseScopeRunId,
           toolOutputTracing: hasToolOutputTracingConfig(
             this.langfuse,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1288,12 +1288,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * component: public run ids are unrestricted and may repeat across
    * concurrently executing runs (retries, duplicate submissions,
    * tenant-local message ids), and equal stamps would let those runs adopt
-   * each other's scopes. One graph instance = one execution's stamp, shared
-   * by the stream handler and every graph-level scope of that execution.
+   * each other's scopes. Fresh stream executions rotate this stamp; resumes
+   * retain it so the continuation stays in the interrupted execution.
    */
-  readonly langfuseScopeRunId: string;
+  langfuseScopeRunId: string;
   /** Opaque key for parenting post-processing observations to this run. */
-  readonly langfuseTraceAnchor: object = {};
+  langfuseTraceAnchor: object = {};
   /**
    * Boundary between historical messages (loaded from conversation state)
    * and messages produced during the current run.  Set once in the state
@@ -1500,6 +1500,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
 
     this.defaultAgentId = agents[0].agentId;
+  }
+
+  /** Rotates the Langfuse identities that must never cross fresh executions. */
+  startFreshLangfuseExecution(): void {
+    this.langfuseTraceAnchor = {};
+    this.langfuseScopeRunId = `${this.runId ?? 'graph'}:${nanoid()}`;
   }
 
   /* Init */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1262,6 +1262,7 @@ export abstract class Graph<
 }
 
 export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
+  readonly runName: string = STANDARD_GRAPH_RUN_NAME;
   overrideModel?: t.ChatModel;
   private subagentModelOverride?: t.ChatModel;
   private readonly graphFactory: GraphFactory;
@@ -5237,7 +5238,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       .addEdge(summarizeNode, agentNode)
       .addEdge(toolNode, agentContext.toolEnd ? END : agentNode);
 
-    return workflow.compile().withConfig({ runName: STANDARD_GRAPH_RUN_NAME });
+    return workflow.compile({ name: STANDARD_GRAPH_RUN_NAME });
   }
 
   createWorkflow(): t.CompiledStateWorkflow {
@@ -5266,11 +5267,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         >,
         { ends: [END] }
       )
-      .addEdge(START, this.defaultAgentId)
-      // LangGraph compile() types are overly strict for opt-in options
-      .compile(this.compileOptions as unknown as never);
+      .addEdge(START, this.defaultAgentId);
 
-    return workflow.withConfig({ runName: STANDARD_GRAPH_RUN_NAME });
+    // LangGraph compile() types are overly strict for opt-in options
+    return workflow.compile({
+      ...this.compileOptions,
+      name: STANDARD_GRAPH_RUN_NAME,
+    } as unknown as never);
   }
 
   /**

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -177,6 +177,7 @@ function withHandoffGroupMetadata(
  * OR continues its workflow (direct edges), but not both simultaneously.
  */
 export class MultiAgentGraph extends StandardGraph {
+  override readonly runName = MULTI_AGENT_GRAPH_RUN_NAME;
   private edges: t.GraphEdge[];
   private startingNodes: Set<string> = new Set();
   private directEdges: t.GraphEdge[] = [];
@@ -1438,8 +1439,9 @@ export class MultiAgentGraph extends StandardGraph {
       }
     }
 
-    return builder
-      .compile(this.compileOptions as unknown as never)
-      .withConfig({ runName: MULTI_AGENT_GRAPH_RUN_NAME });
+    return builder.compile({
+      ...this.compileOptions,
+      name: MULTI_AGENT_GRAPH_RUN_NAME,
+    } as unknown as never);
   }
 }

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -20,9 +20,9 @@ import type { ToolRuntime } from '@langchain/core/tools';
 import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
 import { serializeToolContentBounded } from '@/utils/toolContent';
+import { Constants, MULTI_AGENT_GRAPH_RUN_NAME } from '@/common';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { StandardGraph } from './Graph';
-import { Constants } from '@/common';
 
 /** Pattern to extract instructions from transfer ToolMessage content */
 const HANDOFF_INSTRUCTIONS_PATTERN = /(?:Instructions?|Context):\s*(.+)/is;
@@ -1438,6 +1438,8 @@ export class MultiAgentGraph extends StandardGraph {
       }
     }
 
-    return builder.compile(this.compileOptions as unknown as never);
+    return builder
+      .compile(this.compileOptions as unknown as never)
+      .withConfig({ runName: MULTI_AGENT_GRAPH_RUN_NAME });
   }
 }

--- a/src/graphs/__tests__/createGraph.test.ts
+++ b/src/graphs/__tests__/createGraph.test.ts
@@ -1,11 +1,17 @@
+import { MemorySaver } from '@langchain/langgraph';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { GraphFactory, GraphFactoryRequest } from '@/graphs/graphFactory';
 import type * as t from '@/types';
+import {
+  Constants,
+  Providers,
+  STANDARD_GRAPH_RUN_NAME,
+  MULTI_AGENT_GRAPH_RUN_NAME,
+} from '@/common';
 import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import { createFakeStreamingLLM } from '@/llm/fake';
 import { createGraph } from '@/graphs/createGraph';
-import { Constants, Providers } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
 
 const invokeConfig: RunnableConfig = {
@@ -53,6 +59,42 @@ describe('graph factory', () => {
     expect(standard).toBeInstanceOf(StandardGraph);
     expect(standard).not.toBeInstanceOf(MultiAgentGraph);
     expect(multiAgent).toBeInstanceOf(MultiAgentGraph);
+  });
+
+  it('keeps graph names and checkpoint methods on compiled workflows', () => {
+    const standard = createGraph({
+      kind: 'standard',
+      input: { runId: 'standard-compiled', agents: [makeAgent('standard')] },
+    });
+    const multiAgent = createGraph({
+      kind: 'multi-agent',
+      input: {
+        runId: 'multi-agent-compiled',
+        agents: [makeAgent('multi')],
+        edges: [],
+      },
+    });
+    standard.compileOptions = { checkpointer: new MemorySaver() };
+    multiAgent.compileOptions = { checkpointer: new MemorySaver() };
+
+    const standardWorkflow = standard.createWorkflow();
+    const multiAgentWorkflow = multiAgent.createWorkflow();
+
+    expect(standardWorkflow).toHaveProperty('name', STANDARD_GRAPH_RUN_NAME);
+    expect(standardWorkflow).toHaveProperty('getState', expect.any(Function));
+    expect(standardWorkflow).toHaveProperty(
+      'getStateHistory',
+      expect.any(Function)
+    );
+    expect(multiAgentWorkflow).toHaveProperty(
+      'name',
+      MULTI_AGENT_GRAPH_RUN_NAME
+    );
+    expect(multiAgentWorkflow).toHaveProperty('getState', expect.any(Function));
+    expect(multiAgentWorkflow).toHaveProperty(
+      'getStateHistory',
+      expect.any(Function)
+    );
   });
 
   it('accepts a union-typed graph factory request', () => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -16,9 +16,12 @@ import {
   getLangfuseDestinationKey,
   getLangfuseSpanProcessorParams,
   registerLangfuseManagedSpan,
+  registerLangfuseTraceAnchorSpan,
 } from '@/langfuseSpanRegistry';
 import {
   resolveLangfuseConfigForSpan,
+  resolveLangfuseScopeAgentId,
+  resolveLangfuseTraceAnchor,
   resolveTraceIdSeedForSpan,
 } from '@/langfuseRuntimeScope';
 import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
@@ -137,6 +140,15 @@ class RoutingLangfuseSpanProcessor implements SpanProcessor {
       langfuse
     );
     registerLangfuseManagedSpan(span, destinationKey);
+    const traceAnchor = resolveLangfuseTraceAnchor(parentContext);
+    if (traceAnchor != null) {
+      registerLangfuseTraceAnchorSpan(
+        traceAnchor,
+        span,
+        destinationKey,
+        resolveLangfuseScopeAgentId(parentContext)
+      );
+    }
 
     const librechatTraceAttributes = createLibreChatTraceAttributes(
       langfuse?.librechatTraceAttributes ?? {}

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -69,8 +69,12 @@ type LangfuseHandlerParams = {
   traceIdSeed?: string;
   /** Opaque key used by the span processor to capture this run's parents. */
   traceAnchor?: object;
+  /** Agent lane this handler owns when ambient callback scope is unavailable. */
+  agentId?: string;
   /** Exported observation that auxiliary work should be nested beneath. */
   parentSpanContext?: SpanContext;
+  /** Keep an existing parent trace's user, session, name, and metadata. */
+  inheritTraceIdentity?: boolean;
   /** Identity of the run this handler traces; ambient runtime scopes are
    *  only adopted when stamped with the same run (see
    *  `LangfuseRuntimeContext.runId`). */
@@ -286,6 +290,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly langfuse?: t.LangfuseConfig;
   private readonly traceIdSeed?: string;
   private readonly traceAnchor?: object;
+  private readonly agentId?: string;
   private readonly parentSpanContext?: SpanContext;
   private readonly runId?: string;
   private readonly identity: HandlerIdentity;
@@ -297,25 +302,39 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
       langfuse,
       traceIdSeed,
       traceAnchor,
+      agentId,
       parentSpanContext,
+      inheritTraceIdentity,
       runId,
       toolOutputTracing,
       traceName,
       ...handlerParams
     } = params ?? {};
-    super(handlerParams);
+    super({
+      ...handlerParams,
+      ...(inheritTraceIdentity === true
+        ? {
+          userId: undefined,
+          sessionId: undefined,
+          traceMetadata: undefined,
+        }
+        : {}),
+    });
     this.langfuse = langfuse;
     this.traceIdSeed = traceIdSeed;
     this.traceAnchor = traceAnchor;
+    this.agentId = agentId;
     this.parentSpanContext = parentSpanContext;
     this.runId = runId;
     this.toolOutputTracing = toolOutputTracing;
     this.identity = {
-      userId: handlerParams.userId,
-      sessionId: handlerParams.sessionId,
+      userId: inheritTraceIdentity === true ? undefined : handlerParams.userId,
+      sessionId:
+        inheritTraceIdentity === true ? undefined : handlerParams.sessionId,
       tags: handlerParams.tags,
-      metadata: handlerParams.traceMetadata,
-      traceName,
+      metadata:
+        inheritTraceIdentity === true ? undefined : handlerParams.traceMetadata,
+      traceName: inheritTraceIdentity === true ? undefined : traceName,
     };
   }
 
@@ -446,6 +465,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
             this.getDeterministicTraceSeed(),
           traceAnchor: this.traceAnchor,
           runId: scopeRunId ?? this.runId,
+          agentId: scopeAgentId ?? this.agentId,
         },
         action
       );
@@ -477,6 +497,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
           traceIdSeed: this.getDeterministicTraceSeed(),
           traceAnchor: this.traceAnchor,
           runId: this.runId,
+          agentId: this.agentId,
           toolOutputTracing:
             this.toolOutputTracing ??
             resolveToolOutputTracingConfig(this.langfuse),
@@ -767,7 +788,9 @@ export function createLangfuseHandler({
   tags,
   traceIdSeed,
   traceAnchor,
+  agentId,
   parentSpanContext,
+  inheritTraceIdentity,
   runId,
   toolOutputTracing,
   traceName,
@@ -778,15 +801,17 @@ export function createLangfuseHandler({
   return new ScopedLangfuseCallbackHandler({
     userId,
     sessionId,
-    traceMetadata: mergeLangfuseTraceMetadata(
-      traceMetadata,
-      langfuse?.metadata
-    ),
+    traceMetadata:
+      inheritTraceIdentity === true
+        ? undefined
+        : mergeLangfuseTraceMetadata(traceMetadata, langfuse?.metadata),
     tags: mergeLangfuseTags(tags, langfuse?.tags),
     langfuse,
     traceIdSeed,
     traceAnchor,
+    agentId,
     parentSpanContext,
+    inheritTraceIdentity,
     runId,
     toolOutputTracing,
     traceName,
@@ -800,13 +825,17 @@ function createPropagateAttributeParams({
   traceMetadata,
   traceName,
   tags,
+  inheritTraceIdentity,
 }: LangfuseAttributeParams): PropagateAttributesParams {
   return {
-    userId,
-    sessionId,
-    traceName,
+    userId: inheritTraceIdentity === true ? undefined : userId,
+    sessionId: inheritTraceIdentity === true ? undefined : sessionId,
+    traceName: inheritTraceIdentity === true ? undefined : traceName,
     tags: mergeLangfuseTags(tags, langfuse?.tags),
-    metadata: mergeLangfuseTraceMetadata(traceMetadata, langfuse?.metadata),
+    metadata:
+      inheritTraceIdentity === true
+        ? undefined
+        : mergeLangfuseTraceMetadata(traceMetadata, langfuse?.metadata),
   };
 }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -18,7 +18,7 @@ import type {
   LLMResult,
 } from '@langchain/core/outputs';
 import type { PropagateAttributesParams } from '@langfuse/tracing';
-import type { Context } from '@opentelemetry/api';
+import type { Context, SpanContext } from '@opentelemetry/api';
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
 import {
@@ -36,6 +36,7 @@ import {
 } from '@/langfuseConfig';
 import {
   getLangfuseManagedSpanDestination,
+  registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
@@ -66,6 +67,10 @@ type LangfuseHandlerParams = {
   traceMetadata?: LangfuseTraceMetadata;
   tags?: string[];
   traceIdSeed?: string;
+  /** Opaque key used by the span processor to capture this run's parents. */
+  traceAnchor?: object;
+  /** Exported observation that auxiliary work should be nested beneath. */
+  parentSpanContext?: SpanContext;
   /** Identity of the run this handler traces; ambient runtime scopes are
    *  only adopted when stamped with the same run (see
    *  `LangfuseRuntimeContext.runId`). */
@@ -280,6 +285,8 @@ function detachForeignAmbientSpan(
 class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly langfuse?: t.LangfuseConfig;
   private readonly traceIdSeed?: string;
+  private readonly traceAnchor?: object;
+  private readonly parentSpanContext?: SpanContext;
   private readonly runId?: string;
   private readonly identity: HandlerIdentity;
   private readonly toolOutputTracing?: ResolvedLangfuseToolOutputTracingConfig;
@@ -289,6 +296,8 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     const {
       langfuse,
       traceIdSeed,
+      traceAnchor,
+      parentSpanContext,
       runId,
       toolOutputTracing,
       traceName,
@@ -297,6 +306,8 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     super(handlerParams);
     this.langfuse = langfuse;
     this.traceIdSeed = traceIdSeed;
+    this.traceAnchor = traceAnchor;
+    this.parentSpanContext = parentSpanContext;
     this.runId = runId;
     this.toolOutputTracing = toolOutputTracing;
     this.identity = {
@@ -312,6 +323,22 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     return this.langfuse?.deterministicTraceId === true
       ? this.traceIdSeed
       : undefined;
+  }
+
+  private applyExplicitParent(
+    activeContext: Context,
+    langfuse?: t.LangfuseConfig
+  ): Context {
+    if (this.parentSpanContext == null) {
+      return activeContext;
+    }
+    const destinationKey = resolveLangfuseDestinationKey(langfuse);
+    if (destinationKey == null) {
+      return activeContext;
+    }
+    const parentSpan = otelTrace.wrapSpanContext(this.parentSpanContext);
+    registerLangfuseManagedSpan(parentSpan, destinationKey);
+    return otelTrace.setSpan(activeContext, parentSpan);
   }
 
   /**
@@ -401,12 +428,15 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     }
     const langfuse =
       resolveLangfuseConfigForSpan(currentContext) ?? this.langfuse;
+    const parentedContext = isDetachedRun
+      ? this.applyExplicitParent(currentContext, langfuse)
+      : currentContext;
     const activeContext = isDetachedRun
       ? detachForeignAmbientSpan(
-        currentContext,
+        parentedContext,
         resolveLangfuseDestinationKey(langfuse)
       )
-      : currentContext;
+      : parentedContext;
     const scoped = (): T =>
       withLangfuseRuntimeScope(
         {
@@ -414,6 +444,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
           traceIdSeed:
             resolveTraceIdSeedForSpan(activeContext) ??
             this.getDeterministicTraceSeed(),
+          traceAnchor: this.traceAnchor,
           runId: scopeRunId ?? this.runId,
         },
         action
@@ -438,11 +469,13 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     for (const key of Object.values(LangfuseOtelContextKeys)) {
       cleanContext = cleanContext.deleteValue(key);
     }
+    cleanContext = this.applyExplicitParent(cleanContext, this.langfuse);
     const scoped = (): T =>
       withLangfuseRuntimeScope(
         {
           langfuse: this.langfuse,
           traceIdSeed: this.getDeterministicTraceSeed(),
+          traceAnchor: this.traceAnchor,
           runId: this.runId,
           toolOutputTracing:
             this.toolOutputTracing ??
@@ -733,6 +766,8 @@ export function createLangfuseHandler({
   traceMetadata,
   tags,
   traceIdSeed,
+  traceAnchor,
+  parentSpanContext,
   runId,
   toolOutputTracing,
   traceName,
@@ -750,6 +785,8 @@ export function createLangfuseHandler({
     tags: mergeLangfuseTags(tags, langfuse?.tags),
     langfuse,
     traceIdSeed,
+    traceAnchor,
+    parentSpanContext,
     runId,
     toolOutputTracing,
     traceName,

--- a/src/langfuseOperation.ts
+++ b/src/langfuseOperation.ts
@@ -1,0 +1,2 @@
+/** Internal observation metadata key used to distinguish SDK operations from public tags. */
+export const LANGFUSE_OPERATION_METADATA_KEY = 'librechat.sdk.operation';

--- a/src/langfuseRuntimeContext.ts
+++ b/src/langfuseRuntimeContext.ts
@@ -12,6 +12,8 @@ export type ResolvedLangfuseToolOutputTracingConfig = {
 export type LangfuseRuntimeContext = {
   langfuse?: t.LangfuseConfig;
   traceIdSeed?: string;
+  /** Opaque run-owned key used to recover the exported trace parent. */
+  traceAnchor?: object;
   toolOutputTracing?: ResolvedLangfuseToolOutputTracingConfig;
   /**
    * Identity of the run this scope belongs to. LangChain executes
@@ -44,6 +46,7 @@ export function hasLangfuseRuntimeContextValue(
   return (
     context.langfuse != null ||
     hasText(context.traceIdSeed) ||
+    context.traceAnchor != null ||
     hasText(context.runId) ||
     hasText(context.agentId) ||
     context.toolOutputTracing != null
@@ -99,6 +102,9 @@ export function runWithLangfuseRuntimeContext<T>(
     ...(context.langfuse !== undefined ? { langfuse: context.langfuse } : {}),
     ...(hasText(context.traceIdSeed)
       ? { traceIdSeed: context.traceIdSeed }
+      : {}),
+    ...(context.traceAnchor != null
+      ? { traceAnchor: context.traceAnchor }
       : {}),
     ...(hasText(context.runId) ? { runId: context.runId } : {}),
     ...(hasText(context.agentId) ? { agentId: context.agentId } : {}),

--- a/src/langfuseRuntimeScope.ts
+++ b/src/langfuseRuntimeScope.ts
@@ -7,6 +7,7 @@ import type {
 import type * as t from '@/types';
 import {
   getLangfuseRuntimeConfig,
+  getLangfuseRuntimeContext,
   getLangfuseRuntimeToolOutputTracingConfig,
   getLangfuseScopeAgentId,
   getLangfuseScopeRunId,
@@ -27,6 +28,7 @@ export type ResolveLangfuseRuntimeScopeParams = {
   runLangfuse?: t.LangfuseConfig;
   langfuseOverlay?: t.LangfuseConfig;
   traceIdSeed?: string;
+  traceAnchor?: object;
   runId?: string;
   agentId?: string;
 };
@@ -45,6 +47,9 @@ const langfuseToolOutputTracingConfigKey = createContextKey(
 const langfuseConfigKey = createContextKey('librechat.langfuse.config');
 const langfuseTraceIdSeedKey = createContextKey(
   'librechat.langfuse.trace-id-seed'
+);
+const langfuseTraceAnchorKey = createContextKey(
+  'librechat.langfuse.trace-anchor'
 );
 const langfuseScopeRunIdKey = createContextKey('librechat.langfuse.run-id');
 const langfuseScopeAgentIdKey = createContextKey('librechat.langfuse.agent-id');
@@ -67,6 +72,17 @@ export function getOtelLangfuseConfig(
 export function getOtelTraceIdSeed(activeContext: Context): string | undefined {
   const value = activeContext.getValue(langfuseTraceIdSeedKey);
   return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+export function resolveLangfuseTraceAnchor(
+  activeContext: Context
+): object | undefined {
+  const runtimeAnchor = getLangfuseRuntimeContext()?.traceAnchor;
+  if (runtimeAnchor != null) {
+    return runtimeAnchor;
+  }
+  const value = activeContext.getValue(langfuseTraceAnchorKey);
+  return typeof value === 'object' && value != null ? value : undefined;
 }
 
 export function getOtelToolOutputTracingConfig(
@@ -168,6 +184,12 @@ export function withLangfuseRuntimeScope<T>(
   );
   activeContext = setOrClearContextValue(
     activeContext,
+    langfuseTraceAnchorKey,
+    scope.traceAnchor,
+    replace
+  );
+  activeContext = setOrClearContextValue(
+    activeContext,
     langfuseScopeRunIdKey,
     hasText(scope.runId) ? scope.runId : undefined,
     replace
@@ -194,6 +216,7 @@ export function resolveLangfuseRuntimeScope({
   runLangfuse,
   langfuseOverlay,
   traceIdSeed,
+  traceAnchor,
   runId,
   agentId,
 }: ResolveLangfuseRuntimeScopeParams): LangfuseRuntimeScope {
@@ -204,5 +227,12 @@ export function resolveLangfuseRuntimeScope({
   )
     ? undefined
     : resolveToolOutputTracingConfig(runLangfuse, langfuseOverlay);
-  return { langfuse, traceIdSeed, toolOutputTracing, runId, agentId };
+  return {
+    langfuse,
+    traceIdSeed,
+    traceAnchor,
+    toolOutputTracing,
+    runId,
+    agentId,
+  };
 }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -36,8 +36,13 @@ type AnchoredSpan = {
   spanContext: SpanContext;
 };
 
+type TraceAnchorState = {
+  spans: Map<string, AnchoredSpan>;
+  spanIds: Set<string>;
+};
+
 const ROOT_TRACE_ANCHOR = '';
-const traceAnchorSpans = new WeakMap<object, Map<string, AnchoredSpan>>();
+const traceAnchorStates = new WeakMap<object, TraceAnchorState>();
 
 export function registerLangfuseManagedSpan(
   span: Span,
@@ -59,16 +64,23 @@ export function registerLangfuseTraceAnchorSpan(
   destinationKey: string,
   agentId?: string
 ): void {
-  let spans = traceAnchorSpans.get(anchor);
-  if (spans == null) {
-    spans = new Map<string, AnchoredSpan>();
-    traceAnchorSpans.set(anchor, spans);
+  let state = traceAnchorStates.get(anchor);
+  if (state == null) {
+    state = { spans: new Map<string, AnchoredSpan>(), spanIds: new Set() };
+    traceAnchorStates.set(anchor, state);
   }
+  const spanContext = span.spanContext();
+  state.spanIds.add(spanContext.spanId);
   const key = agentId ?? ROOT_TRACE_ANCHOR;
-  if (spans.has(key)) {
+  if (state.spans.has(key)) {
     return;
   }
-  spans.set(key, { destinationKey, spanContext: span.spanContext() });
+  state.spans.set(key, { destinationKey, spanContext });
+}
+
+/** Starts a fresh execution while retaining the anchor object held by handlers. */
+export function resetLangfuseTraceAnchorSpans(anchor: object): void {
+  traceAnchorStates.delete(anchor);
 }
 
 /**
@@ -86,12 +98,12 @@ export function resolveLangfuseTraceAnchorParent(
   if (anchor == null || destinationKey == null) {
     return undefined;
   }
-  const spans = traceAnchorSpans.get(anchor);
-  if (spans == null) {
+  const state = traceAnchorStates.get(anchor);
+  if (state == null) {
     return undefined;
   }
-  const agentSpan = agentId == null ? undefined : spans.get(agentId);
-  const rootSpan = spans.get(ROOT_TRACE_ANCHOR);
+  const agentSpan = agentId == null ? undefined : state.spans.get(agentId);
+  const rootSpan = state.spans.get(ROOT_TRACE_ANCHOR);
   let anchoredSpan = rootSpan;
   if (anchoredSpan?.destinationKey !== destinationKey) {
     anchoredSpan = agentSpan;
@@ -104,7 +116,8 @@ export function resolveLangfuseTraceAnchorParent(
   if (
     activeSpan != null &&
     getLangfuseManagedSpanDestination(activeSpan) === destinationKey &&
-    activeSpan.spanContext().traceId === anchoredSpan.spanContext.traceId
+    activeSpan.spanContext().traceId === anchoredSpan.spanContext.traceId &&
+    state.spanIds.has(activeSpan.spanContext().spanId)
   ) {
     return activeSpan.spanContext();
   }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -78,11 +78,6 @@ export function registerLangfuseTraceAnchorSpan(
   state.spans.set(key, { destinationKey, spanContext });
 }
 
-/** Starts a fresh execution while retaining the anchor object held by handlers. */
-export function resetLangfuseTraceAnchorSpans(anchor: object): void {
-  traceAnchorStates.delete(anchor);
-}
-
 /**
  * Resolves the most specific safe parent available for auxiliary work. An
  * active observation wins so labels emitted inside a tool or reasoning step

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
+import { context, trace } from '@opentelemetry/api';
 import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
-import type { Span } from '@opentelemetry/api';
+import type { Span, SpanContext } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
   hasLangfuseConfigCredentials,
@@ -30,6 +31,14 @@ import { isPresent } from '@/utils/misc';
  */
 const managedSpanDestinations = new WeakMap<Span, string>();
 
+type AnchoredSpan = {
+  destinationKey: string;
+  spanContext: SpanContext;
+};
+
+const ROOT_TRACE_ANCHOR = '';
+const traceAnchorSpans = new WeakMap<object, Map<string, AnchoredSpan>>();
+
 export function registerLangfuseManagedSpan(
   span: Span,
   destinationKey: string
@@ -41,6 +50,65 @@ export function getLangfuseManagedSpanDestination(
   span: Span
 ): string | undefined {
   return managedSpanDestinations.get(span);
+}
+
+/** Captures the first exported observation for a run and for each agent lane. */
+export function registerLangfuseTraceAnchorSpan(
+  anchor: object,
+  span: Span,
+  destinationKey: string,
+  agentId?: string
+): void {
+  let spans = traceAnchorSpans.get(anchor);
+  if (spans == null) {
+    spans = new Map<string, AnchoredSpan>();
+    traceAnchorSpans.set(anchor, spans);
+  }
+  const key = agentId ?? ROOT_TRACE_ANCHOR;
+  if (spans.has(key)) {
+    return;
+  }
+  spans.set(key, { destinationKey, spanContext: span.spanContext() });
+}
+
+/**
+ * Resolves the most specific safe parent available for auxiliary work. An
+ * active observation wins so labels emitted inside a tool or reasoning step
+ * stay beside their source; otherwise the run root anchors the label in the
+ * same trace. An agent lane is the fallback when its overlay exports to a
+ * different destination. Cross-destination parents are never returned.
+ */
+export function resolveLangfuseTraceAnchorParent(
+  anchor: object | undefined,
+  destinationKey: string | undefined,
+  agentId?: string
+): SpanContext | undefined {
+  if (anchor == null || destinationKey == null) {
+    return undefined;
+  }
+  const spans = traceAnchorSpans.get(anchor);
+  if (spans == null) {
+    return undefined;
+  }
+  const agentSpan = agentId == null ? undefined : spans.get(agentId);
+  const rootSpan = spans.get(ROOT_TRACE_ANCHOR);
+  let anchoredSpan = rootSpan;
+  if (anchoredSpan?.destinationKey !== destinationKey) {
+    anchoredSpan = agentSpan;
+  }
+  if (anchoredSpan?.destinationKey !== destinationKey) {
+    return undefined;
+  }
+
+  const activeSpan = trace.getSpan(context.active());
+  if (
+    activeSpan != null &&
+    getLangfuseManagedSpanDestination(activeSpan) === destinationKey &&
+    activeSpan.spanContext().traceId === anchoredSpan.spanContext.traceId
+  ) {
+    return activeSpan.spanContext();
+  }
+  return anchoredSpan.spanContext;
 }
 
 function resolveLangfuseEnvironment(

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -10,6 +10,7 @@ import {
   ACTIVITY_PHASE_RUN_NAME,
   ACTIVITY_PHASE_LABEL_RUN_NAME,
 } from '@/common';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 
 const LANGGRAPH_START_NODE = '__start__';
 const LANGGRAPH_RUN_NAME = 'LangGraph';
@@ -31,6 +32,7 @@ const ACTIVITY_PHASE_TRACE_TAG = 'activity-phase';
 const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
 const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
 const OBSERVATION_METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
+const OBSERVATION_METADATA_OPERATION = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.${LANGFUSE_OPERATION_METADATA_KEY}`;
 
 type MutableSpan = ReadableSpan & {
   name: string;
@@ -390,15 +392,25 @@ function shapeActivityPhaseSpan(span: MutableSpan): void {
 }
 
 function shapeGenerationSpan(span: MutableSpan): void {
-  if (hasTraceTag(span, ACTIVITY_LABEL_TRACE_TAG)) {
+  if (
+    hasTraceTag(span, ACTIVITY_LABEL_TRACE_TAG) &&
+    span.attributes[OBSERVATION_METADATA_OPERATION] === ACTIVITY_LABEL_RUN_NAME
+  ) {
     span.name = ACTIVITY_LABEL_RUN_NAME;
     return;
   }
-  if (hasTraceTag(span, REASONING_LABEL_TRACE_TAG)) {
+  if (
+    hasTraceTag(span, REASONING_LABEL_TRACE_TAG) &&
+    span.attributes[OBSERVATION_METADATA_OPERATION] === REASONING_LABEL_RUN_NAME
+  ) {
     span.name = REASONING_LABEL_RUN_NAME;
     return;
   }
-  if (hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG)) {
+  if (
+    hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG) &&
+    span.attributes[OBSERVATION_METADATA_OPERATION] ===
+      ACTIVITY_PHASE_LABEL_RUN_NAME
+  ) {
     span.name = ACTIVITY_PHASE_LABEL_RUN_NAME;
     return;
   }
@@ -420,7 +432,10 @@ function isGraphSpan(span: MutableSpan): boolean {
   );
 }
 
-function shapeRootSpan(span: MutableSpan): void {
+function shapeConversationPayload(
+  span: MutableSpan,
+  includeTracePayload: boolean
+): void {
   const inputKey = LangfuseOtelSpanAttributes.OBSERVATION_INPUT;
   const outputKey = LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT;
   const question = findLastMessageText(
@@ -445,6 +460,9 @@ function shapeRootSpan(span: MutableSpan): void {
     if (answer != null) {
       span.attributes[outputKey] = answer;
     }
+  }
+  if (!includeTracePayload) {
+    return;
   }
   const traceInput = question ?? span.attributes[inputKey];
   const traceOutput = answer ?? span.attributes[outputKey];
@@ -587,11 +605,12 @@ function shapeRootObservationType(span: MutableSpan): void {
  */
 export function shapeLangfuseSpan(span: ReadableSpan): void {
   const mutable = span as MutableSpan;
+  const isGraphObservation = isGraphSpan(mutable);
   if (mutable.name.startsWith(LANGGRAPH_AGENT_NODE_PREFIX)) {
     shapeAgentNodeSpan(mutable);
   } else if (mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)) {
     shapeToolNodeSpan(mutable);
-  } else if (isGraphSpan(mutable)) {
+  } else if (isGraphObservation) {
     shapeGraphSpan(mutable);
   } else if (isAgentModelCallSpan(mutable)) {
     shapeAgentModelCallSpan(mutable);
@@ -603,8 +622,11 @@ export function shapeLangfuseSpan(span: ReadableSpan): void {
     shapeEphemeralAgentNodeSpan(mutable);
   }
   if (!isRootSpan(span)) {
+    if (isGraphObservation) {
+      shapeConversationPayload(mutable, false);
+    }
     return;
   }
   shapeRootObservationType(mutable);
-  shapeRootSpan(mutable);
+  shapeConversationPayload(mutable, true);
 }

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -1,9 +1,20 @@
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { Constants } from '@/common';
+import {
+  Constants,
+  STANDARD_GRAPH_RUN_NAME,
+  MULTI_AGENT_GRAPH_RUN_NAME,
+  AGENT_MODEL_CALL_RUN_NAME,
+  ACTIVITY_LABEL_RUN_NAME,
+  REASONING_LABEL_RUN_NAME,
+  ACTIVITY_PHASE_RUN_NAME,
+  ACTIVITY_PHASE_LABEL_RUN_NAME,
+} from '@/common';
 
 const LANGGRAPH_START_NODE = '__start__';
+const LANGGRAPH_RUN_NAME = 'LangGraph';
 const ANONYMOUS_LAMBDA_NAME = 'RunnableLambda';
+const RUNNABLE_SEQUENCE_NAME = 'RunnableSequence';
 const LANGGRAPH_AGENT_NODE_PREFIX = 'agent=';
 const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
 const AGENT_NODE_SPAN_NAME = 'agent';
@@ -14,8 +25,9 @@ const CHAIN_OBSERVATION_TYPE = 'chain';
 const TOOL_OBSERVATION_TYPE = 'tool';
 const AGENT_TRACE_TAG = 'agent';
 const TITLE_TRACE_TAG = 'title';
+const ACTIVITY_LABEL_TRACE_TAG = 'activity-label';
+const REASONING_LABEL_TRACE_TAG = 'reasoning-label';
 const ACTIVITY_PHASE_TRACE_TAG = 'activity-phase';
-const ACTIVITY_PHASE_ROOT_NAME = 'summarize-activity-phase';
 const EPHEMERAL_AGENT_SENDER_SEPARATOR = '___';
 const EPHEMERAL_AGENT_INDEX_SEPARATOR = '____';
 const OBSERVATION_METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
@@ -192,9 +204,7 @@ function getMessageToolCalls(
  */
 /** Tool-result ids present in the serialized state — ToolNode's
  *  `!toolMessageIds.has(id)` execution filter, mirrored for the span. */
-function getToolResultIds(
-  messages: Record<string, unknown>[]
-): Set<string> {
+function getToolResultIds(messages: Record<string, unknown>[]): Set<string> {
   const ids = new Set<string>();
   for (const message of messages) {
     if (getMessageRole(message) !== 'tool') {
@@ -217,7 +227,9 @@ function getMessageInvalidToolCalls(
 ): SerializedToolCall[] {
   const rawCalls =
     message.invalid_tool_calls ??
-    (isRecord(message.kwargs) ? message.kwargs.invalid_tool_calls : undefined) ??
+    (isRecord(message.kwargs)
+      ? message.kwargs.invalid_tool_calls
+      : undefined) ??
     (isRecord(message.data) ? message.data.invalid_tool_calls : undefined);
   if (!Array.isArray(rawCalls)) {
     return [];
@@ -343,6 +355,68 @@ function shapeAgentNodeSpan(span: MutableSpan): void {
   span.name = AGENT_NODE_SPAN_NAME;
   span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
     ROOT_OBSERVATION_TYPE;
+}
+
+function shapeGraphSpan(span: MutableSpan): void {
+  if (span.name === LANGGRAPH_RUN_NAME) {
+    span.name = STANDARD_GRAPH_RUN_NAME;
+  }
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    ROOT_OBSERVATION_TYPE;
+}
+
+function isAgentModelCallSpan(span: MutableSpan): boolean {
+  if (
+    span.name !== RUNNABLE_SEQUENCE_NAME &&
+    span.name !== AGENT_MODEL_CALL_RUN_NAME
+  ) {
+    return false;
+  }
+  const node = span.attributes[OBSERVATION_METADATA_LANGGRAPH_NODE];
+  return (
+    typeof node === 'string' && node.startsWith(LANGGRAPH_AGENT_NODE_PREFIX)
+  );
+}
+
+function shapeAgentModelCallSpan(span: MutableSpan): void {
+  span.name = AGENT_MODEL_CALL_RUN_NAME;
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    CHAIN_OBSERVATION_TYPE;
+}
+
+function shapeActivityPhaseSpan(span: MutableSpan): void {
+  span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
+    CHAIN_OBSERVATION_TYPE;
+}
+
+function shapeGenerationSpan(span: MutableSpan): void {
+  if (hasTraceTag(span, ACTIVITY_LABEL_TRACE_TAG)) {
+    span.name = ACTIVITY_LABEL_RUN_NAME;
+    return;
+  }
+  if (hasTraceTag(span, REASONING_LABEL_TRACE_TAG)) {
+    span.name = REASONING_LABEL_RUN_NAME;
+    return;
+  }
+  if (hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG)) {
+    span.name = ACTIVITY_PHASE_LABEL_RUN_NAME;
+    return;
+  }
+  span.name = GENERATION_SPAN_NAME;
+}
+
+function isGraphSpan(span: MutableSpan): boolean {
+  if (
+    span.name !== LANGGRAPH_RUN_NAME &&
+    span.name !== STANDARD_GRAPH_RUN_NAME &&
+    span.name !== MULTI_AGENT_GRAPH_RUN_NAME
+  ) {
+    return false;
+  }
+  return (
+    isRootSpan(span) ||
+    typeof span.attributes[OBSERVATION_METADATA_LANGGRAPH_NODE] === 'string'
+  );
 }
 
 function shapeRootSpan(span: MutableSpan): void {
@@ -477,7 +551,7 @@ function shapeRootObservationType(span: MutableSpan): void {
   }
   if (
     hasTraceTag(span, TITLE_TRACE_TAG) ||
-    (span.name === ACTIVITY_PHASE_ROOT_NAME &&
+    (span.name === ACTIVITY_PHASE_RUN_NAME &&
       hasTraceTag(span, ACTIVITY_PHASE_TRACE_TAG))
   ) {
     span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] =
@@ -496,17 +570,19 @@ function shapeRootObservationType(span: MutableSpan): void {
  *   (`provider__model`) — strip it so switching models doesn't break
  *   name-based logic (item 1). The outer workflow node is named with the
  *   bare agent id; ephemeral ids reduce to their stable sender name.
+ * - Graph and prompt-to-model framework names become stable SDK operations:
+ *   `StandardGraph` / `MultiAgentGraph` and `AgentModelCall`.
  * - LLM generation spans keep the provider client class name (`ChatOpenAI`,
- *   `AzureChatOpenAI`, …); rename them to a provider-agnostic `llm` so the
- *   name reflects the operation, not the model (the model stays on the
- *   generation's model attribute).
+ *   `AzureChatOpenAI`, …); rename ordinary calls to a provider-agnostic `llm`
+ *   and label calls by their activity/reasoning role. The model stays on the
+ *   generation's model attribute.
  * - Agent nodes become `agent` observations, while tool-dispatch nodes become
  *   stable `chain` observations whose input is scoped to the pending calls.
  *   Individual child calls remain `tool` observations (items 3 & 4).
  * - Agent trace roots become `agent` observations, while title and activity
- *   summary roots become `chain` observations. Root and trace input/output are
- *   reduced to the user question and assistant response when chat messages are
- *   available (item 2).
+ *   summary operations become `chain` observations. Root and trace
+ *   input/output are reduced to the user question and assistant response when
+ *   chat messages are available (item 2).
  */
 export function shapeLangfuseSpan(span: ReadableSpan): void {
   const mutable = span as MutableSpan;
@@ -514,8 +590,14 @@ export function shapeLangfuseSpan(span: ReadableSpan): void {
     shapeAgentNodeSpan(mutable);
   } else if (mutable.name.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)) {
     shapeToolNodeSpan(mutable);
+  } else if (isGraphSpan(mutable)) {
+    shapeGraphSpan(mutable);
+  } else if (isAgentModelCallSpan(mutable)) {
+    shapeAgentModelCallSpan(mutable);
+  } else if (mutable.name === ACTIVITY_PHASE_RUN_NAME) {
+    shapeActivityPhaseSpan(mutable);
   } else if (isGenerationSpan(mutable)) {
-    mutable.name = GENERATION_SPAN_NAME;
+    shapeGenerationSpan(mutable);
   } else {
     shapeEphemeralAgentNodeSpan(mutable);
   }

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -590,7 +590,7 @@ function shapeRootObservationType(span: MutableSpan): void {
  *   name-based logic (item 1). The outer workflow node is named with the
  *   bare agent id; ephemeral ids reduce to their stable sender name.
  * - Graph and prompt-to-model framework names become stable SDK operations:
- *   `StandardGraph` / `MultiAgentGraph` and `AgentModelCall`.
+ *   `AgentGraph` / `MultiAgentGraph` and `AgentModelCall`.
  * - LLM generation spans keep the provider client class name (`ChatOpenAI`,
  *   `AzureChatOpenAI`, …); rename ordinary calls to a provider-agnostic `llm`
  *   and label calls by their activity/reasoning role. The model stays on the

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -415,7 +415,8 @@ function isGraphSpan(span: MutableSpan): boolean {
   }
   return (
     isRootSpan(span) ||
-    typeof span.attributes[OBSERVATION_METADATA_LANGGRAPH_NODE] === 'string'
+    typeof span.attributes[OBSERVATION_METADATA_LANGGRAPH_NODE] === 'string' ||
+    hasTraceTag(span, AGENT_TRACE_TAG)
   );
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1214,18 +1214,22 @@ export class Run<_T extends t.BaseGraphState> {
        * arg to `BaseGraphState`. Cast on the call so the resume path
        * type-checks without widening the wrapper for every caller.
        */
-      const stream = graphRunnable.streamEvents(inputs as t.IState, config, {
-        raiseError: true,
-        /**
-         * Prevent EventStreamCallbackHandler from processing custom events.
-         * Custom events are already handled via our createCustomEventCallback()
-         * which routes them through the handlerRegistry.
-         * Without this flag, EventStreamCallbackHandler throws errors when
-         * custom events are dispatched for run IDs not in its internal map
-         * (due to timing issues in parallel execution or after run cleanup).
-         */
-        ignoreCustomEvent: true,
-      });
+      const stream = graphRunnable.streamEvents(
+        inputs as t.IState,
+        { ...config, runName: graph.runName },
+        {
+          raiseError: true,
+          /**
+           * Prevent EventStreamCallbackHandler from processing custom events.
+           * Custom events are already handled via our createCustomEventCallback()
+           * which routes them through the handlerRegistry.
+           * Without this flag, EventStreamCallbackHandler throws errors when
+           * custom events are dispatched for run IDs not in its internal map
+           * (due to timing issues in parallel execution or after run cleanup).
+           */
+          ignoreCustomEvent: true,
+        }
+      );
 
       for await (const event of stream) {
         const { data, metadata, ...info } = event;

--- a/src/run.ts
+++ b/src/run.ts
@@ -54,6 +54,11 @@ import {
   normalizeReasoningLabel,
 } from '@/prompts/reasoningLabel';
 import {
+  resetLangfuseTraceAnchorSpans,
+  resolveLangfuseDestinationKey,
+  resolveLangfuseTraceAnchorParent,
+} from '@/langfuseSpanRegistry';
+import {
   hasToolOutputTracingConfig,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
@@ -65,10 +70,6 @@ import {
   ACTIVITY_PHASE_RUN_NAME,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
-import {
-  resolveLangfuseDestinationKey,
-  resolveLangfuseTraceAnchorParent,
-} from '@/langfuseSpanRegistry';
 import {
   appendCallbacks,
   filterCallbacks,
@@ -991,6 +992,9 @@ export class Run<_T extends t.BaseGraphState> {
      * instead of `inputs.messages`.
      */
     const isResume = inputs instanceof Command;
+    if (!isResume) {
+      resetLangfuseTraceAnchorSpans(graph.langfuseTraceAnchor);
+    }
     const stateInputs = isResume ? undefined : (inputs as t.IState);
     if (stateInputs != null) {
       this.activityPhaseTraceInput = findActivityPhaseTraceInput(
@@ -2203,6 +2207,7 @@ export class Run<_T extends t.BaseGraphState> {
             ? labelTraceSeed
             : undefined,
         parentSpanContext: labelParentSpanContext,
+        inheritTraceIdentity: labelParentSpanContext != null,
         runId: labelScopeRunId,
         toolOutputTracing: labelRuntimeScope.toolOutputTracing,
         traceName: labelParentSpanContext == null ? labelRunName : undefined,
@@ -2311,6 +2316,7 @@ export class Run<_T extends t.BaseGraphState> {
           traceMetadata:
             labelParentSpanContext == null ? traceMetadata : undefined,
           tags: labelTags,
+          inheritTraceIdentity: labelParentSpanContext != null,
         },
         () =>
           model.invoke(
@@ -2552,6 +2558,7 @@ export class Run<_T extends t.BaseGraphState> {
             ? reasoningTraceSeed
             : undefined,
         parentSpanContext: reasoningParentSpanContext,
+        inheritTraceIdentity: reasoningParentSpanContext != null,
         runId: reasoningScopeRunId,
         toolOutputTracing: reasoningRuntimeScope.toolOutputTracing,
         traceName:
@@ -2619,6 +2626,7 @@ export class Run<_T extends t.BaseGraphState> {
           traceMetadata:
             reasoningParentSpanContext == null ? traceMetadata : undefined,
           tags: reasoningTags,
+          inheritTraceIdentity: reasoningParentSpanContext != null,
         },
         () =>
           model.invoke(
@@ -2888,6 +2896,7 @@ export class Run<_T extends t.BaseGraphState> {
             ? phaseTraceSeed
             : undefined,
         parentSpanContext: phaseParentSpanContext,
+        inheritTraceIdentity: phaseParentSpanContext != null,
         runId: phaseScopeRunId,
         toolOutputTracing: phaseRuntimeScope.toolOutputTracing,
         traceName: phaseParentSpanContext == null ? phaseTraceName : undefined,
@@ -3004,6 +3013,7 @@ export class Run<_T extends t.BaseGraphState> {
             traceMetadata:
               phaseParentSpanContext == null ? traceMetadata : undefined,
             tags: phaseTags,
+            inheritTraceIdentity: phaseParentSpanContext != null,
           },
           () =>
             phaseRunnable.invoke(

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,6 +59,17 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
+  Callback,
+  GraphEvents,
+  TitleMethod,
+  ACTIVITY_PHASE_RUN_NAME,
+  DEFAULT_RECURSION_LIMIT,
+} from '@/common';
+import {
+  resolveLangfuseDestinationKey,
+  resolveLangfuseTraceAnchorParent,
+} from '@/langfuseSpanRegistry';
+import {
   appendCallbacks,
   filterCallbacks,
   findCallback,
@@ -72,12 +83,6 @@ import {
   getRunStepResumeState,
   stripRunStepResumeState,
 } from '@/tools/runStepResume';
-import {
-  Callback,
-  GraphEvents,
-  TitleMethod,
-  DEFAULT_RECURSION_LIMIT,
-} from '@/common';
 import {
   createCompletionTitleRunnable,
   createTitleRunnable,
@@ -1116,6 +1121,7 @@ export class Run<_T extends t.BaseGraphState> {
         streamLangfuseConfig?.deterministicTraceId === true
           ? this.id
           : undefined,
+      traceAnchor: graph.langfuseTraceAnchor,
       // The graph's per-execution stamp, NOT the public run id: public ids
       // may repeat across concurrent executions (retries, tenant-local
       // message ids), and equal stamps defeat foreign-scope rejection.
@@ -1131,6 +1137,7 @@ export class Run<_T extends t.BaseGraphState> {
         streamLangfuseConfig?.deterministicTraceId === true
           ? this.id
           : undefined,
+      traceAnchor: graph.langfuseTraceAnchor,
       runId: graph.langfuseScopeRunId,
       // The aggregate multi-agent policy from the runtime scope — the
       // handler must restore THIS (not the primary agent's config-derived
@@ -1139,7 +1146,6 @@ export class Run<_T extends t.BaseGraphState> {
       traceName,
     });
     if (langfuseHandler != null) {
-      config.runName = traceName;
       config.callbacks = appendCallbacks(config.callbacks, [langfuseHandler]);
     }
 
@@ -2132,7 +2138,7 @@ export class Run<_T extends t.BaseGraphState> {
       ...(labelAgentId == null ? {} : { agentId: labelAgentId }),
       ...(labelAgentName == null ? {} : { agentName: labelAgentName }),
     };
-    const traceMetadata = {
+    const traceMetadata: Record<string, string> = {
       ...createLangfuseTraceMetadata({
         messageId: 'activity-label-' + this.id,
         parentMessageId: labelParentMessageId,
@@ -2150,16 +2156,9 @@ export class Run<_T extends t.BaseGraphState> {
       labelContext?.langfuse
     );
     initializeLangfuseTracing(labelLangfuseConfig);
-    /** Seed policy, threading two constraints:
-     *  1. `runWithLangfuseRuntimeContext` SPREADS the surrounding context, so
-     *     an absent seed INHERITS the parent run's and collapses every label
-     *     into that trace. When a parent seed is active we must override it
-     *     with a per-label one.
-     *  2. Without deterministic tracing there is no parent seed, and forcing
-     *     one here would make label trace ids deterministic when neither
-     *     `processStream` nor `generateTitle` are — so leave it unset.
-     *  Seeded when determinism is opted into OR a parent seed is live;
-     *  otherwise unseeded, matching the other generation paths. */
+    /** A captured source observation parents the label in the agent trace.
+     *  The distinct seed remains the standalone fallback when labeling runs
+     *  before tracing starts or against another Langfuse destination. */
     const inheritedTraceSeed = getTraceIdSeed();
     const labelTraceSeed =
       labelLangfuseConfig?.deterministicTraceId === true ||
@@ -2174,6 +2173,15 @@ export class Run<_T extends t.BaseGraphState> {
       traceIdSeed: labelTraceSeed,
       runId: labelScopeRunId,
     });
+    const labelParentSpanContext = resolveLangfuseTraceAnchorParent(
+      this.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(labelLangfuseConfig),
+      labelAgentId
+    );
+    if (labelParentSpanContext != null) {
+      labelMetadata.sourceTraceId = labelParentSpanContext.traceId;
+      traceMetadata.sourceTraceId = labelParentSpanContext.traceId;
+    }
     /** Handler only when a session id resolved from
      *  `chainOptions.configurable.thread_id`: without it the label call has
      *  no conversation identity, and tracing it would create an orphan
@@ -2187,15 +2195,17 @@ export class Run<_T extends t.BaseGraphState> {
         langfuse: labelLangfuseConfig,
         userId: labelUserId,
         sessionId: labelSessionId,
-        traceMetadata,
+        traceMetadata:
+          labelParentSpanContext == null ? traceMetadata : undefined,
         tags: labelTags,
         traceIdSeed:
           labelLangfuseConfig?.deterministicTraceId === true
             ? labelTraceSeed
             : undefined,
+        parentSpanContext: labelParentSpanContext,
         runId: labelScopeRunId,
         toolOutputTracing: labelRuntimeScope.toolOutputTracing,
-        traceName: labelRunName,
+        traceName: labelParentSpanContext == null ? labelRunName : undefined,
       });
     }
     if (labelLangfuseHandler != null) {
@@ -2297,8 +2307,9 @@ export class Run<_T extends t.BaseGraphState> {
           langfuse: labelLangfuseConfig,
           userId: labelUserId,
           sessionId: labelSessionId,
-          traceName: labelRunName,
-          traceMetadata,
+          traceName: labelParentSpanContext == null ? labelRunName : undefined,
+          traceMetadata:
+            labelParentSpanContext == null ? traceMetadata : undefined,
           tags: labelTags,
         },
         () =>
@@ -2470,7 +2481,7 @@ export class Run<_T extends t.BaseGraphState> {
       ...(reasoningAgentId == null ? {} : { agentId: reasoningAgentId }),
       ...(reasoningAgentName == null ? {} : { agentName: reasoningAgentName }),
     };
-    const traceMetadata = {
+    const traceMetadata: Record<string, string> = {
       ...createLangfuseTraceMetadata({
         messageId: `reasoning-label-${reasoningResponseId}`,
         parentMessageId: reasoningParentMessageId,
@@ -2512,21 +2523,39 @@ export class Run<_T extends t.BaseGraphState> {
       traceIdSeed: reasoningTraceSeed,
       runId: reasoningScopeRunId,
     });
+    const candidateReasoningParent = resolveLangfuseTraceAnchorParent(
+      this.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(reasoningLangfuseConfig),
+      reasoningAgentId
+    );
+    const reasoningParentSpanContext =
+      resolvedSourceRunId === this.id &&
+      (sourceTraceId == null ||
+        sourceTraceId === candidateReasoningParent?.traceId)
+        ? candidateReasoningParent
+        : undefined;
+    if (reasoningParentSpanContext != null) {
+      reasoningMetadata.sourceTraceId = reasoningParentSpanContext.traceId;
+      traceMetadata.sourceTraceId = reasoningParentSpanContext.traceId;
+    }
     let reasoningLangfuseHandler: CallbackEntry | undefined;
     if (reasoningSessionId != null) {
       reasoningLangfuseHandler = createLangfuseHandler({
         langfuse: reasoningLangfuseConfig,
         userId: reasoningUserId,
         sessionId: reasoningSessionId,
-        traceMetadata,
+        traceMetadata:
+          reasoningParentSpanContext == null ? traceMetadata : undefined,
         tags: reasoningTags,
         traceIdSeed:
           reasoningLangfuseConfig?.deterministicTraceId === true
             ? reasoningTraceSeed
             : undefined,
+        parentSpanContext: reasoningParentSpanContext,
         runId: reasoningScopeRunId,
         toolOutputTracing: reasoningRuntimeScope.toolOutputTracing,
-        traceName: reasoningRunName,
+        traceName:
+          reasoningParentSpanContext == null ? reasoningRunName : undefined,
       });
     }
     if (reasoningLangfuseHandler != null) {
@@ -2585,8 +2614,10 @@ export class Run<_T extends t.BaseGraphState> {
           langfuse: reasoningLangfuseConfig,
           userId: reasoningUserId,
           sessionId: reasoningSessionId,
-          traceName: reasoningRunName,
-          traceMetadata,
+          traceName:
+            reasoningParentSpanContext == null ? reasoningRunName : undefined,
+          traceMetadata:
+            reasoningParentSpanContext == null ? traceMetadata : undefined,
           tags: reasoningTags,
         },
         () =>
@@ -2638,9 +2669,10 @@ export class Run<_T extends t.BaseGraphState> {
 
   /**
    * Generates one parent summary for two or more logical activities. The
-   * summary model is traced as a dedicated activity-phase chain root in the
-   * conversation session, with the model callback recorded as its generation
-   * child. No session id means no phase trace, avoiding orphan observations.
+   * summary model is traced as an activity-phase chain beneath the source
+   * agent run, with the model callback recorded as its generation child. It
+   * falls back to a dedicated trace when no source observation is available.
+   * No session id means no phase trace, avoiding orphan observations.
    */
   async generateActivityPhaseLabel({
     provider,
@@ -2785,7 +2817,7 @@ export class Run<_T extends t.BaseGraphState> {
       ...(phaseAgentName == null ? {} : { agentName: phaseAgentName }),
       ...(closingTextPhase == null ? {} : { closingTextPhase }),
     };
-    const traceMetadata = {
+    const traceMetadata: Record<string, string> = {
       ...createLangfuseTraceMetadata({
         messageId: phaseMessageId,
         parentMessageId: phaseParentMessageId,
@@ -2826,6 +2858,19 @@ export class Run<_T extends t.BaseGraphState> {
       traceIdSeed: phaseTraceSeed,
       runId: phaseScopeRunId,
     });
+    const candidatePhaseParent = resolveLangfuseTraceAnchorParent(
+      this.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(phaseLangfuseConfig)
+    );
+    const phaseParentSpanContext =
+      (sourceRunId == null || sourceRunId === this.id) &&
+      (sourceTraceId == null || sourceTraceId === candidatePhaseParent?.traceId)
+        ? candidatePhaseParent
+        : undefined;
+    if (phaseParentSpanContext != null) {
+      phaseMetadata.sourceTraceId = phaseParentSpanContext.traceId;
+      traceMetadata.sourceTraceId = phaseParentSpanContext.traceId;
+    }
     let phaseLangfuseHandler: CallbackEntry | undefined;
     const sourceUserText =
       this.activityPhaseTraceInput ??
@@ -2835,15 +2880,17 @@ export class Run<_T extends t.BaseGraphState> {
         langfuse: phaseLangfuseConfig,
         userId: phaseUserId,
         sessionId: phaseSessionId,
-        traceMetadata,
+        traceMetadata:
+          phaseParentSpanContext == null ? traceMetadata : undefined,
         tags: phaseTags,
         traceIdSeed:
           phaseLangfuseConfig?.deterministicTraceId === true
             ? phaseTraceSeed
             : undefined,
+        parentSpanContext: phaseParentSpanContext,
         runId: phaseScopeRunId,
         toolOutputTracing: phaseRuntimeScope.toolOutputTracing,
-        traceName: phaseTraceName,
+        traceName: phaseParentSpanContext == null ? phaseTraceName : undefined,
       });
     }
     if (phaseLangfuseHandler != null) {
@@ -2864,7 +2911,7 @@ export class Run<_T extends t.BaseGraphState> {
     const invokeConfig = Object.assign({}, phaseChainOptions, {
       run_id: phaseRunId,
       runId: phaseRunId,
-      runName: 'summarize-activity-phase',
+      runName: ACTIVITY_PHASE_RUN_NAME,
       tags: [...new Set([...(phaseChainOptions.tags ?? []), ...phaseTags])],
       metadata: {
         ...(phaseChainOptions.metadata ?? {}),
@@ -2943,7 +2990,7 @@ export class Run<_T extends t.BaseGraphState> {
           ? { label, messages: [new AIMessage(label)] }
           : { messages: [] };
       },
-    }).withConfig({ runName: 'summarize-activity-phase' });
+    }).withConfig({ runName: ACTIVITY_PHASE_RUN_NAME });
 
     try {
       const result = await withLangfuseRuntimeScope(phaseRuntimeScope, () =>
@@ -2952,8 +2999,10 @@ export class Run<_T extends t.BaseGraphState> {
             langfuse: phaseLangfuseConfig,
             userId: phaseUserId,
             sessionId: phaseSessionId,
-            traceName: phaseTraceName,
-            traceMetadata,
+            traceName:
+              phaseParentSpanContext == null ? phaseTraceName : undefined,
+            traceMetadata:
+              phaseParentSpanContext == null ? traceMetadata : undefined,
             tags: phaseTags,
           },
           () =>

--- a/src/run.ts
+++ b/src/run.ts
@@ -27,6 +27,16 @@ import type { StandardGraph } from '@/graphs/Graph';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
+  Callback,
+  GraphEvents,
+  TitleMethod,
+  ACTIVITY_LABEL_RUN_NAME,
+  REASONING_LABEL_RUN_NAME,
+  ACTIVITY_PHASE_RUN_NAME,
+  ACTIVITY_PHASE_LABEL_RUN_NAME,
+  DEFAULT_RECURSION_LIMIT,
+} from '@/common';
+import {
   requireValidSubagentResumeManifest,
   stripSubagentResumeManifest,
   SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
@@ -54,22 +64,14 @@ import {
   normalizeReasoningLabel,
 } from '@/prompts/reasoningLabel';
 import {
-  resetLangfuseTraceAnchorSpans,
-  resolveLangfuseDestinationKey,
-  resolveLangfuseTraceAnchorParent,
-} from '@/langfuseSpanRegistry';
-import {
   hasToolOutputTracingConfig,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
-  Callback,
-  GraphEvents,
-  TitleMethod,
-  ACTIVITY_PHASE_RUN_NAME,
-  DEFAULT_RECURSION_LIMIT,
-} from '@/common';
+  resolveLangfuseDestinationKey,
+  resolveLangfuseTraceAnchorParent,
+} from '@/langfuseSpanRegistry';
 import {
   appendCallbacks,
   filterCallbacks,
@@ -89,6 +91,7 @@ import {
   createTitleRunnable,
 } from '@/utils/title';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { initializeLangfuseTracing } from './instrumentation';
 import { seedRunInitialSessions } from '@/utils/toolSessions';
@@ -993,7 +996,7 @@ export class Run<_T extends t.BaseGraphState> {
      */
     const isResume = inputs instanceof Command;
     if (!isResume) {
-      resetLangfuseTraceAnchorSpans(graph.langfuseTraceAnchor);
+      graph.startFreshLangfuseExecution();
     }
     const stateInputs = isResume ? undefined : (inputs as t.IState);
     if (stateInputs != null) {
@@ -2133,6 +2136,7 @@ export class Run<_T extends t.BaseGraphState> {
     const labelAgentName =
       labelAgentId == null ? undefined : labelContext?.name;
     const labelMetadata: Record<string, unknown> = {
+      [LANGFUSE_OPERATION_METADATA_KEY]: ACTIVITY_LABEL_RUN_NAME,
       sourceRunId: this.id,
       responseId: this.id,
       activityIndex: labelIndex,
@@ -2474,6 +2478,7 @@ export class Run<_T extends t.BaseGraphState> {
     const resolvedSourceRunId = sourceRunId ?? this.id;
     const reasoningResponseId = responseId ?? this.id;
     const reasoningMetadata: Record<string, unknown> = {
+      [LANGFUSE_OPERATION_METADATA_KEY]: REASONING_LABEL_RUN_NAME,
       sourceRunId: resolvedSourceRunId,
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
       responseId: reasoningResponseId,
@@ -2811,6 +2816,7 @@ export class Run<_T extends t.BaseGraphState> {
     const phaseParentMessageId =
       phaseChainOptions.configurable?.requestBody?.parentMessageId;
     const phaseMetadata: Record<string, unknown> = {
+      [LANGFUSE_OPERATION_METADATA_KEY]: ACTIVITY_PHASE_LABEL_RUN_NAME,
       sourceRunId: sourceRunId ?? this.id,
       ...(sourceTraceId == null ? {} : { sourceTraceId }),
       responseId: phaseMessageId,

--- a/src/specs/activity-label-observability.live.test.ts
+++ b/src/specs/activity-label-observability.live.test.ts
@@ -289,7 +289,7 @@ describeIfLive('activity label Langfuse export (live)', () => {
     );
     expect(labelGeneration).toMatchObject({
       parentObservationId: null,
-      name: 'ActivityLabel',
+      name: 'StepLabel',
       model: expect.stringContaining(model),
     });
     expect(labelGeneration?.usage?.total).toBeGreaterThan(0);
@@ -299,14 +299,14 @@ describeIfLive('activity label Langfuse export (live)', () => {
     );
     expect(phaseRoot).toMatchObject({
       type: 'CHAIN',
-      name: 'ActivityPhase',
+      name: 'MultiStepLabel',
     });
     const phaseGeneration = phase.observations?.find(
       (observation) => observation.type === 'GENERATION'
     );
     expect(phaseGeneration).toMatchObject({
       parentObservationId: phaseRoot?.id,
-      name: 'ActivityPhaseLabel',
+      name: 'MultiStepLabelGeneration',
       model: expect.stringContaining(model),
     });
     expect(phaseGeneration?.usage?.total).toBeGreaterThan(0);

--- a/src/specs/activity-label-observability.live.test.ts
+++ b/src/specs/activity-label-observability.live.test.ts
@@ -289,7 +289,7 @@ describeIfLive('activity label Langfuse export (live)', () => {
     );
     expect(labelGeneration).toMatchObject({
       parentObservationId: null,
-      name: 'llm',
+      name: 'ActivityLabel',
       model: expect.stringContaining(model),
     });
     expect(labelGeneration?.usage?.total).toBeGreaterThan(0);
@@ -299,14 +299,14 @@ describeIfLive('activity label Langfuse export (live)', () => {
     );
     expect(phaseRoot).toMatchObject({
       type: 'CHAIN',
-      name: 'summarize-activity-phase',
+      name: 'ActivityPhase',
     });
     const phaseGeneration = phase.observations?.find(
       (observation) => observation.type === 'GENERATION'
     );
     expect(phaseGeneration).toMatchObject({
       parentObservationId: phaseRoot?.id,
-      name: 'llm',
+      name: 'ActivityPhaseLabel',
       model: expect.stringContaining(model),
     });
     expect(phaseGeneration?.usage?.total).toBeGreaterThan(0);
@@ -316,7 +316,7 @@ describeIfLive('activity label Langfuse export (live)', () => {
     );
     expect(reasoningGeneration).toMatchObject({
       parentObservationId: null,
-      name: 'llm',
+      name: 'ReasoningLabel',
       model: expect.stringContaining(model),
     });
     expect(reasoningGeneration?.usage?.total).toBeGreaterThan(0);

--- a/src/specs/activity-label-observability.test.ts
+++ b/src/specs/activity-label-observability.test.ts
@@ -3,10 +3,16 @@ import { propagateAttributes } from '@langfuse/tracing';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type { Span } from '@opentelemetry/api';
 import {
+  Providers,
+  ACTIVITY_LABEL_RUN_NAME,
+  REASONING_LABEL_RUN_NAME,
+  ACTIVITY_PHASE_LABEL_RUN_NAME,
+} from '@/common';
+import {
   registerLangfuseTraceAnchorSpan,
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
-import { Providers } from '@/common';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { Run } from '@/run';
 
 const invoke = jest.fn();
@@ -128,6 +134,7 @@ describe('activity label observability', () => {
       runName: 'LibreChat Activity Label',
       tags: ['librechat', 'activity-label'],
       metadata: {
+        [LANGFUSE_OPERATION_METADATA_KEY]: ACTIVITY_LABEL_RUN_NAME,
         sourceRunId: 'response-1',
         sourceTraceId,
         responseId: 'response-1',
@@ -192,6 +199,7 @@ describe('activity label observability', () => {
       runName: 'LibreChat Reasoning Label',
       tags: ['librechat', 'reasoning-label', 'reasoning-step'],
       metadata: {
+        [LANGFUSE_OPERATION_METADATA_KEY]: REASONING_LABEL_RUN_NAME,
         sourceRunId: 'response-1',
         sourceTraceId: 'source-trace-1',
         responseId: 'response-1',
@@ -286,6 +294,11 @@ describe('activity label observability', () => {
         responseId: 'response-1',
         phaseIndex: '0',
         activityCount: '2',
+      },
+    });
+    expect(invoke.mock.calls[0][1]).toMatchObject({
+      metadata: {
+        [LANGFUSE_OPERATION_METADATA_KEY]: ACTIVITY_PHASE_LABEL_RUN_NAME,
       },
     });
   });

--- a/src/specs/activity-label-observability.test.ts
+++ b/src/specs/activity-label-observability.test.ts
@@ -1,6 +1,11 @@
 import { CallbackHandler } from '@langfuse/langchain';
 import { propagateAttributes } from '@langfuse/tracing';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { Span } from '@opentelemetry/api';
+import {
+  registerLangfuseTraceAnchorSpan,
+  resolveLangfuseDestinationKey,
+} from '@/langfuseSpanRegistry';
 import { Providers } from '@/common';
 import { Run } from '@/run';
 
@@ -68,6 +73,21 @@ describe('activity label observability', () => {
 
   it('uses a stable trace name and source-run metadata for batch labels', async () => {
     const run = await createRun();
+    const sourceTraceId = '0123456789abcdef0123456789abcdef';
+    const destinationKey = resolveLangfuseDestinationKey();
+    const sourceSpan = {
+      spanContext: () => ({
+        traceId: sourceTraceId,
+        spanId: '0123456789abcdef',
+        traceFlags: 1,
+      }),
+    } as unknown as Span;
+    registerLangfuseTraceAnchorSpan(
+      run.Graph?.langfuseTraceAnchor as object,
+      sourceSpan,
+      destinationKey as string,
+      'agent-1'
+    );
 
     await run.generateActivityLabel({
       provider: Providers.OPENAI,
@@ -90,30 +110,19 @@ describe('activity label observability', () => {
 
     expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
     expect(MockedCallbackHandler.mock.calls[0][0]).toMatchObject({
-      traceMetadata: {
-        messageId: 'activity-label-response-1',
-        parentMessageId: 'parent-1',
-        agentId: 'agent-1',
-        agentName: 'Changing Model Name',
-        sourceRunId: 'response-1',
-        responseId: 'response-1',
-        activityIndex: '0',
-      },
+      traceMetadata: undefined,
       tags: ['librechat', 'activity-label'],
     });
     expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
-      traceName: 'LibreChat Activity Label',
-      metadata: {
-        sourceRunId: 'response-1',
-        responseId: 'response-1',
-        activityIndex: '0',
-      },
+      traceName: undefined,
+      metadata: undefined,
     });
     expect(invoke.mock.calls[0][1]).toMatchObject({
       runName: 'LibreChat Activity Label',
       tags: ['librechat', 'activity-label'],
       metadata: {
         sourceRunId: 'response-1',
+        sourceTraceId,
         responseId: 'response-1',
         activityIndex: 0,
         parentMessageId: 'parent-1',

--- a/src/specs/activity-label-observability.test.ts
+++ b/src/specs/activity-label-observability.test.ts
@@ -43,6 +43,9 @@ async function createRun(): Promise<Run<never>> {
           provider: Providers.OPENAI,
           clientOptions: { model: 'gpt-4.1-mini' },
           tools: [],
+          langfuse: {
+            metadata: { overlay: 'must-not-replace-source-identity' },
+          },
         },
       ],
     },
@@ -110,10 +113,14 @@ describe('activity label observability', () => {
 
     expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
     expect(MockedCallbackHandler.mock.calls[0][0]).toMatchObject({
+      userId: undefined,
+      sessionId: undefined,
       traceMetadata: undefined,
       tags: ['librechat', 'activity-label'],
     });
     expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
+      userId: undefined,
+      sessionId: undefined,
       traceName: undefined,
       metadata: undefined,
     });

--- a/src/specs/activity-label-trace-seed.test.ts
+++ b/src/specs/activity-label-trace-seed.test.ts
@@ -5,11 +5,10 @@ import {
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 
 /**
- * `generateActivityLabel` passes one label seed to both the Langfuse handler
- * and the runtime scope it invokes under. This proves the mechanism: a label
- * scope's seed must override an inherited (parent run) seed for the duration
- * of the label call, then restore — otherwise per-batch label generations
- * collapse into the main run trace under deterministic tracing.
+ * `generateActivityLabel` keeps a label-specific seed for its standalone
+ * fallback when no source observation can be captured. An explicit source
+ * parent wins during normal traced runs; this proves fallback seed scoping
+ * does not leak into the surrounding agent run.
  *
  * Asserted through the ALS runtime-context channel (`getTraceIdSeed`), which
  * the trace id generator consults alongside OTel context; tests run without

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -8,10 +8,15 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
+import {
+  resolveLangfuseDestinationKey,
+  resolveLangfuseTraceAnchorParent,
+} from '@/langfuseSpanRegistry';
 import { Constants, ContentTypes, Providers, TitleMethod } from '@/common';
 import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
 import { initializeLangfuseTracing } from '@/instrumentation';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
+import { createLangfuseHandler } from '@/langfuse';
 import * as providers from '@/llm/providers';
 import { Run } from '@/run';
 
@@ -588,7 +593,8 @@ describe('Langfuse per-run routing integration', () => {
         starts,
         traceId: runTraceId,
         names: [
-          `LibreChat Agent: Parent ${tenantId}`,
+          'StandardGraph',
+          'AgentModelCall',
           'FakeChatModel',
           'echo',
           'subagent',
@@ -635,11 +641,7 @@ describe('Langfuse per-run routing integration', () => {
       expectNamedSpansUseTraceId({
         starts,
         traceId,
-        names: [
-          `LibreChat Agent: parent ${tenantId}`,
-          'FakeChatModel',
-          'subagent',
-        ],
+        names: ['StandardGraph', 'AgentModelCall', 'FakeChatModel', 'subagent'],
       });
       expect(
         starts.filter(
@@ -667,7 +669,7 @@ describe('Langfuse per-run routing integration', () => {
         starts,
         traceId: summaryTraceId,
         names: [
-          `LibreChat Agent: Parent ${tenantId}`,
+          'StandardGraph',
           'summarize=parent',
           'summarization:cache_hit_compaction',
           'FakeChatModel',
@@ -712,9 +714,7 @@ describe('Langfuse per-run routing integration', () => {
       )
     ).toHaveLength(0);
 
-    const agentRoot = starts.find(
-      (record) => record.name === `LibreChat Agent: Parent ${tenantId}`
-    );
+    const agentRoot = starts.find((record) => record.name === 'StandardGraph');
     expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${tenantId}`));
     expect(agentRoot?.parentSpanId).toBeUndefined();
 
@@ -746,7 +746,7 @@ describe('Langfuse per-run routing integration', () => {
       spanId: string;
     };
     const agentRoot = startsForTenant(tenantId).find(
-      (record) => record.name === `LibreChat Agent: Parent ${tenantId}`
+      (record) => record.name === 'StandardGraph'
     );
     expect(agentRoot?.traceId).toBe(hostSpanContext.traceId);
     expect(agentRoot?.parentSpanId).toBe(hostSpanContext.spanId);
@@ -777,11 +777,56 @@ describe('Langfuse per-run routing integration', () => {
       spanId: string;
     };
     const agentRoot = startsForTenant(runTenantId).find(
-      (record) => record.name === `LibreChat Agent: Parent ${runTenantId}`
+      (record) => record.name === 'StandardGraph'
     );
     expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${runTenantId}`));
     expect(agentRoot?.traceId).not.toBe(hostSpanContext.traceId);
     expect(agentRoot?.parentSpanId).toBeUndefined();
+  });
+
+  it('parents auxiliary label callbacks beneath the captured agent run', async () => {
+    const tenantId = 'tenant-label-parent';
+    const langfuse = tenantLangfuse(tenantId);
+    const traceAnchor = {};
+    initializeLangfuseTracing(langfuse);
+
+    let agentRoot: MockSpan | undefined;
+    withLangfuseRuntimeScope(
+      { langfuse, traceAnchor, runId: 'source-run' },
+      () => {
+        agentRoot = createMockSpan('StandardGraph');
+      }
+    );
+    const parentSpanContext = resolveLangfuseTraceAnchorParent(
+      traceAnchor,
+      resolveLangfuseDestinationKey(langfuse)
+    );
+    const labelHandler = createLangfuseHandler({
+      langfuse,
+      runId: 'label-run',
+      parentSpanContext,
+      tags: ['librechat', 'activity-label'],
+    });
+
+    await withLangfuseRuntimeScope(
+      { langfuse, runId: 'foreign-background-run' },
+      () =>
+        labelHandler?.handleChainStart(
+          { id: ['ActivityLabel'] } as never,
+          {},
+          'label-chain'
+        )
+    );
+
+    const label = startsForTenant(tenantId).find(
+      (record) => record.name === 'ActivityLabel'
+    );
+    const rootContext = agentRoot?.spanContext() as {
+      traceId: string;
+      spanId: string;
+    };
+    expect(label?.traceId).toBe(rootContext.traceId);
+    expect(label?.parentSpanId).toBe(rootContext.spanId);
   });
 
   it('generates a scope stamp for directly-constructed graphs without a run id', async () => {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -580,6 +580,37 @@ describe('Langfuse per-run routing integration', () => {
     });
   });
 
+  it('keeps caller run names from replacing the graph operation name', async () => {
+    const tenantId = 'tenant-caller-run-name';
+    const run = await Run.create<t.IState>({
+      runId: `routing-${tenantId}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createAgent(tenantId)],
+      },
+      langfuse: tenantLangfuse(tenantId),
+      returnContent: true,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(['Caller name preserved.'], 1);
+
+    await run.processStream(
+      { messages: [new HumanMessage('Keep the operation name stable.')] },
+      {
+        ...callerConfig,
+        runName: 'Host Agent Trace',
+        configurable: {
+          thread_id: `thread-${tenantId}`,
+          user_id: `user-${tenantId}`,
+        },
+      }
+    );
+
+    const starts = startsForTenant(tenantId);
+    expect(starts.some(({ name }) => name === 'AgentGraph')).toBe(true);
+    expect(starts.some(({ name }) => name === 'Host Agent Trace')).toBe(false);
+  });
+
   it('routes parallel root, model, tool, subagent, and title spans to each run config', async () => {
     await Promise.all([runTenantFlow('tenant-a'), runTenantFlow('tenant-b')]);
 

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -9,6 +9,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
+  registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
 } from '@/langfuseSpanRegistry';
@@ -797,9 +798,34 @@ describe('Langfuse per-run routing integration', () => {
         agentRoot = createMockSpan('StandardGraph');
       }
     );
+    const destinationKey = resolveLangfuseDestinationKey(langfuse) as string;
+    const rootActiveContext = otelTrace.setSpan(
+      otelContext.active(),
+      agentRoot as never
+    );
+    const hostSpan = createMockSpan('managed-host', rootActiveContext);
+    registerLangfuseManagedSpan(hostSpan as never, destinationKey);
+    let graphChild: MockSpan | undefined;
+    withLangfuseRuntimeScope(
+      { langfuse, traceAnchor, runId: 'source-run' },
+      () =>
+        otelContext.with(rootActiveContext, () => {
+          graphChild = createMockSpan('agent-child');
+        })
+    );
+    const hostParent = otelContext.with(
+      otelTrace.setSpan(otelContext.active(), hostSpan as never),
+      () => resolveLangfuseTraceAnchorParent(traceAnchor, destinationKey)
+    );
+    const childParent = otelContext.with(
+      otelTrace.setSpan(otelContext.active(), graphChild as never),
+      () => resolveLangfuseTraceAnchorParent(traceAnchor, destinationKey)
+    );
+    expect(hostParent?.spanId).toBe(agentRoot?.spanContext().spanId);
+    expect(childParent?.spanId).toBe(graphChild?.spanContext().spanId);
     const parentSpanContext = resolveLangfuseTraceAnchorParent(
       traceAnchor,
-      resolveLangfuseDestinationKey(langfuse)
+      destinationKey
     );
     const labelHandler = createLangfuseHandler({
       langfuse,
@@ -827,6 +853,88 @@ describe('Langfuse per-run routing integration', () => {
     };
     expect(label?.traceId).toBe(rootContext.traceId);
     expect(label?.parentSpanId).toBe(rootContext.spanId);
+  });
+
+  it('restores an overlay agent lane after rejecting a foreign scope', async () => {
+    const rootLangfuse = tenantLangfuse('tenant-anchor-root');
+    const overlayLangfuse = tenantLangfuse('tenant-anchor-overlay');
+    const traceAnchor = {};
+    initializeLangfuseTracing(rootLangfuse);
+    initializeLangfuseTracing(overlayLangfuse);
+
+    withLangfuseRuntimeScope(
+      { langfuse: rootLangfuse, traceAnchor, runId: 'source-run' },
+      () => createMockSpan('StandardGraph')
+    );
+    const overlayHandler = createLangfuseHandler({
+      langfuse: overlayLangfuse,
+      traceAnchor,
+      agentId: 'overlay-agent',
+      runId: 'source-run',
+      tags: ['librechat', 'agent'],
+    });
+
+    await withLangfuseRuntimeScope(
+      { langfuse: rootLangfuse, runId: 'foreign-run' },
+      () =>
+        overlayHandler?.handleChainStart(
+          { id: ['AgentModelCall'] } as never,
+          {},
+          'overlay-chain'
+        )
+    );
+
+    const overlayParent = resolveLangfuseTraceAnchorParent(
+      traceAnchor,
+      resolveLangfuseDestinationKey(overlayLangfuse),
+      'overlay-agent'
+    );
+    const overlayStart = startsForTenant('tenant-anchor-overlay').find(
+      (record) => record.name === 'AgentModelCall'
+    );
+    expect(overlayParent?.spanId).toBe(overlayStart?.spanId);
+    expect(overlayParent?.traceId).toBe(overlayStart?.traceId);
+  });
+
+  it('rotates the captured root between fresh executions of one run', async () => {
+    const tenantId = 'tenant-anchor-rotation';
+    const langfuse = tenantLangfuse(tenantId);
+    const run = await Run.create<t.IState>({
+      runId: `routing-${tenantId}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createAgent(tenantId)],
+      },
+      langfuse,
+      returnContent: true,
+      skipCleanup: true,
+    });
+    const execute = async (response: string): Promise<void> => {
+      run.Graph?.overrideTestModel([response]);
+      await run.processStream(
+        { messages: [new HumanMessage(response)] },
+        callerConfig
+      );
+    };
+
+    await execute('first execution');
+    const firstParent = resolveLangfuseTraceAnchorParent(
+      run.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(langfuse)
+    );
+    await execute('second execution');
+    const secondParent = resolveLangfuseTraceAnchorParent(
+      run.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(langfuse)
+    );
+    const roots = startsForTenant(tenantId).filter(
+      (record) => record.name === 'StandardGraph' && record.parentSpanId == null
+    );
+
+    expect(roots).toHaveLength(2);
+    expect(firstParent?.spanId).toBe(roots[0].spanId);
+    expect(secondParent?.spanId).toBe(roots[1].spanId);
+    expect(secondParent?.spanId).not.toBe(firstParent?.spanId);
   });
 
   it('generates a scope stamp for directly-constructed graphs without a run id', async () => {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -918,13 +918,29 @@ describe('Langfuse per-run routing integration', () => {
     };
 
     await execute('first execution');
+    const firstTraceAnchor = run.Graph?.langfuseTraceAnchor;
+    const firstScopeRunId = run.Graph?.langfuseScopeRunId;
     const firstParent = resolveLangfuseTraceAnchorParent(
       run.Graph?.langfuseTraceAnchor,
       resolveLangfuseDestinationKey(langfuse)
     );
     await execute('second execution');
+    const secondTraceAnchor = run.Graph?.langfuseTraceAnchor;
+    const secondScopeRunId = run.Graph?.langfuseScopeRunId;
     const secondParent = resolveLangfuseTraceAnchorParent(
       run.Graph?.langfuseTraceAnchor,
+      resolveLangfuseDestinationKey(langfuse)
+    );
+    withLangfuseRuntimeScope(
+      {
+        langfuse,
+        traceAnchor: firstTraceAnchor,
+        runId: firstScopeRunId,
+      },
+      () => createMockSpan('late-first-execution-callback')
+    );
+    const secondParentAfterLateCallback = resolveLangfuseTraceAnchorParent(
+      secondTraceAnchor,
       resolveLangfuseDestinationKey(langfuse)
     );
     const roots = startsForTenant(tenantId).filter(
@@ -934,7 +950,10 @@ describe('Langfuse per-run routing integration', () => {
     expect(roots).toHaveLength(2);
     expect(firstParent?.spanId).toBe(roots[0].spanId);
     expect(secondParent?.spanId).toBe(roots[1].spanId);
+    expect(secondParentAfterLateCallback?.spanId).toBe(roots[1].spanId);
     expect(secondParent?.spanId).not.toBe(firstParent?.spanId);
+    expect(secondTraceAnchor).not.toBe(firstTraceAnchor);
+    expect(secondScopeRunId).not.toBe(firstScopeRunId);
   });
 
   it('generates a scope stamp for directly-constructed graphs without a run id', async () => {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -594,7 +594,7 @@ describe('Langfuse per-run routing integration', () => {
         starts,
         traceId: runTraceId,
         names: [
-          'StandardGraph',
+          'AgentGraph',
           'AgentModelCall',
           'FakeChatModel',
           'echo',
@@ -642,7 +642,7 @@ describe('Langfuse per-run routing integration', () => {
       expectNamedSpansUseTraceId({
         starts,
         traceId,
-        names: ['StandardGraph', 'AgentModelCall', 'FakeChatModel', 'subagent'],
+        names: ['AgentGraph', 'AgentModelCall', 'FakeChatModel', 'subagent'],
       });
       expect(
         starts.filter(
@@ -670,7 +670,7 @@ describe('Langfuse per-run routing integration', () => {
         starts,
         traceId: summaryTraceId,
         names: [
-          'StandardGraph',
+          'AgentGraph',
           'summarize=parent',
           'summarization:cache_hit_compaction',
           'FakeChatModel',
@@ -715,7 +715,7 @@ describe('Langfuse per-run routing integration', () => {
       )
     ).toHaveLength(0);
 
-    const agentRoot = starts.find((record) => record.name === 'StandardGraph');
+    const agentRoot = starts.find((record) => record.name === 'AgentGraph');
     expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${tenantId}`));
     expect(agentRoot?.parentSpanId).toBeUndefined();
 
@@ -747,7 +747,7 @@ describe('Langfuse per-run routing integration', () => {
       spanId: string;
     };
     const agentRoot = startsForTenant(tenantId).find(
-      (record) => record.name === 'StandardGraph'
+      (record) => record.name === 'AgentGraph'
     );
     expect(agentRoot?.traceId).toBe(hostSpanContext.traceId);
     expect(agentRoot?.parentSpanId).toBe(hostSpanContext.spanId);
@@ -778,7 +778,7 @@ describe('Langfuse per-run routing integration', () => {
       spanId: string;
     };
     const agentRoot = startsForTenant(runTenantId).find(
-      (record) => record.name === 'StandardGraph'
+      (record) => record.name === 'AgentGraph'
     );
     expect(agentRoot?.traceId).toBe(traceIdFromSeed(`routing-${runTenantId}`));
     expect(agentRoot?.traceId).not.toBe(hostSpanContext.traceId);
@@ -795,7 +795,7 @@ describe('Langfuse per-run routing integration', () => {
     withLangfuseRuntimeScope(
       { langfuse, traceAnchor, runId: 'source-run' },
       () => {
-        agentRoot = createMockSpan('StandardGraph');
+        agentRoot = createMockSpan('AgentGraph');
       }
     );
     const destinationKey = resolveLangfuseDestinationKey(langfuse) as string;
@@ -838,14 +838,14 @@ describe('Langfuse per-run routing integration', () => {
       { langfuse, runId: 'foreign-background-run' },
       () =>
         labelHandler?.handleChainStart(
-          { id: ['ActivityLabel'] } as never,
+          { id: ['StepLabel'] } as never,
           {},
           'label-chain'
         )
     );
 
     const label = startsForTenant(tenantId).find(
-      (record) => record.name === 'ActivityLabel'
+      (record) => record.name === 'StepLabel'
     );
     const rootContext = agentRoot?.spanContext() as {
       traceId: string;
@@ -864,7 +864,7 @@ describe('Langfuse per-run routing integration', () => {
 
     withLangfuseRuntimeScope(
       { langfuse: rootLangfuse, traceAnchor, runId: 'source-run' },
-      () => createMockSpan('StandardGraph')
+      () => createMockSpan('AgentGraph')
     );
     const overlayHandler = createLangfuseHandler({
       langfuse: overlayLangfuse,
@@ -944,7 +944,7 @@ describe('Langfuse per-run routing integration', () => {
       resolveLangfuseDestinationKey(langfuse)
     );
     const roots = startsForTenant(tenantId).filter(
-      (record) => record.name === 'StandardGraph' && record.parentSpanId == null
+      (record) => record.name === 'AgentGraph' && record.parentSpanId == null
     );
 
     expect(roots).toHaveLength(2);

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -3,6 +3,8 @@ import type * as t from '@/types';
 import {
   getLangfuseSpanProcessorParams,
   getLangfuseManagedSpanDestination,
+  registerLangfuseTraceAnchorSpan,
+  resolveLangfuseTraceAnchorParent,
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
@@ -35,6 +37,28 @@ describe('Langfuse span registry', () => {
 
     const untracked = { name: 'foreign' } as unknown as Span;
     expect(getLangfuseManagedSpanDestination(untracked)).toBeUndefined();
+  });
+
+  it('resolves run anchors only for their export destination', () => {
+    const anchor = {};
+    const spanContext = {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+    };
+    const span = {
+      spanContext: () => spanContext,
+    } as unknown as Span;
+    const destinationKey = resolveLangfuseDestinationKey(tenantConfig());
+
+    registerLangfuseTraceAnchorSpan(anchor, span, destinationKey as string);
+
+    expect(resolveLangfuseTraceAnchorParent(anchor, destinationKey)).toEqual(
+      spanContext
+    );
+    expect(
+      resolveLangfuseTraceAnchorParent(anchor, 'another-destination')
+    ).toBeUndefined();
   });
 
   it('treats processor policy as irrelevant to destination identity', () => {

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -4,6 +4,7 @@ import {
   getLangfuseSpanProcessorParams,
   getLangfuseManagedSpanDestination,
   registerLangfuseTraceAnchorSpan,
+  resetLangfuseTraceAnchorSpans,
   resolveLangfuseTraceAnchorParent,
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
@@ -59,6 +60,39 @@ describe('Langfuse span registry', () => {
     expect(
       resolveLangfuseTraceAnchorParent(anchor, 'another-destination')
     ).toBeUndefined();
+  });
+
+  it('rotates captured spans between fresh executions', () => {
+    const anchor = {};
+    const destinationKey = resolveLangfuseDestinationKey(tenantConfig());
+    const firstContext = {
+      traceId: '11111111111111111111111111111111',
+      spanId: '1111111111111111',
+      traceFlags: 1,
+    };
+    const secondContext = {
+      traceId: '22222222222222222222222222222222',
+      spanId: '2222222222222222',
+      traceFlags: 1,
+    };
+    const createSpan = (spanContext: typeof firstContext): Span =>
+      ({ spanContext: () => spanContext }) as unknown as Span;
+
+    registerLangfuseTraceAnchorSpan(
+      anchor,
+      createSpan(firstContext),
+      destinationKey as string
+    );
+    resetLangfuseTraceAnchorSpans(anchor);
+    registerLangfuseTraceAnchorSpan(
+      anchor,
+      createSpan(secondContext),
+      destinationKey as string
+    );
+
+    expect(resolveLangfuseTraceAnchorParent(anchor, destinationKey)).toEqual(
+      secondContext
+    );
   });
 
   it('treats processor policy as irrelevant to destination identity', () => {

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -4,7 +4,6 @@ import {
   getLangfuseSpanProcessorParams,
   getLangfuseManagedSpanDestination,
   registerLangfuseTraceAnchorSpan,
-  resetLangfuseTraceAnchorSpans,
   resolveLangfuseTraceAnchorParent,
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
@@ -60,39 +59,6 @@ describe('Langfuse span registry', () => {
     expect(
       resolveLangfuseTraceAnchorParent(anchor, 'another-destination')
     ).toBeUndefined();
-  });
-
-  it('rotates captured spans between fresh executions', () => {
-    const anchor = {};
-    const destinationKey = resolveLangfuseDestinationKey(tenantConfig());
-    const firstContext = {
-      traceId: '11111111111111111111111111111111',
-      spanId: '1111111111111111',
-      traceFlags: 1,
-    };
-    const secondContext = {
-      traceId: '22222222222222222222222222222222',
-      spanId: '2222222222222222',
-      traceFlags: 1,
-    };
-    const createSpan = (spanContext: typeof firstContext): Span =>
-      ({ spanContext: () => spanContext }) as unknown as Span;
-
-    registerLangfuseTraceAnchorSpan(
-      anchor,
-      createSpan(firstContext),
-      destinationKey as string
-    );
-    resetLangfuseTraceAnchorSpans(anchor);
-    registerLangfuseTraceAnchorSpan(
-      anchor,
-      createSpan(secondContext),
-      destinationKey as string
-    );
-
-    expect(resolveLangfuseTraceAnchorParent(anchor, destinationKey)).toEqual(
-      secondContext
-    );
   });
 
   it('treats processor policy as irrelevant to destination identity', () => {

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -61,6 +61,47 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[OBSERVATION_TYPE]).toBe('agent');
   });
 
+  it('names graph observations for the SDK runtime pattern', () => {
+    const standard = createSpan(
+      'LangGraph',
+      { [METADATA_LANGGRAPH_NODE]: 'agent_primary' },
+      'parent-1'
+    );
+    const multiAgent = createSpan('MultiAgentGraph', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+    });
+
+    shapeLangfuseSpan(standard);
+    shapeLangfuseSpan(multiAgent);
+
+    expect(standard.name).toBe('StandardGraph');
+    expect(standard.attributes[OBSERVATION_TYPE]).toBe('agent');
+    expect(multiAgent.name).toBe('MultiAgentGraph');
+    expect(multiAgent.attributes[OBSERVATION_TYPE]).toBe('agent');
+  });
+
+  it('names the agent prompt-to-model sequence as an SDK operation', () => {
+    const span = createSpan(
+      'RunnableSequence',
+      { [METADATA_LANGGRAPH_NODE]: 'agent=openAI__gpt-5.4' },
+      'parent-1'
+    );
+
+    shapeLangfuseSpan(span);
+
+    expect(span.name).toBe('AgentModelCall');
+    expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
+  });
+
+  it('does not rename unrelated runnable sequences', () => {
+    const span = createSpan('RunnableSequence', {}, 'parent-1');
+
+    shapeLangfuseSpan(span);
+
+    expect(span.name).toBe('RunnableSequence');
+    expect(span.attributes[OBSERVATION_TYPE]).toBeUndefined();
+  });
+
   it('shapes tool nodes as stable dispatch chains with scoped call inputs', () => {
     const messages = [
       { type: 'human', content: 'hello' },
@@ -182,7 +223,10 @@ describe('shapeLangfuseSpan', () => {
     expect(JSON.parse(mixedSpan.attributes[INPUT] as string)).toEqual([
       { name: 'echo', args: { command: 'hi' } },
       { name: 'echo', args: '"raw unparsed' },
-      { name: 'unknown', args: 'nameless — included with the unknown fallback' },
+      {
+        name: 'unknown',
+        args: 'nameless — included with the unknown fallback',
+      },
     ]);
 
     const invalidOnly = [
@@ -231,7 +275,9 @@ describe('shapeLangfuseSpan', () => {
           {
             type: 'ai',
             id: 'ai_array_span',
-            tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
+            tool_calls: [
+              { name: 'echo', args: { command: 'hi' }, id: 'tc_ok' },
+            ],
             invalid_tool_calls: [invalidCall],
           },
         ]),
@@ -250,7 +296,9 @@ describe('shapeLangfuseSpan', () => {
           messages: [
             {
               type: 'ai',
-              tool_calls: [{ name: 'echo', args: { command: 'hi' }, id: 'tc_ok' }],
+              tool_calls: [
+                { name: 'echo', args: { command: 'hi' }, id: 'tc_ok' },
+              ],
               invalid_tool_calls: [invalidCall],
             },
           ],
@@ -487,7 +535,7 @@ describe('shapeLangfuseSpan', () => {
   });
 
   it('marks activity-phase roots as chains even when tagged as agent work', () => {
-    const span = createSpan('summarize-activity-phase', {
+    const span = createSpan('ActivityPhase', {
       [TRACE_TAGS]: JSON.stringify([
         'librechat',
         'activity-phase',
@@ -500,6 +548,7 @@ describe('shapeLangfuseSpan', () => {
 
     shapeLangfuseSpan(span);
 
+    expect(span.name).toBe('ActivityPhase');
     expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
     expect(span.attributes[TRACE_INPUT]).toBe('What changed?');
     expect(span.attributes[TRACE_OUTPUT]).toBe(
@@ -563,13 +612,38 @@ describe('shapeLangfuseSpan', () => {
 
     shapeLangfuseSpan(span);
 
-    expect(span.name).toBe('llm');
+    expect(span.name).toBe('ActivityLabel');
     expect(span.attributes[INPUT]).toBe(originalInput);
     expect(span.attributes[OUTPUT]).toBe(originalOutput);
     expect(span.attributes[TRACE_INPUT]).toBe(
       'Tool calls:\n- bash(ls) → ok\n\nLabel:'
     );
     expect(span.attributes[TRACE_OUTPUT]).toBe(originalOutput);
+  });
+
+  it('names reasoning and phase-label generations by their role', () => {
+    const reasoning = createSpan(
+      'ChatOpenAI',
+      {
+        [OBSERVATION_TYPE]: 'generation',
+        [TRACE_TAGS]: JSON.stringify(['librechat', 'reasoning-label']),
+      },
+      'parent-1'
+    );
+    const phase = createSpan(
+      'ChatOpenAI',
+      {
+        [OBSERVATION_TYPE]: 'generation',
+        [TRACE_TAGS]: JSON.stringify(['librechat', 'activity-phase']),
+      },
+      'parent-1'
+    );
+
+    shapeLangfuseSpan(reasoning);
+    shapeLangfuseSpan(phase);
+
+    expect(reasoning.name).toBe('ReasoningLabel');
+    expect(phase.name).toBe('ActivityPhaseLabel');
   });
 
   it('still reduces observation input on non-generation roots', () => {

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -80,6 +80,19 @@ describe('shapeLangfuseSpan', () => {
     expect(multiAgent.attributes[OBSERVATION_TYPE]).toBe('agent');
   });
 
+  it('types agent-tagged graph roots nested beneath managed hosts', () => {
+    const standard = createSpan(
+      'StandardGraph',
+      { [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']) },
+      'managed-host-span'
+    );
+
+    shapeLangfuseSpan(standard);
+
+    expect(standard.name).toBe('StandardGraph');
+    expect(standard.attributes[OBSERVATION_TYPE]).toBe('agent');
+  });
+
   it('names the agent prompt-to-model sequence as an SDK operation', () => {
     const span = createSpan(
       'RunnableSequence',

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -81,7 +81,7 @@ describe('shapeLangfuseSpan', () => {
     shapeLangfuseSpan(standard);
     shapeLangfuseSpan(multiAgent);
 
-    expect(standard.name).toBe('StandardGraph');
+    expect(standard.name).toBe('AgentGraph');
     expect(standard.attributes[OBSERVATION_TYPE]).toBe('agent');
     expect(multiAgent.name).toBe('MultiAgentGraph');
     expect(multiAgent.attributes[OBSERVATION_TYPE]).toBe('agent');
@@ -89,7 +89,7 @@ describe('shapeLangfuseSpan', () => {
 
   it('types agent-tagged graph roots nested beneath managed hosts', () => {
     const standard = createSpan(
-      'StandardGraph',
+      'AgentGraph',
       {
         [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
         [INPUT]: JSON.stringify({
@@ -104,7 +104,7 @@ describe('shapeLangfuseSpan', () => {
 
     shapeLangfuseSpan(standard);
 
-    expect(standard.name).toBe('StandardGraph');
+    expect(standard.name).toBe('AgentGraph');
     expect(standard.attributes[OBSERVATION_TYPE]).toBe('agent');
     expect(standard.attributes[INPUT]).toBe('Inspect the nested run');
     expect(standard.attributes[OUTPUT]).toBe('Nested run complete');
@@ -567,7 +567,7 @@ describe('shapeLangfuseSpan', () => {
   });
 
   it('marks activity-phase roots as chains even when tagged as agent work', () => {
-    const span = createSpan('ActivityPhase', {
+    const span = createSpan('MultiStepLabel', {
       [TRACE_TAGS]: JSON.stringify([
         'librechat',
         'activity-phase',
@@ -580,7 +580,7 @@ describe('shapeLangfuseSpan', () => {
 
     shapeLangfuseSpan(span);
 
-    expect(span.name).toBe('ActivityPhase');
+    expect(span.name).toBe('MultiStepLabel');
     expect(span.attributes[OBSERVATION_TYPE]).toBe('chain');
     expect(span.attributes[TRACE_INPUT]).toBe('What changed?');
     expect(span.attributes[TRACE_OUTPUT]).toBe(
@@ -645,7 +645,7 @@ describe('shapeLangfuseSpan', () => {
 
     shapeLangfuseSpan(span);
 
-    expect(span.name).toBe('ActivityLabel');
+    expect(span.name).toBe('StepLabel');
     expect(span.attributes[INPUT]).toBe(originalInput);
     expect(span.attributes[OUTPUT]).toBe(originalOutput);
     expect(span.attributes[TRACE_INPUT]).toBe(
@@ -678,7 +678,7 @@ describe('shapeLangfuseSpan', () => {
     shapeLangfuseSpan(phase);
 
     expect(reasoning.name).toBe('ReasoningLabel');
-    expect(phase.name).toBe('ActivityPhaseLabel');
+    expect(phase.name).toBe('MultiStepLabelGeneration');
   });
 
   it('does not derive generation operation names from public tags alone', () => {

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -1,9 +1,15 @@
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
+  ACTIVITY_LABEL_RUN_NAME,
+  REASONING_LABEL_RUN_NAME,
+  ACTIVITY_PHASE_LABEL_RUN_NAME,
+} from '@/common';
+import {
   shapeLangfuseSpan,
   shouldDropLangfuseSpan,
 } from '@/langfuseTraceShaping';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 
 type TestSpan = ReadableSpan & {
   name: string;
@@ -29,6 +35,7 @@ const TRACE_OUTPUT = LangfuseOtelSpanAttributes.TRACE_OUTPUT;
 const OBSERVATION_TYPE = LangfuseOtelSpanAttributes.OBSERVATION_TYPE;
 const TRACE_TAGS = LangfuseOtelSpanAttributes.TRACE_TAGS;
 const METADATA_LANGGRAPH_NODE = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`;
+const METADATA_OPERATION = `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.${LANGFUSE_OPERATION_METADATA_KEY}`;
 
 /** The outer workflow node: a non-root LangGraph node span whose
  *  `langgraph_node` metadata equals its name. */
@@ -83,7 +90,15 @@ describe('shapeLangfuseSpan', () => {
   it('types agent-tagged graph roots nested beneath managed hosts', () => {
     const standard = createSpan(
       'StandardGraph',
-      { [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']) },
+      {
+        [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+        [INPUT]: JSON.stringify({
+          messages: [{ type: 'human', content: 'Inspect the nested run' }],
+        }),
+        [OUTPUT]: JSON.stringify({
+          messages: [{ type: 'ai', content: 'Nested run complete' }],
+        }),
+      },
       'managed-host-span'
     );
 
@@ -91,6 +106,10 @@ describe('shapeLangfuseSpan', () => {
 
     expect(standard.name).toBe('StandardGraph');
     expect(standard.attributes[OBSERVATION_TYPE]).toBe('agent');
+    expect(standard.attributes[INPUT]).toBe('Inspect the nested run');
+    expect(standard.attributes[OUTPUT]).toBe('Nested run complete');
+    expect(standard.attributes[TRACE_INPUT]).toBeUndefined();
+    expect(standard.attributes[TRACE_OUTPUT]).toBeUndefined();
   });
 
   it('names the agent prompt-to-model sequence as an SDK operation', () => {
@@ -619,6 +638,7 @@ describe('shapeLangfuseSpan', () => {
     const span = createSpan('LibreChat Activity Label', {
       [OBSERVATION_TYPE]: 'generation',
       [TRACE_TAGS]: JSON.stringify(['librechat', 'activity-label']),
+      [METADATA_OPERATION]: ACTIVITY_LABEL_RUN_NAME,
       [INPUT]: originalInput,
       [OUTPUT]: originalOutput,
     });
@@ -640,6 +660,7 @@ describe('shapeLangfuseSpan', () => {
       {
         [OBSERVATION_TYPE]: 'generation',
         [TRACE_TAGS]: JSON.stringify(['librechat', 'reasoning-label']),
+        [METADATA_OPERATION]: REASONING_LABEL_RUN_NAME,
       },
       'parent-1'
     );
@@ -648,6 +669,7 @@ describe('shapeLangfuseSpan', () => {
       {
         [OBSERVATION_TYPE]: 'generation',
         [TRACE_TAGS]: JSON.stringify(['librechat', 'activity-phase']),
+        [METADATA_OPERATION]: ACTIVITY_PHASE_LABEL_RUN_NAME,
       },
       'parent-1'
     );
@@ -657,6 +679,25 @@ describe('shapeLangfuseSpan', () => {
 
     expect(reasoning.name).toBe('ReasoningLabel');
     expect(phase.name).toBe('ActivityPhaseLabel');
+  });
+
+  it('does not derive generation operation names from public tags alone', () => {
+    const tags = ['activity-label', 'reasoning-label', 'activity-phase'];
+
+    for (const tag of tags) {
+      const span = createSpan(
+        'ChatOpenAI',
+        {
+          [OBSERVATION_TYPE]: 'generation',
+          [TRACE_TAGS]: JSON.stringify(['librechat', 'agent', tag]),
+        },
+        'parent-1'
+      );
+
+      shapeLangfuseSpan(span);
+
+      expect(span.name).toBe('llm');
+    }
   });
 
   it('still reduces observation input on non-generation roots', () => {

--- a/src/types/activityLabel.ts
+++ b/src/types/activityLabel.ts
@@ -62,8 +62,9 @@ export type RunActivityLabelOptions = {
   };
   /**
    * Seed for deterministic Langfuse trace ids (e.g. `${runId}-${slotIndex}`)
-   * so each batch's label gets a distinct, reproducible trace. When omitted,
-   * a per-run sequence keeps batches from collapsing into one trace.
+   * for a distinct, reproducible fallback trace when the source agent
+   * observation is unavailable. Normally the label is parented into the
+   * source agent trace instead.
    */
   traceSeed?: string;
 };
@@ -112,7 +113,7 @@ export type RunActivityPhaseLabelOptions = {
   traceSeed?: string;
   /** Stable source run identifier recorded on the phase observation. */
   sourceRunId?: string;
-  /** Source Langfuse trace id for linking this detached summary trace. */
+  /** Source Langfuse trace id retained as correlation metadata. */
   sourceTraceId?: string;
   /** Host response/message identifier recorded on the phase observation. */
   responseId?: string;

--- a/src/types/reasoningLabel.ts
+++ b/src/types/reasoningLabel.ts
@@ -52,7 +52,7 @@ export type RunReasoningLabelOptions = {
   traceSeed?: string;
   /** Stable source run identifier recorded on the observation. */
   sourceRunId?: string;
-  /** Source Langfuse trace id for linking this detached label trace. */
+  /** Source Langfuse trace id retained as correlation metadata. */
   sourceTraceId?: string;
   /** Host response/message identifier recorded on the observation. */
   responseId?: string;


### PR DESCRIPTION
I improved Langfuse trace semantics so agent runs expose LibreChat’s runtime patterns and keep generated activity context inside the source trace.

- Rename framework-level graph observations to `AgentGraph` and `MultiAgentGraph`.
- Rename agent prompt-to-model sequences to `AgentModelCall` while leaving unrelated runnable sequences unchanged.
- Preserve generic model calls as `llm` and identify auxiliary generations as `StepLabel`, `ReasoningLabel`, and `MultiStepLabelGeneration`.
- Represent grouped activity summaries as `MultiStepLabel` chains.
- Nest activity, reasoning, and multi-step observations beneath the originating agent run without replacing its trace name or metadata.
- Retain standalone label traces when no safe source observation is available or the Langfuse destination differs.
- Protect per-tenant routing by resolving trace parents only within the matching export destination.
- Expand trace-shaping, routing, registry, activity-label, deterministic-ID, and live-test expectations.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran the focused Langfuse, deterministic trace ID, graph, activity-label, reasoning-label, and activity-phase-label Jest suites.
- Ran TypeScript type checking and ESLint across every changed source and test file.
- Built the complete ESM, CommonJS, and declaration outputs.
- Ran `npm audit --audit-level=low` with zero vulnerabilities.
- Exported credential-backed smoke traces to the development Langfuse project and verified the `AgentGraph` root `AGENT` observation and `StepLabel` `GENERATION` observation.
- Verified structurally that `ReasoningLabel` is a root-child `GENERATION`, `MultiStepLabel` is a root-child `CHAIN`, and `MultiStepLabelGeneration` is its child `GENERATION`.

### **Test Configuration**:

- Node.js 24
- npm 10
- Langfuse development project
- 240 focused tests passed; one provider-credential live test skipped in the normal suite

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
