### PR TITLE
🧭 feat: Observe Log-First Message Projection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,6 +97,29 @@ provider-consumed tool-call input representation in one pass. Its output is
 the provider-safe preflight input for context-pressure measurement; provider-
 specific replay and wire shaping remain later request projections.
 
+## Model Context Reconstruction
+
+A **Session Log** is the append-only source of persisted conversation events.
+It retains message, summary, and lifecycle history without becoming a second
+mutable message state.
+
+A **Session Message Projection** is the deterministic reconstruction of model
+context from a Session Log. Summary events replace earlier projected context;
+message events append in log order. Agent runs, compaction, and resume derive
+their starting messages through the same projection.
+
+A **Provider Message Projection Invariant** checks the final message batch at
+the chat-model callback boundary, after runnable-level instruction injection
+and before provider serialization or I/O. Source-backed user, model, and tool
+contributions require provenance; source-less contributions are valid only
+when explicitly synthetic. The check reports counts, message positions, and
+roles only—never content, source IDs, or tool data.
+
+The invariant is opt-in through `AGENT_MESSAGE_PROJECTION_INVARIANT=observe`
+or `assert`. The default `off` path adds no callback handler and performs no
+message scan. The initial rollout uses observation to locate provenance gaps;
+assertion is reserved for tests and environments whose projection is complete.
+
 ## Runtime Provider Registration
 
 A **Provider Registration** is the process-local binding of one provider name

--- a/docs/adr/0004-observe-provider-message-projection-provenance.md
+++ b/docs/adr/0004-observe-provider-message-projection-provenance.md
@@ -1,0 +1,57 @@
+# ADR 0004: Observe Provider Message Projection Provenance Before Enforcement
+
+- Status: Accepted
+- Date: 2026-08-24
+
+## Context
+
+Agent sessions now reconstruct model context from one append-only session log,
+but provider-bound messages still pass through several graph, runnable, and
+provider projections. Migrating those paths to a strict log-first invariant in
+one change would make existing unstamped synthetic and runtime-generated
+messages fail without first locating every provenance gap.
+
+The final `handleChatModelStart` callback observes the exact message batch after
+runnable-level instruction injection and before provider serialization or I/O.
+It is shared by primary, fallback, summarization, and nested agent invocations
+that use `attemptInvoke`.
+
+## Decision
+
+Add one opt-in Provider Message Projection Invariant at that callback boundary.
+
+- `off` is the default and adds no callback handler or message scan.
+- `observe` emits one privacy-safe warning per model attempt when gaps exist.
+- `assert` raises before provider I/O and is intended for tests and verified
+  environments.
+
+Source-backed user, model, and tool provenance requires a non-empty source
+message ID. Source-less provenance is accepted only for explicitly synthetic
+contributions. Mixed source-backed and synthetic contributions remain valid.
+
+Reports contain only counts, bounded message positions, roles, and issue codes.
+They never contain message content, source IDs, tool arguments, tool results, or
+message objects. Phase one does not resolve source IDs against a store because
+session entries, checkpoints, graph messages, and nested agents use distinct ID
+namespaces.
+
+## Consequences
+
+Observation can inventory real provenance gaps before enforcement or deeper
+projection consolidation. Assertion provides a host-testable contract without
+changing production defaults. Enabled modes add one linear scan immediately
+before model I/O; the benchmark records that cost.
+
+Auxiliary model calls that bypass `attemptInvoke`, including title and activity
+labels, remain outside this phase. A later decision can enable assertion by
+default only after observation shows complete provenance across supported
+paths.
+
+## Alternatives Considered
+
+- Enforce immediately: rejected because known synthetic and runtime-generated
+  messages are not yet uniformly stamped.
+- Inspect graph state earlier: rejected because runnable-level system messages
+  and final provider transformations would be invisible.
+- Validate source IDs against one store: rejected because no single store owns
+  every valid message namespace.

--- a/docs/message-projection-benchmark.md
+++ b/docs/message-projection-benchmark.md
@@ -1,0 +1,20 @@
+# Provider-request projection benchmark
+
+This benchmark measures the synchronous provider-facing message derivation that
+occurs after graph-state shaping and before the model adapter serializes a
+request. It is a baseline for the log-first projection investigation: it does
+not call a provider or include network latency.
+
+Run it with:
+
+```sh
+npm run bench:provider-projection
+```
+
+The benchmark uses stable text-only and tool-result histories for OpenAI and
+Anthropic projections. It reports median wall-clock time over seven samples and
+checks that each sample produces the same number of provider messages.
+
+Use the tool-result case when evaluating a new projection seam. That path
+performs meaningful provider normalization; a text-only history mostly measures
+the cost of the read-only scans that preserve an unchanged message array.

--- a/docs/message-projection-benchmark.md
+++ b/docs/message-projection-benchmark.md
@@ -13,8 +13,32 @@ npm run bench:provider-projection
 
 The benchmark uses stable text-only and tool-result histories for OpenAI and
 Anthropic projections. It reports median wall-clock time over seven samples and
-checks that each sample produces the same number of provider messages.
+checks that each sample produces the same number of provider messages. Each
+scenario reports the default `off` path and the opt-in `observe` path, which
+adds the read-only provenance invariant scan over valid source-backed messages.
+It isolates synchronous projection and scan cost; it does not include LangChain
+callback dispatch or delivery of a warning for an invalid batch.
 
 Use the tool-result case when evaluating a new projection seam. That path
 performs meaningful provider normalization; a text-only history mostly measures
 the cost of the read-only scans that preserve an unchanged message array.
