### PR TITLE
fix: default missing Responses API annotations to [] before stream conversion

### DIFF
--- a/src/llm/openai/annotations.spec.ts
+++ b/src/llm/openai/annotations.spec.ts
@@ -1,0 +1,84 @@
+import type { OpenAIClient } from '@langchain/openai';
+
+import { ensureResponsesOutputAnnotations } from './index';
+
+/**
+ * Regression coverage for a crash against OpenAI-compatible Responses API
+ * gateways (e.g. the Codex backend used by the SDT deployment) whose terminal
+ * `response.completed` events omit the `annotations` field on `output_text`
+ * content parts. LangChain's responses converter maps over the field
+ * unconditionally, so a missing field threw "Cannot read properties of
+ * undefined (reading 'map')" on every streamed completion from such a server.
+ */
+describe('missing annotations on terminal responses events', () => {
+  it('defaults annotations to [] on output_text parts without the field', () => {
+    const event = {
+      type: 'response.completed',
+      response: {
+        id: 'resp_test',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Hello' }],
+          },
+        ],
+      },
+    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+
+    ensureResponsesOutputAnnotations(event);
+
+    const part = (event as unknown as {
+      response: { output: Array<{ content: Array<{ annotations?: unknown }> }> };
+    }).response.output[0].content[0];
+    expect(part.annotations).toEqual([]);
+  });
+
+  it('leaves existing annotations untouched', () => {
+    const event = {
+      type: 'response.completed',
+      response: {
+        id: 'resp_test',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'Hello',
+                annotations: [{ type: 'url_citation', url: 'https://example.com' }],
+              },
+            ],
+          },
+        ],
+      },
+    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+
+    ensureResponsesOutputAnnotations(event);
+
+    const part = (event as unknown as {
+      response: { output: Array<{ content: Array<{ annotations: unknown }> }> };
+    }).response.output[0].content[0];
+    expect(part.annotations).toEqual([
+      { type: 'url_citation', url: 'https://example.com' },
+    ]);
+  });
+
+  it('does not throw on non-terminal or non-message events', () => {
+    const textDelta = {
+      type: 'response.output_text.delta',
+      delta: 'Hi',
+    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+    const toolCall = {
+      type: 'response.completed',
+      response: {
+        id: 'resp_test',
+        output: [{ type: 'function_call', call_id: 'call_1', name: 'f', arguments: '{}' }],
+      },
+    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+
+    expect(() => ensureResponsesOutputAnnotations(textDelta)).not.toThrow();
+    expect(() => ensureResponsesOutputAnnotations(toolCall)).not.toThrow();
+  });
+});

--- a/src/llm/openai/annotations.test.ts
+++ b/src/llm/openai/annotations.test.ts
@@ -1,6 +1,8 @@
-import type { OpenAIClient } from '@langchain/openai';
-
 import { ensureResponsesOutputAnnotations } from './index';
