### PR TITLE
♻️ refactor: Export the Summarization Primitives

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -51,6 +51,7 @@ import {
 } from '@/common';
 import { isTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { buildSummaryCarrierText } from '@/summarization/shared';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
@@ -934,11 +935,7 @@ export class AgentContext {
   private buildSummaryHumanMessage(
     promptCacheProvider: PromptCacheProvider | undefined
   ): HumanMessage {
-    const wrappedSummary =
-      '<summary>\n' +
-      (this.summaryText as string) +
-      '\n</summary>\n\n' +
-      'This is your own checkpoint: you wrote it to preserve context after compaction. Pick up where you left off based on the summary above. Do not repeat prior tasks, information or acknowledge this checkpoint message directly.';
+    const wrappedSummary = buildSummaryCarrierText(this.summaryText as string);
 
     if (promptCacheProvider !== Providers.ANTHROPIC) {
       return new HumanMessage(wrappedSummary);

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2,6 +2,7 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
+import { buildSummaryCarrierText } from '@/summarization/shared';
 import { addBedrockCacheControl } from '@/messages/cache';
 import { createTokenCounter } from '@/utils/tokens';
 import { Constants, Providers } from '@/common';
@@ -88,6 +89,31 @@ describe('AgentContext', () => {
       const names = (bound as Array<{ name?: string }>).map((t) => t.name);
       expect(names).toContain('ask_user_question');
       expect(names).toContain('echo');
+    });
+  });
+
+  describe('Summary carrier', () => {
+    /** The summary's stored token count is a measurement of the carrier built
+     *  by `buildSummaryCarrierText`. If this context ever injected different
+     *  text, every budget read against a persisted summary would be wrong by
+     *  the difference, silently. Asserting they are the same string is what
+     *  makes the accounting checkable in one place. */
+    it('injects exactly the carrier the summary was measured as', async () => {
+      const ctx = createBasicContext();
+      ctx.setSummary('checkpoint body', 0);
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('after compaction'),
+      ]);
+
+      const injected = result.find(
+        (message) =>
+          typeof message.content === 'string' &&
+          message.content.startsWith('<summary>')
+      );
+      expect(injected?.content).toBe(
+        buildSummaryCarrierText('checkpoint body')
+      );
     });
   });
 

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -28,6 +28,12 @@ import {
   STREAM_LIMIT_ATTEMPT_KEY,
 } from '@/llm/streamLimits';
 import {
+  inspectProviderMessageProjection,
+  ProviderMessageProjectionInvariantError,
+  resolveProviderMessageProjectionInvariantMode,
+  modifyDeltaProperties,
+} from '@/messages';
+import {
   assertPreparedProviderRequestFor,
   prepareProviderRequest,
 } from '@/llm/prepareProviderRequest';
