### PR TITLE
🌐 perf: Keep Execution Worlds Warm

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,3 +75,15 @@ cache boundary and host-lifecycle trade-offs.
 
 The meter's estimates decide overflow and recovery only. Provider-reported
 usage remains the source of truth for billing and Langfuse observations.
+
+## Coding-Tool Execution
+
+An **Execution World** is the stable pairing of a filesystem namespace and a
+subprocess launcher used by coding tools. The Node host has one default world;
+remote backends retain one world per execution configuration so rebuilding an
+agent's tool binding does not make a warm backend look new to capability
+probes. Sandbox identity belongs to the same world, while timeout,
+cancellation, output, and command results remain invocation-scoped.
+
+See [ADR 0002](docs/adr/0002-stable-execution-worlds.md) for the adapter
+identity and compatibility boundary.

--- a/docs/adr/0002-stable-execution-worlds.md
+++ b/docs/adr/0002-stable-execution-worlds.md
@@ -32,6 +32,7 @@ each invocation.
 - Filesystem and subprocess adapters are explicitly paired as one namespace.
 - Local and Cloudflare output, error, timeout, cleanup, and security behavior
   remain in their existing adapters.
-- Hosts should treat an execution configuration as immutable for its lifetime.
+- Changes to captured Cloudflare workspace, timeout, or sandbox settings rebuild
+  the cached world so its filesystem and subprocess capabilities stay paired.
 - Non-bash local `execute_code` staging still uses the host temporary directory;
   moving temporary lifecycle operations into the world is a separate change.

--- a/docs/adr/0002-stable-execution-worlds.md
+++ b/docs/adr/0002-stable-execution-worlds.md
@@ -22,10 +22,11 @@ tool bindings. The existing partial `local.exec` shape and legacy top-level
 `local.spawn` option remain supported at the public configuration boundary.
 
 Capability caches continue to key by the world's subprocess function and
-environment. Environment variants use bounded, non-plaintext keys. Sandbox
-factory results are also tied to the factory identity so a replacement cannot
-be evicted by an older request. Reusing a world therefore reuses only backend
-capability facts; command output, timeout state, cancellation, and tool results
+environment. Environment variants use bounded, non-plaintext keys. Positive
+capability facts remain warm; negative facts expire so stateful worlds can
+discover newly installed or repaired executables. Sandbox factory results are
+also tied to the factory identity so a replacement cannot be evicted by an
+older request. Command output, timeout state, cancellation, and tool results
 remain scoped to each invocation.
 
 ## Consequences

--- a/docs/adr/0002-stable-execution-worlds.md
+++ b/docs/adr/0002-stable-execution-worlds.md
@@ -1,0 +1,37 @@
+# ADR 0002: Keep Execution Worlds Stable Across Tool Bindings
+
+## Status
+
+Accepted
+
+## Context
+
+Coding tools use one filesystem namespace and one subprocess launcher. The
+existing local execution seam represented those capabilities as optional
+fields, and Cloudflare rebuilt both adapters whenever an agent binding rebuilt
+its tool bundle. Capability caches correctly key by subprocess identity, but a
+new adapter function on every binding made a warm Cloudflare runtime look like
+a new backend and repeated remote availability probes.
+
+## Decision
+
+An **Execution World** is the complete filesystem, subprocess, and sandbox
+identity used by a coding-tool bundle. The Node host exposes one default world.
+Cloudflare retains one world per execution configuration and reuses it across
+tool bindings. The existing partial `local.exec` shape and legacy top-level
+`local.spawn` option remain supported at the public configuration boundary.
+
+Capability caches continue to key by the world's subprocess function and
+environment. Reusing a world therefore reuses only backend capability facts;
+command output, timeout state, cancellation, and tool results remain scoped to
+each invocation.
+
+## Consequences
+
+- Rebuilt Cloudflare tool bundles avoid repeated remote capability probes.
+- Filesystem and subprocess adapters are explicitly paired as one namespace.
+- Local and Cloudflare output, error, timeout, cleanup, and security behavior
+  remain in their existing adapters.
+- Hosts should treat an execution configuration as immutable for its lifetime.
+- Non-bash local `execute_code` staging still uses the host temporary directory;
+  moving temporary lifecycle operations into the world is a separate change.

--- a/docs/adr/0002-stable-execution-worlds.md
+++ b/docs/adr/0002-stable-execution-worlds.md
@@ -22,9 +22,11 @@ tool bindings. The existing partial `local.exec` shape and legacy top-level
 `local.spawn` option remain supported at the public configuration boundary.
 
 Capability caches continue to key by the world's subprocess function and
-environment. Reusing a world therefore reuses only backend capability facts;
-command output, timeout state, cancellation, and tool results remain scoped to
-each invocation.
+environment. Environment variants use bounded, non-plaintext keys. Sandbox
+factory results are also tied to the factory identity so a replacement cannot
+be evicted by an older request. Reusing a world therefore reuses only backend
+capability facts; command output, timeout state, cancellation, and tool results
+remain scoped to each invocation.
 
 ## Consequences
 

--- a/docs/execution-world-benchmark.md
+++ b/docs/execution-world-benchmark.md
@@ -1,0 +1,26 @@
+# Execution-world benchmark
+
+The benchmark measures repeated coding-tool bindings against one warm remote
+runtime. Each binding performs a JavaScript syntax check. Before stable world
+identity, every rebuilt adapter misses the backend-keyed Node availability
+cache and performs both a capability probe and the syntax check. With a stable
+world, only the first binding probes Node.
+
+Run it with:
+
+```sh
+npm run bench:execution-world
+```
+
+Result on 2026-08-23 with ten bindings and 10 ms simulated remote latency:
+
+| Metric | Recreated world | Stable world |
+| --- | ---: | ---: |
+| Remote process calls | 20 | 11 |
+| Elapsed time | 237.58 ms | 133.08 ms |
+| Relative speed | 1.00x | 1.79x |
+
+The exact elapsed time depends on the machine and transport latency. The
+deterministic signal is the 45% reduction in remote process calls. A real
+remote runtime generally has higher per-call latency than this benchmark's
+10 ms, so avoiding nine calls also removes nine network/runtime round trips.

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "bench:context-pressure": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-context-pressure-cache.ts",
+    "bench:execution-world": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-execution-world.ts",
     "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",