+
+type ResponsesAnnotationsBoundaryEvent = Parameters<
+  typeof ensureResponsesOutputAnnotations
+>[0];
 
 /**
  * Regression coverage for a crash against OpenAI-compatible Responses API
@@ -12,71 +14,60 @@ import { ensureResponsesOutputAnnotations } from './index';
  */
 describe('missing annotations on terminal responses events', () => {
   it('defaults annotations to [] on output_text parts without the field', () => {
-    const event = {
+    const event: ResponsesAnnotationsBoundaryEvent = {
       type: 'response.completed',
       response: {
-        id: 'resp_test',
         output: [
           {
             type: 'message',
-            role: 'assistant',
-            content: [{ type: 'output_text', text: 'Hello' }],
+            content: [{ type: 'output_text' }],
           },
         ],
       },
-    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+    };
 
     ensureResponsesOutputAnnotations(event);
 
-    const part = (event as unknown as {
-      response: { output: Array<{ content: Array<{ annotations?: unknown }> }> };
-    }).response.output[0].content[0];
-    expect(part.annotations).toEqual([]);
+    const part = event.response?.output?.[0]?.content?.[0];
+    expect(part?.annotations).toEqual([]);
   });
 
   it('leaves existing annotations untouched', () => {
-    const event = {
+    const event: ResponsesAnnotationsBoundaryEvent = {
       type: 'response.completed',
       response: {
-        id: 'resp_test',
         output: [
           {
             type: 'message',
-            role: 'assistant',
             content: [
               {
                 type: 'output_text',
-                text: 'Hello',
                 annotations: [{ type: 'url_citation', url: 'https://example.com' }],
               },
             ],
           },
         ],
       },
-    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+    };
 
     ensureResponsesOutputAnnotations(event);
 
-    const part = (event as unknown as {
-      response: { output: Array<{ content: Array<{ annotations: unknown }> }> };
-    }).response.output[0].content[0];
-    expect(part.annotations).toEqual([
+    const part = event.response?.output?.[0]?.content?.[0];
+    expect(part?.annotations).toEqual([
       { type: 'url_citation', url: 'https://example.com' },
     ]);
   });
 
   it('does not throw on non-terminal or non-message events', () => {
-    const textDelta = {
+    const textDelta: ResponsesAnnotationsBoundaryEvent = {
       type: 'response.output_text.delta',
-      delta: 'Hi',
-    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
-    const toolCall = {
+    };
+    const toolCall: ResponsesAnnotationsBoundaryEvent = {
       type: 'response.completed',
       response: {
-        id: 'resp_test',
-        output: [{ type: 'function_call', call_id: 'call_1', name: 'f', arguments: '{}' }],
+        output: [{ type: 'function_call' }],
       },
-    } as unknown as OpenAIClient.Responses.ResponseStreamEvent;
+    };
 
     expect(() => ensureResponsesOutputAnnotations(textDelta)).not.toThrow();
     expect(() => ensureResponsesOutputAnnotations(toolCall)).not.toThrow();

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -919,6 +919,19 @@ function attachResponsesReplayPosition(
   chunk.message.lc_kwargs.additional_kwargs = additionalKwargs;
 }
 
+type ResponsesAnnotationsBoundaryEvent = {
+  type: OpenAIClient.Responses.ResponseStreamEvent['type'];
+  response?: {
+    output?: Array<{
+      type: string;
+      content?: Array<{
+        type: string;
+        annotations?: object[] | null;
+      }>;
+    }>;
+  };
+};
+
 /**
  * The Responses API spec declares `annotations` required on `output_text`
  * content parts, but some OpenAI-compatible gateways omit the field on the
@@ -927,17 +940,17 @@ function attachResponsesReplayPosition(
  * field crashes the whole stream. Default it to `[]` before conversion.
  */
 export function ensureResponsesOutputAnnotations(
-  event: OpenAIClient.Responses.ResponseStreamEvent
+  event: ResponsesAnnotationsBoundaryEvent
 ): void {
   if (event.type !== 'response.completed' && event.type !== 'response.incomplete') {
     return;
   }
-  const output = event.response.output;
+  const output = event.response?.output;
   if (!Array.isArray(output)) {
     return;
   }
   for (const item of output) {
-    if (item.type !== 'message') {
+    if (item.type !== 'message' || !Array.isArray(item.content)) {
       continue;
     }
     for (const part of item.content) {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -919,6 +919,35 @@ function attachResponsesReplayPosition(
   chunk.message.lc_kwargs.additional_kwargs = additionalKwargs;
 }
 
+/**
+ * The Responses API spec declares `annotations` required on `output_text`
+ * content parts, but some OpenAI-compatible gateways omit the field on the
+ * terminal `response.completed`/`response.incomplete` events. LangChain's
+ * converter calls `part.annotations.map(...)` unconditionally, so a missing
+ * field crashes the whole stream. Default it to `[]` before conversion.
+ */
+export function ensureResponsesOutputAnnotations(
+  event: OpenAIClient.Responses.ResponseStreamEvent
+): void {
+  if (event.type !== 'response.completed' && event.type !== 'response.incomplete') {
+    return;
+  }
+  const output = event.response.output;
+  if (!Array.isArray(output)) {
+    return;
+  }
+  for (const item of output) {
+    if (item.type !== 'message') {
+      continue;
+    }
+    for (const part of item.content) {
+      if (part.type === 'output_text' && part.annotations == null) {
+        part.annotations = [];
+      }
+    }
+  }
+}
+
 function getResponsesStreamError(
   event: OpenAIClient.Responses.ResponseStreamEvent
 ): Error | undefined {
@@ -960,6 +989,7 @@ async function* convertLibreChatResponsesStream(
       if (streamError != null) {
         throw streamError;
       }
+      ensureResponsesOutputAnnotations(event);
       const convertedChunk =
         convertResponsesDeltaToChatGenerationChunk(event) ??
         convertDroppedResponsesReplayOutput(event);

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -941,7 +941,7 @@ export function ensureResponsesOutputAnnotations(
       continue;
     }
     for (const part of item.content) {
-      if (part.type === 'output_text' && part.annotations == null) {
+      if (part.type === 'output_text' && !Array.isArray(part.annotations)) {
         part.annotations = [];
       }
     }


### PR DESCRIPTION
## Problem

Some OpenAI-compatible Responses API gateways (e.g. the Codex backend used by the SDT deployment) omit the `annotations` field on `output_text` content parts in the terminal `response.completed` / `response.incomplete` events, even though the OpenAI SDK types declare it required.

LangChain's `convertResponsesDeltaToChatGenerationChunk` maps over the field unconditionally (`part.annotations.map(...)`), so every streamed completion from such a server crashes with:

```
TypeError: Cannot read properties of undefined (reading 'map')
    at convertResponsesMessageToAIMessage (responses.cjs:246)
    at convertResponsesDeltaToChatGenerationChunk (responses.cjs:525)
```

## Fix

Normalize terminal `response.completed` / `response.incomplete` events before passing them to the LangChain converter: any `output_text` content part whose `annotations` field is missing gets `annotations: []`. Non-terminal events and non-message output items are untouched.

## Verification

- New regression spec `src/llm/openai/annotations.spec.ts` covers missing, present, and non-message/terminal cases (3 tests).
- Full `src/llm/openai/` suite: 14 suites, 182 tests pass.
- `tsc --noEmit` clean.