### PR TITLE
📇 fix: Select Programmatic Tool Schemas by Declared Name

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,3 +41,17 @@ call.
 A **Resume Projection** is the durable manifest view produced from an
 Execution Record. A projection is scoped to one exact fork and resume attempt;
 an unscoped projection fails closed when a parent tool-call ID is ambiguous.
+
+## Tool Caller Capabilities
+
+A **Caller Capability Projection** is the effective classification of tool
+definitions by the contexts permitted by `allowed_callers`: direct model calls,
+programmatic code execution, both, or neither. Prompt guidance, model binding,
+and runtime dispatch derive from this projection rather than recomputing caller
+rules independently.
+
+A **Programmatic Tool Manifest** is the exact list of registered tool names a
+programmatic invocation declares that its code depends on. Mixed direct and
+code-execution configurations require the manifest so caller policy can reject
+direct-only dependencies before starting an execution runtime without parsing
+the submitted programming language.

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -32,6 +32,15 @@ import {
   Constants,
   Providers,
 } from '@/common';
+import {
+  isProgrammaticRunnerAutoBound,
+  resolveLocalToolRegistry,
+} from '@/tools/local/resolveLocalExecutionTools';
+import {
+  allowsToolCaller,
+  isProgrammaticControlTool,
+  resolveCallerCapabilityProjection,
+} from '@/tools/CallerCapabilities';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
@@ -59,7 +68,8 @@ export class AgentContext {
   static fromConfig(
     agentConfig: t.AgentInputs,
     tokenCounter?: t.TokenCounter,
-    indexTokenCountMap?: Record<string, number>
+    indexTokenCountMap?: Record<string, number>,
+    toolExecution?: t.ToolExecutionConfig
   ): AgentContext {
     const {
       agentId,
@@ -103,6 +113,7 @@ export class AgentContext {
       tools,
       toolMap,
       toolRegistry,
+      toolExecution,
       toolDefinitions,
       instructions,
       additionalInstructions: additional_instructions,
@@ -269,6 +280,8 @@ export class AgentContext {
    * Used for tool search and programmatic tool calling.
    */
   toolRegistry?: t.LCToolRegistry;
+  /** Run-scoped backend used to identify auto-bound programmatic runners. */
+  private toolExecution?: t.ToolExecutionConfig;
   /**
    * Serializable tool definitions for event-driven execution.
    * When provided, ToolNode operates in event-driven mode.
@@ -385,6 +398,7 @@ export class AgentContext {
     tools,
     toolMap,
     toolRegistry,
+    toolExecution,
     toolDefinitions,
     instructions,
     additionalInstructions,
@@ -410,6 +424,7 @@ export class AgentContext {
     tools?: t.GraphTools;
     toolMap?: t.ToolMap;
     toolRegistry?: t.LCToolRegistry;
+    toolExecution?: t.ToolExecutionConfig;
     toolDefinitions?: t.LCTool[];
     instructions?: string;
     additionalInstructions?: string;
@@ -434,7 +449,11 @@ export class AgentContext {
     this.tokenCounter = tokenCounter;
     this.tools = tools;
     this.toolMap = toolMap;
-    this.toolRegistry = toolRegistry;
+    this.toolRegistry = resolveLocalToolRegistry({
+      toolRegistry,
+      toolExecution,
+    });
+    this.toolExecution = toolExecution;
     this.toolDefinitions = toolDefinitions;
     this.instructions = instructions;
     this.additionalInstructions = additionalInstructions;
@@ -461,37 +480,48 @@ export class AgentContext {
     }
   }
 
-  /**
-   * Builds instructions text for tools that are ONLY callable via programmatic code execution.
-   * These tools cannot be called directly by the LLM but are available through the
-   * configured programmatic tool.
-   *
-   * Includes:
-   * - Code_execution-only tools that are NOT deferred
-   * - Code_execution-only tools that ARE deferred but have been discovered via tool search
-   */
+  /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
     if (!this.toolRegistry) return '';
 
-    const programmaticOnlyTools: t.LCTool[] = [];
-    for (const [name, toolDef] of this.toolRegistry) {
-      const allowedCallers = toolDef.allowed_callers ?? ['direct'];
-      const isCodeExecutionOnly =
-        allowedCallers.includes('code_execution') &&
-        !allowedCallers.includes('direct');
+    const capabilities = resolveCallerCapabilityProjection(
+      this.toolRegistry.values(),
+      (toolDef) =>
+        toolDef.defer_loading !== true ||
+        this.discoveredToolNames.has(toolDef.name)
+    );
+    const programmaticOnlyTools = capabilities.codeExecutionOnlyTools;
+    const programmaticToolNames = capabilities.codeExecutionTools.map(
+      (toolDef) => toolDef.name
+    );
+    const directOnlyToolNames = capabilities.directOnlyTools
+      .map((toolDef) => toolDef.name)
+      .filter((name) => !isProgrammaticControlTool(name));
 
-      if (!isCodeExecutionOnly) continue;
+    const programmaticTools = this.getProgrammaticToolInstructionTargets();
+    if (programmaticTools.length === 0) return '';
+    const programmaticRunnerNames = programmaticTools
+      .map((tool) => `\`${tool.name}\``)
+      .join(' or ');
+    const quotedProgrammaticNames =
+      programmaticToolNames.length > 0
+        ? programmaticToolNames.map((name) => `\`${name}\``).join(', ')
+        : 'none';
+    const directOnlyBoundary =
+      directOnlyToolNames.length > 0
+        ? `\nCall these tools directly; never list them in the \`tools\` manifest or reference them inside ${programmaticRunnerNames}: ${directOnlyToolNames
+          .map((name) => `\`${name}\``)
+          .join(', ')}. Every ${programmaticRunnerNames} call must include a \`tools\` manifest containing the exact registered names used by its code; the manifest is validated before execution starts.`
+        : '';
+    const boundary =
+      '\n\n## Programmatic Tool Calling\n\n' +
+      `Only these tools may be invoked inside ${programmaticRunnerNames}: ${quotedProgrammaticNames}.` +
+      directOnlyBoundary;
 
-      const isDeferred = toolDef.defer_loading === true;
-      const isDiscovered = this.discoveredToolNames.has(name);
-      if (!isDeferred || isDiscovered) {
-        programmaticOnlyTools.push(toolDef);
-      }
+    if (programmaticOnlyTools.length === 0) {
+      return boundary;
     }
 
-    if (programmaticOnlyTools.length === 0) return '';
-
-    const programmaticTool = this.getProgrammaticToolInstructionTarget();
     const toolDescriptions = programmaticOnlyTools
       .map((tool) => {
         let desc = `- **${tool.name}**`;
@@ -506,41 +536,64 @@ export class AgentContext {
       .join('\n\n');
 
     return (
-      '\n\n## Programmatic-Only Tools\n\n' +
-      `The following tools are available exclusively through the \`${programmaticTool.name}\` tool. ` +
-      `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.language} code that invokes them.\n\n` +
+      boundary +
+      '\n\n### Programmatic-Only Tools\n\n' +
+      `The following tools are available exclusively through ${programmaticRunnerNames}. ` +
+      `You cannot call these tools directly; instead, ${programmaticTools
+        .map(
+          (tool) =>
+            `use \`${tool.name}\` with ${tool.codeGuidance} that invokes them`
+        )
+        .join(', or ')}.\n\n` +
       toolDescriptions
     );
   }
 
-  private getProgrammaticToolInstructionTarget(): {
+  private getProgrammaticToolInstructionTargets(): Array<{
     name: string;
-    language: 'bash' | 'Python';
-    } {
-    if (this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING)) {
-      return {
+    codeGuidance: string;
+  }> {
+    const targets: Array<{ name: string; codeGuidance: string }> = [];
+    if (
+      this.hasBoundTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
+      isProgrammaticRunnerAutoBound(
+        Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+        this.toolExecution
+      )
+    ) {
+      targets.push({
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
-        language: 'bash',
-      };
+        codeGuidance: 'Bash code',
+      });
     }
 
-    if (this.hasAvailableTool(Constants.PROGRAMMATIC_TOOL_CALLING)) {
-      return { name: Constants.PROGRAMMATIC_TOOL_CALLING, language: 'Python' };
+    if (
+      this.hasBoundTool(Constants.PROGRAMMATIC_TOOL_CALLING) ||
+      isProgrammaticRunnerAutoBound(
+        Constants.PROGRAMMATIC_TOOL_CALLING,
+        this.toolExecution
+      )
+    ) {
+      const localDefault =
+        this.toolExecution?.engine === 'local' ||
+        this.toolExecution?.engine === 'cloudflare-sandbox';
+      targets.push({
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        codeGuidance: localDefault
+          ? 'Bash code by default, or set `lang: "py"` to use Python code'
+          : 'Python code',
+      });
     }
 
-    return { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING, language: 'bash' };
+    return targets;
   }
 
-  private hasAvailableTool(name: string): boolean {
-    if (this.toolDefinitions?.some((tool) => tool.name === name) === true)
-      return true;
-    if (
-      this.tools?.some((tool) => 'name' in tool && tool.name === name) === true
-    ) {
-      return true;
-    }
-    if (this.toolMap?.has(name) === true) return true;
-    return this.toolRegistry?.has(name) === true;
+  private hasBoundTool(name: string): boolean {
+    return (
+      this.getToolsForBinding()?.some(
+        (tool) => 'name' in tool && tool.name === name
+      ) === true
+    );
   }
 
   /**
@@ -1083,15 +1136,12 @@ export class AgentContext {
      * alone left programmatic-only definitions counted in
      * `toolSchemaTokens` even though they were never bound.
      */
-    return this.toolDefinitions.filter((def) => {
-      const allowedCallers = def.allowed_callers ?? ['direct'];
-      if (!allowedCallers.includes('direct')) {
-        return false;
-      }
-      return (
-        def.defer_loading !== true || this.discoveredToolNames.has(def.name)
-      );
-    });
+    return resolveCallerCapabilityProjection(
+      this.toolDefinitions,
+      (toolDef) =>
+        toolDef.defer_loading !== true ||
+        this.discoveredToolNames.has(toolDef.name)
+    ).directTools;
   }
 
   /**
@@ -1807,14 +1857,10 @@ export class AgentContext {
         return true;
       }
 
-      if (this.discoveredToolNames.has(tool.name)) {
-        const allowedCallers = toolDef.allowed_callers ?? ['direct'];
-        return allowedCallers.includes('direct');
-      }
-
-      const allowedCallers = toolDef.allowed_callers ?? ['direct'];
       return (
-        allowedCallers.includes('direct') && toolDef.defer_loading !== true
+        allowsToolCaller(toolDef, 'direct') &&
+        (toolDef.defer_loading !== true ||
+          this.discoveredToolNames.has(tool.name))
       );
     });
   }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -38,6 +38,7 @@ import {
 } from '@/tools/local/resolveLocalExecutionTools';
 import {
   allowsToolCaller,
+  isToolDefinitionActive,
   isProgrammaticControlTool,
   resolveCallerCapabilityProjection,
 } from '@/tools/CallerCapabilities';
@@ -486,9 +487,7 @@ export class AgentContext {
 
     const capabilities = resolveCallerCapabilityProjection(
       this.toolRegistry.values(),
-      (toolDef) =>
-        toolDef.defer_loading !== true ||
-        this.discoveredToolNames.has(toolDef.name)
+      (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
     );
     const programmaticOnlyTools = capabilities.codeExecutionOnlyTools;
     const programmaticToolNames = capabilities.codeExecutionTools.map(
@@ -509,9 +508,9 @@ export class AgentContext {
         : 'none';
     const directOnlyBoundary =
       directOnlyToolNames.length > 0
-        ? `\nCall these tools directly; never list them in the \`tools\` manifest or reference them inside ${programmaticRunnerNames}: ${directOnlyToolNames
+        ? `\nCall these tools directly; never list them in the \`tool_manifest\` or reference them inside ${programmaticRunnerNames}: ${directOnlyToolNames
           .map((name) => `\`${name}\``)
-          .join(', ')}. Every ${programmaticRunnerNames} call must include a \`tools\` manifest containing the exact registered names used by its code; the manifest is validated before execution starts.`
+          .join(', ')}. Every ${programmaticRunnerNames} call must include a \`tool_manifest\` containing the exact registered names used by its code; the manifest is validated before execution starts.`
         : '';
     const boundary =
       '\n\n## Programmatic Tool Calling\n\n' +
@@ -1138,9 +1137,7 @@ export class AgentContext {
      */
     return resolveCallerCapabilityProjection(
       this.toolDefinitions,
-      (toolDef) =>
-        toolDef.defer_loading !== true ||
-        this.discoveredToolNames.has(toolDef.name)
+      (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
     ).directTools;
   }
 
@@ -1859,8 +1856,7 @@ export class AgentContext {
 
       return (
         allowsToolCaller(toolDef, 'direct') &&
-        (toolDef.defer_loading !== true ||
-          this.discoveredToolNames.has(tool.name))
+        isToolDefinitionActive(toolDef, this.discoveredToolNames)
       );
     });
   }

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1004,7 +1004,7 @@ describe('AgentContext', () => {
         'Only these tools may be invoked inside `run_tools_with_bash`: `both_tool`, `programmatic_only_tool`.'
       );
       expect(content).toContain(
-        'Call these tools directly; never list them in the `tools` manifest or reference them inside `run_tools_with_bash`: `direct_tool`.'
+        'Call these tools directly; never list them in the `tool_manifest` or reference them inside `run_tools_with_bash`: `direct_tool`.'
       );
       expect(content).toContain(
         'the manifest is validated before execution starts'

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -18,10 +18,16 @@ describe('AgentContext', () => {
     agentConfig?: Partial<t.AgentInputs>;
     tokenCounter?: t.TokenCounter;
     indexTokenCountMap?: Record<string, number>;
+    toolExecution?: t.ToolExecutionConfig;
   };
 
   const createBasicContext = (options: ContextOptions = {}): AgentContext => {
-    const { agentConfig = {}, tokenCounter, indexTokenCountMap } = options;
+    const {
+      agentConfig = {},
+      tokenCounter,
+      indexTokenCountMap,
+      toolExecution,
+    } = options;
     return AgentContext.fromConfig(
       {
         agentId: 'test-agent',
@@ -30,7 +36,8 @@ describe('AgentContext', () => {
         ...agentConfig,
       },
       tokenCounter,
-      indexTokenCountMap
+      indexTokenCountMap,
+      toolExecution
     );
   };
 
@@ -882,6 +889,26 @@ describe('AgentContext', () => {
   });
 
   describe('buildProgrammaticOnlyToolsInstructions', () => {
+    it('omits programmatic guidance when no runner is available', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolRegistry: new Map([
+            [
+              'programmatic_tool',
+              {
+                name: 'programmatic_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe('Base');
+    });
+
     it('includes code_execution-only tools in system message', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
@@ -935,7 +962,7 @@ describe('AgentContext', () => {
       expect(result[0].content).not.toContain('run_tools_with_bash');
     });
 
-    it('excludes direct-callable tools from programmatic section', () => {
+    it('makes mixed direct and programmatic caller boundaries explicit', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
           'direct_tool',
@@ -953,13 +980,196 @@ describe('AgentContext', () => {
             allowed_callers: ['direct', 'code_execution'],
           },
         ],
+        [
+          'programmatic_only_tool',
+          {
+            name: 'programmatic_only_tool',
+            description: 'Programmatic only',
+            allowed_callers: ['code_execution'],
+          },
+        ],
       ]);
 
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Base', toolRegistry },
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry,
+        },
       });
 
-      expect(ctx.systemRunnable).toBeDefined();
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_bash`: `both_tool`, `programmatic_only_tool`.'
+      );
+      expect(content).toContain(
+        'Call these tools directly; never list them in the `tools` manifest or reference them inside `run_tools_with_bash`: `direct_tool`.'
+      );
+      expect(content).toContain(
+        'the manifest is validated before execution starts'
+      );
+      expect(content).toContain('### Programmatic-Only Tools');
+    });
+
+    it('uses the Cloudflare runner effective registry in guidance', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'cloudflare-sandbox',
+          cloudflare: {
+            sandbox: {
+              exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+              readFile: async () => '',
+              writeFile: async () => undefined,
+              mkdir: async () => undefined,
+              listFiles: async () => [],
+              deleteFile: async () => undefined,
+            },
+          },
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain('`read_file`');
+      expect(content).not.toContain('`host_code_tool`');
+    });
+
+    it('recognizes auto-bound local programmatic runners', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: { engine: 'local' },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = String(result[0].content);
+      expect(content).toContain('inside `run_tools_with_bash`');
+      expect(content).toContain('or `run_tools_with_code`');
+      expect(content).toContain('`host_code_tool`');
+    });
+
+    it('describes the Bash default for an auto-bound code runner', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry: new Map([
+            [
+              'host_code_tool',
+              {
+                name: 'host_code_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'local',
+          local: { includeCodingTools: false },
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain('Bash code by default');
+      expect(content).toContain('`lang: "py"`');
+    });
+
+    it('emits direct-only guidance when the allowlist is empty', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: none.'
+      );
+      expect(content).toContain('`direct_tool`');
+    });
+
+    it('omits deferred programmatic runners until discovery', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            {
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              defer_loading: true,
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      expect(String((await ctx.systemRunnable!.invoke([]))[0].content)).toBe(
+        'Base'
+      );
+
+      ctx.markToolsAsDiscovered([Constants.PROGRAMMATIC_TOOL_CALLING]);
+
+      expect(
+        String((await ctx.systemRunnable!.invoke([]))[0].content)
+      ).toContain('inside `run_tools_with_code`');
+    });
+
+    it('omits programmatic runners that are not direct-callable', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            {
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              allowed_callers: ['code_execution'],
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'direct_tool',
+              { name: 'direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+      });
+
+      expect(String((await ctx.systemRunnable!.invoke([]))[0].content)).toBe(
+        'Base'
+      );
     });
 
     it('excludes deferred code_execution-only tools until discovered', () => {
@@ -1122,7 +1332,11 @@ describe('AgentContext', () => {
       ]);
 
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Short', toolRegistry },
+        agentConfig: {
+          instructions: 'Short',
+          toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+        },
         tokenCounter: mockTokenCounter,
       });
 
@@ -1830,7 +2044,10 @@ describe('AgentContext', () => {
 
     it('maintains consistent indexTokenCountMap across turns', () => {
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Base instructions' },
+        agentConfig: {
+          instructions: 'Base instructions',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+        },
         tokenCounter: mockTokenCounter,
       });
 
@@ -1906,6 +2123,7 @@ describe('AgentContext', () => {
         agentConfig: {
           instructions: 'You are helpful.',
           toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
         },
         tokenCounter: mockTokenCounter,
       });
@@ -1949,6 +2167,7 @@ describe('AgentContext', () => {
         agentConfig: {
           instructions: 'Assistant instructions',
           toolRegistry,
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
         },
         tokenCounter: mockTokenCounter,
       });

--- a/src/agents/__tests__/projection.test.ts
+++ b/src/agents/__tests__/projection.test.ts
@@ -1,7 +1,7 @@
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { Providers } from '@/common';
 import { projectAgentContextUsage } from '../projection';
+import { Providers } from '@/common';
 
 const countByChars = (msg: { content: unknown }): number => {
   const content =
@@ -69,5 +69,32 @@ describe('projectAgentContextUsage', () => {
     });
 
     expect(usage).toBeNull();
+  });
+
+  it('projects instructions from the effective execution backend', async () => {
+    const config: t.AgentInputs = {
+      ...agent(100_000),
+      toolRegistry: new Map([
+        [
+          'host_code_tool',
+          { name: 'host_code_tool', allowed_callers: ['code_execution'] },
+        ],
+      ]),
+    };
+    const withoutExecution = await projectAgentContextUsage({
+      agent: config,
+      messages: [],
+      tokenCounter: countByChars,
+    });
+    const withExecution = await projectAgentContextUsage({
+      agent: config,
+      messages: [],
+      tokenCounter: countByChars,
+      toolExecution: { engine: 'local' },
+    });
+
+    expect(withExecution!.breakdown.instructionTokens).toBeGreaterThan(
+      withoutExecution!.breakdown.instructionTokens
+    );
   });
 });

--- a/src/agents/projection.ts
+++ b/src/agents/projection.ts
@@ -13,6 +13,8 @@ export interface ProjectAgentContextUsageParams {
   indexTokenCountMap?: Record<string, number>;
   /** Provider-calibrated ratio from a prior snapshot, applied as a static seed. */
   calibrationRatio?: number;
+  /** Execution backend used to synthesize the live effective tool registry. */
+  toolExecution?: t.ToolExecutionConfig;
   runId?: string;
   agentId?: string;
 }
@@ -32,10 +34,16 @@ export async function projectAgentContextUsage({
   tokenCounter,
   indexTokenCountMap,
   calibrationRatio,
+  toolExecution,
   runId,
   agentId,
 }: ProjectAgentContextUsageParams): Promise<t.ContextUsageEvent | null> {
-  const context = AgentContext.fromConfig(agent, tokenCounter, indexTokenCountMap);
+  const context = AgentContext.fromConfig(
+    agent,
+    tokenCounter,
+    indexTokenCountMap,
+    toolExecution
+  );
   await context.tokenCalculationPromise;
   return context.projectContextUsage(messages, {
     runId,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2564,6 +2564,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         executingAgentId: agentContext?.agentId,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
+        getDiscoveredToolNames: (): readonly string[] =>
+          agentContext?.getDiscoveredTools() ?? [],
         hookRegistry: this.hookRegistry,
         humanInTheLoop: this.humanInTheLoop,
         eagerEventToolExecution: this.eagerEventToolExecution,
@@ -2641,6 +2643,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       errorHandler: (data, metadata): Promise<boolean> =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       toolRegistry: agentContext?.toolRegistry,
+      getDiscoveredToolNames: (): readonly string[] =>
+        agentContext?.getDiscoveredTools() ?? [],
       sessions: this.sessions,
       codeSessionKey: agentContext?.codeSessionKey,
       toolExecution: this.toolExecution,
@@ -2847,6 +2851,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         tools: agentContext.getToolsForBinding(),
         toolExecution: this.toolExecution,
         toolRegistry: agentContext.toolRegistry,
+        discoveredToolNames: new Set(agentContext.getDiscoveredTools()),
       });
 
       /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -34,6 +34,7 @@ import type {
 import type {
   GraphFactory,
   GraphFactoryDependencies,
+  GraphFactoryRequest,
 } from '@/graphs/graphFactory';
 import type { OverflowRecoveryPlan } from '@/llm/contextOverflowRecovery';
 import type { FallbackErrorContext } from '@/llm/invoke';
@@ -1460,6 +1461,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       subagentExecutionContext,
       preemption,
       streamLimits,
+      toolExecution,
     }: t.StandardGraphInput,
     dependencies?: GraphFactoryDependencies
   ) {
@@ -1485,6 +1487,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.subagentExecutionContext = subagentExecutionContext;
     this.preemption = preemption;
     this.streamLimits = resolveStreamLimits(streamLimits);
+    this.toolExecution = toolExecution;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -1494,7 +1497,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const agentContext = AgentContext.fromConfig(
         agentConfig,
         tokenCounter,
-        indexTokenCountMap
+        indexTokenCountMap,
+        toolExecution
       );
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
@@ -2842,6 +2846,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const rawToolsForBinding = resolveLocalToolsForBinding({
         tools: agentContext.getToolsForBinding(),
         toolExecution: this.toolExecution,
+        toolRegistry: agentContext.toolRegistry,
       });
 
       /**
@@ -4812,7 +4817,23 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           };
           const checkpointer = this.compileOptions?.checkpointer;
           return (request): StandardGraph => {
-            const childGraph = graphFactory(request);
+            const configuredRequest: GraphFactoryRequest =
+              request.kind === 'multi-agent'
+                ? {
+                  kind: 'multi-agent',
+                  input: {
+                    ...request.input,
+                    toolExecution: runtimeConfig.toolExecution,
+                  },
+                }
+                : {
+                  kind: 'standard',
+                  input: {
+                    ...request.input,
+                    toolExecution: runtimeConfig.toolExecution,
+                  },
+                };
+            const childGraph = graphFactory(configuredRequest);
             if (subagentModelOverride != null) {
               childGraph.overrideModel = subagentModelOverride;
               childGraph.setSubagentModelOverride(subagentModelOverride);

--- a/src/run.ts
+++ b/src/run.ts
@@ -470,6 +470,7 @@ export class Run<_T extends t.BaseGraphState> {
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
+        toolExecution: this.toolExecution,
       },
     });
     /** Propagate compile options from graph config */
@@ -509,6 +510,7 @@ export class Run<_T extends t.BaseGraphState> {
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
+        toolExecution: this.toolExecution,
       },
     });
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -19,6 +19,8 @@ import {
   formatCompletedResponse,
 } from './ProgrammaticToolCalling';
 import {
+  projectProgrammaticToolMap,
+  resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
   type ProgrammaticInvocationParams,
 } from './ProgrammaticCallerPolicy';
@@ -132,7 +134,7 @@ export function createBashProgrammaticToolCallingSchema(
         minLength: 1,
         description: CODE_PARAM_DESCRIPTION,
       },
-      tools: {
+      tool_manifest: {
         type: 'array',
         items: { type: 'string' },
         uniqueItems: true,
@@ -328,12 +330,14 @@ export function createBashProgrammaticToolCallingTool(
         };
       const {
         toolMap,
-        toolDefs,
         disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+      const toolDefs = resolveProgrammaticToolDefinitions(
+        toolCall as typeof toolCall & { tools?: t.LCTool[] }
+      );
 
       const programmaticToolName =
         toolCall.programmaticToolName ??
@@ -341,7 +345,7 @@ export function createBashProgrammaticToolCallingTool(
           ? toolCall.name
           : Constants.BASH_PROGRAMMATIC_TOOL_CALLING);
       const effectiveTools = selectProgrammaticTools({
-        requestedToolNames: params.tools,
+        requestedToolNames: params.tool_manifest,
         allowedToolDefs: toolDefs,
         disallowedToolDefs,
         programmaticToolName,
@@ -360,6 +364,11 @@ export function createBashProgrammaticToolCallingTool(
             'Either pass tools in the input or ensure ToolNode injects toolDefs.'
         );
       }
+
+      const effectiveToolMap = projectProgrammaticToolMap(
+        toolMap,
+        effectiveTools
+      );
 
       let roundTrip = 0;
 
@@ -447,7 +456,7 @@ export function createBashProgrammaticToolCallingTool(
           const toolResults = normalizeBashToolResultsForReplay(
             await executeTools(
               response.tool_calls ?? [],
-              toolMap,
+              effectiveToolMap,
               Constants.BASH_PROGRAMMATIC_TOOL_CALLING
             )
           );

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -14,15 +14,19 @@ import {
   selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
-  clampCodeApiRunTimeoutMs,
-  createCodeApiRunTimeoutSchema,
-  resolveCodeApiRunTimeoutMs,
-} from './ptcTimeout';
-import {
   makeRequest,
   executeTools,
   formatCompletedResponse,
 } from './ProgrammaticToolCalling';
+import {
+  selectProgrammaticTools,
+  type ProgrammaticInvocationParams,
+} from './ProgrammaticCallerPolicy';
+import {
+  clampCodeApiRunTimeoutMs,
+  createCodeApiRunTimeoutSchema,
+  resolveCodeApiRunTimeoutMs,
+} from './ptcTimeout';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
@@ -108,6 +112,10 @@ ${EXAMPLES}
 
 ${CORE_RULES}`;
 
+const TOOL_MANIFEST_DESCRIPTION =
+  'Exact registered tool names used by the code. Required when direct-only tools are configured; ' +
+  'validated before execution starts.';
+
 // ============================================================================
 // Schema
 // ============================================================================
@@ -123,6 +131,12 @@ export function createBashProgrammaticToolCallingSchema(
         type: 'string',
         minLength: 1,
         description: CODE_PARAM_DESCRIPTION,
+      },
+      tools: {
+        type: 'array',
+        items: { type: 'string' },
+        uniqueItems: true,
+        description: TOOL_MANIFEST_DESCRIPTION,
       },
       timeout: createCodeApiRunTimeoutSchema(maxRunTimeoutMs),
     },
@@ -302,7 +316,7 @@ export function createBashProgrammaticToolCallingTool(
 
   return tool(
     async (rawParams, config) => {
-      const params = rawParams as { code: string; timeout?: number };
+      const params = rawParams as ProgrammaticInvocationParams;
       const { code } = params;
       const timeout = clampCodeApiRunTimeoutMs(params.timeout, maxRunTimeoutMs);
 
@@ -315,10 +329,23 @@ export function createBashProgrammaticToolCallingTool(
       const {
         toolMap,
         toolDefs,
+        disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+
+      const programmaticToolName =
+        toolCall.programmaticToolName ??
+        (typeof toolCall.name === 'string' && toolCall.name !== ''
+          ? toolCall.name
+          : Constants.BASH_PROGRAMMATIC_TOOL_CALLING);
+      const effectiveTools = selectProgrammaticTools({
+        requestedToolNames: params.tools,
+        allowedToolDefs: toolDefs,
+        disallowedToolDefs,
+        programmaticToolName,
+      });
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(
@@ -338,16 +365,14 @@ export function createBashProgrammaticToolCallingTool(
 
       try {
         // ====================================================================
-        // Phase 1: Filter tools and make initial request
+        // Phase 1: Send the validated tool manifest with the initial request
         // ====================================================================
-
-        const effectiveTools = filterBashToolsByUsage(toolDefs, code, debug);
 
         if (debug) {
           // eslint-disable-next-line no-console
           console.log(
             `[BashPTC Debug] Sending ${effectiveTools.length} tools to API ` +
-              `(filtered from ${toolDefs.length})`
+              `(selected from ${toolDefs.length})`
           );
         }
 

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -31,6 +31,15 @@ export function isProgrammaticControlTool(name: string): boolean {
   return PROGRAMMATIC_CONTROL_TOOL_NAMES.has(name);
 }
 
+export function isToolDefinitionActive(
+  toolDef: t.LCTool,
+  discoveredToolNames: ReadonlySet<string>
+): boolean {
+  return (
+    toolDef.defer_loading !== true || discoveredToolNames.has(toolDef.name)
+  );
+}
+
 export function resolveCallerCapabilityProjection(
   toolDefs: Iterable<t.LCTool>,
   isActive: (toolDef: t.LCTool) => boolean = () => true

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -1,0 +1,69 @@
+import type * as t from '@/types';
+import { Constants } from '@/common';
+
+const PROGRAMMATIC_CONTROL_TOOL_NAMES = new Set<string>([
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+  Constants.TOOL_SEARCH,
+]);
+
+export type CallerCapabilityProjection = {
+  directTools: t.LCTool[];
+  codeExecutionTools: t.LCTool[];
+  directOnlyTools: t.LCTool[];
+  codeExecutionOnlyTools: t.LCTool[];
+};
+
+export function getAllowedCallers(
+  toolDef: t.LCTool
+): readonly t.AllowedCaller[] {
+  return toolDef.allowed_callers ?? ['direct'];
+}
+
+export function allowsToolCaller(
+  toolDef: t.LCTool,
+  caller: t.AllowedCaller
+): boolean {
+  return getAllowedCallers(toolDef).includes(caller);
+}
+
+export function isProgrammaticControlTool(name: string): boolean {
+  return PROGRAMMATIC_CONTROL_TOOL_NAMES.has(name);
+}
+
+export function resolveCallerCapabilityProjection(
+  toolDefs: Iterable<t.LCTool>,
+  isActive: (toolDef: t.LCTool) => boolean = () => true
+): CallerCapabilityProjection {
+  const directTools: t.LCTool[] = [];
+  const codeExecutionTools: t.LCTool[] = [];
+  const directOnlyTools: t.LCTool[] = [];
+  const codeExecutionOnlyTools: t.LCTool[] = [];
+
+  for (const toolDef of toolDefs) {
+    if (!isActive(toolDef)) {
+      continue;
+    }
+    const allowsDirect = allowsToolCaller(toolDef, 'direct');
+    const allowsCodeExecution = allowsToolCaller(toolDef, 'code_execution');
+    if (allowsDirect) {
+      directTools.push(toolDef);
+    }
+    if (allowsCodeExecution) {
+      codeExecutionTools.push(toolDef);
+    }
+    if (allowsDirect && !allowsCodeExecution) {
+      directOnlyTools.push(toolDef);
+    }
+    if (allowsCodeExecution && !allowsDirect) {
+      codeExecutionOnlyTools.push(toolDef);
+    }
+  }
+
+  return {
+    directTools,
+    codeExecutionTools,
+    directOnlyTools,
+    codeExecutionOnlyTools,
+  };
+}

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -1,0 +1,81 @@
+import type * as t from '@/types';
+
+export type ProgrammaticInvocationParams = {
+  code: string;
+  tools?: string[];
+  timeout?: number;
+  lang?: string;
+  runtime?: string;
+  language?: string;
+};
+
+export function assertDisallowedToolUsage(
+  disallowedNames: ReadonlySet<string>,
+  programmaticToolName: string
+): void {
+  if (disallowedNames.size === 0) {
+    return;
+  }
+
+  const names = [...disallowedNames];
+  throw new Error(
+    `Tool${names.length === 1 ? '' : 's'} ${names
+      .map((name) => `"${name}"`)
+      .join(', ')} cannot be called from "${programmaticToolName}" because ` +
+      `the${names.length === 1 ? ' tool is' : 'se tools are'} not marked for code_execution. ` +
+      `Call ${names.length === 1 ? 'it' : 'them'} directly instead.`
+  );
+}
+
+export function selectProgrammaticTools(args: {
+  requestedToolNames?: string[];
+  allowedToolDefs?: t.LCTool[];
+  disallowedToolDefs?: t.LCTool[];
+  programmaticToolName: string;
+}): t.LCTool[] {
+  const allowedToolDefs = args.allowedToolDefs ?? [];
+  const disallowedToolDefs = args.disallowedToolDefs ?? [];
+  const requestedToolNames = args.requestedToolNames;
+
+  if (requestedToolNames == null) {
+    if (disallowedToolDefs.length > 0) {
+      throw new Error(
+        `"${args.programmaticToolName}" requires a tools manifest when direct-only tools are configured. ` +
+          'List every registered tool name used by the submitted code in the tools field.'
+      );
+    }
+    return allowedToolDefs;
+  }
+
+  const disallowedNames = new Set(
+    disallowedToolDefs.map((toolDef) => toolDef.name)
+  );
+  const requestedDisallowedNames = new Set(
+    requestedToolNames.filter((name) => disallowedNames.has(name))
+  );
+  assertDisallowedToolUsage(
+    requestedDisallowedNames,
+    args.programmaticToolName
+  );
+
+  const allowedByName = new Map(
+    allowedToolDefs.map((toolDef) => [toolDef.name, toolDef])
+  );
+  const unknownNames = new Set(
+    requestedToolNames.filter((name) => !allowedByName.has(name))
+  );
+  if (unknownNames.size > 0) {
+    throw new Error(
+      `Tool${unknownNames.size === 1 ? '' : 's'} ${[...unknownNames]
+        .map((name) => `"${name}"`)
+        .join(
+          ', '
+        )} cannot be used by "${args.programmaticToolName}" because ` +
+        `${unknownNames.size === 1 ? 'it is' : 'they are'} not available for code_execution.`
+    );
+  }
+
+  return [...new Set(requestedToolNames)].map(
+    (name) => allowedByName.get(name) as t.LCTool
+  );
+}

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -2,12 +2,28 @@ import type * as t from '@/types';
 
 export type ProgrammaticInvocationParams = {
   code: string;
-  tools?: string[];
+  tool_manifest?: string[];
   timeout?: number;
   lang?: string;
   runtime?: string;
   language?: string;
 };
+
+export function resolveProgrammaticToolDefinitions(
+  context: Partial<t.ProgrammaticCache> & { tools?: t.LCTool[] }
+): t.LCTool[] | undefined {
+  return context.toolDefs ?? context.tools;
+}
+
+export function projectProgrammaticToolMap(
+  toolMap: t.ToolMap,
+  selectedToolDefs: readonly t.LCTool[]
+): t.ToolMap {
+  const selectedNames = new Set(selectedToolDefs.map((toolDef) => toolDef.name));
+  return new Map(
+    [...toolMap].filter(([name]) => selectedNames.has(name))
+  );
+}
 
 export function assertDisallowedToolUsage(
   disallowedNames: ReadonlySet<string>,
@@ -40,8 +56,8 @@ export function selectProgrammaticTools(args: {
   if (requestedToolNames == null) {
     if (disallowedToolDefs.length > 0) {
       throw new Error(
-        `"${args.programmaticToolName}" requires a tools manifest when direct-only tools are configured. ` +
-          'List every registered tool name used by the submitted code in the tools field.'
+        `"${args.programmaticToolName}" requires a tool_manifest when direct-only tools are configured. ` +
+          'List every registered tool name used by the submitted code in the tool_manifest field.'
       );
     }
     return allowedToolDefs;

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -26,6 +26,10 @@ import {
   createCodeApiRunTimeoutSchema,
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
+import {
+  selectProgrammaticTools,
+  type ProgrammaticInvocationParams,
+} from './ProgrammaticCallerPolicy';
 import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
@@ -87,6 +91,10 @@ ${EXAMPLES}
 
 ${CORE_RULES}`;
 
+const TOOL_MANIFEST_DESCRIPTION =
+  'Exact registered tool names used by the code. Required when direct-only tools are configured; ' +
+  'validated before execution starts.';
+
 export function createProgrammaticToolCallingSchema(
   maxRunTimeoutMs = DEFAULT_RUN_TIMEOUT_MS
 ): ProgrammaticToolCallingJsonSchema {
@@ -98,6 +106,12 @@ export function createProgrammaticToolCallingSchema(
         type: 'string',
         minLength: 1,
         description: CODE_PARAM_DESCRIPTION,
+      },
+      tools: {
+        type: 'array',
+        items: { type: 'string' },
+        uniqueItems: true,
+        description: TOOL_MANIFEST_DESCRIPTION,
       },
       timeout: createCodeApiRunTimeoutSchema(maxRunTimeoutMs),
     },
@@ -893,7 +907,7 @@ export function createProgrammaticToolCallingTool(
 
   return tool(
     async (rawParams, config) => {
-      const params = rawParams as { code: string; timeout?: number };
+      const params = rawParams as ProgrammaticInvocationParams;
       const { code } = params;
       const timeout = clampCodeApiRunTimeoutMs(params.timeout, maxRunTimeoutMs);
 
@@ -907,10 +921,23 @@ export function createProgrammaticToolCallingTool(
       const {
         toolMap,
         toolDefs,
+        disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+
+      const programmaticToolName =
+        toolCall.programmaticToolName ??
+        (typeof toolCall.name === 'string' && toolCall.name !== ''
+          ? toolCall.name
+          : Constants.PROGRAMMATIC_TOOL_CALLING);
+      const effectiveTools = selectProgrammaticTools({
+        requestedToolNames: params.tools,
+        allowedToolDefs: toolDefs,
+        disallowedToolDefs,
+        programmaticToolName,
+      });
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(
@@ -930,16 +957,14 @@ export function createProgrammaticToolCallingTool(
 
       try {
         // ====================================================================
-        // Phase 1: Filter tools and make initial request
+        // Phase 1: Send the validated tool manifest with the initial request
         // ====================================================================
-
-        const effectiveTools = filterToolsByUsage(toolDefs, code, debug);
 
         if (debug) {
           // eslint-disable-next-line no-console
           console.log(
             `[PTC Debug] Sending ${effectiveTools.length} tools to API ` +
-              `(filtered from ${toolDefs.length})`
+              `(selected from ${toolDefs.length})`
           );
         }
 

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -27,6 +27,8 @@ import {
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
 import {
+  projectProgrammaticToolMap,
+  resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
   type ProgrammaticInvocationParams,
 } from './ProgrammaticCallerPolicy';
@@ -107,7 +109,7 @@ export function createProgrammaticToolCallingSchema(
         minLength: 1,
         description: CODE_PARAM_DESCRIPTION,
       },
-      tools: {
+      tool_manifest: {
         type: 'array',
         items: { type: 'string' },
         uniqueItems: true,
@@ -920,12 +922,14 @@ export function createProgrammaticToolCallingTool(
         };
       const {
         toolMap,
-        toolDefs,
         disallowedToolDefs,
         session_id,
         _injected_files,
         _runtime_session_hint,
       } = toolCall;
+      const toolDefs = resolveProgrammaticToolDefinitions(
+        toolCall as typeof toolCall & { tools?: t.LCTool[] }
+      );
 
       const programmaticToolName =
         toolCall.programmaticToolName ??
@@ -933,7 +937,7 @@ export function createProgrammaticToolCallingTool(
           ? toolCall.name
           : Constants.PROGRAMMATIC_TOOL_CALLING);
       const effectiveTools = selectProgrammaticTools({
-        requestedToolNames: params.tools,
+        requestedToolNames: params.tool_manifest,
         allowedToolDefs: toolDefs,
         disallowedToolDefs,
         programmaticToolName,
@@ -952,6 +956,11 @@ export function createProgrammaticToolCallingTool(
             'Either pass tools in the input or ensure ToolNode injects toolDefs.'
         );
       }
+
+      const effectiveToolMap = projectProgrammaticToolMap(
+        toolMap,
+        effectiveTools
+      );
 
       let roundTrip = 0;
 
@@ -1040,7 +1049,7 @@ export function createProgrammaticToolCallingTool(
 
           const toolResults = await executeTools(
             response.tool_calls ?? [],
-            toolMap
+            effectiveToolMap
           );
 
           response = await makeRequest(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -94,6 +94,10 @@ import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
+import {
+  isProgrammaticControlTool,
+  resolveCallerCapabilityProjection,
+} from '@/tools/CallerCapabilities';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { attachRunStepResumeState } from '@/tools/runStepResume';
@@ -987,6 +991,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const resolved = resolveLocalExecutionTools({
       toolMap: this.toolMap,
       toolExecution: this.toolExecution,
+      toolRegistry: this.toolRegistry,
       fileCheckpointer: this.fileCheckpointer,
     });
 
@@ -1098,29 +1103,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.settledInterruptingResults.clear();
   }
 
-  /**
-   * Returns cached programmatic tools, computing once on first access.
-   * Single iteration builds both toolMap and toolDefs simultaneously.
-   */
-  private getProgrammaticTools(): { toolMap: t.ToolMap; toolDefs: t.LCTool[] } {
+  /** Returns cached tools projected by their effective caller capabilities. */
+  private getProgrammaticTools(): t.ProgrammaticCache {
     if (this.programmaticCache) return this.programmaticCache;
 
     const toolMap: t.ToolMap = new Map();
-    const toolDefs: t.LCTool[] = [];
-
-    if (this.toolRegistry) {
-      for (const [name, toolDef] of this.toolRegistry) {
-        if (
-          (toolDef.allowed_callers ?? ['direct']).includes('code_execution')
-        ) {
-          toolDefs.push(toolDef);
-          const tool = this.toolMap.get(name);
-          if (tool) toolMap.set(name, tool);
-        }
+    const capabilities = resolveCallerCapabilityProjection(
+      this.toolRegistry?.values() ?? []
+    );
+    for (const toolDef of capabilities.codeExecutionTools) {
+      const tool = this.toolMap.get(toolDef.name);
+      if (tool != null) {
+        toolMap.set(toolDef.name, tool);
       }
     }
 
-    this.programmaticCache = { toolMap, toolDefs };
+    this.programmaticCache = {
+      toolMap,
+      toolDefs: capabilities.codeExecutionTools,
+      disallowedToolDefs: capabilities.directOnlyTools
+        .filter((toolDef) => !isProgrammaticControlTool(toolDef.name))
+        .map((toolDef) => ({ name: toolDef.name })),
+    };
     return this.programmaticCache;
   }
 
@@ -1332,11 +1336,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
         call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
-        const { toolMap, toolDefs } = this.getProgrammaticTools();
+        const { toolMap, toolDefs, disallowedToolDefs } =
+          this.getProgrammaticTools();
         invokeParams = {
           ...invokeParams,
           toolMap,
           toolDefs,
+          disallowedToolDefs,
+          programmaticToolName: call.name,
           // Plumb the hook context into the programmatic-tool path so
           // inner tool calls made via the in-process bridge can run
           // through `PreToolUse` (deny / updatedInput) before reaching

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -95,6 +95,7 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import {
+  isToolDefinitionActive,
   isProgrammaticControlTool,
   resolveCallerCapabilityProjection,
 } from '@/tools/CallerCapabilities';
@@ -697,8 +698,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   >();
   /** Tool registry for filtering (lazy computation of programmatic maps) */
   private toolRegistry?: t.LCToolRegistry;
-  /** Cached programmatic tools (computed once on first PTC call) */
-  private programmaticCache?: t.ProgrammaticCache;
+  /** Reads deferred-tool discovery state from the owning agent context. */
+  private getDiscoveredToolNames?: () => readonly string[];
   /** Reference to Graph's sessions map for automatic session injection */
   private sessions?: t.ToolSessionMap;
   /** Partition within `sessions` owned by this agent's execution profile. */
@@ -802,6 +803,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     handleToolErrors,
     loadRuntimeTools,
     toolRegistry,
+    getDiscoveredToolNames,
     sessions,
     codeSessionKey,
     eventDrivenMode,
@@ -877,6 +879,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       toolRegistry,
       toolExecution,
     });
+    this.getDiscoveredToolNames = getDiscoveredToolNames;
     this.sessions = sessions;
     this.codeSessionKey = codeSessionKey ?? Constants.EXECUTE_CODE;
     this.eventDrivenMode = eventDrivenMode ?? false;
@@ -1007,7 +1010,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       ...(this.directToolNames ?? new Set<string>()),
       ...resolved.directToolNames,
     ]);
-    this.programmaticCache = undefined;
   }
 
   /**
@@ -1103,13 +1105,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.settledInterruptingResults.clear();
   }
 
-  /** Returns cached tools projected by their effective caller capabilities. */
+  /** Returns active tools projected by their effective caller capabilities. */
   private getProgrammaticTools(): t.ProgrammaticCache {
-    if (this.programmaticCache) return this.programmaticCache;
-
     const toolMap: t.ToolMap = new Map();
+    const discoveredToolNames = new Set(
+      this.getDiscoveredToolNames?.() ?? []
+    );
     const capabilities = resolveCallerCapabilityProjection(
-      this.toolRegistry?.values() ?? []
+      this.toolRegistry?.values() ?? [],
+      (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
     );
     for (const toolDef of capabilities.codeExecutionTools) {
       const tool = this.toolMap.get(toolDef.name);
@@ -1118,14 +1122,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
 
-    this.programmaticCache = {
+    return {
       toolMap,
       toolDefs: capabilities.codeExecutionTools,
       disallowedToolDefs: capabilities.directOnlyTools
         .filter((toolDef) => !isProgrammaticControlTool(toolDef.name))
         .map((toolDef) => ({ name: toolDef.name })),
     };
-    return this.programmaticCache;
   }
 
   /**
@@ -4489,7 +4492,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.toolMap =
           toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
         this.applyToolExecutionOverrides();
-        this.programmaticCache = undefined; // Invalidate cache on toolMap change
       }
 
       const filteredCalls =

--- a/src/tools/__tests__/CallerCapabilities.test.ts
+++ b/src/tools/__tests__/CallerCapabilities.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from '@jest/globals';
+import type * as t from '@/types';
+import {
+  allowsToolCaller,
+  resolveCallerCapabilityProjection,
+} from '../CallerCapabilities';
+
+describe('Caller Capability Projection', () => {
+  const toolDefs: t.LCTool[] = [
+    { name: 'default_direct' },
+    { name: 'direct_only', allowed_callers: ['direct'] },
+    { name: 'code_only', allowed_callers: ['code_execution'] },
+    {
+      name: 'both',
+      allowed_callers: ['direct', 'code_execution'],
+    },
+    {
+      name: 'deferred_code',
+      allowed_callers: ['code_execution'],
+      defer_loading: true,
+    },
+  ];
+
+  it('classifies every caller combination in one pass', () => {
+    const projection = resolveCallerCapabilityProjection(toolDefs);
+
+    expect(projection.directTools.map((toolDef) => toolDef.name)).toEqual([
+      'default_direct',
+      'direct_only',
+      'both',
+    ]);
+    expect(
+      projection.codeExecutionTools.map((toolDef) => toolDef.name)
+    ).toEqual(['code_only', 'both', 'deferred_code']);
+    expect(projection.directOnlyTools.map((toolDef) => toolDef.name)).toEqual([
+      'default_direct',
+      'direct_only',
+    ]);
+    expect(
+      projection.codeExecutionOnlyTools.map((toolDef) => toolDef.name)
+    ).toEqual(['code_only', 'deferred_code']);
+  });
+
+  it('applies caller classification after effective-activity filtering', () => {
+    const projection = resolveCallerCapabilityProjection(
+      toolDefs,
+      (toolDef) => toolDef.defer_loading !== true
+    );
+
+    expect(
+      projection.codeExecutionTools.map((toolDef) => toolDef.name)
+    ).not.toContain('deferred_code');
+  });
+
+  it('defaults omitted caller metadata to direct-only', () => {
+    expect(allowsToolCaller(toolDefs[0], 'direct')).toBe(true);
+    expect(allowsToolCaller(toolDefs[0], 'code_execution')).toBe(false);
+  });
+});

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -1,3 +1,4 @@
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
   createCloudflareWorkspaceFS,
@@ -10,9 +11,9 @@ import {
   createCloudflareBashProgrammaticToolCallingTool,
   createCloudflareProgrammaticToolCallingTool,
 } from '../cloudflare/CloudflareProgrammaticToolCalling';
-import { isWorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
 import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
+import { isWorkspaceClientTimeoutError } from '../local/workspaceFS';
 import { spawnLocalProcess } from '../local/LocalExecutionEngine';
 import { Constants } from '@/common';
 
@@ -57,6 +58,29 @@ function createRuntime(
     ...overrides,
   };
 }
+
+it('reports the invoked runner name for Cloudflare caller-policy failures', async () => {
+  const programmatic = createCloudflareProgrammaticToolCallingTool({
+    sandbox: createRuntime(),
+  });
+  const toolCall = {
+    id: 'cloudflare-ptc',
+    name: Constants.PROGRAMMATIC_TOOL_CALLING,
+    type: 'tool_call' as const,
+    args: {},
+    programmaticToolName: Constants.PROGRAMMATIC_TOOL_CALLING,
+    disallowedToolDefs: [{ name: 'direct_only_tool' }],
+  } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+  await expect(
+    programmatic.invoke(
+      { code: 'direct_only_tool \'{}\'', tools: ['direct_only_tool'] },
+      { toolCall }
+    )
+  ).rejects.toThrow(
+    'Tool "direct_only_tool" cannot be called from "run_tools_with_code"'
+  );
+});
 
 describe('Cloudflare sandbox execution backend', () => {
   it('normalizes trailing workspace slashes before clamping paths', async () => {

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -74,7 +74,10 @@ it('reports the invoked runner name for Cloudflare caller-policy failures', asyn
 
   await expect(
     programmatic.invoke(
-      { code: 'direct_only_tool \'{}\'', tools: ['direct_only_tool'] },
+      {
+        code: 'direct_only_tool \'{}\'',
+        tool_manifest: ['direct_only_tool'],
+      },
       { toolCall }
     )
   ).rejects.toThrow(

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -68,7 +68,10 @@ it('reports the invoked runner name for local caller-policy failures', async () 
 
   await expect(
     programmatic.invoke(
-      { code: 'direct_only_tool \'{}\'', tools: ['direct_only_tool'] },
+      {
+        code: 'direct_only_tool \'{}\'',
+        tool_manifest: ['direct_only_tool'],
+      },
       { toolCall }
     )
   ).rejects.toThrow(
@@ -204,6 +207,36 @@ describe('local execution tools', () => {
     expect(tools.map((localTool) => localTool.name)).not.toContain(
       'write_file'
     );
+  });
+
+  it('binds a deferred synthesized tool only after discovery', () => {
+    const registry = resolveLocalToolRegistry({
+      toolRegistry: new Map([
+        [
+          'write_file',
+          {
+            name: 'write_file',
+            allowed_callers: ['direct', 'code_execution'],
+            defer_loading: true,
+          },
+        ],
+      ]),
+      toolExecution: { engine: 'local' },
+    });
+    const undiscovered = resolveLocalToolsForBinding({
+      toolExecution: { engine: 'local' },
+      toolRegistry: registry,
+    }) as t.GenericTool[];
+    const discovered = resolveLocalToolsForBinding({
+      toolExecution: { engine: 'local' },
+      toolRegistry: registry,
+      discoveredToolNames: new Set(['write_file']),
+    }) as t.GenericTool[];
+
+    expect(undiscovered.map((toolDef) => toolDef.name)).not.toContain(
+      'write_file'
+    );
+    expect(discovered.map((toolDef) => toolDef.name)).toContain('write_file');
   });
 
   it('updates existing code tool bindings when auto-binding is disabled', () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -20,6 +20,7 @@ import {
   readFile as fsReadFile,
 } from 'fs/promises';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { WorkspaceFS } from '../local/workspaceFS';
 import type * as t from '@/types';
@@ -30,6 +31,10 @@ import {
   _resetLocalEngineWarningsForTests,
 } from '../local/LocalExecutionEngine';
 import {
+  resolveLocalToolRegistry,
+  resolveLocalToolsForBinding,
+} from '../local/resolveLocalExecutionTools';
+import {
   createLocalCodingToolBundle,
   _resetRipgrepCacheForTests,
 } from '../local/LocalCodingTools';
@@ -37,7 +42,7 @@ import {
   runPostEditSyntaxCheck,
   _resetSyntaxCheckProbeCacheForTests,
 } from '../local/syntaxCheck';
-import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
+import { createLocalProgrammaticToolCallingTool } from '../local/LocalProgrammaticToolCalling';
 import { LocalFileCheckpointerImpl } from '../local/FileCheckpointer';
 import { getProviderMessageProvenance } from '@/messages/provenance';
 import { WorkspaceClientTimeoutError } from '../local/workspaceFS';
@@ -49,6 +54,27 @@ import { ToolNode } from '../ToolNode';
 const hasPython3 = spawnSync('python3', ['--version']).status === 0;
 
 const tempDirs: string[] = [];
+
+it('reports the invoked runner name for local caller-policy failures', async () => {
+  const programmatic = createLocalProgrammaticToolCallingTool();
+  const toolCall = {
+    id: 'local-ptc',
+    name: Constants.PROGRAMMATIC_TOOL_CALLING,
+    type: 'tool_call' as const,
+    args: {},
+    programmaticToolName: Constants.PROGRAMMATIC_TOOL_CALLING,
+    disallowedToolDefs: [{ name: 'direct_only_tool' }],
+  } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+  await expect(
+    programmatic.invoke(
+      { code: 'direct_only_tool \'{}\'', tools: ['direct_only_tool'] },
+      { toolCall }
+    )
+  ).rejects.toThrow(
+    'Tool "direct_only_tool" cannot be called from "run_tools_with_code"'
+  );
+});
 
 async function createTempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'lc-local-tools-'));
@@ -143,6 +169,40 @@ describe('local execution tools', () => {
         'glob_search',
         'list_directory',
       ])
+    );
+  });
+
+  it('preserves host caller restrictions for synthesized coding tools', () => {
+    const registry = resolveLocalToolRegistry({
+      toolRegistry: new Map([
+        [
+          'write_file',
+          { name: 'write_file', allowed_callers: ['direct'] },
+        ],
+      ]),
+      toolExecution: { engine: 'local' },
+    });
+
+    expect(registry?.get('write_file')?.allowed_callers).toEqual(['direct']);
+  });
+
+  it('does not directly bind synthesized tools overridden as code-only', () => {
+    const registry = resolveLocalToolRegistry({
+      toolRegistry: new Map([
+        [
+          'write_file',
+          { name: 'write_file', allowed_callers: ['code_execution'] },
+        ],
+      ]),
+      toolExecution: { engine: 'local' },
+    });
+    const tools = resolveLocalToolsForBinding({
+      toolExecution: { engine: 'local' },
+      toolRegistry: registry,
+    }) as t.GenericTool[];
+
+    expect(tools.map((localTool) => localTool.name)).not.toContain(
+      'write_file'
     );
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -4,6 +4,7 @@
  * Tests manual invocation with mock tools and Code API responses.
  */
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
   createProgrammaticToolCallingTool,
@@ -16,16 +17,18 @@ import {
   unwrapToolResponse,
 } from '../ProgrammaticToolCalling';
 import {
+  createBashProgrammaticToolCallingTool,
+  createBashProgrammaticToolCallingSchema,
+  normalizeBashToolResultsForReplay,
+} from '../BashProgrammaticToolCalling';
+import { selectProgrammaticTools } from '../ProgrammaticCallerPolicy';
+import {
   createProgrammaticToolRegistry,
   createGetTeamMembersTool,
   createGetExpensesTool,
   createGetWeatherTool,
   createCalculatorTool,
 } from '@/test/mockTools';
-import {
-  createBashProgrammaticToolCallingSchema,
-  normalizeBashToolResultsForReplay,
-} from '../BashProgrammaticToolCalling';
 import { Constants } from '@/common';
 
 describe('ProgrammaticToolCalling', () => {
@@ -37,6 +40,9 @@ describe('ProgrammaticToolCalling', () => {
       expect(description).toContain('keyword args only');
       expect(description).toContain('never pass a dict');
       expect(description).toContain('Tool results are decoded Python values');
+      expect(schema.properties.tools.description).toContain(
+        'validated before execution starts'
+      );
     });
 
     it('explains bash inner-tool stdout shape', () => {
@@ -53,6 +59,7 @@ describe('ProgrammaticToolCalling', () => {
       expect(description).toContain('/mnt/data/sf.json');
       expect(description).toContain('Failed executions register nothing');
       expect(description).toContain('`/tmp` never survives the call');
+      expect(schema.properties.tools.uniqueItems).toBe(true);
     });
   });
 
@@ -908,6 +915,58 @@ for member in team:
     });
   });
 
+  describe('Programmatic Tool Manifest', () => {
+    const allowedToolDefs: t.LCTool[] = [
+      { name: 'search', allowed_callers: ['code_execution'] },
+      {
+        name: 'calculate',
+        allowed_callers: ['direct', 'code_execution'],
+      },
+    ];
+    const disallowedToolDefs = [{ name: 'send_email' }];
+
+    it('requires a manifest for mixed caller configurations', () => {
+      expect(() =>
+        selectProgrammaticTools({
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toThrow('requires a tools manifest');
+    });
+
+    it('rejects direct-only manifest entries before execution', () => {
+      expect(() =>
+        selectProgrammaticTools({
+          requestedToolNames: ['send_email'],
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toThrow('not marked for code_execution');
+    });
+
+    it('selects declared allowed tools without parsing code', () => {
+      expect(
+        selectProgrammaticTools({
+          requestedToolNames: ['calculate', 'search', 'search'],
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toEqual([allowedToolDefs[1], allowedToolDefs[0]]);
+    });
+
+    it('preserves the all-tools fallback when no direct-only tools exist', () => {
+      expect(
+        selectProgrammaticTools({
+          allowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toBe(allowedToolDefs);
+    });
+  });
+
   describe('formatCompletedResponse', () => {
     it('formats response with stdout', () => {
       const response: t.ProgrammaticExecutionResponse = {
@@ -1031,7 +1090,6 @@ for member in team:
   describe('createProgrammaticToolCallingTool - Manual Invocation', () => {
     let ptcTool: ReturnType<typeof createProgrammaticToolCallingTool>;
     let toolMap: t.ToolMap;
-    let toolDefinitions: t.LCTool[];
 
     beforeEach(() => {
       const tools = [
@@ -1040,11 +1098,6 @@ for member in team:
         createGetWeatherTool(),
       ];
       toolMap = new Map(tools.map((t) => [t.name, t]));
-      toolDefinitions = Array.from(
-        createProgrammaticToolRegistry().values()
-      ).filter((t) =>
-        ['get_team_members', 'get_expenses', 'get_weather'].includes(t.name)
-      );
 
       ptcTool = createProgrammaticToolCallingTool({
         baseUrl: 'http://mock-api',
@@ -1055,8 +1108,6 @@ for member in team:
       await expect(
         ptcTool.invoke({
           code: 'result = await get_weather(city="SF")\nprint(result)',
-          tools: toolDefinitions,
-          toolMap,
         })
       ).rejects.toThrow('No toolMap provided');
     });
@@ -1064,8 +1115,6 @@ for member in team:
     it('throws error when toolMap is empty', async () => {
       const args = {
         code: 'result = await get_weather(city="SF")\nprint(result)',
-        tools: toolDefinitions,
-        toolMap: new Map(),
       };
       const toolCall = {
         name: 'programmatic_tool_calling',
@@ -1131,6 +1180,62 @@ for member in team:
     beforeEach(() => {
       const tools = [createGetWeatherTool()];
       toolMap = new Map(tools.map((t) => [t.name, t]));
+    });
+
+    it('rejects a direct-only Python tool before requiring sandbox context', async () => {
+      const tool = createProgrammaticToolCallingTool();
+      const toolCall = {
+        id: 'ptc-python',
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        args: {},
+        type: 'tool_call' as const,
+        disallowedToolDefs: [
+          {
+            name: 'direct-only-tool',
+            allowed_callers: ['direct'],
+          },
+        ],
+      } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+      await expect(
+        tool.invoke(
+          {
+            code: 'await direct_only_tool(query="test")',
+            tools: ['direct-only-tool'],
+          },
+          { toolCall }
+        )
+      ).rejects.toThrow(
+        'Tool "direct-only-tool" cannot be called from "run_tools_with_code" because the tool is not marked for code_execution'
+      );
+    });
+
+    it('rejects a direct-only bash tool before requiring sandbox context', async () => {
+      const tool = createBashProgrammaticToolCallingTool();
+      const toolCall = {
+        id: 'ptc-bash',
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        args: {},
+        type: 'tool_call' as const,
+        disallowedToolDefs: [
+          {
+            name: 'direct-only-tool',
+            allowed_callers: ['direct'],
+          },
+        ],
+      } satisfies ToolCall & Partial<t.ProgrammaticCache>;
+
+      await expect(
+        tool.invoke(
+          {
+            code: 'direct_only_tool \'{"query":"test"}\'',
+            tools: ['direct-only-tool'],
+          },
+          { toolCall }
+        )
+      ).rejects.toThrow(
+        'Tool "direct-only-tool" cannot be called from "run_tools_with_code" because the tool is not marked for code_execution'
+      );
     });
 
     it('returns error for invalid city without throwing', async () => {
@@ -1350,11 +1455,9 @@ for member in team:
   });
 
   describe('bash bridge script does not require python3 (Codex P2 #19)', () => {
-    /* eslint-disable @typescript-eslint/no-require-imports */
     const {
       _createBashProgramForTests,
     } = require('../local/LocalProgrammaticToolCalling');
-    /* eslint-enable @typescript-eslint/no-require-imports */
 
     it('uses curl as the primary HTTP helper with python3 only as fallback', () => {
       const script: string = _createBashProgramForTests(
@@ -1399,7 +1502,7 @@ for member in team:
       const { tool } = await import('@langchain/core/tools');
       const { z } = await import('zod');
       const { HookRegistry } = await import('@/hooks');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
 
       let callsMade = 0;
@@ -1418,7 +1521,6 @@ for member in team:
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
         hooks: [
-          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async (input) => {
             if (input.toolName === 'write_file') {
               return { decision: 'deny', reason: 'no writes from bridge' };
@@ -1431,7 +1533,7 @@ for member in team:
       // Internal createToolBridge isn't exported, but exercising it via
       // a synthetic HTTP request mirrors the real path. We use a tiny
       // helper to access the (testing-internal) bridge factory.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const http = require('http') as typeof import('http');
 
       // Use the same internal factory the production path uses by
@@ -1464,13 +1566,12 @@ for member in team:
 
     it('threads executingAgentId from the hook context to bridge PreToolUse hooks', async () => {
       const { HookRegistry } = await import('@/hooks');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
       const registry = new HookRegistry();
       let seen: string | undefined = 'UNSET';
       registry.register('PreToolUse', {
         hooks: [
-          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async (input) => {
             seen = input.executingAgentId;
             return { decision: 'allow' };
@@ -1488,12 +1589,11 @@ for member in team:
 
     it('passes through when no hook denies (allow path)', async () => {
       const { HookRegistry } = await import('@/hooks');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
 
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
-        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
         hooks: [async () => ({ decision: 'allow' })],
       });
 
@@ -1509,13 +1609,12 @@ for member in team:
 
     it('applies updatedInput to the inner tool args', async () => {
       const { HookRegistry } = await import('@/hooks');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
 
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
         hooks: [
-          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async () => ({
             decision: 'allow',
             updatedInput: { path: '/tmp/rewritten' },
@@ -1535,12 +1634,11 @@ for member in team:
 
     it('treats `ask` as fail-closed deny (HITL not reachable from bridge)', async () => {
       const { HookRegistry } = await import('@/hooks');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
 
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
-        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
         hooks: [async () => ({ decision: 'ask' })],
       });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -21,7 +21,11 @@ import {
   createBashProgrammaticToolCallingSchema,
   normalizeBashToolResultsForReplay,
 } from '../BashProgrammaticToolCalling';
-import { selectProgrammaticTools } from '../ProgrammaticCallerPolicy';
+import {
+  projectProgrammaticToolMap,
+  resolveProgrammaticToolDefinitions,
+  selectProgrammaticTools,
+} from '../ProgrammaticCallerPolicy';
 import {
   createProgrammaticToolRegistry,
   createGetTeamMembersTool,
@@ -40,7 +44,7 @@ describe('ProgrammaticToolCalling', () => {
       expect(description).toContain('keyword args only');
       expect(description).toContain('never pass a dict');
       expect(description).toContain('Tool results are decoded Python values');
-      expect(schema.properties.tools.description).toContain(
+      expect(schema.properties.tool_manifest.description).toContain(
         'validated before execution starts'
       );
     });
@@ -59,7 +63,7 @@ describe('ProgrammaticToolCalling', () => {
       expect(description).toContain('/mnt/data/sf.json');
       expect(description).toContain('Failed executions register nothing');
       expect(description).toContain('`/tmp` never survives the call');
-      expect(schema.properties.tools.uniqueItems).toBe(true);
+      expect(schema.properties.tool_manifest.uniqueItems).toBe(true);
     });
   });
 
@@ -932,7 +936,7 @@ for member in team:
           disallowedToolDefs,
           programmaticToolName: 'run_tools_with_code',
         })
-      ).toThrow('requires a tools manifest');
+      ).toThrow('requires a tool_manifest');
     });
 
     it('rejects direct-only manifest entries before execution', () => {
@@ -964,6 +968,25 @@ for member in team:
           programmaticToolName: 'run_tools_with_code',
         })
       ).toBe(allowedToolDefs);
+    });
+
+    it('preserves legacy manual tool-definition injection', () => {
+      expect(
+        resolveProgrammaticToolDefinitions({ tools: allowedToolDefs })
+      ).toBe(allowedToolDefs);
+    });
+
+    it('restricts callback execution to the selected manifest', () => {
+      const searchTool = createGetTeamMembersTool();
+      const emailTool = createGetExpensesTool();
+      const toolMap: t.ToolMap = new Map([
+        ['search', searchTool],
+        ['send_email', emailTool],
+      ]);
+
+      expect(
+        projectProgrammaticToolMap(toolMap, [{ name: 'search' }])
+      ).toEqual(new Map([['search', searchTool]]));
     });
   });
 
@@ -1201,7 +1224,7 @@ for member in team:
         tool.invoke(
           {
             code: 'await direct_only_tool(query="test")',
-            tools: ['direct-only-tool'],
+            tool_manifest: ['direct-only-tool'],
           },
           { toolCall }
         )
@@ -1229,7 +1252,7 @@ for member in team:
         tool.invoke(
           {
             code: 'direct_only_tool \'{"query":"test"}\'',
-            tools: ['direct-only-tool'],
+            tool_manifest: ['direct-only-tool'],
           },
           { toolCall }
         )

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -77,4 +77,66 @@ describe('ToolNode programmatic caller policy', () => {
       Constants.PROGRAMMATIC_TOOL_CALLING
     );
   });
+
+  it('projects deferred policy definitions only after discovery', async () => {
+    const capturedConfigs: Array<ToolCall & Partial<t.ProgrammaticCache>> = [];
+    const discovered = new Set<string>();
+    const ptcTool = tool(
+      async (_args, config) => {
+        capturedConfigs.push(
+          config.toolCall as ToolCall & Partial<t.ProgrammaticCache>
+        );
+        return 'done';
+      },
+      {
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        description: 'Run tools with code',
+        schema: z.object({ code: z.string() }),
+      }
+    );
+    const directTool = tool(async () => 'direct', {
+      name: 'deferred_direct_tool',
+      description: 'Deferred direct tool',
+      schema: z.object({}),
+    });
+    const node = new ToolNode({
+      tools: [ptcTool, directTool],
+      toolRegistry: new Map([
+        [
+          directTool.name,
+          {
+            name: directTool.name,
+            allowed_callers: ['direct'],
+            defer_loading: true,
+          },
+        ],
+      ]),
+      getDiscoveredToolNames: () => [...discovered],
+    });
+    const invoke = async (id: string): Promise<void> => {
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id,
+                name: Constants.PROGRAMMATIC_TOOL_CALLING,
+                args: { code: 'print("done")' },
+              },
+            ],
+          }),
+        ],
+      });
+    };
+
+    await invoke('before-discovery');
+    discovered.add(directTool.name);
+    await invoke('after-discovery');
+
+    expect(capturedConfigs[0].disallowedToolDefs).toEqual([]);
+    expect(capturedConfigs[1].disallowedToolDefs).toEqual([
+      { name: directTool.name },
+    ]);
+  });
 });

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+
+describe('ToolNode programmatic caller policy', () => {
+  it('separates programmatic tools from direct-only preflight definitions', async () => {
+    const capturedConfigs: Array<ToolCall & Partial<t.ProgrammaticCache>> = [];
+    const ptcTool = tool(
+      async (_args, config) => {
+        capturedConfigs.push(
+          config.toolCall as ToolCall & Partial<t.ProgrammaticCache>
+        );
+        return 'done';
+      },
+      {
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        description: 'Run tools with code',
+        schema: z.object({ code: z.string() }),
+      }
+    );
+    const programmaticTool = tool(async () => 'programmatic', {
+      name: 'programmatic_tool',
+      description: 'Programmatic tool',
+      schema: z.object({}),
+    });
+    const directTool = tool(async () => 'direct', {
+      name: 'direct_tool',
+      description: 'Direct tool',
+      schema: z.object({}),
+    });
+    const toolRegistry: t.LCToolRegistry = new Map([
+      [
+        programmaticTool.name,
+        {
+          name: programmaticTool.name,
+          allowed_callers: ['code_execution'],
+        },
+      ],
+      [directTool.name, { name: directTool.name, allowed_callers: ['direct'] }],
+    ]);
+    const node = new ToolNode({
+      tools: [ptcTool, programmaticTool, directTool],
+      toolRegistry,
+    });
+
+    await node.invoke({
+      messages: [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'ptc-call',
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              args: { code: 'print("done")' },
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(capturedConfigs).toHaveLength(1);
+    expect(capturedConfigs[0].toolDefs).toEqual([
+      { name: 'programmatic_tool', allowed_callers: ['code_execution'] },
+    ]);
+    expect(capturedConfigs[0].disallowedToolDefs).toEqual([
+      { name: 'direct_tool' },
+    ]);
+    expect(capturedConfigs[0].toolMap).toEqual(
+      new Map([['programmatic_tool', programmaticTool]])
+    );
+    expect(capturedConfigs[0].programmaticToolName).toBe(
+      Constants.PROGRAMMATIC_TOOL_CALLING
+    );
+  });
+});

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -9,14 +9,16 @@ import {
   ProgrammaticToolCallingDescription,
   ProgrammaticToolCallingName,
   ProgrammaticToolCallingSchema,
-  filterToolsByUsage,
 } from '@/tools/ProgrammaticToolCalling';
 import {
   BashProgrammaticToolCallingDescription,
   BashProgrammaticToolCallingSchema,
-  filterBashToolsByUsage,
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
+import {
+  selectProgrammaticTools,
+  type ProgrammaticInvocationParams,
+} from '@/tools/ProgrammaticCallerPolicy';
 import { Constants } from '@/common';
 import {
   clientExecTimeoutMs,
@@ -27,13 +29,7 @@ import {
   validateCloudflareBashCommand,
 } from './CloudflareSandboxExecutionEngine';
 
-type ProgrammaticParams = {
-  code: string;
-  timeout?: number;
-  lang?: string;
-  runtime?: string;
-  language?: string;
-};
+type ProgrammaticParams = ProgrammaticInvocationParams;
 
 const DEFAULT_TIMEOUT = 60000;
 const MIN_TIMEOUT = 1000;
@@ -224,15 +220,8 @@ function resolveRuntime(params: ProgrammaticParams): 'python' | 'bash' {
   return raw === 'py' || raw === 'python' ? 'python' : 'bash';
 }
 
-function filterNativeTools(
-  toolDefs: t.LCTool[],
-  code: string,
-  runtime: 'python' | 'bash'
-): t.LCTool[] {
-  const nativeDefs = toolDefs.filter((def) => NATIVE_TOOL_NAMES.has(def.name));
-  const filter =
-    runtime === 'bash' ? filterBashToolsByUsage : filterToolsByUsage;
-  return filter(nativeDefs, code);
+function filterNativeTools(toolDefs: t.LCTool[]): t.LCTool[] {
+  return toolDefs.filter((def) => NATIVE_TOOL_NAMES.has(def.name));
 }
 
 function indent(code: string, spaces = 4): string {
@@ -1062,12 +1051,18 @@ async function runProgrammatic(args: {
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
   const toolCall = (args.config?.toolCall ??
     {}) as Partial<t.ProgrammaticCache>;
-  const toolDefs = toolCall.toolDefs ?? [];
-  const effectiveTools = filterNativeTools(
-    toolDefs,
-    args.params.code,
-    args.runtime
-  );
+  const programmaticToolName =
+    toolCall.programmaticToolName ??
+    (args.runtime === 'bash'
+      ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      : Constants.PROGRAMMATIC_TOOL_CALLING);
+  const selectedTools = selectProgrammaticTools({
+    requestedToolNames: args.params.tools,
+    allowedToolDefs: toolCall.toolDefs,
+    disallowedToolDefs: toolCall.disallowedToolDefs,
+    programmaticToolName,
+  });
+  const effectiveTools = filterNativeTools(selectedTools);
   const timeoutMs = clampExecutionTimeout(
     args.params.timeout,
     args.cloudflareConfig.timeoutMs

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -16,6 +16,7 @@ import {
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
 import {
+  resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
   type ProgrammaticInvocationParams,
 } from '@/tools/ProgrammaticCallerPolicy';
@@ -1049,16 +1050,18 @@ async function runProgrammatic(args: {
   cloudflareConfig: t.CloudflareSandboxExecutionConfig;
   runtime: 'python' | 'bash';
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const toolCall = (args.config?.toolCall ??
-    {}) as Partial<t.ProgrammaticCache>;
+  const toolCall = (args.config?.toolCall ?? {}) as Partial<
+    t.ProgrammaticCache
+  > & { tools?: t.LCTool[] };
+  const toolDefs = resolveProgrammaticToolDefinitions(toolCall);
   const programmaticToolName =
     toolCall.programmaticToolName ??
     (args.runtime === 'bash'
       ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       : Constants.PROGRAMMATIC_TOOL_CALLING);
   const selectedTools = selectProgrammaticTools({
-    requestedToolNames: args.params.tools,
-    allowedToolDefs: toolCall.toolDefs,
+    requestedToolNames: args.params.tool_manifest,
+    allowedToolDefs: toolDefs,
     disallowedToolDefs: toolCall.disallowedToolDefs,
     programmaticToolName,
   });

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -19,6 +19,7 @@ import {
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
 import {
+  resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
   type ProgrammaticInvocationParams,
 } from '@/tools/ProgrammaticCallerPolicy';
@@ -541,8 +542,10 @@ ${code}
 
 function getProgrammaticContext(config?: {
   toolCall?: unknown;
-}): Partial<t.ProgrammaticCache> {
-  return (config?.toolCall ?? {}) as Partial<t.ProgrammaticCache>;
+}): Partial<t.ProgrammaticCache> & { tools?: t.LCTool[] } {
+  return (config?.toolCall ?? {}) as Partial<t.ProgrammaticCache> & {
+    tools?: t.LCTool[];
+  };
 }
 
 function createEffectiveToolMap(
@@ -569,13 +572,10 @@ async function runLocalProgrammaticTool(args: {
   localConfig: t.LocalExecutionConfig;
   runtime: LocalProgrammaticRuntime;
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const {
-    toolMap,
-    toolDefs,
-    disallowedToolDefs,
-    programmaticToolName,
-    hookContext,
-  } = getProgrammaticContext(args.config);
+  const context = getProgrammaticContext(args.config);
+  const { toolMap, disallowedToolDefs, programmaticToolName, hookContext } =
+    context;
+  const toolDefs = resolveProgrammaticToolDefinitions(context);
 
   const runnerName =
     programmaticToolName ??
@@ -583,7 +583,7 @@ async function runLocalProgrammaticTool(args: {
       ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       : Constants.PROGRAMMATIC_TOOL_CALLING);
   const selectedTools = selectProgrammaticTools({
-    requestedToolNames: args.params.tools,
+    requestedToolNames: args.params.tool_manifest,
     allowedToolDefs: toolDefs,
     disallowedToolDefs,
     programmaticToolName: runnerName,

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -7,7 +7,6 @@ import type { AddressInfo } from 'net';
 import type * as t from '@/types';
 import {
   executeTools,
-  filterToolsByUsage,
   formatCompletedResponse,
   normalizeToPythonIdentifier,
   ProgrammaticToolCallingName,
@@ -17,9 +16,12 @@ import {
 import {
   BashProgrammaticToolCallingSchema,
   BashProgrammaticToolCallingDescription,
-  filterBashToolsByUsage,
   normalizeToBashIdentifier,
 } from '@/tools/BashProgrammaticToolCalling';
+import {
+  selectProgrammaticTools,
+  type ProgrammaticInvocationParams,
+} from '@/tools/ProgrammaticCallerPolicy';
 import {
   executeLocalBash,
   executeLocalCode,
@@ -150,15 +152,7 @@ function constantTimeEquals(a: string, b: string): boolean {
 
 type LocalProgrammaticRuntime = 'python' | 'bash';
 
-type LocalProgrammaticParams = {
-  code: string;
-  timeout?: number;
-  lang?: string;
-  runtime?: string;
-  language?: string;
-};
-
-type ToolFilter = (toolDefs: t.LCTool[], code: string) => t.LCTool[];
+type LocalProgrammaticParams = ProgrammaticInvocationParams;
 
 function resolveRuntime(
   params: LocalProgrammaticParams
@@ -553,11 +547,8 @@ function getProgrammaticContext(config?: {
 
 function createEffectiveToolMap(
   toolMap: t.ToolMap,
-  toolDefs: t.LCTool[],
-  code: string,
-  filterTools: ToolFilter
+  effectiveTools: t.LCTool[]
 ): { effectiveTools: t.LCTool[]; effectiveMap: t.ToolMap } {
-  const effectiveTools = filterTools(toolDefs, code);
   const effectiveMap = new Map<string, t.GenericTool>(
     effectiveTools
       .map((def) => {
@@ -578,9 +569,25 @@ async function runLocalProgrammaticTool(args: {
   localConfig: t.LocalExecutionConfig;
   runtime: LocalProgrammaticRuntime;
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const { toolMap, toolDefs, hookContext } = getProgrammaticContext(
-    args.config
-  );
+  const {
+    toolMap,
+    toolDefs,
+    disallowedToolDefs,
+    programmaticToolName,
+    hookContext,
+  } = getProgrammaticContext(args.config);
+
+  const runnerName =
+    programmaticToolName ??
+    (args.runtime === 'bash'
+      ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      : Constants.PROGRAMMATIC_TOOL_CALLING);
+  const selectedTools = selectProgrammaticTools({
+    requestedToolNames: args.params.tools,
+    allowedToolDefs: toolDefs,
+    disallowedToolDefs,
+    programmaticToolName: runnerName,
+  });
 
   if (toolMap == null || toolMap.size === 0) {
     throw new Error('No toolMap provided for local programmatic execution.');
@@ -593,9 +600,7 @@ async function runLocalProgrammaticTool(args: {
 
   const { effectiveTools, effectiveMap } = createEffectiveToolMap(
     toolMap,
-    toolDefs,
-    args.params.code,
-    args.runtime === 'bash' ? filterBashToolsByUsage : filterToolsByUsage
+    selectedTools
   );
   const bridge = await createToolBridge(effectiveMap, hookContext);
 

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -17,6 +17,7 @@ import {
   createLocalBashExecutionTool,
   createLocalCodeExecutionTool,
 } from './LocalExecutionTools';
+import { allowsToolCaller } from '@/tools/CallerCapabilities';
 import {
   Constants,
   CODE_EXECUTION_TOOLS,
@@ -56,6 +57,25 @@ function shouldIncludeCodingTools(config?: t.ToolExecutionConfig): boolean {
     (shouldUseCloudflareSandboxExecution(config) &&
       config?.cloudflare?.includeCodingTools !== false)
   );
+}
+
+export function isProgrammaticRunnerAutoBound(
+  name: string,
+  config?: t.ToolExecutionConfig
+): boolean {
+  if (
+    !shouldIncludeCodingTools(config) ||
+    (name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+      name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
+  ) {
+    return false;
+  }
+  if (shouldUseCloudflareSandboxExecution(config)) {
+    return getSelectedCloudflareCodingToolNames(
+      getCloudflareConfig(config)
+    ).has(name);
+  }
+  return shouldUseLocalExecution(config);
 }
 
 function getCloudflareConfig(
@@ -150,9 +170,37 @@ function mergeToolsByName(
   return orderedTools;
 }
 
+function filterToolsForDirectCaller(
+  tools: t.GraphTools | undefined,
+  toolRegistry?: t.LCToolRegistry
+): t.GraphTools | undefined {
+  if (tools == null || toolRegistry == null) {
+    return tools;
+  }
+  return tools.filter((tool) => {
+    if (!('name' in tool) || typeof tool.name !== 'string') {
+      return true;
+    }
+    const toolDef = toolRegistry.get(tool.name);
+    return toolDef == null || allowsToolCaller(toolDef, 'direct');
+  });
+}
+
+function addDirectToolName(
+  directToolNames: Set<string>,
+  name: string,
+  toolRegistry?: t.LCToolRegistry
+): void {
+  const toolDef = toolRegistry?.get(name);
+  if (toolDef == null || allowsToolCaller(toolDef, 'direct')) {
+    directToolNames.add(name);
+  }
+}
+
 export function resolveLocalToolsForBinding(args: {
   tools?: t.GraphTools;
   toolExecution?: t.ToolExecutionConfig;
+  toolRegistry?: t.LCToolRegistry;
 }): t.GraphTools | undefined {
   if (
     !shouldUseLocalExecution(args.toolExecution) &&
@@ -166,9 +214,12 @@ export function resolveLocalToolsForBinding(args: {
     if (shouldIncludeCodingTools(args.toolExecution)) {
       const selectedNames =
         getSelectedCloudflareCodingToolNames(cloudflareConfig);
-      return mergeToolsByName(
-        filterCloudflareCodingToolAllowlist(args.tools, selectedNames),
-        createCloudflareCodingTools(cloudflareConfig)
+      return filterToolsForDirectCaller(
+        mergeToolsByName(
+          filterCloudflareCodingToolAllowlist(args.tools, selectedNames),
+          createCloudflareCodingTools(cloudflareConfig)
+        ),
+        args.toolRegistry
       );
     }
 
@@ -187,14 +238,18 @@ export function resolveLocalToolsForBinding(args: {
           cloudflareTool != null
       );
 
-    return replacements.length === 0
+    const resolvedTools = replacements.length === 0
       ? args.tools
       : mergeToolsByName(args.tools, replacements);
+    return filterToolsForDirectCaller(resolvedTools, args.toolRegistry);
   }
 
   const localConfig = args.toolExecution?.local ?? {};
   if (shouldIncludeCodingTools(args.toolExecution)) {
-    return mergeToolsByName(args.tools, createLocalCodingTools(localConfig));
+    return filterToolsForDirectCaller(
+      mergeToolsByName(args.tools, createLocalCodingTools(localConfig)),
+      args.toolRegistry
+    );
   }
 
   const replacements = ((args.tools as t.GenericTool[] | undefined) ?? [])
@@ -209,9 +264,10 @@ export function resolveLocalToolsForBinding(args: {
     )
     .filter((localTool): localTool is t.GenericTool => localTool != null);
 
-  return replacements.length === 0
+  const resolvedTools = replacements.length === 0
     ? args.tools
     : mergeToolsByName(args.tools, replacements);
+  return filterToolsForDirectCaller(resolvedTools, args.toolRegistry);
 }
 
 export function resolveLocalToolRegistry(args: {
@@ -228,12 +284,39 @@ export function resolveLocalToolRegistry(args: {
       getCloudflareConfig(args.toolExecution)
     )
     : undefined;
+
+  if (selectedNames != null) {
+    const callableInsideCloudflare = new Set(selectedNames);
+    callableInsideCloudflare.delete(Constants.PROGRAMMATIC_TOOL_CALLING);
+    callableInsideCloudflare.delete(Constants.BASH_PROGRAMMATIC_TOOL_CALLING);
+    for (const [name, definition] of registry) {
+      if (callableInsideCloudflare.has(name)) {
+        continue;
+      }
+      const allowedCallers = definition.allowed_callers ?? ['direct'];
+      if (allowedCallers.includes('code_execution')) {
+        registry.set(name, {
+          ...definition,
+          allowed_callers: allowedCallers.filter(
+            (caller) => caller !== 'code_execution'
+          ),
+        });
+      }
+    }
+  }
+
   for (const definition of createLocalCodingToolDefinitions()) {
     if (selectedNames != null && !selectedNames.has(definition.name)) {
       registry.delete(definition.name);
       continue;
     }
-    registry.set(definition.name, definition);
+    const existingDefinition = registry.get(definition.name);
+    registry.set(
+      definition.name,
+      existingDefinition == null
+        ? definition
+        : { ...definition, ...existingDefinition }
+    );
   }
   return registry;
 }
@@ -241,6 +324,7 @@ export function resolveLocalToolRegistry(args: {
 export function resolveLocalExecutionTools(args: {
   toolMap: t.ToolMap;
   toolExecution?: t.ToolExecutionConfig;
+  toolRegistry?: t.LCToolRegistry;
   /**
    * Caller-provided checkpointer that overrides the bundle's
    * auto-created one. The Graph layer threads a single per-Run
@@ -281,14 +365,22 @@ export function resolveLocalExecutionTools(args: {
         fileCheckpointer = bundle.checkpointer;
         for (const cloudflareTool of bundle.tools) {
           toolMap.set(cloudflareTool.name, cloudflareTool);
-          directToolNames.add(cloudflareTool.name);
+          addDirectToolName(
+            directToolNames,
+            cloudflareTool.name,
+            args.toolRegistry
+          );
         }
       } else {
         for (const cloudflareTool of createCloudflareCodingTools(
           cloudflareConfig
         )) {
           toolMap.set(cloudflareTool.name, cloudflareTool);
-          directToolNames.add(cloudflareTool.name);
+          addDirectToolName(
+            directToolNames,
+            cloudflareTool.name,
+            args.toolRegistry
+          );
         }
       }
     }
@@ -307,7 +399,7 @@ export function resolveLocalExecutionTools(args: {
       }
 
       toolMap.set(name, cloudflareTool);
-      directToolNames.add(name);
+      addDirectToolName(directToolNames, name, args.toolRegistry);
     }
 
     return { toolMap, directToolNames, fileCheckpointer };
@@ -332,12 +424,20 @@ export function resolveLocalExecutionTools(args: {
       fileCheckpointer = bundle.checkpointer;
       for (const localTool of bundle.tools) {
         toolMap.set(localTool.name, localTool);
-        directToolNames.add(localTool.name);
+        addDirectToolName(
+          directToolNames,
+          localTool.name,
+          args.toolRegistry
+        );
       }
     } else {
       for (const localTool of createLocalCodingTools(localConfig)) {
         toolMap.set(localTool.name, localTool);
-        directToolNames.add(localTool.name);
+        addDirectToolName(
+          directToolNames,
+          localTool.name,
+          args.toolRegistry
+        );
       }
     }
   }
@@ -363,7 +463,7 @@ export function resolveLocalExecutionTools(args: {
     }
 
     toolMap.set(name, localTool);
-    directToolNames.add(name);
+    addDirectToolName(directToolNames, name, args.toolRegistry);
   }
 
   return { toolMap, directToolNames, fileCheckpointer };

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -17,7 +17,10 @@ import {
   createLocalBashExecutionTool,
   createLocalCodeExecutionTool,
 } from './LocalExecutionTools';
-import { allowsToolCaller } from '@/tools/CallerCapabilities';
+import {
+  allowsToolCaller,
+  isToolDefinitionActive,
+} from '@/tools/CallerCapabilities';
 import {
   Constants,
   CODE_EXECUTION_TOOLS,
@@ -172,7 +175,8 @@ function mergeToolsByName(
 
 function filterToolsForDirectCaller(
   tools: t.GraphTools | undefined,
-  toolRegistry?: t.LCToolRegistry
+  toolRegistry?: t.LCToolRegistry,
+  discoveredToolNames: ReadonlySet<string> = new Set()
 ): t.GraphTools | undefined {
   if (tools == null || toolRegistry == null) {
     return tools;
@@ -182,7 +186,11 @@ function filterToolsForDirectCaller(
       return true;
     }
     const toolDef = toolRegistry.get(tool.name);
-    return toolDef == null || allowsToolCaller(toolDef, 'direct');
+    return (
+      toolDef == null ||
+      (allowsToolCaller(toolDef, 'direct') &&
+        isToolDefinitionActive(toolDef, discoveredToolNames))
+    );
   });
 }
 
@@ -201,6 +209,7 @@ export function resolveLocalToolsForBinding(args: {
   tools?: t.GraphTools;
   toolExecution?: t.ToolExecutionConfig;
   toolRegistry?: t.LCToolRegistry;
+  discoveredToolNames?: ReadonlySet<string>;
 }): t.GraphTools | undefined {
   if (
     !shouldUseLocalExecution(args.toolExecution) &&
@@ -219,7 +228,8 @@ export function resolveLocalToolsForBinding(args: {
           filterCloudflareCodingToolAllowlist(args.tools, selectedNames),
           createCloudflareCodingTools(cloudflareConfig)
         ),
-        args.toolRegistry
+        args.toolRegistry,
+        args.discoveredToolNames
       );
     }
 
@@ -241,14 +251,19 @@ export function resolveLocalToolsForBinding(args: {
     const resolvedTools = replacements.length === 0
       ? args.tools
       : mergeToolsByName(args.tools, replacements);
-    return filterToolsForDirectCaller(resolvedTools, args.toolRegistry);
+    return filterToolsForDirectCaller(
+      resolvedTools,
+      args.toolRegistry,
+      args.discoveredToolNames
+    );
   }
 
   const localConfig = args.toolExecution?.local ?? {};
   if (shouldIncludeCodingTools(args.toolExecution)) {
     return filterToolsForDirectCaller(
       mergeToolsByName(args.tools, createLocalCodingTools(localConfig)),
-      args.toolRegistry
+      args.toolRegistry,
+      args.discoveredToolNames
     );
   }
 
@@ -267,7 +282,11 @@ export function resolveLocalToolsForBinding(args: {
   const resolvedTools = replacements.length === 0
     ? args.tools
     : mergeToolsByName(args.tools, replacements);
-  return filterToolsForDirectCaller(resolvedTools, args.toolRegistry);
+  return filterToolsForDirectCaller(
+    resolvedTools,
+    args.toolRegistry,
+    args.discoveredToolNames
+  );
 }
 
 export function resolveLocalToolRegistry(args: {

--- a/src/tools/ptcTimeout.ts
+++ b/src/tools/ptcTimeout.ts
@@ -22,7 +22,7 @@ export type ProgrammaticToolCallingJsonSchema = {
       minLength: number;
       description: string;
     };
-    tools: {
+    tool_manifest: {
       type: 'array';
       items: { type: 'string' };
       uniqueItems: true;

--- a/src/tools/ptcTimeout.ts
+++ b/src/tools/ptcTimeout.ts
@@ -22,6 +22,12 @@ export type ProgrammaticToolCallingJsonSchema = {
       minLength: number;
       description: string;
     };
+    tools: {
+      type: 'array';
+      items: { type: 'string' };
+      uniqueItems: true;
+      description: string;
+    };
     timeout: TimeoutSchema;
   };
   required: readonly ['code'];

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -31,6 +31,7 @@ import type {
   ToolEndEvent,
   GenericTool,
   LCTool,
+  ToolExecutionConfig,
   ToolExecuteBatchRequest,
 } from '@/types/tools';
 import type {
@@ -338,6 +339,8 @@ export type StandardGraphInput = {
   runId?: string;
   signal?: AbortSignal;
   agents: AgentInputs[];
+  /** Execution backend used to resolve the effective tool registry. */
+  toolExecution?: ToolExecutionConfig;
   langfuse?: LangfuseConfig;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -133,6 +133,8 @@ export type ToolNodeOptions = {
   ) => Promise<boolean | void>;
   /** Tool registry for lazy computation of programmatic tools and tool search */
   toolRegistry?: LCToolRegistry;
+  /** Returns the owning agent's currently discovered deferred tool names. */
+  getDiscoveredToolNames?: () => readonly string[];
   /** Reference to Graph's sessions map for automatic session injection */
   sessions?: ToolSessionMap;
   /** Partition within `sessions` used by this agent's code tools. */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,17 +1,17 @@
 // src/types/tools.ts
-import type { StructuredToolInterface } from '@langchain/core/tools';
 import type {
   RunnableConfig,
   RunnableToolLike,
 } from '@langchain/core/runnables';
+import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
-import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
-import type { RunBreakerScope } from '@/llm/streamLimits';
 import type {
   MessageContentComplex,
   RunStepResumeState,
   ToolErrorData,
 } from './stream';
+import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { HumanInTheLoopConfig } from './hitl';
 import type { LangfuseConfig } from './graph';
 import type { HookRegistry } from '@/hooks';
@@ -1171,6 +1171,15 @@ export type ToolExecutionConfig = {
 export type ProgrammaticCache = {
   toolMap: ToolMap;
   toolDefs: LCTool[];
+  /** Actual outer runner name used for caller-policy diagnostics. */
+  programmaticToolName?: string;
+  /**
+   * Known tools that cannot be invoked from programmatic execution. Kept
+   * separate from `toolDefs` so the Programmatic Tool Manifest can be
+   * validated before the execution runtime starts without exposing their
+   * schemas to that runtime.
+   */
+  disallowedToolDefs?: LCTool[];
   /**
    * Hook context plumbed through by ToolNode for the local
    * programmatic-tool path so the in-process bridge can run


### PR DESCRIPTION
I centralized caller-capability policy and replaced runtime code parsing with explicit Programmatic Tool Manifests so mixed direct and programmatic tools receive consistent guidance and fail before execution startup.

- Project caller capabilities once for prompt guidance, model binding, ToolNode dispatch, and token accounting.
- Require a `tools` manifest only when direct-only tools are configured, and validate every declared dependency before a sandbox, request, or local bridge starts.
- Select permitted schemas from the manifest instead of parsing arbitrary Bash or Python code in production.
- Preserve existing usage-filter helper exports for compatibility while removing them from execution policy.
- Honor code-only overrides when local and Cloudflare coding tools are synthesized or marked for direct execution.
- Propagate execution-engine context through usage projection and child graphs.
- Document Caller Capability Projections and Programmatic Tool Manifests in `CONTEXT.md`.
- Add regression coverage for caller classification, mixed-tool guidance, manifest rejection, runtime naming, and synthesized-tool restrictions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx tsc --noEmit` — passed.
- Focused Jest suite — 387 tests passed across caller capabilities, AgentContext, projection, ToolNode policy, remote PTC, local execution, and Cloudflare execution.
- Changed-file ESLint — passed without errors.
- `npm run build` — passed before the final latest-`main` sync; TypeScript and focused tests passed again after syncing.

### **Test Configuration**:

- Node.js 24.16.0
- npm workspace install reused from the main checkout

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
