### PR TITLE
🧮 perf: Reuse Exact Context Counts Across Provider Requests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,8 +62,16 @@ A **Context Pressure Meter** is the request-scoped projection of retained
 conversation messages into the provider's available context budget. It keeps
 provider-grounded attribution and exact token counts together so repeated
 artifact, compaction, prepared-request, and fallback probes tokenize only new
-message objects. Provider projections must clone changed messages; mutating a
-measured message would invalidate its exact cached count.
+message objects. Its Agent Context may retain exact counts across provider
+requests only for stable string-content messages whose token-relevant surface
+still matches.
+Mutable or ambiguous message shapes are recounted. Provider projections must
+clone changed messages; mutating a measured message invalidates its retained
+count on the next comparison. Custom token counters remain uncached unless a
+host explicitly declares that they implement the same deterministic surface
+contract.
+See [ADR 0001](docs/adr/0001-reuse-exact-context-token-counts.md) for the
+cache boundary and host-lifecycle trade-offs.
 
 The meter's estimates decide overflow and recovery only. Provider-reported
 usage remains the source of truth for billing and Langfuse observations.

--- a/docs/adr/0001-reuse-exact-context-token-counts.md
+++ b/docs/adr/0001-reuse-exact-context-token-counts.md
@@ -1,0 +1,45 @@
+# ADR 0001: Reuse Exact Context Token Counts Conservatively
+
+## Status
+
+Accepted
+
+## Context
+
+Context-pressure measurement creates a new meter for each provider request.
+Within agent tool loops, most retained messages are unchanged, but each new
+meter previously tokenized the entire retained history again. Provider
+attribution, calibration, and overflow decisions must remain request-scoped,
+and message objects can contain mutable structured content or metadata.
+Callers may also provide custom token counters with semantics the library does
+not know.
+
+## Decision
+
+`AgentContext` retains a weakly referenced cache of exact per-message counts
+for the built-in tokenizer factory and explicitly compatible host counters. A
+request-scoped context-pressure meter uses this as a second-level cache while
+preserving its existing local cache and all request-specific accounting.
+
+A count is reusable only for a non-proxy message with string content and a
+stable token-relevant surface. The cache compares content, message type, role,
+assistant tool-call state, legacy function-call state, and tool provider type
+before every reuse. Structured content, accessors, proxies, and tool calls
+remain on the exact recount path. Custom token counters are uncached unless a
+host explicitly marks them compatible with the built-in deterministic surface
+contract.
+
+## Consequences
+
+- Retained string messages are tokenized once per `AgentContext`, reducing
+  repeated tokenizer work in multi-step model/tool loops.
+- Mutation, replacement, reordering, compaction, and provider projection keep
+  the same measured results because aggregate accounting is never persisted.
+- The weak map does not keep discarded messages alive.
+- Hosts that reconstruct graphs between HTTP requests need a separate,
+  serialization-safe cache keyed by tokenizer version and message content to
+  reuse counts across those requests.
+- Hosts can opt a wrapper around the built-in counting semantics into reuse;
+  marking a stateful or wider custom counter would violate the cache contract.
+- New token-relevant fields in the built-in counter must be added to the stable
+  surface before affected messages can remain cacheable.

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/search.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
+    "bench:context-pressure": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-context-pressure-cache.ts",
     "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -8,6 +8,7 @@ import type {
 } from '@langchain/core/messages';
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type * as t from '@/types';
+import type { ExactTokenCountCache } from '@/llm/contextPressureMeter';
 import {
   addTailCacheControl,
   addCacheControlToStablePrefixMessages,
@@ -51,6 +52,8 @@ import {
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isThinkingEnabled } from '@/llm/request';
+import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { isTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 import { toJsonSchema } from '@/utils/schema';
 
 type AgentSystemTextBlock = {
@@ -235,6 +238,8 @@ export class AgentContext {
   pruneMessages?: ReturnType<typeof createPruneMessages>;
   /** Token counter function for this agent */
   tokenCounter?: t.TokenCounter;
+  /** Exact stable-message counts reused by request-scoped context-pressure meters. */
+  readonly contextPressureTokenCounts?: ExactTokenCountCache;
   /** Token count for the system message (instructions text). */
   systemMessageTokens: number = 0;
   /** Token count for instruction text emitted outside the system message. */
@@ -460,6 +465,10 @@ export class AgentContext {
     this.maxContextTokens = maxContextTokens;
     this.streamBuffer = streamBuffer;
     this.tokenCounter = tokenCounter;
+    this.contextPressureTokenCounts =
+      tokenCounter != null && isTokenCounterCacheCompatible(tokenCounter)
+        ? createExactTokenCountCache(tokenCounter)
+        : undefined;
     this.tools = tools;
     this.toolMap = toolMap;
     this.toolRegistry = resolveLocalToolRegistry({

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -3,6 +3,8 @@ import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { addBedrockCacheControl } from '@/messages/cache';
 import { Constants, Providers } from '@/common';
+import { createTokenCounter } from '@/utils/tokens';
+import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 import { AgentContext } from '../AgentContext';
 
 describe('AgentContext', () => {
@@ -1924,6 +1926,35 @@ describe('AgentContext', () => {
   });
 
   describe('reset()', () => {
+    it('retains the stable-message token cache across resets', async () => {
+      const tokenCounter = await createTokenCounter();
+      const ctx = createBasicContext({ tokenCounter });
+      const tokenCountCache = ctx.contextPressureTokenCounts;
+
+      ctx.reset();
+
+      expect(tokenCountCache).toBeDefined();
+      expect(ctx.contextPressureTokenCounts).toBe(tokenCountCache);
+    });
+
+    it('does not persist counts from an unmarked custom counter', () => {
+      const ctx = createBasicContext({ tokenCounter: () => 1 });
+
+      expect(ctx.contextPressureTokenCounts).toBeUndefined();
+    });
+
+    it('accepts an explicitly compatible host token counter', () => {
+      const tokenCounter = markTokenCounterCacheCompatible(jest.fn(() => 1));
+      const ctx = createBasicContext({ tokenCounter });
+      const message = new HumanMessage('stable');
+      tokenCounter.mockClear();
+
+      ctx.contextPressureTokenCounts?.count(message);
+      ctx.contextPressureTokenCounts?.count(message);
+
+      expect(tokenCounter).toHaveBeenCalledTimes(1);
+    });
+
     it('clears all cached state', () => {
       const ctx = createBasicContext({ agentConfig: { instructions: 'Test' } });
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3157,6 +3157,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        */
       const contextPressure = createContextPressureMeter({
         tokenCounter: agentContext.tokenCounter,
+        tokenCountCache: agentContext.contextPressureTokenCounts,
         sourceMessages: messages,
         retainedMessages: messagesToUse,
         indexTokenCountMap: agentContext.indexTokenCountMap,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export {
 export type { Interrupt } from '@langchain/langgraph';
 
 /* LLM */
+export { markTokenCounterCacheCompatible } from './llm/tokenCounterCacheCompatibility';
 export { CustomOpenAIClient } from './llm/openai';
 export { ChatOpenRouter } from './llm/openrouter';
 export type {

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -1,9 +1,14 @@
-import { HumanMessage } from '@langchain/core/messages';
-
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-
+import {
+  createContextPressureMeter,
+  createExactTokenCountCache,
+} from './contextPressureMeter';
 import { stampSyntheticProviderMessage } from '@/messages';
-import { createContextPressureMeter } from './contextPressureMeter';
 
 function contentLength(message: BaseMessage): number {
   return typeof message.content === 'string'
@@ -47,6 +52,171 @@ describe('createContextPressureMeter', () => {
     });
     expect(meter.measure(projected).projectedMessageTokens).toBe(33);
     expect(tokenCounter).toHaveBeenCalledTimes(3);
+  });
+
+  it('reuses stable exact counts across request-scoped meters', () => {
+    const retained = Array.from(
+      { length: 100 },
+      (_, index) =>
+        new HumanMessage({ id: `message-${index}`, content: 'retained' })
+    );
+    const tokenCounter = jest.fn(contentLength);
+    const tokenCountCache = createExactTokenCountCache(tokenCounter);
+    const createMeter = (messages: BaseMessage[]) =>
+      createContextPressureMeter({
+        tokenCounter,
+        tokenCountCache,
+        sourceMessages: messages,
+        retainedMessages: messages,
+        indexTokenCountMap: Object.fromEntries(
+          messages.map((_, index) => [index, 8])
+        ),
+        contextUsage: {
+          contextBudget: 10_000,
+          effectiveInstructionTokens: 100,
+          remainingContextTokens: 9_000,
+          calibrationRatio: 1,
+        },
+        instructionTokens: 100,
+        calibrationRatio: 1,
+      });
+
+    createMeter(retained).measure(retained);
+    createMeter(retained).measure(retained);
+
+    const appended = [...retained, new HumanMessage('new')];
+    createMeter(appended).measure(appended);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(101);
+  });
+
+  it('recounts stable messages after a token-relevant mutation', () => {
+    const message = new HumanMessage('short');
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    expect(cache.count(message)).toBe(5);
+    message.content = 'longer content';
+    expect(cache.count(message)).toBe(14);
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps mutable complex messages on the exact recount path', () => {
+    const message = new HumanMessage({
+      content: [{ type: 'text', text: 'mutable' }],
+    });
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    cache.count(message);
+    cache.count(message);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops reusing an AI count when tool calls become mutable', () => {
+    const message = new AIMessage({ content: 'answer', tool_calls: [] });
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    cache.count(message);
+    message.tool_calls = new Proxy([], {});
+    cache.count(message);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('recounts a tool message when its provider type changes', () => {
+    const message = new ToolMessage({
+      content: 'result',
+      tool_call_id: 'call-1',
+    });
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    cache.count(message);
+    message.additional_kwargs.type = 'computer_call_output';
+    cache.count(message);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('recounts when provider metadata gains an accessor', () => {
+    const message = new HumanMessage('content');
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    cache.count(message);
+    Object.defineProperty(message.additional_kwargs, 'type', {
+      configurable: true,
+      get: () => 'computer_call_output',
+    });
+    cache.count(message);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('matches forced recounts across append, replace, reorder, and mutation', () => {
+    const first = new HumanMessage({ id: 'first', content: 'one' });
+    const second = new HumanMessage({ id: 'second', content: 'two' });
+    const third = new AIMessage({ id: 'third', content: 'three' });
+    const tokenCountCache = createExactTokenCountCache(contentLength);
+    const histories = [
+      [first, second],
+      [first, second, third],
+      [first, new HumanMessage({ id: 'replacement', content: 'replacement' })],
+      [second, first, third],
+    ];
+
+    for (const history of histories) {
+      const indexTokenCountMap = Object.fromEntries(
+        history.map((message, index) => [index, contentLength(message)])
+      );
+      const params = {
+        tokenCounter: contentLength,
+        sourceMessages: history,
+        retainedMessages: history,
+        indexTokenCountMap,
+        contextUsage: {
+          contextBudget: 100,
+          effectiveInstructionTokens: 10,
+          remainingContextTokens: 50,
+          calibrationRatio: 1.25,
+        },
+        instructionTokens: 10,
+        calibrationRatio: 1.25,
+      };
+      const cached = createContextPressureMeter({
+        ...params,
+        tokenCountCache,
+      }).measure(history);
+      const recounted = createContextPressureMeter(params).measure(history);
+
+      expect(cached).toEqual(recounted);
+    }
+
+    first.content = 'mutated after caching';
+    const mutatedParams = {
+      tokenCounter: contentLength,
+      sourceMessages: [first],
+      retainedMessages: [first],
+      indexTokenCountMap: { 0: contentLength(first) },
+      contextUsage: {
+        contextBudget: 100,
+        effectiveInstructionTokens: 10,
+        remainingContextTokens: 50,
+        calibrationRatio: 1.25,
+      },
+      instructionTokens: 10,
+      calibrationRatio: 1.25,
+    };
+
+    expect(
+      createContextPressureMeter({
+        ...mutatedParams,
+        tokenCountCache,
+      }).measure([first])
+    ).toEqual(createContextPressureMeter(mutatedParams).measure([first]));
   });
 
   it('tokenizes only changed candidates across a compaction search', () => {

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -1,6 +1,7 @@
+import { isProxy } from 'node:util/types';
 import { ToolMessage } from '@langchain/core/messages';
 
-import type { BaseMessage } from '@langchain/core/messages';
+import type { AIMessage, BaseMessage } from '@langchain/core/messages';
 import type { ProviderPayloadMeasurement } from '@/llm/prepareProviderRequest';
 import type * as t from '@/types';
 
@@ -19,6 +20,7 @@ interface ContextPressureUsage {
 
 interface ContextPressureMeterParams {
   tokenCounter?: t.TokenCounter;
+  tokenCountCache?: ExactTokenCountCache;
   sourceMessages: BaseMessage[];
   retainedMessages: BaseMessage[];
   indexTokenCountMap: Record<string, number | undefined>;
@@ -51,6 +53,164 @@ export interface ContextPressureMeter {
   ): ProviderPayloadMeasurement;
 }
 
+export interface ExactTokenCountCache {
+  count(message: BaseMessage): number;
+}
+
+interface StableTokenSurface {
+  content: string;
+  messageType: string;
+  role?: string;
+  additionalType?: string;
+}
+
+interface ExactTokenCountCacheEntry {
+  surface: StableTokenSurface;
+  tokens: number;
+}
+
+function readDataProperty(
+  owner: object,
+  property: PropertyKey
+): { own: boolean; safe: boolean; value?: unknown } {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(owner, property);
+  } catch {
+    return { own: false, safe: false };
+  }
+  if (descriptor == null) {
+    return { own: false, safe: true };
+  }
+  return 'value' in descriptor
+    ? { own: true, safe: true, value: descriptor.value }
+    : { own: true, safe: false };
+}
+
+function getStableTokenSurface(
+  message: BaseMessage
+): StableTokenSurface | undefined {
+  if (isProxy(message)) {
+    return undefined;
+  }
+  const contentProperty = readDataProperty(message, 'content');
+  if (
+    !contentProperty.safe ||
+    !contentProperty.own ||
+    typeof contentProperty.value !== 'string'
+  ) {
+    return undefined;
+  }
+  const messageType = message.getType();
+  const roleProperty = readDataProperty(message, 'role');
+  if (!roleProperty.safe || (!roleProperty.own && 'role' in message)) {
+    return undefined;
+  }
+  const role = roleProperty.value;
+  if (role != null && typeof role !== 'string') {
+    return undefined;
+  }
+
+  const additionalKwargsProperty = readDataProperty(
+    message,
+    'additional_kwargs'
+  );
+  if (!additionalKwargsProperty.safe || !additionalKwargsProperty.own) {
+    return undefined;
+  }
+  const rawAdditionalKwargs = additionalKwargsProperty.value;
+  if (
+    rawAdditionalKwargs == null ||
+    typeof rawAdditionalKwargs !== 'object' ||
+    isProxy(rawAdditionalKwargs)
+  ) {
+    return undefined;
+  }
+  const additionalKwargs = rawAdditionalKwargs;
+  const typeProperty = readDataProperty(additionalKwargs, 'type');
+  if (!typeProperty.safe) {
+    return undefined;
+  }
+  if (messageType === 'ai' || role === 'assistant') {
+    const toolCallsProperty = readDataProperty(
+      message as AIMessage,
+      'tool_calls'
+    );
+    if (
+      !toolCallsProperty.safe ||
+      (!toolCallsProperty.own && 'tool_calls' in message)
+    ) {
+      return undefined;
+    }
+    const toolCalls = toolCallsProperty.value;
+    if (
+      toolCalls != null &&
+      (!Array.isArray(toolCalls) || isProxy(toolCalls) || toolCalls.length > 0)
+    ) {
+      return undefined;
+    }
+    const functionCall = readDataProperty(additionalKwargs, 'function_call');
+    if (!functionCall.safe || functionCall.value != null) {
+      return undefined;
+    }
+  }
+
+  let additionalType: string | undefined;
+  if (messageType === 'tool') {
+    const typeValue = typeProperty.value;
+    if (typeValue != null && typeof typeValue !== 'string') {
+      return undefined;
+    }
+    additionalType = typeof typeValue === 'string' ? typeValue : undefined;
+  }
+
+  return {
+    content: contentProperty.value,
+    messageType,
+    ...(role != null && { role }),
+    ...(additionalType != null && { additionalType }),
+  };
+}
+
+function tokenSurfacesMatch(
+  left: StableTokenSurface,
+  right: StableTokenSurface
+): boolean {
+  return (
+    left.content === right.content &&
+    left.messageType === right.messageType &&
+    left.role === right.role &&
+    left.additionalType === right.additionalType
+  );
+}
+
+/** Reuses exact counts only while every token-relevant stable field matches. */
+export function createExactTokenCountCache(
+  tokenCounter: t.TokenCounter
+): ExactTokenCountCache {
+  const entries = new WeakMap<BaseMessage, ExactTokenCountCacheEntry>();
+  return {
+    count(message): number {
+      const surface = getStableTokenSurface(message);
+      const cached = entries.get(message);
+      if (
+        surface != null &&
+        cached != null &&
+        tokenSurfacesMatch(cached.surface, surface)
+      ) {
+        return cached.tokens;
+      }
+      const tokens = tokenCounter(message);
+      if (surface != null) {
+        entries.set(message, { surface, tokens });
+      } else {
+        entries.delete(message);
+      }
+      return tokens;
+    },
+  };
+}
+
 function getProviderMessageOriginKey(message: BaseMessage): string | undefined {
   const type = message.getType();
   if (
@@ -69,6 +229,7 @@ function getProviderMessageOriginKey(message: BaseMessage): string | undefined {
 /** Measures repeated provider projections while tokenizing each message object once. */
 export function createContextPressureMeter({
   tokenCounter,
+  tokenCountCache,
   sourceMessages,
   retainedMessages,
   indexTokenCountMap,
@@ -88,12 +249,16 @@ export function createContextPressureMeter({
     if (cached != null) {
       return cached;
     }
-    const tokens = tokenCounter?.(message) ?? 0;
+    const tokens =
+      tokenCountCache?.count(message) ?? tokenCounter?.(message) ?? 0;
     tokenCounts.set(message, tokens);
     return tokens;
   };
 
-  if (contextUsage != null && tokenCounter != null) {
+  if (
+    contextUsage != null &&
+    (tokenCounter != null || tokenCountCache != null)
+  ) {
     const sourceIndices = new WeakMap<BaseMessage, number>();
     for (let i = 0; i < sourceMessages.length; i++) {
       sourceIndices.set(sourceMessages[i], i);
@@ -179,7 +344,7 @@ export function createContextPressureMeter({
       contextUsage?.effectiveInstructionTokens ??
       (forceRawRecount ? instructionTokens : undefined);
     if (
-      tokenCounter == null ||
+      (tokenCounter == null && tokenCountCache == null) ||
       contextBudget == null ||
       effectiveInstructionTokens == null
     ) {

--- a/src/llm/tokenCounterCacheCompatibility.ts
+++ b/src/llm/tokenCounterCacheCompatibility.ts
@@ -1,0 +1,22 @@
+import type { BaseMessage } from '@langchain/core/messages';
+
+const stableMessageTokenCounters = new WeakSet<
+  (message: BaseMessage) => number
+>();
+
+/**
+ * Opts a deterministic counter into stable-message count reuse. The counter
+ * must depend only on the message surface consumed by `getTokenCountForMessage`.
+ */
+export function markTokenCounterCacheCompatible<
+  TCounter extends (message: BaseMessage) => number,
+>(tokenCounter: TCounter): TCounter {
+  stableMessageTokenCounters.add(tokenCounter);
+  return tokenCounter;
+}
+
+export function isTokenCounterCacheCompatible(
+  tokenCounter: (message: BaseMessage) => number
+): boolean {
+  return stableMessageTokenCounters.has(tokenCounter);
+}

--- a/src/scripts/bench-context-pressure-cache.ts
+++ b/src/scripts/bench-context-pressure-cache.ts
@@ -1,0 +1,112 @@
+import { performance } from 'node:perf_hooks';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+
+import {
+  createContextPressureMeter,
+  createExactTokenCountCache,
+} from '@/llm/contextPressureMeter';
+import { createTokenCounter } from '@/utils/tokens';
+
+interface BenchmarkResult {
+  elapsedMs: number;
+  tokenizations: number;
+  checksum: number;
+}
+
+const ITERATIONS = 10;
+const SAMPLE_COUNT = 5;
+
+function createHistory(messageCount: number): BaseMessage[] {
+  return Array.from({ length: messageCount }, (_, index) => {
+    const content = `Message ${index}: ${'retained conversation context '.repeat(32)}`;
+    return index % 2 === 0
+      ? new HumanMessage({ id: `human-${index}`, content })
+      : new AIMessage({ id: `assistant-${index}`, content });
+  });
+}
+
+async function runBenchmark(
+  messageCount: number,
+  useSharedCache: boolean
+): Promise<BenchmarkResult> {
+  const history = createHistory(messageCount);
+  const exactCounter = await createTokenCounter();
+  let tokenizations = 0;
+  const tokenCounter = (message: BaseMessage): number => {
+    tokenizations++;
+    return exactCounter(message);
+  };
+  const tokenCountCache = useSharedCache
+    ? createExactTokenCountCache(tokenCounter)
+    : undefined;
+  const indexTokenCountMap: Record<string, number> = Object.create(null);
+  let checksum = 0;
+  const startedAt = performance.now();
+
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const meter = createContextPressureMeter({
+      tokenCounter,
+      tokenCountCache,
+      sourceMessages: history,
+      retainedMessages: history,
+      indexTokenCountMap,
+      contextUsage: {
+        contextBudget: 1_000_000,
+        effectiveInstructionTokens: 1_000,
+        remainingContextTokens: 900_000,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 1_000,
+      calibrationRatio: 1,
+    });
+    checksum += meter.measure(history).projectedMessageTokens ?? 0;
+  }
+
+  return {
+    elapsedMs: performance.now() - startedAt,
+    tokenizations,
+    checksum,
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+for (const messageCount of [100, 500]) {
+  const beforeSamples: BenchmarkResult[] = [];
+  const afterSamples: BenchmarkResult[] = [];
+
+  await runBenchmark(messageCount, false);
+  await runBenchmark(messageCount, true);
+  for (let sample = 0; sample < SAMPLE_COUNT; sample++) {
+    const firstUsesCache = sample % 2 === 0;
+    const first = await runBenchmark(messageCount, firstUsesCache);
+    const second = await runBenchmark(messageCount, !firstUsesCache);
+    (firstUsesCache ? afterSamples : beforeSamples).push(first);
+    (firstUsesCache ? beforeSamples : afterSamples).push(second);
+  }
+
+  const beforeMs = median(beforeSamples.map(({ elapsedMs }) => elapsedMs));
+  const afterMs = median(afterSamples.map(({ elapsedMs }) => elapsedMs));
+  const before = beforeSamples[0];
+  const after = afterSamples[0];
+  if (before.checksum !== after.checksum) {
+    throw new Error('Cached and uncached context measurements diverged');
+  }
+
+  console.log(
+    JSON.stringify({
+      messages: messageCount,
+      iterations: ITERATIONS,
+      beforeMs: Number(beforeMs.toFixed(2)),
+      afterMs: Number(afterMs.toFixed(2)),
+      speedup: Number((beforeMs / afterMs).toFixed(2)),
+      tokenizationsBefore: before.tokenizations,
+      tokenizationsAfter: after.tokenizations,
+    })
+  );
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -7,6 +7,7 @@ import {
   serializeStructuredValueBounded,
 } from './toolContent';
 import { ContentTypes } from '@/common/enum';
+import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 
 export type EncodingName = 'o200k_base' | 'claude';
 
@@ -1266,13 +1267,13 @@ export const createTokenCounter = async (
   const tok = await getTokenizer(encoding);
   const countTokens = (text: string): number => tok.count(text);
   const isClaude = encoding === 'claude';
-  return (message: BaseMessage): number => {
+  return markTokenCounterCacheCompatible((message: BaseMessage): number => {
     const count = getTokenCountForMessage(message, countTokens, encoding);
     const correctedCount = isClaude
       ? Math.ceil(count * CLAUDE_TOKEN_CORRECTION)
       : count;
     return ensureSafeTokenMeasurement(correctedCount, 'message');
-  };
+  });
 };
 
 /** Utility to manage the token encoder lifecycle explicitly. */


### PR DESCRIPTION
## Summary

I added conservative exact-token reuse across provider requests in an agent run, reducing repeated context-pressure tokenizer work while preserving request-scoped accounting and overflow behavior.

- Retain exact stable-message counts in `AgentContext` through a weak cache while leaving calibration, provider attribution, budgets, and fallback state request-scoped.
- Revalidate every built-in token-relevant field before reuse and force structured content, proxies, accessors, tool calls, and mutations through the exact recount path.
- Keep unmarked custom token counters on the existing uncached path and expose an explicit compatibility marker for deterministic host wrappers such as LibreChat's counter.
- Verify cached and forced-recount measurements match across append, replacement, reordering, mutation, tool metadata changes, and AgentContext resets.
- Add a reproducible real-tokenizer benchmark plus an ADR documenting the correctness and host-lifecycle boundaries.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Ran `npx jest src/llm/contextPressureMeter.test.ts src/agents/__tests__/AgentContext.test.ts --runInBand` (126 tests passed).
- Ran context-overflow, provider-request, tokenizer, and Langfuse focused suites (319 tests passed).
- Ran `npm run build`, `npx tsc --noEmit`, scoped ESLint, and both circular-dependency checks successfully.
- Ran the repository suite: 4,553 tests passed; only three live-provider suites failed because local Anthropic/Google credentials were unavailable and retired Vertex preview models returned 404.
- Ran `npm run bench:context-pressure`; cached and uncached projected totals matched exactly. Ten iterations reduced tokenizer calls from 1,000 to 100 for 100 retained messages and from 5,000 to 500 for 500 retained messages. Median time improved from 8.12 ms to 1.40 ms (5.8x) and from 39.26 ms to 5.92 ms (6.63x).

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2
- macOS arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
