### PR TITLE
🧾 feat: Track Authoritative Subagent Control Receipts

### DIFF
--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -228,14 +228,31 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
 
   /**
    * Payload-free transition seam for hosts that durably project authoritative
-   * receipts. Implementations must return synchronously and must not reproduce
-   * task-store transition rules.
+   * receipts. Implementations must return synchronously, must not reproduce
+   * task-store transition rules, and cannot veto task-store state transitions:
+   * hook failures are deliberately isolated by the caller.
    */
   protected onControlReceipt(
     _scopeId: string,
     _taskId: string,
     _receipt: SubagentTaskControlReceipt
   ): void {}
+
+  private emitControlReceipt(
+    task: StoredTask,
+    receipt: SubagentTaskControlReceipt
+  ): void {
+    try {
+      this.onControlReceipt(
+        task.scopeId,
+        task.id,
+        cloneControlReceipt(receipt)
+      );
+    } catch {
+      // A host projection is observability only. Task admission, draining, and
+      // settlement must remain correct when that projection is unavailable.
+    }
+  }
 
   start(request: SubagentTaskStartRequest): SubagentTaskStartResult {
     const scopeId = request.scopeId.trim();
@@ -480,7 +497,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       updatedAt: task.updatedAt,
     };
     task.controlReceipts.set(control.id, receipt);
-    this.onControlReceipt(task.scopeId, task.id, cloneControlReceipt(receipt));
+    this.emitControlReceipt(task, receipt);
     return {
       status: 'accepted',
       task: snapshot(task),
@@ -613,11 +630,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       ...(detail.reason == null ? {} : { reason: detail.reason }),
     };
     task.controlReceipts.set(controlId, transitioned);
