### PR TITLE
🧮 perf: Measure Context Pressure Incrementally

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,15 @@ programmatic invocation declares that its code depends on. Mixed direct and
 code-execution configurations require the manifest so caller policy can reject
 direct-only dependencies before starting an execution runtime without parsing
 the submitted programming language.
+
+## Context Pressure Measurement
+
+A **Context Pressure Meter** is the request-scoped projection of retained
+conversation messages into the provider's available context budget. It keeps
+provider-grounded attribution and exact token counts together so repeated
+artifact, compaction, prepared-request, and fallback probes tokenize only new
+message objects. Provider projections must clone changed messages; mutating a
+measured message would invalidate its exact cached count.
+
+The meter's estimates decide overflow and recovery only. Provider-reported
+usage remains the source of truth for billing and Langfuse observations.

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -50,8 +50,8 @@ import {
   addBedrockTailCacheControl,
   projectArtifactPayload,
   formatContentStrings,
+  cloneMessage,
   CALIBRATION_RATIO_MAX,
-  REPLY_PRIMER_TOKENS,
   createPruneMessages,
   projectToolCallInputs,
   calculateMaxToolCallInputChars,
@@ -105,6 +105,7 @@ import {
   getFallbackOverflowCandidates,
 } from '@/llm/invoke';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
+import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import {
   resolveStreamLimits,
   StreamLimitExceededError,
@@ -3152,105 +3153,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * baseline, then attribute it across retained messages. Provider
        * transforms can shrink one message while expanding or adding another;
        * per-origin accounting prevents that unrelated shrink from canceling
-       * the expansion. Raw counts are frozen before in-place formatters run.
+       * the expansion. Exact counts are memoized across repeated projections.
        */
-      let providerMessageBaseline:
-        | Array<{ rawTokens: number; accountingWeight: number }>
-        | undefined;
-      const providerMessageOrigins = new WeakMap<BaseMessage, number>();
-      if (contextUsage != null && agentContext.tokenCounter != null) {
-        const sourceIndices = new WeakMap<BaseMessage, number>();
-        for (let i = 0; i < messages.length; i++) {
-          sourceIndices.set(messages[i], i);
-        }
-        providerMessageBaseline = messagesToUse.map((message, index) => {
-          const rawTokens = agentContext.tokenCounter!(message);
-          const sourceIndex = sourceIndices.get(message);
-          const indexedTokens =
-            sourceIndex != null
-              ? agentContext.indexTokenCountMap[sourceIndex]
-              : undefined;
-          const accountingWeight =
-            indexedTokens != null &&
-            Number.isFinite(indexedTokens) &&
-            indexedTokens >= 0
-              ? indexedTokens
-              : rawTokens;
-          if (!providerMessageOrigins.has(message)) {
-            providerMessageOrigins.set(message, index);
-          }
-          return { rawTokens, accountingWeight };
-        });
-      }
-
-      const getProviderMessageOriginKey = (
-        message: BaseMessage
-      ): string | undefined => {
-        const type = message.getType();
-        if (
-          message instanceof ToolMessage &&
-          typeof message.tool_call_id === 'string' &&
-          message.tool_call_id.length > 0
-        ) {
-          return `tool:call:${message.tool_call_id}`;
-        }
-        if (typeof message.id === 'string' && message.id.length > 0) {
-          return `${type}:id:${message.id}`;
-        }
-        return undefined;
-      };
-
-      /**
-       * Provider projections clone messages. Preserve their baseline origin
-       * without writing tracking metadata onto the wire. Synthetic fold
-       * messages intentionally remain unattributed and are charged in full.
-       */
-      const trackProviderMessageOrigins = (
-        before: BaseMessage[],
-        after: BaseMessage[]
-      ): BaseMessage[] => {
-        if (providerMessageBaseline == null || before === after) {
-          return after;
-        }
-        if (before.length === after.length) {
-          for (let i = 0; i < after.length; i++) {
-            const origin = providerMessageOrigins.get(before[i]);
-            if (
-              origin != null &&
-              !providerMessageOrigins.has(after[i]) &&
-              before[i].getType() === after[i].getType() &&
-              !isSyntheticProviderContextMessage(after[i])
-            ) {
-              providerMessageOrigins.set(after[i], origin);
-            }
-          }
-          return after;
-        }
-
-        const keyedOrigins = new Map<string, number | null>();
-        for (const message of before) {
-          const origin = providerMessageOrigins.get(message);
-          const key = getProviderMessageOriginKey(message);
-          if (origin == null || key == null) {
-            continue;
-          }
-          keyedOrigins.set(key, keyedOrigins.has(key) ? null : origin);
-        }
-        for (const message of after) {
-          if (
-            providerMessageOrigins.has(message) ||
-            isSyntheticProviderContextMessage(message)
-          ) {
-            continue;
-          }
-          const key = getProviderMessageOriginKey(message);
-          const origin = key != null ? keyedOrigins.get(key) : undefined;
-          if (origin != null) {
-            providerMessageOrigins.set(message, origin);
-          }
-        }
-        return after;
-      };
+      const contextPressure = createContextPressureMeter({
+        tokenCounter: agentContext.tokenCounter,
+        sourceMessages: messages,
+        retainedMessages: messagesToUse,
+        indexTokenCountMap: agentContext.indexTokenCountMap,
+        contextUsage,
+        instructionTokens: agentContext.instructionTokens,
+        calibrationRatio: agentContext.calibrationRatio,
+      });
+      const trackProviderMessageOrigins = contextPressure.trackProjection;
 
       if (agentContext.useLegacyContent) {
         const before = finalMessages;
@@ -3298,8 +3212,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         typeof lastMessageX.content === 'string'
       ) {
         const trimmed = lastMessageX.content.trim();
-        finalMessages[finalMessages.length - 2].content =
-          trimmed.length > 0 ? [{ type: 'text' as const, text: trimmed }] : '';
+        const before = finalMessages;
+        finalMessages = [...before];
+        finalMessages[finalMessages.length - 2] = cloneMessage(
+          lastMessageX,
+          trimmed.length > 0 ? [{ type: 'text' as const, text: trimmed }] : ''
+        );
+        finalMessages = trackProviderMessageOrigins(before, finalMessages);
       }
 
       const localProviderOverflowMeasurements = new WeakMap<
@@ -3309,123 +3228,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           estimatedPromptTokens: number;
         }
       >();
-      const measureProviderPayload = (
-        candidate: BaseMessage[],
-        contextBudgetOverride?: number,
-        forceRawRecount = false
-      ): {
-        fits: boolean;
-        projectedMessageTokens?: number;
-        availableMessageTokens?: number;
-        contextBudget?: number;
-        effectiveInstructionTokens?: number;
-      } => {
-        const contextBudget =
-          contextBudgetOverride ?? contextUsage?.contextBudget;
-        const effectiveInstructionTokens =
-          contextUsage?.effectiveInstructionTokens ??
-          (forceRawRecount ? agentContext.instructionTokens : undefined);
-        if (
-          agentContext.tokenCounter == null ||
-          contextBudget == null ||
-          effectiveInstructionTokens == null
-        ) {
-          return { fits: true };
-        }
-        const availableMessageTokens = Math.max(
-          0,
-          contextBudget - effectiveInstructionTokens
-        );
-        let usageRatio =
-          agentContext.calibrationRatio > 0 ? agentContext.calibrationRatio : 1;
-        if (
-          contextUsage?.calibrationRatio != null &&
-          contextUsage.calibrationRatio > 0
-        ) {
-          usageRatio = contextUsage.calibrationRatio;
-        }
-        if (forceRawRecount) {
-          usageRatio = Math.max(1, usageRatio);
-        }
-        const baselineRemaining = contextUsage?.remainingContextTokens;
-        const accountedMessageTokens =
-          !forceRawRecount &&
-          providerMessageBaseline != null &&
-          baselineRemaining != null &&
-          Number.isFinite(baselineRemaining)
-            ? availableMessageTokens -
-              Math.min(availableMessageTokens, Math.max(0, baselineRemaining))
-            : undefined;
-
-        let projectedMessageTokens: number;
-        if (accountedMessageTokens != null && providerMessageBaseline != null) {
-          const replyPrimerTokens = Math.round(
-            REPLY_PRIMER_TOKENS * usageRatio
-          );
-          const rawWeights: Record<string, number> = {};
-          let totalWeight = 0;
-          for (let i = 0; i < providerMessageBaseline.length; i++) {
-            const weight = providerMessageBaseline[i].accountingWeight;
-            rawWeights[i] = weight;
-            totalWeight += weight;
-          }
-          const attributableTokens =
-            totalWeight > 0
-              ? Math.min(
-                Math.max(0, accountedMessageTokens - replyPrimerTokens),
-                Math.round(totalWeight * usageRatio)
-              )
-              : 0;
-          const apportionedTokens =
-            totalWeight > 0
-              ? apportionTokenCounts(
-                rawWeights,
-                attributableTokens / totalWeight,
-                attributableTokens
-              )
-              : {};
-          const attributedByOrigin = providerMessageBaseline.map(
-            (_, origin) => apportionedTokens[origin] || 0
-          );
-          projectedMessageTokens = Math.max(
-            replyPrimerTokens,
-            accountedMessageTokens - attributableTokens
-          );
-          let newRawTokens = 0;
-          const usedOrigins = new Set<number>();
-          for (const message of candidate) {
-            const rawTokens = agentContext.tokenCounter(message);
-            const origin = providerMessageOrigins.get(message);
-            if (origin == null || usedOrigins.has(origin)) {
-              newRawTokens += rawTokens;
-              continue;
-            }
-            usedOrigins.add(origin);
-            projectedMessageTokens += Math.max(
-              0,
-              attributedByOrigin[origin] +
-                Math.round(
-                  (rawTokens - providerMessageBaseline[origin].rawTokens) *
-                    usageRatio
-                )
-            );
-          }
-          projectedMessageTokens += Math.round(newRawTokens * usageRatio);
-        } else {
-          let rawTokens = REPLY_PRIMER_TOKENS;
-          for (const message of candidate) {
-            rawTokens += agentContext.tokenCounter(message);
-          }
-          projectedMessageTokens = Math.round(rawTokens * usageRatio);
-        }
-        return {
-          fits: projectedMessageTokens <= availableMessageTokens,
-          projectedMessageTokens,
-          availableMessageTokens,
-          contextBudget,
-          effectiveInstructionTokens,
-        };
-      };
+      const measureProviderPayload = contextPressure.measure;
 
       const createProviderPayloadOverflowError = ({
         projection,
@@ -3780,10 +3583,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         finalMessages = trackProviderMessageOrigins(
           beforeSanitizeMessages,
           sanitizeOrphanToolBlocks(beforeSanitizeMessages, (source, clone) => {
-            const origin = providerMessageOrigins.get(source);
-            if (origin != null) {
-              providerMessageOrigins.set(clone, origin);
-            }
+            contextPressure.trackClone(source, clone);
           })
         );
         if (finalMessages.length !== beforeSanitize) {
@@ -4324,17 +4124,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                           fallbackMessages,
                           preparedMessages
                         ),
-                        fallbackContextBudget,
-                        true
+                        {
+                          contextBudget: fallbackContextBudget,
+                          forceRawRecount: true,
+                        }
                       ),
                   });
                   const projection =
                     preparedFallbackRequest.measurement ??