@@ -38,15 +44,10 @@ import {
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
+import { resolveClientOptionsModel } from '@/llm/request';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { appendCallbacks } from '@/utils/callbacks';
-import {
-  inspectProviderMessageProjection,
-  ProviderMessageProjectionInvariantError,
-  resolveProviderMessageProjectionInvariantMode,
-  modifyDeltaProperties,
-} from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
 import { initializeModel } from '@/llm/init';
 
@@ -715,8 +716,7 @@ async function attemptInvokeBody(
     resolveProviderMessageProjectionInvariantMode();
   let sealedRunId: string | undefined;
   let invocationConfig = config;
-  const captureModelRunId =
-    model.stream != null && context?.preemption != null;
+  const captureModelRunId = model.stream != null && context?.preemption != null;
   if (projectionInvariantMode !== 'off' || captureModelRunId) {
     invocationConfig = withModelStartHandler({
       config,
@@ -934,7 +934,10 @@ async function attemptInvokeBody(
     return { messages: [finalChunk as AIMessageChunk] };
   }
 
-  const finalMessage = await model.invoke(messagesForProvider, invocationConfig);
+  const finalMessage = await model.invoke(
+    messagesForProvider,
+    invocationConfig
+  );
   if ((finalMessage.tool_calls?.length ?? 0) > 0) {
     finalMessage.tool_calls = finalMessage.tool_calls?.filter(
       (tool_call: ToolCall) => !!tool_call.name
@@ -995,25 +998,6 @@ export function getFallbackOverflowCandidates(
     return [];
   }
   return [...(fallbackOverflowCandidates.get(error) ?? [])];
-}
-
-/**
- * Best-effort read of the configured model name from client options.
- * Providers disagree on the key (`model` vs `modelName`).
- */
-function extractClientOptionsModel(
-  clientOptions: t.ClientOptions | undefined
-): string | undefined {
-  const options = clientOptions as
-    | { model?: unknown; modelName?: unknown }
-    | undefined;
-  if (typeof options?.model === 'string' && options.model !== '') {
-    return options.model;
-  }
-  if (typeof options?.modelName === 'string' && options.modelName !== '') {
-    return options.modelName;
-  }
-  return undefined;
 }
 
 /**
@@ -1106,7 +1090,7 @@ export async function tryFallbackProviders({
        * `ls_model_name`. The serving provider is stamped uniformly by
        * `attemptInvoke` (`INVOKED_PROVIDER`).
        */
-      const fbModelName = extractClientOptionsModel(fb.clientOptions);
+      const fbModelName = resolveClientOptionsModel(fb.clientOptions);
       const fbConfig: RunnableConfig | undefined =
         fbModelName == null
           ? config

--- a/src/llm/request.ts
+++ b/src/llm/request.ts
@@ -44,6 +44,30 @@ export function isThinkingEnabled(
 }
 
 /**
+ * Model configured on client options, under whichever of the two keys carries
+ * it. LangChain accepts `modelName` as an alias for `model` and this package
+ * writes both (see `buildSummarizationClientConfig`), while hosts configure
+ * agents through either. Reading only one key therefore does not fail loudly:
+ * it reports an unconfigured model, and every caller here treats that as a cue
+ * to fall back to a default, so a Claude agent configured through the alias is
+ * silently handled as something else.
+ */
+export function resolveClientOptionsModel(
+  clientOptions: t.ClientOptions | undefined
+): string | undefined {
+  const options = clientOptions as
+    | { model?: unknown; modelName?: unknown }
+    | undefined;
+  if (typeof options?.model === 'string' && options.model !== '') {
+    return options.model;
+  }
+  if (typeof options?.modelName === 'string' && options.modelName !== '') {
+    return options.modelName;
+  }
+  return undefined;
+}
+
+/**
  * Returns the correct key for setting max output tokens on the model
  * constructor options.  Google/Vertex use `maxOutputTokens`, all others
  * use `maxTokens`.

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,7 +35,6 @@ import {
   ACTIVITY_PHASE_LABEL_RUN_NAME,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
-import { isBuiltRuntime } from '@/lazyRequire';
 import {
   requireValidSubagentResumeManifest,
   stripSubagentResumeManifest,
@@ -94,14 +93,16 @@ import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { stampSyntheticProviderMessage } from '@/messages/provenance';
+import { isOpenAILike, isLibreChatOpenAIModel } from '@/utils/llm';
 import { initializeLangfuseTracing } from './instrumentation';
 import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
+import { resolveClientOptionsModel } from '@/llm/request';
 import { createGraph } from '@/graphs/createGraph';
 import { resolveMaxSeals } from '@/llm/preempt';
+import { isBuiltRuntime } from '@/lazyRequire';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
-import { isOpenAILike, isLibreChatOpenAIModel } from '@/utils/llm';
 import { executeHooks } from '@/hooks';
 
 /** Source-mode runs have no dist siblings for the lazy-loading seam, so every
@@ -728,12 +729,16 @@ export class Run<_T extends t.BaseGraphState> {
     config: t.RunConfig
   ): Promise<Run<T>> {
     await ensureSourceModeProviders();
-    /** Create tokenCounter if indexTokenCountMap is provided but tokenCounter is not */
+    /** Create tokenCounter if indexTokenCountMap is provided but tokenCounter is
+     *  not. The model is read through both option keys: `modelName` is
+     *  LangChain's alias for `model`, so consulting one alone would give a
+     *  Claude-backed agent an `o200k_base` counter and undercount every message
+     *  it measures. */
     if (config.indexTokenCountMap && !config.tokenCounter) {
       const gc = config.graphConfig;
       const clientOpts =
         'agents' in gc ? gc.agents[0]?.clientOptions : gc.clientOptions;
-      const model = (clientOpts as { model?: string } | undefined)?.model ?? '';
+      const model = resolveClientOptionsModel(clientOpts) ?? '';
       config.tokenCounter = await createTokenCounter(encodingForModel(model));
     }
     return new Run<T>(config);

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -498,7 +498,11 @@ async function runTenantSummarizationFlow(tenantId: string): Promise<void> {
           provider: Providers.OPENAI,
           clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
           instructions: 'Summarize when context is full.',
-          maxContextTokens: 120,
+          /* Under `compactingTokenCounter` a message costs its character
+           * count, so this sits between the summary's own carrier (~272) and
+           * the transcript (~397): high enough that the run survives its
+           * checkpoint, low enough that compaction still fires. */
+          maxContextTokens: 340,
           summarizationEnabled: true,
           summarizationConfig: {
             retainRecent: { turns: 0 },

--- a/src/specs/run-token-counter.test.ts
+++ b/src/specs/run-token-counter.test.ts
@@ -1,0 +1,70 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { createTokenCounter, encodingOfTokenCounter } from '@/utils/tokens';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+/** Korean is the widest measured gap between the two encodings, so a counter
+ *  built for the wrong one undercounts here by the largest factor. */
+const CJK_MESSAGE = new HumanMessage(
+  '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다.'
+);
+
+/**
+ * A host that supplies `indexTokenCountMap` without a counter delegates the
+ * choice of tokenizer to `Run.create`, and every message the run measures is
+ * denominated in whatever it picks. OpenRouter is the provider here because it
+ * serves Claude alongside everything else: the model string is the only signal,
+ * so a run that fails to read it has nothing to fall back on but `o200k_base`.
+ */
+async function deriveRunTokenCounter(
+  clientOptions: Record<string, unknown>
+): Promise<t.TokenCounter> {
+  const config: t.RunConfig = {
+    runId: 'run-token-counter',
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENROUTER,
+        streaming: false,
+        streamUsage: false,
+      },
+      clientOptions,
+      instructions: 'Be concise.',
+    },
+    indexTokenCountMap: { 0: 10 },
+  };
+  await Run.create<t.IState>(config);
+  if (config.tokenCounter == null) {
+    throw new Error('Run.create did not derive a token counter');
+  }
+  return config.tokenCounter;
+}
+
+describe('Run.create token counter derivation', () => {
+  it('reads the model through the modelName alias', async () => {
+    const counter = await deriveRunTokenCounter({
+      modelName: 'anthropic/claude-sonnet-4',
+    });
+
+    expect(encodingOfTokenCounter(counter)).toBe('claude');
+    /* Guards the consequence rather than the label: the two encodings must
+     * disagree on this text, or picking the wrong one would cost nothing. */
+    const openaiCounter = await createTokenCounter('o200k_base');
+    expect(counter(CJK_MESSAGE)).toBeGreaterThan(openaiCounter(CJK_MESSAGE));
+  });
+
+  it('still reads the canonical model key', async () => {
+    const counter = await deriveRunTokenCounter({
+      model: 'anthropic/claude-sonnet-4',
+    });
+
+    expect(encodingOfTokenCounter(counter)).toBe('claude');
+  });
+
+  it('falls back to o200k_base when no model is configured', async () => {
+    const counter = await deriveRunTokenCounter({});
+
+    expect(encodingOfTokenCounter(counter)).toBe('o200k_base');
+  });
+});

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -19,11 +19,10 @@ import { createTokenCounter } from '@/utils/tokens';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { Run } from '@/run';
 import { formatAgentMessages } from '@/messages/format';
+import { buildSummaryCarrierText } from '@/summarization/shared';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import * as providers from '@/llm/providers';
 import { hasAnyEnv, hasEnv, hasEveryEnv } from './spec.utils';
-
-const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
 
 /** Extract plain text from a SummaryContentBlock's content array (test helper). */
 function getSummaryText(summary: t.SummaryContentBlock | undefined): string {
@@ -1477,9 +1476,9 @@ describe('Cross-run summary lifecycle (no API keys)', () => {
     expect(completePayload.summary!.type).toBe(ContentTypes.SUMMARY);
     expect(completePayload.summary!.tokenCount ?? 0).toBeGreaterThan(0);
 
-    const expectedTokenCount =
-      tokenCounter(new SystemMessage(KNOWN_SUMMARY)) +
-      SUMMARY_WRAPPER_OVERHEAD_TOKENS;
+    const expectedTokenCount = tokenCounter(
+      new HumanMessage(buildSummaryCarrierText(KNOWN_SUMMARY))
+    );
     expect(completePayload.summary!.tokenCount).toBe(expectedTokenCount);
 
     const summaryBlock = completePayload.summary!;
@@ -2601,9 +2600,9 @@ const hasAnyApiKey = hasAnyEnv(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
     const summaryText = getSummaryText(completePayload.summary);
     const reportedTokenCount = completePayload.summary!.tokenCount ?? 0;
 
-    const localTokenCount =
-      tokenCounter(new SystemMessage(summaryText)) +
-      SUMMARY_WRAPPER_OVERHEAD_TOKENS;
+    const localTokenCount = tokenCounter(
+      new HumanMessage(buildSummaryCarrierText(summaryText))
+    );
 
     console.log(
       `  Token match: reported=${reportedTokenCount}, local=${localTokenCount}`

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -12,9 +12,11 @@ import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { createSummarizeNode } from '@/summarization/node';
+import { registerProvider } from '@/llm/providerRegistry';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
+import { FakeChatModel } from '@/llm/fake';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -2373,5 +2375,70 @@ describe('summarize node breaker capture', () => {
 
     expect(persistedCount).toBe(claudeCounter(carrier));
     expect(claudeCounter(carrier)).toBeGreaterThan(openaiCounter(carrier));
+  });
+
+  /** A host provider registered with `family: 'anthropic'` serves Claude under
+   *  whatever name and deployment alias the host chose, so an exact match on
+   *  the `ANTHROPIC` enum missed it and fell back to `o200k_base`. The rest of
+   *  the package reads the trait as a family (`isThinkingEnabled`), and the
+   *  tokenizer choice now does too. */
+  it('honors a registered anthropic family with no configured model', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    const dispose = registerProvider({
+      provider: 'claude-host-summarization-test',
+      model: class extends FakeChatModel {
+        constructor() {
+          super({ responses: [summaryBody] });
+        }
+      },
+      family: 'anthropic',
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    try {
+      /* No model on either key: the provider is the only signal there is. */
+      const agentContext = createAgentContext({
+        provider: 'claude-host-summarization-test',
+        clientOptions: {},
+      });
+      const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+        string,
+        number,
+      ];
+      const carrier = new HumanMessage(buildSummaryCarrierText(persistedText));
+      const claudeCounter = await createTokenCounter('claude');
+      const openaiCounter = await createTokenCounter('o200k_base');
+
+      expect(persistedCount).toBe(claudeCounter(carrier));
+      expect(claudeCounter(carrier)).toBeGreaterThan(openaiCounter(carrier));
+    } finally {
+      dispose();
+    }
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -2441,4 +2441,72 @@ describe('summarize node breaker capture', () => {
       dispose();
     }
   });
+
+  /** `encodingForModel` matches the substring `claude`, so an opaque
+   *  deployment alias reports `o200k_base` while proving nothing about the
+   *  model behind it. Treating that as the answer skipped the family lookup
+   *  entirely and under-reserved the CJK checkpoint by the same 1.9x the
+   *  family fix exists to prevent, including against the `o200k_base` counter
+   *  `Run.create` stamps from that same alias. */
+  it('honors a registered anthropic family behind an opaque model alias', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    const dispose = registerProvider({
+      provider: 'claude-alias-summarization-test',
+      model: class extends FakeChatModel {
+        constructor() {
+          super({ responses: [summaryBody] });
+        }
+      },
+      family: 'anthropic',
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    try {
+      const sharedCounter = await createTokenCounter(
+        encodingForModel('production')
+      );
+      const agentContext = createAgentContext({
+        provider: 'claude-alias-summarization-test',
+        clientOptions: { model: 'production' },
+        tokenCounter: sharedCounter,
+      });
+      const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+        string,
+        number,
+      ];
+      const carrier = new HumanMessage(buildSummaryCarrierText(persistedText));
+      const claudeCounter = await createTokenCounter('claude');
+
+      expect(persistedCount).toBe(claudeCounter(carrier));
+      expect(persistedCount).toBeGreaterThan(sharedCounter(carrier));
+    } finally {
+      dispose();
+    }
+  });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -2171,4 +2171,60 @@ describe('summarize node breaker capture', () => {
      * if anyone reintroduces a character heuristic here. */
     expect(persistedCount).toBeGreaterThan(Math.ceil(carrier.length / 4));
   });
+
+  /** The carrier is re-injected into the AGENT's model, so the count has to be
+   *  denominated in the agent's tokenizer, not the summarizer's.
+   *  `summarizationConfig.model` is undefined for ordinary self-summarization,
+   *  so reading the model off the summarizer would silently measure an
+   *  Anthropic agent with `o200k_base` and understate it. */
+  it('measures with the receiving agent tokenizer, not the summarizer', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { model: 'claude-sonnet-4' },
+    });
+    expect(agentContext.tokenCounter).toBeUndefined();
+    /* No dedicated summarizer model: the only model signal is the agent's. */
+    expect(agentContext.summarizationConfig?.model).toBeUndefined();
+    const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+      string,
+      number,
+    ];
+    const carrier = new HumanMessage(buildSummaryCarrierText(persistedText));
+    const claudeCounter = await createTokenCounter('claude');
+    const openaiCounter = await createTokenCounter('o200k_base');
+
+    expect(persistedCount).toBe(claudeCounter(carrier));
+    /* Guards the actual defect: the two encodings must disagree here, or this
+     * test would pass just as well while measuring with the wrong one. */
+    expect(claudeCounter(carrier)).toBeGreaterThan(openaiCounter(carrier));
+  });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -2321,4 +2321,57 @@ describe('summarize node breaker capture', () => {
 
     expect(setSummary.mock.calls[0][1]).toBe(4242);
   });
+
+  /** `modelName` is LangChain's alias for `model` and this repository
+   *  configures agents through both, so reading only `model` reported an
+   *  unconfigured model and fell through to the provider — which for a
+   *  Claude-backed OpenRouter agent means `o200k_base` and the same
+   *  under-reservation the receiving-agent fix exists to prevent. */
+  it('resolves the receiving model through the modelName alias', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    /* OpenRouter, so the provider fallback cannot stand in for the model: it
+     * serves Claude alongside everything else and resolves to `o200k_base`. */
+    const agentContext = createAgentContext({
+      provider: Providers.OPENROUTER,
+      clientOptions: { modelName: 'anthropic/claude-sonnet-4' },
+    });
+    const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+      string,
+      number,
+    ];
+    const carrier = new HumanMessage(buildSummaryCarrierText(persistedText));
+    const claudeCounter = await createTokenCounter('claude');
+    const openaiCounter = await createTokenCounter('o200k_base');
+
+    expect(persistedCount).toBe(claudeCounter(carrier));
+    expect(claudeCounter(carrier)).toBeGreaterThan(openaiCounter(carrier));
+  });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -5,12 +5,14 @@ import type * as t from '@/types';
 import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  buildSummaryCarrierText,
 } from '@/summarization/shared';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { createSummarizeNode } from '@/summarization/node';
 import { AgentContext } from '@/agents/AgentContext';
+import { createTokenCounter } from '@/utils/tokens';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
 
@@ -2116,5 +2118,57 @@ describe('summarize node breaker capture', () => {
     for (const signal of capturedSignals) {
       expect(signal).toBe(entryBreaker.signal);
     }
+  });
+
+  /** `shouldSummarizeOverflow` fires precisely when the host supplied no
+   *  tokenCounter, so this branch IS the overflow-recovery summary, and its
+   *  count is persisted and then reserved on the retry. It used to be a
+   *  four-characters-per-token guess, which understates CJK several-fold and
+   *  so under-reserved exactly where a repeat overflow is most likely. Korean
+   *  is the sample here because it is the worst measured case. */
+  it('measures the carrier with a real tokenizer when the host has none', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    expect(agentContext.tokenCounter).toBeUndefined();
+    const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(setSummary).toHaveBeenCalled();
+    const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+      string,
+      number,
+    ];
+    const carrier = buildSummaryCarrierText(persistedText);
+    const counter = await createTokenCounter();
+
+    expect(persistedCount).toBe(counter(new HumanMessage(carrier)));
+    /* The guess this replaced. Asserting the gap keeps the test from passing
+     * if anyone reintroduces a character heuristic here. */
+    expect(persistedCount).toBeGreaterThan(Math.ceil(carrier.length / 4));
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -7,12 +7,12 @@ import {
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
   buildSummaryCarrierText,
 } from '@/summarization/shared';
+import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { createSummarizeNode } from '@/summarization/node';
 import { AgentContext } from '@/agents/AgentContext';
-import { createTokenCounter } from '@/utils/tokens';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
 
@@ -2226,5 +2226,99 @@ describe('summarize node breaker capture', () => {
     /* Guards the actual defect: the two encodings must disagree here, or this
      * test would pass just as well while measuring with the wrong one. */
     expect(claudeCounter(carrier)).toBeGreaterThan(openaiCounter(carrier));
+  });
+
+  /** `Run.create` derives one counter from `agents[0]` and `StandardGraph`
+   *  hands it to every `AgentContext`, so a Claude agent sitting behind a GPT
+   *  first agent receives an `o200k_base` counter. Trusting it here measured
+   *  the carrier in the wrong units and under-reserved the persisted
+   *  checkpoint on the retry, which is the overflow this count exists to
+   *  prevent. */
+  it('ignores a shared counter built for another agent encoding', async () => {
+    const summaryBody =
+      '사용자가 인증 미들웨어를 리팩터링하여 속도 제한 전에 토큰 검증이 이루어지도록 요청했습니다. 기존 핸들러를 읽어보니 순서가 뒤바뀌어 있었습니다.';
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel(summaryBody);
+        }
+      } as never
+    );
+
+    const sharedCounter = await createTokenCounter(encodingForModel('gpt-4o'));
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { model: 'claude-sonnet-4' },
+      tokenCounter: sharedCounter,
+    });
+    const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    const [persistedText, persistedCount] = setSummary.mock.calls[0] as [
+      string,
+      number,
+    ];
+    const carrier = new HumanMessage(buildSummaryCarrierText(persistedText));
+    const claudeCounter = await createTokenCounter('claude');
+
+    expect(persistedCount).toBe(claudeCounter(carrier));
+    expect(persistedCount).toBeGreaterThan(sharedCounter(carrier));
+  });
+
+  /** The other half of the same rule: a counter the host built itself carries
+   *  no encoding stamp, and its units are the ones the host's own
+   *  `indexTokenCountMap` is denominated in, so it stays authoritative rather
+   *  than being second-guessed by a bundled tokenizer. */
+  it('keeps using a host-supplied counter of unknown encoding', async () => {
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel('Checkpoint body');
+        }
+      } as never
+    );
+
+    const hostCounter = jest.fn((): number => 4242);
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { model: 'claude-sonnet-4' },
+      tokenCounter: hostCounter,
+    });
+    const setSummary = jest.spyOn(agentContext, 'setSummary');
+
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(setSummary.mock.calls[0][1]).toBe(4242);
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -3,13 +3,13 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
-  createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
-} from '@/summarization/node';
+} from '@/summarization/shared';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
+import { createSummarizeNode } from '@/summarization/node';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';

