### PR TITLE
👣 feat: Source-Aware Provenance Tracking for Provider Messages

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -61,6 +61,7 @@ import {
   resolveBedrockPromptCacheTtl,
   supportsBedrockToolCache,
   isSyntheticProviderContextMessage,
+  compactSyntheticProviderContextMessage,
   getMessageId,
   getMessageCreationContentMetadata,
   splitAssistantTextContentByPhase,
@@ -134,11 +135,6 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
-  compactToolContent,
-  getToolContentCharLength,
-  serializeToolContentBounded,
-} from '@/utils/toolContent';
-import {
   annotateMessagesForLLM,
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
@@ -146,6 +142,10 @@ import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import {
+  getToolContentCharLength,
+  serializeToolContentBounded,
+} from '@/utils/toolContent';
 import {
   appendCallbacks,
   findCallback,
@@ -412,7 +412,9 @@ function getCurrentStepIds({
     if (stepKey !== baseStepKey && !stepKey.startsWith(`${baseStepKey}_`)) {
       continue;
     }
-    currentStepIds.push(...stepIds);
+    for (const stepId of stepIds) {
+      currentStepIds.push(stepId);
+    }
   }
   return currentStepIds;
 }
@@ -3553,17 +3555,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const buildCandidate = (scale: number): BaseMessage[] => {
           const compacted = [...candidate];
           for (const { index, message, chars } of synthetic) {
-            const content = compactToolContent(
-              message.content,
+            compacted[index] = compactSyntheticProviderContextMessage(
+              message,
               Math.floor(chars * scale)
-            ).content;
-            compacted[index] = new HumanMessage({
-              content,
-              id: message.id,
-              name: message.name,
-              additional_kwargs: message.additional_kwargs,
-              response_metadata: message.response_metadata,
-            });
+            );
           }
           return compacted;
         };
@@ -4733,7 +4728,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     }
     if (result.injectedMessages.length > 0) {
       try {
-        injected.push(...convertInjectedMessages(result.injectedMessages));
+        const convertedMessages = convertInjectedMessages(
+          result.injectedMessages
+        );
+        for (const convertedMessage of convertedMessages) {
+          injected.push(convertedMessage);
+        }
       } catch (e) {
         console.warn(
           '[StandardGraph] Failed to convert PreemptBoundary injectedMessages:',

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -74,6 +74,7 @@ import {
   strictAlternationProviders,
   appendPredecessorHandoffCue,
   removePredecessorHandoffCue,
+  stampSyntheticProviderMessage,
 } from '@/messages';
 import {
   Constants,
@@ -4720,10 +4721,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     );
     if (contexts.length > 0) {
       injected.push(
-        new HumanMessage({
-          content: contexts.join('\n\n'),
-          additional_kwargs: { role: 'system', isMeta: true, source: 'hook' },
-        })
+        stampSyntheticProviderMessage(
+          new HumanMessage({
+            content: contexts.join('\n\n'),
+            additional_kwargs: {
+              role: 'system',
+              isMeta: true,
+              source: 'hook',
+            },
+          })
+        )
       );
     }
     if (result.injectedMessages.length > 0) {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -502,15 +502,22 @@ export class MultiAgentGraph extends StandardGraph {
       const handoffTools: t.GenericTool[] = [];
       const sourceAgentName = agentContext.name ?? agentId;
       for (const edge of edges) {
-        handoffTools.push(
-          ...this.createHandoffToolsForEdge(edge, agentId, sourceAgentName)
+        const edgeTools = this.createHandoffToolsForEdge(
+          edge,
+          agentId,
+          sourceAgentName
         );
+        for (const edgeTool of edgeTools) {
+          handoffTools.push(edgeTool);
+        }
       }
 
       if (!agentContext.graphTools) {
         agentContext.graphTools = [];
       }
-      agentContext.graphTools.push(...handoffTools);
+      for (const handoffTool of handoffTools) {
+        agentContext.graphTools.push(handoffTool);
+      }
     }
   }
 

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -19,6 +19,7 @@ import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { ToolRuntime } from '@langchain/core/tools';
 import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
+import { stampSyntheticProviderMessage } from '@/messages/provenance';
 import { serializeToolContentBounded } from '@/utils/toolContent';
 import { Constants, MULTI_AGENT_GRAPH_RUN_NAME } from '@/common';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
@@ -36,10 +37,12 @@ const HANDOFF_INSTRUCTIONS_KEY = 'handoff_instructions';
  * message replayed out of the payload.
  */
 function buildRoutingPrompt(content: string): HumanMessage {
-  return new HumanMessage({
-    content,
-    additional_kwargs: { role: 'user', isMeta: true, source: 'routing' },
-  });
+  return stampSyntheticProviderMessage(
+    new HumanMessage({
+      content,
+      additional_kwargs: { role: 'user', isMeta: true, source: 'routing' },
+    })
+  );
 }
 
 function getHandoffInstructions(
@@ -1164,8 +1167,10 @@ export class MultiAgentGraph extends StandardGraph {
             if (lastMsg != null && lastMsg.getType() === 'tool') {
               messagesForAgent = [
                 ...filteredMessages,
-                new AIMessage(
-                  `[Processed tool result and transferring to ${agentId}]`
+                stampSyntheticProviderMessage(
+                  new AIMessage(
+                    `[Processed tool result and transferring to ${agentId}]`
+                  )
                 ),
                 buildRoutingPrompt(instructions),
               ];

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -21,7 +21,8 @@ import type { ProviderMessageProvenancePart } from '@/messages/provenance';
 import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
 import {
-  getProviderMessageProvenance,
+  inspectProviderMessageProvenance,
+  setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
   stampSyntheticProviderMessage,
 } from '@/messages/provenance';
@@ -145,10 +146,15 @@ function copyFilteredAIMessageProvenance(
   target: AIMessage,
   retainedContentPartIndices?: readonly number[]
 ): AIMessage {
-  const provenance = getProviderMessageProvenance(source);
-  if (provenance == null) {
+  const provenanceState = inspectProviderMessageProvenance(source);
+  if (provenanceState.status === 'absent') {
     return target;
   }
+  if (provenanceState.status === 'invalid') {
+    setInvalidProviderMessageProvenance(target);
+    return target;
+  }
+  const provenance = provenanceState.provenance;
   if (
     retainedContentPartIndices == null ||
     !Array.isArray(source.content) ||

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -22,6 +22,7 @@ import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
 import {
   inspectProviderMessageProvenance,
+  inspectProviderSourceMessageIds,
   setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
   stampSyntheticProviderMessage,
@@ -146,21 +147,63 @@ function copyFilteredAIMessageProvenance(
   target: AIMessage,
   retainedContentPartIndices?: readonly number[]
 ): AIMessage {
+  const sourceMessageIdsState = inspectProviderSourceMessageIds(source);
   const provenanceState = inspectProviderMessageProvenance(source);
-  if (provenanceState.status === 'absent') {
-    return target;
-  }
-  if (provenanceState.status === 'invalid') {
+  if (
+    provenanceState.status === 'invalid' ||
+    sourceMessageIdsState.status === 'invalid'
+  ) {
     setInvalidProviderMessageProvenance(target);
     return target;
   }
+  const sourceMessageIds =
+    sourceMessageIdsState.status === 'valid'
+      ? sourceMessageIdsState.sourceMessageIds
+      : [];
+  if (provenanceState.status === 'absent') {
+    if (sourceMessageIds.length > 0) {
+      setProviderMessageProvenance(
+        target,
+        sourceMessageIds.map((sourceMessageId) => ({
+          attribution: 'model',
+          sourceMessageId,
+        }))
+      );
+    }
+    return target;
+  }
   const provenance = provenanceState.provenance;
+  const typedSourceMessageIds = new Set<string>();
+  for (const part of provenance.parts) {
+    if (part.sourceMessageId != null) {
+      typedSourceMessageIds.add(part.sourceMessageId);
+    }
+  }
+  const legacyParts: ProviderMessageProvenancePart[] = [];
+  for (const sourceMessageId of sourceMessageIds) {
+    if (!typedSourceMessageIds.has(sourceMessageId)) {
+      legacyParts.push({ attribution: 'model', sourceMessageId });
+    }
+  }
+  const setFilteredProvenance = (
+    parts: readonly ProviderMessageProvenancePart[]
+  ): void => {
+    if (legacyParts.length === 0) {
+      setProviderMessageProvenance(target, parts);
+      return;
+    }
+    const combinedParts = parts.slice();
+    for (const part of legacyParts) {
+      combinedParts.push(part);
+    }
+    setProviderMessageProvenance(target, combinedParts);
+  };
   if (
     retainedContentPartIndices == null ||
     !Array.isArray(source.content) ||
     retainedContentPartIndices.length === source.content.length
   ) {
-    setProviderMessageProvenance(target, provenance.parts);
+    setFilteredProvenance(provenance.parts);
     return target;
   }
 
@@ -176,7 +219,7 @@ function copyFilteredAIMessageProvenance(
   if (hasUnindexedPart || sourceIndexRefCount !== source.content.length) {
     /** An older or aggregate envelope cannot be mapped to current blocks.
      * Preserve its conservative attribution instead of dropping tool lineage. */
-    setProviderMessageProvenance(target, provenance.parts);
+    setFilteredProvenance(provenance.parts);
     return target;
   }
 
@@ -203,8 +246,7 @@ function copyFilteredAIMessageProvenance(
       });
     }
   }
-  setProviderMessageProvenance(
-    target,
+  setFilteredProvenance(
     retainedParts.length > 0 ? retainedParts : [{ attribution: 'model' }]
   );
   return target;

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -17,9 +17,14 @@ import {
 import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { ToolRuntime } from '@langchain/core/tools';
+import type { ProviderMessageProvenancePart } from '@/messages/provenance';
 import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
-import { stampSyntheticProviderMessage } from '@/messages/provenance';
+import {
+  getProviderMessageProvenance,
+  setProviderMessageProvenance,
+  stampSyntheticProviderMessage,
+} from '@/messages/provenance';
 import { serializeToolContentBounded } from '@/utils/toolContent';
 import { Constants, MULTI_AGENT_GRAPH_RUN_NAME } from '@/common';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
@@ -105,23 +110,98 @@ function isTransferToolName(name: unknown): boolean {
 function filterTransferToolUseBlocks(
   content: AIMessage['content'],
   transferToolCallIds: ReadonlySet<string>
-): AIMessage['content'] {
+): {
+  content: AIMessage['content'];
+  retainedContentPartIndices?: readonly number[];
+} {
   if (!Array.isArray(content)) {
-    return content;
+    return { content };
   }
-  return content.filter((block) => {
+  const filteredContent: typeof content = [];
+  const retainedContentPartIndices: number[] = [];
+  for (let index = 0; index < content.length; index++) {
+    const block = content[index];
     if (
-      typeof block !== 'object' ||
-      (block as { type?: string } | null)?.type !== 'tool_use'
+      typeof block === 'object' &&
+      (block as { type?: string } | null)?.type === 'tool_use'
     ) {
-      return true;
+      const toolUse = block as { id?: string; name?: string };
+      if (
+        (toolUse.id != null && transferToolCallIds.has(toolUse.id)) ||
+        isTransferToolName(toolUse.name)
+      ) {
+        continue;
+      }
     }
-    const toolUse = block as { id?: string; name?: string };
-    if (toolUse.id != null && transferToolCallIds.has(toolUse.id)) {
-      return false;
+    filteredContent.push(block);
+    retainedContentPartIndices.push(index);
+  }
+  return { content: filteredContent, retainedContentPartIndices };
+}
+
+/** Rebuild a handoff AI message without losing authorship for retained bytes. */
+function copyFilteredAIMessageProvenance(
+  source: AIMessage | AIMessageChunk,
+  target: AIMessage,
+  retainedContentPartIndices?: readonly number[]
+): AIMessage {
+  const provenance = getProviderMessageProvenance(source);
+  if (provenance == null) {
+    return target;
+  }
+  if (
+    retainedContentPartIndices == null ||
+    !Array.isArray(source.content) ||
+    retainedContentPartIndices.length === source.content.length
+  ) {
+    setProviderMessageProvenance(target, provenance.parts);
+    return target;
+  }
+
+  let sourceIndexRefCount = 0;
+  let hasUnindexedPart = false;
+  for (const part of provenance.parts) {
+    if (part.sourceContentPartIndices == null) {
+      hasUnindexedPart = true;
+    } else {
+      sourceIndexRefCount += part.sourceContentPartIndices.length;
     }
-    return !isTransferToolName(toolUse.name);
-  });
+  }
+  if (hasUnindexedPart || sourceIndexRefCount !== source.content.length) {
+    /** An older or aggregate envelope cannot be mapped to current blocks.
+     * Preserve its conservative attribution instead of dropping tool lineage. */
+    setProviderMessageProvenance(target, provenance.parts);
+    return target;
+  }
+
+  const retainedParts: ProviderMessageProvenancePart[] = [];
+  let contentPartOrdinal = 0;
+  let retainedOrdinal = 0;
+  for (const part of provenance.parts) {
+    if (part.sourceContentPartIndices == null) {
+      retainedParts.push(part);
+      continue;
+    }
+    const retainedSourceContentPartIndices: number[] = [];
+    for (const sourceContentPartIndex of part.sourceContentPartIndices) {
+      if (retainedContentPartIndices[retainedOrdinal] === contentPartOrdinal) {
+        retainedSourceContentPartIndices.push(sourceContentPartIndex);
+        retainedOrdinal++;
+      }
+      contentPartOrdinal++;
+    }
+    if (retainedSourceContentPartIndices.length > 0) {
+      retainedParts.push({
+        ...part,
+        sourceContentPartIndices: retainedSourceContentPartIndices,
+      });
+    }
+  }
+  setProviderMessageProvenance(
+    target,
+    retainedParts.length > 0 ? retainedParts : [{ attribution: 'model' }]
+  );
+  return target;
 }
 
 function isValidHandoffGroupId(value: unknown): value is number {
@@ -711,11 +791,14 @@ export class MultiAgentGraph extends StandardGraph {
                    * Multiple tool calls - create filtered AIMessage with ONLY this call.
                    * This ensures valid message structure for parallel handoffs.
                    */
-                  const filteredAiMsg = new AIMessage({
-                    content: originalAiMsg.content,
-                    tool_calls: [thisToolCall],
-                    id: originalAiMsg.id,
-                  });
+                  const filteredAiMsg = copyFilteredAIMessageProvenance(
+                    originalAiMsg,
+                    new AIMessage({
+                      content: originalAiMsg.content,
+                      tool_calls: [thisToolCall],
+                      id: originalAiMsg.id,
+                    })
+                  );
 
                   filteredMessages = [
                     ...messages.slice(0, aiMessageIndex),
@@ -991,14 +1074,19 @@ export class MultiAgentGraph extends StandardGraph {
                * result in THIS recipient's state, so its id is never
                * collected, but its name still marks it.
                */
-              const filteredAiMsg = new AIMessage({
-                content: filterTransferToolUseBlocks(
-                  aiMsg.content,
-                  transferToolCallIds
-                ),
-                tool_calls: remainingToolCalls,
-                id: aiMsg.id,
-              });
+              const filteredContent = filterTransferToolUseBlocks(
+                aiMsg.content,
+                transferToolCallIds
+              );
+              const filteredAiMsg = copyFilteredAIMessageProvenance(
+                aiMsg,
+                new AIMessage({
+                  content: filteredContent.content,
+                  tool_calls: remainingToolCalls,
+                  id: aiMsg.id,
+                }),
+                filteredContent.retainedContentPartIndices
+              );
               filteredMessages.push(filteredAiMsg);
             }
             /** If no remaining content or tool calls, skip this message entirely */

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -21,6 +21,7 @@ import type { ProviderMessageProvenancePart } from '@/messages/provenance';
 import type { GraphFactoryDependencies } from '@/graphs/graphFactory';
 import type * as t from '@/types';
 import {
+  hasBijectiveProviderContentPartMapping,
   inspectProviderMessageProvenance,
   inspectProviderSourceMessageIds,
   setInvalidProviderMessageProvenance,
@@ -207,16 +208,12 @@ function copyFilteredAIMessageProvenance(
     return target;
   }
 
-  let sourceIndexRefCount = 0;
-  let hasUnindexedPart = false;
-  for (const part of provenance.parts) {
-    if (part.sourceContentPartIndices == null) {
-      hasUnindexedPart = true;
-    } else {
-      sourceIndexRefCount += part.sourceContentPartIndices.length;
-    }
-  }
-  if (hasUnindexedPart || sourceIndexRefCount !== source.content.length) {
+  if (
+    !hasBijectiveProviderContentPartMapping(
+      provenance.parts,
+      source.content.length
+    )
+  ) {
     /** An older or aggregate envelope cannot be mapped to current blocks.
      * Preserve its conservative attribution instead of dropping tool lineage. */
     setFilteredProvenance(provenance.parts);
@@ -224,8 +221,7 @@ function copyFilteredAIMessageProvenance(
   }
 
   const retainedParts: ProviderMessageProvenancePart[] = [];
-  let contentPartOrdinal = 0;
-  let retainedOrdinal = 0;
+  const retainedContentPartIndexSet = new Set(retainedContentPartIndices);
   for (const part of provenance.parts) {
     if (part.sourceContentPartIndices == null) {
       retainedParts.push(part);
@@ -233,11 +229,9 @@ function copyFilteredAIMessageProvenance(
     }
     const retainedSourceContentPartIndices: number[] = [];
     for (const sourceContentPartIndex of part.sourceContentPartIndices) {
-      if (retainedContentPartIndices[retainedOrdinal] === contentPartOrdinal) {
+      if (retainedContentPartIndexSet.has(sourceContentPartIndex)) {
         retainedSourceContentPartIndices.push(sourceContentPartIndex);
-        retainedOrdinal++;
       }
-      contentPartOrdinal++;
     }
     if (retainedSourceContentPartIndices.length > 0) {
       retainedParts.push({

--- a/src/graphs/__tests__/Graph.preemptSignal.test.ts
+++ b/src/graphs/__tests__/Graph.preemptSignal.test.ts
@@ -1,8 +1,10 @@
 // src/graphs/__tests__/Graph.preemptSignal.test.ts
+import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { Providers } from '@/common';
+import { getProviderMessageProvenance } from '@/messages/provenance';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { StandardGraph } from '../Graph';
+import { Providers } from '@/common';
 
 const makeAgent = (agentId: string): t.AgentInputs => ({
   agentId,
@@ -122,5 +124,25 @@ describe('PreemptBoundary abort-signal composition', () => {
     graph.callerSignal = new AbortController().signal;
     graph.clearHeavyState();
     expect(graph.callerSignal).toBeUndefined();
+  });
+
+  it('marks PreemptBoundary additional context as synthetic provenance', async () => {
+    const graph = new StandardGraph({
+      runId: 'run_1',
+      agents: [makeAgent('agent')],
+    });
+    const registry = new HookRegistry();
+    registry.register('PreemptBoundary', {
+      hooks: [async () => ({ additionalContext: 'resume policy context' })],
+    });
+    graph.hookRegistry = registry;
+
+    const result = await dispatchBoundary(graph);
+    const message = result.messages[0] as BaseMessage;
+
+    expect(message.content).toBe('resume policy context');
+    expect(getProviderMessageProvenance(message)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
   });
 });

--- a/src/graphs/__tests__/MultiAgentGraph.test.ts
+++ b/src/graphs/__tests__/MultiAgentGraph.test.ts
@@ -8,6 +8,7 @@ import type * as t from '@/types';
 import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  PROVIDER_MESSAGE_PROVENANCE_LIMITS,
   setProviderMessageProvenance,
 } from '@/messages/provenance';
 import { MultiAgentGraph } from '../MultiAgentGraph';
@@ -24,6 +25,45 @@ type InvocableGraphTool = {
   name?: string;
   invoke(input: ToolCall, config?: RunnableConfig): Promise<unknown>;
 };
+
+const INVALID_PROVENANCE_CASES = [
+  {
+    label: 'proxy-backed malformed',
+    create: (): unknown => ({
+      version: 1,
+      parts: new Proxy([{ attribution: 'tool' }], {
+        get(target, property, receiver) {
+          return property === 'length'
+            ? Number.NaN
+            : Reflect.get(target, property, receiver);
+        },
+      }),
+    }),
+  },
+  {
+    label: 'plain oversized rehydrated',
+    create: (): unknown => ({
+      version: 1,
+      parts: Array.from(
+        { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1 },
+        () => ({ attribution: 'tool' })
+      ),
+    }),
+  },
+] as const;
+
+function expectCanonicalInvalidProvenance(
+  message: BaseMessage,
+  sourceProvenance: unknown
+): void {
+  expect(message.additional_kwargs.provenance).toEqual({
+    version: 1,
+    parts: null,
+  });
+  expect(message.additional_kwargs.provenance).not.toBe(sourceProvenance);
+  expect(message.lc_kwargs.additional_kwargs).toBe(message.additional_kwargs);
+  expect(getProviderMessageProvenance(message)).toBeUndefined();
+}
 
 describe('MultiAgentGraph.validateEdgeAgents', () => {
   const makeAgent = (agentId: string): t.AgentInputs => ({
@@ -190,6 +230,54 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
     expect(getProviderMessageProvenance(assistant)?.parts).toHaveLength(3);
   });
 
+  it.each(INVALID_PROVENANCE_CASES)(
+    'preserves $label provenance invalidity while filtering handoff content',
+    ({ create }) => {
+      const graph = new MultiAgentGraph({
+        runId: 'invalid-handoff-provenance',
+        agents: [makeAgent('A'), makeAgent('B')],
+        edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+      });
+      const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+      const sourceProvenance = create();
+      const assistant = new AIMessage({
+        content: [
+          { type: 'text', text: 'retained bytes with unknown authorship' },
+          {
+            type: 'tool_use',
+            id: 'transfer-call',
+            name: transferName,
+            input: {},
+          },
+        ],
+        tool_calls: [
+          { id: 'lookup-call', name: 'lookup', args: {} },
+          { id: 'transfer-call', name: transferName, args: {} },
+        ],
+        additional_kwargs: { provenance: sourceProvenance },
+      });
+      const transferResult = new ToolMessage({
+        content: 'Successfully transferred to B',
+        name: transferName,
+        tool_call_id: 'transfer-call',
+      });
+
+      const reception = (
+        graph as unknown as HandoffReception
+      ).processHandoffReception([assistant, transferResult], 'B');
+      const filteredAssistant = reception?.filteredMessages[0] as AIMessage;
+
+      expect(filteredAssistant.content).toEqual([
+        { type: 'text', text: 'retained bytes with unknown authorship' },
+      ]);
+      expectCanonicalInvalidProvenance(
+        filteredAssistant,
+        sourceProvenance
+      );
+      expect(assistant.additional_kwargs.provenance).toBe(sourceProvenance);
+    }
+  );
+
   it('copies provenance into a parallel handoff tool-call projection', async () => {
     const graph = new MultiAgentGraph({
       runId: 'parallel-handoff-provenance',
@@ -252,6 +340,59 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
       },
     ]);
   });
+
+  it.each(INVALID_PROVENANCE_CASES)(
+    'preserves $label provenance invalidity in a parallel handoff projection',
+    async ({ create }) => {
+      const graph = new MultiAgentGraph({
+        runId: 'invalid-parallel-handoff-provenance',
+        agents: [makeAgent('A'), makeAgent('B')],
+        edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+      });
+      const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+      const transferCall: ToolCall = {
+        id: 'transfer-call',
+        name: transferName,
+        args: {},
+        type: 'tool_call',
+      };
+      const sourceProvenance = create();
+      const assistant = new AIMessage({
+        content: 'retained bytes with unknown authorship',
+        tool_calls: [
+          transferCall,
+          { id: 'parallel-call', name: 'lookup', args: {} },
+        ],
+        additional_kwargs: { provenance: sourceProvenance },
+      });
+      const graphTools = graph.agentContexts.get('A')?.graphTools as
+        | InvocableGraphTool[]
+        | undefined;
+      const handoffTool = graphTools?.find(
+        (candidate) => candidate.name === transferName
+      );
+      if (handoffTool == null) {
+        throw new Error('Expected handoff tool');
+      }
+
+      const output = await handoffTool.invoke(transferCall, {
+        state: { messages: [assistant] },
+      } as unknown as RunnableConfig);
+      const command = output as Command<unknown, { messages: BaseMessage[] }>;
+      const update = command.update;
+      if (update == null || Array.isArray(update)) {
+        throw new Error('Expected handoff command update');
+      }
+      const filteredAssistant = update.messages[0] as AIMessage;
+
+      expect(filteredAssistant.tool_calls).toEqual([transferCall]);
+      expectCanonicalInvalidProvenance(
+        filteredAssistant,
+        sourceProvenance
+      );
+      expect(assistant.additional_kwargs.provenance).toBe(sourceProvenance);
+    }
+  );
 
   it('rejects grouped fan-in containing a command-routed source', () => {
     const input: t.MultiAgentGraphInput = {

--- a/src/graphs/__tests__/MultiAgentGraph.test.ts
+++ b/src/graphs/__tests__/MultiAgentGraph.test.ts
@@ -230,6 +230,67 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
     expect(getProviderMessageProvenance(assistant)?.parts).toHaveLength(3);
   });
 
+  it.each([
+    ['duplicate', [[0], [0]], [0, 1]],
+    ['gapped/out-of-range', [[0], [2]], [0, 1]],
+    ['reordered', [[1], [0]], [1]],
+  ])(
+    'handles a %s handoff content mapping without ordinal attribution loss',
+    (_, sourceContentPartIndices, expectedPartIndices) => {
+      const graph = new MultiAgentGraph({
+        runId: 'ambiguous-handoff-provenance',
+        agents: [makeAgent('A'), makeAgent('B')],
+        edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+      });
+      const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+      const assistant = new AIMessage({
+        content: [
+          { type: 'text', text: 'retained bytes' },
+          {
+            type: 'tool_use',
+            id: 'transfer-call',
+            name: transferName,
+            input: {},
+          },
+        ],
+        tool_calls: [
+          { id: 'lookup-call', name: 'lookup', args: {} },
+          { id: 'transfer-call', name: transferName, args: {} },
+        ],
+      });
+      const provenanceParts = [
+        {
+          attribution: 'model' as const,
+          sourceMessageId: 'source-row',
+          sourceContentPartIndices: sourceContentPartIndices[0],
+        },
+        {
+          attribution: 'user' as const,
+          sourceMessageId: 'source-row',
+          sourceContentPartIndices: sourceContentPartIndices[1],
+        },
+      ];
+      setProviderMessageProvenance(assistant, provenanceParts);
+      const transferResult = new ToolMessage({
+        content: 'Successfully transferred to B',
+        name: transferName,
+        tool_call_id: 'transfer-call',
+      });
+
+      const reception = (
+        graph as unknown as HandoffReception
+      ).processHandoffReception([assistant, transferResult], 'B');
+      const filteredAssistant = reception?.filteredMessages[0] as AIMessage;
+
+      expect(filteredAssistant.content).toEqual([
+        { type: 'text', text: 'retained bytes' },
+      ]);
+      expect(getProviderMessageProvenance(filteredAssistant)?.parts).toEqual(
+        expectedPartIndices.map((index) => provenanceParts[index])
+      );
+    }
+  );
+
   it.each(INVALID_PROVENANCE_CASES)(
     'preserves $label provenance invalidity while filtering handoff content',
     ({ create }) => {

--- a/src/graphs/__tests__/MultiAgentGraph.test.ts
+++ b/src/graphs/__tests__/MultiAgentGraph.test.ts
@@ -1,7 +1,29 @@
 // src/graphs/__tests__/MultiAgentGraph.test.ts
+import { Command } from '@langchain/langgraph';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+  setProviderMessageProvenance,
+} from '@/messages/provenance';
 import { MultiAgentGraph } from '../MultiAgentGraph';
-import { Providers } from '@/common';
+import { Constants, Providers } from '@/common';
+
+type HandoffReception = {
+  processHandoffReception(
+    messages: BaseMessage[],
+    agentId: string
+  ): { filteredMessages: BaseMessage[] } | null;
+};
+
+type InvocableGraphTool = {
+  name?: string;
+  invoke(input: ToolCall, config?: RunnableConfig): Promise<unknown>;
+};
 
 describe('MultiAgentGraph.validateEdgeAgents', () => {
   const makeAgent = (agentId: string): t.AgentInputs => ({
@@ -87,6 +109,148 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
       edges: [],
     };
     expect(() => new MultiAgentGraph(input)).not.toThrow();
+  });
+
+  it('projects retained content provenance when filtering handoff calls', () => {
+    const graph = new MultiAgentGraph({
+      runId: 'handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const assistant = new AIMessage({
+      id: 'assistant-source',
+      content: [
+        { type: 'text', text: 'model answer' },
+        { type: 'text', text: 'retained server result' },
+        {
+          type: 'tool_use',
+          id: 'transfer-call',
+          name: transferName,
+          input: {},
+        },
+      ],
+      tool_calls: [
+        { id: 'lookup-call', name: 'lookup', args: {} },
+        { id: 'transfer-call', name: transferName, args: {} },
+      ],
+    });
+    setProviderMessageProvenance(assistant, [
+      {
+        attribution: 'model',
+        sourceMessageId: 'assistant-source',
+        sourceContentPartIndices: [0],
+      },
+      {
+        attribution: 'tool',
+        sourceMessageId: 'server-result-source',
+        sourceContentPartIndices: [1],
+      },
+      {
+        attribution: 'model',
+        sourceMessageId: 'assistant-source',
+        sourceContentPartIndices: [2],
+      },
+    ]);
+    const transferResult = new ToolMessage({
+      content: 'Successfully transferred to B',
+      name: transferName,
+      tool_call_id: 'transfer-call',
+    });
+
+    const reception = (
+      graph as unknown as HandoffReception
+    ).processHandoffReception([assistant, transferResult], 'B');
+    const filteredAssistant = reception?.filteredMessages[0] as AIMessage;
+
+    expect(filteredAssistant).not.toBe(assistant);
+    expect(filteredAssistant.content).toEqual([
+      { type: 'text', text: 'model answer' },
+      { type: 'text', text: 'retained server result' },
+    ]);
+    expect(filteredAssistant.tool_calls).toEqual([
+      { id: 'lookup-call', name: 'lookup', args: {} },
+    ]);
+    expect(getProviderMessageProvenance(filteredAssistant)?.parts).toEqual([
+      {
+        attribution: 'model',
+        sourceMessageId: 'assistant-source',
+        sourceContentPartIndices: [0],
+      },
+      {
+        attribution: 'tool',
+        sourceMessageId: 'server-result-source',
+        sourceContentPartIndices: [1],
+      },
+    ]);
+    expect(getProviderSourceMessageIds(filteredAssistant)).toEqual([
+      'assistant-source',
+      'server-result-source',
+    ]);
+    expect(getProviderMessageProvenance(assistant)?.parts).toHaveLength(3);
+  });
+
+  it('copies provenance into a parallel handoff tool-call projection', async () => {
+    const graph = new MultiAgentGraph({
+      runId: 'parallel-handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const transferCall: ToolCall = {
+      id: 'transfer-call',
+      name: transferName,
+      args: {},
+      type: 'tool_call',
+    };
+    const assistant = new AIMessage({
+      id: 'parallel-assistant-source',
+      content: 'routing with retained model text',
+      tool_calls: [
+        transferCall,
+        { id: 'parallel-call', name: 'lookup', args: {} },
+      ],
+    });
+    setProviderMessageProvenance(assistant, [
+      {
+        attribution: 'model',
+        sourceMessageId: 'parallel-assistant-source',
+      },
+    ]);
+    const graphTools = graph.agentContexts.get('A')?.graphTools as
+      | InvocableGraphTool[]
+      | undefined;
+    const handoffTool = graphTools?.find(
+      (candidate) => candidate.name === transferName
+    );
+    if (handoffTool == null) {
+      throw new Error('Expected handoff tool');
+    }
+
+    const output = await handoffTool.invoke(transferCall, {
+      state: { messages: [assistant] },
+    } as unknown as RunnableConfig);
+    const command = output as Command<unknown, { messages: BaseMessage[] }>;
+    const update = command.update;
+    if (update == null || Array.isArray(update)) {
+      throw new Error('Expected handoff command update');
+    }
+    const filteredAssistant = update.messages[0] as AIMessage;
+
+    expect(filteredAssistant).not.toBe(assistant);
+    expect(filteredAssistant.tool_calls).toEqual([transferCall]);
+    expect(getProviderMessageProvenance(filteredAssistant)?.parts).toEqual([
+      {
+        attribution: 'model',
+        sourceMessageId: 'parallel-assistant-source',
+      },
+    ]);
+    expect(getProviderMessageProvenance(assistant)?.parts).toEqual([
+      {
+        attribution: 'model',
+        sourceMessageId: 'parallel-assistant-source',
+      },
+    ]);
   });
 
   it('rejects grouped fan-in containing a command-routed source', () => {

--- a/src/graphs/__tests__/MultiAgentGraph.test.ts
+++ b/src/graphs/__tests__/MultiAgentGraph.test.ts
@@ -278,6 +278,91 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
     }
   );
 
+  it('preserves validated legacy lineage while filtering handoff content', () => {
+    const graph = new MultiAgentGraph({
+      runId: 'legacy-handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const assistant = new AIMessage({
+      content: [
+        { type: 'text', text: 'retained model bytes' },
+        {
+          type: 'tool_use',
+          id: 'transfer-call',
+          name: transferName,
+          input: {},
+        },
+      ],
+      tool_calls: [
+        { id: 'lookup-call', name: 'lookup', args: {} },
+        { id: 'transfer-call', name: transferName, args: {} },
+      ],
+      additional_kwargs: {
+        sourceMessageId: 'legacy-last',
+        sourceMessageIds: ['legacy-first', 'legacy-last'],
+      },
+    });
+    const transferResult = new ToolMessage({
+      content: 'Successfully transferred to B',
+      name: transferName,
+      tool_call_id: 'transfer-call',
+    });
+
+    const reception = (
+      graph as unknown as HandoffReception
+    ).processHandoffReception([assistant, transferResult], 'B');
+    const filteredAssistant = reception?.filteredMessages[0] as AIMessage;
+
+    expect(getProviderMessageProvenance(filteredAssistant)?.parts).toEqual([
+      { attribution: 'model', sourceMessageId: 'legacy-first' },
+      { attribution: 'model', sourceMessageId: 'legacy-last' },
+    ]);
+    expect(getProviderSourceMessageIds(filteredAssistant)).toEqual([
+      'legacy-first',
+      'legacy-last',
+    ]);
+  });
+
+  it('preserves invalid legacy lineage while filtering handoff content', () => {
+    const graph = new MultiAgentGraph({
+      runId: 'invalid-legacy-handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const sourceMessageIds = { 0: 'forged', length: 1 };
+    const assistant = new AIMessage({
+      content: [
+        { type: 'text', text: 'retained bytes' },
+        {
+          type: 'tool_use',
+          id: 'transfer-call',
+          name: transferName,
+          input: {},
+        },
+      ],
+      tool_calls: [
+        { id: 'lookup-call', name: 'lookup', args: {} },
+        { id: 'transfer-call', name: transferName, args: {} },
+      ],
+      additional_kwargs: { sourceMessageIds },
+    });
+    const transferResult = new ToolMessage({
+      content: 'Successfully transferred to B',
+      name: transferName,
+      tool_call_id: 'transfer-call',
+    });
+
+    const reception = (
+      graph as unknown as HandoffReception
+    ).processHandoffReception([assistant, transferResult], 'B');
+    const filteredAssistant = reception?.filteredMessages[0] as AIMessage;
+
+    expectCanonicalInvalidProvenance(filteredAssistant, sourceMessageIds);
+  });
+
   it('copies provenance into a parallel handoff tool-call projection', async () => {
     const graph = new MultiAgentGraph({
       runId: 'parallel-handoff-provenance',
@@ -393,6 +478,106 @@ describe('MultiAgentGraph.validateEdgeAgents', () => {
       expect(assistant.additional_kwargs.provenance).toBe(sourceProvenance);
     }
   );
+
+  it('preserves validated legacy lineage in a parallel handoff projection', async () => {
+    const graph = new MultiAgentGraph({
+      runId: 'legacy-parallel-handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const transferCall: ToolCall = {
+      id: 'transfer-call',
+      name: transferName,
+      args: {},
+      type: 'tool_call',
+    };
+    const assistant = new AIMessage({
+      content: 'retained model bytes',
+      tool_calls: [
+        transferCall,
+        { id: 'parallel-call', name: 'lookup', args: {} },
+      ],
+      additional_kwargs: {
+        sourceMessageId: 'legacy-last',
+        sourceMessageIds: ['legacy-first', 'legacy-last'],
+      },
+    });
+    const graphTools = graph.agentContexts.get('A')?.graphTools as
+      | InvocableGraphTool[]
+      | undefined;
+    const handoffTool = graphTools?.find(
+      (candidate) => candidate.name === transferName
+    );
+    if (handoffTool == null) {
+      throw new Error('Expected handoff tool');
+    }
+
+    const output = await handoffTool.invoke(transferCall, {
+      state: { messages: [assistant] },
+    } as unknown as RunnableConfig);
+    const command = output as Command<unknown, { messages: BaseMessage[] }>;
+    const update = command.update;
+    if (update == null || Array.isArray(update)) {
+      throw new Error('Expected handoff command update');
+    }
+    const filteredAssistant = update.messages[0] as AIMessage;
+
+    expect(getProviderMessageProvenance(filteredAssistant)?.parts).toEqual([
+      { attribution: 'model', sourceMessageId: 'legacy-first' },
+      { attribution: 'model', sourceMessageId: 'legacy-last' },
+    ]);
+    expect(getProviderSourceMessageIds(filteredAssistant)).toEqual([
+      'legacy-first',
+      'legacy-last',
+    ]);
+  });
+
+  it('preserves invalid legacy lineage in a parallel handoff projection', async () => {
+    const graph = new MultiAgentGraph({
+      runId: 'invalid-legacy-parallel-handoff-provenance',
+      agents: [makeAgent('A'), makeAgent('B')],
+      edges: [{ from: 'A', to: 'B', edgeType: 'handoff' }],
+    });
+    const transferName = `${Constants.LC_TRANSFER_TO_}B`;
+    const transferCall: ToolCall = {
+      id: 'transfer-call',
+      name: transferName,
+      args: {},
+      type: 'tool_call',
+    };
+    const sourceMessageIds = new Array(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+    ).fill('forged');
+    const assistant = new AIMessage({
+      content: 'retained bytes',
+      tool_calls: [
+        transferCall,
+        { id: 'parallel-call', name: 'lookup', args: {} },
+      ],
+      additional_kwargs: { sourceMessageIds },
+    });
+    const graphTools = graph.agentContexts.get('A')?.graphTools as
+      | InvocableGraphTool[]
+      | undefined;
+    const handoffTool = graphTools?.find(
+      (candidate) => candidate.name === transferName
+    );
+    if (handoffTool == null) {
+      throw new Error('Expected handoff tool');
+    }
+
+    const output = await handoffTool.invoke(transferCall, {
+      state: { messages: [assistant] },
+    } as unknown as RunnableConfig);
+    const command = output as Command<unknown, { messages: BaseMessage[] }>;
+    const update = command.update;
+    if (update == null || Array.isArray(update)) {
+      throw new Error('Expected handoff command update');
+    }
+
+    expectCanonicalInvalidProvenance(update.messages[0], sourceMessageIds);
+  });
 
   it('rejects grouped fan-in containing a command-routed source', () => {
     const input: t.MultiAgentGraphInput = {

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { HumanMessage, getBufferString } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
@@ -6,6 +8,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import { getProviderMessageProvenance } from '@/messages/provenance';
 import { MultiAgentGraph } from '../MultiAgentGraph';
 import { Constants, Providers } from '@/common';
 import { FakeChatModel } from '@/llm/fake';
@@ -92,6 +95,45 @@ class GatedMessageCountChatModel extends FakeChatModel {
     const output = `response-${this.responseIndex++}`;
     yield this._createResponseChunk(output);
     void runManager?.handleLLMNewToken(output);
+  }
+}
+
+class HandoffBridgeChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+  private invocationIndex = 0;
+
+  constructor() {
+    super({ responses: ['unused'] });
+  }
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    _options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.invocations.push(messages);
+    const invocationIndex = this.invocationIndex++;
+    if (invocationIndex < 2) {
+      const call =
+        invocationIndex === 0
+          ? { id: 'lookup_1', name: 'lookup', args: '{}' }
+          : {
+            id: 'transfer_1',
+            name: `${Constants.LC_TRANSFER_TO_}B`,
+            args: JSON.stringify({ instructions: 'Take over.' }),
+          };
+      yield this._createResponseChunk('', [
+        {
+          ...call,
+          index: 0,
+          type: 'tool_call_chunk',
+        },
+      ]);
+      void runManager?.handleLLMNewToken('');
+      return;
+    }
+    yield this._createResponseChunk('handoff complete');
+    void runManager?.handleLLMNewToken('handoff complete');
   }
 }
 
@@ -321,6 +363,13 @@ describe('LangGraph composition smoke tests', () => {
     const previousPromptCount =
       downstreamPrompt.match(/Human: Previous context:/g)?.length ?? 0;
     expect(previousPromptCount).toBe(1);
+    const routingPrompt = model.invocations[2].find(
+      (message) => message.additional_kwargs.source === 'routing'
+    );
+    expect(routingPrompt).toBeDefined();
+    expect(getProviderMessageProvenance(routingPrompt!)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
   });
 
   it('compiles and invokes a handoff edge using graph-managed transfer tools', async () => {
@@ -348,6 +397,61 @@ describe('LangGraph composition smoke tests', () => {
     );
 
     expect(getAiContents(result.messages)).toContain('handoff complete');
+  });
+
+  it('marks handoff routing prompts and tool-tail assistant bridges as synthetic', async () => {
+    const lookup = tool(async () => 'lookup result', {
+      name: 'lookup',
+      description: 'lookup',
+      schema: z.object({}),
+    });
+    const model = new HandoffBridgeChatModel();
+    const graph = new MultiAgentGraph({
+      runId: 'handoff-provenance-smoke',
+      agents: [
+        { ...makeAgent('A'), graphTools: [lookup] },
+        makeAgent('B'),
+      ],
+      edges: [
+        {
+          from: 'A',
+          to: 'B',
+          edgeType: 'handoff',
+          prompt: 'Provide transfer instructions.',
+        },
+      ],
+    });
+    graph.overrideModel = model;
+
+    await graph
+      .createWorkflow()
+      .invoke(
+        { messages: [new HumanMessage('start')] },
+        makeConfig('handoff-provenance-smoke')
+      );
+
+    const recipientMessages = model.invocations.find((messages) =>
+      messages.some(
+        (message) => message.additional_kwargs.source === 'routing'
+      )
+    );
+    const routingPrompt = recipientMessages?.find(
+      (message) => message.additional_kwargs.source === 'routing'
+    );
+    const bridge = recipientMessages?.find(
+      (message) =>
+        message.getType() === 'ai' &&
+        String(message.content).startsWith('[Processed tool result')
+    );
+
+    expect(routingPrompt).toBeDefined();
+    expect(bridge).toBeDefined();
+    expect(getProviderMessageProvenance(routingPrompt!)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
+    expect(getProviderMessageProvenance(bridge!)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
   });
 
   it('compiles fan-out/fan-in direct composition with prompt wrapping', () => {

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -1,9 +1,13 @@
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
-import { Providers } from '@/common';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+} from './provenance';
 import {
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
 } from './alternation';
+import { Providers } from '@/common';
 
 describe('strictAlternationProviders', () => {
   it('covers the providers that reject consecutive user turns', () => {
@@ -146,8 +150,117 @@ describe('coalesceAdjacentUserTurns', () => {
       }),
     ]);
     expect(result).toHaveLength(1);
-    expect(result[0].additional_kwargs).toEqual({ role: 'user' });
+    expect(result[0].additional_kwargs).toMatchObject({ role: 'user' });
     expect(result[0].id).toBe('first-id');
+  });
+
+  it('retains every formatted source id in stable content order', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'first',
+        id: 'first-message',
+        additional_kwargs: {
+          sourceMessageId: 'first-message',
+          sourceMessageIds: ['first-message'],
+        },
+      }),
+      new HumanMessage({
+        content: 'middle',
+        additional_kwargs: {
+          sourceMessageId: 'middle-message',
+          sourceMessageIds: ['middle-message'],
+        },
+      }),
+      new HumanMessage({
+        content: 'last',
+        additional_kwargs: {
+          sourceMessageId: 'last-message',
+          sourceMessageIds: ['last-message'],
+        },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('first-message');
+    expect(result[0].additional_kwargs.sourceMessageId).toBe('last-message');
+    expect(result[0].additional_kwargs.sourceMessageIds).toEqual([
+      'first-message',
+      'middle-message',
+      'last-message',
+    ]);
+  });
+
+  it('keeps user and synthetic contributors distinct across a merge', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'real user turn',
+        additional_kwargs: {
+          sourceMessageId: 'user-message',
+          sourceMessageIds: ['user-message'],
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'user',
+                sourceMessageId: 'user-message',
+                sourceContentPartIndices: [1],
+              },
+            ],
+          },
+        },
+      }),
+      new HumanMessage({
+        content: 'skill body',
+        additional_kwargs: { isMeta: true, source: 'skill' },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'user-message',
+          sourceContentPartIndices: [1],
+        },
+        { attribution: 'synthetic' },
+      ],
+    });
+    expect(result[0].additional_kwargs.sourceMessageIds).toEqual([
+      'user-message',
+    ]);
+  });
+
+  it('reconciles plural lineage when explicit legacy parts omit ids', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'legacy first',
+        additional_kwargs: {
+          sourceMessageIds: ['legacy-first'],
+          provenance: {
+            version: 1,
+            parts: [{ attribution: 'user' }],
+          },
+        },
+      }),
+      new HumanMessage({
+        content: 'second',
+        additional_kwargs: { sourceMessageId: 'second' },
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.sourceMessageIds).toEqual([
+      'legacy-first',
+      'second',
+    ]);
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'user', sourceMessageId: 'legacy-first' },
+        { attribution: 'user', sourceMessageId: 'second' },
+      ],
+    });
   });
 
   it('marks the merge meta when the trailing part is the volatile one', () => {
@@ -198,6 +311,181 @@ describe('coalesceAdjacentUserTurns', () => {
       new HumanMessage({ content: 'steer' }),
     ]);
     expect(result).toHaveLength(2);
+  });
+
+  it('does not merge the LangChain server-tool-result block into user text', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [
+          {
+            type: 'server_tool_result',
+            tool_call_id: 'server-call',
+            status: 'success',
+            output: 'tool bytes',
+          },
+        ],
+      }),
+      new HumanMessage({ content: 'next turn' }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not merge a Gemini code-execution result into user text', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [
+          {
+            type: 'codeExecutionResult',
+            codeExecutionResult: {
+              outcome: 'OUTCOME_OK',
+              output: 'tool bytes',
+            },
+          },
+        ],
+      }),
+      new HumanMessage({ content: 'next turn' }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not trust arbitrary source metadata or tool-result suffixes', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [{ type: 'attacker_tool_result', text: 'submitted text' }],
+        additional_kwargs: {
+          source: 'mobile',
+          sourceMessageId: 'first',
+        },
+      }),
+      new HumanMessage({
+        content: 'next',
+        additional_kwargs: { sourceMessageId: 'second' },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'user', sourceMessageId: 'first' },
+        { attribution: 'user', sourceMessageId: 'second' },
+      ],
+    });
+  });
+
+  it('keeps steer user attribution even when legacy metadata marks it meta', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'steer',
+        additional_kwargs: {
+          source: 'steer',
+          isMeta: true,
+          sourceMessageId: 'steer-row',
+        },
+      }),
+      new HumanMessage({
+        content: 'next',
+        additional_kwargs: { sourceMessageId: 'next-row' },
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'user', sourceMessageId: 'steer-row' },
+        { attribution: 'user', sourceMessageId: 'next-row' },
+      ],
+    });
+  });
+
+  it('does not fabricate indexed mappings across plural legacy sources', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: [{ type: 'text', text: 'merged legacy bytes' }],
+        additional_kwargs: {
+          sourceMessageIds: ['first-row', 'second-row'],
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'user',
+                sourceContentPartIndices: [0],
+              },
+            ],
+          },
+        },
+      }),
+      new HumanMessage({
+        content: 'next',
+        additional_kwargs: { sourceMessageId: 'next-row' },
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'user', sourceContentPartIndices: [0] },
+        { attribution: 'user', sourceMessageId: 'first-row' },
+        { attribution: 'user', sourceMessageId: 'second-row' },
+        { attribution: 'user', sourceMessageId: 'next-row' },
+      ],
+    });
+  });
+
+  it('does not attribute leading empty turns that add no provider bytes', () => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: '',
+        additional_kwargs: { sourceMessageId: 'empty-row' },
+      }),
+      new HumanMessage({
+        content: 'visible',
+        additional_kwargs: { sourceMessageId: 'visible-row' },
+      }),
+    ]);
+
+    expect(result[0].content).toBe('visible');
+    expect(getProviderSourceMessageIds(result[0])).toEqual(['visible-row']);
+  });
+
+  it('coalesces a large adjacent run in one pass without truncating lineage', () => {
+    const count = 4_000;
+    const messages = Array.from(
+      { length: count },
+      (_, index) =>
+        new HumanMessage({
+          content: [{ type: 'text', text: String(index) }],
+          additional_kwargs: { sourceMessageId: `source-${index}` },
+        })
+    );
+
+    const result = coalesceAdjacentUserTurns(messages);
+    const sourceMessageIds = getProviderSourceMessageIds(result[0]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(count);
+    expect(sourceMessageIds).toHaveLength(count);
+    expect(getProviderMessageProvenance(result[0])?.parts).toHaveLength(count);
+    expect(sourceMessageIds[0]).toBe('source-0');
+    expect(sourceMessageIds[count - 1]).toBe(`source-${count - 1}`);
+  });
+
+  it('coalesces a very large block array without call-argument spreading', () => {
+    const blockCount = 150_000;
+    const repeatedBlock = { type: 'text', text: 'x' } as const;
+    const largeContent = new Array(blockCount).fill(repeatedBlock);
+    const messages = [
+      new HumanMessage({ content: [{ type: 'text', text: 'first' }] }),
+      new HumanMessage({ content: largeContent }),
+    ];
+
+    const result = coalesceAdjacentUserTurns(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(blockCount + 1);
+    expect(messages[1].content).toBe(largeContent);
   });
 
   it('does not mutate the input array or its messages', () => {

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -103,12 +103,43 @@ describe('coalesceAdjacentUserTurns', () => {
     ]);
   });
 
+  it('does not invoke custom iterators while joining mixed human content', () => {
+    let iteratorReads = 0;
+    const blockContent = [{ type: 'text', text: 'blocks' }];
+    const messages = [
+      new HumanMessage({ content: 'plain' }),
+      new HumanMessage({ content: blockContent }),
+    ];
+    Object.defineProperty(blockContent, Symbol.iterator, {
+      configurable: true,
+      get: () => {
+        iteratorReads++;
+        return Array.prototype[Symbol.iterator];
+      },
+    });
+
+    const result = coalesceAdjacentUserTurns(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toEqual([
+      { type: 'text', text: 'plain' },
+      { type: 'text', text: 'blocks' },
+    ]);
+    expect(iteratorReads).toBe(0);
+  });
+
   /**
    * Both vendored converters merge adjacent tool-result runs themselves, and
    * folding one into a text turn would orphan the pairing.
    */
   it('never merges tool-result turns', () => {
     const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 't1', name: 'lookup', args: {}, type: 'tool_call' },
+          { id: 't2', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+      }),
       new HumanMessage({
         content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
       }),
@@ -116,17 +147,91 @@ describe('coalesceAdjacentUserTurns', () => {
         content: [{ type: 'tool_result', tool_use_id: 't2', content: 'ok' }],
       }),
     ]);
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
   });
 
   it('never merges a tool-result turn into a text turn', () => {
+    const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 't1', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
+      }),
+      new HumanMessage({ content: 'steer' }),
+    ]);
+    expect(result).toHaveLength(3);
+  });
+
+  it('does not invoke custom iterators while pairing tool results', () => {
+    let iteratorReads = 0;
+    const toolCalls = [
+      { id: 't1', name: 'lookup', args: {}, type: 'tool_call' as const },
+    ];
+    const resultContent = [
+      { type: 'tool_result', tool_use_id: 't1', content: 'ok' },
+    ];
+    const messages = [
+      new AIMessage({ content: '', tool_calls: toolCalls }),
+      new HumanMessage({ content: resultContent }),
+      new HumanMessage({ content: 'steer' }),
+    ];
+    for (const array of [toolCalls, resultContent]) {
+      Object.defineProperty(array, Symbol.iterator, {
+        configurable: true,
+        get: () => {
+          iteratorReads++;
+          return Array.prototype[Symbol.iterator];
+        },
+      });
+    }
+
+    expect(coalesceAdjacentUserTurns(messages)).toHaveLength(3);
+    expect(iteratorReads).toBe(0);
+  });
+
+  it('coalesces an exact-looking unpaired tool result as user content', () => {
     const result = coalesceAdjacentUserTurns([
       new HumanMessage({
         content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
       }),
       new HumanMessage({ content: 'steer' }),
     ]);
-    expect(result).toHaveLength(2);
+
+    expect(result).toHaveLength(1);
+    expect(getProviderMessageProvenance(result[0])?.parts).toEqual([
+      { attribution: 'user' },
+      { attribution: 'user' },
+    ]);
+  });
+
+  it('exempts only the first result for a provider call id', () => {
+    const firstResult = new HumanMessage({
+      content: [{ type: 'tool_result', tool_use_id: 't1', content: 'first' }],
+    });
+    const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 't1', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+      }),
+      firstResult,
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'second' }],
+      }),
+      new HumanMessage({ content: 'steer' }),
+    ]);
+
+    expect(result).toHaveLength(3);
+    expect(result[1]).toBe(firstResult);
+    expect(getProviderMessageProvenance(result[2])?.parts).toEqual([
+      { attribution: 'user' },
+      { attribution: 'user' },
+    ]);
   });
 
   /**
@@ -305,15 +410,28 @@ describe('coalesceAdjacentUserTurns', () => {
 
   it('excludes the camelCase toolResult variant too', () => {
     const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: [
+          {
+            type: 'toolUse',
+            toolUse: { toolUseId: 't1', name: 'lookup', input: {} },
+          },
+        ],
+      }),
       new HumanMessage({
-        content: [{ type: 'toolResult', toolResult: { content: 'ok' } }],
+        content: [
+          {
+            type: 'toolResult',
+            toolResult: { toolUseId: 't1', content: [{ text: 'ok' }] },
+          },
+        ],
       }),
       new HumanMessage({ content: 'steer' }),
     ]);
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
   });
 
-  it('does not merge the LangChain server-tool-result block into user text', () => {
+  it('coalesces a LangChain server result presented as user content', () => {
     const result = coalesceAdjacentUserTurns([
       new HumanMessage({
         content: [
@@ -328,10 +446,14 @@ describe('coalesceAdjacentUserTurns', () => {
       new HumanMessage({ content: 'next turn' }),
     ]);
 
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
+    expect(getProviderMessageProvenance(result[0])?.parts).toEqual([
+      { attribution: 'user' },
+      { attribution: 'user' },
+    ]);
   });
 
-  it('does not merge a Gemini code-execution result into user text', () => {
+  it('coalesces a Gemini code result presented as user content', () => {
     const result = coalesceAdjacentUserTurns([
       new HumanMessage({
         content: [
@@ -347,7 +469,11 @@ describe('coalesceAdjacentUserTurns', () => {
       new HumanMessage({ content: 'next turn' }),
     ]);
 
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
+    expect(getProviderMessageProvenance(result[0])?.parts).toEqual([
+      { attribution: 'user' },
+      { attribution: 'user' },
+    ]);
   });
 
   it('does not trust arbitrary source metadata or tool-result suffixes', () => {

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -2,6 +2,8 @@ import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  PROVIDER_MESSAGE_PROVENANCE_LIMITS,
+  stampSyntheticProviderMessage,
 } from './provenance';
 import {
   coalesceAdjacentUserTurns,
@@ -314,10 +316,12 @@ describe('coalesceAdjacentUserTurns', () => {
           },
         },
       }),
-      new HumanMessage({
-        content: 'skill body',
-        additional_kwargs: { isMeta: true, source: 'skill' },
-      }),
+      stampSyntheticProviderMessage(
+        new HumanMessage({
+          content: 'skill body',
+          additional_kwargs: { isMeta: true, source: 'skill' },
+        })
+      ),
     ]);
 
     expect(result).toHaveLength(1);
@@ -499,6 +503,111 @@ describe('coalesceAdjacentUserTurns', () => {
         { attribution: 'user', sourceMessageId: 'second' },
       ],
     });
+  });
+
+  it.each([
+    ['hook source', { source: 'hook' }],
+    ['skill source', { source: 'skill' }],
+    ['system source', { source: 'system' }],
+    ['meta flag', { isMeta: true }],
+    ['injected flag', { injected: true }],
+  ])('defaults an unstamped human with a caller-controlled %s to user', (_, metadata) => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'caller bytes',
+        additional_kwargs: {
+          ...metadata,
+          sourceMessageId: 'caller-row',
+        },
+      }),
+      new HumanMessage({
+        content: 'next',
+        additional_kwargs: { sourceMessageId: 'next-row' },
+      }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'user', sourceMessageId: 'caller-row' },
+        { attribution: 'user', sourceMessageId: 'next-row' },
+      ],
+    });
+  });
+
+  it.each([
+    [
+      'proxy-backed malformed',
+      () => ({
+        version: 1,
+        parts: new Proxy([{ attribution: 'synthetic' }], {
+          get(target, property, receiver) {
+            return property === 'length'
+              ? Number.NaN
+              : Reflect.get(target, property, receiver);
+          },
+        }),
+      }),
+    ],
+    [
+      'plain oversized',
+      () => ({
+        version: 1,
+        parts: Array.from(
+          { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1 },
+          () => ({ attribution: 'synthetic' })
+        ),
+      }),
+    ],
+  ])('preserves %s provenance invalidity across a human merge', (_, create) => {
+    const sourceProvenance = create();
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'caller bytes',
+        additional_kwargs: {
+          source: 'hook',
+          sourceMessageId: 'caller-row',
+          provenance: sourceProvenance,
+        },
+      }),
+      new HumanMessage({ content: 'next' }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: null,
+    });
+    expect(result[0].additional_kwargs.provenance).not.toBe(sourceProvenance);
+    expect(result[0].additional_kwargs.sourceMessageId).toBeUndefined();
+    expect(result[0].lc_kwargs.additional_kwargs).toBe(
+      result[0].additional_kwargs
+    );
+  });
+
+  it.each([
+    ['non-array', { 0: 'forged', length: 1 }],
+    [
+      'oversized',
+      new Array(
+        PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+      ).fill('forged'),
+    ],
+  ])('preserves %s legacy lineage invalidity across a human merge', (_, sourceMessageIds) => {
+    const result = coalesceAdjacentUserTurns([
+      new HumanMessage({
+        content: 'caller bytes',
+        additional_kwargs: { sourceMessageIds },
+      }),
+      new HumanMessage({ content: 'next' }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: null,
+    });
+    expect(result[0].additional_kwargs.provenance).not.toBe(sourceMessageIds);
   });
 
   it('keeps steer user attribution even when legacy metadata marks it meta', () => {

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -12,8 +12,9 @@ import {
   getProviderToolResultPartDescriptor,
 } from './toolResultTypes';
 import {
-  getProviderMessageProvenance,
-  getProviderSourceMessageIds,
+  inspectProviderMessageProvenance,
+  inspectProviderSourceMessageIds,
+  setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
 } from './provenance';
 import { Providers } from '@/common';
@@ -132,43 +133,30 @@ function joinContents(messages: readonly BaseMessage[]): MessageContent {
   return blocks;
 }
 
-function inferHumanMessageAttribution(
-  message: BaseMessage
-): ProviderMessageProvenancePart['attribution'] {
-  const additionalKwargs = message.additional_kwargs as {
-    injected?: unknown;
-    isMeta?: unknown;
-    source?: unknown;
-  };
-  const source =
-    typeof additionalKwargs.source === 'string'
-      ? additionalKwargs.source
-      : undefined;
-  if (source === 'steer') {
-    return 'user';
-  }
-  const isKnownSyntheticSource =
-    source === 'skill' || source === 'hook' || source === 'system';
-  return additionalKwargs.isMeta === true ||
-    isKnownSyntheticSource ||
-    additionalKwargs.injected === true
-    ? 'synthetic'
-    : 'user';
-}
-
 function getHumanMessageProvenanceParts(
   message: BaseMessage
-): ProviderMessageProvenancePart[] {
-  const explicit = getProviderMessageProvenance(message);
-  if (explicit != null && explicit.parts.length > 0) {
-    const parts = [...explicit.parts];
+): ProviderMessageProvenancePart[] | null {
+  const provenanceState = inspectProviderMessageProvenance(message);
+  const sourceMessageIdsState = inspectProviderSourceMessageIds(message);
+  if (
+    provenanceState.status === 'invalid' ||
+    sourceMessageIdsState.status === 'invalid'
+  ) {
+    return null;
+  }
+  const sourceMessageIds =
+    sourceMessageIdsState.status === 'valid'
+      ? sourceMessageIdsState.sourceMessageIds
+      : [];
+  if (provenanceState.status === 'valid') {
+    const parts = [...provenanceState.provenance.parts];
     const representedSourceIds = new Set<string>();
     for (const part of parts) {
       if (part.sourceMessageId != null) {
         representedSourceIds.add(part.sourceMessageId);
       }
     }
-    const missingSourceIds = getProviderSourceMessageIds(message).filter(
+    const missingSourceIds = sourceMessageIds.filter(
       (sourceMessageId) => !representedSourceIds.has(sourceMessageId)
     );
     if (
@@ -181,20 +169,17 @@ function getHumanMessageProvenanceParts(
         sourceMessageId,
       }));
     }
-    const attribution = inferHumanMessageAttribution(message);
     for (const sourceMessageId of missingSourceIds) {
-      parts.push({ attribution, sourceMessageId });
+      parts.push({ attribution: 'user', sourceMessageId });
     }
     return parts;
   }
-  const attribution = inferHumanMessageAttribution(message);
-  const sourceMessageIds = getProviderSourceMessageIds(message);
   return sourceMessageIds.length > 0
     ? sourceMessageIds.map((sourceMessageId) => ({
-      attribution,
+      attribution: 'user' as const,
       sourceMessageId,
     }))
-    : [{ attribution }];
+    : [{ attribution: 'user' }];
 }
 
 function hasProviderVisibleContent(message: BaseMessage): boolean {
@@ -255,22 +240,22 @@ export function coalesceAdjacentUserTurns(
     const run = messages.slice(index, endIndex);
     const last = run[run.length - 1];
     const provenanceParts: ProviderMessageProvenancePart[] = [];
+    let hasInvalidProvenance = false;
     for (const message of run) {
       if (!hasProviderVisibleContent(message)) {
         continue;
       }
-      for (const part of getHumanMessageProvenanceParts(message)) {
+      const messageProvenanceParts = getHumanMessageProvenanceParts(message);
+      if (messageProvenanceParts == null) {
+        hasInvalidProvenance = true;
+        continue;
+      }
+      for (const part of messageProvenanceParts) {
         provenanceParts.push(part);
       }
     }
     if (provenanceParts.length === 0) {
-      provenanceParts.push({
-        attribution: run.some(
-          (message) => inferHumanMessageAttribution(message) === 'user'
-        )
-          ? 'user'
-          : 'synthetic',
-      });
+      provenanceParts.push({ attribution: 'user' });
     }
 
     const mergedMessage = new HumanMessage({
@@ -289,7 +274,11 @@ export function coalesceAdjacentUserTurns(
       additional_kwargs: { ...last.additional_kwargs },
       ...(first.id != null && { id: first.id }),
     });
-    setProviderMessageProvenance(mergedMessage, provenanceParts);
+    if (hasInvalidProvenance) {
+      setInvalidProviderMessageProvenance(mergedMessage);
+    } else {
+      setProviderMessageProvenance(mergedMessage, provenanceParts);
+    }
     result.push(mergedMessage);
     pairedToolCalls = new Map();
     index = endIndex;

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -2,12 +2,20 @@
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage, MessageContent } from '@langchain/core/messages';
 import type { ProviderMessageProvenancePart } from './provenance';
+import type { ProviderToolCallIndex } from './toolResultTypes';
+import {
+  appendProviderToolCallDescriptor,
+  consumeProviderToolResultPair,
+  getBoundedProviderPairingArrayProperty,
+  getProviderAIMessageToolCallDescriptor,
+  getProviderToolCallPartDescriptor,
+  getProviderToolResultPartDescriptor,
+} from './toolResultTypes';
 import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
   setProviderMessageProvenance,
 } from './provenance';
-import { isProviderToolResultPart } from './toolResultTypes';
 import { Providers } from '@/common';
 
 /**
@@ -31,12 +39,52 @@ export const strictAlternationProviders: ReadonlySet<Providers> = new Set([
  * merge adjacent runs of these, and folding one into a text turn would break
  * the tool pairing they depend on — so they are left alone here.
  */
-function isToolResultMessage(message: BaseMessage): boolean {
-  const { content } = message;
-  if (typeof content === 'string' || content.length === 0) {
+function collectProviderToolCalls(message: BaseMessage): ProviderToolCallIndex {
+  const calls: ProviderToolCallIndex = new Map();
+  const content = getBoundedProviderPairingArrayProperty(message, 'content');
+  if (content != null) {
+    for (let index = 0; index < content.length; index++) {
+      const descriptor = getProviderToolCallPartDescriptor(content[index]);
+      if (descriptor != null) {
+        appendProviderToolCallDescriptor(calls, descriptor);
+      }
+    }
+  }
+  const toolCalls = getBoundedProviderPairingArrayProperty(
+    message,
+    'tool_calls'
+  );
+  if (toolCalls != null) {
+    for (let index = 0; index < toolCalls.length; index++) {
+      const descriptor = getProviderAIMessageToolCallDescriptor(
+        toolCalls[index]
+      );
+      if (descriptor != null) {
+        appendProviderToolCallDescriptor(calls, descriptor);
+      }
+    }
+  }
+  return calls;
+}
+
+function isToolResultMessage(
+  message: BaseMessage,
+  pairedToolCalls: ProviderToolCallIndex
+): boolean {
+  const content = getBoundedProviderPairingArrayProperty(message, 'content');
+  if (content == null || content.length === 0) {
     return false;
   }
-  return content.every(isProviderToolResultPart);
+  for (let index = 0; index < content.length; index++) {
+    const descriptor = getProviderToolResultPartDescriptor(content[index]);
+    if (
+      descriptor?.allowHumanMessagePairing !== true ||
+      !consumeProviderToolResultPair(descriptor, pairedToolCalls)
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function toBlocks(content: MessageContent): Exclude<MessageContent, string> {
@@ -72,8 +120,9 @@ function joinContents(messages: readonly BaseMessage[]): MessageContent {
   const prefix = joinStringContents(messages, firstArrayIndex);
   const blocks: Exclude<MessageContent, string> = [];
   const appendBlocks = (content: MessageContent): void => {
-    for (const block of toBlocks(content)) {
-      blocks.push(block);
+    const contentBlocks = toBlocks(content);
+    for (let index = 0; index < contentBlocks.length; index++) {
+      blocks.push(contentBlocks[index]);
     }
   };
   appendBlocks(prefix);
@@ -167,10 +216,22 @@ export function coalesceAdjacentUserTurns(
   messages: BaseMessage[]
 ): BaseMessage[] {
   let result: BaseMessage[] | null = null;
+  let pairedToolCalls: ProviderToolCallIndex = new Map();
   let index = 0;
   while (index < messages.length) {
     const first = messages[index];
-    if (first.getType() !== 'human' || isToolResultMessage(first)) {
+    if (first.getType() === 'ai') {
+      pairedToolCalls = collectProviderToolCalls(first);
+      result?.push(first);
+      index++;
+      continue;
+    }
+    if (first.getType() !== 'human') {
+      result?.push(first);
+      index++;
+      continue;
+    }
+    if (isToolResultMessage(first, pairedToolCalls)) {
       result?.push(first);
       index++;
       continue;
@@ -180,12 +241,13 @@ export function coalesceAdjacentUserTurns(
     while (
       endIndex < messages.length &&
       messages[endIndex].getType() === 'human' &&
-      !isToolResultMessage(messages[endIndex])
+      !isToolResultMessage(messages[endIndex], pairedToolCalls)
     ) {
       endIndex++;
     }
     if (endIndex === index + 1) {
       result?.push(first);
+      pairedToolCalls = new Map();
       index = endIndex;
       continue;
     }
@@ -229,6 +291,7 @@ export function coalesceAdjacentUserTurns(
     });
     setProviderMessageProvenance(mergedMessage, provenanceParts);
     result.push(mergedMessage);
+    pairedToolCalls = new Map();
     index = endIndex;
   }
   /**

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -1,6 +1,13 @@
 // src/messages/alternation.ts
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage, MessageContent } from '@langchain/core/messages';
+import type { ProviderMessageProvenancePart } from './provenance';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+  setProviderMessageProvenance,
+} from './provenance';
+import { isProviderToolResultPart } from './toolResultTypes';
 import { Providers } from '@/common';
 
 /**
@@ -19,8 +26,6 @@ export const strictAlternationProviders: ReadonlySet<Providers> = new Set([
   Providers.MISTRALAI,
 ]);
 
-const TOOL_RESULT_TYPES = new Set(['tool_result', 'toolResult']);
-
 /**
  * True when every block is a tool result. Both vendored converters already
  * merge adjacent runs of these, and folding one into a text turn would break
@@ -31,10 +36,7 @@ function isToolResultMessage(message: BaseMessage): boolean {
   if (typeof content === 'string' || content.length === 0) {
     return false;
   }
-  return content.every(
-    (block) =>
-      typeof block.type === 'string' && TOOL_RESULT_TYPES.has(block.type)
-  );
+  return content.every(isProviderToolResultPart);
 }
 
 function toBlocks(content: MessageContent): Exclude<MessageContent, string> {
@@ -44,14 +46,112 @@ function toBlocks(content: MessageContent): Exclude<MessageContent, string> {
   return content;
 }
 
-function joinContent(
-  left: MessageContent,
-  right: MessageContent
-): MessageContent {
-  if (typeof left === 'string' && typeof right === 'string') {
-    return left === '' ? right : `${left}\n\n${right}`;
+function joinStringContents(
+  messages: readonly BaseMessage[],
+  endIndex = messages.length
+): string {
+  const contents: string[] = [];
+  for (let index = 0; index < endIndex; index++) {
+    const content = messages[index].content as string;
+    if (contents.length === 0 && content === '') {
+      continue;
+    }
+    contents.push(content);
   }
-  return [...toBlocks(left), ...toBlocks(right)];
+  return contents.join('\n\n');
+}
+
+function joinContents(messages: readonly BaseMessage[]): MessageContent {
+  const firstArrayIndex = messages.findIndex((message) =>
+    Array.isArray(message.content)
+  );
+  if (firstArrayIndex === -1) {
+    return joinStringContents(messages);
+  }
+
+  const prefix = joinStringContents(messages, firstArrayIndex);
+  const blocks: Exclude<MessageContent, string> = [];
+  const appendBlocks = (content: MessageContent): void => {
+    for (const block of toBlocks(content)) {
+      blocks.push(block);
+    }
+  };
+  appendBlocks(prefix);
+  for (let index = firstArrayIndex; index < messages.length; index++) {
+    appendBlocks(messages[index].content);
+  }
+  return blocks;
+}
+
+function inferHumanMessageAttribution(
+  message: BaseMessage
+): ProviderMessageProvenancePart['attribution'] {
+  const additionalKwargs = message.additional_kwargs as {
+    injected?: unknown;
+    isMeta?: unknown;
+    source?: unknown;
+  };
+  const source =
+    typeof additionalKwargs.source === 'string'
+      ? additionalKwargs.source
+      : undefined;
+  if (source === 'steer') {
+    return 'user';
+  }
+  const isKnownSyntheticSource =
+    source === 'skill' || source === 'hook' || source === 'system';
+  return additionalKwargs.isMeta === true ||
+    isKnownSyntheticSource ||
+    additionalKwargs.injected === true
+    ? 'synthetic'
+    : 'user';
+}
+
+function getHumanMessageProvenanceParts(
+  message: BaseMessage
+): ProviderMessageProvenancePart[] {
+  const explicit = getProviderMessageProvenance(message);
+  if (explicit != null && explicit.parts.length > 0) {
+    const parts = [...explicit.parts];
+    const representedSourceIds = new Set<string>();
+    for (const part of parts) {
+      if (part.sourceMessageId != null) {
+        representedSourceIds.add(part.sourceMessageId);
+      }
+    }
+    const missingSourceIds = getProviderSourceMessageIds(message).filter(
+      (sourceMessageId) => !representedSourceIds.has(sourceMessageId)
+    );
+    if (
+      parts.length === 1 &&
+      parts[0].sourceMessageId == null &&
+      missingSourceIds.length === 1
+    ) {
+      return missingSourceIds.map((sourceMessageId) => ({
+        ...parts[0],
+        sourceMessageId,
+      }));
+    }
+    const attribution = inferHumanMessageAttribution(message);
+    for (const sourceMessageId of missingSourceIds) {
+      parts.push({ attribution, sourceMessageId });
+    }
+    return parts;
+  }
+  const attribution = inferHumanMessageAttribution(message);
+  const sourceMessageIds = getProviderSourceMessageIds(message);
+  return sourceMessageIds.length > 0
+    ? sourceMessageIds.map((sourceMessageId) => ({
+      attribution,
+      sourceMessageId,
+    }))
+    : [{ attribution }];
+}
+
+function hasProviderVisibleContent(message: BaseMessage): boolean {
+  return typeof message.content === 'string'
+    ? message.content.length > 0
+    : message.content.length > 0;
 }
 
 /**
@@ -66,25 +166,53 @@ function joinContent(
 export function coalesceAdjacentUserTurns(
   messages: BaseMessage[]
 ): BaseMessage[] {
-  const result: BaseMessage[] = [];
-  let mergedAny = false;
-  for (const message of messages) {
-    const previous = result[result.length - 1];
-    const mergeable =
-      result.length > 0 &&
-      previous.getType() === 'human' &&
-      message.getType() === 'human' &&
-      !isToolResultMessage(previous) &&
-      !isToolResultMessage(message);
-
-    if (!mergeable) {
-      result.push(message);
+  let result: BaseMessage[] | null = null;
+  let index = 0;
+  while (index < messages.length) {
+    const first = messages[index];
+    if (first.getType() !== 'human' || isToolResultMessage(first)) {
+      result?.push(first);
+      index++;
       continue;
     }
-    mergedAny = true;
 
-    result[result.length - 1] = new HumanMessage({
-      content: joinContent(previous.content, message.content),
+    let endIndex = index + 1;
+    while (
+      endIndex < messages.length &&
+      messages[endIndex].getType() === 'human' &&
+      !isToolResultMessage(messages[endIndex])
+    ) {
+      endIndex++;
+    }
+    if (endIndex === index + 1) {
+      result?.push(first);
+      index = endIndex;
+      continue;
+    }
+    result ??= messages.slice(0, index);
+    const run = messages.slice(index, endIndex);
+    const last = run[run.length - 1];
+    const provenanceParts: ProviderMessageProvenancePart[] = [];
+    for (const message of run) {
+      if (!hasProviderVisibleContent(message)) {
+        continue;
+      }
+      for (const part of getHumanMessageProvenanceParts(message)) {
+        provenanceParts.push(part);
+      }
+    }
+    if (provenanceParts.length === 0) {
+      provenanceParts.push({
+        attribution: run.some(
+          (message) => inferHumanMessageAttribution(message) === 'user'
+        )
+          ? 'user'
+          : 'synthetic',
+      });
+    }
+
+    const mergedMessage = new HumanMessage({
+      content: joinContents(run),
       /**
        * The LATER turn's kwargs, deliberately. The one provider-path consumer
        * of these flags is the prompt-cache tail anchor, and it reasons
@@ -96,9 +224,12 @@ export function coalesceAdjacentUserTurns(
        * skill body must not pin the cache to the volatile body. The first
        * turn's id is kept so origin tracking can re-attach by key.
        */
-      additional_kwargs: message.additional_kwargs,
-      ...(previous.id != null && { id: previous.id }),
+      additional_kwargs: { ...last.additional_kwargs },
+      ...(first.id != null && { id: first.id }),
     });
+    setProviderMessageProvenance(mergedMessage, provenanceParts);
+    result.push(mergedMessage);
+    index = endIndex;
   }
   /**
    * Identity on the no-merge path. The pass runs twice for a primary
@@ -108,5 +239,5 @@ export function coalesceAdjacentUserTurns(
    * the SAME array rather than reallocating a context-sized copy, and
    * callers can cheaply detect "nothing changed" by identity.
    */
-  return mergedAny ? result : messages;
+  return result ?? messages;
 }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -9,10 +9,12 @@ import {
 } from '@langchain/core/messages';
 import type { ContentBlock as LangChainContentBlock } from '@langchain/core/messages';
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
+import type { ProviderMessageProvenancePart } from './provenance';
 import type * as t from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
+  getToolContentCharLength,
   getBoundedCacheControlledTextToolContent,
   getBoundedSingleTextToolContent,
   getComputerCallOutputScreenshot,
@@ -20,6 +22,11 @@ import {
   isComputerCallOutputMessage,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+  setProviderMessageProvenance,
+} from './provenance';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { stripAnthropicCacheControl } from './cache';
 import { ContentTypes, Providers } from '@/common';
@@ -516,6 +523,164 @@ function appendBoundedContent(
   appendContentBlocks(combined, current);
   appendContentBlocks(combined, boundedNext);
   return compactToolContent(toLangChainContent(combined), maxChars).content;
+}
+
+interface BoundedContentAccumulator {
+  readonly blocks: t.MessageContentComplex[];
+  hasContent: boolean;
+  remainingChars: number;
+}
+
+function createBoundedContentAccumulator(
+  maxChars: number
+): BoundedContentAccumulator {
+  return {
+    blocks: [],
+    hasContent: false,
+    remainingChars: Number.isFinite(maxChars)
+      ? Math.max(0, Math.floor(maxChars))
+      : Number.MAX_SAFE_INTEGER,
+  };
+}
+
+/** Appends a segment only when at least one of its provider-visible bytes fits.
+ * Each segment is compacted against the remaining budget before combination,
+ * so a later segment cannot be credited merely because recompression replaced
+ * earlier bytes with a truncation notice. */
+function appendBoundedContentSegment(
+  accumulator: BoundedContentAccumulator,
+  next: unknown
+): { contributed: boolean; complete: boolean } {
+  const separatorChars = accumulator.hasContent ? 1 : 0;
+  const availableChars = accumulator.remainingChars - separatorChars;
+  const originalChars = getToolContentCharLength(next);
+  if (originalChars <= 0) {
+    return { contributed: false, complete: true };
+  }
+  if (availableChars <= 0) {
+    return { contributed: false, complete: false };
+  }
+  const compactedNext = compactToolContent(next, availableChars);
+  const boundedNext = compactedNext.content;
+  const appendedChars = Math.min(
+    availableChars,
+    getToolContentCharLength(boundedNext)
+  );
+  if (appendedChars <= 0) {
+    return { contributed: false, complete: false };
+  }
+  appendContentBlocks(accumulator.blocks, boundedNext);
+  accumulator.hasContent = true;
+  accumulator.remainingChars -= separatorChars + appendedChars;
+  return {
+    contributed: true,
+    complete: !compactedNext.changed && originalChars <= availableChars,
+  };
+}
+
+function appendBoundedContentContribution(
+  accumulator: BoundedContentAccumulator,
+  next: unknown
+): {
+  contributed: boolean;
+  complete: boolean;
+  retainedContentPartIndices?: ReadonlySet<number>;
+} {
+  if (!Array.isArray(next)) {
+    return appendBoundedContentSegment(accumulator, next);
+  }
+  const retainedContentPartIndices = new Set<number>();
+  let complete = true;
+  for (let index = 0; index < next.length; index++) {
+    const projection = appendBoundedContentSegment(accumulator, [next[index]]);
+    if (!projection.complete) {
+      complete = false;
+    }
+    if (!projection.contributed) {
+      const separatorChars = accumulator.hasContent ? 1 : 0;
+      if (accumulator.remainingChars <= separatorChars) {
+        if (index < next.length - 1) {
+          complete = false;
+        }
+        break;
+      }
+      continue;
+    }
+    retainedContentPartIndices.add(index);
+  }
+  return {
+    contributed: retainedContentPartIndices.size > 0,
+    complete,
+    retainedContentPartIndices,
+  };
+}
+
+function retainProjectedContentPartProvenance(
+  message: BaseMessage,
+  parts: readonly ProviderMessageProvenancePart[],
+  retainedContentPartIndices: ReadonlySet<number> | undefined,
+  complete: boolean
+): ProviderMessageProvenancePart[] {
+  if (
+    complete &&
+    (retainedContentPartIndices == null ||
+      !Array.isArray(message.content) ||
+      retainedContentPartIndices.size === message.content.length)
+  ) {
+    return [...parts];
+  }
+  const sourceIndexRefCount = parts.reduce(
+    (total, part) => total + (part.sourceContentPartIndices?.length ?? 0),
+    0
+  );
+  const mapsOneToOne = sourceIndexRefCount === message.content.length;
+  const distinctSourceMessageIds = new Set<string>();
+  for (const part of parts) {
+    if (part.sourceMessageId != null) {
+      distinctSourceMessageIds.add(part.sourceMessageId);
+    }
+  }
+  if (!Array.isArray(message.content)) {
+    const soleSourceMessageId =
+      distinctSourceMessageIds.size === 1
+        ? distinctSourceMessageIds.values().next().value
+        : undefined;
+    return [
+      {
+        attribution: parts[0]?.attribution ?? 'tool',
+        ...(soleSourceMessageId != null && {
+          sourceMessageId: soleSourceMessageId,
+        }),
+      },
+    ];
+  }
+  const retained: ProviderMessageProvenancePart[] = [];
+  let sourceIndexOrdinal = 0;
+  for (const part of parts) {
+    if (part.sourceContentPartIndices == null) {
+      if (distinctSourceMessageIds.size <= 1) {
+        retained.push(part);
+      }
+      continue;
+    }
+    if (!mapsOneToOne || retainedContentPartIndices == null) {
+      sourceIndexOrdinal += part.sourceContentPartIndices.length;
+      continue;
+    }
+    const sourceContentPartIndices: number[] = [];
+    for (const sourceContentPartIndex of part.sourceContentPartIndices) {
+      if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
+        sourceContentPartIndices.push(sourceContentPartIndex);
+      }
+      sourceIndexOrdinal++;
+    }
+    if (sourceContentPartIndices.length > 0) {
+      retained.push({ ...part, sourceContentPartIndices });
+    }
+  }
+  return retained.length > 0
+    ? retained
+    : [{ attribution: parts[0]?.attribution ?? 'tool' }];
 }
 
 function cloneAIMessageWithToolCalls(
@@ -2323,6 +2488,61 @@ export function projectAnthropicArtifactContent(
   return formattedMessages ?? messages;
 }
 
+function projectProviderMessageAttribution(
+  message: BaseMessage,
+  attribution: ProviderMessageProvenancePart['attribution']
+): ProviderMessageProvenancePart[] {
+  const explicit = getProviderMessageProvenance(message);
+  const sourceMessageIds = getProviderSourceMessageIds(message);
+  const explicitSourceIds = new Set<string>();
+  for (const part of explicit?.parts ?? []) {
+    if (part.sourceMessageId != null) {
+      explicitSourceIds.add(part.sourceMessageId);
+    }
+  }
+  const soleSourceFallback =
+    explicitSourceIds.size === 0 && sourceMessageIds.length === 1
+      ? sourceMessageIds[0]
+      : undefined;
+  const parts: ProviderMessageProvenancePart[] = [];
+  const representedSourceIds = new Set<string>();
+  for (const part of explicit?.parts ?? []) {
+    const sourceMessageId = part.sourceMessageId ?? soleSourceFallback;
+    if (sourceMessageId != null) {
+      representedSourceIds.add(sourceMessageId);
+    }
+    parts.push({
+      attribution,
+      ...(sourceMessageId != null && { sourceMessageId }),
+      ...(part.sourceContentPartIndices != null && {
+        sourceContentPartIndices: part.sourceContentPartIndices,
+      }),
+    });
+  }
+  for (const sourceMessageId of sourceMessageIds) {
+    if (!representedSourceIds.has(sourceMessageId)) {
+      parts.push({ attribution, sourceMessageId });
+    }
+  }
+  return parts.length > 0 ? parts : [{ attribution }];
+}
+
+/** Artifacts are attached to a tool message rather than one of its content
+ * positions. Retain the source row only when it is unambiguous, but never
+ * claim a raw content-part index for artifact-only bytes. */
+function projectUnindexedProviderMessageAttribution(
+  message: BaseMessage,
+  attribution: ProviderMessageProvenancePart['attribution']
+): ProviderMessageProvenancePart {
+  const sourceMessageIds = getProviderSourceMessageIds(message);
+  return {
+    attribution,
+    ...(sourceMessageIds.length === 1 && {
+      sourceMessageId: sourceMessageIds[0],
+    }),
+  };
+}
+
 /**
  * Mutating compatibility wrapper retained for existing package consumers.
  * New provider-call paths should use `projectAnthropicArtifactContent`.
@@ -2363,8 +2583,9 @@ export function projectArtifactPayload(
   if (latestAIParentIndex === -1) return messages;
 
   // Single pass: collect relevant tool messages with artifacts and aggregate
-  let aggregatedContent: BaseMessage['content'] | undefined;
+  const aggregate = createBoundedContentAccumulator(maxChars);
   let formattedMessages: BaseMessage[] | undefined;
+  const artifactProvenanceParts: ProviderMessageProvenancePart[] = [];
 
   for (let i = latestAIParentIndex + 1; i < messages.length; i++) {
     const msg = messages[i];
@@ -2380,13 +2601,12 @@ export function projectArtifactPayload(
     ) {
       continue;
     }
-    aggregatedContent = appendBoundedContent(
-      aggregatedContent,
-      msg.content,
-      maxChars
+    const contentProjection = appendBoundedContentContribution(
+      aggregate,
+      msg.content
     );
     formattedMessages ??= [...messages];
-    formattedMessages[i] = cloneToolMessageWithContent(
+    const placeholder = cloneToolMessageWithContent(
       msg,
       'Tool response is included in the next message as a Human message',
       {
@@ -2394,15 +2614,54 @@ export function projectArtifactPayload(
         content: [],
       }
     );
-    aggregatedContent = appendBoundedContent(
-      aggregatedContent,
-      msg.artifact.content,
-      maxChars
+    const toolProvenanceParts = projectProviderMessageAttribution(msg, 'tool');
+    setProviderMessageProvenance(
+      placeholder,
+      toolProvenanceParts.map((part) => ({
+        ...part,
+        attribution: 'synthetic',
+      }))
     );
+    formattedMessages[i] = placeholder;
+    const artifactProjection = appendBoundedContentContribution(
+      aggregate,
+      msg.artifact.content
+    );
+    if (contentProjection.contributed) {
+      const retainedParts = retainProjectedContentPartProvenance(
+        msg,
+        toolProvenanceParts,
+        contentProjection.retainedContentPartIndices,
+        contentProjection.complete
+      );
+      for (const part of retainedParts) {
+        artifactProvenanceParts.push(part);
+      }
+    }
+    if (artifactProjection.contributed) {
+      const artifactPart = projectUnindexedProviderMessageAttribution(
+        msg,
+        'tool'
+      );
+      const previousPart =
+        artifactProvenanceParts[artifactProvenanceParts.length - 1];
+      if (
+        artifactProvenanceParts.length === 0 ||
+        previousPart.attribution !== artifactPart.attribution ||
+        previousPart.sourceMessageId !== artifactPart.sourceMessageId ||
+        previousPart.sourceContentPartIndices != null
+      ) {
+        artifactProvenanceParts.push(artifactPart);
+      }
+    }
   }
 
-  if (aggregatedContent != null) {
-    formattedMessages?.push(new HumanMessage({ content: aggregatedContent }));
+  if (aggregate.hasContent && artifactProvenanceParts.length > 0) {
+    const artifactPayload = new HumanMessage({
+      content: toLangChainContent(aggregate.blocks),
+    });
+    setProviderMessageProvenance(artifactPayload, artifactProvenanceParts);
+    formattedMessages?.push(artifactPayload);
   }
   return formattedMessages ?? messages;
 }
@@ -2424,9 +2683,15 @@ export function formatArtifactPayload(messages: BaseMessage[]): void {
       projected[i] !== messages[i]
     ) {
       messages[i].content = projected[i].content;
+      const provenance = getProviderMessageProvenance(projected[i]);
+      if (provenance != null) {
+        setProviderMessageProvenance(messages[i], provenance.parts);
+      }
     }
   }
-  messages.push(...projected.slice(originalLength));
+  for (let i = originalLength; i < projected.length; i++) {
+    messages.push(projected[i]);
+  }
 }
 
 export function findLastIndex<T>(

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -26,6 +26,7 @@ import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
   setProviderMessageProvenance,
+  stampSyntheticProviderMessage,
 } from './provenance';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { stripAnthropicCacheControl } from './cache';
@@ -2388,9 +2389,11 @@ export function projectComputerCallOutputsToText(
       continue;
     }
     projected ??= [...messages];
-    projected[i] = cloneToolMessageWithContent(
-      message,
-      '[Computer screenshot omitted for this provider]'
+    projected[i] = stampSyntheticProviderMessage(
+      cloneToolMessageWithContent(
+        message,
+        '[Computer screenshot omitted for this provider]'
+      )
     );
   }
   return projected ?? messages;

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -25,6 +25,7 @@ import {
 import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  hasBijectiveProviderContentPartMapping,
   setProviderMessageProvenance,
   stampSyntheticProviderMessage,
 } from './provenance';
@@ -608,11 +609,10 @@ function retainProjectedContentPartProvenance(
   ) {
     return [...parts];
   }
-  const sourceIndexRefCount = parts.reduce(
-    (total, part) => total + (part.sourceContentPartIndices?.length ?? 0),
-    0
+  const mapsOneToOne = hasBijectiveProviderContentPartMapping(
+    parts,
+    message.content.length
   );
-  const mapsOneToOne = sourceIndexRefCount === message.content.length;
   const distinctSourceMessageIds = new Set<string>();
   for (const part of parts) {
     if (part.sourceMessageId != null) {
@@ -634,24 +634,40 @@ function retainProjectedContentPartProvenance(
     ];
   }
   const retained: ProviderMessageProvenancePart[] = [];
-  let sourceIndexOrdinal = 0;
+  const appendUnindexedAttribution = (
+    part: ProviderMessageProvenancePart
+  ): void => {
+    const sourceMessageId =
+      distinctSourceMessageIds.size <= 1 ? part.sourceMessageId : undefined;
+    if (retained.length > 0) {
+      const previous = retained[retained.length - 1];
+      if (
+        previous.attribution === part.attribution &&
+        previous.sourceMessageId === sourceMessageId &&
+        previous.sourceContentPartIndices == null
+      ) {
+        return;
+      }
+    }
+    retained.push({
+      attribution: part.attribution,
+      ...(sourceMessageId != null && { sourceMessageId }),
+    });
+  };
   for (const part of parts) {
     if (part.sourceContentPartIndices == null) {
-      if (distinctSourceMessageIds.size <= 1) {
-        retained.push(part);
-      }
+      appendUnindexedAttribution(part);
       continue;
     }
     if (!mapsOneToOne || retainedContentPartIndices == null) {
-      sourceIndexOrdinal += part.sourceContentPartIndices.length;
+      appendUnindexedAttribution(part);
       continue;
     }
     const sourceContentPartIndices: number[] = [];
     for (const sourceContentPartIndex of part.sourceContentPartIndices) {
-      if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
+      if (retainedContentPartIndices.has(sourceContentPartIndex)) {
         sourceContentPartIndices.push(sourceContentPartIndex);
       }
-      sourceIndexOrdinal++;
     }
     if (sourceContentPartIndices.length > 0) {
       retained.push({ ...part, sourceContentPartIndices });

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -503,28 +503,6 @@ function appendContentBlocks(
   }
 }
 
-/**
- * Appends one artifact/tool-content segment without retaining an unbounded
- * intermediate block array. Both operands are compacted before they are
- * combined, and the combined result is compacted again under the aggregate
- * cap.
- */
-function appendBoundedContent(
-  current: BaseMessage['content'] | undefined,
-  next: unknown,
-  maxChars: number
-): BaseMessage['content'] {
-  const boundedNext = compactToolContent(next, maxChars).content;
-  if (current == null) {
-    return boundedNext;
-  }
-
-  const combined: t.MessageContentComplex[] = [];
-  appendContentBlocks(combined, current);
-  appendContentBlocks(combined, boundedNext);
-  return compactToolContent(toLangChainContent(combined), maxChars).content;
-}
-
 interface BoundedContentAccumulator {
   readonly blocks: t.MessageContentComplex[];
   hasContent: boolean;
@@ -2473,16 +2451,70 @@ export function projectAnthropicArtifactContent(
       const baseContent = Array.isArray(msg.content)
         ? msg.content
         : stringifyToolMessageContent(msg.content);
-      const content = appendBoundedContent(
-        compactToolContent(baseContent, maxChars).content,
-        artifactContent,
-        maxChars
+      const aggregate = createBoundedContentAccumulator(maxChars);
+      let contentProjection: ReturnType<
+        typeof appendBoundedContentContribution
+      > = { contributed: false, complete: true };
+      /** Preserve the established empty-result text block shape without
+       * crediting it as a provider-visible source contribution. */
+      if (baseContent === '') {
+        aggregate.blocks.push({ type: ContentTypes.TEXT, text: '' });
+        aggregate.hasContent = true;
+      } else {
+        contentProjection = appendBoundedContentContribution(
+          aggregate,
+          baseContent
+        );
+      }
+      const artifactProjection = appendBoundedContentContribution(
+        aggregate,
+        artifactContent
       );
+      const content = toLangChainContent(aggregate.blocks);
       formattedMessages ??= [...messages];
-      formattedMessages[j] = cloneToolMessageWithContent(msg, content, {
+      const projectedMessage = cloneToolMessageWithContent(msg, content, {
         ...msg.artifact,
         content: [],
       });
+      const toolProvenanceParts = projectProviderMessageAttribution(
+        msg,
+        'tool'
+      );
+      const projectedProvenanceParts: ProviderMessageProvenancePart[] = [];
+      if (contentProjection.contributed) {
+        const retainedParts = retainProjectedContentPartProvenance(
+          msg,
+          toolProvenanceParts,
+          contentProjection.retainedContentPartIndices,
+          contentProjection.complete
+        );
+        for (const part of retainedParts) {
+          projectedProvenanceParts.push(part);
+        }
+      }
+      if (artifactProjection.contributed) {
+        const artifactPart = projectUnindexedProviderMessageAttribution(
+          msg,
+          'tool'
+        );
+        const previousPart =
+          projectedProvenanceParts[projectedProvenanceParts.length - 1];
+        if (
+          projectedProvenanceParts.length === 0 ||
+          previousPart.attribution !== artifactPart.attribution ||
+          previousPart.sourceMessageId !== artifactPart.sourceMessageId ||
+          previousPart.sourceContentPartIndices != null
+        ) {
+          projectedProvenanceParts.push(artifactPart);
+        }
+      }
+      if (projectedProvenanceParts.length > 0) {
+        setProviderMessageProvenance(
+          projectedMessage,
+          projectedProvenanceParts
+        );
+      }
+      formattedMessages[j] = projectedMessage;
     }
   }
   return formattedMessages ?? messages;
@@ -2559,6 +2591,10 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
       projected[i] !== messages[i]
     ) {
       messages[i].content = projected[i].content;
+      const provenance = getProviderMessageProvenance(projected[i]);
+      if (provenance != null) {
+        setProviderMessageProvenance(messages[i], provenance.parts);
+      }
     }
   }
 }

--- a/src/messages/ensureThinkingBlock.test.ts
+++ b/src/messages/ensureThinkingBlock.test.ts
@@ -1,5 +1,9 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { ExtendedMessageContent } from '@/types';
+import {
+  getProviderMessageProvenance,
+  setProviderMessageProvenance,
+} from './provenance';
 import { ensureThinkingBlockInMessages } from './format';
 import { Providers, ContentTypes } from '@/common';
 
@@ -242,6 +246,36 @@ describe('ensureThinkingBlockInMessages', () => {
       expect(result[3]).toBeInstanceOf(HumanMessage); // user message
       expect(result[4]).toBeInstanceOf(HumanMessage); // converted — no thinking in this chain
       expect(getTextContent(result[4])).toContain('[Previous agent context]');
+    });
+
+    test('preserves model and tool attribution when folding prior agent context', () => {
+      const assistant = new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'c1', name: 'lookup', args: {}, type: 'tool_call' as const },
+        ],
+      });
+      setProviderMessageProvenance(assistant, [
+        { attribution: 'model', sourceMessageId: 'assistant-row' },
+      ]);
+      const toolResult = new ToolMessage({
+        content: 'trusted tool bytes',
+        tool_call_id: 'c1',
+      });
+      setProviderMessageProvenance(toolResult, [
+        { attribution: 'tool', sourceMessageId: 'tool-row' },
+      ]);
+
+      const result = ensureThinkingBlockInMessages(
+        [new HumanMessage('run lookup'), assistant, toolResult],
+        Providers.BEDROCK
+      );
+
+      expect(getProviderMessageProvenance(result[1])?.parts).toEqual([
+        { attribution: 'synthetic' },
+        { attribution: 'model', sourceMessageId: 'assistant-row' },
+        { attribution: 'tool', sourceMessageId: 'tool-row' },
+      ]);
     });
 
     test('should detect thinking via additional_kwargs.reasoning_content in chain', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@langchain/core/messages';
 import type { ExtendedMessageContent } from '@/types';
 import {
+  compactSyntheticProviderContextMessage,
   foldToolBlocksForToollessAgent,
   isSyntheticProviderContextMessage,
 } from './format';
@@ -73,6 +74,19 @@ describe('foldToolBlocksForToollessAgent', () => {
       new HumanMessage('Search my files for "roadmap"'),
       new AIMessage({
         content: '',
+        additional_kwargs: {
+          sourceMessageId: 'assistant-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'model',
+                sourceMessageId: 'assistant-row',
+                sourceContentPartIndices: [0],
+              },
+            ],
+          },
+        },
         tool_calls: [
           {
             id: 'call_1',
@@ -86,6 +100,19 @@ describe('foldToolBlocksForToollessAgent', () => {
         content: 'Found roadmap.md',
         tool_call_id: 'call_1',
         name: 'file_search',
+        additional_kwargs: {
+          sourceMessageId: 'assistant-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'assistant-row',
+                sourceContentPartIndices: [0],
+              },
+            ],
+          },
+        },
       }),
     ];
 
@@ -100,6 +127,19 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded).toContain('file_search');
     expect(folded).toContain('roadmap');
     expect(folded).toContain('Found roadmap.md');
+    expect(result[1].additional_kwargs.sourceMessageIds).toEqual([
+      'assistant-row',
+    ]);
+    expect(result[1].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'synthetic',
+          sourceMessageId: 'assistant-row',
+          sourceContentPartIndices: [0],
+        },
+      ],
+    });
     expect(isSyntheticProviderContextMessage(result[1])).toBe(true);
     expect(
       isSyntheticProviderContextMessage(
@@ -529,6 +569,291 @@ describe('foldToolBlocksForToollessAgent', () => {
 
     expect(foldedText.length).toBeLessThanOrEqual(HARD_MAX_TOOL_RESULT_CHARS);
     expect(foldedText).toContain('additional folded context omitted');
+  });
+
+  test(
+    'folds a 150k-block tool result without call-argument spreading',
+    () => {
+      const blockCount = 150_000;
+      const repeatedBlock = { type: 'text', text: 'x' } as const;
+      const largeContent = new Array(blockCount).fill(repeatedBlock);
+      const toolMessage = new ToolMessage({
+        content: largeContent,
+        tool_call_id: 'large-result',
+        additional_kwargs: { sourceMessageId: 'large-tool-row' },
+      });
+      const messages = [
+        new HumanMessage('Run'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'large-result',
+              name: 'query',
+              args: {},
+              type: 'tool_call',
+            },
+          ],
+        }),
+        toolMessage,
+      ];
+
+      const result = foldToolBlocksForToollessAgent(messages);
+      const folded = result.find(isSyntheticProviderContextMessage)!;
+
+      expect(folded).toBeInstanceOf(HumanMessage);
+      expect(getTextContent(folded).length).toBeLessThanOrEqual(
+        HARD_MAX_TOOL_RESULT_CHARS
+      );
+      expect(toolMessage.content).toBe(largeContent);
+    },
+    30_000
+  );
+
+  test('omits source rows whose bytes do not survive the shared fold cap', () => {
+    const messages = [
+      new HumanMessage('Run both'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'first', name: 'query', args: {}, type: 'tool_call' },
+          { id: 'second', name: 'query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2),
+        tool_call_id: 'first',
+        additional_kwargs: {
+          sourceMessageId: 'first-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'first-row',
+                sourceContentPartIndices: [0],
+              },
+            ],
+          },
+        },
+      }),
+      new ToolMessage({
+        content: 'OMITTED-SECOND-MARKER',
+        tool_call_id: 'second',
+        additional_kwargs: {
+          sourceMessageId: 'second-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'second-row',
+                sourceContentPartIndices: [0],
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
+
+    expect(getTextContent(folded)).not.toContain('OMITTED-SECOND-MARKER');
+    expect(folded.additional_kwargs.sourceMessageIds).toEqual(['first-row']);
+  });
+
+  test('retains only source part indices whose folded blocks survive the cap', () => {
+    const messages = [
+      new HumanMessage('Run'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_call',
+            tool_call: {
+              id: 'first',
+              name: 'query',
+              args: {},
+              output: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2),
+            },
+          },
+          {
+            type: 'tool_call',
+            tool_call: {
+              id: 'second',
+              name: 'query',
+              args: {},
+              output: 'OMITTED-SECOND-PART',
+            },
+          },
+        ],
+        additional_kwargs: {
+          sourceMessageId: 'assistant-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'model',
+                sourceMessageId: 'assistant-row',
+                sourceContentPartIndices: [0, 1],
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
+
+    expect(getTextContent(folded)).not.toContain('OMITTED-SECOND-PART');
+    expect(folded.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'synthetic',
+          sourceMessageId: 'assistant-row',
+          sourceContentPartIndices: [0],
+        },
+      ],
+    });
+  });
+
+  test('drops indexed claims when parsed tool calls omit malformed raw entries', () => {
+    const messages = [
+      new HumanMessage('Run'),
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          sourceMessageId: 'assistant-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'model',
+                sourceMessageId: 'assistant-row',
+                sourceContentPartIndices: [0, 1],
+              },
+            ],
+          },
+          tool_calls: [
+            { id: 'malformed', type: 'function' },
+            {
+              id: 'valid',
+              type: 'function',
+              function: { name: 'query', arguments: '{}' },
+            },
+          ] as never,
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
+
+    expect(getTextContent(folded)).toContain('[tool_call] query');
+    expect(folded.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'synthetic', sourceMessageId: 'assistant-row' }],
+    });
+  });
+
+  test('drops ambiguous legacy source ids after partial folded compaction', () => {
+    const messages = [
+      new HumanMessage('Run'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_call',
+            tool_call: {
+              id: 'first',
+              name: 'query',
+              args: {},
+              output: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2),
+            },
+          },
+          {
+            type: 'tool_call',
+            tool_call: {
+              id: 'second',
+              name: 'query',
+              args: {},
+              output: 'OMITTED-SECOND-PART',
+            },
+          },
+        ],
+        additional_kwargs: {
+          sourceMessageIds: ['first-row', 'second-row'],
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
+
+    expect(getTextContent(folded)).not.toContain('OMITTED-SECOND-PART');
+    expect(folded.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(folded.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'synthetic' }],
+    });
+  });
+
+  test('drops ambiguous source ids when folded string content is truncated', () => {
+    const messages = [
+      new HumanMessage('Run'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'large', name: 'query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2),
+        tool_call_id: 'large',
+        additional_kwargs: {
+          sourceMessageIds: ['first-row', 'second-row'],
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
+
+    expect(folded.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(folded.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'synthetic' }],
+    });
+  });
+
+  test('fails closed when later overflow recovery compacts folded context', () => {
+    const folded = foldToolBlocksForToollessAgent([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call', name: 'query', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'sensitive tool output'.repeat(100),
+        tool_call_id: 'call',
+        additional_kwargs: { sourceMessageId: 'tool-row' },
+      }),
+    ])[0] as HumanMessage;
+
+    const compacted = compactSyntheticProviderContextMessage(folded, 20);
+
+    expect(isSyntheticProviderContextMessage(compacted)).toBe(true);
+    expect(compacted.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(compacted.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'user' },
+        { attribution: 'tool' },
+      ],
+    });
   });
 
   test('does not emit an empty user message when an earlier fold exhausts the shared budget', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -133,8 +133,14 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(result[1].additional_kwargs.provenance).toEqual({
       version: 1,
       parts: [
+        { attribution: 'synthetic' },
         {
-          attribution: 'synthetic',
+          attribution: 'model',
+          sourceMessageId: 'assistant-row',
+          sourceContentPartIndices: [0],
+        },
+        {
+          attribution: 'tool',
           sourceMessageId: 'assistant-row',
           sourceContentPartIndices: [0],
         },
@@ -146,6 +152,91 @@ describe('foldToolBlocksForToollessAgent', () => {
         new HumanMessage('[Previous tool interaction] user-authored text')
       )
     ).toBe(false);
+  });
+
+  test('attributes unstamped retained sources by message role without ids', () => {
+    const result = foldToolBlocksForToollessAgent([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'legacy tool bytes',
+        tool_call_id: 'call',
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model' },
+        { attribution: 'tool' },
+      ],
+    });
+  });
+
+  test('attributes validated legacy folded lineage by message role', () => {
+    const result = foldToolBlocksForToollessAgent([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+        additional_kwargs: { sourceMessageId: 'assistant-row' },
+      }),
+      new ToolMessage({
+        content: 'legacy tool bytes',
+        tool_call_id: 'call',
+        additional_kwargs: { sourceMessageId: 'tool-row' },
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model', sourceMessageId: 'assistant-row' },
+        { attribution: 'tool', sourceMessageId: 'tool-row' },
+      ],
+    });
+  });
+
+  test.each([
+    ['malformed provenance', { provenance: { version: 1, parts: [null] } }],
+    [
+      'malformed legacy lineage',
+      { sourceMessageIds: { 0: 'forged', length: 1 } },
+    ],
+  ])('preserves %s invalidity when folding retained bytes', (_, additional_kwargs) => {
+    const sourceProvenance = (additional_kwargs as { provenance?: unknown })
+      .provenance;
+    const result = foldToolBlocksForToollessAgent([
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call', name: 'lookup', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'untrusted tool bytes',
+        tool_call_id: 'call',
+        additional_kwargs,
+      }),
+    ]);
+
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: null,
+    });
+    expect(result[0].additional_kwargs.provenance).not.toBe(
+      sourceProvenance
+    );
+    expect(result[0].lc_kwargs.additional_kwargs).toBe(
+      result[0].additional_kwargs
+    );
   });
 
   test('folds historical tool content that precedes the last human turn (the reported bug)', () => {
@@ -710,8 +801,9 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded.additional_kwargs.provenance).toEqual({
       version: 1,
       parts: [
+        { attribution: 'synthetic' },
         {
-          attribution: 'synthetic',
+          attribution: 'model',
           sourceMessageId: 'assistant-row',
           sourceContentPartIndices: [0],
         },
@@ -754,7 +846,10 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(getTextContent(folded)).toContain('[tool_call] query');
     expect(folded.additional_kwargs.provenance).toEqual({
       version: 1,
-      parts: [{ attribution: 'synthetic', sourceMessageId: 'assistant-row' }],
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model', sourceMessageId: 'assistant-row' },
+      ],
     });
   });
 
@@ -795,7 +890,10 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded.additional_kwargs.sourceMessageIds).toBeUndefined();
     expect(folded.additional_kwargs.provenance).toEqual({
       version: 1,
-      parts: [{ attribution: 'synthetic' }],
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model' },
+      ],
     });
   });
 
@@ -823,7 +921,11 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded.additional_kwargs.sourceMessageIds).toBeUndefined();
     expect(folded.additional_kwargs.provenance).toEqual({
       version: 1,
-      parts: [{ attribution: 'synthetic' }],
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model' },
+        { attribution: 'tool' },
+      ],
     });
   });
 

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -811,6 +811,82 @@ describe('foldToolBlocksForToollessAgent', () => {
     });
   });
 
+  test.each([
+    ['duplicate', [[0], [0]]],
+    ['gapped/out-of-range', [[0], [2]]],
+    ['reordered', [[1], [0]]],
+  ])(
+    'handles a %s folded content mapping without ordinal attribution loss',
+    (mappingKind, sourceContentPartIndices) => {
+      const messages = [
+        new HumanMessage('Run'),
+        new AIMessage({
+          content: [
+            {
+              type: 'tool_call',
+              tool_call: {
+                id: 'first',
+                name: 'query',
+                args: {},
+                output: 'x'.repeat(HARD_MAX_TOOL_RESULT_CHARS * 2),
+              },
+            },
+            {
+              type: 'tool_call',
+              tool_call: {
+                id: 'second',
+                name: 'query',
+                args: {},
+                output: 'OMITTED-SECOND-PART',
+              },
+            },
+          ],
+          additional_kwargs: {
+            sourceMessageId: 'source-row',
+            provenance: {
+              version: 1,
+              parts: [
+                {
+                  attribution: 'model',
+                  sourceMessageId: 'source-row',
+                  sourceContentPartIndices: sourceContentPartIndices[0],
+                },
+                {
+                  attribution: 'user',
+                  sourceMessageId: 'source-row',
+                  sourceContentPartIndices: sourceContentPartIndices[1],
+                },
+              ],
+            },
+          },
+        }),
+      ];
+
+      const result = foldToolBlocksForToollessAgent(messages);
+      const folded = result.find(isSyntheticProviderContextMessage)!;
+
+      expect(getTextContent(folded)).not.toContain('OMITTED-SECOND-PART');
+      expect(folded.additional_kwargs.provenance).toEqual({
+        version: 1,
+        parts:
+          mappingKind === 'reordered'
+            ? [
+              { attribution: 'synthetic' },
+              {
+                attribution: 'user',
+                sourceMessageId: 'source-row',
+                sourceContentPartIndices: [0],
+              },
+            ]
+            : [
+              { attribution: 'synthetic' },
+              { attribution: 'model', sourceMessageId: 'source-row' },
+              { attribution: 'user', sourceMessageId: 'source-row' },
+            ],
+      });
+    }
+  );
+
   test('drops indexed claims when parsed tool calls omit malformed raw entries', () => {
     const messages = [
       new HumanMessage('Run'),

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -42,16 +42,17 @@ import {
   hasStructurallyValidAnthropicWebSearchResultContent,
 } from './toolResultTypes';
 import {
+  inspectProviderMessageProvenance,
+  inspectProviderSourceMessageIds,
+  setInvalidProviderMessageProvenance,
+  setProviderMessageProvenance,
+} from './provenance';
+import {
   compactToolContent,
   getToolContentCharLength,
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from '@/utils/toolContent';
-import {
-  getProviderMessageProvenance,
-  getProviderSourceMessageIds,
-  setProviderMessageProvenance,
-} from './provenance';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
@@ -2736,18 +2737,55 @@ interface FoldedSourceMessage {
   readonly mappingAmbiguous?: boolean;
 }
 
+function getFoldedSourceAttribution(
+  message: BaseMessage
+): ProviderMessageAttribution {
+  const messageType = message.getType();
+  if (messageType === 'ai') {
+    return 'model';
+  }
+  if (messageType === 'tool') {
+    return 'tool';
+  }
+  if (messageType === 'system') {
+    return 'synthetic';
+  }
+  return 'user';
+}
+
 function getSyntheticProviderContextProvenanceParts(
   sourceMessages: readonly FoldedSourceMessage[]
-): ProviderMessageProvenancePart[] {
-  const parts: ProviderMessageProvenancePart[] = [];
+): ProviderMessageProvenancePart[] | null {
+  /** Fold labels are generated context, while retained source bytes keep their
+   * original attribution so downstream policy can still route them exactly. */
+  const parts: ProviderMessageProvenancePart[] = [
+    { attribution: 'synthetic' },
+  ];
   for (const source of sourceMessages) {
     const {
       message: sourceMessage,
       retainedContentPartIndices,
       mappingAmbiguous,
     } = source;
-    const explicit = getProviderMessageProvenance(sourceMessage);
-    const sourceMessageIds = getProviderSourceMessageIds(sourceMessage);
+    const provenanceState = inspectProviderMessageProvenance(sourceMessage);
+    const sourceMessageIdsState =
+      inspectProviderSourceMessageIds(sourceMessage);
+    if (
+      provenanceState.status === 'invalid' ||
+      sourceMessageIdsState.status === 'invalid'
+    ) {
+      return null;
+    }
+    const explicit =
+      provenanceState.status === 'valid'
+        ? provenanceState.provenance
+        : undefined;
+    const sourceMessageIds =
+      sourceMessageIdsState.status === 'valid'
+        ? sourceMessageIdsState.sourceMessageIds
+        : [];
+    const fallbackAttribution = getFoldedSourceAttribution(sourceMessage);
+    const sourcePartStart = parts.length;
     const retainedSourceIds = new Set<string>();
     const contentLength = Array.isArray(sourceMessage.content)
       ? sourceMessage.content.length
@@ -2775,7 +2813,7 @@ function getSyntheticProviderContextProvenanceParts(
       let sourceContentPartIndices = part.sourceContentPartIndices;
       if (mappingAmbiguous === true && sourceContentPartIndices != null) {
         sourceIndexOrdinal += sourceContentPartIndices.length;
-        continue;
+        sourceContentPartIndices = undefined;
       }
       if (
         retainedContentPartIndices != null &&
@@ -2784,40 +2822,38 @@ function getSyntheticProviderContextProvenanceParts(
       ) {
         if (!mapsOneToOne) {
           sourceIndexOrdinal += sourceContentPartIndices.length;
-          continue;
-        }
-        const retainedSourceContentPartIndices: number[] = [];
-        for (const sourceContentPartIndex of sourceContentPartIndices) {
-          if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
-            retainedSourceContentPartIndices.push(sourceContentPartIndex);
+          sourceContentPartIndices = undefined;
+        } else {
+          const retainedSourceContentPartIndices: number[] = [];
+          for (const sourceContentPartIndex of sourceContentPartIndices) {
+            if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
+              retainedSourceContentPartIndices.push(sourceContentPartIndex);
+            }
+            sourceIndexOrdinal++;
           }
-          sourceIndexOrdinal++;
+          if (retainedSourceContentPartIndices.length === 0) {
+            continue;
+          }
+          sourceContentPartIndices = retainedSourceContentPartIndices;
         }
-        if (retainedSourceContentPartIndices.length === 0) {
-          continue;
-        }
-        sourceContentPartIndices = retainedSourceContentPartIndices;
       } else {
         sourceIndexOrdinal += sourceContentPartIndices?.length ?? 0;
       }
-      if (
-        sourceContentPartIndices == null &&
-        part.sourceMessageId != null &&
-        !retainUnindexedSourceIds
-      ) {
-        continue;
-      }
+      const sourceMessageId =
+        sourceContentPartIndices != null || retainUnindexedSourceIds
+          ? part.sourceMessageId
+          : undefined;
       parts.push({
-        attribution: 'synthetic',
-        ...(part.sourceMessageId != null && {
-          sourceMessageId: part.sourceMessageId,
+        attribution: part.attribution,
+        ...(sourceMessageId != null && {
+          sourceMessageId,
         }),
         ...(sourceContentPartIndices != null && {
           sourceContentPartIndices,
         }),
       });
-      if (part.sourceMessageId != null) {
-        retainedSourceIds.add(part.sourceMessageId);
+      if (sourceMessageId != null) {
+        retainedSourceIds.add(sourceMessageId);
       }
     }
     for (const sourceMessageId of sourceMessageIds) {
@@ -2825,8 +2861,11 @@ function getSyntheticProviderContextProvenanceParts(
         break;
       }
       if (!retainedSourceIds.has(sourceMessageId)) {
-        parts.push({ attribution: 'synthetic', sourceMessageId });
+        parts.push({ attribution: fallbackAttribution, sourceMessageId });
       }
+    }
+    if (parts.length === sourcePartStart) {
+      parts.push({ attribution: fallbackAttribution });
     }
   }
   return mergeAdjacentProviderProvenanceParts(parts);
@@ -2838,6 +2877,10 @@ function markSyntheticProviderContext<T extends BaseMessage>(
 ): T {
   syntheticProviderContextMessages.add(message);
   const parts = getSyntheticProviderContextProvenanceParts(sourceMessages);
+  if (parts == null) {
+    setInvalidProviderMessageProvenance(message);
+    return message;
+  }
   setProviderMessageProvenance(
     message,
     parts.length > 0 ? parts : [{ attribution: 'synthetic' }]

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -32,6 +32,15 @@ import type {
   ProviderMessageAttribution,
   ProviderMessageProvenancePart,
 } from './provenance';
+import type { ProviderToolCallIndex } from './toolResultTypes';
+import {
+  appendProviderToolCallDescriptor,
+  consumeProviderToolResultPair,
+  getBoundedProviderPairingArrayProperty,
+  getProviderToolCallPartDescriptor,
+  getProviderToolResultPartDescriptor,
+  hasStructurallyValidAnthropicWebSearchResultContent,
+} from './toolResultTypes';
 import {
   compactToolContent,
   getToolContentCharLength,
@@ -47,7 +56,6 @@ import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inpu
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { Providers, ContentTypes, Constants } from '@/common';
-import { isProviderToolResultPart } from './toolResultTypes';
 import { emitAgentLog } from '@/utils/events';
 
 interface MediaMessageParams {
@@ -457,21 +465,81 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
   return part.tool_use_id;
 }
 
-function isValidServerToolResult(part: MessageContentComplex): boolean {
-  const toolUseId = getToolUseId(part);
-  if (
-    toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) !== true ||
-    !('content' in part)
-  ) {
+function collectTrustedToolResultSourceContentPartIndices(
+  content: readonly unknown[] | undefined,
+  sourceContentPartOffset: number
+): Set<number> | undefined {
+  if (content == null) {
+    return undefined;
+  }
+  let calls: ProviderToolCallIndex | undefined;
+  let trusted: Set<number> | undefined;
+  let previousPart: MessageContentComplex | null | undefined;
+  for (let index = 0; index < content.length; index++) {
+    const part = content[index] as
+      | MessageContentComplex
+      | null
+      | undefined;
+    if (part == null) {
+      previousPart = part;
+      continue;
+    }
+    const call = getProviderToolCallPartDescriptor(part);
+    if (call != null) {
+      calls ??= new Map();
+      appendProviderToolCallDescriptor(calls, call);
+    }
+    const result = getProviderToolResultPartDescriptor(part);
+    if (result != null) {
+      calls ??= new Map();
+      if (consumeProviderToolResultPair(result, calls, previousPart)) {
+        trusted ??= new Set();
+        trusted.add(sourceContentPartOffset + index);
+      }
+    }
+    previousPart = part;
+  }
+  return trusted;
+}
+
+function sourceContentPartIndicesAreTrustedToolResult(
+  sourceContentPartIndices: SourceContentPartIndices,
+  trustedToolSourceContentPartIndices: ReadonlySet<number> | undefined
+): boolean {
+  if (typeof sourceContentPartIndices === 'number') {
+    return trustedToolSourceContentPartIndices?.has(sourceContentPartIndices) === true;
+  }
+  if (sourceContentPartIndices.length === 0) {
     return false;
   }
-  const { content } = part as { content?: unknown };
+  for (const sourceContentPartIndex of sourceContentPartIndices) {
+    if (trustedToolSourceContentPartIndices?.has(sourceContentPartIndex) !== true) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isTrustedServerToolResult(
+  part: MessageContentComplex,
+  sourceContentPartIndices: SourceContentPartIndices,
+  trustedToolSourceContentPartIndices: ReadonlySet<number> | undefined
+): boolean {
+  const toolUseId = getToolUseId(part);
   return (
-    Array.isArray(content) ||
-    (content != null &&
-      typeof content === 'object' &&
-      'type' in content &&
-      (content as { type?: unknown }).type === 'web_search_tool_result_error')
+    toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) === true &&
+    sourceContentPartIndicesAreTrustedToolResult(
+      sourceContentPartIndices,
+      trustedToolSourceContentPartIndices
+    )
+  );
+}
+
+function isServerToolResultForWire(part: MessageContentComplex): boolean {
+  const toolUseId = getToolUseId(part);
+  return (
+    toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) === true &&
+    hasStructurallyValidAnthropicWebSearchResultContent(part)
   );
 }
 
@@ -658,12 +726,9 @@ function createProviderContentProvenanceParts(
     if (part == null) {
       continue;
     }
-    const attribution = isProviderToolResultPart(part)
-      ? 'tool'
-      : defaultAttribution;
     appendProviderProvenanceContribution(
       builder,
-      attribution,
+      defaultAttribution,
       sourceMessageId,
       sourceContentPartOffset + index
     );
@@ -890,12 +955,26 @@ function formatAssistantMessage(
     const contentParts = message.content as Array<
       MessageContentComplex | undefined | null
     >;
+    let trustedServerToolResultPartIndices: Set<number> | undefined;
+    let wireServerToolResultPartIndices: Set<number> | undefined;
 
-    for (const part of contentParts) {
+    for (let partIndex = 0; partIndex < contentParts.length; partIndex++) {
+      const part = contentParts[partIndex];
       if (part == null) {
         continue;
       }
-      if (isValidServerToolResult(part)) {
+      const isTrustedResult = isTrustedServerToolResult(
+        part,
+        getSourcePartIndices(partIndex),
+        options?.toolSourceContentPartIndices
+      );
+      if (isTrustedResult) {
+        trustedServerToolResultPartIndices ??= new Set();
+        trustedServerToolResultPartIndices.add(partIndex);
+      }
+      if (isTrustedResult || isServerToolResultForWire(part)) {
+        wireServerToolResultPartIndices ??= new Set();
+        wireServerToolResultPartIndices.add(partIndex);
         serverToolResultIds.add(getToolUseId(part) ?? '');
       }
       if (options?.provider === Providers.ANTHROPIC) {
@@ -921,17 +1000,18 @@ function formatAssistantMessage(
       const sourcePartIndices = getSourcePartIndices(partIndex);
       const toolUseId = getToolUseId(part);
       if (toolUseId != null) {
-        const isServerToolResult = isValidServerToolResult(part);
-        if (
-          toolUseId.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
-          !isServerToolResult
-        ) {
-          continue;
-        }
+        const isServerToolResult =
+          trustedServerToolResultPartIndices?.has(partIndex) === true;
+        const isWireServerToolResult =
+          wireServerToolResultPartIndices?.has(partIndex) === true;
         flushPendingServerToolUse(toolUseId);
-        if (isServerToolResult) {
+        if (isWireServerToolResult) {
           currentContent.push(part);
-          appendCurrentContentProvenance(sourcePartIndices, 'tool');
+          appendCurrentContentProvenance(
+            sourcePartIndices,
+            isServerToolResult ? 'tool' : 'model',
+            !isServerToolResult
+          );
           continue;
         }
       } else if (hasMeaningfulAssistantContent(part)) {
@@ -1186,12 +1266,7 @@ function formatAssistantMessage(
           continue;
         }
         currentContent.push(part);
-        const attribution = isProviderToolResultPart(part) ? 'tool' : 'model';
-        appendCurrentContentProvenance(
-          sourcePartIndices,
-          attribution,
-          attribution === 'model'
-        );
+        appendCurrentContentProvenance(sourcePartIndices, 'model', true);
       }
     }
     for (const pending of pendingServerToolUses.values()) {
@@ -2041,7 +2116,11 @@ export const formatAgentMessages = (
     let processedSourceContentPartIndices:
       | SourceContentPartIndices[]
       | undefined;
-    const processedToolSourceContentPartIndices = new Set<number>();
+    const processedToolSourceContentPartIndices =
+      collectTrustedToolResultSourceContentPartIndices(
+        getBoundedProviderPairingArrayProperty(message, 'content'),
+        sourceContentPartOffset
+      );
     let pendingSkillNames: Set<string> | undefined;
     if (discoveredTools) {
       const content = message.content;
@@ -2060,9 +2139,6 @@ export const formatAgentMessages = (
           const partSourceContentIndices = sourceContentPartOffset + partIndex;
           if (part == null || typeof part !== 'object') {
             continue;
-          }
-          if (isValidServerToolResult(part)) {
-            processedToolSourceContentPartIndices.add(partSourceContentIndices);
           }
           if (part.type !== ContentTypes.TOOL_CALL) {
             filteredContent.push(part);
@@ -2131,7 +2207,6 @@ export const formatAgentMessages = (
               invalidToolSourceContentPartIndices,
               partSourceContentIndices
             );
-            processedToolSourceContentPartIndices.add(partSourceContentIndices);
           }
         }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -28,16 +28,26 @@ import type {
   TPayload,
   TMessage,
 } from '@/types';
+import type {
+  ProviderMessageAttribution,
+  ProviderMessageProvenancePart,
+} from './provenance';
 import {
   compactToolContent,
   getToolContentCharLength,
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from '@/utils/toolContent';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+  setProviderMessageProvenance,
+} from './provenance';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { Providers, ContentTypes, Constants } from '@/common';
+import { isProviderToolResultPart } from './toolResultTypes';
 import { emitAgentLog } from '@/utils/events';
 
 interface MediaMessageParams {
@@ -218,19 +228,27 @@ export const formatMessage = ({
   const mediaParts: MessageContentComplex[] = [];
 
   if (Array.isArray(documents) && documents.length > 0) {
-    mediaParts.push(...documents);
+    for (const document of documents) {
+      mediaParts.push(document);
+    }
   }
 
   if (Array.isArray(videos) && videos.length > 0) {
-    mediaParts.push(...videos);
+    for (const video of videos) {
+      mediaParts.push(video);
+    }
   }
 
   if (Array.isArray(audios) && audios.length > 0) {
-    mediaParts.push(...audios);
+    for (const audio of audios) {
+      mediaParts.push(audio);
+    }
   }
 
   if (Array.isArray(image_urls) && image_urls.length > 0) {
-    mediaParts.push(...image_urls);
+    for (const imageUrl of image_urls) {
+      mediaParts.push(imageUrl);
+    }
   }
 
   if (mediaParts.length > 0 && role === 'user') {
@@ -340,7 +358,12 @@ interface FormatAssistantMessageOptions {
   preserveReasoningContent?: boolean;
   provider?: Providers;
   sourceMessageId?: string;
+  sourceContentPartOffset?: number;
+  sourceContentPartIndices?: readonly SourceContentPartIndices[];
+  toolSourceContentPartIndices?: ReadonlySet<number>;
 }
+
+type SourceContentPartIndices = number | readonly number[];
 
 interface FormatAgentMessagesOptions {
   provider?: Providers;
@@ -496,6 +519,158 @@ function endsWithSteerMessage(
   return formatted[formatted.length - 1].additional_kwargs.source === 'steer';
 }
 
+interface MutableProviderMessageProvenancePart {
+  attribution: ProviderMessageAttribution;
+  sourceMessageId?: string;
+  sourceContentPartIndices?: number[];
+}
+
+interface ProviderMessageProvenanceBuilder {
+  readonly parts: MutableProviderMessageProvenancePart[];
+  lastSeenSourceContentPartIndices?: Set<number>;
+}
+
+function createProviderMessageProvenanceBuilder(): ProviderMessageProvenanceBuilder {
+  return { parts: [] };
+}
+
+function appendProviderProvenanceContribution(
+  builder: ProviderMessageProvenanceBuilder,
+  attribution: ProviderMessageAttribution,
+  sourceMessageId?: string,
+  sourceContentPartIndex?: number
+): void {
+  const last = builder.parts[builder.parts.length - 1];
+  if (
+    builder.parts.length === 0 ||
+    last.attribution !== attribution ||
+    last.sourceMessageId !== sourceMessageId ||
+    (last.sourceContentPartIndices == null) !== (sourceContentPartIndex == null)
+  ) {
+    builder.parts.push({
+      attribution,
+      ...(sourceMessageId != null && { sourceMessageId }),
+      ...(sourceContentPartIndex != null && {
+        sourceContentPartIndices: [sourceContentPartIndex],
+      }),
+    });
+    builder.lastSeenSourceContentPartIndices = undefined;
+    return;
+  }
+  if (sourceContentPartIndex == null) {
+    return;
+  }
+  const sourceContentPartIndices = (last.sourceContentPartIndices ??= []);
+  if (sourceContentPartIndices.length === 0) {
+    sourceContentPartIndices.push(sourceContentPartIndex);
+    return;
+  }
+  const seen = (builder.lastSeenSourceContentPartIndices ??= new Set(
+    sourceContentPartIndices
+  ));
+  if (!seen.has(sourceContentPartIndex)) {
+    seen.add(sourceContentPartIndex);
+    sourceContentPartIndices.push(sourceContentPartIndex);
+  }
+}
+
+function appendProviderProvenanceIndices(
+  builder: ProviderMessageProvenanceBuilder,
+  attribution: ProviderMessageAttribution,
+  sourceMessageId: string | undefined,
+  sourceContentPartIndices?: SourceContentPartIndices,
+  toolSourceContentPartIndices?: ReadonlySet<number>
+): void {
+  if (typeof sourceContentPartIndices === 'number') {
+    appendProviderProvenanceContribution(
+      builder,
+      toolSourceContentPartIndices?.has(sourceContentPartIndices) === true
+        ? 'tool'
+        : attribution,
+      sourceMessageId,
+      sourceContentPartIndices
+    );
+    return;
+  }
+  if (
+    sourceContentPartIndices == null ||
+    sourceContentPartIndices.length === 0
+  ) {
+    appendProviderProvenanceContribution(builder, attribution, sourceMessageId);
+    return;
+  }
+  for (const sourceContentPartIndex of sourceContentPartIndices) {
+    appendProviderProvenanceContribution(
+      builder,
+      toolSourceContentPartIndices?.has(sourceContentPartIndex) === true
+        ? 'tool'
+        : attribution,
+      sourceMessageId,
+      sourceContentPartIndex
+    );
+  }
+}
+
+function appendSourceContentPartIndices(
+  target: number[],
+  sourceContentPartIndices: SourceContentPartIndices
+): void {
+  if (typeof sourceContentPartIndices === 'number') {
+    target.push(sourceContentPartIndices);
+  } else {
+    for (const sourceContentPartIndex of sourceContentPartIndices) {
+      target.push(sourceContentPartIndex);
+    }
+  }
+}
+
+function appendProviderProvenanceParts(
+  builder: ProviderMessageProvenanceBuilder,
+  parts: readonly ProviderMessageProvenancePart[]
+): void {
+  for (const part of parts) {
+    appendProviderProvenanceIndices(
+      builder,
+      part.attribution,
+      part.sourceMessageId,
+      part.sourceContentPartIndices
+    );
+  }
+}
+
+function mergeAdjacentProviderProvenanceParts(
+  parts: readonly ProviderMessageProvenancePart[]
+): ProviderMessageProvenancePart[] {
+  const builder = createProviderMessageProvenanceBuilder();
+  appendProviderProvenanceParts(builder, parts);
+  return builder.parts;
+}
+
+function createProviderContentProvenanceParts(
+  content: readonly MessageContentComplex[],
+  sourceContentPartOffset: number,
+  sourceMessageId: string | undefined,
+  defaultAttribution: ProviderMessageAttribution
+): ProviderMessageProvenancePart[] {
+  const builder = createProviderMessageProvenanceBuilder();
+  for (let index = 0; index < content.length; index++) {
+    const part = content[index] as MessageContentComplex | null | undefined;
+    if (part == null) {
+      continue;
+    }
+    const attribution = isProviderToolResultPart(part)
+      ? 'tool'
+      : defaultAttribution;
+    appendProviderProvenanceContribution(
+      builder,
+      attribution,
+      sourceMessageId,
+      sourceContentPartOffset + index
+    );
+  }
+  return builder.parts;
+}
+
 /**
  * Helper function to format an assistant message
  * @param message The message to format
@@ -515,67 +690,196 @@ function formatAssistantMessage(
     | RoleBearingMessage<ToolMessage>
     | RoleBearingMessage<HumanMessage>
   > = [];
+  const formattedMessageProvenance = new Map<
+    BaseMessage,
+    ProviderMessageProvenanceBuilder
+  >();
   const appendFormattedMessage = (
-    formattedMessage: (typeof formattedMessages)[number]
+    formattedMessage: (typeof formattedMessages)[number],
+    attribution: ProviderMessageAttribution,
+    sourceContentPartIndices?: SourceContentPartIndices,
+    provenanceBuilder?: ProviderMessageProvenanceBuilder
   ): void => {
-    stampSourceMessageIdentity(
-      formattedMessage,
-      options?.sourceMessageId,
-      formattedMessages.length
-    );
+    const builder =
+      provenanceBuilder ?? createProviderMessageProvenanceBuilder();
+    if (provenanceBuilder == null) {
+      appendProviderProvenanceIndices(
+        builder,
+        attribution,
+        options?.sourceMessageId,
+        sourceContentPartIndices
+      );
+    }
+    formattedMessageProvenance.set(formattedMessage, builder);
     formattedMessages.push(formattedMessage);
   };
+  const finalizeFormattedMessages = (): typeof formattedMessages => {
+    for (let index = 0; index < formattedMessages.length; index++) {
+      const formattedMessage = formattedMessages[index];
+      stampSourceMessageIdentity(
+        formattedMessage,
+        options?.sourceMessageId,
+        index,
+        'model',
+        undefined,
+        formattedMessageProvenance.get(formattedMessage)?.parts
+      );
+    }
+    return formattedMessages;
+  };
+  const appendSourcePartIndices = (
+    formattedMessage: (typeof formattedMessages)[number],
+    attribution: ProviderMessageAttribution,
+    sourceContentPartIndices: SourceContentPartIndices
+  ): void => {
+    const builder = formattedMessageProvenance.get(formattedMessage);
+    if (builder == null) {
+      return;
+    }
+    appendProviderProvenanceIndices(
+      builder,
+      attribution,
+      options?.sourceMessageId,
+      sourceContentPartIndices
+    );
+  };
+  const getSourcePartIndices = (partIndex: number): SourceContentPartIndices =>
+    options?.sourceContentPartIndices?.[partIndex] ??
+    (options?.sourceContentPartOffset ?? 0) + partIndex;
+  const createSourceProvenanceBuilder = (
+    sourceContentPartIndices: SourceContentPartIndices,
+    attribution: ProviderMessageAttribution,
+    applyToolOverrides = false
+  ): ProviderMessageProvenanceBuilder => {
+    const builder = createProviderMessageProvenanceBuilder();
+    appendProviderProvenanceIndices(
+      builder,
+      attribution,
+      options?.sourceMessageId,
+      sourceContentPartIndices,
+      applyToolOverrides ? options?.toolSourceContentPartIndices : undefined
+    );
+    return builder;
+  };
   let currentContent: MessageContentComplex[] = [];
+  let currentContentProvenance = createProviderMessageProvenanceBuilder();
+  const appendCurrentContentProvenance = (
+    sourceContentPartIndices: SourceContentPartIndices,
+    attribution: ProviderMessageAttribution,
+    applyToolOverrides = false
+  ): void => {
+    appendProviderProvenanceIndices(
+      currentContentProvenance,
+      attribution,
+      options?.sourceMessageId,
+      sourceContentPartIndices,
+      applyToolOverrides ? options?.toolSourceContentPartIndices : undefined
+    );
+  };
   let lastAIMessage: RoleBearingMessage<AIMessage> | null = null;
   let hasReasoning = false;
   let pendingReasoningContent = '';
+  let pendingReasoningSourcePartIndices: number[] = [];
   const emittedServerToolUseIds = new Set<string>();
-  const pendingServerToolUses = new Map<string, MessageContentComplex>();
+  const pendingServerToolUses = new Map<
+    string,
+    {
+      content: MessageContentComplex;
+      sourceContentPartIndices: SourceContentPartIndices;
+    }
+  >();
   const shouldPreserveReasoningContent =
     options?.preserveReasoningContent === true;
   const serverToolResultIds = new Set<string>();
   const preferredToolCallParts = new Map<string, MessageContentComplex>();
 
-  const takePendingReasoningContent = (): string | undefined => {
+  const takePendingReasoningContent = (): {
+    content?: string;
+    sourceContentPartIndices: number[];
+  } => {
     if (!shouldPreserveReasoningContent || !pendingReasoningContent) {
-      return undefined;
+      return { sourceContentPartIndices: [] };
     }
-    const reasoningContent = pendingReasoningContent;
+    const content = pendingReasoningContent;
+    const sourceContentPartIndices = pendingReasoningSourcePartIndices;
     pendingReasoningContent = '';
-    return reasoningContent;
+    pendingReasoningSourcePartIndices = [];
+    return { content, sourceContentPartIndices };
   };
 
   const createAIMessage = (
     content: MessageContent
-  ): RoleBearingMessage<AIMessage> => {
-    const reasoningContent = takePendingReasoningContent();
-    return withMessageRole(
+  ): {
+    message: RoleBearingMessage<AIMessage>;
+    reasoningSourceContentPartIndices: number[];
+  } => {
+    const reasoning = takePendingReasoningContent();
+    const message = withMessageRole(
       new AIMessage({
         content,
-        ...(reasoningContent != null && {
-          additional_kwargs: { reasoning_content: reasoningContent },
+        ...(reasoning.content != null && {
+          additional_kwargs: { reasoning_content: reasoning.content },
         }),
       }),
       'assistant'
     );
+    return {
+      message,
+      reasoningSourceContentPartIndices: reasoning.sourceContentPartIndices,
+    };
+  };
+
+  const appendAIMessage = (
+    content: MessageContent,
+    provenance: ProviderMessageProvenanceBuilder
+  ): RoleBearingMessage<AIMessage> => {
+    const created = createAIMessage(content);
+    let combinedProvenance = provenance;
+    if (created.reasoningSourceContentPartIndices.length > 0) {
+      combinedProvenance = createProviderMessageProvenanceBuilder();
+      appendProviderProvenanceIndices(
+        combinedProvenance,
+        'model',
+        options?.sourceMessageId,
+        created.reasoningSourceContentPartIndices
+      );
+      appendProviderProvenanceParts(combinedProvenance, provenance.parts);
+    }
+    appendFormattedMessage(
+      created.message,
+      'model',
+      undefined,
+      combinedProvenance
+    );
+    return created.message;
   };
 
   const attachPendingReasoningContent = (aiMessage: AIMessage): void => {
-    const reasoningContent = takePendingReasoningContent();
-    if (reasoningContent == null) {
+    const reasoning = takePendingReasoningContent();
+    if (reasoning.content == null) {
       return;
     }
     aiMessage.additional_kwargs.reasoning_content =
       typeof aiMessage.additional_kwargs.reasoning_content === 'string'
-        ? `${aiMessage.additional_kwargs.reasoning_content}${reasoningContent}`
-        : reasoningContent;
+        ? `${aiMessage.additional_kwargs.reasoning_content}${reasoning.content}`
+        : reasoning.content;
+    appendSourcePartIndices(
+      aiMessage as (typeof formattedMessages)[number],
+      'model',
+      reasoning.sourceContentPartIndices
+    );
   };
 
   const flushPendingServerToolUse = (toolUseId: string): void => {
-    for (const [id, content] of pendingServerToolUses) {
+    for (const [id, pending] of pendingServerToolUses) {
       pendingServerToolUses.delete(id);
       if (id === toolUseId) {
-        currentContent.push(content);
+        currentContent.push(pending.content);
+        appendCurrentContentProvenance(
+          pending.sourceContentPartIndices,
+          'model',
+          true
+        );
         emittedServerToolUseIds.add(id);
         return;
       }
@@ -609,10 +913,12 @@ function formatAssistantMessage(
       }
     }
 
-    for (const part of contentParts) {
+    for (let partIndex = 0; partIndex < contentParts.length; partIndex++) {
+      const part = contentParts[partIndex];
       if (part == null) {
         continue;
       }
+      const sourcePartIndices = getSourcePartIndices(partIndex);
       const toolUseId = getToolUseId(part);
       if (toolUseId != null) {
         const isServerToolResult = isValidServerToolResult(part);
@@ -625,6 +931,7 @@ function formatAssistantMessage(
         flushPendingServerToolUse(toolUseId);
         if (isServerToolResult) {
           currentContent.push(part);
+          appendCurrentContentProvenance(sourcePartIndices, 'tool');
           continue;
         }
       } else if (hasMeaningfulAssistantContent(part)) {
@@ -644,9 +951,13 @@ function formatAssistantMessage(
             currentContent.some((content) => content.type !== ContentTypes.TEXT)
           ) {
             currentContent.push(part);
-            lastAIMessage = createAIMessage(toLangChainContent(currentContent));
-            appendFormattedMessage(lastAIMessage);
+            appendCurrentContentProvenance(sourcePartIndices, 'model', true);
+            lastAIMessage = appendAIMessage(
+              toLangChainContent(currentContent),
+              currentContentProvenance
+            );
             currentContent = [];
+            currentContentProvenance = createProviderMessageProvenanceBuilder();
             continue;
           }
           let content = currentContent.reduce((acc, curr) => {
@@ -656,14 +967,17 @@ function formatAssistantMessage(
             return acc;
           }, '');
           content = `${content}\n${getTextContent(part)}`.trim();
-          lastAIMessage = createAIMessage(content);
-          appendFormattedMessage(lastAIMessage);
+          appendCurrentContentProvenance(sourcePartIndices, 'model', true);
+          lastAIMessage = appendAIMessage(content, currentContentProvenance);
           currentContent = [];
+          currentContentProvenance = createProviderMessageProvenanceBuilder();
           continue;
         }
         // Create a new AIMessage with this text and prepare for tool calls
-        lastAIMessage = createAIMessage(getTextContent(part));
-        appendFormattedMessage(lastAIMessage);
+        lastAIMessage = appendAIMessage(
+          getTextContent(part),
+          createSourceProvenanceBuilder(sourcePartIndices, 'model', true)
+        );
       } else if (part.type === ContentTypes.TOOL_CALL) {
         // Skip malformed tool call entries without tool_call property
         if (part.tool_call == null) {
@@ -711,20 +1025,26 @@ function formatAssistantMessage(
             continue;
           }
           pendingServerToolUses.set(_tool_call.id, {
-            type: 'server_tool_use',
-            id: _tool_call.id,
-            name: _tool_call.name,
-            input: parseServerToolInput(_args),
-          } as MessageContentComplex);
+            content: {
+              type: 'server_tool_use',
+              id: _tool_call.id,
+              name: _tool_call.name,
+              input: parseServerToolInput(_args),
+            } as MessageContentComplex,
+            sourceContentPartIndices: sourcePartIndices,
+          });
           continue;
         }
 
         if (!lastAIMessage) {
           // "Heal" the payload by creating an AIMessage to precede the tool call
-          lastAIMessage = createAIMessage('');
-          appendFormattedMessage(lastAIMessage);
+          lastAIMessage = appendAIMessage(
+            '',
+            createSourceProvenanceBuilder(sourcePartIndices, 'model')
+          );
         } else {
           attachPendingReasoningContent(lastAIMessage);
+          appendSourcePartIndices(lastAIMessage, 'model', sourcePartIndices);
         }
 
         const tool_call: ToolCallPart = _tool_call;
@@ -768,7 +1088,9 @@ function formatAssistantMessage(
               content: formatToolCallOutput(output),
             }),
             'tool'
-          )
+          ),
+          'tool',
+          sourcePartIndices
         );
       } else if (
         part.type === ContentTypes.THINK ||
@@ -779,6 +1101,10 @@ function formatAssistantMessage(
       ) {
         hasReasoning = true;
         pendingReasoningContent += extractReasoningContent(part);
+        appendSourceContentPartIndices(
+          pendingReasoningSourcePartIndices,
+          sourcePartIndices
+        );
         continue;
       } else if (part.type === ContentTypes.STEER) {
         /*
@@ -798,18 +1124,20 @@ function formatAssistantMessage(
           if (
             currentContent.some((content) => content.type !== ContentTypes.TEXT)
           ) {
-            lastAIMessage = createAIMessage(toLangChainContent(currentContent));
-            appendFormattedMessage(lastAIMessage);
+            appendAIMessage(
+              toLangChainContent(currentContent),
+              currentContentProvenance
+            );
           } else {
             const flushed = currentContent
               .reduce((acc, curr) => `${acc}${getTextContent(curr)}\n`, '')
               .trim();
             if (flushed.length > 0) {
-              lastAIMessage = createAIMessage(flushed);
-              appendFormattedMessage(lastAIMessage);
+              appendAIMessage(flushed, currentContentProvenance);
             }
           }
           currentContent = [];
+          currentContentProvenance = createProviderMessageProvenanceBuilder();
         } else if (shouldPreserveReasoningContent && pendingReasoningContent) {
           /**
            * Reasoning directly preceding a steer has no `currentContent`
@@ -818,8 +1146,7 @@ function formatAssistantMessage(
            * `additional_kwargs.reasoning_content`) or the persisted
            * assistant reasoning silently vanishes on replay.
            */
-          lastAIMessage = createAIMessage('');
-          appendFormattedMessage(lastAIMessage);
+          appendAIMessage('', createProviderMessageProvenanceBuilder());
         }
         const steerPart = part as {
           steer?: string;
@@ -836,7 +1163,9 @@ function formatAssistantMessage(
               additional_kwargs: { role: 'user', source: 'steer' },
             }),
             'user'
-          )
+          ),
+          'user',
+          sourcePartIndices
         );
         lastAIMessage = null;
         /** The steer splits the assistant message: the post-steer segment
@@ -844,6 +1173,7 @@ function formatAssistantMessage(
          *  flushed above or intentionally dropped when not preserving). */
         hasReasoning = false;
         pendingReasoningContent = '';
+        pendingReasoningSourcePartIndices = [];
       } else if (
         part.type === ContentTypes.ERROR ||
         part.type === ContentTypes.AGENT_UPDATE ||
@@ -856,10 +1186,21 @@ function formatAssistantMessage(
           continue;
         }
         currentContent.push(part);
+        const attribution = isProviderToolResultPart(part) ? 'tool' : 'model';
+        appendCurrentContentProvenance(
+          sourcePartIndices,
+          attribution,
+          attribution === 'model'
+        );
       }
     }
-    for (const content of pendingServerToolUses.values()) {
-      currentContent.push(content);
+    for (const pending of pendingServerToolUses.values()) {
+      currentContent.push(pending.content);
+      appendCurrentContentProvenance(
+        pending.sourceContentPartIndices,
+        'model',
+        true
+      );
     }
   }
 
@@ -867,34 +1208,44 @@ function formatAssistantMessage(
     let content = '';
     for (const part of currentContent) {
       if (part.type !== ContentTypes.TEXT) {
-        appendFormattedMessage(
-          createAIMessage(toLangChainContent(currentContent))
+        appendAIMessage(
+          toLangChainContent(currentContent),
+          currentContentProvenance
         );
-        return formattedMessages;
+        return finalizeFormattedMessages();
       }
       content += `${getTextContent(part)}\n`;
     }
     content = content.trim();
 
     if (content) {
-      appendFormattedMessage(createAIMessage(content));
+      appendAIMessage(content, currentContentProvenance);
     }
   } else if (currentContent.length > 0) {
-    appendFormattedMessage(createAIMessage(toLangChainContent(currentContent)));
+    appendAIMessage(
+      toLangChainContent(currentContent),
+      currentContentProvenance
+    );
   }
 
-  return formattedMessages;
+  return finalizeFormattedMessages();
 }
 
 function getSourceMessageId(message: Partial<TMessage>): string | undefined {
-  const candidate =
-    (message as { messageId?: string }).messageId ??
-    (message as { id?: string }).id;
-  if (typeof candidate !== 'string') {
-    return undefined;
+  const candidates = [
+    (message as { messageId?: unknown }).messageId,
+    (message as { id?: unknown }).id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+    const normalized = candidate.trim();
+    if (normalized.length > 0) {
+      return normalized;
+    }
   }
-  const normalized = candidate.trim();
-  return normalized.length > 0 ? normalized : undefined;
+  return undefined;
 }
 
 /**
@@ -907,13 +1258,53 @@ function getSourceMessageId(message: Partial<TMessage>): string | undefined {
 function stampSourceMessageIdentity(
   message: RoleBearingMessage<BaseMessage>,
   sourceMessageId: string | undefined,
-  derivedIndex = 0
+  derivedIndex = 0,
+  attribution: ProviderMessageAttribution = 'model',
+  sourceContentPartIndices?: readonly number[],
+  provenanceParts?: readonly ProviderMessageProvenancePart[]
 ): void {
-  if (sourceMessageId == null) {
-    return;
+  if (sourceMessageId != null) {
+    message.additional_kwargs.sourceMessageId = sourceMessageId;
   }
-  message.additional_kwargs.sourceMessageId = sourceMessageId;
-  if (derivedIndex !== 0) {
+  let partsToStamp: readonly ProviderMessageProvenancePart[];
+  if (provenanceParts != null && provenanceParts.length > 0) {
+    let needsSourceMessageId = false;
+    if (sourceMessageId != null) {
+      for (const part of provenanceParts) {
+        if (part.sourceMessageId == null) {
+          needsSourceMessageId = true;
+          break;
+        }
+      }
+    }
+    if (needsSourceMessageId) {
+      const completedParts: ProviderMessageProvenancePart[] = [];
+      for (const part of provenanceParts) {
+        completedParts.push({
+          ...part,
+          ...(part.sourceMessageId == null && { sourceMessageId }),
+        });
+      }
+      partsToStamp = completedParts;
+    } else {
+      partsToStamp = provenanceParts;
+    }
+  } else {
+    partsToStamp = [
+      {
+        attribution,
+        ...(sourceMessageId != null && { sourceMessageId }),
+        ...(sourceContentPartIndices != null && {
+          sourceContentPartIndices,
+        }),
+      },
+    ];
+  }
+  setProviderMessageProvenance(
+    message,
+    partsToStamp
+  );
+  if (sourceMessageId == null || derivedIndex !== 0) {
     return;
   }
   message.id = sourceMessageId;
@@ -979,7 +1370,9 @@ function labelAllAgentContent(
       } as MessageContentComplex);
     } else {
       // No agent ID, pass through as-is
-      result.push(...agentContentBuffer);
+      for (const part of agentContentBuffer) {
+        result.push(part);
+      }
     }
 
     agentContentBuffer = [];
@@ -1108,7 +1501,9 @@ export const labelContentByAgent = (
       }
     } else {
       // Not from a transfer, add as-is
-      result.push(...agentContentBuffer);
+      for (const part of agentContentBuffer) {
+        result.push(part);
+      }
     }
 
     agentContentBuffer = [];
@@ -1541,12 +1936,12 @@ export const formatAgentMessages = (
     if (next.role === 'assistant') {
       return;
     }
-    messages.push(
-      withMessageRole(
-        new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
-        'assistant'
-      )
+    const anchor = withMessageRole(
+      new AIMessage({ content: STEER_ANCHOR_PLACEHOLDER }),
+      'assistant'
     );
+    stampSourceMessageIdentity(anchor, undefined, 0, 'synthetic');
+    messages.push(anchor);
   };
   // If indexTokenCountMap is provided, create a new map to track the updated indices
   const updatedIndexTokenCountMap: Record<number, number> = {};
@@ -1577,6 +1972,12 @@ export const formatAgentMessages = (
       continue;
     }
 
+    const sourceContentPartOffset =
+      summaryBoundary?.mode === 'positional' &&
+      summaryBoundary.messageIndex === i
+        ? summaryBoundary.contentIndex + 1
+        : 0;
+
     // Q: Store the current length of messages to track where this payload message starts in the result?
     // const startIndex = messages.length;
     if (typeof message.content === 'string') {
@@ -1599,7 +2000,26 @@ export const formatAgentMessages = (
         | RoleBearingMessage<HumanMessage>
         | RoleBearingMessage<AIMessage>
         | RoleBearingMessage<SystemMessage>;
-      stampSourceMessageIdentity(formattedMessage, sourceMessageId);
+      let attribution: ProviderMessageAttribution = 'synthetic';
+      if (formattedMessage.role === 'user') {
+        attribution = 'user';
+      } else if (formattedMessage.role === 'assistant') {
+        attribution = 'model';
+      }
+      const provenanceParts = createProviderContentProvenanceParts(
+        message.content as MessageContentComplex[],
+        sourceContentPartOffset,
+        sourceMessageId,
+        attribution
+      );
+      stampSourceMessageIdentity(
+        formattedMessage,
+        sourceMessageId,
+        0,
+        attribution,
+        undefined,
+        provenanceParts
+      );
       flushSteerAnchor(formattedMessage);
       messages.push(formattedMessage);
 
@@ -1618,17 +2038,35 @@ export const formatAgentMessages = (
      * - Dynamically expand the set when tool_search results are encountered
      */
     let processedMessage = message;
+    let processedSourceContentPartIndices:
+      | SourceContentPartIndices[]
+      | undefined;
+    const processedToolSourceContentPartIndices = new Set<number>();
     let pendingSkillNames: Set<string> | undefined;
     if (discoveredTools) {
       const content = message.content;
       if (content != null && Array.isArray(content)) {
         const filteredContent: typeof content = [];
+        const filteredSourceContentPartIndices: SourceContentPartIndices[] = [];
         const invalidToolCallIds = new Set<string>();
         const invalidToolStrings: string[] = [];
+        const invalidToolSourceContentPartIndices: number[] = [];
 
-        for (const part of content) {
+        for (let partIndex = 0; partIndex < content.length; partIndex++) {
+          const part = content[partIndex] as
+            | MessageContentComplex
+            | null
+            | undefined;
+          const partSourceContentIndices = sourceContentPartOffset + partIndex;
+          if (part == null || typeof part !== 'object') {
+            continue;
+          }
+          if (isValidServerToolResult(part)) {
+            processedToolSourceContentPartIndices.add(partSourceContentIndices);
+          }
           if (part.type !== ContentTypes.TOOL_CALL) {
             filteredContent.push(part);
+            filteredSourceContentPartIndices.push(partSourceContentIndices);
             continue;
           }
 
@@ -1668,6 +2106,7 @@ export const formatAgentMessages = (
 
           if (discoveredTools.has(toolName)) {
             filteredContent.push(part);
+            filteredSourceContentPartIndices.push(partSourceContentIndices);
             if (
               toolName === Constants.SKILL_TOOL &&
               skills?.size != null &&
@@ -1688,6 +2127,11 @@ export const formatAgentMessages = (
             }
             const output = part.tool_call.output ?? '';
             invalidToolStrings.push(`Tool: ${toolName}, ${output}`);
+            appendSourceContentPartIndices(
+              invalidToolSourceContentPartIndices,
+              partSourceContentIndices
+            );
+            processedToolSourceContentPartIndices.add(partSourceContentIndices);
           }
         }
 
@@ -1734,12 +2178,23 @@ export const formatAgentMessages = (
                 ? `${existingText}\n${invalidToolText}`
                 : invalidToolText,
             };
+            const lastTextSourceContentPartIndices =
+              filteredSourceContentPartIndices[lastTextPartIndex];
+            filteredSourceContentPartIndices[lastTextPartIndex] = [
+              ...(typeof lastTextSourceContentPartIndices === 'number'
+                ? [lastTextSourceContentPartIndices]
+                : lastTextSourceContentPartIndices),
+              ...invalidToolSourceContentPartIndices,
+            ];
           } else {
             /** No text part exists, create one */
             filteredContent.push({
               type: ContentTypes.TEXT,
               [ContentTypes.TEXT]: invalidToolText,
             });
+            filteredSourceContentPartIndices.push(
+              invalidToolSourceContentPartIndices
+            );
           }
         }
 
@@ -1749,6 +2204,7 @@ export const formatAgentMessages = (
           invalidToolStrings.length > 0
         ) {
           processedMessage = { ...message, content: filteredContent };
+          processedSourceContentPartIndices = filteredSourceContentPartIndices;
         }
       }
     }
@@ -1757,8 +2213,12 @@ export const formatAgentMessages = (
     if (!discoveredTools && skills?.size != null && skills.size > 0) {
       const content = processedMessage.content;
       if (Array.isArray(content)) {
-        for (const part of content) {
+        for (const part of content as Array<
+          MessageContentComplex | null | undefined
+        >) {
           if (
+            part == null ||
+            typeof part !== 'object' ||
             part.type !== ContentTypes.TOOL_CALL ||
             part.tool_call?.name !== Constants.SKILL_TOOL
           ) {
@@ -1779,6 +2239,9 @@ export const formatAgentMessages = (
         options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
       sourceMessageId,
+      sourceContentPartOffset,
+      sourceContentPartIndices: processedSourceContentPartIndices,
+      toolSourceContentPartIndices: processedToolSourceContentPartIndices,
     });
     /**
      * A steer that ends an assistant message leaves the replay on a
@@ -1818,7 +2281,9 @@ export const formatAgentMessages = (
     if (formattedMessages.length > 0) {
       flushSteerAnchor(formattedMessages[0]);
     }
-    messages.push(...formattedMessages);
+    for (const formattedMessage of formattedMessages) {
+      messages.push(formattedMessage);
+    }
     if (endsWithSteerMessage(formattedMessages)) {
       pendingSteerAnchor = true;
     }
@@ -1835,20 +2300,20 @@ export const formatAgentMessages = (
         }
         const body = skills?.get(skillName) ?? '';
         if (body) {
-          messages.push(
-            withMessageRole(
-              new HumanMessage({
-                content: body,
-                additional_kwargs: {
-                  role: 'user',
-                  isMeta: true,
-                  source: 'skill',
-                  skillName,
-                },
-              }),
-              'user'
-            )
+          const skillMessage = withMessageRole(
+            new HumanMessage({
+              content: body,
+              additional_kwargs: {
+                role: 'user',
+                isMeta: true,
+                source: 'skill',
+                skillName,
+              },
+            }),
+            'user'
           );
+          stampSourceMessageIdentity(skillMessage, undefined, 0, 'synthetic');
+          messages.push(skillMessage);
         }
       }
     }
@@ -2188,14 +2653,127 @@ function serializeFoldedValue(value: unknown): string {
       .content;
 }
 
-function markSyntheticProviderContext<T extends BaseMessage>(message: T): T {
+interface FoldedSourceMessage {
+  readonly message: BaseMessage;
+  /** Provider-content positions retained from an array message. Omitted when
+   * string content or tool-call metadata contributed as a whole. */
+  readonly retainedContentPartIndices?: ReadonlySet<number>;
+  readonly mappingAmbiguous?: boolean;
+}
+
+function getSyntheticProviderContextProvenanceParts(
+  sourceMessages: readonly FoldedSourceMessage[]
+): ProviderMessageProvenancePart[] {
+  const parts: ProviderMessageProvenancePart[] = [];
+  for (const source of sourceMessages) {
+    const {
+      message: sourceMessage,
+      retainedContentPartIndices,
+      mappingAmbiguous,
+    } = source;
+    const explicit = getProviderMessageProvenance(sourceMessage);
+    const sourceMessageIds = getProviderSourceMessageIds(sourceMessage);
+    const retainedSourceIds = new Set<string>();
+    const contentLength = Array.isArray(sourceMessage.content)
+      ? sourceMessage.content.length
+      : undefined;
+    const explicitIndexRefCount = (explicit?.parts ?? []).reduce(
+      (total, part) => total + (part.sourceContentPartIndices?.length ?? 0),
+      0
+    );
+    const mapsOneToOne =
+      mappingAmbiguous !== true &&
+      retainedContentPartIndices != null &&
+      contentLength != null &&
+      explicitIndexRefCount === contentLength;
+    const retainedAllContentParts =
+      mappingAmbiguous !== true &&
+      retainedContentPartIndices != null &&
+      contentLength != null &&
+      retainedContentPartIndices.size === contentLength;
+    const retainUnindexedSourceIds =
+      (mappingAmbiguous !== true && retainedContentPartIndices == null) ||
+      retainedAllContentParts ||
+      sourceMessageIds.length <= 1;
+    let sourceIndexOrdinal = 0;
+    for (const part of explicit?.parts ?? []) {
+      let sourceContentPartIndices = part.sourceContentPartIndices;
+      if (mappingAmbiguous === true && sourceContentPartIndices != null) {
+        sourceIndexOrdinal += sourceContentPartIndices.length;
+        continue;
+      }
+      if (
+        retainedContentPartIndices != null &&
+        sourceContentPartIndices != null &&
+        !retainedAllContentParts
+      ) {
+        if (!mapsOneToOne) {
+          sourceIndexOrdinal += sourceContentPartIndices.length;
+          continue;
+        }
+        const retainedSourceContentPartIndices: number[] = [];
+        for (const sourceContentPartIndex of sourceContentPartIndices) {
+          if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
+            retainedSourceContentPartIndices.push(sourceContentPartIndex);
+          }
+          sourceIndexOrdinal++;
+        }
+        if (retainedSourceContentPartIndices.length === 0) {
+          continue;
+        }
+        sourceContentPartIndices = retainedSourceContentPartIndices;
+      } else {
+        sourceIndexOrdinal += sourceContentPartIndices?.length ?? 0;
+      }
+      if (
+        sourceContentPartIndices == null &&
+        part.sourceMessageId != null &&
+        !retainUnindexedSourceIds
+      ) {
+        continue;
+      }
+      parts.push({
+        attribution: 'synthetic',
+        ...(part.sourceMessageId != null && {
+          sourceMessageId: part.sourceMessageId,
+        }),
+        ...(sourceContentPartIndices != null && {
+          sourceContentPartIndices,
+        }),
+      });
+      if (part.sourceMessageId != null) {
+        retainedSourceIds.add(part.sourceMessageId);
+      }
+    }
+    for (const sourceMessageId of sourceMessageIds) {
+      if (!retainUnindexedSourceIds) {
+        break;
+      }
+      if (!retainedSourceIds.has(sourceMessageId)) {
+        parts.push({ attribution: 'synthetic', sourceMessageId });
+      }
+    }
+  }
+  return mergeAdjacentProviderProvenanceParts(parts);
+}
+
+function markSyntheticProviderContext<T extends BaseMessage>(
+  message: T,
+  sourceMessages: readonly FoldedSourceMessage[] = []
+): T {
   syntheticProviderContextMessages.add(message);
+  const parts = getSyntheticProviderContextProvenanceParts(sourceMessages);
+  setProviderMessageProvenance(
+    message,
+    parts.length > 0 ? parts : [{ attribution: 'synthetic' }]
+  );
   return message;
 }
 
 function appendSyntheticProviderContextMessage(
   result: BaseMessage[],
-  parts: MessageContentComplex[]
+  parts: MessageContentComplex[],
+  sourceMessages: readonly FoldedSourceMessage[] = []
 ): boolean {
   if (parts.length === 0) {
     return false;
@@ -2205,7 +2783,8 @@ function appendSyntheticProviderContextMessage(
       withMessageRole(
         new HumanMessage({ content: toLangChainContent(parts) }),
         'user'
-      )
+      ),
+      sourceMessages
     )
   );
   return true;
@@ -2220,6 +2799,34 @@ export function isSyntheticProviderContextMessage(
   message: BaseMessage
 ): boolean {
   return syntheticProviderContextMessages.has(message);
+}
+
+/** Compacts a folded provider-context message without retaining source claims
+ * for bytes whose mapping cannot survive the lossy compaction. The unsourced
+ * user/tool parts intentionally make security consumers inspect the exact
+ * compacted wire under both external trust domains. */
+export function compactSyntheticProviderContextMessage(
+  message: HumanMessage,
+  maxChars: number
+): HumanMessage {
+  const compactedContent = compactToolContent(message.content, maxChars);
+  if (!compactedContent.changed) {
+    return message;
+  }
+  const compacted = new HumanMessage({
+    content: compactedContent.content,
+    id: message.id,
+    name: message.name,
+    additional_kwargs: { ...message.additional_kwargs },
+    response_metadata: message.response_metadata,
+  });
+  syntheticProviderContextMessages.add(compacted);
+  setProviderMessageProvenance(compacted, [
+    { attribution: 'synthetic' },
+    { attribution: 'user' },
+    { attribution: 'tool' },
+  ]);
+  return compacted;
 }
 
 /** Flushes accumulated text chunks into `parts` as a single text block. */
@@ -2254,29 +2861,53 @@ function appendMessageContent(
   textChunks: string[],
   parts: MessageContentComplex[],
   budget: FoldContextBudget
-): void {
+): FoldedSourceMessage | undefined {
   const { content } = msg;
 
   if (typeof content === 'string') {
-    if (content && consumeFoldedWork(textChunks, budget)) {
-      appendFoldedLine(textChunks, budget, [`${role}: `, content]);
+    const remainingCharsBefore = budget.remainingChars;
+    let contentComplete = true;
+    if (content) {
+      contentComplete =
+        consumeFoldedWork(textChunks, budget) &&
+        appendFoldedLine(textChunks, budget, [`${role}: `, content]);
     }
-    appendToolCalls(msg, role, textChunks, budget);
-    return;
+    const toolCalls = appendToolCalls(msg, role, textChunks, budget);
+    return budget.remainingChars < remainingCharsBefore || toolCalls.contributed
+      ? {
+        message: msg,
+        ...((!contentComplete || !toolCalls.complete) && {
+          mappingAmbiguous: true,
+        }),
+      }
+      : undefined;
   }
 
   if (!Array.isArray(content)) {
-    appendToolCalls(msg, role, textChunks, budget);
-    return;
+    const toolCalls = appendToolCalls(msg, role, textChunks, budget);
+    return toolCalls.contributed
+      ? {
+        message: msg,
+        ...(!toolCalls.complete && { mappingAmbiguous: true }),
+      }
+      : undefined;
   }
 
   let hasToolUseBlock = false;
+  const retainedContentPartIndices = new Set<number>();
 
-  for (const block of content as ExtendedMessageContent[]) {
+  for (let blockIndex = 0; blockIndex < content.length; blockIndex++) {
+    const block = content[blockIndex] as ExtendedMessageContent;
     if (!consumeFoldedWork(textChunks, budget)) {
       hasToolUseBlock = true;
       break;
     }
+    const remainingCharsBefore = budget.remainingChars;
+    const markBlockRetained = (): void => {
+      if (budget.remainingChars < remainingCharsBefore) {
+        retainedContentPartIndices.add(blockIndex);
+      }
+    };
     const blockTypeValue = readFoldedDataProperty(block, 'type');
     const blockType =
       typeof blockTypeValue === 'string' ? blockTypeValue : undefined;
@@ -2293,6 +2924,7 @@ function appendMessageContent(
           appendFoldedLine(textChunks, budget, [
             `${role}: [${blockType ?? 'media'} omitted: folded context limit]`,
           ]);
+          markBlockRetained();
           continue;
         }
         flushTextChunks(textChunks, parts);
@@ -2304,6 +2936,7 @@ function appendMessageContent(
           serializeFoldedValue(block),
         ]);
       }
+      markBlockRetained();
       continue;
     }
 
@@ -2315,6 +2948,7 @@ function appendMessageContent(
         `${role}: [tool_use] ${typeof name === 'string' ? name : ''} `,
         serializeFoldedValue(input ?? {}),
       ]);
+      markBlockRetained();
       continue;
     }
 
@@ -2350,6 +2984,7 @@ function appendMessageContent(
           typeof output === 'string' ? output : serializeFoldedValue(output),
         ]);
       }
+      markBlockRetained();
       continue;
     }
 
@@ -2419,6 +3054,7 @@ function appendMessageContent(
           serializeFoldedValue(inner),
         ]);
       }
+      markBlockRetained();
       continue;
     }
 
@@ -2427,6 +3063,7 @@ function appendMessageContent(
       readFoldedDataProperty(block, 'input');
     if (typeof text === 'string' && text) {
       appendFoldedLine(textChunks, budget, [`${role}: `, text]);
+      markBlockRetained();
       continue;
     }
 
@@ -2437,13 +3074,23 @@ function appendMessageContent(
         serializeFoldedValue(block),
       ]);
     }
+    markBlockRetained();
   }
 
   // If content array had no tool_use blocks, fall back to tool_calls metadata
   // (handles edge case: empty content array with tool_calls populated)
-  if (!hasToolUseBlock) {
-    appendToolCalls(msg, role, textChunks, budget);
+  const toolCalls = !hasToolUseBlock
+    ? appendToolCalls(msg, role, textChunks, budget)
+    : { contributed: false, complete: true };
+  if (toolCalls.contributed) {
+    return {
+      message: msg,
+      ...(!toolCalls.complete && { mappingAmbiguous: true }),
+    };
   }
+  return retainedContentPartIndices.size > 0
+    ? { message: msg, retainedContentPartIndices }
+    : undefined;
 }
 
 function appendToolCalls(
@@ -2451,14 +3098,37 @@ function appendToolCalls(
   role: string,
   textChunks: string[],
   budget: FoldContextBudget
-): void {
+): { contributed: boolean; complete: boolean } {
   if (role !== 'AI') {
-    return;
+    return { contributed: false, complete: true };
   }
+  const remainingCharsBefore = budget.remainingChars;
+  let complete = true;
   const aiMsg = msg as AIMessage;
   if (aiMsg.tool_calls && aiMsg.tool_calls.length > 0) {
+    const rawToolCalls = aiMsg.additional_kwargs.tool_calls;
+    if (Array.isArray(rawToolCalls)) {
+      if (rawToolCalls.length !== aiMsg.tool_calls.length) {
+        complete = false;
+      } else {
+        for (let index = 0; index < rawToolCalls.length; index++) {
+          const rawToolCall = rawToolCalls[index];
+          const parsedToolCall = aiMsg.tool_calls[index];
+          const fn = readFoldedDataProperty(rawToolCall, 'function');
+          const rawId = readFoldedDataProperty(rawToolCall, 'id');
+          const rawName = readFoldedDataProperty(fn, 'name');
+          const parsedId = readFoldedDataProperty(parsedToolCall, 'id');
+          const parsedName = readFoldedDataProperty(parsedToolCall, 'name');
+          if (fn == null || rawId !== parsedId || rawName !== parsedName) {
+            complete = false;
+            break;
+          }
+        }
+      }
+    }
     for (const tc of aiMsg.tool_calls) {
       if (!consumeFoldedWork(textChunks, budget)) {
+        complete = false;
         break;
       }
       const name = readFoldedDataProperty(tc, 'name');
@@ -2469,19 +3139,24 @@ function appendToolCalls(
         ')',
       ]);
     }
-    return;
+    return {
+      contributed: budget.remainingChars < remainingCharsBefore,
+      complete,
+    };
   }
   // Fall back to raw provider tool calls kept only in additional_kwargs.
   const rawToolCalls = aiMsg.additional_kwargs.tool_calls;
   if (!Array.isArray(rawToolCalls)) {
-    return;
+    return { contributed: false, complete: true };
   }
   for (const tc of rawToolCalls) {
     if (!consumeFoldedWork(textChunks, budget)) {
+      complete = false;
       break;
     }
     const fn = readFoldedDataProperty(tc, 'function');
     if (fn == null) {
+      complete = false;
       continue;
     }
     const name = readFoldedDataProperty(fn, 'name');
@@ -2492,6 +3167,10 @@ function appendToolCalls(
       ')',
     ]);
   }
+  return {
+    contributed: budget.remainingChars < remainingCharsBefore,
+    complete,
+  };
 }
 
 /**
@@ -2644,24 +3323,43 @@ export function ensureThinkingBlockInMessages(
       // binary data as text (which caused 174× token amplification).
       const parts: MessageContentComplex[] = [];
       const textChunks: string[] = [];
+      const foldedSourceMessages: FoldedSourceMessage[] = [];
       appendFoldedLine(textChunks, foldBudget, ['[Previous agent context]']);
 
-      appendMessageContent(msg, 'AI', textChunks, parts, foldBudget);
+      const aiSource = appendMessageContent(
+        msg,
+        'AI',
+        textChunks,
+        parts,
+        foldBudget
+      );
+      if (aiSource != null) {
+        foldedSourceMessages.push(aiSource);
+      }
 
       let j = i + 1;
       while (j < messages.length && isToolMessage(messages[j])) {
-        appendMessageContent(
+        const toolSource = appendMessageContent(
           messages[j],
           'Tool',
           textChunks,
           parts,
           foldBudget
         );
+        if (toolSource != null) {
+          foldedSourceMessages.push(toolSource);
+        }
         j++;
       }
 
       flushTextChunks(textChunks, parts);
-      if (appendSyntheticProviderContextMessage(result, parts)) {
+      if (
+        appendSyntheticProviderContextMessage(
+          result,
+          parts,
+          foldedSourceMessages
+        )
+      ) {
         emitAgentLog(
           config,
           'warn',
@@ -2779,25 +3477,38 @@ export function foldToolBlocksForToollessAgent(
 
     const parts: MessageContentComplex[] = [];
     const textChunks: string[] = [];
+    const foldedSourceMessages: FoldedSourceMessage[] = [];
     appendFoldedLine(textChunks, foldBudget, ['[Previous tool interaction]']);
-    appendMessageContent(
+    const initialSource = appendMessageContent(
       msg,
       isToolResultMessage(msg) ? 'Tool' : 'AI',
       textChunks,
       parts,
       foldBudget
     );
+    if (initialSource != null) {
+      foldedSourceMessages.push(initialSource);
+    }
     foldedCount++;
 
     let j = i + 1;
     while (j < messages.length && isToolResultMessage(messages[j])) {
-      appendMessageContent(messages[j], 'Tool', textChunks, parts, foldBudget);
+      const toolSource = appendMessageContent(
+        messages[j],
+        'Tool',
+        textChunks,
+        parts,
+        foldBudget
+      );
+      if (toolSource != null) {
+        foldedSourceMessages.push(toolSource);
+      }
       foldedCount++;
       j++;
     }
 
     flushTextChunks(textChunks, parts);
-    appendSyntheticProviderContextMessage(result, parts);
+    appendSyntheticProviderContextMessage(result, parts, foldedSourceMessages);
     i = j;
   }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -42,6 +42,7 @@ import {
   hasStructurallyValidAnthropicWebSearchResultContent,
 } from './toolResultTypes';
 import {
+  hasBijectiveProviderContentPartMapping,
   inspectProviderMessageProvenance,
   inspectProviderSourceMessageIds,
   setInvalidProviderMessageProvenance,
@@ -2790,15 +2791,12 @@ function getSyntheticProviderContextProvenanceParts(
     const contentLength = Array.isArray(sourceMessage.content)
       ? sourceMessage.content.length
       : undefined;
-    const explicitIndexRefCount = (explicit?.parts ?? []).reduce(
-      (total, part) => total + (part.sourceContentPartIndices?.length ?? 0),
-      0
-    );
     const mapsOneToOne =
       mappingAmbiguous !== true &&
       retainedContentPartIndices != null &&
       contentLength != null &&
-      explicitIndexRefCount === contentLength;
+      explicit != null &&
+      hasBijectiveProviderContentPartMapping(explicit.parts, contentLength);
     const retainedAllContentParts =
       mappingAmbiguous !== true &&
       retainedContentPartIndices != null &&
@@ -2808,11 +2806,9 @@ function getSyntheticProviderContextProvenanceParts(
       (mappingAmbiguous !== true && retainedContentPartIndices == null) ||
       retainedAllContentParts ||
       sourceMessageIds.length <= 1;
-    let sourceIndexOrdinal = 0;
     for (const part of explicit?.parts ?? []) {
       let sourceContentPartIndices = part.sourceContentPartIndices;
       if (mappingAmbiguous === true && sourceContentPartIndices != null) {
-        sourceIndexOrdinal += sourceContentPartIndices.length;
         sourceContentPartIndices = undefined;
       }
       if (
@@ -2821,23 +2817,19 @@ function getSyntheticProviderContextProvenanceParts(
         !retainedAllContentParts
       ) {
         if (!mapsOneToOne) {
-          sourceIndexOrdinal += sourceContentPartIndices.length;
           sourceContentPartIndices = undefined;
         } else {
           const retainedSourceContentPartIndices: number[] = [];
           for (const sourceContentPartIndex of sourceContentPartIndices) {
-            if (retainedContentPartIndices.has(sourceIndexOrdinal)) {
+            if (retainedContentPartIndices.has(sourceContentPartIndex)) {
               retainedSourceContentPartIndices.push(sourceContentPartIndex);
             }
-            sourceIndexOrdinal++;
           }
           if (retainedSourceContentPartIndices.length === 0) {
             continue;
           }
           sourceContentPartIndices = retainedSourceContentPartIndices;
         }
-      } else {
-        sourceIndexOrdinal += sourceContentPartIndices?.length ?? 0;
       }
       const sourceMessageId =
         sourceContentPartIndices != null || retainUnindexedSourceIds

--- a/src/messages/formatAgentMessages.reducer.test.ts
+++ b/src/messages/formatAgentMessages.reducer.test.ts
@@ -3,10 +3,10 @@ import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { MessageContentComplex } from '@/types';
+import { Constants, ContentTypes, Providers } from '@/common';
 import { getProviderMessageProvenance } from './provenance';
 import { messagesStateReducer } from './reducer';
 import { formatAgentMessages } from './format';
-import { ContentTypes } from '@/common';
 
 const formatToolTurn = () =>
   formatAgentMessages([
@@ -31,6 +31,205 @@ const formatToolTurn = () =>
       ],
     },
   ]).messages;
+
+const pairedNativeToolResultCases: ReadonlyArray<{
+  label: string;
+  call: Record<string, unknown>;
+  result: Record<string, unknown>;
+}> = [
+  {
+    label: 'LangChain server_tool_call_result',
+    call: {
+      type: 'server_tool_call',
+      id: 'lc-call-result',
+      name: 'code_interpreter',
+      args: { code: 'print(1)' },
+    },
+    result: {
+      type: 'server_tool_call_result',
+      toolCallId: 'lc-call-result',
+      status: 'success',
+      output: { stdout: '1' },
+    },
+  },
+  {
+    label: 'LangChain server_tool_result',
+    call: {
+      type: 'server_tool_call',
+      id: 'lc-server-result',
+      name: 'web_search',
+      args: { query: 'docs' },
+    },
+    result: {
+      type: 'server_tool_result',
+      tool_call_id: 'lc-server-result',
+      status: 'success',
+      output: 'found',
+    },
+  },
+  {
+    label: 'Gemini codeExecutionResult',
+    call: {
+      type: 'executableCode',
+      executableCode: { language: 'python', code: 'print(1)' },
+    },
+    result: {
+      type: 'codeExecutionResult',
+      codeExecutionResult: { outcome: 'OUTCOME_OK', output: '1' },
+    },
+  },
+  {
+    label: 'Gemini toolResponse',
+    call: {
+      type: 'toolCall',
+      toolCall: { id: 'google-call', name: 'google_search', args: {} },
+    },
+    result: {
+      type: 'toolResponse',
+      toolResponse: {
+        id: 'google-call',
+        name: 'google_search',
+        response: { results: [] },
+      },
+    },
+  },
+  {
+    label: 'Anthropic MCP result',
+    call: {
+      type: 'mcp_tool_use',
+      id: 'mcp-call',
+      name: 'lookup',
+      server_name: 'docs',
+      input: {},
+    },
+    result: {
+      type: 'mcp_tool_result',
+      tool_use_id: 'mcp-call',
+      is_error: false,
+      content: [{ type: 'text', text: 'found' }],
+    },
+  },
+  {
+    label: 'Anthropic server result',
+    call: {
+      type: 'server_tool_use',
+      id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}web-search`,
+      name: 'web_search',
+      input: { query: 'docs' },
+    },
+    result: {
+      type: 'web_search_tool_result',
+      tool_use_id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}web-search`,
+      content: [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'ciphertext',
+          title: 'Docs',
+          url: 'https://example.com',
+        },
+      ],
+    },
+  },
+  {
+    label: 'Anthropic advisor result',
+    call: {
+      type: 'server_tool_use',
+      id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-result`,
+      name: 'advisor',
+      input: {},
+    },
+    result: {
+      type: 'advisor_tool_result',
+      tool_use_id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-result`,
+      content: {
+        type: 'advisor_result',
+        text: 'advice',
+        stop_reason: 'end_turn',
+      },
+    },
+  },
+  {
+    label: 'Anthropic advisor redacted result',
+    call: {
+      type: 'server_tool_use',
+      id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-redacted`,
+      name: 'advisor',
+      input: {},
+    },
+    result: {
+      type: 'advisor_tool_result',
+      tool_use_id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-redacted`,
+      content: {
+        type: 'advisor_redacted_result',
+        encrypted_content: 'ciphertext',
+        stop_reason: null,
+      },
+    },
+  },
+  {
+    label: 'Anthropic advisor error',
+    call: {
+      type: 'server_tool_use',
+      id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-error`,
+      name: 'advisor',
+      input: {},
+    },
+    result: {
+      type: 'advisor_tool_result',
+      tool_use_id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}advisor-error`,
+      content: {
+        type: 'advisor_tool_result_error',
+        error_code: 'unavailable',
+      },
+    },
+  },
+  {
+    label: 'Anthropic tool_result',
+    call: {
+      type: 'tool_use',
+      id: 'anthropic-tool-call',
+      name: 'lookup',
+      input: {},
+    },
+    result: {
+      type: 'tool_result',
+      tool_use_id: 'anthropic-tool-call',
+      content: 'found',
+    },
+  },
+  {
+    label: 'Bedrock toolResult',
+    call: {
+      type: 'toolUse',
+      toolUse: { toolUseId: 'bedrock-call', name: 'lookup', input: {} },
+    },
+    result: {
+      type: 'toolResult',
+      toolResult: {
+        toolUseId: 'bedrock-call',
+        content: [{ text: 'found' }],
+        status: 'success',
+      },
+    },
+  },
+];
+
+function attributionsForSourceIndex(
+  messages: BaseMessage[],
+  sourceContentPartIndex: number
+): string[] {
+  const attributions: string[] = [];
+  for (const message of messages) {
+    for (const part of getProviderMessageProvenance(message)?.parts ?? []) {
+      if (
+        part.sourceContentPartIndices?.includes(sourceContentPartIndex) === true
+      ) {
+        attributions.push(part.attribution);
+      }
+    }
+  }
+  return attributions;
+}
 
 describe('formatAgentMessages reducer compatibility', () => {
   it('does not expose derived message ids as OpenAI Responses item ids', () => {
@@ -257,8 +456,8 @@ describe('formatAgentMessages reducer compatibility', () => {
     ['user', 'user'],
     ['assistant', 'model'],
   ] as const)(
-    'splits tool-result and %s prose attribution within one provider message',
-    (role, proseAttribution) => {
+    'does not let an unpaired tool-result envelope override %s attribution',
+    (role, attribution) => {
       const [message] = formatAgentMessages([
         {
           role,
@@ -278,14 +477,9 @@ describe('formatAgentMessages reducer compatibility', () => {
         version: 1,
         parts: [
           {
-            attribution: 'tool',
+            attribution,
             sourceMessageId: `${role}-tool-result-row`,
-            sourceContentPartIndices: [0],
-          },
-          {
-            attribution: proseAttribution,
-            sourceMessageId: `${role}-tool-result-row`,
-            sourceContentPartIndices: [1],
+            sourceContentPartIndices: [0, 1],
           },
         ],
       });
@@ -298,7 +492,9 @@ describe('formatAgentMessages reducer compatibility', () => {
     'codeExecutionResult',
     'code_execution_tool_result',
     'mcp_tool_result',
-  ])('attributes the known %s envelope to tool output', (type) => {
+    'search_result',
+    'web_search_result',
+  ])('keeps a malformed or payload-only %s block model-attributed', (type) => {
     const [message] = formatAgentMessages([
       {
         role: 'assistant',
@@ -314,17 +510,184 @@ describe('formatAgentMessages reducer compatibility', () => {
       version: 1,
       parts: [
         {
-          attribution: 'tool',
-          sourceMessageId: `${type}-row`,
-          sourceContentPartIndices: [0],
-        },
-        {
           attribution: 'model',
           sourceMessageId: `${type}-row`,
-          sourceContentPartIndices: [1],
+          sourceContentPartIndices: [0, 1],
         },
       ],
     });
+  });
+
+  it.each(pairedNativeToolResultCases)(
+    'attributes a structurally valid paired $label block to the tool',
+    ({ label, call, result: toolResult }) => {
+      const { messages } = formatAgentMessages([
+        {
+          role: 'assistant',
+          messageId: `paired-${label}`,
+          content: [
+            call,
+            toolResult,
+            { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'model prose' },
+          ] as MessageContentComplex[],
+        },
+      ]);
+
+      expect(attributionsForSourceIndex(messages, 0)).toContain('model');
+      expect(attributionsForSourceIndex(messages, 1)).toEqual(['tool']);
+      expect(attributionsForSourceIndex(messages, 2)).toContain('model');
+    }
+  );
+
+  it.each(pairedNativeToolResultCases)(
+    'keeps an unpaired $label block from receiving tool attribution',
+    ({ label, result: toolResult }) => {
+      const { messages } = formatAgentMessages([
+        {
+          role: 'assistant',
+          messageId: `unpaired-${label}`,
+          content: [
+            toolResult,
+            { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'model prose' },
+          ] as MessageContentComplex[],
+        },
+      ]);
+
+      expect(
+        messages.flatMap(
+          (message) => getProviderMessageProvenance(message)?.parts ?? []
+        )
+      ).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ attribution: 'tool' })])
+      );
+    }
+  );
+
+  it('does not pair an ordinary tool call with a server-tool result protocol', () => {
+    const { messages } = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'cross-protocol-server-result',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'ordinary-call',
+              name: 'lookup',
+              args: '{}',
+              output: '',
+            },
+          },
+          {
+            type: 'server_tool_call_result',
+            toolCallId: 'ordinary-call',
+            status: 'success',
+            output: { attacker: 'bytes' },
+          },
+        ],
+      },
+    ]);
+
+    expect(attributionsForSourceIndex(messages, 1)).toEqual(['model']);
+  });
+
+  it('consumes a provider call after one matching result', () => {
+    const { call, result: toolResult } = pairedNativeToolResultCases[0];
+    const { messages } = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'duplicate-server-result',
+        content: [call, toolResult, { ...toolResult }] as MessageContentComplex[],
+      },
+    ]);
+
+    expect(attributionsForSourceIndex(messages, 1)).toEqual(['tool']);
+    expect(attributionsForSourceIndex(messages, 2)).toEqual(['model']);
+  });
+
+  it.each([
+    {
+      label: 'tool_result content',
+      call: {
+        type: 'tool_use',
+        id: 'matched-tool-result',
+        name: 'lookup',
+        input: {},
+      },
+      result: {
+        type: 'tool_result',
+        tool_use_id: 'matched-tool-result',
+        text: 'attacker bytes',
+      },
+    },
+    {
+      label: 'mcp_tool_result content',
+      call: {
+        type: 'mcp_tool_use',
+        id: 'matched-mcp-result',
+        name: 'lookup',
+        server_name: 'docs',
+        input: {},
+      },
+      result: {
+        type: 'mcp_tool_result',
+        tool_use_id: 'matched-mcp-result',
+        is_error: false,
+        text: 'attacker bytes',
+      },
+    },
+    {
+      label: 'server_tool_result output',
+      call: {
+        type: 'server_tool_call',
+        id: 'matched-server-result',
+        name: 'lookup',
+        args: {},
+      },
+      result: {
+        type: 'server_tool_result',
+        tool_call_id: 'matched-server-result',
+        status: 'success',
+        text: 'attacker bytes',
+      },
+    },
+  ])('rejects a matched block that substitutes text for $label', ({ call, result }) => {
+    const formatted = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'matched-text-spoof',
+        content: [call, result] as MessageContentComplex[],
+      },
+    ]);
+
+    expect(attributionsForSourceIndex(formatted.messages, 1)).toEqual([
+      'model',
+    ]);
+  });
+
+  it('does not tool-attribute piggyback bytes on a valid paired envelope', () => {
+    const { messages } = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'paired-piggyback-result',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'piggyback-result',
+            name: 'lookup',
+            input: {},
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'piggyback-result',
+            content: 'safe tool bytes',
+            text: 'attacker PII',
+          },
+        ] as MessageContentComplex[],
+      },
+    ]);
+
+    expect(attributionsForSourceIndex(messages, 1)).toEqual(['model']);
   });
 
   it('keeps an unknown tool-result-like user block user-attributed', () => {
@@ -445,6 +808,68 @@ describe('formatAgentMessages reducer compatibility', () => {
     expect(sourceContentPartIndices?.[0]).toBe(0);
     expect(sourceContentPartIndices?.[count - 1]).toBe(count - 1);
   });
+
+  it(
+    'formats a maximum paired server-result wave without deep output walks',
+    () => {
+      const pairCount = 2_048;
+      const resultBlock = {
+        type: 'web_search_result',
+        encrypted_content: 'ciphertext',
+        title: 'Result',
+        url: 'https://example.com',
+      };
+      const opaqueOutput = Array.from(
+        { length: 256 },
+        () => resultBlock
+      );
+      const content: MessageContentComplex[] = [];
+      for (let index = 0; index < pairCount; index++) {
+        const id = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}${index}`;
+        content.push(
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id,
+              name: 'web_search',
+              args: { query: String(index) },
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: id,
+            content: opaqueOutput,
+          } as MessageContentComplex
+        );
+      }
+
+      const startedAt = performance.now();
+      const { messages } = formatAgentMessages(
+        [{ role: 'assistant', messageId: 'server-wave', content }],
+        undefined,
+        new Set(['web_search']),
+        undefined,
+        { provider: Providers.ANTHROPIC }
+      );
+      const elapsedMs = performance.now() - startedAt;
+      let resultCount = 0;
+      for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+        const messageContent = messages[messageIndex].content;
+        if (!Array.isArray(messageContent)) {
+          continue;
+        }
+        for (let partIndex = 0; partIndex < messageContent.length; partIndex++) {
+          if (messageContent[partIndex].type === 'web_search_tool_result') {
+            resultCount++;
+          }
+        }
+      }
+
+      expect(resultCount).toBe(pairCount);
+      expect(elapsedMs).toBeLessThan(5_000);
+    },
+    10_000
+  );
 
   it(
     'formats 150k tool derivatives without call-argument spreading',

--- a/src/messages/formatAgentMessages.reducer.test.ts
+++ b/src/messages/formatAgentMessages.reducer.test.ts
@@ -2,6 +2,8 @@ import { convertMessagesToResponsesInput } from '@langchain/openai';
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { MessageContentComplex } from '@/types';
+import { getProviderMessageProvenance } from './provenance';
 import { messagesStateReducer } from './reducer';
 import { formatAgentMessages } from './format';
 import { ContentTypes } from '@/common';
@@ -108,6 +110,20 @@ describe('formatAgentMessages reducer compatibility', () => {
     expect(merged[2]).toBeInstanceOf(HumanMessage);
   });
 
+  it('uses a valid id when the preferred messageId is blank', () => {
+    const [message] = formatAgentMessages([
+      {
+        role: 'user',
+        messageId: '   ',
+        id: 'fallback-id',
+        content: 'hello',
+      },
+    ]).messages;
+
+    expect(message.additional_kwargs.sourceMessageId).toBe('fallback-id');
+    expect(message.additional_kwargs.sourceMessageIds).toEqual(['fallback-id']);
+  });
+
   it('lets the reducer identify derived messages while retaining source correlation', () => {
     const messages = formatToolTurn();
 
@@ -125,6 +141,29 @@ describe('formatAgentMessages reducer compatibility', () => {
     expect(
       messages.map((message) => message.additional_kwargs.sourceMessageId)
     ).toEqual(['msg_assistant_1', 'msg_assistant_1']);
+    expect(
+      messages.map((message) => message.additional_kwargs.sourceMessageIds)
+    ).toEqual([['msg_assistant_1'], ['msg_assistant_1']]);
+    expect(messages[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'msg_assistant_1',
+          sourceContentPartIndices: [0, 1],
+        },
+      ],
+    });
+    expect(messages[1].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'msg_assistant_1',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
 
     const merged = messagesStateReducer([], messages);
     expect(merged).toHaveLength(2);
@@ -159,4 +198,286 @@ describe('formatAgentMessages reducer compatibility', () => {
     expect((observedMessages[0] as AIMessage).tool_calls).toHaveLength(1);
     expect(observedMessages[1]).toBeInstanceOf(ToolMessage);
   });
+
+  it('keeps per-derived lineage when one assistant row emits model and user turns', () => {
+    const messages = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'mixed-row',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'model prefix' },
+          { type: ContentTypes.STEER, [ContentTypes.STEER]: 'user steer' },
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'model suffix' },
+        ],
+      },
+    ]).messages;
+
+    expect(messages.map((message) => message.getType())).toEqual([
+      'ai',
+      'human',
+      'ai',
+    ]);
+    expect(
+      messages.map((message) => message.additional_kwargs.provenance)
+    ).toEqual([
+      {
+        version: 1,
+        parts: [
+          {
+            attribution: 'model',
+            sourceMessageId: 'mixed-row',
+            sourceContentPartIndices: [0],
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            attribution: 'user',
+            sourceMessageId: 'mixed-row',
+            sourceContentPartIndices: [1],
+          },
+        ],
+      },
+      {
+        version: 1,
+        parts: [
+          {
+            attribution: 'model',
+            sourceMessageId: 'mixed-row',
+            sourceContentPartIndices: [2],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it.each([
+    ['user', 'user'],
+    ['assistant', 'model'],
+  ] as const)(
+    'splits tool-result and %s prose attribution within one provider message',
+    (role, proseAttribution) => {
+      const [message] = formatAgentMessages([
+        {
+          role,
+          messageId: `${role}-tool-result-row`,
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-result-id',
+              content: 'tool bytes',
+            },
+            { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'ordinary prose' },
+          ],
+        },
+      ]).messages;
+
+      expect(message.additional_kwargs.provenance).toEqual({
+        version: 1,
+        parts: [
+          {
+            attribution: 'tool',
+            sourceMessageId: `${role}-tool-result-row`,
+            sourceContentPartIndices: [0],
+          },
+          {
+            attribution: proseAttribution,
+            sourceMessageId: `${role}-tool-result-row`,
+            sourceContentPartIndices: [1],
+          },
+        ],
+      });
+    }
+  );
+
+  it.each([
+    'server_tool_call_result',
+    'server_tool_result',
+    'codeExecutionResult',
+    'code_execution_tool_result',
+    'mcp_tool_result',
+  ])('attributes the known %s envelope to tool output', (type) => {
+    const [message] = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: `${type}-row`,
+        content: [
+          { type, content: 'tool bytes' },
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'model prose' },
+        ],
+      },
+    ]).messages;
+
+    expect(message.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: `${type}-row`,
+          sourceContentPartIndices: [0],
+        },
+        {
+          attribution: 'model',
+          sourceMessageId: `${type}-row`,
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+  });
+
+  it('keeps an unknown tool-result-like user block user-attributed', () => {
+    const [message] = formatAgentMessages([
+      {
+        role: 'user',
+        messageId: 'untrusted-type-row',
+        content: [{ type: 'attacker_tool_result', text: 'submitted bytes' }],
+      },
+    ]).messages;
+
+    expect(message.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'untrusted-type-row',
+          sourceContentPartIndices: [0],
+        },
+      ],
+    });
+  });
+
+  it('ignores null runtime content entries without shifting raw indices', () => {
+    const [message] = formatAgentMessages([
+      {
+        role: 'user',
+        messageId: 'nullable-row',
+        content: [
+          null,
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'visible' },
+        ] as unknown as MessageContentComplex[],
+      },
+    ]).messages;
+
+    expect(message.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'nullable-row',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+
+    const [assistantMessage] = formatAgentMessages(
+      [
+        {
+          role: 'assistant',
+          messageId: 'nullable-assistant-row',
+          content: [
+            null,
+            { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'visible' },
+          ] as unknown as MessageContentComplex[],
+        },
+      ],
+      undefined,
+      new Set(['search'])
+    ).messages;
+
+    expect(assistantMessage.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'nullable-assistant-row',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+
+    const [assistantMessageWithSkills] = formatAgentMessages(
+      [
+        {
+          role: 'assistant',
+          messageId: 'nullable-assistant-skills-row',
+          content: [
+            null,
+            { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'visible' },
+          ] as unknown as MessageContentComplex[],
+        },
+      ],
+      undefined,
+      undefined,
+      new Map([['known-skill', 'body']])
+    ).messages;
+
+    expect(assistantMessageWithSkills.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'nullable-assistant-skills-row',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+  });
+
+  it('accumulates large homogeneous content provenance in one linear group', () => {
+    const count = 4_000;
+    const [message] = formatAgentMessages([
+      {
+        role: 'assistant',
+        messageId: 'large-assistant-row',
+        content: Array.from({ length: count }, (_, index) => ({
+          type: ContentTypes.TEXT,
+          [ContentTypes.TEXT]: String(index),
+        })),
+      },
+    ]).messages;
+
+    const parts = getProviderMessageProvenance(message)!.parts;
+    expect(parts).toHaveLength(1);
+    const sourceContentPartIndices = parts[0]?.sourceContentPartIndices;
+    expect(sourceContentPartIndices).toHaveLength(count);
+    expect(sourceContentPartIndices?.[0]).toBe(0);
+    expect(sourceContentPartIndices?.[count - 1]).toBe(count - 1);
+  });
+
+  it(
+    'formats 150k tool derivatives without call-argument spreading',
+    () => {
+      const count = 150_000;
+      const result = formatAgentMessages(
+        [
+          {
+            role: 'assistant',
+            messageId: 'large-tool-row',
+            content: Array.from({ length: count }, (_, index) => ({
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: `call-${index}`,
+                name: 'allowed',
+                args: {},
+                output: 'x',
+              },
+            })),
+          },
+        ],
+        undefined,
+        new Set(['allowed'])
+      );
+
+      expect(result.messages).toHaveLength(count + 1);
+      expect(result.messages[0]).toBeInstanceOf(AIMessage);
+      expect(result.messages[count]).toBeInstanceOf(ToolMessage);
+      expect(
+        getProviderMessageProvenance(result.messages[count])?.parts[0]
+          .sourceContentPartIndices
+      ).toEqual([count - 1]);
+    },
+    30_000
+  );
 });

--- a/src/messages/formatAgentMessages.steer.test.ts
+++ b/src/messages/formatAgentMessages.steer.test.ts
@@ -255,7 +255,12 @@ describe('formatAgentMessages steer replay', () => {
             type: 'web_search_tool_result',
             tool_use_id: useId,
             content: [
-              { type: 'web_search_result', url: 'https://example.com' },
+              {
+                type: 'web_search_result',
+                encrypted_content: 'ciphertext',
+                title: 'Docs',
+                url: 'https://example.com',
+              },
             ],
           } as unknown as Record<string, unknown>,
         ],

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -137,6 +137,7 @@ describe('formatAgentMessages', () => {
       { role: 'user', content: 'Old user message' },
       { role: 'assistant', content: 'Old assistant message' },
       {
+        messageId: 'summary-boundary-row',
         role: 'assistant',
         content: [
           { type: ContentTypes.TEXT, text: 'Covered by summary' },
@@ -169,6 +170,16 @@ describe('formatAgentMessages', () => {
     ).toMatchObject({
       type: ContentTypes.TEXT,
       text: 'Preserved tail',
+    });
+    expect(result.messages[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'summary-boundary-row',
+          sourceContentPartIndices: [2],
+        },
+      ],
     });
     expect(result.indexTokenCountMap?.[0]).toBeLessThan(18);
     expect(result.indexTokenCountMap?.[0]).toBeGreaterThan(0);
@@ -751,6 +762,7 @@ describe('formatAgentMessages', () => {
         content: 'Search first, then calculate 19 * 23.',
       },
       {
+        messageId: 'server-tool-row',
         role: 'assistant',
         content: [
           {
@@ -834,6 +846,34 @@ describe('formatAgentMessages', () => {
     expect(serverToolUseIndex).toBeGreaterThanOrEqual(0);
     expect(serverResultIndex).toBeGreaterThan(serverToolUseIndex);
     expect(calculatorToolUseIndex).toBeGreaterThan(serverResultIndex);
+    const serverResultMessage = messages.find(
+      (message) =>
+        message instanceof AIMessage &&
+        Array.isArray(message.content) &&
+        (message.content as MessageContentComplex[]).some(
+          (block) => block.type === 'web_search_tool_result'
+        )
+    );
+    expect(serverResultMessage?.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'server-tool-row',
+          sourceContentPartIndices: [0, 1],
+        },
+        {
+          attribution: 'tool',
+          sourceMessageId: 'server-tool-row',
+          sourceContentPartIndices: [2],
+        },
+        {
+          attribution: 'model',
+          sourceMessageId: 'server-tool-row',
+          sourceContentPartIndices: [3, 4],
+        },
+      ],
+    });
     expect(
       messages.some(
         (message) =>
@@ -1662,6 +1702,20 @@ describe('formatAgentMessages', () => {
       new ToolMessage({
         content: 'short result',
         tool_call_id: 'call_artifact_payload',
+        additional_kwargs: {
+          sourceMessageId: 'stored-tool-row',
+          sourceMessageIds: ['stored-tool-row'],
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'stored-tool-row',
+                sourceContentPartIndices: [3],
+              },
+            ],
+          },
+        },
         artifact: {
           content: [
             { type: ContentTypes.TEXT, text: 'artifact'.repeat(1_000) },
@@ -1679,7 +1733,218 @@ describe('formatAgentMessages', () => {
     );
     expect(messages).toHaveLength(2);
     expect((messages[1] as ToolMessage).content).toBe('short result');
+    expect(formatted[1].additional_kwargs).not.toBe(
+      messages[1].additional_kwargs
+    );
+    expect(messages[1].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'stored-tool-row',
+          sourceContentPartIndices: [3],
+        },
+      ],
+    });
+    expect(payload.additional_kwargs.sourceMessageIds).toEqual([
+      'stored-tool-row',
+    ]);
+    expect(payload.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'stored-tool-row',
+          sourceContentPartIndices: [3],
+        },
+        {
+          attribution: 'tool',
+          sourceMessageId: 'stored-tool-row',
+        },
+      ],
+    });
     expect(projectArtifactPayload(formatted, 200)).toBe(formatted);
+  });
+
+  it('stamps only artifact source parts that survive the aggregate cap', () => {
+    const createToolMessage = (
+      toolCallId: string,
+      sourceMessageId: string,
+      content: ToolMessage['content'],
+      artifact: string,
+      sourceContentPartIndices: number[]
+    ): ToolMessage =>
+      new ToolMessage({
+        content,
+        tool_call_id: toolCallId,
+        artifact: { content: artifact },
+        additional_kwargs: {
+          sourceMessageId,
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId,
+                sourceContentPartIndices,
+              },
+            ],
+          },
+        },
+      });
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          { id: 'first', name: 'render', args: {}, type: 'tool_call' },
+          { id: 'second', name: 'render', args: {}, type: 'tool_call' },
+        ],
+      }),
+      createToolMessage(
+        'first',
+        'first-row',
+        [
+          { type: ContentTypes.TEXT, text: 'A'.repeat(1_000) },
+          { type: ContentTypes.TEXT, text: 'OMITTED-FIRST-PART' },
+        ],
+        'omitted first artifact',
+        [0, 1]
+      ),
+      createToolMessage(
+        'second',
+        'second-row',
+        'OMITTED-SECOND-RESULT',
+        'omitted second artifact',
+        [0]
+      ),
+    ];
+
+    const formatted = projectArtifactPayload(messages, 80);
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+    const payloadText = serializeToolContent(payload.content);
+
+    expect(payloadText).not.toContain('OMITTED-FIRST-PART');
+    expect(payloadText).not.toContain('OMITTED-SECOND-RESULT');
+    expect(payload.additional_kwargs.sourceMessageIds).toEqual(['first-row']);
+    expect(payload.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'first-row',
+          sourceContentPartIndices: [0],
+        },
+      ],
+    });
+  });
+
+  it('skips empty artifact blocks without dropping later visible blocks', () => {
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          { id: 'empty-first', name: 'render', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: ContentTypes.TEXT, text: '' },
+          { type: ContentTypes.TEXT, text: 'SECOND-BLOCK' },
+        ],
+        tool_call_id: 'empty-first',
+        artifact: { content: 'ARTIFACT' },
+        additional_kwargs: {
+          sourceMessageId: 'tool-row',
+          provenance: {
+            version: 1,
+            parts: [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'tool-row',
+                sourceContentPartIndices: [0, 1],
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    const formatted = projectArtifactPayload(messages, 1_000);
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+
+    expect(serializeToolContent(payload.content)).toContain('SECOND-BLOCK');
+    expect(serializeToolContent(payload.content)).toContain('ARTIFACT');
+    expect(payload.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'tool-row',
+          sourceContentPartIndices: [1],
+        },
+        { attribution: 'tool', sourceMessageId: 'tool-row' },
+      ],
+    });
+  });
+
+  it('drops ambiguous legacy source ids after partial artifact compaction', () => {
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          { id: 'legacy', name: 'render', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: [
+          { type: ContentTypes.TEXT, text: 'A'.repeat(1_000) },
+          { type: ContentTypes.TEXT, text: 'OMITTED-SECOND' },
+        ],
+        tool_call_id: 'legacy',
+        artifact: { content: 'omitted artifact' },
+        additional_kwargs: { sourceMessageIds: ['first-row', 'second-row'] },
+      }),
+    ];
+
+    const formatted = projectArtifactPayload(messages, 80);
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+
+    expect(serializeToolContent(payload.content)).not.toContain(
+      'OMITTED-SECOND'
+    );
+    expect(payload.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(payload.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'tool' }],
+    });
+  });
+
+  it('drops ambiguous source ids after partial scalar artifact projection', () => {
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          { id: 'scalar', name: 'render', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'A'.repeat(1_000),
+        tool_call_id: 'scalar',
+        artifact: { content: 'omitted artifact' },
+        additional_kwargs: {
+          sourceMessageIds: ['first-row', 'second-row'],
+        },
+      }),
+    ];
+
+    const formatted = projectArtifactPayload(messages, 80);
+    const payload = formatted[formatted.length - 1] as HumanMessage;
+
+    expect(payload.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(payload.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'tool' }],
+    });
   });
 
   it('bounds artifact block arrays without spreading them into call arguments', () => {
@@ -5029,6 +5294,7 @@ describe('formatAgentMessages', () => {
     const tools = new Set(['calculator']);
     const payload = [
       {
+        messageId: 'filtered-tool-row',
         role: 'assistant',
         content: [
           {
@@ -5078,6 +5344,36 @@ describe('formatAgentMessages', () => {
       typeof aiContent === 'string' ? aiContent : JSON.stringify(aiContent);
     expect(aiContentStr).toContain('some_unknown_tool');
     expect(aiContentStr).toContain('This is the result from unknown tool');
+    expect(result.messages[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'filtered-tool-row',
+          sourceContentPartIndices: [0],
+        },
+        {
+          attribution: 'tool',
+          sourceMessageId: 'filtered-tool-row',
+          sourceContentPartIndices: [2],
+        },
+        {
+          attribution: 'model',
+          sourceMessageId: 'filtered-tool-row',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+    expect(result.messages[1].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'tool',
+          sourceMessageId: 'filtered-tool-row',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
   });
 
   it('should simulate realistic deferred tools flow with tool_search', () => {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -29,9 +29,12 @@ import {
   _convertMessagesToOpenAIParams,
   _convertMessagesToOpenAIResponsesParams,
 } from '@/llm/openai/utils';
+import {
+  getProviderMessageProvenance,
+  setProviderMessageProvenance,
+} from './provenance';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
-import { getProviderMessageProvenance } from './provenance';
 import { serializeToolContent } from '@/utils/toolContent';
 import { formatAgentMessages } from './format';
 
@@ -4946,6 +4949,39 @@ describe('formatAgentMessages', () => {
         tool_call_id: 'call_computer_stream',
         content: '[Computer screenshot omitted for this provider]',
       }),
+    ]);
+  });
+
+  it('marks a provider-only computer screenshot omission as synthetic', () => {
+    const computerOutput = new ToolMessage({
+      content: 'data:image/png;base64,AA==',
+      tool_call_id: 'call_computer_omitted',
+      additional_kwargs: { type: 'computer_call_output' },
+    });
+    setProviderMessageProvenance(computerOutput, [
+      {
+        attribution: 'tool',
+        sourceMessageId: 'computer-output-row',
+        sourceContentPartIndices: [0],
+      },
+    ]);
+
+    const messages = [computerOutput];
+    const projected = projectComputerCallOutputsToText(messages);
+
+    expect(projected).not.toBe(messages);
+    expect(projected[0].content).toBe(
+      '[Computer screenshot omitted for this provider]'
+    );
+    expect(getProviderMessageProvenance(projected[0])?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
+    expect(getProviderMessageProvenance(computerOutput)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'computer-output-row',
+        sourceContentPartIndices: [0],
+      },
     ]);
   });
 

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -1938,6 +1938,73 @@ describe('formatAgentMessages', () => {
     });
   });
 
+  it.each([
+    ['duplicate', [[0], [0]]],
+    ['gapped/out-of-range', [[0], [2]]],
+    ['reordered', [[1], [0]]],
+  ])(
+    'handles a %s artifact mapping without ordinal lineage loss',
+    (mappingKind, sourceContentPartIndices) => {
+      const messages = [
+        new AIMessageChunk({
+          content: '',
+          tool_calls: [
+            { id: 'ambiguous', name: 'render', args: {}, type: 'tool_call' },
+          ],
+        }),
+        new ToolMessage({
+          content: [
+            { type: ContentTypes.TEXT, text: 'A'.repeat(1_000) },
+            { type: ContentTypes.TEXT, text: 'OMITTED-SECOND' },
+          ],
+          tool_call_id: 'ambiguous',
+          artifact: { content: 'omitted artifact' },
+          additional_kwargs: {
+            sourceMessageIds: ['first-row', 'second-row'],
+            provenance: {
+              version: 1,
+              parts: [
+                {
+                  attribution: 'model',
+                  sourceMessageId: 'first-row',
+                  sourceContentPartIndices: sourceContentPartIndices[0],
+                },
+                {
+                  attribution: 'user',
+                  sourceMessageId: 'second-row',
+                  sourceContentPartIndices: sourceContentPartIndices[1],
+                },
+              ],
+            },
+          },
+        }),
+      ];
+
+      const formatted = projectArtifactPayload(messages, 80);
+      const payload = formatted[formatted.length - 1] as HumanMessage;
+
+      expect(serializeToolContent(payload.content)).not.toContain(
+        'OMITTED-SECOND'
+      );
+      expect(payload.additional_kwargs.sourceMessageIds).toEqual(
+        mappingKind === 'reordered' ? ['second-row'] : undefined
+      );
+      expect(payload.additional_kwargs.provenance).toEqual({
+        version: 1,
+        parts:
+          mappingKind === 'reordered'
+            ? [
+              {
+                attribution: 'tool',
+                sourceMessageId: 'second-row',
+                sourceContentPartIndices: [0],
+              },
+            ]
+            : [{ attribution: 'tool' }],
+      });
+    }
+  );
+
   it('skips empty artifact blocks without dropping later visible blocks', () => {
     const messages = [
       new AIMessageChunk({

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -31,6 +31,7 @@ import {
 } from '@/llm/openai/utils';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
+import { getProviderMessageProvenance } from './provenance';
 import { serializeToolContent } from '@/utils/toolContent';
 import { formatAgentMessages } from './format';
 
@@ -1092,6 +1093,19 @@ describe('formatAgentMessages', () => {
     expect(serverToolUseIndex).toBeGreaterThanOrEqual(0);
     expect(serverResultIndex).toBeGreaterThan(serverToolUseIndex);
     expect(
+      messages.flatMap(
+        (message) =>
+          getProviderMessageProvenance(message)?.parts.filter((part) =>
+            part.sourceContentPartIndices?.includes(1) === true
+          ) ?? []
+      )
+    ).toEqual([
+      {
+        attribution: 'model',
+        sourceContentPartIndices: [0, 1, 2],
+      },
+    ]);
+    expect(
       messages.some(
         (message) =>
           message instanceof ToolMessage &&
@@ -1649,6 +1663,89 @@ describe('formatAgentMessages', () => {
     ]);
     expect(toolMessage.content).toBe('');
     expect(formattedMessages).not.toBe(originalMessages);
+  });
+
+  it('adds unindexed tool lineage only when Anthropic artifact bytes survive projection', () => {
+    const toolMessage = new ToolMessage({
+      content: [{ type: ContentTypes.TEXT, text: 'base' }],
+      tool_call_id: 'call_artifact_lineage',
+      name: 'render',
+      additional_kwargs: {
+        provenance: {
+          version: 1,
+          parts: [
+            {
+              attribution: 'tool',
+              sourceMessageId: 'stored-tool-row',
+              sourceContentPartIndices: [3],
+            },
+          ],
+        },
+        sourceMessageId: 'stored-tool-row',
+        sourceMessageIds: ['stored-tool-row'],
+      },
+      artifact: {
+        content: [{ type: ContentTypes.TEXT, text: 'artifact' }],
+      },
+    });
+    const messages = [
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_artifact_lineage',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      toolMessage,
+    ];
+
+    const projected = projectAnthropicArtifactContent(messages, 100);
+    const projectedTool = projected[1] as ToolMessage;
+
+    expect(getProviderMessageProvenance(projectedTool)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'stored-tool-row',
+        sourceContentPartIndices: [3],
+      },
+      { attribution: 'tool', sourceMessageId: 'stored-tool-row' },
+    ]);
+    expect(projectedTool.lc_kwargs.additional_kwargs).toBe(
+      projectedTool.additional_kwargs
+    );
+    expect(getProviderMessageProvenance(toolMessage)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'stored-tool-row',
+        sourceContentPartIndices: [3],
+      },
+    ]);
+
+    const capped = projectAnthropicArtifactContent(messages, 4)[1];
+    expect(getProviderMessageProvenance(capped)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'stored-tool-row',
+        sourceContentPartIndices: [3],
+      },
+    ]);
+
+    formatAnthropicArtifactContent(messages);
+    expect(getProviderMessageProvenance(toolMessage)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'stored-tool-row',
+        sourceContentPartIndices: [3],
+      },
+      { attribution: 'tool', sourceMessageId: 'stored-tool-row' },
+    ]);
+    expect(toolMessage.lc_kwargs.additional_kwargs).toBe(
+      toolMessage.additional_kwargs
+    );
   });
 
   it('caps Anthropic artifact expansion after pruning', () => {
@@ -5350,17 +5447,7 @@ describe('formatAgentMessages', () => {
         {
           attribution: 'model',
           sourceMessageId: 'filtered-tool-row',
-          sourceContentPartIndices: [0],
-        },
-        {
-          attribution: 'tool',
-          sourceMessageId: 'filtered-tool-row',
-          sourceContentPartIndices: [2],
-        },
-        {
-          attribution: 'model',
-          sourceMessageId: 'filtered-tool-row',
-          sourceContentPartIndices: [1],
+          sourceContentPartIndices: [0, 2, 1],
         },
       ],
     });
@@ -5374,6 +5461,42 @@ describe('formatAgentMessages', () => {
         },
       ],
     });
+  });
+
+  it('keeps an output-less unavailable tool call model-attributed when flattened', () => {
+    const { messages } = formatAgentMessages(
+      [
+        {
+          role: 'assistant',
+          messageId: 'output-less-filtered-tool-row',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'unavailable-tool',
+                name: 'unavailable_tool',
+                args: '{}',
+                output: '',
+              },
+            },
+          ],
+        },
+      ],
+      undefined,
+      new Set(['available_tool'])
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual([
+      { type: ContentTypes.TEXT, text: 'Tool: unavailable_tool, ' },
+    ]);
+    expect(getProviderMessageProvenance(messages[0])?.parts).toEqual([
+      {
+        attribution: 'model',
+        sourceMessageId: 'output-less-filtered-tool-row',
+        sourceContentPartIndices: [0],
+      },
+    ]);
   });
 
   it('should simulate realistic deferred tools flow with tool_search', () => {

--- a/src/messages/handoffCue.test.ts
+++ b/src/messages/handoffCue.test.ts
@@ -5,6 +5,7 @@ import {
   removePredecessorHandoffCue,
   PREDECESSOR_HANDOFF_CUE,
 } from './handoffCue';
+import { getProviderMessageProvenance } from './provenance';
 
 const runAi = new AIMessage({ content: 'predecessor output', id: 'run-ai-1' });
 const producedIds = new Set(['run-ai-1']);
@@ -17,11 +18,14 @@ describe('appendPredecessorHandoffCue', () => {
     const result = appendPredecessorHandoffCue(payload, isRunProduced);
     expect(result).toHaveLength(3);
     expect(result[2].content).toBe(PREDECESSOR_HANDOFF_CUE);
-    expect(result[2].additional_kwargs).toEqual({
+    expect(result[2].additional_kwargs).toMatchObject({
       role: 'user',
       isMeta: true,
       source: 'handoff',
     });
+    expect(getProviderMessageProvenance(result[2])?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
     /** Non-mutating: the input array is untouched. */
     expect(payload).toHaveLength(2);
   });

--- a/src/messages/handoffCue.ts
+++ b/src/messages/handoffCue.ts
@@ -1,6 +1,7 @@
 // src/messages/handoffCue.ts
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import { stampSyntheticProviderMessage } from './provenance';
 
 /**
  * Bracketed-meta convention, like the handoff path's
@@ -48,10 +49,12 @@ export function appendPredecessorHandoffCue(
   }
   return [
     ...messages,
-    new HumanMessage({
-      content: PREDECESSOR_HANDOFF_CUE,
-      additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
-    }),
+    stampSyntheticProviderMessage(
+      new HumanMessage({
+        content: PREDECESSOR_HANDOFF_CUE,
+        additional_kwargs: { role: 'user', isMeta: true, source: 'handoff' },
+      })
+    ),
   ];
 }
 

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -15,3 +15,4 @@ export * from './contextPruningSettings';
 export * from './reducer';
 export * from './recency';
 export * from './assistantPhase';
+export * from './provenance';

--- a/src/messages/injected.test.ts
+++ b/src/messages/injected.test.ts
@@ -34,7 +34,14 @@ describe('convertInjectedMessages', () => {
 
   it('carries isMeta, source and skillName only when set', () => {
     const [bare] = convertInjectedMessages([{ role: 'user', content: 'x' }]);
-    expect(bare.additional_kwargs).toEqual({ role: 'user', injected: true });
+    expect(bare.additional_kwargs).toEqual({
+      role: 'user',
+      injected: true,
+      provenance: {
+        version: 1,
+        parts: [{ attribution: 'synthetic' }],
+      },
+    });
 
     const [full] = convertInjectedMessages([
       {
@@ -51,6 +58,10 @@ describe('convertInjectedMessages', () => {
       isMeta: true,
       source: 'steer',
       skillName: 'writing',
+      provenance: {
+        version: 1,
+        parts: [{ attribution: 'user' }],
+      },
     });
   });
 

--- a/src/messages/injected.ts
+++ b/src/messages/injected.ts
@@ -2,6 +2,7 @@
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { InjectedMessage } from '@/types/tools';
+import { setProviderMessageProvenance } from './provenance';
 import { toLangChainContent } from './langchain';
 import { ContentTypes } from '@/common';
 
@@ -70,12 +71,14 @@ export function convertInjectedMessages(
     if (msg.source != null) additional_kwargs.source = msg.source;
     if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
 
-    converted.push(
-      new HumanMessage({
-        content: toLangChainContent(msg.content),
-        additional_kwargs,
-      })
-    );
+    const message = new HumanMessage({
+      content: toLangChainContent(msg.content),
+      additional_kwargs,
+    });
+    setProviderMessageProvenance(message, [
+      { attribution: msg.source === 'steer' ? 'user' : 'synthetic' },
+    ]);
+    converted.push(message);
   }
   return converted;
 }

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -4,6 +4,7 @@ import {
   appendProviderMessageProvenance,
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  hasBijectiveProviderContentPartMapping,
   inspectProviderMessageProvenance,
   inspectProviderSourceMessageIds,
   PROVIDER_MESSAGE_PROVENANCE_LIMITS,
@@ -12,6 +13,57 @@ import {
 } from './provenance';
 
 describe('provider message provenance', () => {
+  it('requires unique in-range indices covering every current content part', () => {
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [
+          { attribution: 'model', sourceContentPartIndices: [0] },
+          { attribution: 'tool', sourceContentPartIndices: [1] },
+        ],
+        2
+      )
+    ).toBe(true);
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [
+          { attribution: 'model', sourceContentPartIndices: [1] },
+          { attribution: 'tool', sourceContentPartIndices: [0] },
+        ],
+        2
+      )
+    ).toBe(true);
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [
+          { attribution: 'model', sourceContentPartIndices: [0] },
+          { attribution: 'user', sourceContentPartIndices: [0] },
+        ],
+        2
+      )
+    ).toBe(false);
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [
+          { attribution: 'model', sourceContentPartIndices: [0] },
+          { attribution: 'user', sourceContentPartIndices: [2] },
+        ],
+        2
+      )
+    ).toBe(false);
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [{ attribution: 'model', sourceContentPartIndices: [0, 2] }],
+        3
+      )
+    ).toBe(false);
+    expect(
+      hasBijectiveProviderContentPartMapping(
+        [{ attribution: 'model' }, { attribution: 'user' }],
+        2
+      )
+    ).toBe(false);
+  });
+
   it('synchronizes stable plural ids from ordered lineage', () => {
     const message = new HumanMessage({
       content: 'merged',

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -4,6 +4,7 @@ import {
   appendProviderMessageProvenance,
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  PROVIDER_MESSAGE_PROVENANCE_LIMITS,
   setProviderMessageProvenance,
 } from './provenance';
 
@@ -27,6 +28,13 @@ describe('provider message provenance', () => {
       'last',
     ]);
     expect(getProviderSourceMessageIds(message)).toEqual(['first', 'last']);
+    expect(message.lc_kwargs.additional_kwargs).toBe(message.additional_kwargs);
+    const serialized = message.toJSON() as unknown as {
+      kwargs: { additional_kwargs: unknown };
+    };
+    expect(serialized.kwargs.additional_kwargs).toEqual(
+      message.additional_kwargs
+    );
   });
 
   it('coalesces adjacent contributions through the compatibility helper', () => {
@@ -329,49 +337,509 @@ describe('provider message provenance', () => {
     expect(getProviderSourceMessageIds(message)).toEqual(['safe']);
     expect(pluralReads).toBe(1);
 
-    const previousAdditionalKwargs = {
-      sourceMessageId: 'legacy',
-      retained: true,
-    };
-    const proxiedAdditionalKwargs = new Proxy(previousAdditionalKwargs, {
-      set() {
-        throw new Error('partial write');
-      },
-    });
-    message.additional_kwargs = proxiedAdditionalKwargs;
+    delete message.additional_kwargs.sourceMessageIds;
+    message.additional_kwargs.sourceMessageId = 'legacy';
+    const previousAdditionalKwargs = message.additional_kwargs;
+    previousAdditionalKwargs.retained = true;
 
     expect(() =>
       setProviderMessageProvenance(message, [
         { attribution: 'user', sourceMessageId: 'replacement' },
       ])
     ).not.toThrow();
-    expect(message.additional_kwargs).not.toBe(proxiedAdditionalKwargs);
+    expect(message.additional_kwargs).not.toBe(previousAdditionalKwargs);
     expect(message.additional_kwargs.retained).toBe(true);
-    expect(previousAdditionalKwargs).toEqual({
-      sourceMessageId: 'legacy',
-      retained: true,
-    });
+    expect(previousAdditionalKwargs.retained).toBe(true);
     expect(getProviderSourceMessageIds(message)).toEqual(['replacement']);
+  });
+
+  it('rejects proxied live kwargs without reading or partially publishing them', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageId: 'legacy' },
+    });
+    const previousSerialized = message.lc_kwargs.additional_kwargs;
+    let reads = 0;
+    message.additional_kwargs = new Proxy(message.additional_kwargs, {
+      ownKeys() {
+        reads++;
+        return [];
+      },
+    });
+
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message additional kwargs');
+    expect(reads).toBe(0);
+    expect(message.lc_kwargs.additional_kwargs).toBe(previousSerialized);
+  });
+
+  it('does not publish live metadata when serialized metadata rejects the write', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageId: 'legacy' },
+    });
+    const previousAdditionalKwargs = message.additional_kwargs;
+    const previousSerializedAdditionalKwargs =
+      message.lc_kwargs.additional_kwargs;
+    const previousLcKwargs = message.lc_kwargs;
+    Object.defineProperty(message, 'lc_kwargs', {
+      configurable: true,
+      get: () => previousLcKwargs,
+      set: () => {
+        throw new Error('serialized write rejected');
+      },
+    });
+
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message serialization kwargs');
+    expect(message.additional_kwargs).toBe(previousAdditionalKwargs);
+    expect(message.lc_kwargs.additional_kwargs).toBe(
+      previousSerializedAdditionalKwargs
+    );
+  });
+
+  it('rolls serialized metadata back when the live message rejects the write', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageId: 'legacy' },
+    });
+    const previousAdditionalKwargs = message.additional_kwargs;
+    const previousSerializedAdditionalKwargs =
+      message.lc_kwargs.additional_kwargs;
+    let accessorReads = 0;
+    Object.defineProperty(message, 'additional_kwargs', {
+      configurable: true,
+      get: () => {
+        accessorReads++;
+        return previousAdditionalKwargs;
+      },
+      set: () => {
+        throw new Error('live write rejected');
+      },
+    });
+
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message serialization kwargs');
+    expect(accessorReads).toBe(0);
+    expect(message.lc_kwargs.additional_kwargs).toBe(
+      previousSerializedAdditionalKwargs
+    );
+  });
+
+  it('fails closed before walking oversized sparse plural id arrays', () => {
+    let elementReads = 0;
+    const sourceMessageIds = new Array(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+    );
+    Object.defineProperty(sourceMessageIds, '0', {
+      get() {
+        elementReads++;
+        return 'attacker';
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageIds },
+    });
+
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+    expect(elementReads).toBe(0);
+  });
+
+  it('fails closed when untrusted plural lineage is not an array', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        sourceMessageId: 'must-not-fall-through',
+        sourceMessageIds: { 0: 'forged', length: 1 },
+      },
+    });
+
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+  });
+
+  it('fails closed when an untrusted plural source id exceeds the bound', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        sourceMessageId: 'must-not-fall-through',
+        sourceMessageIds: [
+          'x'.repeat(
+            PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+          ),
+        ],
+      },
+    });
+
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+  });
+
+  it('rejects proxied messages and serialization kwargs without partial publication', () => {
+    const target = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageId: 'legacy' },
+    });
+    const previousLive = target.additional_kwargs;
+    const previousSerialized = target.lc_kwargs.additional_kwargs;
+
+    expect(() =>
+      setProviderMessageProvenance(new Proxy(target, {}), [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message serialization kwargs');
+    expect(target.additional_kwargs).toBe(previousLive);
+    expect(target.lc_kwargs.additional_kwargs).toBe(previousSerialized);
+
+    target.lc_kwargs = new Proxy(target.lc_kwargs, {});
+    expect(() =>
+      setProviderMessageProvenance(target, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message serialization kwargs');
+    expect(target.additional_kwargs).toBe(previousLive);
+    expect(target.lc_kwargs.additional_kwargs).toBe(previousSerialized);
+  });
+
+  it('rejects accessor-backed serialization kwargs without invoking them', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageId: 'legacy' },
+    });
+    const previousLive = message.additional_kwargs;
+    let accessorReads = 0;
+    Object.defineProperty(message.lc_kwargs, 'hostile', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        accessorReads++;
+        return 'attacker';
+      },
+    });
+
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).toThrow('Invalid provider message serialization kwargs');
+    expect(accessorReads).toBe(0);
+    expect(message.additional_kwargs).toBe(previousLive);
+  });
+
+  it('fails closed before walking oversized sparse provenance arrays', () => {
+    let partReads = 0;
+    const parts = new Array(PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1);
+    Object.defineProperty(parts, '0', {
+      get() {
+        partReads++;
+        return { attribution: 'user' };
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { provenance: { version: 1, parts } },
+    });
+
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+    expect(partReads).toBe(0);
+  });
+
+  it('fails closed before walking oversized sparse part-index arrays', () => {
+    let indexReads = 0;
+    const sourceContentPartIndices = new Array(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxIndicesPerPart + 1
+    );
+    Object.defineProperty(sourceContentPartIndices, '0', {
+      get() {
+        indexReads++;
+        return 0;
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        provenance: {
+          version: 1,
+          parts: [{ attribution: 'user', sourceContentPartIndices }],
+        },
+      },
+    });
+
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+    expect(indexReads).toBe(0);
+  });
+
+  it('fails closed on excessive total refs, source indices, and id lengths', () => {
+    const fullIndexList = Array.from(
+      { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxIndicesPerPart },
+      (_, index) => index
+    );
+    const tooManyRefs = Array.from({ length: 17 }, () => ({
+      attribution: 'user' as const,
+      sourceContentPartIndices: fullIndexList,
+    }));
+    const message = new HumanMessage({ content: 'external' });
+
+    message.additional_kwargs.provenance = {
+      version: 1,
+      parts: tooManyRefs,
+    };
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+
+    message.additional_kwargs.provenance = {
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceContentPartIndices: [
+            PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceContentPartIndex + 1,
+          ],
+        },
+      ],
+    };
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+
+    message.additional_kwargs.provenance = {
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'x'.repeat(
+            PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+          ),
+        },
+      ],
+    };
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
   });
 
   it('preserves complete lineage above recommended consumer trust bounds', () => {
     const message = new HumanMessage({ content: 'large' });
-    const sourceContentPartIndices = Array.from(
-      { length: 257 },
-      (_, index) => index
+    const longSourceMessageId = 'x'.repeat(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+    );
+    const parts = Array.from(
+      { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1 },
+      (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId:
+          index === 0 ? longSourceMessageId : `large-source-${index}`,
+        sourceContentPartIndices: [
+          PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceContentPartIndex +
+            index +
+            1,
+        ],
+      })
     );
 
-    setProviderMessageProvenance(message, [
+    setProviderMessageProvenance(message, parts);
+
+    expect(getProviderMessageProvenance(message)?.parts).toHaveLength(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1
+    );
+    expect(getProviderSourceMessageIds(message)).toHaveLength(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+    );
+    expect(getProviderSourceMessageIds(message)[0]).toBe(longSourceMessageId);
+
+    delete message.additional_kwargs.provenance;
+    expect(getProviderSourceMessageIds(message)).toHaveLength(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+    );
+  });
+
+  it('fails closed when untrusted source fields are mixed into oversized trusted lineage', () => {
+    const message = new HumanMessage({ content: 'large' });
+    const parts = Array.from(
+      { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1 },
+      (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId: `trusted-${index}`,
+      })
+    );
+    setProviderMessageProvenance(message, parts);
+
+    message.additional_kwargs.sourceMessageIds = Array.from(
+      { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds },
+      (_, index) => `external-${index}`
+    );
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+
+    setProviderMessageProvenance(message, parts);
+    message.additional_kwargs.sourceMessageId = 'x'.repeat(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+    );
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+
+    setProviderMessageProvenance(message, parts);
+    message.additional_kwargs.sourceMessageId = { forged: true };
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+  });
+
+  it('preflights an untrusted plural before walking oversized trusted provenance', () => {
+    const message = new HumanMessage({ content: 'large' });
+    setProviderMessageProvenance(
+      message,
+      Array.from(
+        { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1 },
+        (_, index) => ({
+          attribution: 'user' as const,
+          sourceMessageId: `trusted-${index}`,
+        })
+      )
+    );
+    let pluralElementReads = 0;
+    const untrustedPlural = ['external'];
+    Object.defineProperty(untrustedPlural, '0', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        pluralElementReads++;
+        return 'external';
+      },
+    });
+    message.additional_kwargs.sourceMessageIds = untrustedPlural;
+    const setHasSpy = jest.spyOn(Set.prototype, 'has');
+
+    const result = getProviderSourceMessageIds(message);
+    const sourceIdLookups = setHasSpy.mock.calls.length;
+    setHasSpy.mockRestore();
+
+    expect(result).toEqual([]);
+    expect(pluralElementReads).toBe(0);
+    expect(sourceIdLookups).toBe(0);
+  });
+
+  it.each([
+    {
+      label: 'invalid',
+      singular: Object.defineProperty({}, 'value', {
+        enumerable: true,
+        get: jest.fn(() => 'attacker'),
+      }),
+    },
+    {
+      label: 'overlong',
+      singular: 'x'.repeat(
+        PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+      ),
+    },
+  ])(
+    'preflights a $label singular before walking oversized trusted provenance',
+    ({ singular }) => {
+      const message = new HumanMessage({ content: 'large' });
+      setProviderMessageProvenance(
+        message,
+        Array.from(
+          { length: PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts + 1 },
+          (_, index) => ({
+            attribution: 'user' as const,
+            sourceMessageId: `trusted-${index}`,
+          })
+        )
+      );
+      message.additional_kwargs.sourceMessageId = singular;
+      const setHasSpy = jest.spyOn(Set.prototype, 'has');
+
+      const result = getProviderSourceMessageIds(message);
+      const sourceIdLookups = setHasSpy.mock.calls.length;
+      setHasSpy.mockRestore();
+
+      expect(result).toEqual([]);
+      expect(sourceIdLookups).toBe(0);
+      const valueDescriptor = Object.getOwnPropertyDescriptor(
+        singular,
+        'value'
+      );
+      if (valueDescriptor?.get != null) {
+        expect(valueDescriptor.get).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it('does not combine independently trusted provenance and plural arrays above limits', () => {
+    const first = new HumanMessage({ content: 'first' });
+    const second = new HumanMessage({ content: 'second' });
+    const half = Math.floor(
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds / 2
+    );
+    setProviderMessageProvenance(
+      first,
+      Array.from({ length: half + 1 }, (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId: `first-${index}`,
+      }))
+    );
+    setProviderMessageProvenance(
+      second,
+      Array.from({ length: half + 1 }, (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId: `second-${index}`,
+      }))
+    );
+
+    first.additional_kwargs.sourceMessageIds =
+      second.additional_kwargs.sourceMessageIds;
+    expect(getProviderSourceMessageIds(first)).toEqual([]);
+  });
+
+  it('rejects an oversized trusted pair splice before walking either side', () => {
+    const first = new HumanMessage({ content: 'first' });
+    const second = new HumanMessage({ content: 'second' });
+    const oversizedLength =
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1;
+    setProviderMessageProvenance(
+      first,
+      Array.from({ length: oversizedLength }, (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId: `first-${index}`,
+      }))
+    );
+    setProviderMessageProvenance(
+      second,
+      Array.from({ length: oversizedLength }, (_, index) => ({
+        attribution: 'user' as const,
+        sourceMessageId: `second-${index}`,
+      }))
+    );
+    first.additional_kwargs.sourceMessageIds =
+      second.additional_kwargs.sourceMessageIds;
+    const setHasSpy = jest.spyOn(Set.prototype, 'has');
+
+    const result = getProviderSourceMessageIds(first);
+    const sourceIdLookups = setHasSpy.mock.calls.length;
+    setHasSpy.mockRestore();
+
+    expect(result).toEqual([]);
+    expect(sourceIdLookups).toBe(0);
+  });
+
+  it('applies source id length bounds to a mismatched trusted pair', () => {
+    const first = new HumanMessage({ content: 'first' });
+    const second = new HumanMessage({ content: 'second' });
+    setProviderMessageProvenance(first, [
       {
         attribution: 'user',
-        sourceMessageId: 'large-source',
-        sourceContentPartIndices,
+        sourceMessageId: 'x'.repeat(
+          PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength + 1
+        ),
       },
     ]);
+    setProviderMessageProvenance(second, [
+      { attribution: 'user', sourceMessageId: 'second' },
+    ]);
+    first.additional_kwargs.sourceMessageIds =
+      second.additional_kwargs.sourceMessageIds;
 
-    expect(
-      getProviderMessageProvenance(message)?.parts[0].sourceContentPartIndices
-    ).toHaveLength(257);
+    expect(getProviderSourceMessageIds(first)).toEqual([]);
   });
 
   it('rebuilds safely after external provenance replacement', () => {

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -455,6 +455,25 @@ describe('provider message provenance', () => {
     expect(elementReads).toBe(0);
   });
 
+  it('fails closed when a proxied plural array reports a non-finite length', () => {
+    const sourceMessageIds = new Proxy(['hidden-user-source'], {
+      get(target, property, receiver) {
+        return property === 'length'
+          ? Number.NaN
+          : Reflect.get(target, property, receiver);
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        sourceMessageId: 'visible-tool-source',
+        sourceMessageIds,
+      },
+    });
+
+    expect(getProviderSourceMessageIds(message)).toEqual([]);
+  });
+
   it('fails closed when untrusted plural lineage is not an array', () => {
     const message = new HumanMessage({
       content: 'external',
@@ -552,6 +571,25 @@ describe('provider message provenance', () => {
     expect(partReads).toBe(0);
   });
 
+  it('rejects proxied provenance arrays that report a non-finite length', () => {
+    const parts = new Proxy([{ attribution: 'tool' as const }], {
+      get(target, property, receiver) {
+        return property === 'length'
+          ? Number.NaN
+          : Reflect.get(target, property, receiver);
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { provenance: { version: 1, parts } },
+    });
+
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+    expect(() => setProviderMessageProvenance(message, parts)).toThrow(
+      'Provider message provenance parts must be an array'
+    );
+  });
+
   it('fails closed before walking oversized sparse part-index arrays', () => {
     let indexReads = 0;
     const sourceContentPartIndices = new Array(
@@ -575,6 +613,32 @@ describe('provider message provenance', () => {
 
     expect(getProviderMessageProvenance(message)).toBeUndefined();
     expect(indexReads).toBe(0);
+  });
+
+  it('does not broaden proxied part indices into whole-message tool attribution', () => {
+    const sourceContentPartIndices = new Proxy([0], {
+      get(target, property, receiver) {
+        return property === 'length'
+          ? Number.NaN
+          : Reflect.get(target, property, receiver);
+      },
+    });
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        provenance: {
+          version: 1,
+          parts: [{ attribution: 'tool', sourceContentPartIndices }],
+        },
+      },
+    });
+
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'tool', sourceContentPartIndices },
+      ])
+    ).toThrow('Provider source content part indices must be a non-empty array');
   });
 
   it('fails closed on excessive total refs, source indices, and id lengths', () => {

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -1,0 +1,400 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type { ProviderMessageProvenancePart } from './provenance';
+import {
+  appendProviderMessageProvenance,
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+  setProviderMessageProvenance,
+} from './provenance';
+
+describe('provider message provenance', () => {
+  it('synchronizes stable plural ids from ordered lineage', () => {
+    const message = new HumanMessage({
+      content: 'merged',
+      additional_kwargs: { sourceMessageId: 'last' },
+    });
+
+    setProviderMessageProvenance(message, [
+      { attribution: 'user', sourceMessageId: 'first' },
+      { attribution: 'synthetic' },
+      { attribution: 'user', sourceMessageId: 'last' },
+      { attribution: 'user', sourceMessageId: 'first' },
+    ]);
+
+    expect(message.additional_kwargs.sourceMessageId).toBe('last');
+    expect(message.additional_kwargs.sourceMessageIds).toEqual([
+      'first',
+      'last',
+    ]);
+    expect(getProviderSourceMessageIds(message)).toEqual(['first', 'last']);
+  });
+
+  it('coalesces adjacent contributions through the compatibility helper', () => {
+    const message = new HumanMessage({ content: 'derived' });
+    appendProviderMessageProvenance(message, {
+      attribution: 'model',
+      sourceMessageId: 'source',
+      sourceContentPartIndices: [2],
+    });
+    appendProviderMessageProvenance(message, {
+      attribution: 'model',
+      sourceMessageId: 'source',
+      sourceContentPartIndices: [4, 2],
+    });
+
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'model',
+          sourceMessageId: 'source',
+          sourceContentPartIndices: [2, 4],
+        },
+      ],
+    });
+  });
+
+  it('migrates singular lineage when appending to a legacy message', () => {
+    const message = new HumanMessage({
+      content: 'legacy',
+      additional_kwargs: {
+        sourceMessageId: 'legacy-source',
+        sourceMessageIds: ['legacy-source'],
+      },
+    });
+
+    appendProviderMessageProvenance(message, {
+      attribution: 'user',
+      sourceContentPartIndices: [1],
+    });
+
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'legacy-source',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+  });
+
+  it('does not inherit a later contribution attribution for legacy lineage', () => {
+    const message = new HumanMessage({
+      content: 'legacy plus derived',
+      additional_kwargs: { sourceMessageId: 'legacy-user-row' },
+    });
+
+    appendProviderMessageProvenance(message, {
+      attribution: 'synthetic',
+      sourceMessageId: 'derived-row',
+    });
+
+    expect(getProviderMessageProvenance(message)?.parts).toEqual([
+      { attribution: 'user', sourceMessageId: 'legacy-user-row' },
+      { attribution: 'synthetic', sourceMessageId: 'derived-row' },
+    ]);
+
+    const implicitSourceMessage = new HumanMessage({
+      content: 'legacy plus derived',
+      additional_kwargs: { sourceMessageId: 'legacy-user-row' },
+    });
+    appendProviderMessageProvenance(implicitSourceMessage, {
+      attribution: 'synthetic',
+      sourceContentPartIndices: [1],
+    });
+    expect(getProviderMessageProvenance(implicitSourceMessage)?.parts).toEqual([
+      { attribution: 'user', sourceMessageId: 'legacy-user-row' },
+      {
+        attribution: 'synthetic',
+        sourceMessageId: 'legacy-user-row',
+        sourceContentPartIndices: [1],
+      },
+    ]);
+  });
+
+  it('does not collapse indexed and unindexed contributions', () => {
+    const message = new HumanMessage({ content: 'mixed mapping' });
+    appendProviderMessageProvenance(message, {
+      attribution: 'tool',
+      sourceMessageId: 'source',
+      sourceContentPartIndices: [0],
+    });
+    appendProviderMessageProvenance(message, {
+      attribution: 'tool',
+      sourceMessageId: 'source',
+    });
+
+    expect(getProviderMessageProvenance(message)?.parts).toEqual([
+      {
+        attribution: 'tool',
+        sourceMessageId: 'source',
+        sourceContentPartIndices: [0],
+      },
+      { attribution: 'tool', sourceMessageId: 'source' },
+    ]);
+  });
+
+  it('replaces stale source lineage when stamping a new origin', () => {
+    const message = new HumanMessage({
+      content: 'legacy merge',
+      additional_kwargs: {
+        sourceMessageId: 'second',
+        sourceMessageIds: ['first', 'second'],
+      },
+    });
+
+    setProviderMessageProvenance(message, [
+      { attribution: 'user', sourceMessageId: 'replacement' },
+    ]);
+
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [{ attribution: 'user', sourceMessageId: 'replacement' }],
+    });
+    expect(message.additional_kwargs.sourceMessageId).toBe('replacement');
+    expect(getProviderSourceMessageIds(message)).toEqual(['replacement']);
+  });
+
+  it('rejects malformed untrusted provenance and retains safe id fallback', () => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        sourceMessageIds: ['safe-fallback'],
+        provenance: { version: 1, parts: [null] },
+      },
+    });
+
+    expect(getProviderMessageProvenance(message)).toBeUndefined();
+    expect(getProviderSourceMessageIds(message)).toEqual(['safe-fallback']);
+  });
+
+  it('publishes deeply immutable metadata and rejects invalid setter attribution', () => {
+    const message = new HumanMessage({ content: 'safe' });
+    setProviderMessageProvenance(message, [
+      {
+        attribution: 'user',
+        sourceMessageId: 'source',
+        sourceContentPartIndices: [0],
+      },
+    ]);
+
+    const provenance = getProviderMessageProvenance(message)!;
+    expect(Object.isFrozen(provenance)).toBe(true);
+    expect(Object.isFrozen(provenance.parts)).toBe(true);
+    expect(Object.isFrozen(provenance.parts[0])).toBe(true);
+    expect(Object.isFrozen(provenance.parts[0].sourceContentPartIndices)).toBe(
+      true
+    );
+    expect(Object.isFrozen(message.additional_kwargs.sourceMessageIds)).toBe(
+      true
+    );
+    expect(Reflect.set(provenance.parts[0], 'attribution', 'tool')).toBe(false);
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'invalid' } as unknown as ProviderMessageProvenancePart,
+      ])
+    ).toThrow(TypeError);
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceContentPartIndices: [] },
+      ])
+    ).toThrow(TypeError);
+    expect(getProviderMessageProvenance(message)).toEqual(provenance);
+  });
+
+  it('captures accessor-backed setter fields exactly once before publication', () => {
+    const reads = { attribution: 0, sourceMessageId: 0, indices: 0 };
+    const input = {
+      get attribution() {
+        reads.attribution++;
+        return reads.attribution === 1 ? 'user' : 'attacker';
+      },
+      get sourceMessageId() {
+        reads.sourceMessageId++;
+        return reads.sourceMessageId === 1 ? 'source' : 'attacker';
+      },
+      get sourceContentPartIndices() {
+        reads.indices++;
+        return reads.indices === 1 ? [1] : [-1];
+      },
+    } as unknown as ProviderMessageProvenancePart;
+    const message = new HumanMessage({ content: 'safe' });
+
+    setProviderMessageProvenance(message, [input]);
+
+    expect(reads).toEqual({ attribution: 1, sourceMessageId: 1, indices: 1 });
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'source',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+  });
+
+  it('returns a canonical snapshot of accessor-backed external provenance', () => {
+    const reads = { version: 0, parts: 0, attribution: 0, sourceId: 0 };
+    const part = {
+      get attribution() {
+        reads.attribution++;
+        return reads.attribution === 1 ? 'user' : 'attacker';
+      },
+      get sourceMessageId() {
+        reads.sourceId++;
+        return reads.sourceId === 1 ? 'source' : 'attacker';
+      },
+    };
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: {
+        provenance: {
+          get version() {
+            reads.version++;
+            return reads.version === 1 ? 1 : 2;
+          },
+          get parts() {
+            reads.parts++;
+            return reads.parts === 1 ? [part] : null;
+          },
+        },
+      },
+    });
+
+    const provenance = getProviderMessageProvenance(message);
+
+    expect(reads).toEqual({
+      version: 1,
+      parts: 1,
+      attribution: 1,
+      sourceId: 1,
+    });
+    expect(provenance).toEqual({
+      version: 1,
+      parts: [{ attribution: 'user', sourceMessageId: 'source' }],
+    });
+    expect(Object.isFrozen(provenance)).toBe(true);
+    expect(Object.isFrozen(provenance?.parts)).toBe(true);
+    expect(Object.isFrozen(provenance?.parts[0])).toBe(true);
+  });
+
+  it('reads hostile public arrays by captured index rather than callbacks', () => {
+    const parts = [
+      {
+        attribution: 'user',
+        sourceMessageId: 'source',
+        sourceContentPartIndices: [0],
+      },
+    ];
+    Object.defineProperty(parts, 'map', {
+      value: () => [{ attribution: 'attacker' }],
+    });
+    Object.defineProperty(parts[0].sourceContentPartIndices, Symbol.iterator, {
+      value: function* () {},
+    });
+    const message = new HumanMessage({ content: 'safe' });
+
+    setProviderMessageProvenance(
+      message,
+      parts as unknown as ProviderMessageProvenancePart[]
+    );
+
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'source',
+          sourceContentPartIndices: [0],
+        },
+      ],
+    });
+  });
+
+  it('captures plural ids once and publishes metadata with one atomic assignment', () => {
+    let pluralReads = 0;
+    const message = new HumanMessage({ content: 'external' });
+    Object.defineProperty(message.additional_kwargs, 'sourceMessageIds', {
+      configurable: true,
+      get() {
+        pluralReads++;
+        return pluralReads === 1 ? ['safe'] : null;
+      },
+    });
+
+    expect(getProviderSourceMessageIds(message)).toEqual(['safe']);
+    expect(pluralReads).toBe(1);
+
+    const previousAdditionalKwargs = {
+      sourceMessageId: 'legacy',
+      retained: true,
+    };
+    const proxiedAdditionalKwargs = new Proxy(previousAdditionalKwargs, {
+      set() {
+        throw new Error('partial write');
+      },
+    });
+    message.additional_kwargs = proxiedAdditionalKwargs;
+
+    expect(() =>
+      setProviderMessageProvenance(message, [
+        { attribution: 'user', sourceMessageId: 'replacement' },
+      ])
+    ).not.toThrow();
+    expect(message.additional_kwargs).not.toBe(proxiedAdditionalKwargs);
+    expect(message.additional_kwargs.retained).toBe(true);
+    expect(previousAdditionalKwargs).toEqual({
+      sourceMessageId: 'legacy',
+      retained: true,
+    });
+    expect(getProviderSourceMessageIds(message)).toEqual(['replacement']);
+  });
+
+  it('preserves complete lineage above recommended consumer trust bounds', () => {
+    const message = new HumanMessage({ content: 'large' });
+    const sourceContentPartIndices = Array.from(
+      { length: 257 },
+      (_, index) => index
+    );
+
+    setProviderMessageProvenance(message, [
+      {
+        attribution: 'user',
+        sourceMessageId: 'large-source',
+        sourceContentPartIndices,
+      },
+    ]);
+
+    expect(
+      getProviderMessageProvenance(message)?.parts[0].sourceContentPartIndices
+    ).toHaveLength(257);
+  });
+
+  it('rebuilds safely after external provenance replacement', () => {
+    const message = new HumanMessage({ content: 'external' });
+    setProviderMessageProvenance(message, [
+      { attribution: 'user', sourceMessageId: 'source' },
+    ]);
+    message.additional_kwargs.provenance = null;
+
+    appendProviderMessageProvenance(message, {
+      attribution: 'user',
+      sourceContentPartIndices: [1],
+    });
+
+    expect(getProviderMessageProvenance(message)).toEqual({
+      version: 1,
+      parts: [
+        {
+          attribution: 'user',
+          sourceMessageId: 'source',
+          sourceContentPartIndices: [1],
+        },
+      ],
+    });
+  });
+});

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -4,7 +4,9 @@ import {
   appendProviderMessageProvenance,
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
+  inspectProviderMessageProvenance,
   PROVIDER_MESSAGE_PROVENANCE_LIMITS,
+  setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
 } from './provenance';
 
@@ -28,6 +30,37 @@ describe('provider message provenance', () => {
       'last',
     ]);
     expect(getProviderSourceMessageIds(message)).toEqual(['first', 'last']);
+    expect(message.lc_kwargs.additional_kwargs).toBe(message.additional_kwargs);
+    const serialized = message.toJSON() as unknown as {
+      kwargs: { additional_kwargs: unknown };
+    };
+    expect(serialized.kwargs.additional_kwargs).toEqual(
+      message.additional_kwargs
+    );
+  });
+
+  it('publishes a canonical invalid marker through live and serialized kwargs', () => {
+    const message = new HumanMessage({
+      content: 'projected',
+      additional_kwargs: {
+        provenance: { hostile: true },
+        sourceMessageId: 'must-not-survive',
+        sourceMessageIds: ['must-not-survive'],
+      },
+    });
+
+    setInvalidProviderMessageProvenance(message);
+
+    expect(message.additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: null,
+    });
+    expect(Object.isFrozen(message.additional_kwargs.provenance)).toBe(true);
+    expect(message.additional_kwargs.sourceMessageId).toBeUndefined();
+    expect(message.additional_kwargs.sourceMessageIds).toBeUndefined();
+    expect(inspectProviderMessageProvenance(message)).toEqual({
+      status: 'invalid',
+    });
     expect(message.lc_kwargs.additional_kwargs).toBe(message.additional_kwargs);
     const serialized = message.toJSON() as unknown as {
       kwargs: { additional_kwargs: unknown };

--- a/src/messages/provenance.test.ts
+++ b/src/messages/provenance.test.ts
@@ -5,6 +5,7 @@ import {
   getProviderMessageProvenance,
   getProviderSourceMessageIds,
   inspectProviderMessageProvenance,
+  inspectProviderSourceMessageIds,
   PROVIDER_MESSAGE_PROVENANCE_LIMITS,
   setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
@@ -209,6 +210,65 @@ describe('provider message provenance', () => {
 
     expect(getProviderMessageProvenance(message)).toBeUndefined();
     expect(getProviderSourceMessageIds(message)).toEqual(['safe-fallback']);
+    expect(inspectProviderSourceMessageIds(message)).toEqual({
+      status: 'invalid',
+    });
+  });
+
+  it('distinguishes absent and validated legacy source lineage', () => {
+    expect(
+      inspectProviderSourceMessageIds(new HumanMessage('absent'))
+    ).toEqual({ status: 'absent' });
+    expect(
+      inspectProviderSourceMessageIds(
+        new HumanMessage({
+          content: 'legacy',
+          additional_kwargs: {
+            sourceMessageId: 'second',
+            sourceMessageIds: ['first', 'second'],
+          },
+        })
+      )
+    ).toEqual({
+      status: 'valid',
+      sourceMessageIds: ['first', 'second'],
+    });
+  });
+
+  it.each([
+    ['non-array plural', { 0: 'forged', length: 1 }],
+    ['empty plural', []],
+    [
+      'oversized plural',
+      new Array(
+        PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds + 1
+      ).fill('forged'),
+    ],
+  ])('reports a %s as invalid legacy source lineage', (_, sourceMessageIds) => {
+    const message = new HumanMessage({
+      content: 'external',
+      additional_kwargs: { sourceMessageIds },
+    });
+
+    expect(inspectProviderSourceMessageIds(message)).toEqual({
+      status: 'invalid',
+    });
+  });
+
+  it('reports a throwing legacy source accessor as invalid', () => {
+    const message = new HumanMessage('external');
+    Object.defineProperty(message.additional_kwargs, 'sourceMessageIds', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        throw new Error('hostile source lineage');
+      },
+    });
+
+    expect(() => inspectProviderSourceMessageIds(message)).not.toThrow();
+    expect(inspectProviderSourceMessageIds(message)).toEqual({
+      status: 'invalid',
+    });
   });
 
   it('publishes deeply immutable metadata and rejects invalid setter attribution', () => {

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -643,6 +643,35 @@ export function inspectProviderSourceMessageIds(
   return { status: 'valid', sourceMessageIds };
 }
 
+/** True when indexed contributions uniquely cover every current content part. */
+export function hasBijectiveProviderContentPartMapping(
+  parts: readonly ProviderMessageProvenancePart[],
+  contentPartCount: number
+): boolean {
+  if (!Number.isSafeInteger(contentPartCount) || contentPartCount <= 0) {
+    return false;
+  }
+  const seen = new Set<number>();
+  for (const part of parts) {
+    const indices = part.sourceContentPartIndices;
+    if (indices == null) {
+      return false;
+    }
+    for (const index of indices) {
+      if (
+        !Number.isSafeInteger(index) ||
+        index < 0 ||
+        index >= contentPartCount ||
+        seen.has(index)
+      ) {
+        return false;
+      }
+      seen.add(index);
+    }
+  }
+  return seen.size === contentPartCount;
+}
+
 /**
  * Returns every explicit persisted source id in stable content order.
  * Typed parts, plural lineage, and the legacy singular id are unioned in that

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -117,13 +117,13 @@ function normalizeSourceContentPartIndices(
   if (indices == null) {
     return undefined;
   }
-  if (!Array.isArray(indices)) {
+  if (isProxy(indices) || !Array.isArray(indices)) {
     throw new TypeError(
       'Provider source content part indices must be a non-empty array'
     );
   }
   const length = indices.length;
-  if (length === 0) {
+  if (!Number.isSafeInteger(length) || length === 0) {
     throw new TypeError(
       'Provider source content part indices must be a non-empty array'
     );
@@ -215,11 +215,11 @@ function normalizeProvenanceParts(
   requireCanonicalSourceMessageId = false,
   enforceTrustBounds = false
 ): readonly ProviderMessageProvenancePart[] {
-  if (!Array.isArray(parts)) {
+  if (isProxy(parts) || !Array.isArray(parts)) {
     throw new TypeError('Provider message provenance parts must be an array');
   }
   const length = parts.length;
-  if (length === 0) {
+  if (!Number.isSafeInteger(length) || length === 0) {
     throw new TypeError('Provider message provenance parts cannot be empty');
   }
   if (
@@ -320,12 +320,17 @@ function collectProviderSourceMessageIds(
    * no longer a trusted combined lineage, so the public bounds apply to both
    * sides and oversized inputs fail before any per-item work. */
   let plural: readonly unknown[] | undefined;
+  let pluralLength = 0;
   try {
     if (pluralInput !== undefined) {
-      if (!Array.isArray(pluralInput)) {
+      if (isProxy(pluralInput) || !Array.isArray(pluralInput)) {
         return undefined;
       }
       plural = pluralInput;
+      pluralLength = pluralInput.length;
+      if (!Number.isSafeInteger(pluralLength)) {
+        return undefined;
+      }
       trustedPlural = immutableProviderSourceMessageIds.has(pluralInput);
       const bindingMismatch = trustedProvenance && boundPlural !== pluralInput;
       if (bindingMismatch) {
@@ -346,6 +351,13 @@ function collectProviderSourceMessageIds(
    * cannot force work over an otherwise trusted oversized lineage. */
   const trustedSingularSourceIds =
     boundPlural ?? (trustedPlural ? plural : undefined);
+  let trustedSingularSourceIdsLength = 0;
+  if (trustedSingularSourceIds != null) {
+    trustedSingularSourceIdsLength =
+      trustedSingularSourceIds === plural
+        ? pluralLength
+        : trustedSingularSourceIds.length;
+  }
   const unboundedSingular =
     singularInput === undefined
       ? undefined
@@ -355,8 +367,8 @@ function collectProviderSourceMessageIds(
     typeof singularInput === 'string' &&
     singularInput === unboundedSingular &&
     trustedSingularSourceIds != null &&
-    trustedSingularSourceIds.length > 0 &&
-    trustedSingularSourceIds[trustedSingularSourceIds.length - 1] ===
+    trustedSingularSourceIdsLength > 0 &&
+    trustedSingularSourceIds[trustedSingularSourceIdsLength - 1] ===
       singularInput;
   if (singularInput !== undefined && !trustedSingularDuplicate) {
     hasUntrustedSourceMetadata = true;
@@ -378,7 +390,7 @@ function collectProviderSourceMessageIds(
       }
       if (
         plural != null &&
-        plural.length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds
+        pluralLength > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds
       ) {
         return undefined;
       }
@@ -408,8 +420,7 @@ function collectProviderSourceMessageIds(
 
   try {
     if (plural != null) {
-      const length = plural.length;
-      for (let index = 0; index < length; index++) {
+      for (let index = 0; index < pluralLength; index++) {
         if (
           !appendSourceMessageId(
             result,

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -39,9 +39,26 @@ export interface ProviderMessageProvenance {
   readonly parts: readonly ProviderMessageProvenancePart[];
 }
 
+/** Inert marker used only when a derived message must retain invalidity. */
+export interface InvalidProviderMessageProvenance {
+  readonly version: typeof PROVIDER_MESSAGE_PROVENANCE_VERSION;
+  readonly parts: null;
+}
+
+/** Distinguishes absent metadata from an explicitly malformed envelope. */
+export type ProviderMessageProvenanceState =
+  | { readonly status: 'absent' }
+  | { readonly status: 'invalid' }
+  | {
+    readonly status: 'valid';
+    readonly provenance: ProviderMessageProvenance;
+  };
+
 /** Typed subset of `additional_kwargs` exposed at provider callbacks. */
 export interface ProviderMessageProvenanceAdditionalKwargs {
-  readonly provenance?: ProviderMessageProvenance;
+  readonly provenance?:
+    | ProviderMessageProvenance
+    | InvalidProviderMessageProvenance;
   readonly sourceMessageId?: string;
   readonly sourceMessageIds?: readonly string[];
 }
@@ -70,6 +87,19 @@ const immutableProviderMessageSourceIds = new WeakMap<
   object,
   readonly string[]
 >();
+const absentProviderMessageProvenanceState = Object.freeze({
+  status: 'absent' as const,
+});
+const invalidProviderMessageProvenanceState = Object.freeze({
+  status: 'invalid' as const,
+});
+/** Fresh projections use this inert envelope to preserve explicit invalidity
+ * without retaining any hostile caller-owned object or array. */
+const invalidProviderMessageProvenanceSentinel: InvalidProviderMessageProvenance =
+  Object.freeze({
+    version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
+    parts: null,
+  });
 
 function normalizeSourceMessageId(
   candidate: unknown,
@@ -509,6 +539,35 @@ export function getProviderMessageProvenance(
   return normalizeProviderMessageProvenance(provenanceInput);
 }
 
+/** Safely preserves the semantic difference between absent and invalid input. */
+export function inspectProviderMessageProvenance(
+  message: BaseMessage
+): ProviderMessageProvenanceState {
+  let additionalKwargs: unknown;
+  try {
+    additionalKwargs = message.additional_kwargs;
+  } catch {
+    return invalidProviderMessageProvenanceState;
+  }
+  if (additionalKwargs == null || typeof additionalKwargs !== 'object') {
+    return absentProviderMessageProvenanceState;
+  }
+  let provenanceInput: unknown;
+  try {
+    provenanceInput = (additionalKwargs as { provenance?: unknown })
+      .provenance;
+  } catch {
+    return invalidProviderMessageProvenanceState;
+  }
+  if (provenanceInput == null) {
+    return absentProviderMessageProvenanceState;
+  }
+  const provenance = normalizeProviderMessageProvenance(provenanceInput);
+  return provenance == null
+    ? invalidProviderMessageProvenanceState
+    : { status: 'valid', provenance };
+}
+
 /**
  * Returns every explicit persisted source id in stable content order.
  * Typed parts, plural lineage, and the legacy singular id are unioned in that
@@ -531,10 +590,10 @@ export function getProviderSourceMessageIds(message: BaseMessage): string[] {
   );
 }
 
-/** Replaces typed provenance and synchronizes its stable plural source ids. */
-export function setProviderMessageProvenance(
+function publishProviderMessageProvenance(
   message: BaseMessage,
-  parts: readonly ProviderMessageProvenancePart[]
+  provenance: unknown,
+  sourceMessageIds?: readonly string[]
 ): void {
   if (isProxy(message)) {
     throw new TypeError('Invalid provider message serialization kwargs');
@@ -582,26 +641,9 @@ export function setProviderMessageProvenance(
   } catch {
     throw new TypeError('Invalid provider message serialization kwargs');
   }
-  const normalizedParts = normalizeProvenanceParts(parts);
-  const provenance: ProviderMessageProvenance = Object.freeze({
-    version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
-    parts: normalizedParts,
-  });
-  immutableProviderMessageProvenance.add(provenance);
-  const sourceMessageIds: string[] = [];
-  const seen = new Set<string>();
-  for (const part of normalizedParts) {
-    appendSourceMessageId(sourceMessageIds, seen, part.sourceMessageId);
-  }
   replacement.provenance = provenance;
-  if (sourceMessageIds.length > 0) {
-    const immutableSourceMessageIds = Object.freeze(sourceMessageIds);
-    immutableProviderSourceMessageIds.add(immutableSourceMessageIds);
-    immutableProviderMessageSourceIds.set(
-      provenance,
-      immutableSourceMessageIds
-    );
-    replacement.sourceMessageIds = immutableSourceMessageIds;
+  if (sourceMessageIds != null && sourceMessageIds.length > 0) {
+    replacement.sourceMessageIds = sourceMessageIds;
     replacement.sourceMessageId = sourceMessageIds[sourceMessageIds.length - 1];
   } else {
     delete replacement.sourceMessageIds;
@@ -618,6 +660,49 @@ export function setProviderMessageProvenance(
   } catch {
     throw new TypeError('Invalid provider message serialization kwargs');
   }
+}
+
+/** Replaces typed provenance and synchronizes its stable plural source ids. */
+export function setProviderMessageProvenance(
+  message: BaseMessage,
+  parts: readonly ProviderMessageProvenancePart[]
+): void {
+  const normalizedParts = normalizeProvenanceParts(parts);
+  const provenance: ProviderMessageProvenance = Object.freeze({
+    version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
+    parts: normalizedParts,
+  });
+  immutableProviderMessageProvenance.add(provenance);
+  const sourceMessageIds: string[] = [];
+  const seen = new Set<string>();
+  for (const part of normalizedParts) {
+    appendSourceMessageId(sourceMessageIds, seen, part.sourceMessageId);
+  }
+  if (sourceMessageIds.length > 0) {
+    const immutableSourceMessageIds = Object.freeze(sourceMessageIds);
+    immutableProviderSourceMessageIds.add(immutableSourceMessageIds);
+    immutableProviderMessageSourceIds.set(
+      provenance,
+      immutableSourceMessageIds
+    );
+    publishProviderMessageProvenance(
+      message,
+      provenance,
+      immutableSourceMessageIds
+    );
+    return;
+  }
+  publishProviderMessageProvenance(message, provenance);
+}
+
+/** Publishes the canonical fail-closed marker for malformed provenance. */
+export function setInvalidProviderMessageProvenance(
+  message: BaseMessage
+): void {
+  publishProviderMessageProvenance(
+    message,
+    invalidProviderMessageProvenanceSentinel
+  );
 }
 
 /** Marks a provider-visible runtime message as host-generated context. */

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -1,0 +1,437 @@
+import type { BaseMessage } from '@langchain/core/messages';
+
+export const PROVIDER_MESSAGE_PROVENANCE_VERSION = 1 as const;
+
+/** Recommended consumer trust bounds. Producers preserve complete lineage
+ * above these limits; security-sensitive consumers must reject oversized
+ * envelopes and take their fail-closed path rather than truncate attribution. */
+export const PROVIDER_MESSAGE_PROVENANCE_LIMITS = Object.freeze({
+  maxParts: 256,
+  maxIndicesPerPart: 256,
+  maxTotalIndexRefs: 4_096,
+  maxSourceMessageIds: 256,
+  maxSourceMessageIdLength: 512,
+  maxSourceContentPartIndex: 4_095,
+} as const);
+
+/** Authorship of one logical contribution to a provider-bound message. */
+export type ProviderMessageAttribution =
+  | 'user'
+  | 'model'
+  | 'tool'
+  | 'synthetic';
+
+/**
+ * Lineage for one logical contribution to a provider-bound message.
+ * `sourceContentPartIndices` index the persisted source message's `content`
+ * array before formatting, filtering, or summary-boundary slicing.
+ */
+export interface ProviderMessageProvenancePart {
+  readonly attribution: ProviderMessageAttribution;
+  readonly sourceMessageId?: string;
+  readonly sourceContentPartIndices?: readonly number[];
+}
+
+/** Stable, versioned provenance carried in `BaseMessage.additional_kwargs`. */
+export interface ProviderMessageProvenance {
+  readonly version: typeof PROVIDER_MESSAGE_PROVENANCE_VERSION;
+  readonly parts: readonly ProviderMessageProvenancePart[];
+}
+
+/** Typed subset of `additional_kwargs` exposed at provider callbacks. */
+export interface ProviderMessageProvenanceAdditionalKwargs {
+  readonly provenance?: ProviderMessageProvenance;
+  readonly sourceMessageId?: string;
+  readonly sourceMessageIds?: readonly string[];
+}
+
+interface UntrustedProviderMessageAdditionalKwargs
+  extends Record<string, unknown> {
+  provenance?: unknown;
+  sourceMessageId?: unknown;
+  sourceMessageIds?: unknown;
+}
+
+const PROVIDER_MESSAGE_ATTRIBUTIONS: ReadonlySet<ProviderMessageAttribution> =
+  new Set(['user', 'model', 'tool', 'synthetic']);
+/** Only envelopes built from copied/frozen inputs by the setter enter this
+ * identity set. It avoids repeated O(n) canonicalization without trusting a
+ * message or caller-owned envelope identity. */
+const immutableProviderMessageProvenance = new WeakSet<object>();
+
+function normalizeSourceMessageId(candidate: unknown): string | undefined {
+  if (typeof candidate !== 'string') {
+    return undefined;
+  }
+  const normalized = candidate.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function appendSourceMessageId(
+  result: string[],
+  seen: Set<string>,
+  candidate: unknown
+): void {
+  const sourceMessageId = normalizeSourceMessageId(candidate);
+  if (sourceMessageId == null || seen.has(sourceMessageId)) {
+    return;
+  }
+  seen.add(sourceMessageId);
+  result.push(sourceMessageId);
+}
+
+function normalizeSourceContentPartIndices(
+  indices: readonly number[] | undefined
+): number[] | undefined {
+  if (indices == null) {
+    return undefined;
+  }
+  if (!Array.isArray(indices)) {
+    throw new TypeError(
+      'Provider source content part indices must be a non-empty array'
+    );
+  }
+  const length = indices.length;
+  if (length === 0) {
+    throw new TypeError(
+      'Provider source content part indices must be a non-empty array'
+    );
+  }
+  const normalized: number[] = [];
+  const seen = new Set<number>();
+  for (let position = 0; position < length; position++) {
+    const index = indices[position];
+    if (!Number.isSafeInteger(index) || index < 0) {
+      throw new TypeError('Invalid provider source content part index');
+    }
+    if (seen.has(index)) {
+      continue;
+    }
+    seen.add(index);
+    normalized.push(index);
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeProvenancePart(
+  part: ProviderMessageProvenancePart | null | undefined,
+  requireCanonicalSourceMessageId = false
+): ProviderMessageProvenancePart {
+  if (part == null || typeof part !== 'object') {
+    throw new TypeError('Invalid provider message provenance attribution');
+  }
+  /** Capture each potentially accessor-backed public input exactly once before
+   * validation so a changing getter cannot pass one value and publish another. */
+  const attribution = part.attribution;
+  const sourceMessageIdInput = part.sourceMessageId;
+  const sourceContentPartIndicesInput = part.sourceContentPartIndices;
+  if (!PROVIDER_MESSAGE_ATTRIBUTIONS.has(attribution)) {
+    throw new TypeError('Invalid provider message provenance attribution');
+  }
+  const sourceMessageId = normalizeSourceMessageId(sourceMessageIdInput);
+  if (
+    sourceMessageIdInput !== undefined &&
+    (sourceMessageId == null ||
+      (requireCanonicalSourceMessageId &&
+        sourceMessageId !== sourceMessageIdInput))
+  ) {
+    throw new TypeError('Invalid provider source message id');
+  }
+  const sourceContentPartIndices = normalizeSourceContentPartIndices(
+    sourceContentPartIndicesInput
+  );
+  return Object.freeze({
+    attribution,
+    ...(sourceMessageId != null && { sourceMessageId }),
+    ...(sourceContentPartIndices != null && {
+      sourceContentPartIndices: Object.freeze(sourceContentPartIndices),
+    }),
+  });
+}
+
+function normalizeProvenanceParts(
+  parts: unknown,
+  requireCanonicalSourceMessageId = false
+): readonly ProviderMessageProvenancePart[] {
+  if (!Array.isArray(parts)) {
+    throw new TypeError('Provider message provenance parts must be an array');
+  }
+  const length = parts.length;
+  if (length === 0) {
+    throw new TypeError('Provider message provenance parts cannot be empty');
+  }
+  const normalizedParts: ProviderMessageProvenancePart[] = [];
+  for (let index = 0; index < length; index++) {
+    const part = parts[index] as
+      | ProviderMessageProvenancePart
+      | null
+      | undefined;
+    normalizedParts.push(
+      normalizeProvenancePart(part, requireCanonicalSourceMessageId)
+    );
+  }
+  return Object.freeze(normalizedParts);
+}
+
+function normalizeProviderMessageProvenance(
+  provenanceInput: unknown
+): ProviderMessageProvenance | undefined {
+  try {
+    if (provenanceInput == null || typeof provenanceInput !== 'object') {
+      return undefined;
+    }
+    if (immutableProviderMessageProvenance.has(provenanceInput)) {
+      return provenanceInput as ProviderMessageProvenance;
+    }
+    const provenance = provenanceInput as {
+      version?: unknown;
+      parts?: unknown;
+    };
+    /** Capture accessor-backed envelope fields exactly once, then publish only
+     * a canonical immutable copy rather than returning the untrusted object. */
+    const version = provenance.version;
+    const partsInput = provenance.parts;
+    if (version !== PROVIDER_MESSAGE_PROVENANCE_VERSION) {
+      return undefined;
+    }
+    const parts = normalizeProvenanceParts(partsInput, true);
+    return Object.freeze({
+      version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
+      parts,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function getUntrustedAdditionalKwargs(
+  message: BaseMessage
+): UntrustedProviderMessageAdditionalKwargs | undefined {
+  try {
+    const additionalKwargs: unknown = message.additional_kwargs;
+    return additionalKwargs != null && typeof additionalKwargs === 'object'
+      ? (additionalKwargs as UntrustedProviderMessageAdditionalKwargs)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readAdditionalKwarg(
+  additionalKwargs: UntrustedProviderMessageAdditionalKwargs | undefined,
+  key: keyof UntrustedProviderMessageAdditionalKwargs
+): unknown {
+  try {
+    return additionalKwargs?.[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function collectProviderSourceMessageIds(
+  provenance: ProviderMessageProvenance | undefined,
+  pluralInput: unknown,
+  singularInput: unknown
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const part of provenance?.parts ?? []) {
+    appendSourceMessageId(result, seen, part.sourceMessageId);
+  }
+
+  let pluralCandidates: unknown[] | undefined;
+  try {
+    if (Array.isArray(pluralInput)) {
+      const length = pluralInput.length;
+      pluralCandidates = [];
+      for (let index = 0; index < length; index++) {
+        pluralCandidates.push(pluralInput[index]);
+      }
+    }
+  } catch {
+    pluralCandidates = undefined;
+  }
+  for (const candidate of pluralCandidates ?? []) {
+    appendSourceMessageId(result, seen, candidate);
+  }
+  appendSourceMessageId(result, seen, singularInput);
+  return result;
+}
+
+/** Legacy Human rows are treated as user-authored when no typed metadata is
+ * available. Unknown custom message types take the same conservative path. */
+function inferLegacyMessageAttribution(
+  message: BaseMessage
+): ProviderMessageAttribution {
+  const messageType = message.type;
+  if (messageType === 'ai') {
+    return 'model';
+  }
+  if (messageType === 'tool') {
+    return 'tool';
+  }
+  if (messageType === 'system') {
+    return 'synthetic';
+  }
+  return 'user';
+}
+
+/** Returns explicitly stamped provenance without inferring from message role. */
+export function getProviderMessageProvenance(
+  message: BaseMessage
+): ProviderMessageProvenance | undefined {
+  const additionalKwargs = getUntrustedAdditionalKwargs(message);
+  const provenanceInput = readAdditionalKwarg(
+    additionalKwargs,
+    'provenance'
+  );
+  return normalizeProviderMessageProvenance(provenanceInput);
+}
+
+/**
+ * Returns every explicit persisted source id in stable content order.
+ * Typed parts, plural lineage, and the legacy singular id are unioned in that
+ * precedence order; duplicates are removed without reordering.
+ */
+export function getProviderSourceMessageIds(message: BaseMessage): string[] {
+  const additionalKwargs = getUntrustedAdditionalKwargs(message);
+  const provenanceInput = readAdditionalKwarg(
+    additionalKwargs,
+    'provenance'
+  );
+  const pluralInput = readAdditionalKwarg(
+    additionalKwargs,
+    'sourceMessageIds'
+  );
+  const singularInput = readAdditionalKwarg(
+    additionalKwargs,
+    'sourceMessageId'
+  );
+  return collectProviderSourceMessageIds(
+    normalizeProviderMessageProvenance(provenanceInput),
+    pluralInput,
+    singularInput
+  );
+}
+
+/** Replaces typed provenance and synchronizes its stable plural source ids. */
+export function setProviderMessageProvenance(
+  message: BaseMessage,
+  parts: readonly ProviderMessageProvenancePart[]
+): void {
+  const normalizedParts = normalizeProvenanceParts(parts);
+  const provenance: ProviderMessageProvenance = Object.freeze({
+    version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
+    parts: normalizedParts,
+  });
+  immutableProviderMessageProvenance.add(provenance);
+  const sourceMessageIds: string[] = [];
+  const seen = new Set<string>();
+  for (const part of normalizedParts) {
+    appendSourceMessageId(sourceMessageIds, seen, part.sourceMessageId);
+  }
+  const currentAdditionalKwargs = getUntrustedAdditionalKwargs(message);
+  let replacement: UntrustedProviderMessageAdditionalKwargs;
+  try {
+    replacement = { ...(currentAdditionalKwargs ?? {}) };
+  } catch {
+    throw new TypeError('Invalid provider message additional kwargs');
+  }
+  replacement.provenance = provenance;
+  if (sourceMessageIds.length > 0) {
+    replacement.sourceMessageIds = Object.freeze(sourceMessageIds);
+    replacement.sourceMessageId =
+      sourceMessageIds[sourceMessageIds.length - 1];
+  } else {
+    delete replacement.sourceMessageIds;
+    delete replacement.sourceMessageId;
+  }
+  message.additional_kwargs = replacement;
+}
+
+/**
+ * Adds one logical lineage contribution, migrating legacy ids on first use.
+ * This compatibility helper rebuilds validated public metadata; hot formatters
+ * should accumulate locally and call `setProviderMessageProvenance` once.
+ */
+export function appendProviderMessageProvenance(
+  message: BaseMessage,
+  part: ProviderMessageProvenancePart
+): void {
+  let normalizedPart = normalizeProvenancePart(part);
+  const additionalKwargs = getUntrustedAdditionalKwargs(message);
+  const provenanceInput = readAdditionalKwarg(
+    additionalKwargs,
+    'provenance'
+  );
+  const pluralInput = readAdditionalKwarg(
+    additionalKwargs,
+    'sourceMessageIds'
+  );
+  const singularInput = readAdditionalKwarg(
+    additionalKwargs,
+    'sourceMessageId'
+  );
+  const provenance = normalizeProviderMessageProvenance(provenanceInput);
+  const existing = provenance?.parts ?? [];
+  const representedSourceIds = new Set<string>();
+  for (const existingPart of existing) {
+    if (existingPart.sourceMessageId != null) {
+      representedSourceIds.add(existingPart.sourceMessageId);
+    }
+  }
+  const sourceMessageIds = collectProviderSourceMessageIds(
+    provenance,
+    pluralInput,
+    singularInput
+  );
+  const missingLegacySourceIds = sourceMessageIds.filter(
+    (sourceMessageId) => !representedSourceIds.has(sourceMessageId)
+  );
+  const migratedParts: ProviderMessageProvenancePart[] = [...existing];
+  const legacyAttribution = inferLegacyMessageAttribution(message);
+  for (const sourceMessageId of missingLegacySourceIds) {
+    migratedParts.push({
+      attribution: legacyAttribution,
+      sourceMessageId,
+    });
+  }
+  if (normalizedPart.sourceMessageId == null && sourceMessageIds.length === 1) {
+    normalizedPart = {
+      ...normalizedPart,
+      sourceMessageId: sourceMessageIds[0],
+    };
+    const migratedIndex = migratedParts.findIndex(
+      (migratedPart, index) =>
+        index >= existing.length &&
+        migratedPart.attribution === normalizedPart.attribution &&
+        migratedPart.sourceMessageId === sourceMessageIds[0]
+    );
+    if (migratedIndex >= 0) {
+      migratedParts.splice(migratedIndex, 1);
+    }
+  }
+  const lastPart = migratedParts[migratedParts.length - 1];
+  if (
+    migratedParts.length > 0 &&
+    lastPart.attribution === normalizedPart.attribution &&
+    lastPart.sourceMessageId === normalizedPart.sourceMessageId &&
+    (lastPart.sourceContentPartIndices == null) ===
+      (normalizedPart.sourceContentPartIndices == null)
+  ) {
+    const sourceContentPartIndices = normalizeSourceContentPartIndices([
+      ...(lastPart.sourceContentPartIndices ?? []),
+      ...(normalizedPart.sourceContentPartIndices ?? []),
+    ]);
+    migratedParts[migratedParts.length - 1] = {
+      attribution: lastPart.attribution,
+      ...(lastPart.sourceMessageId != null && {
+        sourceMessageId: lastPart.sourceMessageId,
+      }),
+      ...(sourceContentPartIndices != null && { sourceContentPartIndices }),
+    };
+  } else {
+    migratedParts.push(normalizedPart);
+  }
+  setProviderMessageProvenance(message, migratedParts);
+}

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -54,6 +54,15 @@ export type ProviderMessageProvenanceState =
     readonly provenance: ProviderMessageProvenance;
   };
 
+/** Distinguishes absent lineage from validated ids and malformed metadata. */
+export type ProviderSourceMessageIdsState =
+  | { readonly status: 'absent' }
+  | { readonly status: 'invalid' }
+  | {
+    readonly status: 'valid';
+    readonly sourceMessageIds: readonly string[];
+  };
+
 /** Typed subset of `additional_kwargs` exposed at provider callbacks. */
 export interface ProviderMessageProvenanceAdditionalKwargs {
   readonly provenance?:
@@ -91,6 +100,12 @@ const absentProviderMessageProvenanceState = Object.freeze({
   status: 'absent' as const,
 });
 const invalidProviderMessageProvenanceState = Object.freeze({
+  status: 'invalid' as const,
+});
+const absentProviderSourceMessageIdsState = Object.freeze({
+  status: 'absent' as const,
+});
+const invalidProviderSourceMessageIdsState = Object.freeze({
   status: 'invalid' as const,
 });
 /** Fresh projections use this inert envelope to preserve explicit invalidity
@@ -358,7 +373,7 @@ function collectProviderSourceMessageIds(
       }
       plural = pluralInput;
       pluralLength = pluralInput.length;
-      if (!Number.isSafeInteger(pluralLength)) {
+      if (!Number.isSafeInteger(pluralLength) || pluralLength === 0) {
         return undefined;
       }
       trustedPlural = immutableProviderSourceMessageIds.has(pluralInput);
@@ -566,6 +581,66 @@ export function inspectProviderMessageProvenance(
   return provenance == null
     ? invalidProviderMessageProvenanceState
     : { status: 'valid', provenance };
+}
+
+function readProviderSourceMessageIds(
+  message: BaseMessage
+): string[] | null | undefined {
+  let additionalKwargs: unknown;
+  try {
+    additionalKwargs = message.additional_kwargs;
+  } catch {
+    return null;
+  }
+  if (additionalKwargs == null || typeof additionalKwargs !== 'object') {
+    return undefined;
+  }
+  if (isProxy(additionalKwargs)) {
+    return null;
+  }
+  let provenanceInput: unknown;
+  let pluralInput: unknown;
+  let singularInput: unknown;
+  try {
+    const sourceMetadata =
+      additionalKwargs as UntrustedProviderMessageAdditionalKwargs;
+    provenanceInput = sourceMetadata.provenance;
+    pluralInput = sourceMetadata.sourceMessageIds;
+    singularInput = sourceMetadata.sourceMessageId;
+  } catch {
+    return null;
+  }
+  const hasProvenanceInput = provenanceInput != null;
+  const hasLegacyInput =
+    pluralInput !== undefined || singularInput !== undefined;
+  if (!hasProvenanceInput && !hasLegacyInput) {
+    return undefined;
+  }
+  const provenance = normalizeProviderMessageProvenance(provenanceInput);
+  if (hasProvenanceInput && provenance == null) {
+    return null;
+  }
+  return (
+    collectProviderSourceMessageIds(
+      provenance,
+      pluralInput,
+      singularInput
+    ) ?? null
+  );
+}
+
+/** Safely distinguishes missing source lineage from malformed metadata. */
+export function inspectProviderSourceMessageIds(
+  message: BaseMessage
+): ProviderSourceMessageIdsState {
+  const sourceMessageIds = readProviderSourceMessageIds(message);
+  if (sourceMessageIds === undefined) {
+    return absentProviderSourceMessageIdsState;
+  }
+  if (sourceMessageIds === null) {
+    return invalidProviderSourceMessageIdsState;
+  }
+  return { status: 'valid', sourceMessageIds };
 }
 
 /**

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -1,3 +1,4 @@
+import { isProxy } from 'node:util/types';
 import type { BaseMessage } from '@langchain/core/messages';
 
 export const PROVIDER_MESSAGE_PROVENANCE_VERSION = 1 as const;
@@ -58,9 +59,30 @@ const PROVIDER_MESSAGE_ATTRIBUTIONS: ReadonlySet<ProviderMessageAttribution> =
  * identity set. It avoids repeated O(n) canonicalization without trusting a
  * message or caller-owned envelope identity. */
 const immutableProviderMessageProvenance = new WeakSet<object>();
+/** Plural source-id arrays minted by the setter are copied and frozen before
+ * entering this set. Their complete lineage may intentionally exceed the
+ * public trust bounds without forcing repeated validation on reads. */
+const immutableProviderSourceMessageIds = new WeakSet<object>();
+/** Binds the two immutable objects produced by one setter call. Independently
+ * valid envelopes from different messages must not be combined into a new
+ * oversized lineage that no setter ever published. */
+const immutableProviderMessageSourceIds = new WeakMap<
+  object,
+  readonly string[]
+>();
 
-function normalizeSourceMessageId(candidate: unknown): string | undefined {
+function normalizeSourceMessageId(
+  candidate: unknown,
+  enforceTrustBounds = false
+): string | undefined {
   if (typeof candidate !== 'string') {
+    return undefined;
+  }
+  if (
+    enforceTrustBounds &&
+    candidate.length >
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIdLength
+  ) {
     return undefined;
   }
   const normalized = candidate.trim();
@@ -70,18 +92,27 @@ function normalizeSourceMessageId(candidate: unknown): string | undefined {
 function appendSourceMessageId(
   result: string[],
   seen: Set<string>,
-  candidate: unknown
-): void {
-  const sourceMessageId = normalizeSourceMessageId(candidate);
-  if (sourceMessageId == null || seen.has(sourceMessageId)) {
-    return;
+  candidate: unknown,
+  enforceTrustBounds = false
+): boolean {
+  const sourceMessageId = normalizeSourceMessageId(
+    candidate,
+    enforceTrustBounds
+  );
+  if (sourceMessageId == null) {
+    return candidate === undefined;
+  }
+  if (seen.has(sourceMessageId)) {
+    return true;
   }
   seen.add(sourceMessageId);
   result.push(sourceMessageId);
+  return true;
 }
 
 function normalizeSourceContentPartIndices(
-  indices: readonly number[] | undefined
+  indices: readonly number[] | undefined,
+  trustState?: { totalIndexRefs: number }
 ): number[] | undefined {
   if (indices == null) {
     return undefined;
@@ -97,11 +128,27 @@ function normalizeSourceContentPartIndices(
       'Provider source content part indices must be a non-empty array'
     );
   }
+  if (
+    trustState != null &&
+    (length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxIndicesPerPart ||
+      trustState.totalIndexRefs + length >
+        PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxTotalIndexRefs)
+  ) {
+    throw new TypeError('Provider source content part indices exceed limits');
+  }
+  if (trustState != null) {
+    trustState.totalIndexRefs += length;
+  }
   const normalized: number[] = [];
   const seen = new Set<number>();
   for (let position = 0; position < length; position++) {
     const index = indices[position];
-    if (!Number.isSafeInteger(index) || index < 0) {
+    if (
+      !Number.isSafeInteger(index) ||
+      index < 0 ||
+      (trustState != null &&
+        index > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceContentPartIndex)
+    ) {
       throw new TypeError('Invalid provider source content part index');
     }
     if (seen.has(index)) {
@@ -115,7 +162,8 @@ function normalizeSourceContentPartIndices(
 
 function normalizeProvenancePart(
   part: ProviderMessageProvenancePart | null | undefined,
-  requireCanonicalSourceMessageId = false
+  requireCanonicalSourceMessageId = false,
+  trustState?: { totalIndexRefs: number; sourceMessageIdRefs: number }
 ): ProviderMessageProvenancePart {
   if (part == null || typeof part !== 'object') {
     throw new TypeError('Invalid provider message provenance attribution');
@@ -128,7 +176,10 @@ function normalizeProvenancePart(
   if (!PROVIDER_MESSAGE_ATTRIBUTIONS.has(attribution)) {
     throw new TypeError('Invalid provider message provenance attribution');
   }
-  const sourceMessageId = normalizeSourceMessageId(sourceMessageIdInput);
+  const sourceMessageId = normalizeSourceMessageId(
+    sourceMessageIdInput,
+    trustState != null
+  );
   if (
     sourceMessageIdInput !== undefined &&
     (sourceMessageId == null ||
@@ -137,8 +188,18 @@ function normalizeProvenancePart(
   ) {
     throw new TypeError('Invalid provider source message id');
   }
+  if (sourceMessageId != null && trustState != null) {
+    trustState.sourceMessageIdRefs++;
+    if (
+      trustState.sourceMessageIdRefs >
+      PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds
+    ) {
+      throw new TypeError('Provider source message ids exceed limits');
+    }
+  }
   const sourceContentPartIndices = normalizeSourceContentPartIndices(
-    sourceContentPartIndicesInput
+    sourceContentPartIndicesInput,
+    trustState
   );
   return Object.freeze({
     attribution,
@@ -151,7 +212,8 @@ function normalizeProvenancePart(
 
 function normalizeProvenanceParts(
   parts: unknown,
-  requireCanonicalSourceMessageId = false
+  requireCanonicalSourceMessageId = false,
+  enforceTrustBounds = false
 ): readonly ProviderMessageProvenancePart[] {
   if (!Array.isArray(parts)) {
     throw new TypeError('Provider message provenance parts must be an array');
@@ -160,6 +222,15 @@ function normalizeProvenanceParts(
   if (length === 0) {
     throw new TypeError('Provider message provenance parts cannot be empty');
   }
+  if (
+    enforceTrustBounds &&
+    length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts
+  ) {
+    throw new TypeError('Provider message provenance parts exceed limits');
+  }
+  const trustState = enforceTrustBounds
+    ? { totalIndexRefs: 0, sourceMessageIdRefs: 0 }
+    : undefined;
   const normalizedParts: ProviderMessageProvenancePart[] = [];
   for (let index = 0; index < length; index++) {
     const part = parts[index] as
@@ -167,7 +238,7 @@ function normalizeProvenanceParts(
       | null
       | undefined;
     normalizedParts.push(
-      normalizeProvenancePart(part, requireCanonicalSourceMessageId)
+      normalizeProvenancePart(part, requireCanonicalSourceMessageId, trustState)
     );
   }
   return Object.freeze(normalizedParts);
@@ -194,7 +265,7 @@ function normalizeProviderMessageProvenance(
     if (version !== PROVIDER_MESSAGE_PROVENANCE_VERSION) {
       return undefined;
     }
-    const parts = normalizeProvenanceParts(partsInput, true);
+    const parts = normalizeProvenanceParts(partsInput, true, true);
     return Object.freeze({
       version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
       parts,
@@ -232,29 +303,171 @@ function collectProviderSourceMessageIds(
   provenance: ProviderMessageProvenance | undefined,
   pluralInput: unknown,
   singularInput: unknown
-): string[] {
+): string[] | undefined {
   const result: string[] = [];
   const seen = new Set<string>();
-  for (const part of provenance?.parts ?? []) {
-    appendSourceMessageId(result, seen, part.sourceMessageId);
-  }
+  const trustedProvenance =
+    provenance != null && immutableProviderMessageProvenance.has(provenance);
+  const boundPlural = trustedProvenance
+    ? immutableProviderMessageSourceIds.get(provenance!)
+    : undefined;
+  let hasUntrustedSourceMetadata = provenance != null && !trustedProvenance;
+  let trustedPlural = false;
+  const provenanceParts = provenance?.parts;
 
-  let pluralCandidates: unknown[] | undefined;
+  /** Resolve trust across the setter-minted envelope/id pair before walking
+   * either collection. A trusted object spliced from another setter call is
+   * no longer a trusted combined lineage, so the public bounds apply to both
+   * sides and oversized inputs fail before any per-item work. */
+  let plural: readonly unknown[] | undefined;
   try {
-    if (Array.isArray(pluralInput)) {
-      const length = pluralInput.length;
-      pluralCandidates = [];
-      for (let index = 0; index < length; index++) {
-        pluralCandidates.push(pluralInput[index]);
+    if (pluralInput !== undefined) {
+      if (!Array.isArray(pluralInput)) {
+        return undefined;
+      }
+      plural = pluralInput;
+      trustedPlural = immutableProviderSourceMessageIds.has(pluralInput);
+      const bindingMismatch = trustedProvenance && boundPlural !== pluralInput;
+      if (bindingMismatch) {
+        trustedPlural = false;
+      }
+      if (!trustedPlural) {
+        hasUntrustedSourceMetadata = true;
       }
     }
   } catch {
-    pluralCandidates = undefined;
+    return undefined;
   }
-  for (const candidate of pluralCandidates ?? []) {
-    appendSourceMessageId(result, seen, candidate);
+
+  /** A primitive singular id has no identity of its own. Treat it as the
+   * setter's compatibility duplicate only when it exactly matches the last id
+   * of an immutable plural array published by that setter. This classification
+   * happens before either collection is walked so malformed singular metadata
+   * cannot force work over an otherwise trusted oversized lineage. */
+  const trustedSingularSourceIds =
+    boundPlural ?? (trustedPlural ? plural : undefined);
+  const unboundedSingular =
+    singularInput === undefined
+      ? undefined
+      : normalizeSourceMessageId(singularInput);
+  const trustedSingularDuplicate =
+    singularInput !== undefined &&
+    typeof singularInput === 'string' &&
+    singularInput === unboundedSingular &&
+    trustedSingularSourceIds != null &&
+    trustedSingularSourceIds.length > 0 &&
+    trustedSingularSourceIds[trustedSingularSourceIds.length - 1] ===
+      singularInput;
+  if (singularInput !== undefined && !trustedSingularDuplicate) {
+    hasUntrustedSourceMetadata = true;
+    if (normalizeSourceMessageId(singularInput, true) == null) {
+      return undefined;
+    }
   }
-  appendSourceMessageId(result, seen, singularInput);
+
+  /** Any untrusted lineage field revokes the setter-only size exemption for
+   * every collection participating in the union. Preflight all public bounds
+   * before reading a part or plural element. */
+  if (hasUntrustedSourceMetadata) {
+    try {
+      if (
+        provenanceParts != null &&
+        provenanceParts.length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxParts
+      ) {
+        return undefined;
+      }
+      if (
+        plural != null &&
+        plural.length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds
+      ) {
+        return undefined;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+  const provenanceRequiresValidation =
+    !trustedProvenance || hasUntrustedSourceMetadata;
+  const pluralRequiresValidation = !trustedPlural || hasUntrustedSourceMetadata;
+
+  if (provenanceParts != null) {
+    const length = provenanceParts.length;
+    for (let index = 0; index < length; index++) {
+      if (
+        !appendSourceMessageId(
+          result,
+          seen,
+          provenanceParts[index].sourceMessageId,
+          provenanceRequiresValidation
+        )
+      ) {
+        return undefined;
+      }
+    }
+  }
+
+  try {
+    if (plural != null) {
+      const length = plural.length;
+      for (let index = 0; index < length; index++) {
+        if (
+          !appendSourceMessageId(
+            result,
+            seen,
+            plural[index],
+            pluralRequiresValidation
+          )
+        ) {
+          return undefined;
+        }
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  if (singularInput !== undefined) {
+    if (trustedSingularDuplicate) {
+      if (!seen.has(singularInput)) {
+        return undefined;
+      }
+    } else {
+      if (!appendSourceMessageId(result, seen, singularInput, true)) {
+        return undefined;
+      }
+    }
+  }
+  if (
+    hasUntrustedSourceMetadata &&
+    result.length > PROVIDER_MESSAGE_PROVENANCE_LIMITS.maxSourceMessageIds
+  ) {
+    return undefined;
+  }
+  return result;
+}
+
+function copyOwnEnumerableDataProperties(
+  input: object
+): Record<PropertyKey, unknown> {
+  if (isProxy(input)) {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
+  const result: Record<PropertyKey, unknown> = {};
+  const descriptors = Object.getOwnPropertyDescriptors(input);
+  for (const key of Reflect.ownKeys(descriptors)) {
+    const descriptor = Reflect.get(descriptors, key) as PropertyDescriptor;
+    if (descriptor.enumerable !== true) {
+      continue;
+    }
+    if (!('value' in descriptor)) {
+      throw new TypeError('Invalid provider message serialization kwargs');
+    }
+    Object.defineProperty(result, key, {
+      configurable: true,
+      enumerable: true,
+      value: descriptor.value,
+      writable: true,
+    });
+  }
   return result;
 }
 
@@ -281,10 +494,7 @@ export function getProviderMessageProvenance(
   message: BaseMessage
 ): ProviderMessageProvenance | undefined {
   const additionalKwargs = getUntrustedAdditionalKwargs(message);
-  const provenanceInput = readAdditionalKwarg(
-    additionalKwargs,
-    'provenance'
-  );
+  const provenanceInput = readAdditionalKwarg(additionalKwargs, 'provenance');
   return normalizeProviderMessageProvenance(provenanceInput);
 }
 
@@ -295,22 +505,18 @@ export function getProviderMessageProvenance(
  */
 export function getProviderSourceMessageIds(message: BaseMessage): string[] {
   const additionalKwargs = getUntrustedAdditionalKwargs(message);
-  const provenanceInput = readAdditionalKwarg(
-    additionalKwargs,
-    'provenance'
-  );
-  const pluralInput = readAdditionalKwarg(
-    additionalKwargs,
-    'sourceMessageIds'
-  );
+  const provenanceInput = readAdditionalKwarg(additionalKwargs, 'provenance');
+  const pluralInput = readAdditionalKwarg(additionalKwargs, 'sourceMessageIds');
   const singularInput = readAdditionalKwarg(
     additionalKwargs,
     'sourceMessageId'
   );
-  return collectProviderSourceMessageIds(
-    normalizeProviderMessageProvenance(provenanceInput),
-    pluralInput,
-    singularInput
+  return (
+    collectProviderSourceMessageIds(
+      normalizeProviderMessageProvenance(provenanceInput),
+      pluralInput,
+      singularInput
+    ) ?? []
   );
 }
 
@@ -319,6 +525,52 @@ export function setProviderMessageProvenance(
   message: BaseMessage,
   parts: readonly ProviderMessageProvenancePart[]
 ): void {
+  if (isProxy(message)) {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
+  const liveDescriptor = Object.getOwnPropertyDescriptor(
+    message,
+    'additional_kwargs'
+  );
+  const lcKwargsDescriptor = Object.getOwnPropertyDescriptor(
+    message,
+    'lc_kwargs'
+  );
+  if (
+    liveDescriptor == null ||
+    !('value' in liveDescriptor) ||
+    liveDescriptor.writable !== true ||
+    lcKwargsDescriptor == null ||
+    !('value' in lcKwargsDescriptor) ||
+    lcKwargsDescriptor.writable !== true
+  ) {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
+  const currentAdditionalKwargsInput: unknown = liveDescriptor.value;
+  if (
+    currentAdditionalKwargsInput == null ||
+    typeof currentAdditionalKwargsInput !== 'object'
+  ) {
+    throw new TypeError('Invalid provider message additional kwargs');
+  }
+  let replacement: UntrustedProviderMessageAdditionalKwargs;
+  try {
+    replacement = copyOwnEnumerableDataProperties(
+      currentAdditionalKwargsInput
+    ) as UntrustedProviderMessageAdditionalKwargs;
+  } catch {
+    throw new TypeError('Invalid provider message additional kwargs');
+  }
+  const lcKwargsInput: unknown = lcKwargsDescriptor.value;
+  if (lcKwargsInput == null || typeof lcKwargsInput !== 'object') {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
+  let serializedReplacement: Record<PropertyKey, unknown>;
+  try {
+    serializedReplacement = copyOwnEnumerableDataProperties(lcKwargsInput);
+  } catch {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
   const normalizedParts = normalizeProvenanceParts(parts);
   const provenance: ProviderMessageProvenance = Object.freeze({
     version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
@@ -330,23 +582,39 @@ export function setProviderMessageProvenance(
   for (const part of normalizedParts) {
     appendSourceMessageId(sourceMessageIds, seen, part.sourceMessageId);
   }
-  const currentAdditionalKwargs = getUntrustedAdditionalKwargs(message);
-  let replacement: UntrustedProviderMessageAdditionalKwargs;
-  try {
-    replacement = { ...(currentAdditionalKwargs ?? {}) };
-  } catch {
-    throw new TypeError('Invalid provider message additional kwargs');
-  }
   replacement.provenance = provenance;
   if (sourceMessageIds.length > 0) {
-    replacement.sourceMessageIds = Object.freeze(sourceMessageIds);
-    replacement.sourceMessageId =
-      sourceMessageIds[sourceMessageIds.length - 1];
+    const immutableSourceMessageIds = Object.freeze(sourceMessageIds);
+    immutableProviderSourceMessageIds.add(immutableSourceMessageIds);
+    immutableProviderMessageSourceIds.set(
+      provenance,
+      immutableSourceMessageIds
+    );
+    replacement.sourceMessageIds = immutableSourceMessageIds;
+    replacement.sourceMessageId = sourceMessageIds[sourceMessageIds.length - 1];
   } else {
     delete replacement.sourceMessageIds;
     delete replacement.sourceMessageId;
   }
-  message.additional_kwargs = replacement;
+  serializedReplacement.additional_kwargs = replacement;
+  try {
+    /** Both own data properties are prevalidated before one descriptor batch,
+     * so custom accessors cannot observe or create a split publication. */
+    Object.defineProperties(message, {
+      additional_kwargs: { ...liveDescriptor, value: replacement },
+      lc_kwargs: { ...lcKwargsDescriptor, value: serializedReplacement },
+    });
+  } catch {
+    throw new TypeError('Invalid provider message serialization kwargs');
+  }
+}
+
+/** Marks a provider-visible runtime message as host-generated context. */
+export function stampSyntheticProviderMessage<T extends BaseMessage>(
+  message: T
+): T {
+  setProviderMessageProvenance(message, [{ attribution: 'synthetic' }]);
+  return message;
 }
 
 /**
@@ -360,14 +628,8 @@ export function appendProviderMessageProvenance(
 ): void {
   let normalizedPart = normalizeProvenancePart(part);
   const additionalKwargs = getUntrustedAdditionalKwargs(message);
-  const provenanceInput = readAdditionalKwarg(
-    additionalKwargs,
-    'provenance'
-  );
-  const pluralInput = readAdditionalKwarg(
-    additionalKwargs,
-    'sourceMessageIds'
-  );
+  const provenanceInput = readAdditionalKwarg(additionalKwargs, 'provenance');
+  const pluralInput = readAdditionalKwarg(additionalKwargs, 'sourceMessageIds');
   const singularInput = readAdditionalKwarg(
     additionalKwargs,
     'sourceMessageId'
@@ -380,11 +642,9 @@ export function appendProviderMessageProvenance(
       representedSourceIds.add(existingPart.sourceMessageId);
     }
   }
-  const sourceMessageIds = collectProviderSourceMessageIds(
-    provenance,
-    pluralInput,
-    singularInput
-  );
+  const sourceMessageIds =
+    collectProviderSourceMessageIds(provenance, pluralInput, singularInput) ??
+    [];
   const missingLegacySourceIds = sourceMessageIds.filter(
     (sourceMessageId) => !representedSourceIds.has(sourceMessageId)
   );

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -43,6 +43,28 @@ function sumTokenCounts(
   return total;
 }
 
+function appendItems<T>(target: T[], source: readonly T[]): void {
+  for (const item of source) {
+    target.push(item);
+  }
+}
+
+/** Prepends in stable order without turning a large array into call arguments. */
+function prependItems<T>(target: T[], prefix: readonly T[]): void {
+  const prefixLength = prefix.length;
+  if (prefixLength === 0) {
+    return;
+  }
+  const originalLength = target.length;
+  target.length = prefixLength + originalLength;
+  for (let index = originalLength - 1; index >= 0; index--) {
+    target[prefixLength + index] = target[index];
+  }
+  for (let index = 0; index < prefixLength; index++) {
+    target[index] = prefix[index];
+  }
+}
+
 /** Default fraction of the token budget reserved as headroom (5 %). */
 export const DEFAULT_RESERVE_RATIO = 0.05;
 
@@ -953,7 +975,7 @@ export function getMessagesWithinTokenLimit({
   prunedMemory.reverse();
 
   if (messages.length > 0) {
-    prunedMemory.unshift(...messages);
+    prependItems(prunedMemory, messages);
   }
 
   remainingContextTokens -= currentTokenCount;
@@ -1070,7 +1092,6 @@ export function getMessagesWithinTokenLimit({
   if (startType != null && startType.length > 0 && newContext.length > 0) {
     let requiredTypeIndex = -1;
 
-    let totalTokens = 0;
     for (let i = newContext.length - 1; i >= 0; i--) {
       const currentType = newContext[i]?.getType() ?? '';
       if (
@@ -1081,12 +1102,9 @@ export function getMessagesWithinTokenLimit({
         requiredTypeIndex = i + 1;
         break;
       }
-      const originalIndex = originalLength - 1 - i;
-      totalTokens += indexTokenCountMap[originalIndex] ?? 0;
     }
 
     if (requiredTypeIndex > 0) {
-      currentTokenCount -= totalTokens;
       newContext = newContext.slice(0, requiredTypeIndex);
     }
   }
@@ -2753,7 +2771,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // tool results (otherwise the summary says "in progress" for a tool
     // call that already completed, causing the model to repeat it).
     if (droppedMessages.length > 0) {
-      messagesToRefine.push(...droppedMessages);
+      appendItems(messagesToRefine, droppedMessages);
     }
 
     // ---------------------------------------------------------------
@@ -2828,9 +2846,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       if (fadingRepaired.context.length > 0) {
         context = fadingRepaired.context;
         reclaimedTokens = fadingRepaired.reclaimedTokens;
-        messagesToRefine.push(...fadingRetry.messagesToRefine);
+        appendItems(messagesToRefine, fadingRetry.messagesToRefine);
         if (fadingRepaired.droppedMessages.length > 0) {
-          messagesToRefine.push(...fadingRepaired.droppedMessages);
+          appendItems(messagesToRefine, fadingRepaired.droppedMessages);
         }
 
         factoryParams.log?.('debug', 'Fallback fading recovered context', {
@@ -2964,9 +2982,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
 
         context = repaired.context;
         reclaimedTokens = repaired.reclaimedTokens;
-        messagesToRefine.push(...retryResult.messagesToRefine);
+        appendItems(messagesToRefine, retryResult.messagesToRefine);
         if (repaired.droppedMessages.length > 0) {
-          messagesToRefine.push(...repaired.droppedMessages);
+          appendItems(messagesToRefine, repaired.droppedMessages);
         }
 
         factoryParams.log?.('debug', 'Emergency truncation retry result', {

--- a/src/messages/toolResultTypes.test.ts
+++ b/src/messages/toolResultTypes.test.ts
@@ -1,0 +1,919 @@
+import type {
+  ProviderToolCallIndex,
+  ProviderToolCallPartDescriptor,
+} from './toolResultTypes';
+import {
+  PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS,
+  PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS,
+  PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES,
+  appendProviderToolCallDescriptor,
+  consumeProviderToolResultPair,
+  getBoundedProviderPairingArray,
+  getBoundedProviderPairingArrayProperty,
+  getProviderAIMessageToolCallDescriptor,
+  getProviderToolCallPartDescriptor,
+  getProviderToolResultPartDescriptor,
+  hasStructurallyValidAnthropicWebSearchResultContent,
+} from './toolResultTypes';
+
+describe('provider tool-result shape validation', () => {
+  it('rejects oversized nested arrays before reading an element', () => {
+    let reads = 0;
+    const content = new Array(PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES + 1);
+    Object.defineProperty(content, '0', {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return { type: 'text', text: 'attacker' };
+      },
+    });
+
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        is_error: false,
+        content,
+      })
+    ).toBeUndefined();
+    expect(reads).toBe(0);
+  });
+
+  it('treats nested output blocks as opaque without invoking accessors', () => {
+    let reads = 0;
+    const content: unknown[] = [];
+    Object.defineProperty(content, '0', {
+      configurable: true,
+      enumerable: true,
+      get: () => {
+        reads++;
+        return { type: 'text', text: 'attacker' };
+      },
+    });
+
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'tool_result',
+        tool_use_id: 'tool-call',
+        content,
+      })
+    ).toBeDefined();
+    expect(reads).toBe(0);
+  });
+
+  it('accepts a dense structurally valid nested array at the cap', () => {
+    const content = Array.from(
+      { length: PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES },
+      () => ({ type: 'text', text: 'ok' })
+    );
+
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        is_error: false,
+        content,
+      })
+    ).toMatchObject({ type: 'mcp_tool_result', toolCallId: 'mcp-call' });
+  });
+
+  it('accepts Anthropic MCP response text blocks with citations', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        is_error: false,
+        content: [{ type: 'text', text: 'found', citations: null }],
+      })
+    ).toMatchObject({ type: 'mcp_tool_result', toolCallId: 'mcp-call' });
+  });
+
+  it('requires the Anthropic MCP error flag to be present and boolean', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        content: 'safe',
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        is_error: 'false',
+        content: 'safe',
+      })
+    ).toBeUndefined();
+    for (const isError of [false, true]) {
+      expect(
+        getProviderToolResultPartDescriptor({
+          type: 'mcp_tool_result',
+          tool_use_id: 'mcp-call',
+          is_error: isError,
+          content: 'safe',
+        })
+      ).toMatchObject({ type: 'mcp_tool_result', toolCallId: 'mcp-call' });
+    }
+  });
+
+  it('requires the declared payload field on optional-output protocols', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'tool_result',
+        tool_use_id: 'tool-call',
+        text: 'attacker bytes',
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'mcp_tool_result',
+        tool_use_id: 'mcp-call',
+        is_error: false,
+        text: 'attacker bytes',
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'server_tool_result',
+        tool_call_id: 'server-call',
+        status: 'success',
+        text: 'attacker bytes',
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      type: 'tool_result',
+      tool_use_id: 'tool-call',
+      content: 'safe',
+      text: 'attacker bytes',
+    },
+    {
+      type: 'mcp_tool_result',
+      tool_use_id: 'mcp-call',
+      is_error: false,
+      content: 'safe',
+      text: 'attacker bytes',
+    },
+    {
+      type: 'server_tool_result',
+      tool_call_id: 'server-call',
+      status: 'success',
+      output: 'safe',
+      text: 'attacker bytes',
+    },
+    {
+      type: 'codeExecutionResult',
+      codeExecutionResult: {
+        outcome: 'OUTCOME_OK',
+        output: 'safe',
+        text: 'attacker bytes',
+      },
+    },
+    {
+      type: 'toolResult',
+      toolResult: {
+        toolUseId: 'bedrock-call',
+        content: [{ text: 'safe' }],
+        text: 'attacker bytes',
+      },
+    },
+  ])('rejects extra content-bearing fields in $type shapes', (part) => {
+    expect(getProviderToolResultPartDescriptor(part)).toBeUndefined();
+  });
+
+  it('never classifies top-level result leaves as tool-result envelopes', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'search_result',
+        source: 'https://example.com',
+        title: 'Result',
+        content: [{ type: 'text', text: 'bytes' }],
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'web_search_result',
+        url: 'https://example.com',
+        title: 'Result',
+        encrypted_content: 'ciphertext',
+      })
+    ).toBeUndefined();
+  });
+
+  it('rejects over-cap call ids, result ids, and tool names', () => {
+    const overCap = 'x'.repeat(PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS + 1);
+
+    expect(
+      getProviderToolCallPartDescriptor({
+        type: 'tool_use',
+        id: overCap,
+        name: 'lookup',
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolCallPartDescriptor({
+        type: 'tool_use',
+        id: 'tool-call',
+        name: overCap,
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'tool_result',
+        tool_use_id: overCap,
+        content: 'bytes',
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: 'nested LibreChat call',
+      call: {
+        type: 'tool_call',
+        tool_call: { id: 'call-id', name: 'lookup', args: {} },
+      },
+    },
+    {
+      label: 'Anthropic tool use',
+      call: {
+        type: 'tool_use',
+        id: 'call-id',
+        name: 'lookup',
+        input: {},
+      },
+    },
+    {
+      label: 'Anthropic server tool use',
+      call: {
+        type: 'server_tool_use',
+        id: 'call-id',
+        name: 'web_search',
+        input: {},
+      },
+    },
+    {
+      label: 'Anthropic MCP tool use',
+      call: {
+        type: 'mcp_tool_use',
+        id: 'call-id',
+        name: 'lookup',
+        input: {},
+        server_name: 'docs',
+      },
+    },
+    {
+      label: 'LangChain server call',
+      call: {
+        type: 'server_tool_call',
+        id: 'call-id',
+        name: 'lookup',
+        args: {},
+      },
+    },
+    {
+      label: 'Gemini call',
+      call: {
+        type: 'toolCall',
+        toolCall: { id: 'call-id', name: 'lookup', args: {} },
+      },
+    },
+    {
+      label: 'Bedrock call',
+      call: {
+        type: 'toolUse',
+        toolUse: {
+          toolUseId: 'call-id',
+          name: 'lookup',
+          input: {},
+        },
+      },
+    },
+  ])('requires the declared payload slot on $label', ({ call }) => {
+    expect(getProviderToolCallPartDescriptor(call)).toBeDefined();
+
+    const copy = structuredClone(call) as Record<string, unknown>;
+    let payload = copy;
+    if ('tool_call' in copy) {
+      payload = copy.tool_call as Record<string, unknown>;
+    } else if ('toolCall' in copy) {
+      payload = copy.toolCall as Record<string, unknown>;
+    } else if ('toolUse' in copy) {
+      payload = copy.toolUse as Record<string, unknown>;
+    }
+    let payloadKey = 'server_name';
+    if ('input' in payload) {
+      payloadKey = 'input';
+    } else if ('args' in payload) {
+      payloadKey = 'args';
+    }
+    delete payload[payloadKey];
+
+    expect(getProviderToolCallPartDescriptor(copy)).toBeUndefined();
+  });
+
+  it('rejects extra and accessor-backed call fields without invoking accessors', () => {
+    const extra = {
+      type: 'tool_use',
+      id: 'call-id',
+      name: 'lookup',
+      input: {},
+      text: 'attacker',
+    };
+    expect(getProviderToolCallPartDescriptor(extra)).toBeUndefined();
+
+    let reads = 0;
+    const accessor = {
+      type: 'tool_use',
+      id: 'call-id',
+      name: 'lookup',
+    };
+    Object.defineProperty(accessor, 'input', {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return {};
+      },
+    });
+    expect(getProviderToolCallPartDescriptor(accessor)).toBeUndefined();
+    expect(reads).toBe(0);
+  });
+
+  it('requires exact AI tool-call keys and arguments', () => {
+    expect(
+      getProviderAIMessageToolCallDescriptor({
+        id: 'call-id',
+        name: 'lookup',
+        args: {},
+        type: 'tool_call',
+      })
+    ).toBeDefined();
+    expect(
+      getProviderAIMessageToolCallDescriptor({
+        id: 'call-id',
+        name: 'lookup',
+        type: 'tool_call',
+      })
+    ).toBeUndefined();
+    expect(
+      getProviderAIMessageToolCallDescriptor({
+        id: 'call-id',
+        name: 'lookup',
+        args: {},
+        type: 'tool_call',
+        text: 'attacker',
+      })
+    ).toBeUndefined();
+  });
+
+  it('fails closed without throwing for revoked proxies', () => {
+    const record = Proxy.revocable({}, {});
+    const array = Proxy.revocable([], {});
+    record.revoke();
+    array.revoke();
+
+    expect(() => getProviderToolResultPartDescriptor(record.proxy)).not.toThrow();
+    expect(getProviderToolResultPartDescriptor(record.proxy)).toBeUndefined();
+    expect(() => getBoundedProviderPairingArray(array.proxy)).not.toThrow();
+    expect(getBoundedProviderPairingArray(array.proxy)).toBeUndefined();
+  });
+
+  it.each(['symbol', 'non-enumerable', 'inherited'] as const)(
+    'rejects %s fields hidden outside the exact result wrapper',
+    (kind) => {
+      const base = {
+        type: 'tool_result',
+        tool_use_id: 'tool-call',
+        content: 'safe',
+      };
+      let part: Record<PropertyKey, unknown>;
+      if (kind === 'inherited') {
+        part = Object.assign(Object.create({ text: 'attacker' }), base);
+      } else {
+        part = { ...base };
+        Object.defineProperty(
+          part,
+          kind === 'symbol' ? Symbol('attacker') : 'text',
+          { value: 'attacker', enumerable: kind === 'symbol' }
+        );
+      }
+
+      expect(getProviderToolResultPartDescriptor(part)).toBeUndefined();
+    }
+  );
+
+  it('accepts only installed Anthropic result callers', () => {
+    const result = (caller: Record<string, unknown>) => ({
+      type: 'web_search_tool_result',
+      tool_use_id: 'server-call',
+      caller,
+      content: [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'ciphertext',
+          title: 'Result',
+          url: 'https://example.com',
+        },
+      ],
+    });
+
+    expect(
+      getProviderToolResultPartDescriptor(result({ type: 'direct' }))
+    ).toBeDefined();
+    expect(
+      getProviderToolResultPartDescriptor(
+        result({ type: 'code_execution_20250825', tool_id: 'code-call' })
+      )
+    ).toBeDefined();
+    expect(
+      getProviderToolResultPartDescriptor(
+        result({ type: 'code_execution_20260120', tool_id: 'code-call' })
+      )
+    ).toBeDefined();
+    expect(
+      getProviderToolResultPartDescriptor(
+        result({ type: 'code_execution_20260521', tool_id: 'code-call' })
+      )
+    ).toBeUndefined();
+  });
+
+  it('rejects hidden fields in discriminated provider payload wrappers', () => {
+    const response = {
+      id: 'google-call',
+      name: 'lookup',
+      response: { output: 'safe' },
+    };
+    Object.defineProperty(response, 'text', {
+      value: 'attacker',
+      enumerable: false,
+    });
+
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'toolResponse',
+        toolResponse: response,
+      })
+    ).toBeUndefined();
+  });
+
+  it('requires one exact Gemini tool response variant', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'toolResponse',
+        toolResponse: {
+          id: 'google-call',
+          name: 'lookup',
+          response: { output: 'safe' },
+        },
+      })
+    ).toBeDefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'toolResponse',
+        toolResponse: {
+          id: 'google-call',
+          toolType: 'google_search',
+          result: { output: 'safe' },
+        },
+      })
+    ).toBeDefined();
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'toolResponse',
+        toolResponse: {
+          id: 'google-call',
+          name: 'lookup',
+          response: { output: 'safe' },
+          result: { output: 'attacker' },
+        },
+      })
+    ).toBeUndefined();
+  });
+
+  it('keeps Bedrock designated result blocks opaque', () => {
+    expect(
+      getProviderToolResultPartDescriptor({
+        type: 'toolResult',
+        toolResult: {
+          toolUseId: 'bedrock-call',
+          content: [{ $unknown: ['attacker', 'bytes'] }],
+        },
+      })
+    ).toBeDefined();
+  });
+
+  it('keeps deep web-search checks isolated to wire repair', () => {
+    const valid = {
+      type: 'web_search_tool_result',
+      tool_use_id: 'server-call',
+      content: [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'ciphertext',
+          title: 'Result',
+          url: 'https://example.com',
+        },
+      ],
+    };
+    expect(
+      hasStructurallyValidAnthropicWebSearchResultContent(valid)
+    ).toBe(true);
+    expect(
+      hasStructurallyValidAnthropicWebSearchResultContent({
+        ...valid,
+        content: [{ ...valid.content[0], text: 'unexpected wire field' }],
+      })
+    ).toBe(false);
+    expect(
+      getProviderToolResultPartDescriptor({
+        ...valid,
+        content: [{ ...valid.content[0], text: 'opaque tool output' }],
+      })
+    ).toBeDefined();
+  });
+
+  it('validates 4096 maximum nested outputs without walking their blocks', () => {
+    let reads = 0;
+    const content = new Array(PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES);
+    Object.defineProperty(content, '0', {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return { type: 'text', text: 'opaque' };
+      },
+    });
+    const startedAt = performance.now();
+    let validated = 0;
+    for (
+      let index = 0;
+      index < PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS;
+      index++
+    ) {
+      if (
+        getProviderToolResultPartDescriptor({
+          type: 'tool_result',
+          tool_use_id: `call-${index}`,
+          content,
+        }) != null
+      ) {
+        validated++;
+      }
+    }
+
+    expect(validated).toBe(PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS);
+    expect(reads).toBe(0);
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+  });
+});
+
+describe('provider tool-result pairing index', () => {
+  const call = (
+    sourceType: string,
+    name = 'lookup'
+  ): ProviderToolCallPartDescriptor => ({
+    callId: 'call-id',
+    kind: 'tool',
+    name,
+    sourceType,
+  });
+
+  const result = () => {
+    const descriptor = getProviderToolResultPartDescriptor({
+      type: 'tool_result',
+      tool_use_id: 'call-id',
+      content: 'bytes',
+    });
+    expect(descriptor).toBeDefined();
+    return descriptor!;
+  };
+
+  it('deduplicates identical dual representations and consumes once', () => {
+    const calls: ProviderToolCallIndex = new Map();
+    appendProviderToolCallDescriptor(calls, call('tool_call'));
+    appendProviderToolCallDescriptor(calls, call('ai_tool_calls'));
+
+    expect(calls.get('call-id')).not.toBeNull();
+    expect(consumeProviderToolResultPair(result(), calls)).toBe(true);
+    expect(consumeProviderToolResultPair(result(), calls)).toBe(false);
+  });
+
+  it('marks same-representation duplicates and conflicts ambiguous', () => {
+    const duplicateCalls: ProviderToolCallIndex = new Map();
+    appendProviderToolCallDescriptor(duplicateCalls, call('tool_call'));
+    for (let index = 0; index < 20_000; index++) {
+      appendProviderToolCallDescriptor(duplicateCalls, call('tool_call'));
+    }
+    expect(duplicateCalls.get('call-id')).toBeNull();
+    expect(consumeProviderToolResultPair(result(), duplicateCalls)).toBe(false);
+
+    const conflictingCalls: ProviderToolCallIndex = new Map();
+    appendProviderToolCallDescriptor(conflictingCalls, call('tool_call'));
+    appendProviderToolCallDescriptor(
+      conflictingCalls,
+      call('ai_tool_calls', 'different')
+    );
+    expect(conflictingCalls.get('call-id')).toBeNull();
+  });
+
+  it('pairs Anthropic server results only with the server protocol', () => {
+    const resultDescriptor = getProviderToolResultPartDescriptor({
+      type: 'web_search_tool_result',
+      tool_use_id: 'server-call',
+      content: [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'ciphertext',
+          title: 'Result',
+          url: 'https://example.com',
+        },
+      ],
+    });
+    expect(resultDescriptor).toBeDefined();
+
+    const anthropicCalls: ProviderToolCallIndex = new Map();
+    const anthropicCall = getProviderToolCallPartDescriptor({
+      type: 'server_tool_use',
+      id: 'server-call',
+      name: 'web_search',
+      input: {},
+      index: 0,
+    });
+    expect(anthropicCall?.kind).toBe('anthropic-server');
+    appendProviderToolCallDescriptor(anthropicCalls, anthropicCall!);
+    expect(
+      consumeProviderToolResultPair(resultDescriptor!, anthropicCalls)
+    ).toBe(true);
+
+    const langChainCalls: ProviderToolCallIndex = new Map();
+    const langChainCall = getProviderToolCallPartDescriptor({
+      type: 'server_tool_call',
+      id: 'server-call',
+      name: 'web_search',
+      args: {},
+    });
+    appendProviderToolCallDescriptor(langChainCalls, langChainCall!);
+    expect(
+      consumeProviderToolResultPair(resultDescriptor!, langChainCalls)
+    ).toBe(false);
+  });
+
+  it('canonicalizes indexed and dual Anthropic server-call representations', () => {
+    const callId = 'srvtoolu_server-call';
+    const resultDescriptor = getProviderToolResultPartDescriptor({
+      type: 'web_search_tool_result',
+      tool_use_id: callId,
+      content: [
+        {
+          type: 'web_search_result',
+          encrypted_content: 'ciphertext',
+          title: 'Result',
+          url: 'https://example.com',
+        },
+      ],
+    });
+    expect(resultDescriptor).toBeDefined();
+
+    const calls: ProviderToolCallIndex = new Map();
+    const nativeCall = getProviderToolCallPartDescriptor({
+      type: 'server_tool_use',
+      id: callId,
+      name: 'web_search',
+      input: {},
+      index: 3,
+    });
+    const genericCall = getProviderAIMessageToolCallDescriptor({
+      type: 'tool_call',
+      id: callId,
+      name: 'web_search',
+      args: {},
+    });
+    expect(nativeCall?.kind).toBe('anthropic-server');
+    expect(genericCall?.kind).toBe('anthropic-server');
+    appendProviderToolCallDescriptor(calls, nativeCall!);
+    appendProviderToolCallDescriptor(calls, genericCall!);
+    expect(calls.get(callId)).not.toBeNull();
+    expect(consumeProviderToolResultPair(resultDescriptor!, calls)).toBe(true);
+
+    const streamedCalls: ProviderToolCallIndex = new Map();
+    const streamedCall = getProviderToolCallPartDescriptor({
+      type: 'server_tool_call',
+      id: callId,
+      name: 'web_search',
+      args: {},
+      index: 3,
+    });
+    expect(streamedCall?.kind).toBe('anthropic-server');
+    appendProviderToolCallDescriptor(streamedCalls, streamedCall!);
+    expect(
+      consumeProviderToolResultPair(resultDescriptor!, streamedCalls)
+    ).toBe(true);
+  });
+
+  it('does not pair MCP results with an ordinary generic call', () => {
+    const resultDescriptor = getProviderToolResultPartDescriptor({
+      type: 'mcp_tool_result',
+      tool_use_id: 'mcp-call',
+      is_error: false,
+      content: 'found',
+    });
+    const calls: ProviderToolCallIndex = new Map();
+    const genericCall = getProviderAIMessageToolCallDescriptor({
+      type: 'tool_call',
+      id: 'mcp-call',
+      name: 'lookup',
+      args: {},
+    });
+    appendProviderToolCallDescriptor(calls, genericCall!);
+
+    expect(consumeProviderToolResultPair(resultDescriptor!, calls)).toBe(
+      false
+    );
+  });
+
+  it('stores the common call index without allocating per-call sets', () => {
+    const calls: ProviderToolCallIndex = new Map();
+    for (
+      let index = 0;
+      index < PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS;
+      index++
+    ) {
+      appendProviderToolCallDescriptor(calls, {
+        callId: `call-${index}`,
+        kind: 'tool',
+        name: 'lookup',
+        sourceType: 'tool_call',
+      });
+    }
+
+    expect(calls.size).toBe(PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS);
+    calls.forEach((entry) => {
+      expect(entry).not.toBeNull();
+      expect(entry).not.toHaveProperty('sourceTypes');
+      expect(entry).not.toHaveProperty('secondarySourceType');
+    });
+  });
+
+  it('handles a maximum mixed-provider pairing wave in bounded time', () => {
+    const cases = [
+      (id: string) => ({
+        call: { type: 'tool_use', id, name: 'lookup', input: {} },
+        result: { type: 'tool_result', tool_use_id: id, content: 'ok' },
+      }),
+      (id: string) => ({
+        call: {
+          type: 'server_tool_call',
+          id,
+          name: 'lookup',
+          args: {},
+        },
+        result: {
+          type: 'server_tool_call_result',
+          toolCallId: id,
+          status: 'success',
+          output: 'ok',
+        },
+      }),
+      (id: string) => ({
+        call: {
+          type: 'server_tool_use',
+          id,
+          name: 'web_search',
+          input: {},
+        },
+        result: {
+          type: 'web_search_tool_result',
+          tool_use_id: id,
+          content: [
+            {
+              type: 'web_search_result',
+              encrypted_content: 'ciphertext',
+              title: 'Result',
+              url: 'https://example.com',
+            },
+          ],
+        },
+      }),
+      (id: string) => ({
+        call: {
+          type: 'mcp_tool_use',
+          id,
+          name: 'lookup',
+          input: {},
+          server_name: 'docs',
+        },
+        result: {
+          type: 'mcp_tool_result',
+          tool_use_id: id,
+          is_error: false,
+          content: 'ok',
+        },
+      }),
+      (id: string) => ({
+        call: {
+          type: 'toolCall',
+          toolCall: { id, name: 'google_search', args: {} },
+        },
+        result: {
+          type: 'toolResponse',
+          toolResponse: {
+            id,
+            name: 'google_search',
+            response: { output: 'ok' },
+          },
+        },
+      }),
+      (id: string) => ({
+        call: {
+          type: 'toolUse',
+          toolUse: { toolUseId: id, name: 'lookup', input: {} },
+        },
+        result: {
+          type: 'toolResult',
+          toolResult: { toolUseId: id, content: [{ text: 'ok' }] },
+        },
+      }),
+    ];
+    const calls: ProviderToolCallIndex = new Map();
+    const iterations = Math.floor(
+      PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS / cases.length
+    );
+    let consumed = 0;
+    const startedAt = performance.now();
+    for (let iteration = 0; iteration < iterations; iteration++) {
+      for (let caseIndex = 0; caseIndex < cases.length; caseIndex++) {
+        const id =
+          caseIndex === 2
+            ? `srvtoolu_${iteration}-${caseIndex}`
+            : `call-${iteration}-${caseIndex}`;
+        const { call, result } = cases[caseIndex](id);
+        const callDescriptor = getProviderToolCallPartDescriptor(call);
+        const resultDescriptor = getProviderToolResultPartDescriptor(result);
+        if (callDescriptor != null && resultDescriptor != null) {
+          appendProviderToolCallDescriptor(calls, callDescriptor);
+          if (consumeProviderToolResultPair(resultDescriptor, calls)) {
+            consumed++;
+          }
+        }
+      }
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(consumed).toBe(iterations * cases.length);
+    expect(calls.size).toBe(0);
+    expect(elapsedMs).toBeLessThan(5_000);
+  });
+
+  it('bounds outer pairing scans without allocating a copy', () => {
+    const atCap = Array.from(
+      { length: PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS },
+      () => ({ type: 'text', text: 'ok' })
+    );
+    expect(getBoundedProviderPairingArray(atCap)).toBe(atCap);
+
+    let reads = 0;
+    const oversized = new Array(PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS + 1);
+    Object.defineProperty(oversized, '0', {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return {};
+      },
+    });
+    expect(getBoundedProviderPairingArray(oversized)).toBeUndefined();
+    expect(reads).toBe(0);
+  });
+
+  it('never invokes a custom iterator on a validated zero-copy array', () => {
+    let iteratorReads = 0;
+    const content = [{ type: 'text', text: 'safe' }];
+    Object.defineProperty(content, Symbol.iterator, {
+      configurable: true,
+      get: () => {
+        iteratorReads++;
+        return Array.prototype[Symbol.iterator];
+      },
+    });
+
+    expect(getBoundedProviderPairingArray(content)).toBe(content);
+    expect(iteratorReads).toBe(0);
+  });
+
+  it('rejects unsafe outer properties without invoking accessors', () => {
+    let reads = 0;
+    const message = {};
+    Object.defineProperty(message, 'content', {
+      enumerable: true,
+      get: () => {
+        reads++;
+        return [];
+      },
+    });
+
+    expect(
+      getBoundedProviderPairingArrayProperty(message, 'content')
+    ).toBeUndefined();
+    expect(reads).toBe(0);
+  });
+});

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1,33 +1,1174 @@
-/** Provider/SDK block types whose payload bytes are tool-produced. Keep this
- * explicit: suffix matching would let untrusted content invent tool authority. */
-const PROVIDER_TOOL_RESULT_TYPES: ReadonlySet<string> = new Set([
-  'advisor_tool_result',
-  'bash_code_execution_tool_result',
-  'codeExecutionResult',
-  'code_execution_tool_result',
-  'mcp_tool_result',
-  'search_result',
-  'server_tool_call_result',
-  'server_tool_result',
-  'text_editor_code_execution_tool_result',
-  'tool_result',
-  'tool_search_tool_result',
-  'toolResponse',
-  'toolResult',
-  'web_fetch_tool_result',
-  'web_search_result',
-  'web_search_tool_result',
-]);
+import { isProxy } from 'node:util/types';
 
-export function isProviderToolResultType(type: unknown): boolean {
-  return typeof type === 'string' && PROVIDER_TOOL_RESULT_TYPES.has(type);
+export type ProviderToolCallKind =
+  | 'tool'
+  | 'server'
+  | 'anthropic-server'
+  | 'mcp'
+  | 'google'
+  | 'bedrock';
+
+export interface ProviderToolCallPartDescriptor {
+  readonly callId: string;
+  readonly kind: ProviderToolCallKind;
+  readonly name?: string;
+  readonly sourceType: string;
 }
 
-export function isProviderToolResultPart(part: unknown): boolean {
+export interface ProviderToolResultPartDescriptor {
+  readonly type: string;
+  readonly compatibleCallKinds: readonly ProviderToolCallKind[];
+  readonly toolCallId?: string;
+  readonly expectedToolNames?: readonly string[];
+  readonly requiresPreviousExecutableCode?: boolean;
+  readonly allowHumanMessagePairing?: boolean;
+}
+
+export interface ProviderToolCallIndexEntry {
+  readonly descriptor: ProviderToolCallPartDescriptor;
+  secondarySourceType?: string;
+}
+
+export type ProviderToolCallIndex = Map<
+  string,
+  ProviderToolCallIndexEntry | null
+>;
+
+type DataProperty =
+  | { readonly found: true; readonly value: unknown }
+  | { readonly found: false };
+
+interface ValidationBudget {
+  remaining: number;
+}
+
+export const PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES = 256;
+export const PROVIDER_TOOL_RESULT_MAX_VALIDATION_ENTRIES = 4096;
+export const PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS = 512;
+export const PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS = 4096;
+
+const TOOL_CALL_KINDS = ['tool'] as const;
+const SERVER_CALL_KINDS = ['server'] as const;
+const ANTHROPIC_SERVER_CALL_KINDS = ['anthropic-server'] as const;
+const MCP_CALL_KINDS = ['mcp'] as const;
+const GOOGLE_CALL_KINDS = ['google'] as const;
+const BEDROCK_CALL_KINDS = ['bedrock', 'tool'] as const;
+
+const ADVISOR_TOOL_NAMES = ['advisor'] as const;
+const BASH_TOOL_NAMES = ['bash_code_execution'] as const;
+const CODE_EXECUTION_TOOL_NAMES = ['code_execution'] as const;
+const TEXT_EDITOR_TOOL_NAMES = ['text_editor_code_execution'] as const;
+const TOOL_SEARCH_TOOL_NAMES = [
+  'tool_search_tool_regex',
+  'tool_search_tool_bm25',
+] as const;
+const WEB_FETCH_TOOL_NAMES = ['web_fetch'] as const;
+const WEB_SEARCH_TOOL_NAMES = ['web_search'] as const;
+const ANTHROPIC_SERVER_TOOL_ID_PREFIX = 'srvtoolu_';
+
+function stringSet(values: readonly string[]): ReadonlySet<string> {
+  return new Set(values);
+}
+
+const GOOGLE_CODE_EXECUTION_OUTCOMES = stringSet([
+  'OUTCOME_DEADLINE_EXCEEDED',
+  'OUTCOME_FAILED',
+  'OUTCOME_OK',
+  'OUTCOME_UNSPECIFIED',
+  'outcome_deadline_exceeded',
+  'outcome_failed',
+  'outcome_ok',
+  'outcome_unspecified',
+]);
+const PROVIDER_TOOL_CALL_KINDS = stringSet([
+  'anthropic-server',
+  'bedrock',
+  'google',
+  'mcp',
+  'server',
+  'tool',
+]);
+const ANTHROPIC_SERVER_TOOL_NAMES = stringSet([
+  ...ADVISOR_TOOL_NAMES,
+  ...BASH_TOOL_NAMES,
+  ...CODE_EXECUTION_TOOL_NAMES,
+  ...TEXT_EDITOR_TOOL_NAMES,
+  ...TOOL_SEARCH_TOOL_NAMES,
+  ...WEB_FETCH_TOOL_NAMES,
+  ...WEB_SEARCH_TOOL_NAMES,
+]);
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value == null || typeof value !== 'object') {
+    return undefined;
+  }
+  try {
+    if (isProxy(value) || Array.isArray(value)) {
+      return undefined;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null
+      ? (value as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPropertyContainer(
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (value == null || typeof value !== 'object') {
+    return undefined;
+  }
+  try {
+    return !isProxy(value) && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getArray(value: unknown): readonly unknown[] | undefined {
+  if (value == null || typeof value !== 'object') {
+    return undefined;
+  }
+  try {
+    return !isProxy(value) && Array.isArray(value)
+      ? (value as readonly unknown[])
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readDataProperty(
+  record: Record<string, unknown>,
+  key: string
+): DataProperty {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (
+      descriptor == null ||
+      descriptor.enumerable !== true ||
+      !('value' in descriptor)
+    ) {
+      return { found: false };
+    }
+    return { found: true, value: descriptor.value };
+  } catch {
+    return { found: false };
+  }
+}
+
+function hasOnlyOwnDataProperties(
+  record: Record<string, unknown>,
+  allowed: readonly string[]
+): boolean {
+  try {
+    const keys = Reflect.ownKeys(record);
+    if (keys.length > allowed.length) {
+      return false;
+    }
+    for (let index = 0; index < keys.length; index++) {
+      const key = keys[index];
+      if (typeof key !== 'string' || !allowed.includes(key)) {
+        return false;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (
+        descriptor == null ||
+        descriptor.enumerable !== true ||
+        !('value' in descriptor)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getBoundedDataArray(
+  value: unknown,
+  maxEntries: number,
+  budget?: ValidationBudget
+): readonly unknown[] | undefined {
+  const array = getArray(value);
+  if (
+    array == null ||
+    array.length > maxEntries ||
+    (budget != null && array.length > budget.remaining)
+  ) {
+    return undefined;
+  }
+  if (budget != null) {
+    budget.remaining -= array.length;
+  }
+  for (let index = 0; index < array.length; index++) {
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(array, String(index));
+    } catch {
+      return undefined;
+    }
+    if (
+      descriptor == null ||
+      descriptor.enumerable !== true ||
+      !('value' in descriptor)
+    ) {
+      return undefined;
+    }
+  }
+  return array;
+}
+
+export function getBoundedProviderPairingArray(
+  value: unknown
+): readonly unknown[] | undefined {
+  return getBoundedDataArray(value, PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS);
+}
+
+export function getBoundedProviderPairingArrayProperty(
+  value: unknown,
+  key: string
+): readonly unknown[] | undefined {
+  const record = getPropertyContainer(value);
+  if (record == null) {
+    return undefined;
+  }
+  const property = readDataProperty(record, key);
+  return property.found
+    ? getBoundedProviderPairingArray(property.value)
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+  allowEmpty = false
+): string | undefined {
+  const property = readDataProperty(record, key);
+  return property.found &&
+    typeof property.value === 'string' &&
+    (allowEmpty || property.value.length > 0)
+    ? property.value
+    : undefined;
+}
+
+export function isBoundedProviderPairingString(
+  value: unknown,
+  allowEmpty = false
+): value is string {
   return (
-    part != null &&
-    typeof part === 'object' &&
-    'type' in part &&
-    isProviderToolResultType(part.type)
+    typeof value === 'string' &&
+    (allowEmpty || value.length > 0) &&
+    value.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
   );
+}
+
+function readPairingString(
+  record: Record<string, unknown>,
+  key: string,
+  allowEmpty = false
+): string | undefined {
+  const property = readDataProperty(record, key);
+  return property.found &&
+    isBoundedProviderPairingString(property.value, allowEmpty)
+    ? property.value
+    : undefined;
+}
+
+function hasRequiredDataProperties(
+  record: Record<string, unknown>,
+  keys: readonly string[] | undefined
+): boolean {
+  if (keys == null) {
+    return true;
+  }
+  for (let index = 0; index < keys.length; index++) {
+    const property = readDataProperty(record, keys[index]);
+    if (!property.found || property.value === undefined) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hasOptionalNullableString(
+  record: Record<string, unknown>,
+  key: string
+): boolean {
+  const property = readDataProperty(record, key);
+  return (
+    !property.found ||
+    property.value === null ||
+    typeof property.value === 'string'
+  );
+}
+
+function isCacheControl(value: unknown): boolean {
+  if (value == null) {
+    return true;
+  }
+  const record = getRecord(value);
+  if (
+    record == null ||
+    !hasOnlyOwnDataProperties(record, ['type', 'ttl']) ||
+    readString(record, 'type') !== 'ephemeral'
+  ) {
+    return false;
+  }
+  const ttl = readDataProperty(record, 'ttl');
+  return (
+    !ttl.found ||
+    ttl.value === null ||
+    ttl.value === '5m' ||
+    ttl.value === '1h'
+  );
+}
+
+function hasValidCacheControlProperty(
+  record: Record<string, unknown>
+): boolean {
+  const property = readDataProperty(record, 'cache_control');
+  return !property.found || isCacheControl(property.value);
+}
+
+function isServerToolCaller(value: unknown): boolean {
+  const record = getRecord(value);
+  if (record == null) {
+    return false;
+  }
+  const type = readString(record, 'type');
+  if (type === 'direct') {
+    return hasOnlyOwnDataProperties(record, ['type']);
+  }
+  return (
+    (type === 'code_execution_20250825' ||
+      type === 'code_execution_20260120') &&
+    hasOnlyOwnDataProperties(record, ['type', 'tool_id']) &&
+    readPairingString(record, 'tool_id') != null
+  );
+}
+
+function hasValidCallerProperty(record: Record<string, unknown>): boolean {
+  const property = readDataProperty(record, 'caller');
+  return !property.found || isServerToolCaller(property.value);
+}
+
+function hasValidProviderMetadata(
+  record: Record<string, unknown>
+): boolean {
+  const id = readDataProperty(record, 'id');
+  if (id.found && !isBoundedProviderPairingString(id.value)) {
+    return false;
+  }
+  const agentId = readDataProperty(record, 'agentId');
+  if (agentId.found && !isBoundedProviderPairingString(agentId.value)) {
+    return false;
+  }
+  const index = readDataProperty(record, 'index');
+  if (
+    index.found &&
+    !(
+      (typeof index.value === 'number' && Number.isSafeInteger(index.value)) ||
+      isBoundedProviderPairingString(index.value)
+    )
+  ) {
+    return false;
+  }
+  const groupId = readDataProperty(record, 'groupId');
+  if (
+    groupId.found &&
+    !(typeof groupId.value === 'number' && Number.isFinite(groupId.value))
+  ) {
+    return false;
+  }
+  const thought = readDataProperty(record, 'thought');
+  if (thought.found && typeof thought.value !== 'boolean') {
+    return false;
+  }
+  const signature = readDataProperty(record, 'thoughtSignature');
+  return (
+    !signature.found ||
+    isBoundedProviderPairingString(signature.value, true)
+  );
+}
+
+const ANTHROPIC_STRUCTURED_RESULT_TOOL_NAMES: Readonly<
+  Partial<Record<string, readonly string[]>>
+> = {
+  advisor_tool_result: ADVISOR_TOOL_NAMES,
+  bash_code_execution_tool_result: BASH_TOOL_NAMES,
+  code_execution_tool_result: CODE_EXECUTION_TOOL_NAMES,
+  text_editor_code_execution_tool_result: TEXT_EDITOR_TOOL_NAMES,
+  tool_search_tool_result: TOOL_SEARCH_TOOL_NAMES,
+  web_fetch_tool_result: WEB_FETCH_TOOL_NAMES,
+};
+
+/** Designated provider output is opaque once its exact envelope and matching
+ * call establish authorship. Only its container size/proxy identity is read;
+ * nested values are deliberately not walked on the formatting hot path. */
+function isOpaqueBoundedArray(value: unknown): boolean {
+  const array = getArray(value);
+  return (
+    array != null && array.length <= PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES
+  );
+}
+
+function isOpaqueStringOrBoundedArray(value: unknown): boolean {
+  return typeof value === 'string' || isOpaqueBoundedArray(value);
+}
+
+function isWebSearchResult(value: unknown): boolean {
+  const record = getRecord(value);
+  return (
+    record != null &&
+    hasOnlyOwnDataProperties(record, [
+      'type',
+      'encrypted_content',
+      'title',
+      'url',
+      'page_age',
+    ]) &&
+    readString(record, 'type') === 'web_search_result' &&
+    readString(record, 'encrypted_content', true) != null &&
+    readString(record, 'title', true) != null &&
+    readString(record, 'url') != null &&
+    hasOptionalNullableString(record, 'page_age')
+  );
+}
+
+function isWireWebSearchContent(
+  value: unknown,
+  budget: ValidationBudget
+): boolean {
+  const error = getRecord(value);
+  if (error != null) {
+    return (
+      hasOnlyOwnDataProperties(error, ['type', 'error_code']) &&
+      readString(error, 'type') === 'web_search_tool_result_error' &&
+      readString(error, 'error_code') != null
+    );
+  }
+  const results = getBoundedDataArray(
+    value,
+    PROVIDER_TOOL_RESULT_MAX_ARRAY_ENTRIES,
+    budget
+  );
+  if (results == null) {
+    return false;
+  }
+  for (let index = 0; index < results.length; index++) {
+    if (!isWebSearchResult(results[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function hasStructurallyValidAnthropicWebSearchResultContent(
+  part: unknown
+): boolean {
+  const record = getRecord(part);
+  if (record == null || readPairingString(record, 'tool_use_id') == null) {
+    return false;
+  }
+  const content = readDataProperty(record, 'content');
+  return (
+    content.found &&
+    isWireWebSearchContent(content.value, {
+      remaining: PROVIDER_TOOL_RESULT_MAX_VALIDATION_ENTRIES,
+    })
+  );
+}
+
+function isGoogleCodeExecutionResult(
+  record: Record<string, unknown>
+): boolean {
+  const nested = readDataProperty(record, 'codeExecutionResult');
+  const result = nested.found ? getRecord(nested.value) : undefined;
+  const outcome = result == null ? undefined : readString(result, 'outcome');
+  return (
+    result != null &&
+    hasOnlyOwnDataProperties(result, ['outcome', 'output']) &&
+    outcome != null &&
+    GOOGLE_CODE_EXECUTION_OUTCOMES.has(outcome) &&
+    readString(result, 'output', true) != null
+  );
+}
+
+function getGoogleToolResponseDescriptor(
+  record: Record<string, unknown>,
+  type: string
+): ProviderToolResultPartDescriptor | undefined {
+  const nested = readDataProperty(record, 'toolResponse');
+  const response = nested.found ? getRecord(nested.value) : undefined;
+  if (response == null) {
+    return undefined;
+  }
+  const toolCallId = readPairingString(response, 'id');
+  const responsePayload = readDataProperty(response, 'response');
+  const resultPayload = readDataProperty(response, 'result');
+  if (toolCallId == null) {
+    return undefined;
+  }
+  if (
+    responsePayload.found &&
+    responsePayload.value !== undefined &&
+    !resultPayload.found &&
+    hasOnlyOwnDataProperties(response, ['id', 'name', 'response'])
+  ) {
+    const name = readPairingString(response, 'name');
+    return name == null
+      ? undefined
+      : {
+        type,
+        toolCallId,
+        compatibleCallKinds: GOOGLE_CALL_KINDS,
+        expectedToolNames: [name],
+      };
+  }
+  if (
+    resultPayload.found &&
+    resultPayload.value !== undefined &&
+    !responsePayload.found &&
+    hasOnlyOwnDataProperties(response, ['id', 'toolType', 'result']) &&
+    readPairingString(response, 'toolType') != null
+  ) {
+    return { type, toolCallId, compatibleCallKinds: GOOGLE_CALL_KINDS };
+  }
+  return undefined;
+}
+
+function getBedrockDescriptor(
+  record: Record<string, unknown>,
+  type: string
+): ProviderToolResultPartDescriptor | undefined {
+  const nested = readDataProperty(record, 'toolResult');
+  const result = nested.found ? getRecord(nested.value) : undefined;
+  if (
+    result == null ||
+    !hasOnlyOwnDataProperties(result, [
+      'toolUseId',
+      'content',
+      'status',
+      'type',
+    ])
+  ) {
+    return undefined;
+  }
+  const toolCallId = readPairingString(result, 'toolUseId');
+  const content = readDataProperty(result, 'content');
+  const status = readDataProperty(result, 'status');
+  const nestedType = readDataProperty(result, 'type');
+  if (
+    toolCallId == null ||
+    !content.found ||
+    !isOpaqueBoundedArray(content.value) ||
+    (status.found && status.value !== 'success' && status.value !== 'error') ||
+    (nestedType.found && typeof nestedType.value !== 'string')
+  ) {
+    return undefined;
+  }
+  return {
+    type,
+    toolCallId,
+    compatibleCallKinds: BEDROCK_CALL_KINDS,
+    allowHumanMessagePairing: true,
+  };
+}
+
+const ANTHROPIC_RESULT_FIELDS = [
+  'type',
+  'tool_use_id',
+  'content',
+  'cache_control',
+] as const;
+const ANTHROPIC_GENERIC_RESULT_FIELDS = [
+  ...ANTHROPIC_RESULT_FIELDS,
+  'is_error',
+] as const;
+const ANTHROPIC_SERVER_RESULT_FIELDS = [
+  ...ANTHROPIC_RESULT_FIELDS,
+  'caller',
+] as const;
+const LOCAL_RESULT_METADATA_FIELDS = [
+  'id',
+  'index',
+  'agentId',
+  'groupId',
+] as const;
+const TOOL_RESULT_ENVELOPE_FIELDS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  advisor_tool_result: ANTHROPIC_RESULT_FIELDS,
+  bash_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+  code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+  mcp_tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
+  text_editor_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+  tool_search_tool_result: ANTHROPIC_RESULT_FIELDS,
+  tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
+  web_fetch_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
+  web_search_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
+  server_tool_call_result: [
+    'type',
+    'toolCallId',
+    'status',
+    'output',
+    ...LOCAL_RESULT_METADATA_FIELDS,
+  ],
+  server_tool_result: [
+    'type',
+    'tool_call_id',
+    'status',
+    'output',
+    ...LOCAL_RESULT_METADATA_FIELDS,
+  ],
+  codeExecutionResult: [
+    'type',
+    'codeExecutionResult',
+    'agentId',
+    'groupId',
+  ],
+  toolResponse: [
+    'type',
+    'toolResponse',
+    'thought',
+    'thoughtSignature',
+    'agentId',
+    'groupId',
+  ],
+  toolResult: ['type', 'toolResult', 'agentId', 'groupId'],
+};
+
+function anthropicDescriptor(
+  record: Record<string, unknown>,
+  type: string,
+  expectedToolNames: readonly string[]
+): ProviderToolResultPartDescriptor | undefined {
+  const toolCallId = readPairingString(record, 'tool_use_id');
+  const content = readDataProperty(record, 'content');
+  return toolCallId != null &&
+    content.found &&
+    getRecord(content.value) != null
+    ? {
+      type,
+      toolCallId,
+      compatibleCallKinds: ANTHROPIC_SERVER_CALL_KINDS,
+      expectedToolNames,
+    }
+    : undefined;
+}
+
+export function getProviderToolResultPartDescriptor(
+  part: unknown
+): ProviderToolResultPartDescriptor | undefined {
+  const record = getRecord(part);
+  if (record == null) {
+    return undefined;
+  }
+  const type = readString(record, 'type');
+  const allowedFields = type == null ? undefined : TOOL_RESULT_ENVELOPE_FIELDS[type];
+  if (
+    type == null ||
+    allowedFields == null ||
+    !hasOnlyOwnDataProperties(record, allowedFields) ||
+    !hasValidProviderMetadata(record) ||
+    !hasValidCacheControlProperty(record) ||
+    !hasValidCallerProperty(record)
+  ) {
+    return undefined;
+  }
+  const structuredToolNames = ANTHROPIC_STRUCTURED_RESULT_TOOL_NAMES[type];
+  if (structuredToolNames != null) {
+    return anthropicDescriptor(
+      record,
+      type,
+      structuredToolNames
+    );
+  }
+  if (type === 'web_search_tool_result') {
+    const toolCallId = readPairingString(record, 'tool_use_id');
+    const content = readDataProperty(record, 'content');
+    return toolCallId != null &&
+      content.found &&
+      (getRecord(content.value) != null ||
+        isOpaqueBoundedArray(content.value))
+      ? {
+        type,
+        toolCallId,
+        compatibleCallKinds: ANTHROPIC_SERVER_CALL_KINDS,
+        expectedToolNames: WEB_SEARCH_TOOL_NAMES,
+      }
+      : undefined;
+  }
+  if (type === 'mcp_tool_result') {
+    const toolCallId = readPairingString(record, 'tool_use_id');
+    const content = readDataProperty(record, 'content');
+    const isError = readDataProperty(record, 'is_error');
+    return toolCallId != null &&
+      content.found &&
+      isOpaqueStringOrBoundedArray(content.value) &&
+      isError.found &&
+      typeof isError.value === 'boolean'
+      ? { type, toolCallId, compatibleCallKinds: MCP_CALL_KINDS }
+      : undefined;
+  }
+  if (type === 'server_tool_call_result' || type === 'server_tool_result') {
+    const toolCallId = readPairingString(
+      record,
+      type === 'server_tool_call_result' ? 'toolCallId' : 'tool_call_id'
+    );
+    const status = readString(record, 'status');
+    const output = readDataProperty(record, 'output');
+    return toolCallId != null &&
+      (status === 'success' || status === 'error') &&
+      output.found &&
+      output.value !== undefined
+      ? { type, toolCallId, compatibleCallKinds: SERVER_CALL_KINDS }
+      : undefined;
+  }
+  if (type === 'codeExecutionResult') {
+    return isGoogleCodeExecutionResult(record)
+      ? {
+        type,
+        compatibleCallKinds: GOOGLE_CALL_KINDS,
+        requiresPreviousExecutableCode: true,
+      }
+      : undefined;
+  }
+  if (type === 'toolResponse') {
+    return getGoogleToolResponseDescriptor(record, type);
+  }
+  if (type === 'toolResult') {
+    return getBedrockDescriptor(record, type);
+  }
+  if (type === 'tool_result') {
+    const toolCallId = readPairingString(record, 'tool_use_id');
+    const content = readDataProperty(record, 'content');
+    const isError = readDataProperty(record, 'is_error');
+    return toolCallId != null &&
+      content.found &&
+      isOpaqueStringOrBoundedArray(content.value) &&
+      (!isError.found || typeof isError.value === 'boolean')
+      ? {
+        type,
+        toolCallId,
+        compatibleCallKinds: TOOL_CALL_KINDS,
+        allowHumanMessagePairing: true,
+      }
+      : undefined;
+  }
+  return undefined;
+}
+
+function optionalName(
+  record: Record<string, unknown>
+): { readonly name?: string } | undefined {
+  const property = readDataProperty(record, 'name');
+  if (!property.found || property.value === undefined) {
+    return {};
+  }
+  return isBoundedProviderPairingString(property.value)
+    ? { name: property.value }
+    : undefined;
+}
+
+function hasExactCallShape(
+  record: Record<string, unknown>,
+  fields: readonly string[],
+  required: readonly string[]
+): boolean {
+  return (
+    hasOnlyOwnDataProperties(record, fields) &&
+    hasRequiredDataProperties(record, required) &&
+    hasValidProviderMetadata(record)
+  );
+}
+
+function hasOptionalCallType(
+  record: Record<string, unknown>,
+  expected: string
+): boolean {
+  const type = readDataProperty(record, 'type');
+  return !type.found || type.value === expected;
+}
+
+function isAnthropicServerToolCall(
+  callId: string,
+  name: string | undefined
+): boolean {
+  return (
+    callId.startsWith(ANTHROPIC_SERVER_TOOL_ID_PREFIX) &&
+    name != null &&
+    ANTHROPIC_SERVER_TOOL_NAMES.has(name)
+  );
+}
+
+function getAnthropicCallKind(
+  type: 'tool_use' | 'server_tool_use' | 'mcp_tool_use',
+  callId: string,
+  name: string | undefined
+): ProviderToolCallKind {
+  if (type === 'mcp_tool_use') {
+    return 'mcp';
+  }
+  if (
+    type === 'server_tool_use' ||
+    isAnthropicServerToolCall(callId, name)
+  ) {
+    return 'anthropic-server';
+  }
+  return 'tool';
+}
+
+const AI_TOOL_CALL_FIELDS = ['type', 'id', 'name', 'args'] as const;
+const LOCAL_CALL_METADATA_FIELDS = ['agentId', 'groupId'] as const;
+const STANDARD_CALL_FIELDS = [
+  'type',
+  'id',
+  'name',
+  'args',
+  'index',
+  ...LOCAL_CALL_METADATA_FIELDS,
+] as const;
+const LIBRECHAT_CALL_FIELDS = [
+  'type',
+  'id',
+  'name',
+  'args',
+  'output',
+  'outcome',
+  'auth',
+  'expires_at',
+] as const;
+const ANTHROPIC_CALL_FIELDS = [
+  'type',
+  'id',
+  'name',
+  'input',
+  'caller',
+  'cache_control',
+  'index',
+  ...LOCAL_CALL_METADATA_FIELDS,
+] as const;
+const ANTHROPIC_MCP_CALL_FIELDS = [
+  'type',
+  'id',
+  'name',
+  'input',
+  'server_name',
+  'cache_control',
+  'index',
+  ...LOCAL_CALL_METADATA_FIELDS,
+] as const;
+const GOOGLE_CALL_FIELDS = [
+  'type',
+  'toolCall',
+  'thought',
+  'thoughtSignature',
+  ...LOCAL_CALL_METADATA_FIELDS,
+] as const;
+
+export function getProviderAIMessageToolCallDescriptor(
+  toolCall: unknown
+): ProviderToolCallPartDescriptor | undefined {
+  const record = getRecord(toolCall);
+  if (
+    record == null ||
+    !hasExactCallShape(
+      record,
+      AI_TOOL_CALL_FIELDS,
+      ['id', 'name', 'args']
+    ) ||
+    !hasOptionalCallType(record, 'tool_call')
+  ) {
+    return undefined;
+  }
+  const callId = readPairingString(record, 'id');
+  const name = optionalName(record);
+  return callId == null || name == null
+    ? undefined
+    : {
+      callId,
+      kind: isAnthropicServerToolCall(callId, name.name)
+        ? 'anthropic-server'
+        : 'tool',
+      sourceType: 'ai_tool_calls',
+      ...name,
+    };
+}
+
+export function getProviderToolCallPartDescriptor(
+  part: unknown
+): ProviderToolCallPartDescriptor | undefined {
+  const record = getRecord(part);
+  if (record == null) {
+    return undefined;
+  }
+  const type = readString(record, 'type');
+  if (type === 'tool_call') {
+    const nested = readDataProperty(record, 'tool_call');
+    const call = nested.found ? getRecord(nested.value) : record;
+    const outerIsValid = nested.found
+      ? hasExactCallShape(
+        record,
+        ['type', 'tool_call', 'agentId', 'groupId'],
+        ['tool_call']
+      )
+      : hasExactCallShape(
+        record,
+        STANDARD_CALL_FIELDS,
+        ['id', 'name', 'args']
+      );
+    const callIsValid = nested.found
+      ? call != null &&
+        hasExactCallShape(
+          call,
+          LIBRECHAT_CALL_FIELDS,
+          ['id', 'name', 'args']
+        ) &&
+        hasOptionalCallType(call, 'tool_call')
+      : call != null;
+    if (!outerIsValid || !callIsValid) {
+      return undefined;
+    }
+    const callId = call == null ? undefined : readPairingString(call, 'id');
+    const name = call == null ? undefined : optionalName(call);
+    return callId == null || name == null
+      ? undefined
+      : {
+        callId,
+        kind: isAnthropicServerToolCall(callId, name.name)
+          ? 'anthropic-server'
+          : 'tool',
+        sourceType: type,
+        ...name,
+      };
+  }
+  if (
+    type === 'tool_use' ||
+    type === 'server_tool_use' ||
+    type === 'mcp_tool_use'
+  ) {
+    const fields =
+      type === 'mcp_tool_use'
+        ? ANTHROPIC_MCP_CALL_FIELDS
+        : ANTHROPIC_CALL_FIELDS;
+    const required =
+      type === 'mcp_tool_use'
+        ? ['id', 'name', 'input', 'server_name']
+        : ['id', 'name', 'input'];
+    if (
+      !hasExactCallShape(record, fields, required) ||
+      !hasValidCacheControlProperty(record) ||
+      !hasValidCallerProperty(record) ||
+      (type === 'mcp_tool_use' &&
+        readPairingString(record, 'server_name') == null)
+    ) {
+      return undefined;
+    }
+    const callId = readPairingString(record, 'id');
+    const name = optionalName(record);
+    if (
+      type === 'server_tool_use' &&
+      (name?.name == null || !ANTHROPIC_SERVER_TOOL_NAMES.has(name.name))
+    ) {
+      return undefined;
+    }
+    return callId == null || name == null
+      ? undefined
+      : {
+        callId,
+        kind: getAnthropicCallKind(type, callId, name.name),
+        sourceType: type,
+        ...name,
+      };
+  }
+  if (type === 'server_tool_call') {
+    if (
+      !hasExactCallShape(
+        record,
+        STANDARD_CALL_FIELDS,
+        ['id', 'name', 'args']
+      )
+    ) {
+      return undefined;
+    }
+    const callId = readPairingString(record, 'id');
+    const name = optionalName(record);
+    return callId == null || name == null
+      ? undefined
+      : {
+        callId,
+        kind: isAnthropicServerToolCall(callId, name.name)
+          ? 'anthropic-server'
+          : 'server',
+        sourceType: type,
+        ...name,
+      };
+  }
+  if (type === 'toolCall' || type === 'toolUse') {
+    const outerFields =
+      type === 'toolCall'
+        ? GOOGLE_CALL_FIELDS
+        : ['type', 'toolUse', 'agentId', 'groupId'];
+    if (
+      !hasExactCallShape(record, outerFields, [type]) ||
+      !hasValidProviderMetadata(record)
+    ) {
+      return undefined;
+    }
+    const nested = readDataProperty(record, type);
+    const call = nested.found ? getRecord(nested.value) : undefined;
+    if (call == null) {
+      return undefined;
+    }
+    if (type === 'toolCall') {
+      const isNamedVariant = hasExactCallShape(
+        call,
+        ['id', 'name', 'args'],
+        ['id', 'name', 'args']
+      );
+      const isTypedVariant = hasExactCallShape(
+        call,
+        ['id', 'toolType', 'args'],
+        ['id', 'toolType', 'args']
+      );
+      if (
+        (!isNamedVariant && !isTypedVariant) ||
+        (isTypedVariant && readPairingString(call, 'toolType') == null)
+      ) {
+        return undefined;
+      }
+    } else {
+      const nestedType = readDataProperty(call, 'type');
+      if (
+        !hasExactCallShape(
+          call,
+          ['toolUseId', 'name', 'input', 'type'],
+          ['toolUseId', 'name', 'input']
+        ) ||
+        (nestedType.found && typeof nestedType.value !== 'string')
+      ) {
+        return undefined;
+      }
+    }
+    const callId = readPairingString(
+      call,
+      type === 'toolCall' ? 'id' : 'toolUseId'
+    );
+    const name = optionalName(call);
+    return callId == null || name == null
+      ? undefined
+      : {
+        callId,
+        kind: type === 'toolCall' ? 'google' : 'bedrock',
+        sourceType: type,
+        ...name,
+      };
+  }
+  return undefined;
+}
+
+export function appendProviderToolCallDescriptor(
+  index: ProviderToolCallIndex,
+  descriptor: ProviderToolCallPartDescriptor
+): void {
+  if (
+    !PROVIDER_TOOL_CALL_KINDS.has(descriptor.kind) ||
+    !isBoundedProviderPairingString(descriptor.callId) ||
+    !isBoundedProviderPairingString(descriptor.sourceType) ||
+    (descriptor.name != null &&
+      !isBoundedProviderPairingString(descriptor.name))
+  ) {
+    return;
+  }
+  const existing = index.get(descriptor.callId);
+  if (existing === undefined) {
+    if (index.size >= PROVIDER_TOOL_PAIRING_MAX_OUTER_PARTS) {
+      return;
+    }
+    index.set(descriptor.callId, { descriptor });
+    return;
+  }
+  if (existing === null) {
+    return;
+  }
+  const isDualRepresentation =
+    existing.secondarySourceType == null &&
+    existing.descriptor.sourceType !== descriptor.sourceType &&
+    (existing.descriptor.sourceType === 'ai_tool_calls' ||
+      descriptor.sourceType === 'ai_tool_calls');
+  if (
+    existing.descriptor.kind === descriptor.kind &&
+    existing.descriptor.name === descriptor.name &&
+    isDualRepresentation
+  ) {
+    existing.secondarySourceType = descriptor.sourceType;
+    return;
+  }
+  index.set(descriptor.callId, null);
+}
+
+function isExecutableCodePart(part: unknown): boolean {
+  const record = getRecord(part);
+  if (
+    record == null ||
+    readString(record, 'type') !== 'executableCode' ||
+    !hasOnlyOwnDataProperties(record, [
+      'type',
+      'executableCode',
+      'agentId',
+      'groupId',
+    ]) ||
+    !hasValidProviderMetadata(record)
+  ) {
+    return false;
+  }
+  const nested = readDataProperty(record, 'executableCode');
+  const executable = nested.found ? getRecord(nested.value) : undefined;
+  return (
+    executable != null &&
+    hasOnlyOwnDataProperties(executable, ['language', 'code']) &&
+    readString(executable, 'language') != null &&
+    readString(executable, 'code', true) != null
+  );
+}
+
+export function consumeProviderToolResultPair(
+  descriptor: ProviderToolResultPartDescriptor,
+  calls: ProviderToolCallIndex,
+  previousPart?: unknown
+): boolean {
+  if (descriptor.requiresPreviousExecutableCode === true) {
+    return isExecutableCodePart(previousPart);
+  }
+  if (
+    descriptor.toolCallId == null ||
+    !isBoundedProviderPairingString(descriptor.toolCallId)
+  ) {
+    return false;
+  }
+  const entry = calls.get(descriptor.toolCallId);
+  if (entry == null) {
+    return false;
+  }
+  const candidate = entry.descriptor;
+  if (!descriptor.compatibleCallKinds.includes(candidate.kind)) {
+    return false;
+  }
+  if (
+    descriptor.expectedToolNames != null &&
+    (candidate.name == null ||
+      !descriptor.expectedToolNames.includes(candidate.name))
+  ) {
+    return false;
+  }
+  calls.delete(descriptor.toolCallId);
+  return true;
 }

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1,0 +1,33 @@
+/** Provider/SDK block types whose payload bytes are tool-produced. Keep this
+ * explicit: suffix matching would let untrusted content invent tool authority. */
+const PROVIDER_TOOL_RESULT_TYPES: ReadonlySet<string> = new Set([
+  'advisor_tool_result',
+  'bash_code_execution_tool_result',
+  'codeExecutionResult',
+  'code_execution_tool_result',
+  'mcp_tool_result',
+  'search_result',
+  'server_tool_call_result',
+  'server_tool_result',
+  'text_editor_code_execution_tool_result',
+  'tool_result',
+  'tool_search_tool_result',
+  'toolResponse',
+  'toolResult',
+  'web_fetch_tool_result',
+  'web_search_result',
+  'web_search_tool_result',
+]);
+
+export function isProviderToolResultType(type: unknown): boolean {
+  return typeof type === 'string' && PROVIDER_TOOL_RESULT_TYPES.has(type);
+}
+
+export function isProviderToolResultPart(part: unknown): boolean {
+  return (
+    part != null &&
+    typeof part === 'object' &&
+    'type' in part &&
+    isProviderToolResultType(part.type)
+  );
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -93,6 +93,7 @@ import {
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
+import { stampSyntheticProviderMessage } from '@/messages/provenance';
 import { initializeLangfuseTracing } from './instrumentation';
 import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
@@ -699,10 +700,12 @@ export class Run<_T extends t.BaseGraphState> {
        * it into the agent's `instructions` config instead.
        */
       stateInputs.messages.push(
-        new HumanMessage({
-          content: preStreamContexts.join('\n\n'),
-          additional_kwargs: { role: 'system', source: 'hook' },
-        })
+        stampSyntheticProviderMessage(
+          new HumanMessage({
+            content: preStreamContexts.join('\n\n'),
+            additional_kwargs: { role: 'system', source: 'hook' },
+          })
+        )
       );
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -62,7 +62,6 @@ import {
   SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_REPLAY_CONTROLLER,
 } from '@/tools/subagent/SubagentReplay';
-import { attachRunStepResumeState } from '@/tools/runStepResume';
 import {
   INTENT_ARG,
   readOutcomeFields,
@@ -97,6 +96,7 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
+import { attachRunStepResumeState } from '@/tools/runStepResume';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
  * hosts spread `configurable` into their own run configs. */
@@ -110,6 +110,7 @@ function stripRunBreakerScope(
   return rest;
 }
 import { convertInjectedMessages } from '@/messages/injected';
+import { stampSyntheticProviderMessage } from '@/messages/provenance';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { RunnableCallable, composeAbortSignals } from '@/utils';
 import {
@@ -3927,10 +3928,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * a user message; `role` is metadata only.
        */
       injected.push(
-        new HumanMessage({
-          content: batchAdditionalContexts.join('\n\n'),
-          additional_kwargs: { role: 'system', source: 'hook' },
-        })
+        stampSyntheticProviderMessage(
+          new HumanMessage({
+            content: batchAdditionalContexts.join('\n\n'),
+            additional_kwargs: { role: 'system', source: 'hook' },
+          })
+        )
       );
     }
 
@@ -4423,13 +4426,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         directAdditionalContexts.length > 0
           ? [
             sendOutput,
-            new HumanMessage({
-              content: directAdditionalContexts.join('\n\n'),
-              // Match the event-driven path's marker so hosts /
-              // model-side annotators treat this as system intent
-              // rather than ordinary user text. Codex P2 [46].
-              additional_kwargs: { role: 'system', source: 'hook' },
-            }),
+            stampSyntheticProviderMessage(
+              new HumanMessage({
+                content: directAdditionalContexts.join('\n\n'),
+                // Match the event-driven path's marker so hosts /
+                // model-side annotators treat this as system intent
+                // rather than ordinary user text. Codex P2 [46].
+                additional_kwargs: { role: 'system', source: 'hook' },
+              })
+            ),
           ]
           : [sendOutput];
       await this.handleRunToolCompletions(
@@ -4721,14 +4726,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directInjected: BaseMessage[] =
           directAdditionalContexts.length > 0
             ? [
-              new HumanMessage({
-                content: directAdditionalContexts.join('\n\n'),
-                // System-role metadata to match the event-driven
-                // path so policy/recovery guidance is treated
-                // consistently regardless of whether the tool ran
-                // direct or dispatched. Codex P2 [46].
-                additional_kwargs: { role: 'system', source: 'hook' },
-              }),
+              stampSyntheticProviderMessage(
+                new HumanMessage({
+                  content: directAdditionalContexts.join('\n\n'),
+                  // System-role metadata to match the event-driven
+                  // path so policy/recovery guidance is treated
+                  // consistently regardless of whether the tool ran
+                  // direct or dispatched. Codex P2 [46].
+                  additional_kwargs: { role: 'system', source: 'hook' },
+                })
+              ),
             ]
             : [];
         outputs = [
@@ -4782,13 +4789,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               ...promotedPrefix,
               ...toolOutputs,
               ...invalidCallResults,
-              new HumanMessage({
-                content: directAdditionalContexts.join('\n\n'),
-                // Same system-role marker the event-driven path
-                // uses so direct vs dispatched is invisible to
-                // downstream consumers. Codex P2 [46].
-                additional_kwargs: { role: 'system', source: 'hook' },
-              }),
+              stampSyntheticProviderMessage(
+                new HumanMessage({
+                  content: directAdditionalContexts.join('\n\n'),
+                  // Same system-role marker the event-driven path
+                  // uses so direct vs dispatched is invisible to
+                  // downstream consumers. Codex P2 [46].
+                  additional_kwargs: { role: 'system', source: 'hook' },
+                })
+              ),
             ]
             : [...promotedPrefix, ...toolOutputs, ...invalidCallResults];
       }

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -21,6 +21,7 @@ import {
 } from 'fs/promises';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { WorkspaceFS } from '../local/workspaceFS';
 import type * as t from '@/types';
 import {
   executeLocalBash,
@@ -37,9 +38,9 @@ import {
   _resetSyntaxCheckProbeCacheForTests,
 } from '../local/syntaxCheck';
 import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
-import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
-import type { WorkspaceFS } from '../local/workspaceFS';
 import { LocalFileCheckpointerImpl } from '../local/FileCheckpointer';
+import { getProviderMessageProvenance } from '@/messages/provenance';
+import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { createCompileCheckTool } from '../local/CompileCheckTool';
 import { runBashAstChecks } from '../local/bashAst';
 import { Constants, Providers } from '@/common';
@@ -2467,6 +2468,9 @@ describe('comprehensive review (round 14) — Codex P1 #37 + P2 #38/#40/#41', ()
           m.content.includes('SEND-CTX')
       );
       expect(found).toBeDefined();
+      expect(getProviderMessageProvenance(found!)?.parts).toEqual([
+        { attribution: 'synthetic' },
+      ]);
     });
   });
 
@@ -2576,6 +2580,9 @@ describe('comprehensive review (round 14) — Codex P1 #37 + P2 #38/#40/#41', ()
         role: 'system',
         source: 'hook',
       });
+      expect(getProviderMessageProvenance(human!)?.parts).toEqual([
+        { attribution: 'synthetic' },
+      ]);
     });
   });
 

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -33,6 +33,7 @@ import type {
 } from '@/hooks';
 import type * as t from '@/types';
 import { Constants, Providers as providers, GraphEvents } from '@/common';
+import { getProviderMessageProvenance } from '@/messages/provenance';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
@@ -1147,10 +1148,8 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       ],
     };
     const getState = jest.fn(
-      async (
-        _config: RunnableConfig,
-        _options?: { subgraphs?: boolean }
-      ) => persistedState
+      async (_config: RunnableConfig, _options?: { subgraphs?: boolean }) =>
+        persistedState
     );
     run.graphRunnable = { getState } as unknown as t.CompiledStateWorkflow;
     const processSpy = jest
@@ -1667,6 +1666,59 @@ describe('ToolNode HITL — additionalContext injection from hooks', () => {
     );
     expect(injected).toBeUndefined();
   });
+
+  it('marks mixed direct/event batch context as synthetic provenance', async () => {
+    mockEventDispatch([
+      { toolCallId: 'event_1', content: 'host-result', status: 'success' },
+    ]);
+    const direct = tool(async () => 'direct-result', {
+      name: 'direct_echo',
+      description: 'direct echo',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => ({
+          decision: 'allow',
+          ...(input.toolName === 'direct_echo' && {
+            additionalContext: 'direct policy context',
+          }),
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools: [direct, createSchemaStub('event_echo')],
+      eventDrivenMode: true,
+      directToolNames: new Set(['direct_echo']),
+      agentId: 'agent-x',
+      toolCallStepIds: new Map([
+        ['direct_1', 'step_direct_1'],
+        ['event_1', 'step_event_1'],
+      ]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: false },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'direct_1', name: 'direct_echo', args: { command: 'a' } },
+      { id: 'event_1', name: 'event_echo', args: { command: 'b' } },
+    ]);
+
+    const result = (await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: 'mixed-context-thread' } }
+    )) as { messages: BaseMessage[] };
+    const context = result.messages.find(
+      (message) =>
+        message.getType() === 'human' &&
+        String(message.content).includes('direct policy context')
+    );
+
+    expect(context).toBeDefined();
+    expect(getProviderMessageProvenance(context!)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
+  });
 });
 
 describe('ToolNode HITL — PostToolBatch hook', () => {
@@ -1777,6 +1829,9 @@ describe('ToolNode HITL — PostToolBatch hook', () => {
     );
     expect(injected).toBeDefined();
     expect(String(injected!.content)).toContain('format the response as JSON');
+    expect(getProviderMessageProvenance(injected!)?.parts).toEqual([
+      { attribution: 'synthetic' },
+    ]);
   });
 
   it('PostToolBatch injectedMessages land as individual HumanMessages after the consolidated context', async () => {
@@ -1944,6 +1999,55 @@ describe('Run — preventContinuation honored for pre-stream hooks', () => {
   });
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('marks consolidated pre-stream hook context as synthetic provenance', async () => {
+    const { Run } = await import('@/run');
+    const { Providers } = await import('@/common');
+    const { HumanMessage: HM } = await import('@langchain/core/messages');
+    const registry = new HookRegistry();
+    registry.register('RunStart', {
+      hooks: [
+        async (): Promise<RunStartHookOutput> => ({
+          additionalContext: 'runtime policy context',
+        }),
+      ],
+    });
+    const run = await Run.create<t.IState>({
+      runId: 'prestream-provenance',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: Providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: false },
+    });
+    const stateInputs = {
+      messages: [new HM('hello')],
+    } as t.IState;
+    const halted = await (
+      run as unknown as {
+        runPreStreamHooks: (
+          state: t.IState,
+          threadId: string,
+          config: Record<string, unknown>
+        ) => Promise<boolean>;
+      }
+    ).runPreStreamHooks(stateInputs, 'prestream-thread', {});
+
+    expect(halted).toBe(false);
+    expect(stateInputs.messages).toHaveLength(2);
+    expect(
+      getProviderMessageProvenance(stateInputs.messages[1])?.parts
+    ).toEqual([{ attribution: 'synthetic' }]);
   });
 
   it('returns undefined without invoking the graph when RunStart hook returns preventContinuation', async () => {

--- a/src/utils/toolContent.ts
+++ b/src/utils/toolContent.ts
@@ -1818,7 +1818,7 @@ function classifyToolContentBlock(
     }
   }
   const remaining = { value: MAX_ATOMIC_VALIDATION_WORK };
-  let kind = TOOL_BLOCK_OPAQUE;
+  let kind: number;
   try {
     if (
       hasUnsafeCallableToJSON(
@@ -2701,7 +2701,7 @@ export function cloneToolMessageWithContent(
     status: message.status,
     artifact,
     metadata: message.metadata,
-    additional_kwargs: message.additional_kwargs,
+    additional_kwargs: { ...message.additional_kwargs },
     response_metadata: message.response_metadata,
   });
 }


### PR DESCRIPTION
## Summary

I added an additive, versioned provider-message provenance contract so downstream consumers can distinguish user-, model-, tool-, and synthetic-authored provider-visible content without changing existing message shapes. Final hardening is in `fc2194d8`.

- Export stable provenance types, trust bounds, tri-state inspection, getters, setters, and append helpers.
- Preserve ordered source message IDs and content-part indices through formatting, coalescing, artifact projection, tool folding, injected context, graph handoffs, and filtered multi-agent handoffs.
- Require bijective content-part mappings before using projected indices, preserving conservative attribution for duplicate, missing, and out-of-range mappings while supporting valid reordered mappings.
- Preserve legacy lineage through derived messages, default unstamped human content to user attribution, honor typed synthetic metadata, and propagate malformed provenance as a canonical invalid marker.
- Attribute folded tool labels as synthetic while retaining the original model-, tool-, user-, or system-derived attribution of payload bytes.
- Require strict provider-specific call/result envelopes and one-to-one protocol pairing before granting tool attribution.
- Stamp direct hook context, handoff cues, routing prompts, tool-to-assistant bridges, and computer-screenshot omission markers as synthetic.
- Synchronize immutable provenance into live and serialized LangChain kwargs with fail-closed proxy, accessor, sparse-array, and mixed-trust handling.
- Keep high-cardinality formatting linear and avoid unbounded call-argument spreads or nested tool-output walks.
- Complement [LibreChat PR #14425](https://github.com/danny-avila/LibreChat/pull/14425), which consumes this typed provenance for source-aware content protection.
- Keep the package at `3.6.9`; this additive API is intended for the next patch release and is not published by this PR.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Passed all 13 CI checks on exact head `fc2194d8`, including four unit shards, lint, typecheck, circular dependencies, integration, and four summarization providers.
- Passed the final local regression matrix: 11 suites, 508 passed, 1 skipped; TypeScript, targeted ESLint, import ordering, circular-dependency analysis, and diff checks also passed.
- Passed an independent exact-head audit: 6 suites, 361 passed, 1 skipped; TypeScript, targeted ESLint, exact/full diff inspection, and an adversarial duplicate-mapping reproduction passed with no actionable findings.
- Received a clean Codex review of exact commit `fc2194d8` and resolved every prior review thread.
- Reduced the 4,096-result × 256-block adversarial validation case from approximately 186ms to 2.6–3.4ms while performing zero nested payload reads.
- Covered 150,000-part formatter, coalescer, artifact, and fold boundaries without truncation, mutation, or call-stack overflow.

Reproduce the focused checks with:

```sh
npx jest \
  src/messages/provenance.test.ts \
  src/messages/toolResultTypes.test.ts \
  src/messages/formatAgentMessages.test.ts \
  src/messages/cache.tail.test.ts \
  src/graphs/__tests__/MultiAgentGraph.test.ts \
  src/graphs/__tests__/composition.smoke.test.ts \
  src/graphs/__tests__/agent-handoffs.test.ts \
  --runInBand

npx tsc --noEmit --pretty false
npm run check:circular-deps
```

### Test Configuration

- Node.js: `24.16.0`
- npm: `11.16.0`
- Platform: macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
