### PR TITLE
🧬 test: Guard Detached Sibling Lifetimes

### DIFF
--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -682,35 +682,53 @@ describe('SubagentExecutor', () => {
   it('keeps detached siblings alive after their parent aborts', async () => {
     const store = new InMemorySubagentTaskStore();
     const parentController = new AbortController();
-    const observedSignals: AbortSignal[] = [];
-    let finishFirst = (_value: { messages: BaseMessage[] }): void => undefined;
-    let finishSecond = (_value: { messages: BaseMessage[] }): void => undefined;
-    const firstInvocation = new Promise<{ messages: BaseMessage[] }>(
-      (resolve) => {
-        finishFirst = resolve;
-      }
-    );
-    const secondInvocation = new Promise<{ messages: BaseMessage[] }>(
-      (resolve) => {
-        finishSecond = resolve;
-      }
-    );
-    const invoke = jest.fn(async () => {
-      const signal = AsyncLocalStorageProviderSingleton.getRunnableConfig()
-        ?.signal as AbortSignal | undefined;
-      if (signal == null) {
-        throw new Error('Detached child did not receive a runnable signal.');
-      }
-      observedSignals.push(signal);
-      return observedSignals.length === 1 ? firstInvocation : secondInvocation;
-    });
+    const started = new Set<string>();
+    const createInvocation = (): {
+      promise: Promise<{ messages: BaseMessage[] }>;
+      finish: (value: { messages: BaseMessage[] }) => void;
+      signal?: AbortSignal;
+    } => {
+      let finish = (_value: { messages: BaseMessage[] }): void => undefined;
+      const promise = new Promise<{ messages: BaseMessage[] }>((resolve) => {
+        finish = resolve;
+      });
+      return { promise, finish };
+    };
+    const invocationByCall = new Map([
+      ['call_detached_first', createInvocation()],
+      ['call_detached_second', createInvocation()],
+    ]);
     const executor = createExecutor({
       taskConfig: { store, scopeId: 'owner:conversation' },
-      createChildGraph: (): StandardGraph =>
-        ({
+      createChildGraph: (input): StandardGraph => {
+        const parentToolCallId =
+          input.subagentExecutionContext?.ancestry.at(-1)?.parentToolCallId;
+        if (parentToolCallId == null) {
+          throw new Error('Detached child invocation was not attributed.');
+        }
+        const invocation = invocationByCall.get(parentToolCallId);
+        if (invocation == null) {
+          throw new Error('Detached child invocation was not attributed.');
+        }
+        const attributedCallId = parentToolCallId;
+        const invoke = jest.fn(async () => {
+          invocation.signal =
+            AsyncLocalStorageProviderSingleton.getRunnableConfig()?.signal as
+              | AbortSignal
+              | undefined;
+          if (invocation.signal == null) {
+            throw new Error(
+              'Detached child did not receive a runnable signal.'
+            );
+          }
+          started.add(attributedCallId);
+          return invocation.promise;
+        });
+        return {
           createWorkflow: () => ({ invoke }),
           clearHeavyState: jest.fn(),
-        }) as unknown as StandardGraph,
+        } as unknown as StandardGraph;
+      },
     });
 
     const responses = await AsyncLocalStorageProviderSingleton.runWithConfig(
@@ -732,12 +750,21 @@ describe('SubagentExecutor', () => {
         waitForTask(
           store,
           response.background_task_id,
-          () => invoke.mock.calls.length === 2
+          () => started.size === 2
         )
       )
     );
 
     parentController.abort();
+    const firstInvocation = invocationByCall.get('call_detached_first');
+    const secondInvocation = invocationByCall.get('call_detached_second');
+    if (firstInvocation == null || secondInvocation == null) {
+      throw new Error('Detached child invocation fixture is incomplete.');
+    }
+    if (firstInvocation.signal == null || secondInvocation.signal == null) {
+      throw new Error('Detached child runnable signal was not captured.');
+    }
+    const observedSignals = [firstInvocation.signal, secondInvocation.signal];
     expect(observedSignals).toHaveLength(2);
     expect(observedSignals).not.toContain(parentController.signal);
     expect(new Set(observedSignals).size).toBe(2);
@@ -745,13 +772,23 @@ describe('SubagentExecutor', () => {
       true
     );
 
-    finishFirst({ messages: [new AIMessage('first detached result')] });
+    firstInvocation.finish({
+      messages: [new AIMessage('first detached result')],
+    });
     await waitForTask(
       store,
       responses[0].background_task_id,
       (status) => status === 'completed'
     );
-    finishSecond({ messages: [new AIMessage('second detached result')] });
+    expect(secondInvocation.signal?.aborted).toBe(false);
+    expect(
+      store.get('owner:conversation', responses[1].background_task_id)
+    ).toMatchObject({
+      status: 'running',
+    });
+    secondInvocation.finish({
+      messages: [new AIMessage('second detached result')],
+    });
     await waitForTask(
       store,
       responses[1].background_task_id,

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -679,6 +679,99 @@ describe('SubagentExecutor', () => {
     );
   });
 
+  it('keeps detached siblings alive after their parent aborts', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const parentController = new AbortController();
+    const observedSignals: AbortSignal[] = [];
+    let finishFirst = (_value: { messages: BaseMessage[] }): void => undefined;
+    let finishSecond = (_value: { messages: BaseMessage[] }): void => undefined;
+    const firstInvocation = new Promise<{ messages: BaseMessage[] }>(
+      (resolve) => {
+        finishFirst = resolve;
+      }
+    );
+    const secondInvocation = new Promise<{ messages: BaseMessage[] }>(
+      (resolve) => {
+        finishSecond = resolve;
+      }
+    );
+    const invoke = jest.fn(async () => {
+      const signal = AsyncLocalStorageProviderSingleton.getRunnableConfig()
+        ?.signal as AbortSignal | undefined;
+      if (signal == null) {
+        throw new Error('Detached child did not receive a runnable signal.');
+      }
+      observedSignals.push(signal);
+      return observedSignals.length === 1 ? firstInvocation : secondInvocation;
+    });
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const responses = await AsyncLocalStorageProviderSingleton.runWithConfig(
+      { signal: parentController.signal },
+      async () =>
+        ['call_detached_first', 'call_detached_second'].map(
+          (parentToolCallId) =>
+            JSON.parse(
+              executor.executeInBackground({
+                description: 'Finish independently after the parent.',
+                subagentType: 'researcher',
+                parentToolCallId,
+              })
+            ) as { background_task_id: string }
+        )
+    );
+    await Promise.all(
+      responses.map((response) =>
+        waitForTask(
+          store,
+          response.background_task_id,
+          () => invoke.mock.calls.length === 2
+        )
+      )
+    );
+
+    parentController.abort();
+    expect(observedSignals).toHaveLength(2);
+    expect(observedSignals).not.toContain(parentController.signal);
+    expect(new Set(observedSignals).size).toBe(2);
+    expect(observedSignals.every((signal) => signal.aborted === false)).toBe(
+      true
+    );
+
+    finishFirst({ messages: [new AIMessage('first detached result')] });
+    await waitForTask(
+      store,
+      responses[0].background_task_id,
+      (status) => status === 'completed'
+    );
+    finishSecond({ messages: [new AIMessage('second detached result')] });
+    await waitForTask(
+      store,
+      responses[1].background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(
+      store.claim('owner:conversation', responses[0].background_task_id)
+    ).toMatchObject({
+      status: 'completed',
+      result: 'first detached result',
+    });
+    expect(
+      store.claim('owner:conversation', responses[1].background_task_id)
+    ).toMatchObject({
+      status: 'completed',
+      result: 'second detached result',
+    });
+  });
+
   it('continues the same detached child for a queued parent message', async () => {
     const store = new InMemorySubagentTaskStore();
     let finishFirst = (_value: { messages: BaseMessage[] }): void => undefined;


### PR DESCRIPTION
I added focused regression coverage for detached sibling subagents surviving their parent turn's abort signal.

- Start two detached children from the same parent runnable context.
- Abort the parent after both child invocations have started.
- Verify each child owns a distinct signal that remains active after the parent aborts.
- Complete the siblings independently and verify both results remain claimable.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/__tests__/SubagentExecutor.test.ts --runInBand` — 125 tests passed.
- `npx tsc --noEmit` — passed.
- `git diff --check` — passed.

### **Test Configuration**:

- Node.js and the repository's existing npm dependency tree.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
