### PR TITLE
📦 chore: Bump Version to 3.6.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.6.13",
+      "version": "3.6.14",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
## Summary

I bumped `@librechat/agents` from `3.6.13` to `3.6.14` after merging the warm execution-world performance work.

- Update the package manifest version to `3.6.14`.
- Update the package-lock root version entries to `3.6.14`.
- Leave dependency resolutions and package contents unchanged.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Parsed both manifests and verified the package, lockfile, and lockfile root-package versions are exactly `3.6.14`.
- Normalized the two version fields and verified the lockfile hash matches `origin/main`, confirming no dependency resolution changes.
- Ran `git diff --check` successfully.
- Confirmed all 13 CI jobs passed on the underlying execution-world PR.

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2
- macOS arm64

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with the underlying feature changes