--- a/src/scripts/bench-execution-world.ts
+++ b/src/scripts/bench-execution-world.ts
@@ -1,0 +1,76 @@
+import { performance } from 'node:perf_hooks';
+
+import type * as t from '@/types';
+
+import { createCloudflareLocalExecutionConfig } from '@/tools/cloudflare/CloudflareSandboxExecutionEngine';
+import {
+  runPostEditSyntaxCheck,
+  _resetSyntaxCheckProbeCacheForTests,
+} from '@/tools/local/syntaxCheck';
+
+const BINDINGS = 10;
+const REMOTE_LATENCY_MS = 10;
+
+type BenchmarkResult = {
+  elapsedMs: number;
+  remoteExecCalls: number;
+};
+
+function delayedRuntime(counter: { calls: number }): t.CloudflareSandboxRuntime {
+  return {
+    exec: async (): Promise<t.CloudflareSandboxExecResult> => {
+      counter.calls++;
+      await new Promise((resolve) => setTimeout(resolve, REMOTE_LATENCY_MS));
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    readFile: async () => '',
+    writeFile: async () => undefined,
+    mkdir: async () => undefined,
+    listFiles: async () => [],
+    deleteFile: async () => undefined,
+  };
+}
+
+async function runBenchmark(reuseWorld: boolean): Promise<BenchmarkResult> {
+  _resetSyntaxCheckProbeCacheForTests();
+  const counter = { calls: 0 };
+  const sandbox = delayedRuntime(counter);
+  const sharedConfig: t.CloudflareSandboxExecutionConfig = { sandbox };
+  const startedAt = performance.now();
+
+  for (let binding = 0; binding < BINDINGS; binding++) {
+    const config = reuseWorld ? sharedConfig : { sandbox };
+    const localConfig = createCloudflareLocalExecutionConfig(config);
+    await runPostEditSyntaxCheck('/workspace/benchmark.js', localConfig);
+  }
+
+  return {
+    elapsedMs: performance.now() - startedAt,
+    remoteExecCalls: counter.calls,
+  };
+}
+
+await runBenchmark(false);
+await runBenchmark(true);
+const before = await runBenchmark(false);
+const after = await runBenchmark(true);
+
+if (before.remoteExecCalls !== BINDINGS * 2) {
+  throw new Error(`Unexpected uncached call count: ${before.remoteExecCalls}`);
+}
+if (after.remoteExecCalls !== BINDINGS + 1) {
+  throw new Error(`Unexpected cached call count: ${after.remoteExecCalls}`);
+}
+
+// eslint-disable-next-line no-console
+console.log(
+  JSON.stringify({
+    bindings: BINDINGS,
+    simulatedRemoteLatencyMs: REMOTE_LATENCY_MS,
+    beforeMs: Number(before.elapsedMs.toFixed(2)),
+    afterMs: Number(after.elapsedMs.toFixed(2)),
+    speedup: Number((before.elapsedMs / after.elapsedMs).toFixed(2)),
+    remoteExecCallsBefore: before.remoteExecCalls,
+    remoteExecCallsAfter: after.remoteExecCalls,
+  })
+);

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -80,6 +80,29 @@ it('reuses one execution world for repeated Cloudflare tool bindings', () => {
   expect(Object.isFrozen(firstWorld)).toBe(true);
 });
 
+it('rebuilds the world when captured Cloudflare settings change', async () => {
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: createRuntime(),
+    workspaceRoot: '/first',
+    timeoutMs: 100,
+  };
+
+  const firstWorld = createCloudflareExecutionWorld(config);
+  config.workspaceRoot = '/second';
+  const secondWorld = createCloudflareExecutionWorld(config);
+  config.timeoutMs = 200;
+  const thirdWorld = createCloudflareExecutionWorld(config);
+
+  expect(secondWorld).not.toBe(firstWorld);
+  expect(thirdWorld).not.toBe(secondWorld);
+  await expect(secondWorld.fs.realpath('/second/file.ts')).resolves.toBe(
+    '/second/file.ts'
+  );
+  await expect(firstWorld.fs.realpath('/second/file.ts')).rejects.toThrow(
+    'outside the Cloudflare sandbox workspace'
+  );
+});
+
 it('keeps remote capability probes warm across Cloudflare tool bindings', async () => {
   _resetSyntaxCheckProbeCacheForTests();
   let execCalls = 0;

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -76,6 +76,7 @@ it('reuses one execution world for repeated Cloudflare tool bindings', () => {
   expect(secondWorld).toBe(firstWorld);
   expect(localConfig.exec).toBe(firstWorld);
   expect(firstWorld.sandboxed).toBe(true);
+  expect(Object.isFrozen(firstWorld.fs)).toBe(true);
   expect(Object.isFrozen(firstWorld)).toBe(true);
 });
 
@@ -96,6 +97,42 @@ it('keeps remote capability probes warm across Cloudflare tool bindings', async 
   await runPostEditSyntaxCheck('/workspace/first.js', firstBinding);
   await runPostEditSyntaxCheck('/workspace/second.js', secondBinding);
 
+  expect(execCalls).toBe(3);
+});
+
+it('retries a transient capability-probe failure in a stable world', async () => {
+  _resetSyntaxCheckProbeCacheForTests();
+  let execCalls = 0;
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: createRuntime({
+      exec: async () => {
+        execCalls++;
+        if (execCalls === 1) {
+          throw new Error('transient sandbox RPC failure');
+        }
+        if (execCalls === 2) {
+          return { exitCode: 0, stdout: 'v22', stderr: '' };
+        }
+        return { exitCode: 1, stdout: '', stderr: 'syntax error' };
+      },
+    }),
+  };
+
+  const first = await runPostEditSyntaxCheck(
+    '/workspace/first.js',
+    createCloudflareLocalExecutionConfig(config)
+  );
+  const second = await runPostEditSyntaxCheck(
+    '/workspace/second.js',
+    createCloudflareLocalExecutionConfig(config)
+  );
+
+  expect(first).toEqual({ ok: true });
+  expect(second).toEqual({
+    ok: false,
+    checker: 'node --check',
+    output: 'syntax error',
+  });
   expect(execCalls).toBe(3);
 });
 

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -209,6 +209,48 @@ it('retries a transient capability-probe failure in a stable world', async () =>
   expect(execCalls).toBe(3);
 });
 
