### PR TITLE
🎭 feat: Langfuse privacy masking for trace content

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -63,9 +63,9 @@ export const COMPACTION_SEMANTIC_INDEX_LIMITS = Object.freeze({
 } as const);
 
 /**
- * Whether this build enforces `LangfuseConfig.privacy` (content masking and
- * media suppression on exported traces). Hosts gate on it to fail closed:
- * with an older runtime that ignores the field, a privacy mode must disable
- * export rather than silently send unmasked content.
+ * Whether this build enforces `LangfuseConfig.privacy` (content redaction
+ * and media suppression on exported traces). Hosts gate on it to fail
+ * closed: with an older runtime that ignores the field, a privacy mode must
+ * disable export rather than silently send unmasked content.
  */
-export const LANGFUSE_PRIVACY_MASKING_SUPPORTED = true;
+export const LANGFUSE_PRIVACY_ENFORCEMENT_SUPPORTED = true;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -61,3 +61,11 @@ export const COMPACTION_SEMANTIC_INDEX_LIMITS = Object.freeze({
   maxIdentityChars: 512,
   maxSourceContentIndex: 4_095,
 } as const);
+
+/**
+ * Whether this build enforces `LangfuseConfig.privacy` (content masking and
+ * media suppression on exported traces). Hosts gate on it to fail closed:
+ * with an older runtime that ignores the field, a privacy mode must disable
+ * export rather than silently send unmasked content.
+ */
+export const LANGFUSE_PRIVACY_MASKING_SUPPORTED = true;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -79,8 +79,9 @@ export function ensureOpenTelemetryContextManager(): void {
 }
 
 /** Cache key for processor instances: the destination plus processor-level
- *  policy (`toolOutputTracing` is baked into each processor's redaction
- *  behavior), unlike the pure destination identity used for span parenting. */
+ *  policy (`toolOutputTracing` and `privacy` are baked into each processor's
+ *  redaction behavior), unlike the pure destination identity used for span
+ *  parenting. */
 function getLangfuseProcessorCacheKey(
   destinationKey: string,
   langfuse?: t.LangfuseConfig
@@ -89,6 +90,7 @@ function getLangfuseProcessorCacheKey(
     destinationKey,
     mediaUploadEnabled: langfuse?.mediaUploadEnabled,
     toolOutputTracing: langfuse?.toolOutputTracing,
+    privacy: langfuse?.privacy,
   });
 }
 

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -709,7 +709,9 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
 
 function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
   return (
-    langfuse?.toolNodeTracing != null || langfuse?.toolOutputTracing != null
+    langfuse?.toolNodeTracing != null ||
+    langfuse?.toolOutputTracing != null ||
+    langfuse?.privacy != null
   );
 }
 

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -1,6 +1,7 @@
 import type { MaskFunction } from '@langfuse/otel';
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { parseBooleanEnv } from '@/utils/misc';
 
 export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
