### PR TITLE
⚡ perf: Derive Provider Tool Messages in One Pass

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,14 @@ probes, so plain content objects never pay an exception per value.
 The meter's estimates decide overflow and recovery only. Provider-reported
 usage remains the source of truth for billing and Langfuse observations.
 
+## Provider Tool Derivation
+
+A **Provider Tool Derivation** is the copy-on-write projection of retained
+assistant history that drops incomplete streamed text blocks and bounds every
+provider-consumed tool-call input representation in one pass. Its output is
+the provider-safe preflight input for context-pressure measurement; provider-
+specific replay and wire shaping remain later request projections.
+
 ## Runtime Provider Registration
 
 A **Provider Registration** is the process-local binding of one provider name

--- a/docs/provider-derivation-benchmark.md
+++ b/docs/provider-derivation-benchmark.md
@@ -1,0 +1,26 @@
+# Provider-tool derivation benchmark
+
+The graph used to make two universal passes before provider-specific request
+shaping: first to drop incomplete streamed text blocks, then to bound every
+tool-call input representation. The new provider-tool derivation performs both
+operations in one pass and makes one clone when an assistant message needs both
+repairs.
+
+Run it with:
+
+```sh
+npm run bench:provider-derivation
+```
+
+Result on 2026-08-24, median of seven alternating samples with 250 derivations
+per sample:
+
+| Scenario          | Sequential passes | One-pass derivation | Relative speed |
+| ----------------- | ----------------: | ------------------: | -------------: |
+| 500 text messages |           0.35 ms |             0.20 ms |          1.69x |
+| 100 tool turns    |        1452.26 ms |          1367.12 ms |          1.06x |
+
+The tool case is the decision metric. Its 5.9% CPU reduction is modest because
+safe serialization and truncation of tool arguments still dominate the work;
+the benchmark verifies the provider-visible serialized messages are identical
+before timing either path.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "bench:context-pressure": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-context-pressure-cache.ts",
+    "bench:provider-derivation": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-provider-derivation.ts",
     "bench:execution-world": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-execution-world.ts",
     "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -53,9 +53,8 @@ import {
   cloneMessage,
   CALIBRATION_RATIO_MAX,
   createPruneMessages,
-  projectToolCallInputs,
+  projectToolMessagesForProvider,
   calculateMaxToolCallInputChars,
-  projectToolStreamContentForProvider,
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
@@ -3178,15 +3177,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const maxProviderToolResultChars =
         agentContext.maxToolResultChars ??
         calculateMaxToolResultChars(agentContext.maxContextTokens);
-      const beforeToolStreamProjection = finalMessages;
-      finalMessages = trackProviderMessageOrigins(
-        beforeToolStreamProjection,
-        projectToolStreamContentForProvider(beforeToolStreamProjection)
-      );
       const beforeToolInputProjection = finalMessages;
       finalMessages = trackProviderMessageOrigins(
         beforeToolInputProjection,
-        projectToolCallInputs(
+        projectToolMessagesForProvider(
           beforeToolInputProjection,
           calculateMaxToolCallInputChars(agentContext.maxContextTokens)
         )

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -980,6 +980,19 @@ function isCompleteToolStreamContentBlock(block: unknown): boolean {
   }
 }
 
+/** Drops incomplete streamed text blocks before provider-facing tool shaping. */
+export function dropIncompleteToolStreamContent(
+  content: AIMessage['content']
+): AIMessage['content'] {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  const completeContent = content.filter(isCompleteToolStreamContentBlock);
+  return completeContent.length === content.length
+    ? content
+    : toLangChainContent(completeContent);
+}
+
 function projectPreemptedResponsesV1Content(
   content: AIMessage['content'],
   reasoning: unknown,
@@ -2026,20 +2039,12 @@ export function projectToolStreamContentForProvider(
       }
       continue;
     }
-    if (!Array.isArray(assistantMessage.content)) {
-      continue;
-    }
-    const content = assistantMessage.content.filter(
-      isCompleteToolStreamContentBlock
-    );
-    if (content.length === assistantMessage.content.length) {
+    const content = dropIncompleteToolStreamContent(assistantMessage.content);
+    if (content === assistantMessage.content) {
       continue;
     }
     projected ??= [...messages];
-    projected[i] = cloneAIMessageWithContent(
-      assistantMessage,
-      toLangChainContent(content)
-    );
+    projected[i] = cloneAIMessageWithContent(assistantMessage, content);
   }
   return projected ?? messages;
 }

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -31,6 +31,7 @@ import { resolveContextPruningSettings } from './contextPruningSettings';
 import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
 import { ContentTypes, Providers, Constants } from '@/common';
 import { getProviderFamily } from '@/llm/providerRegistry';