-                    measureProviderPayload(
-                      preparedFallbackRequest.messages,
-                      fallbackContextBudget,
-                      true
-                    );
+                    measureProviderPayload(preparedFallbackRequest.messages, {
+                      contextBudget: fallbackContextBudget,
+                      forceRawRecount: true,
+                    });
                   if (!projection.fits) {
                     throw createProviderPayloadOverflowError({
                       projection,

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -1,0 +1,112 @@
+import { HumanMessage } from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+
+import { stampSyntheticProviderMessage } from '@/messages';
+import { createContextPressureMeter } from './contextPressureMeter';
+
+function contentLength(message: BaseMessage): number {
+  return typeof message.content === 'string'
+    ? message.content.length
+    : JSON.stringify(message.content).length;
+}
+
+describe('createContextPressureMeter', () => {
+  it('preserves provider-grounded attribution while caching exact counts', () => {
+    const source = [
+      new HumanMessage({ id: 'first', content: 'a' }),
+      new HumanMessage({ id: 'second', content: 'bb' }),
+    ];
+    const tokenCounter = jest.fn(contentLength);
+    const meter = createContextPressureMeter({
+      tokenCounter,
+      sourceMessages: source,
+      retainedMessages: source,
+      indexTokenCountMap: { 0: 10, 1: 20 },
+      contextUsage: {
+        contextBudget: 100,
+        effectiveInstructionTokens: 10,
+        remainingContextTokens: 60,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 10,
+      calibrationRatio: 1,
+    });
+    const projected = [
+      new HumanMessage({ id: 'first', content: 'aaaa' }),
+      source[1],
+    ];
+    meter.trackProjection(source, projected);
+
+    expect(meter.measure(projected)).toEqual({
+      fits: true,
+      projectedMessageTokens: 33,
+      availableMessageTokens: 90,
+      contextBudget: 100,
+      effectiveInstructionTokens: 10,
+    });
+    expect(meter.measure(projected).projectedMessageTokens).toBe(33);
+    expect(tokenCounter).toHaveBeenCalledTimes(3);
+  });
+
+  it('tokenizes only changed candidates across a compaction search', () => {
+    const retained = Array.from(
+      { length: 100 },
+      (_, index) =>
+        new HumanMessage({ id: `message-${index}`, content: 'retained' })
+    );
+    const tokenCounter = jest.fn(contentLength);
+    const meter = createContextPressureMeter({
+      tokenCounter,
+      sourceMessages: retained,
+      retainedMessages: retained,
+      indexTokenCountMap: Object.fromEntries(
+        retained.map((_, index) => [index, 8])
+      ),
+      contextUsage: {
+        contextBudget: 10_000,
+        effectiveInstructionTokens: 100,
+        remainingContextTokens: 9_000,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 100,
+      calibrationRatio: 1,
+    });
+
+    for (let i = 0; i < 13; i++) {
+      meter.measure([
+        ...retained,
+        stampSyntheticProviderMessage(
+          new HumanMessage({ content: 'x'.repeat(i + 1) })
+        ),
+      ]);
+    }
+
+    expect(tokenCounter).toHaveBeenCalledTimes(113);
+  });
+
+  it('uses a conservative ratio for fallback payloads', () => {
+    const message = new HumanMessage('1234567890');
+    const meter = createContextPressureMeter({
+      tokenCounter: contentLength,
+      sourceMessages: [message],
+      retainedMessages: [message],
+      indexTokenCountMap: { 0: 10 },
+      instructionTokens: 5,
+      calibrationRatio: 0.5,
+    });
+
+    expect(
+      meter.measure([message], {
+        contextBudget: 17,
+        forceRawRecount: true,
+      })
+    ).toEqual({
+      fits: false,
+      projectedMessageTokens: 13,
+      availableMessageTokens: 12,
+      contextBudget: 17,
+      effectiveInstructionTokens: 5,
+    });
+  });
+});

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -1,0 +1,284 @@
+import { ToolMessage } from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ProviderPayloadMeasurement } from '@/llm/prepareProviderRequest';
+import type * as t from '@/types';
+
+import {
+  REPLY_PRIMER_TOKENS,
+  isSyntheticProviderContextMessage,
+} from '@/messages';
+import { apportionTokenCounts } from '@/utils';
+
+interface ContextPressureUsage {
+  contextBudget?: number;
+  effectiveInstructionTokens?: number;
+  remainingContextTokens?: number;
+  calibrationRatio?: number;
+}
+
+interface ContextPressureMeterParams {
+  tokenCounter?: t.TokenCounter;
+  sourceMessages: BaseMessage[];
+  retainedMessages: BaseMessage[];
+  indexTokenCountMap: Record<string, number | undefined>;
+  contextUsage?: ContextPressureUsage | null;
+  instructionTokens: number;
+  calibrationRatio: number;
+}
+
+interface ProviderPayloadMeasureOptions {
+  contextBudget?: number;
+  forceRawRecount?: boolean;
+}
+
+interface ProviderMessageBaseline {
+  rawTokens: number;
+  accountingWeight: number;
+}
+
+interface ProviderBaselineAttribution {
+  attributedByOrigin: number[];
+  projectedBaseTokens: number;
+}
+
+export interface ContextPressureMeter {
+  trackProjection(before: BaseMessage[], after: BaseMessage[]): BaseMessage[];
+  trackClone(source: BaseMessage, clone: BaseMessage): void;
+  measure(
+    messages: BaseMessage[],
+    options?: ProviderPayloadMeasureOptions
+  ): ProviderPayloadMeasurement;
+}
+
+function getProviderMessageOriginKey(message: BaseMessage): string | undefined {
+  const type = message.getType();
+  if (
+    message instanceof ToolMessage &&
+    typeof message.tool_call_id === 'string' &&
+    message.tool_call_id.length > 0
+  ) {
+    return `tool:call:${message.tool_call_id}`;
+  }
+  if (typeof message.id === 'string' && message.id.length > 0) {
+    return `${type}:id:${message.id}`;
+  }
+  return undefined;
+}
+
+/** Measures repeated provider projections while tokenizing each message object once. */
+export function createContextPressureMeter({
+  tokenCounter,
+  sourceMessages,
+  retainedMessages,
+  indexTokenCountMap,
+  contextUsage,
+  instructionTokens,
+  calibrationRatio,
+}: ContextPressureMeterParams): ContextPressureMeter {
+  const tokenCounts = new WeakMap<BaseMessage, number>();
+  const origins = new WeakMap<BaseMessage, number>();
+  const baselineAttributions = new Map<number, ProviderBaselineAttribution>();
+  let baseline: ProviderMessageBaseline[] | undefined;
+  let baselineWeights: Record<string, number> | undefined;
+  let totalBaselineWeight = 0;
+
+  const count = (message: BaseMessage): number => {
+    const cached = tokenCounts.get(message);
+    if (cached != null) {
+      return cached;
+    }
+    const tokens = tokenCounter?.(message) ?? 0;
+    tokenCounts.set(message, tokens);
+    return tokens;
+  };
+
+  if (contextUsage != null && tokenCounter != null) {
+    const sourceIndices = new WeakMap<BaseMessage, number>();
+    for (let i = 0; i < sourceMessages.length; i++) {
+      sourceIndices.set(sourceMessages[i], i);
+    }
+    baseline = retainedMessages.map((message, index) => {
+      const rawTokens = count(message);
+      const sourceIndex = sourceIndices.get(message);
+      const indexedTokens =
+        sourceIndex != null ? indexTokenCountMap[sourceIndex] : undefined;
+      const accountingWeight =
+        indexedTokens != null &&
+        Number.isFinite(indexedTokens) &&
+        indexedTokens >= 0
+          ? indexedTokens
+          : rawTokens;
+      if (!origins.has(message)) {
+        origins.set(message, index);
+      }
+      return { rawTokens, accountingWeight };
+    });
+    baselineWeights = {};
+    for (let i = 0; i < baseline.length; i++) {
+      baselineWeights[i] = baseline[i].accountingWeight;
+      totalBaselineWeight += baseline[i].accountingWeight;
+    }
+  }
+
+  const trackClone = (source: BaseMessage, clone: BaseMessage): void => {
+    const origin = origins.get(source);
+    if (origin != null && !origins.has(clone)) {
+      origins.set(clone, origin);
+    }
+  };
+
+  const trackProjection = (
+    before: BaseMessage[],
+    after: BaseMessage[]
+  ): BaseMessage[] => {
+    if (baseline == null || before === after) {
+      return after;
+    }
+    if (before.length === after.length) {
+      for (let i = 0; i < after.length; i++) {
+        if (
+          before[i].getType() === after[i].getType() &&
+          !isSyntheticProviderContextMessage(after[i])
+        ) {
+          trackClone(before[i], after[i]);
+        }
+      }
+      return after;
+    }
+
+    const keyedOrigins = new Map<string, number | null>();
+    for (const message of before) {
+      const origin = origins.get(message);
+      const key = getProviderMessageOriginKey(message);
+      if (origin == null || key == null) {
+        continue;
+      }
+      keyedOrigins.set(key, keyedOrigins.has(key) ? null : origin);
+    }
+    for (const message of after) {
+      if (origins.has(message) || isSyntheticProviderContextMessage(message)) {
+        continue;
+      }
+      const key = getProviderMessageOriginKey(message);
+      const origin = key != null ? keyedOrigins.get(key) : undefined;
+      if (origin != null) {
+        origins.set(message, origin);
+      }
+    }
+    return after;
+  };
+
+  const measure = (
+    messages: BaseMessage[],
+    options?: ProviderPayloadMeasureOptions
+  ): ProviderPayloadMeasurement => {
+    const contextBudget = options?.contextBudget ?? contextUsage?.contextBudget;
+    const forceRawRecount = options?.forceRawRecount === true;
+    const effectiveInstructionTokens =
+      contextUsage?.effectiveInstructionTokens ??
+      (forceRawRecount ? instructionTokens : undefined);
+    if (
+      tokenCounter == null ||
+      contextBudget == null ||
+      effectiveInstructionTokens == null
+    ) {
+      return { fits: true };
+    }
+    const availableMessageTokens = Math.max(
+      0,
+      contextBudget - effectiveInstructionTokens
+    );
+    let usageRatio = calibrationRatio > 0 ? calibrationRatio : 1;
+    if (
+      contextUsage?.calibrationRatio != null &&
+      contextUsage.calibrationRatio > 0
+    ) {
+      usageRatio = contextUsage.calibrationRatio;
+    }
+    if (forceRawRecount) {
+      usageRatio = Math.max(1, usageRatio);
+    }
+    const baselineRemaining = contextUsage?.remainingContextTokens;
+    const accountedMessageTokens =
+      !forceRawRecount &&
+      baseline != null &&
+      baselineRemaining != null &&
+      Number.isFinite(baselineRemaining)
+        ? availableMessageTokens -
+          Math.min(availableMessageTokens, Math.max(0, baselineRemaining))
+        : undefined;
+
+    let projectedMessageTokens: number;
+    if (
+      accountedMessageTokens != null &&
+      baseline != null &&
+      baselineWeights != null
+    ) {
+      let attribution = baselineAttributions.get(availableMessageTokens);
+      if (attribution == null) {
+        const replyPrimerTokens = Math.round(
+          REPLY_PRIMER_TOKENS * usageRatio
+        );
+        const attributableTokens =
+          totalBaselineWeight > 0
+            ? Math.min(
+              Math.max(0, accountedMessageTokens - replyPrimerTokens),
+              Math.round(totalBaselineWeight * usageRatio)
+            )
+            : 0;
+        const apportionedTokens =
+          totalBaselineWeight > 0
+            ? apportionTokenCounts(
+              baselineWeights,
+              attributableTokens / totalBaselineWeight,
+              attributableTokens
+            )
+            : {};
+        attribution = {
+          attributedByOrigin: baseline.map(
+            (_, origin) => apportionedTokens[origin] || 0
+          ),
+          projectedBaseTokens: Math.max(
+            replyPrimerTokens,
+            accountedMessageTokens - attributableTokens
+          ),
+        };
+        baselineAttributions.set(availableMessageTokens, attribution);
+      }
+      projectedMessageTokens = attribution.projectedBaseTokens;
+      let newRawTokens = 0;
+      const usedOrigins = new Set<number>();
+      for (const message of messages) {
+        const rawTokens = count(message);
+        const origin = origins.get(message);
+        if (origin == null || usedOrigins.has(origin)) {
+          newRawTokens += rawTokens;
+          continue;
+        }
+        usedOrigins.add(origin);
+        projectedMessageTokens += Math.max(
+          0,
+          attribution.attributedByOrigin[origin] +
+            Math.round((rawTokens - baseline[origin].rawTokens) * usageRatio)
+        );
+      }
+      projectedMessageTokens += Math.round(newRawTokens * usageRatio);
+    } else {
+      let rawTokens = REPLY_PRIMER_TOKENS;
+      for (const message of messages) {
+        rawTokens += count(message);
+      }
+      projectedMessageTokens = Math.round(rawTokens * usageRatio);
+    }
+    return {
+      fits: projectedMessageTokens <= availableMessageTokens,
+      projectedMessageTokens,
+      availableMessageTokens,
+      contextBudget,
+      effectiveInstructionTokens,
+    };
+  };
+
+  return { trackProjection, trackClone, measure };
+}

--- a/src/messages/content.test.ts
+++ b/src/messages/content.test.ts
@@ -22,6 +22,11 @@ describe('formatContentStrings', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].content).toBe('Hello\nWorld');
+      expect(result[0]).not.toBe(messages[0]);
+      expect(messages[0].content).toEqual([
+        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Hello' },
+        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'World' },
+      ]);
     });
 
     it('should not convert human message with mixed content types (text + image)', () => {

--- a/src/messages/content.ts
+++ b/src/messages/content.ts
@@ -3,6 +3,7 @@ import type {
   MessageContentComplex,
 } from '@langchain/core/messages';
 import { ContentTypes } from '@/common';
+import { cloneMessage } from './cache';
 
 /**
  * Whether {@link formatContentStrings} will flatten this message's content:
@@ -42,13 +43,12 @@ export const formatContentStrings = (
     const blocks = message.content as MessageContentComplex[];
     const content = blocks.reduce((acc, curr) => {
       if (curr.type === ContentTypes.TEXT) {
-        return `${acc}${curr[ContentTypes.TEXT] || ''}\n`;
+        return `${acc}${curr[ContentTypes.TEXT] ?? ''}\n`;
       }
       return acc;
     }, '');
 
-    message.content = content.trim();
-    result.push(message);
+    result.push(cloneMessage(message, content.trim()));
   }
 
   return result;


### PR DESCRIPTION
I implemented a request-scoped context-pressure meter on top of the prepared provider-request seam from #448, preserving exact overflow behavior while eliminating repeated tokenizer work across provider projections.

- Extracted provider-grounded baseline attribution, origin tracking, fallback accounting, and payload measurement from `Graph.ts` into a focused in-process meter.
- Memoized exact token counts by provider-message identity and reused baseline apportionment across artifact checks, synthetic-context compaction probes, final prepared requests, and fallbacks.
- Preserved the real tokenizer, calibration ratio, reply primer, conservative fallback floor, overflow diagnostics, and Langfuse billing/usage boundaries.
- Changed legacy content formatting and the Bedrock tail normalization to clone changed messages so cached exact counts cannot become stale through in-place mutation.
- Added deterministic coverage showing a 100-message, 13-probe compaction pass uses 113 tokenizer calls instead of the prior 1,413 total calls, a 92% reduction.
- Documented the Context Pressure Meter invariant and its separation from provider-reported usage.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `npx jest src/llm/prepareProviderRequest.test.ts src/llm/contextPressureMeter.test.ts src/messages/content.test.ts src/graphs/__tests__/Graph.contextOverflow.test.ts --runInBand` (55 tests passed).
- Ran `npx tsc --noEmit`.
- Ran ESLint against every changed TypeScript file.
- Ran `npm run build`.
- Ran a local exact-tokenizer microbenchmark over 100 retained messages and 13 compaction probes; the request-scoped meter completed in 2.54 ms versus 27.02 ms for repeated full recounts (10.65x in that run).

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2-compatible workspace
- macOS arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective and the feature works
- [x] Local unit tests pass with my changes
