### PR TITLE
🎒 fix: Carry Deferred Discovery State into Event-Driven Tool Execution

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -66,6 +66,13 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
         toolDefinitions: [{ name: 'weather' }],
         graphTools: [],
         agentId: 'agent_1',
+        getCallerCapabilityProjectionSnapshot: jest.fn(() => ({
+          version: 1,
+          directToolNames: ['weather'],
+          codeExecutionToolNames: [],
+          directOnlyToolNames: ['weather'],
+          codeExecutionOnlyToolNames: [],
+        })),
       })
     ),
     getStepKey: jest.fn(() => 'step-key'),
@@ -214,6 +221,13 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       args: { city: 'NYC' },
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
+    });
+    expect(toolExecuteCalls[0].callerCapabilityProjection).toEqual({
+      version: 1,
+      directToolNames: ['weather'],
+      codeExecutionToolNames: [],
+      directOnlyToolNames: ['weather'],
+      codeExecutionOnlyToolNames: [],
     });
     expect(graph.eagerEventToolExecutions.get('call_weather')).toMatchObject({
       toolCallId: 'call_weather',

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -67,7 +67,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
         graphTools: [],
         agentId: 'agent_1',
         getCallerCapabilityProjectionSnapshot: jest.fn(() => ({
-          version: 1,
+          version: 1 as const,
           directToolNames: ['weather'],
           codeExecutionToolNames: [],
           directOnlyToolNames: ['weather'],

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -63,6 +63,12 @@ type AgentSystemContentBlock =
 
 type PromptCacheProvider = Providers.ANTHROPIC | Providers.OPENROUTER;
 
+type ProgrammaticToolInstructionTarget = {
+  name: string;
+  codeGuidance: string;
+  executesDirectly: boolean;
+};
+
 /**
  * Encapsulates agent-specific state that can vary between agents in a multi-agent system
  */
@@ -489,19 +495,55 @@ export class AgentContext {
   private buildProgrammaticOnlyToolsInstructions(): string {
     const programmaticTools = this.getProgrammaticToolInstructionTargets();
     if (programmaticTools.length === 0) return '';
-    const isDirectProgrammaticRunner = programmaticTools.some(
+    const directProgrammaticTools = programmaticTools.filter(
       (tool) => tool.executesDirectly
     );
-    if (isDirectProgrammaticRunner && !this.toolRegistry) {
+    const eventProgrammaticTools = programmaticTools.filter(
+      (tool) => !tool.executesDirectly
+    );
+    const groups: Array<{
+      tools: ProgrammaticToolInstructionTarget[];
+      capabilities: CallerCapabilityProjection;
+      label: string;
+    }> = [];
+    if (directProgrammaticTools.length > 0 && this.toolRegistry) {
+      groups.push({
+        tools: directProgrammaticTools,
+        capabilities: resolveCallerCapabilityProjection(
+          this.toolRegistry.values(),
+          (toolDef) =>
+            isToolDefinitionActive(toolDef, this.discoveredToolNames)
+        ),
+        label: 'Direct programmatic runners',
+      });
+    }
+    if (eventProgrammaticTools.length > 0) {
+      groups.push({
+        tools: eventProgrammaticTools,
+        capabilities: this.getCallerCapabilityProjection(),
+        label: 'Event-dispatched programmatic runners',
+      });
+    }
+    if (groups.length === 0) {
       return '';
     }
-    const capabilities = isDirectProgrammaticRunner
-      ? resolveCallerCapabilityProjection(
-        this.toolRegistry?.values() ?? [],
-        (toolDef) =>
-          isToolDefinitionActive(toolDef, this.discoveredToolNames)
-      )
-      : this.getCallerCapabilityProjection();
+    const showGroupLabels = groups.length > 1;
+    return (
+      '\n\n## Programmatic Tool Calling' +
+      groups
+        .map(
+          ({ tools, capabilities, label }) =>
+            (showGroupLabels ? `\n\n### ${label}` : '') +
+            this.buildProgrammaticToolGroupInstructions(tools, capabilities)
+        )
+        .join('')
+    );
+  }
+
+  private buildProgrammaticToolGroupInstructions(
+    programmaticTools: ProgrammaticToolInstructionTarget[],
+    capabilities: CallerCapabilityProjection
+  ): string {
     const programmaticOnlyTools = capabilities.codeExecutionOnlyTools;
     const programmaticToolNames = capabilities.codeExecutionTools.map(
       (toolDef) => toolDef.name
@@ -524,7 +566,7 @@ export class AgentContext {
           .join(', ')}. Every ${programmaticRunnerNames} call must include a \`tool_manifest\` containing the exact registered names used by its code; the manifest is validated before execution starts.`
         : '';
     const boundary =
-      '\n\n## Programmatic Tool Calling\n\n' +
+      '\n\n' +
       `Only these tools may be invoked inside ${programmaticRunnerNames}: ${quotedProgrammaticNames}.` +
       directOnlyBoundary;
 
@@ -559,16 +601,8 @@ export class AgentContext {
     );
   }
 
-  private getProgrammaticToolInstructionTargets(): Array<{
-    name: string;
-    codeGuidance: string;
-    executesDirectly: boolean;
-  }> {
-    const targets: Array<{
-      name: string;
-      codeGuidance: string;
-      executesDirectly: boolean;
-    }> = [];
+  private getProgrammaticToolInstructionTargets(): ProgrammaticToolInstructionTarget[] {
+    const targets: ProgrammaticToolInstructionTarget[] = [];
     if (
       this.hasBoundTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
       isProgrammaticRunnerAutoBound(
@@ -611,8 +645,14 @@ export class AgentContext {
 
   /** Whether ToolNode executes this runner in-process instead of via an event. */
   private isProgrammaticRunnerDirectlyBound(name: string): boolean {
+    const usesDirectExecutionEngine =
+      this.toolExecution?.engine === 'local' ||
+      this.toolExecution?.engine === 'cloudflare-sandbox';
     return (
       isProgrammaticRunnerAutoBound(name, this.toolExecution) ||
+      (usesDirectExecutionEngine &&
+        this.toolDefinitions?.some((toolDef) => toolDef.name === name) ===
+          true) ||
       this.graphTools?.some(
         (tool) => 'name' in tool && tool.name === name
       ) === true

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -34,6 +34,7 @@ import {
 } from '@/common';
 import {
   isProgrammaticRunnerAutoBound,
+  isProgrammaticRunnerResolvedDirectly,
   resolveLocalToolRegistry,
 } from '@/tools/local/resolveLocalExecutionTools';
 import {
@@ -645,14 +646,12 @@ export class AgentContext {
 
   /** Whether ToolNode executes this runner in-process instead of via an event. */
   private isProgrammaticRunnerDirectlyBound(name: string): boolean {
-    const usesDirectExecutionEngine =
-      this.toolExecution?.engine === 'local' ||
-      this.toolExecution?.engine === 'cloudflare-sandbox';
     return (
-      isProgrammaticRunnerAutoBound(name, this.toolExecution) ||
-      (usesDirectExecutionEngine &&
-        this.toolDefinitions?.some((toolDef) => toolDef.name === name) ===
-          true) ||
+      isProgrammaticRunnerResolvedDirectly(
+        name,
+        this.toolExecution,
+        this.toolDefinitions?.some((toolDef) => toolDef.name === name) === true
+      ) ||
       this.graphTools?.some(
         (tool) => 'name' in tool && tool.name === name
       ) === true

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -487,9 +487,11 @@ export class AgentContext {
 
   /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
-    const isDirectProgrammaticRunner =
-      this.toolExecution?.engine === 'local' ||
-      this.toolExecution?.engine === 'cloudflare-sandbox';
+    const programmaticTools = this.getProgrammaticToolInstructionTargets();
+    if (programmaticTools.length === 0) return '';
+    const isDirectProgrammaticRunner = programmaticTools.some(
+      (tool) => tool.executesDirectly
+    );
     if (isDirectProgrammaticRunner && !this.toolRegistry) {
       return '';
     }
@@ -508,8 +510,6 @@ export class AgentContext {
       .map((toolDef) => toolDef.name)
       .filter((name) => !isProgrammaticControlTool(name));
 
-    const programmaticTools = this.getProgrammaticToolInstructionTargets();
-    if (programmaticTools.length === 0) return '';
     const programmaticRunnerNames = programmaticTools
       .map((tool) => `\`${tool.name}\``)
       .join(' or ');
@@ -562,8 +562,13 @@ export class AgentContext {
   private getProgrammaticToolInstructionTargets(): Array<{
     name: string;
     codeGuidance: string;
+    executesDirectly: boolean;
   }> {
-    const targets: Array<{ name: string; codeGuidance: string }> = [];
+    const targets: Array<{
+      name: string;
+      codeGuidance: string;
+      executesDirectly: boolean;
+    }> = [];
     if (
       this.hasBoundTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING) ||
       isProgrammaticRunnerAutoBound(
@@ -574,6 +579,9 @@ export class AgentContext {
       targets.push({
         name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
         codeGuidance: 'Bash code',
+        executesDirectly: this.isProgrammaticRunnerDirectlyBound(
+          Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+        ),
       });
     }
 
@@ -592,10 +600,23 @@ export class AgentContext {
         codeGuidance: localDefault
           ? 'Bash code by default, or set `lang: "py"` to use Python code'
           : 'Python code',
+        executesDirectly: this.isProgrammaticRunnerDirectlyBound(
+          Constants.PROGRAMMATIC_TOOL_CALLING
+        ),
       });
     }
 
     return targets;
+  }
+
+  /** Whether ToolNode executes this runner in-process instead of via an event. */
+  private isProgrammaticRunnerDirectlyBound(name: string): boolean {
+    return (
+      isProgrammaticRunnerAutoBound(name, this.toolExecution) ||
+      this.graphTools?.some(
+        (tool) => 'name' in tool && tool.name === name
+      ) === true
+    );
   }
 
   private hasBoundTool(name: string): boolean {
@@ -1134,9 +1155,21 @@ export class AgentContext {
     this.indexTokenCountMap = { ...baseTokenMap };
   }
 
+  /** Event definitions with matching runtime caller/defer metadata applied. */
+  getEffectiveToolDefinitions(): t.LCTool[] | undefined {
+    if (!this.toolDefinitions) {
+      return undefined;
+    }
+    return applyCallerCapabilityDefinitionOverrides(
+      this.toolDefinitions,
+      this.toolRegistry?.values()
+    );
+  }
+
   /** Active tool definitions for token accounting (excludes deferred-and-undiscovered entries). */
   private getActiveToolDefinitions(): t.LCTool[] {
-    if (!this.toolDefinitions) {
+    const effectiveToolDefinitions = this.getEffectiveToolDefinitions();
+    if (!effectiveToolDefinitions) {
       return [];
     }
     /**
@@ -1147,10 +1180,7 @@ export class AgentContext {
      * `toolSchemaTokens` even though they were never bound.
      */
     return resolveCallerCapabilityProjection(
-      applyCallerCapabilityDefinitionOverrides(
-        this.toolDefinitions,
-        this.toolRegistry?.values()
-      ),
+      effectiveToolDefinitions,
       (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
     ).directTools;
   }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -684,12 +684,23 @@ export class AgentContext {
     )) {
       implementationNames.add(name);
     }
-    return resolveCallerCapabilityProjection(
+    const activeCapabilities = resolveCallerCapabilityProjection(
+      this.toolRegistry?.values() ?? [],
+      (toolDef) =>
+        isToolDefinitionActive(toolDef, this.discoveredToolNames)
+    );
+    const executableCapabilities = resolveCallerCapabilityProjection(
       this.toolRegistry?.values() ?? [],
       (toolDef) =>
         implementationNames.has(toolDef.name) &&
         isToolDefinitionActive(toolDef, this.discoveredToolNames)
     );
+    return {
+      directTools: activeCapabilities.directTools,
+      directOnlyTools: activeCapabilities.directOnlyTools,
+      codeExecutionTools: executableCapabilities.codeExecutionTools,
+      codeExecutionOnlyTools: executableCapabilities.codeExecutionOnlyTools,
+    };
   }
 
   private hasBoundTool(name: string): boolean {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -38,6 +38,7 @@ import {
 } from '@/tools/local/resolveLocalExecutionTools';
 import {
   allowsToolCaller,
+  createCallerCapabilityProjectionSnapshot,
   isToolDefinitionActive,
   isProgrammaticControlTool,
   resolveCallerCapabilityProjection,
@@ -1765,6 +1766,15 @@ export class AgentContext {
   /** Returns a snapshot of the deferred tools discovered in this context. */
   getDiscoveredTools(): string[] {
     return Array.from(this.discoveredToolNames);
+  }
+
+  /** Returns the SDK-owned active caller projection for event-driven hosts. */
+  getCallerCapabilityProjectionSnapshot(): t.CallerCapabilityProjectionSnapshot {
+    const capabilities = resolveCallerCapabilityProjection(
+      this.toolRegistry?.values() ?? this.toolDefinitions ?? [],
+      (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
+    );
+    return createCallerCapabilityProjectionSnapshot(capabilities);
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -37,10 +37,12 @@ import {
   resolveLocalToolRegistry,
 } from '@/tools/local/resolveLocalExecutionTools';
 import {
+  type CallerCapabilityProjection,
   allowsToolCaller,
   createCallerCapabilityProjectionSnapshot,
   isToolDefinitionActive,
   isProgrammaticControlTool,
+  mergeCallerCapabilityDefinitions,
   resolveCallerCapabilityProjection,
 } from '@/tools/CallerCapabilities';
 import { createSchemaOnlyTools } from '@/tools/schema';
@@ -484,12 +486,7 @@ export class AgentContext {
 
   /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
-    if (!this.toolRegistry) return '';
-
-    const capabilities = resolveCallerCapabilityProjection(
-      this.toolRegistry.values(),
-      (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
-    );
+    const capabilities = this.getCallerCapabilityProjection();
     const programmaticOnlyTools = capabilities.codeExecutionOnlyTools;
     const programmaticToolNames = capabilities.codeExecutionTools.map(
       (toolDef) => toolDef.name
@@ -1768,13 +1765,22 @@ export class AgentContext {
     return Array.from(this.discoveredToolNames);
   }
 
-  /** Returns the SDK-owned active caller projection for event-driven hosts. */
-  getCallerCapabilityProjectionSnapshot(): t.CallerCapabilityProjectionSnapshot {
-    const capabilities = resolveCallerCapabilityProjection(
-      this.toolRegistry?.values() ?? this.toolDefinitions ?? [],
+  /** Returns the live projection shared by prompt and event execution. */
+  private getCallerCapabilityProjection(): CallerCapabilityProjection {
+    return resolveCallerCapabilityProjection(
+      mergeCallerCapabilityDefinitions(
+        this.toolDefinitions,
+        this.toolRegistry?.values()
+      ),
       (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
     );
-    return createCallerCapabilityProjectionSnapshot(capabilities);
+  }
+
+  /** Returns the SDK-owned active caller projection for event-driven hosts. */
+  getCallerCapabilityProjectionSnapshot(): t.CallerCapabilityProjectionSnapshot {
+    return createCallerCapabilityProjectionSnapshot(
+      this.getCallerCapabilityProjection()
+    );
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -35,6 +35,7 @@ import {
 import {
   isProgrammaticRunnerAutoBound,
   isProgrammaticRunnerResolvedDirectly,
+  resolveLocalImplementationNames,
   resolveLocalToolRegistry,
 } from '@/tools/local/resolveLocalExecutionTools';
 import {
@@ -510,11 +511,7 @@ export class AgentContext {
     if (directProgrammaticTools.length > 0 && this.toolRegistry) {
       groups.push({
         tools: directProgrammaticTools,
-        capabilities: resolveCallerCapabilityProjection(
-          this.toolRegistry.values(),
-          (toolDef) =>
-            isToolDefinitionActive(toolDef, this.discoveredToolNames)
-        ),
+        capabilities: this.getDirectProgrammaticCapabilityProjection(),
         label: 'Direct programmatic runners',
       });
     }
@@ -655,6 +652,43 @@ export class AgentContext {
       this.graphTools?.some(
         (tool) => 'name' in tool && tool.name === name
       ) === true
+    );
+  }
+
+  /** Mirrors ToolNode's executable implementation gate for direct runners. */
+  private getDirectProgrammaticCapabilityProjection(): CallerCapabilityProjection {
+    const implementationNames = new Set<string>();
+    const isEventDriven = (this.toolDefinitions?.length ?? 0) > 0;
+    const resolverInputNames = new Set<string>();
+    if (isEventDriven) {
+      for (const toolDef of this.toolDefinitions ?? []) {
+        resolverInputNames.add(toolDef.name);
+      }
+    } else {
+      for (const tool of (this.tools as t.GenericTool[] | undefined) ?? []) {
+        if ('name' in tool && typeof tool.name === 'string') {
+          implementationNames.add(tool.name);
+          resolverInputNames.add(tool.name);
+        }
+      }
+    }
+    for (const tool of (this.graphTools as t.GenericTool[] | undefined) ?? []) {
+      if ('name' in tool && typeof tool.name === 'string') {
+        implementationNames.add(tool.name);
+        resolverInputNames.add(tool.name);
+      }
+    }
+    for (const name of resolveLocalImplementationNames(
+      resolverInputNames,
+      this.toolExecution
+    )) {
+      implementationNames.add(name);
+    }
+    return resolveCallerCapabilityProjection(
+      this.toolRegistry?.values() ?? [],
+      (toolDef) =>
+        implementationNames.has(toolDef.name) &&
+        isToolDefinitionActive(toolDef, this.discoveredToolNames)
     );
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -508,7 +508,7 @@ export class AgentContext {
       capabilities: CallerCapabilityProjection;
       label: string;
     }> = [];
-    if (directProgrammaticTools.length > 0 && this.toolRegistry) {
+    if (directProgrammaticTools.length > 0) {
       groups.push({
         tools: directProgrammaticTools,
         capabilities: this.getDirectProgrammaticCapabilityProjection(),
@@ -684,11 +684,7 @@ export class AgentContext {
     )) {
       implementationNames.add(name);
     }
-    const activeCapabilities = resolveCallerCapabilityProjection(
-      this.toolRegistry?.values() ?? [],
-      (toolDef) =>
-        isToolDefinitionActive(toolDef, this.discoveredToolNames)
-    );
+    const activeCapabilities = this.getCallerCapabilityProjection();
     const executableCapabilities = resolveCallerCapabilityProjection(
       this.toolRegistry?.values() ?? [],
       (toolDef) =>

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -39,6 +39,7 @@ import {
 import {
   type CallerCapabilityProjection,
   allowsToolCaller,
+  applyCallerCapabilityDefinitionOverrides,
   createCallerCapabilityProjectionSnapshot,
   isToolDefinitionActive,
   isProgrammaticControlTool,
@@ -486,7 +487,19 @@ export class AgentContext {
 
   /** Builds the caller boundary and schemas for programmatic-only tools. */
   private buildProgrammaticOnlyToolsInstructions(): string {
-    const capabilities = this.getCallerCapabilityProjection();
+    const isDirectProgrammaticRunner =
+      this.toolExecution?.engine === 'local' ||
+      this.toolExecution?.engine === 'cloudflare-sandbox';
+    if (isDirectProgrammaticRunner && !this.toolRegistry) {
+      return '';
+    }
+    const capabilities = isDirectProgrammaticRunner
+      ? resolveCallerCapabilityProjection(
+        this.toolRegistry?.values() ?? [],
+        (toolDef) =>
+          isToolDefinitionActive(toolDef, this.discoveredToolNames)
+      )
+      : this.getCallerCapabilityProjection();
     const programmaticOnlyTools = capabilities.codeExecutionOnlyTools;
     const programmaticToolNames = capabilities.codeExecutionTools.map(
       (toolDef) => toolDef.name
@@ -1134,7 +1147,10 @@ export class AgentContext {
      * `toolSchemaTokens` even though they were never bound.
      */
     return resolveCallerCapabilityProjection(
-      this.toolDefinitions,
+      applyCallerCapabilityDefinitionOverrides(
+        this.toolDefinitions,
+        this.toolRegistry?.values()
+      ),
       (toolDef) => isToolDefinitionActive(toolDef, this.discoveredToolNames)
     ).directTools;
   }

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1297,6 +1297,34 @@ describe('AgentContext', () => {
       const result = ctx.getToolsForBinding();
       expect(result?.length).toBe(1);
     });
+
+    it('applies registry caller overrides to event-driven model binding', () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          toolDefinitions: [
+            {
+              name: 'event_tool',
+              description: 'Model-facing schema',
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'event_tool',
+              {
+                name: 'event_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+      });
+
+      expect(ctx.getToolsForBinding()).toEqual([]);
+      expect(ctx.getCallerCapabilityProjectionSnapshot()).toMatchObject({
+        directToolNames: [],
+        codeExecutionToolNames: ['event_tool'],
+      });
+    });
   });
 
   describe('Token Accounting', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1047,6 +1047,34 @@ describe('AgentContext', () => {
       expect(content).not.toContain('`host_code_tool`');
     });
 
+    it('uses executable registry guidance for a directly bound graph runner', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          graphTools: [createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING)],
+          toolDefinitions: [
+            {
+              name: 'event_schema_tool',
+              allowed_callers: ['code_execution'],
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'executable_tool',
+              {
+                name: 'executable_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain('`executable_tool`');
+      expect(content).not.toContain('`event_schema_tool`');
+    });
+
     it('recognizes auto-bound local programmatic runners', async () => {
       const ctx = createBasicContext({
         agentConfig: {
@@ -1324,6 +1352,36 @@ describe('AgentContext', () => {
         directToolNames: [],
         codeExecutionToolNames: ['event_tool'],
       });
+    });
+
+    it('exposes effective defer metadata for provider cache partitioning', () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          toolDefinitions: [
+            {
+              name: 'event_tool',
+              defer_loading: true,
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'event_tool',
+              {
+                name: 'event_tool',
+                defer_loading: false,
+              },
+            ],
+          ]),
+        },
+      });
+
+      expect(ctx.getEffectiveToolDefinitions()).toEqual([
+        {
+          name: 'event_tool',
+          allowed_callers: undefined,
+          defer_loading: false,
+        },
+      ]);
     });
   });
 

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1263,6 +1263,37 @@ describe('AgentContext', () => {
       expect(content).toContain('`direct_tool`');
     });
 
+    it('preserves direct-only boundaries for a locally replaced runner', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            { name: Constants.PROGRAMMATIC_TOOL_CALLING },
+            { name: 'event_direct_tool', allowed_callers: ['direct'] },
+          ],
+          toolRegistry: new Map([
+            [
+              'event_direct_tool',
+              { name: 'event_direct_tool', allowed_callers: ['direct'] },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'local',
+          local: { includeCodingTools: false },
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: none.'
+      );
+      expect(content).toContain(
+        'Call these tools directly; never list them in the `tool_manifest`'
+      );
+      expect(content).toContain('`event_direct_tool`');
+    });
+
     it('omits deferred programmatic runners until discovery', async () => {
       const ctx = createBasicContext({
         agentConfig: {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1075,6 +1075,73 @@ describe('AgentContext', () => {
       expect(content).not.toContain('`event_schema_tool`');
     });
 
+    it('uses executable guidance for an explicitly overridden local runner', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            { name: Constants.PROGRAMMATIC_TOOL_CALLING },
+            {
+              name: 'event_schema_tool',
+              allowed_callers: ['code_execution'],
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'executable_tool',
+              {
+                name: 'executable_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+        toolExecution: {
+          engine: 'local',
+          local: { includeCodingTools: false },
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain('`executable_tool`');
+      expect(content).not.toContain('`event_schema_tool`');
+    });
+
+    it('keeps direct and event runner capability guidance separate', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          graphTools: [createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING)],
+          toolDefinitions: [
+            { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING },
+            {
+              name: 'event_schema_tool',
+              allowed_callers: ['code_execution'],
+            },
+          ],
+          toolRegistry: new Map([
+            [
+              'executable_tool',
+              {
+                name: 'executable_tool',
+                allowed_callers: ['code_execution'],
+              },
+            ],
+          ]),
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain('### Direct programmatic runners');
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: `executable_tool`.'
+      );
+      expect(content).toContain('### Event-dispatched programmatic runners');
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_bash`: `event_schema_tool`, `executable_tool`.'
+      );
+    });
+
     it('recognizes auto-bound local programmatic runners', async () => {
       const ctx = createBasicContext({
         agentConfig: {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1051,7 +1051,10 @@ describe('AgentContext', () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base',
-          graphTools: [createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING)],
+          graphTools: [
+            createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING),
+            createMockTool('executable_tool'),
+          ],
           toolDefinitions: [
             {
               name: 'event_schema_tool',
@@ -1103,7 +1106,10 @@ describe('AgentContext', () => {
       });
 
       const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
-      expect(content).toContain('`executable_tool`');
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: none.'
+      );
+      expect(content).not.toContain('`executable_tool`');
       expect(content).not.toContain('`event_schema_tool`');
     });
 
@@ -1145,7 +1151,10 @@ describe('AgentContext', () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base',
-          graphTools: [createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING)],
+          graphTools: [
+            createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING),
+            createMockTool('executable_tool'),
+          ],
           toolDefinitions: [
             { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING },
             {
@@ -1197,19 +1206,26 @@ describe('AgentContext', () => {
       const content = String(result[0].content);
       expect(content).toContain('inside `run_tools_with_bash`');
       expect(content).toContain('or `run_tools_with_code`');
-      expect(content).toContain('`host_code_tool`');
+      expect(content).toContain('`write_file`');
+      expect(content).not.toContain('`host_code_tool`');
     });
 
     it('describes the Bash default for an auto-bound code runner', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base',
-          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolDefinitions: [
+            { name: Constants.PROGRAMMATIC_TOOL_CALLING },
+            {
+              name: Constants.BASH_TOOL,
+              allowed_callers: ['code_execution'],
+            },
+          ],
           toolRegistry: new Map([
             [
-              'host_code_tool',
+              Constants.BASH_TOOL,
               {
-                name: 'host_code_tool',
+                name: Constants.BASH_TOOL,
                 allowed_callers: ['code_execution'],
               },
             ],

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1263,7 +1263,7 @@ describe('AgentContext', () => {
       expect(content).toContain('`direct_tool`');
     });
 
-    it('preserves direct-only boundaries for a locally replaced runner', async () => {
+    it('preserves definition-only boundaries for a locally replaced runner', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base',
@@ -1271,12 +1271,6 @@ describe('AgentContext', () => {
             { name: Constants.PROGRAMMATIC_TOOL_CALLING },
             { name: 'event_direct_tool', allowed_callers: ['direct'] },
           ],
-          toolRegistry: new Map([
-            [
-              'event_direct_tool',
-              { name: 'event_direct_tool', allowed_callers: ['direct'] },
-            ],
-          ]),
         },
         toolExecution: {
           engine: 'local',

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1107,6 +1107,40 @@ describe('AgentContext', () => {
       expect(content).not.toContain('`event_schema_tool`');
     });
 
+    it('keeps a Cloudflare runner outside the coding allowlist event-dispatched', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [
+            { name: Constants.PROGRAMMATIC_TOOL_CALLING },
+            {
+              name: 'event_schema_tool',
+              allowed_callers: ['code_execution'],
+            },
+          ],
+        },
+        toolExecution: {
+          engine: 'cloudflare-sandbox',
+          cloudflare: {
+            codingToolNames: [Constants.BASH_TOOL],
+            sandbox: {
+              exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+              readFile: async () => '',
+              writeFile: async () => undefined,
+              mkdir: async () => undefined,
+              listFiles: async () => [],
+              deleteFile: async () => undefined,
+            },
+          },
+        },
+      });
+
+      const content = String((await ctx.systemRunnable!.invoke([]))[0].content);
+      expect(content).toContain(
+        'Only these tools may be invoked inside `run_tools_with_code`: `event_schema_tool`.'
+      );
+    });
+
     it('keeps direct and event runner capability guidance separate', async () => {
       const ctx = createBasicContext({
         agentConfig: {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2868,6 +2868,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * the breakpoint and don't invalidate the prefix.
        */
       let toolsForBinding = rawToolsForBinding;
+      const isDeferredTool = makeIsDeferred(
+        agentContext.getEffectiveToolDefinitions()
+      );
       if (
         agentContext.provider === Providers.ANTHROPIC &&
         (agentContext.clientOptions as t.AnthropicClientOptions | undefined)
@@ -2876,7 +2879,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         toolsForBinding =
           partitionAndMarkAnthropicToolCache(
             rawToolsForBinding,
-            makeIsDeferred(agentContext.toolDefinitions),
+            isDeferredTool,
             resolvePromptCacheTtl(
               (
                 agentContext.clientOptions as
@@ -2896,7 +2899,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         toolsForBinding =
           partitionAndMarkOpenRouterToolCache(
             rawToolsForBinding,
-            makeIsDeferred(agentContext.toolDefinitions),
+            isDeferredTool,
             resolvePromptCacheTtl(
               (
                 agentContext.clientOptions as
@@ -2923,7 +2926,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           toolsForBinding =
             partitionAndMarkBedrockToolCache(
               rawToolsForBinding,
-              makeIsDeferred(agentContext.toolDefinitions)
+              isDeferredTool
             ) ?? rawToolsForBinding;
         }
       }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -820,6 +820,12 @@ function startEagerToolExecutions(args: {
       toolCalls: entries.map((entry) => entry.request),
       userId: graph.config?.configurable?.user_id as string | undefined,
       agentId: agentContext?.agentId,
+      callerCapabilityProjection:
+        (
+          agentContext as
+            | Partial<Pick<AgentContext, 'getCallerCapabilityProjectionSnapshot'>>
+            | undefined
+        )?.getCallerCapabilityProjectionSnapshot?.(),
       configurable: graph.config?.configurable as
         | Record<string, unknown>
         | undefined,

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -14,6 +14,25 @@ export type CallerCapabilityProjection = {
   codeExecutionOnlyTools: t.LCTool[];
 };
 
+/**
+ * Combines definition sources by name. Later sources win so the resolved
+ * runtime registry can override a schema-only event definition.
+ */
+export function mergeCallerCapabilityDefinitions(
+  ...sources: Array<Iterable<t.LCTool> | null | undefined>
+): t.LCTool[] {
+  const merged = new Map<string, t.LCTool>();
+  for (const source of sources) {
+    if (source == null) {
+      continue;
+    }
+    for (const toolDef of source) {
+      merged.set(toolDef.name, toolDef);
+    }
+  }
+  return Array.from(merged.values());
+}
+
 /** Converts the live projection into the versioned event transport shape. */
 export function createCallerCapabilityProjectionSnapshot(
   projection: CallerCapabilityProjection

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -33,6 +33,31 @@ export function mergeCallerCapabilityDefinitions(
   return Array.from(merged.values());
 }
 
+/**
+ * Applies runtime caller metadata to schema-only event definitions without
+ * adding registry-only tools or replacing their model-facing schemas.
+ */
+export function applyCallerCapabilityDefinitionOverrides(
+  toolDefs: Iterable<t.LCTool>,
+  overrides: Iterable<t.LCTool> | null | undefined
+): t.LCTool[] {
+  const overridesByName = new Map<string, t.LCTool>();
+  for (const override of overrides ?? []) {
+    overridesByName.set(override.name, override);
+  }
+  return Array.from(toolDefs, (toolDef) => {
+    const override = overridesByName.get(toolDef.name);
+    if (override == null) {
+      return toolDef;
+    }
+    return {
+      ...toolDef,
+      allowed_callers: override.allowed_callers,
+      defer_loading: override.defer_loading,
+    };
+  });
+}
+
 /** Converts the live projection into the versioned event transport shape. */
 export function createCallerCapabilityProjectionSnapshot(
   projection: CallerCapabilityProjection

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -14,6 +14,25 @@ export type CallerCapabilityProjection = {
   codeExecutionOnlyTools: t.LCTool[];
 };
 
+/** Converts the live projection into the versioned event transport shape. */
+export function createCallerCapabilityProjectionSnapshot(
+  projection: CallerCapabilityProjection
+): t.CallerCapabilityProjectionSnapshot {
+  return {
+    version: 1,
+    directToolNames: projection.directTools.map((toolDef) => toolDef.name),
+    codeExecutionToolNames: projection.codeExecutionTools.map(
+      (toolDef) => toolDef.name
+    ),
+    directOnlyToolNames: projection.directOnlyTools.map(
+      (toolDef) => toolDef.name
+    ),
+    codeExecutionOnlyToolNames: projection.codeExecutionOnlyTools.map(
+      (toolDef) => toolDef.name
+    ),
+  };
+}
+
 export function getAllowedCallers(
   toolDef: t.LCTool
 ): readonly t.AllowedCaller[] {

--- a/src/tools/CallerCapabilities.ts
+++ b/src/tools/CallerCapabilities.ts
@@ -15,19 +15,24 @@ export type CallerCapabilityProjection = {
 };
 
 /**
- * Combines definition sources by name. Later sources win so the resolved
- * runtime registry can override a schema-only event definition.
+ * Combines event schemas with runtime capability metadata. Matching runtime
+ * entries override caller/defer policy without replacing the event schema;
+ * runtime-only definitions are appended intact.
  */
 export function mergeCallerCapabilityDefinitions(
-  ...sources: Array<Iterable<t.LCTool> | null | undefined>
+  toolDefs: Iterable<t.LCTool> | null | undefined,
+  overrides: Iterable<t.LCTool> | null | undefined
 ): t.LCTool[] {
-  const merged = new Map<string, t.LCTool>();
-  for (const source of sources) {
-    if (source == null) {
-      continue;
-    }
-    for (const toolDef of source) {
-      merged.set(toolDef.name, toolDef);
+  const runtimeDefinitions = Array.from(overrides ?? []);
+  const merged = new Map(
+    applyCallerCapabilityDefinitionOverrides(
+      toolDefs ?? [],
+      runtimeDefinitions
+    ).map((toolDef) => [toolDef.name, toolDef])
+  );
+  for (const override of runtimeDefinitions) {
+    if (!merged.has(override.name)) {
+      merged.set(override.name, override);
     }
   }
   return Array.from(merged.values());

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -95,6 +95,8 @@ import {
   resolveLocalExecutionTools,
 } from '@/tools/local';
 import {
+  type CallerCapabilityProjection,
+  createCallerCapabilityProjectionSnapshot,
   isToolDefinitionActive,
   isProgrammaticControlTool,
   resolveCallerCapabilityProjection,
@@ -1105,16 +1107,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.settledInterruptingResults.clear();
   }
 
-  /** Returns active tools projected by their effective caller capabilities. */
-  private getProgrammaticTools(): t.ProgrammaticCache {
-    const toolMap: t.ToolMap = new Map();
+  /** Returns the live caller projection used by direct and event execution. */
+  private getCallerCapabilityProjection(): CallerCapabilityProjection {
     const discoveredToolNames = new Set(
       this.getDiscoveredToolNames?.() ?? []
     );
-    const capabilities = resolveCallerCapabilityProjection(
+    return resolveCallerCapabilityProjection(
       this.toolRegistry?.values() ?? [],
       (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
     );
+  }
+
+  /** Serializes the live caller projection for event-driven hosts. */
+  private getCallerCapabilityProjectionSnapshot(): t.CallerCapabilityProjectionSnapshot {
+    return createCallerCapabilityProjectionSnapshot(
+      this.getCallerCapabilityProjection()
+    );
+  }
+
+  /** Returns active tools projected by their effective caller capabilities. */
+  private getProgrammaticTools(): t.ProgrammaticCache {
+    const toolMap: t.ToolMap = new Map();
+    const capabilities = this.getCallerCapabilityProjection();
     for (const toolDef of capabilities.codeExecutionTools) {
       const tool = this.toolMap.get(toolDef.name);
       if (tool != null) {
@@ -3455,6 +3469,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               // the eager path sends `agentContext.agentId` — this must
               // match it at the top level too.
               agentId: this.executingAgentId,
+              callerCapabilityProjection:
+                this.getCallerCapabilityProjectionSnapshot(),
               configurable: stripRunBreakerScope(
                   config.configurable as Record<string, unknown> | undefined
               ),

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1136,18 +1136,25 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /** Returns active tools projected by their effective caller capabilities. */
   private getProgrammaticTools(): t.ProgrammaticCache {
     const toolMap: t.ToolMap = new Map();
-    const capabilities = this.getCallerCapabilityProjection();
-    for (const toolDef of capabilities.codeExecutionTools) {
+    const discoveredToolNames = new Set(
+      this.getDiscoveredToolNames?.() ?? []
+    );
+    const executableCapabilities = resolveCallerCapabilityProjection(
+      this.toolRegistry?.values() ?? [],
+      (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
+    );
+    for (const toolDef of executableCapabilities.codeExecutionTools) {
       const tool = this.toolMap.get(toolDef.name);
       if (tool != null) {
         toolMap.set(toolDef.name, tool);
       }
     }
+    const activeCapabilities = this.getCallerCapabilityProjection();
 
     return {
       toolMap,
-      toolDefs: capabilities.codeExecutionTools,
-      disallowedToolDefs: capabilities.directOnlyTools
+      toolDefs: executableCapabilities.codeExecutionTools,
+      disallowedToolDefs: activeCapabilities.directOnlyTools
         .filter((toolDef) => !isProgrammaticControlTool(toolDef.name))
         .map((toolDef) => ({ name: toolDef.name })),
     };

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -99,6 +99,7 @@ import {
   createCallerCapabilityProjectionSnapshot,
   isToolDefinitionActive,
   isProgrammaticControlTool,
+  mergeCallerCapabilityDefinitions,
   resolveCallerCapabilityProjection,
 } from '@/tools/CallerCapabilities';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
@@ -700,6 +701,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   >();
   /** Tool registry for filtering (lazy computation of programmatic maps) */
   private toolRegistry?: t.LCToolRegistry;
+  /** Schema-only definitions used when event mode has no runtime registry. */
+  private toolDefinitions?: t.LCToolRegistry;
   /** Reads deferred-tool discovery state from the owning agent context. */
   private getDiscoveredToolNames?: () => readonly string[];
   /** Reference to Graph's sessions map for automatic session injection */
@@ -805,6 +808,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     handleToolErrors,
     loadRuntimeTools,
     toolRegistry,
+    toolDefinitions,
     getDiscoveredToolNames,
     sessions,
     codeSessionKey,
@@ -881,6 +885,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       toolRegistry,
       toolExecution,
     });
+    this.toolDefinitions = toolDefinitions;
     this.getDiscoveredToolNames = getDiscoveredToolNames;
     this.sessions = sessions;
     this.codeSessionKey = codeSessionKey ?? Constants.EXECUTE_CODE;
@@ -1113,7 +1118,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       this.getDiscoveredToolNames?.() ?? []
     );
     return resolveCallerCapabilityProjection(
-      this.toolRegistry?.values() ?? [],
+      mergeCallerCapabilityDefinitions(
+        this.toolDefinitions?.values(),
+        this.toolRegistry?.values()
+      ),
       (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
     );
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1136,6 +1136,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /** Returns active tools projected by their effective caller capabilities. */
   private getProgrammaticTools(): t.ProgrammaticCache {
     const toolMap: t.ToolMap = new Map();
+    const toolDefs: t.LCTool[] = [];
     const discoveredToolNames = new Set(
       this.getDiscoveredToolNames?.() ?? []
     );
@@ -1144,16 +1145,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
     );
     for (const toolDef of executableCapabilities.codeExecutionTools) {
+      if (
+        this.eventDrivenMode &&
+        this.directToolNames?.has(toolDef.name) !== true
+      ) {
+        continue;
+      }
       const tool = this.toolMap.get(toolDef.name);
       if (tool != null) {
         toolMap.set(toolDef.name, tool);
+        toolDefs.push(toolDef);
       }
     }
     const activeCapabilities = this.getCallerCapabilityProjection();
 
     return {
       toolMap,
-      toolDefs: executableCapabilities.codeExecutionTools,
+      toolDefs,
       disallowedToolDefs: activeCapabilities.directOnlyTools
         .filter((toolDef) => !isProgrammaticControlTool(toolDef.name))
         .map((toolDef) => ({ name: toolDef.name })),

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -703,6 +703,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolRegistry?: t.LCToolRegistry;
   /** Schema-only definitions used when event mode has no runtime registry. */
   private toolDefinitions?: t.LCToolRegistry;
+  /** Tool-map entries created or replaced by the local execution resolver. */
+  private localImplementationNames = new Set<string>();
   /** Reads deferred-tool discovery state from the owning agent context. */
   private getDiscoveredToolNames?: () => readonly string[];
   /** Reference to Graph's sessions map for automatic session injection */
@@ -1006,6 +1008,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     });
 
     this.toolMap = resolved.toolMap;
+    this.localImplementationNames = resolved.localImplementationNames;
     if (resolved.fileCheckpointer != null) {
       this.fileCheckpointer = resolved.fileCheckpointer;
     }
@@ -1147,7 +1150,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     for (const toolDef of executableCapabilities.codeExecutionTools) {
       if (
         this.eventDrivenMode &&
-        this.directToolNames?.has(toolDef.name) !== true
+        this.directToolNames?.has(toolDef.name) !== true &&
+        !this.localImplementationNames.has(toolDef.name)
       ) {
         continue;
       }

--- a/src/tools/__tests__/CallerCapabilities.test.ts
+++ b/src/tools/__tests__/CallerCapabilities.test.ts
@@ -59,17 +59,34 @@ describe('Caller Capability Projection', () => {
     expect(allowsToolCaller(toolDefs[0], 'code_execution')).toBe(false);
   });
 
-  it('merges schema-only and runtime definitions with runtime precedence', () => {
+  it('preserves event schemas while applying runtime capability metadata', () => {
     expect(
       mergeCallerCapabilityDefinitions(
-        [{ name: 'shared' }, { name: 'schema_only' }],
         [
-          { name: 'shared', allowed_callers: ['code_execution'] },
+          {
+            name: 'shared',
+            description: 'Model-facing schema',
+            parameters: { type: 'object', properties: {} },
+          },
+          { name: 'schema_only' },
+        ],
+        [
+          {
+            name: 'shared',
+            allowed_callers: ['code_execution'],
+            defer_loading: true,
+          },
           { name: 'runtime_only' },
         ]
       )
     ).toEqual([
-      { name: 'shared', allowed_callers: ['code_execution'] },
+      {
+        name: 'shared',
+        description: 'Model-facing schema',
+        parameters: { type: 'object', properties: {} },
+        allowed_callers: ['code_execution'],
+        defer_loading: true,
+      },
       { name: 'schema_only' },
       { name: 'runtime_only' },
     ]);

--- a/src/tools/__tests__/CallerCapabilities.test.ts
+++ b/src/tools/__tests__/CallerCapabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import type * as t from '@/types';
 import {
   allowsToolCaller,
+  applyCallerCapabilityDefinitionOverrides,
   mergeCallerCapabilityDefinitions,
   resolveCallerCapabilityProjection,
 } from '../CallerCapabilities';
@@ -71,6 +72,34 @@ describe('Caller Capability Projection', () => {
       { name: 'shared', allowed_callers: ['code_execution'] },
       { name: 'schema_only' },
       { name: 'runtime_only' },
+    ]);
+  });
+
+  it('overrides caller metadata without adding registry-only definitions', () => {
+    expect(
+      applyCallerCapabilityDefinitionOverrides(
+        [
+          {
+            name: 'event_tool',
+            description: 'Model-facing schema',
+          },
+        ],
+        [
+          {
+            name: 'event_tool',
+            allowed_callers: ['code_execution'],
+            defer_loading: true,
+          },
+          { name: 'registry_only' },
+        ]
+      )
+    ).toEqual([
+      {
+        name: 'event_tool',
+        description: 'Model-facing schema',
+        allowed_callers: ['code_execution'],
+        defer_loading: true,
+      },
     ]);
   });
 });

--- a/src/tools/__tests__/CallerCapabilities.test.ts
+++ b/src/tools/__tests__/CallerCapabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import type * as t from '@/types';
 import {
   allowsToolCaller,
+  mergeCallerCapabilityDefinitions,
   resolveCallerCapabilityProjection,
 } from '../CallerCapabilities';
 
@@ -55,5 +56,21 @@ describe('Caller Capability Projection', () => {
   it('defaults omitted caller metadata to direct-only', () => {
     expect(allowsToolCaller(toolDefs[0], 'direct')).toBe(true);
     expect(allowsToolCaller(toolDefs[0], 'code_execution')).toBe(false);
+  });
+
+  it('merges schema-only and runtime definitions with runtime precedence', () => {
+    expect(
+      mergeCallerCapabilityDefinitions(
+        [{ name: 'shared' }, { name: 'schema_only' }],
+        [
+          { name: 'shared', allowed_callers: ['code_execution'] },
+          { name: 'runtime_only' },
+        ]
+      )
+    ).toEqual([
+      { name: 'shared', allowed_callers: ['code_execution'] },
+      { name: 'schema_only' },
+      { name: 'runtime_only' },
+    ]);
   });
 });

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -334,4 +334,61 @@ describe('ToolNode programmatic caller policy', () => {
       Constants.WRITE_FILE
     );
   });
+
+  it('does not treat unsupported Cloudflare allowlist names as implementations', () => {
+    const unsupportedName = 'unsupported_cloudflare_tool';
+    const unsupportedStub = tool(async () => 'schema stub should not run', {
+      name: unsupportedName,
+      description: 'Unsupported Cloudflare tool',
+      schema: z.object({}),
+    });
+    const node = new ToolNode({
+      tools: [unsupportedStub],
+      eventDrivenMode: true,
+      toolExecution: {
+        engine: 'cloudflare-sandbox',
+        cloudflare: {
+          codingToolNames: [
+            Constants.PROGRAMMATIC_TOOL_CALLING,
+            unsupportedName,
+          ],
+          sandbox: {
+            exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+            readFile: async () => '',
+            writeFile: async () => undefined,
+            mkdir: async () => undefined,
+            listFiles: async () => [],
+            deleteFile: async () => undefined,
+          },
+        },
+      },
+      toolRegistry: new Map([
+        [
+          unsupportedName,
+          {
+            name: unsupportedName,
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]),
+      toolDefinitions: new Map([
+        [
+          unsupportedName,
+          {
+            name: unsupportedName,
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]),
+    });
+
+    const cache = (
+      node as unknown as {
+        getProgrammaticTools(): t.ProgrammaticCache;
+      }
+    ).getProgrammaticTools();
+
+    expect(cache.toolDefs).toEqual([]);
+    expect(cache.toolMap).toEqual(new Map());
+  });
 });

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -299,4 +299,39 @@ describe('ToolNode programmatic caller policy', () => {
     expect(capturedConfigs[0].toolDefs).toEqual([]);
     expect(capturedConfigs[0].toolMap).toEqual(new Map());
   });
+
+  it('keeps synthesized code-only implementations in the runner cache', () => {
+    const node = new ToolNode({
+      tools: [],
+      eventDrivenMode: true,
+      toolExecution: { engine: 'local' },
+      toolRegistry: new Map([
+        [
+          Constants.WRITE_FILE,
+          {
+            name: Constants.WRITE_FILE,
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]),
+    });
+
+    const cache = (
+      node as unknown as {
+        getProgrammaticTools(): t.ProgrammaticCache;
+      }
+    ).getProgrammaticTools();
+
+    expect(cache.toolDefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: Constants.WRITE_FILE,
+          allowed_callers: ['code_execution'],
+        }),
+      ])
+    );
+    expect(cache.toolMap.get(Constants.WRITE_FILE)?.name).toBe(
+      Constants.WRITE_FILE
+    );
+  });
 });

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -235,4 +235,59 @@ describe('ToolNode programmatic caller policy', () => {
       },
     ]);
   });
+
+  it('keeps schema-only event definitions out of a direct runner cache', async () => {
+    const capturedConfigs: Array<ToolCall & Partial<t.ProgrammaticCache>> = [];
+    const ptcTool = tool(
+      async (_args, config) => {
+        capturedConfigs.push(
+          config.toolCall as ToolCall & Partial<t.ProgrammaticCache>
+        );
+        return 'done';
+      },
+      {
+        name: Constants.PROGRAMMATIC_TOOL_CALLING,
+        description: 'Run tools with code',
+        schema: z.object({ code: z.string() }),
+      }
+    );
+    const eventStub = tool(async () => 'schema stub should not run', {
+      name: 'event_programmatic_tool',
+      description: 'Event programmatic tool',
+      schema: z.object({}),
+    });
+    const node = new ToolNode({
+      tools: [ptcTool, eventStub],
+      eventDrivenMode: true,
+      directToolNames: new Set([Constants.PROGRAMMATIC_TOOL_CALLING]),
+      toolDefinitions: new Map([
+        [
+          eventStub.name,
+          {
+            name: eventStub.name,
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]),
+    });
+
+    await node.invoke({
+      messages: [
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'local-ptc',
+              name: Constants.PROGRAMMATIC_TOOL_CALLING,
+              args: { code: 'event_programmatic_tool "{}"' },
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(capturedConfigs).toHaveLength(1);
+    expect(capturedConfigs[0].toolDefs).toEqual([]);
+    expect(capturedConfigs[0].toolMap).toEqual(new Map());
+  });
 });

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -170,7 +170,7 @@ describe('ToolNode programmatic caller policy', () => {
       description: 'Event tool',
       schema: z.object({}),
     });
-    const toolRegistry: t.LCToolRegistry = new Map([
+    const toolDefinitions: t.LCToolRegistry = new Map([
       [eventTool.name, { name: eventTool.name }],
       [
         'deferred_programmatic_tool',
@@ -180,6 +180,8 @@ describe('ToolNode programmatic caller policy', () => {
           defer_loading: true,
         },
       ],
+    ]);
+    const toolRegistry: t.LCToolRegistry = new Map([
       [
         'deferred_direct_tool',
         {
@@ -192,6 +194,7 @@ describe('ToolNode programmatic caller policy', () => {
     const node = new ToolNode({
       tools: [eventTool],
       toolRegistry,
+      toolDefinitions,
       eventDrivenMode: true,
       getDiscoveredToolNames: () => [...discovered],
       toolCallStepIds: new Map([

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -260,6 +260,15 @@ describe('ToolNode programmatic caller policy', () => {
       tools: [ptcTool, eventStub],
       eventDrivenMode: true,
       directToolNames: new Set([Constants.PROGRAMMATIC_TOOL_CALLING]),
+      toolRegistry: new Map([
+        [
+          eventStub.name,
+          {
+            name: eventStub.name,
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]),
       toolDefinitions: new Map([
         [
           eventStub.name,

--- a/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
+++ b/src/tools/__tests__/ToolNode.programmaticPolicy.test.ts
@@ -1,13 +1,18 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
 import { AIMessage } from '@langchain/core/messages';
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { ToolNode } from '../ToolNode';
-import { Constants } from '@/common';
+import * as events from '@/utils/events';
+import { Constants, GraphEvents } from '@/common';
 
 describe('ToolNode programmatic caller policy', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('separates programmatic tools from direct-only preflight definitions', async () => {
     const capturedConfigs: Array<ToolCall & Partial<t.ProgrammaticCache>> = [];
     const ptcTool = tool(
@@ -137,6 +142,94 @@ describe('ToolNode programmatic caller policy', () => {
     expect(capturedConfigs[0].disallowedToolDefs).toEqual([]);
     expect(capturedConfigs[1].disallowedToolDefs).toEqual([
       { name: directTool.name },
+    ]);
+  });
+
+  it('dispatches the same live caller projection in event-driven mode', async () => {
+    const discovered = new Set<string>();
+    const snapshots: t.CallerCapabilityProjectionSnapshot[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        snapshots.push(batch.callerCapabilityProjection!);
+        batch.resolve(
+          batch.toolCalls.map((toolCall) => ({
+            toolCallId: toolCall.id,
+            status: 'success',
+            content: 'done',
+          }))
+        );
+      });
+
+    const eventTool = tool(async () => 'should dispatch', {
+      name: 'event_tool',
+      description: 'Event tool',
+      schema: z.object({}),
+    });
+    const toolRegistry: t.LCToolRegistry = new Map([
+      [eventTool.name, { name: eventTool.name }],
+      [
+        'deferred_programmatic_tool',
+        {
+          name: 'deferred_programmatic_tool',
+          allowed_callers: ['code_execution'],
+          defer_loading: true,
+        },
+      ],
+      [
+        'deferred_direct_tool',
+        {
+          name: 'deferred_direct_tool',
+          allowed_callers: ['direct'],
+          defer_loading: true,
+        },
+      ],
+    ]);
+    const node = new ToolNode({
+      tools: [eventTool],
+      toolRegistry,
+      eventDrivenMode: true,
+      getDiscoveredToolNames: () => [...discovered],
+      toolCallStepIds: new Map([
+        ['before-discovery', 'step-before'],
+        ['after-discovery', 'step-after'],
+      ]),
+    });
+    const invoke = async (id: string): Promise<void> => {
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id, name: eventTool.name, args: {} }],
+          }),
+        ],
+      });
+    };
+
+    await invoke('before-discovery');
+    discovered.add('deferred_programmatic_tool');
+    discovered.add('deferred_direct_tool');
+    await invoke('after-discovery');
+
+    expect(snapshots).toEqual([
+      {
+        version: 1,
+        directToolNames: ['event_tool'],
+        codeExecutionToolNames: [],
+        directOnlyToolNames: ['event_tool'],
+        codeExecutionOnlyToolNames: [],
+      },
+      {
+        version: 1,
+        directToolNames: ['event_tool', 'deferred_direct_tool'],
+        codeExecutionToolNames: ['deferred_programmatic_tool'],
+        directOnlyToolNames: ['event_tool', 'deferred_direct_tool'],
+        codeExecutionOnlyToolNames: ['deferred_programmatic_tool'],
+      },
     ]);
   });
 });

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -81,6 +81,29 @@ export function isProgrammaticRunnerAutoBound(
   return shouldUseLocalExecution(config);
 }
 
+/** Mirrors whether resolver policy creates or replaces this runner locally. */
+export function isProgrammaticRunnerResolvedDirectly(
+  name: string,
+  config?: t.ToolExecutionConfig,
+  hasExplicitBinding: boolean = false
+): boolean {
+  if (isProgrammaticRunnerAutoBound(name, config)) {
+    return true;
+  }
+  if (
+    !hasExplicitBinding ||
+    (name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+      name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
+  ) {
+    return false;
+  }
+  return (
+    (shouldUseLocalExecution(config) ||
+      shouldUseCloudflareSandboxExecution(config)) &&
+    !shouldIncludeCodingTools(config)
+  );
+}
+
 function getCloudflareConfig(
   config?: t.ToolExecutionConfig
 ): t.CloudflareSandboxExecutionConfig {

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -365,6 +365,28 @@ export function resolveLocalToolRegistry(args: {
   return registry;
 }
 
+/** Names that this execution config creates or replaces in the local tool map. */
+export function resolveLocalImplementationNames(
+  toolNames: Iterable<string>,
+  toolExecution?: t.ToolExecutionConfig
+): Set<string> {
+  if (
+    !shouldUseLocalExecution(toolExecution) &&
+    !shouldUseCloudflareSandboxExecution(toolExecution)
+  ) {
+    return new Set();
+  }
+  if (shouldIncludeCodingTools(toolExecution)) {
+    return shouldUseCloudflareSandboxExecution(toolExecution)
+      ? getSelectedCloudflareCodingToolNames(getCloudflareConfig(toolExecution))
+      : new Set(LOCAL_CODING_BUNDLE_NAMES);
+  }
+  const existingNames = new Set(toolNames);
+  return new Set(
+    [...CODE_EXECUTION_TOOLS].filter((name) => existingNames.has(name))
+  );
+}
+
 export function resolveLocalExecutionTools(args: {
   toolMap: t.ToolMap;
   toolExecution?: t.ToolExecutionConfig;
@@ -380,7 +402,10 @@ export function resolveLocalExecutionTools(args: {
   fileCheckpointer?: t.LocalFileCheckpointer;
 }): ResolveLocalToolsResult {
   const directToolNames = new Set<string>();
-  const localImplementationNames = new Set<string>();
+  const localImplementationNames = resolveLocalImplementationNames(
+    args.toolMap.keys(),
+    args.toolExecution
+  );
   if (
     !shouldUseLocalExecution(args.toolExecution) &&
     !shouldUseCloudflareSandboxExecution(args.toolExecution)

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -4,6 +4,7 @@ import {
   createLocalProgrammaticToolCallingTool,
 } from './LocalProgrammaticToolCalling';
 import {
+  CLOUDFLARE_CODING_TOOL_NAMES,
   createCloudflareCodingToolBundle,
   createCloudflareCodingTools,
   createCloudflareExecutionTool,
@@ -120,7 +121,12 @@ function getCloudflareConfig(
 function getSelectedCloudflareCodingToolNames(
   config: t.CloudflareSandboxExecutionConfig
 ): Set<string> {
-  return new Set(config.codingToolNames ?? LOCAL_CODING_BUNDLE_NAMES);
+  const requestedNames = new Set(
+    config.codingToolNames ?? CLOUDFLARE_CODING_TOOL_NAMES
+  );
+  return new Set(
+    CLOUDFLARE_CODING_TOOL_NAMES.filter((name) => requestedNames.has(name))
+  );
 }
 
 function filterCloudflareCodingToolAllowlist(

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -30,6 +30,8 @@ import {
 type ResolveLocalToolsResult = {
   toolMap: t.ToolMap;
   directToolNames: Set<string>;
+  /** Names whose toolMap entries were created or replaced by this resolver. */
+  localImplementationNames: Set<string>;
   /**
    * Set when `local.fileCheckpointing === true` AND the auto-bind
    * coding suite is in use. ToolNode stashes this on the node and
@@ -378,6 +380,7 @@ export function resolveLocalExecutionTools(args: {
   fileCheckpointer?: t.LocalFileCheckpointer;
 }): ResolveLocalToolsResult {
   const directToolNames = new Set<string>();
+  const localImplementationNames = new Set<string>();
   if (
     !shouldUseLocalExecution(args.toolExecution) &&
     !shouldUseCloudflareSandboxExecution(args.toolExecution)
@@ -385,6 +388,7 @@ export function resolveLocalExecutionTools(args: {
     return {
       toolMap: args.toolMap,
       directToolNames,
+      localImplementationNames,
     };
   }
 
@@ -407,6 +411,7 @@ export function resolveLocalExecutionTools(args: {
         fileCheckpointer = bundle.checkpointer;
         for (const cloudflareTool of bundle.tools) {
           toolMap.set(cloudflareTool.name, cloudflareTool);
+          localImplementationNames.add(cloudflareTool.name);
           addDirectToolName(
             directToolNames,
             cloudflareTool.name,
@@ -418,6 +423,7 @@ export function resolveLocalExecutionTools(args: {
           cloudflareConfig
         )) {
           toolMap.set(cloudflareTool.name, cloudflareTool);
+          localImplementationNames.add(cloudflareTool.name);
           addDirectToolName(
             directToolNames,
             cloudflareTool.name,
@@ -441,10 +447,16 @@ export function resolveLocalExecutionTools(args: {
       }
 
       toolMap.set(name, cloudflareTool);
+      localImplementationNames.add(name);
       addDirectToolName(directToolNames, name, args.toolRegistry);
     }
 
-    return { toolMap, directToolNames, fileCheckpointer };
+    return {
+      toolMap,
+      directToolNames,
+      localImplementationNames,
+      fileCheckpointer,
+    };
   }
 
   const localConfig = args.toolExecution?.local ?? {};
@@ -466,6 +478,7 @@ export function resolveLocalExecutionTools(args: {
       fileCheckpointer = bundle.checkpointer;
       for (const localTool of bundle.tools) {
         toolMap.set(localTool.name, localTool);
+        localImplementationNames.add(localTool.name);
         addDirectToolName(
           directToolNames,
           localTool.name,
@@ -475,6 +488,7 @@ export function resolveLocalExecutionTools(args: {
     } else {
       for (const localTool of createLocalCodingTools(localConfig)) {
         toolMap.set(localTool.name, localTool);
+        localImplementationNames.add(localTool.name);
         addDirectToolName(
           directToolNames,
           localTool.name,
@@ -505,8 +519,14 @@ export function resolveLocalExecutionTools(args: {
     }
 
     toolMap.set(name, localTool);
+    localImplementationNames.add(name);
     addDirectToolName(directToolNames, name, args.toolRegistry);
   }
 
-  return { toolMap, directToolNames, fileCheckpointer };
+  return {
+    toolMap,
+    directToolNames,
+    localImplementationNames,
+    fileCheckpointer,
+  };
 }

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -557,6 +557,19 @@ export type ToolCallRequest = {
   runtimeSessionHint?: string;
 };
 
+/**
+ * Serializable view of the active tools grouped by their effective caller
+ * capabilities. Event-driven hosts use this snapshot to preserve the SDK's
+ * live deferred-tool discovery state without reimplementing its policy.
+ */
+export type CallerCapabilityProjectionSnapshot = {
+  version: 1;
+  directToolNames: string[];
+  codeExecutionToolNames: string[];
+  directOnlyToolNames: string[];
+  codeExecutionOnlyToolNames: string[];
+};
+
 /** Batch request containing ALL tool calls for a graph step */
 export type ToolExecuteBatchRequest = {
   /** All tool calls from the AIMessage */
@@ -565,6 +578,11 @@ export type ToolExecuteBatchRequest = {
   userId?: string;
   /** Agent ID for context */
   agentId?: string;
+  /**
+   * SDK-owned snapshot of the active caller capability projection. Optional
+   * so older event handlers remain compatible with newer SDKs.
+   */
+  callerCapabilityProjection?: CallerCapabilityProjectionSnapshot;
   /** Runtime configurable from RunnableConfig (includes user, userMCPAuthMap, etc.) */
   configurable?: Record<string, unknown>;
   /** Runtime metadata from RunnableConfig (includes thread_id, run_id, provider, etc.) */


### PR DESCRIPTION
## Summary

I propagated the SDK-owned live Caller Capability Projection through event-driven tool execution so hosts receive deferred-discovery state without reconstructing policy from a static registry.

- Add a versioned, serializable caller capability projection snapshot to normal and eager tool execution batches.
- Merge schema-only event definitions with matching runtime caller metadata for the host-facing snapshot and model binding.
- Keep direct local and Cloudflare programmatic execution limited to executable registry-backed definitions.
- Reuse the same projection Implementation across prompt guidance, model binding, native PTC injection, normal event dispatch, and eager event prestarts.
- Preserve rolling compatibility by keeping the event field optional.
- Cover deferred tools, mixed caller modes, event schema overrides, and the direct-execution trust boundary.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm test -- --runInBand CallerCapabilities AgentContext ToolNode.programmaticPolicy stream.eager` — 405 tests passed, 6 skipped.
- `npx tsc --noEmit` — passed.
- `npm run build` — passed on the current head.
- Changed-file ESLint — passed without errors.

### **Test Configuration**:

- Node.js with the repository lockfile dependency versions

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes