### PR TITLE
⚡ perf: Compact Closed Tool Steps Within Long Turns

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,6 +89,16 @@ entry's graph regresses every host's boot.
 The meter's estimates decide overflow and recovery only. Provider-reported
 usage remains the source of truth for billing and Langfuse observations.
 
+A **Compaction Range** is the contiguous conversation prefix replaced by one
+durable checkpoint. Range selection prefers whole user-led turns. If that
+would leave no compactable prefix in a tool-heavy run, it may cut after an
+older closed tool-call/result unit while retaining a token-priced recent tail.
+Open and parallel tool units are indivisible, and a lone user payload is never
+eligible for the intra-turn fallback.
+
+See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
+range-selection and retention trade-offs.
+
 ## Provider Tool Derivation
 
 A **Provider Tool Derivation** is the copy-on-write projection of retained

--- a/docs/adr/0005-pairing-balanced-compaction-ranges.md
+++ b/docs/adr/0005-pairing-balanced-compaction-ranges.md
@@ -26,9 +26,13 @@ boundary inside the earliest retained turn.
 
 The fallback selects a contiguous prefix and may end only while no tool call is
 pending. Parallel calls remain pending until every matching result arrives, and
-an open call remains in the retained tail. The tail retains the configured
-`retainRecent.tokens` budget, or 16% of the context window when no explicit
-budget exists. A lone user message has no closed tool unit and remains intact.
+an open call remains in the retained tail. Pairing recognizes parsed, raw
+provider, and content-block call/result representations. A boundary also cannot
+split messages derived from one persisted source row, because summary replay
+can currently anchor coverage only at row granularity. The tail retains the
+configured `retainRecent.tokens` budget, or 16% of the context window when no
+explicit budget exists. A lone user message has no closed tool unit and remains
+intact.
 
 Range pricing reuses the `AgentContext` exact-token cache when its counter is
 compatible. Summarization, state replacement, source coverage, hooks, and

--- a/docs/adr/0005-pairing-balanced-compaction-ranges.md
+++ b/docs/adr/0005-pairing-balanced-compaction-ranges.md
@@ -27,12 +27,15 @@ boundary inside the earliest retained turn.
 The fallback selects a contiguous prefix and may end only while no tool call is
 pending. Parallel calls remain pending until every matching result arrives, and
 an open call remains in the retained tail. Pairing recognizes parsed, raw
-provider, and content-block call/result representations. A boundary also cannot
-split messages derived from one persisted source row, because summary replay
-can currently anchor coverage only at row granularity. The tail retains the
-configured `retainRecent.tokens` budget, or 16% of the context window when no
-explicit budget exists. A lone user message has no closed tool unit and remains
-intact.
+provider, and content-block call/result representations. It validates provider
+protocol and tool-name compatibility, and supports Gemini's adjacent,
+identifier-less code-execution pair. A provider-shaped HumanMessage is treated
+as a tool result only after it consumes a validated preceding call; otherwise
+it remains a user turn. A boundary also cannot split messages derived from one
+persisted source row, because summary replay can currently anchor coverage only
+at row granularity. The tail retains the configured `retainRecent.tokens`
+budget, or 16% of the context window when no explicit budget exists. A lone
+user message has no closed tool unit and remains intact.
 
 Range pricing reuses the `AgentContext` exact-token cache when its counter is
 compatible. Summarization, state replacement, source coverage, hooks, and

--- a/docs/adr/0005-pairing-balanced-compaction-ranges.md
+++ b/docs/adr/0005-pairing-balanced-compaction-ranges.md
@@ -37,6 +37,14 @@ at row granularity. The tail retains the configured `retainRecent.tokens`
 budget, or 16% of the context window when no explicit budget exists. A lone
 user message has no closed tool unit and remains intact.
 
+The fallback search ends at the next user turn; a closed pair in an older turn
+cannot authorize compacting a newer turn that contains no closed work of its
+own. If every summarizer attempt fails, the metadata-only emergency stub is not
+allowed to replace a fallback range because it cannot preserve the original
+goal or tool evidence. A successful checkpoint is injected before the entire
+retained tail, including for prompt-cache providers, so it never appears after
+newer assistant/tool activity or between a call and its native result.
+
 Range pricing reuses the `AgentContext` exact-token cache when its counter is
 compatible. Summarization, state replacement, source coverage, hooks, and
 Langfuse observations stay behind the existing summarize node.

--- a/docs/adr/0005-pairing-balanced-compaction-ranges.md
+++ b/docs/adr/0005-pairing-balanced-compaction-ranges.md
@@ -1,0 +1,49 @@
+# ADR 0005: Select Pairing-Balanced Compaction Ranges
+
+## Status
+
+Accepted
+
+## Context
+
+Compaction previously cut only at user-message boundaries and always retained
+the complete most recent user-led turn. That protected a lone pasted payload,
+but it also made a normal first-turn agent loop indivisible: dozens of closed
+assistant tool calls and results exposed no compactable prefix. Overflow
+recovery then had no summarization path even though most of the turn was
+completed history.
+
+A benchmark with 20, 50, and 100 tool steps measured zero compactable tokens
+under the turn-only policy. Pairing-balanced cuts exposed 79.8% to 83.0% of the
+same histories while preserving every call/result pair.
+
+## Decision
+
+Compaction range selection continues to prefer whole user-led turns. Only when
+that policy exposes no head, a token counter and context window are available,
+and at least one tool call has a matching result, selection may fall back to a
+boundary inside the earliest retained turn.
+
+The fallback selects a contiguous prefix and may end only while no tool call is
+pending. Parallel calls remain pending until every matching result arrives, and
+an open call remains in the retained tail. The tail retains the configured
+`retainRecent.tokens` budget, or 16% of the context window when no explicit
+budget exists. A lone user message has no closed tool unit and remains intact.
+
+Range pricing reuses the `AgentContext` exact-token cache when its counter is
+compatible. Summarization, state replacement, source coverage, hooks, and
+Langfuse observations stay behind the existing summarize node.
+
+## Consequences
+
+- Long single-turn tool loops gain a usable overflow and pressure-compaction
+  path instead of deterministically exposing an empty head.
+- Recent raw evidence remains verbatim, and tool call/result pairing is valid
+  on both sides of the boundary.
+- The initial user request can enter the summarized prefix after completed tool
+  work exists; the checkpoint prompt must continue preserving the goal and
+  exact constraints. User-only payloads retain the previous protection.
+- Selection adds one bounded linear scan only after compaction has already
+  fired and the turn-level policy found no head.
+- Exact system + tools + messages replay for provider cache reuse remains a
+  separate request-projection concern.

--- a/docs/compaction-range-benchmark.md
+++ b/docs/compaction-range-benchmark.md
@@ -1,0 +1,30 @@
+# Compaction range benchmark
+
+The benchmark models a common long-running agent shape: one user request
+followed by many assistant tool calls and large tool results. The prior
+turn-boundary selector treated that entire history as one indivisible turn, so
+it exposed no compactable head even after context pressure triggered.
+
+Run it with:
+
+```sh
+npm run bench:compaction-range
+```
+
+The before case uses the previous user-turn-only selection. The after case
+keeps the same turn preference, then falls back to a token-priced boundary only
+after closed tool-call/result units. The benchmark uses the SDK's deterministic
+`o200k_base` token counter and fails if any tool pair crosses the boundary.
+
+Results on 2026-08-24:
+
+| Scenario       | Total tokens | Compactable before | Compactable after | Retained after |
+| -------------- | -----------: | -----------------: | ----------------: | -------------: |
+| 20 tool steps  |       50,824 |                  0 |    40,570 (79.8%) |         10,254 |
+| 50 tool steps  |      126,541 |                  0 |   103,861 (82.1%) |         22,680 |
+| 100 tool steps |      253,006 |                  0 |   209,968 (83.0%) |         43,038 |
+
+This is a provider-runtime optimization rather than a local CPU microbenchmark:
+the selection adds one bounded linear scan only when compaction has already
+fired. The decision metric is how much repeated provider input becomes
+replaceable by one checkpoint while preserving recent raw evidence.

--- a/docs/compaction-range-benchmark.md
+++ b/docs/compaction-range-benchmark.md
@@ -25,6 +25,7 @@ Results on 2026-08-24:
 | 100 tool steps |      253,006 |                  0 |   209,968 (83.0%) |         43,038 |
 
 This is a provider-runtime optimization rather than a local CPU microbenchmark:
-the selection adds one bounded linear scan only when compaction has already
-fired. The decision metric is how much repeated provider input becomes
+the selection adds bounded linear work only when compaction has already fired.
+A 5,000-iteration local probe over 100 tool steps averaged 0.073 ms per
+selection. The decision metric is how much repeated provider input becomes
 replaceable by one checkpoint while preserving recent raw evidence.

--- a/docs/summarization-behavior.md
+++ b/docs/summarization-behavior.md
@@ -82,7 +82,7 @@ After compaction, the message array is empty. On the next agent node turn:
 
 ### Summarization Invocation
 
-Raw conversation messages are sent to the LLM via `attemptInvoke` with the summarization instruction appended as the final HumanMessage. Tools are bound so providers that require tool definitions (e.g. Bedrock) accept the messages. This preserves the original message format and enables cache hits on the system prompt + tool definitions prefix.
+Raw conversation messages are sent to the LLM via `attemptInvoke` with the summarization instruction appended as the final HumanMessage. Tools are bound so providers that require tool definitions (e.g. Bedrock) accept the messages and cache-capable providers can reuse the tool-schema prefix. The summarization model does not currently pass through `AgentContext.systemRunnable`, so exact replay of the main request's full system + tools + messages prefix is not guaranteed.
 
 If the primary call fails, fallback providers are attempted (via `tryFallbackProviders`). If all providers fail, a metadata stub is generated mechanically — no LLM call, just tool names and message counts.
 
@@ -191,7 +191,7 @@ Masking uses `truncateToolResultContent` with a ~300 char limit, producing head+
 | `updatePrompt`     | `string`       | Built-in update prompt     | Custom prompt for re-compaction when a prior summary exists. Falls back to `prompt`.   |
 | `trigger`          | `object`       | Always on overflow         | When to fire summarization. See trigger types below.                                   |
 | `reserveRatio`     | `number (0-1)` | `0.05`                     | Fraction of token budget reserved as headroom. Pruning triggers at `budget * (1 - r)`. |
-| `maxSummaryTokens` | `number`       | `2048`                     | Max output tokens for the summarization model.                                         |
+| `maxSummaryTokens` | `number`       | Provider/client default    | Optional max output tokens for the summarization model.                                |
 | `contextPruning`   | `object`       | disabled                   | Position-based context pruning (only applies when summarization is disabled).          |
 
 ### Trigger types (`trigger` field)
@@ -215,6 +215,6 @@ Masking uses `truncateToolResultContent` with a ~300 char limit, producing head+
 
 ### `parameters` sub-fields (extracted before passing to LLM)
 
-| Field              | Type     | Default | Description                                     |
-| ------------------ | -------- | ------- | ----------------------------------------------- |
-| `maxSummaryTokens` | `number` | `2048`  | Can also be set here (same as top-level field). |
+| Field              | Type     | Default                 | Description                                     |
+| ------------------ | -------- | ----------------------- | ----------------------------------------------- |
+| `maxSummaryTokens` | `number` | Provider/client default | Can also be set here (same as top-level field). |

--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
     "bench:cache": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-prompt-cache.ts",
     "bench:context-pressure": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-context-pressure-cache.ts",
+    "bench:compaction-range": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-compaction-range.ts",
     "bench:provider-derivation": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-provider-derivation.ts",
     "bench:provider-projection": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-provider-request-projection.ts",
     "bench:execution-world": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/bench-execution-world.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -357,6 +357,8 @@ export class AgentContext {
    * - `'none'`: no summary present
    */
   private _summaryLocation: 'system_prompt' | 'user_message' | 'none' = 'none';
+  /** Whether a mid-run summary must appear before every retained message. */
+  private summaryPrecedesMessages: boolean = false;
   /**
    * Durable summary that survives reset() calls. Set from initialSummary
    * during fromConfig() and updated by setSummary() so that the latest
@@ -365,6 +367,7 @@ export class AgentContext {
    */
   private _durableSummaryText?: string;
   private _durableSummaryTokenCount: number = 0;
+  private durableSummaryPrecedesMessages: boolean = false;
   /** Number of summarization cycles that have occurred for this agent context */
   private _summaryVersion: number = 0;
   /**
@@ -989,10 +992,10 @@ export class AgentContext {
       return messages;
     }
 
-    const tailIndex = this.getPromptCacheDynamicTailIndex(
-      messages,
-      promptCacheProvider
-    );
+    const tailIndex =
+      this._summaryLocation === 'user_message' && this.summaryPrecedesMessages
+        ? 0
+        : this.getPromptCacheDynamicTailIndex(messages, promptCacheProvider);
     const stablePrefix = messages.slice(0, tailIndex);
     const trailingMessages = messages.slice(tailIndex);
     const cacheablePrefix = this.addStablePromptCacheMarkers(
@@ -1204,6 +1207,7 @@ export class AgentContext {
 
     this.summaryText = this._durableSummaryText;
     this.summaryTokenCount = this._durableSummaryTokenCount;
+    this.summaryPrecedesMessages = this.durableSummaryPrecedesMessages;
     this._lastSummarizationMsgCount = 0;
     this.lastCallUsage = undefined;
     this.totalTokensFresh = false;
@@ -1461,12 +1465,18 @@ export class AgentContext {
     }
   }
 
-  setSummary(text: string, tokenCount: number): void {
+  setSummary(
+    text: string,
+    tokenCount: number,
+    options?: { precedesMessages?: boolean }
+  ): void {
     this.summaryText = text;
     this.summaryTokenCount = tokenCount;
     this._summaryLocation = 'user_message';
+    this.summaryPrecedesMessages = options?.precedesMessages === true;
     this._durableSummaryText = text;
     this._durableSummaryTokenCount = tokenCount;
+    this.durableSummaryPrecedesMessages = this.summaryPrecedesMessages;
     this._summaryVersion += 1;
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
@@ -1477,8 +1487,10 @@ export class AgentContext {
     this.summaryText = text;
     this.summaryTokenCount = tokenCount;
     this._summaryLocation = 'system_prompt';
+    this.summaryPrecedesMessages = false;
     this._durableSummaryText = text;
     this._durableSummaryTokenCount = tokenCount;
+    this.durableSummaryPrecedesMessages = false;
     this._summaryVersion += 1;
     this.systemRunnableStale = true;
   }
@@ -1683,6 +1695,8 @@ export class AgentContext {
       this.summaryTokenCount = 0;
       this._durableSummaryText = undefined;
       this._durableSummaryTokenCount = 0;
+      this.summaryPrecedesMessages = false;
+      this.durableSummaryPrecedesMessages = false;
       this._summaryLocation = 'none';
       this.systemRunnableStale = true;
     }

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -778,6 +778,87 @@ describe('AgentContext', () => {
       expect(result[3].content).toBe('Second');
     });
 
+    it.each([Providers.ANTHROPIC, Providers.OPENROUTER])(
+      'places an intra-turn %s checkpoint before an assistant/tool tail',
+      async (provider) => {
+        const ctx = createBasicContext({
+          agentConfig: {
+            provider,
+            clientOptions: {
+              model:
+                provider === Providers.ANTHROPIC
+                  ? 'claude-haiku-4-5'
+                  : 'anthropic/claude-haiku-4.5',
+              promptCache: true,
+            },
+            instructions: 'Stable instructions',
+          },
+        });
+        ctx.setSummary('Intra-turn checkpoint', 7, {
+          precedesMessages: true,
+        });
+
+        const result = await ctx.systemRunnable!.invoke([
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'call_1', name: 'calculator', args: { value: 2 } },
+            ],
+          }),
+          new ToolMessage({
+            content: '4',
+            name: 'calculator',
+            tool_call_id: 'call_1',
+          }),
+        ]);
+
+        expect(JSON.stringify(result[1].content)).toContain(
+          'Intra-turn checkpoint'
+        );
+        expect((result[2] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+        expect(result[3].getType()).toBe('tool');
+      }
+    );
+
+    it('does not insert an Anthropic checkpoint between a native call and result', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-haiku-4-5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+        },
+      });
+      ctx.setSummary('Intra-turn checkpoint', 7, {
+        precedesMessages: true,
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new AIMessage({
+          content: [
+            { type: 'tool_use', id: 'call_1', name: 'search', input: {} },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_1',
+              content: 'result',
+            },
+          ],
+        }),
+      ]);
+
+      expect(JSON.stringify(result[1].content)).toContain(
+        'Intra-turn checkpoint'
+      );
+      expect(result[2].getType()).toBe('ai');
+      expect(result[3].getType()).toBe('human');
+    });
+
     it('preserves the Bedrock system cache point through message cache-control pass', async () => {
       const ctx = createBasicContext({
         agentConfig: {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -68,6 +68,7 @@ import {
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
   DEFAULT_RETAIN_RECENT_TURNS,
+  resolveIntraTurnRetainTokens,
   splitAtRecencyBoundary,
   convertInjectedMessages,
   coalesceAdjacentUserTurns,
@@ -3936,6 +3937,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          */
         const estimatedPromptTokens = getEstimatedPromptTokens(contextUsage);
 
+        const recencyTokenCounter =
+          agentContext.contextPressureTokenCounts?.count ??
+          agentContext.tokenCounter;
         const canSummarizeOverflow =
           agentContext.summarizationEnabled === true &&
           splitAtRecencyBoundary(messages, {
@@ -3943,7 +3947,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               agentContext.summarizationConfig?.retainRecent?.turns ??
               DEFAULT_RETAIN_RECENT_TURNS,
             tokens: agentContext.summarizationConfig?.retainRecent?.tokens,
-            tokenCounter: agentContext.tokenCounter,
+            tokenCounter: recencyTokenCounter,
+            intraTurnTokens: resolveIntraTurnRetainTokens({
+              tokens: agentContext.summarizationConfig?.retainRecent?.tokens,
+              maxContextTokens: agentContext.maxContextTokens,
+            }),
           }).head.length > 0;
 
         const getLocalProviderOverflowMeasurement = (

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -219,6 +219,7 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.head).toEqual(messages.slice(0, 7));
       expect(result.tail).toEqual(messages.slice(7));
       expect(result.tailStartIndex).toBe(7);
+      expect(result.usedIntraTurnFallback).toBe(true);
       expect(result.tail[0]).toBeInstanceOf(AIMessage);
       expect((result.tail[0] as AIMessage).tool_calls?.[0]?.id).toBe('call_3');
       expect((result.tail[1] as ToolMessage).tool_call_id).toBe('call_3');
@@ -554,6 +555,35 @@ describe('splitAtRecencyBoundary', () => {
 
       expect(result.head).toEqual(messages.slice(0, 3));
       expect(result.tail).toEqual(messages.slice(3));
+    });
+
+    it('does not let an older tool pair license a cut in a later turn', () => {
+      const messages = [
+        new HumanMessage('first turn'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'closed', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'closed result',
+          tool_call_id: 'closed',
+          name: 'search',
+        }),
+        new HumanMessage('large second user request'),
+        new AIMessage('working'),
+        new AIMessage('still working'),
+        new AIMessage('latest state'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 200,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 3));
+      expect(result.tail).toEqual(messages.slice(3));
+      expect(result.usedIntraTurnFallback).toBe(true);
     });
 
     it('retains an open tool call and protects a lone user payload', () => {

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -399,6 +399,47 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tail).toEqual(messages.slice(5));
     });
 
