### PR TITLE
🛂 refactor: Reject Direct-Only Tool Calls Before Sandbox Startup

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -566,7 +566,7 @@ export class AgentContext {
   }> {
     const targets: Array<{ name: string; codeGuidance: string }> = [];
     if (
-      this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
+      this.hasBoundTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
       isProgrammaticRunnerAutoBound(
         Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
         this.toolExecution
@@ -579,7 +579,7 @@ export class AgentContext {
     }
 
     if (
-      this.hasAvailableTool(Constants.PROGRAMMATIC_TOOL_CALLING) ||
+      this.hasBoundTool(Constants.PROGRAMMATIC_TOOL_CALLING) ||
       isProgrammaticRunnerAutoBound(
         Constants.PROGRAMMATIC_TOOL_CALLING,
         this.toolExecution
@@ -599,16 +599,12 @@ export class AgentContext {
     return targets;
   }
 
-  private hasAvailableTool(name: string): boolean {
-    if (this.toolDefinitions?.some((tool) => tool.name === name) === true)
-      return true;
-    if (
-      this.tools?.some((tool) => 'name' in tool && tool.name === name) === true
-    ) {
-      return true;
-    }
-    if (this.toolMap?.has(name) === true) return true;
-    return this.toolRegistry?.has(name) === true;
+  private hasBoundTool(name: string): boolean {
+    return (
+      this.getToolsForBinding()?.some(
+        (tool) => 'name' in tool && tool.name === name
+      ) === true
+    );
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -461,37 +461,61 @@ export class AgentContext {
     }
   }
 
-  /**
-   * Builds instructions text for tools that are ONLY callable via programmatic code execution.
-   * These tools cannot be called directly by the LLM but are available through the
-   * configured programmatic tool.
-   *
-   * Includes:
-   * - Code_execution-only tools that are NOT deferred
-   * - Code_execution-only tools that ARE deferred but have been discovered via tool search
-   */
+  /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
     if (!this.toolRegistry) return '';
 
     const programmaticOnlyTools: t.LCTool[] = [];
+    const programmaticToolNames: string[] = [];
+    const directOnlyToolNames: string[] = [];
     for (const [name, toolDef] of this.toolRegistry) {
       const allowedCallers = toolDef.allowed_callers ?? ['direct'];
-      const isCodeExecutionOnly =
-        allowedCallers.includes('code_execution') &&
-        !allowedCallers.includes('direct');
-
-      if (!isCodeExecutionOnly) continue;
-
       const isDeferred = toolDef.defer_loading === true;
       const isDiscovered = this.discoveredToolNames.has(name);
-      if (!isDeferred || isDiscovered) {
+      if (isDeferred && !isDiscovered) {
+        continue;
+      }
+
+      const allowsProgrammatic = allowedCallers.includes('code_execution');
+      const allowsDirect = allowedCallers.includes('direct');
+      if (allowsProgrammatic) {
+        programmaticToolNames.push(name);
+      }
+      if (allowsProgrammatic && !allowsDirect) {
         programmaticOnlyTools.push(toolDef);
+      }
+      if (
+        allowsDirect &&
+        !allowsProgrammatic &&
+        name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+        name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
+        name !== Constants.TOOL_SEARCH
+      ) {
+        directOnlyToolNames.push(name);
       }
     }
 
-    if (programmaticOnlyTools.length === 0) return '';
+    if (programmaticToolNames.length === 0) return '';
 
     const programmaticTool = this.getProgrammaticToolInstructionTarget();
+    const quotedProgrammaticNames = programmaticToolNames
+      .map((name) => `\`${name}\``)
+      .join(', ');
+    const directOnlyBoundary =
+      directOnlyToolNames.length > 0
+        ? `\nCall these tools directly; never reference them inside \`${programmaticTool.name}\`: ${directOnlyToolNames
+          .map((name) => `\`${name}\``)
+          .join(', ')}.`
+        : '';
+    const boundary =
+      '\n\n## Programmatic Tool Calling\n\n' +
+      `Only these tools may be invoked inside \`${programmaticTool.name}\`: ${quotedProgrammaticNames}.` +
+      directOnlyBoundary;
+
+    if (programmaticOnlyTools.length === 0) {
+      return boundary;
+    }
+
     const toolDescriptions = programmaticOnlyTools
       .map((tool) => {
         let desc = `- **${tool.name}**`;
@@ -506,7 +530,8 @@ export class AgentContext {
       .join('\n\n');
 
     return (
-      '\n\n## Programmatic-Only Tools\n\n' +
+      boundary +
+      '\n\n### Programmatic-Only Tools\n\n' +
       `The following tools are available exclusively through the \`${programmaticTool.name}\` tool. ` +
       `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.language} code that invokes them.\n\n` +
       toolDescriptions

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -32,7 +32,10 @@ import {
   Constants,
   Providers,
 } from '@/common';
-import { resolveLocalToolRegistry } from '@/tools/local/resolveLocalExecutionTools';
+import {
+  isProgrammaticRunnerAutoBound,
+  resolveLocalToolRegistry,
+} from '@/tools/local/resolveLocalExecutionTools';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
@@ -272,6 +275,8 @@ export class AgentContext {
    * Used for tool search and programmatic tool calling.
    */
   toolRegistry?: t.LCToolRegistry;
+  /** Run-scoped backend used to identify auto-bound programmatic runners. */
+  private toolExecution?: t.ToolExecutionConfig;
   /**
    * Serializable tool definitions for event-driven execution.
    * When provided, ToolNode operates in event-driven mode.
@@ -443,6 +448,7 @@ export class AgentContext {
       toolRegistry,
       toolExecution,
     });
+    this.toolExecution = toolExecution;
     this.toolDefinitions = toolDefinitions;
     this.instructions = instructions;
     this.additionalInstructions = additionalInstructions;
@@ -551,14 +557,26 @@ export class AgentContext {
     name: string;
     language: 'bash' | 'Python';
   } | undefined {
-    if (this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING)) {
+    if (
+      this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
+      isProgrammaticRunnerAutoBound(
+        Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+        this.toolExecution
+      )
+    ) {
       return {
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
         language: 'bash',
       };
     }
 
-    if (this.hasAvailableTool(Constants.PROGRAMMATIC_TOOL_CALLING)) {
+    if (
+      this.hasAvailableTool(Constants.PROGRAMMATIC_TOOL_CALLING) ||
+      isProgrammaticRunnerAutoBound(
+        Constants.PROGRAMMATIC_TOOL_CALLING,
+        this.toolExecution
+      )
+    ) {
       return { name: Constants.PROGRAMMATIC_TOOL_CALLING, language: 'Python' };
     }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -509,13 +509,12 @@ export class AgentContext {
       }
     }
 
-    if (programmaticToolNames.length === 0) return '';
-
     const programmaticTool = this.getProgrammaticToolInstructionTarget();
     if (programmaticTool == null) return '';
-    const quotedProgrammaticNames = programmaticToolNames
-      .map((name) => `\`${name}\``)
-      .join(', ');
+    const quotedProgrammaticNames =
+      programmaticToolNames.length > 0
+        ? programmaticToolNames.map((name) => `\`${name}\``).join(', ')
+        : 'none';
     const directOnlyBoundary =
       directOnlyToolNames.length > 0
         ? `\nCall these tools directly; never reference them inside \`${programmaticTool.name}\`: ${directOnlyToolNames
@@ -548,14 +547,14 @@ export class AgentContext {
       boundary +
       '\n\n### Programmatic-Only Tools\n\n' +
       `The following tools are available exclusively through the \`${programmaticTool.name}\` tool. ` +
-      `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.language} code that invokes them.\n\n` +
+      `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.codeGuidance} that invokes them.\n\n` +
       toolDescriptions
     );
   }
 
   private getProgrammaticToolInstructionTarget(): {
     name: string;
-    language: 'bash' | 'Python';
+    codeGuidance: string;
   } | undefined {
     if (
       this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
@@ -566,7 +565,7 @@ export class AgentContext {
     ) {
       return {
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
-        language: 'bash',
+        codeGuidance: 'Bash code',
       };
     }
 
@@ -577,7 +576,15 @@ export class AgentContext {
         this.toolExecution
       )
     ) {
-      return { name: Constants.PROGRAMMATIC_TOOL_CALLING, language: 'Python' };
+      const localDefault =
+        this.toolExecution?.engine === 'local' ||
+        this.toolExecution?.engine === 'cloudflare-sandbox';
+      return {
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        codeGuidance: localDefault
+          ? 'Bash code by default, or set `lang: "py"` to use Python code'
+          : 'Python code',
+      };
     }
 
     return undefined;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -509,21 +509,24 @@ export class AgentContext {
       }
     }
 
-    const programmaticTool = this.getProgrammaticToolInstructionTarget();
-    if (programmaticTool == null) return '';
+    const programmaticTools = this.getProgrammaticToolInstructionTargets();
+    if (programmaticTools.length === 0) return '';
+    const programmaticRunnerNames = programmaticTools
+      .map((tool) => `\`${tool.name}\``)
+      .join(' or ');
     const quotedProgrammaticNames =
       programmaticToolNames.length > 0
         ? programmaticToolNames.map((name) => `\`${name}\``).join(', ')
         : 'none';
     const directOnlyBoundary =
       directOnlyToolNames.length > 0
-        ? `\nCall these tools directly; never reference them inside \`${programmaticTool.name}\`: ${directOnlyToolNames
+        ? `\nCall these tools directly; never reference them inside ${programmaticRunnerNames}: ${directOnlyToolNames
           .map((name) => `\`${name}\``)
           .join(', ')}.`
         : '';
     const boundary =
       '\n\n## Programmatic Tool Calling\n\n' +
-      `Only these tools may be invoked inside \`${programmaticTool.name}\`: ${quotedProgrammaticNames}.` +
+      `Only these tools may be invoked inside ${programmaticRunnerNames}: ${quotedProgrammaticNames}.` +
       directOnlyBoundary;
 
     if (programmaticOnlyTools.length === 0) {
@@ -546,16 +549,22 @@ export class AgentContext {
     return (
       boundary +
       '\n\n### Programmatic-Only Tools\n\n' +
-      `The following tools are available exclusively through the \`${programmaticTool.name}\` tool. ` +
-      `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.codeGuidance} that invokes them.\n\n` +
+      `The following tools are available exclusively through ${programmaticRunnerNames}. ` +
+      `You cannot call these tools directly; instead, ${programmaticTools
+        .map(
+          (tool) =>
+            `use \`${tool.name}\` with ${tool.codeGuidance} that invokes them`
+        )
+        .join(', or ')}.\n\n` +
       toolDescriptions
     );
   }
 
-  private getProgrammaticToolInstructionTarget(): {
+  private getProgrammaticToolInstructionTargets(): Array<{
     name: string;
     codeGuidance: string;
-  } | undefined {
+  }> {
+    const targets: Array<{ name: string; codeGuidance: string }> = [];
     if (
       this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
       isProgrammaticRunnerAutoBound(
@@ -563,10 +572,10 @@ export class AgentContext {
         this.toolExecution
       )
     ) {
-      return {
+      targets.push({
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
         codeGuidance: 'Bash code',
-      };
+      });
     }
 
     if (
@@ -579,15 +588,15 @@ export class AgentContext {
       const localDefault =
         this.toolExecution?.engine === 'local' ||
         this.toolExecution?.engine === 'cloudflare-sandbox';
-      return {
+      targets.push({
         name: Constants.PROGRAMMATIC_TOOL_CALLING,
         codeGuidance: localDefault
           ? 'Bash code by default, or set `lang: "py"` to use Python code'
           : 'Python code',
-      };
+      });
     }
 
-    return undefined;
+    return targets;
   }
 
   private hasAvailableTool(name: string): boolean {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -32,6 +32,7 @@ import {
   Constants,
   Providers,
 } from '@/common';
+import { resolveLocalToolRegistry } from '@/tools/local/resolveLocalExecutionTools';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
@@ -59,7 +60,8 @@ export class AgentContext {
   static fromConfig(
     agentConfig: t.AgentInputs,
     tokenCounter?: t.TokenCounter,
-    indexTokenCountMap?: Record<string, number>
+    indexTokenCountMap?: Record<string, number>,
+    toolExecution?: t.ToolExecutionConfig
   ): AgentContext {
     const {
       agentId,
@@ -103,6 +105,7 @@ export class AgentContext {
       tools,
       toolMap,
       toolRegistry,
+      toolExecution,
       toolDefinitions,
       instructions,
       additionalInstructions: additional_instructions,
@@ -385,6 +388,7 @@ export class AgentContext {
     tools,
     toolMap,
     toolRegistry,
+    toolExecution,
     toolDefinitions,
     instructions,
     additionalInstructions,
@@ -410,6 +414,7 @@ export class AgentContext {
     tools?: t.GraphTools;
     toolMap?: t.ToolMap;
     toolRegistry?: t.LCToolRegistry;
+    toolExecution?: t.ToolExecutionConfig;
     toolDefinitions?: t.LCTool[];
     instructions?: string;
     additionalInstructions?: string;
@@ -434,7 +439,10 @@ export class AgentContext {
     this.tokenCounter = tokenCounter;
     this.tools = tools;
     this.toolMap = toolMap;
-    this.toolRegistry = toolRegistry;
+    this.toolRegistry = resolveLocalToolRegistry({
+      toolRegistry,
+      toolExecution,
+    });
     this.toolDefinitions = toolDefinitions;
     this.instructions = instructions;
     this.additionalInstructions = additionalInstructions;
@@ -498,6 +506,7 @@ export class AgentContext {
     if (programmaticToolNames.length === 0) return '';
 
     const programmaticTool = this.getProgrammaticToolInstructionTarget();
+    if (programmaticTool == null) return '';
     const quotedProgrammaticNames = programmaticToolNames
       .map((name) => `\`${name}\``)
       .join(', ');
@@ -541,7 +550,7 @@ export class AgentContext {
   private getProgrammaticToolInstructionTarget(): {
     name: string;
     language: 'bash' | 'Python';
-    } {
+  } | undefined {
     if (this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING)) {
       return {
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
@@ -553,7 +562,7 @@ export class AgentContext {
       return { name: Constants.PROGRAMMATIC_TOOL_CALLING, language: 'Python' };
     }
 
-    return { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING, language: 'bash' };
+    return undefined;
   }
 
   private hasAvailableTool(name: string): boolean {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1115,6 +1115,60 @@ describe('AgentContext', () => {
       expect(content).toContain('`direct_tool`');
     });
 
+    it('omits deferred programmatic runners until discovery', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            {
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              defer_loading: true,
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      expect(String((await ctx.systemRunnable!.invoke([]))[0].content)).toBe(
+        'Base'
+      );
+
+      ctx.markToolsAsDiscovered([Constants.PROGRAMMATIC_TOOL_CALLING]);
+
+      expect(
+        String((await ctx.systemRunnable!.invoke([]))[0].content)
+      ).toContain('inside `run_tools_with_code`');
+    });
+
+    it('omits programmatic runners that are not direct-callable', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            {
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              allowed_callers: ['code_execution'],
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      expect(String((await ctx.systemRunnable!.invoke([]))[0].content)).toBe(
+        'Base'
+      );
+    });
+
     it('excludes deferred code_execution-only tools until discovered', () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1064,6 +1064,7 @@ describe('AgentContext', () => {
       const result = await ctx.systemRunnable!.invoke([]);
       const content = String(result[0].content);
       expect(content).toContain('inside `run_tools_with_bash`');
+      expect(content).toContain('or `run_tools_with_code`');
       expect(content).toContain('`host_code_tool`');
     });
 

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -18,10 +18,16 @@ describe('AgentContext', () => {
     agentConfig?: Partial<t.AgentInputs>;
     tokenCounter?: t.TokenCounter;
     indexTokenCountMap?: Record<string, number>;
+    toolExecution?: t.ToolExecutionConfig;
   };
 
   const createBasicContext = (options: ContextOptions = {}): AgentContext => {
-    const { agentConfig = {}, tokenCounter, indexTokenCountMap } = options;
+    const {
+      agentConfig = {},
+      tokenCounter,
+      indexTokenCountMap,
+      toolExecution,
+    } = options;
     return AgentContext.fromConfig(
       {
         agentId: 'test-agent',
@@ -30,7 +36,8 @@ describe('AgentContext', () => {
         ...agentConfig,
       },
       tokenCounter,
-      indexTokenCountMap
+      indexTokenCountMap,
+      toolExecution
     );
   };
 
@@ -882,6 +889,26 @@ describe('AgentContext', () => {
   });
 
   describe('buildProgrammaticOnlyToolsInstructions', () => {
+    it('omits programmatic guidance when no runner is available', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolRegistry: new Map([
+            [
+              'programmatic_tool',
+              {
+                name: 'programmatic_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe('Base');
+    });
+
     it('includes code_execution-only tools in system message', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
@@ -980,6 +1007,42 @@ describe('AgentContext', () => {
         'Call these tools directly; never reference them inside `run_tools_with_bash`: `direct_tool`.'
       );
       expect(content).toContain('### Programmatic-Only Tools');
+    });
+
+    it('uses the Cloudflare runner effective registry in guidance', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'cloudflare-sandbox',
+          cloudflare: {
+            sandbox: {
+              exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+              readFile: async () => '',
+              writeFile: async () => undefined,
+              mkdir: async () => undefined,
+              listFiles: async () => [],
+              deleteFile: async () => undefined,
+            },
+          },
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain('`read_file`');
+      expect(content).not.toContain('`host_code_tool`');
     });
 
     it('excludes deferred code_execution-only tools until discovered', () => {
@@ -1142,7 +1205,11 @@ describe('AgentContext', () => {
       ]);
 
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Short', toolRegistry },
+        agentConfig: {
+          instructions: 'Short',
+          toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+        },
         tokenCounter: mockTokenCounter,
       });
 
@@ -1850,7 +1917,10 @@ describe('AgentContext', () => {
 
     it('maintains consistent indexTokenCountMap across turns', () => {
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Base instructions' },
+        agentConfig: {
+          instructions: 'Base instructions',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+        },
         tokenCounter: mockTokenCounter,
       });
 
@@ -1926,6 +1996,7 @@ describe('AgentContext', () => {
         agentConfig: {
           instructions: 'You are helpful.',
           toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
         },
         tokenCounter: mockTokenCounter,
       });
@@ -1969,6 +2040,7 @@ describe('AgentContext', () => {
         agentConfig: {
           instructions: 'Assistant instructions',
           toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
         },
         tokenCounter: mockTokenCounter,
       });

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1067,6 +1067,53 @@ describe('AgentContext', () => {
       expect(content).toContain('`host_code_tool`');
     });
 
+    it('describes the Bash default for an auto-bound code runner', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'local',
+          local: { includeCodingTools: false },
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain('Bash code by default');
+      expect(content).toContain('`lang: "py"`');
+    });
+
+    it('emits direct-only guidance when the allowlist is empty', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: none.'
+      );
+      expect(content).toContain('`direct_tool`');
+    });
+
     it('excludes deferred code_execution-only tools until discovered', () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1013,7 +1013,6 @@ describe('AgentContext', () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base',
-          toolDefinitions: [{ name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING }],
           toolRegistry: new Map([
             [
               'host_code_tool',
@@ -1043,6 +1042,29 @@ describe('AgentContext', () => {
       const content = String(result[0].content);
       expect(content).toContain('`read_file`');
       expect(content).not.toContain('`host_code_tool`');
+    });
+
+    it('recognizes auto-bound local programmatic runners', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: { engine: 'local' },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain('inside `run_tools_with_bash`');
+      expect(content).toContain('`host_code_tool`');
     });
 
     it('excludes deferred code_execution-only tools until discovered', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -935,7 +935,7 @@ describe('AgentContext', () => {
       expect(result[0].content).not.toContain('run_tools_with_bash');
     });
 
-    it('excludes direct-callable tools from programmatic section', () => {
+    it('makes mixed direct and programmatic caller boundaries explicit', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
           'direct_tool',
@@ -953,13 +953,33 @@ describe('AgentContext', () => {
             allowed_callers: ['direct', 'code_execution'],
           },
         ],
+        [
+          'programmatic_only_tool',
+          {
+            name: 'programmatic_only_tool',
+            description: 'Programmatic only',
+            allowed_callers: ['code_execution'],
+          },
+        ],
       ]);
 
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Base', toolRegistry },
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry,
+        },
       });
 
-      expect(ctx.systemRunnable).toBeDefined();
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_bash`: `both_tool`, `programmatic_only_tool`.'
+      );
+      expect(content).toContain(
+        'Call these tools directly; never reference them inside `run_tools_with_bash`: `direct_tool`.'
+      );
+      expect(content).toContain('### Programmatic-Only Tools');
     });
 
     it('excludes deferred code_execution-only tools until discovered', () => {

--- a/src/agents/__tests__/projection.test.ts
+++ b/src/agents/__tests__/projection.test.ts
@@ -1,7 +1,7 @@
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { Providers } from '@/common';
 import { projectAgentContextUsage } from '../projection';
+import { Providers } from '@/common';
 
 const countByChars = (msg: { content: unknown }): number => {
   const content =
@@ -69,5 +69,32 @@ describe('projectAgentContextUsage', () => {
     });
 
     expect(usage).toBeNull();
+  });
+
+  it('projects instructions from the effective execution backend', async () => {
+    const config: t.AgentInputs = {
+      ...agent(100_000),
+      toolRegistry: new Map([
+        [
+          'host_code_tool',
+          { name: 'host_code_tool', allowed_callers: ['code_execution'] },
+        ],
+      ]),
+    };
+    const withoutExecution = await projectAgentContextUsage({
+      agent: config,
+      messages: [],
+      tokenCounter: countByChars,
+    });
+    const withExecution = await projectAgentContextUsage({
+      agent: config,
+      messages: [],
+      tokenCounter: countByChars,
+      toolExecution: { engine: 'local' },
+    });
+
+    expect(withExecution!.breakdown.instructionTokens).toBeGreaterThan(
+      withoutExecution!.breakdown.instructionTokens
+    );
   });
 });

--- a/src/agents/projection.ts
+++ b/src/agents/projection.ts
@@ -13,6 +13,8 @@ export interface ProjectAgentContextUsageParams {
   indexTokenCountMap?: Record<string, number>;
   /** Provider-calibrated ratio from a prior snapshot, applied as a static seed. */
   calibrationRatio?: number;
+  /** Execution backend used to synthesize the live effective tool registry. */
+  toolExecution?: t.ToolExecutionConfig;
   runId?: string;
   agentId?: string;
 }
@@ -32,10 +34,16 @@ export async function projectAgentContextUsage({
   tokenCounter,
   indexTokenCountMap,
   calibrationRatio,
+  toolExecution,
   runId,
   agentId,
 }: ProjectAgentContextUsageParams): Promise<t.ContextUsageEvent | null> {
-  const context = AgentContext.fromConfig(agent, tokenCounter, indexTokenCountMap);
+  const context = AgentContext.fromConfig(
+    agent,
+    tokenCounter,
+    indexTokenCountMap,
+    toolExecution
+  );
   await context.tokenCalculationPromise;
   return context.projectContextUsage(messages, {
     runId,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -34,6 +34,7 @@ import type {
 import type {
   GraphFactory,
   GraphFactoryDependencies,
+  GraphFactoryRequest,
 } from '@/graphs/graphFactory';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
@@ -1457,6 +1458,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       subagentExecutionContext,
       preemption,
       streamLimits,
+      toolExecution,
     }: t.StandardGraphInput,
     dependencies?: GraphFactoryDependencies
   ) {
@@ -1482,6 +1484,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.subagentExecutionContext = subagentExecutionContext;
     this.preemption = preemption;
     this.streamLimits = resolveStreamLimits(streamLimits);
+    this.toolExecution = toolExecution;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -1491,7 +1494,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const agentContext = AgentContext.fromConfig(
         agentConfig,
         tokenCounter,
-        indexTokenCountMap
+        indexTokenCountMap,
+        toolExecution
       );
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
@@ -4805,7 +4809,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           };
           const checkpointer = this.compileOptions?.checkpointer;
           return (request): StandardGraph => {
-            const childGraph = graphFactory(request);
+            const configuredRequest: GraphFactoryRequest =
+              request.kind === 'multi-agent'
+                ? {
+                  kind: 'multi-agent',
+                  input: {
+                    ...request.input,
+                    toolExecution: runtimeConfig.toolExecution,
+                  },
+                }
+                : {
+                  kind: 'standard',
+                  input: {
+                    ...request.input,
+                    toolExecution: runtimeConfig.toolExecution,
+                  },
+                };
+            const childGraph = graphFactory(configuredRequest);
             if (subagentModelOverride != null) {
               childGraph.overrideModel = subagentModelOverride;
               childGraph.setSubagentModelOverride(subagentModelOverride);

--- a/src/run.ts
+++ b/src/run.ts
@@ -469,6 +469,7 @@ export class Run<_T extends t.BaseGraphState> {
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
+        toolExecution: this.toolExecution,
       },
     });
     /** Propagate compile options from graph config */
@@ -508,6 +509,7 @@ export class Run<_T extends t.BaseGraphState> {
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
+        toolExecution: this.toolExecution,
       },
     });
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -22,6 +22,7 @@ import {
   makeRequest,
   executeTools,
   formatCompletedResponse,
+  assertDisallowedToolUsage,
 } from './ProgrammaticToolCalling';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
@@ -236,6 +237,27 @@ export function extractUsedBashToolNames(
   return usedTools;
 }
 
+/** Rejects direct-only tools before any bash sandbox request is made. */
+export function assertBashToolsAllowProgrammaticCalling(
+  toolDefs: t.LCTool[] | undefined,
+  code: string,
+  programmaticToolName: string = Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+): void {
+  if (toolDefs == null || toolDefs.length === 0) {
+    return;
+  }
+
+  const toolNameMap = new Map<string, string>();
+  for (const toolDef of toolDefs) {
+    toolNameMap.set(normalizeToBashIdentifier(toolDef.name), toolDef.name);
+  }
+
+  assertDisallowedToolUsage(
+    extractUsedBashToolNames(code, toolNameMap),
+    programmaticToolName
+  );
+}
+
 /**
  * Filters tool definitions to only include tools actually used in the bash code.
  */
@@ -315,10 +337,19 @@ export function createBashProgrammaticToolCallingTool(
       const {
         toolMap,
         toolDefs,
+        disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+
+      assertBashToolsAllowProgrammaticCalling(
+        disallowedToolDefs,
+        code,
+        typeof toolCall.name === 'string' && toolCall.name !== ''
+          ? toolCall.name
+          : Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      );
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -269,6 +269,7 @@ const DECLARATION_BUILTINS = new Set([
 
 type BashToken =
   | { type: 'word'; value: string }
+  | { type: 'functionName' }
   | { type: 'separator' }
   | { type: 'closeParen' }
   | { type: 'caseArmEnd' }
@@ -330,6 +331,10 @@ function collectBashCommandNames(
   };
 
   for (const token of tokens) {
+    if (token.type === 'functionName') {
+      expectsCommand = false;
+      continue;
+    }
     if (token.type === 'nested') {
       collectBashCommandNames(token.tokens, commands, knownToolNames);
       if (skipRedirectTarget) {
@@ -625,6 +630,12 @@ function tokenizeBash(code: string): BashToken[] {
     }
     if (char === '(') {
       const previousToken = tokens.at(-1);
+      if (previousToken?.type === 'word' && code[index + 1] === ')') {
+        tokens.pop();
+        tokens.push({ type: 'functionName' });
+        index += 2;
+        continue;
+      }
       if (
         previousToken?.type === 'word' &&
         /^[A-Za-z_][A-Za-z0-9_]*\+?=$/.test(previousToken.value)

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -239,6 +239,7 @@ export function extractUsedBashToolNames(
 const COMMAND_PREFIXES = new Set([
   'builtin',
   'command',
+  'coproc',
   'env',
   'exec',
   'nohup',
@@ -333,6 +334,11 @@ function tokenizeBash(code: string): BashToken[] {
     const char = code[index];
     if (char === ' ' || char === '\t' || char === '\r') {
       index += 1;
+      continue;
+    }
+    if (code.slice(index, index + 2) === '&>') {
+      tokens.push({ type: 'redirect' });
+      index += code[index + 2] === '>' ? 3 : 2;
       continue;
     }
     if (char === '\n' || char === ';' || char === '|' || char === '&') {
@@ -682,6 +688,9 @@ function restoreBashHeredocSubstitutions(
   bodyEnd: number
 ): void {
   for (let index = bodyStart; index < bodyEnd; index++) {
+    if (isBashCharacterEscaped(code, index, bodyStart)) {
+      continue;
+    }
     let substitutionEnd: number | undefined;
     if (code.slice(index, index + 2) === '$(') {
       substitutionEnd = findBashCommandSubstitutionEnd(code, index + 2);
@@ -696,6 +705,21 @@ function restoreBashHeredocSubstitutions(
     }
     index = substitutionEnd;
   }
+}
+
+function isBashCharacterEscaped(
+  code: string,
+  index: number,
+  lowerBound: number
+): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= lowerBound; cursor--) {
+    if (code[cursor] !== '\\') {
+      break;
+    }
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
 }
 
 function findBashHeredocDeclaration(

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -284,6 +284,9 @@ function collectBashCommandNames(
   let pendingCoprocWord: string | undefined;
   let evalWords: string[] | undefined;
   const assignments = new Map<string, string>();
+  const pendingAssignments = new Map<string, string>();
+  let commandPrefix: string | undefined;
+  let skipPrefixOptionOperand = false;
 
   const flushEval = (): void => {
     if (evalWords != null && evalWords.length > 0) {
@@ -302,6 +305,12 @@ function collectBashCommandNames(
     }
     if (token.type === 'separator') {
       flushEval();
+      for (const [name, value] of pendingAssignments) {
+        assignments.set(name, value);
+      }
+      pendingAssignments.clear();
+      commandPrefix = undefined;
+      skipPrefixOptionOperand = false;
       if (pendingCoprocWord != null) {
         commands.add(pendingCoprocWord);
         pendingCoprocWord = undefined;
@@ -350,10 +359,20 @@ function collectBashCommandNames(
     }
     const assignment = word.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
     if (assignment != null) {
-      assignments.set(assignment[1], assignment[2]);
+      if (commandPrefix == null) {
+        pendingAssignments.set(assignment[1], assignment[2]);
+      }
       continue;
     }
     if (/^[A-Za-z_][A-Za-z0-9_]*\+=/.test(word)) {
+      continue;
+    }
+    if (skipPrefixOptionOperand) {
+      skipPrefixOptionOperand = false;
+      continue;
+    }
+    if (commandPrefix === 'env' && (word === '-u' || word === '--unset')) {
+      skipPrefixOptionOperand = true;
       continue;
     }
     if (word.startsWith('-')) {
@@ -376,25 +395,31 @@ function collectBashCommandNames(
       continue;
     }
     if (COMMAND_PREFIXES.has(word)) {
+      commandPrefix = word;
       continue;
     }
 
     const variable = word.match(/^\$(?:{([A-Za-z_][A-Za-z0-9_]*)}|([A-Za-z_][A-Za-z0-9_]*))$/);
-    const variableName =
-      variable == null
-        ? undefined
-        : word.startsWith('${')
-          ? word.slice(2, -1)
-          : word.slice(1);
+    let variableName: string | undefined;
+    if (variable != null) {
+      variableName = word.startsWith('${')
+        ? word.slice(2, -1)
+        : word.slice(1);
+    }
     const resolvedWord =
       variableName == null ? word : (assignments.get(variableName) ?? word);
     commands.add(resolvedWord);
+    pendingAssignments.clear();
+    commandPrefix = undefined;
     expectsCommand = false;
   }
 
   flushEval();
   if (pendingCoprocWord != null) {
     commands.add(pendingCoprocWord);
+  }
+  for (const [name, value] of pendingAssignments) {
+    assignments.set(name, value);
   }
 }
 
@@ -909,6 +934,14 @@ function findBashHeredocDeclarations(
     }
     if (char === '\'' || char === '"') {
       quote = char;
+      continue;
+    }
+    if (line.slice(index, index + 3) === '$((') {
+      const arithmeticEnd = findBashArithmeticExpansionEnd(line, index + 3);
+      if (arithmeticEnd == null) {
+        break;
+      }
+      index = arithmeticEnd;
       continue;
     }
     if (char === '#' && (index === 0 || /\s/.test(line[index - 1]))) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -259,6 +259,14 @@ const COMMAND_START_WORDS = new Set([
   'while',
 ]);
 
+const DECLARATION_BUILTINS = new Set([
+  'declare',
+  'export',
+  'local',
+  'readonly',
+  'typeset',
+]);
+
 type BashToken =
   | { type: 'word'; value: string }
   | { type: 'separator' }
@@ -296,6 +304,7 @@ function collectBashCommandNames(
   let commandPrefix: string | undefined;
   let skipPrefixOptionOperand = false;
   let expectsTrapAction = false;
+  let readsDeclarationOperands = false;
   const caseModes: Array<'subject' | 'awaitIn' | 'pattern' | 'body'> = [];
 
   const flushEval = (): void => {
@@ -322,6 +331,7 @@ function collectBashCommandNames(
       commandPrefix = undefined;
       skipPrefixOptionOperand = false;
       expectsTrapAction = false;
+      readsDeclarationOperands = false;
       if (pendingCoprocWord != null) {
         commands.add(pendingCoprocWord);
         pendingCoprocWord = undefined;
@@ -376,6 +386,15 @@ function collectBashCommandNames(
         commands.add(pendingCoprocWord);
         pendingCoprocWord = undefined;
         expectsCommand = false;
+      }
+      continue;
+    }
+    if (readsDeclarationOperands) {
+      const assignment = token.value.match(
+        /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+      );
+      if (assignment != null) {
+        assignments.set(assignment[1], assignment[2]);
       }
       continue;
     }
@@ -445,6 +464,13 @@ function collectBashCommandNames(
     }
     if (word === 'trap') {
       expectsTrapAction = true;
+      continue;
+    }
+    if (DECLARATION_BUILTINS.has(word)) {
+      readsDeclarationOperands = true;
+      pendingAssignments.clear();
+      commandPrefix = undefined;
+      expectsCommand = false;
       continue;
     }
     if (COMMAND_PREFIXES.has(word)) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -325,6 +325,7 @@ function collectBashCommandNames(
 
 /** Minimal shell lexer for locating command positions without executing code. */
 function tokenizeBash(code: string): BashToken[] {
+  code = maskQuotedBashHeredocBodies(code);
   const tokens: BashToken[] = [];
   let index = 0;
 
@@ -338,6 +339,16 @@ function tokenizeBash(code: string): BashToken[] {
       tokens.push({ type: 'separator' });
       index += code[index + 1] === char ? 2 : 1;
       continue;
+    }
+    if (/[0-9]/.test(char)) {
+      let redirectIndex = index + 1;
+      while (/[0-9]/.test(code[redirectIndex] ?? '')) {
+        redirectIndex += 1;
+      }
+      if (code[redirectIndex] === '<' || code[redirectIndex] === '>') {
+        index = redirectIndex;
+        continue;
+      }
     }
     if (code.slice(index, index + 3) === '$((') {
       const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 3);
@@ -360,6 +371,19 @@ function tokenizeBash(code: string): BashToken[] {
         tokens.push({
           type: 'nested',
           tokens: tokenizeBash(code.slice(bodyStart, bodyEnd)),
+        });
+        index = bodyEnd + 1;
+      }
+      continue;
+    }
+    if (char === '`') {
+      const bodyEnd = findBashBacktickEnd(code, index + 1);
+      if (bodyEnd == null) {
+        index = code.length;
+      } else {
+        tokens.push({
+          type: 'nested',
+          tokens: tokenizeBash(code.slice(index + 1, bodyEnd)),
         });
         index = bodyEnd + 1;
       }
@@ -394,6 +418,9 @@ function tokenizeBash(code: string): BashToken[] {
         break;
       }
       if (code.slice(index, index + 2) === '$(') {
+        break;
+      }
+      if (current === '`') {
         break;
       }
       if (current === '\\' && index + 1 < code.length) {
@@ -437,6 +464,23 @@ function tokenizeBash(code: string): BashToken[] {
               tokens.push({
                 type: 'nested',
                 tokens: tokenizeBash(code.slice(bodyStart, bodyEnd)),
+              });
+              index = bodyEnd + 1;
+            }
+            continue;
+          }
+          if (quote === '"' && code[index] === '`') {
+            if (value !== '') {
+              tokens.push({ type: 'word', value });
+              value = '';
+            }
+            const bodyEnd = findBashBacktickEnd(code, index + 1);
+            if (bodyEnd == null) {
+              index = code.length;
+            } else {
+              tokens.push({
+                type: 'nested',
+                tokens: tokenizeBash(code.slice(index + 1, bodyEnd)),
               });
               index = bodyEnd + 1;
             }
@@ -494,6 +538,14 @@ function findBashCommandSubstitutionEnd(
       quote = char;
       continue;
     }
+    if (char === '`') {
+      const backtickEnd = findBashBacktickEnd(code, index + 1);
+      if (backtickEnd == null) {
+        return undefined;
+      }
+      index = backtickEnd;
+      continue;
+    }
     if (
       char === '#' &&
       (index === bodyStart || /[\s;|&()]/.test(code[index - 1]))
@@ -547,6 +599,110 @@ function findBashCommandSubstitutionEnd(
       } else if (caseDepth === 0) {
         return index;
       }
+    }
+  }
+
+  return undefined;
+}
+
+/** Finds the closing delimiter for a legacy backtick command substitution. */
+function findBashBacktickEnd(
+  code: string,
+  bodyStart: number
+): number | undefined {
+  for (let index = bodyStart; index < code.length; index++) {
+    if (code[index] === '\\') {
+      index += 1;
+    } else if (code[index] === '`') {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+/** Masks quoted heredoc bodies, where shell expansion is disabled. */
+function maskQuotedBashHeredocBodies(code: string): string {
+  const masked = [...code];
+  let lineStart = 0;
+
+  while (lineStart < code.length) {
+    const lineEnd = code.indexOf('\n', lineStart);
+    const contentEnd = lineEnd === -1 ? code.length : lineEnd;
+    const declaration = findQuotedBashHeredocDeclaration(
+      code.slice(lineStart, contentEnd)
+    );
+    if (declaration == null || lineEnd === -1) {
+      lineStart = lineEnd === -1 ? code.length : lineEnd + 1;
+      continue;
+    }
+
+    let bodyStart = lineEnd + 1;
+    while (bodyStart <= code.length) {
+      const bodyLineEnd = code.indexOf('\n', bodyStart);
+      const bodyContentEnd =
+        bodyLineEnd === -1 ? code.length : bodyLineEnd;
+      const bodyLine = code.slice(bodyStart, bodyContentEnd);
+      const comparableLine = declaration.stripTabs
+        ? bodyLine.replace(/^\t+/, '')
+        : bodyLine;
+      for (let index = bodyStart; index < bodyContentEnd; index++) {
+        masked[index] = ' ';
+      }
+      bodyStart = bodyLineEnd === -1 ? code.length + 1 : bodyLineEnd + 1;
+      if (comparableLine === declaration.delimiter) {
+        break;
+      }
+    }
+    lineStart = bodyStart;
+  }
+
+  return masked.join('');
+}
+
+function findQuotedBashHeredocDeclaration(
+  line: string
+): { delimiter: string; stripTabs: boolean } | undefined {
+  let quote: '\'' | '"' | undefined;
+
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (quote != null) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === '#' && (index === 0 || /\s/.test(line[index - 1]))) {
+      return undefined;
+    }
+    if (line.slice(index, index + 2) !== '<<') {
+      continue;
+    }
+
+    let targetStart = index + 2;
+    const stripTabs = line[targetStart] === '-';
+    targetStart += stripTabs ? 1 : 0;
+    while (/[ \t]/.test(line[targetStart] ?? '')) {
+      targetStart += 1;
+    }
+    const delimiterQuote = line[targetStart];
+    if (delimiterQuote !== '\'' && delimiterQuote !== '"') {
+      continue;
+    }
+    const targetEnd = line.indexOf(delimiterQuote, targetStart + 1);
+    if (targetEnd !== -1) {
+      return {
+        delimiter: line.slice(targetStart + 1, targetEnd),
+        stripTabs,
+      };
     }
   }
 
@@ -684,15 +840,23 @@ function findBashArithmeticExpansionEnd(
 export function assertBashToolsAllowProgrammaticCalling(
   toolDefs: t.LCTool[] | undefined,
   code: string,
-  programmaticToolName: string = Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+  programmaticToolName: string = Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+  allowedToolDefs?: t.LCTool[]
 ): void {
   if (toolDefs == null || toolDefs.length === 0) {
     return;
   }
 
   const toolNameMap = new Map<string, string>();
+  const allowedNames = new Set(
+    allowedToolDefs?.map((toolDef) => normalizeToBashIdentifier(toolDef.name)) ??
+      []
+  );
   for (const toolDef of toolDefs) {
-    toolNameMap.set(normalizeToBashIdentifier(toolDef.name), toolDef.name);
+    const normalizedName = normalizeToBashIdentifier(toolDef.name);
+    if (!allowedNames.has(normalizedName)) {
+      toolNameMap.set(normalizedName, toolDef.name);
+    }
   }
 
   assertDisallowedToolUsage(
@@ -792,7 +956,8 @@ export function createBashProgrammaticToolCallingTool(
         toolCall.programmaticToolName ??
           (typeof toolCall.name === 'string' && toolCall.name !== ''
             ? toolCall.name
-            : Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
+            : Constants.BASH_PROGRAMMATIC_TOOL_CALLING),
+        toolDefs
       );
 
       if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -283,6 +283,7 @@ function collectBashCommandNames(
   let expectsCoprocWord = false;
   let pendingCoprocWord: string | undefined;
   let evalWords: string[] | undefined;
+  const assignments = new Map<string, string>();
 
   const flushEval = (): void => {
     if (evalWords != null && evalWords.length > 0) {
@@ -347,7 +348,12 @@ function collectBashCommandNames(
       expectsFunctionName = false;
       continue;
     }
-    if (/^[A-Za-z_][A-Za-z0-9_]*\+?=/.test(word)) {
+    const assignment = word.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (assignment != null) {
+      assignments.set(assignment[1], assignment[2]);
+      continue;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*\+=/.test(word)) {
       continue;
     }
     if (word.startsWith('-')) {
@@ -373,7 +379,16 @@ function collectBashCommandNames(
       continue;
     }
 
-    commands.add(word);
+    const variable = word.match(/^\$(?:{([A-Za-z_][A-Za-z0-9_]*)}|([A-Za-z_][A-Za-z0-9_]*))$/);
+    const variableName =
+      variable == null
+        ? undefined
+        : word.startsWith('${')
+          ? word.slice(2, -1)
+          : word.slice(1);
+    const resolvedWord =
+      variableName == null ? word : (assignments.get(variableName) ?? word);
+    commands.add(resolvedWord);
     expectsCommand = false;
   }
 
@@ -505,6 +520,14 @@ function tokenizeBash(code: string): BashToken[] {
         break;
       }
       if (current === '\\' && index + 1 < code.length) {
+        if (code[index + 1] === '\n') {
+          index += 2;
+          continue;
+        }
+        if (code[index + 1] === '\r' && code[index + 2] === '\n') {
+          index += 3;
+          continue;
+        }
         value += code[index + 1];
         index += 2;
         continue;
@@ -572,6 +595,14 @@ function tokenizeBash(code: string): BashToken[] {
             code[index] === '\\' &&
             index + 1 < code.length
           ) {
+            if (code[index + 1] === '\n') {
+              index += 2;
+              continue;
+            }
+            if (code[index + 1] === '\r' && code[index + 2] === '\n') {
+              index += 3;
+              continue;
+            }
             value += code[index + 1];
             index += 2;
           } else {
@@ -761,48 +792,53 @@ function maskBashHeredocBodies(code: string): string {
   while (lineStart < code.length) {
     const lineEnd = code.indexOf('\n', lineStart);
     const contentEnd = lineEnd === -1 ? code.length : lineEnd;
-    const declaration = findBashHeredocDeclaration(
+    const declarations = findBashHeredocDeclarations(
       code.slice(lineStart, contentEnd)
     );
-    if (declaration == null || lineEnd === -1) {
+    if (declarations.length === 0 || lineEnd === -1) {
       lineStart = lineEnd === -1 ? code.length : lineEnd + 1;
       continue;
     }
 
-    const bodyStart = lineEnd + 1;
-    let bodyLineStart = bodyStart;
-    let delimiterStart = code.length;
-    let afterDelimiter = code.length;
-    while (bodyLineStart <= code.length) {
-      const bodyLineEnd = code.indexOf('\n', bodyLineStart);
-      const bodyContentEnd =
-        bodyLineEnd === -1 ? code.length : bodyLineEnd;
-      const bodyLine = code.slice(bodyLineStart, bodyContentEnd);
-      const comparableLine = declaration.stripTabs
-        ? bodyLine.replace(/^\t+/, '')
-        : bodyLine;
-      if (comparableLine === declaration.delimiter) {
-        delimiterStart = bodyLineStart;
-        afterDelimiter = bodyLineEnd === -1 ? code.length : bodyLineEnd + 1;
-        break;
+    let nextBodyStart = lineEnd + 1;
+    for (const declaration of declarations) {
+      const bodyStart = nextBodyStart;
+      let bodyLineStart = bodyStart;
+      let delimiterStart = code.length;
+      let afterDelimiter = code.length;
+      while (bodyLineStart <= code.length) {
+        const bodyLineEnd = code.indexOf('\n', bodyLineStart);
+        const bodyContentEnd =
+          bodyLineEnd === -1 ? code.length : bodyLineEnd;
+        const bodyLine = code.slice(bodyLineStart, bodyContentEnd);
+        const comparableLine = declaration.stripTabs
+          ? bodyLine.replace(/^\t+/, '')
+          : bodyLine;
+        if (comparableLine === declaration.delimiter) {
+          delimiterStart = bodyLineStart;
+          afterDelimiter = bodyLineEnd === -1 ? code.length : bodyLineEnd + 1;
+          break;
+        }
+        bodyLineStart =
+          bodyLineEnd === -1 ? code.length + 1 : bodyLineEnd + 1;
       }
-      bodyLineStart = bodyLineEnd === -1 ? code.length + 1 : bodyLineEnd + 1;
-    }
 
-    for (let index = bodyStart; index < afterDelimiter; index++) {
-      if (masked[index] !== '\n' && masked[index] !== '\r') {
-        masked[index] = ' ';
+      for (let index = bodyStart; index < afterDelimiter; index++) {
+        if (masked[index] !== '\n' && masked[index] !== '\r') {
+          masked[index] = ' ';
+        }
       }
+      if (!declaration.quoted) {
+        restoreBashHeredocSubstitutions(
+          code,
+          masked,
+          bodyStart,
+          delimiterStart
+        );
+      }
+      nextBodyStart = afterDelimiter;
     }
-    if (!declaration.quoted) {
-      restoreBashHeredocSubstitutions(
-        code,
-        masked,
-        bodyStart,
-        delimiterStart
-      );
-    }
-    lineStart = afterDelimiter;
+    lineStart = nextBodyStart;
   }
 
   return masked.join('');
@@ -849,9 +885,14 @@ function isBashCharacterEscaped(
   return backslashes % 2 === 1;
 }
 
-function findBashHeredocDeclaration(
+function findBashHeredocDeclarations(
   line: string
-): { delimiter: string; stripTabs: boolean; quoted: boolean } | undefined {
+): Array<{ delimiter: string; stripTabs: boolean; quoted: boolean }> {
+  const declarations: Array<{
+    delimiter: string;
+    stripTabs: boolean;
+    quoted: boolean;
+  }> = [];
   let quote: '\'' | '"' | undefined;
 
   for (let index = 0; index < line.length; index++) {
@@ -871,7 +912,7 @@ function findBashHeredocDeclaration(
       continue;
     }
     if (char === '#' && (index === 0 || /\s/.test(line[index - 1]))) {
-      return undefined;
+      break;
     }
     if (line.slice(index, index + 2) !== '<<') {
       continue;
@@ -893,11 +934,13 @@ function findBashHeredocDeclaration(
       if (targetEnd === -1) {
         continue;
       }
-      return {
+      declarations.push({
         delimiter: line.slice(targetStart + 1, targetEnd),
         stripTabs,
         quoted: true,
-      };
+      });
+      index = targetEnd;
+      continue;
     }
     let targetEnd = targetStart;
     while (
@@ -907,15 +950,16 @@ function findBashHeredocDeclaration(
       targetEnd += 1;
     }
     if (targetEnd > targetStart) {
-      return {
+      declarations.push({
         delimiter: line.slice(targetStart, targetEnd),
         stripTabs,
         quoted: false,
-      };
+      });
+      index = targetEnd - 1;
     }
   }
 
-  return undefined;
+  return declarations;
 }
 
 /** Returns whether a reserved word begins where a shell command may begin. */

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -325,7 +325,7 @@ function collectBashCommandNames(
 
 /** Minimal shell lexer for locating command positions without executing code. */
 function tokenizeBash(code: string): BashToken[] {
-  code = maskQuotedBashHeredocBodies(code);
+  code = maskBashHeredocBodies(code);
   const tokens: BashToken[] = [];
   let index = 0;
 
@@ -620,15 +620,15 @@ function findBashBacktickEnd(
   return undefined;
 }
 
-/** Masks quoted heredoc bodies, where shell expansion is disabled. */
-function maskQuotedBashHeredocBodies(code: string): string {
+/** Masks heredoc literals while preserving executable unquoted substitutions. */
+function maskBashHeredocBodies(code: string): string {
   const masked = [...code];
   let lineStart = 0;
 
   while (lineStart < code.length) {
     const lineEnd = code.indexOf('\n', lineStart);
     const contentEnd = lineEnd === -1 ? code.length : lineEnd;
-    const declaration = findQuotedBashHeredocDeclaration(
+    const declaration = findBashHeredocDeclaration(
       code.slice(lineStart, contentEnd)
     );
     if (declaration == null || lineEnd === -1) {
@@ -636,32 +636,71 @@ function maskQuotedBashHeredocBodies(code: string): string {
       continue;
     }
 
-    let bodyStart = lineEnd + 1;
-    while (bodyStart <= code.length) {
-      const bodyLineEnd = code.indexOf('\n', bodyStart);
+    const bodyStart = lineEnd + 1;
+    let bodyLineStart = bodyStart;
+    let delimiterStart = code.length;
+    let afterDelimiter = code.length;
+    while (bodyLineStart <= code.length) {
+      const bodyLineEnd = code.indexOf('\n', bodyLineStart);
       const bodyContentEnd =
         bodyLineEnd === -1 ? code.length : bodyLineEnd;
-      const bodyLine = code.slice(bodyStart, bodyContentEnd);
+      const bodyLine = code.slice(bodyLineStart, bodyContentEnd);
       const comparableLine = declaration.stripTabs
         ? bodyLine.replace(/^\t+/, '')
         : bodyLine;
-      for (let index = bodyStart; index < bodyContentEnd; index++) {
-        masked[index] = ' ';
-      }
-      bodyStart = bodyLineEnd === -1 ? code.length + 1 : bodyLineEnd + 1;
       if (comparableLine === declaration.delimiter) {
+        delimiterStart = bodyLineStart;
+        afterDelimiter = bodyLineEnd === -1 ? code.length : bodyLineEnd + 1;
         break;
       }
+      bodyLineStart = bodyLineEnd === -1 ? code.length + 1 : bodyLineEnd + 1;
     }
-    lineStart = bodyStart;
+
+    for (let index = bodyStart; index < afterDelimiter; index++) {
+      if (masked[index] !== '\n' && masked[index] !== '\r') {
+        masked[index] = ' ';
+      }
+    }
+    if (!declaration.quoted) {
+      restoreBashHeredocSubstitutions(
+        code,
+        masked,
+        bodyStart,
+        delimiterStart
+      );
+    }
+    lineStart = afterDelimiter;
   }
 
   return masked.join('');
 }
 
-function findQuotedBashHeredocDeclaration(
+function restoreBashHeredocSubstitutions(
+  code: string,
+  masked: string[],
+  bodyStart: number,
+  bodyEnd: number
+): void {
+  for (let index = bodyStart; index < bodyEnd; index++) {
+    let substitutionEnd: number | undefined;
+    if (code.slice(index, index + 2) === '$(') {
+      substitutionEnd = findBashCommandSubstitutionEnd(code, index + 2);
+    } else if (code[index] === '`') {
+      substitutionEnd = findBashBacktickEnd(code, index + 1);
+    }
+    if (substitutionEnd == null || substitutionEnd >= bodyEnd) {
+      continue;
+    }
+    for (let restore = index; restore <= substitutionEnd; restore++) {
+      masked[restore] = code[restore];
+    }
+    index = substitutionEnd;
+  }
+}
+
+function findBashHeredocDeclaration(
   line: string
-): { delimiter: string; stripTabs: boolean } | undefined {
+): { delimiter: string; stripTabs: boolean; quoted: boolean } | undefined {
   let quote: '\'' | '"' | undefined;
 
   for (let index = 0; index < line.length; index++) {
@@ -694,14 +733,29 @@ function findQuotedBashHeredocDeclaration(
       targetStart += 1;
     }
     const delimiterQuote = line[targetStart];
-    if (delimiterQuote !== '\'' && delimiterQuote !== '"') {
-      continue;
-    }
-    const targetEnd = line.indexOf(delimiterQuote, targetStart + 1);
-    if (targetEnd !== -1) {
+    if (delimiterQuote === '\'' || delimiterQuote === '"') {
+      const targetEnd = line.indexOf(delimiterQuote, targetStart + 1);
+      if (targetEnd === -1) {
+        continue;
+      }
       return {
         delimiter: line.slice(targetStart + 1, targetEnd),
         stripTabs,
+        quoted: true,
+      };
+    }
+    let targetEnd = targetStart;
+    while (
+      targetEnd < line.length &&
+      !/[ \t;&|()<>]/.test(line[targetEnd])
+    ) {
+      targetEnd += 1;
+    }
+    if (targetEnd > targetStart) {
+      return {
+        delimiter: line.slice(targetStart, targetEnd),
+        stripTabs,
+        quoted: false,
       };
     }
   }

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -262,6 +262,8 @@ const COMMAND_START_WORDS = new Set([
 type BashToken =
   | { type: 'word'; value: string }
   | { type: 'separator' }
+  | { type: 'closeParen' }
+  | { type: 'caseArmEnd' }
   | { type: 'redirect' }
   | { type: 'nested'; tokens: BashToken[] };
 
@@ -287,6 +289,7 @@ function collectBashCommandNames(
   const pendingAssignments = new Map<string, string>();
   let commandPrefix: string | undefined;
   let skipPrefixOptionOperand = false;
+  let caseMode: 'subject' | 'awaitIn' | 'pattern' | 'body' | undefined;
 
   const flushEval = (): void => {
     if (evalWords != null && evalWords.length > 0) {
@@ -303,7 +306,7 @@ function collectBashCommandNames(
       }
       continue;
     }
-    if (token.type === 'separator') {
+    if (token.type === 'separator' || token.type === 'caseArmEnd') {
       flushEval();
       for (const [name, value] of pendingAssignments) {
         assignments.set(name, value);
@@ -318,6 +321,17 @@ function collectBashCommandNames(
       expectsCoprocWord = false;
       expectsCommand = true;
       skipRedirectTarget = false;
+      if (token.type === 'caseArmEnd' && caseMode === 'body') {
+        caseMode = 'pattern';
+      }
+      continue;
+    }
+    if (token.type === 'closeParen') {
+      expectsCommand = true;
+      skipRedirectTarget = false;
+      if (caseMode === 'pattern') {
+        caseMode = 'body';
+      }
       continue;
     }
     if (token.type === 'redirect') {
@@ -353,6 +367,22 @@ function collectBashCommandNames(
     }
 
     const word = token.value;
+    if (caseMode === 'subject') {
+      caseMode = 'awaitIn';
+      continue;
+    }
+    if (caseMode === 'awaitIn') {
+      if (word === 'in') caseMode = 'pattern';
+      continue;
+    }
+    if (caseMode === 'pattern') {
+      if (word === 'esac') caseMode = undefined;
+      continue;
+    }
+    if (caseMode === 'body' && word === 'esac') {
+      caseMode = undefined;
+      continue;
+    }
     if (expectsFunctionName) {
       expectsFunctionName = false;
       continue;
@@ -379,6 +409,7 @@ function collectBashCommandNames(
       continue;
     }
     if (COMMAND_START_WORDS.has(word) || word === '!' || word === '{') {
+      if (word === 'case') caseMode = 'subject';
       continue;
     }
     if (word === 'function') {
@@ -441,7 +472,9 @@ function tokenizeBash(code: string): BashToken[] {
       continue;
     }
     if (char === '\n' || char === ';' || char === '|' || char === '&') {
-      tokens.push({ type: 'separator' });
+      tokens.push({
+        type: char === ';' && code[index + 1] === ';' ? 'caseArmEnd' : 'separator',
+      });
       index += code[index + 1] === char ? 2 : 1;
       continue;
     }
@@ -511,12 +544,21 @@ function tokenizeBash(code: string): BashToken[] {
         }
         continue;
       }
-      tokens.push({ type: 'separator' });
-      index += 1;
+      const groupEnd = findBashArrayLiteralEnd(code, index + 1);
+      if (groupEnd == null) {
+        index = code.length;
+      } else {
+        tokens.push({
+          type: 'nested',
+          tokens: tokenizeBash(code.slice(index + 1, groupEnd)),
+        });
+        tokens.push({ type: 'separator' });
+        index = groupEnd + 1;
+      }
       continue;
     }
     if (char === ')') {
-      tokens.push({ type: 'separator' });
+      tokens.push({ type: 'closeParen' });
       index += 1;
       continue;
     }

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -14,16 +14,16 @@ import {
   selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
-  clampCodeApiRunTimeoutMs,
-  createCodeApiRunTimeoutSchema,
-  resolveCodeApiRunTimeoutMs,
-} from './ptcTimeout';
-import {
   makeRequest,
   executeTools,
   formatCompletedResponse,
   assertDisallowedToolUsage,
 } from './ProgrammaticToolCalling';
+import {
+  clampCodeApiRunTimeoutMs,
+  createCodeApiRunTimeoutSchema,
+  resolveCodeApiRunTimeoutMs,
+} from './ptcTimeout';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
@@ -224,17 +224,192 @@ export function extractUsedBashToolNames(
   toolNameMap: Map<string, string>
 ): Set<string> {
   const usedTools = new Set<string>();
+  const commandNames = extractBashCommandNames(code);
 
-  for (const [bashName, originalName] of toolNameMap) {
-    const escapedName = bashName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
-
-    if (pattern.test(code)) {
+  for (const commandName of commandNames) {
+    const originalName = toolNameMap.get(commandName);
+    if (originalName != null) {
       usedTools.add(originalName);
     }
   }
 
   return usedTools;
+}
+
+const COMMAND_PREFIXES = new Set([
+  'builtin',
+  'command',
+  'env',
+  'exec',
+  'nohup',
+  'sudo',
+]);
+
+const COMMAND_START_WORDS = new Set([
+  'do',
+  'elif',
+  'else',
+  'if',
+  'then',
+  'time',
+  'until',
+  'while',
+]);
+
+type BashToken =
+  | { type: 'word'; value: string }
+  | { type: 'separator' }
+  | { type: 'redirect' };
+
+/** Returns shell words at command position, excluding arguments and comments. */
+function extractBashCommandNames(code: string): Set<string> {
+  const commands = new Set<string>();
+  let expectsCommand = true;
+  let skipRedirectTarget = false;
+
+  for (const token of tokenizeBash(code)) {
+    if (token.type === 'separator') {
+      expectsCommand = true;
+      skipRedirectTarget = false;
+      continue;
+    }
+    if (token.type === 'redirect') {
+      skipRedirectTarget = true;
+      continue;
+    }
+    if (skipRedirectTarget) {
+      skipRedirectTarget = false;
+      continue;
+    }
+    if (!expectsCommand) {
+      continue;
+    }
+
+    const word = token.value;
+    if (/^[A-Za-z_][A-Za-z0-9_]*\+?=/.test(word)) {
+      continue;
+    }
+    if (word.startsWith('-')) {
+      continue;
+    }
+    if (COMMAND_START_WORDS.has(word) || word === '!' || word === '{') {
+      continue;
+    }
+    if (COMMAND_PREFIXES.has(word)) {
+      continue;
+    }
+
+    commands.add(word);
+    expectsCommand = false;
+  }
+
+  return commands;
+}
+
+/** Minimal shell lexer for locating command positions without executing code. */
+function tokenizeBash(code: string): BashToken[] {
+  const tokens: BashToken[] = [];
+  let index = 0;
+
+  while (index < code.length) {
+    const char = code[index];
+    if (char === ' ' || char === '\t' || char === '\r') {
+      index += 1;
+      continue;
+    }
+    if (char === '\n' || char === ';' || char === '|' || char === '&') {
+      tokens.push({ type: 'separator' });
+      index += code[index + 1] === char ? 2 : 1;
+      continue;
+    }
+    if (char === '(' || code.slice(index, index + 2) === '$(') {
+      tokens.push({ type: 'separator' });
+      index += char === '(' ? 1 : 2;
+      continue;
+    }
+    if (char === ')') {
+      index += 1;
+      continue;
+    }
+    if (char === '<' || char === '>') {
+      tokens.push({ type: 'redirect' });
+      index += code[index + 1] === char ? 2 : 1;
+      continue;
+    }
+    if (char === '#') {
+      while (index < code.length && code[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+
+    let value = '';
+    while (index < code.length) {
+      const current = code[index];
+      if (/\s/.test(current) || ';|&()<>'.includes(current)) {
+        break;
+      }
+      if (code.slice(index, index + 2) === '$(') {
+        break;
+      }
+      if (current === '\\' && index + 1 < code.length) {
+        value += code[index + 1];
+        index += 2;
+        continue;
+      }
+      if (current === '\'' || current === '"') {
+        const quote = current;
+        let commandSubstitutionDepth = 0;
+        index += 1;
+        while (index < code.length && code[index] !== quote) {
+          if (quote === '"' && code.slice(index, index + 2) === '$(') {
+            if (value !== '') {
+              tokens.push({ type: 'word', value });
+              value = '';
+            }
+            tokens.push({ type: 'separator' });
+            commandSubstitutionDepth += 1;
+            index += 2;
+            continue;
+          }
+          if (
+            quote === '"' &&
+            commandSubstitutionDepth > 0 &&
+            code[index] === ')'
+          ) {
+            if (value !== '') {
+              tokens.push({ type: 'word', value });
+              value = '';
+            }
+            commandSubstitutionDepth -= 1;
+            index += 1;
+            continue;
+          }
+          if (
+            quote === '"' &&
+            code[index] === '\\' &&
+            index + 1 < code.length
+          ) {
+            value += code[index + 1];
+            index += 2;
+          } else {
+            value += code[index++];
+          }
+        }
+        if (code[index] === quote) {
+          index += 1;
+        }
+        continue;
+      }
+      value += current;
+      index += 1;
+    }
+    if (value !== '') {
+      tokens.push({ type: 'word', value });
+    }
+  }
+
+  return tokens;
 }
 
 /** Rejects direct-only tools before any bash sandbox request is made. */
@@ -346,9 +521,10 @@ export function createBashProgrammaticToolCallingTool(
       assertBashToolsAllowProgrammaticCalling(
         disallowedToolDefs,
         code,
-        typeof toolCall.name === 'string' && toolCall.name !== ''
-          ? toolCall.name
-          : Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+        toolCall.programmaticToolName ??
+          (typeof toolCall.name === 'string' && toolCall.name !== ''
+            ? toolCall.name
+            : Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
       );
 
       if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -289,6 +289,7 @@ function collectBashCommandNames(
   const pendingAssignments = new Map<string, string>();
   let commandPrefix: string | undefined;
   let skipPrefixOptionOperand = false;
+  let expectsTrapAction = false;
   const caseModes: Array<'subject' | 'awaitIn' | 'pattern' | 'body'> = [];
 
   const flushEval = (): void => {
@@ -314,6 +315,7 @@ function collectBashCommandNames(
       pendingAssignments.clear();
       commandPrefix = undefined;
       skipPrefixOptionOperand = false;
+      expectsTrapAction = false;
       if (pendingCoprocWord != null) {
         commands.add(pendingCoprocWord);
         pendingCoprocWord = undefined;
@@ -347,6 +349,12 @@ function collectBashCommandNames(
     }
     if (evalWords != null) {
       evalWords.push(token.value);
+      continue;
+    }
+    if (expectsTrapAction) {
+      collectBashCommandNames(tokenizeBash(token.value), commands);
+      expectsTrapAction = false;
+      expectsCommand = false;
       continue;
     }
     if (expectsCoprocWord) {
@@ -427,6 +435,10 @@ function collectBashCommandNames(
     if (word === 'eval') {
       evalWords = [];
       expectsCommand = false;
+      continue;
+    }
+    if (word === 'trap') {
+      expectsTrapAction = true;
       continue;
     }
     if (COMMAND_PREFIXES.has(word)) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -289,7 +289,7 @@ function collectBashCommandNames(
   const pendingAssignments = new Map<string, string>();
   let commandPrefix: string | undefined;
   let skipPrefixOptionOperand = false;
-  let caseMode: 'subject' | 'awaitIn' | 'pattern' | 'body' | undefined;
+  const caseModes: Array<'subject' | 'awaitIn' | 'pattern' | 'body'> = [];
 
   const flushEval = (): void => {
     if (evalWords != null && evalWords.length > 0) {
@@ -321,16 +321,19 @@ function collectBashCommandNames(
       expectsCoprocWord = false;
       expectsCommand = true;
       skipRedirectTarget = false;
-      if (token.type === 'caseArmEnd' && caseMode === 'body') {
-        caseMode = 'pattern';
+      if (
+        token.type === 'caseArmEnd' &&
+        caseModes[caseModes.length - 1] === 'body'
+      ) {
+        caseModes[caseModes.length - 1] = 'pattern';
       }
       continue;
     }
     if (token.type === 'closeParen') {
       expectsCommand = true;
       skipRedirectTarget = false;
-      if (caseMode === 'pattern') {
-        caseMode = 'body';
+      if (caseModes[caseModes.length - 1] === 'pattern') {
+        caseModes[caseModes.length - 1] = 'body';
       }
       continue;
     }
@@ -367,20 +370,21 @@ function collectBashCommandNames(
     }
 
     const word = token.value;
+    const caseMode = caseModes[caseModes.length - 1];
     if (caseMode === 'subject') {
-      caseMode = 'awaitIn';
+      caseModes[caseModes.length - 1] = 'awaitIn';
       continue;
     }
     if (caseMode === 'awaitIn') {
-      if (word === 'in') caseMode = 'pattern';
+      if (word === 'in') caseModes[caseModes.length - 1] = 'pattern';
       continue;
     }
     if (caseMode === 'pattern') {
-      if (word === 'esac') caseMode = undefined;
+      if (word === 'esac') caseModes.pop();
       continue;
     }
-    if (caseMode === 'body' && word === 'esac') {
-      caseMode = undefined;
+    if (word === 'esac') {
+      if (caseMode != null) caseModes.pop();
       continue;
     }
     if (expectsFunctionName) {
@@ -409,7 +413,7 @@ function collectBashCommandNames(
       continue;
     }
     if (COMMAND_START_WORDS.has(word) || word === '!' || word === '{') {
-      if (word === 'case') caseMode = 'subject';
+      if (word === 'case') caseModes.push('subject');
       continue;
     }
     if (word === 'function') {
@@ -511,6 +515,18 @@ function tokenizeBash(code: string): BashToken[] {
           tokens: tokenizeBash(code.slice(bodyStart, bodyEnd)),
         });
         index = bodyEnd + 1;
+      }
+      continue;
+    }
+    if (code.slice(index, index + 2) === '((') {
+      const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 2);
+      if (arithmeticEnd == null) {
+        index = code.length;
+      } else {
+        tokens.push(
+          ...tokenizeBashArithmeticSubstitutions(code, index + 2, arithmeticEnd)
+        );
+        index = arithmeticEnd + 1;
       }
       continue;
     }

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -279,6 +279,17 @@ function collectBashCommandNames(
 ): void {
   let expectsCommand = true;
   let skipRedirectTarget = false;
+  let expectsFunctionName = false;
+  let expectsCoprocWord = false;
+  let pendingCoprocWord: string | undefined;
+  let evalWords: string[] | undefined;
+
+  const flushEval = (): void => {
+    if (evalWords != null && evalWords.length > 0) {
+      collectBashCommandNames(tokenizeBash(evalWords.join(' ')), commands);
+    }
+    evalWords = undefined;
+  };
 
   for (const token of tokens) {
     if (token.type === 'nested') {
@@ -289,6 +300,12 @@ function collectBashCommandNames(
       continue;
     }
     if (token.type === 'separator') {
+      flushEval();
+      if (pendingCoprocWord != null) {
+        commands.add(pendingCoprocWord);
+        pendingCoprocWord = undefined;
+      }
+      expectsCoprocWord = false;
       expectsCommand = true;
       skipRedirectTarget = false;
       continue;
@@ -301,11 +318,35 @@ function collectBashCommandNames(
       skipRedirectTarget = false;
       continue;
     }
+    if (evalWords != null) {
+      evalWords.push(token.value);
+      continue;
+    }
+    if (expectsCoprocWord) {
+      pendingCoprocWord = token.value;
+      expectsCoprocWord = false;
+      continue;
+    }
+    if (pendingCoprocWord != null) {
+      if (token.value === '{') {
+        pendingCoprocWord = undefined;
+        expectsCommand = true;
+      } else {
+        commands.add(pendingCoprocWord);
+        pendingCoprocWord = undefined;
+        expectsCommand = false;
+      }
+      continue;
+    }
     if (!expectsCommand) {
       continue;
     }
 
     const word = token.value;
+    if (expectsFunctionName) {
+      expectsFunctionName = false;
+      continue;
+    }
     if (/^[A-Za-z_][A-Za-z0-9_]*\+?=/.test(word)) {
       continue;
     }
@@ -315,12 +356,30 @@ function collectBashCommandNames(
     if (COMMAND_START_WORDS.has(word) || word === '!' || word === '{') {
       continue;
     }
+    if (word === 'function') {
+      expectsFunctionName = true;
+      continue;
+    }
+    if (word === 'coproc') {
+      expectsCoprocWord = true;
+      continue;
+    }
+    if (word === 'eval') {
+      evalWords = [];
+      expectsCommand = false;
+      continue;
+    }
     if (COMMAND_PREFIXES.has(word)) {
       continue;
     }
 
     commands.add(word);
     expectsCommand = false;
+  }
+
+  flushEval();
+  if (pendingCoprocWord != null) {
+    commands.add(pendingCoprocWord);
   }
 }
 
@@ -396,6 +455,22 @@ function tokenizeBash(code: string): BashToken[] {
       continue;
     }
     if (char === '(') {
+      const previousToken = tokens.at(-1);
+      if (
+        previousToken?.type === 'word' &&
+        /^[A-Za-z_][A-Za-z0-9_]*\+?=$/.test(previousToken.value)
+      ) {
+        const arrayEnd = findBashArrayLiteralEnd(code, index + 1);
+        if (arrayEnd == null) {
+          index = code.length;
+        } else {
+          tokens.push(
+            ...tokenizeBashSubstitutions(code, index + 1, arrayEnd)
+          );
+          index = arrayEnd + 1;
+        }
+        continue;
+      }
       tokens.push({ type: 'separator' });
       index += 1;
       continue;
@@ -626,6 +701,58 @@ function findBashBacktickEnd(
   return undefined;
 }
 
+/** Finds the close parenthesis for a Bash array assignment literal. */
+function findBashArrayLiteralEnd(
+  code: string,
+  bodyStart: number
+): number | undefined {
+  let depth = 0;
+  let quote: '\'' | '"' | undefined;
+
+  for (let index = bodyStart; index < code.length; index++) {
+    const char = code[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (quote != null) {
+      if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (code.slice(index, index + 3) === '$((') {
+      const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 3);
+      if (arithmeticEnd == null) return undefined;
+      index = arithmeticEnd;
+      continue;
+    }
+    if (code.slice(index, index + 2) === '$(') {
+      const substitutionEnd = findBashCommandSubstitutionEnd(code, index + 2);
+      if (substitutionEnd == null) return undefined;
+      index = substitutionEnd;
+      continue;
+    }
+    if (char === '`') {
+      const backtickEnd = findBashBacktickEnd(code, index + 1);
+      if (backtickEnd == null) return undefined;
+      index = backtickEnd;
+      continue;
+    }
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')' && depth > 0) {
+      depth -= 1;
+    } else if (char === ')') {
+      return index;
+    }
+  }
+
+  return undefined;
+}
+
 /** Masks heredoc literals while preserving executable unquoted substitutions. */
 function maskBashHeredocBodies(code: string): string {
   const masked = [...code];
@@ -749,6 +876,10 @@ function findBashHeredocDeclaration(
     if (line.slice(index, index + 2) !== '<<') {
       continue;
     }
+    if (line.slice(index, index + 3) === '<<<') {
+      index += 2;
+      continue;
+    }
 
     let targetStart = index + 2;
     const stripTabs = line[targetStart] === '-';
@@ -818,8 +949,15 @@ function tokenizeBashArithmeticSubstitutions(
   bodyStart: number,
   arithmeticEnd: number
 ): BashToken[] {
+  return tokenizeBashSubstitutions(code, bodyStart, arithmeticEnd - 1);
+}
+
+function tokenizeBashSubstitutions(
+  code: string,
+  bodyStart: number,
+  bodyEnd: number
+): BashToken[] {
   const tokens: BashToken[] = [];
-  const bodyEnd = arithmeticEnd - 1;
   let quote: '\'' | '"' | undefined;
 
   for (let index = bodyStart; index < bodyEnd; index++) {
@@ -851,7 +989,7 @@ function tokenizeBashArithmeticSubstitutions(
         code,
         index + 3
       );
-      if (nestedArithmeticEnd == null || nestedArithmeticEnd > arithmeticEnd) {
+      if (nestedArithmeticEnd == null || nestedArithmeticEnd > bodyEnd) {
         break;
       }
       tokens.push(
@@ -864,12 +1002,24 @@ function tokenizeBashArithmeticSubstitutions(
       index = nestedArithmeticEnd;
       continue;
     }
+    if (code[index] === '`') {
+      const backtickEnd = findBashBacktickEnd(code, index + 1);
+      if (backtickEnd == null || backtickEnd >= bodyEnd) {
+        break;
+      }
+      tokens.push({
+        type: 'nested',
+        tokens: tokenizeBash(code.slice(index + 1, backtickEnd)),
+      });
+      index = backtickEnd;
+      continue;
+    }
     if (code.slice(index, index + 2) !== '$(') {
       continue;
     }
 
     const nestedEnd = findBashCommandSubstitutionEnd(code, index + 2);
-    if (nestedEnd == null || nestedEnd >= arithmeticEnd) {
+    if (nestedEnd == null || nestedEnd >= bodyEnd) {
       break;
     }
     tokens.push({

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -275,6 +275,12 @@ function extractBashCommandNames(code: string): Set<string> {
   return commands;
 }
 
+/** Sourced files can invoke any injected function outside the visible code. */
+function requiresAllBashTools(code: string): boolean {
+  const commandNames = extractBashCommandNames(code);
+  return commandNames.has('source') || commandNames.has('.');
+}
+
 function collectBashCommandNames(
   tokens: BashToken[],
   commands: Set<string>
@@ -1234,10 +1240,10 @@ export function assertBashToolsAllowProgrammaticCalling(
     }
   }
 
-  assertDisallowedToolUsage(
-    extractUsedBashToolNames(code, toolNameMap),
-    programmaticToolName
-  );
+  const disallowedUsage = requiresAllBashTools(code)
+    ? new Set(toolNameMap.values())
+    : extractUsedBashToolNames(code, toolNameMap);
+  assertDisallowedToolUsage(disallowedUsage, programmaticToolName);
 }
 
 /**
@@ -1248,6 +1254,16 @@ export function filterBashToolsByUsage(
   code: string,
   debug = false
 ): t.LCTool[] {
+  if (requiresAllBashTools(code)) {
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[BashPTC Debug] Sourced script detected - sending all tools as fallback'
+      );
+    }
+    return toolDefs;
+  }
+
   const toolNameMap = new Map<string, string>();
   for (const def of toolDefs) {
     const bashName = normalizeToBashIdentifier(def.name);

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -282,6 +282,9 @@ function collectBashCommandNames(
   for (const token of tokens) {
     if (token.type === 'nested') {
       collectBashCommandNames(token.tokens, commands);
+      if (skipRedirectTarget) {
+        skipRedirectTarget = false;
+      }
       continue;
     }
     if (token.type === 'separator') {
@@ -338,7 +341,14 @@ function tokenizeBash(code: string): BashToken[] {
     }
     if (code.slice(index, index + 3) === '$((') {
       const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 3);
-      index = arithmeticEnd == null ? code.length : arithmeticEnd + 1;
+      if (arithmeticEnd == null) {
+        index = code.length;
+      } else {
+        tokens.push(
+          ...tokenizeBashArithmeticSubstitutions(code, index + 3, arithmeticEnd)
+        );
+        index = arithmeticEnd + 1;
+      }
       continue;
     }
     if (code.slice(index, index + 2) === '$(') {
@@ -400,7 +410,18 @@ function tokenizeBash(code: string): BashToken[] {
               code,
               index + 3
             );
-            index = arithmeticEnd == null ? code.length : arithmeticEnd + 1;
+            if (arithmeticEnd == null) {
+              index = code.length;
+            } else {
+              tokens.push(
+                ...tokenizeBashArithmeticSubstitutions(
+                  code,
+                  index + 3,
+                  arithmeticEnd
+                )
+              );
+              index = arithmeticEnd + 1;
+            }
             continue;
           }
           if (quote === '"' && code.slice(index, index + 2) === '$(') {
@@ -475,7 +496,7 @@ function findBashCommandSubstitutionEnd(
     }
     if (
       char === '#' &&
-      (index === bodyStart || /[\s;|&(]/.test(code[index - 1]))
+      (index === bodyStart || /[\s;|&()]/.test(code[index - 1]))
     ) {
       while (index < code.length && code[index] !== '\n') {
         index += 1;
@@ -504,9 +525,13 @@ function findBashCommandSubstitutionEnd(
         wordEnd += 1;
       }
       const word = code.slice(index, wordEnd);
-      if (word === 'case') {
+      if (word === 'case' && isBashKeywordPosition(code, index, bodyStart)) {
         caseDepth += 1;
-      } else if (word === 'esac' && caseDepth > 0) {
+      } else if (
+        word === 'esac' &&
+        caseDepth > 0 &&
+        isBashKeywordPosition(code, index, bodyStart)
+      ) {
         caseDepth -= 1;
       }
       index = wordEnd - 1;
@@ -526,6 +551,101 @@ function findBashCommandSubstitutionEnd(
   }
 
   return undefined;
+}
+
+/** Returns whether a reserved word begins where a shell command may begin. */
+function isBashKeywordPosition(
+  code: string,
+  wordStart: number,
+  bodyStart: number
+): boolean {
+  let index = wordStart - 1;
+  while (index >= bodyStart && /[ \t\r]/.test(code[index])) {
+    index -= 1;
+  }
+
+  if (index < bodyStart || /[\n;|&(){}]/.test(code[index])) {
+    return true;
+  }
+
+  if (!/[A-Za-z0-9_]/.test(code[index])) {
+    return false;
+  }
+  const wordEnd = index + 1;
+  while (index >= bodyStart && /[A-Za-z0-9_]/.test(code[index])) {
+    index -= 1;
+  }
+  return COMMAND_START_WORDS.has(code.slice(index + 1, wordEnd));
+}
+
+/** Extracts command substitutions nested inside a `$((...))` expansion. */
+function tokenizeBashArithmeticSubstitutions(
+  code: string,
+  bodyStart: number,
+  arithmeticEnd: number
+): BashToken[] {
+  const tokens: BashToken[] = [];
+  const bodyEnd = arithmeticEnd - 1;
+  let quote: '\'' | '"' | undefined;
+
+  for (let index = bodyStart; index < bodyEnd; index++) {
+    const char = code[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (quote === '\'') {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (quote === '"' && char === '"') {
+      quote = undefined;
+      continue;
+    }
+    if (quote == null && char === '\'') {
+      quote = char;
+      continue;
+    }
+    if (quote == null && char === '"') {
+      quote = '"';
+      continue;
+    }
+    if (code.slice(index, index + 3) === '$((') {
+      const nestedArithmeticEnd = findBashArithmeticExpansionEnd(
+        code,
+        index + 3
+      );
+      if (nestedArithmeticEnd == null || nestedArithmeticEnd > arithmeticEnd) {
+        break;
+      }
+      tokens.push(
+        ...tokenizeBashArithmeticSubstitutions(
+          code,
+          index + 3,
+          nestedArithmeticEnd
+        )
+      );
+      index = nestedArithmeticEnd;
+      continue;
+    }
+    if (code.slice(index, index + 2) !== '$(') {
+      continue;
+    }
+
+    const nestedEnd = findBashCommandSubstitutionEnd(code, index + 2);
+    if (nestedEnd == null || nestedEnd >= arithmeticEnd) {
+      break;
+    }
+    tokens.push({
+      type: 'nested',
+      tokens: tokenizeBash(code.slice(index + 2, nestedEnd)),
+    });
+    index = nestedEnd;
+  }
+
+  return tokens;
 }
 
 /** Finds the second close parenthesis terminating a `$((...))` expansion. */

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -359,7 +359,6 @@ function tokenizeBash(code: string): BashToken[] {
       }
       if (current === '\'' || current === '"') {
         const quote = current;
-        let commandSubstitutionDepth = 0;
         index += 1;
         while (index < code.length && code[index] !== quote) {
           if (quote === '"' && code.slice(index, index + 2) === '$(') {
@@ -368,21 +367,14 @@ function tokenizeBash(code: string): BashToken[] {
               value = '';
             }
             tokens.push({ type: 'separator' });
-            commandSubstitutionDepth += 1;
-            index += 2;
-            continue;
-          }
-          if (
-            quote === '"' &&
-            commandSubstitutionDepth > 0 &&
-            code[index] === ')'
-          ) {
-            if (value !== '') {
-              tokens.push({ type: 'word', value });
-              value = '';
+            const bodyStart = index + 2;
+            const bodyEnd = findBashCommandSubstitutionEnd(code, bodyStart);
+            if (bodyEnd == null) {
+              index = bodyStart;
+            } else {
+              tokens.push(...tokenizeBash(code.slice(bodyStart, bodyEnd)));
+              index = bodyEnd + 1;
             }
-            commandSubstitutionDepth -= 1;
-            index += 1;
             continue;
           }
           if (
@@ -410,6 +402,56 @@ function tokenizeBash(code: string): BashToken[] {
   }
 
   return tokens;
+}
+
+/** Finds the matching close parenthesis for a `$(` command substitution. */
+function findBashCommandSubstitutionEnd(
+  code: string,
+  bodyStart: number
+): number | undefined {
+  let depth = 1;
+  let quote: '\'' | '"' | undefined;
+
+  for (let index = bodyStart; index < code.length; index++) {
+    const char = code[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (quote != null) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === '#') {
+      while (index < code.length && code[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+    if (code.slice(index, index + 2) === '$(') {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /** Rejects direct-only tools before any bash sandbox request is made. */

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -315,6 +315,7 @@ function collectBashCommandNames(
   let skipPrefixOptionOperand = false;
   let expectsTrapAction = false;
   let readsDeclarationOperands = false;
+  let readsCommandLookupOperands = false;
   const caseModes: Array<'subject' | 'awaitIn' | 'pattern' | 'body'> = [];
 
   const flushEval = (): void => {
@@ -346,6 +347,7 @@ function collectBashCommandNames(
       skipPrefixOptionOperand = false;
       expectsTrapAction = false;
       readsDeclarationOperands = false;
+      readsCommandLookupOperands = false;
       if (pendingCoprocWord != null) {
         commands.add(pendingCoprocWord);
         pendingCoprocWord = undefined;
@@ -416,6 +418,9 @@ function collectBashCommandNames(
       }
       continue;
     }
+    if (readsCommandLookupOperands) {
+      continue;
+    }
     if (!expectsCommand) {
       continue;
     }
@@ -465,6 +470,12 @@ function collectBashCommandNames(
     }
     if (commandPrefix === 'env' && (word === '-u' || word === '--unset')) {
       skipPrefixOptionOperand = true;
+      continue;
+    }
+    if (commandPrefix === 'command' && (word === '-v' || word === '-V')) {
+      readsCommandLookupOperands = true;
+      commandPrefix = undefined;
+      expectsCommand = false;
       continue;
     }
     if (word.startsWith('-')) {
@@ -788,7 +799,7 @@ function findBashCommandSubstitutionEnd(
 
   for (let index = bodyStart; index < code.length; index++) {
     const char = code[index];
-    if (char === '\\') {
+    if (char === '\\' && quote !== '\'') {
       index += 1;
       continue;
     }

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -249,7 +249,9 @@ const COMMAND_START_WORDS = new Set([
   'do',
   'elif',
   'else',
+  'case',
   'if',
+  'in',
   'then',
   'time',
   'until',
@@ -259,15 +261,29 @@ const COMMAND_START_WORDS = new Set([
 type BashToken =
   | { type: 'word'; value: string }
   | { type: 'separator' }
-  | { type: 'redirect' };
+  | { type: 'redirect' }
+  | { type: 'nested'; tokens: BashToken[] };
 
 /** Returns shell words at command position, excluding arguments and comments. */
 function extractBashCommandNames(code: string): Set<string> {
   const commands = new Set<string>();
+
+  collectBashCommandNames(tokenizeBash(code), commands);
+  return commands;
+}
+
+function collectBashCommandNames(
+  tokens: BashToken[],
+  commands: Set<string>
+): void {
   let expectsCommand = true;
   let skipRedirectTarget = false;
 
-  for (const token of tokenizeBash(code)) {
+  for (const token of tokens) {
+    if (token.type === 'nested') {
+      collectBashCommandNames(token.tokens, commands);
+      continue;
+    }
     if (token.type === 'separator') {
       expectsCommand = true;
       skipRedirectTarget = false;
@@ -302,8 +318,6 @@ function extractBashCommandNames(code: string): Set<string> {
     commands.add(word);
     expectsCommand = false;
   }
-
-  return commands;
 }
 
 /** Minimal shell lexer for locating command positions without executing code. */
@@ -322,12 +336,32 @@ function tokenizeBash(code: string): BashToken[] {
       index += code[index + 1] === char ? 2 : 1;
       continue;
     }
-    if (char === '(' || code.slice(index, index + 2) === '$(') {
+    if (code.slice(index, index + 3) === '$((') {
+      const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 3);
+      index = arithmeticEnd == null ? code.length : arithmeticEnd + 1;
+      continue;
+    }
+    if (code.slice(index, index + 2) === '$(') {
+      const bodyStart = index + 2;
+      const bodyEnd = findBashCommandSubstitutionEnd(code, bodyStart);
+      if (bodyEnd == null) {
+        index = code.length;
+      } else {
+        tokens.push({
+          type: 'nested',
+          tokens: tokenizeBash(code.slice(bodyStart, bodyEnd)),
+        });
+        index = bodyEnd + 1;
+      }
+      continue;
+    }
+    if (char === '(') {
       tokens.push({ type: 'separator' });
-      index += char === '(' ? 1 : 2;
+      index += 1;
       continue;
     }
     if (char === ')') {
+      tokens.push({ type: 'separator' });
       index += 1;
       continue;
     }
@@ -361,18 +395,28 @@ function tokenizeBash(code: string): BashToken[] {
         const quote = current;
         index += 1;
         while (index < code.length && code[index] !== quote) {
+          if (quote === '"' && code.slice(index, index + 3) === '$((') {
+            const arithmeticEnd = findBashArithmeticExpansionEnd(
+              code,
+              index + 3
+            );
+            index = arithmeticEnd == null ? code.length : arithmeticEnd + 1;
+            continue;
+          }
           if (quote === '"' && code.slice(index, index + 2) === '$(') {
             if (value !== '') {
               tokens.push({ type: 'word', value });
               value = '';
             }
-            tokens.push({ type: 'separator' });
             const bodyStart = index + 2;
             const bodyEnd = findBashCommandSubstitutionEnd(code, bodyStart);
             if (bodyEnd == null) {
-              index = bodyStart;
+              index = code.length;
             } else {
-              tokens.push(...tokenizeBash(code.slice(bodyStart, bodyEnd)));
+              tokens.push({
+                type: 'nested',
+                tokens: tokenizeBash(code.slice(bodyStart, bodyEnd)),
+              });
               index = bodyEnd + 1;
             }
             continue;
@@ -409,7 +453,8 @@ function findBashCommandSubstitutionEnd(
   code: string,
   bodyStart: number
 ): number | undefined {
-  let depth = 1;
+  let groupedParentheses = 0;
+  let caseDepth = 0;
   let quote: '\'' | '"' | undefined;
 
   for (let index = bodyStart; index < code.length; index++) {
@@ -428,26 +473,87 @@ function findBashCommandSubstitutionEnd(
       quote = char;
       continue;
     }
-    if (char === '#') {
+    if (
+      char === '#' &&
+      (index === bodyStart || /[\s;|&(]/.test(code[index - 1]))
+    ) {
       while (index < code.length && code[index] !== '\n') {
         index += 1;
       }
       continue;
     }
+    if (code.slice(index, index + 3) === '$((') {
+      const arithmeticEnd = findBashArithmeticExpansionEnd(code, index + 3);
+      if (arithmeticEnd == null) {
+        return undefined;
+      }
+      index = arithmeticEnd;
+      continue;
+    }
     if (code.slice(index, index + 2) === '$(') {
-      depth += 1;
+      const nestedEnd = findBashCommandSubstitutionEnd(code, index + 2);
+      if (nestedEnd == null) {
+        return undefined;
+      }
+      index = nestedEnd;
+      continue;
+    }
+    if (/[A-Za-z_]/.test(char)) {
+      let wordEnd = index + 1;
+      while (wordEnd < code.length && /[A-Za-z0-9_]/.test(code[wordEnd])) {
+        wordEnd += 1;
+      }
+      const word = code.slice(index, wordEnd);
+      if (word === 'case') {
+        caseDepth += 1;
+      } else if (word === 'esac' && caseDepth > 0) {
+        caseDepth -= 1;
+      }
+      index = wordEnd - 1;
+      continue;
+    }
+    if (char === '(') {
+      groupedParentheses += 1;
+      continue;
+    }
+    if (char === ')') {
+      if (groupedParentheses > 0) {
+        groupedParentheses -= 1;
+      } else if (caseDepth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Finds the second close parenthesis terminating a `$((...))` expansion. */
+function findBashArithmeticExpansionEnd(
+  code: string,
+  bodyStart: number
+): number | undefined {
+  let groupedParentheses = 0;
+
+  for (let index = bodyStart; index < code.length; index++) {
+    const char = code[index];
+    if (char === '\\') {
       index += 1;
       continue;
     }
     if (char === '(') {
-      depth += 1;
+      groupedParentheses += 1;
       continue;
     }
-    if (char === ')') {
-      depth -= 1;
-      if (depth === 0) {
-        return index;
-      }
+    if (char !== ')') {
+      continue;
+    }
+    if (groupedParentheses > 0) {
+      groupedParentheses -= 1;
+      continue;
+    }
+    if (code[index + 1] === ')') {
+      return index + 1;
     }
   }
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -287,9 +287,15 @@ function extractBashCommandNames(
 }
 
 /** Sourced files can invoke any injected function outside the visible code. */
-function requiresAllBashTools(code: string): boolean {
-  const commandNames = extractBashCommandNames(code);
-  return commandNames.has('source') || commandNames.has('.');
+function requiresAllBashTools(
+  code: string,
+  knownToolNames?: { has(name: string): boolean }
+): boolean {
+  const commandNames = extractBashCommandNames(code, knownToolNames);
+  return (
+    commandNames.has('.') ||
+    (commandNames.has('source') && knownToolNames?.has('source') !== true)
+  );
 }
 
 function collectBashCommandNames(
@@ -936,11 +942,17 @@ function maskBashHeredocBodies(code: string): string {
   let lineStart = 0;
 
   while (lineStart < code.length) {
-    const lineEnd = code.indexOf('\n', lineStart);
-    const contentEnd = lineEnd === -1 ? code.length : lineEnd;
-    const declarations = findBashHeredocDeclarations(
-      code.slice(lineStart, contentEnd)
-    );
+    let lineEnd = code.indexOf('\n', lineStart);
+    let contentEnd = lineEnd === -1 ? code.length : lineEnd;
+    let logicalLine = code.slice(lineStart, contentEnd);
+    while (lineEnd !== -1 && hasBashLineContinuation(logicalLine)) {
+      const continuedStart = lineEnd + 1;
+      lineEnd = code.indexOf('\n', continuedStart);
+      contentEnd = lineEnd === -1 ? code.length : lineEnd;
+      logicalLine =
+        logicalLine.slice(0, -1) + code.slice(continuedStart, contentEnd);
+    }
+    const declarations = findBashHeredocDeclarations(logicalLine);
     if (declarations.length === 0 || lineEnd === -1) {
       lineStart = lineEnd === -1 ? code.length : lineEnd + 1;
       continue;
@@ -988,6 +1000,28 @@ function maskBashHeredocBodies(code: string): string {
   }
 
   return masked.join('');
+}
+
+function hasBashLineContinuation(line: string): boolean {
+  let quote: '\'' | '"' | undefined;
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index];
+    if (char === '\\' && quote !== '\'') {
+      if (index === line.length - 1) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      if (quote == null) {
+        quote = char;
+      } else if (quote === char) {
+        quote = undefined;
+      }
+    }
+  }
+  return false;
 }
 
 function restoreBashHeredocSubstitutions(
@@ -1311,7 +1345,8 @@ export function assertBashToolsAllowProgrammaticCalling(
     }
   }
 
-  const disallowedUsage = requiresAllBashTools(code)
+  const knownNames = new Set([...allowedNames, ...toolNameMap.keys()]);
+  const disallowedUsage = requiresAllBashTools(code, knownNames)
     ? new Set(toolNameMap.values())
     : extractUsedBashToolNames(code, toolNameMap);
   assertDisallowedToolUsage(disallowedUsage, programmaticToolName);
@@ -1325,7 +1360,13 @@ export function filterBashToolsByUsage(
   code: string,
   debug = false
 ): t.LCTool[] {
-  if (requiresAllBashTools(code)) {
+  const toolNameMap = new Map<string, string>();
+  for (const def of toolDefs) {
+    const bashName = normalizeToBashIdentifier(def.name);
+    toolNameMap.set(bashName, def.name);
+  }
+
+  if (requiresAllBashTools(code, toolNameMap)) {
     if (debug) {
       // eslint-disable-next-line no-console
       console.log(
@@ -1333,12 +1374,6 @@ export function filterBashToolsByUsage(
       );
     }
     return toolDefs;
-  }
-
-  const toolNameMap = new Map<string, string>();
-  for (const def of toolDefs) {
-    const bashName = normalizeToBashIdentifier(def.name);
-    toolNameMap.set(bashName, def.name);
   }
 
   const usedToolNames = extractUsedBashToolNames(code, toolNameMap);

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -224,7 +224,7 @@ export function extractUsedBashToolNames(
   toolNameMap: Map<string, string>
 ): Set<string> {
   const usedTools = new Set<string>();
-  const commandNames = extractBashCommandNames(code);
+  const commandNames = extractBashCommandNames(code, toolNameMap);
 
   for (const commandName of commandNames) {
     const originalName = toolNameMap.get(commandName);
@@ -276,10 +276,13 @@ type BashToken =
   | { type: 'nested'; tokens: BashToken[] };
 
 /** Returns shell words at command position, excluding arguments and comments. */
-function extractBashCommandNames(code: string): Set<string> {
+function extractBashCommandNames(
+  code: string,
+  knownToolNames?: { has(name: string): boolean }
+): Set<string> {
   const commands = new Set<string>();
 
-  collectBashCommandNames(tokenizeBash(code), commands);
+  collectBashCommandNames(tokenizeBash(code), commands, knownToolNames);
   return commands;
 }
 
@@ -291,7 +294,8 @@ function requiresAllBashTools(code: string): boolean {
 
 function collectBashCommandNames(
   tokens: BashToken[],
-  commands: Set<string>
+  commands: Set<string>,
+  knownToolNames?: { has(name: string): boolean }
 ): void {
   let expectsCommand = true;
   let skipRedirectTarget = false;
@@ -309,14 +313,18 @@ function collectBashCommandNames(
 
   const flushEval = (): void => {
     if (evalWords != null && evalWords.length > 0) {
-      collectBashCommandNames(tokenizeBash(evalWords.join(' ')), commands);
+      collectBashCommandNames(
+        tokenizeBash(evalWords.join(' ')),
+        commands,
+        knownToolNames
+      );
     }
     evalWords = undefined;
   };
 
   for (const token of tokens) {
     if (token.type === 'nested') {
-      collectBashCommandNames(token.tokens, commands);
+      collectBashCommandNames(token.tokens, commands, knownToolNames);
       if (skipRedirectTarget) {
         skipRedirectTarget = false;
       }
@@ -368,7 +376,11 @@ function collectBashCommandNames(
       continue;
     }
     if (expectsTrapAction) {
-      collectBashCommandNames(tokenizeBash(token.value), commands);
+      collectBashCommandNames(
+        tokenizeBash(token.value),
+        commands,
+        knownToolNames
+      );
       expectsTrapAction = false;
       expectsCommand = false;
       continue;
@@ -422,6 +434,13 @@ function collectBashCommandNames(
     }
     if (expectsFunctionName) {
       expectsFunctionName = false;
+      continue;
+    }
+    if (knownToolNames?.has(word) === true) {
+      commands.add(word);
+      pendingAssignments.clear();
+      commandPrefix = undefined;
+      expectsCommand = false;
       continue;
     }
     const assignment = word.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
@@ -1063,38 +1082,64 @@ function findBashHeredocDeclarations(
     while (/[ \t]/.test(line[targetStart] ?? '')) {
       targetStart += 1;
     }
-    const delimiterQuote = line[targetStart];
-    if (delimiterQuote === '\'' || delimiterQuote === '"') {
-      const targetEnd = line.indexOf(delimiterQuote, targetStart + 1);
-      if (targetEnd === -1) {
-        continue;
-      }
+    const parsedDelimiter = parseBashHeredocDelimiter(line, targetStart);
+    if (parsedDelimiter != null) {
       declarations.push({
-        delimiter: line.slice(targetStart + 1, targetEnd),
+        delimiter: parsedDelimiter.delimiter,
         stripTabs,
-        quoted: true,
+        quoted: parsedDelimiter.quoted,
       });
-      index = targetEnd;
-      continue;
-    }
-    let targetEnd = targetStart;
-    while (
-      targetEnd < line.length &&
-      !/[ \t;&|()<>]/.test(line[targetEnd])
-    ) {
-      targetEnd += 1;
-    }
-    if (targetEnd > targetStart) {
-      declarations.push({
-        delimiter: line.slice(targetStart, targetEnd),
-        stripTabs,
-        quoted: false,
-      });
-      index = targetEnd - 1;
+      index = parsedDelimiter.end - 1;
     }
   }
 
   return declarations;
+}
+
+function parseBashHeredocDelimiter(
+  line: string,
+  start: number
+): { delimiter: string; end: number; quoted: boolean } | undefined {
+  let delimiter = '';
+  let quoted = false;
+  let quote: '\'' | '"' | undefined;
+  let index = start;
+
+  while (index < line.length) {
+    const char = line[index];
+    if (quote == null && /[ \t;&|()<>]/.test(char)) {
+      break;
+    }
+    if (char === '\\' && quote !== '\'') {
+      const next = line[index + 1];
+      if (next != null && (quote == null || /[$`"\\\n]/.test(next))) {
+        quoted = true;
+        if (next !== '\n') delimiter += next;
+        index += 2;
+        continue;
+      }
+    }
+    if (char === '\'' || char === '"') {
+      if (quote == null) {
+        quote = char;
+        quoted = true;
+        index += 1;
+        continue;
+      }
+      if (quote === char) {
+        quote = undefined;
+        index += 1;
+        continue;
+      }
+    }
+    delimiter += char;
+    index += 1;
+  }
+
+  if (delimiter === '' || quote != null) {
+    return undefined;
+  }
+  return { delimiter, end: index, quoted };
 }
 
 /** Returns whether a reserved word begins where a shell command may begin. */

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -330,11 +330,16 @@ export function extractUsedToolNames(
       }
       if (
         executableCode[prefix] !== '.' &&
-        isPythonCallableInvocation(
+        (isPythonCallableInvocation(
           executableCode,
           match.index,
           match.index + pythonName.length
-        )
+        ) ||
+          isPythonCallableValueReference(
+            executableCode,
+            match.index,
+            match.index + pythonName.length
+          ))
       ) {
         usedTools.add(originalName);
         break;
@@ -343,6 +348,20 @@ export function extractUsedToolNames(
   }
 
   return usedTools;
+}
+
+function isPythonCallableValueReference(
+  code: string,
+  nameStart: number,
+  nameEnd: number
+): boolean {
+  const suffix = skipPythonCallWhitespace(code, nameEnd);
+  if (code[suffix] === '=' && code[suffix + 1] !== '=') {
+    return false;
+  }
+
+  const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+  return !['as', 'class', 'def', 'import'].includes(prefix?.[1] ?? '');
 }
 
 function isPythonCallableInvocation(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -172,6 +172,81 @@ const PYTHON_KEYWORDS = new Set([
   'yield',
 ]);
 
+/** Callable builtins remain available when a direct-only tool has the same name. */
+const PYTHON_CALLABLE_BUILTINS = new Set([
+  '__import__',
+  'abs',
+  'aiter',
+  'all',
+  'anext',
+  'any',
+  'ascii',
+  'bin',
+  'bool',
+  'breakpoint',
+  'bytearray',
+  'bytes',
+  'callable',
+  'chr',
+  'classmethod',
+  'compile',
+  'complex',
+  'delattr',
+  'dict',
+  'dir',
+  'divmod',
+  'enumerate',
+  'eval',
+  'exec',
+  'filter',
+  'float',
+  'format',
+  'frozenset',
+  'getattr',
+  'globals',
+  'hasattr',
+  'hash',
+  'help',
+  'hex',
+  'id',
+  'input',
+  'int',
+  'isinstance',
+  'issubclass',
+  'iter',
+  'len',
+  'list',
+  'locals',
+  'map',
+  'max',
+  'memoryview',
+  'min',
+  'next',
+  'object',
+  'oct',
+  'open',
+  'ord',
+  'pow',
+  'print',
+  'property',
+  'range',
+  'repr',
+  'reversed',
+  'round',
+  'set',
+  'setattr',
+  'slice',
+  'sorted',
+  'staticmethod',
+  'str',
+  'sum',
+  'super',
+  'tuple',
+  'type',
+  'vars',
+  'zip',
+]);
+
 export type FetchSessionFilesScope =
   | { kind: 'skill'; id: string; version: number }
   | { kind: 'agent' | 'user'; id: string; version?: never };
@@ -339,7 +414,12 @@ export function extractUsedToolNames(
         shadowedScopes.add(lexicalScope);
         continue;
       }
-      if (shadowedScopes.has(lexicalScope)) {
+      if (
+        [...shadowedScopes].some(
+          (scope) =>
+            lexicalScope === scope || lexicalScope.startsWith(`${scope}/`)
+        )
+      ) {
         continue;
       }
       let prefix = match.index - 1;
@@ -436,6 +516,9 @@ function isPythonBindingTarget(
   }
   const suffix = skipPythonCallWhitespace(code, nameEnd);
   if (code[suffix] === '=' && code[suffix + 1] !== '=') {
+    if (isPythonFStringDebugMarker(code, suffix)) {
+      return false;
+    }
     return !isPythonKeywordArgument(code, nameStart);
   }
   const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
@@ -498,12 +581,24 @@ function isPythonCallableValueReference(
   nameEnd: number
 ): boolean {
   const suffix = skipPythonCallWhitespace(code, nameEnd);
-  if (code[suffix] === '=' && code[suffix + 1] !== '=') {
+  if (
+    code[suffix] === '=' &&
+    code[suffix + 1] !== '=' &&
+    !isPythonFStringDebugMarker(code, suffix)
+  ) {
     return false;
   }
 
   const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
   return !['as', 'class', 'def', 'import'].includes(prefix?.[1] ?? '');
+}
+
+function isPythonFStringDebugMarker(
+  code: string,
+  equalsIndex: number
+): boolean {
+  const next = skipPythonCallWhitespace(code, equalsIndex + 1);
+  return code[next] === '}' || code[next] === '!' || code[next] === ':';
 }
 
 function isPythonCallableInvocation(
@@ -745,7 +840,18 @@ function findPythonFStringFormatStart(
     else if (char === '[') closers.push(']');
     else if (char === '{') closers.push('}');
     else if (char === closers[closers.length - 1]) closers.pop();
-    else if (closers.length === 0 && char === ':') {
+    else if (
+      closers.length === 0 &&
+      char === '=' &&
+      !/[=!<>:]/.test(field[index - 1] ?? '') &&
+      field[index + 1] !== '='
+    ) {
+      const colon = field.indexOf(':', index + 1);
+      return {
+        separator: index,
+        spec: colon === -1 ? undefined : colon + 1,
+      };
+    } else if (closers.length === 0 && char === ':') {
       return { separator: index, spec: index + 1 };
     } else if (
       closers.length === 0 &&
@@ -885,7 +991,10 @@ export function assertPythonToolsAllowProgrammaticCalling(
   );
   for (const toolDef of toolDefs) {
     const normalizedName = normalizeToPythonIdentifier(toolDef.name);
-    if (!allowedNames.has(normalizedName)) {
+    if (
+      !allowedNames.has(normalizedName) &&
+      !PYTHON_CALLABLE_BUILTINS.has(normalizedName)
+    ) {
       toolNameMap.set(normalizedName, toolDef.name);
     }
   }

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -350,10 +350,7 @@ function isPythonCallableInvocation(
   nameStart: number,
   nameEnd: number
 ): boolean {
-  let suffix = nameEnd;
-  while (/\s/.test(code[suffix] ?? '')) {
-    suffix += 1;
-  }
+  let suffix = skipPythonCallWhitespace(code, nameEnd);
   if (code[suffix] === '(') {
     return true;
   }
@@ -366,12 +363,33 @@ function isPythonCallableInvocation(
     return false;
   }
   while (code[suffix] === ')') {
-    suffix += 1;
-    while (/\s/.test(code[suffix] ?? '')) {
-      suffix += 1;
-    }
+    suffix = skipPythonCallWhitespace(code, suffix + 1);
   }
   return code[suffix] === '(';
+}
+
+function skipPythonCallWhitespace(code: string, start: number): number {
+  let index = start;
+  while (index < code.length) {
+    if (/\s/.test(code[index])) {
+      index += 1;
+      continue;
+    }
+    if (code[index] === '\\' && code[index + 1] === '\n') {
+      index += 2;
+      continue;
+    }
+    if (
+      code[index] === '\\' &&
+      code[index + 1] === '\r' &&
+      code[index + 2] === '\n'
+    ) {
+      index += 3;
+      continue;
+    }
+    break;
+  }
+  return index;
 }
 
 /**

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -323,7 +323,21 @@ export function extractUsedToolNames(
     const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
 
+    let shadowed = false;
     for (const match of executableCode.matchAll(pattern)) {
+      if (
+        isPythonBindingTarget(
+          executableCode,
+          match.index,
+          match.index + pythonName.length
+        )
+      ) {
+        shadowed = true;
+        continue;
+      }
+      if (shadowed) {
+        continue;
+      }
       let prefix = match.index - 1;
       while (prefix >= 0 && /\s/.test(executableCode[prefix])) {
         prefix -= 1;
@@ -348,6 +362,19 @@ export function extractUsedToolNames(
   }
 
   return usedTools;
+}
+
+function isPythonBindingTarget(
+  code: string,
+  nameStart: number,
+  nameEnd: number
+): boolean {
+  const suffix = skipPythonCallWhitespace(code, nameEnd);
+  if (code[suffix] === '=' && code[suffix + 1] !== '=') {
+    return true;
+  }
+  const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+  return ['as', 'class', 'def', 'for', 'import'].includes(prefix?.[1] ?? '');
 }
 
 function isPythonCallableValueReference(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -323,8 +323,15 @@ export function extractUsedToolNames(
     const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`\\b${escapedName}\\s*\\(`, 'g');
 
-    if (pattern.test(executableCode)) {
-      usedTools.add(originalName);
+    for (const match of executableCode.matchAll(pattern)) {
+      let prefix = match.index - 1;
+      while (prefix >= 0 && /\s/.test(executableCode[prefix])) {
+        prefix -= 1;
+      }
+      if (executableCode[prefix] !== '.') {
+        usedTools.add(originalName);
+        break;
+      }
     }
   }
 
@@ -604,15 +611,24 @@ export function assertDisallowedToolUsage(
 export function assertPythonToolsAllowProgrammaticCalling(
   toolDefs: t.LCTool[] | undefined,
   code: string,
-  programmaticToolName: string = Constants.PROGRAMMATIC_TOOL_CALLING
+  programmaticToolName: string = Constants.PROGRAMMATIC_TOOL_CALLING,
+  allowedToolDefs?: t.LCTool[]
 ): void {
   if (toolDefs == null || toolDefs.length === 0) {
     return;
   }
 
   const toolNameMap = new Map<string, string>();
+  const allowedNames = new Set(
+    allowedToolDefs?.map((toolDef) =>
+      normalizeToPythonIdentifier(toolDef.name)
+    ) ?? []
+  );
   for (const toolDef of toolDefs) {
-    toolNameMap.set(normalizeToPythonIdentifier(toolDef.name), toolDef.name);
+    const normalizedName = normalizeToPythonIdentifier(toolDef.name);
+    if (!allowedNames.has(normalizedName)) {
+      toolNameMap.set(normalizedName, toolDef.name);
+    }
   }
 
   assertDisallowedToolUsage(
@@ -1210,7 +1226,8 @@ export function createProgrammaticToolCallingTool(
         toolCall.programmaticToolName ??
           (typeof toolCall.name === 'string' && toolCall.name !== ''
             ? toolCall.name
-            : Constants.PROGRAMMATIC_TOOL_CALLING)
+            : Constants.PROGRAMMATIC_TOOL_CALLING),
+        toolDefs
       );
 
       if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -321,14 +321,21 @@ export function extractUsedToolNames(
 
   for (const [pythonName, originalName] of toolNameMap) {
     const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = new RegExp(`\\b${escapedName}\\s*\\(`, 'g');
+    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
 
     for (const match of executableCode.matchAll(pattern)) {
       let prefix = match.index - 1;
       while (prefix >= 0 && /\s/.test(executableCode[prefix])) {
         prefix -= 1;
       }
-      if (executableCode[prefix] !== '.') {
+      if (
+        executableCode[prefix] !== '.' &&
+        isPythonCallableInvocation(
+          executableCode,
+          match.index,
+          match.index + pythonName.length
+        )
+      ) {
         usedTools.add(originalName);
         break;
       }
@@ -336,6 +343,35 @@ export function extractUsedToolNames(
   }
 
   return usedTools;
+}
+
+function isPythonCallableInvocation(
+  code: string,
+  nameStart: number,
+  nameEnd: number
+): boolean {
+  let suffix = nameEnd;
+  while (/\s/.test(code[suffix] ?? '')) {
+    suffix += 1;
+  }
+  if (code[suffix] === '(') {
+    return true;
+  }
+
+  let prefix = nameStart - 1;
+  while (/\s/.test(code[prefix] ?? '')) {
+    prefix -= 1;
+  }
+  if (code[prefix] !== ')' && code[prefix] !== '(') {
+    return false;
+  }
+  while (code[suffix] === ')') {
+    suffix += 1;
+    while (/\s/.test(code[suffix] ?? '')) {
+      suffix += 1;
+    }
+  }
+  return code[suffix] === '(';
 }
 
 /**

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -479,19 +479,28 @@ function findPythonFStringFormatStart(
 ): { separator: number; spec?: number } | undefined {
   const closers: string[] = [];
   let quote: '\'' | '"' | undefined;
+  let triple = false;
 
   for (let index = 0; index < field.length; index++) {
     const char = field[index];
     if (quote != null) {
       if (char === '\\') {
         index += 1;
-      } else if (char === quote) {
+      } else if (
+        triple
+          ? field.slice(index, index + 3) === quote.repeat(3)
+          : char === quote
+      ) {
+        index += triple ? 2 : 0;
         quote = undefined;
+        triple = false;
       }
       continue;
     }
     if (char === '\'' || char === '"') {
       quote = char;
+      triple = field.slice(index, index + 3) === char.repeat(3);
+      index += triple ? 2 : 0;
       continue;
     }
     if (char === '(') closers.push(')');
@@ -500,7 +509,11 @@ function findPythonFStringFormatStart(
     else if (char === closers[closers.length - 1]) closers.pop();
     else if (closers.length === 0 && char === ':') {
       return { separator: index, spec: index + 1 };
-    } else if (closers.length === 0 && char === '!') {
+    } else if (
+      closers.length === 0 &&
+      char === '!' &&
+      /[ars]/i.test(field[index + 1] ?? '')
+    ) {
       const colon = field.indexOf(':', index + 1);
       return {
         separator: index,

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -323,8 +323,12 @@ export function extractUsedToolNames(
     const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
 
-    let shadowed = false;
+    const shadowedScopes = new Set<string>();
     for (const match of executableCode.matchAll(pattern)) {
+      const lexicalScope = getPythonLexicalScopeKey(
+        executableCode,
+        match.index
+      );
       if (
         isPythonBindingTarget(
           executableCode,
@@ -332,10 +336,10 @@ export function extractUsedToolNames(
           match.index + pythonName.length
         )
       ) {
-        shadowed = true;
+        shadowedScopes.add(lexicalScope);
         continue;
       }
-      if (shadowed) {
+      if (shadowedScopes.has(lexicalScope)) {
         continue;
       }
       let prefix = match.index - 1;
@@ -362,6 +366,40 @@ export function extractUsedToolNames(
   }
 
   return usedTools;
+}
+
+function getPythonLexicalScopeKey(code: string, position: number): string {
+  const lines = code.slice(0, position).split('\n');
+  const scopes: Array<{ indent: number; key: string }> = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length - 1; lineIndex++) {
+    const line = lines[lineIndex];
+    const content = line.trim();
+    if (content === '') continue;
+    const indent = line.length - line.trimStart().length;
+    while (
+      scopes.length > 0 &&
+      indent <= scopes[scopes.length - 1].indent
+    ) {
+      scopes.pop();
+    }
+    if (/^(?:async\s+)?def\s+|^class\s+/.test(content)) {
+      scopes.push({ indent, key: `${lineIndex}:${indent}` });
+    }
+  }
+
+  const currentLine = lines[lines.length - 1];
+  const currentIndent = currentLine.length - currentLine.trimStart().length;
+  while (
+    scopes.length > 0 &&
+    currentIndent <= scopes[scopes.length - 1].indent
+  ) {
+    scopes.pop();
+  }
+
+  return scopes.length === 0
+    ? 'module'
+    : scopes.map((scope) => scope.key).join('/');
 }
 
 function isPythonBindingTarget(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -396,6 +396,15 @@ function getPythonLexicalScopeKey(code: string, position: number): string {
   ) {
     scopes.pop();
   }
+  const inlineScope = currentLine.match(
+    /(?:^|;)\s*(?:(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)|class\s+[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?)\s*:\s*$/
+  );
+  if (inlineScope != null) {
+    scopes.push({
+      indent: currentIndent,
+      key: `inline:${lines.length - 1}:${inlineScope.index ?? 0}`,
+    });
+  }
 
   return scopes.length === 0
     ? 'module'
@@ -507,7 +516,17 @@ function maskPythonStringsAndComments(code: string): string {
 
     const triple = code.slice(index, index + 3) === quote.repeat(3);
     const delimiterLength = triple ? 3 : 1;
-    const isFString = hasPythonFStringPrefix(code, index);
+    const stringPrefix = getPythonStringPrefix(code, index);
+    const isFString = stringPrefix?.isFString === true;
+    if (stringPrefix != null) {
+      for (
+        let prefixIndex = stringPrefix.start;
+        prefixIndex < index;
+        prefixIndex++
+      ) {
+        mask(prefixIndex);
+      }
+    }
     for (let offset = 0; offset < delimiterLength; offset++) {
       mask(index + offset);
     }
@@ -568,7 +587,10 @@ function maskPythonStringsAndComments(code: string): string {
   return masked.join('');
 }
 
-function hasPythonFStringPrefix(code: string, quoteIndex: number): boolean {
+function getPythonStringPrefix(
+  code: string,
+  quoteIndex: number
+): { start: number; isFString: boolean } | undefined {
   let prefixStart = quoteIndex;
   while (prefixStart > 0 && /[A-Za-z]/.test(code[prefixStart - 1])) {
     prefixStart -= 1;
@@ -577,10 +599,13 @@ function hasPythonFStringPrefix(code: string, quoteIndex: number): boolean {
     prefixStart > 0 &&
     /[A-Za-z0-9_]/.test(code[prefixStart - 1])
   ) {
-    return false;
+    return undefined;
   }
   const prefix = code.slice(prefixStart, quoteIndex);
-  return /^[rRuUbBfF]*[fF][rRuUbBfF]*$/.test(prefix);
+  if (!/^[rRuUbBfF]*$/.test(prefix)) {
+    return undefined;
+  }
+  return { start: prefixStart, isFString: /[fF]/.test(prefix) };
 }
 
 /** Keeps executable field expressions while masking literal format specs. */

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -378,7 +378,7 @@ function maskPythonStringsAndComments(code: string): string {
         const expressionEnd = findPythonFStringExpressionEnd(code, index + 1);
         if (expressionEnd != null) {
           mask(index);
-          const expression = maskPythonStringsAndComments(
+          const expression = maskPythonFStringField(
             code.slice(index + 1, expressionEnd)
           );
           for (let offset = 0; offset < expression.length; offset++) {
@@ -436,6 +436,80 @@ function hasPythonFStringPrefix(code: string, quoteIndex: number): boolean {
   }
   const prefix = code.slice(prefixStart, quoteIndex);
   return /^[rRuUbBfF]*[fF][rRuUbBfF]*$/.test(prefix);
+}
+
+/** Keeps executable field expressions while masking literal format specs. */
+function maskPythonFStringField(field: string): string {
+  const masked: string[] = field.split('').map((char) =>
+    char === '\n' || char === '\r' ? char : ' '
+  );
+  const formatStart = findPythonFStringFormatStart(field);
+  const valueEnd = formatStart?.separator ?? field.length;
+  const value = maskPythonStringsAndComments(field.slice(0, valueEnd));
+  for (let index = 0; index < value.length; index++) {
+    masked[index] = value[index];
+  }
+
+  if (formatStart?.spec == null) {
+    return masked.join('');
+  }
+
+  let index = formatStart.spec;
+  while (index < field.length) {
+    if (field[index] !== '{' || field[index + 1] === '{') {
+      index += field[index] === '{' ? 2 : 1;
+      continue;
+    }
+    const nestedEnd = findPythonFStringExpressionEnd(field, index + 1);
+    if (nestedEnd == null) {
+      break;
+    }
+    const nested = maskPythonFStringField(field.slice(index + 1, nestedEnd));
+    for (let offset = 0; offset < nested.length; offset++) {
+      masked[index + 1 + offset] = nested[offset];
+    }
+    index = nestedEnd + 1;
+  }
+
+  return masked.join('');
+}
+
+function findPythonFStringFormatStart(
+  field: string
+): { separator: number; spec?: number } | undefined {
+  const closers: string[] = [];
+  let quote: '\'' | '"' | undefined;
+
+  for (let index = 0; index < field.length; index++) {
+    const char = field[index];
+    if (quote != null) {
+      if (char === '\\') {
+        index += 1;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') closers.push(')');
+    else if (char === '[') closers.push(']');
+    else if (char === '{') closers.push('}');
+    else if (char === closers[closers.length - 1]) closers.pop();
+    else if (closers.length === 0 && char === ':') {
+      return { separator: index, spec: index + 1 };
+    } else if (closers.length === 0 && char === '!') {
+      const colon = field.indexOf(':', index + 1);
+      return {
+        separator: index,
+        spec: colon === -1 ? undefined : colon + 1,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 /** Finds the matching brace for an executable Python f-string expression. */

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -791,6 +791,28 @@ function findPythonFStringExpressionEnd(
   return undefined;
 }
 
+function requiresAllPythonTools(
+  code: string,
+  knownToolNames?: { has(name: string): boolean }
+): boolean {
+  const executableCode = maskPythonStringsAndComments(code);
+  const dynamicCall = /\b(eval|exec)\s*\(/g;
+  for (const match of executableCode.matchAll(dynamicCall)) {
+    const name = match[1];
+    if (knownToolNames?.has(name) === true) {
+      continue;
+    }
+    let prefix = (match.index ?? 0) - 1;
+    while (prefix >= 0 && /\s/.test(executableCode[prefix])) {
+      prefix -= 1;
+    }
+    if (executableCode[prefix] !== '.') {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Throws a caller-policy error for tools referenced by programmatic code. */
 export function assertDisallowedToolUsage(
   disallowedNames: ReadonlySet<string>,
@@ -834,10 +856,11 @@ export function assertPythonToolsAllowProgrammaticCalling(
     }
   }
 
-  assertDisallowedToolUsage(
-    extractUsedToolNames(code, toolNameMap),
-    programmaticToolName
-  );
+  const knownNames = new Set([...allowedNames, ...toolNameMap.keys()]);
+  const disallowedUsage = requiresAllPythonTools(code, knownNames)
+    ? new Set(toolNameMap.values())
+    : extractUsedToolNames(code, toolNameMap);
+  assertDisallowedToolUsage(disallowedUsage, programmaticToolName);
 }
 
 /**
@@ -857,6 +880,16 @@ export function filterToolsByUsage(
   for (const tool of toolDefs) {
     const pythonName = normalizeToPythonIdentifier(tool.name);
     toolNameMap.set(pythonName, tool.name);
+  }
+
+  if (requiresAllPythonTools(code, toolNameMap)) {
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[PTC Debug] Dynamic eval/exec detected - sending all tools as fallback'
+      );
+    }
+    return toolDefs;
   }
 
   const usedToolNames = extractUsedToolNames(code, toolNameMap);

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -362,12 +362,42 @@ function maskPythonStringsAndComments(code: string): string {
 
     const triple = code.slice(index, index + 3) === quote.repeat(3);
     const delimiterLength = triple ? 3 : 1;
+    const isFString = hasPythonFStringPrefix(code, index);
     for (let offset = 0; offset < delimiterLength; offset++) {
       mask(index + offset);
     }
     index += delimiterLength;
 
     while (index < code.length) {
+      if (isFString && code[index] === '{') {
+        if (code[index + 1] === '{') {
+          mask(index++);
+          mask(index++);
+          continue;
+        }
+        const expressionEnd = findPythonFStringExpressionEnd(code, index + 1);
+        if (expressionEnd != null) {
+          mask(index);
+          const expression = maskPythonStringsAndComments(
+            code.slice(index + 1, expressionEnd)
+          );
+          for (let offset = 0; offset < expression.length; offset++) {
+            masked[index + 1 + offset] = expression[offset];
+          }
+          mask(expressionEnd);
+          index = expressionEnd + 1;
+          continue;
+        }
+      }
+      if (
+        isFString &&
+        code[index] === '}' &&
+        code[index + 1] === '}'
+      ) {
+        mask(index++);
+        mask(index++);
+        continue;
+      }
       if (code[index] === '\\') {
         mask(index++);
         if (index < code.length) {
@@ -391,6 +421,77 @@ function maskPythonStringsAndComments(code: string): string {
   }
 
   return masked.join('');
+}
+
+function hasPythonFStringPrefix(code: string, quoteIndex: number): boolean {
+  let prefixStart = quoteIndex;
+  while (prefixStart > 0 && /[A-Za-z]/.test(code[prefixStart - 1])) {
+    prefixStart -= 1;
+  }
+  if (
+    prefixStart > 0 &&
+    /[A-Za-z0-9_]/.test(code[prefixStart - 1])
+  ) {
+    return false;
+  }
+  const prefix = code.slice(prefixStart, quoteIndex);
+  return /^[rRuUbBfF]*[fF][rRuUbBfF]*$/.test(prefix);
+}
+
+/** Finds the matching brace for an executable Python f-string expression. */
+function findPythonFStringExpressionEnd(
+  code: string,
+  expressionStart: number
+): number | undefined {
+  let depth = 1;
+  let quote: '\'' | '"' | undefined;
+  let triple = false;
+
+  for (let index = expressionStart; index < code.length; index++) {
+    const char = code[index];
+    if (quote != null) {
+      if (char === '\\') {
+        index += 1;
+        continue;
+      }
+      if (
+        triple
+          ? code.slice(index, index + 3) === quote.repeat(3)
+          : char === quote
+      ) {
+        index += triple ? 2 : 0;
+        quote = undefined;
+        triple = false;
+      }
+      continue;
+    }
+    if (char === '#') {
+      while (index < code.length && code[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+    if (char === '\'' || char === '"') {
+      quote = char;
+      triple = code.slice(index, index + 3) === char.repeat(3);
+      if (triple) {
+        index += 2;
+      }
+      continue;
+    }
+    if (char === '{') {
+      depth += 1;
+      continue;
+    }
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /** Throws a caller-policy error for tools referenced by programmatic code. */

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -418,10 +418,50 @@ function isPythonBindingTarget(
 ): boolean {
   const suffix = skipPythonCallWhitespace(code, nameEnd);
   if (code[suffix] === '=' && code[suffix + 1] !== '=') {
-    return true;
+    return !isPythonKeywordArgument(code, nameStart);
   }
   const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
   return ['as', 'class', 'def', 'for', 'import'].includes(prefix?.[1] ?? '');
+}
+
+function isPythonKeywordArgument(code: string, nameStart: number): boolean {
+  let nestedDepth = 0;
+  let argumentStart = nameStart;
+  let openParen = -1;
+
+  for (let index = nameStart - 1; index >= 0; index--) {
+    const char = code[index];
+    if (char === ')' || char === ']' || char === '}') {
+      nestedDepth += 1;
+      continue;
+    }
+    if (char === '(' || char === '[' || char === '{') {
+      if (nestedDepth > 0) {
+        nestedDepth -= 1;
+        continue;
+      }
+      if (char === '(') {
+        openParen = index;
+      }
+      break;
+    }
+    if (char === ',' && nestedDepth === 0) {
+      argumentStart = index + 1;
+    }
+  }
+
+  if (
+    openParen < 0 ||
+    code.slice(argumentStart, nameStart).trim() !== ''
+  ) {
+    return false;
+  }
+
+  const beforeParen = code.slice(0, openParen).trimEnd();
+  if (/(?:^|\W)(?:(?:async\s+)?def|class)\s+[A-Za-z_][A-Za-z0-9_]*$/.test(beforeParen)) {
+    return false;
+  }
+  return /[A-Za-z0-9_\])}]$/.test(beforeParen);
 }
 
 function isPythonCallableValueReference(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -396,14 +396,29 @@ function getPythonLexicalScopeKey(code: string, position: number): string {
   ) {
     scopes.pop();
   }
-  const inlineScope = currentLine.match(
-    /(?:^|;)\s*(?:(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)|class\s+[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?)\s*:\s*$/
-  );
-  if (inlineScope != null) {
+  const inlineDefinitions = [
+    ...currentLine.matchAll(
+      /(?:^|;)\s*(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\(/g
+    ),
+  ];
+  const inlineDefinition = inlineDefinitions[inlineDefinitions.length - 1];
+  if (inlineDefinition != null) {
     scopes.push({
       indent: currentIndent,
-      key: `inline:${lines.length - 1}:${inlineScope.index ?? 0}`,
+      key: `${lines.length - 1}:${currentIndent}`,
     });
+  } else {
+    const statementStart = currentLine.lastIndexOf(';') + 1;
+    const lambdaIndex = currentLine.lastIndexOf('lambda');
+    if (
+      lambdaIndex >= statementStart &&
+      /\blambda\b/.test(currentLine.slice(lambdaIndex, lambdaIndex + 6))
+    ) {
+      scopes.push({
+        indent: currentIndent,
+        key: `lambda:${lines.length - 1}:${lambdaIndex}`,
+      });
+    }
   }
 
   return scopes.length === 0
@@ -416,12 +431,25 @@ function isPythonBindingTarget(
   nameStart: number,
   nameEnd: number
 ): boolean {
+  if (isPythonParameterBinding(code, nameStart)) {
+    return true;
+  }
   const suffix = skipPythonCallWhitespace(code, nameEnd);
   if (code[suffix] === '=' && code[suffix + 1] !== '=') {
     return !isPythonKeywordArgument(code, nameStart);
   }
   const prefix = code.slice(0, nameStart).match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/);
   return ['as', 'class', 'def', 'for', 'import'].includes(prefix?.[1] ?? '');
+}
+
+function isPythonParameterBinding(code: string, nameStart: number): boolean {
+  const lineStart = code.lastIndexOf('\n', nameStart - 1) + 1;
+  const prefix = code.slice(lineStart, nameStart);
+  return (
+    /(?:^|;)\s*(?:async\s+)?def\s+[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*$/.test(
+      prefix
+    ) || /\blambda\s+[^:]*$/.test(prefix)
+  );
 }
 
 function isPythonKeywordArgument(code: string, nameStart: number): boolean {
@@ -796,7 +824,7 @@ function requiresAllPythonTools(
   knownToolNames?: { has(name: string): boolean }
 ): boolean {
   const executableCode = maskPythonStringsAndComments(code);
-  const dynamicCall = /\b(eval|exec)\s*\(/g;
+  const dynamicCall = /\b(eval|exec|globals)\s*\(/g;
   for (const match of executableCode.matchAll(dynamicCall)) {
     const name = match[1];
     if (knownToolNames?.has(name) === true) {
@@ -805,6 +833,12 @@ function requiresAllPythonTools(
     let prefix = (match.index ?? 0) - 1;
     while (prefix >= 0 && /\s/.test(executableCode[prefix])) {
       prefix -= 1;
+    }
+    const prefixWord = executableCode
+      .slice(0, (match.index ?? 0))
+      .match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/)?.[1];
+    if (prefixWord === 'def' || prefixWord === 'class') {
+      continue;
     }
     if (executableCode[prefix] !== '.') {
       return true;

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -330,6 +330,46 @@ export function extractUsedToolNames(
   return usedTools;
 }
 
+/** Throws a caller-policy error for tools referenced by programmatic code. */
+export function assertDisallowedToolUsage(
+  disallowedNames: ReadonlySet<string>,
+  programmaticToolName: string
+): void {
+  if (disallowedNames.size === 0) {
+    return;
+  }
+
+  const names = [...disallowedNames];
+  throw new Error(
+    `Tool${names.length === 1 ? '' : 's'} ${names
+      .map((name) => `"${name}"`)
+      .join(', ')} cannot be called from "${programmaticToolName}" because ` +
+      `the${names.length === 1 ? ' tool is' : 'se tools are'} not marked for code_execution. ` +
+      `Call ${names.length === 1 ? 'it' : 'them'} directly instead.`
+  );
+}
+
+/** Rejects direct-only tools before any Python sandbox request is made. */
+export function assertPythonToolsAllowProgrammaticCalling(
+  toolDefs: t.LCTool[] | undefined,
+  code: string,
+  programmaticToolName: string = Constants.PROGRAMMATIC_TOOL_CALLING
+): void {
+  if (toolDefs == null || toolDefs.length === 0) {
+    return;
+  }
+
+  const toolNameMap = new Map<string, string>();
+  for (const toolDef of toolDefs) {
+    toolNameMap.set(normalizeToPythonIdentifier(toolDef.name), toolDef.name);
+  }
+
+  assertDisallowedToolUsage(
+    extractUsedToolNames(code, toolNameMap),
+    programmaticToolName
+  );
+}
+
 /**
  * Filters tool definitions to only include tools actually used in the code.
  * Handles the hyphen-to-underscore conversion for Python compatibility.
@@ -907,10 +947,19 @@ export function createProgrammaticToolCallingTool(
       const {
         toolMap,
         toolDefs,
+        disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+
+      assertPythonToolsAllowProgrammaticCalling(
+        disallowedToolDefs,
+        code,
+        typeof toolCall.name === 'string' && toolCall.name !== ''
+          ? toolCall.name
+          : Constants.PROGRAMMATIC_TOOL_CALLING
+      );
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -317,17 +317,80 @@ export function extractUsedToolNames(
   toolNameMap: Map<string, string>
 ): Set<string> {
   const usedTools = new Set<string>();
+  const executableCode = maskPythonStringsAndComments(code);
 
   for (const [pythonName, originalName] of toolNameMap) {
     const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const pattern = new RegExp(`\\b${escapedName}\\s*\\(`, 'g');
 
-    if (pattern.test(code)) {
+    if (pattern.test(executableCode)) {
       usedTools.add(originalName);
     }
   }
 
   return usedTools;
+}
+
+/**
+ * Replaces Python comments and string literal contents with spaces while
+ * preserving newlines and source offsets. Tool-name preflight checks should
+ * inspect executable syntax, not examples or prose embedded in the program.
+ */
+function maskPythonStringsAndComments(code: string): string {
+  const masked = [...code];
+  let index = 0;
+
+  const mask = (position: number): void => {
+    if (masked[position] !== '\n' && masked[position] !== '\r') {
+      masked[position] = ' ';
+    }
+  };
+
+  while (index < code.length) {
+    if (code[index] === '#') {
+      while (index < code.length && code[index] !== '\n') {
+        mask(index++);
+      }
+      continue;
+    }
+
+    const quote = code[index];
+    if (quote !== '\'' && quote !== '"') {
+      index += 1;
+      continue;
+    }
+
+    const triple = code.slice(index, index + 3) === quote.repeat(3);
+    const delimiterLength = triple ? 3 : 1;
+    for (let offset = 0; offset < delimiterLength; offset++) {
+      mask(index + offset);
+    }
+    index += delimiterLength;
+
+    while (index < code.length) {
+      if (code[index] === '\\') {
+        mask(index++);
+        if (index < code.length) {
+          mask(index++);
+        }
+        continue;
+      }
+      if (
+        triple
+          ? code.slice(index, index + 3) === quote.repeat(3)
+          : code[index] === quote
+      ) {
+        for (let offset = 0; offset < delimiterLength; offset++) {
+          mask(index + offset);
+        }
+        index += delimiterLength;
+        break;
+      }
+      mask(index++);
+    }
+  }
+
+  return masked.join('');
 }
 
 /** Throws a caller-policy error for tools referenced by programmatic code. */
@@ -956,9 +1019,10 @@ export function createProgrammaticToolCallingTool(
       assertPythonToolsAllowProgrammaticCalling(
         disallowedToolDefs,
         code,
-        typeof toolCall.name === 'string' && toolCall.name !== ''
-          ? toolCall.name
-          : Constants.PROGRAMMATIC_TOOL_CALLING
+        toolCall.programmaticToolName ??
+          (typeof toolCall.name === 'string' && toolCall.name !== ''
+            ? toolCall.name
+            : Constants.PROGRAMMATIC_TOOL_CALLING)
       );
 
       if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1101,25 +1101,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * Returns cached programmatic tools, computing once on first access.
    * Single iteration builds both toolMap and toolDefs simultaneously.
    */
-  private getProgrammaticTools(): { toolMap: t.ToolMap; toolDefs: t.LCTool[] } {
+  private getProgrammaticTools(): t.ProgrammaticCache {
     if (this.programmaticCache) return this.programmaticCache;
 
     const toolMap: t.ToolMap = new Map();
     const toolDefs: t.LCTool[] = [];
+    const disallowedToolDefs: t.LCTool[] = [];
 
     if (this.toolRegistry) {
       for (const [name, toolDef] of this.toolRegistry) {
-        if (
-          (toolDef.allowed_callers ?? ['direct']).includes('code_execution')
-        ) {
+        const allowedCallers = toolDef.allowed_callers ?? ['direct'];
+        if (allowedCallers.includes('code_execution')) {
           toolDefs.push(toolDef);
           const tool = this.toolMap.get(name);
           if (tool) toolMap.set(name, tool);
+        } else {
+          disallowedToolDefs.push({ name });
         }
       }
     }
 
-    this.programmaticCache = { toolMap, toolDefs };
+    this.programmaticCache = { toolMap, toolDefs, disallowedToolDefs };
     return this.programmaticCache;
   }
 
@@ -1331,11 +1333,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
         call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
-        const { toolMap, toolDefs } = this.getProgrammaticTools();
+        const { toolMap, toolDefs, disallowedToolDefs } =
+          this.getProgrammaticTools();
         invokeParams = {
           ...invokeParams,
           toolMap,
           toolDefs,
+          disallowedToolDefs,
           // Plumb the hook context into the programmatic-tool path so
           // inner tool calls made via the in-process bridge can run
           // through `PreToolUse` (deny / updatedInput) before reaching

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -62,7 +62,6 @@ import {
   SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_REPLAY_CONTROLLER,
 } from '@/tools/subagent/SubagentReplay';
-import { attachRunStepResumeState } from '@/tools/runStepResume';
 import {
   INTENT_ARG,
   readOutcomeFields,
@@ -97,6 +96,7 @@ import {
 } from '@/tools/local';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
+import { attachRunStepResumeState } from '@/tools/runStepResume';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
  * hosts spread `configurable` into their own run configs. */
@@ -1340,6 +1340,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           toolMap,
           toolDefs,
           disallowedToolDefs,
+          programmaticToolName: call.name,
           // Plumb the hook context into the programmatic-tool path so
           // inner tool calls made via the in-process bridge can run
           // through `PreToolUse` (deny / updatedInput) before reaching

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -1,3 +1,4 @@
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
   createCloudflareWorkspaceFS,
@@ -10,9 +11,9 @@ import {
   createCloudflareBashProgrammaticToolCallingTool,
   createCloudflareProgrammaticToolCallingTool,
 } from '../cloudflare/CloudflareProgrammaticToolCalling';
-import { isWorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
 import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
+import { isWorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { spawnLocalProcess } from '../local/LocalExecutionEngine';
 import { Constants } from '@/common';
 
@@ -57,6 +58,26 @@ function createRuntime(
     ...overrides,
   };
 }
+
+it('reports the invoked runner name for Cloudflare caller-policy failures', async () => {
+  const programmatic = createCloudflareProgrammaticToolCallingTool({
+    sandbox: createRuntime(),
+  });
+  const toolCall = {
+    id: 'cloudflare-ptc',
+    name: Constants.PROGRAMMATIC_TOOL_CALLING,
+    type: 'tool_call' as const,
+    args: {},
+    programmaticToolName: Constants.PROGRAMMATIC_TOOL_CALLING,
+    disallowedToolDefs: [{ name: 'direct_only_tool' }],
+  } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+  await expect(
+    programmatic.invoke({ code: 'direct_only_tool \'{}\'' }, { toolCall })
+  ).rejects.toThrow(
+    'Tool "direct_only_tool" cannot be called from "run_tools_with_code"'
+  );
+});
 
 describe('Cloudflare sandbox execution backend', () => {
   it('normalizes trailing workspace slashes before clamping paths', async () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -31,6 +31,10 @@ import {
   _resetLocalEngineWarningsForTests,
 } from '../local/LocalExecutionEngine';
 import {
+  resolveLocalToolRegistry,
+  resolveLocalToolsForBinding,
+} from '../local/resolveLocalExecutionTools';
+import {
   createLocalCodingToolBundle,
   _resetRipgrepCacheForTests,
 } from '../local/LocalCodingTools';
@@ -39,7 +43,6 @@ import {
   _resetSyntaxCheckProbeCacheForTests,
 } from '../local/syntaxCheck';
 import { createLocalProgrammaticToolCallingTool } from '../local/LocalProgrammaticToolCalling';
-import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
 import { LocalFileCheckpointerImpl } from '../local/FileCheckpointer';
 import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { createCompileCheckTool } from '../local/CompileCheckTool';
@@ -163,6 +166,20 @@ describe('local execution tools', () => {
         'list_directory',
       ])
     );
+  });
+
+  it('preserves host caller restrictions for synthesized coding tools', () => {
+    const registry = resolveLocalToolRegistry({
+      toolRegistry: new Map([
+        [
+          'write_file',
+          { name: 'write_file', allowed_callers: ['direct'] },
+        ],
+      ]),
+      toolExecution: { engine: 'local' },
+    });
+
+    expect(registry?.get('write_file')?.allowed_callers).toEqual(['direct']);
   });
 
   it('updates existing code tool bindings when auto-binding is disabled', () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -20,7 +20,9 @@ import {
   readFile as fsReadFile,
 } from 'fs/promises';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { WorkspaceFS } from '../local/workspaceFS';
 import type * as t from '@/types';
 import {
   executeLocalBash,
@@ -36,10 +38,10 @@ import {
   runPostEditSyntaxCheck,
   _resetSyntaxCheckProbeCacheForTests,
 } from '../local/syntaxCheck';
+import { createLocalProgrammaticToolCallingTool } from '../local/LocalProgrammaticToolCalling';
 import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
-import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
-import type { WorkspaceFS } from '../local/workspaceFS';
 import { LocalFileCheckpointerImpl } from '../local/FileCheckpointer';
+import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { createCompileCheckTool } from '../local/CompileCheckTool';
 import { runBashAstChecks } from '../local/bashAst';
 import { Constants, Providers } from '@/common';
@@ -48,6 +50,24 @@ import { ToolNode } from '../ToolNode';
 const hasPython3 = spawnSync('python3', ['--version']).status === 0;
 
 const tempDirs: string[] = [];
+
+it('reports the invoked runner name for local caller-policy failures', async () => {
+  const programmatic = createLocalProgrammaticToolCallingTool();
+  const toolCall = {
+    id: 'local-ptc',
+    name: Constants.PROGRAMMATIC_TOOL_CALLING,
+    type: 'tool_call' as const,
+    args: {},
+    programmaticToolName: Constants.PROGRAMMATIC_TOOL_CALLING,
+    disallowedToolDefs: [{ name: 'direct_only_tool' }],
+  } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+  await expect(
+    programmatic.invoke({ code: 'direct_only_tool \'{}\'' }, { toolCall })
+  ).rejects.toThrow(
+    'Tool "direct_only_tool" cannot be called from "run_tools_with_code"'
+  );
+});
 
 async function createTempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'lc-local-tools-'));

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -835,6 +835,14 @@ print(example)`;
       );
     });
 
+    it('finds injected tools referenced through callable aliases', () => {
+      const code = 'await get_weather(); fn = search_docs; await fn()';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -1129,6 +1137,33 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
     it('removes escaped newlines while lexing command words', () => {
       const used = extractUsedBashToolNames(
         'get_weather \'{}\'; search_docs\\\n \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('does not persist temporary command-prefix assignments', () => {
+      const used = extractUsedBashToolNames(
+        'cmd=search_docs; cmd=printf env true; get_weather \'{}\'; "$cmd" \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('consumes env option operands before selecting the command', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; env -u HOME search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('does not interpret arithmetic shifts as heredocs', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; n=$((1 << 2))\nsearch_docs \'{}\'',
         availableTools
       );
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1053,6 +1053,60 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
 
       expect(used).toEqual(new Set());
     });
+
+    it('does not treat here-strings as heredoc declarations', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; cat <<< payload\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('does not treat Bash array values as commands', () => {
+      const used = extractUsedBashToolNames(
+        'values=(get_weather); search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('preserves command substitutions inside Bash array values', () => {
+      const used = extractUsedBashToolNames(
+        'values=($(get_weather \'{}\')); search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('finds tools in one-line function declarations', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; function wrapper { search_docs \'{}\'; }; wrapper',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('finds tools in literal eval input', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; eval "search_docs \'{}\'"',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('finds tools in named compound coprocesses', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; coproc WORKER { search_docs \'{}\'; }',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
   });
 
   describe('caller-policy normalization collisions', () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -829,6 +829,22 @@ value = f"{value:calculator()} {value:{search_docs(query='width')}}"`;
       );
     });
 
+    it('preserves calls after inequality operators in f-string fields', () => {
+      const code = 'value = f"{x != await search_docs(query=\'forecast\')}"';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['search_docs'])
+      );
+    });
+
+    it('ignores colons in triple-quoted strings inside f-string fields', () => {
+      const code = 'value = f"{\'\'\'it\'s: literal\'\'\' + search_docs(query=\'forecast\')}"';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['search_docs'])
+      );
+    });
+
     it('handles tool names with special characters via normalization', () => {
       const specialTools = createToolMap(['get_data.v2', 'calc+plus']);
       const code = `await get_datav2()
@@ -913,6 +929,42 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('finds command substitutions nested in arithmetic expansions', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; n=$(( $(search_docs \'{}\') + 1 ))',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('does not treat case arguments as case statements', () => {
+      const used = extractUsedBashToolNames(
+        'value=$(printf \'%s\' case); search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('consumes substitution-only redirect targets', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; > "$(printf target;)" search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('starts comments immediately after closing parentheses', () => {
+      const used = extractUsedBashToolNames(
+        'value="$( (printf nested)# comment with )\nsearch_docs \'{}\')"',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -843,6 +843,14 @@ print(example)`;
       );
     });
 
+    it('ignores tool names shadowed by loop bindings', () => {
+      const code = `callbacks = [lambda: "ok"]
+for search_docs in callbacks:
+    print(search_docs())`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -1168,6 +1176,24 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('keeps assignments inside subshells scoped to the subshell', () => {
+      const used = extractUsedBashToolNames(
+        'cmd=search_docs; (cmd=printf); get_weather \'{}\'; "$cmd" \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('does not treat case arm patterns as commands', () => {
+      const used = extractUsedBashToolNames(
+        'case "$kind" in other) echo x;; search_docs) echo y;; esac',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set());
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -17,17 +17,19 @@ import {
   unwrapToolResponse,
 } from '../ProgrammaticToolCalling';
 import {
+  createBashProgrammaticToolCallingTool,
+  createBashProgrammaticToolCallingSchema,
+  extractUsedBashToolNames,
+  normalizeBashToolResultsForReplay,
+  normalizeToBashIdentifier,
+} from '../BashProgrammaticToolCalling';
+import {
   createProgrammaticToolRegistry,
   createGetTeamMembersTool,
   createGetExpensesTool,
   createGetWeatherTool,
   createCalculatorTool,
 } from '@/test/mockTools';
-import {
-  createBashProgrammaticToolCallingTool,
-  createBashProgrammaticToolCallingSchema,
-  normalizeBashToolResultsForReplay,
-} from '../BashProgrammaticToolCalling';
 import { Constants } from '@/common';
 
 describe('ProgrammaticToolCalling', () => {
@@ -800,6 +802,15 @@ x = 1 + 2`;
       expect(used.size).toBe(0);
     });
 
+    it('ignores tool-like calls in strings and comments', () => {
+      const code = `# await get_weather(city="SF")
+example = "get_expenses(user_id='u1')"
+documentation = '''calculator(expression="1+1")'''
+print(example)`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
+    });
+
     it('handles tool names with special characters via normalization', () => {
       const specialTools = createToolMap(['get_data.v2', 'calc+plus']);
       const code = `await get_datav2()
@@ -823,6 +834,37 @@ print(result)`;
 
       expect(used.size).toBe(1);
       expect(used.has('create_spreadsheet_mcp_Google-Workspace')).toBe(true);
+    });
+  });
+
+  describe('extractUsedBashToolNames', () => {
+    const availableTools = new Map(
+      ['get_weather', 'search_docs'].map((name) => [
+        normalizeToBashIdentifier(name),
+        name,
+      ])
+    );
+
+    it('finds tools invoked as commands and in command substitutions', () => {
+      const used = extractUsedBashToolNames(
+        `weather=$(get_weather '{}')
+search_docs '{"query":"forecast"}'
+printf '%s' "$(get_weather '{}')"`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('ignores tool names passed as arguments or written in comments', () => {
+      const used = extractUsedBashToolNames(
+        `echo "get_weather"
+printf '%s' search_docs
+# get_weather '{}'`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set());
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -873,6 +873,20 @@ await search_docs()`;
       );
     });
 
+    it('treats function and lambda parameters as scoped bindings', () => {
+      const functionCode = `def helper(search_docs): return search_docs()
+helper(lambda: "ok")`;
+      const lambdaCode = `helper = lambda search_docs: search_docs()
+helper(lambda: "ok")`;
+
+      expect(extractUsedToolNames(functionCode, availableTools)).toEqual(
+        new Set()
+      );
+      expect(extractUsedToolNames(lambdaCode, availableTools)).toEqual(
+        new Set()
+      );
+    });
+
     it('does not treat Python keyword arguments as bindings', () => {
       const code = `dict(search_docs=lambda: None)
 await get_weather()
@@ -1246,6 +1260,24 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       expect(used).toEqual(new Set(['env', 'command', 'eval', 'trap']));
     });
 
+    it('does not execute command lookup operands', () => {
+      expect(
+        extractUsedBashToolNames(
+          'command -v search_docs; command -V get_weather',
+          availableTools
+        )
+      ).toEqual(new Set());
+    });
+
+    it('preserves backslashes inside single-quoted substitutions', () => {
+      const used = extractUsedBashToolNames(
+        String.raw`get_weather '{}'; printf '%s\n' "$(printf '%s' '\')"; search_docs '{}'`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
     it('does not interpret arithmetic shifts as heredocs', () => {
       const used = extractUsedBashToolNames(
         'get_weather \'{}\'; n=$((1 << 2))\nsearch_docs \'{}\'',
@@ -1479,6 +1511,12 @@ for member in team:
         filterToolsByUsage(
           allToolDefs,
           'await get_weather(); exec(dynamic_code)'
+        )
+      ).toEqual(allToolDefs);
+      expect(
+        filterToolsByUsage(
+          allToolDefs,
+          'await get_weather(); globals()["calculator"]()'
         )
       ).toEqual(allToolDefs);
     });

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -827,6 +827,14 @@ print(example)`;
       );
     });
 
+    it('finds calls after explicit line continuations', () => {
+      const code = 'await get_weather(); await search_docs\\\n()';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -1017,6 +1025,33 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('leaves escaped unquoted-heredoc substitutions masked', () => {
+      const used = extractUsedBashToolNames(
+        'cat <<EOF\n\\$(get_weather \'{}\')\n$(search_docs \'{}\')\nEOF',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('finds commands launched by coproc', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; coproc search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('treats combined output redirects as redirects, not separators', () => {
+      const used = extractUsedBashToolNames(
+        'printf \'%s\' data &>/tmp/out get_weather',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set());
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -811,6 +811,15 @@ print(example)`;
       expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
     });
 
+    it('preserves executable calls inside f-string expressions', () => {
+      const code = `await get_weather(city="SF")
+value = f"result: {await search_docs(query='forecast')}"`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('handles tool names with special characters via normalization', () => {
       const specialTools = createToolMap(['get_data.v2', 'calc+plus']);
       const code = `await get_datav2()
@@ -850,6 +859,15 @@ print(result)`;
         `weather=$(get_weather '{}')
 search_docs '{"query":"forecast"}'
 printf '%s' "$(get_weather '{}')"`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('tokenizes commands and arguments inside quoted substitutions', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; value="$(search_docs \'{"query":"forecast"}\')"',
         availableTools
       );
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -820,6 +820,15 @@ value = f"result: {await search_docs(query='forecast')}"`;
       );
     });
 
+    it('masks literal format specs but preserves nested format fields', () => {
+      const code = `await get_weather(city="SF")
+value = f"{value:calculator()} {value:{search_docs(query='width')}}"`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('handles tool names with special characters via normalization', () => {
       const specialTools = createToolMap(['get_data.v2', 'calc+plus']);
       const code = `await get_datav2()
@@ -883,6 +892,27 @@ printf '%s' search_docs
       );
 
       expect(used).toEqual(new Set());
+    });
+
+    it('ignores arithmetic variables and preserves the outer command state', () => {
+      const used = extractUsedBashToolNames(
+        `echo "$((search_docs + 1))"
+echo "$(get_weather '{}';)" search_docs`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather']));
+    });
+
+    it('handles case patterns and literal hashes inside substitutions', () => {
+      const used = extractUsedBashToolNames(
+        `printf '%s' start
+result="$(case "$x" in yes) get_weather '{}';; esac)"
+value="$(printf '%s' value#fragment; search_docs '{}')"`,
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -887,6 +887,15 @@ helper(lambda: "ok")`;
       );
     });
 
+    it('honors bindings inherited by nested Python scopes', () => {
+      const code = `def outer(search_docs):
+    def inner():
+        return search_docs()
+    return inner()`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
+    });
+
     it('does not treat Python keyword arguments as bindings', () => {
       const code = `dict(search_docs=lambda: None)
 await get_weather()
@@ -910,6 +919,15 @@ print(fr"both={value}")`;
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
+    it('preserves tool references in f-string debug expressions', () => {
+      const code = `await get_weather()
+print(f"{search_docs=}")`;
 
       expect(extractUsedToolNames(code, availableTools)).toEqual(
         new Set(['get_weather', 'search_docs'])
@@ -1185,6 +1203,15 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
     });
 
+    it('does not treat matching function declarations as tool calls', () => {
+      const used = extractUsedBashToolNames(
+        'search_docs() { printf ok; }; get_weather \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather']));
+    });
+
     it('finds tools in literal eval input', () => {
       const used = extractUsedBashToolNames(
         'get_weather \'{}\'; eval "search_docs \'{}\'"',
@@ -1419,6 +1446,16 @@ readonly fourth=get_team_members; "$fourth" '{}'`,
           'await foo_bar()',
           Constants.PROGRAMMATIC_TOOL_CALLING,
           allowed
+        )
+      ).not.toThrow();
+    });
+
+    it('allows Python builtins that share direct-only tool names', () => {
+      expect(() =>
+        assertPythonToolsAllowProgrammaticCalling(
+          [{ name: 'open' }, { name: 'print' }],
+          'with open("/tmp/data", "w") as file: print(file)',
+          Constants.PROGRAMMATIC_TOOL_CALLING
         )
       ).not.toThrow();
     });

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -851,6 +851,17 @@ for search_docs in callbacks:
       expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
     });
 
+    it('keeps Python shadowing scoped to its lexical block', () => {
+      const code = `await get_weather()
+def helper():
+    search_docs = lambda: None
+await search_docs()`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -1194,6 +1205,24 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set());
+    });
+
+    it('tracks nested Bash case statements independently', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; case x in x) case y in y) :;; esac;; search_docs) :;; esac',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather']));
+    });
+
+    it('does not treat bare arithmetic expressions as commands', () => {
+      const used = extractUsedBashToolNames(
+        '(( get_weather += 1 )); search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -873,6 +873,16 @@ await search_docs()`;
       );
     });
 
+    it('does not treat Python keyword arguments as bindings', () => {
+      const code = `dict(search_docs=lambda: None)
+await get_weather()
+await search_docs()`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('masks Python string literal prefixes', () => {
       const prefixedTools = createToolMap(['f', 'r', 'b', 'fr']);
       const code = `print(f"value={value}")
@@ -1253,6 +1263,36 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('tracks assignments made by shell declaration builtins', () => {
+      const declarationTools = new Map(
+        [
+          'get_weather',
+          'search_docs',
+          'calculator',
+          'get_expenses',
+          'get_team_members',
+        ].map((name) => [normalizeToBashIdentifier(name), name])
+      );
+      const used = extractUsedBashToolNames(
+        `get_weather '{}'
+export first=search_docs; "$first" '{}'
+declare second=calculator; "$second" '{}'
+typeset third=get_expenses; "$third" '{}'
+readonly fourth=get_team_members; "$fourth" '{}'`,
+        declarationTools
+      );
+
+      expect(used).toEqual(
+        new Set([
+          'get_weather',
+          'search_docs',
+          'calculator',
+          'get_expenses',
+          'get_team_members',
+        ])
+      );
     });
 
     it('keeps every tool available when sourcing a shell script', () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -862,6 +862,26 @@ await search_docs()`;
       );
     });
 
+    it('scopes bindings in one-line Python function suites', () => {
+      const code = `await get_weather()
+def helper(): search_docs = lambda: None
+await search_docs()`;
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
+    it('masks Python string literal prefixes', () => {
+      const prefixedTools = createToolMap(['f', 'r', 'b', 'fr']);
+      const code = `print(f"value={value}")
+print(r"raw")
+print(b"bytes")
+print(fr"both={value}")`;
+
+      expect(extractUsedToolNames(code, prefixedTools)).toEqual(new Set());
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -1223,6 +1243,15 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('finds tools executed by static trap handlers', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; trap "search_docs \'{}\'" EXIT',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1085,6 +1085,20 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       expect(used).toEqual(new Set(['search_docs']));
     });
 
+    it('applies quote removal to heredoc delimiters', () => {
+      const escaped = extractUsedBashToolNames(
+        'cat <<E\\OF\n$(get_weather \'{}\')\nEOF\nsearch_docs \'{}\'',
+        availableTools
+      );
+      const mixedQuoted = extractUsedBashToolNames(
+        'cat <<E"O"F\n$(get_weather \'{}\')\nEOF\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(escaped).toEqual(new Set(['search_docs']));
+      expect(mixedQuoted).toEqual(new Set(['search_docs']));
+    });
+
     it('leaves escaped unquoted-heredoc substitutions masked', () => {
       const used = extractUsedBashToolNames(
         'cat <<EOF\n\\$(get_weather \'{}\')\n$(search_docs \'{}\')\nEOF',
@@ -1209,6 +1223,18 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('prefers registered tool functions over shell scanner controls', () => {
+      const controlTools = new Map(
+        ['env', 'command', 'eval', 'trap'].map((name) => [name, name])
+      );
+      const used = extractUsedBashToolNames(
+        'env \'{}\'; command \'{}\'; eval \'{}\'; trap \'{}\'',
+        controlTools
+      );
+
+      expect(used).toEqual(new Set(['env', 'command', 'eval', 'trap']));
     });
 
     it('does not interpret arithmetic shifts as heredocs', () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -4,6 +4,7 @@
  * Tests manual invocation with mock tools and Code API responses.
  */
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
   createProgrammaticToolCallingTool,
@@ -23,6 +24,7 @@ import {
   createCalculatorTool,
 } from '@/test/mockTools';
 import {
+  createBashProgrammaticToolCallingTool,
   createBashProgrammaticToolCallingSchema,
   normalizeBashToolResultsForReplay,
 } from '../BashProgrammaticToolCalling';
@@ -1131,6 +1133,56 @@ for member in team:
     beforeEach(() => {
       const tools = [createGetWeatherTool()];
       toolMap = new Map(tools.map((t) => [t.name, t]));
+    });
+
+    it('rejects a direct-only Python tool before requiring sandbox context', async () => {
+      const tool = createProgrammaticToolCallingTool();
+      const toolCall = {
+        id: 'ptc-python',
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        args: {},
+        type: 'tool_call' as const,
+        disallowedToolDefs: [
+          {
+            name: 'direct-only-tool',
+            allowed_callers: ['direct'],
+          },
+        ],
+      } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+      await expect(
+        tool.invoke(
+          { code: 'await direct_only_tool(query="test")' },
+          { toolCall }
+        )
+      ).rejects.toThrow(
+        'Tool "direct-only-tool" cannot be called from "run_tools_with_code" because the tool is not marked for code_execution'
+      );
+    });
+
+    it('rejects a direct-only bash tool before requiring sandbox context', async () => {
+      const tool = createBashProgrammaticToolCallingTool();
+      const toolCall = {
+        id: 'ptc-bash',
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        args: {},
+        type: 'tool_call' as const,
+        disallowedToolDefs: [
+          {
+            name: 'direct-only-tool',
+            allowed_callers: ['direct'],
+          },
+        ],
+      } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+      await expect(
+        tool.invoke(
+          { code: 'direct_only_tool \'{"query":"test"}\'' },
+          { toolCall }
+        )
+      ).rejects.toThrow(
+        'Tool "direct-only-tool" cannot be called from "run_tools_with_code" because the tool is not marked for code_execution'
+      );
     });
 
     it('returns error for invalid city without throwing', async () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -21,6 +21,7 @@ import {
   createBashProgrammaticToolCallingTool,
   createBashProgrammaticToolCallingSchema,
   extractUsedBashToolNames,
+  filterBashToolsByUsage,
   assertBashToolsAllowProgrammaticCalling,
   normalizeBashToolResultsForReplay,
   normalizeToBashIdentifier,
@@ -1252,6 +1253,34 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('keeps every tool available when sourcing a shell script', () => {
+      const toolDefs = [
+        { name: 'get_weather' },
+        { name: 'search_docs' },
+      ] as t.LCTool[];
+
+      expect(
+        filterBashToolsByUsage(
+          toolDefs,
+          'get_weather \'{}\'; source ./calls.sh'
+        )
+      ).toEqual(toolDefs);
+      expect(
+        filterBashToolsByUsage(toolDefs, 'get_weather \'{}\'; . ./calls.sh')
+      ).toEqual(toolDefs);
+    });
+
+    it('rejects sourced scripts when direct-only tools could be hidden', () => {
+      expect(() =>
+        assertBashToolsAllowProgrammaticCalling(
+          [{ name: 'search_docs' }],
+          'get_weather \'{}\'; source ./calls.sh',
+          Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+          [{ name: 'get_weather' }]
+        )
+      ).toThrow('Tool "search_docs" cannot be called');
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1107,6 +1107,33 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
 
       expect(used).toEqual(new Set(['get_weather', 'search_docs']));
     });
+
+    it('masks every heredoc body declared on one command', () => {
+      const used = extractUsedBashToolNames(
+        'cat <<\'A\' <<\'B\'\nget_weather \'{}\'\nA\nget_weather \'{}\'\nB\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('resolves simple assignments used as command names', () => {
+      const used = extractUsedBashToolNames(
+        'cmd=search_docs; get_weather \'{}\'; "$cmd" \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('removes escaped newlines while lexing command words', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; search_docs\\\n \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
   });
 
   describe('caller-policy normalization collisions', () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -12,6 +12,7 @@ import {
   formatCompletedResponse,
   extractUsedToolNames,
   filterToolsByUsage,
+  assertPythonToolsAllowProgrammaticCalling,
   executeTools,
   normalizeToPythonIdentifier,
   unwrapToolResponse,
@@ -20,6 +21,7 @@ import {
   createBashProgrammaticToolCallingTool,
   createBashProgrammaticToolCallingSchema,
   extractUsedBashToolNames,
+  assertBashToolsAllowProgrammaticCalling,
   normalizeBashToolResultsForReplay,
   normalizeToBashIdentifier,
 } from '../BashProgrammaticToolCalling';
@@ -811,6 +813,12 @@ print(example)`;
       expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
     });
 
+    it('ignores matching attribute method calls', () => {
+      const code = 'client . get_weather(city="SF")';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -965,6 +973,60 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       );
 
       expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('finds tools in legacy backtick command substitutions', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; result=`search_docs \'{}\'`',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('treats IO numbers as part of redirects', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; 2>/dev/null search_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
+    it('ignores tool-like commands in quoted heredoc bodies', () => {
+      const used = extractUsedBashToolNames(
+        'cat <<\'EOF\'\nget_weather \'{}\'\nEOF\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+  });
+
+  describe('caller-policy normalization collisions', () => {
+    const allowed = [{ name: 'foo_bar' }] as t.LCTool[];
+    const disallowed = [{ name: 'foo-bar' }] as t.LCTool[];
+
+    it('prefers an allowed Python tool with the same normalized name', () => {
+      expect(() =>
+        assertPythonToolsAllowProgrammaticCalling(
+          disallowed,
+          'await foo_bar()',
+          Constants.PROGRAMMATIC_TOOL_CALLING,
+          allowed
+        )
+      ).not.toThrow();
+    });
+
+    it('prefers an allowed Bash tool with the same normalized name', () => {
+      expect(() =>
+        assertBashToolsAllowProgrammaticCalling(
+          disallowed,
+          'foo_bar \'{}\'',
+          Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+          allowed
+        )
+      ).not.toThrow();
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -819,6 +819,14 @@ print(example)`;
       expect(extractUsedToolNames(code, availableTools)).toEqual(new Set());
     });
 
+    it('finds parenthesized callable tool expressions', () => {
+      const code = 'await get_weather(); await (search_docs)()';
+
+      expect(extractUsedToolNames(code, availableTools)).toEqual(
+        new Set(['get_weather', 'search_docs'])
+      );
+    });
+
     it('preserves executable calls inside f-string expressions', () => {
       const code = `await get_weather(city="SF")
 value = f"result: {await search_docs(query='forecast')}"`;
@@ -996,6 +1004,15 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
     it('ignores tool-like commands in quoted heredoc bodies', () => {
       const used = extractUsedBashToolNames(
         'cat <<\'EOF\'\nget_weather \'{}\'\nEOF\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['search_docs']));
+    });
+
+    it('masks unquoted heredoc literals but preserves command substitutions', () => {
+      const used = extractUsedBashToolNames(
+        'cat <<EOF\nget_weather \'{}\'\n$(search_docs \'{}\')\nEOF',
         availableTools
       );
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1099,6 +1099,15 @@ value="$(printf '%s' value#fragment; search_docs '{}')"`,
       expect(mixedQuoted).toEqual(new Set(['search_docs']));
     });
 
+    it('joins continued heredoc delimiter words', () => {
+      const used = extractUsedBashToolNames(
+        'get_weather \'{}\'; cat <<E\\\nOF\nget_weather \'{}\'\nEOF\nsearch_docs \'{}\'',
+        availableTools
+      );
+
+      expect(used).toEqual(new Set(['get_weather', 'search_docs']));
+    });
+
     it('leaves escaped unquoted-heredoc substitutions masked', () => {
       const used = extractUsedBashToolNames(
         'cat <<EOF\n\\$(get_weather \'{}\')\n$(search_docs \'{}\')\nEOF',
@@ -1348,6 +1357,23 @@ readonly fourth=get_team_members; "$fourth" '{}'`,
         )
       ).toThrow('Tool "search_docs" cannot be called');
     });
+
+    it('distinguishes a registered source tool from the shell builtin', () => {
+      const sourceTool = [{ name: 'source' }] as t.LCTool[];
+      const directOnly = [{ name: 'search_docs' }] as t.LCTool[];
+
+      expect(() =>
+        assertBashToolsAllowProgrammaticCalling(
+          directOnly,
+          'source \'{}\'',
+          Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+          sourceTool
+        )
+      ).not.toThrow();
+      expect(
+        filterBashToolsByUsage([...sourceTool, ...directOnly], 'source \'{}\'')
+      ).toEqual(sourceTool);
+    });
   });
 
   describe('caller-policy normalization collisions', () => {
@@ -1440,6 +1466,32 @@ for member in team:
       const filtered = filterToolsByUsage(allToolDefs, code);
 
       expect(filtered).toHaveLength(4);
+    });
+
+    it('returns all tools for builtin Python eval or exec', () => {
+      expect(
+        filterToolsByUsage(
+          allToolDefs,
+          'await get_weather(); eval("calculator()")'
+        )
+      ).toEqual(allToolDefs);
+      expect(
+        filterToolsByUsage(
+          allToolDefs,
+          'await get_weather(); exec(dynamic_code)'
+        )
+      ).toEqual(allToolDefs);
+    });
+
+    it('rejects dynamic Python evaluation when direct-only tools exist', () => {
+      expect(() =>
+        assertPythonToolsAllowProgrammaticCalling(
+          [{ name: 'calculator' }],
+          'await get_weather(); eval("calculator()")',
+          Constants.PROGRAMMATIC_TOOL_CALLING,
+          [{ name: 'get_weather' }]
+        )
+      ).toThrow('Tool "calculator" cannot be called');
     });
 
     it('preserves tool definition structure', () => {

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+
+describe('ToolNode programmatic caller policy', () => {
+  it('separates programmatic tools from direct-only preflight definitions', async () => {
+    const capturedConfigs: Record<string, unknown>[] = [];
+    const ptcTool = tool(
+      async (_args, config) => {
+        capturedConfigs.push({ ...(config.toolCall ?? {}) });
+        return 'done';
+      },
+      {
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        description: 'Run tools with code',
+        schema: z.object({ code: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const programmaticTool = tool(async () => 'programmatic', {
+      name: 'programmatic_tool',
+      description: 'Programmatic tool',
+      schema: z.object({}),
+    }) as unknown as StructuredToolInterface;
+    const directTool = tool(async () => 'direct', {
+      name: 'direct_tool',
+      description: 'Direct tool',
+      schema: z.object({}),
+    }) as unknown as StructuredToolInterface;
+    const toolRegistry: t.LCToolRegistry = new Map([
+      [
+        programmaticTool.name,
+        {
+          name: programmaticTool.name,
+          allowed_callers: ['code_execution'],
+        },
+      ],
+      [directTool.name, { name: directTool.name, allowed_callers: ['direct'] }],
+    ]);
+    const node = new ToolNode({
+      tools: [ptcTool, programmaticTool, directTool],
+      toolRegistry,
+    });
+
+    await node.invoke({
+      messages: [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'ptc-call',
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              args: { code: 'print("done")' },
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(capturedConfigs).toHaveLength(1);
+    expect(capturedConfigs[0].toolDefs).toEqual([
+      { name: 'programmatic_tool', allowed_callers: ['code_execution'] },
+    ]);
+    expect(capturedConfigs[0].disallowedToolDefs).toEqual([
+      { name: 'direct_tool' },
+    ]);
+    expect(capturedConfigs[0].toolMap).toEqual(
+      new Map([['programmatic_tool', programmaticTool]])
+    );
+  });
+});

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -2,17 +2,19 @@ import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
 import { AIMessage } from '@langchain/core/messages';
 import { describe, it, expect } from '@jest/globals';
-import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { ToolNode } from '../ToolNode';
 import { Constants } from '@/common';
 
 describe('ToolNode programmatic caller policy', () => {
   it('separates programmatic tools from direct-only preflight definitions', async () => {
-    const capturedConfigs: Record<string, unknown>[] = [];
+    const capturedConfigs: Array<ToolCall & Partial<t.ProgrammaticCache>> = [];
     const ptcTool = tool(
       async (_args, config) => {
-        capturedConfigs.push({ ...(config.toolCall ?? {}) });
+        capturedConfigs.push(
+          config.toolCall as ToolCall & Partial<t.ProgrammaticCache>
+        );
         return 'done';
       },
       {
@@ -20,17 +22,17 @@ describe('ToolNode programmatic caller policy', () => {
         description: 'Run tools with code',
         schema: z.object({ code: z.string() }),
       }
-    ) as unknown as StructuredToolInterface;
+    );
     const programmaticTool = tool(async () => 'programmatic', {
       name: 'programmatic_tool',
       description: 'Programmatic tool',
       schema: z.object({}),
-    }) as unknown as StructuredToolInterface;
+    });
     const directTool = tool(async () => 'direct', {
       name: 'direct_tool',
       description: 'Direct tool',
       schema: z.object({}),
-    }) as unknown as StructuredToolInterface;
+    });
     const toolRegistry: t.LCToolRegistry = new Map([
       [
         programmaticTool.name,
@@ -70,6 +72,9 @@ describe('ToolNode programmatic caller policy', () => {
     ]);
     expect(capturedConfigs[0].toolMap).toEqual(
       new Map([['programmatic_tool', programmaticTool]])
+    );
+    expect(capturedConfigs[0].programmaticToolName).toBe(
+      Constants.PROGRAMMATIC_TOOL_CALLING
     );
   });
 });

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1068,13 +1068,13 @@ async function runProgrammatic(args: {
     assertBashToolsAllowProgrammaticCalling(
       toolCall.disallowedToolDefs,
       args.params.code,
-      Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      toolCall.programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
     );
   } else {
     assertPythonToolsAllowProgrammaticCalling(
       toolCall.disallowedToolDefs,
       args.params.code,
-      Constants.PROGRAMMATIC_TOOL_CALLING
+      toolCall.programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING
     );
   }
   const toolDefs = toolCall.toolDefs ?? [];

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1068,13 +1068,15 @@ async function runProgrammatic(args: {
     assertBashToolsAllowProgrammaticCalling(
       toolCall.disallowedToolDefs,
       args.params.code,
-      toolCall.programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      toolCall.programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      toolCall.toolDefs
     );
   } else {
     assertPythonToolsAllowProgrammaticCalling(
       toolCall.disallowedToolDefs,
       args.params.code,
-      toolCall.programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING
+      toolCall.programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING,
+      toolCall.toolDefs
     );
   }
   const toolDefs = toolCall.toolDefs ?? [];

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -5,6 +5,7 @@ import type * as t from '@/types';
 /* eslint-disable no-useless-escape -- generated sandbox helper source needs escapes for emitted JS/Python string literals. */
 import {
   formatCompletedResponse,
+  assertPythonToolsAllowProgrammaticCalling,
   normalizeToPythonIdentifier,
   ProgrammaticToolCallingDescription,
   ProgrammaticToolCallingName,
@@ -15,6 +16,7 @@ import {
   BashProgrammaticToolCallingDescription,
   BashProgrammaticToolCallingSchema,
   filterBashToolsByUsage,
+  assertBashToolsAllowProgrammaticCalling,
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
 import { Constants } from '@/common';
@@ -1062,6 +1064,19 @@ async function runProgrammatic(args: {
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
   const toolCall = (args.config?.toolCall ??
     {}) as Partial<t.ProgrammaticCache>;
+  if (args.runtime === 'bash') {
+    assertBashToolsAllowProgrammaticCalling(
+      toolCall.disallowedToolDefs,
+      args.params.code,
+      Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+    );
+  } else {
+    assertPythonToolsAllowProgrammaticCalling(
+      toolCall.disallowedToolDefs,
+      args.params.code,
+      Constants.PROGRAMMATIC_TOOL_CALLING
+    );
+  }
   const toolDefs = toolCall.toolDefs ?? [];
   const effectiveTools = filterNativeTools(
     toolDefs,

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -7,6 +7,7 @@ import type { AddressInfo } from 'net';
 import type * as t from '@/types';
 import {
   executeTools,
+  assertPythonToolsAllowProgrammaticCalling,
   filterToolsByUsage,
   formatCompletedResponse,
   normalizeToPythonIdentifier,
@@ -18,6 +19,7 @@ import {
   BashProgrammaticToolCallingSchema,
   BashProgrammaticToolCallingDescription,
   filterBashToolsByUsage,
+  assertBashToolsAllowProgrammaticCalling,
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
 import {
@@ -578,9 +580,22 @@ async function runLocalProgrammaticTool(args: {
   localConfig: t.LocalExecutionConfig;
   runtime: LocalProgrammaticRuntime;
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const { toolMap, toolDefs, hookContext } = getProgrammaticContext(
-    args.config
-  );
+  const { toolMap, toolDefs, disallowedToolDefs, hookContext } =
+    getProgrammaticContext(args.config);
+
+  if (args.runtime === 'bash') {
+    assertBashToolsAllowProgrammaticCalling(
+      disallowedToolDefs,
+      args.params.code,
+      Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+    );
+  } else {
+    assertPythonToolsAllowProgrammaticCalling(
+      disallowedToolDefs,
+      args.params.code,
+      Constants.PROGRAMMATIC_TOOL_CALLING
+    );
+  }
 
   if (toolMap == null || toolMap.size === 0) {
     throw new Error('No toolMap provided for local programmatic execution.');

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -592,13 +592,15 @@ async function runLocalProgrammaticTool(args: {
     assertBashToolsAllowProgrammaticCalling(
       disallowedToolDefs,
       args.params.code,
-      programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      toolDefs
     );
   } else {
     assertPythonToolsAllowProgrammaticCalling(
       disallowedToolDefs,
       args.params.code,
-      programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING
+      programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING,
+      toolDefs
     );
   }
 

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -580,20 +580,25 @@ async function runLocalProgrammaticTool(args: {
   localConfig: t.LocalExecutionConfig;
   runtime: LocalProgrammaticRuntime;
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const { toolMap, toolDefs, disallowedToolDefs, hookContext } =
-    getProgrammaticContext(args.config);
+  const {
+    toolMap,
+    toolDefs,
+    disallowedToolDefs,
+    programmaticToolName,
+    hookContext,
+  } = getProgrammaticContext(args.config);
 
   if (args.runtime === 'bash') {
     assertBashToolsAllowProgrammaticCalling(
       disallowedToolDefs,
       args.params.code,
-      Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      programmaticToolName ?? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
     );
   } else {
     assertPythonToolsAllowProgrammaticCalling(
       disallowedToolDefs,
       args.params.code,
-      Constants.PROGRAMMATIC_TOOL_CALLING
+      programmaticToolName ?? Constants.PROGRAMMATIC_TOOL_CALLING
     );
   }
 

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -228,6 +228,27 @@ export function resolveLocalToolRegistry(args: {
       getCloudflareConfig(args.toolExecution)
     )
     : undefined;
+
+  if (selectedNames != null) {
+    const callableInsideCloudflare = new Set(selectedNames);
+    callableInsideCloudflare.delete(Constants.PROGRAMMATIC_TOOL_CALLING);
+    callableInsideCloudflare.delete(Constants.BASH_PROGRAMMATIC_TOOL_CALLING);
+    for (const [name, definition] of registry) {
+      if (callableInsideCloudflare.has(name)) {
+        continue;
+      }
+      const allowedCallers = definition.allowed_callers ?? ['direct'];
+      if (allowedCallers.includes('code_execution')) {
+        registry.set(name, {
+          ...definition,
+          allowed_callers: allowedCallers.filter(
+            (caller) => caller !== 'code_execution'
+          ),
+        });
+      }
+    }
+  }
+
   for (const definition of createLocalCodingToolDefinitions()) {
     if (selectedNames != null && !selectedNames.has(definition.name)) {
       registry.delete(definition.name);

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -273,7 +273,13 @@ export function resolveLocalToolRegistry(args: {
       registry.delete(definition.name);
       continue;
     }
-    registry.set(definition.name, definition);
+    const existingDefinition = registry.get(definition.name);
+    registry.set(
+      definition.name,
+      existingDefinition == null
+        ? definition
+        : { ...definition, ...existingDefinition }
+    );
   }
   return registry;
 }

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -58,6 +58,25 @@ function shouldIncludeCodingTools(config?: t.ToolExecutionConfig): boolean {
   );
 }
 
+export function isProgrammaticRunnerAutoBound(
+  name: string,
+  config?: t.ToolExecutionConfig
+): boolean {
+  if (
+    !shouldIncludeCodingTools(config) ||
+    (name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+      name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
+  ) {
+    return false;
+  }
+  if (shouldUseCloudflareSandboxExecution(config)) {
+    return getSelectedCloudflareCodingToolNames(
+      getCloudflareConfig(config)
+    ).has(name);
+  }
+  return shouldUseLocalExecution(config);
+}
+
 function getCloudflareConfig(
   config?: t.ToolExecutionConfig
 ): t.CloudflareSandboxExecutionConfig {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -31,6 +31,7 @@ import type {
   ToolEndEvent,
   GenericTool,
   LCTool,
+  ToolExecutionConfig,
   ToolExecuteBatchRequest,
 } from '@/types/tools';
 import type {
@@ -338,6 +339,8 @@ export type StandardGraphInput = {
   runId?: string;
   signal?: AbortSignal;
   agents: AgentInputs[];
+  /** Execution backend used to resolve the effective tool registry. */
+  toolExecution?: ToolExecutionConfig;
   langfuse?: LangfuseConfig;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,17 +1,17 @@
 // src/types/tools.ts
-import type { StructuredToolInterface } from '@langchain/core/tools';
 import type {
   RunnableConfig,
   RunnableToolLike,
 } from '@langchain/core/runnables';
+import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
-import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
-import type { RunBreakerScope } from '@/llm/streamLimits';
 import type {
   MessageContentComplex,
   RunStepResumeState,
   ToolErrorData,
 } from './stream';
+import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { HumanInTheLoopConfig } from './hitl';
 import type { LangfuseConfig } from './graph';
 import type { HookRegistry } from '@/hooks';
@@ -1171,6 +1171,8 @@ export type ToolExecutionConfig = {
 export type ProgrammaticCache = {
   toolMap: ToolMap;
   toolDefs: LCTool[];
+  /** Actual outer runner name used for caller-policy diagnostics. */
+  programmaticToolName?: string;
   /**
    * Known tools that cannot be invoked from programmatic execution. This is
    * kept separate from `toolDefs` so the sandbox never receives their schemas,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1172,6 +1172,12 @@ export type ProgrammaticCache = {
   toolMap: ToolMap;
   toolDefs: LCTool[];
   /**
+   * Known tools that cannot be invoked from programmatic execution. This is
+   * kept separate from `toolDefs` so the sandbox never receives their schemas,
+   * while the runner can still reject invalid code before starting a sandbox.
+   */
+  disallowedToolDefs?: LCTool[];
+  /**
    * Hook context plumbed through by ToolNode for the local
    * programmatic-tool path so the in-process bridge can run
    * `PreToolUse` hooks (deny / updatedInput) for inner tool calls.


### PR DESCRIPTION
I implemented explicit caller boundaries for mixed direct and programmatic tools, plus preflight rejection before an invalid PTC call starts a sandbox.

- Explain which tools may run inside the configured programmatic runner and which must be called directly.
- Separate PTC-eligible tool definitions from direct-only preflight metadata in `ToolNode`.
- Reject direct-only Python and Bash references before sandbox context validation or Code API requests.
- Apply the same preflight policy to remote, local, and Cloudflare execution engines.
- Preserve the actual invoked runner name in errors, including the legacy Bash-backed `run_tools_with_code` alias.
- Add regression coverage for mixed caller guidance, ToolNode classification, and Python/Bash fast failures.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/agents/__tests__/AgentContext.test.ts src/tools/__tests__/ProgrammaticToolCalling.test.ts src/tools/__tests__/ToolNode.programmaticPolicy.test.ts --runInBand` — 190 tests passed.
- `npx tsc --noEmit` — passed.
- Targeted ESLint — passed without errors.

### **Test Configuration**:

- Node.js 24.16.0
- npm workspace install reused from the main checkout

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
