### PR TITLE
fix(compaction): preserve legacy and empty user turns

### DIFF
--- a/docs/adr/0005-pairing-balanced-compaction-ranges.md
+++ b/docs/adr/0005-pairing-balanced-compaction-ranges.md
@@ -27,15 +27,16 @@ boundary inside the earliest retained turn.
 The fallback selects a contiguous prefix and may end only while no tool call is
 pending. Parallel calls remain pending until every matching result arrives, and
 an open call remains in the retained tail. Pairing recognizes parsed, raw
-provider, and content-block call/result representations. It validates provider
-protocol and tool-name compatibility, and supports Gemini's adjacent,
-identifier-less code-execution pair. A provider-shaped HumanMessage is treated
-as a tool result only after it consumes a validated preceding call; otherwise
-it remains a user turn. A boundary also cannot split messages derived from one
-persisted source row, because summary replay can currently anchor coverage only
-at row granularity. The tail retains the configured `retainRecent.tokens`
-budget, or 16% of the context window when no explicit budget exists. A lone
-user message has no closed tool unit and remains intact.
+provider, legacy OpenAI function, and content-block call/result
+representations. It validates provider protocol and tool-name compatibility,
+and supports Gemini's adjacent, identifier-less code-execution pair. A
+provider-shaped HumanMessage is treated as a tool result only after at least
+one block consumes a validated preceding call; otherwise it remains a user
+turn. A boundary also cannot split messages derived from one persisted source
+row, because summary replay can currently anchor coverage only at row
+granularity. The tail retains the configured `retainRecent.tokens` budget, or
+16% of the context window when no explicit budget exists. A lone user message
+has no closed tool unit and remains intact.
 
 The fallback search ends at the next user turn; a closed pair in an older turn
 cannot authorize compacting a newer turn that contains no closed work of its

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -1,5 +1,6 @@
 import {
   AIMessage,
+  FunctionMessage,
   HumanMessage,
   ToolMessage,
   SystemMessage,
@@ -463,6 +464,29 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tailTurnCount).toBe(1);
     });
 
+    it('preserves an empty HumanMessage as a user turn', () => {
+      const messages = [
+        new HumanMessage('first turn'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'closed', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'closed result',
+          tool_call_id: 'closed',
+          name: 'search',
+        }),
+        new HumanMessage({ content: [] }),
+        new AIMessage('working'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, { turns: 1 });
+
+      expect(result.head).toEqual(messages.slice(0, 3));
+      expect(result.tail).toEqual(messages.slice(3));
+      expect(result.tailTurnCount).toBe(1);
+    });
+
     it('keeps incompatible provider results from closing a tool call', () => {
       const messages = [
         new HumanMessage('inspect'),
@@ -517,6 +541,38 @@ describe('splitAtRecencyBoundary', () => {
 
       expect(result.head).toEqual(messages.slice(0, 4));
       expect(result.tail).toEqual(messages.slice(4));
+    });
+
+    it('keeps legacy OpenAI function calls with their FunctionMessage', () => {
+      const legacyCall = new AIMessage('');
+      legacyCall.additional_kwargs.function_call = {
+        name: 'lookup',
+        arguments: '{}',
+      };
+      const messages = [
+        new HumanMessage('inspect'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'closed', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'closed result',
+          tool_call_id: 'closed',
+          name: 'search',
+        }),
+        legacyCall,
+        new FunctionMessage({ name: 'lookup', content: 'legacy result' }),
+        new AIMessage('done'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokenCounter: () => 100,
+        intraTurnTokens: 200,
+      });
+
+      expect(result.head).toEqual(messages.slice(0, 3));
+      expect(result.tail).toEqual(messages.slice(3));
     });
 
     it('compacts paired Gemini code-execution units without identifiers', () => {

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -120,6 +120,29 @@ function readOwnString(value: unknown, key: string): string | undefined {
   }
 }
 
+function readOwnValue(value: unknown, key: string): unknown {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor != null && 'value' in descriptor
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const LEGACY_FUNCTION_CALL_PREFIX = 'legacy_function:';
+
+function getLegacyFunctionCallId(name: string): string | undefined {
+  const callId = `${LEGACY_FUNCTION_CALL_PREFIX}${name}`;
+  return callId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+    ? callId
+    : undefined;
+}
+
 function getRawToolCallDescriptor(
   toolCall: unknown
 ): ProviderToolCallPartDescriptor | undefined {
@@ -175,11 +198,40 @@ function appendMessageToolCalls(
       }
     }
   }
+
+  const legacyFunctionCall = readOwnValue(
+    message.additional_kwargs,
+    'function_call'
+  );
+  const legacyFunctionName = readOwnString(legacyFunctionCall, 'name');
+  const legacyFunctionCallId =
+    legacyFunctionName == null
+      ? undefined
+      : getLegacyFunctionCallId(legacyFunctionName);
+  if (legacyFunctionCallId != null) {
+    appendProviderToolCallDescriptor(calls, {
+      callId: legacyFunctionCallId,
+      kind: 'tool',
+      name: legacyFunctionName,
+      sourceType: 'legacy_function_call',
+    });
+  }
 }
 
 function getToolMessageResultDescriptor(
   message: BaseMessage
 ): ProviderToolResultPartDescriptor | undefined {
+  if (message.getType() === 'function' && message.name != null) {
+    const toolCallId = getLegacyFunctionCallId(message.name);
+    return toolCallId == null
+      ? undefined
+      : {
+        type: 'function_message',
+        toolCallId,
+        compatibleCallKinds: ['tool'],
+        expectedToolNames: [message.name],
+      };
+  }
   if (message.getType() !== 'tool') {
     return undefined;
   }
@@ -257,7 +309,9 @@ function inspectMessagePairing(
   }
 
   const trustedHumanToolResult =
-    everyPartIsTrustedHumanResult && resultPartCount === content?.length;
+    everyPartIsTrustedHumanResult &&
+    resultPartCount > 0 &&
+    resultPartCount === content?.length;
   if (trustedHumanToolResult) {
     calls.clear();
     for (const [callId, entry] of candidateCalls) {


### PR DESCRIPTION
## Summary

Follow-up to #464 for two edge cases found by the final Codex review after that PR was merged:

- pair legacy OpenAI `additional_kwargs.function_call` with `FunctionMessage` using a bounded function-name key, preventing an intra-turn cut from orphaning the result
- require at least one validated result block before classifying a `HumanMessage` as a tool-result continuation, preserving empty user turns
- document the added legacy representation and fail-closed boundary behavior

Malformed, oversized, or duplicate legacy calls remain ambiguous/pending, so range selection declines unsafe cuts.

## Verification

- `npx jest src/messages/__tests__/recency.test.ts src/summarization/__tests__/node.test.ts src/agents/__tests__/AgentContext.test.ts src/graphs/__tests__/Graph.contextOverflow.test.ts src/session/__tests__/deriveMessages.test.ts src/messages/projectionInvariant.test.ts --runInBand` (240 passed)
- focused ESLint
- `npx tsc --noEmit`
- `npm run build`
- `npm ci --ignore-scripts` (0 vulnerabilities)