+    it('does not treat provider-native result messages as user turns', () => {
+      const messages = [
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: [
+            { type: 'tool_use', id: 'call_a', name: 'search', input: {} },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_a',
+              content: 'result A',
+            },
+          ],
+        }),
+        new AIMessage({
+          content: [
+            { type: 'tool_use', id: 'call_b', name: 'search', input: {} },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'call_b',
+              content: 'result B',
+            },
+          ],
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, { turns: 1 });
+
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+      expect(result.tailTurnCount).toBe(1);
+    });
+
     it('retains an open tool call and protects a lone user payload', () => {
       const openCall = [
         new HumanMessage('inspect'),

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -5,7 +5,37 @@ import {
   SystemMessage,
   type BaseMessage,
 } from '@langchain/core/messages';
-import { splitAtRecencyBoundary } from '@/messages/recency';
+import {
+  resolveIntraTurnRetainTokens,
+  splitAtRecencyBoundary,
+} from '@/messages/recency';
+
+describe('resolveIntraTurnRetainTokens', () => {
+  it('prefers an explicit budget and otherwise retains 16% of context', () => {
+    expect(
+      resolveIntraTurnRetainTokens({
+        tokens: 4_096,
+        maxContextTokens: 100_000,
+      })
+    ).toBe(4_096);
+    expect(
+      resolveIntraTurnRetainTokens({ maxContextTokens: 100_000 })
+    ).toBe(16_000);
+  });
+
+  it('disables the fallback without a usable context budget', () => {
+    expect(resolveIntraTurnRetainTokens({})).toBeUndefined();
+    expect(
+      resolveIntraTurnRetainTokens({ maxContextTokens: 0 })
+    ).toBeUndefined();
+    expect(
+      resolveIntraTurnRetainTokens({
+        tokens: 0,
+        maxContextTokens: 100_000,
+      })
+    ).toBeUndefined();
+  });
+});
 
 describe('splitAtRecencyBoundary', () => {
   describe('default behavior (turns: 2)', () => {
@@ -158,6 +188,146 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tailTurnCount).toBe(2);
       expect(result.head).toEqual([]);
       expect(result.tail).toEqual(messages);
+    });
+  });
+
+  describe('pairing-balanced intra-turn fallback', () => {
+    it('compacts older closed tool units from a single long turn', () => {
+      const messages: BaseMessage[] = [new HumanMessage('inspect the repo')];
+      for (let index = 0; index < 4; index++) {
+        const id = `call_${index}`;
+        messages.push(
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id, name: 'search', args: { query: index } }],
+          }),
+          new ToolMessage({
+            content: `result ${index}`,
+            tool_call_id: id,
+            name: 'search',
+          })
+        );
+      }
+      messages.push(new AIMessage('preparing the change'));
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 300,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 7));
+      expect(result.tail).toEqual(messages.slice(7));
+      expect(result.tailStartIndex).toBe(7);
+      expect(result.tail[0]).toBeInstanceOf(AIMessage);
+      expect((result.tail[0] as AIMessage).tool_calls?.[0]?.id).toBe('call_3');
+      expect((result.tail[1] as ToolMessage).tool_call_id).toBe('call_3');
+    });
+
+    it('does not split parallel tool calls from their results', () => {
+      const messages = [
+        new HumanMessage('compare both'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'call_a', name: 'search', args: {} },
+            { id: 'call_b', name: 'search', args: {} },
+          ],
+        }),
+        new ToolMessage({
+          content: 'result A',
+          tool_call_id: 'call_a',
+          name: 'search',
+        }),
+        new ToolMessage({
+          content: 'result B',
+          tool_call_id: 'call_b',
+          name: 'search',
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_c', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'result C',
+          tool_call_id: 'call_c',
+          name: 'search',
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 300,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 4));
+      expect(result.tail).toEqual(messages.slice(4));
+    });
+
+    it('retains an open tool call and protects a lone user payload', () => {
+      const openCall = [
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'closed', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'closed result',
+          tool_call_id: 'closed',
+          name: 'search',
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'open', name: 'search', args: {} }],
+        }),
+      ];
+      const options = {
+        turns: 2,
+        tokenCounter: (): number => 100,
+        intraTurnTokens: 100,
+      };
+
+      const openResult = splitAtRecencyBoundary(openCall, options);
+      const loneUser = [new HumanMessage('payload'.repeat(10_000))];
+      const loneResult = splitAtRecencyBoundary(loneUser, options);
+
+      expect(openResult.head).toEqual(openCall.slice(0, 3));
+      expect(openResult.tail).toEqual(openCall.slice(3));
+      expect(loneResult.head).toEqual([]);
+      expect(loneResult.tail).toEqual(loneUser);
+    });
+
+    it('counts every message at most once when falling back within a turn', () => {
+      const messages: BaseMessage[] = [new HumanMessage('inspect')];
+      for (let index = 0; index < 100; index++) {
+        const id = `call_${index}`;
+        messages.push(
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id, name: 'search', args: {} }],
+          }),
+          new ToolMessage({
+            content: `result ${index}`,
+            tool_call_id: id,
+            name: 'search',
+          })
+        );
+      }
+      let calls = 0;
+
+      splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokens: 30,
+        tokenCounter: () => {
+          calls += 1;
+          return 1;
+        },
+        intraTurnTokens: 30,
+      });
+
+      expect(calls).toBe(messages.length);
     });
   });
 

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -266,6 +266,139 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tail).toEqual(messages.slice(4));
     });
 
+    it('falls back within the first turn after a leading preamble', () => {
+      const messages = [
+        new SystemMessage('programmatic preamble'),
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_a', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'result A',
+          tool_call_id: 'call_a',
+          name: 'search',
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_b', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'result B',
+          tool_call_id: 'call_b',
+          name: 'search',
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 300,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 4));
+      expect(result.tail).toEqual(messages.slice(4));
+    });
+
+    it('does not split messages derived from one persisted source row', () => {
+      const messages = [
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_a', name: 'search', args: {} }],
+          additional_kwargs: { sourceMessageId: 'expanded-row' },
+        }),
+        new ToolMessage({
+          content: 'result A',
+          tool_call_id: 'call_a',
+          name: 'search',
+          additional_kwargs: { sourceMessageId: 'expanded-row' },
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_b', name: 'search', args: {} }],
+          additional_kwargs: { sourceMessageId: 'expanded-row' },
+        }),
+        new ToolMessage({
+          content: 'result B',
+          tool_call_id: 'call_b',
+          name: 'search',
+          additional_kwargs: { sourceMessageId: 'expanded-row' },
+        }),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_c', name: 'search', args: {} }],
+          additional_kwargs: { sourceMessageId: 'retained-row' },
+        }),
+        new ToolMessage({
+          content: 'result C',
+          tool_call_id: 'call_c',
+          name: 'search',
+          additional_kwargs: { sourceMessageId: 'retained-row' },
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 300,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 5));
+      expect(result.tail).toEqual(messages.slice(5));
+    });
+
+    it('recognizes raw and content-block provider tool pairs', () => {
+      const rawCallMessage = new AIMessage('');
+      rawCallMessage.additional_kwargs.tool_calls = [
+        {
+          id: 'raw_call',
+          type: 'function',
+          function: { name: 'search', arguments: '{}' },
+        },
+      ];
+      const messages = [
+        new HumanMessage('inspect'),
+        rawCallMessage,
+        new ToolMessage({
+          content: 'raw result',
+          tool_call_id: 'raw_call',
+          name: 'search',
+        }),
+        new AIMessage({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'content_call',
+              name: 'search',
+              input: {},
+            },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'content_call',
+              content: 'content result',
+            },
+          ],
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 100,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 5));
+      expect(result.tail).toEqual(messages.slice(5));
+    });
+
     it('retains an open tool call and protects a lone user payload', () => {
       const openCall = [
         new HumanMessage('inspect'),

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -440,6 +440,122 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tailTurnCount).toBe(1);
     });
 
