### PR TITLE
🧵 fix: Isolate Detached Subagent Run Context

### DIFF
--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { GraphInterrupt, MemorySaver } from '@langchain/langgraph';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type {
@@ -624,6 +625,58 @@ describe('SubagentExecutor', () => {
     expect(fallbackFactory).not.toHaveBeenCalled();
     expect(clearHeavyState).toHaveBeenCalled();
     expect(hookRegistry.hasHookFor('PreToolUse', 'test-run')).toBe(false);
+  });
+
+  it('replaces the ambient parent run config for detached child execution', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const parentController = new AbortController();
+    let observedSignal: AbortSignal | undefined;
+    let finish = (_value: { messages: BaseMessage[] }): void => undefined;
+    const invocation = new Promise<{ messages: BaseMessage[] }>((resolve) => {
+      finish = resolve;
+    });
+    const invoke = jest.fn(async () => {
+      observedSignal = AsyncLocalStorageProviderSingleton.getRunnableConfig()
+        ?.signal as AbortSignal | undefined;
+      return invocation;
+    });
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const response = await AsyncLocalStorageProviderSingleton.runWithConfig(
+      { signal: parentController.signal },
+      async () =>
+        JSON.parse(
+          executor.executeInBackground({
+            description: 'Outlive the parent turn.',
+            subagentType: 'researcher',
+            parentToolCallId: 'call_detached_signal',
+          })
+        ) as { background_task_id: string }
+    );
+    await waitForTask(
+      store,
+      response.background_task_id,
+      () => invoke.mock.calls.length > 0
+    );
+
+    parentController.abort();
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal).not.toBe(parentController.signal);
+    expect(observedSignal?.aborted).toBe(false);
+
+    finish({ messages: [new AIMessage('detached result')] });
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
   });
 
   it('continues the same detached child for a queued parent message', async () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2745,10 +2745,14 @@ export class SubagentExecutor {
 
         for (;;) {
           let childResult: MultiAgentGraphState;
-          if (this.humanInTheLoop?.enabled === true) {
-            /** Execute as an independently checkpointed root instead of inheriting
-             * the parent's Pregel namespace. Parent decisions are routed explicitly
-             * by interrupt id, so concurrent children keep isolated resume state. */
+          if (
+            this.humanInTheLoop?.enabled === true ||
+            params.taskRuntime != null
+          ) {
+            /** Execute as an independent LangGraph root. HITL children need an
+             * isolated Pregel namespace, while detached children must replace the
+             * parent ToolNode's ambient runnable config so its AbortSignal cannot
+             * cancel task-owned work when the parent stream settles. */
             childResult =
               await AsyncLocalStorageProviderSingleton.runWithConfig(
                 childInvokeConfig,


### PR DESCRIPTION
## Summary

I isolated detached subagent executions from the parent ToolNode's ambient LangGraph runnable configuration so a completed parent turn cannot abort still-running background children.

- Run detached child workflows inside a task-owned runnable context carrying the detached task's abort signal.
- Preserve existing foreground and HITL cancellation behavior.
- Add a regression that starts detached work inside a parent signal context, aborts the parent, and proves the child retains its independent live signal and completes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/__tests__/SubagentExecutor.test.ts --runInBand` (124/124)
- `npx eslint src/tools/subagent/SubagentExecutor.ts src/tools/__tests__/SubagentExecutor.test.ts --max-warnings=0`
- `npx tsc --noEmit`
- `git diff --check`

### **Test Configuration**:

- Node.js local development environment
- Reproduced from a real LibreChat two-child fan-out where the faster detached child completed and the slower child received `AbortError` as the parent turn settled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in the complex lifecycle area
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
