### PR TITLE
🚀 v3.6.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.6.11",
+      "version": "3.6.12",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
I bumped `@librechat/agents` from `3.6.11` to `3.6.12` following the same release pattern as the prior version commit.

- Updated the package version in `package.json`.
- Updated the root package and workspace version entries in `package-lock.json`.
- Kept the change limited to the two established release surfaces.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Parsed `package.json` and `package-lock.json` with Node.js and verified all root version surfaces equal `3.6.12`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2-compatible workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local verification passes with my changes