@@ -162,19 +163,37 @@ export function resolveLangfusePrivacyConfig(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
 ): t.LangfusePrivacyConfig | undefined {
-  const runPrivacy = runLangfuse?.privacy;
-  const agentPrivacy = agentLangfuse?.privacy;
-  if (runPrivacy == null && agentPrivacy == null) {
+  // Overlay order: the agent's fields win per-field, like every other
+  // per-field merge in this module.
+  return resolveStrictestLangfusePrivacy([
+    agentLangfuse?.privacy,
+    runLangfuse?.privacy,
+  ]);
+}
+
+/**
+ * Resolves the strictest policy across any number of configs (a run plus
+ * every agent overlay). Shared spans (the run's root trace, conversation
+ * payloads, activity-phase traces) carry every agent's content, so their
+ * policy must be at least as strict as each contributor's.
+ */
+export function resolveStrictestLangfusePrivacy(
+  privacies: Array<t.LangfusePrivacyConfig | undefined>
+): t.LangfusePrivacyConfig | undefined {
+  const present = privacies.filter(
+    (privacy): privacy is t.LangfusePrivacyConfig => privacy != null
+  );
+  if (present.length === 0) {
     return undefined;
   }
   // The stricter mode wins so an agent overlay can tighten the run's
   // privacy policy but never loosen it.
-  const mode =
-    runPrivacy?.mode === 'metricsOnly' || agentPrivacy?.mode === 'metricsOnly'
-      ? 'metricsOnly'
-      : 'full';
-  const redactionText =
-    agentPrivacy?.redactionText ?? runPrivacy?.redactionText;
+  const mode = present.some((privacy) => privacy.mode === 'metricsOnly')
+    ? 'metricsOnly'
+    : 'full';
+  const redactionText = present.find(
+    (privacy) => privacy.redactionText != null
+  )?.redactionText;
   return {
     mode,
     ...(redactionText != null ? { redactionText } : {}),
@@ -182,10 +201,48 @@ export function resolveLangfusePrivacyConfig(
 }
 
 /**
+ * Run-correlation identity preserved from masked metadata values. These keys
+ * are SDK-written identifiers (never user content) that Langfuse consumers
+ * need to link observations back to LibreChat runs, so `metricsOnly` keeps
+ * them while every other metadata entry is dropped.
+ */
+const PRESERVED_TRACE_IDENTITY_KEYS = [
+  'messageId',
+  'parentMessageId',
+  'agentId',
+  'agentName',
+  'sourceRunId',
+  'responseId',
+  LANGFUSE_OPERATION_METADATA_KEY,
+] as const;
+
+export function resolveLangfuseContentRedactionText(
+  privacy?: t.LangfusePrivacyConfig
+): string {
+  return isPresent(privacy?.redactionText)
+    ? privacy.redactionText.trim()
+    : LANGFUSE_CONTENT_REDACTION_TEXT;
+}
+
+function preserveTraceIdentity(value: object, redactionText: string): string {
+  const preserved: Record<string, unknown> = {};
+  for (const key of PRESERVED_TRACE_IDENTITY_KEYS) {
+    if (key in value) {
+      preserved[key] = (value as Record<string, unknown>)[key];
+    }
+  }
+  return Object.keys(preserved).length > 0
+    ? JSON.stringify(preserved)
+    : redactionText;
+}
+
+/**
  * Builds the SDK mask that replaces content-bearing trace and observation
  * attributes (input, output, metadata) with the configured redaction text.
- * The span processor applies the mask before export and, should the mask
- * itself throw, fully masks the value instead of exporting it verbatim.
+ * Object-shaped values keep only run-correlation identity keys, so trace
+ * metadata still links observations to runs. The span processor applies the
+ * mask before export and, should the mask itself throw, fully masks the
+ * value instead of exporting it verbatim.
  */
 export function createLangfusePrivacyMask(
   privacy?: t.LangfusePrivacyConfig
@@ -193,10 +250,24 @@ export function createLangfusePrivacyMask(
   if (privacy?.mode !== 'metricsOnly') {
     return undefined;
   }
-  const redactionText = isPresent(privacy.redactionText)
-    ? privacy.redactionText.trim()
-    : LANGFUSE_CONTENT_REDACTION_TEXT;
-  return () => redactionText;
+  const redactionText = resolveLangfuseContentRedactionText(privacy);
+  return ({ data }) => {
+    if (typeof data === 'string') {
+      const trimmed = data.trim();
+      if (trimmed.startsWith('{')) {
+        try {
+          return preserveTraceIdentity(JSON.parse(trimmed), redactionText);
+        } catch {
+          return redactionText;
+        }
+      }
+      return redactionText;
+    }
+    if (data != null && typeof data === 'object' && !Array.isArray(data)) {
+      return preserveTraceIdentity(data, redactionText);
+    }
+    return redactionText;
+  };
 }
 
 export function resolveToolOutputTracingConfig(

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -1,8 +1,10 @@
+import type { MaskFunction } from '@langfuse/otel';
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
 import { parseBooleanEnv } from '@/utils/misc';
 
 export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
+export const LANGFUSE_CONTENT_REDACTION_TEXT = '[CONTENT REDACTED]';
 
 function isPresent(value: unknown): value is string {
   return typeof value === 'string' && value.trim() !== '';
@@ -156,6 +158,47 @@ export function hasToolOutputTracingConfig(
   );
 }
 
+export function resolveLangfusePrivacyConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): t.LangfusePrivacyConfig | undefined {
+  const runPrivacy = runLangfuse?.privacy;
+  const agentPrivacy = agentLangfuse?.privacy;
+  if (runPrivacy == null && agentPrivacy == null) {
+    return undefined;
+  }
+  // The stricter mode wins so an agent overlay can tighten the run's
+  // privacy policy but never loosen it.
+  const mode =
+    runPrivacy?.mode === 'metricsOnly' || agentPrivacy?.mode === 'metricsOnly'
+      ? 'metricsOnly'
+      : 'full';
+  const redactionText =
+    agentPrivacy?.redactionText ?? runPrivacy?.redactionText;
+  return {
+    mode,
+    ...(redactionText != null ? { redactionText } : {}),
+  };
+}
+
+/**
+ * Builds the SDK mask that replaces content-bearing trace and observation
+ * attributes (input, output, metadata) with the configured redaction text.
+ * The span processor applies the mask before export and, should the mask
+ * itself throw, fully masks the value instead of exporting it verbatim.
+ */
+export function createLangfusePrivacyMask(
+  privacy?: t.LangfusePrivacyConfig
+): MaskFunction | undefined {
+  if (privacy?.mode !== 'metricsOnly') {
+    return undefined;
+  }
+  const redactionText = isPresent(privacy.redactionText)
+    ? privacy.redactionText.trim()
+    : LANGFUSE_CONTENT_REDACTION_TEXT;
+  return () => redactionText;
+}
+
 export function resolveToolOutputTracingConfig(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
@@ -267,6 +310,7 @@ export function resolveLangfuseConfig(
         ]),
       ]
       : undefined;
+  const privacy = resolveLangfusePrivacyConfig(runLangfuse, agentLangfuse);
 
   return {
     ...runLangfuse,
@@ -277,5 +321,6 @@ export function resolveLangfuseConfig(
     ...(tags != null ? { tags } : {}),
     ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
     ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
+    ...(privacy != null ? { privacy } : {}),
   };
 }

--- a/src/langfuseConfig.ts
+++ b/src/langfuseConfig.ts
@@ -1,7 +1,5 @@
-import type { MaskFunction } from '@langfuse/otel';
 import type { ResolvedLangfuseToolOutputTracingConfig } from '@/langfuseRuntimeContext';
 import type * as t from '@/types';
-import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { parseBooleanEnv } from '@/utils/misc';
 
 export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
@@ -159,62 +157,31 @@ export function hasToolOutputTracingConfig(
   );
 }
 
+/**
+ * Resolves the effective privacy policy. Privacy is a run-level deployment
+ * policy, not a per-agent knob: shared spans (the root trace, conversation
+ * payloads, activity-phase traces, parent generations embedding subagent
+ * results) carry every agent's content, and a policy that only some of them
+ * enforce would leak the others'. Agent overlays therefore cannot set it,
+ * and one that asks for `metricsOnly` when the run has not fails closed
+ * (export disabled) rather than export content the host asked to suppress.
+ */
 export function resolveLangfusePrivacyConfig(
+  runLangfuse?: t.LangfuseConfig
+): t.LangfusePrivacyConfig | undefined {
+  return runLangfuse?.privacy;
+}
+
+/** Whether an agent overlay demands privacy the run does not provide. */
+export function hasUnsupportedAgentPrivacy(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
-): t.LangfusePrivacyConfig | undefined {
-  // Overlay order: the agent's fields win per-field, like every other
-  // per-field merge in this module.
-  return resolveStrictestLangfusePrivacy([
-    agentLangfuse?.privacy,
-    runLangfuse?.privacy,
-  ]);
-}
-
-/**
- * Resolves the strictest policy across any number of configs (a run plus
- * every agent overlay). Shared spans (the run's root trace, conversation
- * payloads, activity-phase traces) carry every agent's content, so their
- * policy must be at least as strict as each contributor's.
- */
-export function resolveStrictestLangfusePrivacy(
-  privacies: Array<t.LangfusePrivacyConfig | undefined>
-): t.LangfusePrivacyConfig | undefined {
-  const present = privacies.filter(
-    (privacy): privacy is t.LangfusePrivacyConfig => privacy != null
+): boolean {
+  return (
+    agentLangfuse?.privacy?.mode === 'metricsOnly' &&
+    runLangfuse?.privacy?.mode !== 'metricsOnly'
   );
-  if (present.length === 0) {
-    return undefined;
-  }
-  // The stricter mode wins so an agent overlay can tighten the run's
-  // privacy policy but never loosen it.
-  const mode = present.some((privacy) => privacy.mode === 'metricsOnly')
-    ? 'metricsOnly'
-    : 'full';
-  const redactionText = present.find(
-    (privacy) => privacy.redactionText != null
-  )?.redactionText;
-  return {
-    mode,
-    ...(redactionText != null ? { redactionText } : {}),
-  };
 }
-
-/**
- * Run-correlation identity preserved from masked metadata values. These keys
- * are SDK-written identifiers (never user content) that Langfuse consumers
- * need to link observations back to LibreChat runs, so `metricsOnly` keeps
- * them while every other metadata entry is dropped.
- */
-const PRESERVED_TRACE_IDENTITY_KEYS = [
-  'messageId',
-  'parentMessageId',
-  'agentId',
-  'agentName',
-  'sourceRunId',
-  'responseId',
-  LANGFUSE_OPERATION_METADATA_KEY,
-] as const;
 
 export function resolveLangfuseContentRedactionText(
   privacy?: t.LangfusePrivacyConfig
@@ -222,52 +189,6 @@ export function resolveLangfuseContentRedactionText(
   return isPresent(privacy?.redactionText)
     ? privacy.redactionText.trim()
     : LANGFUSE_CONTENT_REDACTION_TEXT;
-}
-
-function preserveTraceIdentity(value: object, redactionText: string): string {
-  const preserved: Record<string, unknown> = {};
-  for (const key of PRESERVED_TRACE_IDENTITY_KEYS) {
-    if (key in value) {
-      preserved[key] = (value as Record<string, unknown>)[key];
-    }
-  }
-  return Object.keys(preserved).length > 0
-    ? JSON.stringify(preserved)
-    : redactionText;
-}
-
-/**
- * Builds the SDK mask that replaces content-bearing trace and observation
- * attributes (input, output, metadata) with the configured redaction text.
- * Object-shaped values keep only run-correlation identity keys, so trace
- * metadata still links observations to runs. The span processor applies the
- * mask before export and, should the mask itself throw, fully masks the
- * value instead of exporting it verbatim.
- */
-export function createLangfusePrivacyMask(
-  privacy?: t.LangfusePrivacyConfig
-): MaskFunction | undefined {
-  if (privacy?.mode !== 'metricsOnly') {
-    return undefined;
-  }
-  const redactionText = resolveLangfuseContentRedactionText(privacy);
-  return ({ data }) => {
-    if (typeof data === 'string') {
-      const trimmed = data.trim();
-      if (trimmed.startsWith('{')) {
-        try {
-          return preserveTraceIdentity(JSON.parse(trimmed), redactionText);
-        } catch {
-          return redactionText;
-        }
-      }
-      return redactionText;
-    }
-    if (data != null && typeof data === 'object' && !Array.isArray(data)) {
-      return preserveTraceIdentity(data, redactionText);
-    }
-    return redactionText;
-  };
 }
 
 export function resolveToolOutputTracingConfig(
@@ -332,7 +253,15 @@ export function resolveLangfuseConfig(
   agentLangfuse?: t.LangfuseConfig
 ): t.LangfuseConfig | undefined {
   if (runLangfuse == null) {
-    return agentLangfuse;
+    // No run config exists to carry a run-level policy, so the overlay's
+    // privacy cannot be enforced either: strip it, failing closed when it
+    // asked for metricsOnly.
+    if (agentLangfuse?.privacy?.mode === 'metricsOnly') {
+      return { ...agentLangfuse, privacy: undefined, enabled: false };
+    }
+    return agentLangfuse?.privacy == null
+      ? agentLangfuse
+      : { ...agentLangfuse, privacy: undefined };
   }
   if (agentLangfuse == null) {
     return runLangfuse;
@@ -381,8 +310,6 @@ export function resolveLangfuseConfig(
         ]),
       ]
       : undefined;
-  const privacy = resolveLangfusePrivacyConfig(runLangfuse, agentLangfuse);
-
   return {
     ...runLangfuse,
     ...agentLangfuse,
@@ -392,6 +319,12 @@ export function resolveLangfuseConfig(
     ...(tags != null ? { tags } : {}),
     ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
     ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
-    ...(privacy != null ? { privacy } : {}),
+    // Privacy is run-level: the overlay's copy above never takes effect.
+    ...(runLangfuse.privacy != null
+      ? { privacy: runLangfuse.privacy }
+      : { privacy: undefined }),
+    ...(hasUnsupportedAgentPrivacy(runLangfuse, agentLangfuse)
+      ? { enabled: false }
+      : {}),
   };
 }

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -4,7 +4,6 @@ import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Span, SpanContext } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
-  createLangfusePrivacyMask,
   hasLangfuseConfigCredentials,
   hasLangfuseEnvCredentials,
   hasLangfuseEnvConfig,
@@ -152,14 +151,14 @@ export function getLangfuseSpanProcessorParams(
   const additionalHeaders = hasAdditionalHeaders(langfuse?.additionalHeaders)
     ? { additionalHeaders: langfuse.additionalHeaders }
     : {};
-  const mask = createLangfusePrivacyMask(langfuse?.privacy);
   // metricsOnly suppresses media too: media payloads are content, so the
-  // processor must not run its media create/upload/patch operations.
-  const mediaUploadEnabled =
-    mask != null ? false : langfuse?.mediaUploadEnabled;
+  // processor must not run its media create/upload/patch operations. Content
+  // attributes themselves are redacted by the wrapping span processor, which
+  // unlike the SDK `mask` callback knows which attribute it is handling.
+  const metricsOnly = langfuse?.privacy?.mode === 'metricsOnly';
+  const mediaUploadEnabled = metricsOnly ? false : langfuse?.mediaUploadEnabled;
   const contentPolicy = {
     ...(mediaUploadEnabled != null ? { mediaUploadEnabled } : {}),
-    ...(mask != null ? { mask } : {}),
   };
   if (hasLangfuseConfigCredentials(langfuse)) {
     return {

--- a/src/langfuseSpanRegistry.ts
+++ b/src/langfuseSpanRegistry.ts
@@ -4,6 +4,7 @@ import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Span, SpanContext } from '@opentelemetry/api';
 import type * as t from '@/types';
 import {
+  createLangfusePrivacyMask,
   hasLangfuseConfigCredentials,
   hasLangfuseEnvCredentials,
   hasLangfuseEnvConfig,
@@ -151,15 +152,22 @@ export function getLangfuseSpanProcessorParams(
   const additionalHeaders = hasAdditionalHeaders(langfuse?.additionalHeaders)
     ? { additionalHeaders: langfuse.additionalHeaders }
     : {};
+  const mask = createLangfusePrivacyMask(langfuse?.privacy);
+  // metricsOnly suppresses media too: media payloads are content, so the
+  // processor must not run its media create/upload/patch operations.
+  const mediaUploadEnabled =
+    mask != null ? false : langfuse?.mediaUploadEnabled;
+  const contentPolicy = {
+    ...(mediaUploadEnabled != null ? { mediaUploadEnabled } : {}),
+    ...(mask != null ? { mask } : {}),
+  };
   if (hasLangfuseConfigCredentials(langfuse)) {
     return {
       publicKey: langfuse.publicKey,
       secretKey: langfuse.secretKey,
       ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
       ...(isPresent(environment) ? { environment } : {}),
-      ...(langfuse.mediaUploadEnabled != null
-        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
-        : {}),
+      ...contentPolicy,
       ...additionalHeaders,
     };
   }
@@ -173,9 +181,7 @@ export function getLangfuseSpanProcessorParams(
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       ...(isPresent(baseUrl) ? { baseUrl } : {}),
       ...(isPresent(environment) ? { environment } : {}),
-      ...(langfuse?.mediaUploadEnabled != null
-        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
-        : {}),
+      ...contentPolicy,
       ...additionalHeaders,
     };
   }
@@ -185,9 +191,7 @@ export function getLangfuseSpanProcessorParams(
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
       baseUrl: langfuse.baseUrl,
       ...(isPresent(environment) ? { environment } : {}),
-      ...(langfuse.mediaUploadEnabled != null
-        ? { mediaUploadEnabled: langfuse.mediaUploadEnabled }
-        : {}),
+      ...contentPolicy,
       ...additionalHeaders,
     };
   }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -15,6 +15,8 @@ import {
   normalizeToolName,
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
+  resolveLangfuseContentRedactionText,
+  resolveLangfusePrivacyConfig
 } from '@/langfuseConfig';
 import {
   shapeLangfuseSpan,
@@ -784,20 +786,60 @@ export function redactLangfuseSpanToolOutputs(
   }
 }
 
+/**
+ * Redacts content the SDK mask never sees: the OTel status message and
+ * exception events. Error strings routinely embed request data (a tool
+ * reporting an invalid user value, an upstream response body), and the
+ * Langfuse mask only rewrites the input, output, and metadata attribute
+ * families, so `metricsOnly` closes this channel itself. The status code
+ * stays: error vs. ok is operational data.
+ */
+function redactLangfuseSpanStatusContent(
+  span: ReadableSpan,
+  redactionText: string
+): void {
+  if (isPresent(span.status.message)) {
+    span.status.message = redactionText;
+  }
+  const statusMessageKey =
+    LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE;
+  if (statusMessageKey in span.attributes) {
+    span.attributes[statusMessageKey] = redactionText;
+  }
+  for (const event of span.events) {
+    if (event.name !== 'exception') {
+      continue;
+    }
+    for (const key of ['exception.message', 'exception.stacktrace']) {
+      if (event.attributes != null && key in event.attributes) {
+        event.attributes[key] = redactionText;
+      }
+    }
+  }
+}
+
 export function prepareLangfuseSpanForExport(
   span: ReadableSpan,
-  config?: ResolvedLangfuseToolOutputTracingConfig
+  config?: ResolvedLangfuseToolOutputTracingConfig,
+  privacy?: t.LangfusePrivacyConfig
 ): void {
   classifyLangfuseToolNodeSpan(span);
   if (config != null) {
     redactLangfuseSpanToolOutputs(span, config);
   }
   shapeLangfuseSpan(span);
+  if (privacy?.mode === 'metricsOnly') {
+    redactLangfuseSpanStatusContent(
+      span,
+      resolveLangfuseContentRedactionText(privacy)
+    );
+  }
 }
 
 class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   private readonly processor: LangfuseSpanProcessor;
   private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
+  private readonly privacy?: t.LangfusePrivacyConfig;
   private readonly spanConfigs = new WeakMap<
     object,
     ResolvedLangfuseToolOutputTracingConfig
@@ -805,10 +847,12 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
 
   constructor(
     params?: LangfuseSpanProcessorParams,
-    fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig
+    fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig,
+    privacy?: t.LangfusePrivacyConfig
   ) {
     this.processor = new LangfuseSpanProcessor(params);
     this.fallbackConfig = fallbackConfig;
+    this.privacy = privacy;
   }
 
   onStart(span: Span, parentContext: Context): void {
@@ -829,7 +873,7 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
       return;
     }
     const config = this.spanConfigs.get(span) ?? this.fallbackConfig;
-    prepareLangfuseSpanForExport(span, config);
+    prepareLangfuseSpanForExport(span, config, this.privacy);
     this.processor.onEnd(span);
   }
 
@@ -850,7 +894,11 @@ export function createLangfuseSpanProcessor(
   const fallbackConfig = hasToolOutputTracingConfig(runLangfuse, agentLangfuse)
     ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
     : undefined;
-  return new ToolOutputRedactingLangfuseSpanProcessor(params, fallbackConfig);
+  return new ToolOutputRedactingLangfuseSpanProcessor(
+    params,
+    fallbackConfig,
+    resolveLangfusePrivacyConfig(runLangfuse, agentLangfuse)
+  );
 }
 
 function hasLangfuseEnvKeys(): boolean {

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -832,6 +832,28 @@ function preserveTraceIdentity(value: unknown, redactionText: string): string {
     : redactionText;
 }
 
+/** Metadata also rides flattened, one attribute per entry. */
+const PRESERVED_TRACE_IDENTITY_KEY_SET = new Set<string>(
+  PRESERVED_TRACE_IDENTITY_KEYS
+);
+
+function redactFlattenedMetadata(attributes: Record<string, unknown>): void {
+  const prefixes = [
+    `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.`,
+    `${LangfuseOtelSpanAttributes.TRACE_METADATA}.`,
+  ];
+  for (const key of Object.keys(attributes)) {
+    const prefix = prefixes.find((candidate) => key.startsWith(candidate));
+    if (prefix == null) {
+      continue;
+    }
+    if (PRESERVED_TRACE_IDENTITY_KEY_SET.has(key.slice(prefix.length))) {
+      continue;
+    }
+    delete attributes[key];
+  }
+}
+
 /**
  * Applies the `metricsOnly` policy to a span's content-bearing attributes
  * before export.
@@ -842,7 +864,12 @@ function preserveTraceIdentity(value: unknown, redactionText: string): string {
  * preserve same-named keys in user content (a tool returning
  * `{"messageId": "..."}`), and a blanket replacement would strip the
  * identity Langfuse consumers need. Per-attribute, input and output values
- * are replaced wholesale while metadata keeps only SDK-written identifiers.
+ * are replaced wholesale while metadata keeps only SDK-written identifiers;
+ * flattened metadata entries are dropped unless they carry that identity.
+ *
+ * Model parameters are redacted too: they can embed content-bearing values
+ * (caller-supplied stop strings, user identifiers, tool schemas and
+ * descriptions). The model name, usage, and cost attributes stay.
  *
  * Fail closed: if any step throws, every masked family is replaced with the
  * redaction text instead of exporting the value verbatim.
@@ -858,6 +885,7 @@ function redactLangfuseSpanContent(
     LangfuseOtelSpanAttributes.TRACE_INPUT,
     LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
     LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+    LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS,
   ];
   const metadataKeys = [
     LangfuseOtelSpanAttributes.OBSERVATION_METADATA,
@@ -874,6 +902,7 @@ function redactLangfuseSpanContent(
         attributes[key] = preserveTraceIdentity(attributes[key], redactionText);
       }
     }
+    redactFlattenedMetadata(attributes);
     redactLangfuseSpanStatusContent(span, redactionText);
   } catch {
     for (const key of [...contentKeys, ...metadataKeys]) {
@@ -882,6 +911,7 @@ function redactLangfuseSpanContent(
       }
     }
     try {
+      redactFlattenedMetadata(attributes);
       redactLangfuseSpanStatusContent(span, redactionText);
     } catch {
       // Status redaction is best-effort; content attributes above are the

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -16,13 +16,14 @@ import {
   resolveLangfuseConfig,
   resolveToolOutputTracingConfig,
   resolveLangfuseContentRedactionText,
-  resolveLangfusePrivacyConfig
+  resolveLangfusePrivacyConfig,
 } from '@/langfuseConfig';
 import {
   shapeLangfuseSpan,
   shouldDropLangfuseSpan,
 } from '@/langfuseTraceShaping';
 import { resolveToolOutputTracingConfigForSpan } from '@/langfuseRuntimeScope';
+import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 
 export { LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT, resolveLangfuseConfig };
 
@@ -787,12 +788,113 @@ export function redactLangfuseSpanToolOutputs(
 }
 
 /**
- * Redacts content the SDK mask never sees: the OTel status message and
- * exception events. Error strings routinely embed request data (a tool
- * reporting an invalid user value, an upstream response body), and the
- * Langfuse mask only rewrites the input, output, and metadata attribute
- * families, so `metricsOnly` closes this channel itself. The status code
- * stays: error vs. ok is operational data.
+ * Run-correlation identity preserved from masked metadata values. These keys
+ * are SDK-written identifiers (never user content) that Langfuse consumers
+ * need to link observations back to LibreChat runs, so `metricsOnly` keeps
+ * them while every other metadata entry is dropped.
+ */
+const PRESERVED_TRACE_IDENTITY_KEYS = [
+  'messageId',
+  'parentMessageId',
+  'agentId',
+  'agentName',
+  'sourceRunId',
+  'responseId',
+  LANGFUSE_OPERATION_METADATA_KEY,
+] as const;
+
+function preserveTraceIdentity(value: unknown, redactionText: string): string {
+  if (typeof value !== 'string') {
+    return redactionText;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{')) {
+    return redactionText;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return redactionText;
+  }
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return redactionText;
+  }
+  const source = parsed as Record<string, unknown>;
+  const preserved: Record<string, unknown> = {};
+  for (const key of PRESERVED_TRACE_IDENTITY_KEYS) {
+    if (key in source) {
+      preserved[key] = source[key];
+    }
+  }
+  return Object.keys(preserved).length > 0
+    ? JSON.stringify(preserved)
+    : redactionText;
+}
+
+/**
+ * Applies the `metricsOnly` policy to a span's content-bearing attributes
+ * before export.
+ *
+ * Redaction happens here rather than through the Langfuse span processor's
+ * `mask` callback because the callback cannot tell which attribute it is
+ * handling: preserving run-correlation identity in metadata would also
+ * preserve same-named keys in user content (a tool returning
+ * `{"messageId": "..."}`), and a blanket replacement would strip the
+ * identity Langfuse consumers need. Per-attribute, input and output values
+ * are replaced wholesale while metadata keeps only SDK-written identifiers.
+ *
+ * Fail closed: if any step throws, every masked family is replaced with the
+ * redaction text instead of exporting the value verbatim.
+ */
+function redactLangfuseSpanContent(
+  span: ReadableSpan,
+  privacy: t.LangfusePrivacyConfig
+): void {
+  const redactionText = resolveLangfuseContentRedactionText(privacy);
+  const attributes = span.attributes;
+  const contentKeys = [
+    LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+    LangfuseOtelSpanAttributes.TRACE_INPUT,
+    LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+    LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+  ];
+  const metadataKeys = [
+    LangfuseOtelSpanAttributes.OBSERVATION_METADATA,
+    LangfuseOtelSpanAttributes.TRACE_METADATA,
+  ];
+  try {
+    for (const key of contentKeys) {
+      if (key in attributes) {
+        attributes[key] = redactionText;
+      }
+    }
+    for (const key of metadataKeys) {
+      if (key in attributes) {
+        attributes[key] = preserveTraceIdentity(attributes[key], redactionText);
+      }
+    }
+    redactLangfuseSpanStatusContent(span, redactionText);
+  } catch {
+    for (const key of [...contentKeys, ...metadataKeys]) {
+      if (key in attributes) {
+        attributes[key] = redactionText;
+      }
+    }
+    try {
+      redactLangfuseSpanStatusContent(span, redactionText);
+    } catch {
+      // Status redaction is best-effort; content attributes above are the
+      // values that must never export verbatim.
+    }
+  }
+}
+
+/**
+ * Redacts content that rides outside the masked attribute families: the
+ * OTel status message and exception events. Error strings routinely embed
+ * request data (a tool reporting an invalid user value, an upstream
+ * response body). The status code stays: error vs. ok is operational data.
  */
 function redactLangfuseSpanStatusContent(
   span: ReadableSpan,
@@ -829,10 +931,7 @@ export function prepareLangfuseSpanForExport(
   }
   shapeLangfuseSpan(span);
   if (privacy?.mode === 'metricsOnly') {
-    redactLangfuseSpanStatusContent(
-      span,
-      resolveLangfuseContentRedactionText(privacy)
-    );
+    redactLangfuseSpanContent(span, privacy);
   }
 }
 
@@ -897,7 +996,7 @@ export function createLangfuseSpanProcessor(
   return new ToolOutputRedactingLangfuseSpanProcessor(
     params,
     fallbackConfig,
-    resolveLangfusePrivacyConfig(runLangfuse, agentLangfuse)
+    resolveLangfusePrivacyConfig(runLangfuse)
   );
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,16 +59,17 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
+  hasToolOutputTracingConfig,
+  resolveLangfuseConfig,
+  resolveStrictestLangfusePrivacy,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
+import {
   REASONING_LABEL_PROMPT,
   buildReasoningLabelTraceSeed,
   buildReasoningLabelPrompt,
   normalizeReasoningLabel,
 } from '@/prompts/reasoningLabel';
-import {
-  hasToolOutputTracingConfig,
-  resolveLangfuseConfig,
-  resolveToolOutputTracingConfig,
-} from '@/langfuseConfig';
 import {
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
@@ -1084,17 +1085,39 @@ export class Run<_T extends t.BaseGraphState> {
     graph: StandardGraph | MultiAgentGraph
   ): t.LangfuseConfig | undefined {
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
-    if (primaryContext != null) {
-      return resolveLangfuseConfig(this.langfuse, primaryContext.langfuse);
-    }
+    const base =
+      primaryContext != null
+        ? resolveLangfuseConfig(this.langfuse, primaryContext.langfuse)
+        : this.resolveFirstAgentLangfuseConfig(graph);
 
+    // The stream config owns the shared root trace, whose conversation
+    // payload carries every agent's content. Its privacy policy must be at
+    // least as strict as each agent overlay's, so resolve across all of
+    // them rather than only the default agent's.
+    const privacy = resolveStrictestLangfusePrivacy([
+      base?.privacy,
+      ...Array.from(graph.agentContexts.values(), (context) => {
+        return resolveLangfuseConfig(this.langfuse, context.langfuse)?.privacy;
+      }),
+    ]);
+    if (base == null) {
+      return privacy == null ? undefined : { privacy };
+    }
+    if (privacy == null || base.privacy === privacy) {
+      return base;
+    }
+    return { ...base, privacy };
+  }
+
+  private resolveFirstAgentLangfuseConfig(
+    graph: StandardGraph | MultiAgentGraph
+  ): t.LangfuseConfig | undefined {
     for (const context of graph.agentContexts.values()) {
       const langfuse = resolveLangfuseConfig(this.langfuse, context.langfuse);
       if (langfuse != null) {
         return langfuse;
       }
     }
-
     return this.langfuse;
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,17 +59,16 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
-  hasToolOutputTracingConfig,
-  resolveLangfuseConfig,
-  resolveStrictestLangfusePrivacy,
-  resolveToolOutputTracingConfig,
-} from '@/langfuseConfig';
-import {
   REASONING_LABEL_PROMPT,
   buildReasoningLabelTraceSeed,
   buildReasoningLabelPrompt,
   normalizeReasoningLabel,
 } from '@/prompts/reasoningLabel';
+import {
+  hasToolOutputTracingConfig,
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
 import {
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
@@ -1085,39 +1084,17 @@ export class Run<_T extends t.BaseGraphState> {
     graph: StandardGraph | MultiAgentGraph
   ): t.LangfuseConfig | undefined {
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
-    const base =
-      primaryContext != null
-        ? resolveLangfuseConfig(this.langfuse, primaryContext.langfuse)
-        : this.resolveFirstAgentLangfuseConfig(graph);
-
-    // The stream config owns the shared root trace, whose conversation
-    // payload carries every agent's content. Its privacy policy must be at
-    // least as strict as each agent overlay's, so resolve across all of
-    // them rather than only the default agent's.
-    const privacy = resolveStrictestLangfusePrivacy([
-      base?.privacy,
-      ...Array.from(graph.agentContexts.values(), (context) => {
-        return resolveLangfuseConfig(this.langfuse, context.langfuse)?.privacy;
-      }),
-    ]);
-    if (base == null) {
-      return privacy == null ? undefined : { privacy };
+    if (primaryContext != null) {
+      return resolveLangfuseConfig(this.langfuse, primaryContext.langfuse);
     }
-    if (privacy == null || base.privacy === privacy) {
-      return base;
-    }
-    return { ...base, privacy };
-  }
 
-  private resolveFirstAgentLangfuseConfig(
-    graph: StandardGraph | MultiAgentGraph
-  ): t.LangfuseConfig | undefined {
     for (const context of graph.agentContexts.values()) {
       const langfuse = resolveLangfuseConfig(this.langfuse, context.langfuse);
       if (langfuse != null) {
         return langfuse;
       }
     }
+
     return this.langfuse;
   }
 

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -203,7 +203,7 @@ describe('Langfuse instrumentation', () => {
     );
   });
 
-  it('constructs the span processor with a privacy mask under metricsOnly', async () => {
+  it('constructs the span processor with media upload disabled under metricsOnly', async () => {
     const { initializeLangfuseTracing } = await import('@/instrumentation');
     initializeLangfuseTracing({
       publicKey: 'pk-config',
@@ -215,11 +215,10 @@ describe('Langfuse instrumentation', () => {
     expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
       expect.objectContaining({
         mediaUploadEnabled: false,
-        mask: expect.any(Function),
       })
     );
     const params = mockLangfuseSpanProcessor.mock.calls[0][0];
-    expect(params?.mask?.({ data: 'conversation text' })).toBe('[private]');
+    expect(params?.mask).toBeUndefined();
   });
 
   it('falls back to NODE_ENV when LANGFUSE_TRACING_ENVIRONMENT is unset', async () => {

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -1,6 +1,10 @@
 const mockLangfuseSpanProcessorInstance = {};
+type MockLangfuseSpanProcessorParams = {
+  mask?: (input: { data: unknown }) => string;
+};
 const mockLangfuseSpanProcessor = jest.fn(
-  () => mockLangfuseSpanProcessorInstance
+  (_params?: MockLangfuseSpanProcessorParams) =>
+    mockLangfuseSpanProcessorInstance
 );
 const mockSetLangfuseTracerProvider = jest.fn();
 let mockContextHasActiveValue = false;
@@ -214,10 +218,8 @@ describe('Langfuse instrumentation', () => {
         mask: expect.any(Function),
       })
     );
-    const params = mockLangfuseSpanProcessor.mock.calls[0][0] as {
-      mask?: (input: { data: unknown }) => string;
-    };
-    expect(params.mask?.({ data: 'conversation text' })).toBe('[private]');
+    const params = mockLangfuseSpanProcessor.mock.calls[0][0];
+    expect(params?.mask?.({ data: 'conversation text' })).toBe('[private]');
   });
 
   it('falls back to NODE_ENV when LANGFUSE_TRACING_ENVIRONMENT is unset', async () => {

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -199,6 +199,27 @@ describe('Langfuse instrumentation', () => {
     );
   });
 
+  it('constructs the span processor with a privacy mask under metricsOnly', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+      privacy: { mode: 'metricsOnly', redactionText: '[private]' },
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUploadEnabled: false,
+        mask: expect.any(Function),
+      })
+    );
+    const params = mockLangfuseSpanProcessor.mock.calls[0][0] as {
+      mask?: (input: { data: unknown }) => string;
+    };
+    expect(params.mask?.({ data: 'conversation text' })).toBe('[private]');
+  });
+
   it('falls back to NODE_ENV when LANGFUSE_TRACING_ENVIRONMENT is unset', async () => {
     delete process.env.LANGFUSE_TRACING_ENVIRONMENT;
     process.env.NODE_ENV = 'production';

--- a/src/specs/langfuse-privacy-masking.test.ts
+++ b/src/specs/langfuse-privacy-masking.test.ts
@@ -157,6 +157,21 @@ describe('Langfuse privacy masking', () => {
     ).toBe(JSON.stringify({ messageId: 'run-1' }));
   });
 
+  it('does not preserve identity keys from content attributes', async () => {
+    const span = await exportSpanWithPrivacy(
+      { mode: 'metricsOnly' },
+      {
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+          messageId: 'private user value produced by a tool',
+        }),
+      }
+    );
+
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+    ).toBe('[CONTENT REDACTED]');
+  });
+
   it('redacts status messages and exception content in metricsOnly', async () => {
     const span = await exportSpanWithPrivacy(
       { mode: 'metricsOnly' },

--- a/src/specs/langfuse-privacy-masking.test.ts
+++ b/src/specs/langfuse-privacy-masking.test.ts
@@ -1,0 +1,127 @@
+import { LangfuseSpanProcessor } from '@langfuse/otel';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import type {
+  ReadableSpan,
+  Span,
+  SpanExporter,
+} from '@opentelemetry/sdk-trace-base';
+import type { ExportResult } from '@opentelemetry/core';
+import { getLangfuseSpanProcessorParams } from '@/langfuseSpanRegistry';
+
+class InMemoryExporter implements SpanExporter {
+  readonly exportedSpans: ReadableSpan[] = [];
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    this.exportedSpans.push(...spans);
+    resultCallback({ code: 0 });
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Drives the real `LangfuseSpanProcessor` (no `@langfuse/otel` mocks) with the
+ * params `getLangfuseSpanProcessorParams` builds under `metricsOnly`, so the
+ * test proves the registry's privacy wiring reaches the SDK's masking layer
+ * and that operational attributes survive it.
+ */
+describe('Langfuse privacy masking', () => {
+  async function exportSpanWithPrivacy(
+    privacy: { mode: 'full' | 'metricsOnly'; redactionText?: string },
+    attributes: Record<string, unknown>
+  ): Promise<ReadableSpan | undefined> {
+    const exporter = new InMemoryExporter();
+    const params = getLangfuseSpanProcessorParams({
+      publicKey: 'pk-privacy',
+      secretKey: 'sk-privacy',
+      baseUrl: 'https://langfuse.privacy',
+      privacy,
+    });
+    if (params == null) {
+      throw new Error(
+        'expected span processor params for configured credentials'
+      );
+    }
+    const processor = new LangfuseSpanProcessor({
+      ...params,
+      exporter,
+      shouldExportSpan: () => true,
+    });
+    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+
+    const span = provider
+      .getTracer('privacy-masking-test')
+      .startSpan('ChatGeneration') as Span;
+    span.setAttributes(attributes);
+    span.end();
+    await processor.forceFlush();
+    await provider.shutdown();
+    return exporter.exportedSpans[0];
+  }
+
+  it('replaces content attributes while keeping operational data', async () => {
+    const span = await exportSpanWithPrivacy(
+      { mode: 'metricsOnly', redactionText: '[private]' },
+      {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+          { role: 'user', content: 'What is my API key sk-secret?' },
+        ]),
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'Here is your key',
+        [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify({
+          tenantId: 'tenant-7',
+        }),
+        [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify({
+          source: 'api',
+        }),
+        [LangfuseOtelSpanAttributes.OBSERVATION_MODEL]: 'gpt-5.2',
+        [LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]: JSON.stringify({
+          input: 120,
+          output: 34,
+        }),
+      }
+    );
+
+    expect(span).toBeDefined();
+    expect(span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]).toBe(
+      '[private]'
+    );
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+    ).toBe('[private]');
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_METADATA]
+    ).toBe('[private]');
+    expect(span?.attributes[LangfuseOtelSpanAttributes.TRACE_METADATA]).toBe(
+      '[private]'
+    );
+    expect(span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL]).toBe(
+      'gpt-5.2'
+    );
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]
+    ).toBe(JSON.stringify({ input: 120, output: 34 }));
+  });
+
+  it('exports content unchanged in full mode', async () => {
+    const span = await exportSpanWithPrivacy(
+      { mode: 'full' },
+      {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: 'plain prompt',
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'plain completion',
+      }
+    );
+
+    expect(span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]).toBe(
+      'plain prompt'
+    );
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+    ).toBe('plain completion');
+  });
+});

--- a/src/specs/langfuse-privacy-masking.test.ts
+++ b/src/specs/langfuse-privacy-masking.test.ts
@@ -1,4 +1,3 @@
-import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type {
@@ -8,6 +7,8 @@ import type {
 } from '@opentelemetry/sdk-trace-base';
 import type { ExportResult } from '@opentelemetry/core';
 import type { Attributes } from '@opentelemetry/api';
+import type * as t from '@/types';
+import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
 import { getLangfuseSpanProcessorParams } from '@/langfuseSpanRegistry';
 
 class InMemoryExporter implements SpanExporter {
@@ -27,39 +28,53 @@ class InMemoryExporter implements SpanExporter {
 }
 
 /**
- * Drives the real `LangfuseSpanProcessor` (no `@langfuse/otel` mocks) with the
- * params `getLangfuseSpanProcessorParams` builds under `metricsOnly`, so the
- * test proves the registry's privacy wiring reaches the SDK's masking layer
- * and that operational attributes survive it.
+ * Drives the full export path: the redacting wrapper around the real
+ * `LangfuseSpanProcessor` (no `@langfuse/otel` mocks) with the params
+ * `getLangfuseSpanProcessorParams` builds under `metricsOnly`. The test
+ * proves the registry's privacy wiring reaches the SDK's masking layer, that
+ * run-correlation identity survives it, and that status and exception
+ * content is redacted before export.
  */
 describe('Langfuse privacy masking', () => {
   async function exportSpanWithPrivacy(
-    privacy: { mode: 'full' | 'metricsOnly'; redactionText?: string },
-    attributes: Attributes
+    privacy: t.LangfusePrivacyConfig,
+    attributes: Attributes,
+    {
+      recordException,
+      statusMessage,
+    }: { recordException?: Error; statusMessage?: string } = {}
   ): Promise<ReadableSpan | undefined> {
     const exporter = new InMemoryExporter();
-    const params = getLangfuseSpanProcessorParams({
+    const langfuse: t.LangfuseConfig = {
       publicKey: 'pk-privacy',
       secretKey: 'sk-privacy',
       baseUrl: 'https://langfuse.privacy',
       privacy,
-    });
+    };
+    const params = getLangfuseSpanProcessorParams(langfuse);
     if (params == null) {
       throw new Error(
         'expected span processor params for configured credentials'
       );
     }
-    const processor = new LangfuseSpanProcessor({
-      ...params,
-      exporter,
-      shouldExportSpan: () => true,
+    const processor = createLangfuseSpanProcessor(
+      { ...params, exporter, shouldExportSpan: () => true },
+      langfuse
+    );
+    const provider = new BasicTracerProvider({
+      spanProcessors: [processor],
     });
-    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
 
     const span = provider
       .getTracer('privacy-masking-test')
       .startSpan('ChatGeneration') as Span;
     span.setAttributes(attributes);
+    if (recordException != null) {
+      span.recordException(recordException);
+    }
+    if (statusMessage != null) {
+      span.setStatus({ code: 2, message: statusMessage });
+    }
     span.end();
     await processor.forceFlush();
     await provider.shutdown();
@@ -109,12 +124,81 @@ describe('Langfuse privacy masking', () => {
     ).toBe(JSON.stringify({ input: 120, output: 34 }));
   });
 
+  it('preserves run-correlation identity from masked metadata', async () => {
+    const span = await exportSpanWithPrivacy(
+      { mode: 'metricsOnly' },
+      {
+        [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify({
+          messageId: 'run-1',
+          parentMessageId: 'run-0',
+          agentId: 'research',
+          agentName: 'Research Agent',
+          tenantId: 'tenant-7',
+          userNotes: 'internal note with content',
+        }),
+        [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify({
+          messageId: 'run-1',
+          nested: { secret: 'value' },
+        }),
+      }
+    );
+
+    const expectedIdentity = JSON.stringify({
+      messageId: 'run-1',
+      parentMessageId: 'run-0',
+      agentId: 'research',
+      agentName: 'Research Agent',
+    });
+    expect(span?.attributes[LangfuseOtelSpanAttributes.TRACE_METADATA]).toBe(
+      expectedIdentity
+    );
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_METADATA]
+    ).toBe(JSON.stringify({ messageId: 'run-1' }));
+  });
+
+  it('redacts status messages and exception content in metricsOnly', async () => {
+    const span = await exportSpanWithPrivacy(
+      { mode: 'metricsOnly' },
+      {
+        [LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]:
+          'Invalid user value sk-secret',
+      },
+      {
+        statusMessage: 'upstream rejected sk-secret',
+        recordException: new Error('tool failed with sk-secret in args'),
+      }
+    );
+
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE]
+    ).toBe('[CONTENT REDACTED]');
+    expect(span?.status.message).toBe('[CONTENT REDACTED]');
+    expect(span?.status.code).toBe(2);
+    const exceptionEvent = span?.events.find(
+      (event) => event.name === 'exception'
+    );
+    expect(exceptionEvent?.attributes?.['exception.message']).toBe(
+      '[CONTENT REDACTED]'
+    );
+    expect(exceptionEvent?.attributes?.['exception.stacktrace']).toBe(
+      '[CONTENT REDACTED]'
+    );
+  });
+
   it('exports content unchanged in full mode', async () => {
     const span = await exportSpanWithPrivacy(
       { mode: 'full' },
       {
         [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: 'plain prompt',
         [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'plain completion',
+        [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify({
+          messageId: 'run-1',
+        }),
+      },
+      {
+        statusMessage: 'kept status message',
+        recordException: new Error('kept exception'),
       }
     );
 
@@ -124,5 +208,15 @@ describe('Langfuse privacy masking', () => {
     expect(
       span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
     ).toBe('plain completion');
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_METADATA]
+    ).toBe(JSON.stringify({ messageId: 'run-1' }));
+    expect(span?.status.message).toBe('kept status message');
+    const exceptionEvent = span?.events.find(
+      (event) => event.name === 'exception'
+    );
+    expect(exceptionEvent?.attributes?.['exception.message']).toBe(
+      'kept exception'
+    );
   });
 });

--- a/src/specs/langfuse-privacy-masking.test.ts
+++ b/src/specs/langfuse-privacy-masking.test.ts
@@ -95,6 +95,12 @@ describe('Langfuse privacy masking', () => {
         [LangfuseOtelSpanAttributes.TRACE_METADATA]: JSON.stringify({
           source: 'api',
         }),
+        [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.customerNote`]:
+          'internal note with content',
+        [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.messageId`]:
+          'run-1',
+        [LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]:
+          JSON.stringify({ stop: ['reveal the key'], temperature: 0.7 }),
         [LangfuseOtelSpanAttributes.OBSERVATION_MODEL]: 'gpt-5.2',
         [LangfuseOtelSpanAttributes.OBSERVATION_USAGE_DETAILS]: JSON.stringify({
           input: 120,
@@ -116,6 +122,19 @@ describe('Langfuse privacy masking', () => {
     expect(span?.attributes[LangfuseOtelSpanAttributes.TRACE_METADATA]).toBe(
       '[private]'
     );
+    expect(
+      span?.attributes[
+        `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.customerNote`
+      ]
+    ).toBeUndefined();
+    expect(
+      span?.attributes[
+        `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.messageId`
+      ]
+    ).toBe('run-1');
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]
+    ).toBe('[private]');
     expect(span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL]).toBe(
       'gpt-5.2'
     );
@@ -210,6 +229,10 @@ describe('Langfuse privacy masking', () => {
         [LangfuseOtelSpanAttributes.OBSERVATION_METADATA]: JSON.stringify({
           messageId: 'run-1',
         }),
+        [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.customerNote`]:
+          'kept note',
+        [LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]:
+          JSON.stringify({ stop: ['kept stop'] }),
       },
       {
         statusMessage: 'kept status message',
@@ -226,6 +249,14 @@ describe('Langfuse privacy masking', () => {
     expect(
       span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_METADATA]
     ).toBe(JSON.stringify({ messageId: 'run-1' }));
+    expect(
+      span?.attributes[
+        `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.customerNote`
+      ]
+    ).toBe('kept note');
+    expect(
+      span?.attributes[LangfuseOtelSpanAttributes.OBSERVATION_MODEL_PARAMETERS]
+    ).toBe(JSON.stringify({ stop: ['kept stop'] }));
     expect(span?.status.message).toBe('kept status message');
     const exceptionEvent = span?.events.find(
       (event) => event.name === 'exception'

--- a/src/specs/langfuse-privacy-masking.test.ts
+++ b/src/specs/langfuse-privacy-masking.test.ts
@@ -7,6 +7,7 @@ import type {
   SpanExporter,
 } from '@opentelemetry/sdk-trace-base';
 import type { ExportResult } from '@opentelemetry/core';
+import type { Attributes } from '@opentelemetry/api';
 import { getLangfuseSpanProcessorParams } from '@/langfuseSpanRegistry';
 
 class InMemoryExporter implements SpanExporter {
@@ -34,7 +35,7 @@ class InMemoryExporter implements SpanExporter {
 describe('Langfuse privacy masking', () => {
   async function exportSpanWithPrivacy(
     privacy: { mode: 'full' | 'metricsOnly'; redactionText?: string },
-    attributes: Record<string, unknown>
+    attributes: Attributes
   ): Promise<ReadableSpan | undefined> {
     const exporter = new InMemoryExporter();
     const params = getLangfuseSpanProcessorParams({

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -89,7 +89,7 @@ describe('Langfuse span registry', () => {
     );
   });
 
-  it('masks content and disables media upload under metricsOnly privacy', () => {
+  it('disables media upload under metricsOnly privacy', () => {
     const params = getLangfuseSpanProcessorParams(
       tenantConfig({
         mediaUploadEnabled: true,
@@ -101,19 +101,7 @@ describe('Langfuse span registry', () => {
         mediaUploadEnabled: false,
       })
     );
-    expect(typeof params?.mask).toBe('function');
-    expect(params?.mask?.({ data: { messages: ['secret'] } })).toBe(
-      '[CONTENT REDACTED]'
-    );
-  });
-
-  it('uses the configured redaction text in the privacy mask', () => {
-    const params = getLangfuseSpanProcessorParams(
-      tenantConfig({
-        privacy: { mode: 'metricsOnly', redactionText: '[private]' },
-      })
-    );
-    expect(params?.mask?.({ data: 'prompt text' })).toBe('[private]');
+    expect(params?.mask).toBeUndefined();
   });
 
   it('leaves content params untouched in full privacy mode', () => {
@@ -121,7 +109,6 @@ describe('Langfuse span registry', () => {
       tenantConfig({ mediaUploadEnabled: true, privacy: { mode: 'full' } })
     );
     expect(params?.mediaUploadEnabled).toBe(true);
-    expect(params?.mask).toBeUndefined();
   });
 
   it('separates destinations by credentials, endpoint, and environment', () => {

--- a/src/specs/langfuse-span-registry.test.ts
+++ b/src/specs/langfuse-span-registry.test.ts
@@ -69,8 +69,12 @@ describe('Langfuse span registry', () => {
     const mediaDisabled = resolveLangfuseDestinationKey(
       tenantConfig({ mediaUploadEnabled: false })
     );
+    const privacyOnly = resolveLangfuseDestinationKey(
+      tenantConfig({ privacy: { mode: 'metricsOnly' } })
+    );
     expect(redacting).toBe(base);
     expect(mediaDisabled).toBe(base);
+    expect(privacyOnly).toBe(base);
   });
 
   it('passes media upload policy to the Langfuse span processor params', () => {
@@ -83,6 +87,41 @@ describe('Langfuse span registry', () => {
         mediaUploadEnabled: false,
       })
     );
+  });
+
+  it('masks content and disables media upload under metricsOnly privacy', () => {
+    const params = getLangfuseSpanProcessorParams(
+      tenantConfig({
+        mediaUploadEnabled: true,
+        privacy: { mode: 'metricsOnly' },
+      })
+    );
+    expect(params).toEqual(
+      expect.objectContaining({
+        mediaUploadEnabled: false,
+      })
+    );
+    expect(typeof params?.mask).toBe('function');
+    expect(params?.mask?.({ data: { messages: ['secret'] } })).toBe(
+      '[CONTENT REDACTED]'
+    );
+  });
+
+  it('uses the configured redaction text in the privacy mask', () => {
+    const params = getLangfuseSpanProcessorParams(
+      tenantConfig({
+        privacy: { mode: 'metricsOnly', redactionText: '[private]' },
+      })
+    );
+    expect(params?.mask?.({ data: 'prompt text' })).toBe('[private]');
+  });
+
+  it('leaves content params untouched in full privacy mode', () => {
+    const params = getLangfuseSpanProcessorParams(
+      tenantConfig({ mediaUploadEnabled: true, privacy: { mode: 'full' } })
+    );
+    expect(params?.mediaUploadEnabled).toBe(true);
+    expect(params?.mask).toBeUndefined();
   });
 
   it('separates destinations by credentials, endpoint, and environment', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -19,13 +19,14 @@ import {
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
 import {
+  resolveLangfuseConfig,
+  resolveStrictestLangfusePrivacy,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
+import {
   runWithLangfuseRuntimeContext,
   type ResolvedLangfuseToolOutputTracingConfig,
 } from '@/langfuseRuntimeContext';
-import {
-  resolveLangfuseConfig,
-  resolveToolOutputTracingConfig,
-} from '@/langfuseConfig';
 import { ensureOpenTelemetryContextManager } from '@/instrumentation';
 import { projectToolStreamContentForProvider } from '@/messages/core';
 import { formatAgentMessages } from '@/messages/format';
@@ -1578,6 +1579,26 @@ describe('Langfuse tool output tracing redaction', () => {
         { privacy: { mode: 'full' } }
       )?.privacy
     ).toEqual({ mode: 'full' });
+  });
+
+  it('resolves the strictest privacy across every agent overlay', () => {
+    expect(
+      resolveStrictestLangfusePrivacy([
+        undefined,
+        { mode: 'full' },
+        { mode: 'metricsOnly' },
+        { mode: 'full' },
+      ])
+    ).toEqual({ mode: 'metricsOnly' });
+    expect(
+      resolveStrictestLangfusePrivacy([
+        { mode: 'full' },
+        { mode: 'full', redactionText: '[agent]' },
+      ])
+    ).toEqual({ mode: 'full', redactionText: '[agent]' });
+    expect(resolveStrictestLangfusePrivacy([undefined, undefined])).toBe(
+      undefined
+    );
   });
 
   it('merges run and agent custom headers with the agent winning collisions', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -19,14 +19,13 @@ import {
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
 import {
-  resolveLangfuseConfig,
-  resolveStrictestLangfusePrivacy,
-  resolveToolOutputTracingConfig,
-} from '@/langfuseConfig';
-import {
   runWithLangfuseRuntimeContext,
   type ResolvedLangfuseToolOutputTracingConfig,
 } from '@/langfuseRuntimeContext';
+import {
+  resolveLangfuseConfig,
+  resolveToolOutputTracingConfig,
+} from '@/langfuseConfig';
 import { ensureOpenTelemetryContextManager } from '@/instrumentation';
 import { projectToolStreamContentForProvider } from '@/messages/core';
 import { formatAgentMessages } from '@/messages/format';
@@ -1553,7 +1552,7 @@ describe('Langfuse tool output tracing redaction', () => {
     });
   });
 
-  it('merges privacy policy with the stricter mode winning', () => {
+  it('keeps privacy run-level and fails closed on agent overlays', () => {
     const credentials = {
       publicKey: 'pk-run',
       secretKey: 'sk-run',
@@ -1566,39 +1565,31 @@ describe('Langfuse tool output tracing redaction', () => {
           privacy: { mode: 'metricsOnly', redactionText: '[run]' },
         },
         { privacy: { mode: 'full' } }
-      )?.privacy
-    ).toEqual({ mode: 'metricsOnly', redactionText: '[run]' });
+      )
+    ).toMatchObject({
+      privacy: { mode: 'metricsOnly', redactionText: '[run]' },
+    });
+    // An agent overlay asking for metricsOnly without a run-level policy
+    // cannot be enforced on the shared trace, so export is disabled.
+    expect(
+      resolveLangfuseConfig(credentials, {
+        privacy: { mode: 'metricsOnly', redactionText: '[agent]' },
+      })
+    ).toMatchObject({ enabled: false });
     expect(
       resolveLangfuseConfig(credentials, {
         privacy: { mode: 'metricsOnly', redactionText: '[agent]' },
       })?.privacy
-    ).toEqual({ mode: 'metricsOnly', redactionText: '[agent]' });
+    ).toBeUndefined();
+    // Agent-only configs cannot carry privacy either.
     expect(
-      resolveLangfuseConfig(
-        { privacy: { mode: 'full' } },
-        { privacy: { mode: 'full' } }
-      )?.privacy
-    ).toEqual({ mode: 'full' });
-  });
-
-  it('resolves the strictest privacy across every agent overlay', () => {
+      resolveLangfuseConfig(undefined, {
+        privacy: { mode: 'metricsOnly' },
+      })
+    ).toMatchObject({ enabled: false });
     expect(
-      resolveStrictestLangfusePrivacy([
-        undefined,
-        { mode: 'full' },
-        { mode: 'metricsOnly' },
-        { mode: 'full' },
-      ])
-    ).toEqual({ mode: 'metricsOnly' });
-    expect(
-      resolveStrictestLangfusePrivacy([
-        { mode: 'full' },
-        { mode: 'full', redactionText: '[agent]' },
-      ])
-    ).toEqual({ mode: 'full', redactionText: '[agent]' });
-    expect(resolveStrictestLangfusePrivacy([undefined, undefined])).toBe(
-      undefined
-    );
+      resolveLangfuseConfig(undefined, { privacy: { mode: 'full' } })?.privacy
+    ).toBeUndefined();
   });
 
   it('merges run and agent custom headers with the agent winning collisions', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -1552,6 +1552,34 @@ describe('Langfuse tool output tracing redaction', () => {
     });
   });
 
+  it('merges privacy policy with the stricter mode winning', () => {
+    const credentials = {
+      publicKey: 'pk-run',
+      secretKey: 'sk-run',
+      baseUrl: 'https://langfuse.test',
+    };
+    expect(
+      resolveLangfuseConfig(
+        {
+          ...credentials,
+          privacy: { mode: 'metricsOnly', redactionText: '[run]' },
+        },
+        { privacy: { mode: 'full' } }
+      )?.privacy
+    ).toEqual({ mode: 'metricsOnly', redactionText: '[run]' });
+    expect(
+      resolveLangfuseConfig(credentials, {
+        privacy: { mode: 'metricsOnly', redactionText: '[agent]' },
+      })?.privacy
+    ).toEqual({ mode: 'metricsOnly', redactionText: '[agent]' });
+    expect(
+      resolveLangfuseConfig(
+        { privacy: { mode: 'full' } },
+        { privacy: { mode: 'full' } }
+      )?.privacy
+    ).toEqual({ mode: 'full' });
+  });
+
   it('merges run and agent custom headers with the agent winning collisions', () => {
     const resolved = resolveLangfuseConfig(
       {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -831,6 +831,13 @@ export interface LangfuseConfig {
   /**
    * Content privacy policy applied to trace data before it leaves the
    * process. Applies to every export destination the run resolves to.
+   *
+   * Run-level only: shared observations (the root trace, conversation
+   * payloads, activity-phase traces, parent generations embedding subagent
+   * results) carry every agent's content, so a policy only some spans enforce
+   * would leak the rest. An agent overlay setting `metricsOnly` while the run
+   * does not fails closed: export is disabled for those spans instead of
+   * sending content the host asked to suppress.
    */
   privacy?: LangfusePrivacyConfig;
   /**

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -775,6 +775,18 @@ export type LangfuseToolNodeTracingConfig = {
   enabled?: boolean;
 };
 
+export type LangfusePrivacyConfig = {
+  /**
+   * `metricsOnly` replaces every exported trace and observation input,
+   * output, and metadata value with `redactionText` and disables media
+   * upload, while trace structure, timing, model, usage, and status stay
+   * intact. The default `full` mode exports content unchanged.
+   */
+  mode?: 'full' | 'metricsOnly';
+  /** Replacement text used for suppressed content. */
+  redactionText?: string;
+};
+
 export interface LangfuseConfig {
   enabled?: boolean;
   publicKey?: string;
@@ -816,6 +828,11 @@ export interface LangfuseConfig {
   tags?: string[];
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;
+  /**
+   * Content privacy policy applied to trace data before it leaves the
+   * process. Applies to every export destination the run resolves to.
+   */
+  privacy?: LangfusePrivacyConfig;
   /**
    * When true, derive the run's root Langfuse trace id deterministically from
    * its `runId` (`sha256(runId)` → 32 hex chars, matching `@langfuse/tracing`


### PR DESCRIPTION
## Summary

Trace export currently sends every message, tool argument and output, metadata payload, and media to Langfuse with no suppression option. Hosts under GDPR-style data-protection requirements want operational telemetry (latency, model, token usage, cost, errors) without conversation content leaving the application boundary.

This adds a `privacy` block to `LangfuseConfig`:

```ts
langfuse: {
  publicKey,
  secretKey,
  privacy: {
    mode: 'metricsOnly',          // or 'full' (default, unchanged behavior)
    redactionText: '[CONTENT REDACTED]',
  },
}
```

In `metricsOnly` mode:

- A mask function is passed to the Langfuse span processor, replacing every exported trace and observation `input`, `output`, and `metadata` value with the redaction text. This covers user/system/assistant message content, tool arguments, tool outputs, and metadata in one pass, since the SDK applies the mask to exactly those attribute families.
- `mediaUploadEnabled` is forced false, so the processor never runs its media create/upload/patch operations. Media is content, not a media reference to redact.
- Trace structure, timing, model name, token usage, cost details, and error status remain exported; none of those attributes are in the SDK's masked set.

Design notes:

- Privacy is part of the processor cache key (like `toolOutputTracing`, it is baked into each processor) but not part of destination identity, so it never splits span parenting.
- Run and agent overlays merge with the stricter mode winning: an agent overlay can tighten the run's privacy policy but never loosen it.
- `LANGFUSE_PRIVACY_MASKING_SUPPORTED` is exported so hosts can detect whether the installed runtime enforces the field and fail closed when it does not.
- The mask itself is fail-closed by construction: the SDK fully masks a value when the mask function throws, so content is never exported verbatim on a masking failure.

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

```bash
NODE_OPTIONS='--experimental-vm-modules' npx jest src/specs/langfuse-
# 10 suites, 189 tests, all passing
npx tsc -p tsconfig.build.json --emitDeclarationOnly false --declaration false
npx eslint <touched files>
npm run build
```

- `langfuse-privacy-masking.test.ts` drives the real `@langfuse/otel` `LangfuseSpanProcessor` (no SDK mocks) with an in-memory exporter and asserts content attributes are replaced while model and usage attributes survive, and that `full` mode exports unchanged.
- Registry, instrumentation, and config-merge specs cover params construction (mask attached, media forced off), processor cache-key separation, and run/agent overlay merging.
- Tested against @langfuse/otel 5.10.1.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes