### PR TITLE
⚡ perf: Skip Exact Token Counts the Host Already Supplies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,12 @@ host explicitly declares that they implement the same deterministic surface
 contract.
 See [ADR 0001](docs/adr/0001-reuse-exact-context-token-counts.md) for the
 cache boundary and host-lifecycle trade-offs.
+Host-supplied index token counts are the baseline's accounting weight; a
+retained message is tokenized only when no such count exists or when a
+provider projection replaced its object, since the exact count then serves
+only as the subtrahend of that projection's delta. Native brand checks in
+content validation use `node:util/types` slot reads rather than throwing
+probes, so plain content objects never pay an exception per value.
 
 The meter's estimates decide overflow and recovery only. Provider-reported
 usage remains the source of truth for billing and Langfuse observations.

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -1,8 +1,4 @@
-import {
-  AIMessage,
-  HumanMessage,
-  ToolMessage,
-} from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   createContextPressureMeter,
@@ -51,7 +47,9 @@ describe('createContextPressureMeter', () => {
       effectiveInstructionTokens: 10,
     });
     expect(meter.measure(projected).projectedMessageTokens).toBe(33);
-    expect(tokenCounter).toHaveBeenCalledTimes(3);
+    /** Stored counts cover the baseline; only the changed projection and its
+     *  baseline subtrahend are tokenized, never the untouched message. */
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
   });
 
   it('reuses stable exact counts across request-scoped meters', () => {
@@ -71,6 +69,40 @@ describe('createContextPressureMeter', () => {
         indexTokenCountMap: Object.fromEntries(
           messages.map((_, index) => [index, 8])
         ),
+        contextUsage: {
+          contextBudget: 10_000,
+          effectiveInstructionTokens: 100,
+          remainingContextTokens: 9_000,
+          calibrationRatio: 1,
+        },
+        instructionTokens: 100,
+        calibrationRatio: 1,
+      });
+
+    createMeter(retained).measure(retained);
+    createMeter(retained).measure(retained);
+
+    const appended = [...retained, new HumanMessage('new')];
+    createMeter(appended).measure(appended);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(0);
+  });
+
+  it('reuses exact counts across request-scoped meters when no stored counts exist', () => {
+    const retained = Array.from(
+      { length: 100 },
+      (_, index) =>
+        new HumanMessage({ id: `message-${index}`, content: 'retained' })
+    );
+    const tokenCounter = jest.fn(contentLength);
+    const tokenCountCache = createExactTokenCountCache(tokenCounter);
+    const createMeter = (messages: BaseMessage[]) =>
+      createContextPressureMeter({
+        tokenCounter,
+        tokenCountCache,
+        sourceMessages: messages,
+        retainedMessages: messages,
+        indexTokenCountMap: {},
         contextUsage: {
           contextBudget: 10_000,
           effectiveInstructionTokens: 100,
@@ -252,7 +284,7 @@ describe('createContextPressureMeter', () => {
       ]);
     }
 
-    expect(tokenCounter).toHaveBeenCalledTimes(113);
+    expect(tokenCounter).toHaveBeenCalledTimes(13);
   });
 
   it('uses a conservative ratio for fallback payloads', () => {

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -35,7 +35,9 @@ interface ProviderPayloadMeasureOptions {
 }
 
 interface ProviderMessageBaseline {
-  rawTokens: number;
+  message: BaseMessage;
+  /** Lazily tokenized: reading it costs a full count, so only read it on a changed projection. */
+  readonly rawTokens: number;
   accountingWeight: number;
 }
 
@@ -264,20 +266,27 @@ export function createContextPressureMeter({
       sourceIndices.set(sourceMessages[i], i);
     }
     baseline = retainedMessages.map((message, index) => {
-      const rawTokens = count(message);
       const sourceIndex = sourceIndices.get(message);
       const indexedTokens =
         sourceIndex != null ? indexTokenCountMap[sourceIndex] : undefined;
-      const accountingWeight =
+      const hasIndexedTokens =
         indexedTokens != null &&
         Number.isFinite(indexedTokens) &&
-        indexedTokens >= 0
-          ? indexedTokens
-          : rawTokens;
+        indexedTokens >= 0;
+      const accountingWeight = hasIndexedTokens
+        ? indexedTokens
+        : count(message);
       if (!origins.has(message)) {
         origins.set(message, index);
       }
-      return { rawTokens, accountingWeight };
+      return {
+        message,
+        /** Exact count is only needed as the subtrahend when a projection changed this message. */
+        get rawTokens(): number {
+          return count(message);
+        },
+        accountingWeight,
+      };
     });
     baselineWeights = {};
     for (let i = 0; i < baseline.length; i++) {
@@ -382,9 +391,7 @@ export function createContextPressureMeter({
     ) {
       let attribution = baselineAttributions.get(availableMessageTokens);
       if (attribution == null) {
-        const replyPrimerTokens = Math.round(
-          REPLY_PRIMER_TOKENS * usageRatio
-        );
+        const replyPrimerTokens = Math.round(REPLY_PRIMER_TOKENS * usageRatio);
         const attributableTokens =
           totalBaselineWeight > 0
             ? Math.min(
@@ -415,17 +422,20 @@ export function createContextPressureMeter({
       let newRawTokens = 0;
       const usedOrigins = new Set<number>();
       for (const message of messages) {
-        const rawTokens = count(message);
         const origin = origins.get(message);
         if (origin == null || usedOrigins.has(origin)) {
-          newRawTokens += rawTokens;
+          newRawTokens += count(message);
           continue;
         }
         usedOrigins.add(origin);
+        const projectionDelta =
+          message === baseline[origin].message
+            ? 0
+            : count(message) - baseline[origin].rawTokens;
         projectedMessageTokens += Math.max(
           0,
           attribution.attributedByOrigin[origin] +
-            Math.round((rawTokens - baseline[origin].rawTokens) * usageRatio)
+            Math.round(projectionDelta * usageRatio)
         );
       }
       projectedMessageTokens += Math.round(newRawTokens * usageRatio);

--- a/src/utils/toolContent.ts
+++ b/src/utils/toolContent.ts
@@ -1,4 +1,4 @@
-import { isProxy } from 'node:util/types';
+import { isArrayBuffer, isDate, isProxy } from 'node:util/types';
 import { ToolMessage, type BaseMessage } from '@langchain/core/messages';
 import {
   HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
@@ -151,11 +151,17 @@ function jsonStringLength(
 
 type NativeDateRead = { matched: true; time: number } | { matched: false };
 
+/**
+ * `isArrayBuffer` reads the internal slot natively (no user code, cross-realm safe) and
+ * costs nothing for the plain objects that make up almost all content; the getter's
+ * throw path was the expensive part, so it only runs once the brand is already known.
+ */
 function readNativeArrayBufferByteLength(value: unknown): number | undefined {
   if (
     value == null ||
     typeof value !== 'object' ||
-    NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER == null
+    NATIVE_ARRAY_BUFFER_BYTE_LENGTH_GETTER == null ||
+    !isArrayBuffer(value)
   ) {
     return undefined;
   }
@@ -167,7 +173,7 @@ function readNativeArrayBufferByteLength(value: unknown): number | undefined {
 }
 
 function readNativeDate(value: unknown): NativeDateRead {
-  if (value == null || typeof value !== 'object') {
+  if (value == null || typeof value !== 'object' || !isDate(value)) {
     return { matched: false };
   }
   try {


### PR DESCRIPTION
## Summary

Profiling LibreChat follow-up turns on a 300-message conversation showed **29% of per-turn CPU** in one chain:

`contextPressureMeter.count → getTokenCountForMessage → processValue → isAtomicToolContentBlock → hasUnsafeCallableToJSON → readNativeDate / readNativeArrayBufferByteLength`

Two compounding causes, both fixed here.

### Exact counts were computed and then discarded

`createContextPressureMeter`'s baseline tokenized every retained message up front as `rawTokens`, then — whenever the host had supplied a stored count in `indexTokenCountMap` — used the stored value and dropped the expensive one. `rawTokens` is only ever read as the subtrahend of a projection delta (`rawTokens − baseline[origin].rawTokens`), and that delta is zero by construction when the projected message is the same object as its baseline. The baseline now tokenizes only when no stored count exists, exposes `rawTokens` as a lazy getter for the changed-projection case, and `measure()` skips counting entirely for same-object messages. `forceRawRecount` still takes the unchanged full-recount branch.

The #452 exact-count cache is keyed by message object identity on the per-run `AgentContext`, so it reuses counts across provider requests within a run but cannot hit across turns — every turn builds fresh message objects. That is by design; this change just stops paying for counts nobody reads.

### Native brand checks threw an exception per object

`readNativeDate` called `Date.prototype.getTime.call(value)` on every object and caught the `TypeError`; `readNativeArrayBufferByteLength` did the same with the `byteLength` getter. For the plain objects that make up nearly all message content that is two thrown exceptions — with captured stacks — per object. `node:util/types` `isDate` / `isArrayBuffer` read the same internal slots natively: no user code, no throw, cross-realm correct, and already imported here for `isProxy`. Verified equivalent to the throwing probes on a real Date, a prototype-swapped real Date, a fake with `Date.prototype`, and a plain object; `isArrayBuffer` (not `isAnyArrayBuffer`) preserves the getter's rejection of `SharedArrayBuffer`.

## Measured

LibreChat `main`, Node 24, local MongoDB, in-process fake model, 40 follow-up turns per variant, three alternating rounds:

| conversation | metric | 3.6.14 | this branch |
|---|---|---|---|
| 300 messages | CPU / turn (median) | 58.8 ms | 39.1 ms (−33%) |
| 300 messages | CPU / turn (best stock round vs worst patched) | 44.3 ms | 40.4 ms (−9%) |
| 1000 messages | turn p50 | 76 ms | 56 ms (−27%) |
| 1000 messages | throughput | 13.0/s | 17.7/s (+36%) |

The stock variance across rounds (44 → 63 → 59 ms) is itself the exception/GC pressure; the patched build sat at 37–40 ms. In the windowed CPU profile both probe functions drop out of the top 40 entirely and `@librechat/agents` self-time falls 282 → 108 ms over 20 turns.

## Tests

Three `toHaveBeenCalledTimes` assertions pinned the old tokenizer invocation count and are updated (3 → 2, 101 → 0, 113 → 13 — each the minimum for its scenario). One new test keeps the cross-meter exact-count cache covered for the no-stored-count path (101 calls). `contextPressureMeter`, `toolContent`, and `tokens` suites: 69/69. The provider `llm.spec.ts` suites fail identically on clean `main` (they need live credentials).

`CONTEXT.md` notes the new baseline contract.

Note: the commit is unsigned — GPG wasn't available in the environment that produced it.