+
+The default mode is `off`; it does not create a callback handler or run the
+invariant scan. The observed measurements quantify rollout cost and are not a
+production default.
+
+## Representative result
+
+On Node 24.16.0 / Apple Silicon, 250 projections produced these medians:
+
+| Scenario | Provider | Off | Observe | Added per request |
+| --- | --- | ---: | ---: | ---: |
+| text-100 | OpenAI | 0.71 ms | 1.26 ms | 2.20 µs |
+| text-100 | Anthropic | 0.34 ms | 0.81 ms | 1.88 µs |
+| text-500 | OpenAI | 3.13 ms | 6.26 ms | 12.52 µs |
+| text-500 | Anthropic | 1.54 ms | 4.71 ms | 12.68 µs |
+| tools-100 | OpenAI | 19.57 ms | 22.02 ms | 9.80 µs |
+| tools-100 | Anthropic | 10.93 ms | 12.76 ms | 7.32 µs |
+
+The measured observation scan added 1.88–12.68 µs per request. Timing varies
+by host, so rerun the benchmark when changing the invariant or projection path.

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "bench:context-pressure": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-context-pressure-cache.ts",
     "bench:provider-derivation": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-provider-derivation.ts",
+    "bench:provider-projection": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-provider-request-projection.ts",
     "bench:execution-world": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-execution-world.ts",
     "probe:overflow": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/context-overflow-probe.ts",
     "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",