-    this.onControlReceipt(
-      task.scopeId,
-      task.id,
-      cloneControlReceipt(transitioned)
-    );
+    this.emitControlReceipt(task, transitioned);
   }
 
   private failPendingControls(

--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -4,6 +4,7 @@ import type {
   SubagentTaskBoundary,
   SubagentTaskClaim,
   SubagentTaskControlCommand,
+  SubagentTaskControlReceipt,
   SubagentTaskControlResult,
   SubagentTaskProgress,
   SubagentTaskRuntime,
@@ -20,6 +21,7 @@ const DEFAULT_MAX_ERROR_CHARS = 4 * 1024;
 const DEFAULT_MAX_MESSAGE_CHARS = 64 * 1024;
 const DEFAULT_TASK_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_CONTROLS = 32;
+const DEFAULT_MAX_CONTROL_RECEIPTS = 64;
 const DEFAULT_MAX_RESULT_CHARS = 100_000;
 const DEFAULT_MAX_RUNNING_PER_SCOPE = 10;
 const DEFAULT_MAX_RUNNING_TOTAL = 100;
@@ -30,6 +32,7 @@ export interface InMemorySubagentTaskStoreOptions {
   completedTtlMs?: number;
   maxControlMessageChars?: number;
   maxControlsPerTask?: number;
+  maxControlReceiptsPerTask?: number;
   maxErrorChars?: number;
   maxResultChars?: number;
   maxRunningPerScope?: number;
@@ -57,6 +60,7 @@ type StoredTask = {
   updatedAt: number;
   controller: AbortController;
   controls: PendingControl[];
+  controlReceipts: Map<string, SubagentTaskControlReceipt>;
   progressEvents: number;
   resultClaimed: boolean;
   acceptingControls: boolean;
@@ -106,6 +110,13 @@ function resolveOptions(
     maxControlsPerTask: resolvePositiveInteger(
       options.maxControlsPerTask,
       DEFAULT_MAX_CONTROLS
+    ),
+    maxControlReceiptsPerTask: Math.max(
+      resolvePositiveInteger(
+        options.maxControlReceiptsPerTask,
+        DEFAULT_MAX_CONTROL_RECEIPTS
+      ),
+      resolvePositiveInteger(options.maxControlsPerTask, DEFAULT_MAX_CONTROLS)
     ),
     maxErrorChars: resolvePositiveInteger(
       options.maxErrorChars,
@@ -177,6 +188,9 @@ function snapshot(task: StoredTask): SubagentTaskSnapshot {
       task.status === 'completed' && task.result != null && !task.resultClaimed,
     resultClaimed: task.resultClaimed,
     pendingControls: task.controls.length,
+    controlReceipts: [...task.controlReceipts.values()].map((receipt) => ({
+      ...receipt,
+    })),
     ...(task.progress == null ? {} : { progress: { ...task.progress } }),
     ...(task.error == null ? {} : { error: task.error }),
   };
@@ -272,6 +286,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       updatedAt: now,
       controller: new AbortController(),
       controls: [],
+      controlReceipts: new Map(),
       progressEvents: 0,
       resultClaimed: false,
       acceptingControls: true,
@@ -312,6 +327,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
           }
           task.status = 'completed';
           task.acceptingControls = false;
+          this.failPendingControls(task, 'task_completed');
           task.controls.length = 0;
           task.result = truncateMiddle(
             result.content,
@@ -399,9 +415,16 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       if (index < 0) {
         return { status: 'control_not_found', task: snapshot(task) };
       }
-      task.controls.splice(index, 1);
+      const [control] = task.controls.splice(index, 1);
       task.updatedAt = Date.now();
-      return { status: 'accepted', task: snapshot(task) };
+      this.transitionControl(task, control.id, 'rejected', {
+        reason: 'withdrawn',
+      });
+      return {
+        status: 'accepted',
+        task: snapshot(task),
+        controlId: control.id,
+      };
     }
     const message = command.message.trim();
     if (message === '') {
@@ -419,6 +442,12 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
         message: `Task already has ${this.options.maxControlsPerTask} pending messages.`,
       };
     }
+    if (!this.makeRoomForControlReceipt(task)) {
+      return {
+        status: 'invalid',
+        message: 'Task control receipt capacity is unavailable.',
+      };
+    }
     const control: PendingControl = {
       id: nanoid(),
       action: command.action,
@@ -426,6 +455,13 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     };
     task.controls.push(control);
     task.updatedAt = Date.now();
+    task.controlReceipts.set(control.id, {
+      controlId: control.id,
+      action: control.action,
+      status: 'accepted',
+      createdAt: task.updatedAt,
+      updatedAt: task.updatedAt,
+    });
     return {
       status: 'accepted',
       task: snapshot(task),
@@ -525,6 +561,57 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     }
   }
 
+  private makeRoomForControlReceipt(task: StoredTask): boolean {
+    while (
+      task.controlReceipts.size >= this.options.maxControlReceiptsPerTask
+    ) {
+      const terminal = [...task.controlReceipts].find(
+        ([, receipt]) => receipt.status !== 'accepted'
+      );
+      if (terminal == null) {
+        return false;
+      }
+      task.controlReceipts.delete(terminal[0]);
+    }
+    return true;
+  }
+
+  private transitionControl(
+    task: StoredTask,
+    controlId: string,
+    status: Exclude<SubagentTaskControlReceipt['status'], 'accepted'>,
+    detail: Pick<SubagentTaskControlReceipt, 'boundary' | 'reason'> = {}
+  ): void {
+    const receipt = task.controlReceipts.get(controlId);
+    if (receipt == null || receipt.status !== 'accepted') {
+      return;
+    }
+    task.controlReceipts.set(controlId, {
+      ...receipt,
+      status,
+      updatedAt: Date.now(),
+      ...(detail.boundary == null ? {} : { boundary: detail.boundary }),
+      ...(detail.reason == null ? {} : { reason: detail.reason }),
+    });
+  }
+
+  private failPendingControls(
+    task: StoredTask,
+    reason: Extract<
+      NonNullable<SubagentTaskControlReceipt['reason']>,
+      'task_completed' | 'task_cancelled' | 'task_failed'
+    >
+  ): void {
+    for (const control of task.controls) {
+      this.transitionControl(
+        task,
+        control.id,
+        reason === 'task_failed' ? 'failed' : 'rejected',
+        { reason }
+      );
+    }
+  }
+
   private scheduleExpiry(task: StoredTask): void {
     this.clearTaskTimeout(task);
     this.clearTaskExpiry(task);
@@ -566,6 +653,10 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     task.status = status;
     this.runningTasks -= 1;
     task.acceptingControls = false;
+    this.failPendingControls(
+      task,
+      status === 'cancelled' ? 'task_cancelled' : 'task_failed'
+    );
     task.controls.length = 0;
     task.error = message;
     task.updatedAt = Date.now();
@@ -575,6 +666,7 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
 
   private createRuntime(task: StoredTask): SubagentTaskRuntime {
     const take = (
+      boundary: SubagentTaskBoundary,
       accept: (control: PendingControl) => boolean
     ): InjectedMessage[] => {
       if (task.status !== 'running') {
@@ -588,6 +680,9 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
       task.controls = retained;
       if (selected.length > 0) {
         task.updatedAt = Date.now();
+        for (const control of selected) {
+          this.transitionControl(task, control.id, 'applied', { boundary });
+        }
       }
       return selected.map(toInjectedMessage);
     };
@@ -599,15 +694,15 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
         task.controls.some((control) => control.action === 'interrupt'),
       drain: (boundary: SubagentTaskBoundary): InjectedMessage[] => {
         if (boundary === 'preempt') {
-          return take((control) => control.action === 'interrupt');
+          return take(boundary, (control) => control.action === 'interrupt');
         }
         if (boundary === 'tool') {
-          return take((control) => control.action !== 'queue');
+          return take(boundary, (control) => control.action !== 'queue');
         }
-        return take(() => true);
+        return take(boundary, () => true);
       },
       closeTurn: (): { closed: boolean; messages: InjectedMessage[] } => {
-        const messages = take(() => true);
+        const messages = take('turn', () => true);
         if (messages.length > 0) {
           return { closed: false, messages };
         }

--- a/src/tools/subagent/InMemorySubagentTaskStore.ts
+++ b/src/tools/subagent/InMemorySubagentTaskStore.ts
@@ -196,6 +196,12 @@ function snapshot(task: StoredTask): SubagentTaskSnapshot {
   };
 }
 
+function cloneControlReceipt(
+  receipt: SubagentTaskControlReceipt
+): SubagentTaskControlReceipt {
+  return { ...receipt };
+}
+
 function abortReason(signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason
@@ -219,6 +225,17 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
   constructor(options: InMemorySubagentTaskStoreOptions = {}) {
     this.options = resolveOptions(options);
   }
+
+  /**
+   * Payload-free transition seam for hosts that durably project authoritative
+   * receipts. Implementations must return synchronously and must not reproduce
+   * task-store transition rules.
+   */
+  protected onControlReceipt(
+    _scopeId: string,
+    _taskId: string,
+    _receipt: SubagentTaskControlReceipt
+  ): void {}
 
   start(request: SubagentTaskStartRequest): SubagentTaskStartResult {
     const scopeId = request.scopeId.trim();
@@ -455,13 +472,15 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     };
     task.controls.push(control);
     task.updatedAt = Date.now();
-    task.controlReceipts.set(control.id, {
+    const receipt: SubagentTaskControlReceipt = {
       controlId: control.id,
       action: control.action,
       status: 'accepted',
       createdAt: task.updatedAt,
       updatedAt: task.updatedAt,
-    });
+    };
+    task.controlReceipts.set(control.id, receipt);
+    this.onControlReceipt(task.scopeId, task.id, cloneControlReceipt(receipt));
     return {
       status: 'accepted',
       task: snapshot(task),
@@ -586,13 +605,19 @@ export class InMemorySubagentTaskStore implements SubagentTaskStore {
     if (receipt == null || receipt.status !== 'accepted') {
       return;
     }
-    task.controlReceipts.set(controlId, {
+    const transitioned: SubagentTaskControlReceipt = {
       ...receipt,
       status,
       updatedAt: Date.now(),
       ...(detail.boundary == null ? {} : { boundary: detail.boundary }),
       ...(detail.reason == null ? {} : { reason: detail.reason }),
-    });
+    };
+    task.controlReceipts.set(controlId, transitioned);
+    this.onControlReceipt(
+      task.scopeId,
+      task.id,
+      cloneControlReceipt(transitioned)
+    );
   }
 
   private failPendingControls(

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -14,6 +14,12 @@ class ReceiptObservingStore extends InMemorySubagentTaskStore {
   }
 }
 
+class ThrowingReceiptStore extends InMemorySubagentTaskStore {
+  protected override onControlReceipt(): void {
+    throw new Error('projection unavailable');
+  }
+}
+
 const settle = async (): Promise<void> => {
   await Promise.resolve();
   await Promise.resolve();
@@ -623,6 +629,45 @@ describe('InMemorySubagentTaskStore', () => {
       action: 'cancel',
     });
     await settle();
+  });
+
+  it('isolates receipt projection failures from admission, drain, and settlement', async () => {
+    const store = new ThrowingReceiptStore({ maxRunningPerScope: 1 });
+    let runtime: SubagentTaskRuntime | undefined;
+    let finish: ((value: { content: string }) => void) | undefined;
+    const started = start(
+      store,
+      async (taskRuntime) =>
+        new Promise<{ content: string }>((resolve) => {
+          runtime = taskRuntime;
+          finish = resolve;
+        })
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'steer',
+        message: 'continue',
+      })
+    ).toMatchObject({ status: 'accepted' });
+    expect(runtime?.drain('tool')).toEqual([
+      expect.objectContaining({ content: 'continue' }),
+    ]);
+    finish?.({ content: 'done' });
+    await settle();
+
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'completed',
+    });
+    expect(
+      start(store, async () => ({ content: 'replacement' }), {
+        idempotencyKey: 'replacement-after-projection-failure',
+      })
+    ).toMatchObject({ accepted: true, isNew: true });
   });
 
   it('times out a non-cooperative task and frees its running slot', async () => {

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -28,9 +28,7 @@ const start = (
     ...(overrides.requestFingerprint == null
       ? {}
       : { requestFingerprint: overrides.requestFingerprint }),
-    ...(overrides.threadId == null
-      ? {}
-      : { threadId: overrides.threadId }),
+    ...(overrides.threadId == null ? {} : { threadId: overrides.threadId }),
     input: 'Research the question.',
     subagentKind: 'agent',
     subagentType: overrides.subagentType ?? 'researcher',
@@ -245,11 +243,33 @@ describe('InMemorySubagentTaskStore', () => {
     });
     expect(interrupt).toMatchObject({ status: 'accepted' });
     expect(steer).toMatchObject({ status: 'accepted' });
+    expect(
+      store.get('user:conversation', started.task.taskId)?.controlReceipts
+    ).toEqual([
+      expect.objectContaining({
+        controlId:
+          interrupt.status === 'accepted' ? interrupt.controlId : undefined,
+        action: 'interrupt',
+        status: 'accepted',
+      }),
+      expect.objectContaining({
+        controlId: steer.status === 'accepted' ? steer.controlId : undefined,
+        action: 'steer',
+        status: 'accepted',
+      }),
+      expect.objectContaining({ action: 'queue', status: 'accepted' }),
+    ]);
     expect(runtime?.shouldPreempt()).toBe(true);
     expect(runtime?.drain('preempt').map((message) => message.content)).toEqual(
       ['Stop searching and summarize now.']
     );
     expect(runtime?.shouldPreempt()).toBe(false);
+    expect(
+      store.get('user:conversation', started.task.taskId)?.controlReceipts?.[0]
+    ).toMatchObject({
+      status: 'applied',
+      boundary: 'preempt',
+    });
     expect(runtime?.drain('tool').map((message) => message.content)).toEqual([
       'Also check the primary source.',
     ]);
@@ -263,6 +283,25 @@ describe('InMemorySubagentTaskStore', () => {
         },
       ],
     });
+    expect(
+      store.get('user:conversation', started.task.taskId)?.controlReceipts
+    ).toEqual([
+      expect.objectContaining({
+        action: 'interrupt',
+        status: 'applied',
+        boundary: 'preempt',
+      }),
+      expect.objectContaining({
+        action: 'steer',
+        status: 'applied',
+        boundary: 'tool',
+      }),
+      expect.objectContaining({
+        action: 'queue',
+        status: 'applied',
+        boundary: 'turn',
+      }),
+    ]);
     expect(runtime?.closeTurn()).toEqual({ closed: true, messages: [] });
 
     finish({ content: 'done' });
@@ -295,13 +334,236 @@ describe('InMemorySubagentTaskStore', () => {
     if (queued.status !== 'accepted' || queued.controlId == null) {
       throw new Error('Expected a cancellable control receipt.');
     }
+    const cancelled = store.control('user:conversation', started.task.taskId, {
+      action: 'cancel_message',
+      controlId: queued.controlId,
+    });
+    expect(cancelled).toMatchObject({
+      status: 'accepted',
+      controlId: queued.controlId,
+    });
+    expect(
+      cancelled.status === 'accepted' ? cancelled.task.controlReceipts : []
+    ).toEqual([
+      expect.objectContaining({
+        controlId: queued.controlId,
+        status: 'rejected',
+        reason: 'withdrawn',
+      }),
+    ]);
+    expect(runtime?.drain('tool')).toEqual([]);
+    store.control('user:conversation', started.task.taskId, {
+      action: 'cancel',
+    });
+    await settle();
+  });
+
+  it('rejects accepted controls that lose a completion race', async () => {
+    let finish = (_result: { content: string }): void => undefined;
+    const result = new Promise<{ content: string }>((resolve) => {
+      finish = resolve;
+    });
+    const store = new InMemorySubagentTaskStore();
+    const started = start(store, async () => result);
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+    const queued = store.control('user:conversation', started.task.taskId, {
+      action: 'queue',
+      message: 'This arrives too late.',
+    });
+    expect(queued).toMatchObject({ status: 'accepted' });
+
+    finish({ content: 'done' });
+    await settle();
+
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'completed',
+      controlReceipts: [
+        expect.objectContaining({
+          action: 'queue',
+          status: 'rejected',
+          reason: 'task_completed',
+        }),
+      ],
+    });
+  });
+
+  it('marks accepted controls failed when child execution fails', async () => {
+    let fail = (_error: Error): void => undefined;
+    const result = new Promise<{ content: string }>((_resolve, reject) => {
+      fail = reject;
+    });
+    const store = new InMemorySubagentTaskStore();
+    const started = start(store, async () => result);
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
     expect(
       store.control('user:conversation', started.task.taskId, {
-        action: 'cancel_message',
-        controlId: queued.controlId,
+        action: 'interrupt',
+        message: 'Stop and report now.',
       })
     ).toMatchObject({ status: 'accepted' });
+
+    fail(new Error('provider failed'));
+    await settle();
+
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'error',
+      controlReceipts: [
+        expect.objectContaining({
+          action: 'interrupt',
+          status: 'failed',
+          reason: 'task_failed',
+        }),
+      ],
+    });
+  });
+
+  it('rejects pending controls separately when the child is cancelled', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const started = start(
+      store,
+      async (runtime) =>
+        new Promise((_resolve, reject) => {
+          runtime.signal.addEventListener(
+            'abort',
+            () => reject(runtime.signal.reason),
+            { once: true }
+          );
+        })
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'queue',
+        message: 'Wait for the next turn.',
+      })
+    ).toMatchObject({ status: 'accepted' });
+
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'cancel',
+      })
+    ).toMatchObject({ status: 'cancelled' });
+    await settle();
+
+    expect(store.get('user:conversation', started.task.taskId)).toMatchObject({
+      status: 'cancelled',
+      controlReceipts: [
+        expect.objectContaining({
+          action: 'queue',
+          status: 'rejected',
+          reason: 'task_cancelled',
+        }),
+      ],
+    });
+  });
+
+  it('refuses saturation without evicting accepted controls', async () => {
+    const store = new InMemorySubagentTaskStore({
+      maxControlsPerTask: 2,
+      maxControlReceiptsPerTask: 2,
+    });
+    let runtime: SubagentTaskRuntime | undefined;
+    const started = start(
+      store,
+      async (taskRuntime) =>
+        new Promise((_resolve, reject) => {
+          runtime = taskRuntime;
+          taskRuntime.signal.addEventListener(
+            'abort',
+            () => reject(taskRuntime.signal.reason),
+            { once: true }
+          );
+        })
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+    for (const message of ['first', 'second']) {
+      expect(
+        store.control('user:conversation', started.task.taskId, {
+          action: 'steer',
+          message,
+        })
+      ).toMatchObject({ status: 'accepted' });
+    }
+
+    expect(
+      store.control('user:conversation', started.task.taskId, {
+        action: 'steer',
+        message: 'third',
+      })
+    ).toEqual({
+      status: 'invalid',
+      message: 'Task already has 2 pending messages.',
+    });
+    expect(
+      store.get('user:conversation', started.task.taskId)?.controlReceipts
+    ).toEqual([
+      expect.objectContaining({ status: 'accepted' }),
+      expect.objectContaining({ status: 'accepted' }),
+    ]);
+    expect(runtime?.drain('tool').map((message) => message.content)).toEqual([
+      'first',
+      'second',
+    ]);
     expect(runtime?.drain('tool')).toEqual([]);
+    store.control('user:conversation', started.task.taskId, {
+      action: 'cancel',
+    });
+    await settle();
+  });
+
+  it('bounds terminal control receipts without dropping accepted commands', async () => {
+    const store = new InMemorySubagentTaskStore({
+      maxControlsPerTask: 1,
+      maxControlReceiptsPerTask: 2,
+    });
+    let runtime: SubagentTaskRuntime | undefined;
+    const started = start(
+      store,
+      async (taskRuntime) =>
+        new Promise((_resolve, reject) => {
+          runtime = taskRuntime;
+          taskRuntime.signal.addEventListener(
+            'abort',
+            () => reject(taskRuntime.signal.reason),
+            {
+              once: true,
+            }
+          );
+        })
+    );
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+
+    for (const message of ['first', 'second', 'third']) {
+      expect(
+        store.control('user:conversation', started.task.taskId, {
+          action: 'steer',
+          message,
+        })
+      ).toMatchObject({ status: 'accepted' });
+      expect(runtime?.drain('tool')).toHaveLength(1);
+    }
+
+    expect(
+      store.get('user:conversation', started.task.taskId)?.controlReceipts
+    ).toEqual([
+      expect.objectContaining({ status: 'applied' }),
+      expect.objectContaining({ status: 'applied' }),
+    ]);
     store.control('user:conversation', started.task.taskId, {
       action: 'cancel',
     });

--- a/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
+++ b/src/tools/subagent/__tests__/InMemorySubagentTaskStore.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import type { SubagentTaskRuntime } from '@/types';
+import type { SubagentTaskControlReceipt, SubagentTaskRuntime } from '@/types';
 import { InMemorySubagentTaskStore } from '@/tools/subagent/InMemorySubagentTaskStore';
+
+class ReceiptObservingStore extends InMemorySubagentTaskStore {
+  readonly observed: SubagentTaskControlReceipt[] = [];
+
+  protected override onControlReceipt(
+    _scopeId: string,
+    _taskId: string,
+    receipt: SubagentTaskControlReceipt
+  ): void {
+    this.observed.push(receipt);
+  }
+}
 
 const settle = async (): Promise<void> => {
   await Promise.resolve();
@@ -306,6 +318,49 @@ describe('InMemorySubagentTaskStore', () => {
 
     finish({ content: 'done' });
     await settle();
+  });
+
+  it('reports authoritative receipt transitions through one host seam', async () => {
+    const store = new ReceiptObservingStore();
+    let runtime: SubagentTaskRuntime | undefined;
+    let finish = (_result: { content: string }): void => undefined;
+    const result = new Promise<{ content: string }>((resolve) => {
+      finish = resolve;
+    });
+    const started = start(store, async (taskRuntime) => {
+      runtime = taskRuntime;
+      return result;
+    });
+    if (!started.accepted) {
+      throw new Error('Expected task dispatch to be accepted.');
+    }
+    await settle();
+    store.control('user:conversation', started.task.taskId, {
+      action: 'steer',
+      message: 'Use the primary source.',
+    });
+    store.control('user:conversation', started.task.taskId, {
+      action: 'queue',
+      message: 'Compare the result next turn.',
+    });
+    runtime?.drain('tool');
+    finish({ content: 'done' });
+    await settle();
+
+    expect(store.observed).toEqual([
+      expect.objectContaining({ action: 'steer', status: 'accepted' }),
+      expect.objectContaining({ action: 'queue', status: 'accepted' }),
+      expect.objectContaining({
+        action: 'steer',
+        status: 'applied',
+        boundary: 'tool',
+      }),
+      expect.objectContaining({
+        action: 'queue',
+        status: 'rejected',
+        reason: 'task_completed',
+      }),
+    ]);
   });
 
   it('cancels a pending message before it drains', async () => {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -614,6 +614,7 @@ export type SubagentUpdatePhase =
   | 'run_step_closed'
   | 'message_delta'
   | 'reasoning_delta'
+  | 'control'
   | 'stop'
   | 'error';
 

--- a/src/types/subagentTasks.ts
+++ b/src/types/subagentTasks.ts
@@ -12,6 +12,28 @@ export type SubagentTaskStatus =
 /** Where a pending parent message may enter the child run. */
 export type SubagentTaskBoundary = 'preempt' | 'tool' | 'turn';
 
+/**
+ * Lifecycle of one parent-to-child message after the task store accepts it.
+ * Hosts may render a transient `submitted` state before this authoritative
+ * receipt exists; that transport state is intentionally not persisted here.
+ */
+export type SubagentTaskControlReceiptStatus =
+  | 'accepted'
+  | 'applied'
+  | 'rejected'
+  | 'failed';
+
+/** Bounded authoritative receipt for one steer, queue, or interrupt command. */
+export interface SubagentTaskControlReceipt {
+  controlId: string;
+  action: 'steer' | 'queue' | 'interrupt';
+  status: SubagentTaskControlReceiptStatus;
+  createdAt: number;
+  updatedAt: number;
+  boundary?: SubagentTaskBoundary;
+  reason?: 'withdrawn' | 'task_completed' | 'task_cancelled' | 'task_failed';
+}
+
 /** Parent-to-child control operations accepted while a task is running. */
 export type SubagentTaskControlCommand =
   | { action: 'steer' | 'queue' | 'interrupt'; message: string }
@@ -42,6 +64,12 @@ export interface SubagentTaskSnapshot {
   resultAvailable: boolean;
   resultClaimed: boolean;
   pendingControls: number;
+  /**
+   * Bounded receipts emitted by stores that support authoritative control
+   * tracking. Optional so legacy and custom stores remain compatible during
+   * rolling upgrades.
+   */
+  controlReceipts?: SubagentTaskControlReceipt[];
   progress?: SubagentTaskProgress;
   error?: string;
 }


### PR DESCRIPTION
## Summary

I added bounded, authoritative receipts for parent-to-subagent steer, queue, and interrupt commands so callers can distinguish command delivery from the child task lifecycle.

- Track accepted commands by control ID without retaining their message payloads.
- Mark commands applied only when the child drains them at the preempt, tool, or turn seam.
- Mark withdrawn and terminal-race commands rejected while reserving failed for child execution failures.
- Bound terminal receipt retention without evicting accepted commands.
- Keep receipt snapshots optional for legacy and custom task stores during rolling upgrades.
- Add a control activity phase for host-owned activity adapters.
- Cover exact drain seams, withdrawal, completion/cancellation/failure races, saturation, and bounded retention.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npm test -- --runInBand src/tools/subagent/__tests__` (124 tests)
- `npx tsc --noEmit`
- Targeted ESLint on changed files with zero warnings
- Targeted Prettier verification
- `npm run build`
- `git diff --check`

### **Test Configuration**:

- Node.js 24-compatible local dependency tree
- In-memory SDK task store; no external services required

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