+import { dropIncompleteToolStreamContent } from './core';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
 
@@ -1412,6 +1413,47 @@ function cloneWithProjectedProperties<T extends object>(
   ) as T;
 }
 
+function cloneAIMessageWithProjectedStreamContent(
+  message: AIMessage | AIMessageChunk,
+  changes: Readonly<Record<string, unknown>>,
+  streamContent: AIMessage['content']
+): AIMessage | AIMessageChunk {
+  const descriptors = Object.getOwnPropertyDescriptors(message) as Record<
+    string,
+    PropertyDescriptor | undefined
+  >;
+  for (const [key, projectedValue] of Object.entries(changes)) {
+    const descriptor = descriptors[key];
+    descriptors[key] = {
+      configurable: descriptor?.configurable ?? true,
+      enumerable: descriptor?.enumerable ?? true,
+      value: projectedValue,
+      writable: descriptor?.writable ?? true,
+    };
+  }
+  const lcKwargs = descriptors.lc_kwargs;
+  if (
+    lcKwargs != null &&
+    'value' in lcKwargs &&
+    typeof lcKwargs.value === 'object' &&
+    lcKwargs.value != null
+  ) {
+    descriptors.lc_kwargs = {
+      ...lcKwargs,
+      value: {
+        ...(lcKwargs.value as Record<string, unknown>),
+        ...(message.response_metadata.output_version === 'v1'
+          ? { content: undefined, contentBlocks: streamContent }
+          : { content: streamContent }),
+      },
+    };
+  }
+  return Object.create(
+    Object.getPrototypeOf(message),
+    descriptors as PropertyDescriptorMap
+  ) as AIMessage | AIMessageChunk;
+}
+
 function createBoundedTruncationValue(
   preview: string,
   originalChars: number,
@@ -1875,9 +1917,10 @@ export function calculateMaxToolCallInputChars(
  * Returns the original array when no message changes and otherwise clones only
  * the array and AI messages whose inline input or `tool_calls` args changed.
  */
-export function projectToolCallInputs(
+function projectToolCallInputsInternal(
   messages: BaseMessage[],
-  maxInputChars: number
+  maxInputChars: number,
+  dropIncompleteStreamContent: boolean
 ): BaseMessage[] {
   const normalizedMaxInputChars = normalizeToolInputLimit(maxInputChars);
   let projectedMessages: BaseMessage[] | undefined;
@@ -1889,16 +1932,21 @@ export function projectToolCallInputs(
     }
 
     const aiMessage = message as AIMessage | AIMessageChunk;
-    let projectedContent = aiMessage.content;
-    let contentChanged = false;
-    if (Array.isArray(aiMessage.content)) {
-      const originalContent = aiMessage.content as MessageContentComplex[];
+    const streamContent = dropIncompleteStreamContent
+      ? dropIncompleteToolStreamContent(aiMessage.content)
+      : aiMessage.content;
+    let projectedContent = streamContent;
+    let contentChanged = streamContent !== aiMessage.content;
+    if (Array.isArray(streamContent)) {
+      const originalContent = streamContent as MessageContentComplex[];
       const mappedContent = originalContent.map((block) =>
         projectInlineToolInput(block, normalizedMaxInputChars)
       );
-      contentChanged = mappedContent.some(
-        (block, blockIndex) => block !== originalContent[blockIndex]
-      );
+      contentChanged =
+        contentChanged ||
+        mappedContent.some(
+          (block, blockIndex) => block !== originalContent[blockIndex]
+        );
       projectedContent = toLangChainContent(mappedContent);
     }
 
@@ -2020,16 +2068,43 @@ export function projectToolCallInputs(
       continue;
     }
 
-    const projectedMessage = cloneWithProjectedProperties(aiMessage, {
+    const changes = {
       content: projectedContent,
       tool_calls: projectedToolCalls.length > 0 ? projectedToolCalls : [],
       additional_kwargs: projectedAdditionalKwargs,
       response_metadata: projectedResponseMetadata,
-    });
+    };
+    const projectedMessage =
+      streamContent === aiMessage.content
+        ? cloneWithProjectedProperties(aiMessage, changes)
+        : cloneAIMessageWithProjectedStreamContent(
+          aiMessage,
+          changes,
+          streamContent
+        );
     projectedMessages ??= [...messages];
     projectedMessages[i] = projectedMessage;
   }
   return projectedMessages ?? messages;
+}
+
+/** Projects all historical tool-call input representations to bounded values. */
+export function projectToolCallInputs(
+  messages: BaseMessage[],
+  maxInputChars: number
+): BaseMessage[] {
+  return projectToolCallInputsInternal(messages, maxInputChars, false);
+}
+
+/**
+ * Derives provider-safe tool history in one pass by dropping incomplete stream
+ * content and bounding every provider-consumed tool-call input representation.
+ */
+export function projectToolMessagesForProvider(
+  messages: BaseMessage[],
+  maxInputChars: number
+): BaseMessage[] {
+  return projectToolCallInputsInternal(messages, maxInputChars, true);
 }
 
 export function preFlightTruncateToolCallInputs(params: {

--- a/src/scripts/bench-provider-derivation.ts
+++ b/src/scripts/bench-provider-derivation.ts
@@ -1,0 +1,150 @@
+/* eslint-disable no-console */
+import { performance } from 'node:perf_hooks';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+import { projectToolStreamContentForProvider } from '@/messages/core';
+import {
+  projectToolCallInputs,
+  projectToolMessagesForProvider,
+} from '@/messages/prune';
+import { serializeMessage } from '@/session/messageSerialization';
+
+interface BenchmarkResult {
+  elapsedMs: number;
+  checksum: number;
+}
+
+const ITERATIONS = 250;
+const SAMPLE_COUNT = 7;
+const MAX_TOOL_INPUT_CHARS = 800;
+
+function createTextHistory(messageCount: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let index = 0; index < messageCount; index++) {
+    messages.push(
+      new HumanMessage(
+        `Message ${index}: ${'retained conversation context '.repeat(24)}`
+      )
+    );
+  }
+  return messages;
+}
+
+function createToolHistory(turnCount: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let index = 0; index < turnCount; index++) {
+    const callId = `call-${index}`;
+    const query = `query-${index}-${'x'.repeat(2_000)}`;
+    messages.push(
+      new HumanMessage(`Find context for turn ${index}.`),
+      new AIMessageChunk({
+        content: [
+          { type: 'text', text: '' },
+          {
+            type: 'tool_use',
+            id: callId,
+            name: 'search',
+            input: { query },
+          },
+        ],
+        tool_calls: [
+          {
+            id: callId,
+            name: 'search',
+            args: { query },
+          },
+        ],
+      })
+    );
+  }
+  return messages;
+}
+
+function serialize(messages: BaseMessage[]): string {
+  return JSON.stringify(messages.map(serializeMessage));
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function runBefore(messages: BaseMessage[]): BenchmarkResult {
+  let checksum = 0;
+  const startedAt = performance.now();
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    checksum += projectToolCallInputs(
+      projectToolStreamContentForProvider(messages),
+      MAX_TOOL_INPUT_CHARS
+    ).length;
+  }
+  return { elapsedMs: performance.now() - startedAt, checksum };
+}
+
+function runAfter(messages: BaseMessage[]): BenchmarkResult {
+  let checksum = 0;
+  const startedAt = performance.now();
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    checksum += projectToolMessagesForProvider(
+      messages,
+      MAX_TOOL_INPUT_CHARS
+    ).length;
+  }
+  return { elapsedMs: performance.now() - startedAt, checksum };
+}
+
+for (const scenario of [
+  { name: 'text-500', messages: createTextHistory(500) },
+  { name: 'tools-100', messages: createToolHistory(100) },
+]) {
+  const beforeProjection = projectToolCallInputs(
+    projectToolStreamContentForProvider(scenario.messages),
+    MAX_TOOL_INPUT_CHARS
+  );
+  const afterProjection = projectToolMessagesForProvider(
+    scenario.messages,
+    MAX_TOOL_INPUT_CHARS
+  );
+  if (serialize(beforeProjection) !== serialize(afterProjection)) {
+    throw new Error(`Provider derivation changed ${scenario.name} output`);
+  }
+
+  runBefore(scenario.messages);
+  runAfter(scenario.messages);
+  const beforeSamples: BenchmarkResult[] = [];
+  const afterSamples: BenchmarkResult[] = [];
+  for (let sample = 0; sample < SAMPLE_COUNT; sample++) {
+    const beforeFirst = sample % 2 === 0;
+    const first = beforeFirst
+      ? runBefore(scenario.messages)
+      : runAfter(scenario.messages);
+    const second = beforeFirst
+      ? runAfter(scenario.messages)
+      : runBefore(scenario.messages);
+    (beforeFirst ? beforeSamples : afterSamples).push(first);
+    (beforeFirst ? afterSamples : beforeSamples).push(second);
+  }
+  const beforeMs = median(beforeSamples.map(({ elapsedMs }) => elapsedMs));
+  const afterMs = median(afterSamples.map(({ elapsedMs }) => elapsedMs));
+  if (
+    beforeSamples[0].checksum !== afterSamples[0].checksum ||
+    beforeSamples.some(
+      (sample) => sample.checksum !== beforeSamples[0].checksum
+    ) ||
+    afterSamples.some((sample) => sample.checksum !== afterSamples[0].checksum)
+  ) {
+    throw new Error(
+      `Provider derivation changed ${scenario.name} message count`
+    );
+  }
+  console.log(
+    JSON.stringify({
+      scenario: scenario.name,
+      iterations: ITERATIONS,
+      beforeMs: Number(beforeMs.toFixed(2)),
+      afterMs: Number(afterMs.toFixed(2)),
+      speedup: Number((beforeMs / afterMs).toFixed(2)),
+    })
+  );
+}

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -24,8 +24,10 @@ import {
   calculateMaxToolCallInputChars,
   createPruneMessages,
   projectToolCallInputs,
+  projectToolMessagesForProvider,
   serializeToolCallInput,
 } from '@/messages/prune';
+import { projectToolStreamContentForProvider } from '@/messages/core';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { ensureThinkingBlockInMessages } from '@/messages/format';
 import { Providers, ContentTypes } from '@/common';
@@ -1439,6 +1441,53 @@ describe('Prune Messages Tests', () => {
   });
 
   describe('projectToolCallInputs', () => {
+    it('matches sequential stream and tool-input projection in one pass', () => {
+      const messages: BaseMessage[] = [
+        new HumanMessage('Use the tool.'),
+        new AIMessageChunk({
+          content: [
+            { type: 'text', text: '' },
+            {
+              type: 'tool_use',
+              id: 'call-1',
+              name: 'search',
+              input: { query: 'x'.repeat(2_000) },
+            },
+          ],
+          tool_calls: [
+            {
+              id: 'call-1',
+              name: 'search',
+              args: { query: 'x'.repeat(2_000) },
+            },
+          ],
+        }),
+      ];
+
+      const sequential = projectToolCallInputs(
+        projectToolStreamContentForProvider(messages),
+        200
+      );
+      const derived = projectToolMessagesForProvider(messages, 200);
+
+      expect(derived).toEqual(sequential);
+      expect(derived[1]).not.toBe(sequential[1]);
+      expect(derived[1]).not.toBe(messages[1]);
+    });
+
+    it('returns the original array when stream content and inputs are safe', () => {
+      const messages: BaseMessage[] = [
+        new AIMessage({
+          content: [{ type: 'text', text: 'Calling search.' }],
+          tool_calls: [
+            { id: 'call-1', name: 'search', args: { query: 'safe' } },
+          ],
+        }),
+      ];
+
+      expect(projectToolMessagesForProvider(messages, 200)).toBe(messages);
+    });
+
     it('uses the shared 15%-of-context cap with a 200K ceiling', () => {
       expect(calculateMaxToolCallInputChars()).toBe(200_000);
       expect(calculateMaxToolCallInputChars(0)).toBe(200_000);


### PR DESCRIPTION
## Summary

I consolidated the Graph provider-tool preflight work into one copy-on-write derivation, preserving the existing provider-visible payload while removing a redundant message-array walk.

- Combine incomplete streamed-text removal and tool-call input bounding in `projectToolMessagesForProvider`.
- Preserve `lc_kwargs` replay state when both transforms change one assistant message.
- Route Graph context-pressure preparation through the single provider-tool derivation.
- Add parity tests and a reproducible before/after benchmark.
- Record the Provider Tool Derivation term and benchmark results.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx tsc --noEmit`
- `npx jest src/specs/prune.test.ts src/messages/formatAgentMessages.test.ts src/llm/prepareProviderRequest.test.ts src/graphs/__tests__/Graph.contextOverflow.test.ts src/graphs/__tests__/Graph.reasoning.test.ts --runInBand`
- `npx jest src/specs/langfuse-tool-output-tracing.test.ts src/graphs/__tests__/Graph.preemptSignal.test.ts src/llm/invoke.test.ts --runInBand`
- `npm run bench:provider-derivation`

The benchmark verifies identical serialized provider messages before timing. On the 100-tool-turn case it measured approximately 1.05–1.06x faster, with safe tool-input serialization remaining the dominant cost.

### **Test Configuration**:

- Node.js 24.16.0
- npm 10.5.2

## Checklist

- [x] My code adheres to this projects style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.