### PR TITLE
📬 chore: Bump Version to 3.6.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.14",
+  "version": "3.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.6.14",
+      "version": "3.6.15",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.6.14",
+  "version": "3.6.15",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
## Summary

I bumped @librechat/agents from 3.6.14 to 3.6.15 after merging the measured token-count hot-path optimization.

- Update the package manifest version to 3.6.15.
- Update the package-lock root version entries to 3.6.15.
- Leave dependency resolutions and package contents unchanged.
- Prepare publication of the optimization that reduced CPU per turn by 33% at 300 messages and improved throughput by 36% at 1,000 messages in the LibreChat benchmark.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Parsed both manifests and verified the package, lockfile, and lockfile root-package versions are exactly 3.6.15.
- Normalized the two version fields and verified the lockfile matches origin/main, confirming no dependency resolution changes.
- Ran git diff --check successfully.
- Confirmed all 13 CI jobs passed on the underlying performance PR.
- Confirmed Codex reviewed the exact underlying head b01ab9402cf9bfa3100e4e30e68268cb2d7d30b1 and found no major issues.

### **Test Configuration**:

- Node.js 24
- npm 10.5.2
- macOS arm64

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with the underlying feature changes
