### PR TITLE
v3.6.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.6.8",
+      "version": "3.6.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
## Summary

I bumped @librechat/agents to 3.6.9 so the detached subagent runnable-context fix from #437 can publish and be consumed by LibreChat.

- Publish the task-owned detached execution context fix.
- Prevent a settled parent ToolNode signal from aborting a still-running background child.
- Unblock the LibreChat fan-out deployment and exact production canary.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified package.json and package-lock.json both resolve to 3.6.9.
- git diff --check
- Relies on the fully green CI and live two-child fan-out canary from #437.

### **Test Configuration**:

- Node.js package release workflow
- Live LibreChat API with the exact #437 SDK build hot-deployed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that the underlying fix is effective
- [x] Local unit tests pass with the underlying fix