### PR TITLE
🐚 fix: Guard Bash PTC Wrapper Under Nounset

### DIFF
--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -40,6 +40,7 @@ config();
 
 const DEFAULT_MAX_ROUND_TRIPS = 20;
 const DEFAULT_RUN_TIMEOUT_MS = resolveCodeApiRunTimeoutMs();
+const BASH_LAST_BACKGROUND_PID_GUARD = ': &\nwait "$!"';
 
 /** Bash reserved words that get `_tool` suffix when used as function names */
 const BASH_RESERVED = new Set([
@@ -170,6 +171,14 @@ export const BashProgrammaticToolCallingDefinition = {
   description: BashProgrammaticToolCallingDescription,
   schema: BashProgrammaticToolCallingSchema,
 } as const;
+
+function prepareBashProgrammaticCode(code: string): string {
+  /* The Code API's generated Bash wrapper reads `$!` after user code. A user
+   * `set -u` makes that expansion fail when no background process has run.
+   * Seed and reap a no-op job before user code so strict mode remains active
+   * for the payload while the wrapper can safely read its special parameter. */
+  return `${BASH_LAST_BACKGROUND_PID_GUARD}\n${code}`;
+}
 
 function maybeParseJsonResultString(result: unknown): unknown {
   if (typeof result !== 'string') {
@@ -320,6 +329,7 @@ export function createBashProgrammaticToolCallingTool(
     async (rawParams, config) => {
       const params = rawParams as ProgrammaticInvocationParams;
       const { code } = params;
+      const preparedCode = prepareBashProgrammaticCode(code);
       const timeout = clampCodeApiRunTimeoutMs(params.timeout, maxRunTimeoutMs);
 
       const toolCall = (config.toolCall ?? {}) as ToolCall &
@@ -417,7 +427,7 @@ export function createBashProgrammaticToolCallingTool(
           EXEC_ENDPOINT,
           {
             lang: 'bash',
-            code,
+            code: preparedCode,
             tools: effectiveTools,
             session_id,
             timeout,

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -34,6 +34,7 @@ type FetchMock = jest.MockedFunction<
 >;
 
 type CodeApiRequestBody = {
+  code?: string;
   timeout?: number;
   continuation_token?: string;
   runtime_session_hint?: string;
@@ -797,6 +798,26 @@ describe('CodeAPI auth header injection', () => {
     );
 
     expect(requestBodyAt(0).timeout).toBe(15000);
+  });
+
+  it('initializes Bash’s last background PID before strict user code', async () => {
+    const tool = createBashProgrammaticToolCallingTool();
+
+    await tool.invoke(
+      { code: 'set -euo pipefail\nlookup_user "{}"' },
+      {
+        toolCall: {
+          name: 'bash_programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+        },
+      }
+    );
+
+    expect(requestBodyAt(0).code).toBe(
+      ': &\nwait "$!"\nset -euo pipefail\nlookup_user "{}"'
+    );
   });
 
   it('describes the PTC timeout as a single sandbox run cap', () => {


### PR DESCRIPTION
## Summary

I prevent Code API Bash wrapper failures when a Programmatic Tool Calling payload enables `set -u`.

- Seed and reap a no-op background process before user Bash so the wrapper’s `$!` remains defined under nounset.
- Preserve strict-mode behavior throughout the user payload.
- Add a regression test that asserts the guarded payload sent to Code API.

Fixes danny-avila/LibreChat#15214

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/__tests__/CodeApiAuthHeaders.test.ts --runInBand`
- `npx eslint src/tools/BashProgrammaticToolCalling.ts src/tools/__tests__/CodeApiAuthHeaders.test.ts --quiet`
- `npx tsc --noEmit`

### **Test Configuration**:

- Node.js and npm dependencies installed from `package-lock.json` with `npm ci --ignore-scripts`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.