### PR TITLE
🪵 feat: Add Checkpoint-Forked Event Actors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,10 +57,12 @@ the generation and prior checkpoint identity.
 An **Event Actor Event** is immutable JSON data snapshotted at every public and
 host-adapter boundary. Cold reconstruction receives the explicit task-owned
 cancellation signal and owns rollback until it returns a validated invocation.
+Prepared invocations and unavailable request/head pairs carry integrity
+bindings so independently valid lifecycle evidence cannot be recombined.
 Public invocation produces an executor-issued **Applied Settlement** that binds
-terminal checkpoint evidence to the exact invocation reference that ran;
-commit consumes that settlement rather than accepting a second caller-supplied
-invocation.
+immutable result and terminal checkpoint evidence to the exact invocation
+reference that ran; commit consumes that settlement rather than accepting a
+second caller-supplied invocation.
 
 Applied work may commit its Invocation Fork. Failed, cancelled, and
 completed-without-action invocations discard their forks. An applied fork that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,6 +54,14 @@ logical checkpoint thread and changes only its invocation namespace. The host
 advances the Event Actor Head only through an atomic comparison against both
 the generation and prior checkpoint identity.
 
+An **Event Actor Event** is immutable JSON data snapshotted at every public and
+host-adapter boundary. Cold reconstruction receives the explicit task-owned
+cancellation signal and owns rollback until it returns a validated invocation.
+Public invocation produces an executor-issued **Applied Settlement** that binds
+terminal checkpoint evidence to the exact invocation reference that ran;
+commit consumes that settlement rather than accepting a second caller-supplied
+invocation.
+
 Applied work may commit its Invocation Fork. Failed, cancelled, and
 completed-without-action invocations discard their forks. An applied fork that
 loses the head comparison remains available for reconciliation. A missing or

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,8 +49,10 @@ of authoritative host events without retaining a live executor between them.
 
 An **Event Actor Head** is the current committed checkpoint identity and its
 monotonic generation. Each invocation runs on an **Invocation Fork** owned by
-that invocation. The host advances the Event Actor Head only through an atomic
-comparison against both the generation and prior checkpoint identity.
+that invocation. Once committed state exists, every fork stays on the same
+logical checkpoint thread and changes only its invocation namespace. The host
+advances the Event Actor Head only through an atomic comparison against both
+the generation and prior checkpoint identity.
 
 Applied work may commit its Invocation Fork. Failed, cancelled, and
 completed-without-action invocations discard their forks. An applied fork that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,8 +66,12 @@ across executor lifetimes provide the same private preparation signing key to
 every authorized executor.
 Public invocation produces an executor-issued **Applied Settlement** that binds
 immutable result and terminal checkpoint evidence to the exact invocation
-reference that ran; commit consumes that settlement rather than accepting a
-second caller-supplied invocation.
+reference that ran. Invocation start phase-fences the prepared capability so it
+cannot subsequently authorize discard of active or applied work. Commit
+consumes the settlement exactly once and returns structured indeterminate
+evidence for missing or invalid acknowledgements rather than exposing a
+retryable-looking exception. A host mailbox remains the durable cross-runtime
+owner and deduplication fence.
 
 Applied work may commit its Invocation Fork. Failed, cancelled, and
 completed-without-action invocations discard their forks. An applied fork that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,8 +57,11 @@ the generation and prior checkpoint identity.
 An **Event Actor Event** is immutable JSON data snapshotted at every public and
 host-adapter boundary. Cold reconstruction receives the explicit task-owned
 cancellation signal and owns rollback until it returns a validated invocation.
-Prepared invocations and unavailable request/head pairs carry integrity
-bindings so independently valid lifecycle evidence cannot be recombined.
+Prepared invocations and unavailable request/head pairs carry canonical,
+executor-authenticated integrity bindings so independently valid lifecycle
+evidence cannot be forged or recombined. Hosts that persist those handoffs
+across executor lifetimes provide the same private preparation signing key to
+every authorized executor.
 Public invocation produces an executor-issued **Applied Settlement** that binds
 immutable result and terminal checkpoint evidence to the exact invocation
 reference that ran; commit consumes that settlement rather than accepting a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,8 +55,10 @@ advances the Event Actor Head only through an atomic comparison against both
 the generation and prior checkpoint identity.
 
 An **Event Actor Event** is immutable JSON data snapshotted at every public and
-host-adapter boundary. Cold reconstruction receives the explicit task-owned
-cancellation signal and owns rollback until it returns a validated invocation.
+host-adapter boundary; signed zero normalizes to JSON's zero representation.
+Checkpoint snapshots retain only the declared identity fields. Cold
+reconstruction receives the explicit task-owned cancellation signal and owns
+rollback until it returns a validated invocation.
 Prepared invocations and unavailable request/head pairs carry canonical,
 executor-authenticated integrity bindings so independently valid lifecycle
 evidence cannot be forged or recombined. Hosts that persist those handoffs
@@ -76,6 +78,8 @@ same logical Event Actor identity. An indeterminate applied settlement,
 including malformed action checkpoint evidence or an ambiguous commit
 acknowledgement, is retained for reconciliation because deleting its fork
 could erase the only durable evidence of an external action.
+LangGraph interrupts and parent commands also retain the fork and propagate as
+control flow so the host can resume or route the checkpointed actor.
 
 ## Tool Caller Capabilities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,8 +52,9 @@ monotonic generation. Each invocation runs on an **Invocation Fork** owned by
 that invocation. The host advances the Event Actor Head only through an atomic
 comparison against both the generation and prior checkpoint identity.
 
-Applied work may commit its Invocation Fork. Failed, cancelled, stale, and
-completed-without-action invocations discard their forks. A missing or
+Applied work may commit its Invocation Fork. Failed, cancelled, and
+completed-without-action invocations discard their forks. An applied fork that
+loses the head comparison remains available for reconciliation. A missing or
 incompatible warm checkpoint uses **Cold Continuation**: the host rebuilds an
 Invocation Fork from bounded transcript and summary state while preserving the
 same logical Event Actor identity. An indeterminate commit is retained for

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,7 +71,11 @@ cannot subsequently authorize discard of active or applied work. Commit
 consumes the settlement exactly once and returns structured indeterminate
 evidence for missing or invalid acknowledgements rather than exposing a
 retryable-looking exception. A host mailbox remains the durable cross-runtime
-owner and deduplication fence.
+owner and deduplication fence. The executor retains local terminal phase fences
+only for the dormant-checkpoint TTL; active phase count remains bounded by host
+admission, while prepared invocation authority carries an authenticated expiry
+so pruning cannot re-enable a stale capability. The mailbox prevents stale
+cross-runtime replay after expiry.
 
 Applied work may commit its Invocation Fork. Failed, cancelled, and
 completed-without-action invocations discard their forks. An applied fork that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,24 @@ A **Resume Projection** is the durable manifest view produced from an
 Execution Record. A projection is scoped to one exact fork and resume attempt;
 an unscoped projection fails closed when a parent tool-call ID is ambiguous.
 
+## Event Actors
+
+An **Event Actor** is one stable logical child thread that handles a sequence
+of authoritative host events without retaining a live executor between them.
+
+An **Event Actor Head** is the current committed checkpoint identity and its
+monotonic generation. Each invocation runs on an **Invocation Fork** owned by
+that invocation. The host advances the Event Actor Head only through an atomic
+comparison against both the generation and prior checkpoint identity.
+
+Applied work may commit its Invocation Fork. Failed, cancelled, stale, and
+completed-without-action invocations discard their forks. A missing or
+incompatible warm checkpoint uses **Cold Continuation**: the host rebuilds an
+Invocation Fork from bounded transcript and summary state while preserving the
+same logical Event Actor identity. An indeterminate commit is retained for
+reconciliation because deleting its fork could delete an actor head that the
+durable compare-and-swap already advanced.
+
 ## Tool Caller Capabilities
 
 A **Caller Capability Projection** is the effective classification of tool

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,9 +57,10 @@ completed-without-action invocations discard their forks. An applied fork that
 loses the head comparison remains available for reconciliation. A missing or
 incompatible warm checkpoint uses **Cold Continuation**: the host rebuilds an
 Invocation Fork from bounded transcript and summary state while preserving the
-same logical Event Actor identity. An indeterminate commit is retained for
-reconciliation because deleting its fork could delete an actor head that the
-durable compare-and-swap already advanced.
+same logical Event Actor identity. An indeterminate applied settlement,
+including malformed action checkpoint evidence or an ambiguous commit
+acknowledgement, is retained for reconciliation because deleting its fork
+could erase the only durable evidence of an external action.
 
 ## Tool Caller Capabilities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,10 +60,11 @@ Checkpoint snapshots retain only the declared identity fields. Cold
 reconstruction receives the explicit task-owned cancellation signal and owns
 rollback until it returns a validated invocation.
 Prepared invocations and unavailable request/head pairs carry canonical,
-executor-authenticated integrity bindings so independently valid lifecycle
-evidence cannot be forged or recombined. Hosts that persist those handoffs
-across executor lifetimes provide the same private preparation signing key to
-every authorized executor.
+time-bounded, executor-authenticated integrity bindings so independently valid
+lifecycle evidence cannot be forged, recombined, or replayed after expiry.
+Cold continuation consumes its unavailable handoff before adapter work. Hosts
+that persist those handoffs across executor lifetimes provide the same private
+preparation signing key to every authorized executor.
 Public invocation produces an executor-issued **Applied Settlement** that binds
 immutable result and terminal checkpoint evidence to the exact invocation
 reference that ran. Invocation start phase-fences the prepared capability so it
@@ -71,10 +72,12 @@ cannot subsequently authorize discard of active or applied work. Commit
 consumes the settlement exactly once and returns structured indeterminate
 evidence for missing or invalid acknowledgements rather than exposing a
 retryable-looking exception. A host mailbox remains the durable cross-runtime
-owner and deduplication fence. The executor retains local terminal phase fences
-only for the dormant-checkpoint TTL; active phase count remains bounded by host
-admission, while prepared invocation authority carries an authenticated expiry
-so pruning cannot re-enable a stale capability. The mailbox prevents stale
+owner and deduplication fence. Public invocation reclaims definitely-no-action
+forks before returning or rethrowing, while ambiguous and applied outcomes stay
+retained. The executor opportunistically prunes local terminal phase fences
+after the dormant-checkpoint TTL without scheduling timers that retain
+short-lived executors. A fence never expires before its signed authority, so
+pruning cannot re-enable a stale capability; the mailbox prevents stale
 cross-runtime replay after expiry.
 
 Applied work may commit its Invocation Fork. Failed, cancelled, and

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -108,9 +108,10 @@ function validateInvocation<TEvent>(
   invocation: EventActorInvocation<TEvent>,
   continuation: 'warm' | 'cold',
   checkpointNs: string,
+  maxDepth: number,
   expectedHead?: EventActorInvocation<TEvent>['base']
 ): void {
-  validateInvocationReference(invocation);
+  validateInvocationReference(invocation, maxDepth);
   if (
     invocation.actorThreadId !== request.actorThreadId ||
     invocation.invocationId !== request.invocationId ||
@@ -144,12 +145,18 @@ function validateInvocation<TEvent>(
 }
 
 function validateInvocationReference(
-  invocation: EventActorInvocationReference
+  invocation: EventActorInvocationReference,
+  maxDepth?: number
 ): void {
   requireNonEmpty(invocation.actorThreadId, 'actorThreadId');
   requireNonEmpty(invocation.invocationId, 'invocationId');
   if (!Number.isSafeInteger(invocation.depth) || invocation.depth < 1) {
     throw new Error('Event actor invocation depth is invalid');
+  }
+  if (maxDepth != null && invocation.depth > maxDepth) {
+    throw new Error(
+      `Event actor depth ${invocation.depth} exceeds maximum ${maxDepth}`
+    );
   }
   const continuation: unknown = invocation.continuation;
   if (continuation !== 'warm' && continuation !== 'cold') {
@@ -172,6 +179,19 @@ function validateInvocationReference(
       'fork.checkpointId for resumed actor'
     );
   }
+}
+
+function checkpointsMatch(
+  left: EventActorCheckpointFork | EventActorHead['checkpoint'],
+  right: EventActorCheckpointFork | EventActorHead['checkpoint']
+): boolean {
+  return (
+    left != null &&
+    right != null &&
+    left.threadId === right.threadId &&
+    left.checkpointNs === right.checkpointNs &&
+    left.checkpointId === right.checkpointId
+  );
 }
 
 function validateTerminalCheckpoint(
@@ -342,17 +362,19 @@ export class EventActorExecutor<TEvent, TResult> {
     request: EventActorPrepareRequest<TEvent>
   ): Promise<EventActorPreparation<TEvent>> {
     this.validatePrepareRequest(request);
+    const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
       ...request,
-      checkpointNs: createInvocationCheckpointNs(request),
+      checkpointNs,
     };
-    const preparation = await this.adapter.prepare(adapterRequest);
+    const preparation = await this.adapter.prepare({ ...adapterRequest });
     if (preparation.status === 'ready') {
       validateInvocation(
         request,
         preparation.invocation,
         'warm',
-        adapterRequest.checkpointNs
+        checkpointNs,
+        this.maxDepth
       );
       return {
         status: 'ready',
@@ -377,19 +399,21 @@ export class EventActorExecutor<TEvent, TResult> {
     this.validatePrepareRequest(request);
     const trustedHead = snapshotHead(head);
     validateHead(trustedHead, request.actorThreadId);
+    const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
       ...request,
-      checkpointNs: createInvocationCheckpointNs(request),
+      checkpointNs,
     };
     const invocation = await this.adapter.coldContinue(
-      adapterRequest,
+      { ...adapterRequest },
       snapshotHead(trustedHead)
     );
     validateInvocation(
       request,
       invocation,
       'cold',
-      adapterRequest.checkpointNs,
+      checkpointNs,
+      this.maxDepth,
       trustedHead
     );
     return {
@@ -424,7 +448,8 @@ export class EventActorExecutor<TEvent, TResult> {
       },
       invocation,
       invocation.continuation,
-      invocation.fork.checkpointNs
+      invocation.fork.checkpointNs,
+      this.maxDepth
     );
     const controller = new AbortController();
     const abort = (): void => controller.abort(signal?.reason);
@@ -460,7 +485,7 @@ export class EventActorExecutor<TEvent, TResult> {
     terminal: EventActorAppliedResult<TResult>
   ): Promise<EventActorCommitResult> {
     const trustedInvocation = snapshotInvocationReference(invocation);
-    validateInvocationReference(trustedInvocation);
+    validateInvocationReference(trustedInvocation, this.maxDepth);
     const trustedCheckpoint = { ...terminal.checkpoint };
     validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
     const committed = await this.adapter.commit({
@@ -487,11 +512,20 @@ export class EventActorExecutor<TEvent, TResult> {
         throw new Error('Stale event actor head did not advance past its base');
       }
       if (
-        trustedInvocation.base.checkpoint != null &&
-        committed.head.checkpoint?.threadId !==
-          trustedInvocation.base.checkpoint.threadId
+        committed.head.checkpoint?.threadId !== trustedInvocation.fork.threadId
       ) {
         throw new Error('Stale event actor head changed its checkpoint thread');
+      }
+      if (
+        checkpointsMatch(
+          committed.head.checkpoint,
+          trustedInvocation.base.checkpoint
+        ) ||
+        checkpointsMatch(committed.head.checkpoint, trustedCheckpoint)
+      ) {
+        throw new Error(
+          'Stale event actor head does not identify a competing checkpoint'
+        );
       }
       return { status: 'stale', head: snapshotHead(committed.head) };
     }
@@ -503,7 +537,7 @@ export class EventActorExecutor<TEvent, TResult> {
     reason: EventActorDiscardReason
   ): Promise<void> {
     const trustedInvocation = snapshotInvocationReference(invocation);
-    validateInvocationReference(trustedInvocation);
+    validateInvocationReference(trustedInvocation, this.maxDepth);
     return this.adapter.discard({
       invocation: trustedInvocation,
       reason,

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -160,7 +160,8 @@ function validateTerminalCheckpoint(
     checkpoint.threadId !== invocation.fork.threadId ||
     checkpoint.checkpointNs !== invocation.fork.checkpointNs ||
     checkpoint.checkpointId == null ||
-    checkpoint.checkpointId.trim() === ''
+    checkpoint.checkpointId.trim() === '' ||
+    checkpoint.checkpointId === invocation.fork.checkpointId
   ) {
     throw new Error(
       'Event actor result escaped its invocation checkpoint fork'

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -131,6 +131,12 @@ function validateInvocation<TEvent>(
   requireNonEmpty(invocation.fork.threadId, 'fork.threadId');
   requireNonEmpty(invocation.fork.checkpointNs, 'fork.checkpointNs');
   if (
+    invocation.base.checkpoint != null &&
+    invocation.fork.threadId !== invocation.base.checkpoint.threadId
+  ) {
+    throw new Error('Event actor fork changed its logical checkpoint thread');
+  }
+  if (
     expectedHead != null &&
     (expectedHead.actorThreadId !== request.actorThreadId ||
       invocation.base.generation !== expectedHead.generation ||
@@ -181,6 +187,13 @@ function createRunnableConfig(
   delete configurable.event_actor_continuation;
   return {
     signal,
+    ...(ambient?.recursionLimit == null
+      ? {}
+      : { recursionLimit: ambient.recursionLimit }),
+    ...(ambient?.maxConcurrency == null
+      ? {}
+      : { maxConcurrency: ambient.maxConcurrency }),
+    ...(ambient?.timeout == null ? {} : { timeout: ambient.timeout }),
     ...(ambient?.callbacks == null ? {} : { callbacks: ambient.callbacks }),
     ...(ambient?.tags == null ? {} : { tags: ambient.tags }),
     metadata: {
@@ -401,6 +414,9 @@ export class EventActorExecutor<TEvent, TResult> {
     }
     if (committed.head != null) {
       validateHead(committed.head, trustedInvocation.actorThreadId);
+      if (committed.head.generation <= trustedInvocation.base.generation) {
+        throw new Error('Stale event actor head did not advance past its base');
+      }
       return { status: 'stale', head: snapshotHead(committed.head) };
     }
     return committed;
@@ -480,6 +496,8 @@ export class EventActorExecutor<TEvent, TResult> {
     } catch (error) {
       return {
         status: 'commit_indeterminate',
+        result: terminal.result,
+        checkpoint: { ...invocationReference.fork },
         error: asError(error),
         continuation,
       };
@@ -490,6 +508,8 @@ export class EventActorExecutor<TEvent, TResult> {
     } catch (error) {
       return {
         status: 'commit_indeterminate',
+        result: terminal.result,
+        checkpoint: { ...terminal.checkpoint },
         error: asError(error),
         continuation,
       };
@@ -499,6 +519,9 @@ export class EventActorExecutor<TEvent, TResult> {
         status: 'commit_conflict',
         result: terminal.result,
         checkpoint: { ...terminal.checkpoint },
+        ...(committed.head == null
+          ? {}
+          : { head: snapshotHead(committed.head) }),
         continuation,
       };
     }

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -173,8 +173,18 @@ function createRunnableConfig(
   signal: AbortSignal,
   ambient?: RunnableConfig
 ): RunnableConfig {
+  const {
+    signal: _ambientSignal,
+    runId: _ambientRunId,
+    runName: _ambientRunName,
+    callbacks: ambientCallbacks,
+    tags: ambientTags,
+    metadata: ambientMetadata,
+    configurable: ambientConfigurable,
+    ...ambientRuntime
+  } = ambient ?? {};
   const configurable = Object.fromEntries(
-    Object.entries(ambient?.configurable ?? {}).filter(
+    Object.entries(ambientConfigurable ?? {}).filter(
       ([key]) =>
         !key.startsWith('__pregel_') &&
         !key.startsWith('__librechat_') &&
@@ -191,18 +201,12 @@ function createRunnableConfig(
   delete configurable.event_actor_depth;
   delete configurable.event_actor_continuation;
   return {
+    ...ambientRuntime,
     signal,
-    ...(ambient?.recursionLimit == null
-      ? {}
-      : { recursionLimit: ambient.recursionLimit }),
-    ...(ambient?.maxConcurrency == null
-      ? {}
-      : { maxConcurrency: ambient.maxConcurrency }),
-    ...(ambient?.timeout == null ? {} : { timeout: ambient.timeout }),
-    ...(ambient?.callbacks == null ? {} : { callbacks: ambient.callbacks }),
-    ...(ambient?.tags == null ? {} : { tags: ambient.tags }),
+    ...(ambientCallbacks == null ? {} : { callbacks: ambientCallbacks }),
+    ...(ambientTags == null ? {} : { tags: ambientTags }),
     metadata: {
-      ...(ambient?.metadata ?? {}),
+      ...(ambientMetadata ?? {}),
       eventActorThreadId: invocation.actorThreadId,
       eventActorInvocationId: invocation.invocationId,
       eventActorGeneration: invocation.base.generation,

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -192,6 +192,7 @@ function createRunnableConfig(
         key !== 'lc_run_breaker_scope'
     )
   );
+  delete configurable.run_id;
   delete configurable.thread_id;
   delete configurable.checkpoint_ns;
   delete configurable.checkpoint_id;
@@ -201,13 +202,27 @@ function createRunnableConfig(
   delete configurable.event_actor_generation;
   delete configurable.event_actor_depth;
   delete configurable.event_actor_continuation;
+  const metadata = Object.fromEntries(
+    Object.entries(ambientMetadata ?? {}).filter(
+      ([key]) =>
+        !key.startsWith('langgraph_') &&
+        !key.startsWith('__pregel_') &&
+        key !== 'run_id' &&
+        key !== 'thread_id' &&
+        key !== 'checkpoint_ns' &&
+        key !== 'checkpoint_id' &&
+        key !== 'checkpoint_map'
+    )
+  );
   return {
     ...ambientRuntime,
     signal,
     ...(ambientCallbacks == null ? {} : { callbacks: ambientCallbacks }),
     ...(ambientTags == null ? {} : { tags: ambientTags }),
     metadata: {
-      ...(ambientMetadata ?? {}),
+      ...metadata,
+      thread_id: invocation.fork.threadId,
+      checkpoint_ns: invocation.fork.checkpointNs,
       eventActorThreadId: invocation.actorThreadId,
       eventActorInvocationId: invocation.invocationId,
       eventActorGeneration: invocation.base.generation,
@@ -553,14 +568,19 @@ export class EventActorExecutor<TEvent, TResult> {
         continuation,
       };
     }
+    const trustedTerminal: EventActorAppliedResult<TResult> = {
+      status: 'applied',
+      result: terminal.result,
+      checkpoint: { ...terminal.checkpoint },
+    };
     let committed;
     try {
-      committed = await this.commit(invocationReference, terminal);
+      committed = await this.commit(invocationReference, trustedTerminal);
     } catch (error) {
       return {
         status: 'commit_indeterminate',
-        result: terminal.result,
-        checkpoint: { ...terminal.checkpoint },
+        result: trustedTerminal.result,
+        checkpoint: { ...trustedTerminal.checkpoint },
         error: asError(error),
         continuation,
       };
@@ -568,8 +588,8 @@ export class EventActorExecutor<TEvent, TResult> {
     if (committed.status === 'stale') {
       return {
         status: 'commit_conflict',
-        result: terminal.result,
-        checkpoint: { ...terminal.checkpoint },
+        result: trustedTerminal.result,
+        checkpoint: { ...trustedTerminal.checkpoint },
         ...(committed.head == null
           ? {}
           : { head: snapshotHead(committed.head) }),
@@ -578,7 +598,7 @@ export class EventActorExecutor<TEvent, TResult> {
     }
     return {
       status: 'applied',
-      result: terminal.result,
+      result: trustedTerminal.result,
       head: committed.head,
       continuation,
     };

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -1,5 +1,11 @@
-import { createHash, randomUUID } from 'node:crypto';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from 'node:crypto';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
   EventActorAdapterPrepareRequest,
@@ -168,56 +174,68 @@ function freezeInvocation<TEvent extends EventActorEvent>(
   });
 }
 
-function createPreparationDigest(value: object): string {
-  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+function snapshotPreparedInvocation<TEvent extends EventActorEvent>(
+  invocation: EventActorPreparedInvocation<TEvent>
+): EventActorPreparedInvocation<TEvent> {
+  return Object.freeze({
+    ...freezeInvocation(invocation),
+    preparationDigest: invocation.preparationDigest,
+  });
 }
 
-function createInvocationPreparationDigest<TEvent extends EventActorEvent>(
+function canonicalHead(head: EventActorHead): object {
+  if (head.checkpoint == null) {
+    return {
+      actorThreadId: head.actorThreadId,
+      generation: head.generation,
+      checkpoint: null,
+    };
+  }
+  return {
+    actorThreadId: head.actorThreadId,
+    generation: head.generation,
+    checkpoint: {
+      threadId: head.checkpoint.threadId,
+      checkpointId: head.checkpoint.checkpointId ?? null,
+      checkpointNs: head.checkpoint.checkpointNs,
+    },
+  };
+}
+
+function serializeInvocationPreparation<TEvent extends EventActorEvent>(
   invocation: EventActorInvocation<TEvent>
 ): string {
-  return createPreparationDigest({
+  return JSON.stringify({
     kind: 'invocation',
     actorThreadId: invocation.actorThreadId,
     invocationId: invocation.invocationId,
     depth: invocation.depth,
     continuation: invocation.continuation,
-    base: invocation.base,
-    fork: invocation.fork,
-    event: invocation.event,
+    base: canonicalHead(invocation.base),
+    fork: {
+      invocationId: invocation.fork.invocationId,
+      threadId: invocation.fork.threadId,
+      checkpointId: invocation.fork.checkpointId ?? null,
+      checkpointNs: invocation.fork.checkpointNs,
+    },
+    event: snapshotEvent(invocation.event),
   });
 }
 
-function createUnavailablePreparationDigest<TEvent extends EventActorEvent>(
+function serializeUnavailablePreparation<TEvent extends EventActorEvent>(
   request: EventActorPrepareRequest<TEvent>,
   head: EventActorHead
 ): string {
-  return createPreparationDigest({
+  return JSON.stringify({
     kind: 'checkpoint_unavailable',
-    request,
-    head,
+    request: {
+      actorThreadId: request.actorThreadId,
+      invocationId: request.invocationId,
+      depth: request.depth,
+      event: snapshotEvent(request.event),
+    },
+    head: canonicalHead(head),
   });
-}
-
-function createPreparedInvocation<TEvent extends EventActorEvent>(
-  invocation: EventActorInvocation<TEvent>
-): EventActorPreparedInvocation<TEvent> {
-  const trustedInvocation = freezeInvocation(invocation);
-  return Object.freeze({
-    ...trustedInvocation,
-    preparationDigest: createInvocationPreparationDigest(trustedInvocation),
-  });
-}
-
-function validatePreparedInvocation<TEvent extends EventActorEvent>(
-  invocation: EventActorPreparedInvocation<TEvent>
-): void {
-  requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
-  if (
-    invocation.preparationDigest !==
-    createInvocationPreparationDigest(invocation)
-  ) {
-    throw new Error('Event actor prepared invocation binding is invalid');
-  }
 }
 
 function freezePrepareRequest<TEvent extends EventActorEvent>(
@@ -554,6 +572,7 @@ export class EventActorExecutor<
 > {
   private readonly maxDepth: number;
   private readonly dormantCheckpointTtlMs: number;
+  private readonly preparationSigningKey: Uint8Array;
   private readonly issuedSettlements = new WeakSet<object>();
 
   constructor(
@@ -563,6 +582,13 @@ export class EventActorExecutor<
     this.maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
     this.dormantCheckpointTtlMs =
       options.dormantCheckpointTtlMs ?? DEFAULT_DORMANT_CHECKPOINT_TTL_MS;
+    const signingKey = Buffer.from(
+      options.preparationSigningKey ?? randomBytes(32)
+    );
+    if (signingKey.byteLength < 32) {
+      throw new Error('preparationSigningKey must contain at least 32 bytes');
+    }
+    this.preparationSigningKey = signingKey;
     if (!Number.isSafeInteger(this.maxDepth) || this.maxDepth < 1) {
       throw new Error('maxDepth must be a positive safe integer');
     }
@@ -571,6 +597,51 @@ export class EventActorExecutor<
       this.dormantCheckpointTtlMs < 1
     ) {
       throw new Error('dormantCheckpointTtlMs must be a positive safe integer');
+    }
+  }
+
+  private signPreparation(payload: string): string {
+    return createHmac('sha256', this.preparationSigningKey)
+      .update(payload)
+      .digest('hex');
+  }
+
+  private preparationSignatureMatches(
+    signature: string,
+    payload: string
+  ): boolean {
+    if (!/^[a-f0-9]{64}$/.test(signature)) {
+      return false;
+    }
+    return timingSafeEqual(
+      Buffer.from(signature, 'hex'),
+      Buffer.from(this.signPreparation(payload), 'hex')
+    );
+  }
+
+  private createPreparedInvocation(
+    invocation: EventActorInvocation<TEvent>
+  ): EventActorPreparedInvocation<TEvent> {
+    const trustedInvocation = freezeInvocation(invocation);
+    return Object.freeze({
+      ...trustedInvocation,
+      preparationDigest: this.signPreparation(
+        serializeInvocationPreparation(trustedInvocation)
+      ),
+    });
+  }
+
+  private validatePreparedInvocation(
+    invocation: EventActorPreparedInvocation<TEvent>
+  ): void {
+    requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
+    if (
+      !this.preparationSignatureMatches(
+        invocation.preparationDigest,
+        serializeInvocationPreparation(invocation)
+      )
+    ) {
+      throw new Error('Event actor prepared invocation binding is invalid');
     }
   }
 
@@ -618,19 +689,20 @@ export class EventActorExecutor<
       signal?.removeEventListener('abort', abort);
     }
     if (preparation.status === 'ready') {
+      const adapterInvocation = snapshotInvocation(preparation.invocation);
       validateInvocation(
         trustedRequest,
-        preparation.invocation,
+        adapterInvocation,
         'warm',
         checkpointNs,
         this.maxDepth
       );
-      const preparedInvocation = createPreparedInvocation({
-        ...snapshotInvocation(preparation.invocation),
+      const preparedInvocation = this.createPreparedInvocation({
+        ...adapterInvocation,
         event: snapshotEvent(trustedRequest.event),
       });
       if (isAborted(controller.signal)) {
-        await this.discard(
+        await this.discardInvocationReference(
           snapshotInvocationReference(preparedInvocation),
           'cancelled'
         );
@@ -644,7 +716,8 @@ export class EventActorExecutor<
         invocation: preparedInvocation,
       });
     } else {
-      validateHead(preparation.head, trustedRequest.actorThreadId);
+      const preparedHead = freezeHead(preparation.head);
+      validateHead(preparedHead, trustedRequest.actorThreadId);
       if (isAborted(controller.signal)) {
         throw new EventActorPreparationCancelledError(
           'warm',
@@ -652,14 +725,12 @@ export class EventActorExecutor<
         );
       }
       const preparedRequest = freezePrepareRequest(trustedRequest);
-      const preparedHead = freezeHead(preparation.head);
       return Object.freeze({
         status: 'checkpoint_unavailable',
         request: preparedRequest,
         head: preparedHead,
-        preparationDigest: createUnavailablePreparationDigest(
-          preparedRequest,
-          preparedHead
+        preparationDigest: this.signPreparation(
+          serializeUnavailablePreparation(preparedRequest, preparedHead)
         ),
       });
     }
@@ -672,15 +743,18 @@ export class EventActorExecutor<
     >,
     signal?: AbortSignal
   ): Promise<EventActorPreparedInvocation<TEvent>> {
-    requireNonEmpty(preparation.preparationDigest, 'preparationDigest');
+    const request = snapshotPrepareRequest(preparation.request);
+    const trustedHead = snapshotHead(preparation.head);
+    const preparationDigest = preparation.preparationDigest;
+    requireNonEmpty(preparationDigest, 'preparationDigest');
     if (
-      preparation.preparationDigest !==
-      createUnavailablePreparationDigest(preparation.request, preparation.head)
+      !this.preparationSignatureMatches(
+        preparationDigest,
+        serializeUnavailablePreparation(request, trustedHead)
+      )
     ) {
       throw new Error('Event actor unavailable preparation binding is invalid');
     }
-    const request = snapshotPrepareRequest(preparation.request);
-    const trustedHead = snapshotHead(preparation.head);
     resolveExecutionDepth(
       request.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
@@ -721,20 +795,21 @@ export class EventActorExecutor<
     } finally {
       signal?.removeEventListener('abort', abort);
     }
+    const adapterInvocation = snapshotInvocation(invocation);
     validateInvocation(
       request,
-      invocation,
+      adapterInvocation,
       'cold',
       checkpointNs,
       this.maxDepth,
       trustedHead
     );
     const trustedInvocation: EventActorInvocation<TEvent> = {
-      ...snapshotInvocation(invocation),
+      ...adapterInvocation,
       event: snapshotEvent(request.event),
     };
     if (isAborted(controller.signal)) {
-      await this.discard(
+      await this.discardInvocationReference(
         snapshotInvocationReference(trustedInvocation),
         'cancelled'
       );
@@ -743,15 +818,15 @@ export class EventActorExecutor<
         controller.signal.reason
       );
     }
-    return createPreparedInvocation(trustedInvocation);
+    return this.createPreparedInvocation(trustedInvocation);
   }
 
   async invoke(
     invocation: EventActorPreparedInvocation<TEvent>,
     signal?: AbortSignal
   ): Promise<EventActorInvocationResult<TResult>> {
-    validatePreparedInvocation(invocation);
-    const trustedInvocation = snapshotInvocation(invocation);
+    const trustedInvocation = snapshotPreparedInvocation(invocation);
+    this.validatePreparedInvocation(trustedInvocation);
     const settlementInvocation = snapshotInvocationReference(trustedInvocation);
     const terminal = await this.invokeWithConfig(
       snapshotInvocation(trustedInvocation),
@@ -853,43 +928,54 @@ export class EventActorExecutor<
       },
     });
     if (committed.status === 'committed') {
+      const committedHead = snapshotHead(committed.head);
       validateCommittedHead(
         trustedInvocation,
         trustedCheckpoint,
-        committed.head
+        committedHead
       );
-      return { status: 'committed', head: snapshotHead(committed.head) };
+      return { status: 'committed', head: committedHead };
     }
     if (committed.head != null) {
-      validateHead(committed.head, trustedInvocation.actorThreadId);
-      if (committed.head.generation <= trustedInvocation.base.generation) {
+      const committedHead = snapshotHead(committed.head);
+      validateHead(committedHead, trustedInvocation.actorThreadId);
+      if (committedHead.generation <= trustedInvocation.base.generation) {
         throw new Error('Stale event actor head did not advance past its base');
       }
       if (
         trustedInvocation.base.checkpoint != null &&
-        committed.head.checkpoint?.threadId !==
+        committedHead.checkpoint?.threadId !==
           trustedInvocation.base.checkpoint.threadId
       ) {
         throw new Error('Stale event actor head changed its checkpoint thread');
       }
       if (
         checkpointIdsMatch(
-          committed.head.checkpoint,
+          committedHead.checkpoint,
           trustedInvocation.base.checkpoint
         ) ||
-        checkpointIdsMatch(committed.head.checkpoint, trustedInvocation.fork) ||
-        checkpointsMatch(committed.head.checkpoint, trustedCheckpoint)
+        checkpointIdsMatch(committedHead.checkpoint, trustedInvocation.fork) ||
+        checkpointsMatch(committedHead.checkpoint, trustedCheckpoint)
       ) {
         throw new Error(
           'Stale event actor head does not identify a competing checkpoint'
         );
       }
-      return { status: 'stale', head: snapshotHead(committed.head) };
+      return { status: 'stale', head: committedHead };
     }
     return committed;
   }
 
   discard(
+    invocation: EventActorPreparedInvocation<TEvent>,
+    reason: EventActorDiscardReason
+  ): Promise<void> {
+    const trustedInvocation = snapshotPreparedInvocation(invocation);
+    this.validatePreparedInvocation(trustedInvocation);
+    return this.discardInvocationReference(trustedInvocation, reason);
+  }
+
+  private discardInvocationReference(
     invocation: EventActorInvocationReference,
     reason: EventActorDiscardReason
   ): Promise<void> {
@@ -968,7 +1054,7 @@ export class EventActorExecutor<
     const invocationReference = snapshotInvocationReference(invocation);
     const invocationForAdapter = snapshotInvocation(invocation);
     if (isAborted(trustedRequest.signal)) {
-      await this.discard(invocationReference, 'cancelled');
+      await this.discardInvocationReference(invocationReference, 'cancelled');
       return { status: 'cancelled', continuation };
     }
     let terminal;
@@ -980,7 +1066,7 @@ export class EventActorExecutor<
       );
     } catch (error) {
       const reason = isAborted(trustedRequest.signal) ? 'cancelled' : 'failed';
-      await this.discard(invocationReference, reason);
+      await this.discardInvocationReference(invocationReference, reason);
       if (reason === 'cancelled') {
         return { status: 'cancelled', continuation };
       }
@@ -991,19 +1077,24 @@ export class EventActorExecutor<
         terminal.result === undefined
           ? undefined
           : snapshotEvent(terminal.result);
-      await this.discard(invocationReference, 'completed_no_action');
+      await this.discardInvocationReference(
+        invocationReference,
+        'completed_no_action'
+      );
       return {
         status: 'completed_no_action',
         ...(result === undefined ? {} : { result }),
         continuation,
       };
     }
+    const trustedResult = snapshotEvent(terminal.result);
+    const trustedCheckpoint = { ...terminal.checkpoint };
     try {
-      validateTerminalCheckpoint(invocationReference, terminal.checkpoint);
+      validateTerminalCheckpoint(invocationReference, trustedCheckpoint);
     } catch (error) {
       return {
         status: 'commit_indeterminate',
-        result: terminal.result,
+        result: trustedResult,
         checkpoint: {
           invocationId: invocationReference.fork.invocationId,
           threadId: invocationReference.fork.threadId,
@@ -1013,7 +1104,11 @@ export class EventActorExecutor<
         continuation,
       };
     }
-    const trustedTerminal = this.issueSettlement(invocationReference, terminal);
+    const trustedTerminal = this.issueSettlement(invocationReference, {
+      ...terminal,
+      result: trustedResult,
+      checkpoint: trustedCheckpoint,
+    });
     let committed;
     try {
       committed = await this.commit(trustedTerminal);

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -567,12 +567,14 @@ function snapshotAppliedTerminal<TResult extends EventActorEvent>(
   let result: TResult | undefined;
   try {
     result = snapshotEvent(terminal.result);
-    return {
+    const snapshot: EventActorAppliedSnapshot<TResult> = {
       status: 'snapshot_ready',
       result,
       checkpoint: snapshotCheckpointFork(terminal.checkpoint),
       invocation: freezeInvocationReference(invocation),
     };
+    validateTerminalCheckpoint(snapshot.invocation, snapshot.checkpoint);
+    return snapshot;
   } catch (error) {
     return createIndeterminateResult(invocation, error, result);
   }
@@ -1163,21 +1165,6 @@ export class EventActorExecutor<
     );
     if (appliedSnapshot.status === 'commit_indeterminate') {
       return { ...appliedSnapshot, continuation };
-    }
-    try {
-      validateTerminalCheckpoint(
-        invocationReference,
-        appliedSnapshot.checkpoint
-      );
-    } catch (error) {
-      return {
-        ...createIndeterminateResult(
-          invocationReference,
-          error,
-          appliedSnapshot.result
-        ),
-        continuation,
-      };
     }
     const trustedTerminal = this.#issueSettlement(appliedSnapshot);
     let committed;

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -13,7 +13,6 @@ import type {
   EventActorAppliedResult,
   EventActorCheckpointFork,
   EventActorCheckpointReference,
-  EventActorCommitResult,
   EventActorDiscardReason,
   EventActorEvent,
   EventActorExecutionRequest,
@@ -28,6 +27,7 @@ import type {
   EventActorPreparedInvocation,
   EventActorPrepareRequest,
   EventActorPreparation,
+  EventActorSettlementResult,
   EventActorTerminalResult,
 } from './types';
 
@@ -139,7 +139,7 @@ function snapshotCheckpointFork(
 function snapshotHead(head: EventActorHead): EventActorHead {
   return {
     actorThreadId: head.actorThreadId,
-    generation: head.generation,
+    generation: Object.is(head.generation, -0) ? 0 : head.generation,
     ...(head.checkpoint == null
       ? {}
       : { checkpoint: snapshotCheckpointReference(head.checkpoint) }),
@@ -533,7 +533,11 @@ function createRunnableConfig(
 }
 
 function asError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  try {
+    return error instanceof Error ? error : new Error(String(error));
+  } catch {
+    return new Error('Unknown event actor error');
+  }
 }
 
 type EventActorAppliedSnapshot<TResult extends EventActorEvent> = {
@@ -556,6 +560,18 @@ function createIndeterminateResult<TResult extends EventActorEvent>(
       threadId: invocation.fork.threadId,
       checkpointNs: invocation.fork.checkpointNs,
     }),
+    error: asError(error),
+  });
+}
+
+function createSettlementIndeterminateResult<TResult extends EventActorEvent>(
+  settlement: EventActorAppliedResult<TResult>,
+  error: unknown
+): EventActorIndeterminateResult<TResult> {
+  return Object.freeze({
+    status: 'commit_indeterminate',
+    result: settlement.result,
+    checkpoint: Object.freeze(snapshotCheckpointFork(settlement.checkpoint)),
     error: asError(error),
   });
 }
@@ -645,6 +661,10 @@ export class EventActorExecutor<
   readonly #dormantCheckpointTtlMs: number;
   readonly #preparationSigningKey: Uint8Array;
   readonly #issuedSettlements = new WeakSet<object>();
+  readonly #preparationPhases = new Map<
+    string,
+    'invoking' | 'retained' | 'discarding' | 'discarded'
+  >();
 
   constructor(
     adapter: EventActorHostAdapter<TEvent, TResult>,
@@ -896,24 +916,62 @@ export class EventActorExecutor<
   ): Promise<EventActorInvocationResult<TResult>> {
     const trustedInvocation = snapshotPreparedInvocation(invocation);
     this.#validatePreparedInvocation(trustedInvocation);
-    const settlementInvocation = snapshotInvocationReference(trustedInvocation);
-    const terminal = await this.#invokeWithConfig(
-      snapshotInvocation(trustedInvocation),
-      signal,
-      AsyncLocalStorageProviderSingleton.getRunnableConfig()
-    );
-    if (terminal.status === 'applied') {
-      const snapshot = snapshotAppliedTerminal(settlementInvocation, terminal);
-      return snapshot.status === 'snapshot_ready'
-        ? this.#issueSettlement(snapshot)
-        : snapshot;
+    const preparationDigest = trustedInvocation.preparationDigest;
+    if (this.#preparationPhases.has(preparationDigest)) {
+      throw new Error('Event actor prepared invocation was already consumed');
     }
-    return Object.freeze({
-      status: 'completed_no_action' as const,
-      ...(terminal.result === undefined
-        ? {}
-        : { result: snapshotEvent(terminal.result) }),
-    });
+    this.#preparationPhases.set(preparationDigest, 'invoking');
+    const settlementInvocation = snapshotInvocationReference(trustedInvocation);
+    let invocationCompleted = false;
+    let definitelyNoAction = false;
+    try {
+      const terminal = await this.#invokeWithConfig(
+        snapshotInvocation(trustedInvocation),
+        signal,
+        AsyncLocalStorageProviderSingleton.getRunnableConfig()
+      );
+      invocationCompleted = true;
+      this.#preparationPhases.set(preparationDigest, 'retained');
+      const status: unknown = terminal.status;
+      if (status === 'applied') {
+        const snapshot = snapshotAppliedTerminal<TResult>(
+          settlementInvocation,
+          terminal as Extract<
+            EventActorTerminalResult<TResult>,
+            { status: 'applied' }
+          >
+        );
+        return snapshot.status === 'snapshot_ready'
+          ? this.#issueSettlement(snapshot)
+          : snapshot;
+      }
+      if (status !== 'completed_no_action') {
+        return createIndeterminateResult(
+          settlementInvocation,
+          new Error('Event actor invocation returned an invalid status')
+        );
+      }
+      definitelyNoAction = true;
+      const completed = Object.freeze({
+        status: 'completed_no_action' as const,
+        ...(terminal.result === undefined
+          ? {}
+          : { result: snapshotEvent(terminal.result) }),
+      });
+      this.#preparationPhases.delete(preparationDigest);
+      return completed;
+    } catch (error) {
+      if (
+        isGraphInterrupt(error) ||
+        isParentCommand(error) ||
+        (invocationCompleted && !definitelyNoAction)
+      ) {
+        this.#preparationPhases.set(preparationDigest, 'retained');
+      } else {
+        this.#preparationPhases.delete(preparationDigest);
+      }
+      throw error;
+    }
   }
 
   #issueSettlement(
@@ -978,7 +1036,7 @@ export class EventActorExecutor<
 
   async commit(
     settlement: EventActorAppliedResult<TResult>
-  ): Promise<EventActorCommitResult> {
+  ): Promise<EventActorSettlementResult<TResult>> {
     if (!this.#issuedSettlements.has(settlement)) {
       throw new Error('Event actor settlement was not issued by this executor');
     }
@@ -988,62 +1046,102 @@ export class EventActorExecutor<
     validateInvocationReference(trustedInvocation, this.#maxDepth);
     const trustedCheckpoint = snapshotCheckpointFork(settlement.checkpoint);
     validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
-    const committed = await this.#adapter.commit({
-      invocation: snapshotInvocationReference(trustedInvocation),
-      expectedHead: snapshotHead(trustedInvocation.base),
-      checkpoint: { ...trustedCheckpoint },
-      result: settlement.result,
-      retention: {
-        committedCheckpoints: 2,
-        dormantCheckpointTtlMs: this.#dormantCheckpointTtlMs,
-      },
-    });
-    if (committed.status === 'committed') {
-      const committedHead = snapshotHead(committed.head);
-      validateCommittedHead(
-        trustedInvocation,
-        trustedCheckpoint,
-        committedHead
-      );
-      return { status: 'committed', head: committedHead };
-    }
-    if (committed.head != null) {
-      const committedHead = snapshotHead(committed.head);
-      validateHead(committedHead, trustedInvocation.actorThreadId);
-      if (committedHead.generation <= trustedInvocation.base.generation) {
-        throw new Error('Stale event actor head did not advance past its base');
-      }
-      if (
-        trustedInvocation.base.checkpoint != null &&
-        committedHead.checkpoint?.threadId !==
-          trustedInvocation.base.checkpoint.threadId
-      ) {
-        throw new Error('Stale event actor head changed its checkpoint thread');
-      }
-      if (
-        checkpointIdsMatch(
-          committedHead.checkpoint,
-          trustedInvocation.base.checkpoint
-        ) ||
-        checkpointIdsMatch(committedHead.checkpoint, trustedInvocation.fork) ||
-        checkpointsMatch(committedHead.checkpoint, trustedCheckpoint)
-      ) {
-        throw new Error(
-          'Stale event actor head does not identify a competing checkpoint'
+    this.#issuedSettlements.delete(settlement);
+    try {
+      const committed = await this.#adapter.commit({
+        invocation: snapshotInvocationReference(trustedInvocation),
+        expectedHead: snapshotHead(trustedInvocation.base),
+        checkpoint: { ...trustedCheckpoint },
+        result: settlement.result,
+        retention: {
+          committedCheckpoints: 2,
+          dormantCheckpointTtlMs: this.#dormantCheckpointTtlMs,
+        },
+      });
+      const status: unknown = committed.status;
+      if (status === 'committed') {
+        const committedHead = snapshotHead(
+          (committed as { status: 'committed'; head: EventActorHead }).head
         );
+        validateCommittedHead(
+          trustedInvocation,
+          trustedCheckpoint,
+          committedHead
+        );
+        return { status: 'committed', head: committedHead };
       }
-      return { status: 'stale', head: committedHead };
+      if (status !== 'stale') {
+        throw new Error('Event actor commit returned an invalid status');
+      }
+      const staleHead = committed.head;
+      if (staleHead != null) {
+        const committedHead = snapshotHead(staleHead);
+        validateHead(committedHead, trustedInvocation.actorThreadId);
+        if (committedHead.generation <= trustedInvocation.base.generation) {
+          throw new Error(
+            'Stale event actor head did not advance past its base'
+          );
+        }
+        if (
+          trustedInvocation.base.checkpoint != null &&
+          committedHead.checkpoint?.threadId !==
+            trustedInvocation.base.checkpoint.threadId
+        ) {
+          throw new Error(
+            'Stale event actor head changed its checkpoint thread'
+          );
+        }
+        if (
+          checkpointIdsMatch(
+            committedHead.checkpoint,
+            trustedInvocation.base.checkpoint
+          ) ||
+          checkpointIdsMatch(
+            committedHead.checkpoint,
+            trustedInvocation.fork
+          ) ||
+          checkpointsMatch(committedHead.checkpoint, trustedCheckpoint)
+        ) {
+          throw new Error(
+            'Stale event actor head does not identify a competing checkpoint'
+          );
+        }
+        return { status: 'stale', head: committedHead };
+      }
+      return { status: 'stale' };
+    } catch (error) {
+      return createSettlementIndeterminateResult(settlement, error);
     }
-    return committed;
   }
 
-  discard(
+  async discard(
     invocation: EventActorPreparedInvocation<TEvent>,
     reason: EventActorDiscardReason
   ): Promise<void> {
+    const discardReason: unknown = reason;
+    if (
+      discardReason !== 'cancelled' &&
+      discardReason !== 'completed_no_action' &&
+      discardReason !== 'failed'
+    ) {
+      throw new Error('Event actor discard reason is invalid');
+    }
     const trustedInvocation = snapshotPreparedInvocation(invocation);
     this.#validatePreparedInvocation(trustedInvocation);
-    return this.#discardInvocationReference(trustedInvocation, reason);
+    const preparationDigest = trustedInvocation.preparationDigest;
+    if (this.#preparationPhases.has(preparationDigest)) {
+      throw new Error(
+        'Event actor prepared invocation is no longer discardable'
+      );
+    }
+    this.#preparationPhases.set(preparationDigest, 'discarding');
+    try {
+      await this.#discardInvocationReference(trustedInvocation, reason);
+      this.#preparationPhases.set(preparationDigest, 'discarded');
+    } catch (error) {
+      this.#preparationPhases.delete(preparationDigest);
+      throw error;
+    }
   }
 
   #discardInvocationReference(
@@ -1144,11 +1242,29 @@ export class EventActorExecutor<
       }
       return { status: 'failed', error: asError(error), continuation };
     }
-    if (terminal.status === 'completed_no_action') {
-      const result =
-        terminal.result === undefined
-          ? undefined
-          : snapshotEvent(terminal.result);
+    let terminalStatus: unknown;
+    try {
+      terminalStatus = terminal.status;
+    } catch (error) {
+      return {
+        ...createIndeterminateResult(invocationReference, error),
+        continuation,
+      };
+    }
+    if (terminalStatus === 'completed_no_action') {
+      let result: TResult | undefined;
+      try {
+        result =
+          terminal.result === undefined
+            ? undefined
+            : snapshotEvent(terminal.result);
+      } catch (error) {
+        await this.#discardInvocationReference(
+          invocationReference,
+          'completed_no_action'
+        );
+        return { status: 'failed', error: asError(error), continuation };
+      }
       await this.#discardInvocationReference(
         invocationReference,
         'completed_no_action'
@@ -1159,23 +1275,30 @@ export class EventActorExecutor<
         continuation,
       };
     }
-    const appliedSnapshot = snapshotAppliedTerminal(
+    if (terminalStatus !== 'applied') {
+      return {
+        ...createIndeterminateResult(
+          invocationReference,
+          new Error('Event actor invocation returned an invalid status')
+        ),
+        continuation,
+      };
+    }
+    const appliedSnapshot = snapshotAppliedTerminal<TResult>(
       invocationReference,
-      terminal
+      terminal as Extract<
+        EventActorTerminalResult<TResult>,
+        { status: 'applied' }
+      >
     );
     if (appliedSnapshot.status === 'commit_indeterminate') {
       return { ...appliedSnapshot, continuation };
     }
     const trustedTerminal = this.#issueSettlement(appliedSnapshot);
-    let committed;
-    try {
-      committed = await this.commit(trustedTerminal);
-    } catch (error) {
+    const committed = await this.commit(trustedTerminal);
+    if (committed.status === 'commit_indeterminate') {
       return {
-        status: 'commit_indeterminate',
-        result: trustedTerminal.result,
-        checkpoint: { ...trustedTerminal.checkpoint },
-        error: asError(error),
+        ...committed,
         continuation,
       };
     }

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -178,7 +178,24 @@ function validateInvocationReference(
       invocation.fork.checkpointId ?? '',
       'fork.checkpointId for resumed actor'
     );
+    if (
+      invocation.continuation === 'warm' &&
+      invocation.fork.checkpointId !== invocation.base.checkpoint.checkpointId
+    ) {
+      throw new Error(
+        'Warm event actor fork did not start from the committed checkpoint'
+      );
+    }
   }
+}
+
+function checkpointIdsMatch(
+  left: EventActorCheckpointFork | EventActorHead['checkpoint'],
+  right: EventActorCheckpointFork | EventActorHead['checkpoint']
+): boolean {
+  return (
+    left != null && right != null && left.checkpointId === right.checkpointId
+  );
 }
 
 function checkpointsMatch(
@@ -186,11 +203,9 @@ function checkpointsMatch(
   right: EventActorCheckpointFork | EventActorHead['checkpoint']
 ): boolean {
   return (
-    left != null &&
-    right != null &&
-    left.threadId === right.threadId &&
-    left.checkpointNs === right.checkpointNs &&
-    left.checkpointId === right.checkpointId
+    checkpointIdsMatch(left, right) &&
+    left?.threadId === right?.threadId &&
+    left?.checkpointNs === right?.checkpointNs
   );
 }
 
@@ -427,11 +442,22 @@ export class EventActorExecutor<TEvent, TResult> {
     signal?: AbortSignal
   ): Promise<EventActorTerminalResult<TResult>> {
     const trustedInvocation = snapshotInvocation(invocation);
-    return this.invokeWithConfig(
+    const terminal = await this.invokeWithConfig(
       trustedInvocation,
       signal,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
+    if (terminal.status === 'applied') {
+      return {
+        status: 'applied',
+        result: terminal.result,
+        checkpoint: { ...terminal.checkpoint },
+      };
+    }
+    return {
+      status: 'completed_no_action',
+      ...(terminal.result === undefined ? {} : { result: terminal.result }),
+    };
   }
 
   private async invokeWithConfig(
@@ -439,6 +465,7 @@ export class EventActorExecutor<TEvent, TResult> {
     signal: AbortSignal | undefined,
     ambientConfig: RunnableConfig | undefined
   ): Promise<EventActorTerminalResult<TResult>> {
+    resolveExecutionDepth(invocation.depth, ambientConfig);
     validateInvocation(
       {
         actorThreadId: invocation.actorThreadId,
@@ -512,12 +539,14 @@ export class EventActorExecutor<TEvent, TResult> {
         throw new Error('Stale event actor head did not advance past its base');
       }
       if (
-        committed.head.checkpoint?.threadId !== trustedInvocation.fork.threadId
+        trustedInvocation.base.checkpoint != null &&
+        committed.head.checkpoint?.threadId !==
+          trustedInvocation.base.checkpoint.threadId
       ) {
         throw new Error('Stale event actor head changed its checkpoint thread');
       }
       if (
-        checkpointsMatch(
+        checkpointIdsMatch(
           committed.head.checkpoint,
           trustedInvocation.base.checkpoint
         ) ||

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -10,6 +10,7 @@ import {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
   EventActorAdapterPrepareRequest,
+  EventActorAdapterPreparation,
   EventActorAppliedResult,
   EventActorCheckpointFork,
   EventActorCheckpointReference,
@@ -33,6 +34,7 @@ import type {
 
 const DEFAULT_MAX_DEPTH = 1;
 const DEFAULT_DORMANT_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1_000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 function createInvocationCheckpointNs(
   request: EventActorPrepareRequest<EventActorEvent>,
@@ -547,6 +549,13 @@ type EventActorAppliedSnapshot<TResult extends EventActorEvent> = {
   invocation: EventActorInvocationReference;
 };
 
+type EventActorPreparationPhase =
+  | { status: 'invoking' | 'discarding' }
+  | {
+      status: 'discardable' | 'retained' | 'discarded';
+      expiresAt: number;
+    };
+
 function createIndeterminateResult<TResult extends EventActorEvent>(
   invocation: EventActorInvocationReference,
   error: unknown,
@@ -661,10 +670,9 @@ export class EventActorExecutor<
   readonly #dormantCheckpointTtlMs: number;
   readonly #preparationSigningKey: Uint8Array;
   readonly #issuedSettlements = new WeakSet<object>();
-  readonly #preparationPhases = new Map<
-    string,
-    'invoking' | 'retained' | 'discarding' | 'discarded'
-  >();
+  readonly #preparationPhases = new Map<string, EventActorPreparationPhase>();
+  #phaseCleanupTimer: ReturnType<typeof setTimeout> | undefined;
+  #nextPhaseExpiry = Number.POSITIVE_INFINITY;
 
   constructor(
     adapter: EventActorHostAdapter<TEvent, TResult>,
@@ -712,26 +720,95 @@ export class EventActorExecutor<
     invocation: EventActorInvocation<TEvent>
   ): EventActorPreparedInvocation<TEvent> {
     const trustedInvocation = freezeInvocation(invocation);
+    const expiresAt = Math.min(
+      Number.MAX_SAFE_INTEGER,
+      Date.now() + this.#dormantCheckpointTtlMs
+    );
+    const payload = serializeInvocationPreparation(trustedInvocation);
     return Object.freeze({
       ...trustedInvocation,
-      preparationDigest: this.#signPreparation(
-        serializeInvocationPreparation(trustedInvocation)
-      ),
+      preparationDigest: `${expiresAt}.${this.#signPreparation(
+        `${expiresAt}\0${payload}`
+      )}`,
     });
   }
 
   #validatePreparedInvocation(
-    invocation: EventActorPreparedInvocation<TEvent>
-  ): void {
+    invocation: EventActorPreparedInvocation<TEvent>,
+    allowExpired = false
+  ): number {
     requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
+    const match = /^(\d+)\.([a-f0-9]{64})$/.exec(invocation.preparationDigest);
+    const expiresAt = Number(match?.[1]);
     if (
+      match == null ||
+      !Number.isSafeInteger(expiresAt) ||
+      expiresAt < 1 ||
       !this.#preparationSignatureMatches(
-        invocation.preparationDigest,
-        serializeInvocationPreparation(invocation)
+        match[2],
+        `${expiresAt}\0${serializeInvocationPreparation(invocation)}`
       )
     ) {
       throw new Error('Event actor prepared invocation binding is invalid');
     }
+    if (!allowExpired && expiresAt <= Date.now()) {
+      throw new Error('Event actor prepared invocation binding has expired');
+    }
+    return expiresAt;
+  }
+
+  #prunePreparationPhases(now = Date.now()): void {
+    if (this.#phaseCleanupTimer != null) {
+      clearTimeout(this.#phaseCleanupTimer);
+      this.#phaseCleanupTimer = undefined;
+    }
+    this.#nextPhaseExpiry = Number.POSITIVE_INFINITY;
+    for (const [digest, phase] of this.#preparationPhases) {
+      if ('expiresAt' in phase && phase.expiresAt <= now) {
+        this.#preparationPhases.delete(digest);
+      } else if ('expiresAt' in phase) {
+        this.#schedulePhaseCleanup(phase.expiresAt, now);
+      }
+    }
+  }
+
+  #schedulePhaseCleanup(expiresAt: number, now = Date.now()): void {
+    if (expiresAt >= this.#nextPhaseExpiry) {
+      return;
+    }
+    if (this.#phaseCleanupTimer != null) {
+      clearTimeout(this.#phaseCleanupTimer);
+    }
+    this.#nextPhaseExpiry = expiresAt;
+    this.#phaseCleanupTimer = setTimeout(
+      () => this.#prunePreparationPhases(),
+      Math.min(MAX_TIMEOUT_MS, Math.max(0, expiresAt - now))
+    );
+    this.#phaseCleanupTimer.unref();
+  }
+
+  #getPreparationPhase(
+    preparationDigest: string
+  ): EventActorPreparationPhase | undefined {
+    if (Date.now() >= this.#nextPhaseExpiry) {
+      this.#prunePreparationPhases();
+    }
+    return this.#preparationPhases.get(preparationDigest);
+  }
+
+  #setTerminalPreparationPhase(
+    preparationDigest: string,
+    status: 'discardable' | 'retained' | 'discarded'
+  ): void {
+    const phase = {
+      status,
+      expiresAt: Math.min(
+        Number.MAX_SAFE_INTEGER,
+        Date.now() + this.#dormantCheckpointTtlMs
+      ),
+    } as const;
+    this.#preparationPhases.set(preparationDigest, phase);
+    this.#schedulePhaseCleanup(phase.expiresAt);
   }
 
   async prepare(
@@ -777,8 +854,13 @@ export class EventActorExecutor<
     } finally {
       signal?.removeEventListener('abort', abort);
     }
-    if (preparation.status === 'ready') {
-      const adapterInvocation = snapshotInvocation(preparation.invocation);
+    const preparationStatus: unknown = preparation.status;
+    if (preparationStatus === 'ready') {
+      const readyPreparation = preparation as Extract<
+        EventActorAdapterPreparation<TEvent>,
+        { status: 'ready' }
+      >;
+      const adapterInvocation = snapshotInvocation(readyPreparation.invocation);
       validateInvocation(
         trustedRequest,
         adapterInvocation,
@@ -805,7 +887,14 @@ export class EventActorExecutor<
         invocation: preparedInvocation,
       });
     } else {
-      const preparedHead = freezeHead(preparation.head);
+      if (preparationStatus !== 'checkpoint_unavailable') {
+        throw new Error('Event actor preparation returned an invalid status');
+      }
+      const unavailablePreparation = preparation as Extract<
+        EventActorAdapterPreparation<TEvent>,
+        { status: 'checkpoint_unavailable' }
+      >;
+      const preparedHead = freezeHead(unavailablePreparation.head);
       validateHead(preparedHead, trustedRequest.actorThreadId);
       if (isAborted(controller.signal)) {
         throw new EventActorPreparationCancelledError(
@@ -917,10 +1006,10 @@ export class EventActorExecutor<
     const trustedInvocation = snapshotPreparedInvocation(invocation);
     this.#validatePreparedInvocation(trustedInvocation);
     const preparationDigest = trustedInvocation.preparationDigest;
-    if (this.#preparationPhases.has(preparationDigest)) {
+    if (this.#getPreparationPhase(preparationDigest) != null) {
       throw new Error('Event actor prepared invocation was already consumed');
     }
-    this.#preparationPhases.set(preparationDigest, 'invoking');
+    this.#preparationPhases.set(preparationDigest, { status: 'invoking' });
     const settlementInvocation = snapshotInvocationReference(trustedInvocation);
     let invocationCompleted = false;
     let definitelyNoAction = false;
@@ -931,8 +1020,13 @@ export class EventActorExecutor<
         AsyncLocalStorageProviderSingleton.getRunnableConfig()
       );
       invocationCompleted = true;
-      this.#preparationPhases.set(preparationDigest, 'retained');
-      const status: unknown = terminal.status;
+      this.#setTerminalPreparationPhase(preparationDigest, 'retained');
+      let status: unknown;
+      try {
+        status = terminal.status;
+      } catch (error) {
+        return createIndeterminateResult(settlementInvocation, error);
+      }
       if (status === 'applied') {
         const snapshot = snapshotAppliedTerminal<TResult>(
           settlementInvocation,
@@ -958,7 +1052,7 @@ export class EventActorExecutor<
           ? {}
           : { result: snapshotEvent(terminal.result) }),
       });
-      this.#preparationPhases.delete(preparationDigest);
+      this.#setTerminalPreparationPhase(preparationDigest, 'discardable');
       return completed;
     } catch (error) {
       if (
@@ -966,9 +1060,9 @@ export class EventActorExecutor<
         isParentCommand(error) ||
         (invocationCompleted && !definitelyNoAction)
       ) {
-        this.#preparationPhases.set(preparationDigest, 'retained');
+        this.#setTerminalPreparationPhase(preparationDigest, 'retained');
       } else {
-        this.#preparationPhases.delete(preparationDigest);
+        this.#setTerminalPreparationPhase(preparationDigest, 'discardable');
       }
       throw error;
     }
@@ -1127,19 +1221,30 @@ export class EventActorExecutor<
       throw new Error('Event actor discard reason is invalid');
     }
     const trustedInvocation = snapshotPreparedInvocation(invocation);
-    this.#validatePreparedInvocation(trustedInvocation);
+    const expiresAt = this.#validatePreparedInvocation(trustedInvocation, true);
     const preparationDigest = trustedInvocation.preparationDigest;
-    if (this.#preparationPhases.has(preparationDigest)) {
+    const previousPhase = this.#getPreparationPhase(preparationDigest);
+    if (expiresAt <= Date.now() && previousPhase == null) {
+      throw new Error('Event actor prepared invocation binding has expired');
+    }
+    if (previousPhase != null && previousPhase.status !== 'discardable') {
       throw new Error(
         'Event actor prepared invocation is no longer discardable'
       );
     }
-    this.#preparationPhases.set(preparationDigest, 'discarding');
+    this.#preparationPhases.set(preparationDigest, { status: 'discarding' });
     try {
       await this.#discardInvocationReference(trustedInvocation, reason);
-      this.#preparationPhases.set(preparationDigest, 'discarded');
+      this.#setTerminalPreparationPhase(preparationDigest, 'discarded');
     } catch (error) {
-      this.#preparationPhases.delete(preparationDigest);
+      if (previousPhase == null) {
+        this.#preparationPhases.delete(preparationDigest);
+      } else {
+        this.#preparationPhases.set(preparationDigest, previousPhase);
+        if ('expiresAt' in previousPhase) {
+          this.#schedulePhaseCleanup(previousPhase.expiresAt);
+        }
+      }
       throw error;
     }
   }

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -406,21 +406,25 @@ export class EventActorExecutor<TEvent, TResult> {
       validateHead(preparation.head, request.actorThreadId);
       return {
         status: 'checkpoint_unavailable',
+        request: { ...request, event: request.event },
         head: snapshotHead(preparation.head),
       };
     }
   }
 
   async coldContinue(
-    request: EventActorPrepareRequest<TEvent>,
-    head: EventActorHead
+    preparation: Extract<
+      EventActorPreparation<TEvent>,
+      { status: 'checkpoint_unavailable' }
+    >
   ): Promise<EventActorInvocation<TEvent>> {
+    const request = preparation.request;
     resolveExecutionDepth(
       request.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
     this.validatePrepareRequest(request);
-    const trustedHead = snapshotHead(head);
+    const trustedHead = snapshotHead(preparation.head);
     validateHead(trustedHead, request.actorThreadId);
     const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
@@ -620,7 +624,7 @@ export class EventActorExecutor<TEvent, TResult> {
     const invocation =
       preparation.status === 'ready'
         ? preparation.invocation
-        : await this.coldContinue(prepareRequest, preparation.head);
+        : await this.coldContinue(preparation);
     const continuation = preparation.status === 'ready' ? 'warm' : 'cold';
     const invocationReference = snapshotInvocationReference(invocation);
     const invocationForAdapter = snapshotInvocation(invocation);

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -173,9 +173,14 @@ function createRunnableConfig(
   signal: AbortSignal,
   ambient?: RunnableConfig
 ): RunnableConfig {
-  const configurable: Record<string, unknown> = {
-    ...(ambient?.configurable ?? {}),
-  };
+  const configurable = Object.fromEntries(
+    Object.entries(ambient?.configurable ?? {}).filter(
+      ([key]) =>
+        !key.startsWith('__pregel_') &&
+        !key.startsWith('__librechat_') &&
+        key !== 'lc_run_breaker_scope'
+    )
+  );
   delete configurable.thread_id;
   delete configurable.checkpoint_ns;
   delete configurable.checkpoint_id;
@@ -417,6 +422,13 @@ export class EventActorExecutor<TEvent, TResult> {
       if (committed.head.generation <= trustedInvocation.base.generation) {
         throw new Error('Stale event actor head did not advance past its base');
       }
+      if (
+        trustedInvocation.base.checkpoint != null &&
+        committed.head.checkpoint?.threadId !==
+          trustedInvocation.base.checkpoint.threadId
+      ) {
+        throw new Error('Stale event actor head changed its checkpoint thread');
+      }
       return { status: 'stale', head: snapshotHead(committed.head) };
     }
     return committed;
@@ -497,7 +509,11 @@ export class EventActorExecutor<TEvent, TResult> {
       return {
         status: 'commit_indeterminate',
         result: terminal.result,
-        checkpoint: { ...invocationReference.fork },
+        checkpoint: {
+          invocationId: invocationReference.fork.invocationId,
+          threadId: invocationReference.fork.threadId,
+          checkpointNs: invocationReference.fork.checkpointNs,
+        },
         error: asError(error),
         continuation,
       };

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -233,6 +233,26 @@ function isAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true;
 }
 
+function resolveExecutionDepth(
+  requestedDepth: number | undefined,
+  ambientConfig: RunnableConfig | undefined
+): number {
+  const ambientDepth = ambientConfig?.configurable?.event_actor_depth;
+  if (ambientDepth == null) {
+    return requestedDepth ?? 1;
+  }
+  if (!Number.isSafeInteger(ambientDepth) || Number(ambientDepth) < 1) {
+    throw new Error('Ambient event actor depth is invalid');
+  }
+  const nestedDepth = Number(ambientDepth) + 1;
+  if (requestedDepth != null && requestedDepth !== nestedDepth) {
+    throw new Error(
+      `Nested event actor depth ${requestedDepth} must advance parent depth ${ambientDepth}`
+    );
+  }
+  return nestedDepth;
+}
+
 function validateCommittedHead(
   invocation: EventActorInvocationReference,
   checkpoint: EventActorCheckpointFork,
@@ -465,7 +485,7 @@ export class EventActorExecutor<TEvent, TResult> {
   ): Promise<EventActorExecutionResult<TResult>> {
     const ambientConfig =
       AsyncLocalStorageProviderSingleton.getRunnableConfig();
-    const depth = request.depth ?? 1;
+    const depth = resolveExecutionDepth(request.depth, ambientConfig);
     const prepareRequest: EventActorPrepareRequest<TEvent> = {
       actorThreadId: request.actorThreadId,
       invocationId: request.invocationId,
@@ -473,6 +493,12 @@ export class EventActorExecutor<TEvent, TResult> {
       event: request.event,
     };
     const preparation = await this.prepare(prepareRequest);
+    if (
+      preparation.status === 'checkpoint_unavailable' &&
+      isAborted(request.signal)
+    ) {
+      return { status: 'cancelled', continuation: 'cold' };
+    }
     const invocation =
       preparation.status === 'ready'
         ? preparation.invocation
@@ -501,7 +527,11 @@ export class EventActorExecutor<TEvent, TResult> {
     }
     if (terminal.status === 'completed_no_action') {
       await this.discard(invocationReference, 'completed_no_action');
-      return { status: 'completed_no_action', continuation };
+      return {
+        status: 'completed_no_action',
+        ...(terminal.result === undefined ? {} : { result: terminal.result }),
+        continuation,
+      };
     }
     try {
       validateTerminalCheckpoint(invocationReference, terminal.checkpoint);

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -7,12 +7,14 @@ import type {
   EventActorCheckpointFork,
   EventActorCommitResult,
   EventActorDiscardReason,
+  EventActorEvent,
   EventActorExecutionRequest,
   EventActorExecutionResult,
   EventActorExecutorOptions,
   EventActorHead,
   EventActorHostAdapter,
   EventActorInvocation,
+  EventActorInvocationResult,
   EventActorInvocationReference,
   EventActorPrepareRequest,
   EventActorPreparation,
@@ -23,7 +25,7 @@ const DEFAULT_MAX_DEPTH = 1;
 const DEFAULT_DORMANT_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1_000;
 
 function createInvocationCheckpointNs(
-  request: EventActorPrepareRequest<unknown>,
+  request: EventActorPrepareRequest<EventActorEvent>,
   attemptId = randomUUID()
 ): string {
   return `event-actor/${createHash('sha256')
@@ -34,6 +36,57 @@ function createInvocationCheckpointNs(
     .update(attemptId)
     .digest('hex')
     .slice(0, 32)}`;
+}
+
+function snapshotEvent<TEvent extends EventActorEvent>(event: TEvent): TEvent {
+  const ancestors = new WeakSet<object>();
+  const clone = (value: unknown): EventActorEvent => {
+    if (
+      value === null ||
+      typeof value === 'string' ||
+      typeof value === 'boolean'
+    ) {
+      return value;
+    }
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) {
+        throw new Error('Event actor event numbers must be finite');
+      }
+      return value;
+    }
+    if (typeof value !== 'object') {
+      throw new Error('Event actor events must contain only JSON values');
+    }
+    if (ancestors.has(value)) {
+      throw new Error('Event actor events must not contain cycles');
+    }
+    ancestors.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return Object.freeze(value.map((item) => clone(item)));
+      }
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error('Event actor events must contain only JSON objects');
+      }
+      if (Object.getOwnPropertySymbols(value).length > 0) {
+        throw new Error('Event actor events must not contain symbol keys');
+      }
+      const snapshot: Record<string, EventActorEvent> = {};
+      for (const [key, item] of Object.entries(value)) {
+        Object.defineProperty(snapshot, key, {
+          configurable: false,
+          enumerable: true,
+          writable: false,
+          value: clone(item),
+        });
+      }
+      return Object.freeze(snapshot);
+    } finally {
+      ancestors.delete(value);
+    }
+  };
+  return clone(event) as TEvent;
 }
 
 function snapshotHead(head: EventActorHead): EventActorHead {
@@ -57,24 +110,59 @@ function snapshotInvocationReference(
   };
 }
 
-function snapshotInvocation<TEvent>(
+function snapshotInvocation<TEvent extends EventActorEvent>(
   invocation: EventActorInvocation<TEvent>
 ): EventActorInvocation<TEvent> {
   return {
     ...snapshotInvocationReference(invocation),
-    event: invocation.event,
+    event: snapshotEvent(invocation.event),
   };
 }
 
-function snapshotPrepareRequest<TEvent>(
+function snapshotPrepareRequest<TEvent extends EventActorEvent>(
   request: EventActorPrepareRequest<TEvent>
 ): EventActorPrepareRequest<TEvent> {
   return {
     actorThreadId: request.actorThreadId,
     invocationId: request.invocationId,
     depth: request.depth,
-    event: request.event,
+    event: snapshotEvent(request.event),
   };
+}
+
+function freezeInvocationReference(
+  invocation: EventActorInvocationReference
+): EventActorInvocationReference {
+  const snapshot = snapshotInvocationReference(invocation);
+  if (snapshot.base.checkpoint != null) {
+    Object.freeze(snapshot.base.checkpoint);
+  }
+  Object.freeze(snapshot.base);
+  Object.freeze(snapshot.fork);
+  return Object.freeze(snapshot);
+}
+
+function freezeInvocation<TEvent extends EventActorEvent>(
+  invocation: EventActorInvocation<TEvent>
+): EventActorInvocation<TEvent> {
+  return Object.freeze({
+    ...freezeInvocationReference(invocation),
+    event: snapshotEvent(invocation.event),
+  });
+}
+
+function freezePrepareRequest<TEvent extends EventActorEvent>(
+  request: EventActorPrepareRequest<TEvent>
+): EventActorPrepareRequest<TEvent> {
+  return Object.freeze(snapshotPrepareRequest(request));
+}
+
+function freezeHead(head: EventActorHead): EventActorHead {
+  const snapshot = snapshotHead(head);
+  if (snapshot.checkpoint != null) {
+    Object.freeze(snapshot.checkpoint);
+  }
+  return Object.freeze(snapshot);
 }
 
 function snapshotAmbientConfig(
@@ -130,7 +218,7 @@ function validateHead(
   );
 }
 
-function validateInvocation<TEvent>(
+function validateInvocation<TEvent extends EventActorEvent>(
   request: EventActorPrepareRequest<TEvent>,
   invocation: EventActorInvocation<TEvent>,
   continuation: 'warm' | 'cold',
@@ -246,7 +334,8 @@ function validateTerminalCheckpoint(
     checkpoint.checkpointNs !== invocation.fork.checkpointNs ||
     checkpoint.checkpointId == null ||
     checkpoint.checkpointId.trim() === '' ||
-    checkpoint.checkpointId === invocation.fork.checkpointId
+    checkpoint.checkpointId === invocation.fork.checkpointId ||
+    checkpointIdsMatch(checkpoint, invocation.base.checkpoint)
   ) {
     throw new Error(
       'Event actor result escaped its invocation checkpoint fork'
@@ -378,9 +467,10 @@ function validateCommittedHead(
  * Runs one event against an isolated checkpoint fork and advances the stable
  * actor head only through the host's atomic commit interface.
  */
-export class EventActorExecutor<TEvent, TResult> {
+export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
   private readonly maxDepth: number;
   private readonly dormantCheckpointTtlMs: number;
+  private readonly issuedSettlements = new WeakSet<object>();
 
   constructor(
     private readonly adapter: EventActorHostAdapter<TEvent, TResult>,
@@ -411,7 +501,7 @@ export class EventActorExecutor<TEvent, TResult> {
     this.validatePrepareRequest(trustedRequest);
     const checkpointNs = createInvocationCheckpointNs(trustedRequest);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
-      ...trustedRequest,
+      ...snapshotPrepareRequest(trustedRequest),
       checkpointNs,
     };
     const preparation = await this.adapter.prepare({ ...adapterRequest });
@@ -423,20 +513,20 @@ export class EventActorExecutor<TEvent, TResult> {
         checkpointNs,
         this.maxDepth
       );
-      return {
+      return Object.freeze({
         status: 'ready',
-        invocation: {
+        invocation: freezeInvocation({
           ...snapshotInvocation(preparation.invocation),
-          event: trustedRequest.event,
-        },
-      };
+          event: snapshotEvent(trustedRequest.event),
+        }),
+      });
     } else {
       validateHead(preparation.head, trustedRequest.actorThreadId);
-      return {
+      return Object.freeze({
         status: 'checkpoint_unavailable',
-        request: snapshotPrepareRequest(trustedRequest),
-        head: snapshotHead(preparation.head),
-      };
+        request: freezePrepareRequest(trustedRequest),
+        head: freezeHead(preparation.head),
+      });
     }
   }
 
@@ -444,7 +534,8 @@ export class EventActorExecutor<TEvent, TResult> {
     preparation: Extract<
       EventActorPreparation<TEvent>,
       { status: 'checkpoint_unavailable' }
-    >
+    >,
+    signal?: AbortSignal
   ): Promise<EventActorInvocation<TEvent>> {
     const request = snapshotPrepareRequest(preparation.request);
     const trustedHead = snapshotHead(preparation.head);
@@ -456,13 +547,30 @@ export class EventActorExecutor<TEvent, TResult> {
     validateHead(trustedHead, request.actorThreadId);
     const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
-      ...request,
+      ...snapshotPrepareRequest(request),
       checkpointNs,
     };
-    const invocation = await this.adapter.coldContinue(
-      { ...adapterRequest },
-      snapshotHead(trustedHead)
-    );
+    const controller = new AbortController();
+    const abort = (): void => controller.abort(signal?.reason);
+    if (isAborted(signal)) {
+      abort();
+    } else {
+      signal?.addEventListener('abort', abort, { once: true });
+    }
+    if (isAborted(controller.signal)) {
+      signal?.removeEventListener('abort', abort);
+      throw asError(controller.signal.reason ?? 'Event actor cancelled');
+    }
+    let invocation;
+    try {
+      invocation = await this.adapter.coldContinue(
+        { ...adapterRequest },
+        snapshotHead(trustedHead),
+        { signal: controller.signal }
+      );
+    } finally {
+      signal?.removeEventListener('abort', abort);
+    }
     validateInvocation(
       request,
       invocation,
@@ -471,33 +579,52 @@ export class EventActorExecutor<TEvent, TResult> {
       this.maxDepth,
       trustedHead
     );
-    return {
+    const trustedInvocation: EventActorInvocation<TEvent> = {
       ...snapshotInvocation(invocation),
-      event: request.event,
+      event: snapshotEvent(request.event),
     };
+    if (isAborted(controller.signal)) {
+      await this.discard(
+        snapshotInvocationReference(trustedInvocation),
+        'cancelled'
+      );
+      throw asError(controller.signal.reason ?? 'Event actor cancelled');
+    }
+    return freezeInvocation(trustedInvocation);
   }
 
   async invoke(
     invocation: EventActorInvocation<TEvent>,
     signal?: AbortSignal
-  ): Promise<EventActorTerminalResult<TResult>> {
+  ): Promise<EventActorInvocationResult<TResult>> {
     const trustedInvocation = snapshotInvocation(invocation);
+    const settlementInvocation = snapshotInvocationReference(trustedInvocation);
     const terminal = await this.invokeWithConfig(
-      trustedInvocation,
+      snapshotInvocation(trustedInvocation),
       signal,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
     if (terminal.status === 'applied') {
-      return {
-        status: 'applied',
-        result: terminal.result,
-        checkpoint: { ...terminal.checkpoint },
-      };
+      return this.issueSettlement(settlementInvocation, terminal);
     }
-    return {
-      status: 'completed_no_action',
+    return Object.freeze({
+      status: 'completed_no_action' as const,
       ...(terminal.result === undefined ? {} : { result: terminal.result }),
-    };
+    });
+  }
+
+  private issueSettlement(
+    invocation: EventActorInvocationReference,
+    terminal: Extract<EventActorTerminalResult<TResult>, { status: 'applied' }>
+  ): EventActorAppliedResult<TResult> {
+    const settlement = Object.freeze({
+      status: 'applied' as const,
+      result: terminal.result,
+      checkpoint: Object.freeze({ ...terminal.checkpoint }),
+      invocation: freezeInvocationReference(invocation),
+    });
+    this.issuedSettlements.add(settlement);
+    return settlement;
   }
 
   private async invokeWithConfig(
@@ -548,18 +675,22 @@ export class EventActorExecutor<TEvent, TResult> {
   }
 
   async commit(
-    invocation: EventActorInvocationReference,
-    terminal: EventActorAppliedResult<TResult>
+    settlement: EventActorAppliedResult<TResult>
   ): Promise<EventActorCommitResult> {
-    const trustedInvocation = snapshotInvocationReference(invocation);
+    if (!this.issuedSettlements.has(settlement)) {
+      throw new Error('Event actor settlement was not issued by this executor');
+    }
+    const trustedInvocation = snapshotInvocationReference(
+      settlement.invocation
+    );
     validateInvocationReference(trustedInvocation, this.maxDepth);
-    const trustedCheckpoint = { ...terminal.checkpoint };
+    const trustedCheckpoint = { ...settlement.checkpoint };
     validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
     const committed = await this.adapter.commit({
       invocation: snapshotInvocationReference(trustedInvocation),
       expectedHead: snapshotHead(trustedInvocation.base),
       checkpoint: { ...trustedCheckpoint },
-      result: terminal.result,
+      result: settlement.result,
       retention: {
         committedCheckpoints: 2,
         dormantCheckpointTtlMs: this.dormantCheckpointTtlMs,
@@ -636,7 +767,7 @@ export class EventActorExecutor<TEvent, TResult> {
     const trustedRequest: EventActorExecutionRequest<TEvent> = {
       actorThreadId: request.actorThreadId,
       invocationId: request.invocationId,
-      event: request.event,
+      event: snapshotEvent(request.event),
       ...(request.depth == null ? {} : { depth: request.depth }),
       ...(request.signal == null ? {} : { signal: request.signal }),
     };
@@ -657,10 +788,21 @@ export class EventActorExecutor<TEvent, TResult> {
     ) {
       return { status: 'cancelled', continuation: 'cold' };
     }
-    const invocation =
-      preparation.status === 'ready'
-        ? preparation.invocation
-        : await this.coldContinue(preparation);
+    let invocation;
+    try {
+      invocation =
+        preparation.status === 'ready'
+          ? preparation.invocation
+          : await this.coldContinue(preparation, trustedRequest.signal);
+    } catch (error) {
+      if (
+        preparation.status === 'checkpoint_unavailable' &&
+        isAborted(trustedRequest.signal)
+      ) {
+        return { status: 'cancelled', continuation: 'cold' };
+      }
+      throw error;
+    }
     const continuation = preparation.status === 'ready' ? 'warm' : 'cold';
     const invocationReference = snapshotInvocationReference(invocation);
     const invocationForAdapter = snapshotInvocation(invocation);
@@ -706,14 +848,10 @@ export class EventActorExecutor<TEvent, TResult> {
         continuation,
       };
     }
-    const trustedTerminal: EventActorAppliedResult<TResult> = {
-      status: 'applied',
-      result: terminal.result,
-      checkpoint: { ...terminal.checkpoint },
-    };
+    const trustedTerminal = this.issueSettlement(invocationReference, terminal);
     let committed;
     try {
-      committed = await this.commit(invocationReference, trustedTerminal);
+      committed = await this.commit(trustedTerminal);
     } catch (error) {
       return {
         status: 'commit_indeterminate',
@@ -743,7 +881,10 @@ export class EventActorExecutor<TEvent, TResult> {
   }
 }
 
-export function createEventActorExecutor<TEvent, TResult>(
+export function createEventActorExecutor<
+  TEvent extends EventActorEvent,
+  TResult,
+>(
   adapter: EventActorHostAdapter<TEvent, TResult>,
   options: EventActorExecutorOptions = {}
 ): EventActorExecutor<TEvent, TResult> {

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -66,6 +66,33 @@ function snapshotInvocation<TEvent>(
   };
 }
 
+function snapshotPrepareRequest<TEvent>(
+  request: EventActorPrepareRequest<TEvent>
+): EventActorPrepareRequest<TEvent> {
+  return {
+    actorThreadId: request.actorThreadId,
+    invocationId: request.invocationId,
+    depth: request.depth,
+    event: request.event,
+  };
+}
+
+function snapshotAmbientConfig(
+  config: RunnableConfig | undefined
+): RunnableConfig | undefined {
+  if (config == null) {
+    return undefined;
+  }
+  return {
+    ...config,
+    ...(config.tags == null ? {} : { tags: [...config.tags] }),
+    ...(config.metadata == null ? {} : { metadata: { ...config.metadata } }),
+    ...(config.configurable == null
+      ? {}
+      : { configurable: { ...config.configurable } }),
+  };
+}
+
 function requireNonEmpty(value: string, name: string): void {
   if (value.trim() === '') {
     throw new Error(`${name} must not be empty`);
@@ -376,20 +403,21 @@ export class EventActorExecutor<TEvent, TResult> {
   async prepare(
     request: EventActorPrepareRequest<TEvent>
   ): Promise<EventActorPreparation<TEvent>> {
+    const trustedRequest = snapshotPrepareRequest(request);
     resolveExecutionDepth(
-      request.depth,
+      trustedRequest.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
-    this.validatePrepareRequest(request);
-    const checkpointNs = createInvocationCheckpointNs(request);
+    this.validatePrepareRequest(trustedRequest);
+    const checkpointNs = createInvocationCheckpointNs(trustedRequest);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
-      ...request,
+      ...trustedRequest,
       checkpointNs,
     };
     const preparation = await this.adapter.prepare({ ...adapterRequest });
     if (preparation.status === 'ready') {
       validateInvocation(
-        request,
+        trustedRequest,
         preparation.invocation,
         'warm',
         checkpointNs,
@@ -399,14 +427,14 @@ export class EventActorExecutor<TEvent, TResult> {
         status: 'ready',
         invocation: {
           ...snapshotInvocation(preparation.invocation),
-          event: request.event,
+          event: trustedRequest.event,
         },
       };
     } else {
-      validateHead(preparation.head, request.actorThreadId);
+      validateHead(preparation.head, trustedRequest.actorThreadId);
       return {
         status: 'checkpoint_unavailable',
-        request: { ...request, event: request.event },
+        request: snapshotPrepareRequest(trustedRequest),
         head: snapshotHead(preparation.head),
       };
     }
@@ -418,13 +446,13 @@ export class EventActorExecutor<TEvent, TResult> {
       { status: 'checkpoint_unavailable' }
     >
   ): Promise<EventActorInvocation<TEvent>> {
-    const request = preparation.request;
+    const request = snapshotPrepareRequest(preparation.request);
+    const trustedHead = snapshotHead(preparation.head);
     resolveExecutionDepth(
       request.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
     this.validatePrepareRequest(request);
-    const trustedHead = snapshotHead(preparation.head);
     validateHead(trustedHead, request.actorThreadId);
     const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
@@ -605,19 +633,27 @@ export class EventActorExecutor<TEvent, TResult> {
   async execute(
     request: EventActorExecutionRequest<TEvent>
   ): Promise<EventActorExecutionResult<TResult>> {
-    const ambientConfig =
-      AsyncLocalStorageProviderSingleton.getRunnableConfig();
-    const depth = resolveExecutionDepth(request.depth, ambientConfig);
-    const prepareRequest: EventActorPrepareRequest<TEvent> = {
+    const trustedRequest: EventActorExecutionRequest<TEvent> = {
       actorThreadId: request.actorThreadId,
       invocationId: request.invocationId,
-      depth,
       event: request.event,
+      ...(request.depth == null ? {} : { depth: request.depth }),
+      ...(request.signal == null ? {} : { signal: request.signal }),
+    };
+    const ambientConfig = snapshotAmbientConfig(
+      AsyncLocalStorageProviderSingleton.getRunnableConfig()
+    );
+    const depth = resolveExecutionDepth(trustedRequest.depth, ambientConfig);
+    const prepareRequest: EventActorPrepareRequest<TEvent> = {
+      actorThreadId: trustedRequest.actorThreadId,
+      invocationId: trustedRequest.invocationId,
+      depth,
+      event: trustedRequest.event,
     };
     const preparation = await this.prepare(prepareRequest);
     if (
       preparation.status === 'checkpoint_unavailable' &&
-      isAborted(request.signal)
+      isAborted(trustedRequest.signal)
     ) {
       return { status: 'cancelled', continuation: 'cold' };
     }
@@ -628,7 +664,7 @@ export class EventActorExecutor<TEvent, TResult> {
     const continuation = preparation.status === 'ready' ? 'warm' : 'cold';
     const invocationReference = snapshotInvocationReference(invocation);
     const invocationForAdapter = snapshotInvocation(invocation);
-    if (isAborted(request.signal)) {
+    if (isAborted(trustedRequest.signal)) {
       await this.discard(invocationReference, 'cancelled');
       return { status: 'cancelled', continuation };
     }
@@ -636,11 +672,11 @@ export class EventActorExecutor<TEvent, TResult> {
     try {
       terminal = await this.invokeWithConfig(
         invocationForAdapter,
-        request.signal,
+        trustedRequest.signal,
         ambientConfig
       );
     } catch (error) {
-      const reason = isAborted(request.signal) ? 'cancelled' : 'failed';
+      const reason = isAborted(trustedRequest.signal) ? 'cancelled' : 'failed';
       await this.discard(invocationReference, reason);
       if (reason === 'cancelled') {
         return { status: 'cancelled', continuation };

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -376,6 +376,10 @@ export class EventActorExecutor<TEvent, TResult> {
   async prepare(
     request: EventActorPrepareRequest<TEvent>
   ): Promise<EventActorPreparation<TEvent>> {
+    resolveExecutionDepth(
+      request.depth,
+      AsyncLocalStorageProviderSingleton.getRunnableConfig()
+    );
     this.validatePrepareRequest(request);
     const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
@@ -411,6 +415,10 @@ export class EventActorExecutor<TEvent, TResult> {
     request: EventActorPrepareRequest<TEvent>,
     head: EventActorHead
   ): Promise<EventActorInvocation<TEvent>> {
+    resolveExecutionDepth(
+      request.depth,
+      AsyncLocalStorageProviderSingleton.getRunnableConfig()
+    );
     this.validatePrepareRequest(request);
     const trustedHead = snapshotHead(head);
     validateHead(trustedHead, request.actorThreadId);
@@ -550,6 +558,7 @@ export class EventActorExecutor<TEvent, TResult> {
           committed.head.checkpoint,
           trustedInvocation.base.checkpoint
         ) ||
+        checkpointIdsMatch(committed.head.checkpoint, trustedInvocation.fork) ||
         checkpointsMatch(committed.head.checkpoint, trustedCheckpoint)
       ) {
         throw new Error(

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -110,6 +110,7 @@ function validateInvocation<TEvent>(
   checkpointNs: string,
   expectedHead?: EventActorInvocation<TEvent>['base']
 ): void {
+  validateInvocationReference(invocation);
   if (
     invocation.actorThreadId !== request.actorThreadId ||
     invocation.invocationId !== request.invocationId ||
@@ -127,15 +128,6 @@ function validateInvocation<TEvent>(
       'Event actor preparation returned mismatched checkpoint ownership'
     );
   }
-  validateHead(invocation.base, request.actorThreadId);
-  requireNonEmpty(invocation.fork.threadId, 'fork.threadId');
-  requireNonEmpty(invocation.fork.checkpointNs, 'fork.checkpointNs');
-  if (
-    invocation.base.checkpoint != null &&
-    invocation.fork.threadId !== invocation.base.checkpoint.threadId
-  ) {
-    throw new Error('Event actor fork changed its logical checkpoint thread');
-  }
   if (
     expectedHead != null &&
     (expectedHead.actorThreadId !== request.actorThreadId ||
@@ -148,6 +140,37 @@ function validateInvocation<TEvent>(
         expectedHead.checkpoint?.checkpointNs)
   ) {
     throw new Error('Cold continuation did not use the prepared actor head');
+  }
+}
+
+function validateInvocationReference(
+  invocation: EventActorInvocationReference
+): void {
+  requireNonEmpty(invocation.actorThreadId, 'actorThreadId');
+  requireNonEmpty(invocation.invocationId, 'invocationId');
+  if (!Number.isSafeInteger(invocation.depth) || invocation.depth < 1) {
+    throw new Error('Event actor invocation depth is invalid');
+  }
+  const continuation: unknown = invocation.continuation;
+  if (continuation !== 'warm' && continuation !== 'cold') {
+    throw new Error('Event actor invocation continuation is invalid');
+  }
+  validateHead(invocation.base, invocation.actorThreadId);
+  if (invocation.fork.invocationId !== invocation.invocationId) {
+    throw new Error(
+      'Event actor invocation has mismatched checkpoint ownership'
+    );
+  }
+  requireNonEmpty(invocation.fork.threadId, 'fork.threadId');
+  requireNonEmpty(invocation.fork.checkpointNs, 'fork.checkpointNs');
+  if (invocation.base.checkpoint != null) {
+    if (invocation.fork.threadId !== invocation.base.checkpoint.threadId) {
+      throw new Error('Event actor fork changed its logical checkpoint thread');
+    }
+    requireNonEmpty(
+      invocation.fork.checkpointId ?? '',
+      'fork.checkpointId for resumed actor'
+    );
   }
 }
 
@@ -437,6 +460,7 @@ export class EventActorExecutor<TEvent, TResult> {
     terminal: EventActorAppliedResult<TResult>
   ): Promise<EventActorCommitResult> {
     const trustedInvocation = snapshotInvocationReference(invocation);
+    validateInvocationReference(trustedInvocation);
     const trustedCheckpoint = { ...terminal.checkpoint };
     validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
     const committed = await this.adapter.commit({
@@ -478,8 +502,10 @@ export class EventActorExecutor<TEvent, TResult> {
     invocation: EventActorInvocationReference,
     reason: EventActorDiscardReason
   ): Promise<void> {
+    const trustedInvocation = snapshotInvocationReference(invocation);
+    validateInvocationReference(trustedInvocation);
     return this.adapter.discard({
-      invocation: snapshotInvocationReference(invocation),
+      invocation: trustedInvocation,
       reason,
     });
   }

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -1,0 +1,405 @@
+import { createHash } from 'node:crypto';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type {
+  EventActorAdapterPrepareRequest,
+  EventActorAppliedResult,
+  EventActorCheckpointFork,
+  EventActorCommitResult,
+  EventActorDiscardReason,
+  EventActorExecutionRequest,
+  EventActorExecutionResult,
+  EventActorExecutorOptions,
+  EventActorHead,
+  EventActorHostAdapter,
+  EventActorInvocation,
+  EventActorInvocationReference,
+  EventActorPrepareRequest,
+  EventActorPreparation,
+  EventActorTerminalResult,
+} from './types';
+
+const DEFAULT_MAX_DEPTH = 1;
+const DEFAULT_DORMANT_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1_000;
+
+function createInvocationCheckpointNs(
+  request: EventActorPrepareRequest<unknown>
+): string {
+  return `event-actor/${createHash('sha256')
+    .update(request.actorThreadId)
+    .update('\0')
+    .update(request.invocationId)
+    .digest('hex')
+    .slice(0, 32)}`;
+}
+
+function requireNonEmpty(value: string, name: string): void {
+  if (value.trim() === '') {
+    throw new Error(`${name} must not be empty`);
+  }
+}
+
+function validateHead(
+  head: EventActorHead,
+  actorThreadId: string,
+  checkpointRequired = false
+): void {
+  if (
+    head.actorThreadId !== actorThreadId ||
+    !Number.isSafeInteger(head.generation) ||
+    head.generation < 0
+  ) {
+    throw new Error('Event actor head is invalid');
+  }
+  if (head.checkpoint == null) {
+    if (checkpointRequired) {
+      throw new Error('Committed event actor head has no checkpoint');
+    }
+    return;
+  }
+  requireNonEmpty(head.checkpoint.threadId, 'head.checkpoint.threadId');
+  requireNonEmpty(head.checkpoint.checkpointNs, 'head.checkpoint.checkpointNs');
+  requireNonEmpty(
+    head.checkpoint.checkpointId ?? '',
+    'head.checkpoint.checkpointId'
+  );
+}
+
+function validateInvocation<TEvent>(
+  request: EventActorPrepareRequest<TEvent>,
+  invocation: EventActorInvocation<TEvent>,
+  continuation: 'warm' | 'cold',
+  checkpointNs: string,
+  expectedHead?: EventActorInvocation<TEvent>['base']
+): void {
+  if (
+    invocation.actorThreadId !== request.actorThreadId ||
+    invocation.invocationId !== request.invocationId ||
+    invocation.depth !== request.depth ||
+    invocation.continuation !== continuation
+  ) {
+    throw new Error('Event actor preparation returned a mismatched invocation');
+  }
+  if (
+    invocation.base.actorThreadId !== request.actorThreadId ||
+    invocation.fork.invocationId !== request.invocationId ||
+    invocation.fork.checkpointNs !== checkpointNs
+  ) {
+    throw new Error(
+      'Event actor preparation returned mismatched checkpoint ownership'
+    );
+  }
+  validateHead(invocation.base, request.actorThreadId);
+  requireNonEmpty(invocation.fork.threadId, 'fork.threadId');
+  requireNonEmpty(invocation.fork.checkpointNs, 'fork.checkpointNs');
+  if (
+    expectedHead != null &&
+    (expectedHead.actorThreadId !== request.actorThreadId ||
+      invocation.base.generation !== expectedHead.generation ||
+      invocation.base.checkpoint?.threadId !==
+        expectedHead.checkpoint?.threadId ||
+      invocation.base.checkpoint?.checkpointId !==
+        expectedHead.checkpoint?.checkpointId ||
+      invocation.base.checkpoint?.checkpointNs !==
+        expectedHead.checkpoint?.checkpointNs)
+  ) {
+    throw new Error('Cold continuation did not use the prepared actor head');
+  }
+}
+
+function validateTerminalCheckpoint(
+  invocation: EventActorInvocationReference,
+  checkpoint: EventActorCheckpointFork
+): void {
+  if (
+    checkpoint.invocationId !== invocation.invocationId ||
+    checkpoint.threadId !== invocation.fork.threadId ||
+    checkpoint.checkpointNs !== invocation.fork.checkpointNs ||
+    checkpoint.checkpointId == null ||
+    checkpoint.checkpointId.trim() === ''
+  ) {
+    throw new Error(
+      'Event actor result escaped its invocation checkpoint fork'
+    );
+  }
+}
+
+function createRunnableConfig(
+  invocation: EventActorInvocationReference,
+  signal: AbortSignal
+): RunnableConfig {
+  return {
+    signal,
+    configurable: {
+      thread_id: invocation.fork.threadId,
+      checkpoint_ns: invocation.fork.checkpointNs,
+      ...(invocation.fork.checkpointId == null
+        ? {}
+        : { checkpoint_id: invocation.fork.checkpointId }),
+      event_actor_thread_id: invocation.actorThreadId,
+      event_actor_invocation_id: invocation.invocationId,
+      event_actor_generation: invocation.base.generation,
+      event_actor_depth: invocation.depth,
+      event_actor_continuation: invocation.continuation,
+    },
+  };
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+function validateCommittedHead(
+  invocation: EventActorInvocationReference,
+  head: EventActorInvocationReference['base']
+): void {
+  validateHead(head, invocation.actorThreadId, true);
+  if (head.generation !== invocation.base.generation + 1) {
+    throw new Error('Event actor commit returned an invalid logical head');
+  }
+}
+
+/**
+ * Runs one event against an isolated checkpoint fork and advances the stable
+ * actor head only through the host's atomic commit interface.
+ */
+export class EventActorExecutor<TEvent, TResult> {
+  private readonly maxDepth: number;
+  private readonly dormantCheckpointTtlMs: number;
+
+  constructor(
+    private readonly adapter: EventActorHostAdapter<TEvent, TResult>,
+    options: EventActorExecutorOptions = {}
+  ) {
+    this.maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+    this.dormantCheckpointTtlMs =
+      options.dormantCheckpointTtlMs ?? DEFAULT_DORMANT_CHECKPOINT_TTL_MS;
+    if (!Number.isSafeInteger(this.maxDepth) || this.maxDepth < 1) {
+      throw new Error('maxDepth must be a positive safe integer');
+    }
+    if (
+      !Number.isSafeInteger(this.dormantCheckpointTtlMs) ||
+      this.dormantCheckpointTtlMs < 1
+    ) {
+      throw new Error('dormantCheckpointTtlMs must be a positive safe integer');
+    }
+  }
+
+  async prepare(
+    request: EventActorPrepareRequest<TEvent>
+  ): Promise<EventActorPreparation<TEvent>> {
+    this.validatePrepareRequest(request);
+    const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
+      ...request,
+      checkpointNs: createInvocationCheckpointNs(request),
+    };
+    const preparation = await this.adapter.prepare(adapterRequest);
+    if (preparation.status === 'ready') {
+      try {
+        validateInvocation(
+          request,
+          preparation.invocation,
+          'warm',
+          adapterRequest.checkpointNs
+        );
+      } catch (error) {
+        await this.adapter.discard({
+          invocation: preparation.invocation,
+          reason: 'failed',
+        });
+        throw error;
+      }
+    } else {
+      validateHead(preparation.head, request.actorThreadId);
+    }
+    return preparation;
+  }
+
+  async coldContinue(
+    request: EventActorPrepareRequest<TEvent>,
+    head: EventActorHead
+  ): Promise<EventActorInvocation<TEvent>> {
+    this.validatePrepareRequest(request);
+    const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
+      ...request,
+      checkpointNs: createInvocationCheckpointNs(request),
+    };
+    const invocation = await this.adapter.coldContinue(adapterRequest, head);
+    try {
+      validateInvocation(
+        request,
+        invocation,
+        'cold',
+        adapterRequest.checkpointNs,
+        head
+      );
+    } catch (error) {
+      await this.adapter.discard({ invocation, reason: 'failed' });
+      throw error;
+    }
+    return invocation;
+  }
+
+  async invoke(
+    invocation: EventActorInvocation<TEvent>,
+    signal?: AbortSignal
+  ): Promise<EventActorTerminalResult<TResult>> {
+    validateInvocation(
+      {
+        actorThreadId: invocation.actorThreadId,
+        invocationId: invocation.invocationId,
+        depth: invocation.depth,
+        event: invocation.event,
+      },
+      invocation,
+      invocation.continuation,
+      createInvocationCheckpointNs(invocation)
+    );
+    const controller = new AbortController();
+    const abort = (): void => controller.abort(signal?.reason);
+    if (isAborted(signal)) {
+      abort();
+    } else {
+      signal?.addEventListener('abort', abort, { once: true });
+    }
+    const config = createRunnableConfig(invocation, controller.signal);
+    try {
+      if (controller.signal.aborted) {
+        throw asError(controller.signal.reason ?? 'Event actor cancelled');
+      }
+      return await AsyncLocalStorageProviderSingleton.runWithConfig(
+        config,
+        () =>
+          this.adapter.invoke(invocation, {
+            signal: controller.signal,
+            config,
+          })
+      );
+    } finally {
+      signal?.removeEventListener('abort', abort);
+    }
+  }
+
+  async commit(
+    invocation: EventActorInvocationReference,
+    terminal: EventActorAppliedResult<TResult>
+  ): Promise<EventActorCommitResult> {
+    validateTerminalCheckpoint(invocation, terminal.checkpoint);
+    const committed = await this.adapter.commit({
+      invocation,
+      expectedHead: invocation.base,
+      checkpoint: terminal.checkpoint,
+      result: terminal.result,
+      retention: {
+        committedCheckpoints: 2,
+        dormantCheckpointTtlMs: this.dormantCheckpointTtlMs,
+      },
+    });
+    if (committed.status === 'committed') {
+      validateCommittedHead(invocation, committed.head);
+    }
+    return committed;
+  }
+
+  discard(
+    invocation: EventActorInvocationReference,
+    reason: EventActorDiscardReason
+  ): Promise<void> {
+    return this.adapter.discard({ invocation, reason });
+  }
+
+  private validatePrepareRequest(
+    request: EventActorPrepareRequest<TEvent>
+  ): void {
+    requireNonEmpty(request.actorThreadId, 'actorThreadId');
+    requireNonEmpty(request.invocationId, 'invocationId');
+    if (
+      !Number.isSafeInteger(request.depth) ||
+      request.depth < 1 ||
+      request.depth > this.maxDepth
+    ) {
+      throw new Error(
+        `Event actor depth ${request.depth} exceeds maximum ${this.maxDepth}`
+      );
+    }
+  }
+
+  async execute(
+    request: EventActorExecutionRequest<TEvent>
+  ): Promise<EventActorExecutionResult<TResult>> {
+    const depth = request.depth ?? 1;
+    const prepareRequest: EventActorPrepareRequest<TEvent> = {
+      actorThreadId: request.actorThreadId,
+      invocationId: request.invocationId,
+      depth,
+      event: request.event,
+    };
+    const preparation = await this.prepare(prepareRequest);
+    const invocation =
+      preparation.status === 'ready'
+        ? preparation.invocation
+        : await this.coldContinue(prepareRequest, preparation.head);
+    const continuation = preparation.status === 'ready' ? 'warm' : 'cold';
+    const invocationReference: EventActorInvocationReference = invocation;
+    if (isAborted(request.signal)) {
+      await this.discard(invocationReference, 'cancelled');
+      return { status: 'cancelled', continuation };
+    }
+    let terminal;
+    try {
+      terminal = await this.invoke(invocation, request.signal);
+    } catch (error) {
+      const reason = isAborted(request.signal) ? 'cancelled' : 'failed';
+      await this.discard(invocationReference, reason);
+      if (reason === 'cancelled') {
+        return { status: 'cancelled', continuation };
+      }
+      return { status: 'failed', error: asError(error), continuation };
+    }
+    if (isAborted(request.signal)) {
+      await this.discard(invocationReference, 'cancelled');
+      return { status: 'cancelled', continuation };
+    }
+    if (terminal.status === 'completed_no_action') {
+      await this.discard(invocationReference, 'completed_no_action');
+      return { status: 'completed_no_action', continuation };
+    }
+    try {
+      validateTerminalCheckpoint(invocationReference, terminal.checkpoint);
+    } catch (error) {
+      await this.discard(invocationReference, 'failed');
+      return { status: 'failed', error: asError(error), continuation };
+    }
+    let committed;
+    try {
+      committed = await this.commit(invocationReference, terminal);
+    } catch (error) {
+      return {
+        status: 'commit_indeterminate',
+        error: asError(error),
+        continuation,
+      };
+    }
+    if (committed.status === 'stale') {
+      await this.discard(invocationReference, 'stale');
+      return { status: 'stale', continuation };
+    }
+    return {
+      status: 'applied',
+      result: terminal.result,
+      head: committed.head,
+      continuation,
+    };
+  }
+}
+
+export function createEventActorExecutor<TEvent, TResult>(
+  adapter: EventActorHostAdapter<TEvent, TResult>,
+  options: EventActorExecutorOptions = {}
+): EventActorExecutor<TEvent, TResult> {
+  return new EventActorExecutor(adapter, options);
+}

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -16,6 +16,7 @@ import type {
   EventActorInvocation,
   EventActorInvocationResult,
   EventActorInvocationReference,
+  EventActorPreparedInvocation,
   EventActorPrepareRequest,
   EventActorPreparation,
   EventActorTerminalResult,
@@ -63,7 +64,22 @@ function snapshotEvent<TEvent extends EventActorEvent>(event: TEvent): TEvent {
     ancestors.add(value);
     try {
       if (Array.isArray(value)) {
-        return Object.freeze(value.map((item) => clone(item)));
+        if (Object.getOwnPropertySymbols(value).length > 0) {
+          throw new Error('Event actor event arrays must not contain symbols');
+        }
+        const snapshot: EventActorEvent[] = [];
+        for (let index = 0; index < value.length; index += 1) {
+          if (!Object.hasOwn(value, index)) {
+            throw new Error('Event actor event arrays must not contain holes');
+          }
+          snapshot.push(clone(value[index]));
+        }
+        if (Object.keys(value).length !== value.length) {
+          throw new Error(
+            'Event actor event arrays must not contain named properties'
+          );
+        }
+        return Object.freeze(snapshot);
       }
       const prototype = Object.getPrototypeOf(value);
       if (prototype !== Object.prototype && prototype !== null) {
@@ -73,7 +89,8 @@ function snapshotEvent<TEvent extends EventActorEvent>(event: TEvent): TEvent {
         throw new Error('Event actor events must not contain symbol keys');
       }
       const snapshot: Record<string, EventActorEvent> = {};
-      for (const [key, item] of Object.entries(value)) {
+      for (const key of Object.keys(value).sort()) {
+        const item = value[key as keyof typeof value];
         Object.defineProperty(snapshot, key, {
           configurable: false,
           enumerable: true,
@@ -149,6 +166,58 @@ function freezeInvocation<TEvent extends EventActorEvent>(
     ...freezeInvocationReference(invocation),
     event: snapshotEvent(invocation.event),
   });
+}
+
+function createPreparationDigest(value: object): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function createInvocationPreparationDigest<TEvent extends EventActorEvent>(
+  invocation: EventActorInvocation<TEvent>
+): string {
+  return createPreparationDigest({
+    kind: 'invocation',
+    actorThreadId: invocation.actorThreadId,
+    invocationId: invocation.invocationId,
+    depth: invocation.depth,
+    continuation: invocation.continuation,
+    base: invocation.base,
+    fork: invocation.fork,
+    event: invocation.event,
+  });
+}
+
+function createUnavailablePreparationDigest<TEvent extends EventActorEvent>(
+  request: EventActorPrepareRequest<TEvent>,
+  head: EventActorHead
+): string {
+  return createPreparationDigest({
+    kind: 'checkpoint_unavailable',
+    request,
+    head,
+  });
+}
+
+function createPreparedInvocation<TEvent extends EventActorEvent>(
+  invocation: EventActorInvocation<TEvent>
+): EventActorPreparedInvocation<TEvent> {
+  const trustedInvocation = freezeInvocation(invocation);
+  return Object.freeze({
+    ...trustedInvocation,
+    preparationDigest: createInvocationPreparationDigest(trustedInvocation),
+  });
+}
+
+function validatePreparedInvocation<TEvent extends EventActorEvent>(
+  invocation: EventActorPreparedInvocation<TEvent>
+): void {
+  requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
+  if (
+    invocation.preparationDigest !==
+    createInvocationPreparationDigest(invocation)
+  ) {
+    throw new Error('Event actor prepared invocation binding is invalid');
+  }
 }
 
 function freezePrepareRequest<TEvent extends EventActorEvent>(
@@ -427,6 +496,18 @@ function isAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true;
 }
 
+class EventActorPreparationCancelledError extends Error {
+  constructor(
+    readonly continuation: 'warm' | 'cold',
+    reason: unknown
+  ) {
+    super(`Event actor ${continuation} preparation was cancelled`, {
+      cause: reason,
+    });
+    this.name = 'EventActorPreparationCancelledError';
+  }
+}
+
 function resolveExecutionDepth(
   requestedDepth: number | undefined,
   ambientConfig: RunnableConfig | undefined
@@ -467,7 +548,10 @@ function validateCommittedHead(
  * Runs one event against an isolated checkpoint fork and advances the stable
  * actor head only through the host's atomic commit interface.
  */
-export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
+export class EventActorExecutor<
+  TEvent extends EventActorEvent,
+  TResult extends EventActorEvent,
+> {
   private readonly maxDepth: number;
   private readonly dormantCheckpointTtlMs: number;
   private readonly issuedSettlements = new WeakSet<object>();
@@ -491,7 +575,8 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
   }
 
   async prepare(
-    request: EventActorPrepareRequest<TEvent>
+    request: EventActorPrepareRequest<TEvent>,
+    signal?: AbortSignal
   ): Promise<EventActorPreparation<TEvent>> {
     const trustedRequest = snapshotPrepareRequest(request);
     resolveExecutionDepth(
@@ -504,7 +589,34 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
       ...snapshotPrepareRequest(trustedRequest),
       checkpointNs,
     };
-    const preparation = await this.adapter.prepare({ ...adapterRequest });
+    const controller = new AbortController();
+    const abort = (): void => controller.abort(signal?.reason);
+    if (isAborted(signal)) {
+      abort();
+    } else {
+      signal?.addEventListener('abort', abort, { once: true });
+    }
+    if (isAborted(controller.signal)) {
+      signal?.removeEventListener('abort', abort);
+      throw new EventActorPreparationCancelledError(
+        'warm',
+        controller.signal.reason
+      );
+    }
+    let preparation;
+    try {
+      preparation = await this.adapter.prepare(
+        { ...adapterRequest },
+        { signal: controller.signal }
+      );
+    } catch (error) {
+      if (isAborted(controller.signal) && error === controller.signal.reason) {
+        throw new EventActorPreparationCancelledError('warm', error);
+      }
+      throw error;
+    } finally {
+      signal?.removeEventListener('abort', abort);
+    }
     if (preparation.status === 'ready') {
       validateInvocation(
         trustedRequest,
@@ -513,19 +625,42 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
         checkpointNs,
         this.maxDepth
       );
+      const preparedInvocation = createPreparedInvocation({
+        ...snapshotInvocation(preparation.invocation),
+        event: snapshotEvent(trustedRequest.event),
+      });
+      if (isAborted(controller.signal)) {
+        await this.discard(
+          snapshotInvocationReference(preparedInvocation),
+          'cancelled'
+        );
+        throw new EventActorPreparationCancelledError(
+          'warm',
+          controller.signal.reason
+        );
+      }
       return Object.freeze({
         status: 'ready',
-        invocation: freezeInvocation({
-          ...snapshotInvocation(preparation.invocation),
-          event: snapshotEvent(trustedRequest.event),
-        }),
+        invocation: preparedInvocation,
       });
     } else {
       validateHead(preparation.head, trustedRequest.actorThreadId);
+      if (isAborted(controller.signal)) {
+        throw new EventActorPreparationCancelledError(
+          'warm',
+          controller.signal.reason
+        );
+      }
+      const preparedRequest = freezePrepareRequest(trustedRequest);
+      const preparedHead = freezeHead(preparation.head);
       return Object.freeze({
         status: 'checkpoint_unavailable',
-        request: freezePrepareRequest(trustedRequest),
-        head: freezeHead(preparation.head),
+        request: preparedRequest,
+        head: preparedHead,
+        preparationDigest: createUnavailablePreparationDigest(
+          preparedRequest,
+          preparedHead
+        ),
       });
     }
   }
@@ -536,7 +671,14 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
       { status: 'checkpoint_unavailable' }
     >,
     signal?: AbortSignal
-  ): Promise<EventActorInvocation<TEvent>> {
+  ): Promise<EventActorPreparedInvocation<TEvent>> {
+    requireNonEmpty(preparation.preparationDigest, 'preparationDigest');
+    if (
+      preparation.preparationDigest !==
+      createUnavailablePreparationDigest(preparation.request, preparation.head)
+    ) {
+      throw new Error('Event actor unavailable preparation binding is invalid');
+    }
     const request = snapshotPrepareRequest(preparation.request);
     const trustedHead = snapshotHead(preparation.head);
     resolveExecutionDepth(
@@ -559,7 +701,10 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
     }
     if (isAborted(controller.signal)) {
       signal?.removeEventListener('abort', abort);
-      throw asError(controller.signal.reason ?? 'Event actor cancelled');
+      throw new EventActorPreparationCancelledError(
+        'cold',
+        controller.signal.reason
+      );
     }
     let invocation;
     try {
@@ -568,6 +713,11 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
         snapshotHead(trustedHead),
         { signal: controller.signal }
       );
+    } catch (error) {
+      if (isAborted(controller.signal) && error === controller.signal.reason) {
+        throw new EventActorPreparationCancelledError('cold', error);
+      }
+      throw error;
     } finally {
       signal?.removeEventListener('abort', abort);
     }
@@ -588,15 +738,19 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
         snapshotInvocationReference(trustedInvocation),
         'cancelled'
       );
-      throw asError(controller.signal.reason ?? 'Event actor cancelled');
+      throw new EventActorPreparationCancelledError(
+        'cold',
+        controller.signal.reason
+      );
     }
-    return freezeInvocation(trustedInvocation);
+    return createPreparedInvocation(trustedInvocation);
   }
 
   async invoke(
-    invocation: EventActorInvocation<TEvent>,
+    invocation: EventActorPreparedInvocation<TEvent>,
     signal?: AbortSignal
   ): Promise<EventActorInvocationResult<TResult>> {
+    validatePreparedInvocation(invocation);
     const trustedInvocation = snapshotInvocation(invocation);
     const settlementInvocation = snapshotInvocationReference(trustedInvocation);
     const terminal = await this.invokeWithConfig(
@@ -609,7 +763,9 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
     }
     return Object.freeze({
       status: 'completed_no_action' as const,
-      ...(terminal.result === undefined ? {} : { result: terminal.result }),
+      ...(terminal.result === undefined
+        ? {}
+        : { result: snapshotEvent(terminal.result) }),
     });
   }
 
@@ -619,7 +775,7 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
   ): EventActorAppliedResult<TResult> {
     const settlement = Object.freeze({
       status: 'applied' as const,
-      result: terminal.result,
+      result: snapshotEvent(terminal.result),
       checkpoint: Object.freeze({ ...terminal.checkpoint }),
       invocation: freezeInvocationReference(invocation),
     });
@@ -781,7 +937,15 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
       depth,
       event: trustedRequest.event,
     };
-    const preparation = await this.prepare(prepareRequest);
+    let preparation;
+    try {
+      preparation = await this.prepare(prepareRequest, trustedRequest.signal);
+    } catch (error) {
+      if (error instanceof EventActorPreparationCancelledError) {
+        return { status: 'cancelled', continuation: error.continuation };
+      }
+      throw error;
+    }
     if (
       preparation.status === 'checkpoint_unavailable' &&
       isAborted(trustedRequest.signal)
@@ -795,10 +959,7 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
           ? preparation.invocation
           : await this.coldContinue(preparation, trustedRequest.signal);
     } catch (error) {
-      if (
-        preparation.status === 'checkpoint_unavailable' &&
-        isAborted(trustedRequest.signal)
-      ) {
+      if (error instanceof EventActorPreparationCancelledError) {
         return { status: 'cancelled', continuation: 'cold' };
       }
       throw error;
@@ -826,10 +987,14 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
       return { status: 'failed', error: asError(error), continuation };
     }
     if (terminal.status === 'completed_no_action') {
+      const result =
+        terminal.result === undefined
+          ? undefined
+          : snapshotEvent(terminal.result);
       await this.discard(invocationReference, 'completed_no_action');
       return {
         status: 'completed_no_action',
-        ...(terminal.result === undefined ? {} : { result: terminal.result }),
+        ...(result === undefined ? {} : { result }),
         continuation,
       };
     }
@@ -883,7 +1048,7 @@ export class EventActorExecutor<TEvent extends EventActorEvent, TResult> {
 
 export function createEventActorExecutor<
   TEvent extends EventActorEvent,
-  TResult,
+  TResult extends EventActorEvent,
 >(
   adapter: EventActorHostAdapter<TEvent, TResult>,
   options: EventActorExecutorOptions = {}

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
@@ -23,14 +23,47 @@ const DEFAULT_MAX_DEPTH = 1;
 const DEFAULT_DORMANT_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1_000;
 
 function createInvocationCheckpointNs(
-  request: EventActorPrepareRequest<unknown>
+  request: EventActorPrepareRequest<unknown>,
+  attemptId = randomUUID()
 ): string {
   return `event-actor/${createHash('sha256')
     .update(request.actorThreadId)
     .update('\0')
     .update(request.invocationId)
+    .update('\0')
+    .update(attemptId)
     .digest('hex')
     .slice(0, 32)}`;
+}
+
+function snapshotHead(head: EventActorHead): EventActorHead {
+  return {
+    actorThreadId: head.actorThreadId,
+    generation: head.generation,
+    ...(head.checkpoint == null ? {} : { checkpoint: { ...head.checkpoint } }),
+  };
+}
+
+function snapshotInvocationReference(
+  invocation: EventActorInvocationReference
+): EventActorInvocationReference {
+  return {
+    actorThreadId: invocation.actorThreadId,
+    invocationId: invocation.invocationId,
+    depth: invocation.depth,
+    continuation: invocation.continuation,
+    base: snapshotHead(invocation.base),
+    fork: { ...invocation.fork },
+  };
+}
+
+function snapshotInvocation<TEvent>(
+  invocation: EventActorInvocation<TEvent>
+): EventActorInvocation<TEvent> {
+  return {
+    ...snapshotInvocationReference(invocation),
+    event: invocation.event,
+  };
 }
 
 function requireNonEmpty(value: string, name: string): void {
@@ -131,6 +164,18 @@ function createRunnableConfig(
   signal: AbortSignal,
   ambient?: RunnableConfig
 ): RunnableConfig {
+  const configurable: Record<string, unknown> = {
+    ...(ambient?.configurable ?? {}),
+  };
+  delete configurable.thread_id;
+  delete configurable.checkpoint_ns;
+  delete configurable.checkpoint_id;
+  delete configurable.checkpoint_map;
+  delete configurable.event_actor_thread_id;
+  delete configurable.event_actor_invocation_id;
+  delete configurable.event_actor_generation;
+  delete configurable.event_actor_depth;
+  delete configurable.event_actor_continuation;
   return {
     signal,
     ...(ambient?.callbacks == null ? {} : { callbacks: ambient.callbacks }),
@@ -144,6 +189,7 @@ function createRunnableConfig(
       eventActorContinuation: invocation.continuation,
     },
     configurable: {
+      ...configurable,
       thread_id: invocation.fork.threadId,
       checkpoint_ns: invocation.fork.checkpointNs,
       ...(invocation.fork.checkpointId == null
@@ -235,17 +281,22 @@ export class EventActorExecutor<TEvent, TResult> {
     head: EventActorHead
   ): Promise<EventActorInvocation<TEvent>> {
     this.validatePrepareRequest(request);
+    const trustedHead = snapshotHead(head);
+    validateHead(trustedHead, request.actorThreadId);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
       ...request,
       checkpointNs: createInvocationCheckpointNs(request),
     };
-    const invocation = await this.adapter.coldContinue(adapterRequest, head);
+    const invocation = await this.adapter.coldContinue(
+      adapterRequest,
+      snapshotHead(trustedHead)
+    );
     validateInvocation(
       request,
       invocation,
       'cold',
       adapterRequest.checkpointNs,
-      head
+      trustedHead
     );
     return invocation;
   }
@@ -254,8 +305,9 @@ export class EventActorExecutor<TEvent, TResult> {
     invocation: EventActorInvocation<TEvent>,
     signal?: AbortSignal
   ): Promise<EventActorTerminalResult<TResult>> {
+    const trustedInvocation = snapshotInvocation(invocation);
     return this.invokeWithConfig(
-      invocation,
+      trustedInvocation,
       signal,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
@@ -275,7 +327,7 @@ export class EventActorExecutor<TEvent, TResult> {
       },
       invocation,
       invocation.continuation,
-      createInvocationCheckpointNs(invocation)
+      invocation.fork.checkpointNs
     );
     const controller = new AbortController();
     const abort = (): void => controller.abort(signal?.reason);
@@ -310,11 +362,13 @@ export class EventActorExecutor<TEvent, TResult> {
     invocation: EventActorInvocationReference,
     terminal: EventActorAppliedResult<TResult>
   ): Promise<EventActorCommitResult> {
-    validateTerminalCheckpoint(invocation, terminal.checkpoint);
+    const trustedInvocation = snapshotInvocationReference(invocation);
+    const trustedCheckpoint = { ...terminal.checkpoint };
+    validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
     const committed = await this.adapter.commit({
-      invocation,
-      expectedHead: invocation.base,
-      checkpoint: terminal.checkpoint,
+      invocation: snapshotInvocationReference(trustedInvocation),
+      expectedHead: snapshotHead(trustedInvocation.base),
+      checkpoint: { ...trustedCheckpoint },
       result: terminal.result,
       retention: {
         committedCheckpoints: 2,
@@ -322,7 +376,11 @@ export class EventActorExecutor<TEvent, TResult> {
       },
     });
     if (committed.status === 'committed') {
-      validateCommittedHead(invocation, terminal.checkpoint, committed.head);
+      validateCommittedHead(
+        trustedInvocation,
+        trustedCheckpoint,
+        committed.head
+      );
     }
     return committed;
   }
@@ -331,7 +389,10 @@ export class EventActorExecutor<TEvent, TResult> {
     invocation: EventActorInvocationReference,
     reason: EventActorDiscardReason
   ): Promise<void> {
-    return this.adapter.discard({ invocation, reason });
+    return this.adapter.discard({
+      invocation: snapshotInvocationReference(invocation),
+      reason,
+    });
   }
 
   private validatePrepareRequest(
@@ -368,7 +429,8 @@ export class EventActorExecutor<TEvent, TResult> {
         ? preparation.invocation
         : await this.coldContinue(prepareRequest, preparation.head);
     const continuation = preparation.status === 'ready' ? 'warm' : 'cold';
-    const invocationReference: EventActorInvocationReference = invocation;
+    const invocationReference = snapshotInvocationReference(invocation);
+    const invocationForAdapter = snapshotInvocation(invocation);
     if (isAborted(request.signal)) {
       await this.discard(invocationReference, 'cancelled');
       return { status: 'cancelled', continuation };
@@ -376,7 +438,7 @@ export class EventActorExecutor<TEvent, TResult> {
     let terminal;
     try {
       terminal = await this.invokeWithConfig(
-        invocation,
+        invocationForAdapter,
         request.signal,
         ambientConfig
       );
@@ -409,8 +471,12 @@ export class EventActorExecutor<TEvent, TResult> {
       };
     }
     if (committed.status === 'stale') {
-      await this.discard(invocationReference, 'stale');
-      return { status: 'stale', continuation };
+      return {
+        status: 'commit_conflict',
+        result: terminal.result,
+        checkpoint: { ...terminal.checkpoint },
+        continuation,
+      };
     }
     return {
       status: 'applied',

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -1,3 +1,4 @@
+import { isGraphInterrupt, isParentCommand } from '@langchain/langgraph';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import {
   createHash,
@@ -11,6 +12,7 @@ import type {
   EventActorAdapterPrepareRequest,
   EventActorAppliedResult,
   EventActorCheckpointFork,
+  EventActorCheckpointReference,
   EventActorCommitResult,
   EventActorDiscardReason,
   EventActorEvent,
@@ -19,6 +21,7 @@ import type {
   EventActorExecutorOptions,
   EventActorHead,
   EventActorHostAdapter,
+  EventActorIndeterminateResult,
   EventActorInvocation,
   EventActorInvocationResult,
   EventActorInvocationReference,
@@ -59,7 +62,7 @@ function snapshotEvent<TEvent extends EventActorEvent>(event: TEvent): TEvent {
       if (!Number.isFinite(value)) {
         throw new Error('Event actor event numbers must be finite');
       }
-      return value;
+      return Object.is(value, -0) ? 0 : value;
     }
     if (typeof value !== 'object') {
       throw new Error('Event actor events must contain only JSON values');
@@ -112,11 +115,34 @@ function snapshotEvent<TEvent extends EventActorEvent>(event: TEvent): TEvent {
   return clone(event) as TEvent;
 }
 
+function snapshotCheckpointReference(
+  checkpoint: EventActorCheckpointReference
+): EventActorCheckpointReference {
+  return {
+    threadId: checkpoint.threadId,
+    ...(checkpoint.checkpointId == null
+      ? {}
+      : { checkpointId: checkpoint.checkpointId }),
+    checkpointNs: checkpoint.checkpointNs,
+  };
+}
+
+function snapshotCheckpointFork(
+  checkpoint: EventActorCheckpointFork
+): EventActorCheckpointFork {
+  return {
+    ...snapshotCheckpointReference(checkpoint),
+    invocationId: checkpoint.invocationId,
+  };
+}
+
 function snapshotHead(head: EventActorHead): EventActorHead {
   return {
     actorThreadId: head.actorThreadId,
     generation: head.generation,
-    ...(head.checkpoint == null ? {} : { checkpoint: { ...head.checkpoint } }),
+    ...(head.checkpoint == null
+      ? {}
+      : { checkpoint: snapshotCheckpointReference(head.checkpoint) }),
   };
 }
 
@@ -129,7 +155,7 @@ function snapshotInvocationReference(
     depth: invocation.depth,
     continuation: invocation.continuation,
     base: snapshotHead(invocation.base),
-    fork: { ...invocation.fork },
+    fork: snapshotCheckpointFork(invocation.fork),
   };
 }
 
@@ -510,6 +536,48 @@ function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+type EventActorAppliedSnapshot<TResult extends EventActorEvent> = {
+  status: 'snapshot_ready';
+  result: TResult;
+  checkpoint: EventActorCheckpointFork;
+  invocation: EventActorInvocationReference;
+};
+
+function createIndeterminateResult<TResult extends EventActorEvent>(
+  invocation: EventActorInvocationReference,
+  error: unknown,
+  result?: TResult
+): EventActorIndeterminateResult<TResult> {
+  return Object.freeze({
+    status: 'commit_indeterminate',
+    ...(result === undefined ? {} : { result }),
+    checkpoint: Object.freeze({
+      invocationId: invocation.fork.invocationId,
+      threadId: invocation.fork.threadId,
+      checkpointNs: invocation.fork.checkpointNs,
+    }),
+    error: asError(error),
+  });
+}
+
+function snapshotAppliedTerminal<TResult extends EventActorEvent>(
+  invocation: EventActorInvocationReference,
+  terminal: Extract<EventActorTerminalResult<TResult>, { status: 'applied' }>
+): EventActorAppliedSnapshot<TResult> | EventActorIndeterminateResult<TResult> {
+  let result: TResult | undefined;
+  try {
+    result = snapshotEvent(terminal.result);
+    return {
+      status: 'snapshot_ready',
+      result,
+      checkpoint: snapshotCheckpointFork(terminal.checkpoint),
+      invocation: freezeInvocationReference(invocation),
+    };
+  } catch (error) {
+    return createIndeterminateResult(invocation, error, result);
+  }
+}
+
 function isAborted(signal?: AbortSignal): boolean {
   return signal?.aborted === true;
 }
@@ -570,17 +638,19 @@ export class EventActorExecutor<
   TEvent extends EventActorEvent,
   TResult extends EventActorEvent,
 > {
-  private readonly maxDepth: number;
-  private readonly dormantCheckpointTtlMs: number;
-  private readonly preparationSigningKey: Uint8Array;
-  private readonly issuedSettlements = new WeakSet<object>();
+  readonly #adapter: EventActorHostAdapter<TEvent, TResult>;
+  readonly #maxDepth: number;
+  readonly #dormantCheckpointTtlMs: number;
+  readonly #preparationSigningKey: Uint8Array;
+  readonly #issuedSettlements = new WeakSet<object>();
 
   constructor(
-    private readonly adapter: EventActorHostAdapter<TEvent, TResult>,
+    adapter: EventActorHostAdapter<TEvent, TResult>,
     options: EventActorExecutorOptions = {}
   ) {
-    this.maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
-    this.dormantCheckpointTtlMs =
+    this.#adapter = adapter;
+    this.#maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+    this.#dormantCheckpointTtlMs =
       options.dormantCheckpointTtlMs ?? DEFAULT_DORMANT_CHECKPOINT_TTL_MS;
     const signingKey = Buffer.from(
       options.preparationSigningKey ?? randomBytes(32)
@@ -588,55 +658,52 @@ export class EventActorExecutor<
     if (signingKey.byteLength < 32) {
       throw new Error('preparationSigningKey must contain at least 32 bytes');
     }
-    this.preparationSigningKey = signingKey;
-    if (!Number.isSafeInteger(this.maxDepth) || this.maxDepth < 1) {
+    this.#preparationSigningKey = signingKey;
+    if (!Number.isSafeInteger(this.#maxDepth) || this.#maxDepth < 1) {
       throw new Error('maxDepth must be a positive safe integer');
     }
     if (
-      !Number.isSafeInteger(this.dormantCheckpointTtlMs) ||
-      this.dormantCheckpointTtlMs < 1
+      !Number.isSafeInteger(this.#dormantCheckpointTtlMs) ||
+      this.#dormantCheckpointTtlMs < 1
     ) {
       throw new Error('dormantCheckpointTtlMs must be a positive safe integer');
     }
   }
 
-  private signPreparation(payload: string): string {
-    return createHmac('sha256', this.preparationSigningKey)
+  #signPreparation(payload: string): string {
+    return createHmac('sha256', this.#preparationSigningKey)
       .update(payload)
       .digest('hex');
   }
 
-  private preparationSignatureMatches(
-    signature: string,
-    payload: string
-  ): boolean {
+  #preparationSignatureMatches(signature: string, payload: string): boolean {
     if (!/^[a-f0-9]{64}$/.test(signature)) {
       return false;
     }
     return timingSafeEqual(
       Buffer.from(signature, 'hex'),
-      Buffer.from(this.signPreparation(payload), 'hex')
+      Buffer.from(this.#signPreparation(payload), 'hex')
     );
   }
 
-  private createPreparedInvocation(
+  #createPreparedInvocation(
     invocation: EventActorInvocation<TEvent>
   ): EventActorPreparedInvocation<TEvent> {
     const trustedInvocation = freezeInvocation(invocation);
     return Object.freeze({
       ...trustedInvocation,
-      preparationDigest: this.signPreparation(
+      preparationDigest: this.#signPreparation(
         serializeInvocationPreparation(trustedInvocation)
       ),
     });
   }
 
-  private validatePreparedInvocation(
+  #validatePreparedInvocation(
     invocation: EventActorPreparedInvocation<TEvent>
   ): void {
     requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
     if (
-      !this.preparationSignatureMatches(
+      !this.#preparationSignatureMatches(
         invocation.preparationDigest,
         serializeInvocationPreparation(invocation)
       )
@@ -654,7 +721,7 @@ export class EventActorExecutor<
       trustedRequest.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
-    this.validatePrepareRequest(trustedRequest);
+    this.#validatePrepareRequest(trustedRequest);
     const checkpointNs = createInvocationCheckpointNs(trustedRequest);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
       ...snapshotPrepareRequest(trustedRequest),
@@ -676,7 +743,7 @@ export class EventActorExecutor<
     }
     let preparation;
     try {
-      preparation = await this.adapter.prepare(
+      preparation = await this.#adapter.prepare(
         { ...adapterRequest },
         { signal: controller.signal }
       );
@@ -695,14 +762,14 @@ export class EventActorExecutor<
         adapterInvocation,
         'warm',
         checkpointNs,
-        this.maxDepth
+        this.#maxDepth
       );
-      const preparedInvocation = this.createPreparedInvocation({
+      const preparedInvocation = this.#createPreparedInvocation({
         ...adapterInvocation,
         event: snapshotEvent(trustedRequest.event),
       });
       if (isAborted(controller.signal)) {
-        await this.discardInvocationReference(
+        await this.#discardInvocationReference(
           snapshotInvocationReference(preparedInvocation),
           'cancelled'
         );
@@ -729,7 +796,7 @@ export class EventActorExecutor<
         status: 'checkpoint_unavailable',
         request: preparedRequest,
         head: preparedHead,
-        preparationDigest: this.signPreparation(
+        preparationDigest: this.#signPreparation(
           serializeUnavailablePreparation(preparedRequest, preparedHead)
         ),
       });
@@ -748,7 +815,7 @@ export class EventActorExecutor<
     const preparationDigest = preparation.preparationDigest;
     requireNonEmpty(preparationDigest, 'preparationDigest');
     if (
-      !this.preparationSignatureMatches(
+      !this.#preparationSignatureMatches(
         preparationDigest,
         serializeUnavailablePreparation(request, trustedHead)
       )
@@ -759,7 +826,7 @@ export class EventActorExecutor<
       request.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
-    this.validatePrepareRequest(request);
+    this.#validatePrepareRequest(request);
     validateHead(trustedHead, request.actorThreadId);
     const checkpointNs = createInvocationCheckpointNs(request);
     const adapterRequest: EventActorAdapterPrepareRequest<TEvent> = {
@@ -782,7 +849,7 @@ export class EventActorExecutor<
     }
     let invocation;
     try {
-      invocation = await this.adapter.coldContinue(
+      invocation = await this.#adapter.coldContinue(
         { ...adapterRequest },
         snapshotHead(trustedHead),
         { signal: controller.signal }
@@ -801,7 +868,7 @@ export class EventActorExecutor<
       adapterInvocation,
       'cold',
       checkpointNs,
-      this.maxDepth,
+      this.#maxDepth,
       trustedHead
     );
     const trustedInvocation: EventActorInvocation<TEvent> = {
@@ -809,7 +876,7 @@ export class EventActorExecutor<
       event: snapshotEvent(request.event),
     };
     if (isAborted(controller.signal)) {
-      await this.discardInvocationReference(
+      await this.#discardInvocationReference(
         snapshotInvocationReference(trustedInvocation),
         'cancelled'
       );
@@ -818,7 +885,7 @@ export class EventActorExecutor<
         controller.signal.reason
       );
     }
-    return this.createPreparedInvocation(trustedInvocation);
+    return this.#createPreparedInvocation(trustedInvocation);
   }
 
   async invoke(
@@ -826,15 +893,18 @@ export class EventActorExecutor<
     signal?: AbortSignal
   ): Promise<EventActorInvocationResult<TResult>> {
     const trustedInvocation = snapshotPreparedInvocation(invocation);
-    this.validatePreparedInvocation(trustedInvocation);
+    this.#validatePreparedInvocation(trustedInvocation);
     const settlementInvocation = snapshotInvocationReference(trustedInvocation);
-    const terminal = await this.invokeWithConfig(
+    const terminal = await this.#invokeWithConfig(
       snapshotInvocation(trustedInvocation),
       signal,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
     );
     if (terminal.status === 'applied') {
-      return this.issueSettlement(settlementInvocation, terminal);
+      const snapshot = snapshotAppliedTerminal(settlementInvocation, terminal);
+      return snapshot.status === 'snapshot_ready'
+        ? this.#issueSettlement(snapshot)
+        : snapshot;
     }
     return Object.freeze({
       status: 'completed_no_action' as const,
@@ -844,21 +914,20 @@ export class EventActorExecutor<
     });
   }
 
-  private issueSettlement(
-    invocation: EventActorInvocationReference,
-    terminal: Extract<EventActorTerminalResult<TResult>, { status: 'applied' }>
+  #issueSettlement(
+    snapshot: EventActorAppliedSnapshot<TResult>
   ): EventActorAppliedResult<TResult> {
     const settlement = Object.freeze({
       status: 'applied' as const,
-      result: snapshotEvent(terminal.result),
-      checkpoint: Object.freeze({ ...terminal.checkpoint }),
-      invocation: freezeInvocationReference(invocation),
+      result: snapshot.result,
+      checkpoint: Object.freeze(snapshotCheckpointFork(snapshot.checkpoint)),
+      invocation: freezeInvocationReference(snapshot.invocation),
     });
-    this.issuedSettlements.add(settlement);
+    this.#issuedSettlements.add(settlement);
     return settlement;
   }
 
-  private async invokeWithConfig(
+  async #invokeWithConfig(
     invocation: EventActorInvocation<TEvent>,
     signal: AbortSignal | undefined,
     ambientConfig: RunnableConfig | undefined
@@ -874,7 +943,7 @@ export class EventActorExecutor<
       invocation,
       invocation.continuation,
       invocation.fork.checkpointNs,
-      this.maxDepth
+      this.#maxDepth
     );
     const controller = new AbortController();
     const abort = (): void => controller.abort(signal?.reason);
@@ -895,7 +964,7 @@ export class EventActorExecutor<
       return await AsyncLocalStorageProviderSingleton.runWithConfig(
         config,
         () =>
-          this.adapter.invoke(invocation, {
+          this.#adapter.invoke(invocation, {
             signal: controller.signal,
             config,
           })
@@ -908,23 +977,23 @@ export class EventActorExecutor<
   async commit(
     settlement: EventActorAppliedResult<TResult>
   ): Promise<EventActorCommitResult> {
-    if (!this.issuedSettlements.has(settlement)) {
+    if (!this.#issuedSettlements.has(settlement)) {
       throw new Error('Event actor settlement was not issued by this executor');
     }
     const trustedInvocation = snapshotInvocationReference(
       settlement.invocation
     );
-    validateInvocationReference(trustedInvocation, this.maxDepth);
-    const trustedCheckpoint = { ...settlement.checkpoint };
+    validateInvocationReference(trustedInvocation, this.#maxDepth);
+    const trustedCheckpoint = snapshotCheckpointFork(settlement.checkpoint);
     validateTerminalCheckpoint(trustedInvocation, trustedCheckpoint);
-    const committed = await this.adapter.commit({
+    const committed = await this.#adapter.commit({
       invocation: snapshotInvocationReference(trustedInvocation),
       expectedHead: snapshotHead(trustedInvocation.base),
       checkpoint: { ...trustedCheckpoint },
       result: settlement.result,
       retention: {
         committedCheckpoints: 2,
-        dormantCheckpointTtlMs: this.dormantCheckpointTtlMs,
+        dormantCheckpointTtlMs: this.#dormantCheckpointTtlMs,
       },
     });
     if (committed.status === 'committed') {
@@ -971,34 +1040,32 @@ export class EventActorExecutor<
     reason: EventActorDiscardReason
   ): Promise<void> {
     const trustedInvocation = snapshotPreparedInvocation(invocation);
-    this.validatePreparedInvocation(trustedInvocation);
-    return this.discardInvocationReference(trustedInvocation, reason);
+    this.#validatePreparedInvocation(trustedInvocation);
+    return this.#discardInvocationReference(trustedInvocation, reason);
   }
 
-  private discardInvocationReference(
+  #discardInvocationReference(
     invocation: EventActorInvocationReference,
     reason: EventActorDiscardReason
   ): Promise<void> {
     const trustedInvocation = snapshotInvocationReference(invocation);
-    validateInvocationReference(trustedInvocation, this.maxDepth);
-    return this.adapter.discard({
+    validateInvocationReference(trustedInvocation, this.#maxDepth);
+    return this.#adapter.discard({
       invocation: trustedInvocation,
       reason,
     });
   }
 
-  private validatePrepareRequest(
-    request: EventActorPrepareRequest<TEvent>
-  ): void {
+  #validatePrepareRequest(request: EventActorPrepareRequest<TEvent>): void {
     requireNonEmpty(request.actorThreadId, 'actorThreadId');
     requireNonEmpty(request.invocationId, 'invocationId');
     if (
       !Number.isSafeInteger(request.depth) ||
       request.depth < 1 ||
-      request.depth > this.maxDepth
+      request.depth > this.#maxDepth
     ) {
       throw new Error(
-        `Event actor depth ${request.depth} exceeds maximum ${this.maxDepth}`
+        `Event actor depth ${request.depth} exceeds maximum ${this.#maxDepth}`
       );
     }
   }
@@ -1054,19 +1121,22 @@ export class EventActorExecutor<
     const invocationReference = snapshotInvocationReference(invocation);
     const invocationForAdapter = snapshotInvocation(invocation);
     if (isAborted(trustedRequest.signal)) {
-      await this.discardInvocationReference(invocationReference, 'cancelled');
+      await this.#discardInvocationReference(invocationReference, 'cancelled');
       return { status: 'cancelled', continuation };
     }
     let terminal;
     try {
-      terminal = await this.invokeWithConfig(
+      terminal = await this.#invokeWithConfig(
         invocationForAdapter,
         trustedRequest.signal,
         ambientConfig
       );
     } catch (error) {
+      if (isGraphInterrupt(error) || isParentCommand(error)) {
+        throw error;
+      }
       const reason = isAborted(trustedRequest.signal) ? 'cancelled' : 'failed';
-      await this.discardInvocationReference(invocationReference, reason);
+      await this.#discardInvocationReference(invocationReference, reason);
       if (reason === 'cancelled') {
         return { status: 'cancelled', continuation };
       }
@@ -1077,7 +1147,7 @@ export class EventActorExecutor<
         terminal.result === undefined
           ? undefined
           : snapshotEvent(terminal.result);
-      await this.discardInvocationReference(
+      await this.#discardInvocationReference(
         invocationReference,
         'completed_no_action'
       );
@@ -1087,28 +1157,29 @@ export class EventActorExecutor<
         continuation,
       };
     }
-    const trustedResult = snapshotEvent(terminal.result);
-    const trustedCheckpoint = { ...terminal.checkpoint };
+    const appliedSnapshot = snapshotAppliedTerminal(
+      invocationReference,
+      terminal
+    );
+    if (appliedSnapshot.status === 'commit_indeterminate') {
+      return { ...appliedSnapshot, continuation };
+    }
     try {
-      validateTerminalCheckpoint(invocationReference, trustedCheckpoint);
+      validateTerminalCheckpoint(
+        invocationReference,
+        appliedSnapshot.checkpoint
+      );
     } catch (error) {
       return {
-        status: 'commit_indeterminate',
-        result: trustedResult,
-        checkpoint: {
-          invocationId: invocationReference.fork.invocationId,
-          threadId: invocationReference.fork.threadId,
-          checkpointNs: invocationReference.fork.checkpointNs,
-        },
-        error: asError(error),
+        ...createIndeterminateResult(
+          invocationReference,
+          error,
+          appliedSnapshot.result
+        ),
         continuation,
       };
     }
-    const trustedTerminal = this.issueSettlement(invocationReference, {
-      ...terminal,
-      result: trustedResult,
-      checkpoint: trustedCheckpoint,
-    });
+    const trustedTerminal = this.#issueSettlement(appliedSnapshot);
     let committed;
     try {
       committed = await this.commit(trustedTerminal);

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -88,6 +88,9 @@ function validateHead(
     if (checkpointRequired) {
       throw new Error('Committed event actor head has no checkpoint');
     }
+    if (head.generation > 0) {
+      throw new Error('Advanced event actor head has no checkpoint');
+    }
     return;
   }
   requireNonEmpty(head.checkpoint.threadId, 'head.checkpoint.threadId');
@@ -270,10 +273,20 @@ export class EventActorExecutor<TEvent, TResult> {
         'warm',
         adapterRequest.checkpointNs
       );
+      return {
+        status: 'ready',
+        invocation: {
+          ...snapshotInvocation(preparation.invocation),
+          event: request.event,
+        },
+      };
     } else {
       validateHead(preparation.head, request.actorThreadId);
+      return {
+        status: 'checkpoint_unavailable',
+        head: snapshotHead(preparation.head),
+      };
     }
-    return preparation;
   }
 
   async coldContinue(
@@ -298,7 +311,10 @@ export class EventActorExecutor<TEvent, TResult> {
       adapterRequest.checkpointNs,
       trustedHead
     );
-    return invocation;
+    return {
+      ...snapshotInvocation(invocation),
+      event: request.event,
+    };
   }
 
   async invoke(
@@ -381,6 +397,11 @@ export class EventActorExecutor<TEvent, TResult> {
         trustedCheckpoint,
         committed.head
       );
+      return { status: 'committed', head: snapshotHead(committed.head) };
+    }
+    if (committed.head != null) {
+      validateHead(committed.head, trustedInvocation.actorThreadId);
+      return { status: 'stale', head: snapshotHead(committed.head) };
     }
     return committed;
   }
@@ -457,8 +478,11 @@ export class EventActorExecutor<TEvent, TResult> {
     try {
       validateTerminalCheckpoint(invocationReference, terminal.checkpoint);
     } catch (error) {
-      await this.discard(invocationReference, 'failed');
-      return { status: 'failed', error: asError(error), continuation };
+      return {
+        status: 'commit_indeterminate',
+        error: asError(error),
+        continuation,
+      };
     }
     let committed;
     try {

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -34,7 +34,6 @@ import type {
 
 const DEFAULT_MAX_DEPTH = 1;
 const DEFAULT_DORMANT_CHECKPOINT_TTL_MS = 24 * 60 * 60 * 1_000;
-const MAX_TIMEOUT_MS = 2_147_483_647;
 
 function createInvocationCheckpointNs(
   request: EventActorPrepareRequest<EventActorEvent>,
@@ -671,7 +670,6 @@ export class EventActorExecutor<
   readonly #preparationSigningKey: Uint8Array;
   readonly #issuedSettlements = new WeakSet<object>();
   readonly #preparationPhases = new Map<string, EventActorPreparationPhase>();
-  #phaseCleanupTimer: ReturnType<typeof setTimeout> | undefined;
   #nextPhaseExpiry = Number.POSITIVE_INFINITY;
 
   constructor(
@@ -720,71 +718,68 @@ export class EventActorExecutor<
     invocation: EventActorInvocation<TEvent>
   ): EventActorPreparedInvocation<TEvent> {
     const trustedInvocation = freezeInvocation(invocation);
+    const payload = serializeInvocationPreparation(trustedInvocation);
+    return Object.freeze({
+      ...trustedInvocation,
+      preparationDigest: this.#createTimedPreparationDigest(payload),
+    });
+  }
+
+  #createTimedPreparationDigest(payload: string): string {
     const expiresAt = Math.min(
       Number.MAX_SAFE_INTEGER,
       Date.now() + this.#dormantCheckpointTtlMs
     );
-    const payload = serializeInvocationPreparation(trustedInvocation);
-    return Object.freeze({
-      ...trustedInvocation,
-      preparationDigest: `${expiresAt}.${this.#signPreparation(
-        `${expiresAt}\0${payload}`
-      )}`,
-    });
+    return `${expiresAt}.${this.#signPreparation(`${expiresAt}\0${payload}`)}`;
+  }
+
+  #validateTimedPreparationDigest(
+    preparationDigest: string,
+    payload: string,
+    subject: 'prepared invocation' | 'unavailable preparation',
+    allowExpired = false
+  ): number {
+    requireNonEmpty(preparationDigest, 'preparationDigest');
+    const match = /^(\d+)\.([a-f0-9]{64})$/.exec(preparationDigest);
+    const expiresAt = Number(match?.[1]);
+    if (
+      match == null ||
+      !Number.isSafeInteger(expiresAt) ||
+      expiresAt < 1 ||
+      !this.#preparationSignatureMatches(match[2], `${expiresAt}\0${payload}`)
+    ) {
+      throw new Error(`Event actor ${subject} binding is invalid`);
+    }
+    if (!allowExpired && expiresAt <= Date.now()) {
+      throw new Error(`Event actor ${subject} binding has expired`);
+    }
+    return expiresAt;
   }
 
   #validatePreparedInvocation(
     invocation: EventActorPreparedInvocation<TEvent>,
     allowExpired = false
   ): number {
-    requireNonEmpty(invocation.preparationDigest, 'preparationDigest');
-    const match = /^(\d+)\.([a-f0-9]{64})$/.exec(invocation.preparationDigest);
-    const expiresAt = Number(match?.[1]);
-    if (
-      match == null ||
-      !Number.isSafeInteger(expiresAt) ||
-      expiresAt < 1 ||
-      !this.#preparationSignatureMatches(
-        match[2],
-        `${expiresAt}\0${serializeInvocationPreparation(invocation)}`
-      )
-    ) {
-      throw new Error('Event actor prepared invocation binding is invalid');
-    }
-    if (!allowExpired && expiresAt <= Date.now()) {
-      throw new Error('Event actor prepared invocation binding has expired');
-    }
-    return expiresAt;
+    return this.#validateTimedPreparationDigest(
+      invocation.preparationDigest,
+      serializeInvocationPreparation(invocation),
+      'prepared invocation',
+      allowExpired
+    );
   }
 
   #prunePreparationPhases(now = Date.now()): void {
-    if (this.#phaseCleanupTimer != null) {
-      clearTimeout(this.#phaseCleanupTimer);
-      this.#phaseCleanupTimer = undefined;
-    }
     this.#nextPhaseExpiry = Number.POSITIVE_INFINITY;
     for (const [digest, phase] of this.#preparationPhases) {
       if ('expiresAt' in phase && phase.expiresAt <= now) {
         this.#preparationPhases.delete(digest);
       } else if ('expiresAt' in phase) {
-        this.#schedulePhaseCleanup(phase.expiresAt, now);
+        this.#nextPhaseExpiry = Math.min(
+          this.#nextPhaseExpiry,
+          phase.expiresAt
+        );
       }
     }
-  }
-
-  #schedulePhaseCleanup(expiresAt: number, now = Date.now()): void {
-    if (expiresAt >= this.#nextPhaseExpiry) {
-      return;
-    }
-    if (this.#phaseCleanupTimer != null) {
-      clearTimeout(this.#phaseCleanupTimer);
-    }
-    this.#nextPhaseExpiry = expiresAt;
-    this.#phaseCleanupTimer = setTimeout(
-      () => this.#prunePreparationPhases(),
-      Math.min(MAX_TIMEOUT_MS, Math.max(0, expiresAt - now))
-    );
-    this.#phaseCleanupTimer.unref();
   }
 
   #getPreparationPhase(
@@ -798,17 +793,22 @@ export class EventActorExecutor<
 
   #setTerminalPreparationPhase(
     preparationDigest: string,
-    status: 'discardable' | 'retained' | 'discarded'
+    status: 'discardable' | 'retained' | 'discarded',
+    authorityExpiresAt: number
   ): void {
+    const now = Date.now();
+    if (now >= this.#nextPhaseExpiry) {
+      this.#prunePreparationPhases(now);
+    }
     const phase = {
       status,
-      expiresAt: Math.min(
-        Number.MAX_SAFE_INTEGER,
-        Date.now() + this.#dormantCheckpointTtlMs
+      expiresAt: Math.max(
+        authorityExpiresAt,
+        Math.min(Number.MAX_SAFE_INTEGER, now + this.#dormantCheckpointTtlMs)
       ),
     } as const;
     this.#preparationPhases.set(preparationDigest, phase);
-    this.#schedulePhaseCleanup(phase.expiresAt);
+    this.#nextPhaseExpiry = Math.min(this.#nextPhaseExpiry, phase.expiresAt);
   }
 
   async prepare(
@@ -907,7 +907,7 @@ export class EventActorExecutor<
         status: 'checkpoint_unavailable',
         request: preparedRequest,
         head: preparedHead,
-        preparationDigest: this.#signPreparation(
+        preparationDigest: this.#createTimedPreparationDigest(
           serializeUnavailablePreparation(preparedRequest, preparedHead)
         ),
       });
@@ -924,15 +924,11 @@ export class EventActorExecutor<
     const request = snapshotPrepareRequest(preparation.request);
     const trustedHead = snapshotHead(preparation.head);
     const preparationDigest = preparation.preparationDigest;
-    requireNonEmpty(preparationDigest, 'preparationDigest');
-    if (
-      !this.#preparationSignatureMatches(
-        preparationDigest,
-        serializeUnavailablePreparation(request, trustedHead)
-      )
-    ) {
-      throw new Error('Event actor unavailable preparation binding is invalid');
-    }
+    const authorityExpiresAt = this.#validateTimedPreparationDigest(
+      preparationDigest,
+      serializeUnavailablePreparation(request, trustedHead),
+      'unavailable preparation'
+    );
     resolveExecutionDepth(
       request.depth,
       AsyncLocalStorageProviderSingleton.getRunnableConfig()
@@ -958,6 +954,13 @@ export class EventActorExecutor<
         controller.signal.reason
       );
     }
+    if (this.#getPreparationPhase(preparationDigest) != null) {
+      signal?.removeEventListener('abort', abort);
+      throw new Error(
+        'Event actor unavailable preparation was already consumed'
+      );
+    }
+    this.#preparationPhases.set(preparationDigest, { status: 'invoking' });
     let invocation;
     try {
       invocation = await this.#adapter.coldContinue(
@@ -966,6 +969,11 @@ export class EventActorExecutor<
         { signal: controller.signal }
       );
     } catch (error) {
+      this.#setTerminalPreparationPhase(
+        preparationDigest,
+        'discarded',
+        authorityExpiresAt
+      );
       if (isAborted(controller.signal) && error === controller.signal.reason) {
         throw new EventActorPreparationCancelledError('cold', error);
       }
@@ -973,6 +981,11 @@ export class EventActorExecutor<
     } finally {
       signal?.removeEventListener('abort', abort);
     }
+    this.#setTerminalPreparationPhase(
+      preparationDigest,
+      'retained',
+      authorityExpiresAt
+    );
     const adapterInvocation = snapshotInvocation(invocation);
     validateInvocation(
       request,
@@ -991,12 +1004,24 @@ export class EventActorExecutor<
         snapshotInvocationReference(trustedInvocation),
         'cancelled'
       );
+      this.#setTerminalPreparationPhase(
+        preparationDigest,
+        'discarded',
+        authorityExpiresAt
+      );
       throw new EventActorPreparationCancelledError(
         'cold',
         controller.signal.reason
       );
     }
-    return this.#createPreparedInvocation(trustedInvocation);
+    const preparedInvocation =
+      this.#createPreparedInvocation(trustedInvocation);
+    this.#setTerminalPreparationPhase(
+      preparationDigest,
+      'discarded',
+      authorityExpiresAt
+    );
+    return preparedInvocation;
   }
 
   async invoke(
@@ -1004,68 +1029,97 @@ export class EventActorExecutor<
     signal?: AbortSignal
   ): Promise<EventActorInvocationResult<TResult>> {
     const trustedInvocation = snapshotPreparedInvocation(invocation);
-    this.#validatePreparedInvocation(trustedInvocation);
+    const authorityExpiresAt =
+      this.#validatePreparedInvocation(trustedInvocation);
     const preparationDigest = trustedInvocation.preparationDigest;
     if (this.#getPreparationPhase(preparationDigest) != null) {
       throw new Error('Event actor prepared invocation was already consumed');
     }
     this.#preparationPhases.set(preparationDigest, { status: 'invoking' });
     const settlementInvocation = snapshotInvocationReference(trustedInvocation);
-    let invocationCompleted = false;
-    let definitelyNoAction = false;
+    let terminal: EventActorTerminalResult<TResult>;
     try {
-      const terminal = await this.#invokeWithConfig(
+      terminal = await this.#invokeWithConfig(
         snapshotInvocation(trustedInvocation),
         signal,
         AsyncLocalStorageProviderSingleton.getRunnableConfig()
       );
-      invocationCompleted = true;
-      this.#setTerminalPreparationPhase(preparationDigest, 'retained');
-      let status: unknown;
-      try {
-        status = terminal.status;
-      } catch (error) {
-        return createIndeterminateResult(settlementInvocation, error);
-      }
-      if (status === 'applied') {
-        const snapshot = snapshotAppliedTerminal<TResult>(
-          settlementInvocation,
-          terminal as Extract<
-            EventActorTerminalResult<TResult>,
-            { status: 'applied' }
-          >
+    } catch (error) {
+      if (isGraphInterrupt(error) || isParentCommand(error)) {
+        this.#setTerminalPreparationPhase(
+          preparationDigest,
+          'retained',
+          authorityExpiresAt
         );
-        return snapshot.status === 'snapshot_ready'
-          ? this.#issueSettlement(snapshot)
-          : snapshot;
+        throw error;
       }
-      if (status !== 'completed_no_action') {
-        return createIndeterminateResult(
-          settlementInvocation,
-          new Error('Event actor invocation returned an invalid status')
-        );
-      }
-      definitelyNoAction = true;
-      const completed = Object.freeze({
+      this.#setTerminalPreparationPhase(
+        preparationDigest,
+        'discardable',
+        authorityExpiresAt
+      );
+      await this.discard(
+        trustedInvocation,
+        isAborted(signal) ? 'cancelled' : 'failed'
+      );
+      throw error;
+    }
+    this.#setTerminalPreparationPhase(
+      preparationDigest,
+      'retained',
+      authorityExpiresAt
+    );
+    let status: unknown;
+    try {
+      status = terminal.status;
+    } catch (error) {
+      return createIndeterminateResult(settlementInvocation, error);
+    }
+    if (status === 'applied') {
+      const snapshot = snapshotAppliedTerminal<TResult>(
+        settlementInvocation,
+        terminal as Extract<
+          EventActorTerminalResult<TResult>,
+          { status: 'applied' }
+        >
+      );
+      return snapshot.status === 'snapshot_ready'
+        ? this.#issueSettlement(snapshot)
+        : snapshot;
+    }
+    if (status !== 'completed_no_action') {
+      return createIndeterminateResult(
+        settlementInvocation,
+        new Error('Event actor invocation returned an invalid status')
+      );
+    }
+    let completed: Extract<
+      EventActorTerminalResult<TResult>,
+      { status: 'completed_no_action' }
+    >;
+    try {
+      completed = Object.freeze({
         status: 'completed_no_action' as const,
         ...(terminal.result === undefined
           ? {}
           : { result: snapshotEvent(terminal.result) }),
       });
-      this.#setTerminalPreparationPhase(preparationDigest, 'discardable');
-      return completed;
     } catch (error) {
-      if (
-        isGraphInterrupt(error) ||
-        isParentCommand(error) ||
-        (invocationCompleted && !definitelyNoAction)
-      ) {
-        this.#setTerminalPreparationPhase(preparationDigest, 'retained');
-      } else {
-        this.#setTerminalPreparationPhase(preparationDigest, 'discardable');
-      }
+      this.#setTerminalPreparationPhase(
+        preparationDigest,
+        'discardable',
+        authorityExpiresAt
+      );
+      await this.discard(trustedInvocation, 'completed_no_action');
       throw error;
     }
+    this.#setTerminalPreparationPhase(
+      preparationDigest,
+      'discardable',
+      authorityExpiresAt
+    );
+    await this.discard(trustedInvocation, 'completed_no_action');
+    return completed;
   }
 
   #issueSettlement(
@@ -1235,14 +1289,21 @@ export class EventActorExecutor<
     this.#preparationPhases.set(preparationDigest, { status: 'discarding' });
     try {
       await this.#discardInvocationReference(trustedInvocation, reason);
-      this.#setTerminalPreparationPhase(preparationDigest, 'discarded');
+      this.#setTerminalPreparationPhase(
+        preparationDigest,
+        'discarded',
+        expiresAt
+      );
     } catch (error) {
       if (previousPhase == null) {
         this.#preparationPhases.delete(preparationDigest);
       } else {
         this.#preparationPhases.set(preparationDigest, previousPhase);
         if ('expiresAt' in previousPhase) {
-          this.#schedulePhaseCleanup(previousPhase.expiresAt);
+          this.#nextPhaseExpiry = Math.min(
+            this.#nextPhaseExpiry,
+            previousPhase.expiresAt
+          );
         }
       }
       throw error;

--- a/src/eventActor/EventActorExecutor.ts
+++ b/src/eventActor/EventActorExecutor.ts
@@ -58,7 +58,9 @@ function validateHead(
     return;
   }
   requireNonEmpty(head.checkpoint.threadId, 'head.checkpoint.threadId');
-  requireNonEmpty(head.checkpoint.checkpointNs, 'head.checkpoint.checkpointNs');
+  if (typeof head.checkpoint.checkpointNs !== 'string') {
+    throw new Error('head.checkpoint.checkpointNs must be a string');
+  }
   requireNonEmpty(
     head.checkpoint.checkpointId ?? '',
     'head.checkpoint.checkpointId'
@@ -126,10 +128,21 @@ function validateTerminalCheckpoint(
 
 function createRunnableConfig(
   invocation: EventActorInvocationReference,
-  signal: AbortSignal
+  signal: AbortSignal,
+  ambient?: RunnableConfig
 ): RunnableConfig {
   return {
     signal,
+    ...(ambient?.callbacks == null ? {} : { callbacks: ambient.callbacks }),
+    ...(ambient?.tags == null ? {} : { tags: ambient.tags }),
+    metadata: {
+      ...(ambient?.metadata ?? {}),
+      eventActorThreadId: invocation.actorThreadId,
+      eventActorInvocationId: invocation.invocationId,
+      eventActorGeneration: invocation.base.generation,
+      eventActorDepth: invocation.depth,
+      eventActorContinuation: invocation.continuation,
+    },
     configurable: {
       thread_id: invocation.fork.threadId,
       checkpoint_ns: invocation.fork.checkpointNs,
@@ -155,10 +168,16 @@ function isAborted(signal?: AbortSignal): boolean {
 
 function validateCommittedHead(
   invocation: EventActorInvocationReference,
+  checkpoint: EventActorCheckpointFork,
   head: EventActorInvocationReference['base']
 ): void {
   validateHead(head, invocation.actorThreadId, true);
-  if (head.generation !== invocation.base.generation + 1) {
+  if (
+    head.generation !== invocation.base.generation + 1 ||
+    head.checkpoint?.threadId !== checkpoint.threadId ||
+    head.checkpoint.checkpointNs !== checkpoint.checkpointNs ||
+    head.checkpoint.checkpointId !== checkpoint.checkpointId
+  ) {
     throw new Error('Event actor commit returned an invalid logical head');
   }
 }
@@ -199,20 +218,12 @@ export class EventActorExecutor<TEvent, TResult> {
     };
     const preparation = await this.adapter.prepare(adapterRequest);
     if (preparation.status === 'ready') {
-      try {
-        validateInvocation(
-          request,
-          preparation.invocation,
-          'warm',
-          adapterRequest.checkpointNs
-        );
-      } catch (error) {
-        await this.adapter.discard({
-          invocation: preparation.invocation,
-          reason: 'failed',
-        });
-        throw error;
-      }
+      validateInvocation(
+        request,
+        preparation.invocation,
+        'warm',
+        adapterRequest.checkpointNs
+      );
     } else {
       validateHead(preparation.head, request.actorThreadId);
     }
@@ -229,24 +240,31 @@ export class EventActorExecutor<TEvent, TResult> {
       checkpointNs: createInvocationCheckpointNs(request),
     };
     const invocation = await this.adapter.coldContinue(adapterRequest, head);
-    try {
-      validateInvocation(
-        request,
-        invocation,
-        'cold',
-        adapterRequest.checkpointNs,
-        head
-      );
-    } catch (error) {
-      await this.adapter.discard({ invocation, reason: 'failed' });
-      throw error;
-    }
+    validateInvocation(
+      request,
+      invocation,
+      'cold',
+      adapterRequest.checkpointNs,
+      head
+    );
     return invocation;
   }
 
   async invoke(
     invocation: EventActorInvocation<TEvent>,
     signal?: AbortSignal
+  ): Promise<EventActorTerminalResult<TResult>> {
+    return this.invokeWithConfig(
+      invocation,
+      signal,
+      AsyncLocalStorageProviderSingleton.getRunnableConfig()
+    );
+  }
+
+  private async invokeWithConfig(
+    invocation: EventActorInvocation<TEvent>,
+    signal: AbortSignal | undefined,
+    ambientConfig: RunnableConfig | undefined
   ): Promise<EventActorTerminalResult<TResult>> {
     validateInvocation(
       {
@@ -266,7 +284,11 @@ export class EventActorExecutor<TEvent, TResult> {
     } else {
       signal?.addEventListener('abort', abort, { once: true });
     }
-    const config = createRunnableConfig(invocation, controller.signal);
+    const config = createRunnableConfig(
+      invocation,
+      controller.signal,
+      ambientConfig
+    );
     try {
       if (controller.signal.aborted) {
         throw asError(controller.signal.reason ?? 'Event actor cancelled');
@@ -300,7 +322,7 @@ export class EventActorExecutor<TEvent, TResult> {
       },
     });
     if (committed.status === 'committed') {
-      validateCommittedHead(invocation, committed.head);
+      validateCommittedHead(invocation, terminal.checkpoint, committed.head);
     }
     return committed;
   }
@@ -331,6 +353,8 @@ export class EventActorExecutor<TEvent, TResult> {
   async execute(
     request: EventActorExecutionRequest<TEvent>
   ): Promise<EventActorExecutionResult<TResult>> {
+    const ambientConfig =
+      AsyncLocalStorageProviderSingleton.getRunnableConfig();
     const depth = request.depth ?? 1;
     const prepareRequest: EventActorPrepareRequest<TEvent> = {
       actorThreadId: request.actorThreadId,
@@ -351,7 +375,11 @@ export class EventActorExecutor<TEvent, TResult> {
     }
     let terminal;
     try {
-      terminal = await this.invoke(invocation, request.signal);
+      terminal = await this.invokeWithConfig(
+        invocation,
+        request.signal,
+        ambientConfig
+      );
     } catch (error) {
       const reason = isAborted(request.signal) ? 'cancelled' : 'failed';
       await this.discard(invocationReference, reason);
@@ -359,10 +387,6 @@ export class EventActorExecutor<TEvent, TResult> {
         return { status: 'cancelled', continuation };
       }
       return { status: 'failed', error: asError(error), continuation };
-    }
-    if (isAborted(request.signal)) {
-      await this.discard(invocationReference, 'cancelled');
-      return { status: 'cancelled', continuation };
     }
     if (terminal.status === 'completed_no_action') {
       await this.discard(invocationReference, 'completed_no_action');

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
   EventActorAdapterPrepareRequest,
   EventActorCommitRequest,
@@ -7,6 +8,7 @@ import type {
   EventActorHead,
   EventActorHostAdapter,
   EventActorInvocation,
+  EventActorInvocationContext,
   EventActorPrepareRequest,
   EventActorTerminalResult,
 } from '@/eventActor';
@@ -14,7 +16,11 @@ import { EventActorExecutor } from '@/eventActor';
 
 type TestEvent = { text: string };
 
-const head = (generation = 0): EventActorHead => {
+const head = (
+  generation = 0,
+  checkpointNs = 'committed',
+  checkpointId = `checkpoint-${generation}`
+): EventActorHead => {
   const actorHead: EventActorHead = {
     actorThreadId: 'actor-thread',
     generation,
@@ -26,8 +32,8 @@ const head = (generation = 0): EventActorHead => {
     ...actorHead,
     checkpoint: {
       threadId: 'actor-checkpoints',
-      checkpointNs: 'committed',
-      checkpointId: `checkpoint-${generation}`,
+      checkpointNs,
+      checkpointId,
     },
   };
 };
@@ -50,6 +56,8 @@ const invocation = (
 class TestHost implements EventActorHostAdapter<TestEvent, string> {
   generation = 0;
   checkpointAvailable = true;
+  committedCheckpointNs = 'committed';
+  committedCheckpointId = 'checkpoint-0';
   invokes = 0;
   activeInvocations = 0;
   maxActiveInvocations = 0;
@@ -57,6 +65,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
   readonly commits: EventActorCommitRequest<string>[] = [];
   readonly discards: EventActorDiscardRequest[] = [];
   readonly invokeSignals: AbortSignal[] = [];
+  readonly invokeConfigs: RunnableConfig[] = [];
   readonly forkNamespaces: string[] = [];
   invokeImpl?: (
     prepared: EventActorInvocation<TestEvent>,
@@ -67,12 +76,23 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     if (!this.checkpointAvailable) {
       return {
         status: 'checkpoint_unavailable' as const,
-        head: head(this.generation),
+        head: head(
+          this.generation,
+          this.committedCheckpointNs,
+          this.committedCheckpointId
+        ),
       };
     }
     return {
       status: 'ready' as const,
-      invocation: invocation(request, 'warm', this.generation),
+      invocation: {
+        ...invocation(request, 'warm', this.generation),
+        base: head(
+          this.generation,
+          this.committedCheckpointNs,
+          this.committedCheckpointId
+        ),
+      },
     };
   }
 
@@ -80,12 +100,19 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     request: EventActorAdapterPrepareRequest<TestEvent>,
     _head: EventActorHead
   ) {
-    return invocation(request, 'cold', this.generation);
+    return {
+      ...invocation(request, 'cold', this.generation),
+      base: head(
+        this.generation,
+        this.committedCheckpointNs,
+        this.committedCheckpointId
+      ),
+    };
   }
 
   async invoke(
     prepared: EventActorInvocation<TestEvent>,
-    context: { signal: AbortSignal }
+    context: EventActorInvocationContext
   ) {
     this.invokes += 1;
     this.activeInvocations += 1;
@@ -94,6 +121,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
       this.activeInvocations
     );
     this.invokeSignals.push(context.signal);
+    this.invokeConfigs.push(context.config);
     this.forkNamespaces.push(prepared.fork.checkpointNs);
     try {
       if (this.invokeImpl != null) {
@@ -118,10 +146,26 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
       throw this.commitError;
     }
     if (request.expectedHead.generation !== this.generation) {
-      return { status: 'stale' as const, head: head(this.generation) };
+      return {
+        status: 'stale' as const,
+        head: head(
+          this.generation,
+          this.committedCheckpointNs,
+          this.committedCheckpointId
+        ),
+      };
     }
     this.generation += 1;
-    return { status: 'committed' as const, head: head(this.generation) };
+    this.committedCheckpointNs = request.checkpoint.checkpointNs;
+    this.committedCheckpointId = request.checkpoint.checkpointId ?? '';
+    return {
+      status: 'committed' as const,
+      head: head(
+        this.generation,
+        this.committedCheckpointNs,
+        this.committedCheckpointId
+      ),
+    };
   }
 
   async discard(request: EventActorDiscardRequest) {
@@ -205,6 +249,25 @@ describe('EventActorExecutor', () => {
     expect(host.commits[0].invocation).toMatchObject({
       actorThreadId: 'actor-thread',
       continuation: 'cold',
+    });
+  });
+
+  it('accepts a committed actor head in LangGraph root checkpoint namespace', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.committedCheckpointNs = '';
+    host.committedCheckpointId = 'root-checkpoint';
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('root-namespace'))
+    ).resolves.toMatchObject({
+      status: 'applied',
+      head: { generation: 2 },
+    });
+    expect(host.commits[0].expectedHead.checkpoint).toMatchObject({
+      checkpointNs: '',
+      checkpointId: 'root-checkpoint',
     });
   });
 
@@ -321,6 +384,27 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(0);
   });
 
+  it('rejects a committed head that does not promote the terminal checkpoint', async () => {
+    const host = new TestHost();
+    const commit = host.commit.bind(host);
+    host.commit = async (commitRequest) => {
+      const result = await commit(commitRequest);
+      if (result.status === 'committed' && result.head.checkpoint != null) {
+        result.head.checkpoint.checkpointId = 'different-checkpoint';
+      }
+      return result;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('wrong-head'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      error: { message: 'Event actor commit returned an invalid logical head' },
+    });
+    expect(host.discards).toHaveLength(0);
+  });
+
   it('replaces an ambient parent signal with independent task-owned signals', async () => {
     const host = new TestHost();
     const parentController = new AbortController();
@@ -341,13 +425,19 @@ describe('EventActorExecutor', () => {
     };
     const executor = new EventActorExecutor(host);
 
-    const executions = await AsyncLocalStorageProviderSingleton.runWithConfig(
-      { signal: parentController.signal },
-      async () => [
-        executor.execute(request('sibling-a')),
-        executor.execute(request('sibling-b')),
-      ]
-    );
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue({
+        signal: parentController.signal,
+        callbacks: [],
+        tags: ['parent-trace'],
+        metadata: { userId: 'user-1', sessionId: 'session-1' },
+      });
+    const executions = [
+      executor.execute(request('sibling-a')),
+      executor.execute(request('sibling-b')),
+    ];
+    runnableConfigSpy.mockRestore();
     while (host.invokes < 2) {
       await Promise.resolve();
     }
@@ -362,6 +452,16 @@ describe('EventActorExecutor', () => {
     ).toBe(true);
     expect(host.invokeSignals).not.toContain(parentController.signal);
     expect(host.invokeSignals.every((signal) => !signal.aborted)).toBe(true);
+    expect(host.invokeConfigs).toHaveLength(2);
+    expect(host.invokeConfigs[0]).toMatchObject({
+      callbacks: [],
+      tags: ['parent-trace'],
+      metadata: {
+        userId: 'user-1',
+        sessionId: 'session-1',
+        eventActorThreadId: 'actor-thread',
+      },
+    });
     release();
 
     const results = await Promise.all(executions);
@@ -408,7 +508,32 @@ describe('EventActorExecutor', () => {
     expect(host.discards[0].reason).toBe('failed');
   });
 
-  it('rejects and discards a preparation that reuses another fork namespace', async () => {
+  it('commits an applied result even when cancellation arrives as invoke returns', async () => {
+    const host = new TestHost();
+    const controller = new AbortController();
+    host.invokeImpl = async (prepared) => {
+      controller.abort(new Error('parent settled'));
+      return {
+        status: 'applied',
+        result: 'move submitted',
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: 'applied-before-abort',
+        },
+      };
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(
+        request('applied-before-abort', { signal: controller.signal })
+      )
+    ).resolves.toMatchObject({ status: 'applied', head: { generation: 1 } });
+    expect(host.commits).toHaveLength(1);
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('rejects a preparation without discarding its untrusted fork reference', async () => {
     const host = new TestHost();
     const prepare = host.prepare.bind(host);
     host.prepare = async (prepareRequest) => {
@@ -423,8 +548,6 @@ describe('EventActorExecutor', () => {
     await expect(executor.execute(request('wrong-namespace'))).rejects.toThrow(
       'mismatched checkpoint ownership'
     );
-    expect(host.discards).toEqual([
-      expect.objectContaining({ reason: 'failed' }),
-    ]);
+    expect(host.discards).toHaveLength(0);
   });
 });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -6,6 +6,7 @@ import type {
   EventActorCheckpointFork,
   EventActorCommitRequest,
   EventActorDiscardRequest,
+  EventActorEvent,
   EventActorHead,
   EventActorHostAdapter,
   EventActorInvocation,
@@ -68,6 +69,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
   readonly commits: EventActorCommitRequest<string>[] = [];
   readonly discards: EventActorDiscardRequest[] = [];
   readonly invokeSignals: AbortSignal[] = [];
+  readonly prepareSignals: AbortSignal[] = [];
   readonly coldContinueSignals: AbortSignal[] = [];
   readonly invokeConfigs: RunnableConfig[] = [];
   readonly forkNamespaces: string[] = [];
@@ -76,7 +78,13 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     signal: AbortSignal
   ) => Promise<EventActorTerminalResult<string>>;
 
-  async prepare(request: EventActorAdapterPrepareRequest<TestEvent>) {
+  async prepare(
+    request: EventActorAdapterPrepareRequest<TestEvent>,
+    context?: EventActorPreparationContext
+  ) {
+    if (context != null) {
+      this.prepareSignals.push(context.signal);
+    }
     if (!this.checkpointAvailable) {
       return {
         status: 'checkpoint_unavailable' as const,
@@ -288,6 +296,66 @@ describe('EventActorExecutor', () => {
     await expect(executor.commit(settlement)).resolves.toMatchObject({
       status: 'committed',
       head: { generation: 2 },
+    });
+  });
+
+  it('snapshots mutable settlement results before commit', async () => {
+    type ObjectResult = { outcome: string; detail: { code: number } };
+    const host = new TestHost();
+    const adapterResult: ObjectResult = {
+      outcome: 'applied',
+      detail: { code: 200 },
+    };
+    let committedResult: ObjectResult | undefined;
+    const adapter: EventActorHostAdapter<TestEvent, ObjectResult> = {
+      prepare: host.prepare.bind(host),
+      coldContinue: host.coldContinue.bind(host),
+      invoke: async (prepared) => ({
+        status: 'applied',
+        result: adapterResult,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: 'object-result-terminal',
+        },
+      }),
+      commit: async (commitRequest) => {
+        committedResult = commitRequest.result;
+        return {
+          status: 'committed',
+          head: {
+            actorThreadId: commitRequest.invocation.actorThreadId,
+            generation: commitRequest.expectedHead.generation + 1,
+            checkpoint: { ...commitRequest.checkpoint },
+          },
+        };
+      },
+      discard: host.discard.bind(host),
+    };
+    const executor = new EventActorExecutor(adapter);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'immutable-result',
+      depth: 1,
+      event: { text: 'immutable-result' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const settlement = await executor.invoke(preparation.invocation);
+    if (settlement.status !== 'applied') {
+      throw new Error('Expected applied settlement');
+    }
+
+    adapterResult.outcome = 'mutated';
+    adapterResult.detail.code = 500;
+    expect(() => {
+      settlement.result.outcome = 'forged';
+    }).toThrow();
+    await executor.commit(settlement);
+
+    expect(committedResult).toEqual({
+      outcome: 'applied',
+      detail: { code: 200 },
     });
   });
 
@@ -702,7 +770,7 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(2);
   });
 
-  it('enforces maxDepth for host-driven invocation', async () => {
+  it('rejects forged host-driven invocation depth', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host, { maxDepth: 1 });
     const preparation = await executor.prepare({
@@ -723,7 +791,7 @@ describe('EventActorExecutor', () => {
     };
 
     await expect(executor.invoke(forgedInvocation)).rejects.toThrow(
-      'exceeds maximum 1'
+      'prepared invocation binding is invalid'
     );
     expect(host.invokes).toBe(0);
   });
@@ -752,7 +820,17 @@ describe('EventActorExecutor', () => {
 
   it('binds ambient actor depth during public preparation', async () => {
     const host = new TestHost();
+    host.checkpointAvailable = false;
     const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const unavailablePreparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'ambient-cold-prepare',
+      depth: 1,
+      event: { text: 'ambient-cold-prepare' },
+    });
+    if (unavailablePreparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
     const runnableConfigSpy = jest
       .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
       .mockReturnValue({ configurable: { event_actor_depth: 1 } });
@@ -762,16 +840,7 @@ describe('EventActorExecutor', () => {
       depth: 1,
       event: { text: 'ambient-warm-prepare' },
     });
-    const coldPreparation = executor.coldContinue({
-      status: 'checkpoint_unavailable',
-      request: {
-        actorThreadId: 'actor-thread',
-        invocationId: 'ambient-cold-prepare',
-        depth: 1,
-        event: { text: 'ambient-cold-prepare' },
-      },
-      head: head(0),
-    });
+    const coldPreparation = executor.coldContinue(unavailablePreparation);
     runnableConfigSpy.mockRestore();
 
     await expect(warmPreparation).rejects.toThrow(
@@ -867,6 +936,71 @@ describe('EventActorExecutor', () => {
     });
   });
 
+  it('rejects sparse arrays at the immutable JSON event boundary', async () => {
+    const adapter: EventActorHostAdapter<EventActorEvent, string> = {
+      prepare: async () => {
+        throw new Error('prepare must not run');
+      },
+      coldContinue: async () => {
+        throw new Error('coldContinue must not run');
+      },
+      invoke: async () => {
+        throw new Error('invoke must not run');
+      },
+      commit: async () => {
+        throw new Error('commit must not run');
+      },
+      discard: async () => undefined,
+    };
+    const prepareSpy = jest.spyOn(adapter, 'prepare');
+    const executor = new EventActorExecutor(adapter);
+
+    await expect(
+      executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'sparse-event',
+        depth: 1,
+        event: new Array<EventActorEvent>(1),
+      })
+    ).rejects.toThrow('event arrays must not contain holes');
+    expect(prepareSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects recombined unavailable request and head evidence', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host);
+    const first = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'first-unavailable',
+      depth: 1,
+      event: { text: 'first-unavailable' },
+    });
+    host.generation = 1;
+    const second = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'second-unavailable',
+      depth: 1,
+      event: { text: 'second-unavailable' },
+    });
+    if (
+      first.status !== 'checkpoint_unavailable' ||
+      second.status !== 'checkpoint_unavailable'
+    ) {
+      throw new Error('Expected unavailable checkpoints');
+    }
+
+    await expect(
+      executor.coldContinue({
+        status: 'checkpoint_unavailable',
+        request: first.request,
+        head: second.head,
+        preparationDigest: first.preparationDigest,
+      })
+    ).rejects.toThrow('unavailable preparation binding is invalid');
+    expect(host.coldContinues).toBe(0);
+  });
+
   it('snapshots the cold-continuation handoff before adapter work can yield', async () => {
     const host = new TestHost();
     host.checkpointAvailable = false;
@@ -902,6 +1036,7 @@ describe('EventActorExecutor', () => {
           ? {}
           : { checkpoint: { ...preparation.head.checkpoint } }),
       },
+      preparationDigest: preparation.preparationDigest,
     };
     const continuationPromise = executor.coldContinue(mutablePreparation);
     mutablePreparation.request.actorThreadId = 'mutated-actor';
@@ -980,7 +1115,7 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
-  it('cancels before unavailable checkpoints enter cold continuation', async () => {
+  it('cancels in-flight initial preparation before cold continuation', async () => {
     const host = new TestHost();
     host.checkpointAvailable = false;
     const prepare = host.prepare.bind(host);
@@ -988,9 +1123,9 @@ describe('EventActorExecutor', () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    host.prepare = async (prepareRequest) => {
+    host.prepare = async (prepareRequest, context) => {
       await gate;
-      return prepare(prepareRequest);
+      return prepare(prepareRequest, context);
     };
     const controller = new AbortController();
     const execution = new EventActorExecutor(host).execute(
@@ -1001,8 +1136,10 @@ describe('EventActorExecutor', () => {
 
     await expect(execution).resolves.toEqual({
       status: 'cancelled',
-      continuation: 'cold',
+      continuation: 'warm',
     });
+    expect(host.prepareSignals).toHaveLength(1);
+    expect(host.prepareSignals[0].aborted).toBe(true);
     expect(host.coldContinues).toBe(0);
     expect(host.invokes).toBe(0);
     expect(host.discards).toHaveLength(0);
@@ -1045,6 +1182,39 @@ describe('EventActorExecutor', () => {
     expect(host.coldContinueSignals[0].aborted).toBe(true);
     expect(host.invokes).toBe(0);
     expect(host.discards).toHaveLength(0);
+  });
+
+  it('surfaces cleanup failure after cold continuation cancellation', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    let started = (): void => undefined;
+    const coldStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      started();
+      await new Promise<void>((resolve) => {
+        context.signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+      return coldContinue(prepareRequest, actorHead, context);
+    };
+    host.discard = async () => {
+      throw new Error('cold cleanup failed');
+    };
+    const controller = new AbortController();
+    const executor = new EventActorExecutor(host);
+    const execution = executor.execute(
+      request('cleanup-failure', { signal: controller.signal })
+    );
+    await coldStarted;
+
+    controller.abort(new Error('cancel cold reconstruction'));
+
+    await expect(execution).rejects.toThrow('cold cleanup failed');
+    expect(host.invokes).toBe(0);
   });
 
   it('retains an applied result with a checkpoint outside the invocation fork', async () => {
@@ -1218,6 +1388,29 @@ describe('EventActorExecutor', () => {
       status: 'applied',
       result: 'authoritative-event',
     });
+  });
+
+  it('rejects an event recombined with another prepared invocation', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'bound-event',
+      depth: 1,
+      event: { text: 'bound-event' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const forgedInvocation = {
+      ...preparation.invocation,
+      event: { text: 'replacement-event' },
+    };
+
+    await expect(executor.invoke(forgedInvocation)).rejects.toThrow(
+      'prepared invocation binding is invalid'
+    );
+    expect(host.invokes).toBe(0);
   });
 
   it('invokes with the authoritative request event after cold continuation', async () => {
@@ -1622,18 +1815,18 @@ describe('EventActorExecutor', () => {
 
   it('validates a cold-continuation head before adapter work', async () => {
     const host = new TestHost();
+    host.prepare = async () => ({
+      status: 'checkpoint_unavailable' as const,
+      head: { actorThreadId: 'another-actor', generation: 0 },
+    });
     const executor = new EventActorExecutor(host);
 
     await expect(
-      executor.coldContinue({
-        status: 'checkpoint_unavailable',
-        request: {
-          actorThreadId: 'actor-thread',
-          invocationId: 'foreign-head',
-          depth: 1,
-          event: { text: 'foreign-head' },
-        },
-        head: { actorThreadId: 'another-actor', generation: 0 },
+      executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'foreign-head',
+        depth: 1,
+        event: { text: 'foreign-head' },
       })
     ).rejects.toThrow('Event actor head is invalid');
     expect(host.coldContinues).toBe(0);
@@ -1676,7 +1869,18 @@ describe('EventActorExecutor', () => {
 
   it('detects a cold adapter mutating its copy of the prepared head', async () => {
     const host = new TestHost();
-    const validHead = head(1);
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'mutated-head',
+      depth: 1,
+      event: { text: 'mutated-head' },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
     host.coldContinue = async (prepareRequest, adapterHead) => {
       adapterHead.generation = 2;
       return {
@@ -1688,21 +1892,11 @@ describe('EventActorExecutor', () => {
         },
       };
     };
-    const executor = new EventActorExecutor(host);
 
-    await expect(
-      executor.coldContinue({
-        status: 'checkpoint_unavailable',
-        request: {
-          actorThreadId: 'actor-thread',
-          invocationId: 'mutated-head',
-          depth: 1,
-          event: { text: 'mutated-head' },
-        },
-        head: validHead,
-      })
-    ).rejects.toThrow('Cold continuation did not use the prepared actor head');
-    expect(validHead.generation).toBe(1);
+    await expect(executor.coldContinue(preparation)).rejects.toThrow(
+      'Cold continuation did not use the prepared actor head'
+    );
+    expect(preparation.head.generation).toBe(1);
   });
 
   it('uses the validated ownership snapshot after adapter invocation', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -623,6 +623,28 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('enforces ambient actor depth for host-driven invocation', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'ambient-host-driven-depth',
+      depth: 1,
+      event: { text: 'ambient-host-driven-depth' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue({ configurable: { event_actor_depth: 1 } });
+    const execution = executor.invoke(preparation.invocation);
+    runnableConfigSpy.mockRestore();
+
+    await expect(execution).rejects.toThrow('must advance parent depth 1');
+    expect(host.invokes).toBe(0);
+  });
+
   it('derives nested depth from actor-owned ambient context', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host);
@@ -885,6 +907,42 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('binds a warm resumed fork to the committed checkpoint', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.fork.checkpointId = 'another-checkpoint';
+      }
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('wrong-warm-start'))).rejects.toThrow(
+      'did not start from the committed checkpoint'
+    );
+    expect(host.invokes).toBe(0);
+  });
+
+  it('allows a cold resumed fork to start from reconstructed state', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead) => {
+      const prepared = await coldContinue(prepareRequest, actorHead);
+      prepared.fork.checkpointId = 'reconstructed-start';
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('reconstructed-cold-start'))
+    ).resolves.toMatchObject({ status: 'applied', continuation: 'cold' });
+  });
+
   it('requires a cold resumed fork to identify its starting checkpoint', async () => {
     const host = new TestHost();
     host.generation = 1;
@@ -1018,13 +1076,13 @@ describe('EventActorExecutor', () => {
     ).rejects.toThrow('changed its checkpoint thread');
   });
 
-  it('retains applied work when a stale head only relabels the base checkpoint', async () => {
+  it('retains applied work when stale moves the base checkpoint to another namespace', async () => {
     const host = new TestHost();
     host.generation = 1;
     host.commit = async () => ({
       status: 'stale' as const,
       head: {
-        ...head(1, 'committed', 'checkpoint-0'),
+        ...head(1, 'another-namespace', 'checkpoint-0'),
         generation: 2,
       },
     });
@@ -1066,6 +1124,33 @@ describe('EventActorExecutor', () => {
       },
     });
     expect(host.discards).toHaveLength(0);
+  });
+
+  it('accepts an initial stale winner that establishes another checkpoint thread', async () => {
+    const host = new TestHost();
+    host.commit = async () => ({
+      status: 'stale' as const,
+      head: {
+        actorThreadId: 'actor-thread',
+        generation: 1,
+        checkpoint: {
+          threadId: 'winner-checkpoint-thread',
+          checkpointNs: 'winner-namespace',
+          checkpointId: 'winner-checkpoint',
+        },
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('initial-thread-race'))
+    ).resolves.toMatchObject({
+      status: 'commit_conflict',
+      head: {
+        generation: 1,
+        checkpoint: { threadId: 'winner-checkpoint-thread' },
+      },
+    });
   });
 
   it('commits an applied result even when cancellation arrives as invoke returns', async () => {
@@ -1253,6 +1338,47 @@ describe('EventActorExecutor', () => {
     if (terminal.status !== 'applied') {
       throw new Error('Expected applied terminal result');
     }
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).resolves.toMatchObject({ status: 'committed' });
+  });
+
+  it('snapshots applied checkpoint evidence returned by public invoke', async () => {
+    const host = new TestHost();
+    let adapterCheckpoint: EventActorCheckpointFork | undefined;
+    host.invokeImpl = async (prepared) => {
+      adapterCheckpoint = {
+        ...prepared.fork,
+        checkpointId: 'public-invoke-terminal',
+      };
+      return {
+        status: 'applied',
+        result: 'public-invoke-action',
+        checkpoint: adapterCheckpoint,
+      };
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-invoke-snapshot',
+      depth: 1,
+      event: { text: 'public-invoke-snapshot' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    const terminal = await executor.invoke(preparation.invocation);
+    if (terminal.status !== 'applied' || adapterCheckpoint == null) {
+      throw new Error('Expected applied terminal result');
+    }
+    adapterCheckpoint.checkpointId = 'mutated-checkpoint';
+    adapterCheckpoint.checkpointNs = 'mutated-namespace';
+
+    expect(terminal.checkpoint).toMatchObject({
+      checkpointId: 'public-invoke-terminal',
+      checkpointNs: expect.stringMatching(/^event-actor\/[a-f0-9]{32}$/),
+    });
     await expect(
       executor.commit(preparation.invocation, terminal)
     ).resolves.toMatchObject({ status: 'committed' });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -458,6 +458,11 @@ describe('EventActorExecutor', () => {
           checkpoint_ns: 'parent-namespace',
           checkpoint_id: 'parent-checkpoint',
           checkpoint_map: { parent: 'checkpoint' },
+          __pregel_checkpointer: { parent: true },
+          __pregel_scratchpad: { parent: true },
+          __librechat_subagent_resume_manifest: { parent: true },
+          __librechat_tool_approval_execution_scope: { parent: true },
+          lc_run_breaker_scope: { parent: true },
         },
       });
     const executions = [
@@ -510,6 +515,14 @@ describe('EventActorExecutor', () => {
     expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
       'checkpoint_map'
     );
+    expect(
+      Object.keys(host.invokeConfigs[0].configurable ?? {}).some(
+        (key) => key.startsWith('__pregel_') || key.startsWith('__librechat_')
+      )
+    ).toBe(false);
+    expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
+      'lc_run_breaker_scope'
+    );
     expect(host.invokeConfigs[0]).not.toHaveProperty('runId');
     expect(host.invokeConfigs[0]).not.toHaveProperty('runName');
     release();
@@ -536,6 +549,14 @@ describe('EventActorExecutor', () => {
 
   it('retains an applied result with a checkpoint outside the invocation fork', async () => {
     const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.fork.checkpointId = 'starting-checkpoint';
+      }
+      return prepared;
+    };
     host.invokeImpl = async () => ({
       status: 'applied',
       result: 'bad',
@@ -548,7 +569,8 @@ describe('EventActorExecutor', () => {
     });
     const executor = new EventActorExecutor(host);
 
-    await expect(executor.execute(request('escape'))).resolves.toMatchObject({
+    const result = await executor.execute(request('escape'));
+    expect(result).toMatchObject({
       status: 'commit_indeterminate',
       result: 'bad',
       checkpoint: {
@@ -559,6 +581,11 @@ describe('EventActorExecutor', () => {
         message: 'Event actor result escaped its invocation checkpoint fork',
       }),
     });
+    expect(result).toHaveProperty('checkpoint');
+    if (result.status !== 'commit_indeterminate') {
+      throw new Error('Expected indeterminate commit');
+    }
+    expect(result.checkpoint).not.toHaveProperty('checkpointId');
     expect(host.commits).toHaveLength(0);
     expect(host.discards).toHaveLength(0);
   });
@@ -685,6 +712,41 @@ describe('EventActorExecutor', () => {
     await expect(
       executor.commit(preparation.invocation, terminal)
     ).rejects.toThrow('did not advance past its base');
+  });
+
+  it('rejects a stale commit head that switches checkpoint threads', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.commit = async () => ({
+      status: 'stale' as const,
+      head: {
+        actorThreadId: 'actor-thread',
+        generation: 2,
+        checkpoint: {
+          threadId: 'another-checkpoint-thread',
+          checkpointNs: 'other-namespace',
+          checkpointId: 'other-checkpoint',
+        },
+      },
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'switched-stale-thread',
+      depth: 1,
+      event: { text: 'switched-stale-thread' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const terminal = await executor.invoke(preparation.invocation);
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).rejects.toThrow('changed its checkpoint thread');
   });
 
   it('commits an applied result even when cancellation arrives as invoke returns', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
   EventActorAdapterPrepareRequest,
+  EventActorCheckpointFork,
   EventActorCommitRequest,
   EventActorDiscardRequest,
   EventActorHead,
@@ -447,7 +448,17 @@ describe('EventActorExecutor', () => {
       signal: parentController.signal,
       callbacks: [],
       tags: ['parent-trace'],
-      metadata: { userId: 'user-1', sessionId: 'session-1' },
+      metadata: {
+        userId: 'user-1',
+        sessionId: 'session-1',
+        run_id: 'parent-run',
+        thread_id: 'parent-thread',
+        checkpoint_ns: 'parent-namespace',
+        checkpoint_id: 'parent-checkpoint',
+        checkpoint_map: { parent: 'checkpoint' },
+        langgraph_checkpoint_ns: 'parent-langgraph-namespace',
+        __pregel_scratchpad: { parent: true },
+      },
       recursionLimit: 80,
       maxConcurrency: 4,
       timeout: 30_000,
@@ -457,6 +468,7 @@ describe('EventActorExecutor', () => {
       context: ambientContext,
       configurable: {
         user_id: 'user-1',
+        run_id: 'parent-configurable-run',
         requestBody: { conversationId: 'conversation-1' },
         userMCPAuthMap: { chess: 'credential' },
         thread_id: 'parent-thread',
@@ -508,6 +520,8 @@ describe('EventActorExecutor', () => {
       metadata: {
         userId: 'user-1',
         sessionId: 'session-1',
+        thread_id: 'actor-checkpoints',
+        checkpoint_ns: expect.stringMatching(/^event-actor\/[a-f0-9]{32}$/),
         eventActorThreadId: 'actor-thread',
       },
       configurable: {
@@ -537,8 +551,20 @@ describe('EventActorExecutor', () => {
     expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
       'lc_run_breaker_scope'
     );
+    expect(host.invokeConfigs[0].configurable).not.toHaveProperty('run_id');
     expect(host.invokeConfigs[0]).not.toHaveProperty('runId');
     expect(host.invokeConfigs[0]).not.toHaveProperty('runName');
+    expect(host.invokeConfigs[0].metadata).not.toHaveProperty('run_id');
+    expect(host.invokeConfigs[0].metadata).not.toHaveProperty('checkpoint_id');
+    expect(host.invokeConfigs[0].metadata).not.toHaveProperty('checkpoint_map');
+    expect(host.invokeConfigs[0].metadata).not.toHaveProperty(
+      'langgraph_checkpoint_ns'
+    );
+    expect(
+      Object.keys(host.invokeConfigs[0].metadata ?? {}).some((key) =>
+        key.startsWith('__pregel_')
+      )
+    ).toBe(false);
     release();
 
     const results = await Promise.all(executions);
@@ -688,6 +714,45 @@ describe('EventActorExecutor', () => {
     expect(result.checkpoint).not.toHaveProperty('checkpointId');
     expect(host.commits).toHaveLength(0);
     expect(host.discards).toHaveLength(0);
+  });
+
+  it('snapshots validated terminal evidence before awaiting commit', async () => {
+    const host = new TestHost();
+    let terminalCheckpoint: EventActorCheckpointFork | undefined;
+    host.invokeImpl = async (prepared) => {
+      terminalCheckpoint = {
+        ...prepared.fork,
+        checkpointId: 'trusted-terminal',
+      };
+      return {
+        status: 'applied',
+        result: 'action-completed',
+        checkpoint: terminalCheckpoint,
+      };
+    };
+    host.commit = async () => {
+      if (terminalCheckpoint == null) {
+        throw new Error('Expected terminal checkpoint');
+      }
+      terminalCheckpoint.threadId = 'mutated-thread';
+      terminalCheckpoint.checkpointNs = 'mutated-namespace';
+      terminalCheckpoint.checkpointId = 'mutated-checkpoint';
+      return { status: 'stale' as const, head: head(1) };
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('mutable-terminal'))
+    ).resolves.toMatchObject({
+      status: 'commit_conflict',
+      result: 'action-completed',
+      checkpoint: {
+        invocationId: 'mutable-terminal',
+        threadId: 'actor-checkpoints',
+        checkpointNs: expect.stringMatching(/^event-actor\/[a-f0-9]{32}$/),
+        checkpointId: 'trusted-terminal',
+      },
+    });
   });
 
   it('invokes with the authoritative request event after warm preparation', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -603,6 +603,26 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(2);
   });
 
+  it('enforces maxDepth for host-driven invocation', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host, { maxDepth: 1 });
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'host-driven-depth',
+      depth: 1,
+      event: { text: 'host-driven-depth' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    preparation.invocation.depth = 2;
+
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'exceeds maximum 1'
+    );
+    expect(host.invokes).toBe(0);
+  });
+
   it('derives nested depth from actor-owned ambient context', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host);
@@ -883,6 +903,37 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('retains the SDK-generated namespace across warm adapter mutation', async () => {
+    const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      prepareRequest.checkpointNs = 'shared-namespace';
+      return prepare(prepareRequest);
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('mutated-warm-namespace'))
+    ).rejects.toThrow('mismatched checkpoint ownership');
+    expect(host.invokes).toBe(0);
+  });
+
+  it('retains the SDK-generated namespace across cold adapter mutation', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead) => {
+      prepareRequest.checkpointNs = 'shared-namespace';
+      return coldContinue(prepareRequest, actorHead);
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('mutated-cold-namespace'))
+    ).rejects.toThrow('mismatched checkpoint ownership');
+    expect(host.invokes).toBe(0);
+  });
+
   it('rejects a stale commit result for another actor', async () => {
     const host = new TestHost();
     host.commit = async () => ({
@@ -965,6 +1016,56 @@ describe('EventActorExecutor', () => {
     await expect(
       executor.commit(preparation.invocation, terminal)
     ).rejects.toThrow('changed its checkpoint thread');
+  });
+
+  it('retains applied work when a stale head only relabels the base checkpoint', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.commit = async () => ({
+      status: 'stale' as const,
+      head: {
+        ...head(1, 'committed', 'checkpoint-0'),
+        generation: 2,
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('stale-base-checkpoint'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'stale-base-checkpoint',
+      error: {
+        message:
+          'Stale event actor head does not identify a competing checkpoint',
+      },
+    });
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('retains applied work when stale names the submitted checkpoint', async () => {
+    const host = new TestHost();
+    host.commit = async (commitRequest) => ({
+      status: 'stale' as const,
+      head: {
+        actorThreadId: 'actor-thread',
+        generation: 1,
+        checkpoint: { ...commitRequest.checkpoint },
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('stale-terminal-checkpoint'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'stale-terminal-checkpoint',
+      error: {
+        message:
+          'Stale event actor head does not identify a competing checkpoint',
+      },
+    });
+    expect(host.discards).toHaveLength(0);
   });
 
   it('commits an applied result even when cancellation arrives as invoke returns', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it, jest } from '@jest/globals';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -225,6 +226,15 @@ const request = (
 });
 
 describe('EventActorExecutor', () => {
+  it('rejects preparation signing keys below 256 bits', () => {
+    expect(
+      () =>
+        new EventActorExecutor(new TestHost(), {
+          preparationSigningKey: 'short-key',
+        })
+    ).toThrow('preparationSigningKey must contain at least 32 bytes');
+  });
+
   it('exposes the lifecycle seam for host-driven mailbox orchestration', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host);
@@ -357,6 +367,93 @@ describe('EventActorExecutor', () => {
       outcome: 'applied',
       detail: { code: 200 },
     });
+  });
+
+  it('snapshots applied results before reporting an invalid terminal checkpoint', async () => {
+    type ObjectResult = { outcome: string; detail: { code: number } };
+    const host = new TestHost();
+    const adapterResult: ObjectResult = {
+      outcome: 'applied',
+      detail: { code: 200 },
+    };
+    const adapter: EventActorHostAdapter<TestEvent, ObjectResult> = {
+      prepare: host.prepare.bind(host),
+      coldContinue: host.coldContinue.bind(host),
+      invoke: async () => ({
+        status: 'applied',
+        result: adapterResult,
+        checkpoint: {
+          invocationId: 'invalid-terminal',
+          threadId: 'foreign-checkpoint-thread',
+          checkpointNs: 'foreign-checkpoint-namespace',
+        },
+      }),
+      commit: async () => {
+        throw new Error('commit must not run');
+      },
+      discard: host.discard.bind(host),
+    };
+    const executor = new EventActorExecutor(adapter);
+
+    const execution = await executor.execute({
+      actorThreadId: 'actor-thread',
+      invocationId: 'invalid-terminal',
+      event: { text: 'invalid-terminal' },
+    });
+    if (execution.status !== 'commit_indeterminate') {
+      throw new Error('Expected an indeterminate commit');
+    }
+    adapterResult.outcome = 'mutated';
+    adapterResult.detail.code = 500;
+
+    expect(execution.result).toEqual({
+      outcome: 'applied',
+      detail: { code: 200 },
+    });
+    expect(Object.isFrozen(execution.result)).toBe(true);
+    expect(Object.isFrozen(execution.result.detail)).toBe(true);
+  });
+
+  it('validates and commits the same terminal checkpoint snapshot', async () => {
+    const host = new TestHost();
+    let namespaceReads = 0;
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: 'single-read-terminal',
+      checkpoint: Object.defineProperties(
+        {},
+        {
+          invocationId: {
+            enumerable: true,
+            value: prepared.invocationId,
+          },
+          threadId: { enumerable: true, value: prepared.fork.threadId },
+          checkpointNs: {
+            enumerable: true,
+            get: () => {
+              namespaceReads += 1;
+              return namespaceReads === 1
+                ? prepared.fork.checkpointNs
+                : 'forged-namespace';
+            },
+          },
+          checkpointId: {
+            enumerable: true,
+            value: 'single-read-terminal-checkpoint',
+          },
+        }
+      ) as EventActorCheckpointFork,
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('single-read-terminal'))
+    ).resolves.toMatchObject({
+      status: 'applied',
+      result: 'single-read-terminal',
+      head: { generation: 1 },
+    });
+    expect(namespaceReads).toBe(1);
   });
 
   it('commits applied work with current-plus-previous retention', async () => {
@@ -796,6 +893,160 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('rejects a publicly recomputable digest as preparation authority', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'plain-digest-forgery',
+      depth: 1,
+      event: { text: 'plain-digest-forgery' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const forgedEvent = { text: 'forged-event' };
+    const forgedDigest = createHash('sha256')
+      .update(
+        JSON.stringify({
+          kind: 'invocation',
+          actorThreadId: preparation.invocation.actorThreadId,
+          invocationId: preparation.invocation.invocationId,
+          depth: preparation.invocation.depth,
+          continuation: preparation.invocation.continuation,
+          base: {
+            actorThreadId: preparation.invocation.base.actorThreadId,
+            generation: preparation.invocation.base.generation,
+            checkpoint: null,
+          },
+          fork: {
+            invocationId: preparation.invocation.fork.invocationId,
+            threadId: preparation.invocation.fork.threadId,
+            checkpointId: null,
+            checkpointNs: preparation.invocation.fork.checkpointNs,
+          },
+          event: forgedEvent,
+        })
+      )
+      .digest('hex');
+
+    await expect(
+      executor.invoke({
+        ...preparation.invocation,
+        event: forgedEvent,
+        preparationDigest: forgedDigest,
+      })
+    ).rejects.toThrow('prepared invocation binding is invalid');
+    expect(host.invokes).toBe(0);
+  });
+
+  it('restores canonical prepared authority with the same private key', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    const signingKey = 'stable-preparation-key'.repeat(2);
+    const firstExecutor = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+    const preparation = await firstExecutor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'restored-warm-authority',
+      depth: 1,
+      event: { text: 'restored-warm-authority' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const baseCheckpoint = preparation.invocation.base.checkpoint;
+    if (baseCheckpoint == null) {
+      throw new Error('Expected a committed base checkpoint');
+    }
+    const restored = {
+      preparationDigest: preparation.invocation.preparationDigest,
+      event: { text: preparation.invocation.event.text },
+      fork: {
+        checkpointNs: preparation.invocation.fork.checkpointNs,
+        checkpointId: preparation.invocation.fork.checkpointId,
+        threadId: preparation.invocation.fork.threadId,
+        invocationId: preparation.invocation.fork.invocationId,
+      },
+      base: {
+        checkpoint: {
+          checkpointNs: baseCheckpoint.checkpointNs,
+          checkpointId: baseCheckpoint.checkpointId,
+          threadId: baseCheckpoint.threadId,
+        },
+        generation: preparation.invocation.base.generation,
+        actorThreadId: preparation.invocation.base.actorThreadId,
+      },
+      continuation: preparation.invocation.continuation,
+      depth: preparation.invocation.depth,
+      invocationId: preparation.invocation.invocationId,
+      actorThreadId: preparation.invocation.actorThreadId,
+    };
+    const restoredExecutor = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+
+    await expect(restoredExecutor.invoke(restored)).resolves.toMatchObject({
+      status: 'applied',
+      result: 'restored-warm-authority',
+    });
+  });
+
+  it('rejects restored prepared authority signed by another executor', async () => {
+    const host = new TestHost();
+    const issuer = new EventActorExecutor(host, {
+      preparationSigningKey: 'issuer-key'.repeat(4),
+    });
+    const preparation = await issuer.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'foreign-authority',
+      depth: 1,
+      event: { text: 'foreign-authority' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const verifier = new EventActorExecutor(host, {
+      preparationSigningKey: 'different-key'.repeat(4),
+    });
+
+    await expect(verifier.invoke(preparation.invocation)).rejects.toThrow(
+      'prepared invocation binding is invalid'
+    );
+    expect(host.invokes).toBe(0);
+  });
+
+  it('authenticates and executes the same immutable invocation snapshot', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'single-read-invocation',
+      depth: 1,
+      event: { text: 'single-read-invocation' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    let reads = 0;
+    const event = Object.defineProperty({}, 'text', {
+      enumerable: true,
+      get: () => {
+        reads += 1;
+        return reads === 1 ? 'single-read-invocation' : 'forged-event';
+      },
+    }) as TestEvent;
+
+    await expect(
+      executor.invoke({ ...preparation.invocation, event })
+    ).resolves.toMatchObject({
+      status: 'applied',
+      result: 'single-read-invocation',
+    });
+    expect(reads).toBe(1);
+  });
+
   it('enforces ambient actor depth for host-driven invocation', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host, { maxDepth: 2 });
@@ -999,6 +1250,84 @@ describe('EventActorExecutor', () => {
       })
     ).rejects.toThrow('unavailable preparation binding is invalid');
     expect(host.coldContinues).toBe(0);
+  });
+
+  it('restores canonical unavailable authority with the same private key', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const signingKey = 'stable-unavailable-key'.repeat(2);
+    const issuer = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+    const preparation = await issuer.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'restored-unavailable-authority',
+      depth: 1,
+      event: { text: 'restored-unavailable-authority' },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+    const restored = {
+      preparationDigest: preparation.preparationDigest,
+      head: {
+        checkpoint: {
+          checkpointNs: preparation.head.checkpoint?.checkpointNs ?? '',
+          checkpointId: preparation.head.checkpoint?.checkpointId,
+          threadId: preparation.head.checkpoint?.threadId ?? '',
+        },
+        generation: preparation.head.generation,
+        actorThreadId: preparation.head.actorThreadId,
+      },
+      request: {
+        event: { text: preparation.request.event.text },
+        depth: preparation.request.depth,
+        invocationId: preparation.request.invocationId,
+        actorThreadId: preparation.request.actorThreadId,
+      },
+      status: 'checkpoint_unavailable' as const,
+    };
+    const verifier = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+
+    await expect(verifier.coldContinue(restored)).resolves.toMatchObject({
+      actorThreadId: 'actor-thread',
+      invocationId: 'restored-unavailable-authority',
+      continuation: 'cold',
+    });
+  });
+
+  it('authenticates and cold-continues the same immutable handoff snapshot', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'single-read-cold-handoff',
+      depth: 1,
+      event: { text: 'single-read-cold-handoff' },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+    let reads = 0;
+    const event = Object.defineProperty({}, 'text', {
+      enumerable: true,
+      get: () => {
+        reads += 1;
+        return reads === 1 ? 'single-read-cold-handoff' : 'forged-event';
+      },
+    }) as TestEvent;
+
+    await expect(
+      executor.coldContinue({
+        ...preparation,
+        request: { ...preparation.request, event },
+      })
+    ).resolves.toMatchObject({ event: { text: 'single-read-cold-handoff' } });
+    expect(reads).toBe(1);
   });
 
   it('snapshots the cold-continuation handoff before adapter work can yield', async () => {
@@ -1854,7 +2183,7 @@ describe('EventActorExecutor', () => {
     }
 
     expect(() => executor.discard(malformed, 'failed')).toThrow(
-      'Event actor head is invalid'
+      'prepared invocation binding is invalid'
     );
     const forgedSettlement = {
       ...terminal,
@@ -1865,6 +2194,35 @@ describe('EventActorExecutor', () => {
     );
     expect(host.discards).toHaveLength(0);
     expect(host.commits).toHaveLength(0);
+  });
+
+  it('requires executor-issued authority before public discard', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'authorized-discard',
+      depth: 1,
+      event: { text: 'authorized-discard' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).resolves.toBeUndefined();
+    expect(host.discards).toHaveLength(1);
+    expect(() =>
+      executor.discard(
+        {
+          ...preparation.invocation,
+          preparationDigest: '0'.repeat(64),
+        },
+        'failed'
+      )
+    ).toThrow('prepared invocation binding is invalid');
+    expect(host.discards).toHaveLength(1);
   });
 
   it('detects a cold adapter mutating its copy of the prepared head', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -441,34 +441,42 @@ describe('EventActorExecutor', () => {
       };
     };
     const executor = new EventActorExecutor(host);
+    const ambientStore = { get: jest.fn() };
+    const ambientContext = { tenantId: 'tenant-1' };
+    const ambientConfig = {
+      signal: parentController.signal,
+      callbacks: [],
+      tags: ['parent-trace'],
+      metadata: { userId: 'user-1', sessionId: 'session-1' },
+      recursionLimit: 80,
+      maxConcurrency: 4,
+      timeout: 30_000,
+      runId: 'parent-run',
+      runName: 'parent-run-name',
+      store: ambientStore,
+      context: ambientContext,
+      configurable: {
+        user_id: 'user-1',
+        requestBody: { conversationId: 'conversation-1' },
+        userMCPAuthMap: { chess: 'credential' },
+        thread_id: 'parent-thread',
+        checkpoint_ns: 'parent-namespace',
+        checkpoint_id: 'parent-checkpoint',
+        checkpoint_map: { parent: 'checkpoint' },
+        __pregel_checkpointer: { parent: true },
+        __pregel_scratchpad: { parent: true },
+        __librechat_subagent_resume_manifest: { parent: true },
+        __librechat_tool_approval_execution_scope: { parent: true },
+        lc_run_breaker_scope: { parent: true },
+      },
+    } as RunnableConfig & {
+      store: typeof ambientStore;
+      context: typeof ambientContext;
+    };
 
     const runnableConfigSpy = jest
       .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
-      .mockReturnValue({
-        signal: parentController.signal,
-        callbacks: [],
-        tags: ['parent-trace'],
-        metadata: { userId: 'user-1', sessionId: 'session-1' },
-        recursionLimit: 80,
-        maxConcurrency: 4,
-        timeout: 30_000,
-        runId: 'parent-run',
-        runName: 'parent-run-name',
-        configurable: {
-          user_id: 'user-1',
-          requestBody: { conversationId: 'conversation-1' },
-          userMCPAuthMap: { chess: 'credential' },
-          thread_id: 'parent-thread',
-          checkpoint_ns: 'parent-namespace',
-          checkpoint_id: 'parent-checkpoint',
-          checkpoint_map: { parent: 'checkpoint' },
-          __pregel_checkpointer: { parent: true },
-          __pregel_scratchpad: { parent: true },
-          __librechat_subagent_resume_manifest: { parent: true },
-          __librechat_tool_approval_execution_scope: { parent: true },
-          lc_run_breaker_scope: { parent: true },
-        },
-      });
+      .mockReturnValue(ambientConfig);
     const executions = [
       executor.execute(request('sibling-a')),
       executor.execute(request('sibling-b')),
@@ -495,6 +503,8 @@ describe('EventActorExecutor', () => {
       recursionLimit: 80,
       maxConcurrency: 4,
       timeout: 30_000,
+      store: ambientStore,
+      context: ambientContext,
       metadata: {
         userId: 'user-1',
         sessionId: 'session-1',

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -2494,4 +2494,41 @@ describe('EventActorExecutor', () => {
       status: 'committed',
     });
   });
+
+  it('returns indeterminate evidence for an invalid public terminal checkpoint', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: 'public-invalid-checkpoint',
+      checkpoint: {
+        ...prepared.fork,
+        checkpointNs: 'foreign-checkpoint-namespace',
+        checkpointId: 'public-invalid-terminal',
+      },
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-invalid-checkpoint',
+      depth: 1,
+      event: { text: 'public-invalid-checkpoint' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    const terminal = await executor.invoke(preparation.invocation);
+
+    expect(terminal).toEqual(
+      expect.objectContaining({
+        status: 'commit_indeterminate',
+        result: 'public-invalid-checkpoint',
+        error: expect.objectContaining({
+          message: expect.stringContaining('escaped its invocation'),
+        }),
+      })
+    );
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards).toHaveLength(0);
+  });
 });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { describe, expect, it, jest } from '@jest/globals';
+import { Command, GraphInterrupt, ParentCommand } from '@langchain/langgraph';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type {
@@ -18,7 +19,7 @@ import type {
 } from '@/eventActor';
 import { EventActorExecutor } from '@/eventActor';
 
-type TestEvent = { text: string };
+type TestEvent = { text: string; value?: number };
 
 const head = (
   generation = 0,
@@ -226,6 +227,18 @@ const request = (
 });
 
 describe('EventActorExecutor', () => {
+  it('keeps lifecycle capability state runtime-private', () => {
+    const executor = new EventActorExecutor(new TestHost());
+
+    expect(Object.getOwnPropertyNames(executor)).toEqual([]);
+    expect(Reflect.get(executor, 'preparationSigningKey')).toBeUndefined();
+    expect(Reflect.get(executor, 'issuedSettlements')).toBeUndefined();
+    expect(Reflect.get(executor, 'signPreparation')).toBeUndefined();
+    expect(Reflect.get(executor, 'issueSettlement')).toBeUndefined();
+    expect(Reflect.get(executor, 'invokeWithConfig')).toBeUndefined();
+    expect(Reflect.get(executor, 'discardInvocationReference')).toBeUndefined();
+  });
+
   it('rejects preparation signing keys below 256 bits', () => {
     expect(
       () =>
@@ -403,6 +416,9 @@ describe('EventActorExecutor', () => {
     if (execution.status !== 'commit_indeterminate') {
       throw new Error('Expected an indeterminate commit');
     }
+    if (execution.result == null) {
+      throw new Error('Expected preserved applied result evidence');
+    }
     adapterResult.outcome = 'mutated';
     adapterResult.detail.code = 500;
 
@@ -412,6 +428,41 @@ describe('EventActorExecutor', () => {
     });
     expect(Object.isFrozen(execution.result)).toBe(true);
     expect(Object.isFrozen(execution.result.detail)).toBe(true);
+  });
+
+  it('returns indeterminate evidence when an applied result is not JSON-safe', async () => {
+    const host = new TestHost();
+    const sparseResult = new Array<EventActorEvent>(1);
+    const adapter: EventActorHostAdapter<TestEvent, EventActorEvent> = {
+      prepare: host.prepare.bind(host),
+      coldContinue: host.coldContinue.bind(host),
+      invoke: async (prepared) => ({
+        status: 'applied',
+        result: sparseResult,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: 'sparse-result-terminal',
+        },
+      }),
+      commit: async () => {
+        throw new Error('commit must not run');
+      },
+      discard: host.discard.bind(host),
+    };
+    const executor = new EventActorExecutor(adapter);
+
+    const execution = await executor.execute(request('sparse-result'));
+    expect(execution).toEqual(
+      expect.objectContaining({
+        status: 'commit_indeterminate',
+        error: expect.objectContaining({
+          message: expect.stringContaining('arrays must not contain holes'),
+        }),
+        continuation: 'warm',
+      })
+    );
+    expect(execution).not.toHaveProperty('result');
+    expect(host.discards).toHaveLength(0);
   });
 
   it('validates and commits the same terminal checkpoint snapshot', async () => {
@@ -620,6 +671,21 @@ describe('EventActorExecutor', () => {
     expect(cancelledHost.commits).toHaveLength(0);
     expect(failedHost.discards[0].reason).toBe('failed');
     expect(cancelledHost.discards[0].reason).toBe('cancelled');
+  });
+
+  it.each([
+    ['GraphInterrupt', new GraphInterrupt([])],
+    ['ParentCommand', new ParentCommand(new Command({ goto: 'parent-node' }))],
+  ])('propagates %s without discarding its resumable fork', async (_, flow) => {
+    const host = new TestHost();
+    host.invokeImpl = async () => {
+      throw flow;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('control-flow'))).rejects.toBe(flow);
+    expect(host.discards).toHaveLength(0);
+    expect(host.commits).toHaveLength(0);
   });
 
   it('isolates duplicate deliveries and retains an applied CAS conflict', async () => {
@@ -983,6 +1049,28 @@ describe('EventActorExecutor', () => {
       invocationId: preparation.invocation.invocationId,
       actorThreadId: preparation.invocation.actorThreadId,
     };
+    const extension = Symbol('checkpoint-extension');
+    Object.assign(restored.fork, { untrustedExtension: 'fork-extension' });
+    Object.assign(restored.base.checkpoint, {
+      untrustedExtension: 'checkpoint-extension',
+    });
+    Object.defineProperty(restored.fork, extension, {
+      enumerable: true,
+      value: 'symbol-extension',
+    });
+    host.invokeImpl = async (prepared) => {
+      expect(prepared.fork).not.toHaveProperty('untrustedExtension');
+      expect(prepared.base.checkpoint).not.toHaveProperty('untrustedExtension');
+      expect(Object.getOwnPropertySymbols(prepared.fork)).toHaveLength(0);
+      return {
+        status: 'applied',
+        result: prepared.event.text,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: 'restored-authority-terminal',
+        },
+      };
+    };
     const restoredExecutor = new EventActorExecutor(host, {
       preparationSigningKey: signingKey,
     });
@@ -1217,6 +1305,38 @@ describe('EventActorExecutor', () => {
     expect(prepareSpy).not.toHaveBeenCalled();
   });
 
+  it('normalizes signed zero at the immutable JSON boundary', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: Object.is(prepared.event.value, -0) ? 'negative-zero' : 'zero',
+      checkpoint: {
+        ...prepared.fork,
+        checkpointId: 'signed-zero-terminal',
+      },
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'signed-zero',
+      depth: 1,
+      event: { text: 'signed-zero', value: -0 },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const restored = {
+      ...preparation.invocation,
+      event: { text: 'signed-zero', value: 0 },
+    };
+
+    expect(Object.is(preparation.invocation.event.value, -0)).toBe(false);
+    await expect(executor.invoke(restored)).resolves.toMatchObject({
+      status: 'applied',
+      result: 'zero',
+    });
+  });
+
   it('rejects recombined unavailable request and head evidence', async () => {
     const host = new TestHost();
     host.checkpointAvailable = false;
@@ -1287,6 +1407,15 @@ describe('EventActorExecutor', () => {
         actorThreadId: preparation.request.actorThreadId,
       },
       status: 'checkpoint_unavailable' as const,
+    };
+    Object.assign(restored.head.checkpoint, {
+      untrustedExtension: 'checkpoint-extension',
+    });
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (adapterRequest, actorHead, context) => {
+      expect(actorHead).not.toHaveProperty('untrustedExtension');
+      expect(actorHead.checkpoint).not.toHaveProperty('untrustedExtension');
+      return coldContinue(adapterRequest, actorHead, context);
     };
     const verifier = new EventActorExecutor(host, {
       preparationSigningKey: signingKey,

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -293,11 +293,15 @@ describe('EventActorExecutor', () => {
 
   it('discards normal completions without qualifying action evidence', async () => {
     const host = new TestHost();
-    host.invokeImpl = async () => ({ status: 'completed_no_action' });
+    host.invokeImpl = async () => ({
+      status: 'completed_no_action',
+      result: 'observation recorded',
+    });
     const executor = new EventActorExecutor(host);
 
     await expect(executor.execute(request('no-action'))).resolves.toEqual({
       status: 'completed_no_action',
+      result: 'observation recorded',
       continuation: 'warm',
     });
     expect(host.commits).toHaveLength(0);
@@ -545,6 +549,54 @@ describe('EventActorExecutor', () => {
       executor.execute(request('grandchild', { depth: 2 }))
     ).rejects.toThrow('exceeds maximum 1');
     expect(host.invokes).toBe(2);
+  });
+
+  it('derives nested depth from actor-owned ambient context', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const ambientConfig: RunnableConfig = {
+      configurable: { event_actor_depth: 1 },
+    };
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue(ambientConfig);
+
+    await expect(
+      executor.execute(request('implicit-grandchild'))
+    ).rejects.toThrow('exceeds maximum 1');
+    await expect(
+      executor.execute(request('forged-grandchild', { depth: 1 }))
+    ).rejects.toThrow('must advance parent depth 1');
+    runnableConfigSpy.mockRestore();
+    expect(host.invokes).toBe(0);
+  });
+
+  it('cancels before unavailable checkpoints enter cold continuation', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const prepare = host.prepare.bind(host);
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.prepare = async (prepareRequest) => {
+      await gate;
+      return prepare(prepareRequest);
+    };
+    const controller = new AbortController();
+    const execution = new EventActorExecutor(host).execute(
+      request('cancel-before-cold', { signal: controller.signal })
+    );
+    controller.abort(new Error('cancelled'));
+    release();
+
+    await expect(execution).resolves.toEqual({
+      status: 'cancelled',
+      continuation: 'cold',
+    });
+    expect(host.coldContinues).toBe(0);
+    expect(host.invokes).toBe(0);
+    expect(host.discards).toHaveLength(0);
   });
 
   it('retains an applied result with a checkpoint outside the invocation fork', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -365,6 +365,13 @@ describe('EventActorExecutor', () => {
       'applied',
       'commit_conflict',
     ]);
+    expect(
+      results.find((result) => result.status === 'commit_conflict')
+    ).toMatchObject({
+      result: 'same-event',
+      checkpoint: { invocationId: 'same-event' },
+      head: { actorThreadId: 'actor-thread', generation: 1 },
+    });
     expect(host.generation).toBe(1);
     expect(new Set(host.forkNamespaces).size).toBe(2);
     expect(host.discards).toHaveLength(0);
@@ -378,6 +385,11 @@ describe('EventActorExecutor', () => {
     await expect(executor.execute(request('uncertain'))).resolves.toMatchObject(
       {
         status: 'commit_indeterminate',
+        result: 'uncertain',
+        checkpoint: {
+          invocationId: 'uncertain',
+          checkpointId: 'result-uncertain',
+        },
         error: { message: 'connection dropped after commit' },
       }
     );
@@ -433,6 +445,11 @@ describe('EventActorExecutor', () => {
         callbacks: [],
         tags: ['parent-trace'],
         metadata: { userId: 'user-1', sessionId: 'session-1' },
+        recursionLimit: 80,
+        maxConcurrency: 4,
+        timeout: 30_000,
+        runId: 'parent-run',
+        runName: 'parent-run-name',
         configurable: {
           user_id: 'user-1',
           requestBody: { conversationId: 'conversation-1' },
@@ -466,6 +483,9 @@ describe('EventActorExecutor', () => {
     expect(host.invokeConfigs[0]).toMatchObject({
       callbacks: [],
       tags: ['parent-trace'],
+      recursionLimit: 80,
+      maxConcurrency: 4,
+      timeout: 30_000,
       metadata: {
         userId: 'user-1',
         sessionId: 'session-1',
@@ -490,6 +510,8 @@ describe('EventActorExecutor', () => {
     expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
       'checkpoint_map'
     );
+    expect(host.invokeConfigs[0]).not.toHaveProperty('runId');
+    expect(host.invokeConfigs[0]).not.toHaveProperty('runName');
     release();
 
     const results = await Promise.all(executions);
@@ -528,6 +550,11 @@ describe('EventActorExecutor', () => {
 
     await expect(executor.execute(request('escape'))).resolves.toMatchObject({
       status: 'commit_indeterminate',
+      result: 'bad',
+      checkpoint: {
+        invocationId: 'escape',
+        threadId: 'actor-checkpoints',
+      },
       error: expect.objectContaining({
         message: 'Event actor result escaped its invocation checkpoint fork',
       }),
@@ -592,6 +619,25 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('rejects a fork that leaves the committed logical checkpoint thread', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.fork.threadId = 'another-checkpoint-thread';
+      }
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('foreign-checkpoint-thread'))
+    ).rejects.toThrow('changed its logical checkpoint thread');
+    expect(host.invokes).toBe(0);
+  });
+
   it('rejects a stale commit result for another actor', async () => {
     const host = new TestHost();
     host.commit = async () => ({
@@ -616,6 +662,29 @@ describe('EventActorExecutor', () => {
     await expect(
       executor.commit(preparation.invocation, terminal)
     ).rejects.toThrow('Event actor head is invalid');
+  });
+
+  it('rejects a stale commit head that did not advance past its base', async () => {
+    const host = new TestHost();
+    host.commit = async () => ({ status: 'stale' as const, head: head(0) });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'non-advanced-stale-head',
+      depth: 1,
+      event: { text: 'non-advanced-stale-head' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const terminal = await executor.invoke(preparation.invocation);
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).rejects.toThrow('did not advance past its base');
   });
 
   it('commits an applied result even when cancellation arrives as invoke returns', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -512,7 +512,7 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(2);
   });
 
-  it('discards a checkpoint outside the invocation fork', async () => {
+  it('retains an applied result with a checkpoint outside the invocation fork', async () => {
     const host = new TestHost();
     host.invokeImpl = async () => ({
       status: 'applied',
@@ -527,13 +527,95 @@ describe('EventActorExecutor', () => {
     const executor = new EventActorExecutor(host);
 
     await expect(executor.execute(request('escape'))).resolves.toMatchObject({
-      status: 'failed',
+      status: 'commit_indeterminate',
       error: expect.objectContaining({
         message: 'Event actor result escaped its invocation checkpoint fork',
       }),
     });
     expect(host.commits).toHaveLength(0);
-    expect(host.discards[0].reason).toBe('failed');
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('invokes with the authoritative request event after warm preparation', async () => {
+    const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.event = { text: 'stale-event' };
+      }
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('authoritative-event'))
+    ).resolves.toMatchObject({
+      status: 'applied',
+      result: 'authoritative-event',
+    });
+  });
+
+  it('invokes with the authoritative request event after cold continuation', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead) => {
+      const prepared = await coldContinue(prepareRequest, actorHead);
+      prepared.event = { text: 'stale-event' };
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('authoritative-cold-event'))
+    ).resolves.toMatchObject({
+      status: 'applied',
+      result: 'authoritative-cold-event',
+      continuation: 'cold',
+    });
+  });
+
+  it('rejects an advanced head without committed checkpoint identity', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.prepare = async () => ({
+      status: 'checkpoint_unavailable' as const,
+      head: { actorThreadId: 'actor-thread', generation: 1 },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('missing-head-checkpoint'))
+    ).rejects.toThrow('Advanced event actor head has no checkpoint');
+    expect(host.coldContinues).toBe(0);
+    expect(host.invokes).toBe(0);
+  });
+
+  it('rejects a stale commit result for another actor', async () => {
+    const host = new TestHost();
+    host.commit = async () => ({
+      status: 'stale' as const,
+      head: { actorThreadId: 'another-actor', generation: 0 },
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'foreign-stale-head',
+      depth: 1,
+      event: { text: 'foreign-stale-head' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const terminal = await executor.invoke(preparation.invocation);
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).rejects.toThrow('Event actor head is invalid');
   });
 
   it('commits an applied result even when cancellation arrives as invoke returns', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -652,6 +652,44 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(0);
   });
 
+  it('retains an applied result that reports the fork starting checkpoint', async () => {
+    const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.fork.checkpointId = 'starting-checkpoint';
+      }
+      return prepared;
+    };
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: 'action-claimed',
+      checkpoint: { ...prepared.fork },
+    });
+    const executor = new EventActorExecutor(host);
+
+    const result = await executor.execute(request('unchanged-checkpoint'));
+
+    expect(result).toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'action-claimed',
+      checkpoint: {
+        invocationId: 'unchanged-checkpoint',
+        threadId: 'actor-checkpoints',
+      },
+      error: {
+        message: 'Event actor result escaped its invocation checkpoint fork',
+      },
+    });
+    if (result.status !== 'commit_indeterminate') {
+      throw new Error('Expected indeterminate commit');
+    }
+    expect(result.checkpoint).not.toHaveProperty('checkpointId');
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards).toHaveLength(0);
+  });
+
   it('invokes with the authoritative request event after warm preparation', async () => {
     const host = new TestHost();
     const prepare = host.prepare.bind(host);

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -317,7 +317,82 @@ describe('EventActorExecutor', () => {
         executor.discard(consumed.invocation, 'completed_no_action')
       ).rejects.toThrow('prepared invocation binding has expired');
       expect(host.invokes).toBe(1);
-      expect(host.discards).toHaveLength(0);
+      expect(host.discards).toHaveLength(1);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('retains a terminal fence through signed authority expiry after clock rollback', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    try {
+      const host = new TestHost();
+      const executor = new EventActorExecutor(host, {
+        dormantCheckpointTtlMs: 100,
+      });
+      const preparation = await executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'rollback-terminal-fence',
+        depth: 1,
+        event: { text: 'rollback-terminal-fence' },
+      });
+      if (preparation.status !== 'ready') {
+        throw new Error('Expected warm preparation');
+      }
+
+      now.mockReturnValue(900);
+      await expect(
+        executor.invoke(preparation.invocation)
+      ).resolves.toMatchObject({ status: 'applied' });
+      now.mockReturnValue(1_050);
+      await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+        'already consumed'
+      );
+      expect(host.invokes).toBe(1);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('time-bounds and consumes checkpoint-unavailable handoffs', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    try {
+      const host = new TestHost();
+      host.checkpointAvailable = false;
+      const executor = new EventActorExecutor(host, {
+        dormantCheckpointTtlMs: 10,
+      });
+      const consumed = await executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'consumed-unavailable',
+        depth: 1,
+        event: { text: 'consumed-unavailable' },
+      });
+      if (consumed.status !== 'checkpoint_unavailable') {
+        throw new Error('Expected unavailable checkpoint');
+      }
+      await expect(executor.coldContinue(consumed)).resolves.toMatchObject({
+        invocationId: 'consumed-unavailable',
+        continuation: 'cold',
+      });
+      await expect(executor.coldContinue(consumed)).rejects.toThrow(
+        'unavailable preparation was already consumed'
+      );
+
+      const expired = await executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'expired-unavailable',
+        depth: 1,
+        event: { text: 'expired-unavailable' },
+      });
+      if (expired.status !== 'checkpoint_unavailable') {
+        throw new Error('Expected unavailable checkpoint');
+      }
+      now.mockReturnValue(1_010);
+      await expect(executor.coldContinue(expired)).rejects.toThrow(
+        'unavailable preparation binding has expired'
+      );
+      expect(host.coldContinues).toBe(1);
     } finally {
       now.mockRestore();
     }
@@ -2550,7 +2625,7 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(1);
   });
 
-  it('keeps a public no-action capability discardable but non-invokable', async () => {
+  it('reclaims a public no-action fork before returning and prevents reinvocation', async () => {
     const host = new TestHost();
     host.invokeImpl = async () => ({
       status: 'completed_no_action',
@@ -2576,9 +2651,71 @@ describe('EventActorExecutor', () => {
     );
     await expect(
       executor.discard(preparation.invocation, 'completed_no_action')
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow('no longer discardable');
     expect(host.invokes).toBe(1);
     expect(host.discards).toHaveLength(1);
+  });
+
+  it('reclaims a definitely failed public invocation before rethrowing', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => {
+      throw new Error('provider failed before action');
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-failure-cleanup',
+      depth: 1,
+      event: { text: 'public-failure-cleanup' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'provider failed before action'
+    );
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'already consumed'
+    );
+    expect(host.discards).toEqual([
+      expect.objectContaining({ reason: 'failed' }),
+    ]);
+  });
+
+  it('preserves cleanup-only authority after public failure cleanup rejects', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => {
+      throw new Error('provider failed before action');
+    };
+    host.discard = async (discardRequest) => {
+      host.discards.push(discardRequest);
+      throw new Error('cleanup failed');
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-failure-cleanup-retry',
+      depth: 1,
+      event: { text: 'public-failure-cleanup-retry' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'cleanup failed'
+    );
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'already consumed'
+    );
+    host.discard = async (discardRequest) => {
+      host.discards.push(discardRequest);
+    };
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).resolves.toBeUndefined();
+    expect(host.discards).toHaveLength(2);
   });
 
   it('revokes public discard authority while invocation is active and after action', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -657,15 +657,16 @@ describe('EventActorExecutor', () => {
       depth: 1,
       event: { text: 'ambient-warm-prepare' },
     });
-    const coldPreparation = executor.coldContinue(
-      {
+    const coldPreparation = executor.coldContinue({
+      status: 'checkpoint_unavailable',
+      request: {
         actorThreadId: 'actor-thread',
         invocationId: 'ambient-cold-prepare',
         depth: 1,
         event: { text: 'ambient-cold-prepare' },
       },
-      head(0)
-    );
+      head: head(0),
+    });
     runnableConfigSpy.mockRestore();
 
     await expect(warmPreparation).rejects.toThrow(
@@ -676,6 +677,36 @@ describe('EventActorExecutor', () => {
     );
     expect(host.coldContinues).toBe(0);
     expect(host.invokes).toBe(0);
+  });
+
+  it('preserves prepared ancestry after async-local context ends', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue({ configurable: { event_actor_depth: 1 } });
+    const preparationPromise = executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'persisted-cold-ancestry',
+      depth: 2,
+      event: { text: 'persisted-cold-ancestry' },
+    });
+    runnableConfigSpy.mockRestore();
+    const preparation = await preparationPromise;
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+
+    const invocation = await executor.coldContinue(preparation);
+
+    expect(preparation.request.depth).toBe(2);
+    expect(invocation).toMatchObject({
+      actorThreadId: 'actor-thread',
+      invocationId: 'persisted-cold-ancestry',
+      depth: 2,
+      continuation: 'cold',
+    });
   });
 
   it('derives nested depth from actor-owned ambient context', async () => {
@@ -1271,15 +1302,16 @@ describe('EventActorExecutor', () => {
     const executor = new EventActorExecutor(host);
 
     await expect(
-      executor.coldContinue(
-        {
+      executor.coldContinue({
+        status: 'checkpoint_unavailable',
+        request: {
           actorThreadId: 'actor-thread',
           invocationId: 'foreign-head',
           depth: 1,
           event: { text: 'foreign-head' },
         },
-        { actorThreadId: 'another-actor', generation: 0 }
-      )
+        head: { actorThreadId: 'another-actor', generation: 0 },
+      })
     ).rejects.toThrow('Event actor head is invalid');
     expect(host.coldContinues).toBe(0);
   });
@@ -1332,15 +1364,16 @@ describe('EventActorExecutor', () => {
     const executor = new EventActorExecutor(host);
 
     await expect(
-      executor.coldContinue(
-        {
+      executor.coldContinue({
+        status: 'checkpoint_unavailable',
+        request: {
           actorThreadId: 'actor-thread',
           invocationId: 'mutated-head',
           depth: 1,
           event: { text: 'mutated-head' },
         },
-        validHead
-      )
+        head: validHead,
+      })
     ).rejects.toThrow('Cold continuation did not use the prepared actor head');
     expect(validHead.generation).toBe(1);
   });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -232,6 +232,7 @@ describe('EventActorExecutor', () => {
 
     expect(Object.getOwnPropertyNames(executor)).toEqual([]);
     expect(Reflect.get(executor, 'preparationSigningKey')).toBeUndefined();
+    expect(Reflect.get(executor, 'preparationPhases')).toBeUndefined();
     expect(Reflect.get(executor, 'issuedSettlements')).toBeUndefined();
     expect(Reflect.get(executor, 'signPreparation')).toBeUndefined();
     expect(Reflect.get(executor, 'issueSettlement')).toBeUndefined();
@@ -642,6 +643,29 @@ describe('EventActorExecutor', () => {
     ]);
   });
 
+  it('discards a no-action fork when its result cannot be snapshotted', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => ({
+      status: 'completed_no_action',
+      result: new Array<EventActorEvent>(1) as unknown as string,
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('invalid-no-action-result'))
+    ).resolves.toMatchObject({
+      status: 'failed',
+      error: {
+        message: expect.stringContaining('arrays must not contain holes'),
+      },
+      continuation: 'warm',
+    });
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards).toEqual([
+      expect.objectContaining({ reason: 'completed_no_action' }),
+    ]);
+  });
+
   it('discards failures and explicit cancellations without advancing the head', async () => {
     const failedHost = new TestHost();
     failedHost.invokeImpl = async () => {
@@ -745,6 +769,59 @@ describe('EventActorExecutor', () => {
       }
     );
     expect(host.commits).toHaveLength(1);
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('returns indeterminate evidence from the public commit seam', async () => {
+    const host = new TestHost();
+    host.commitError = new Error('response lost after public commit');
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-uncertain',
+      depth: 1,
+      event: { text: 'public-uncertain' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const settlement = await executor.invoke(preparation.invocation);
+    if (settlement.status !== 'applied') {
+      throw new Error('Expected applied settlement');
+    }
+
+    await expect(executor.commit(settlement)).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'public-uncertain',
+      checkpoint: { checkpointId: 'result-public-uncertain' },
+      error: { message: 'response lost after public commit' },
+    });
+    await expect(executor.commit(settlement)).rejects.toThrow(
+      'settlement was not issued by this executor'
+    );
+    expect(host.commits).toHaveLength(1);
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('converts hostile post-action errors without throwing', async () => {
+    const hostileError = {
+      [Symbol.toPrimitive]: () => {
+        throw new Error('string conversion failed');
+      },
+    };
+    const host = new TestHost();
+    host.commit = async () => {
+      throw hostileError;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('hostile-commit-error'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'hostile-commit-error',
+      error: { message: 'Unknown event actor error' },
+    });
     expect(host.discards).toHaveLength(0);
   });
 
@@ -1334,6 +1411,45 @@ describe('EventActorExecutor', () => {
     await expect(executor.invoke(restored)).resolves.toMatchObject({
       status: 'applied',
       result: 'zero',
+    });
+  });
+
+  it('normalizes signed zero in authenticated actor heads', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: Object.is(prepared.base.generation, -0)
+        ? 'negative-zero-generation'
+        : 'zero-generation',
+      checkpoint: {
+        ...prepared.fork,
+        checkpointId: 'signed-zero-head-terminal',
+      },
+    });
+    const signingKey = 's'.repeat(32);
+    const issuer = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+    const preparation = await issuer.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'signed-zero-head',
+      depth: 1,
+      event: { text: 'signed-zero-head' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const restored = {
+      ...preparation.invocation,
+      base: { ...preparation.invocation.base, generation: -0 },
+    };
+    const verifier = new EventActorExecutor(host, {
+      preparationSigningKey: signingKey,
+    });
+
+    await expect(verifier.invoke(restored)).resolves.toMatchObject({
+      status: 'applied',
+      result: 'zero-generation',
     });
   });
 
@@ -2051,9 +2167,10 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(executor.commit(terminal)).rejects.toThrow(
-      'Event actor head is invalid'
-    );
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      error: { message: 'Event actor head is invalid' },
+    });
   });
 
   it('rejects a stale commit head that did not advance past its base', async () => {
@@ -2074,9 +2191,10 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(executor.commit(terminal)).rejects.toThrow(
-      'did not advance past its base'
-    );
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      error: { message: expect.stringContaining('did not advance past') },
+    });
   });
 
   it('rejects a stale commit head that switches checkpoint threads', async () => {
@@ -2109,9 +2227,10 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(executor.commit(terminal)).rejects.toThrow(
-      'changed its checkpoint thread'
-    );
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      error: { message: expect.stringContaining('changed its checkpoint') },
+    });
   });
 
   it('retains applied work when stale moves the base checkpoint to another namespace', async () => {
@@ -2311,7 +2430,7 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    expect(() => executor.discard(malformed, 'failed')).toThrow(
+    await expect(executor.discard(malformed, 'failed')).rejects.toThrow(
       'prepared invocation binding is invalid'
     );
     const forgedSettlement = {
@@ -2339,10 +2458,13 @@ describe('EventActorExecutor', () => {
     }
 
     await expect(
+      executor.discard(preparation.invocation, 'applied' as unknown as 'failed')
+    ).rejects.toThrow('discard reason is invalid');
+    await expect(
       executor.discard(preparation.invocation, 'failed')
     ).resolves.toBeUndefined();
     expect(host.discards).toHaveLength(1);
-    expect(() =>
+    await expect(
       executor.discard(
         {
           ...preparation.invocation,
@@ -2350,8 +2472,87 @@ describe('EventActorExecutor', () => {
         },
         'failed'
       )
-    ).toThrow('prepared invocation binding is invalid');
+    ).rejects.toThrow('prepared invocation binding is invalid');
     expect(host.discards).toHaveLength(1);
+  });
+
+  it('revokes public discard authority while invocation is active and after action', async () => {
+    const host = new TestHost();
+    let started = (): void => undefined;
+    let release = (): void => undefined;
+    const invocationStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.invokeImpl = async (prepared) => {
+      started();
+      await gate;
+      return {
+        status: 'applied',
+        result: 'action-applied',
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: 'phase-bound-terminal',
+        },
+      };
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'phase-bound-discard',
+      depth: 1,
+      event: { text: 'phase-bound-discard' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    const invocationResult = executor.invoke(preparation.invocation);
+    await invocationStarted;
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).rejects.toThrow('no longer discardable');
+    release();
+    await expect(invocationResult).resolves.toMatchObject({
+      status: 'applied',
+    });
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).rejects.toThrow('no longer discardable');
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('revokes public discard authority for indeterminate applied evidence', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: 'action-applied',
+      checkpoint: {
+        ...prepared.fork,
+        checkpointNs: 'foreign-namespace',
+        checkpointId: 'indeterminate-terminal',
+      },
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'indeterminate-discard',
+      depth: 1,
+      event: { text: 'indeterminate-discard' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(
+      executor.invoke(preparation.invocation)
+    ).resolves.toMatchObject({ status: 'commit_indeterminate' });
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).rejects.toThrow('no longer discardable');
+    expect(host.discards).toHaveLength(0);
   });
 
   it('detects a cold adapter mutating its copy of the prepared head', async () => {

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -58,6 +58,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
   checkpointAvailable = true;
   committedCheckpointNs = 'committed';
   committedCheckpointId = 'checkpoint-0';
+  coldContinues = 0;
   invokes = 0;
   activeInvocations = 0;
   maxActiveInvocations = 0;
@@ -100,6 +101,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     request: EventActorAdapterPrepareRequest<TestEvent>,
     _head: EventActorHead
   ) {
+    this.coldContinues += 1;
     return {
       ...invocation(request, 'cold', this.generation),
       base: head(
@@ -335,7 +337,7 @@ describe('EventActorExecutor', () => {
     expect(cancelledHost.discards[0].reason).toBe('cancelled');
   });
 
-  it('allows only one concurrent invocation from a committed generation to advance', async () => {
+  it('isolates duplicate deliveries and retains an applied CAS conflict', async () => {
     const host = new TestHost();
     let release = (): void => undefined;
     const gate = new Promise<void>((resolve) => {
@@ -353,20 +355,19 @@ describe('EventActorExecutor', () => {
       };
     };
     const executor = new EventActorExecutor(host);
-    const first = executor.execute(request('event-a'));
-    const second = executor.execute(request('event-b'));
+    const first = executor.execute(request('same-event'));
+    const second = executor.execute(request('same-event'));
     await Promise.resolve();
     release();
 
     const results = await Promise.all([first, second]);
     expect(results.map((result) => result.status).sort()).toEqual([
       'applied',
-      'stale',
+      'commit_conflict',
     ]);
     expect(host.generation).toBe(1);
-    expect(host.discards).toEqual([
-      expect.objectContaining({ reason: 'stale' }),
-    ]);
+    expect(new Set(host.forkNamespaces).size).toBe(2);
+    expect(host.discards).toHaveLength(0);
   });
 
   it('retains a fork when commit acknowledgement is indeterminate', async () => {
@@ -432,6 +433,15 @@ describe('EventActorExecutor', () => {
         callbacks: [],
         tags: ['parent-trace'],
         metadata: { userId: 'user-1', sessionId: 'session-1' },
+        configurable: {
+          user_id: 'user-1',
+          requestBody: { conversationId: 'conversation-1' },
+          userMCPAuthMap: { chess: 'credential' },
+          thread_id: 'parent-thread',
+          checkpoint_ns: 'parent-namespace',
+          checkpoint_id: 'parent-checkpoint',
+          checkpoint_map: { parent: 'checkpoint' },
+        },
       });
     const executions = [
       executor.execute(request('sibling-a')),
@@ -461,7 +471,25 @@ describe('EventActorExecutor', () => {
         sessionId: 'session-1',
         eventActorThreadId: 'actor-thread',
       },
+      configurable: {
+        user_id: 'user-1',
+        requestBody: { conversationId: 'conversation-1' },
+        userMCPAuthMap: { chess: 'credential' },
+        event_actor_thread_id: 'actor-thread',
+      },
     });
+    expect(host.invokeConfigs[0].configurable?.thread_id).toBe(
+      'actor-checkpoints'
+    );
+    expect(host.invokeConfigs[0].configurable?.checkpoint_ns).toMatch(
+      /^event-actor\/[a-f0-9]{32}$/
+    );
+    expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
+      'checkpoint_id'
+    );
+    expect(host.invokeConfigs[0].configurable).not.toHaveProperty(
+      'checkpoint_map'
+    );
     release();
 
     const results = await Promise.all(executions);
@@ -549,5 +577,117 @@ describe('EventActorExecutor', () => {
       'mismatched checkpoint ownership'
     );
     expect(host.discards).toHaveLength(0);
+  });
+
+  it('validates a cold-continuation head before adapter work', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.coldContinue(
+        {
+          actorThreadId: 'actor-thread',
+          invocationId: 'foreign-head',
+          depth: 1,
+          event: { text: 'foreign-head' },
+        },
+        { actorThreadId: 'another-actor', generation: 0 }
+      )
+    ).rejects.toThrow('Event actor head is invalid');
+    expect(host.coldContinues).toBe(0);
+  });
+
+  it('detects a cold adapter mutating its copy of the prepared head', async () => {
+    const host = new TestHost();
+    const validHead = head(1);
+    host.coldContinue = async (prepareRequest, adapterHead) => {
+      adapterHead.generation = 2;
+      return {
+        ...invocation(prepareRequest, 'cold', 2),
+        base: adapterHead,
+      };
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.coldContinue(
+        {
+          actorThreadId: 'actor-thread',
+          invocationId: 'mutated-head',
+          depth: 1,
+          event: { text: 'mutated-head' },
+        },
+        validHead
+      )
+    ).rejects.toThrow('Cold continuation did not use the prepared actor head');
+    expect(validHead.generation).toBe(1);
+  });
+
+  it('uses the validated ownership snapshot after adapter invocation', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => {
+      const checkpoint = {
+        ...prepared.fork,
+        checkpointId: 'trusted-terminal',
+      };
+      prepared.actorThreadId = 'another-actor';
+      prepared.base.generation = 99;
+      prepared.fork.checkpointNs = 'another-fork';
+      return {
+        status: 'applied',
+        result: 'applied-before-mutation',
+        checkpoint,
+      };
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('mutating-adapter'))
+    ).resolves.toMatchObject({
+      status: 'applied',
+      head: { actorThreadId: 'actor-thread', generation: 1 },
+    });
+    expect(host.commits[0].invocation).toMatchObject({
+      actorThreadId: 'actor-thread',
+      invocationId: 'mutating-adapter',
+      base: { generation: 0 },
+      fork: { checkpointNs: expect.stringMatching(/^event-actor\//) },
+    });
+  });
+
+  it('keeps a host-driven prepared invocation immutable across invoke', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async (prepared) => {
+      const checkpoint = {
+        ...prepared.fork,
+        checkpointId: 'host-driven-terminal',
+      };
+      prepared.base.generation = 99;
+      prepared.fork.checkpointNs = 'mutated-by-adapter';
+      return { status: 'applied', result: 'done', checkpoint };
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'host-driven-mutation',
+      depth: 1,
+      event: { text: 'host-driven-mutation' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const originalNamespace = preparation.invocation.fork.checkpointNs;
+
+    const terminal = await executor.invoke(preparation.invocation);
+
+    expect(preparation.invocation.base.generation).toBe(0);
+    expect(preparation.invocation.fork.checkpointNs).toBe(originalNamespace);
+    expect(terminal.status).toBe('applied');
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).resolves.toMatchObject({ status: 'committed' });
   });
 });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -645,6 +645,39 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('binds ambient actor depth during public preparation', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue({ configurable: { event_actor_depth: 1 } });
+    const warmPreparation = executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'ambient-warm-prepare',
+      depth: 1,
+      event: { text: 'ambient-warm-prepare' },
+    });
+    const coldPreparation = executor.coldContinue(
+      {
+        actorThreadId: 'actor-thread',
+        invocationId: 'ambient-cold-prepare',
+        depth: 1,
+        event: { text: 'ambient-cold-prepare' },
+      },
+      head(0)
+    );
+    runnableConfigSpy.mockRestore();
+
+    await expect(warmPreparation).rejects.toThrow(
+      'must advance parent depth 1'
+    );
+    await expect(coldPreparation).rejects.toThrow(
+      'must advance parent depth 1'
+    );
+    expect(host.coldContinues).toBe(0);
+    expect(host.invokes).toBe(0);
+  });
+
   it('derives nested depth from actor-owned ambient context', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host);
@@ -1118,6 +1151,43 @@ describe('EventActorExecutor', () => {
     ).resolves.toMatchObject({
       status: 'commit_indeterminate',
       result: 'stale-terminal-checkpoint',
+      error: {
+        message:
+          'Stale event actor head does not identify a competing checkpoint',
+      },
+    });
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('retains cold-applied work when stale names its reconstructed start', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead) => {
+      const prepared = await coldContinue(prepareRequest, actorHead);
+      prepared.fork.checkpointId = 'reconstructed-start';
+      return prepared;
+    };
+    host.commit = async () => ({
+      status: 'stale' as const,
+      head: {
+        actorThreadId: 'actor-thread',
+        generation: 2,
+        checkpoint: {
+          threadId: 'actor-checkpoints',
+          checkpointNs: 'winner-namespace',
+          checkpointId: 'reconstructed-start',
+        },
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('stale-reconstructed-start'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'stale-reconstructed-start',
       error: {
         message:
           'Stale event actor head does not identify a competing checkpoint',

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -10,6 +10,7 @@ import type {
   EventActorHostAdapter,
   EventActorInvocation,
   EventActorInvocationContext,
+  EventActorPreparationContext,
   EventActorPrepareRequest,
   EventActorTerminalResult,
 } from '@/eventActor';
@@ -67,6 +68,7 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
   readonly commits: EventActorCommitRequest<string>[] = [];
   readonly discards: EventActorDiscardRequest[] = [];
   readonly invokeSignals: AbortSignal[] = [];
+  readonly coldContinueSignals: AbortSignal[] = [];
   readonly invokeConfigs: RunnableConfig[] = [];
   readonly forkNamespaces: string[] = [];
   invokeImpl?: (
@@ -108,9 +110,11 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
 
   async coldContinue(
     request: EventActorAdapterPrepareRequest<TestEvent>,
-    _head: EventActorHead
+    _head: EventActorHead,
+    context: EventActorPreparationContext
   ) {
     this.coldContinues += 1;
+    this.coldContinueSignals.push(context.signal);
     const actorHead = head(
       this.generation,
       this.committedCheckpointNs,
@@ -164,14 +168,23 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     if (this.commitError != null) {
       throw this.commitError;
     }
-    if (request.expectedHead.generation !== this.generation) {
+    const currentHead = head(
+      this.generation,
+      this.committedCheckpointNs,
+      this.committedCheckpointId
+    );
+    if (
+      request.expectedHead.generation !== currentHead.generation ||
+      request.expectedHead.checkpoint?.threadId !==
+        currentHead.checkpoint?.threadId ||
+      request.expectedHead.checkpoint?.checkpointNs !==
+        currentHead.checkpoint?.checkpointNs ||
+      request.expectedHead.checkpoint?.checkpointId !==
+        currentHead.checkpoint?.checkpointId
+    ) {
       return {
         status: 'stale' as const,
-        head: head(
-          this.generation,
-          this.committedCheckpointNs,
-          this.committedCheckpointId
-        ),
+        head: currentHead,
       };
     }
     this.generation += 1;
@@ -224,13 +237,58 @@ describe('EventActorExecutor', () => {
     if (terminal.status !== 'applied') {
       throw new Error('Expected applied terminal result');
     }
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).resolves.toMatchObject({
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
       status: 'committed',
       head: { generation: 1 },
     });
     expect(host.activeInvocations).toBe(0);
+  });
+
+  it('binds host-driven commit to the exact invocation that executed', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
+      prepared.fork.checkpointId = 'reconstructed-start';
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'sealed-settlement',
+      depth: 1,
+      event: { text: 'sealed-settlement' },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+    const prepared = await executor.coldContinue(preparation);
+    const settlement = await executor.invoke(prepared);
+    if (settlement.status !== 'applied') {
+      throw new Error('Expected applied settlement');
+    }
+
+    expect(Object.isFrozen(settlement)).toBe(true);
+    expect(Object.isFrozen(settlement.invocation)).toBe(true);
+    expect(() => {
+      settlement.invocation.base.generation = 2;
+    }).toThrow();
+    const forgedSettlement = {
+      ...settlement,
+      invocation: {
+        ...settlement.invocation,
+        base: head(2, 'later', 'later-checkpoint'),
+      },
+    };
+    await expect(executor.commit(forgedSettlement)).rejects.toThrow(
+      'settlement was not issued by this executor'
+    );
+    await expect(executor.commit(settlement)).resolves.toMatchObject({
+      status: 'committed',
+      head: { generation: 2 },
+    });
   });
 
   it('commits applied work with current-plus-previous retention', async () => {
@@ -254,6 +312,47 @@ describe('EventActorExecutor', () => {
       },
     });
     expect(host.discards).toHaveLength(0);
+  });
+
+  it('models checkpoint identity in the test adapter CAS', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    const fork: EventActorCheckpointFork = {
+      invocationId: 'same-generation-mismatch',
+      threadId: 'actor-checkpoints',
+      checkpointNs: 'attempt',
+      checkpointId: 'terminal',
+    };
+
+    await expect(
+      host.commit({
+        invocation: {
+          actorThreadId: 'actor-thread',
+          invocationId: 'same-generation-mismatch',
+          depth: 1,
+          continuation: 'warm',
+          base: head(1, 'wrong-namespace', 'checkpoint-0'),
+          fork,
+        },
+        expectedHead: head(1, 'wrong-namespace', 'checkpoint-0'),
+        checkpoint: fork,
+        result: 'must-not-commit',
+        retention: {
+          committedCheckpoints: 2,
+          dormantCheckpointTtlMs: 60_000,
+        },
+      })
+    ).resolves.toMatchObject({
+      status: 'stale',
+      head: {
+        generation: 1,
+        checkpoint: {
+          checkpointNs: 'committed',
+          checkpointId: 'checkpoint-0',
+        },
+      },
+    });
+    expect(host.generation).toBe(1);
   });
 
   it('cold-continues the same logical actor when its checkpoint is unavailable', async () => {
@@ -615,9 +714,15 @@ describe('EventActorExecutor', () => {
     if (preparation.status !== 'ready') {
       throw new Error('Expected warm preparation');
     }
-    preparation.invocation.depth = 2;
+    expect(() => {
+      preparation.invocation.depth = 2;
+    }).toThrow();
+    const forgedInvocation = {
+      ...preparation.invocation,
+      depth: 2,
+    };
 
-    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+    await expect(executor.invoke(forgedInvocation)).rejects.toThrow(
       'exceeds maximum 1'
     );
     expect(host.invokes).toBe(0);
@@ -737,16 +842,28 @@ describe('EventActorExecutor', () => {
     mutableRequest.actorThreadId = 'mutated-actor';
     mutableRequest.invocationId = 'mutated-invocation';
     mutableRequest.depth = 1;
+    mutableRequest.event.text = 'mutated-event';
     release();
 
-    await expect(preparationPromise).resolves.toMatchObject({
+    const preparation = await preparationPromise;
+    expect(preparation).toMatchObject({
       status: 'checkpoint_unavailable',
       request: {
         actorThreadId: 'actor-thread',
         invocationId: 'mutable-prepared-ancestry',
         depth: 2,
+        event: { text: 'mutable-prepared-ancestry' },
       },
       head: { actorThreadId: 'actor-thread', generation: 0 },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+    expect(() => {
+      preparation.request.event.text = 'mutated-after-prepare';
+    }).toThrow();
+    await expect(executor.coldContinue(preparation)).resolves.toMatchObject({
+      event: { text: 'mutable-prepared-ancestry' },
     });
   });
 
@@ -768,16 +885,29 @@ describe('EventActorExecutor', () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    host.coldContinue = async (adapterRequest, actorHead) => {
+    host.coldContinue = async (adapterRequest, actorHead, context) => {
       await gate;
-      return coldContinue(adapterRequest, actorHead);
+      return coldContinue(adapterRequest, actorHead, context);
     };
 
-    const continuationPromise = executor.coldContinue(preparation);
-    preparation.request.actorThreadId = 'mutated-actor';
-    preparation.request.invocationId = 'mutated-invocation';
-    preparation.request.depth = 1;
-    preparation.head.actorThreadId = 'mutated-actor';
+    const mutablePreparation = {
+      status: 'checkpoint_unavailable' as const,
+      request: {
+        ...preparation.request,
+        event: { ...preparation.request.event },
+      },
+      head: {
+        ...preparation.head,
+        ...(preparation.head.checkpoint == null
+          ? {}
+          : { checkpoint: { ...preparation.head.checkpoint } }),
+      },
+    };
+    const continuationPromise = executor.coldContinue(mutablePreparation);
+    mutablePreparation.request.actorThreadId = 'mutated-actor';
+    mutablePreparation.request.invocationId = 'mutated-invocation';
+    mutablePreparation.request.depth = 1;
+    mutablePreparation.head.actorThreadId = 'mutated-actor';
     release();
 
     await expect(continuationPromise).resolves.toMatchObject({
@@ -878,6 +1008,45 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(0);
   });
 
+  it('propagates task cancellation into in-flight cold continuation', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    let started = (): void => undefined;
+    const coldStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    host.coldContinue = async (_prepareRequest, _actorHead, context) => {
+      host.coldContinueSignals.push(context.signal);
+      started();
+      return await new Promise<EventActorInvocation<TestEvent>>(
+        (_resolve, reject) => {
+          context.signal.addEventListener(
+            'abort',
+            () => reject(context.signal.reason),
+            { once: true }
+          );
+        }
+      );
+    };
+    const controller = new AbortController();
+    const executor = new EventActorExecutor(host);
+    const execution = executor.execute(
+      request('cancel-during-cold', { signal: controller.signal })
+    );
+    await coldStarted;
+
+    controller.abort(new Error('cancel cold reconstruction'));
+
+    await expect(execution).resolves.toEqual({
+      status: 'cancelled',
+      continuation: 'cold',
+    });
+    expect(host.coldContinueSignals).toHaveLength(1);
+    expect(host.coldContinueSignals[0].aborted).toBe(true);
+    expect(host.invokes).toBe(0);
+    expect(host.discards).toHaveLength(0);
+  });
+
   it('retains an applied result with a checkpoint outside the invocation fork', async () => {
     const host = new TestHost();
     const prepare = host.prepare.bind(host);
@@ -959,6 +1128,39 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(0);
   });
 
+  it('retains a cold-applied result that reports the committed base checkpoint', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
+      prepared.fork.checkpointId = 'reconstructed-start';
+      return prepared;
+    };
+    host.invokeImpl = async (prepared) => ({
+      status: 'applied',
+      result: 'action-claimed',
+      checkpoint: {
+        ...prepared.fork,
+        checkpointId: prepared.base.checkpoint?.checkpointId,
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('cold-base-terminal'))
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      result: 'action-claimed',
+      error: {
+        message: 'Event actor result escaped its invocation checkpoint fork',
+      },
+    });
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards).toHaveLength(0);
+  });
+
   it('snapshots validated terminal evidence before awaiting commit', async () => {
     const host = new TestHost();
     let terminalCheckpoint: EventActorCheckpointFork | undefined;
@@ -1022,8 +1224,8 @@ describe('EventActorExecutor', () => {
     const host = new TestHost();
     host.checkpointAvailable = false;
     const coldContinue = host.coldContinue.bind(host);
-    host.coldContinue = async (prepareRequest, actorHead) => {
-      const prepared = await coldContinue(prepareRequest, actorHead);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
       prepared.event = { text: 'stale-event' };
       return prepared;
     };
@@ -1116,8 +1318,8 @@ describe('EventActorExecutor', () => {
     host.generation = 1;
     host.checkpointAvailable = false;
     const coldContinue = host.coldContinue.bind(host);
-    host.coldContinue = async (prepareRequest, actorHead) => {
-      const prepared = await coldContinue(prepareRequest, actorHead);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
       prepared.fork.checkpointId = 'reconstructed-start';
       return prepared;
     };
@@ -1133,8 +1335,8 @@ describe('EventActorExecutor', () => {
     host.generation = 1;
     host.checkpointAvailable = false;
     const coldContinue = host.coldContinue.bind(host);
-    host.coldContinue = async (prepareRequest, actorHead) => {
-      const prepared = await coldContinue(prepareRequest, actorHead);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
       delete prepared.fork.checkpointId;
       return prepared;
     };
@@ -1165,9 +1367,9 @@ describe('EventActorExecutor', () => {
     const host = new TestHost();
     host.checkpointAvailable = false;
     const coldContinue = host.coldContinue.bind(host);
-    host.coldContinue = async (prepareRequest, actorHead) => {
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
       prepareRequest.checkpointNs = 'shared-namespace';
-      return coldContinue(prepareRequest, actorHead);
+      return coldContinue(prepareRequest, actorHead, context);
     };
     const executor = new EventActorExecutor(host);
 
@@ -1198,9 +1400,9 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).rejects.toThrow('Event actor head is invalid');
+    await expect(executor.commit(terminal)).rejects.toThrow(
+      'Event actor head is invalid'
+    );
   });
 
   it('rejects a stale commit head that did not advance past its base', async () => {
@@ -1221,9 +1423,9 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).rejects.toThrow('did not advance past its base');
+    await expect(executor.commit(terminal)).rejects.toThrow(
+      'did not advance past its base'
+    );
   });
 
   it('rejects a stale commit head that switches checkpoint threads', async () => {
@@ -1256,9 +1458,9 @@ describe('EventActorExecutor', () => {
       throw new Error('Expected applied terminal result');
     }
 
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).rejects.toThrow('changed its checkpoint thread');
+    await expect(executor.commit(terminal)).rejects.toThrow(
+      'changed its checkpoint thread'
+    );
   });
 
   it('retains applied work when stale moves the base checkpoint to another namespace', async () => {
@@ -1316,8 +1518,8 @@ describe('EventActorExecutor', () => {
     host.generation = 1;
     host.checkpointAvailable = false;
     const coldContinue = host.coldContinue.bind(host);
-    host.coldContinue = async (prepareRequest, actorHead) => {
-      const prepared = await coldContinue(prepareRequest, actorHead);
+    host.coldContinue = async (prepareRequest, actorHead, context) => {
+      const prepared = await coldContinue(prepareRequest, actorHead, context);
       prepared.fork.checkpointId = 'reconstructed-start';
       return prepared;
     };
@@ -1461,8 +1663,12 @@ describe('EventActorExecutor', () => {
     expect(() => executor.discard(malformed, 'failed')).toThrow(
       'Event actor head is invalid'
     );
-    await expect(executor.commit(malformed, terminal)).rejects.toThrow(
-      'Event actor head is invalid'
+    const forgedSettlement = {
+      ...terminal,
+      invocation: malformed,
+    };
+    await expect(executor.commit(forgedSettlement)).rejects.toThrow(
+      'settlement was not issued by this executor'
     );
     expect(host.discards).toHaveLength(0);
     expect(host.commits).toHaveLength(0);
@@ -1562,9 +1768,9 @@ describe('EventActorExecutor', () => {
     if (terminal.status !== 'applied') {
       throw new Error('Expected applied terminal result');
     }
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).resolves.toMatchObject({ status: 'committed' });
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
+      status: 'committed',
+    });
   });
 
   it('snapshots applied checkpoint evidence returned by public invoke', async () => {
@@ -1603,8 +1809,8 @@ describe('EventActorExecutor', () => {
       checkpointId: 'public-invoke-terminal',
       checkpointNs: expect.stringMatching(/^event-actor\/[a-f0-9]{32}$/),
     });
-    await expect(
-      executor.commit(preparation.invocation, terminal)
-    ).resolves.toMatchObject({ status: 'committed' });
+    await expect(executor.commit(terminal)).resolves.toMatchObject({
+      status: 'committed',
+    });
   });
 });

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -709,6 +709,127 @@ describe('EventActorExecutor', () => {
     });
   });
 
+  it('snapshots prepared ancestry before adapter work can yield', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const prepare = host.prepare.bind(host);
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.prepare = async (adapterRequest) => {
+      await gate;
+      return prepare(adapterRequest);
+    };
+    const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const mutableRequest: EventActorPrepareRequest<TestEvent> = {
+      actorThreadId: 'actor-thread',
+      invocationId: 'mutable-prepared-ancestry',
+      depth: 2,
+      event: { text: 'mutable-prepared-ancestry' },
+    };
+    const runnableConfigSpy = jest
+      .spyOn(AsyncLocalStorageProviderSingleton, 'getRunnableConfig')
+      .mockReturnValue({ configurable: { event_actor_depth: 1 } });
+
+    const preparationPromise = executor.prepare(mutableRequest);
+    runnableConfigSpy.mockRestore();
+    mutableRequest.actorThreadId = 'mutated-actor';
+    mutableRequest.invocationId = 'mutated-invocation';
+    mutableRequest.depth = 1;
+    release();
+
+    await expect(preparationPromise).resolves.toMatchObject({
+      status: 'checkpoint_unavailable',
+      request: {
+        actorThreadId: 'actor-thread',
+        invocationId: 'mutable-prepared-ancestry',
+        depth: 2,
+      },
+      head: { actorThreadId: 'actor-thread', generation: 0 },
+    });
+  });
+
+  it('snapshots the cold-continuation handoff before adapter work can yield', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host, { maxDepth: 2 });
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'mutable-cold-handoff',
+      depth: 2,
+      event: { text: 'mutable-cold-handoff' },
+    });
+    if (preparation.status !== 'checkpoint_unavailable') {
+      throw new Error('Expected unavailable checkpoint');
+    }
+    const coldContinue = host.coldContinue.bind(host);
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.coldContinue = async (adapterRequest, actorHead) => {
+      await gate;
+      return coldContinue(adapterRequest, actorHead);
+    };
+
+    const continuationPromise = executor.coldContinue(preparation);
+    preparation.request.actorThreadId = 'mutated-actor';
+    preparation.request.invocationId = 'mutated-invocation';
+    preparation.request.depth = 1;
+    preparation.head.actorThreadId = 'mutated-actor';
+    release();
+
+    await expect(continuationPromise).resolves.toMatchObject({
+      actorThreadId: 'actor-thread',
+      invocationId: 'mutable-cold-handoff',
+      depth: 2,
+      continuation: 'cold',
+      base: { actorThreadId: 'actor-thread', generation: 0 },
+    });
+  });
+
+  it('snapshots the execution identity and signal before preparation yields', async () => {
+    const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.prepare = async (adapterRequest) => {
+      await gate;
+      return prepare(adapterRequest);
+    };
+    const executor = new EventActorExecutor(host);
+    const originalController = new AbortController();
+    const replacementController = new AbortController();
+    const mutableRequest = request('mutable-execution', {
+      signal: originalController.signal,
+    });
+
+    const execution = executor.execute(mutableRequest);
+    mutableRequest.actorThreadId = 'mutated-actor';
+    mutableRequest.invocationId = 'mutated-invocation';
+    mutableRequest.signal = replacementController.signal;
+    originalController.abort(new Error('cancel original execution'));
+    release();
+
+    await expect(execution).resolves.toMatchObject({
+      status: 'cancelled',
+      continuation: 'warm',
+    });
+    expect(host.invokes).toBe(0);
+    expect(host.discards).toEqual([
+      expect.objectContaining({
+        invocation: expect.objectContaining({
+          actorThreadId: 'actor-thread',
+          invocationId: 'mutable-execution',
+        }),
+        reason: 'cancelled',
+      }),
+    ]);
+  });
+
   it('derives nested depth from actor-owned ambient context', async () => {
     const host = new TestHost();
     const executor = new EventActorExecutor(host);

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -85,15 +85,23 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
         ),
       };
     }
+    const actorHead = head(
+      this.generation,
+      this.committedCheckpointNs,
+      this.committedCheckpointId
+    );
+    const prepared = invocation(request, 'warm', this.generation);
     return {
       status: 'ready' as const,
       invocation: {
-        ...invocation(request, 'warm', this.generation),
-        base: head(
-          this.generation,
-          this.committedCheckpointNs,
-          this.committedCheckpointId
-        ),
+        ...prepared,
+        base: actorHead,
+        fork: {
+          ...prepared.fork,
+          ...(actorHead.checkpoint?.checkpointId == null
+            ? {}
+            : { checkpointId: actorHead.checkpoint.checkpointId }),
+        },
       },
     };
   }
@@ -103,13 +111,21 @@ class TestHost implements EventActorHostAdapter<TestEvent, string> {
     _head: EventActorHead
   ) {
     this.coldContinues += 1;
+    const actorHead = head(
+      this.generation,
+      this.committedCheckpointNs,
+      this.committedCheckpointId
+    );
+    const prepared = invocation(request, 'cold', this.generation);
     return {
-      ...invocation(request, 'cold', this.generation),
-      base: head(
-        this.generation,
-        this.committedCheckpointNs,
-        this.committedCheckpointId
-      ),
+      ...prepared,
+      base: actorHead,
+      fork: {
+        ...prepared.fork,
+        ...(actorHead.checkpoint?.checkpointId == null
+          ? {}
+          : { checkpointId: actorHead.checkpoint.checkpointId }),
+      },
     };
   }
 
@@ -830,6 +846,43 @@ describe('EventActorExecutor', () => {
     expect(host.invokes).toBe(0);
   });
 
+  it('requires a warm resumed fork to identify its starting checkpoint', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        delete prepared.invocation.fork.checkpointId;
+      }
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('missing-warm-start'))
+    ).rejects.toThrow('fork.checkpointId for resumed actor');
+    expect(host.invokes).toBe(0);
+  });
+
+  it('requires a cold resumed fork to identify its starting checkpoint', async () => {
+    const host = new TestHost();
+    host.generation = 1;
+    host.checkpointAvailable = false;
+    const coldContinue = host.coldContinue.bind(host);
+    host.coldContinue = async (prepareRequest, actorHead) => {
+      const prepared = await coldContinue(prepareRequest, actorHead);
+      delete prepared.fork.checkpointId;
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.execute(request('missing-cold-start'))
+    ).rejects.toThrow('fork.checkpointId for resumed actor');
+    expect(host.invokes).toBe(0);
+  });
+
   it('rejects a stale commit result for another actor', async () => {
     const host = new TestHost();
     host.commit = async () => ({
@@ -975,6 +1028,37 @@ describe('EventActorExecutor', () => {
     expect(host.coldContinues).toBe(0);
   });
 
+  it('rejects malformed ownership before destructive host operations', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'malformed-ownership',
+      depth: 1,
+      event: { text: 'malformed-ownership' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const malformed = {
+      ...preparation.invocation,
+      base: { ...preparation.invocation.base, actorThreadId: 'another-actor' },
+    };
+    const terminal = await executor.invoke(preparation.invocation);
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+
+    expect(() => executor.discard(malformed, 'failed')).toThrow(
+      'Event actor head is invalid'
+    );
+    await expect(executor.commit(malformed, terminal)).rejects.toThrow(
+      'Event actor head is invalid'
+    );
+    expect(host.discards).toHaveLength(0);
+    expect(host.commits).toHaveLength(0);
+  });
+
   it('detects a cold adapter mutating its copy of the prepared head', async () => {
     const host = new TestHost();
     const validHead = head(1);
@@ -983,6 +1067,10 @@ describe('EventActorExecutor', () => {
       return {
         ...invocation(prepareRequest, 'cold', 2),
         base: adapterHead,
+        fork: {
+          ...invocation(prepareRequest, 'cold', 2).fork,
+          checkpointId: adapterHead.checkpoint?.checkpointId,
+        },
       };
     };
     const executor = new EventActorExecutor(host);

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from '@jest/globals';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import type {
+  EventActorAdapterPrepareRequest,
+  EventActorCommitRequest,
+  EventActorDiscardRequest,
+  EventActorHead,
+  EventActorHostAdapter,
+  EventActorInvocation,
+  EventActorPrepareRequest,
+  EventActorTerminalResult,
+} from '@/eventActor';
+import { EventActorExecutor } from '@/eventActor';
+
+type TestEvent = { text: string };
+
+const head = (generation = 0): EventActorHead => {
+  const actorHead: EventActorHead = {
+    actorThreadId: 'actor-thread',
+    generation,
+  };
+  if (generation === 0) {
+    return actorHead;
+  }
+  return {
+    ...actorHead,
+    checkpoint: {
+      threadId: 'actor-checkpoints',
+      checkpointNs: 'committed',
+      checkpointId: `checkpoint-${generation}`,
+    },
+  };
+};
+
+const invocation = (
+  request: EventActorAdapterPrepareRequest<TestEvent>,
+  continuation: 'warm' | 'cold' = 'warm',
+  generation = 0
+): EventActorInvocation<TestEvent> => ({
+  ...request,
+  continuation,
+  base: head(generation),
+  fork: {
+    invocationId: request.invocationId,
+    threadId: 'actor-checkpoints',
+    checkpointNs: request.checkpointNs,
+  },
+});
+
+class TestHost implements EventActorHostAdapter<TestEvent, string> {
+  generation = 0;
+  checkpointAvailable = true;
+  invokes = 0;
+  activeInvocations = 0;
+  maxActiveInvocations = 0;
+  commitError?: Error;
+  readonly commits: EventActorCommitRequest<string>[] = [];
+  readonly discards: EventActorDiscardRequest[] = [];
+  readonly invokeSignals: AbortSignal[] = [];
+  readonly forkNamespaces: string[] = [];
+  invokeImpl?: (
+    prepared: EventActorInvocation<TestEvent>,
+    signal: AbortSignal
+  ) => Promise<EventActorTerminalResult<string>>;
+
+  async prepare(request: EventActorAdapterPrepareRequest<TestEvent>) {
+    if (!this.checkpointAvailable) {
+      return {
+        status: 'checkpoint_unavailable' as const,
+        head: head(this.generation),
+      };
+    }
+    return {
+      status: 'ready' as const,
+      invocation: invocation(request, 'warm', this.generation),
+    };
+  }
+
+  async coldContinue(
+    request: EventActorAdapterPrepareRequest<TestEvent>,
+    _head: EventActorHead
+  ) {
+    return invocation(request, 'cold', this.generation);
+  }
+
+  async invoke(
+    prepared: EventActorInvocation<TestEvent>,
+    context: { signal: AbortSignal }
+  ) {
+    this.invokes += 1;
+    this.activeInvocations += 1;
+    this.maxActiveInvocations = Math.max(
+      this.maxActiveInvocations,
+      this.activeInvocations
+    );
+    this.invokeSignals.push(context.signal);
+    this.forkNamespaces.push(prepared.fork.checkpointNs);
+    try {
+      if (this.invokeImpl != null) {
+        return await this.invokeImpl(prepared, context.signal);
+      }
+      return {
+        status: 'applied' as const,
+        result: prepared.event.text,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: `result-${prepared.invocationId}`,
+        },
+      };
+    } finally {
+      this.activeInvocations -= 1;
+    }
+  }
+
+  async commit(request: EventActorCommitRequest<string>) {
+    this.commits.push(request);
+    if (this.commitError != null) {
+      throw this.commitError;
+    }
+    if (request.expectedHead.generation !== this.generation) {
+      return { status: 'stale' as const, head: head(this.generation) };
+    }
+    this.generation += 1;
+    return { status: 'committed' as const, head: head(this.generation) };
+  }
+
+  async discard(request: EventActorDiscardRequest) {
+    this.discards.push(request);
+  }
+}
+
+const request = (
+  invocationId: string,
+  overrides: Partial<{ depth: number; signal: AbortSignal }> = {}
+) => ({
+  actorThreadId: 'actor-thread',
+  invocationId,
+  event: { text: invocationId },
+  ...(overrides.depth == null ? {} : { depth: overrides.depth }),
+  ...(overrides.signal == null ? {} : { signal: overrides.signal }),
+});
+
+describe('EventActorExecutor', () => {
+  it('exposes the lifecycle seam for host-driven mailbox orchestration', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+    const prepareRequest: EventActorPrepareRequest<TestEvent> = {
+      actorThreadId: 'actor-thread',
+      invocationId: 'host-driven',
+      depth: 1,
+      event: { text: 'host-driven' },
+    };
+
+    const preparation = await executor.prepare(prepareRequest);
+    expect(preparation.status).toBe('ready');
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+    const terminal = await executor.invoke(preparation.invocation);
+    expect(terminal.status).toBe('applied');
+    if (terminal.status !== 'applied') {
+      throw new Error('Expected applied terminal result');
+    }
+    await expect(
+      executor.commit(preparation.invocation, terminal)
+    ).resolves.toMatchObject({
+      status: 'committed',
+      head: { generation: 1 },
+    });
+    expect(host.activeInvocations).toBe(0);
+  });
+
+  it('commits applied work with current-plus-previous retention', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host, {
+      dormantCheckpointTtlMs: 60_000,
+    });
+
+    await expect(executor.execute(request('move-1'))).resolves.toMatchObject({
+      status: 'applied',
+      result: 'move-1',
+      continuation: 'warm',
+      head: { generation: 1 },
+    });
+    expect(host.commits).toHaveLength(1);
+    expect(host.commits[0]).toMatchObject({
+      expectedHead: { generation: 0 },
+      retention: {
+        committedCheckpoints: 2,
+        dormantCheckpointTtlMs: 60_000,
+      },
+    });
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('cold-continues the same logical actor when its checkpoint is unavailable', async () => {
+    const host = new TestHost();
+    host.checkpointAvailable = false;
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('cold-1'))).resolves.toMatchObject({
+      status: 'applied',
+      continuation: 'cold',
+    });
+    expect(host.commits[0].invocation).toMatchObject({
+      actorThreadId: 'actor-thread',
+      continuation: 'cold',
+    });
+  });
+
+  it('pauses and warm-resumes one logical actor without retaining an executor', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('turn-1'))).resolves.toMatchObject({
+      status: 'applied',
+      head: { actorThreadId: 'actor-thread', generation: 1 },
+    });
+    expect(host.activeInvocations).toBe(0);
+    await expect(executor.execute(request('turn-2'))).resolves.toMatchObject({
+      status: 'applied',
+      continuation: 'warm',
+      head: { actorThreadId: 'actor-thread', generation: 2 },
+    });
+    expect(host.commits[1].expectedHead).toMatchObject({ generation: 1 });
+    expect(host.activeInvocations).toBe(0);
+  });
+
+  it('discards normal completions without qualifying action evidence', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => ({ status: 'completed_no_action' });
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('no-action'))).resolves.toEqual({
+      status: 'completed_no_action',
+      continuation: 'warm',
+    });
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards).toEqual([
+      expect.objectContaining({ reason: 'completed_no_action' }),
+    ]);
+  });
+
+  it('discards failures and explicit cancellations without advancing the head', async () => {
+    const failedHost = new TestHost();
+    failedHost.invokeImpl = async () => {
+      throw new Error('provider failed');
+    };
+    const cancelledHost = new TestHost();
+    cancelledHost.invokeImpl = async (_prepared, signal) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    const controller = new AbortController();
+
+    await expect(
+      new EventActorExecutor(failedHost).execute(request('failed'))
+    ).resolves.toMatchObject({ status: 'failed', continuation: 'warm' });
+    const cancelled = new EventActorExecutor(cancelledHost).execute(
+      request('cancelled', { signal: controller.signal })
+    );
+    controller.abort(new Error('cancelled'));
+    await expect(cancelled).resolves.toEqual({
+      status: 'cancelled',
+      continuation: 'warm',
+    });
+    expect(failedHost.commits).toHaveLength(0);
+    expect(cancelledHost.commits).toHaveLength(0);
+    expect(failedHost.discards[0].reason).toBe('failed');
+    expect(cancelledHost.discards[0].reason).toBe('cancelled');
+  });
+
+  it('allows only one concurrent invocation from a committed generation to advance', async () => {
+    const host = new TestHost();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.invokeImpl = async (prepared) => {
+      await gate;
+      return {
+        status: 'applied',
+        result: prepared.invocationId,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: `result-${prepared.invocationId}`,
+        },
+      };
+    };
+    const executor = new EventActorExecutor(host);
+    const first = executor.execute(request('event-a'));
+    const second = executor.execute(request('event-b'));
+    await Promise.resolve();
+    release();
+
+    const results = await Promise.all([first, second]);
+    expect(results.map((result) => result.status).sort()).toEqual([
+      'applied',
+      'stale',
+    ]);
+    expect(host.generation).toBe(1);
+    expect(host.discards).toEqual([
+      expect.objectContaining({ reason: 'stale' }),
+    ]);
+  });
+
+  it('retains a fork when commit acknowledgement is indeterminate', async () => {
+    const host = new TestHost();
+    host.commitError = new Error('connection dropped after commit');
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('uncertain'))).resolves.toMatchObject(
+      {
+        status: 'commit_indeterminate',
+        error: { message: 'connection dropped after commit' },
+      }
+    );
+    expect(host.commits).toHaveLength(1);
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('replaces an ambient parent signal with independent task-owned signals', async () => {
+    const host = new TestHost();
+    const parentController = new AbortController();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    host.invokeImpl = async (prepared) => {
+      await gate;
+      return {
+        status: 'applied',
+        result: prepared.invocationId,
+        checkpoint: {
+          ...prepared.fork,
+          checkpointId: `result-${prepared.invocationId}`,
+        },
+      };
+    };
+    const executor = new EventActorExecutor(host);
+
+    const executions = await AsyncLocalStorageProviderSingleton.runWithConfig(
+      { signal: parentController.signal },
+      async () => [
+        executor.execute(request('sibling-a')),
+        executor.execute(request('sibling-b')),
+      ]
+    );
+    while (host.invokes < 2) {
+      await Promise.resolve();
+    }
+    parentController.abort();
+    expect(host.invokeSignals).toHaveLength(2);
+    expect(new Set(host.invokeSignals).size).toBe(2);
+    expect(new Set(host.forkNamespaces).size).toBe(2);
+    expect(
+      host.forkNamespaces.every((namespace) =>
+        /^event-actor\/[a-f0-9]{32}$/.test(namespace)
+      )
+    ).toBe(true);
+    expect(host.invokeSignals).not.toContain(parentController.signal);
+    expect(host.invokeSignals.every((signal) => !signal.aborted)).toBe(true);
+    release();
+
+    const results = await Promise.all(executions);
+    expect(results).toHaveLength(2);
+    expect(host.activeInvocations).toBe(0);
+    expect(host.maxActiveInvocations).toBe(2);
+  });
+
+  it('permits depth-one siblings and rejects event-actor grandchildren', async () => {
+    const host = new TestHost();
+    const executor = new EventActorExecutor(host);
+
+    await Promise.all([
+      executor.execute(request('sibling-1')),
+      executor.execute(request('sibling-2')),
+    ]);
+    await expect(
+      executor.execute(request('grandchild', { depth: 2 }))
+    ).rejects.toThrow('exceeds maximum 1');
+    expect(host.invokes).toBe(2);
+  });
+
+  it('discards a checkpoint outside the invocation fork', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => ({
+      status: 'applied',
+      result: 'bad',
+      checkpoint: {
+        invocationId: 'another-invocation',
+        threadId: 'actor-checkpoints',
+        checkpointNs: 'invocations/another-invocation',
+        checkpointId: 'bad-result',
+      },
+    });
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('escape'))).resolves.toMatchObject({
+      status: 'failed',
+      error: expect.objectContaining({
+        message: 'Event actor result escaped its invocation checkpoint fork',
+      }),
+    });
+    expect(host.commits).toHaveLength(0);
+    expect(host.discards[0].reason).toBe('failed');
+  });
+
+  it('rejects and discards a preparation that reuses another fork namespace', async () => {
+    const host = new TestHost();
+    const prepare = host.prepare.bind(host);
+    host.prepare = async (prepareRequest) => {
+      const prepared = await prepare(prepareRequest);
+      if (prepared.status === 'ready') {
+        prepared.invocation.fork.checkpointNs = 'shared';
+      }
+      return prepared;
+    };
+    const executor = new EventActorExecutor(host);
+
+    await expect(executor.execute(request('wrong-namespace'))).rejects.toThrow(
+      'mismatched checkpoint ownership'
+    );
+    expect(host.discards).toEqual([
+      expect.objectContaining({ reason: 'failed' }),
+    ]);
+  });
+});

--- a/src/eventActor/__tests__/EventActorExecutor.test.ts
+++ b/src/eventActor/__tests__/EventActorExecutor.test.ts
@@ -240,6 +240,27 @@ describe('EventActorExecutor', () => {
     expect(Reflect.get(executor, 'discardInvocationReference')).toBeUndefined();
   });
 
+  it('rejects unknown adapter preparation statuses', async () => {
+    const host = new TestHost();
+    host.prepare = async () =>
+      ({
+        status: 'unknown',
+        head: head(0),
+      }) as unknown as Awaited<ReturnType<TestHost['prepare']>>;
+    const executor = new EventActorExecutor(host);
+
+    await expect(
+      executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'unknown-preparation-status',
+        depth: 1,
+        event: { text: 'unknown-preparation-status' },
+      })
+    ).rejects.toThrow('preparation returned an invalid status');
+    expect(host.coldContinues).toBe(0);
+    expect(host.invokes).toBe(0);
+  });
+
   it('rejects preparation signing keys below 256 bits', () => {
     expect(
       () =>
@@ -247,6 +268,59 @@ describe('EventActorExecutor', () => {
           preparationSigningKey: 'short-key',
         })
     ).toThrow('preparationSigningKey must contain at least 32 bytes');
+  });
+
+  it('expires signed prepared invocation authority with its dormant fork', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    try {
+      const host = new TestHost();
+      const executor = new EventActorExecutor(host, {
+        dormantCheckpointTtlMs: 10,
+      });
+      const preparation = await executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'expired-preparation',
+        depth: 1,
+        event: { text: 'expired-preparation' },
+      });
+      if (preparation.status !== 'ready') {
+        throw new Error('Expected warm preparation');
+      }
+
+      now.mockReturnValue(1_010);
+      await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+        'prepared invocation binding has expired'
+      );
+      await expect(
+        executor.discard(preparation.invocation, 'failed')
+      ).rejects.toThrow('prepared invocation binding has expired');
+      expect(host.invokes).toBe(0);
+      expect(host.discards).toHaveLength(0);
+
+      now.mockReturnValue(2_000);
+      host.invokeImpl = async () => ({ status: 'completed_no_action' });
+      const consumed = await executor.prepare({
+        actorThreadId: 'actor-thread',
+        invocationId: 'expired-terminal-phase',
+        depth: 1,
+        event: { text: 'expired-terminal-phase' },
+      });
+      if (consumed.status !== 'ready') {
+        throw new Error('Expected warm preparation');
+      }
+      await expect(executor.invoke(consumed.invocation)).resolves.toEqual({
+        status: 'completed_no_action',
+      });
+
+      now.mockReturnValue(2_010);
+      await expect(
+        executor.discard(consumed.invocation, 'completed_no_action')
+      ).rejects.toThrow('prepared invocation binding has expired');
+      expect(host.invokes).toBe(1);
+      expect(host.discards).toHaveLength(0);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it('exposes the lifecycle seam for host-driven mailbox orchestration', async () => {
@@ -2476,6 +2550,37 @@ describe('EventActorExecutor', () => {
     expect(host.discards).toHaveLength(1);
   });
 
+  it('keeps a public no-action capability discardable but non-invokable', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () => ({
+      status: 'completed_no_action',
+      result: 'nothing-applied',
+    });
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'public-no-action-phase',
+      depth: 1,
+      event: { text: 'public-no-action-phase' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(executor.invoke(preparation.invocation)).resolves.toEqual({
+      status: 'completed_no_action',
+      result: 'nothing-applied',
+    });
+    await expect(executor.invoke(preparation.invocation)).rejects.toThrow(
+      'already consumed'
+    );
+    await expect(
+      executor.discard(preparation.invocation, 'completed_no_action')
+    ).resolves.toBeUndefined();
+    expect(host.invokes).toBe(1);
+    expect(host.discards).toHaveLength(1);
+  });
+
   it('revokes public discard authority while invocation is active and after action', async () => {
     const host = new TestHost();
     let started = (): void => undefined;
@@ -2549,6 +2654,37 @@ describe('EventActorExecutor', () => {
     await expect(
       executor.invoke(preparation.invocation)
     ).resolves.toMatchObject({ status: 'commit_indeterminate' });
+    await expect(
+      executor.discard(preparation.invocation, 'failed')
+    ).rejects.toThrow('no longer discardable');
+    expect(host.discards).toHaveLength(0);
+  });
+
+  it('returns indeterminate evidence when a public status read throws', async () => {
+    const host = new TestHost();
+    host.invokeImpl = async () =>
+      Object.defineProperty({}, 'status', {
+        get: () => {
+          throw new Error('terminal status unavailable');
+        },
+      }) as EventActorTerminalResult<string>;
+    const executor = new EventActorExecutor(host);
+    const preparation = await executor.prepare({
+      actorThreadId: 'actor-thread',
+      invocationId: 'throwing-public-status',
+      depth: 1,
+      event: { text: 'throwing-public-status' },
+    });
+    if (preparation.status !== 'ready') {
+      throw new Error('Expected warm preparation');
+    }
+
+    await expect(
+      executor.invoke(preparation.invocation)
+    ).resolves.toMatchObject({
+      status: 'commit_indeterminate',
+      error: { message: 'terminal status unavailable' },
+    });
     await expect(
       executor.discard(preparation.invocation, 'failed')
     ).rejects.toThrow('no longer discardable');

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -1,0 +1,25 @@
+export {
+  EventActorExecutor,
+  createEventActorExecutor,
+} from './EventActorExecutor';
+export type {
+  EventActorAdapterPrepareRequest,
+  EventActorAppliedResult,
+  EventActorCheckpointFork,
+  EventActorCheckpointReference,
+  EventActorCommitRequest,
+  EventActorCommitResult,
+  EventActorDiscardReason,
+  EventActorDiscardRequest,
+  EventActorExecutionRequest,
+  EventActorExecutionResult,
+  EventActorExecutorOptions,
+  EventActorHead,
+  EventActorHostAdapter,
+  EventActorInvocation,
+  EventActorInvocationContext,
+  EventActorInvocationReference,
+  EventActorPreparation,
+  EventActorPrepareRequest,
+  EventActorTerminalResult,
+} from './types';

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -24,6 +24,7 @@ export type {
   EventActorInvocationResult,
   EventActorPreparation,
   EventActorPreparationContext,
+  EventActorPreparedInvocation,
   EventActorPrepareRequest,
   EventActorTerminalResult,
 } from './types';

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -20,6 +20,7 @@ export type {
   EventActorHostAdapter,
   EventActorInvocation,
   EventActorInvocationContext,
+  EventActorIndeterminateResult,
   EventActorInvocationReference,
   EventActorInvocationResult,
   EventActorPreparation,

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -4,6 +4,7 @@ export {
 } from './EventActorExecutor';
 export type {
   EventActorAdapterPrepareRequest,
+  EventActorAdapterPreparation,
   EventActorAppliedResult,
   EventActorCheckpointFork,
   EventActorCheckpointReference,

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -12,6 +12,7 @@ export type {
   EventActorCommitResult,
   EventActorDiscardReason,
   EventActorDiscardRequest,
+  EventActorEvent,
   EventActorExecutionRequest,
   EventActorExecutionResult,
   EventActorExecutorOptions,
@@ -20,7 +21,9 @@ export type {
   EventActorInvocation,
   EventActorInvocationContext,
   EventActorInvocationReference,
+  EventActorInvocationResult,
   EventActorPreparation,
+  EventActorPreparationContext,
   EventActorPrepareRequest,
   EventActorTerminalResult,
 } from './types';

--- a/src/eventActor/index.ts
+++ b/src/eventActor/index.ts
@@ -27,5 +27,6 @@ export type {
   EventActorPreparationContext,
   EventActorPreparedInvocation,
   EventActorPrepareRequest,
+  EventActorSettlementResult,
   EventActorTerminalResult,
 } from './types';

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -75,7 +75,7 @@ export type EventActorAppliedResult<TResult extends EventActorEvent> = Extract<
   EventActorTerminalResult<TResult>,
   { status: 'applied' }
 > & {
-  /** Executor-issued immutable reference to the invocation that produced this action. */
+  /** Executor-issued one-shot settlement for the invocation that produced this action. */
   invocation: EventActorInvocationReference;
 };
 
@@ -134,6 +134,11 @@ export interface EventActorCommitRequest<TResult extends EventActorEvent> {
 export type EventActorCommitResult =
   | { status: 'committed'; head: EventActorHead }
   | { status: 'stale'; head?: EventActorHead };
+
+/** Public settlement outcome after an action has already been applied. */
+export type EventActorSettlementResult<TResult extends EventActorEvent> =
+  | EventActorCommitResult
+  | EventActorIndeterminateResult<TResult>;
 
 export type EventActorDiscardReason =
   | 'cancelled'

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -34,9 +34,17 @@ export interface EventActorInvocation<TEvent>
   event: TEvent;
 }
 
-export type EventActorPreparation<TEvent> =
+export type EventActorAdapterPreparation<TEvent> =
   | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
   | { status: 'checkpoint_unavailable'; head: EventActorHead };
+
+export type EventActorPreparation<TEvent> =
+  | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
+  | {
+      status: 'checkpoint_unavailable';
+      request: EventActorPrepareRequest<TEvent>;
+      head: EventActorHead;
+    };
 
 export type EventActorTerminalResult<TResult> =
   | {
@@ -112,7 +120,7 @@ export interface EventActorDiscardRequest {
 export interface EventActorHostAdapter<TEvent, TResult> {
   prepare(
     request: EventActorAdapterPrepareRequest<TEvent>
-  ): Promise<EventActorPreparation<TEvent>>;
+  ): Promise<EventActorAdapterPreparation<TEvent>>;
   coldContinue(
     request: EventActorAdapterPrepareRequest<TEvent>,
     head: EventActorHead

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -1,0 +1,151 @@
+import type { RunnableConfig } from '@langchain/core/runnables';
+
+/** Stable reference to one persisted LangGraph checkpoint. */
+export interface EventActorCheckpointReference {
+  threadId: string;
+  checkpointId?: string;
+  checkpointNs: string;
+}
+
+/** Committed logical head read before an event invocation is prepared. */
+export interface EventActorHead {
+  actorThreadId: string;
+  generation: number;
+  checkpoint?: EventActorCheckpointReference;
+}
+
+/** Invocation-owned checkpoint fork that cannot become authoritative in place. */
+export interface EventActorCheckpointFork
+  extends EventActorCheckpointReference {
+  invocationId: string;
+}
+
+export interface EventActorInvocationReference {
+  actorThreadId: string;
+  invocationId: string;
+  depth: number;
+  continuation: 'warm' | 'cold';
+  base: EventActorHead;
+  fork: EventActorCheckpointFork;
+}
+
+export interface EventActorInvocation<TEvent>
+  extends EventActorInvocationReference {
+  event: TEvent;
+}
+
+export type EventActorPreparation<TEvent> =
+  | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
+  | { status: 'checkpoint_unavailable'; head: EventActorHead };
+
+export type EventActorTerminalResult<TResult> =
+  | {
+      status: 'applied';
+      result: TResult;
+      checkpoint: EventActorCheckpointFork;
+    }
+  | { status: 'completed_no_action'; result?: TResult };
+
+export type EventActorAppliedResult<TResult> = Extract<
+  EventActorTerminalResult<TResult>,
+  { status: 'applied' }
+>;
+
+export interface EventActorInvocationContext {
+  signal: AbortSignal;
+  config: RunnableConfig;
+}
+
+export interface EventActorPrepareRequest<TEvent> {
+  actorThreadId: string;
+  invocationId: string;
+  depth: number;
+  event: TEvent;
+}
+
+export interface EventActorAdapterPrepareRequest<TEvent>
+  extends EventActorPrepareRequest<TEvent> {
+  checkpointNs: string;
+}
+
+export interface EventActorCommitRequest<TResult> {
+  invocation: EventActorInvocationReference;
+  expectedHead: EventActorHead;
+  checkpoint: EventActorCheckpointFork;
+  result: TResult;
+  retention: {
+    committedCheckpoints: 2;
+    dormantCheckpointTtlMs: number;
+  };
+}
+
+export type EventActorCommitResult =
+  | { status: 'committed'; head: EventActorHead }
+  | { status: 'stale'; head?: EventActorHead };
+
+export type EventActorDiscardReason =
+  | 'cancelled'
+  | 'completed_no_action'
+  | 'failed'
+  | 'stale';
+
+export interface EventActorDiscardRequest {
+  invocation: EventActorInvocationReference;
+  reason: EventActorDiscardReason;
+}
+
+/**
+ * Host adapter for durable actor state and the concrete agent invocation.
+ * `commit` must compare both the expected generation and checkpoint identity
+ * atomically before advancing the logical actor head. Preparation methods own
+ * rollback until they return a ready invocation; `invoke` returns only after
+ * its provider, stream, timer, and executor resources have been released.
+ */
+export interface EventActorHostAdapter<TEvent, TResult> {
+  prepare(
+    request: EventActorAdapterPrepareRequest<TEvent>
+  ): Promise<EventActorPreparation<TEvent>>;
+  coldContinue(
+    request: EventActorAdapterPrepareRequest<TEvent>,
+    head: EventActorHead
+  ): Promise<EventActorInvocation<TEvent>>;
+  invoke(
+    invocation: EventActorInvocation<TEvent>,
+    context: EventActorInvocationContext
+  ): Promise<EventActorTerminalResult<TResult>>;
+  commit(
+    request: EventActorCommitRequest<TResult>
+  ): Promise<EventActorCommitResult>;
+  discard(request: EventActorDiscardRequest): Promise<void>;
+}
+
+export interface EventActorExecutionRequest<TEvent> {
+  actorThreadId: string;
+  invocationId: string;
+  event: TEvent;
+  depth?: number;
+  /** Explicit task-owned signal. Ambient parent-run signals are ignored. */
+  signal?: AbortSignal;
+}
+
+export type EventActorExecutionResult<TResult> =
+  | {
+      status: 'applied';
+      result: TResult;
+      head: EventActorHead;
+      continuation: 'warm' | 'cold';
+    }
+  | {
+      status: 'completed_no_action' | 'cancelled' | 'stale';
+      continuation: 'warm' | 'cold';
+    }
+  | {
+      status: 'commit_indeterminate' | 'failed';
+      error: Error;
+      continuation: 'warm' | 'cold';
+    };
+
+export interface EventActorExecutorOptions {
+  maxDepth?: number;
+  dormantCheckpointTtlMs?: number;
+}

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -152,7 +152,13 @@ export type EventActorExecutionResult<TResult> =
       continuation: 'warm' | 'cold';
     }
   | {
-      status: 'commit_indeterminate' | 'failed';
+      /** Applied handling cannot be proven safe to retry; retain its fork. */
+      status: 'commit_indeterminate';
+      error: Error;
+      continuation: 'warm' | 'cold';
+    }
+  | {
+      status: 'failed';
       error: Error;
       continuation: 'warm' | 'cold';
     };

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -43,19 +43,27 @@ export interface EventActorInvocation<TEvent extends EventActorEvent>
   event: TEvent;
 }
 
+export interface EventActorPreparedInvocation<TEvent extends EventActorEvent>
+  extends EventActorInvocation<TEvent> {
+  /** Integrity binding over the complete prepared invocation. */
+  preparationDigest: string;
+}
+
 export type EventActorAdapterPreparation<TEvent extends EventActorEvent> =
   | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
   | { status: 'checkpoint_unavailable'; head: EventActorHead };
 
 export type EventActorPreparation<TEvent extends EventActorEvent> =
-  | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
+  | { status: 'ready'; invocation: EventActorPreparedInvocation<TEvent> }
   | {
       status: 'checkpoint_unavailable';
       request: EventActorPrepareRequest<TEvent>;
       head: EventActorHead;
+      /** Integrity binding over this exact request/head pair. */
+      preparationDigest: string;
     };
 
-export type EventActorTerminalResult<TResult> =
+export type EventActorTerminalResult<TResult extends EventActorEvent> =
   | {
       status: 'applied';
       result: TResult;
@@ -63,7 +71,7 @@ export type EventActorTerminalResult<TResult> =
     }
   | { status: 'completed_no_action'; result?: TResult };
 
-export type EventActorAppliedResult<TResult> = Extract<
+export type EventActorAppliedResult<TResult extends EventActorEvent> = Extract<
   EventActorTerminalResult<TResult>,
   { status: 'applied' }
 > & {
@@ -71,7 +79,7 @@ export type EventActorAppliedResult<TResult> = Extract<
   invocation: EventActorInvocationReference;
 };
 
-export type EventActorInvocationResult<TResult> =
+export type EventActorInvocationResult<TResult extends EventActorEvent> =
   | EventActorAppliedResult<TResult>
   | Extract<
       EventActorTerminalResult<TResult>,
@@ -101,7 +109,7 @@ export interface EventActorAdapterPrepareRequest<TEvent extends EventActorEvent>
   checkpointNs: string;
 }
 
-export interface EventActorCommitRequest<TResult> {
+export interface EventActorCommitRequest<TResult extends EventActorEvent> {
   invocation: EventActorInvocationReference;
   expectedHead: EventActorHead;
   checkpoint: EventActorCheckpointFork;
@@ -133,20 +141,23 @@ export interface EventActorDiscardRequest {
  * deduplicates the logical `invocationId` before entering this seam, while each
  * SDK execution attempt receives a distinct checkpoint namespace. Preparation
  * methods own rollback until they return a ready invocation and must treat the
- * request event as immutable. `invoke` returns only after its provider, stream,
- * timer, and executor resources have been released. Once qualifying action
- * evidence exists, `invoke` must return `applied` even if a later abort or
- * provider failure occurs; a thrown error is therefore a definite no-action
- * failure whose fork is safe to discard. `commit` must not reclaim an applied
- * stale fork: the SDK retains and surfaces it as `commit_conflict` for host
+ * request event as immutable. On cancellation they roll back and reject with
+ * `context.signal.reason`; cleanup failures reject with their own error so they
+ * remain observable. `invoke` returns only after its provider, stream, timer,
+ * and executor resources have been released. Once qualifying action evidence
+ * exists, `invoke` must return `applied` even if a later abort or provider
+ * failure occurs; a thrown error is therefore a definite no-action failure
+ * whose fork is safe to discard. `commit` must not reclaim an applied stale
+ * fork: the SDK retains and surfaces it as `commit_conflict` for host
  * reconciliation.
  */
 export interface EventActorHostAdapter<
   TEvent extends EventActorEvent,
-  TResult,
+  TResult extends EventActorEvent,
 > {
   prepare(
-    request: EventActorAdapterPrepareRequest<TEvent>
+    request: EventActorAdapterPrepareRequest<TEvent>,
+    context: EventActorPreparationContext
   ): Promise<EventActorAdapterPreparation<TEvent>>;
   coldContinue(
     request: EventActorAdapterPrepareRequest<TEvent>,
@@ -172,7 +183,7 @@ export interface EventActorExecutionRequest<TEvent extends EventActorEvent> {
   signal?: AbortSignal;
 }
 
-export type EventActorExecutionResult<TResult> =
+export type EventActorExecutionResult<TResult extends EventActorEvent> =
   | {
       status: 'applied';
       result: TResult;

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -79,8 +79,19 @@ export type EventActorAppliedResult<TResult extends EventActorEvent> = Extract<
   invocation: EventActorInvocationReference;
 };
 
+export interface EventActorIndeterminateResult<
+  TResult extends EventActorEvent,
+> {
+  /** Applied handling cannot be proven safe to retry; retain its fork. */
+  status: 'commit_indeterminate';
+  result?: TResult;
+  checkpoint: EventActorCheckpointFork;
+  error: Error;
+}
+
 export type EventActorInvocationResult<TResult extends EventActorEvent> =
   | EventActorAppliedResult<TResult>
+  | EventActorIndeterminateResult<TResult>
   | Extract<
       EventActorTerminalResult<TResult>,
       { status: 'completed_no_action' }
@@ -210,7 +221,7 @@ export type EventActorExecutionResult<TResult extends EventActorEvent> =
   | {
       /** Applied handling cannot be proven safe to retry; retain its fork. */
       status: 'commit_indeterminate';
-      result: TResult;
+      result?: TResult;
       checkpoint: EventActorCheckpointFork;
       error: Error;
       continuation: 'warm' | 'cold';

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -45,7 +45,7 @@ export interface EventActorInvocation<TEvent extends EventActorEvent>
 
 export interface EventActorPreparedInvocation<TEvent extends EventActorEvent>
   extends EventActorInvocation<TEvent> {
-  /** Integrity binding over the complete prepared invocation. */
+  /** Executor-authenticated binding over the complete prepared invocation. */
   preparationDigest: string;
 }
 
@@ -59,7 +59,7 @@ export type EventActorPreparation<TEvent extends EventActorEvent> =
       status: 'checkpoint_unavailable';
       request: EventActorPrepareRequest<TEvent>;
       head: EventActorHead;
-      /** Integrity binding over this exact request/head pair. */
+      /** Executor-authenticated binding over this exact request/head pair. */
       preparationDigest: string;
     };
 
@@ -224,4 +224,6 @@ export type EventActorExecutionResult<TResult extends EventActorEvent> =
 export interface EventActorExecutorOptions {
   maxDepth?: number;
   dormantCheckpointTtlMs?: number;
+  /** Stable private key of at least 32 bytes for cross-lifetime handoffs. */
+  preparationSigningKey?: string | Uint8Array;
 }

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -144,7 +144,12 @@ export type EventActorExecutionResult<TResult> =
       continuation: 'warm' | 'cold';
     }
   | {
-      status: 'completed_no_action' | 'cancelled';
+      status: 'completed_no_action';
+      result?: TResult;
+      continuation: 'warm' | 'cold';
+    }
+  | {
+      status: 'cancelled';
       continuation: 'warm' | 'cold';
     }
   | {

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -1,5 +1,14 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
 
+/** Durable event payload accepted by the actor lifecycle. */
+export type EventActorEvent =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly EventActorEvent[]
+  | { readonly [key: string]: EventActorEvent };
+
 /** Stable reference to one persisted LangGraph checkpoint. */
 export interface EventActorCheckpointReference {
   threadId: string;
@@ -29,16 +38,16 @@ export interface EventActorInvocationReference {
   fork: EventActorCheckpointFork;
 }
 
-export interface EventActorInvocation<TEvent>
+export interface EventActorInvocation<TEvent extends EventActorEvent>
   extends EventActorInvocationReference {
   event: TEvent;
 }
 
-export type EventActorAdapterPreparation<TEvent> =
+export type EventActorAdapterPreparation<TEvent extends EventActorEvent> =
   | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
   | { status: 'checkpoint_unavailable'; head: EventActorHead };
 
-export type EventActorPreparation<TEvent> =
+export type EventActorPreparation<TEvent extends EventActorEvent> =
   | { status: 'ready'; invocation: EventActorInvocation<TEvent> }
   | {
       status: 'checkpoint_unavailable';
@@ -57,21 +66,36 @@ export type EventActorTerminalResult<TResult> =
 export type EventActorAppliedResult<TResult> = Extract<
   EventActorTerminalResult<TResult>,
   { status: 'applied' }
->;
+> & {
+  /** Executor-issued immutable reference to the invocation that produced this action. */
+  invocation: EventActorInvocationReference;
+};
+
+export type EventActorInvocationResult<TResult> =
+  | EventActorAppliedResult<TResult>
+  | Extract<
+      EventActorTerminalResult<TResult>,
+      { status: 'completed_no_action' }
+    >;
 
 export interface EventActorInvocationContext {
   signal: AbortSignal;
   config: RunnableConfig;
 }
 
-export interface EventActorPrepareRequest<TEvent> {
+export interface EventActorPreparationContext {
+  /** Explicit task-owned cancellation; parent-run ambient signals are excluded. */
+  signal: AbortSignal;
+}
+
+export interface EventActorPrepareRequest<TEvent extends EventActorEvent> {
   actorThreadId: string;
   invocationId: string;
   depth: number;
   event: TEvent;
 }
 
-export interface EventActorAdapterPrepareRequest<TEvent>
+export interface EventActorAdapterPrepareRequest<TEvent extends EventActorEvent>
   extends EventActorPrepareRequest<TEvent> {
   /** Unique execution-attempt namespace; invocationId remains the logical idempotency key. */
   checkpointNs: string;
@@ -117,13 +141,17 @@ export interface EventActorDiscardRequest {
  * stale fork: the SDK retains and surfaces it as `commit_conflict` for host
  * reconciliation.
  */
-export interface EventActorHostAdapter<TEvent, TResult> {
+export interface EventActorHostAdapter<
+  TEvent extends EventActorEvent,
+  TResult,
+> {
   prepare(
     request: EventActorAdapterPrepareRequest<TEvent>
   ): Promise<EventActorAdapterPreparation<TEvent>>;
   coldContinue(
     request: EventActorAdapterPrepareRequest<TEvent>,
-    head: EventActorHead
+    head: EventActorHead,
+    context: EventActorPreparationContext
   ): Promise<EventActorInvocation<TEvent>>;
   invoke(
     invocation: EventActorInvocation<TEvent>,
@@ -135,7 +163,7 @@ export interface EventActorHostAdapter<TEvent, TResult> {
   discard(request: EventActorDiscardRequest): Promise<void>;
 }
 
-export interface EventActorExecutionRequest<TEvent> {
+export interface EventActorExecutionRequest<TEvent extends EventActorEvent> {
   actorThreadId: string;
   invocationId: string;
   event: TEvent;

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -87,8 +87,7 @@ export type EventActorCommitResult =
 export type EventActorDiscardReason =
   | 'cancelled'
   | 'completed_no_action'
-  | 'failed'
-  | 'stale';
+  | 'failed';
 
 export interface EventActorDiscardRequest {
   invocation: EventActorInvocationReference;
@@ -101,10 +100,14 @@ export interface EventActorDiscardRequest {
  * atomically before advancing the logical actor head. The host mailbox
  * deduplicates the logical `invocationId` before entering this seam, while each
  * SDK execution attempt receives a distinct checkpoint namespace. Preparation
- * methods own rollback until they return a ready invocation; `invoke` returns
- * only after its provider, stream, timer, and executor resources have been
- * released. `commit` must not reclaim an applied stale fork: the SDK retains
- * and surfaces it as `commit_conflict` for host reconciliation.
+ * methods own rollback until they return a ready invocation and must treat the
+ * request event as immutable. `invoke` returns only after its provider, stream,
+ * timer, and executor resources have been released. Once qualifying action
+ * evidence exists, `invoke` must return `applied` even if a later abort or
+ * provider failure occurs; a thrown error is therefore a definite no-action
+ * failure whose fork is safe to discard. `commit` must not reclaim an applied
+ * stale fork: the SDK retains and surfaces it as `commit_conflict` for host
+ * reconciliation.
  */
 export interface EventActorHostAdapter<TEvent, TResult> {
   prepare(
@@ -149,11 +152,14 @@ export type EventActorExecutionResult<TResult> =
       status: 'commit_conflict';
       result: TResult;
       checkpoint: EventActorCheckpointFork;
+      head?: EventActorHead;
       continuation: 'warm' | 'cold';
     }
   | {
       /** Applied handling cannot be proven safe to retry; retain its fork. */
       status: 'commit_indeterminate';
+      result: TResult;
+      checkpoint: EventActorCheckpointFork;
       error: Error;
       continuation: 'warm' | 'cold';
     }

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -45,7 +45,10 @@ export interface EventActorInvocation<TEvent extends EventActorEvent>
 
 export interface EventActorPreparedInvocation<TEvent extends EventActorEvent>
   extends EventActorInvocation<TEvent> {
-  /** Executor-authenticated binding over the complete prepared invocation. */
+  /**
+   * Executor-authenticated, time-bounded binding over the complete prepared
+   * invocation. Its wire representation is opaque to callers.
+   */
   preparationDigest: string;
 }
 

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -168,7 +168,8 @@ export interface EventActorDiscardRequest {
  * failure occurs; a thrown error is therefore a definite no-action failure
  * whose fork is safe to discard. `commit` must not reclaim an applied stale
  * fork: the SDK retains and surfaces it as `commit_conflict` for host
- * reconciliation.
+ * reconciliation. `discard` must be idempotent for the same invocation because
+ * an ambiguous cleanup failure can be retried through the public lifecycle.
  */
 export interface EventActorHostAdapter<
   TEvent extends EventActorEvent,
@@ -242,6 +243,7 @@ export type EventActorExecutionResult<TResult extends EventActorEvent> =
 
 export interface EventActorExecutorOptions {
   maxDepth?: number;
+  /** Also bounds signed preparation authority and local terminal fences. */
   dormantCheckpointTtlMs?: number;
   /** Stable private key of at least 32 bytes for cross-lifetime handoffs. */
   preparationSigningKey?: string | Uint8Array;

--- a/src/eventActor/types.ts
+++ b/src/eventActor/types.ts
@@ -65,6 +65,7 @@ export interface EventActorPrepareRequest<TEvent> {
 
 export interface EventActorAdapterPrepareRequest<TEvent>
   extends EventActorPrepareRequest<TEvent> {
+  /** Unique execution-attempt namespace; invocationId remains the logical idempotency key. */
   checkpointNs: string;
 }
 
@@ -97,9 +98,13 @@ export interface EventActorDiscardRequest {
 /**
  * Host adapter for durable actor state and the concrete agent invocation.
  * `commit` must compare both the expected generation and checkpoint identity
- * atomically before advancing the logical actor head. Preparation methods own
- * rollback until they return a ready invocation; `invoke` returns only after
- * its provider, stream, timer, and executor resources have been released.
+ * atomically before advancing the logical actor head. The host mailbox
+ * deduplicates the logical `invocationId` before entering this seam, while each
+ * SDK execution attempt receives a distinct checkpoint namespace. Preparation
+ * methods own rollback until they return a ready invocation; `invoke` returns
+ * only after its provider, stream, timer, and executor resources have been
+ * released. `commit` must not reclaim an applied stale fork: the SDK retains
+ * and surfaces it as `commit_conflict` for host reconciliation.
  */
 export interface EventActorHostAdapter<TEvent, TResult> {
   prepare(
@@ -136,7 +141,14 @@ export type EventActorExecutionResult<TResult> =
       continuation: 'warm' | 'cold';
     }
   | {
-      status: 'completed_no_action' | 'cancelled' | 'stale';
+      status: 'completed_no_action' | 'cancelled';
+      continuation: 'warm' | 'cold';
+    }
+  | {
+      /** The action happened, but another head won the CAS. Reconcile; do not retry. */
+      status: 'commit_conflict';
+      result: TResult;
+      checkpoint: EventActorCheckpointFork;
       continuation: 'warm' | 'cold';
     }
   | {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,9 @@ export * from './hooks';
 /* Programmatic sessions */
 export * from './session';
 
+/* Event actors */
+export * from './eventActor';
+
 /* HITL helpers */
 export * from './hitl';
 


### PR DESCRIPTION
## Summary

I added an opt-in event-actor execution module that preserves one logical actor thread while isolating each invocation in a task-owned checkpoint fork.

- Expose a host-facing prepare, cold-continue, invoke, commit, and discard interface plus a high-level execute path.
- Derive bounded unique checkpoint namespaces per execution attempt while retaining the logical invocation ID for host deduplication.
- Preserve caller tracing fields while replacing ambient parent signal and checkpoint state with an invocation-owned runnable context.
- Fence actor-head advancement with the base generation and checkpoint identity supplied to the host adapter.
- Commit only applied outcomes; discard cancelled, failed, and completed-without-action forks, while retaining applied CAS conflicts for reconciliation.
- Preserve indeterminate commit forks for reconciliation instead of risking deletion after an ambiguous durable write.
- Pass current-plus-previous retention and dormant TTL policy to the host adapter.
- Default event-actor recursion depth to one while permitting sibling actors.
- Document Event Actor, Event Actor Head, Invocation Fork, and Cold Continuation domain terms.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- `NODE_OPTIONS=--experimental-vm-modules jest src/tools/__tests__/SubagentExecutor.test.ts src/tools/subagent/__tests__/SubagentExecutor.lazy.test.ts src/eventActor/__tests__/EventActorExecutor.test.ts --runInBand` (263 passed)
- `npm run check:circular-deps`
- `npm run build`
- Focused ESLint, TypeScript, Prettier, and import-order checks

### Test Configuration

- Node.js 24
- Existing repository dependency tree
- No provider credentials or external services required

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of the code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