+it('reprobes an expired negative capability in a stateful world', async () => {
+  jest.useFakeTimers();
+  try {
+    jest.setSystemTime(0);
+    let execCalls = 0;
+    const config: t.CloudflareSandboxExecutionConfig = {
+      sandbox: createRuntime({
+        exec: async () => {
+          execCalls++;
+          if (execCalls === 1) {
+            return { exitCode: 127, stdout: '', stderr: 'node not found' };
+          }
+          if (execCalls === 2) {
+            return { exitCode: 0, stdout: 'v22', stderr: '' };
+          }
+          return { exitCode: 1, stdout: '', stderr: 'syntax error' };
+        },
+      }),
+    };
+
+    const first = await runPostEditSyntaxCheck(
+      '/workspace/first.js',
+      createCloudflareLocalExecutionConfig(config)
+    );
+    jest.setSystemTime(6000);
+    const second = await runPostEditSyntaxCheck(
+      '/workspace/second.js',
+      createCloudflareLocalExecutionConfig(config)
+    );
+
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({
+      ok: false,
+      checker: 'node --check',
+      output: 'syntax error',
+    });
+    expect(execCalls).toBe(3);
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
 it('reports the invoked runner name for Cloudflare caller-policy failures', async () => {
   const programmatic = createCloudflareProgrammaticToolCallingTool({
     sandbox: createRuntime(),

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -103,6 +103,56 @@ it('rebuilds the world when captured Cloudflare settings change', async () => {
   );
 });
 
+it('preserves a prewarmed factory when creating the first world', async () => {
+  let factoryCalls = 0;
+  const runtime = createRuntime({ readFile: async () => 'ok' });
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: async () => {
+      factoryCalls++;
+      return runtime;
+    },
+  };
+
+  await createCloudflareWorkspaceFS(config).readFile('/workspace/first.txt');
+  const world = createCloudflareExecutionWorld(config);
+  await world.fs.readFile('/workspace/second.txt');
+
+  expect(factoryCalls).toBe(1);
+});
+
+it('does not let a stale factory rejection evict its replacement', async () => {
+  let rejectFirst: ((error: Error) => void) | undefined;
+  const firstFactory = new Promise<t.CloudflareSandboxRuntime>(
+    (_resolve, reject) => {
+      rejectFirst = reject;
+    }
+  );
+  let replacementCalls = 0;
+  const replacement = createRuntime({ readFile: async () => 'replacement' });
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: () => firstFactory,
+  };
+
+  const firstWorld = createCloudflareExecutionWorld(config);
+  const staleRead = firstWorld.fs.readFile('/workspace/stale.txt');
+  await Promise.resolve();
+  config.sandbox = async () => {
+    replacementCalls++;
+    return replacement;
+  };
+  const replacementWorld = createCloudflareExecutionWorld(config);
+  await expect(
+    replacementWorld.fs.readFile('/workspace/replacement.txt', 'utf8')
+  ).resolves.toBe('replacement');
+  rejectFirst?.(new Error('stale factory failed'));
+  await expect(staleRead).rejects.toThrow('stale factory failed');
+  await expect(
+    replacementWorld.fs.readFile('/workspace/reused.txt', 'utf8')
+  ).resolves.toBe('replacement');
+
+  expect(replacementCalls).toBe(1);
+});
+
 it('keeps remote capability probes warm across Cloudflare tool bindings', async () => {
   _resetSyntaxCheckProbeCacheForTests();
   let execCalls = 0;

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -1,6 +1,7 @@
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
+  createCloudflareExecutionWorld,
   createCloudflareWorkspaceFS,
   createCloudflareLocalExecutionConfig,
   execWithClientTimeout,
@@ -11,6 +12,10 @@ import {
   createCloudflareBashProgrammaticToolCallingTool,
   createCloudflareProgrammaticToolCallingTool,
 } from '../cloudflare/CloudflareProgrammaticToolCalling';
+import {
+  runPostEditSyntaxCheck,
+  _resetSyntaxCheckProbeCacheForTests,
+} from '../local/syntaxCheck';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
 import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
 import { isWorkspaceClientTimeoutError } from '../local/workspaceFS';
@@ -58,6 +63,40 @@ function createRuntime(
     ...overrides,
   };
 }
+
+it('reuses one execution world for repeated Cloudflare tool bindings', () => {
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: createRuntime(),
+  };
+
+  const firstWorld = createCloudflareExecutionWorld(config);
+  const secondWorld = createCloudflareExecutionWorld(config);
+  const localConfig = createCloudflareLocalExecutionConfig(config);
+
+  expect(secondWorld).toBe(firstWorld);
+  expect(localConfig.exec).toBe(firstWorld);
+  expect(firstWorld.sandboxed).toBe(true);
+});
+
+it('keeps remote capability probes warm across Cloudflare tool bindings', async () => {
+  _resetSyntaxCheckProbeCacheForTests();
+  let execCalls = 0;
+  const config: t.CloudflareSandboxExecutionConfig = {
+    sandbox: createRuntime({
+      exec: async () => {
+        execCalls++;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    }),
+  };
+
+  const firstBinding = createCloudflareLocalExecutionConfig(config);
+  const secondBinding = createCloudflareLocalExecutionConfig(config);
+  await runPostEditSyntaxCheck('/workspace/first.js', firstBinding);
+  await runPostEditSyntaxCheck('/workspace/second.js', secondBinding);
+
+  expect(execCalls).toBe(3);
+});
 
 it('reports the invoked runner name for Cloudflare caller-policy failures', async () => {
   const programmatic = createCloudflareProgrammaticToolCallingTool({

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -76,6 +76,7 @@ it('reuses one execution world for repeated Cloudflare tool bindings', () => {
   expect(secondWorld).toBe(firstWorld);
   expect(localConfig.exec).toBe(firstWorld);
   expect(firstWorld.sandboxed).toBe(true);
+  expect(Object.isFrozen(firstWorld)).toBe(true);
 });
 
 it('keeps remote capability probes warm across Cloudflare tool bindings', async () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -963,6 +963,38 @@ describe('codex review fixes', () => {
       expect(probeCalls).toBe(2);
       expect(searchCalls).toBe(1);
     });
+
+    it('caches a native ENOENT ripgrep verdict on the same backend', async () => {
+      _resetRipgrepCacheForTests();
+      const realSpawn = (
+        require('child_process') as typeof import('child_process')
+      ).spawn;
+      let probeCalls = 0;
+      const missingBackend: t.LocalSpawn = ((
+        cmd: string,
+        args: string[],
+        opts: import('child_process').SpawnOptions
+      ) => {
+        if (cmd === 'rg') {
+          probeCalls++;
+          return realSpawn(`missing-rg-${process.pid}`, args, opts);
+        }
+        return realSpawn(cmd, args, opts);
+      }) as unknown as t.LocalSpawn;
+      const cwd = await createTempDir();
+      await fsWriteFile(join(cwd, 'file.ts'), 'needle\n', 'utf8');
+      const grep = createLocalCodingToolBundle({
+        cwd,
+        exec: { spawn: missingBackend },
+      }).tools.find((tool) => tool.name === 'grep_search')!;
+
+      const first = await grep.invoke({ pattern: 'needle' });
+      const second = await grep.invoke({ pattern: 'needle' });
+
+      expect(JSON.stringify(first)).toContain('needle');
+      expect(JSON.stringify(second)).toContain('needle');
+      expect(probeCalls).toBe(1);
+    });
   });
 
   describe('additionalRoots resolved against workspace root (Codex P2 #3)', () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -921,6 +921,48 @@ describe('codex review fixes', () => {
         .invoke({ pattern: 'needle' });
       expect(String(bResult)).toContain('needle');
     });
+
+    it('retries a transient ripgrep probe failure on the same backend', async () => {
+      _resetRipgrepCacheForTests();
+      const realSpawn = (
+        require('child_process') as typeof import('child_process')
+      ).spawn;
+      let probeCalls = 0;
+      let searchCalls = 0;
+      const transientBackend: t.LocalSpawn = ((
+        cmd: string,
+        args: string[],
+        opts: import('child_process').SpawnOptions
+      ) => {
+        if (cmd === 'rg' && args[0] === '--version') {
+          probeCalls++;
+          return realSpawn(
+            'sh',
+            ['-c', probeCalls === 1 ? 'exit 1' : 'exit 0'],
+            opts
+          );
+        }
+        if (cmd === 'rg') {
+          searchCalls++;
+          return realSpawn('sh', ['-c', 'printf \'file.ts:1:needle\\n\''], opts);
+        }
+        return realSpawn(cmd, args, opts);
+      }) as unknown as t.LocalSpawn;
+      const cwd = await createTempDir();
+      await fsWriteFile(join(cwd, 'file.ts'), 'needle\n', 'utf8');
+      const grep = createLocalCodingToolBundle({
+        cwd,
+        exec: { spawn: transientBackend },
+      }).tools.find((tool) => tool.name === 'grep_search')!;
+
+      const first = await grep.invoke({ pattern: 'needle' });
+      const second = await grep.invoke({ pattern: 'needle' });
+
+      expect(JSON.stringify(first)).toContain('needle');
+      expect(JSON.stringify(second)).toContain('needle');
+      expect(probeCalls).toBe(2);
+      expect(searchCalls).toBe(1);
+    });
   });
 
   describe('additionalRoots resolved against workspace root (Codex P2 #3)', () => {

--- a/src/tools/__tests__/LocalExecutionTools.test.ts
+++ b/src/tools/__tests__/LocalExecutionTools.test.ts
@@ -995,6 +995,42 @@ describe('codex review fixes', () => {
       expect(JSON.stringify(second)).toContain('needle');
       expect(probeCalls).toBe(1);
     });
+
+    it('does not cache ENOENT from a missing working directory', async () => {
+      _resetSyntaxCheckProbeCacheForTests();
+      const realSpawn = (
+        require('child_process') as typeof import('child_process')
+      ).spawn;
+      let probeCalls = 0;
+      const backend: t.LocalSpawn = ((
+        cmd: string,
+        args: string[],
+        opts: import('child_process').SpawnOptions
+      ) => {
+        if (cmd === 'node' && args[0] === '--version') {
+          probeCalls++;
+        }
+        return realSpawn(cmd, args, opts);
+      }) as unknown as t.LocalSpawn;
+      const cwd = await createTempDir();
+      const sourcePath = join(cwd, 'valid.js');
+      await fsWriteFile(sourcePath, 'const valid = true;\n', 'utf8');
+
+      await runPostEditSyntaxCheck(sourcePath, {
+        cwd: join(cwd, 'missing'),
+        exec: { spawn: backend },
+      });
+      await runPostEditSyntaxCheck(sourcePath, {
+        cwd,
+        exec: { spawn: backend },
+      });
+      await runPostEditSyntaxCheck(sourcePath, {
+        cwd,
+        exec: { spawn: backend },
+      });
+
+      expect(probeCalls).toBe(2);
+    });
   });
 
   describe('additionalRoots resolved against workspace root (Codex P2 #3)', () => {

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -100,6 +100,7 @@ describe('workspace seam', () => {
       expect(world.fs).toBe(nodeWorkspaceFS);
       expect(world.spawn).toBe(getExecutionWorld().spawn);
       expect(world.sandboxed).toBe(false);
+      expect(Object.isFrozen(world)).toBe(true);
     });
 
     it('defaults to the Node host fs when nothing is supplied', () => {

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -10,6 +10,7 @@ import {
   jest,
 } from '@jest/globals';
 import type { WorkspaceFS } from '../local/workspaceFS';
+import type * as t from '@/types';
 import {
   getExecutionWorld,
   resolveWorkspacePathSafe,
@@ -100,7 +101,20 @@ describe('workspace seam', () => {
       expect(world.fs).toBe(nodeWorkspaceFS);
       expect(world.spawn).toBe(getExecutionWorld().spawn);
       expect(world.sandboxed).toBe(false);
+      expect(Object.isFrozen(world.fs)).toBe(true);
       expect(Object.isFrozen(world)).toBe(true);
+    });
+
+    it('keeps the public override config incrementally mutable', () => {
+      const world = getExecutionWorld();
+      const config: t.LocalExecConfig = {};
+
+      config.spawn = world.spawn;
+      config.fs = { ...nodeWorkspaceFS } as WorkspaceFS;
+      config.sandboxed = true;
+
+      expect(config.spawn).toBe(world.spawn);
+      expect(config.sandboxed).toBe(true);
     });
 
     it('defaults to the Node host fs when nothing is supplied', () => {

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@jest/globals';
 import type { WorkspaceFS } from '../local/workspaceFS';
 import {
+  getExecutionWorld,
   resolveWorkspacePathSafe,
   getWorkspaceFS,
 } from '../local/LocalExecutionEngine';
@@ -93,6 +94,14 @@ describe('workspace seam', () => {
   });
 
   describe('WorkspaceFS seam', () => {
+    it('resolves the default filesystem and subprocess as one world', () => {
+      const world = getExecutionWorld({ workspace: { root: workspace } });
+
+      expect(world.fs).toBe(nodeWorkspaceFS);
+      expect(world.spawn).toBe(getExecutionWorld().spawn);
+      expect(world.sandboxed).toBe(false);
+    });
+
     it('defaults to the Node host fs when nothing is supplied', () => {
       expect(getWorkspaceFS({ workspace: { root: workspace } })).toBe(
         nodeWorkspaceFS

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -12,9 +12,11 @@ import {
 import type { WorkspaceFS } from '../local/workspaceFS';
 import type * as t from '@/types';
 import {
+  commandAvailabilityEnvCacheKey,
   getExecutionWorld,
   resolveWorkspacePathSafe,
   getWorkspaceFS,
+  setCommandAvailabilityCacheEntry,
 } from '../local/LocalExecutionEngine';
 import { createLocalCodingToolBundle } from '../local/LocalCodingTools';
 import { nodeWorkspaceFS } from '../local/workspaceFS';
@@ -115,6 +117,22 @@ describe('workspace seam', () => {
 
       expect(config.spawn).toBe(world.spawn);
       expect(config.sandboxed).toBe(true);
+    });
+
+    it('bounds hashed command-availability environment entries', () => {
+      const cache = new Map<string, number>();
+      for (let index = 0; index < 17; index++) {
+        setCommandAvailabilityCacheEntry(cache, `environment-${index}`, index);
+      }
+      const secret = 'credential-that-must-not-be-retained';
+      const key = commandAvailabilityEnvCacheKey({ TOKEN: secret, PATH: '/bin' });
+
+      expect(cache.size).toBe(16);
+      expect(cache.has('environment-0')).toBe(false);
+      expect(key).not.toContain(secret);
+      expect(key).toBe(
+        commandAvailabilityEnvCacheKey({ PATH: '/bin', TOKEN: secret })
+      );
     });
 
     it('defaults to the Node host fs when nothing is supplied', () => {

--- a/src/tools/__tests__/workspaceSeam.test.ts
+++ b/src/tools/__tests__/workspaceSeam.test.ts
@@ -133,6 +133,9 @@ describe('workspace seam', () => {
       expect(key).toBe(
         commandAvailabilityEnvCacheKey({ PATH: '/bin', TOKEN: secret })
       );
+      expect(commandAvailabilityEnvCacheKey({})).not.toBe(
+        commandAvailabilityEnvCacheKey({ PATH: undefined })
+      );
     });
 
     it('defaults to the Node host fs when nothing is supplied', () => {

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -702,11 +702,11 @@ export function createCloudflareExecutionWorld(
 ): t.ExecutionWorld {
   let world = executionWorldCache.get(config);
   if (world == null) {
-    world = {
+    world = Object.freeze({
       spawn: createCloudflareSpawn(config),
       fs: createCloudflareWorkspaceFS(config),
       sandboxed: true,
-    };
+    });
     executionWorldCache.set(config, world);
   }
   return world;

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -5,11 +5,11 @@ import type { WriteFileOptions, MakeDirectoryOptions, Stats } from 'fs';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import type { FileHandle } from 'fs/promises';
 import type { WorkspaceFS, ReaddirEntry } from '@/tools/local/workspaceFS';
+import type * as t from '@/types';
 import {
   WorkspaceClientTimeoutError,
   isWorkspaceClientTimeoutError,
 } from '@/tools/local/workspaceFS';
-import type * as t from '@/types';
 import {
   LOCAL_SPAWN_TIMEOUT_MS,
   validateBashCommand,
@@ -43,6 +43,11 @@ type SandboxRuntimeContext = {
   maxOutputChars: number;
   shell: string;
 };
+
+const executionWorldCache = new WeakMap<
+  t.CloudflareSandboxExecutionConfig,
+  t.ExecutionWorld
+>();
 
 const sandboxFactoryCache = new WeakMap<
   t.CloudflareSandboxExecutionConfig,
@@ -687,6 +692,26 @@ function createCloudflareSpawn(
   };
 }
 
+/**
+ * Returns one stable filesystem/process world for a Cloudflare configuration.
+ * Probe caches key on the spawn identity, so retaining it avoids repeating
+ * remote capability checks whenever an agent binding rebuilds its tools.
+ */
+export function createCloudflareExecutionWorld(
+  config: t.CloudflareSandboxExecutionConfig
+): t.ExecutionWorld {
+  let world = executionWorldCache.get(config);
+  if (world == null) {
+    world = {
+      spawn: createCloudflareSpawn(config),
+      fs: createCloudflareWorkspaceFS(config),
+      sandboxed: true,
+    };
+    executionWorldCache.set(config, world);
+  }
+  return world;
+}
+
 export function createCloudflareLocalExecutionConfig(
   config: t.CloudflareSandboxExecutionConfig
 ): t.LocalExecutionConfig {
@@ -694,11 +719,7 @@ export function createCloudflareLocalExecutionConfig(
   return {
     cwd: workspaceRoot,
     workspace: { root: workspaceRoot },
-    exec: {
-      spawn: createCloudflareSpawn(config),
-      fs: createCloudflareWorkspaceFS(config),
-      sandboxed: true,
-    },
+    exec: createCloudflareExecutionWorld(config),
     shell: config.shell ?? 'bash',
     timeoutMs: config.timeoutMs,
     maxOutputChars: config.maxOutputChars,

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -56,9 +56,16 @@ const executionWorldCache = new WeakMap<
   ExecutionWorldCacheEntry
 >();
 
+type SandboxFactoryCacheEntry = {
+  sandbox: () =>
+    | t.CloudflareSandboxRuntime
+    | Promise<t.CloudflareSandboxRuntime>;
+  promise: Promise<t.CloudflareSandboxRuntime>;
+};
+
 const sandboxFactoryCache = new WeakMap<
   t.CloudflareSandboxExecutionConfig,
-  Promise<t.CloudflareSandboxRuntime>
+  SandboxFactoryCacheEntry
 >();
 
 function normalizeWorkspaceRoot(workspaceRoot: string): string {
@@ -81,17 +88,20 @@ export async function resolveCloudflareSandbox(
   if (typeof sandbox !== 'function') {
     return sandbox;
   }
-  let cached = sandboxFactoryCache.get(config);
-  if (cached == null) {
-    cached = Promise.resolve()
-      .then(() => sandbox())
-      .catch((error: unknown) => {
-        sandboxFactoryCache.delete(config);
-        throw error;
-      });
-    sandboxFactoryCache.set(config, cached);
+  const cached = sandboxFactoryCache.get(config);
+  if (cached?.sandbox === sandbox) {
+    return cached.promise;
   }
-  return cached;
+  const promise = Promise.resolve()
+    .then(() => sandbox())
+    .catch((error: unknown) => {
+      if (sandboxFactoryCache.get(config)?.promise === promise) {
+        sandboxFactoryCache.delete(config);
+      }
+      throw error;
+    });
+  sandboxFactoryCache.set(config, { sandbox, promise });
+  return promise;
 }
 
 async function getRuntimeContext(
@@ -716,9 +726,6 @@ export function createCloudflareExecutionWorld(
     cached.sandbox === config.sandbox
   ) {
     return cached.world;
-  }
-  if (cached?.sandbox !== config.sandbox) {
-    sandboxFactoryCache.delete(config);
   }
   const fs = Object.freeze(createCloudflareWorkspaceFS(config));
   const world = Object.freeze({

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -44,9 +44,16 @@ type SandboxRuntimeContext = {
   shell: string;
 };
 
+type ExecutionWorldCacheEntry = {
+  world: t.ExecutionWorld;
+  workspaceRoot: string;
+  timeoutMs: number;
+  sandbox: t.CloudflareSandboxExecutionConfig['sandbox'];
+};
+
 const executionWorldCache = new WeakMap<
   t.CloudflareSandboxExecutionConfig,
-  t.ExecutionWorld
+  ExecutionWorldCacheEntry
 >();
 
 const sandboxFactoryCache = new WeakMap<
@@ -700,16 +707,31 @@ function createCloudflareSpawn(
 export function createCloudflareExecutionWorld(
   config: t.CloudflareSandboxExecutionConfig
 ): t.ExecutionWorld {
-  let world = executionWorldCache.get(config);
-  if (world == null) {
-    const fs = Object.freeze(createCloudflareWorkspaceFS(config));
-    world = Object.freeze({
-      spawn: createCloudflareSpawn(config),
-      fs,
-      sandboxed: true,
-    });
-    executionWorldCache.set(config, world);
+  const workspaceRoot = getCloudflareWorkspaceRoot(config);
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const cached = executionWorldCache.get(config);
+  if (
+    cached?.workspaceRoot === workspaceRoot &&
+    Object.is(cached.timeoutMs, timeoutMs) &&
+    cached.sandbox === config.sandbox
+  ) {
+    return cached.world;
   }
+  if (cached?.sandbox !== config.sandbox) {
+    sandboxFactoryCache.delete(config);
+  }
+  const fs = Object.freeze(createCloudflareWorkspaceFS(config));
+  const world = Object.freeze({
+    spawn: createCloudflareSpawn(config),
+    fs,
+    sandboxed: true,
+  });
+  executionWorldCache.set(config, {
+    world,
+    workspaceRoot,
+    timeoutMs,
+    sandbox: config.sandbox,
+  });
   return world;
 }
 

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -702,9 +702,10 @@ export function createCloudflareExecutionWorld(
 ): t.ExecutionWorld {
   let world = executionWorldCache.get(config);
   if (world == null) {
+    const fs = Object.freeze(createCloudflareWorkspaceFS(config));
     world = Object.freeze({
       spawn: createCloudflareSpawn(config),
-      fs: createCloudflareWorkspaceFS(config),
+      fs,
       sandboxed: true,
     });
     executionWorldCache.set(config, world);

--- a/src/tools/cloudflare/CloudflareSandboxTools.ts
+++ b/src/tools/cloudflare/CloudflareSandboxTools.ts
@@ -2,8 +2,8 @@ import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
+  createCloudflareExecutionWorld,
   createCloudflareLocalExecutionConfig,
-  createCloudflareWorkspaceFS,
   executeCloudflareBash,
   executeCloudflareCode,
   formatCloudflareOutput,
@@ -161,7 +161,7 @@ export function createCloudflareCodingTools(
     options.checkpointer ??
     (config.fileCheckpointing === true
       ? createLocalFileCheckpointer({
-        fs: createCloudflareWorkspaceFS(config),
+        fs: createCloudflareExecutionWorld(config).fs,
       })
       : undefined);
   const tools = [
@@ -193,11 +193,12 @@ export function createCloudflareCodingToolBundle(
   config: t.CloudflareSandboxExecutionConfig,
   options: { checkpointer?: t.LocalFileCheckpointer } = {}
 ): CloudflareCodingToolBundle {
+  const world = createCloudflareExecutionWorld(config);
   const checkpointer =
     options.checkpointer ??
     (config.fileCheckpointing === true
       ? createLocalFileCheckpointer({
-        fs: createCloudflareWorkspaceFS(config),
+        fs: world.fs,
       })
       : undefined);
   return {

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -4,10 +4,12 @@ import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
+  commandAvailabilityEnvCacheKey,
   getSpawn,
   getWorkspaceFS,
   probeLocalCommandAvailability,
   resolveWorkspacePathSafe,
+  setCommandAvailabilityCacheEntry,
   spawnLocalProcess,
   truncateLocalOutput,
 } from './LocalExecutionEngine';
@@ -737,29 +739,13 @@ export function createLocalEditFileTool(
  * spawn-per-search.
  */
 // Per-backend × per-env cache. Codex P1 #34 — keying by spawn
-// backend alone misses the case where two Runs share a backend but
-// vary `local.env` (especially PATH). Stale cache then claims `rg`
-// is available, the rg path runs, and the spawn fails with ENOENT
-// instead of falling back to the Node walker. The inner Map is
-// keyed by a stable JSON hash of the effective env so each unique
-// env gets its own probe.
+// backend alone misses the case where two Runs share a backend but vary
+// `local.env`. The inner map uses non-plaintext environment hashes and is
+// bounded so stable worlds do not retain unbounded variants or raw secrets.
 let ripgrepAvailabilityByBackend = new WeakMap<
   t.LocalSpawn,
   Map<string, ReturnType<typeof probeLocalCommandAvailability>>
 >();
-
-function envCacheKey(env: NodeJS.ProcessEnv | undefined): string {
-  // PATH is the only env entry that affects command lookup, but
-  // hashing the whole env keeps the key correct for hosts that
-  // vary anything else relevant. Stable JSON via sorted keys so
-  // {A:1,B:2} and {B:2,A:1} produce the same hash.
-  if (env == null) return '';
-  const sorted: Record<string, string | undefined> = {};
-  for (const k of Object.keys(env).sort()) {
-    sorted[k] = env[k];
-  }
-  return JSON.stringify(sorted);
-}
 
 async function isRipgrepAvailable(
   config: t.LocalExecutionConfig
@@ -770,11 +756,11 @@ async function isRipgrepAvailable(
     envMap = new Map();
     ripgrepAvailabilityByBackend.set(backend, envMap);
   }
-  const envKey = envCacheKey(config.env);
+  const envKey = commandAvailabilityEnvCacheKey(config.env);
   let probePromise = envMap.get(envKey);
   if (probePromise == null) {
     probePromise = probeLocalCommandAvailability('rg', ['--version'], config);
-    envMap.set(envKey, probePromise);
+    setCommandAvailabilityCacheEntry(envMap, envKey, probePromise);
   }
   const result = await probePromise;
   if (!result.cacheable && envMap.get(envKey) === probePromise) {

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -766,6 +766,12 @@ async function isRipgrepAvailable(
   if (!result.cacheable && envMap.get(envKey) === probePromise) {
     envMap.delete(envKey);
   }
+  if (result.cacheUntil != null && result.cacheUntil <= Date.now()) {
+    if (envMap.get(envKey) === probePromise) {
+      envMap.delete(envKey);
+    }
+    return isRipgrepAvailable(config);
+  }
   return result.available;
 }
 

--- a/src/tools/local/LocalCodingTools.ts
+++ b/src/tools/local/LocalCodingTools.ts
@@ -4,16 +4,17 @@ import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
-  createLocalBashProgrammaticToolCallingTool,
-  createLocalProgrammaticToolCallingTool,
-} from './LocalProgrammaticToolCalling';
-import {
   getSpawn,
   getWorkspaceFS,
+  probeLocalCommandAvailability,
   resolveWorkspacePathSafe,
   spawnLocalProcess,
   truncateLocalOutput,
 } from './LocalExecutionEngine';
+import {
+  createLocalBashProgrammaticToolCallingTool,
+  createLocalProgrammaticToolCallingTool,
+} from './LocalProgrammaticToolCalling';
 import {
   createLocalBashExecutionTool,
   createLocalCodeExecutionTool,
@@ -744,7 +745,7 @@ export function createLocalEditFileTool(
 // env gets its own probe.
 let ripgrepAvailabilityByBackend = new WeakMap<
   t.LocalSpawn,
-  Map<string, Promise<boolean>>
+  Map<string, ReturnType<typeof probeLocalCommandAvailability>>
 >();
 
 function envCacheKey(env: NodeJS.ProcessEnv | undefined): string {
@@ -772,17 +773,14 @@ async function isRipgrepAvailable(
   const envKey = envCacheKey(config.env);
   let probePromise = envMap.get(envKey);
   if (probePromise == null) {
-    probePromise = spawnLocalProcess(
-      'rg',
-      ['--version'],
-      { ...config, timeoutMs: 5000, sandbox: { enabled: false } },
-      { internal: true }
-    )
-      .then((probe) => probe.exitCode === 0)
-      .catch(() => false);
+    probePromise = probeLocalCommandAvailability('rg', ['--version'], config);
     envMap.set(envKey, probePromise);
   }
-  return probePromise;
+  const result = await probePromise;
+  if (!result.cacheable && envMap.get(envKey) === probePromise) {
+    envMap.delete(envKey);
+  }
+  return result.available;
 }
 
 /**

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -21,6 +21,36 @@ const DEFAULT_MAX_OUTPUT_CHARS = 200000;
 const DEFAULT_MAX_SPAWNED_BYTES = 50 * 1024 * 1024;
 const DEFAULT_LOCAL_SESSION_ID = 'local';
 const DEFAULT_SHELL = process.platform === 'win32' ? 'bash.exe' : 'bash';
+const MAX_COMMAND_AVAILABILITY_ENVIRONMENTS = 16;
+
+/** Produces a stable, non-plaintext key for environment-sensitive probes. */
+export function commandAvailabilityEnvCacheKey(
+  env: NodeJS.ProcessEnv | undefined
+): string {
+  if (env == null) {
+    return '';
+  }
+  const sorted: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env).sort()) {
+    sorted[key] = env[key];
+  }
+  return createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
+}
+
+/** Adds a probe entry while bounding retained environment variants. */
+export function setCommandAvailabilityCacheEntry<T>(
+  cache: Map<string, T>,
+  key: string,
+  value: T
+): void {
+  if (!cache.has(key) && cache.size >= MAX_COMMAND_AVAILABILITY_ENVIRONMENTS) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
+  cache.set(key, value);
+}
 
 // `(?:--\s+)?` before each destructive-target alternation: GNU/BSD
 // utilities accept `--` as an end-of-options marker, so `rm -rf -- /`

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -931,10 +931,18 @@ export type CommandAvailabilityProbe = {
   cacheable: boolean;
 };
 
+function isDurableCommandLookupError(error: object): boolean {
+  if (!('code' in error)) {
+    return false;
+  }
+  return error.code === 'ENOENT' || error.code === 'EACCES';
+}
+
 /**
  * Probes one executable without turning transient backend failures into
  * permanent capability facts. Exit 126/127 is a definite unusable/missing
- * executable; timeouts, transport failures, and other exits are retried.
+ * executable, as are native ENOENT/EACCES lookup failures. Timeouts,
+ * transport failures, and other exits are retried.
  */
 export async function probeLocalCommandAvailability(
   command: string,
@@ -954,8 +962,14 @@ export async function probeLocalCommandAvailability(
       cacheable:
         available || result.exitCode === 126 || result.exitCode === 127,
     };
-  } catch {
-    return { available: false, cacheable: false };
+  } catch (error) {
+    return {
+      available: false,
+      cacheable:
+        typeof error === 'object' &&
+        error != null &&
+        isDurableCommandLookupError(error),
+    };
   }
 }
 

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -260,11 +260,11 @@ export function getWorkspaceRoots(config?: t.LocalExecutionConfig): string[] {
 }
 
 /** Node-host execution world used when no backend override is configured. */
-export const nodeExecutionWorld: t.ExecutionWorld = {
+export const nodeExecutionWorld: t.ExecutionWorld = Object.freeze({
   spawn: spawn as t.LocalSpawn,
   fs: nodeWorkspaceFS,
   sandboxed: false,
-};
+});
 
 /** Resolves filesystem and subprocess capabilities as one execution world. */
 export function getExecutionWorld(

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -931,18 +931,27 @@ export type CommandAvailabilityProbe = {
   cacheable: boolean;
 };
 
-function isDurableCommandLookupError(error: object): boolean {
-  if (!('code' in error)) {
+async function isDurableCommandLookupError(
+  error: object,
+  config: t.LocalExecutionConfig
+): Promise<boolean> {
+  if (!('code' in error) || error.code !== 'ENOENT') {
     return false;
   }
-  return error.code === 'ENOENT' || error.code === 'EACCES';
+  try {
+    const cwd = getLocalCwd(config);
+    return (await getWorkspaceFS(config).stat(cwd)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Probes one executable without turning transient backend failures into
  * permanent capability facts. Exit 126/127 is a definite unusable/missing
- * executable, as are native ENOENT/EACCES lookup failures. Timeouts,
- * transport failures, and other exits are retried.
+ * executable. A native ENOENT is stable only when the current working
+ * directory exists; timeouts, transport failures, and ambiguous lookup
+ * failures are retried.
  */
 export async function probeLocalCommandAvailability(
   command: string,
@@ -963,12 +972,13 @@ export async function probeLocalCommandAvailability(
         available || result.exitCode === 126 || result.exitCode === 127,
     };
   } catch (error) {
+    const cacheable =
+      typeof error === 'object' &&
+      error != null &&
+      (await isDurableCommandLookupError(error, config));
     return {
       available: false,
-      cacheable:
-        typeof error === 'object' &&
-        error != null &&
-        isDurableCommandLookupError(error),
+      cacheable,
     };
   }
 }

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -22,6 +22,7 @@ const DEFAULT_MAX_SPAWNED_BYTES = 50 * 1024 * 1024;
 const DEFAULT_LOCAL_SESSION_ID = 'local';
 const DEFAULT_SHELL = process.platform === 'win32' ? 'bash.exe' : 'bash';
 const MAX_COMMAND_AVAILABILITY_ENVIRONMENTS = 16;
+const NEGATIVE_COMMAND_AVAILABILITY_TTL_MS = 5000;
 
 /** Produces a stable, non-plaintext key for environment-sensitive probes. */
 export function commandAvailabilityEnvCacheKey(
@@ -30,10 +31,9 @@ export function commandAvailabilityEnvCacheKey(
   if (env == null) {
     return '';
   }
-  const sorted: Record<string, string | undefined> = {};
-  for (const key of Object.keys(env).sort()) {
-    sorted[key] = env[key];
-  }
+  const sorted = Object.keys(env)
+    .sort()
+    .map((key): [string, string | null] => [key, env[key] ?? null]);
   return createHash('sha256').update(JSON.stringify(sorted)).digest('hex');
 }
 
@@ -959,6 +959,7 @@ export async function spawnLocalProcess(
 export type CommandAvailabilityProbe = {
   available: boolean;
   cacheable: boolean;
+  cacheUntil?: number;
 };
 
 async function isDurableCommandLookupError(
@@ -996,10 +997,14 @@ export async function probeLocalCommandAvailability(
       { internal: true }
     );
     const available = result.exitCode === 0;
+    const durableNegative =
+      result.exitCode === 126 || result.exitCode === 127;
     return {
       available,
-      cacheable:
-        available || result.exitCode === 126 || result.exitCode === 127,
+      cacheable: available || durableNegative,
+      ...(durableNegative
+        ? { cacheUntil: Date.now() + NEGATIVE_COMMAND_AVAILABILITY_TTL_MS }
+        : {}),
     };
   } catch (error) {
     const cacheable =
@@ -1009,6 +1014,9 @@ export async function probeLocalCommandAvailability(
     return {
       available: false,
       cacheable,
+      ...(cacheable
+        ? { cacheUntil: Date.now() + NEGATIVE_COMMAND_AVAILABILITY_TTL_MS }
+        : {}),
     };
   }
 }

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -925,6 +925,40 @@ export async function spawnLocalProcess(
   });
 }
 
+/** Result of a command-availability probe and whether its verdict is stable. */
+export type CommandAvailabilityProbe = {
+  available: boolean;
+  cacheable: boolean;
+};
+
+/**
+ * Probes one executable without turning transient backend failures into
+ * permanent capability facts. Exit 126/127 is a definite unusable/missing
+ * executable; timeouts, transport failures, and other exits are retried.
+ */
+export async function probeLocalCommandAvailability(
+  command: string,
+  args: string[],
+  config: t.LocalExecutionConfig
+): Promise<CommandAvailabilityProbe> {
+  try {
+    const result = await spawnLocalProcess(
+      command,
+      args,
+      { ...config, timeoutMs: 5000, sandbox: { enabled: false } },
+      { internal: true }
+    );
+    const available = result.exitCode === 0;
+    return {
+      available,
+      cacheable:
+        available || result.exitCode === 126 || result.exitCode === 127,
+    };
+  } catch {
+    return { available: false, cacheable: false };
+  }
+}
+
 export async function executeLocalBash(
   command: string,
   config: t.LocalExecutionConfig = {}

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -259,13 +259,34 @@ export function getWorkspaceRoots(config?: t.LocalExecutionConfig): string[] {
   return out;
 }
 
+/** Node-host execution world used when no backend override is configured. */
+export const nodeExecutionWorld: t.ExecutionWorld = {
+  spawn: spawn as t.LocalSpawn,
+  fs: nodeWorkspaceFS,
+  sandboxed: false,
+};
+
+/** Resolves filesystem and subprocess capabilities as one execution world. */
+export function getExecutionWorld(
+  config?: t.LocalExecutionConfig
+): t.ExecutionWorld {
+  if (config?.exec == null && config?.spawn == null) {
+    return nodeExecutionWorld;
+  }
+  return {
+    spawn: config.exec?.spawn ?? config.spawn ?? nodeExecutionWorld.spawn,
+    fs: config.exec?.fs ?? nodeExecutionWorld.fs,
+    sandboxed: config.exec?.sandboxed ?? false,
+  };
+}
+
 /**
  * Pluggable spawn resolver. Honours `local.exec.spawn` first, falls
  * back to the legacy top-level `local.spawn`, then to Node's
  * `child_process.spawn`. Centralised so engine swapping is one knob.
  */
 export function getSpawn(config?: t.LocalExecutionConfig): t.LocalSpawn {
-  return (config?.exec?.spawn ?? config?.spawn ?? spawn) as t.LocalSpawn;
+  return getExecutionWorld(config).spawn;
 }
 
 /**
@@ -274,7 +295,7 @@ export function getSpawn(config?: t.LocalExecutionConfig): t.LocalSpawn {
  * its own implementation here and inherits every file-touching tool.
  */
 export function getWorkspaceFS(config?: t.LocalExecutionConfig): WorkspaceFS {
-  return config?.exec?.fs ?? nodeWorkspaceFS;
+  return getExecutionWorld(config).fs;
 }
 
 /**
@@ -345,7 +366,7 @@ function maybeWarnSandboxOff(config: t.LocalExecutionConfig): void {
   if (
     sandboxOffWarned ||
     shouldUseLocalSandbox(config) ||
-    config.exec?.sandboxed === true
+    getExecutionWorld(config).sandboxed
   ) {
     return;
   }

--- a/src/tools/local/syntaxCheck.ts
+++ b/src/tools/local/syntaxCheck.ts
@@ -96,6 +96,12 @@ async function probe(
   if (!result.cacheable && entry[cached] === probePromise) {
     delete entry[cached];
   }
+  if (result.cacheUntil != null && result.cacheUntil <= Date.now()) {
+    if (entry[cached] === probePromise) {
+      delete entry[cached];
+    }
+    return probe(command, args, cached, config);
+  }
   return result.available;
 }
 

--- a/src/tools/local/syntaxCheck.ts
+++ b/src/tools/local/syntaxCheck.ts
@@ -19,9 +19,11 @@
 import { extname } from 'path';
 import type * as t from '@/types';
 import {
+  commandAvailabilityEnvCacheKey,
   getSpawn,
   getWorkspaceFS,
   probeLocalCommandAvailability,
+  setCommandAvailabilityCacheEntry,
   spawnLocalProcess,
 } from './LocalExecutionEngine';
 import { isWorkspaceClientTimeoutError } from './workspaceFS';
@@ -53,23 +55,12 @@ type ProbeCache = Partial<
   Record<ProbeKind, ReturnType<typeof probeLocalCommandAvailability>>
 >;
 
-// Per-backend × per-env cache. Codex P2 #40 — keying by spawn
-// backend alone misses env-driven availability changes (e.g. PATH
-// loses node between Runs that share the same backend). Same fix
-// shape as the ripgrep cache (Codex P1 #34).
+// Per-backend × hashed-env cache. The inner map is bounded so a long-lived
+// world cannot retain unbounded environment variants.
 let probeCacheByBackend = new WeakMap<
   t.LocalSpawn,
   Map<string, ProbeCache>
 >();
-
-function envCacheKey(env: NodeJS.ProcessEnv | undefined): string {
-  if (env == null) return '';
-  const sorted: Record<string, string | undefined> = {};
-  for (const k of Object.keys(env).sort()) {
-    sorted[k] = env[k];
-  }
-  return JSON.stringify(sorted);
-}
 
 function cacheFor(
   config: t.LocalExecutionConfig
@@ -80,11 +71,11 @@ function cacheFor(
     envMap = new Map();
     probeCacheByBackend.set(backend, envMap);
   }
-  const envKey = envCacheKey(config.env);
+  const envKey = commandAvailabilityEnvCacheKey(config.env);
   let entry = envMap.get(envKey);
   if (entry == null) {
     entry = {};
-    envMap.set(envKey, entry);
+    setCommandAvailabilityCacheEntry(envMap, envKey, entry);
   }
   return entry;
 }

--- a/src/tools/local/syntaxCheck.ts
+++ b/src/tools/local/syntaxCheck.ts
@@ -18,12 +18,13 @@
 
 import { extname } from 'path';
 import type * as t from '@/types';
-import { isWorkspaceClientTimeoutError } from './workspaceFS';
 import {
   getSpawn,
   getWorkspaceFS,
+  probeLocalCommandAvailability,
   spawnLocalProcess,
 } from './LocalExecutionEngine';
+import { isWorkspaceClientTimeoutError } from './workspaceFS';
 
 export type SyntaxCheckOutcome =
   | { ok: true }
@@ -48,7 +49,9 @@ export type SyntaxChecker = (
  * reset hook re-creates the map.
  */
 type ProbeKind = 'hasNode' | 'hasPython' | 'hasBash';
-type ProbeCache = Partial<Record<ProbeKind, Promise<boolean>>>;
+type ProbeCache = Partial<
+  Record<ProbeKind, ReturnType<typeof probeLocalCommandAvailability>>
+>;
 
 // Per-backend × per-env cache. Codex P2 #40 — keying by spawn
 // backend alone misses env-driven availability changes (e.g. PATH
@@ -95,17 +98,14 @@ async function probe(
   const entry = cacheFor(config);
   let probePromise = entry[cached];
   if (probePromise == null) {
-    probePromise = spawnLocalProcess(
-      command,
-      args,
-      { ...config, timeoutMs: 5000, sandbox: { enabled: false } },
-      { internal: true }
-    )
-      .then((result) => result != null && result.exitCode === 0)
-      .catch(() => false);
+    probePromise = probeLocalCommandAvailability(command, args, config);
     entry[cached] = probePromise;
   }
-  return probePromise;
+  const result = await probePromise;
+  if (!result.cacheable && entry[cached] === probePromise) {
+    delete entry[cached];
+  }
+  return result.available;
 }
 
 /**

--- a/src/tools/local/workspaceFS.ts
+++ b/src/tools/local/workspaceFS.ts
@@ -92,10 +92,9 @@ export interface WorkspaceFS {
  * Returned by `getWorkspaceFS(config)` when the host hasn't supplied
  * an override on `local.exec.fs`.
  */
-export const nodeWorkspaceFS: WorkspaceFS = {
+export const nodeWorkspaceFS = Object.freeze<WorkspaceFS>({
   // The runtime impl ignores the encoding-vs-buffer distinction; the
   // overload signatures above are what callers see.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readFile: ((path: string, encoding?: 'utf8') =>
     encoding != null
       ? fsReadFile(path, encoding)
@@ -113,4 +112,4 @@ export const nodeWorkspaceFS: WorkspaceFS = {
   realpath: (path) => fsRealpath(path),
   unlink: (path) => fsUnlink(path),
   open: (path, flags) => fsOpen(path, flags),
-};
+});

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -828,7 +828,7 @@ export interface ExecutionWorld {
   /** Launches a process inside this world's filesystem namespace. */
   readonly spawn: LocalSpawn;
   /** Reads and writes the same namespace observed by `spawn`. */
-  readonly fs: import('@/tools/local/workspaceFS').WorkspaceFS;
+  readonly fs: Readonly<import('@/tools/local/workspaceFS').WorkspaceFS>;
   /** Whether the world already enforces a sandbox boundary. */
   readonly sandboxed: boolean;
 }
@@ -845,7 +845,11 @@ export interface ExecutionWorld {
  * adversarial-model threat model, use a backend sandbox boundary rather than
  * relying on validation alone.
  */
-export type LocalExecConfig = Partial<ExecutionWorld>;
+export type LocalExecConfig = {
+  -readonly [Key in keyof ExecutionWorld]?: Key extends 'fs'
+    ? import('@/tools/local/workspaceFS').WorkspaceFS
+    : ExecutionWorld[Key];
+};
 
 export type LocalExecutionConfig = {
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -820,48 +820,32 @@ export type LocalWorkspaceConfig = {
 };
 
 /**
- * Engine-agnostic execution seam. Default uses Node's
- * `child_process.spawn` and `fs/promises`. A future engine (e.g.
- * stateful remote sandbox) supplies its own `spawn` and `fs` and
- * inherits every tool factory unchanged.
- *
- * **Important — pair `spawn` and `fs` together.** Most file-touching
- * surfaces in the local engine route through `getWorkspaceFS(config)`
- * so a host can transparently swap in a remote/in-memory FS. A small
- * set of helpers — currently the `execute_code` non-bash temp-file
- * write (Codex P2 [48]) — still uses host `fs/promises` directly to
- * stage source on disk before invoking the spawn. If you override
- * `spawn` to point at a remote runtime (SSH, container, etc.) you
- * MUST also override `fs` with the corresponding remote
- * implementation; otherwise temp source files written to the host
- * `/tmp` won't be visible to the remote interpreter and `py`/`js`/
- * `ts`/etc. executions will fail. (Bash-style executions go through
- * `executeLocalBash` which doesn't stage temp files, so they're
- * unaffected.)
- *
- * Threat-model note: the regex-based command validators
- * (`dangerousCommandPatterns`, `quotedDestructivePatterns`, etc.) and
- * the workspace policy hook are documented as best-effort tripwires.
- * The hard security boundary is `local.sandbox.enabled: true` (which
- * wraps execution in `@anthropic-ai/sandbox-runtime`); for adversarial-
- * model threat models, do NOT rely on the regex layer alone.
+ * One execution world shared by filesystem and subprocess operations.
+ * Backend identity is stable so capability probes remain warm when tool
+ * bundles are rebuilt for later agent bindings.
  */
-export type LocalExecConfig = {
-  /** Pluggable spawn (for SSH, container, remote workers, etc.). */
-  spawn?: LocalSpawn;
-  /**
-   * Pluggable filesystem (for remote-workspace engines). Pair with
-   * `spawn` — see the type-level note above on why both should be
-   * overridden together for non-host engines.
-   */
-  fs?: import('@/tools/local/workspaceFS').WorkspaceFS;
-  /**
-   * Set by custom execution backends that already provide their own
-   * sandbox boundary. Suppresses the local host-sandbox warning while
-   * preserving the warning for plain host `child_process` execution.
-   */
-  sandboxed?: boolean;
-};
+export interface ExecutionWorld {
+  /** Launches a process inside this world's filesystem namespace. */
+  spawn: LocalSpawn;
+  /** Reads and writes the same namespace observed by `spawn`. */
+  fs: import('@/tools/local/workspaceFS').WorkspaceFS;
+  /** Whether the world already enforces a sandbox boundary. */
+  sandboxed: boolean;
+}
+
+/**
+ * Backward-compatible partial execution-world override. Omitted fields use
+ * the Node host world; remote backends should provide the complete trio.
+ *
+ * Non-bash `execute_code` still stages source through the host temporary
+ * directory. Remote runtimes should use their dedicated execution engine for
+ * that tool until temporary lifecycle operations join this seam.
+ *
+ * Command validators and workspace policies are best-effort tripwires. For an
+ * adversarial-model threat model, use a backend sandbox boundary rather than
+ * relying on validation alone.
+ */
+export type LocalExecConfig = Partial<ExecutionWorld>;
 
 export type LocalExecutionConfig = {
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -826,11 +826,11 @@ export type LocalWorkspaceConfig = {
  */
 export interface ExecutionWorld {
   /** Launches a process inside this world's filesystem namespace. */
-  spawn: LocalSpawn;
+  readonly spawn: LocalSpawn;
   /** Reads and writes the same namespace observed by `spawn`. */
-  fs: import('@/tools/local/workspaceFS').WorkspaceFS;
+  readonly fs: import('@/tools/local/workspaceFS').WorkspaceFS;
   /** Whether the world already enforces a sandbox boundary. */
-  sandboxed: boolean;
+  readonly sandboxed: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

I introduced a stable execution-world abstraction for coding tools and reused each Cloudflare filesystem/process adapter across rebuilt agent bindings, preserving warm backend capability caches.

- Define the public `ExecutionWorld` interface while preserving the partial `local.exec` and legacy `local.spawn` configuration paths.
- Reuse one Cloudflare execution world per execution configuration so ripgrep and syntax-check availability probes do not repeat remote subprocess calls across tool bindings.
- Route Cloudflare file checkpointing through the same stable filesystem adapter as the tool bundle.
- Document the execution-world domain boundary and architecture decision, including the remaining temporary-file seam.
- Add a reproducible cold-versus-warm benchmark that reduces remote process calls from 20 to 11 and improves simulated-latency time from 237.58 ms to 133.08 ms (1.79x).
- Add regression coverage for Node defaults, Cloudflare world identity, and warm remote capability probes.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx jest src/tools/__tests__/workspaceSeam.test.ts src/tools/__tests__/CloudflareSandboxExecution.test.ts --runInBand` (43 tests passed)
- `npx tsc --noEmit`
- `npx eslint` on every changed TypeScript source and test file
- `npx eslint --no-ignore src/scripts/bench-execution-world.ts`
- `npm run build`
- `npm run bench:execution-world` (20 → 11 remote calls; 237.58 ms → 133.08 ms; 1.79x)
- `git diff --check`
- Project import-order check on every changed non-script TypeScript file

### **Test Configuration**:

- Node.js 24
- macOS arm64
- Simulated remote subprocess latency: 10 ms
- Rebuilt tool bindings per benchmark sample: 10

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
