### PR TITLE
⚡ perf: Keep History Message Identity Across Turn Formatting

### DIFF
--- a/src/messages/content.ts
+++ b/src/messages/content.ts
@@ -22,6 +22,20 @@ export const isLegacyConvertible = (message: BaseMessage): boolean => {
   return message.content.every((block) => block.type === ContentTypes.TEXT);
 };
 
+/** Joins the text of {@link isLegacyConvertible} content blocks into the exact
+ *  string {@link formatContentStrings} has always produced for them. */
+export const flattenLegacyContent = (
+  blocks: MessageContentComplex[]
+): string => {
+  const content = blocks.reduce((acc, curr) => {
+    if (curr.type === ContentTypes.TEXT) {
+      return `${acc}${curr[ContentTypes.TEXT] ?? ''}\n`;
+    }
+    return acc;
+  }, '');
+  return content.trim();
+};
+
 /**
  * Formats an array of messages for LangChain, making sure all content fields are strings
  * @param {Array<HumanMessage | AIMessage | SystemMessage | ToolMessage>} payload - The array of messages to format.
@@ -39,16 +53,12 @@ export const formatContentStrings = (
       continue;
     }
 
-    // Reduce text types to a single string
-    const blocks = message.content as MessageContentComplex[];
-    const content = blocks.reduce((acc, curr) => {
-      if (curr.type === ContentTypes.TEXT) {
-        return `${acc}${curr[ContentTypes.TEXT] ?? ''}\n`;
-      }
-      return acc;
-    }, '');
-
-    result.push(cloneMessage(message, content.trim()));
+    result.push(
+      cloneMessage(
+        message,
+        flattenLegacyContent(message.content as MessageContentComplex[])
+      )
+    );
   }
 
   return result;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -46,6 +46,7 @@ import {
   hasBijectiveProviderContentPartMapping,
   inspectProviderMessageProvenance,
   inspectProviderSourceMessageIds,
+  setFreshProviderMessageProvenance,
   setInvalidProviderMessageProvenance,
   setProviderMessageProvenance,
 } from './provenance';
@@ -57,6 +58,7 @@ import {
 } from '@/utils/toolContent';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
+import { flattenLegacyContent, isLegacyConvertible } from './content';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { Providers, ContentTypes, Constants } from '@/common';
 import { emitAgentLog } from '@/utils/events';
@@ -378,6 +380,12 @@ type SourceContentPartIndices = number | readonly number[];
 
 interface FormatAgentMessagesOptions {
   provider?: ProviderName;
+  /** Emit flattenable text content as the joined string the legacy-content
+   *  projection would produce, so the per-request `formatContentStrings` pass
+   *  finds nothing to convert and every history message keeps its identity —
+   *  which is what lets exact-count reuse skip re-tokenizing it. Set this if
+   *  and only if the run's provider uses legacy string content. */
+  legacyContent?: boolean;
   /** Reconstruct hidden `reasoning_content` from `THINK` parts onto prior
    *  tool-call messages. Explicit opt-in for OpenAI-compatible endpoints that
    *  replay reasoning across turns; defaults to on for DeepSeek thinking-mode. */
@@ -1380,7 +1388,7 @@ function stampSourceMessageIdentity(
       },
     ];
   }
-  setProviderMessageProvenance(message, partsToStamp);
+  setFreshProviderMessageProvenance(message, partsToStamp);
   if (sourceMessageId == null || derivedIndex !== 0) {
     return;
   }
@@ -2574,6 +2582,19 @@ export const formatAgentMessages = (
         updatedIndexTokenCountMap[resultIndices[lastIdx]] =
           tokenCount - distributed;
       }