--- a/src/summarization/__tests__/shared.test.ts
+++ b/src/summarization/__tests__/shared.test.ts
@@ -1,0 +1,71 @@
+import {
+  SUMMARY_WRAPPER_OVERHEAD_TOKENS,
+  DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  separateSummarizationParameters,
+  buildSummarizationInstruction,
+} from '@/summarization';
+
+describe('summarization primitives', () => {
+  it('exports the wrapper overhead the summary token count is measured against', () => {
+    expect(SUMMARY_WRAPPER_OVERHEAD_TOKENS).toBe(33);
+  });
+
+  describe('separateSummarizationParameters', () => {
+    it('lifts maxSummaryTokens out of the parameters passed to the model', () => {
+      const result = separateSummarizationParameters({
+        maxSummaryTokens: 512,
+        temperature: 0.2,
+      });
+      expect(result).toEqual({
+        llmParams: { temperature: 0.2 },
+        maxSummaryTokens: 512,
+      });
+    });
+
+    it('ignores a maxSummaryTokens that is not a positive number', () => {
+      expect(separateSummarizationParameters({ maxSummaryTokens: 0 })).toEqual({
+        llmParams: {},
+        maxSummaryTokens: undefined,
+      });
+      expect(
+        separateSummarizationParameters({ maxSummaryTokens: '512' })
+      ).toEqual({ llmParams: {}, maxSummaryTokens: undefined });
+    });
+  });
+
+  describe('buildSummarizationInstruction', () => {
+    it('sends the fresh prompt when there is no prior summary', () => {
+      expect(
+        buildSummarizationInstruction(
+          DEFAULT_SUMMARIZATION_PROMPT,
+          DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+          undefined
+        )
+      ).toBe(DEFAULT_SUMMARIZATION_PROMPT);
+    });
+
+    it('sends the update prompt with the prior summary appended', () => {
+      const result = buildSummarizationInstruction(
+        'fresh',
+        'update',
+        'earlier checkpoint'
+      );
+      expect(result).toBe(
+        'update\n\n<previous-summary>\nearlier checkpoint\n</previous-summary>'
+      );
+    });
+
+    it('falls back to the fresh prompt when no update prompt is configured', () => {
+      expect(buildSummarizationInstruction('fresh', undefined, 'prior')).toBe(
+        'fresh\n\n<previous-summary>\nprior\n</previous-summary>'
+      );
+    });
+
+    it('treats a blank prior summary as absent rather than consolidating nothing', () => {
+      expect(buildSummarizationInstruction('fresh', 'update', '   \n ')).toBe(
+        'fresh'
+      );
+    });
+  });
+});