+    it('preserves an unpaired provider-native result as a user turn', () => {
+      const messages = [
+        new HumanMessage('first turn'),
+        new AIMessage('first reply'),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'missing_call',
+              content: 'user-authored payload',
+            },
+          ],
+        }),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, { turns: 1 });
+
+      expect(result.head).toEqual(messages.slice(0, 2));
+      expect(result.tail).toEqual(messages.slice(2));
+      expect(result.tailTurnCount).toBe(1);
+    });
+
+    it('keeps incompatible provider results from closing a tool call', () => {
+      const messages = [
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: [
+            { type: 'tool_use', id: 'shared', name: 'search', input: {} },
+          ],
+        }),
+        new AIMessage({
+          content: [
+            {
+              type: 'toolResponse',
+              toolResponse: {
+                id: 'shared',
+                name: 'search',
+                response: { output: 'wrong protocol' },
+              },
+            },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'shared',
+              content: 'matched result',
+            },
+          ],
+        }),
+        new AIMessage({
+          content: [
+            { type: 'tool_use', id: 'recent', name: 'search', input: {} },
+          ],
+        }),
+        new HumanMessage({
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'recent',
+              content: 'recent result',
+            },
+          ],
+        }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 300,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 4));
+      expect(result.tail).toEqual(messages.slice(4));
+    });
+
+    it('compacts paired Gemini code-execution units without identifiers', () => {
+      const codeUnit = (value: number): AIMessage =>
+        new AIMessage({
+          content: [
+            {
+              type: 'executableCode',
+              executableCode: {
+                language: 'PYTHON',
+                code: `print(${value})`,
+              },
+            },
+            {
+              type: 'codeExecutionResult',
+              codeExecutionResult: {
+                outcome: 'OUTCOME_OK',
+                output: String(value),
+              },
+            },
+          ],
+        });
+      const messages = [
+        new HumanMessage('run the calculations'),
+        codeUnit(1),
+        codeUnit(2),
+        codeUnit(3),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 200,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 3));
+      expect(result.tail).toEqual(messages.slice(3));
+    });
+
     it('retains an open tool call and protects a lone user payload', () => {
       const openCall = [
         new HumanMessage('inspect'),

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -3,6 +3,14 @@ import type {
   BaseMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import { getProviderSourceMessageIds } from './provenance';
+import {
+  getBoundedProviderPairingArray,
+  getBoundedProviderPairingArrayProperty,
+  getProviderToolCallPartDescriptor,
+  getProviderToolResultPartDescriptor,
+  PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS,
+} from './toolResultTypes';
 
 export const DEFAULT_RETAIN_RECENT_TURNS = 2;
 export const DEFAULT_INTRA_TURN_RETAIN_RATIO = 0.16;
@@ -84,21 +92,113 @@ export function resolveIntraTurnRetainTokens({
   );
 }
 
-function getToolCallIds(message: BaseMessage): string[] {
-  if (message.getType() !== 'ai') {
-    return [];
+function readOwnString(value: unknown, key: string): string | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
   }
-  const toolCalls = (message as AIMessage).tool_calls;
-  if (toolCalls == null || toolCalls.length === 0) {
-    return [];
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor != null &&
+      'value' in descriptor &&
+      typeof descriptor.value === 'string' &&
+      descriptor.value !== '' &&
+      descriptor.value.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
   }
-  const ids: string[] = [];
-  for (const toolCall of toolCalls) {
-    if (toolCall.id != null && toolCall.id !== '') {
-      ids.push(toolCall.id);
+}
+
+function addToolPairingId(ids: Set<string>, candidate: unknown): void {
+  if (
+    typeof candidate === 'string' &&
+    candidate !== '' &&
+    candidate.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+  ) {
+    ids.add(candidate);
+  }
+}
+
+function getToolCallIds(message: BaseMessage): Set<string> {
+  const ids = new Set<string>();
+  const messageRole = (message as BaseMessage & { role?: unknown }).role;
+  if (message.getType() !== 'ai' && messageRole !== 'assistant') {
+    return ids;
+  }
+
+  for (const toolCall of (message as AIMessage).tool_calls ?? []) {
+    addToolPairingId(ids, toolCall.id);
+  }
+
+  const rawToolCalls = getBoundedProviderPairingArrayProperty(
+    message.additional_kwargs,
+    'tool_calls'
+  );
+  if (rawToolCalls != null) {
+    for (const toolCall of rawToolCalls) {
+      const id = readOwnString(toolCall, 'id');
+      addToolPairingId(ids, id);
     }
   }
+
+  const content = getBoundedProviderPairingArray(message.content);
+  if (content != null) {
+    for (const part of content) {
+      const descriptor = getProviderToolCallPartDescriptor(part);
+      if (descriptor != null) {
+        addToolPairingId(ids, descriptor.callId);
+      }
+    }
+  }
+
   return ids;
+}
+
+function getToolResultIds(message: BaseMessage): Set<string> {
+  const ids = new Set<string>();
+  if (message.getType() === 'tool') {
+    const toolMessage = message as ToolMessage & { toolCallId?: unknown };
+    addToolPairingId(ids, toolMessage.tool_call_id);
+    addToolPairingId(ids, toolMessage.toolCallId);
+  }
+
+  const content = getBoundedProviderPairingArray(message.content);
+  if (content != null) {
+    for (const part of content) {
+      const descriptor = getProviderToolResultPartDescriptor(part);
+      if (descriptor?.toolCallId != null) {
+        addToolPairingId(ids, descriptor.toolCallId);
+      }
+    }
+  }
+
+  return ids;
+}
+
+function isToolResultOnlyMessage(message: BaseMessage): boolean {
+  if (message.getType() === 'tool') {
+    return true;
+  }
+  const content = getBoundedProviderPairingArray(message.content);
+  if (content == null || content.length === 0) {
+    return false;
+  }
+  for (const part of content) {
+    if (getProviderToolResultPartDescriptor(part)?.toolCallId == null) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getCoverageSourceIds(message: BaseMessage): string[] {
+  const sourceIds = getProviderSourceMessageIds(message);
+  if (sourceIds.length > 0) {
+    return sourceIds;
+  }
+  const messageId = message.id?.trim();
+  return messageId != null && messageId !== '' ? [messageId] : [];
 }
 
 function findIntraTurnBoundary(
@@ -114,7 +214,18 @@ function findIntraTurnBoundary(
     return undefined;
   }
 
+  const sourceIdsByIndex = new Array<string[]>(messages.length);
+  const lastIndexBySourceId = new Map<string, number>();
+  for (let i = 0; i < messages.length; i++) {
+    const sourceIds = getCoverageSourceIds(messages[i] as BaseMessage);
+    sourceIdsByIndex[i] = sourceIds;
+    for (const sourceId of sourceIds) {
+      lastIndexBySourceId.set(sourceId, i);
+    }
+  }
+
   const pendingToolCallIds = new Set<string>();
+  const straddlingSourceIds = new Set<string>();
   let completedToolCalls = 0;
   let boundary: number | undefined;
 
@@ -126,10 +237,18 @@ function findIntraTurnBoundary(
       pendingToolCallIds.add(callId);
     }
 
-    if (message.getType() === 'tool') {
-      const toolCallId = (message as ToolMessage).tool_call_id;
+    const toolResultIds = getToolResultIds(message);
+    for (const toolCallId of toolResultIds) {
       if (pendingToolCallIds.delete(toolCallId)) {
         completedToolCalls += 1;
+      }
+    }
+
+    for (const sourceId of sourceIdsByIndex[i] as string[]) {
+      if (lastIndexBySourceId.get(sourceId) === i) {
+        straddlingSourceIds.delete(sourceId);
+      } else {
+        straddlingSourceIds.add(sourceId);
       }
     }
 
@@ -139,7 +258,8 @@ function findIntraTurnBoundary(
     if (
       completedToolCalls > 0 &&
       pendingToolCallIds.size === 0 &&
-      message.getType() !== 'human'
+      straddlingSourceIds.size === 0 &&
+      (message.getType() !== 'human' || isToolResultOnlyMessage(message))
     ) {
       boundary = i + 1;
     }
@@ -257,7 +377,7 @@ export function splitAtRecencyBoundary(
     tailTurnCount += 1;
   }
 
-  if (tailStartIndex === 0) {
+  if (tailStartIndex === turnStarts[0]) {
     const intraTurnTokens = options.intraTurnTokens;
     if (
       intraTurnTokens != null &&

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -21,11 +21,11 @@ export const DEFAULT_INTRA_TURN_RETAIN_RATIO = 0.16;
  */
 export interface RecencyWindowOptions {
   /**
-   * Maximum number of recent user-led turns to keep in the tail.  A "turn"
-   * begins at a HumanMessage and includes every following AIMessage and
-   * ToolMessage up to (but not including) the next HumanMessage.  Cutting
-   * at turn boundaries guarantees that tool_use / tool_result pairs are
-   * never split across the head/tail divide.
+   * Maximum number of recent user-led turns to keep in the tail. A "turn"
+   * begins at a user-authored HumanMessage and includes every following
+   * AIMessage and tool result up to the next user-authored HumanMessage.
+   * Provider-native HumanMessages containing only tool results remain in the
+   * current turn, so the boundary cannot split them from their calls.
    *
    * The most recent turn is preserved unless `intraTurnTokens` enables the
    * pairing-balanced fallback for a tool-heavy history. A lone oversized user
@@ -302,7 +302,10 @@ export function splitAtRecencyBoundary(
 
   const turnStarts: number[] = [];
   for (let i = 0; i < messages.length; i++) {
-    if (messages[i].getType() === 'human') {
+    if (
+      messages[i].getType() === 'human' &&
+      !isToolResultOnlyMessage(messages[i] as BaseMessage)
+    ) {
       turnStarts.push(i);
     }
   }

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -3,10 +3,18 @@ import type {
   BaseMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import type {
+  ProviderToolCallIndex,
+  ProviderToolCallPartDescriptor,
+  ProviderToolResultPartDescriptor,
+} from './toolResultTypes';
 import { getProviderSourceMessageIds } from './provenance';
 import {
+  appendProviderToolCallDescriptor,
+  consumeProviderToolResultPair,
   getBoundedProviderPairingArray,
   getBoundedProviderPairingArrayProperty,
+  getProviderAIMessageToolCallDescriptor,
   getProviderToolCallPartDescriptor,
   getProviderToolResultPartDescriptor,
   PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS,
@@ -110,25 +118,47 @@ function readOwnString(value: unknown, key: string): string | undefined {
   }
 }
 
-function addToolPairingId(ids: Set<string>, candidate: unknown): void {
-  if (
-    typeof candidate === 'string' &&
-    candidate !== '' &&
-    candidate.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
-  ) {
-    ids.add(candidate);
+function getRawToolCallDescriptor(
+  toolCall: unknown
+): ProviderToolCallPartDescriptor | undefined {
+  const callId = readOwnString(toolCall, 'id');
+  if (callId == null) {
+    return undefined;
   }
+  let name: string | undefined;
+  if (toolCall != null && typeof toolCall === 'object') {
+    try {
+      const property = Object.getOwnPropertyDescriptor(toolCall, 'function');
+      name =
+        property != null && 'value' in property
+          ? readOwnString(property.value, 'name')
+          : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return {
+    callId,
+    kind: 'tool',
+    sourceType: 'raw_tool_calls',
+    ...(name == null ? {} : { name }),
+  };
 }
 
-function getToolCallIds(message: BaseMessage): Set<string> {
-  const ids = new Set<string>();
+function appendMessageToolCalls(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex
+): void {
   const messageRole = (message as BaseMessage & { role?: unknown }).role;
   if (message.getType() !== 'ai' && messageRole !== 'assistant') {
-    return ids;
+    return;
   }
 
   for (const toolCall of (message as AIMessage).tool_calls ?? []) {
-    addToolPairingId(ids, toolCall.id);
+    const descriptor = getProviderAIMessageToolCallDescriptor(toolCall);
+    if (descriptor != null) {
+      appendProviderToolCallDescriptor(calls, descriptor);
+    }
   }
 
   const rawToolCalls = getBoundedProviderPairingArrayProperty(
@@ -137,59 +167,122 @@ function getToolCallIds(message: BaseMessage): Set<string> {
   );
   if (rawToolCalls != null) {
     for (const toolCall of rawToolCalls) {
-      const id = readOwnString(toolCall, 'id');
-      addToolPairingId(ids, id);
-    }
-  }
-
-  const content = getBoundedProviderPairingArray(message.content);
-  if (content != null) {
-    for (const part of content) {
-      const descriptor = getProviderToolCallPartDescriptor(part);
+      const descriptor = getRawToolCallDescriptor(toolCall);
       if (descriptor != null) {
-        addToolPairingId(ids, descriptor.callId);
+        appendProviderToolCallDescriptor(calls, descriptor);
       }
     }
   }
-
-  return ids;
 }
 
-function getToolResultIds(message: BaseMessage): Set<string> {
-  const ids = new Set<string>();
-  if (message.getType() === 'tool') {
-    const toolMessage = message as ToolMessage & { toolCallId?: unknown };
-    addToolPairingId(ids, toolMessage.tool_call_id);
-    addToolPairingId(ids, toolMessage.toolCallId);
+function getToolMessageResultDescriptor(
+  message: BaseMessage
+): ProviderToolResultPartDescriptor | undefined {
+  if (message.getType() !== 'tool') {
+    return undefined;
   }
+  const toolMessage = message as ToolMessage & { toolCallId?: unknown };
+  const toolCallId =
+    typeof toolMessage.tool_call_id === 'string'
+      ? toolMessage.tool_call_id
+      : toolMessage.toolCallId;
+  return typeof toolCallId === 'string' &&
+    toolCallId !== '' &&
+    toolCallId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+    ? {
+      type: 'tool_message',
+      toolCallId,
+      compatibleCallKinds: ['tool'],
+    }
+    : undefined;
+}
 
+interface MessagePairingResult {
+  completedToolCalls: number;
+  trustedHumanToolResult: boolean;
+}
+
+function inspectMessagePairing(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex
+): MessagePairingResult {
+  const isHuman = message.getType() === 'human';
+  const candidateCalls = isHuman ? new Map(calls) : calls;
+  if (!isHuman) {
+    appendMessageToolCalls(message, candidateCalls);
+  }
   const content = getBoundedProviderPairingArray(message.content);
+  let completedToolCalls = 0;
+  let resultPartCount = 0;
+  let everyPartIsTrustedHumanResult = isHuman && content != null;
   if (content != null) {
+    let previousPart: unknown;
     for (const part of content) {
-      const descriptor = getProviderToolResultPartDescriptor(part);
-      if (descriptor?.toolCallId != null) {
-        addToolPairingId(ids, descriptor.toolCallId);
+      const callDescriptor = getProviderToolCallPartDescriptor(part);
+      if (callDescriptor != null && !isHuman) {
+        appendProviderToolCallDescriptor(candidateCalls, callDescriptor);
       }
+      const resultDescriptor = getProviderToolResultPartDescriptor(part);
+      if (resultDescriptor == null) {
+        everyPartIsTrustedHumanResult = false;
+      } else {
+        resultPartCount += 1;
+        const canPairHumanResult =
+          !isHuman || resultDescriptor.allowHumanMessagePairing === true;
+        if (
+          canPairHumanResult &&
+          consumeProviderToolResultPair(
+            resultDescriptor,
+            candidateCalls,
+            previousPart
+          )
+        ) {
+          completedToolCalls += 1;
+        } else {
+          everyPartIsTrustedHumanResult = false;
+        }
+      }
+      previousPart = part;
     }
   }
 
-  return ids;
+  const toolMessageResult = getToolMessageResultDescriptor(message);
+  if (
+    toolMessageResult != null &&
+    consumeProviderToolResultPair(toolMessageResult, candidateCalls)
+  ) {
+    completedToolCalls += 1;
+  }
+
+  const trustedHumanToolResult =
+    everyPartIsTrustedHumanResult && resultPartCount === content?.length;
+  if (trustedHumanToolResult) {
+    calls.clear();
+    for (const [callId, entry] of candidateCalls) {
+      calls.set(callId, entry);
+    }
+  }
+  return {
+    completedToolCalls: isHuman && !trustedHumanToolResult
+      ? 0
+      : completedToolCalls,
+    trustedHumanToolResult,
+  };
 }
 
-function isToolResultOnlyMessage(message: BaseMessage): boolean {
-  if (message.getType() === 'tool') {
-    return true;
-  }
-  const content = getBoundedProviderPairingArray(message.content);
-  if (content == null || content.length === 0) {
-    return false;
-  }
-  for (const part of content) {
-    if (getProviderToolResultPartDescriptor(part)?.toolCallId == null) {
-      return false;
+function findTurnStarts(messages: BaseMessage[]): number[] {
+  const turnStarts: number[] = [];
+  const calls: ProviderToolCallIndex = new Map();
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i] as BaseMessage;
+    const pairing = inspectMessagePairing(message, calls);
+    if (message.getType() !== 'human' || pairing.trustedHumanToolResult) {
+      continue;
     }
+    turnStarts.push(i);
+    calls.clear();
   }
-  return true;
+  return turnStarts;
 }
 
 function getCoverageSourceIds(message: BaseMessage): string[] {
@@ -224,7 +317,7 @@ function findIntraTurnBoundary(
     }
   }
 
-  const pendingToolCallIds = new Set<string>();
+  const pendingToolCalls: ProviderToolCallIndex = new Map();
   const straddlingSourceIds = new Set<string>();
   let completedToolCalls = 0;
   let boundary: number | undefined;
@@ -233,15 +326,10 @@ function findIntraTurnBoundary(
     const message = messages[i] as BaseMessage;
     remainingTokens -= countMessageAt(i);
 
-    for (const callId of getToolCallIds(message)) {
-      pendingToolCallIds.add(callId);
-    }
-
-    const toolResultIds = getToolResultIds(message);
-    for (const toolCallId of toolResultIds) {
-      if (pendingToolCallIds.delete(toolCallId)) {
-        completedToolCalls += 1;
-      }
+    const pairing = inspectMessagePairing(message, pendingToolCalls);
+    completedToolCalls += pairing.completedToolCalls;
+    if (message.getType() === 'human' && !pairing.trustedHumanToolResult) {
+      pendingToolCalls.clear();
     }
 
     for (const sourceId of sourceIdsByIndex[i] as string[]) {
@@ -257,9 +345,9 @@ function findIntraTurnBoundary(
     }
     if (
       completedToolCalls > 0 &&
-      pendingToolCallIds.size === 0 &&
+      pendingToolCalls.size === 0 &&
       straddlingSourceIds.size === 0 &&
-      (message.getType() !== 'human' || isToolResultOnlyMessage(message))
+      (message.getType() !== 'human' || pairing.trustedHumanToolResult)
     ) {
       boundary = i + 1;
     }
@@ -300,15 +388,7 @@ export function splitAtRecencyBoundary(
     };
   }
 
-  const turnStarts: number[] = [];
-  for (let i = 0; i < messages.length; i++) {
-    if (
-      messages[i].getType() === 'human' &&
-      !isToolResultOnlyMessage(messages[i] as BaseMessage)
-    ) {
-      turnStarts.push(i);
-    }
-  }
+  const turnStarts = findTurnStarts(messages);
 
   if (turnStarts.length === 0) {
     return {

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -73,6 +73,8 @@ export interface RecencySplit {
   tailTurnCount: number;
   /** Index in the original `messages` array where the tail begins. */
   tailStartIndex: number;
+  /** True when the pairing-balanced fallback selected the boundary. */
+  usedIntraTurnFallback: boolean;
 }
 
 export function resolveIntraTurnRetainTokens({
@@ -297,7 +299,8 @@ function getCoverageSourceIds(message: BaseMessage): string[] {
 function findIntraTurnBoundary(
   messages: BaseMessage[],
   countMessageAt: (index: number) => number,
-  retainTokens: number
+  retainTokens: number,
+  earliestRetainedTurnEndIndex: number
 ): number | undefined {
   let remainingTokens = 0;
   for (let i = 0; i < messages.length; i++) {
@@ -322,7 +325,11 @@ function findIntraTurnBoundary(
   let completedToolCalls = 0;
   let boundary: number | undefined;
 
-  for (let i = 0; i < messages.length - 1; i++) {
+  const boundarySearchEnd = Math.min(
+    messages.length - 1,
+    earliestRetainedTurnEndIndex - 1
+  );
+  for (let i = 0; i <= boundarySearchEnd; i++) {
     const message = messages[i] as BaseMessage;
     remainingTokens -= countMessageAt(i);
 
@@ -385,6 +392,7 @@ export function splitAtRecencyBoundary(
       tail: [],
       tailTurnCount: 0,
       tailStartIndex: messages.length,
+      usedIntraTurnFallback: false,
     };
   }
 
@@ -396,6 +404,7 @@ export function splitAtRecencyBoundary(
       tail: [],
       tailTurnCount: 0,
       tailStartIndex: messages.length,
+      usedIntraTurnFallback: false,
     };
   }
 
@@ -471,7 +480,8 @@ export function splitAtRecencyBoundary(
       const intraTurnBoundary = findIntraTurnBoundary(
         messages,
         countMessageAt,
-        intraTurnTokens
+        intraTurnTokens,
+        turnStarts[1] ?? messages.length
       );
       if (intraTurnBoundary != null) {
         return {
@@ -479,6 +489,7 @@ export function splitAtRecencyBoundary(
           tail: messages.slice(intraTurnBoundary),
           tailTurnCount,
           tailStartIndex: intraTurnBoundary,
+          usedIntraTurnFallback: true,
         };
       }
     }
@@ -489,5 +500,6 @@ export function splitAtRecencyBoundary(
     tail: messages.slice(tailStartIndex),
     tailTurnCount,
     tailStartIndex,
+    usedIntraTurnFallback: false,
   };
 }

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -1,6 +1,11 @@
-import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AIMessage,
+  BaseMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 
 export const DEFAULT_RETAIN_RECENT_TURNS = 2;
+export const DEFAULT_INTRA_TURN_RETAIN_RATIO = 0.16;
 
 /**
  * Configuration for splitting a message list into a head (to be summarized)
@@ -14,9 +19,9 @@ export interface RecencyWindowOptions {
    * at turn boundaries guarantees that tool_use / tool_result pairs are
    * never split across the head/tail divide.
    *
-   * The most recent turn is always preserved regardless of this value or
-   * the token cap, so that a single oversized first message is never
-   * destroyed by summarization.
+   * The most recent turn is preserved unless `intraTurnTokens` enables the
+   * pairing-balanced fallback for a tool-heavy history. A lone oversized user
+   * message is never eligible for that fallback.
    *
    * Defaults to `2`.  A value of `0` disables the recency window (head =
    * everything, tail = empty), restoring the pre-recency-window behavior.
@@ -34,12 +39,19 @@ export interface RecencyWindowOptions {
   tokens?: number;
   /** Token-counter used to evaluate the optional `tokens` cap. */
   tokenCounter?: (m: BaseMessage) => number;
+  /**
+   * Minimum token budget to retain when the turn window would otherwise make
+   * the whole history indivisible. When set with `tokenCounter`, older closed
+   * tool-call/result units may be summarized from within the earliest retained
+   * turn. A lone user payload and open tool units remain indivisible.
+   */
+  intraTurnTokens?: number;
 }
 
 export interface RecencySplit {
   /** Older messages eligible for summarization.  Empty when nothing to summarize. */
   head: BaseMessage[];
-  /** Recent messages preserved verbatim.  Always contains the most recent turn when any HumanMessage exists. */
+  /** Recent messages preserved verbatim, beginning at a pairing-balanced boundary. */
   tail: BaseMessage[];
   /** Number of user-led turns retained in the tail (0 if no HumanMessage exists). */
   tailTurnCount: number;
@@ -47,18 +59,105 @@ export interface RecencySplit {
   tailStartIndex: number;
 }
 
+export function resolveIntraTurnRetainTokens({
+  tokens,
+  maxContextTokens,
+}: {
+  tokens?: number;
+  maxContextTokens?: number;
+}): number | undefined {
+  if (tokens != null) {
+    return Number.isFinite(tokens) && tokens > 0
+      ? Math.floor(tokens)
+      : undefined;
+  }
+  if (
+    maxContextTokens == null ||
+    !Number.isFinite(maxContextTokens) ||
+    maxContextTokens <= 0
+  ) {
+    return undefined;
+  }
+  return Math.max(
+    1,
+    Math.floor(maxContextTokens * DEFAULT_INTRA_TURN_RETAIN_RATIO)
+  );
+}
+
+function getToolCallIds(message: BaseMessage): string[] {
+  if (message.getType() !== 'ai') {
+    return [];
+  }
+  const toolCalls = (message as AIMessage).tool_calls;
+  if (toolCalls == null || toolCalls.length === 0) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const toolCall of toolCalls) {
+    if (toolCall.id != null && toolCall.id !== '') {
+      ids.push(toolCall.id);
+    }
+  }
+  return ids;
+}
+
+function findIntraTurnBoundary(
+  messages: BaseMessage[],
+  countMessageAt: (index: number) => number,
+  retainTokens: number
+): number | undefined {
+  let remainingTokens = 0;
+  for (let i = 0; i < messages.length; i++) {
+    remainingTokens += countMessageAt(i);
+  }
+  if (remainingTokens <= retainTokens) {
+    return undefined;
+  }
+
+  const pendingToolCallIds = new Set<string>();
+  let completedToolCalls = 0;
+  let boundary: number | undefined;
+
+  for (let i = 0; i < messages.length - 1; i++) {
+    const message = messages[i] as BaseMessage;
+    remainingTokens -= countMessageAt(i);
+
+    for (const callId of getToolCallIds(message)) {
+      pendingToolCallIds.add(callId);
+    }
+
+    if (message.getType() === 'tool') {
+      const toolCallId = (message as ToolMessage).tool_call_id;
+      if (pendingToolCallIds.delete(toolCallId)) {
+        completedToolCalls += 1;
+      }
+    }
+
+    if (remainingTokens < retainTokens) {
+      break;
+    }
+    if (
+      completedToolCalls > 0 &&
+      pendingToolCallIds.size === 0 &&
+      message.getType() !== 'human'
+    ) {
+      boundary = i + 1;
+    }
+  }
+
+  return boundary;
+}
+
 /**
  * Splits `messages` into a head (older, to summarize) and a tail (recent,
- * to preserve verbatim) at user-message boundaries.  The most recent
- * user-led turn is always included in the tail; additional older turns
- * are added subject to `turns` and `tokens` caps.
+ * to preserve verbatim), preferring user-message boundaries. The most recent
+ * user-led turn is normally included in the tail; additional older turns are
+ * added subject to `turns` and `tokens` caps.
  *
- * Cutting strictly at HumanMessage boundaries ensures that:
- * - tool_use ↔ tool_result pairs are never split (they always live within
- *   the same turn);
- * - the first user message is never replaced by a summary, addressing
- *   the "first turn destruction" failure mode where a single large
- *   user-pasted payload would otherwise be replaced by a generic summary.
+ * When that policy exposes no compactable head, `intraTurnTokens` may select
+ * a boundary after older closed tool-call/result units. This keeps runaway
+ * first-turn tool loops compactable without splitting parallel calls from
+ * their results. A user payload without a completed tool unit stays intact.
  *
  * When `messages` contains no HumanMessage (degenerate state — e.g. system
  * + assistant messages from a programmatic preamble), everything is
@@ -105,6 +204,16 @@ export function splitAtRecencyBoundary(
   const tokenCounter = options.tokenCounter;
   const trackTokens =
     tokensCap != null && Number.isFinite(tokensCap) && tokenCounter != null;
+  const messageTokens: Array<number | undefined> = new Array(messages.length);
+  const countMessageAt = (index: number): number => {
+    const cached = messageTokens[index];
+    if (cached != null) {
+      return cached;
+    }
+    const count = tokenCounter?.(messages[index] as BaseMessage) ?? 0;
+    messageTokens[index] = count;
+    return count;
+  };
 
   /**
    * Token-counting strategy: each candidate turn `t` spans the half-open
@@ -122,7 +231,7 @@ export function splitAtRecencyBoundary(
   let tailTokens = 0;
   if (trackTokens) {
     for (let i = lastTurnStart; i < messages.length; i++) {
-      tailTokens += tokenCounter(messages[i] as BaseMessage);
+      tailTokens += countMessageAt(i);
     }
   }
 
@@ -136,7 +245,7 @@ export function splitAtRecencyBoundary(
     if (trackTokens) {
       let turnTokens = 0;
       for (let i = turnStart; i < turnEnd; i++) {
-        turnTokens += tokenCounter(messages[i] as BaseMessage);
+        turnTokens += countMessageAt(i);
       }
       if (tailTokens + turnTokens > (tokensCap as number)) {
         break;
@@ -146,6 +255,30 @@ export function splitAtRecencyBoundary(
 
     tailStartIndex = turnStart;
     tailTurnCount += 1;
+  }
+
+  if (tailStartIndex === 0) {
+    const intraTurnTokens = options.intraTurnTokens;
+    if (
+      intraTurnTokens != null &&
+      Number.isFinite(intraTurnTokens) &&
+      intraTurnTokens > 0 &&
+      tokenCounter != null
+    ) {
+      const intraTurnBoundary = findIntraTurnBoundary(
+        messages,
+        countMessageAt,
+        intraTurnTokens
+      );
+      if (intraTurnBoundary != null) {
+        return {
+          head: messages.slice(0, intraTurnBoundary),
+          tail: messages.slice(intraTurnBoundary),
+          tailTurnCount,
+          tailStartIndex: intraTurnBoundary,
+        };
+      }
+    }
   }
 
   return {

--- a/src/scripts/bench-compaction-range.ts
+++ b/src/scripts/bench-compaction-range.ts
@@ -1,0 +1,162 @@
+/* eslint-disable no-console */
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+import { createTokenCounter } from '@/utils/tokens';
+import {
+  resolveIntraTurnRetainTokens,
+  splitAtRecencyBoundary,
+} from '@/messages/recency';
+
+interface Scenario {
+  name: string;
+  toolSteps: number;
+  toolOutputChars: number;
+  maxContextTokens: number;
+}
+
+function createToolOutput(step: number, charCount: number): string {
+  let state = (step + 1) * 2_654_435_761;
+  let output = `step=${step}; identifier=VALUE_${step}\n`;
+  while (output.length < charCount) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    output += `${(state >>> 0).toString(16).padStart(8, '0')} `;
+  }
+  return output.slice(0, charCount);
+}
+
+function createToolHistory({
+  toolSteps,
+  toolOutputChars,
+}: Scenario): BaseMessage[] {
+  const messages: BaseMessage[] = [
+    new HumanMessage(
+      'Inspect the repository, fix the issue, test it, and open a PR.'
+    ),
+  ];
+  for (let index = 0; index < toolSteps; index++) {
+    const callId = `call_${index}`;
+    messages.push(
+      new AIMessage({
+        content: `Inspecting repository evidence for step ${index}.`,
+        tool_calls: [
+          {
+            id: callId,
+            name: 'exec_command',
+            args: {
+              intent: `Inspecting repository evidence for step ${index}`,
+              cmd: `rg pattern_${index}`,
+            },
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: createToolOutput(index, toolOutputChars),
+        tool_call_id: callId,
+        name: 'exec_command',
+      })
+    );
+  }
+  messages.push(
+    new AIMessage('I have enough evidence and am preparing the implementation.')
+  );
+  return messages;
+}
+
+function sumTokens(
+  messages: BaseMessage[],
+  tokenCounter: (message: BaseMessage) => number
+): number {
+  let total = 0;
+  for (const message of messages) {
+    total += tokenCounter(message);
+  }
+  return total;
+}
+
+function assertPairingPreserved(
+  head: BaseMessage[],
+  tail: BaseMessage[]
+): void {
+  const sideByCallId = new Map<string, 'head' | 'tail'>();
+  for (const [side, messages] of [
+    ['head', head],
+    ['tail', tail],
+  ] as const) {
+    for (const message of messages) {
+      if (message.getType() === 'ai') {
+        for (const call of (message as AIMessage).tool_calls ?? []) {
+          if (call.id != null) {
+            sideByCallId.set(call.id, side);
+          }
+        }
+        continue;
+      }
+      if (message.getType() !== 'tool') {
+        continue;
+      }
+      const callId = (message as ToolMessage).tool_call_id;
+      if (sideByCallId.get(callId) !== side) {
+        throw new Error(`Compaction split tool pair ${callId}`);
+      }
+    }
+  }
+}
+
+const tokenCounter = await createTokenCounter();
+const scenarios: Scenario[] = [
+  {
+    name: '20 tool steps',
+    toolSteps: 20,
+    toolOutputChars: 4_096,
+    maxContextTokens: 64_000,
+  },
+  {
+    name: '50 tool steps',
+    toolSteps: 50,
+    toolOutputChars: 4_096,
+    maxContextTokens: 128_000,
+  },
+  {
+    name: '100 tool steps',
+    toolSteps: 100,
+    toolOutputChars: 4_096,
+    maxContextTokens: 256_000,
+  },
+];
+
+for (const scenario of scenarios) {
+  const messages = createToolHistory(scenario);
+  const before = splitAtRecencyBoundary(messages, {
+    turns: 2,
+    tokenCounter,
+  });
+  const after = splitAtRecencyBoundary(messages, {
+    turns: 2,
+    tokenCounter,
+    intraTurnTokens: resolveIntraTurnRetainTokens({
+      maxContextTokens: scenario.maxContextTokens,
+    }),
+  });
+  assertPairingPreserved(after.head, after.tail);
+
+  const totalTokens = sumTokens(messages, tokenCounter);
+  const beforeCompactableTokens = sumTokens(before.head, tokenCounter);
+  const afterCompactableTokens = sumTokens(after.head, tokenCounter);
+  const retainedTokens = sumTokens(after.tail, tokenCounter);
+  console.log(
+    JSON.stringify({
+      scenario: scenario.name,
+      totalTokens,
+      beforeCompactableTokens,
+      afterCompactableTokens,
+      compactablePercent: Number(
+        ((afterCompactableTokens / totalTokens) * 100).toFixed(1)
+      ),
+      retainedTokens,
+      toolPairingPreserved: true,
+    })
+  );
+}

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -942,9 +942,68 @@ describe('recency window — first-turn protection', () => {
     expect(capturedMessages.slice(0, -1)).toEqual(messages.slice(0, 7));
     expect(setSummary).toHaveBeenCalledWith(
       expect.stringContaining('Checkpoint of the completed work'),
-      expect.any(Number)
+      expect.any(Number),
+      { precedesMessages: true }
     );
     expect(result.messages?.slice(1)).toEqual(messages.slice(7));
+  });
+
+  it('keeps a single-turn history when summarization degrades to metadata', async () => {
+    captureEvents();
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: (): never => {
+              throw new Error('summarizer unavailable');
+            },
+            stream: (): never => {
+              throw new Error('summarizer unavailable');
+            },
+          };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      summarizationConfig: {},
+      maxContextTokens: 1_000,
+      tokenCounter: () => 100,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+    const messages: BaseMessage[] = [new HumanMessage('inspect the repo')];
+    for (let index = 0; index < 4; index++) {
+      const id = `call_${index}`;
+      messages.push(
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id, name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: `result ${index}`,
+          tool_call_id: id,
+          name: 'search',
+        })
+      );
+    }
+    messages.push(new AIMessage('preparing the change'));
+
+    const result = await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(agentContext.hasSummary()).toBe(false);
+    expect(result.messages).toBeUndefined();
   });
 
   it('still summarizes the head when older turns exist beyond the recency window', async () => {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -882,6 +882,71 @@ describe('recency window — first-turn protection', () => {
     expect(result.messages).toBeUndefined();
   });
 
+  it('summarizes older closed tool units inside a long single turn', async () => {
+    captureEvents();
+
+    let capturedMessages: BaseMessage[] = [];
+    const invokeMock = jest.fn().mockImplementation((messages: unknown) => {
+      capturedMessages = messages as BaseMessage[];
+      return Promise.resolve({ content: 'Checkpoint of the completed work' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: {},
+      maxContextTokens: 1_000,
+      tokenCounter: () => 100,
+      setSummary,
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+    const messages: BaseMessage[] = [new HumanMessage('inspect the repo')];
+    for (let index = 0; index < 4; index++) {
+      const id = `call_${index}`;
+      messages.push(
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id, name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: `result ${index}`,
+          tool_call_id: id,
+          name: 'search',
+        })
+      );
+    }
+    messages.push(new AIMessage('preparing the change'));
+
+    const result = await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedMessages.slice(0, -1)).toEqual(messages.slice(0, 7));
+    expect(setSummary).toHaveBeenCalledWith(
+      expect.stringContaining('Checkpoint of the completed work'),
+      expect.any(Number)
+    );
+    expect(result.messages?.slice(1)).toEqual(messages.slice(7));
+  });
+
   it('still summarizes the head when older turns exist beyond the recency window', async () => {
     captureEvents();
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1095,18 +1095,19 @@ export function createSummarizeNode({
     const recencyTokenCounter =
       agentContext.contextPressureTokenCounts?.count ??
       agentContext.tokenCounter;
-    const { head: messagesToRefine, tailStartIndex } = splitAtRecencyBoundary(
-      restoredMessages,
-      {
-        turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+    const {
+      head: messagesToRefine,
+      tailStartIndex,
+      usedIntraTurnFallback,
+    } = splitAtRecencyBoundary(restoredMessages, {
+      turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+      tokens: retainRecent?.tokens,
+      tokenCounter: recencyTokenCounter,
+      intraTurnTokens: resolveIntraTurnRetainTokens({
         tokens: retainRecent?.tokens,
-        tokenCounter: recencyTokenCounter,
-        intraTurnTokens: resolveIntraTurnRetainTokens({
-          tokens: retainRecent?.tokens,
-          maxContextTokens: agentContext.maxContextTokens,
-        }),
-      }
-    );
+        maxContextTokens: agentContext.maxContextTokens,
+      }),
+    });
     /**
      * Use the *masked* messages for the retained tail so that any
      * truncation prune applied to oversized ToolMessage content stays
@@ -1313,10 +1314,17 @@ export function createSummarizeNode({
      * supposed to preserve. Leave state untouched and let the provider error
      * surface instead.
      */
-    if (usedMetadataStub === true && request.reason === 'overflow') {
+    if (
+      usedMetadataStub === true &&
+      (request.reason === 'overflow' || usedIntraTurnFallback)
+    ) {
+      const preservationReason =
+        request.reason === 'overflow'
+          ? 'overflow recovery'
+          : 'intra-turn compaction';
       log(
         'warn',
-        'Overflow summarization failed; keeping history rather than replacing it with a metadata stub'
+        `Summarization failed during ${preservationReason}; keeping history rather than replacing it with a metadata stub`
       );
       agentContext.markSummarizationTriggered(state.messages.length);
       /**
@@ -1338,8 +1346,7 @@ export function createSummarizeNode({
           {
             id: stepId,
             agentId: request.agentId,
-            error:
-              'Summarization failed during overflow recovery; conversation history was preserved',
+            error: `Summarization failed during ${preservationReason}; conversation history was preserved`,
           } satisfies t.SummarizeCompleteEvent,
           runnableConfig
         );
@@ -1372,7 +1379,13 @@ export function createSummarizeNode({
       agentContext.tokenCounter
     );
 
-    agentContext.setSummary(summaryText, tokenCount);
+    if (usedIntraTurnFallback) {
+      agentContext.setSummary(summaryText, tokenCount, {
+        precedesMessages: true,
+      });
+    } else {
+      agentContext.setSummary(summaryText, tokenCount);
+    }
 
     log('info', 'Summary persisted');
     log('debug', 'Summary details', {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -29,6 +29,7 @@ import {
 } from '@/messages/cache';
 import {
   DEFAULT_RETAIN_RECENT_TURNS,
+  resolveIntraTurnRetainTokens,
   splitAtRecencyBoundary,
 } from '@/messages/recency';
 import {
@@ -1091,12 +1092,19 @@ export function createSummarizeNode({
     const runnableConfig = config ?? graph.config;
 
     const retainRecent = agentContext.summarizationConfig?.retainRecent;
+    const recencyTokenCounter =
+      agentContext.contextPressureTokenCounts?.count ??
+      agentContext.tokenCounter;
     const { head: messagesToRefine, tailStartIndex } = splitAtRecencyBoundary(
       restoredMessages,
       {
         turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
         tokens: retainRecent?.tokens,
-        tokenCounter: agentContext.tokenCounter,
+        tokenCounter: recencyTokenCounter,
+        intraTurnTokens: resolveIntraTurnRetainTokens({
+          tokens: retainRecent?.tokens,
+          maxContextTokens: agentContext.maxContextTokens,
+        }),
       }
     );
     /**
@@ -1596,9 +1604,10 @@ function traceConfig(
 
 /**
  * Cache-friendly compaction: sends raw conversation messages with the
- * summarization instruction appended as the final HumanMessage.
- * Providers with prompt caching get a cache hit on the system prompt +
- * tool definitions prefix.
+ * summarization instruction appended as the final HumanMessage. Bound tool
+ * definitions can reuse their cache prefix. Exact replay of the main request's
+ * system + tools + messages prefix requires a routed-request projection that
+ * this summarization path does not currently own.
  */
 async function summarizeWithCacheHit({
   model,

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -18,12 +18,12 @@ export type SummarizationTrigger = {
  */
 export type RetainRecentConfig = {
   /**
-   * Maximum number of recent user-led turns to keep in the tail.  A turn
-   * begins at a HumanMessage and includes every following AIMessage and
-   * ToolMessage up to (but not including) the next HumanMessage.  Cutting
-   * at turn boundaries guarantees tool_use / tool_result pairs are never
-   * split.  Set to `0` to disable the recency window (legacy behavior:
-   * summarize everything).  Defaults to `2`.
+   * Maximum number of recent user-led turns to keep in the tail. A turn begins
+   * at a user-authored HumanMessage and includes every following AIMessage and
+   * tool result up to the next user-authored HumanMessage. Provider-native
+   * HumanMessages containing only tool results remain in the current turn.
+   * Set to `0` to disable the recency window (legacy behavior: summarize
+   * everything). Defaults to `2`.
    */
   turns?: number;
   /**

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -11,10 +11,10 @@ export type SummarizationTrigger = {
 };
 
 /**
- * Controls how many recent messages are preserved verbatim during
- * compaction.  The most recent user-led turn is always preserved
- * regardless of these caps, so a single oversized first message is
- * never destroyed by summarization.
+ * Controls how much recent context is preserved verbatim during compaction.
+ * User-turn boundaries are preferred. Under context pressure, older closed
+ * tool units inside an otherwise indivisible turn may be summarized while a
+ * token-priced recent tail is retained. A lone user payload stays intact.
  */
 export type RetainRecentConfig = {
   /**
@@ -27,9 +27,11 @@ export type RetainRecentConfig = {
    */
   turns?: number;
   /**
-   * Optional cap on retained-recent tokens beyond the most recent turn.
-   * Older turns are added whole only while cumulative tokens stay below
-   * the cap.  Defaults to undefined (no cap; bounded only by `turns`).
+   * Optional retained-recent token budget. Older turns are added whole only
+   * while cumulative tokens stay below the cap. If a tool-heavy history has
+   * no compactable turn-level head, this is also the minimum recent tail kept
+   * behind a pairing-balanced intra-turn cut. When omitted, that fallback
+   * retains 16% of the configured context window.
    */
   tokens?: number;
 };


### PR DESCRIPTION
## Summary

- keep the existing whole-turn compaction boundary when it exposes a useful head
- fall back to a token-priced, tool-pairing-balanced boundary for long single-turn agent loops
- reuse the AgentContext exact-token ledger during range selection and add a reproducible before/after benchmark

## Why

The existing recency window makes the newest user-led turn indivisible. In the common shape of one user request followed by dozens of model/tool iterations, compaction therefore exposes an empty head and skips summarization—even during provider-confirmed overflow recovery.

DeepSeek Harness avoids this by retaining a token-priced recent tail and rounding the cut only far enough to preserve tool-call/result pairing. This PR adopts that narrow range-selection idea without copying its plugin kernel or replacing our stronger pruning pipeline.

## Measured result

`npm run bench:compaction-range` uses the SDK tokenizer and asserts that no call/result pair crosses the boundary.

| Scenario | Total tokens | Before | After | Retained |
| --- | ---: | ---: | ---: | ---: |
| 20 tool steps | 50,824 | 0 | 40,570 (79.8%) | 10,254 |
| 50 tool steps | 126,541 | 0 | 103,861 (82.1%) | 22,680 |
| 100 tool steps | 253,006 | 0 | 209,968 (83.0%) | 43,038 |

This is provider-runtime leverage, not a local CPU micro-optimization: 80%+ of repeated prompt history becomes replaceable by one checkpoint where the prior selector could replace nothing.

## Safety and quality boundaries

- no fallback without a deterministic token counter and usable retention budget
- no fallback unless at least one tool call has a matching result
- parallel calls remain indivisible until every result arrives
- open calls stay in the retained tail
- a lone user payload retains the existing first-turn protection
- ordinary multi-turn compaction keeps the existing HumanMessage boundary
- no new graph node or Langfuse observation shape

The retained tail defaults to 16% of the configured context window, matching the measured DeepSeek policy; an explicit `retainRecent.tokens` value remains authoritative.

## Additional DeepSeek findings

The deeper comparison found two worthwhile follow-ups that are deliberately not implemented here:

1. DeepSeek rejects non-shrinking summaries. Agents currently commits any non-empty summary, and the docs incorrectly claimed a 2,048-token default that code does not apply. This PR corrects the docs; enforcement should follow source-vs-summary shrink telemetry so it does not add retries without evidence.
2. DeepSeek replays the exact routed system + tools + message prefix. Agents currently replays raw messages and binds tools, but the summarizer does not pass through `AgentContext.systemRunnable`. PR #463 observes final projection provenance but does not yet durably capture the routed request envelope, so exact replay belongs after that seam deepens.

Activity/reasoning labels are not used as replacement evidence: tool intent is already present in raw call args, while UI labels omit identifiers and unresolved details in the existing corpus. They need a continuation-quality eval and redaction-safe host carrier first.

## Verification

- `npm run bench:compaction-range`
- `npx jest src/messages/__tests__/recency.test.ts src/summarization/__tests__/node.test.ts src/graphs/__tests__/Graph.contextOverflow.test.ts src/session/__tests__/deriveMessages.test.ts src/messages/projectionInvariant.test.ts --runInBand` (110 tests)
- `npx tsc --noEmit`
- focused ESLint on changed TypeScript
- `npm run build`