--- a/src/llm/invoke.projectionInvariant.test.ts
+++ b/src/llm/invoke.projectionInvariant.test.ts
@@ -1,0 +1,165 @@
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { AgentLogEvent } from '@/types';
+import type * as t from '@/types';
+import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
+import { attemptInvoke } from '@/llm/invoke';
+import {
+  ProviderMessageProjectionInvariantError,
+  setProviderMessageProvenance,
+} from '@/messages';
+import { GraphEvents, Providers } from '@/common';
+
+const originalInvariantMode =
+  process.env.AGENT_MESSAGE_PROJECTION_INVARIANT;
+
+afterEach(() => {
+  if (originalInvariantMode == null) {
+    delete process.env.AGENT_MESSAGE_PROJECTION_INVARIANT;
+  } else {
+    process.env.AGENT_MESSAGE_PROJECTION_INVARIANT = originalInvariantMode;
+  }
+  jest.restoreAllMocks();
+});
+
+function createStreamingRequest(messages: BaseMessage[]): {
+  model: FakeListChatModel;
+  request: ReturnType<typeof prepareProviderRequest>;
+} {
+  const model = new FakeListChatModel({ responses: ['ok'] });
+  return {
+    model,
+    request: prepareProviderRequest({
+      model,
+      messages,
+      provider: Providers.OPENAI,
+    }),
+  };
+}
+
+function createNonStreamingRequest(messages: BaseMessage[]): {
+  model: FakeListChatModel;
+  request: ReturnType<typeof prepareProviderRequest>;
+} {
+  const model = new FakeListChatModel({ responses: ['ok'] });
+  Object.defineProperty(model, 'stream', { value: undefined });
+  return {
+    model,
+    request: prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.OPENAI,
+    }),
+  };
+}
+
+describe('attemptInvoke provider message projection invariant', () => {
+  it('keeps the disabled path free of an added callback handler', async () => {
+    delete process.env.AGENT_MESSAGE_PROJECTION_INVARIANT;
+    const callbacks = [BaseCallbackHandler.fromMethods({})];
+    const capturedCallbacks: unknown[] = [];
+    const model: t.ChatModel = {
+      invoke: async (_messages, config): Promise<AIMessageChunk> => {
+        capturedCallbacks.push(config?.callbacks);
+        return new AIMessageChunk('ok');
+      },
+    };
+    const request = prepareProviderRequest({
+      model,
+      messages: [new HumanMessage('unstamped')],
+      provider: Providers.OPENAI,
+    });
+
+    await attemptInvoke({ request }, { callbacks });
+
+    expect(capturedCallbacks).toEqual([callbacks]);
+  });
+
+  it('observes gaps once and still invokes the streaming provider', async () => {
+    process.env.AGENT_MESSAGE_PROJECTION_INVARIANT = 'observe';
+    const logs: AgentLogEvent[] = [];
+    const logHandler = BaseCallbackHandler.fromMethods({
+      handleCustomEvent: (eventName: string, data: unknown): void => {
+        if (eventName === GraphEvents.ON_AGENT_LOG) {
+          logs.push(data as AgentLogEvent);
+        }
+      },
+    });
+    const { model, request } = createStreamingRequest([
+      new HumanMessage('private-content'),
+    ]);
+    const providerCall = jest.spyOn(model, '_streamResponseChunks');
+
+    await attemptInvoke({ request, onChunk: async () => {} }, {
+      callbacks: [logHandler],
+    });
+
+    expect(providerCall).toHaveBeenCalledTimes(1);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      level: 'warn',
+      scope: 'projection',
+      data: {
+        provider: Providers.OPENAI,
+        report: { valid: false, gapMessageCount: 1 },
+      },
+    });
+    expect(JSON.stringify(logs[0])).not.toContain('private-content');
+  });
+
+  it('asserts before streaming provider I/O when provenance has a gap', async () => {
+    process.env.AGENT_MESSAGE_PROJECTION_INVARIANT = 'assert';
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { model, request } = createStreamingRequest([
+      new HumanMessage('unstamped'),
+    ]);
+    const providerCall = jest.spyOn(model, '_streamResponseChunks');
+
+    await expect(attemptInvoke({ request })).rejects.toBeInstanceOf(
+      ProviderMessageProjectionInvariantError
+    );
+    expect(providerCall).not.toHaveBeenCalled();
+  });
+
+  it('asserts before non-streaming provider I/O when provenance has a gap', async () => {
+    process.env.AGENT_MESSAGE_PROJECTION_INVARIANT = 'assert';
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { model, request } = createNonStreamingRequest([
+      new HumanMessage('unstamped'),
+    ]);
+    const providerCall = jest.spyOn(model, '_generate');
+
+    await expect(attemptInvoke({ request })).rejects.toBeInstanceOf(
+      ProviderMessageProjectionInvariantError
+    );
+    expect(providerCall).not.toHaveBeenCalled();
+  });
+
+  it('allows valid provenance through both invocation paths', async () => {
+    process.env.AGENT_MESSAGE_PROJECTION_INVARIANT = 'assert';
+    const streamingMessage = new HumanMessage('streaming');
+    setProviderMessageProvenance(streamingMessage, [
+      { attribution: 'user', sourceMessageId: 'streaming-source' },
+    ]);
+    const nonStreamingMessage = new HumanMessage('non-streaming');
+    setProviderMessageProvenance(nonStreamingMessage, [
+      { attribution: 'user', sourceMessageId: 'non-streaming-source' },
+    ]);
+    const streaming = createStreamingRequest([streamingMessage]);
+    const nonStreaming = createNonStreamingRequest([nonStreamingMessage]);
+    const streamCall = jest.spyOn(streaming.model, '_streamResponseChunks');
+    const invokeCall = jest.spyOn(nonStreaming.model, '_generate');
+
+    await attemptInvoke({
+      request: streaming.request,
+      onChunk: async () => {},
+    });
+    await attemptInvoke({ request: nonStreaming.request });
+
+    expect(streamCall).toHaveBeenCalledTimes(1);
+    expect(invokeCall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1,5 +1,6 @@
 import { concat } from '@langchain/core/utils/stream';
 import { AIMessageChunk } from '@langchain/core/messages';
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { getCallbackManagerForConfig } from '@langchain/core/runnables';
 import {
   CallbackManager,
@@ -40,7 +41,12 @@ import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { appendCallbacks } from '@/utils/callbacks';
-import { modifyDeltaProperties } from '@/messages';
+import {
+  inspectProviderMessageProjection,
+  ProviderMessageProjectionInvariantError,
+  resolveProviderMessageProjectionInvariantMode,
+  modifyDeltaProperties,
+} from '@/messages';
 import { canSealPreempt } from '@/llm/preempt';
 import { initializeModel } from '@/llm/init';
 
@@ -105,6 +111,79 @@ export type OnChunk = (
 
 /** Unique per-model-attempt sequence; see the stamp in `attemptInvoke`. */
 let streamLimitAttemptSeq = 0;
+
+function createModelStartHandler({
+  config,
+  mode,
+  provider,
+  captureRunId,
+}: {
+  config: RunnableConfig;
+  mode: ReturnType<typeof resolveProviderMessageProjectionInvariantMode>;
+  provider: t.ProviderName;
+  captureRunId?: (runId: string) => void;
+}): BaseCallbackHandler {
+  let inspected = false;
+  const handler = BaseCallbackHandler.fromMethods({
+    handleChatModelStart: async (
+      _llm: Serialized,
+      messageBatches: BaseMessage[][],
+      runId: string
+    ): Promise<void> => {
+      captureRunId?.(runId);
+      if (mode === 'off' || inspected) {
+        return;
+      }
+      inspected = true;
+      const report = inspectProviderMessageProjection(messageBatches[0] ?? []);
+      if (report.valid) {
+        return;
+      }
+      if (mode === 'assert') {
+        throw new ProviderMessageProjectionInvariantError(report);
+      }
+      try {
+        const callbackManager = await getCallbackManagerForConfig(config);
+        await callbackManager?.handleCustomEvent?.(
+          GraphEvents.ON_AGENT_LOG,
+          {
+            level: 'warn',
+            scope: 'projection',
+            message: 'Provider message projection has provenance gaps',
+            data: { provider, report },
+            runId,
+          } satisfies t.AgentLogEvent,
+          runId
+        );
+      } catch {
+        return;
+      }
+    },
+  });
+  handler.name = 'provider-message-projection-invariant';
+  handler.raiseError = mode === 'assert';
+  handler.awaitHandlers = true;
+  return handler;
+}
+
+function withModelStartHandler({
+  config,
+  mode,
+  provider,
+  captureRunId,
+}: {
+  config: RunnableConfig;
+  mode: ReturnType<typeof resolveProviderMessageProjectionInvariantMode>;
+  provider: t.ProviderName;
+  captureRunId?: (runId: string) => void;
+}): RunnableConfig {
+  return {
+    ...config,
+    callbacks: appendCallbacks(config.callbacks, [
+      createModelStartHandler({ config, mode, provider, captureRunId }),
+    ]),
+  };
+}
 
 function getManualToolStreamNormalizationProvider(
   provider: t.ProviderName
@@ -632,6 +711,24 @@ async function attemptInvokeBody(
   config: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
   const { model, messages: messagesForProvider, provider } = request;
+  const projectionInvariantMode =
+    resolveProviderMessageProjectionInvariantMode();
+  let sealedRunId: string | undefined;
+  let invocationConfig = config;
+  const captureModelRunId =
+    model.stream != null && context?.preemption != null;
+  if (projectionInvariantMode !== 'off' || captureModelRunId) {
+    invocationConfig = withModelStartHandler({
+      config,
+      mode: projectionInvariantMode,
+      provider,
+      captureRunId: captureModelRunId
+        ? (runId: string): void => {
+          sealedRunId ??= runId;
+        }
+        : undefined,
+    });
+  }
 
   /**
    * Stamp the provider that is ACTUALLY serving this invocation onto the
@@ -647,28 +744,10 @@ async function attemptInvokeBody(
      * Observed, not dictated. `handleChatModelStart` fires with the chat
      * model's real run id before the first chunk, which is the only way to
      * name the run a seal has to close — pinning `config.runId` does not
-     * survive the bound runnable. Installed only when preemption is
-     * configured, so a run that cannot seal carries no extra handler.
+     * survive the bound runnable. The same handler owns the opt-in projection
+     * invariant so enabled diagnostics do not stack a second model callback.
      */
-    let sealedRunId: string | undefined;
-    const streamConfig =
-      context?.preemption == null
-        ? config
-        : {
-          ...config,
-          callbacks: appendCallbacks(config.callbacks, [
-            {
-              handleChatModelStart: (
-                _llm: Serialized,
-                _messages: BaseMessage[][],
-                runId: string
-              ): void => {
-                sealedRunId ??= runId;
-              },
-            },
-          ]),
-        };
-    const stream = await model.stream(messagesForProvider, streamConfig);
+    const stream = await model.stream(messagesForProvider, invocationConfig);
     let finalChunk: AIMessageChunk | undefined;
     let preempted = false;
     const registeredStreamHandler =
@@ -855,7 +934,7 @@ async function attemptInvokeBody(
     return { messages: [finalChunk as AIMessageChunk] };
   }
 
-  const finalMessage = await model.invoke(messagesForProvider, config);
+  const finalMessage = await model.invoke(messagesForProvider, invocationConfig);
   if ((finalMessage.tool_calls?.length ?? 0) > 0) {
     finalMessage.tool_calls = finalMessage.tool_calls?.filter(
       (tool_call: ToolCall) => !!tool_call.name

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -16,3 +16,4 @@ export * from './reducer';
 export * from './recency';
 export * from './assistantPhase';
 export * from './provenance';
+export * from './projectionInvariant';

--- a/src/messages/projectionInvariant.test.ts
+++ b/src/messages/projectionInvariant.test.ts
@@ -1,0 +1,141 @@
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import {
+  setInvalidProviderMessageProvenance,
+  setProviderMessageProvenance,
+  stampSyntheticProviderMessage,
+} from './provenance';
+import {
+  inspectProviderMessageProjection,
+  ProviderMessageProjectionInvariantError,
+  resolveProviderMessageProjectionInvariantMode,
+} from './projectionInvariant';
+
+describe('provider message projection invariant', () => {
+  it('classifies source-backed, synthetic, and mixed provenance', () => {
+    const sourceBacked = new HumanMessage('source-backed');
+    setProviderMessageProvenance(sourceBacked, [
+      { attribution: 'user', sourceMessageId: 'user-row' },
+    ]);
+    const synthetic = stampSyntheticProviderMessage(
+      new SystemMessage('synthetic')
+    );
+    const mixed = new HumanMessage('mixed');
+    setProviderMessageProvenance(mixed, [
+      { attribution: 'user', sourceMessageId: 'user-row' },
+      { attribution: 'synthetic' },
+    ]);
+
+    expect(
+      inspectProviderMessageProjection([sourceBacked, synthetic, mixed])
+    ).toEqual({
+      valid: true,
+      messageCount: 3,
+      sourceBackedMessageCount: 2,
+      syntheticMessageCount: 1,
+      gapMessageCount: 0,
+      issues: [],
+    });
+  });
+
+  it('reports absent, invalid, and unsourced non-synthetic provenance', () => {
+    const absent = new HumanMessage('absent');
+    const invalid = new HumanMessage('invalid');
+    setInvalidProviderMessageProvenance(invalid);
+    const unsourced = new HumanMessage('unsourced');
+    setProviderMessageProvenance(unsourced, [{ attribution: 'user' }]);
+
+    expect(
+      inspectProviderMessageProjection([absent, invalid, unsourced])
+    ).toEqual({
+      valid: false,
+      messageCount: 3,
+      sourceBackedMessageCount: 0,
+      syntheticMessageCount: 0,
+      gapMessageCount: 3,
+      issues: [
+        {
+          code: 'absent_provenance',
+          messageIndex: 0,
+          messageType: 'human',
+        },
+        {
+          code: 'invalid_provenance',
+          messageIndex: 1,
+          messageType: 'human',
+        },
+        {
+          code: 'unsourced_non_synthetic_part',
+          messageIndex: 2,
+          messageType: 'human',
+        },
+      ],
+    });
+  });
+
+  it('fails closed on hostile provenance access without reading content', () => {
+    const message = new HumanMessage('never-read-content');
+    const hostile = new Proxy(message, {
+      get(target, property, receiver) {
+        if (property === 'additional_kwargs') {
+          throw new Error('hostile provenance accessor');
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(inspectProviderMessageProjection([hostile])).toMatchObject({
+      valid: false,
+      gapMessageCount: 1,
+      issues: [{ code: 'invalid_provenance' }],
+    });
+  });
+
+  it('bounds stable issues and never exposes content or source ids', () => {
+    const secretContent = 'private-message-content';
+    const secretId = 'private-source-id';
+    const messages = Array.from({ length: 70 }, () => {
+      const message = new HumanMessage(secretContent);
+      setProviderMessageProvenance(message, [
+        { attribution: 'user' },
+        { attribution: 'synthetic', sourceMessageId: secretId },
+      ]);
+      return message;
+    });
+
+    const report = inspectProviderMessageProjection(messages);
+    const serialized = JSON.stringify(report);
+    expect(report.gapMessageCount).toBe(70);
+    expect(report.issues).toHaveLength(64);
+    expect(report.issues[0]).toEqual({
+      code: 'unsourced_non_synthetic_part',
+      messageIndex: 0,
+      messageType: 'human',
+    });
+    expect(report.issues[63]?.messageIndex).toBe(63);
+    expect(serialized).not.toContain(secretContent);
+    expect(serialized).not.toContain(secretId);
+  });
+
+  it('resolves only supported opt-in modes', () => {
+    expect(resolveProviderMessageProjectionInvariantMode('observe')).toBe(
+      'observe'
+    );
+    expect(resolveProviderMessageProjectionInvariantMode('assert')).toBe(
+      'assert'
+    );
+    expect(resolveProviderMessageProjectionInvariantMode('true')).toBe('off');
+    expect(resolveProviderMessageProjectionInvariantMode(undefined)).toBe(
+      'off'
+    );
+  });
+
+  it('exposes only a privacy-safe report on assertion errors', () => {
+    const message = new HumanMessage('private-message-content');
+    const report = inspectProviderMessageProjection([message]);
+    const error = new ProviderMessageProjectionInvariantError(report);
+
+    expect(error.name).toBe('ProviderMessageProjectionInvariantError');
+    expect(error.message).toBe('Provider message projection invariant failed');
+    expect(JSON.stringify(error.report)).not.toContain('private-message-content');
+  });
+});

--- a/src/messages/projectionInvariant.ts
+++ b/src/messages/projectionInvariant.ts
@@ -1,0 +1,134 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import { inspectProviderMessageProvenance } from './provenance';
+
+export type ProviderMessageProjectionInvariantMode =
+  | 'off'
+  | 'observe'
+  | 'assert';
+
+export type ProviderMessageProjectionIssueCode =
+  | 'absent_provenance'
+  | 'invalid_provenance'
+  | 'unsourced_non_synthetic_part';
+
+export interface ProviderMessageProjectionInvariantIssue {
+  readonly code: ProviderMessageProjectionIssueCode;
+  readonly messageIndex: number;
+  readonly messageType: string;
+}
+
+export interface ProviderMessageProjectionInvariantReport {
+  readonly valid: boolean;
+  readonly messageCount: number;
+  readonly sourceBackedMessageCount: number;
+  readonly syntheticMessageCount: number;
+  readonly gapMessageCount: number;
+  readonly issues: readonly ProviderMessageProjectionInvariantIssue[];
+}
+
+const MAX_REPORTED_PROJECTION_ISSUES = 64;
+
+function getMessageType(message: BaseMessage): string {
+  try {
+    return typeof message.type === 'string' ? message.type : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function appendIssue(
+  issues: ProviderMessageProjectionInvariantIssue[],
+  code: ProviderMessageProjectionIssueCode,
+  messageIndex: number,
+  messageType: string
+): void {
+  if (issues.length >= MAX_REPORTED_PROJECTION_ISSUES) {
+    return;
+  }
+  issues.push(Object.freeze({ code, messageIndex, messageType }));
+}
+
+/** Resolves the opt-in provider projection invariant without enabling it for
+ * unrecognized values. */
+export function resolveProviderMessageProjectionInvariantMode(
+  value = process.env.AGENT_MESSAGE_PROJECTION_INVARIANT
+): ProviderMessageProjectionInvariantMode {
+  if (value === 'observe' || value === 'assert') {
+    return value;
+  }
+  return 'off';
+}
+
+/** Inspects provider-bound lineage without reading message content or source ids. */
+export function inspectProviderMessageProjection(
+  messages: readonly BaseMessage[]
+): ProviderMessageProjectionInvariantReport {
+  const issues: ProviderMessageProjectionInvariantIssue[] = [];
+  let sourceBackedMessageCount = 0;
+  let syntheticMessageCount = 0;
+  let gapMessageCount = 0;
+
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const message = messages[messageIndex];
+    const messageType = getMessageType(message);
+    const state = inspectProviderMessageProvenance(message);
+    if (state.status !== 'valid') {
+      gapMessageCount++;
+      appendIssue(
+        issues,
+        state.status === 'absent'
+          ? 'absent_provenance'
+          : 'invalid_provenance',
+        messageIndex,
+        messageType
+      );
+      continue;
+    }
+
+    let hasSourceBackedPart = false;
+    let hasGap = false;
+    for (const part of state.provenance.parts) {
+      if (part.sourceMessageId != null) {
+        hasSourceBackedPart = true;
+        continue;
+      }
+      if (part.attribution === 'synthetic') {
+        continue;
+      }
+      hasGap = true;
+      appendIssue(
+        issues,
+        'unsourced_non_synthetic_part',
+        messageIndex,
+        messageType
+      );
+    }
+
+    if (hasGap) {
+      gapMessageCount++;
+    } else if (hasSourceBackedPart) {
+      sourceBackedMessageCount++;
+    } else {
+      syntheticMessageCount++;
+    }
+  }
+
+  return Object.freeze({
+    valid: gapMessageCount === 0,
+    messageCount: messages.length,
+    sourceBackedMessageCount,
+    syntheticMessageCount,
+    gapMessageCount,
+    issues: Object.freeze(issues),
+  });
+}
+
+export class ProviderMessageProjectionInvariantError extends Error {
+  readonly report: ProviderMessageProjectionInvariantReport;
+
+  constructor(report: ProviderMessageProjectionInvariantReport) {
+    super('Provider message projection invariant failed');
+    this.name = 'ProviderMessageProjectionInvariantError';
+    this.report = report;
+  }
+}

--- a/src/scripts/bench-provider-request-projection.ts
+++ b/src/scripts/bench-provider-request-projection.ts
@@ -1,0 +1,135 @@
+/* eslint-disable no-console */
+import { performance } from 'node:perf_hooks';
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
+
+interface BenchmarkResult {
+  elapsedMs: number;
+  checksum: number;
+}
+
+const ITERATIONS = 250;
+const SAMPLE_COUNT = 7;
+
+const benchmarkModel = {
+  model: 'projection-benchmark',
+  invoke: async (): Promise<AIMessageChunk> => new AIMessageChunk(''),
+} as t.ChatModel;
+
+function createTextHistory(messageCount: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let index = 0; index < messageCount; index++) {
+    const content = `Message ${index}: ${'retained conversation context '.repeat(24)}`;
+    messages.push(
+      index % 2 === 0
+        ? new HumanMessage({ id: `human-${index}`, content })
+        : new AIMessage({ id: `assistant-${index}`, content })
+    );
+  }
+  return messages;
+}
+
+function createToolHistory(turnCount: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let index = 0; index < turnCount; index++) {
+    const callId = `call-${index}`;
+    messages.push(
+      new HumanMessage({
+        id: `human-${index}`,
+        content: `Find context for turn ${index}.`,
+      }),
+      new AIMessage({
+        id: `assistant-${index}`,
+        content: '',
+        tool_calls: [
+          {
+            id: callId,
+            name: 'search',
+            args: { query: `turn-${index}` },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: callId,
+        content: [
+          {
+            type: 'text',
+            text: `Result ${index}: ${'structured provider-neutral tool output '.repeat(12)}`,
+          },
+        ],
+      })
+    );
+  }
+  return messages;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function runBenchmark(
+  messages: BaseMessage[],
+  provider: t.ProviderName
+): BenchmarkResult {
+  let checksum = 0;
+  const startedAt = performance.now();
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const request = prepareProviderRequest({
+      model: benchmarkModel,
+      messages,
+      provider,
+    });
+    checksum += request.messages.length;
+  }
+  return {
+    elapsedMs: performance.now() - startedAt,
+    checksum,
+  };
+}
+
+for (const scenario of [
+  { name: 'text-100', messages: createTextHistory(100) },
+  { name: 'text-500', messages: createTextHistory(500) },
+  { name: 'tools-100', messages: createToolHistory(100) },
+]) {
+  for (const provider of [Providers.OPENAI, Providers.ANTHROPIC]) {
+    runBenchmark(scenario.messages, provider);
+    const samples: BenchmarkResult[] = [];
+    for (let sample = 0; sample < SAMPLE_COUNT; sample++) {
+      samples.push(runBenchmark(scenario.messages, provider));
+    }
+    const checksum = samples[0].checksum;
+    if (samples.some((sample) => sample.checksum !== checksum)) {
+      throw new Error(
+        `Provider projection output changed for ${scenario.name}`
+      );
+    }
+    console.log(
+      JSON.stringify({
+        scenario: scenario.name,
+        provider,
+        iterations: ITERATIONS,
+        medianMs: Number(
+          median(samples.map(({ elapsedMs }) => elapsedMs)).toFixed(2)
+        ),
+        messagesPerSecond: Number(
+          (
+            (scenario.messages.length * ITERATIONS * 1_000) /
+            median(samples.map(({ elapsedMs }) => elapsedMs))
+          ).toFixed(0)
+        ),
+      })
+    );
+  }
+}

--- a/src/scripts/bench-provider-request-projection.ts
+++ b/src/scripts/bench-provider-request-projection.ts
@@ -9,6 +9,10 @@ import {
 
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import {
+  inspectProviderMessageProjection,
+  setProviderMessageProvenance,
+} from '@/messages';
 import { Providers } from '@/common';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 
@@ -29,11 +33,20 @@ function createTextHistory(messageCount: number): BaseMessage[] {
   const messages: BaseMessage[] = [];
   for (let index = 0; index < messageCount; index++) {
     const content = `Message ${index}: ${'retained conversation context '.repeat(24)}`;
-    messages.push(
-      index % 2 === 0
-        ? new HumanMessage({ id: `human-${index}`, content })
-        : new AIMessage({ id: `assistant-${index}`, content })
-    );
+    const isUserMessage = index % 2 === 0;
+    const sourceMessageId = isUserMessage
+      ? `human-${index}`
+      : `assistant-${index}`;
+    const message = isUserMessage
+      ? new HumanMessage({ id: sourceMessageId, content })
+      : new AIMessage({ id: sourceMessageId, content });
+    setProviderMessageProvenance(message, [
+      {
+        attribution: isUserMessage ? 'user' : 'model',
+        sourceMessageId,
+      },
+    ]);
+    messages.push(message);
   }
   return messages;
 }
@@ -42,33 +55,42 @@ function createToolHistory(turnCount: number): BaseMessage[] {
   const messages: BaseMessage[] = [];
   for (let index = 0; index < turnCount; index++) {
     const callId = `call-${index}`;
-    messages.push(
-      new HumanMessage({
-        id: `human-${index}`,
-        content: `Find context for turn ${index}.`,
-      }),
-      new AIMessage({
-        id: `assistant-${index}`,
-        content: '',
-        tool_calls: [
-          {
-            id: callId,
-            name: 'search',
-            args: { query: `turn-${index}` },
-            type: 'tool_call',
-          },
-        ],
-      }),
-      new ToolMessage({
-        tool_call_id: callId,
-        content: [
-          {
-            type: 'text',
-            text: `Result ${index}: ${'structured provider-neutral tool output '.repeat(12)}`,
-          },
-        ],
-      })
-    );
+    const user = new HumanMessage({
+      id: `human-${index}`,
+      content: `Find context for turn ${index}.`,
+    });
+    const assistant = new AIMessage({
+      id: `assistant-${index}`,
+      content: '',
+      tool_calls: [
+        {
+          id: callId,
+          name: 'search',
+          args: { query: `turn-${index}` },
+          type: 'tool_call',
+        },
+      ],
+    });
+    const toolResult = new ToolMessage({
+      id: `tool-${index}`,
+      tool_call_id: callId,
+      content: [
+        {
+          type: 'text',
+          text: `Result ${index}: ${'structured provider-neutral tool output '.repeat(12)}`,
+        },
+      ],
+    });
+    setProviderMessageProvenance(user, [
+      { attribution: 'user', sourceMessageId: `human-${index}` },
+    ]);
+    setProviderMessageProvenance(assistant, [
+      { attribution: 'model', sourceMessageId: `assistant-${index}` },
+    ]);
+    setProviderMessageProvenance(toolResult, [
+      { attribution: 'tool', sourceMessageId: `tool-${index}` },
+    ]);
+    messages.push(user, assistant, toolResult);
   }
   return messages;
 }
@@ -80,7 +102,8 @@ function median(values: number[]): number {
 
 function runBenchmark(
   messages: BaseMessage[],
-  provider: t.ProviderName
+  provider: t.ProviderName,
+  inspectInvariant = false
 ): BenchmarkResult {
   let checksum = 0;
   const startedAt = performance.now();
@@ -91,6 +114,13 @@ function runBenchmark(
       provider,
     });
     checksum += request.messages.length;
+    if (inspectInvariant) {
+      const report = inspectProviderMessageProjection(request.messages);
+      if (!report.valid) {
+        throw new Error('Benchmark projection has provenance gaps');
+      }
+      checksum += report.sourceBackedMessageCount;
+    }
   }
   return {
     elapsedMs: performance.now() - startedAt,
@@ -104,32 +134,37 @@ for (const scenario of [
   { name: 'tools-100', messages: createToolHistory(100) },
 ]) {
   for (const provider of [Providers.OPENAI, Providers.ANTHROPIC]) {
-    runBenchmark(scenario.messages, provider);
-    const samples: BenchmarkResult[] = [];
-    for (let sample = 0; sample < SAMPLE_COUNT; sample++) {
-      samples.push(runBenchmark(scenario.messages, provider));
-    }
-    const checksum = samples[0].checksum;
-    if (samples.some((sample) => sample.checksum !== checksum)) {
-      throw new Error(
-        `Provider projection output changed for ${scenario.name}`
+    for (const invariant of ['off', 'observe'] as const) {
+      const inspectInvariant = invariant === 'observe';
+      runBenchmark(scenario.messages, provider, inspectInvariant);
+      const samples: BenchmarkResult[] = [];
+      for (let sample = 0; sample < SAMPLE_COUNT; sample++) {
+        samples.push(
+          runBenchmark(scenario.messages, provider, inspectInvariant)
+        );
+      }
+      const checksum = samples[0].checksum;
+      if (samples.some((sample) => sample.checksum !== checksum)) {
+        throw new Error(
+          `Provider projection output changed for ${scenario.name}`
+        );
+      }
+      const medianMs = median(samples.map(({ elapsedMs }) => elapsedMs));
+      console.log(
+        JSON.stringify({
+          scenario: scenario.name,
+          provider,
+          invariant,
+          iterations: ITERATIONS,
+          medianMs: Number(medianMs.toFixed(2)),
+          messagesPerSecond: Number(
+            (
+              (scenario.messages.length * ITERATIONS * 1_000) /
+              medianMs
+            ).toFixed(0)
+          ),
+        })
       );
     }
-    console.log(
-      JSON.stringify({
-        scenario: scenario.name,
-        provider,
-        iterations: ITERATIONS,
-        medianMs: Number(
-          median(samples.map(({ elapsedMs }) => elapsedMs)).toFixed(2)
-        ),
-        messagesPerSecond: Number(
-          (
-            (scenario.messages.length * ITERATIONS * 1_000) /
-            median(samples.map(({ elapsedMs }) => elapsedMs))
-          ).toFixed(0)
-        ),
-      })
-    );
   }
 }

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -23,7 +23,7 @@ import type {
 } from './types';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
-import { deserializeMessage } from './messageSerialization';
+import { deriveMessages } from './deriveMessages';
 import { createSummarizeNode } from '@/summarization/node';
 import { resolveStreamLimits } from '@/llm/streamLimits';
 import { JsonlSessionStore } from './JsonlSessionStore';
@@ -491,32 +491,6 @@ function createCheckpointReference(params: {
     checkpointNs,
     ...(parentCheckpointId != null ? { parentCheckpointId } : {}),
   };
-}
-
-function createSessionRunState(entries: SessionEntry[]): {
-  messages: BaseMessage[];
-  initialSummary?: InitialSummary;
-} {
-  const messages: BaseMessage[] = [];
-  let initialSummary: InitialSummary | undefined;
-  for (const entry of entries) {
-    if (entry.type === 'summary') {
-      initialSummary = {
-        text: entry.data.text,
-        tokenCount:
-          typeof entry.data.tokenCount === 'number' &&
-          Number.isFinite(entry.data.tokenCount)
-            ? entry.data.tokenCount
-            : 0,
-      };
-      messages.length = 0;
-      continue;
-    }
-    if (entry.type === 'message') {
-      messages.push(deserializeMessage(entry.data.message));
-    }
-  }
-  return { messages, initialSummary };
 }
 
 function isMessageEntry(
@@ -1103,7 +1077,7 @@ export class AgentSession {
       handlerResult.events.push(streamEvent);
       onEvent?.(streamEvent);
     };
-    const sessionState = createSessionRunState(
+    const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
     let run: Run<t.IState> | undefined;
@@ -1349,7 +1323,7 @@ export class AgentSession {
       throw new Error('Cannot compact an ephemeral session');
     }
     const activePath = path ?? store.getPath();
-    const sessionState = createSessionRunState(activePath);
+    const sessionState = deriveMessages(activePath);
     const messageEntries = activePath.filter(isMessageEntry);
     if (sessionState.messages.length === 0) {
       return undefined;
@@ -1474,7 +1448,7 @@ export class AgentSession {
       threadId,
       userHandlers: this.runConfig.customHandlers,
     });
-    const sessionState = createSessionRunState(
+    const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
     let run: Run<t.IState> | undefined;

--- a/src/session/__tests__/deriveMessages.test.ts
+++ b/src/session/__tests__/deriveMessages.test.ts
@@ -1,0 +1,93 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type {
+  SessionEntry,
+  SessionMessageEntry,
+  SessionSummaryEntry,
+} from '@/session';
+import { deriveMessages } from '@/session';
+import { serializeMessage } from '@/session/messageSerialization';
+
+function createMessageEntry(
+  id: string,
+  message: HumanMessage | AIMessage
+): SessionMessageEntry {
+  return {
+    type: 'message',
+    id,
+    parentId: null,
+    timestamp: '2026-08-24T00:00:00.000Z',
+    data: {
+      role: message.getType(),
+      message: serializeMessage(message),
+    },
+  };
+}
+
+function createSummaryEntry(id: string): SessionSummaryEntry {
+  return {
+    type: 'summary',
+    id,
+    parentId: null,
+    timestamp: '2026-08-24T00:00:00.000Z',
+    data: {
+      text: 'Earlier conversation summary',
+      tokenCount: 42,
+      retainedEntryIds: [],
+      summarizedEntryIds: [],
+    },
+  };
+}
+
+describe('deriveMessages', () => {
+  it('derives active messages after the latest compaction summary', () => {
+    const entries: SessionEntry[] = [
+      createMessageEntry('old-user', new HumanMessage('old question')),
+      createMessageEntry('old-assistant', new AIMessage('old answer')),
+      createSummaryEntry('summary'),
+      {
+        type: 'run_event',
+        id: 'completed',
+        parentId: 'summary',
+        timestamp: '2026-08-24T00:01:00.000Z',
+        data: { event: 'run.completed' },
+      },
+      createMessageEntry('recent-user', new HumanMessage('recent question')),
+    ];
+
+    const derived = deriveMessages(entries);
+
+    expect(derived.initialSummary).toEqual({
+      text: 'Earlier conversation summary',
+      tokenCount: 42,
+    });
+    expect(derived.messages.map((message) => message.content)).toEqual([
+      'recent question',
+    ]);
+  });
+
+  it('uses a zero token count when a legacy summary omitted one', () => {
+    const summary = createSummaryEntry('summary');
+    delete summary.data.tokenCount;
+
+    const derived = deriveMessages([summary]);
+
+    expect(derived.initialSummary).toEqual({
+      text: 'Earlier conversation summary',
+      tokenCount: 0,
+    });
+    expect(derived.messages).toEqual([]);
+  });
+
+  it('keeps the full path when the log has no summary', () => {
+    const derived = deriveMessages([
+      createMessageEntry('user', new HumanMessage('hello')),
+      createMessageEntry('assistant', new AIMessage('hi')),
+    ]);
+
+    expect(derived.initialSummary).toBeUndefined();
+    expect(derived.messages.map((message) => message.content)).toEqual([
+      'hello',
+      'hi',
+    ]);
+  });
+});

--- a/src/session/deriveMessages.ts
+++ b/src/session/deriveMessages.ts
@@ -1,0 +1,37 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { SessionEntry } from './types';
+import { deserializeMessage } from './messageSerialization';
+
+export interface DerivedSessionMessages {
+  initialSummary?: {
+    text: string;
+    tokenCount: number;
+  };
+  messages: BaseMessage[];
+}
+
+/** Derives the active model context from one append-only session-log path. */
+export function deriveMessages(
+  entries: readonly SessionEntry[]
+): DerivedSessionMessages {
+  const messages: BaseMessage[] = [];
+  let initialSummary: DerivedSessionMessages['initialSummary'];
+  for (const entry of entries) {
+    if (entry.type === 'summary') {
+      initialSummary = {
+        text: entry.data.text,
+        tokenCount:
+          typeof entry.data.tokenCount === 'number' &&
+          Number.isFinite(entry.data.tokenCount)
+            ? entry.data.tokenCount
+            : 0,
+      };
+      messages.length = 0;
+      continue;
+    }
+    if (entry.type === 'message') {
+      messages.push(deserializeMessage(entry.data.message));
+    }
+  }
+  return { messages, ...(initialSummary != null && { initialSummary }) };
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,4 +1,5 @@
 export { AgentSession, createAgentSession } from './AgentSession';
+export { deriveMessages } from './deriveMessages';
 export { JsonlSessionStore, SessionManager } from './JsonlSessionStore';
 export { createRunHandlers } from './handlers';
 export {
@@ -42,3 +43,4 @@ export type {
   SessionSummaryEntry,
   SessionTreeNode,
 } from './types';
+export type { DerivedSessionMessages } from './deriveMessages';


### PR DESCRIPTION
## Summary

I established the first enforceable log-first message projection boundary while keeping the default provider invocation path unchanged.

- Derived AgentSession run, compaction, and resume messages through one deterministic `deriveMessages` projection over the append-only session log.
- Added an opt-in provider message projection invariant at the final chat-model callback boundary, after runnable instruction injection and before provider I/O.
- Supported `AGENT_MESSAGE_PROJECTION_INVARIANT=observe` for privacy-safe provenance-gap telemetry and `assert` for verified environments and tests.
- Consolidated the existing stream-preemption run capture into the same callback handler so enabled diagnostics do not stack callback scans.
- Bounded reports to counts, message positions, roles, and issue codes without exposing content, source IDs, tool arguments, or tool results.
- Added architecture terminology, an ADR, focused unit/integration coverage, and a reproducible OpenAI/Anthropic projection benchmark.
- Measured the opt-in valid-provenance scan at 1.88–12.68 μs per request across 100–500-message text histories and 100 tool turns; the default `off` mode performs no message scan or handler allocation.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npx tsc --noEmit`.
- Ran targeted ESLint checks for all changed source and test files with no findings.
- Ran 87 focused invocation, projection-invariant, session-projection, and JSONL session tests.
- Ran `npm run bench:provider-projection` across OpenAI and Anthropic text/tool histories.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js 24.16.0
- npm workspace dependencies from the current v3.7.0 lockfile

## Checklist

- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where the invariant boundary is non-obvious
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective and preserve provider invocation behavior
- [x] Local unit tests pass with my changes