--- a/src/summarization/__tests__/shared.test.ts
+++ b/src/summarization/__tests__/shared.test.ts
@@ -1,14 +1,29 @@
 import {
-  SUMMARY_WRAPPER_OVERHEAD_TOKENS,
-  DEFAULT_SUMMARIZATION_PROMPT,
-  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  buildSummaryCarrierText,
   separateSummarizationParameters,
   buildSummarizationInstruction,
 } from '@/summarization';
+import {
+  DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+} from '@/summarization/shared';
 
 describe('summarization primitives', () => {
-  it('exports the wrapper overhead the summary token count is measured against', () => {
-    expect(SUMMARY_WRAPPER_OVERHEAD_TOKENS).toBe(33);
+  describe('buildSummaryCarrierText', () => {
+    it('wraps the summary in the tags and instruction it is re-injected with', () => {
+      const carrier = buildSummaryCarrierText('checkpoint body');
+      expect(
+        carrier.startsWith('<summary>\ncheckpoint body\n</summary>\n\n')
+      ).toBe(true);
+      expect(carrier).toContain('This is your own checkpoint');
+    });
+
+    /** A stored summary is budgeted for by measuring this, so the wrapper has
+     *  to cost enough to be worth measuring: the literal it replaced claimed 33
+     *  tokens for a carrier that had already grown well past that. */
+    it('carries an instruction long enough to matter to a context budget', () => {
+      expect(buildSummaryCarrierText('').length).toBeGreaterThan(200);
+    });
   });
 
   describe('separateSummarizationParameters', () => {

--- a/src/summarization/index.ts
+++ b/src/summarization/index.ts
@@ -1,6 +1,15 @@
 import type { SummarizationTrigger } from '@/types';
 
-export * from './shared';
+/**
+ * The summary-boundary seam a caller compacting outside a run needs. The two
+ * default prompts stay out of it: LibreChat's manual flow deliberately words
+ * its own, so exporting these would publish an API with no consumer.
+ */
+export {
+  buildSummarizationInstruction,
+  buildSummaryCarrierText,
+  separateSummarizationParameters,
+} from './shared';
 
 const VALID_TRIGGER_TYPES = [
   'token_ratio',

--- a/src/summarization/index.ts
+++ b/src/summarization/index.ts
@@ -1,5 +1,7 @@
 import type { SummarizationTrigger } from '@/types';
 
+export * from './shared';
+
 const VALID_TRIGGER_TYPES = [
   'token_ratio',
   'remaining_tokens',

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -36,6 +36,11 @@ import {
   type PromptCacheTtl,
 } from '@/messages/cache';
 import {
+  createTokenCounter,
+  encodingForModel,
+  encodingOfTokenCounter,
+} from '@/utils/tokens';
+import {
   Constants,
   ContentTypes,
   GraphEvents,
@@ -43,7 +48,6 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -308,18 +312,33 @@ function buildSummarizationClientConfig(
  * understates base64 by 1.5x and Korean by 4.6x, and coefficients large enough
  * to cover those overestimate English prose by roughly 4x. So this falls back
  * to the tokenizer this package already bundles rather than to an estimate.
+ *
+ * A host counter that is present is not automatically the right one either. In
+ * a heterogeneous multi-agent run `Run.create` derives a single counter from
+ * `agents[0]` and `StandardGraph` hands that same counter to every
+ * `AgentContext`, so a Claude agent behind a GPT first agent would otherwise
+ * measure its carrier in `o200k_base` and under-reserve by up to 1.9x on CJK.
+ * When the counter came from `createTokenCounter` its encoding is known, so a
+ * disagreement with the receiving agent's encoding takes the bundled path
+ * instead. A counter the host built itself is unstamped and stays authoritative:
+ * its units are the ones the rest of that host's accounting is denominated in.
  */
 async function computeSummaryTokenCount(
   summaryText: string,
   agentContext: AgentContext
 ): Promise<number> {
   const carrier = new HumanMessage(buildSummaryCarrierText(summaryText));
-  if (agentContext.tokenCounter) {
-    return agentContext.tokenCounter(carrier);
+  const encoding = encodingForReceivingAgent(agentContext);
+  const hostCounter = agentContext.tokenCounter;
+  const hostEncoding =
+    hostCounter != null ? encodingOfTokenCounter(hostCounter) : undefined;
+  if (
+    hostCounter != null &&
+    (hostEncoding == null || hostEncoding === encoding)
+  ) {
+    return hostCounter(carrier);
   }
-  const bundledCounter = await createTokenCounter(
-    encodingForReceivingAgent(agentContext)
-  );
+  const bundledCounter = await createTokenCounter(encoding);
   return bundledCounter(carrier);
 }
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1,9 +1,4 @@
-import {
-  AIMessage,
-  ToolMessage,
-  HumanMessage,
-  SystemMessage,
-} from '@langchain/core/messages';
+import { AIMessage, ToolMessage, HumanMessage } from '@langchain/core/messages';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { StreamLimitState } from '@/llm/streamLimits';
@@ -11,6 +6,14 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
+import {
+  DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  buildSummaryCarrierText,
+  estimateSummaryCarrierTokens,
+  separateSummarizationParameters,
+  buildSummarizationInstruction,
+} from './shared';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
@@ -47,18 +50,6 @@ import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
-import {
-  SUMMARY_WRAPPER_OVERHEAD_TOKENS,
-  DEFAULT_SUMMARIZATION_PROMPT,
-  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
-  separateSummarizationParameters,
-  buildSummarizationInstruction,
-} from './shared';
-
-export {
-  DEFAULT_SUMMARIZATION_PROMPT,
-  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
-} from './shared';
 
 /**
  * Default number of recent user-led turns preserved verbatim during
@@ -296,23 +287,29 @@ function buildSummarizationClientConfig(
   };
 }
 
-/** Computes the token count for a summary, preferring provider output tokens when available. */
+/**
+ * Sizes a summary from the text that will actually be re-injected, carrier
+ * included, so the stored count is a measurement rather than a body count plus
+ * a remembered constant.
+ *
+ * The provider's `output_tokens` is deliberately not consulted. On a reasoning
+ * summarizer the two diverge by the hidden thinking, which is billed but never
+ * written into the checkpoint, so using it here would make every later context
+ * calculation reserve room for tokens that are never sent. Provider usage stays
+ * exclusively a billing input.
+ */
 function computeSummaryTokenCount(
   summaryText: string,
-  summaryUsage: Partial<UsageMetadata> | undefined,
   tokenCounter?: (message: BaseMessage) => number
 ): number {
-  const providerOutputTokens = Number(summaryUsage?.output_tokens) || 0;
-  if (providerOutputTokens > 0) {
-    return providerOutputTokens + SUMMARY_WRAPPER_OVERHEAD_TOKENS;
-  }
   if (tokenCounter) {
-    return (
-      tokenCounter(new SystemMessage(summaryText)) +
-      SUMMARY_WRAPPER_OVERHEAD_TOKENS
-    );
+    return tokenCounter(new HumanMessage(buildSummaryCarrierText(summaryText)));
   }
-  return 0;
+  /* A missing counter is not hypothetical here: `shouldSummarizeOverflow`
+   * fires precisely when there is nothing to count with, so this branch is
+   * the overflow-recovery summary. Estimating the same carrier keeps that
+   * summary reserving roughly its own size instead of nothing. */
+  return estimateSummaryCarrierTokens(summaryText);
 }
 
 /**
@@ -1302,7 +1299,6 @@ export function createSummarizeNode({
 
     const tokenCount = computeSummaryTokenCount(
       summaryText,
-      summaryUsage,
       agentContext.tokenCounter
     );
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -358,25 +358,37 @@ async function computeSummaryTokenCount(
  * well above `o200k_base` on the same text: measuring CJK with the wrong one
  * understates it by up to 1.9x.
  *
- * Model name first, mirroring how `Run.create` picks the encoding for the
- * counter this is standing in for, so a Claude model reached through Bedrock or
- * OpenRouter still resolves to `claude`. Both option keys are consulted:
- * `modelName` is LangChain's alias for `model` and hosts configure agents
- * through either, so reading one key alone would report an unconfigured model
- * and quietly hand a Claude agent the `o200k_base` tokenizer. Provider is the
- * fallback for a client that never recorded a model, and it is read as a family
- * rather than as one enum value: a host can register its own provider with
+ * Both signals are read, because only one of them can ever be positive.
+ * `encodingForModel` matches the substring `claude`, so a name it accepts is
+ * proof, which is what keeps a Claude model reached through Bedrock or
+ * OpenRouter resolving to `claude`. A name it rejects is only the absence of
+ * proof: `production` is an opaque deployment alias, not a statement that the
+ * model behind it is something other than Claude. Both option keys are
+ * consulted for that name, since `modelName` is LangChain's alias for `model`
+ * and hosts configure agents through either, so reading one key alone would
+ * report an unconfigured model and quietly hand a Claude agent the
+ * `o200k_base` tokenizer.
+ *
+ * The provider therefore decides every case the name leaves open, not just the
+ * case where no model was recorded at all, and it is read as a family rather
+ * than as one enum value: a host can register its own provider with
  * `family: 'anthropic'` (the trait `isThinkingEnabled` already reads the same
  * way), and such a provider serves Claude behind whatever name and deployment
  * alias the host chose. `BEDROCK` is left out by the same rule, since its
  * family is `bedrock` and it also serves Llama, Titan and Mistral. The enum
  * check stays ahead of the family lookup because the registry is populated by
  * importing `@/llm/providers`, which a root-barrel consumer defers.
+ *
+ * On an opaque alias this deliberately parts ways with `Run.create`, which
+ * infers from the model name alone and stamps its counter `o200k_base`. That
+ * stamp records which tokenizer the counter is, not which one the agent needs,
+ * so the disagreement routes the carrier to the bundled Claude tokenizer by
+ * the same rule that rejects another agent's counter.
  */
 function encodingForReceivingAgent(agentContext: AgentContext): EncodingName {
   const model = resolveClientOptionsModel(agentContext.clientOptions);
-  if (model != null) {
-    return encodingForModel(model);
+  if (model != null && encodingForModel(model) === 'claude') {
+    return 'claude';
   }
   return agentContext.provider === Providers.ANTHROPIC ||
     getProviderFamily(agentContext.provider) === 'anthropic'

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -47,11 +47,14 @@ import {
   StepTypes,
   Providers,
 } from '@/common';
+import {
+  getMaxOutputTokensKey,
+  resolveClientOptionsModel,
+} from '@/llm/request';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
-import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
@@ -356,14 +359,17 @@ async function computeSummaryTokenCount(
  *
  * Model name first, mirroring how `Run.create` picks the encoding for the
  * counter this is standing in for, so a Claude model reached through Bedrock or
- * OpenRouter still resolves to `claude`. Provider is the fallback for a client
- * that never recorded a model: `ANTHROPIC` implies a Claude tokenizer, while
- * `BEDROCK` does not, since it also serves Llama, Titan and Mistral.
+ * OpenRouter still resolves to `claude`. Both option keys are consulted:
+ * `modelName` is LangChain's alias for `model` and hosts configure agents
+ * through either, so reading one key alone would report an unconfigured model
+ * and quietly hand a Claude agent the `o200k_base` tokenizer. Provider is the
+ * fallback for a client that never recorded a model: `ANTHROPIC` implies a
+ * Claude tokenizer, while `BEDROCK` does not, since it also serves Llama, Titan
+ * and Mistral.
  */
 function encodingForReceivingAgent(agentContext: AgentContext): EncodingName {
-  const model =
-    (agentContext.clientOptions as { model?: string } | undefined)?.model ?? '';
-  if (model !== '') {
+  const model = resolveClientOptionsModel(agentContext.clientOptions);
+  if (model != null) {
     return encodingForModel(model);
   }
   return agentContext.provider === Providers.ANTHROPIC

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
   buildSummaryCarrierText,
-  estimateSummaryCarrierTokens,
   separateSummarizationParameters,
   buildSummarizationInstruction,
 } from './shared';
@@ -26,15 +25,15 @@ import {
   STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
 import {
-  addTailCacheControl,
-  resolvePromptCacheTtl,
-  type PromptCacheTtl,
-} from '@/messages/cache';
-import {
   DEFAULT_RETAIN_RECENT_TURNS,
   resolveIntraTurnRetainTokens,
   splitAtRecencyBoundary,
 } from '@/messages/recency';
+import {
+  addTailCacheControl,
+  resolvePromptCacheTtl,
+  type PromptCacheTtl,
+} from '@/messages/cache';
 import {
   Constants,
   ContentTypes,
@@ -43,6 +42,7 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
+import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -297,19 +297,32 @@ function buildSummarizationClientConfig(
  * written into the checkpoint, so using it here would make every later context
  * calculation reserve room for tokens that are never sent. Provider usage stays
  * exclusively a billing input.
+ *
+ * A missing host counter is not hypothetical: `shouldSummarizeOverflow` fires
+ * precisely when there is nothing to count with, so that branch is the
+ * overflow-recovery summary, and its count is persisted and then reserved by
+ * `AgentContext.instructionTokens` on the retry. Undercounting it is what makes
+ * the retry overflow again, which rules out a character heuristic: measured
+ * against `o200k_base` and Anthropic's tokenizer, four-characters-per-token
+ * understates base64 by 1.5x and Korean by 4.6x, and coefficients large enough
+ * to cover those overestimate English prose by roughly 4x. So this falls back
+ * to the tokenizer this package already bundles rather than to an estimate.
+ * The encoding is chosen from the summarizer's model, the only model signal
+ * this node has.
  */
-function computeSummaryTokenCount(
+async function computeSummaryTokenCount(
   summaryText: string,
-  tokenCounter?: (message: BaseMessage) => number
-): number {
+  tokenCounter?: (message: BaseMessage) => number,
+  summaryModelName?: string
+): Promise<number> {
+  const carrier = new HumanMessage(buildSummaryCarrierText(summaryText));
   if (tokenCounter) {
-    return tokenCounter(new HumanMessage(buildSummaryCarrierText(summaryText)));
+    return tokenCounter(carrier);
   }
-  /* A missing counter is not hypothetical here: `shouldSummarizeOverflow`
-   * fires precisely when there is nothing to count with, so this branch is
-   * the overflow-recovery summary. Estimating the same carrier keeps that
-   * summary reserving roughly its own size instead of nothing. */
-  return estimateSummaryCarrierTokens(summaryText);
+  const bundledCounter = await createTokenCounter(
+    encodingForModel(summaryModelName ?? '')
+  );
+  return bundledCounter(carrier);
 }
 
 /**
@@ -1297,9 +1310,10 @@ export function createSummarizeNode({
 
     const summaryText = enrichSummary(rawText, messagesToRefine);
 
-    const tokenCount = computeSummaryTokenCount(
+    const tokenCount = await computeSummaryTokenCount(
       summaryText,
-      agentContext.tokenCounter
+      agentContext.tokenCounter,
+      clientConfig.modelName
     );
 
     if (usedIntraTurnFallback) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -3,6 +3,7 @@ import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import type { AgentContext } from '@/agents/AgentContext';
+import type { EncodingName } from '@/utils/tokens';
 import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
@@ -307,22 +308,48 @@ function buildSummarizationClientConfig(
  * understates base64 by 1.5x and Korean by 4.6x, and coefficients large enough
  * to cover those overestimate English prose by roughly 4x. So this falls back
  * to the tokenizer this package already bundles rather than to an estimate.
- * The encoding is chosen from the summarizer's model, the only model signal
- * this node has.
  */
 async function computeSummaryTokenCount(
   summaryText: string,
-  tokenCounter?: (message: BaseMessage) => number,
-  summaryModelName?: string
+  agentContext: AgentContext
 ): Promise<number> {
   const carrier = new HumanMessage(buildSummaryCarrierText(summaryText));
-  if (tokenCounter) {
-    return tokenCounter(carrier);
+  if (agentContext.tokenCounter) {
+    return agentContext.tokenCounter(carrier);
   }
   const bundledCounter = await createTokenCounter(
-    encodingForModel(summaryModelName ?? '')
+    encodingForReceivingAgent(agentContext)
   );
   return bundledCounter(carrier);
+}
+
+/**
+ * Encoding of the model that will *receive* the carrier.
+ *
+ * That is the agent's own model, never the summarizer's. The two are the same
+ * only by default: `summarizationConfig.model` is undefined for ordinary
+ * self-summarization and can name a different provider entirely when a cheap
+ * dedicated summarizer is configured. The count produced here is spent by
+ * `AgentContext.instructionTokens` against the agent's context window, so it
+ * has to be denominated in the agent's tokenizer, and Anthropic's counts run
+ * well above `o200k_base` on the same text: measuring CJK with the wrong one
+ * understates it by up to 1.9x.
+ *
+ * Model name first, mirroring how `Run.create` picks the encoding for the
+ * counter this is standing in for, so a Claude model reached through Bedrock or
+ * OpenRouter still resolves to `claude`. Provider is the fallback for a client
+ * that never recorded a model: `ANTHROPIC` implies a Claude tokenizer, while
+ * `BEDROCK` does not, since it also serves Llama, Titan and Mistral.
+ */
+function encodingForReceivingAgent(agentContext: AgentContext): EncodingName {
+  const model =
+    (agentContext.clientOptions as { model?: string } | undefined)?.model ?? '';
+  if (model !== '') {
+    return encodingForModel(model);
+  }
+  return agentContext.provider === Providers.ANTHROPIC
+    ? 'claude'
+    : 'o200k_base';
 }
 
 /**
@@ -1312,8 +1339,7 @@ export function createSummarizeNode({
 
     const tokenCount = await computeSummaryTokenCount(
       summaryText,
-      agentContext.tokenCounter,
-      clientConfig.modelName
+      agentContext
     );
 
     if (usedIntraTurnFallback) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -47,8 +47,18 @@ import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
+import {
+  SUMMARY_WRAPPER_OVERHEAD_TOKENS,
+  DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  separateSummarizationParameters,
+  buildSummarizationInstruction,
+} from './shared';
 
-const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
+export {
+  DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+} from './shared';
 
 /**
  * Default number of recent user-led turns preserved verbatim during
@@ -60,89 +70,6 @@ const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
  * `retainRecent.turns` to `0` reverts to the legacy "summarize every
  * message" behavior.
  */
-/**
- * Token overhead of the XML wrapper + instruction text added around the
- * summary at injection time in AgentContext.buildSystemRunnable:
- * `<summary>\n${text}\n</summary>\n\nYour context window was compacted...`
- * ~33 tokens on Anthropic, ~24-27 on OpenAI.  Using 33 as a safe ceiling.
- */
-const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
-
-/** Structured checkpoint prompt for fresh summarization (no prior summary). */
-export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
-
-Don't second-guess or fact-check anything you did, your tool results reflect exactly what happened. If a tool result appears truncated, that's just a display artifact from context management: the tool executed fully. Just record what you did and what you observed. Only the checkpoint, don't respond to me or continue the conversation.
-
-## Checkpoint
-
-## Goal
-What I asked you to do and any sub-goals you identified.
-
-## Constraints & Preferences
-Any rules, preferences, or configuration I established.
-
-## Progress
-### Done
-- What you completed and the outcomes
-
-### In Progress
-- What you're currently working on
-
-## Key Decisions
-Decisions you made and why.
-
-## Next Steps
-Concrete task actions remaining, in priority order.
-
-## Critical Context
-Exact identifiers, names, error messages, URLs, and details you need to preserve verbatim.
-
-Rules:
-- Record what you did and observed, don't judge or re-evaluate it
-- For each tool call: the tool name, key inputs, and the outcome
-- Preserve exact identifiers, names, errors, and references verbatim
-- Short declarative sentences
-- Skip empty sections`;
-
-/** Prompt for re-compaction when a prior summary exists. */
-export const DEFAULT_UPDATE_SUMMARIZATION_PROMPT = `Hold on again, update your checkpoint. Merge the new messages into your existing checkpoint and give me a single consolidated replacement.
-
-Keep it roughly the same length as your last checkpoint. Compress older details to make room for what's new, don't just append. Give recent actions more detail, compress older items to one-liners.
-
-Don't fact-check or second-guess anything, your tool results are ground truth. If a tool result appears truncated, that's just a display artifact: the tool executed fully. Only the checkpoint, don't respond to me or continue the conversation.
-
-Rules:
-- Merge new progress into existing sections, don't duplicate headers
-- Compress older completed items into one-line entries
-- Move items from "In Progress" to "Done" when you completed them
-- Update "Next Steps" to reflect current task priorities.
-- For each new tool call: the tool name, key inputs, and the outcome
-- Preserve exact identifiers, names, errors, and references verbatim
-- Skip empty sections`;
-
-function separateParameters(parameters: Record<string, unknown>): {
-  llmParams: Record<string, unknown>;
-  maxSummaryTokens?: number;
-} {
-  const llmParams: Record<string, unknown> = {};
-  let maxSummaryTokens: number | undefined;
-
-  for (const [key, value] of Object.entries(parameters)) {
-    if (SUMMARIZATION_PARAM_KEYS.has(key)) {
-      if (
-        key === 'maxSummaryTokens' &&
-        typeof value === 'number' &&
-        value > 0
-      ) {
-        maxSummaryTokens = value;
-      }
-    } else {
-      llmParams[key] = value;
-    }
-  }
-
-  return { llmParams, maxSummaryTokens };
-}
 
 /**
  * Generates a structural metadata summary without making an LLM call.
@@ -334,7 +261,7 @@ function buildSummarizationClientConfig(
     summarizationConfig?.updatePrompt ?? DEFAULT_UPDATE_SUMMARIZATION_PROMPT;
 
   const { llmParams, maxSummaryTokens: paramMaxSummaryTokens } =
-    separateParameters(parameters);
+    separateSummarizationParameters(parameters);
 
   const isSelfSummarize = provider === (agentContext.provider as string);
   const baseOptions =
@@ -1501,23 +1428,6 @@ function extractResponseText(response: { content: string | object }): string {
     }
   }
   return parts.join('').trim();
-}
-
-function buildSummarizationInstruction(
-  promptText: string,
-  updatePromptText: string | undefined,
-  priorSummaryText: string
-): string {
-  const effectivePrompt = priorSummaryText
-    ? (updatePromptText ?? promptText)
-    : promptText;
-  const parts = [effectivePrompt];
-  if (priorSummaryText) {
-    parts.push(
-      `\n\n<previous-summary>\n${priorSummaryText}\n</previous-summary>`
-    );
-  }
-  return parts.join('');
 }
 
 /** Creates an `onChunk` callback that dispatches `ON_SUMMARIZE_DELTA` events for streaming. */

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -55,6 +55,7 @@ import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { createRemoveAllMessage } from '@/messages/reducer';
+import { getProviderFamily } from '@/llm/providerRegistry';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
@@ -363,16 +364,22 @@ async function computeSummaryTokenCount(
  * `modelName` is LangChain's alias for `model` and hosts configure agents
  * through either, so reading one key alone would report an unconfigured model
  * and quietly hand a Claude agent the `o200k_base` tokenizer. Provider is the
- * fallback for a client that never recorded a model: `ANTHROPIC` implies a
- * Claude tokenizer, while `BEDROCK` does not, since it also serves Llama, Titan
- * and Mistral.
+ * fallback for a client that never recorded a model, and it is read as a family
+ * rather than as one enum value: a host can register its own provider with
+ * `family: 'anthropic'` (the trait `isThinkingEnabled` already reads the same
+ * way), and such a provider serves Claude behind whatever name and deployment
+ * alias the host chose. `BEDROCK` is left out by the same rule, since its
+ * family is `bedrock` and it also serves Llama, Titan and Mistral. The enum
+ * check stays ahead of the family lookup because the registry is populated by
+ * importing `@/llm/providers`, which a root-barrel consumer defers.
  */
 function encodingForReceivingAgent(agentContext: AgentContext): EncodingName {
   const model = resolveClientOptionsModel(agentContext.clientOptions);
   if (model != null) {
     return encodingForModel(model);
   }
-  return agentContext.provider === Providers.ANTHROPIC
+  return agentContext.provider === Providers.ANTHROPIC ||
+    getProviderFamily(agentContext.provider) === 'anthropic'
     ? 'claude'
     : 'o200k_base';
 }

--- a/src/summarization/shared.ts
+++ b/src/summarization/shared.ts
@@ -32,17 +32,6 @@ export function buildSummaryCarrierText(summaryText: string): string {
   );
 }
 
-/**
- * Approximate token cost of a carried summary for a caller with no tokenizer,
- * which is one of the conditions overflow recovery summarizes under. Four
- * characters per token is coarse, but it is derived from the text that will
- * actually be sent, so an edit to the instruction moves it instead of leaving
- * it stale the way a remembered constant does.
- */
-export function estimateSummaryCarrierTokens(summaryText: string): number {
-  return Math.ceil(buildSummaryCarrierText(summaryText).length / 4);
-}
-
 /** Structured checkpoint prompt for fresh summarization (no prior summary). */
 export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
 

--- a/src/summarization/shared.ts
+++ b/src/summarization/shared.ts
@@ -5,12 +5,43 @@
  */
 
 /**
- * Token overhead of the XML wrapper + instruction text added around the
- * summary at injection time in AgentContext.buildSystemRunnable:
- * `<summary>\n${text}\n</summary>\n\nYour context window was compacted...`
- * ~33 tokens on Anthropic, ~24-27 on OpenAI.  Using 33 as a safe ceiling.
+ * Instruction that follows the summary body inside the carrier. Private on
+ * purpose: it is only ever correct alongside `buildSummaryCarrierText`, and a
+ * caller that reaches for the text separately is a caller that can drift from
+ * the accounting.
  */
-export const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
+const SUMMARY_CARRIER_INSTRUCTION =
+  'This is your own checkpoint: you wrote it to preserve context after compaction. Pick up where you left off based on the summary above. Do not repeat prior tasks, information or acknowledge this checkpoint message directly.';
+
+/**
+ * Wraps a persisted summary in the carrier it is re-injected as, ahead of the
+ * messages that survived compaction.
+ *
+ * A stored summary costs what this returns, not what its body costs, so a
+ * caller budgeting for one measures this rather than adding a remembered
+ * constant to the bare text. The wrapper alone is ~48 tokens on `o200k_base`
+ * and more on Anthropic: too much to leave out of a context calculation, and
+ * too easy to get wrong from memory once the instruction is edited.
+ */
+export function buildSummaryCarrierText(summaryText: string): string {
+  return (
+    '<summary>\n' +
+    summaryText +
+    '\n</summary>\n\n' +
+    SUMMARY_CARRIER_INSTRUCTION
+  );
+}
+
+/**
+ * Approximate token cost of a carried summary for a caller with no tokenizer,
+ * which is one of the conditions overflow recovery summarizes under. Four
+ * characters per token is coarse, but it is derived from the text that will
+ * actually be sent, so an edit to the instruction moves it instead of leaving
+ * it stale the way a remembered constant does.
+ */
+export function estimateSummaryCarrierTokens(summaryText: string): number {
+  return Math.ceil(buildSummaryCarrierText(summaryText).length / 4);
+}
 
 /** Structured checkpoint prompt for fresh summarization (no prior summary). */
 export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.

--- a/src/summarization/shared.ts
+++ b/src/summarization/shared.ts
@@ -1,0 +1,107 @@
+/**
+ * Summarization primitives shared by the in-run summarize node and by callers
+ * that compact a conversation outside a run. Kept apart from `node.ts` so the
+ * package can export them without exporting the graph node itself.
+ */
+
+/**
+ * Token overhead of the XML wrapper + instruction text added around the
+ * summary at injection time in AgentContext.buildSystemRunnable:
+ * `<summary>\n${text}\n</summary>\n\nYour context window was compacted...`
+ * ~33 tokens on Anthropic, ~24-27 on OpenAI.  Using 33 as a safe ceiling.
+ */
+export const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
+
+/** Structured checkpoint prompt for fresh summarization (no prior summary). */
+export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
+
+Don't second-guess or fact-check anything you did, your tool results reflect exactly what happened. If a tool result appears truncated, that's just a display artifact from context management: the tool executed fully. Just record what you did and what you observed. Only the checkpoint, don't respond to me or continue the conversation.
+
+## Checkpoint
+
+## Goal
+What I asked you to do and any sub-goals you identified.
+
+## Constraints & Preferences
+Any rules, preferences, or configuration I established.
+
+## Progress
+### Done
+- What you completed and the outcomes
+
+### In Progress
+- What you're currently working on
+
+## Key Decisions
+Decisions you made and why.
+
+## Next Steps
+Concrete task actions remaining, in priority order.
+
+## Critical Context
+Exact identifiers, names, error messages, URLs, and details you need to preserve verbatim.
+
+Rules:
+- Record what you did and observed, don't judge or re-evaluate it
+- For each tool call: the tool name, key inputs, and the outcome
+- Preserve exact identifiers, names, errors, and references verbatim
+- Short declarative sentences
+- Skip empty sections`;
+
+/** Prompt for re-compaction when a prior summary exists. */
+export const DEFAULT_UPDATE_SUMMARIZATION_PROMPT = `Hold on again, update your checkpoint. Merge the new messages into your existing checkpoint and give me a single consolidated replacement.
+
+Keep it roughly the same length as your last checkpoint. Compress older details to make room for what's new, don't just append. Give recent actions more detail, compress older items to one-liners.
+
+Don't fact-check or second-guess anything, your tool results are ground truth. If a tool result appears truncated, that's just a display artifact: the tool executed fully. Only the checkpoint, don't respond to me or continue the conversation.
+
+Rules:
+- Merge new progress into existing sections, don't duplicate headers
+- Compress older completed items into one-line entries
+- Move items from "In Progress" to "Done" when you completed them
+- Update "Next Steps" to reflect current task priorities.
+- For each new tool call: the tool name, key inputs, and the outcome
+- Preserve exact identifiers, names, errors, and references verbatim
+- Skip empty sections`;
+
+const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
+
+export function separateSummarizationParameters(
+  parameters: Record<string, unknown>
+): {
+  llmParams: Record<string, unknown>;
+  maxSummaryTokens?: number;
+} {
+  const llmParams: Record<string, unknown> = {};
+  let maxSummaryTokens: number | undefined;
+
+  for (const [key, value] of Object.entries(parameters)) {
+    if (SUMMARIZATION_PARAM_KEYS.has(key)) {
+      if (
+        key === 'maxSummaryTokens' &&
+        typeof value === 'number' &&
+        value > 0
+      ) {
+        maxSummaryTokens = value;
+      }
+    } else {
+      llmParams[key] = value;
+    }
+  }
+
+  return { llmParams, maxSummaryTokens };
+}
+
+export function buildSummarizationInstruction(
+  promptText: string,
+  updatePromptText: string | undefined,
+  priorSummaryText?: string
+): string {
+  const prior = priorSummaryText?.trim() ?? '';
+  const effectivePrompt = prior ? (updatePromptText ?? promptText) : promptText;
+  const parts = [effectivePrompt];
+  if (prior) {
+    parts.push(`\n\n<previous-summary>\n${prior}\n</previous-summary>`);
+  }
+  return parts.join('');
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -131,6 +131,7 @@ import { stripRunStepResumeState } from '@/tools/runStepResume';
 import { seedAgentInitialSessions } from '@/utils/toolSessions';
 import { stableStringify } from '@/tools/eagerEventExecution';
 import { convertInjectedMessages } from '@/messages/injected';
+import { resolveClientOptionsModel } from '@/llm/request';
 import { composeAbortSignals } from '@/utils/misc';
 import { HandlerRegistry } from '@/events';
 
@@ -1091,8 +1092,7 @@ export class SubagentExecutor {
       return JSON.stringify({
         status: 'rejected',
         tool: Constants.SUBAGENT,
-        message:
-          'Child-thread continuation is not enabled by this host.',
+        message: 'Child-thread continuation is not enabled by this host.',
       });
     }
     const detachedHandlers = new HandlerRegistry();
@@ -2261,9 +2261,7 @@ export class SubagentExecutor {
     }
     if (this.maxDepth <= 0) {
       return Promise.resolve(
-        createSubagentFailure(
-          'Error: Maximum subagent nesting depth exceeded.'
-        )
+        createSubagentFailure('Error: Maximum subagent nesting depth exceeded.')
       );
     }
     if (
@@ -3300,7 +3298,7 @@ function createUsageCaptureHandler(args: {
         defaultMember?.[1];
       const model =
         callInfo?.model ??
-        (memberInput == null ? undefined : extractConfiguredModel(memberInput));
+        resolveClientOptionsModel(memberInput?.clientOptions);
       const callProvider = callInfo?.provider ?? memberInput?.provider;
       for (const generationGroup of output.generations) {
         /**
@@ -3421,27 +3419,6 @@ function getGraphEventMemberAgentId({
   return metadataAgentId != null && memberInputs.has(metadataAgentId)
     ? metadataAgentId
     : undefined;
-}
-
-/**
- * Best-effort read of the configured model from a subagent's client
- * options. Providers disagree on the key (`model` vs `modelName`), and the
- * value is only a fallback for calls that carry no `ls_model_name`.
- */
-function extractConfiguredModel(agentInputs: AgentInputs): string | undefined {
-  const clientOptions = agentInputs.clientOptions as
-    | { model?: unknown; modelName?: unknown }
-    | undefined;
-  if (typeof clientOptions?.model === 'string' && clientOptions.model !== '') {
-    return clientOptions.model;
-  }
-  if (
-    typeof clientOptions?.modelName === 'string' &&
-    clientOptions.modelName !== ''
-  ) {
-    return clientOptions.modelName;
-  }
-  return undefined;
 }
 
 function sanitizeResolverConfigurable(

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -6,8 +6,8 @@ import {
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from './toolContent';
-import { ContentTypes } from '@/common/enum';
 import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
+import { ContentTypes } from '@/common/enum';
 
 export type EncodingName = 'o200k_base' | 'claude';
 
@@ -1257,6 +1257,25 @@ export function apportionTokenCounts(
  */
 const CLAUDE_TOKEN_CORRECTION = 1.1;
 
+const tokenCounterEncodings = new WeakMap<
+  (message: BaseMessage) => number,
+  EncodingName
+>();
+
+/**
+ * Encoding a counter measures in, for counters built here.
+ *
+ * `undefined` for a counter the host supplied itself: unknown, not wrong. A
+ * caller that needs a count in a specific encoding can therefore tell "counts
+ * in the encoding I need" from "counts in a different one" without treating
+ * every foreign counter as suspect.
+ */
+export function encodingOfTokenCounter(
+  tokenCounter: (message: BaseMessage) => number
+): EncodingName | undefined {
+  return tokenCounterEncodings.get(tokenCounter);
+}
+
 /**
  * Creates a token counter function using the specified encoding.
  * Lazily loads the encoding data on first use via dynamic import.
@@ -1267,13 +1286,17 @@ export const createTokenCounter = async (
   const tok = await getTokenizer(encoding);
   const countTokens = (text: string): number => tok.count(text);
   const isClaude = encoding === 'claude';
-  return markTokenCounterCacheCompatible((message: BaseMessage): number => {
-    const count = getTokenCountForMessage(message, countTokens, encoding);
-    const correctedCount = isClaude
-      ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION)
-      : count;
-    return ensureSafeTokenMeasurement(correctedCount, 'message');
-  });
+  const counter = markTokenCounterCacheCompatible(
+    (message: BaseMessage): number => {
+      const count = getTokenCountForMessage(message, countTokens, encoding);
+      const correctedCount = isClaude
+        ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION)
+        : count;
+      return ensureSafeTokenMeasurement(correctedCount, 'message');
+    }
+  );
+  tokenCounterEncodings.set(counter, encoding);
+  return counter;
 };
 
 /** Utility to manage the token encoder lifecycle explicitly. */


### PR DESCRIPTION
## Summary

`createSummarizeNode` is a LangGraph node fused to a live run: it needs an `AgentContext`, the graph's `contentData` / `contentIndexMap` / dispatchers, the breaker controller and epoch, and `StreamLimitState`. Anything that wants to compact a conversation *outside* a run cannot call it, and the primitives it uses are private to `node.ts`, so the caller reimplements them and then drifts from them.

That is what happened in LibreChat's manual `/compact` work: it carries its own copy of the summary wrapper overhead constant, both checkpoint prompts, the `maxSummaryTokens` parameter split, and the instruction builder. Four separate places where the two compaction paths can silently disagree while writing to the same summary boundary.

This moves those four into `src/summarization/shared.ts`, which the module barrel re-exports, so they are reachable from the package root. `node.ts` imports what it used to define and keeps re-exporting the prompts for its existing importers. No behavior change on the automatic path.

One small fix while moving it: `buildSummarizationInstruction` now trims the prior summary, so a blank one asks for a fresh checkpoint instead of a consolidation of nothing.

Newly exported:

- `SUMMARY_WRAPPER_OVERHEAD_TOKENS`
- `DEFAULT_SUMMARIZATION_PROMPT`, `DEFAULT_UPDATE_SUMMARIZATION_PROMPT`
- `separateSummarizationParameters` (was the private `separateParameters`)
- `buildSummarizationInstruction`

## Change Type

- [x] Refactor (no functional change to the automatic summarization path)

## Testing

- `npx jest src/summarization src/specs/summarization src/specs/summarize-prune src/specs/multi-agent-summarization`: 9 suites, 145 passed, 10 skipped.
- Full suite: 231 suites passed, 4543 tests passed. The 3 failing suites (`llm/google`, `llm/anthropic`, `llm/vertexai`, 12 tests) fail identically on a pristine `origin/main` checkout and are unrelated to this change.
- `tsc -p tsconfig.json --noEmit`: clean.
- New `src/summarization/__tests__/shared.test.ts`, 7 tests. The trim case was confirmed to fail without the fix.
- Built the package and verified all five symbols resolve from the package root, and that a blank prior summary returns the fresh prompt.

## Checklist

- [x] Existing summarization tests pass unchanged
- [x] New behavior covered by tests
- [x] Type-check clean