+    }
+  }
+
+  if (options?.legacyContent === true) {
+    for (const message of messages) {
+      if (!isLegacyConvertible(message)) {
+        continue;
+      }
+      const flattened = flattenLegacyContent(
+        message.content as MessageContentComplex[]
+      );
+      message.content = flattened;
+      message.lc_kwargs.content = flattened;
     }
   }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -2004,6 +2004,22 @@ export const formatAgentMessages = (
    * assistant turn. Held rather than emitted so an entry that produces
    * nothing cannot leave the anchor stranded as the final turn.
    */
+  const legacyContentEnabled = options?.legacyContent === true;
+  /** Emission choke point: every formatted message enters the result here, so
+   *  the legacy flatten happens once per message with no closing rescan. The
+   *  summary boundary slices payload entries before formatting, and nothing
+   *  mutates an emitted message's content afterwards, so flattening at
+   *  emission and flattening at return are equivalent. */
+  const emitFormattedMessage = (message: (typeof messages)[number]): void => {
+    if (legacyContentEnabled && isLegacyConvertible(message)) {
+      const flattened = flattenLegacyContent(
+        message.content as MessageContentComplex[]
+      );
+      message.content = flattened;
+      message.lc_kwargs.content = flattened;
+    }
+    messages.push(message);
+  };
   let pendingSteerAnchor = false;
   /**
    * Emits the deferred anchor ahead of `next` — the message about to be
@@ -2026,7 +2042,7 @@ export const formatAgentMessages = (
       'assistant'
     );
     stampSourceMessageIdentity(anchor, undefined, 0, 'synthetic');
-    messages.push(anchor);
+    emitFormattedMessage(anchor);
   };
   // If indexTokenCountMap is provided, create a new map to track the updated indices
   const updatedIndexTokenCountMap: Record<number, number> = {};
@@ -2106,7 +2122,7 @@ export const formatAgentMessages = (
         provenanceParts
       );
       flushSteerAnchor(formattedMessage);
-      messages.push(formattedMessage);
+      emitFormattedMessage(formattedMessage);
 
       // Update the index mapping for this message
       indexMapping[i] = [messages.length - 1];
@@ -2367,7 +2383,7 @@ export const formatAgentMessages = (
       flushSteerAnchor(formattedMessages[0]);
     }
     for (const formattedMessage of formattedMessages) {
-      messages.push(formattedMessage);
+      emitFormattedMessage(formattedMessage);
     }
     if (endsWithSteerMessage(formattedMessages)) {
       pendingSteerAnchor = true;
@@ -2398,7 +2414,7 @@ export const formatAgentMessages = (
             'user'
           );
           stampSourceMessageIdentity(skillMessage, undefined, 0, 'synthetic');
-          messages.push(skillMessage);
+          emitFormattedMessage(skillMessage);
         }
       }
     }
@@ -2582,19 +2598,6 @@ export const formatAgentMessages = (
         updatedIndexTokenCountMap[resultIndices[lastIdx]] =
           tokenCount - distributed;
       }
-    }
-  }
-
-  if (options?.legacyContent === true) {
-    for (const message of messages) {
-      if (!isLegacyConvertible(message)) {
-        continue;
-      }
-      const flattened = flattenLegacyContent(
-        message.content as MessageContentComplex[]
-      );
-      message.content = flattened;
-      message.lc_kwargs.content = flattened;
     }
   }
 

--- a/src/messages/formatAgentMessages.legacyContent.test.ts
+++ b/src/messages/formatAgentMessages.legacyContent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { HumanMessage } from '@langchain/core/messages';
-import type { TPayload } from '@/types';
+import type { MessageContentComplex, TPayload } from '@/types';
 import { formatContentStrings, isLegacyConvertible } from './content';
 import {
   getProviderMessageProvenance,
@@ -10,27 +10,26 @@ import {
 import { formatAgentMessages } from './format';
 import { ContentTypes } from '@/common';
 
-const textPart = (text: string) => ({ type: ContentTypes.TEXT, [ContentTypes.TEXT]: text });
+const textPart = (text: string): MessageContentComplex => ({
+  type: ContentTypes.TEXT,
+  [ContentTypes.TEXT]: text,
+});
 
-const buildPayload = (): TPayload =>
-  [
-    { role: 'system', content: 'You are helpful.' },
-    { role: 'user', content: [textPart('  hello '), textPart('there')] },
-    {
-      messageId: 'assistant-1',
-      isCreatedByUser: false,
-      content: [
-        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'first block' },
-        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'second block' },
-      ],
-    },
-    { role: 'user', content: 'plain string turn' },
-    {
-      messageId: 'assistant-2',
-      isCreatedByUser: false,
-      content: [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'reply' }],
-    },
-  ] as unknown as TPayload;
+const buildPayload = (): TPayload => [
+  { role: 'system', content: 'You are helpful.' },
+  { role: 'user', content: [textPart('  hello '), textPart('there')] },
+  {
+    messageId: 'assistant-1',
+    isCreatedByUser: false,
+    content: [textPart('first block'), textPart('second block')],
+  },
+  { role: 'user', content: 'plain string turn' },
+  {
+    messageId: 'assistant-2',
+    isCreatedByUser: false,
+    content: [textPart('reply')],
+  },
+];
 
 describe('formatAgentMessages legacyContent option', () => {
   it('produces byte-identical content to the legacy projection applied afterwards', () => {

--- a/src/messages/formatAgentMessages.legacyContent.test.ts
+++ b/src/messages/formatAgentMessages.legacyContent.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from '@jest/globals';
+import { HumanMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import { formatContentStrings, isLegacyConvertible } from './content';
+import {
+  getProviderMessageProvenance,
+  setFreshProviderMessageProvenance,
+  setProviderMessageProvenance,
+} from './provenance';
+import { formatAgentMessages } from './format';
+import { ContentTypes } from '@/common';
+
+const textPart = (text: string) => ({ type: ContentTypes.TEXT, [ContentTypes.TEXT]: text });
+
+const buildPayload = (): TPayload =>
+  [
+    { role: 'system', content: 'You are helpful.' },
+    { role: 'user', content: [textPart('  hello '), textPart('there')] },
+    {
+      messageId: 'assistant-1',
+      isCreatedByUser: false,
+      content: [
+        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'first block' },
+        { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'second block' },
+      ],
+    },
+    { role: 'user', content: 'plain string turn' },
+    {
+      messageId: 'assistant-2',
+      isCreatedByUser: false,
+      content: [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'reply' }],
+    },
+  ] as unknown as TPayload;
+
+describe('formatAgentMessages legacyContent option', () => {
+  it('produces byte-identical content to the legacy projection applied afterwards', () => {
+    const { messages: eager } = formatAgentMessages(
+      buildPayload(),
+      undefined,
+      undefined,
+      undefined,
+      { legacyContent: true }
+    );
+    const { messages: baseline } = formatAgentMessages(buildPayload());
+    const projected = formatContentStrings(baseline);
+    expect(eager.length).toBe(projected.length);
+    for (let i = 0; i < eager.length; i++) {
+      expect(eager[i].content).toEqual(projected[i].content);
+      expect(eager[i].getType()).toBe(projected[i].getType());
+      expect(eager[i].lc_kwargs.content).toEqual(projected[i].content);
+    }
+  });
+
+  it('leaves nothing for the legacy projection to convert, preserving identity', () => {
+    const { messages } = formatAgentMessages(
+      buildPayload(),
+      undefined,
+      undefined,
+      undefined,
+      { legacyContent: true }
+    );
+    for (const message of messages) {
+      expect(isLegacyConvertible(message)).toBe(false);
+    }
+    const projected = formatContentStrings(messages);
+    for (let i = 0; i < messages.length; i++) {
+      expect(projected[i]).toBe(messages[i]);
+    }
+  });
+
+  it('keeps array content untouched without the option', () => {
+    const { messages } = formatAgentMessages(buildPayload());
+    expect(messages.some((message) => Array.isArray(message.content))).toBe(true);
+  });
+});
+
+describe('setFreshProviderMessageProvenance', () => {
+  const buildMessage = () =>
+    new HumanMessage({
+      content: 'hello',
+      additional_kwargs: { existing: 'kept', sourceMessageId: 'stale' },
+    });
+
+  it('produces the same end state as the hardened publication', () => {
+    const hardened = buildMessage();
+    const fresh = buildMessage();
+    const parts = [
+      { attribution: 'user' as const, sourceMessageId: 'msg-1' },
+      { attribution: 'model' as const, sourceMessageId: 'msg-2' },
+    ];
+    setProviderMessageProvenance(hardened, parts);
+    setFreshProviderMessageProvenance(fresh, parts);
+    expect(fresh.additional_kwargs).toEqual(hardened.additional_kwargs);
+    expect(fresh.lc_kwargs.additional_kwargs).toBe(fresh.additional_kwargs);
+    expect(hardened.lc_kwargs.additional_kwargs).toBe(hardened.additional_kwargs);
+    expect(getProviderMessageProvenance(fresh)).toEqual(
+      getProviderMessageProvenance(hardened)
+    );
+  });
+
+  it('clears stale source ids when parts carry none', () => {
+    const hardened = buildMessage();
+    const fresh = buildMessage();
+    const parts = [{ attribution: 'synthetic' as const }];
+    setProviderMessageProvenance(hardened, parts);
+    setFreshProviderMessageProvenance(fresh, parts);
+    expect(fresh.additional_kwargs).toEqual(hardened.additional_kwargs);
+    expect('sourceMessageId' in fresh.additional_kwargs).toBe(false);
+    expect('sourceMessageIds' in fresh.additional_kwargs).toBe(false);
+  });
+
+  it('replaces the kwargs objects rather than mutating the originals', () => {
+    const fresh = buildMessage();
+    const originalKwargs = fresh.additional_kwargs;
+    const originalLcKwargs = fresh.lc_kwargs;
+    setFreshProviderMessageProvenance(fresh, [{ attribution: 'user' as const }]);
+    expect(fresh.additional_kwargs).not.toBe(originalKwargs);
+    expect(fresh.lc_kwargs).not.toBe(originalLcKwargs);
+    expect('provenance' in originalKwargs).toBe(false);
+  });
+});

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -766,11 +766,14 @@ function publishProviderMessageProvenance(
   }
 }
 
-/** Replaces typed provenance and synchronizes its stable plural source ids. */
-export function setProviderMessageProvenance(
-  message: BaseMessage,
+interface ResolvedProvenancePublication {
+  provenance: ProviderMessageProvenance;
+  sourceMessageIds?: readonly string[];
+}
+
+function resolveProvenancePublication(
   parts: readonly ProviderMessageProvenancePart[]
-): void {
+): ResolvedProvenancePublication {
   const normalizedParts = normalizeProvenanceParts(parts);
   const provenance: ProviderMessageProvenance = Object.freeze({
     version: PROVIDER_MESSAGE_PROVENANCE_VERSION,
@@ -782,21 +785,60 @@ export function setProviderMessageProvenance(
   for (const part of normalizedParts) {
     appendSourceMessageId(sourceMessageIds, seen, part.sourceMessageId);
   }
-  if (sourceMessageIds.length > 0) {
-    const immutableSourceMessageIds = Object.freeze(sourceMessageIds);
-    immutableProviderSourceMessageIds.add(immutableSourceMessageIds);
-    immutableProviderMessageSourceIds.set(
-      provenance,
-      immutableSourceMessageIds
-    );
-    publishProviderMessageProvenance(
-      message,
-      provenance,
-      immutableSourceMessageIds
-    );
-    return;
+  if (sourceMessageIds.length === 0) {
+    return { provenance };
   }
-  publishProviderMessageProvenance(message, provenance);
+  const immutableSourceMessageIds = Object.freeze(sourceMessageIds);
+  immutableProviderSourceMessageIds.add(immutableSourceMessageIds);
+  immutableProviderMessageSourceIds.set(provenance, immutableSourceMessageIds);
+  return { provenance, sourceMessageIds: immutableSourceMessageIds };
+}
+
+/** Replaces typed provenance and synchronizes its stable plural source ids. */
+export function setProviderMessageProvenance(
+  message: BaseMessage,
+  parts: readonly ProviderMessageProvenancePart[]
+): void {
+  const resolved = resolveProvenancePublication(parts);
+  publishProviderMessageProvenance(
+    message,
+    resolved.provenance,
+    resolved.sourceMessageIds
+  );
+}
+
+/**
+ * {@link setProviderMessageProvenance} for a message the caller itself just
+ * constructed from locally built plain objects. Such a message cannot carry
+ * proxies, accessors, or foreign aliases in `additional_kwargs`/`lc_kwargs`,
+ * so the publication skips the hardened descriptor walks while producing the
+ * same end state: fresh replacement objects on both slots, with the
+ * serialization mirror aliasing the live kwargs. Never call this with a
+ * message received across a seam — that is what the hardened variant is for.
+ */
+export function setFreshProviderMessageProvenance(
+  message: BaseMessage,
+  parts: readonly ProviderMessageProvenancePart[]
+): void {
+  const resolved = resolveProvenancePublication(parts);
+  const replacement: UntrustedProviderMessageAdditionalKwargs = {
+    ...(message.additional_kwargs as Record<string, unknown>),
+  };
+  replacement.provenance = resolved.provenance;
+  const sourceMessageIds = resolved.sourceMessageIds;
+  if (sourceMessageIds != null && sourceMessageIds.length > 0) {
+    replacement.sourceMessageIds = sourceMessageIds;
+    replacement.sourceMessageId = sourceMessageIds[sourceMessageIds.length - 1];
+  } else {
+    delete replacement.sourceMessageIds;
+    delete replacement.sourceMessageId;
+  }
+  const serializedReplacement: Record<PropertyKey, unknown> = {
+    ...(message.lc_kwargs as Record<string, unknown>),
+  };
+  serializedReplacement.additional_kwargs = replacement;
+  message.additional_kwargs = replacement as BaseMessage['additional_kwargs'];
+  message.lc_kwargs = serializedReplacement;
 }
 
 /** Publishes the canonical fail-closed marker for malformed provenance. */

--- a/src/messages/provenance.ts
+++ b/src/messages/provenance.ts
@@ -822,7 +822,7 @@ export function setFreshProviderMessageProvenance(
 ): void {
   const resolved = resolveProvenancePublication(parts);
   const replacement: UntrustedProviderMessageAdditionalKwargs = {
-    ...(message.additional_kwargs as Record<string, unknown>),
+    ...message.additional_kwargs,
   };
   replacement.provenance = resolved.provenance;
   const sourceMessageIds = resolved.sourceMessageIds;
@@ -833,11 +833,11 @@ export function setFreshProviderMessageProvenance(
     delete replacement.sourceMessageIds;
     delete replacement.sourceMessageId;
   }
-  const serializedReplacement: Record<PropertyKey, unknown> = {
-    ...(message.lc_kwargs as Record<string, unknown>),
+  const serializedReplacement: BaseMessage['lc_kwargs'] = {
+    ...message.lc_kwargs,
   };
   serializedReplacement.additional_kwargs = replacement;
-  message.additional_kwargs = replacement as BaseMessage['additional_kwargs'];
+  message.additional_kwargs = replacement;
   message.lc_kwargs = serializedReplacement;
 }
 


### PR DESCRIPTION
## Summary

Two per-turn formatting passes redid O(history) work every turn whose output was identical to the previous turn's — and one of them silently defeated #456's token-count reuse.

### 1. `legacyContent` option on `formatAgentMessages`
On legacy-content providers, `formatContentStrings` cloned **every** text-only history message **every turn** (`cloneMessage` was the single hottest SDK frame at depth). Worse: the clones replaced the objects the context-pressure meter had baselined, so the `message === baseline.message` fast path from #456 never matched and the entire history was re-tokenized (twice) per turn despite host-supplied counts.

With `legacyContent: true`, flattenable text is emitted as the joined string **at construction** — through the same shared helper (`flattenLegacyContent`) the projection uses, so output is byte-identical — and the per-request projection finds nothing to convert: zero clones, identity preserved, meter fast path restored. Hosts that don't opt in get byte-identical behavior to today (the Graph projection remains as the backstop for other message sources).

### 2. `setFreshProviderMessageProvenance`
Stamping paid two hardened descriptor-walk copies per message per turn — on messages `format.ts` had **just constructed itself** from locally built plain objects, where proxies/accessors/foreign aliases are impossible. The fresh variant shares the hardened path's normalization + immutability registration and publishes with plain spreads — same end state (fresh replacement objects on both slots, serialization mirror aliasing live kwargs), proven by equality tests. Every external seam (`MultiAgentGraph`, `alternation`, `injected`, compaction of non-local messages) keeps the hardened variant; the JSDoc documents the trust contract.

## Measurements
LibreChat runtime bench, fake model, exact 30-turn CPU-profile windows, 1000-message history:

| | before | after |
|---|---|---|
| busy CPU / turn | 54.7 ms | **39.9 ms (−27%)** |
| agents message machinery / turn | 9.0 ms | 2.5 ms |
| tokenizer / turn | 2.2 ms | **0.08 ms** |
| GC / turn | 3.5 ms | 1.9 ms |

A 1000-message turn now costs what a 300-message turn did before the change (history-linear SDK cost ~eliminated).

## Testing
- New suite: byte-equality of `legacyContent` output vs the projection applied afterwards; identity preservation (projection returns the same objects); fresh-vs-hardened provenance end-state equality incl. `lc_kwargs` mirror aliasing and recognized-authentic provenance; stale source-id clearing; original-kwargs non-mutation.
- Full jest: baseline-identical (only the 3 credential-gated provider suites fail, same as main).

LibreChat companion (passes `legacyContent` from `agent.useLegacyContent`) follows after publish.