### PR TITLE
🧭 fix: Coerce Schema-Guided Tool Arguments

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -736,6 +736,12 @@ function createEagerToolExecutionPlan(args: {
   if (candidateToolCalls.length === 0) {
     return [];
   }
+  const toolSchemas = new Map(
+    agentContext?.toolDefinitions?.map(({ name, parameters }) => [
+      name,
+      parameters,
+    ])
+  );
 
   // Eager execution must preserve ToolNode batch semantics exactly for every
   // unstarted call. If any candidate cannot be planned, fall back for that
@@ -770,9 +776,7 @@ function createEagerToolExecutionPlan(args: {
       ),
     })),
     usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
-    getToolSchema: (toolName) =>
-      agentContext?.toolDefinitions?.find((tool) => tool.name === toolName)
-        ?.parameters,
+    getToolSchema: (toolName) => toolSchemas.get(toolName),
   });
   if (plan == null) {
     return undefined;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -770,6 +770,9 @@ function createEagerToolExecutionPlan(args: {
       ),
     })),
     usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
+    getToolSchema: (toolName) =>
+      agentContext?.toolDefinitions?.find((tool) => tool.name === toolName)
+        ?.parameters,
   });
   if (plan == null) {
     return undefined;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -71,6 +71,7 @@ import {
 } from '@/tools/intentArg';
 import {
   buildToolExecutionRequestPlan,
+  coerceArgsForSchema,
   resolveRuntimeSessionHint,
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
@@ -1127,6 +1128,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       ),
       (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
     );
+  }
+
+  private getToolParameterSchema(
+    toolName: string
+  ): t.JsonSchemaType | undefined {
+    return (
+      this.toolDefinitions?.get(toolName)?.parameters ??
+      this.toolRegistry?.get(toolName)?.parameters
+    );
+  }
+
+  private coerceEventToolArgs(
+    toolName: string,
+    args: Record<string, unknown>
+  ): Record<string, unknown> {
+    return coerceArgsForSchema(args, this.getToolParameterSchema(toolName));
   }
 
   /** Serializes the live caller projection for event-driven hosts. */
@@ -2758,7 +2775,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return {
         call,
         stepId: this.toolCallStepIds?.get(call.id!) ?? '',
-        args: resolvedArgs,
+        args: this.coerceEventToolArgs(call.name, resolvedArgs),
         batchIndex: batchIndices?.[i],
       };
     });
@@ -3002,7 +3019,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               entry.call.name
             ),
           });
-          entry.args = resolved as Record<string, unknown>;
+          entry.args = this.coerceEventToolArgs(
+            entry.call.name,
+            resolved as Record<string, unknown>
+          );
           if (entry.call.id != null) {
             if (unresolved.length > 0) {
               unresolvedByCallId.set(entry.call.id, unresolved);
@@ -3012,7 +3032,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           }
           return;
         }
-        entry.args = nextArgs;
+        entry.args = this.coerceEventToolArgs(entry.call.name, nextArgs);
       };
 
       const askEntries: Array<{
@@ -3369,9 +3389,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }),
         usageCount: this.toolUsageCount,
         invalidArgsBehavior: 'error-result',
-        getToolSchema: (toolName) =>
-          this.toolDefinitions?.get(toolName)?.parameters ??
-          this.toolRegistry?.get(toolName)?.parameters,
+        getToolSchema: (toolName) => this.getToolParameterSchema(toolName),
         recordTurn: (toolName, reservedTurn, callId) => {
           this.recordEventToolPlanningTurn(
             toolName,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -72,6 +72,7 @@ import {
 import {
   buildToolExecutionRequestPlan,
   coerceArgsForSchema,
+  coerceRecordArgs,
   resolveRuntimeSessionHint,
   recordArgsEqual,
 } from '@/tools/eagerEventExecution';
@@ -1141,9 +1142,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
   private coerceEventToolArgs(
     toolName: string,
-    args: Record<string, unknown>
+    args: unknown
   ): Record<string, unknown> {
-    return coerceArgsForSchema(args, this.getToolParameterSchema(toolName));
+    const recordArgs = coerceRecordArgs(args);
+    return coerceArgsForSchema(
+      recordArgs ?? (args as Record<string, unknown>),
+      this.getToolParameterSchema(toolName)
+    );
   }
 
   /** Serializes the live caller projection for event-driven hosts. */

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3369,6 +3369,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }),
         usageCount: this.toolUsageCount,
         invalidArgsBehavior: 'error-result',
+        getToolSchema: (toolName) =>
+          this.toolDefinitions?.get(toolName)?.parameters ??
+          this.toolRegistry?.get(toolName)?.parameters,
         recordTurn: (toolName, reservedTurn, callId) => {
           this.recordEventToolPlanningTurn(
             toolName,

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -165,6 +165,55 @@ describe('ToolNode eager event tool execution', () => {
     });
   });
 
+  it('parses serialized event arguments before policy hooks', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('ran');
+    const receivedHookInputs: PreToolUseHookInput[] = [];
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => {
+          receivedHookInputs.push(input);
+          return { decision: 'allow' };
+        },
+      ],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('issue_write')],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      toolCallStepIds: new Map([['call_issue', 'step_issue']]),
+      toolDefinitions: new Map([
+        [
+          'issue_write',
+          {
+            name: 'issue_write',
+            parameters: {
+              type: 'object',
+              properties: { issue_number: { type: 'integer' } },
+            },
+          },
+        ],
+      ]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          {
+            id: 'call_issue',
+            name: 'issue_write',
+            args: '{"issue_number":"2365"}',
+          },
+        ]),
+      ],
+    });
+
+    expect(receivedHookInputs[0].toolInput).toEqual({ issue_number: 2365 });
+    expect(toolExecuteCalls[0].toolCalls[0].args).toEqual({
+      issue_number: 2365,
+    });
+  });
+
   it('uses a prestarted event result when final args are canonically equivalent', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -117,6 +117,54 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
+  it('normalizes schema arguments before hooks and after hook edits', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('ran');
+    const receivedHookInputs: PreToolUseHookInput[] = [];
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => {
+          receivedHookInputs.push(input);
+          return {
+            decision: 'allow',
+            updatedInput: { issue_number: '2365' },
+          };
+        },
+      ],
+    });
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('issue_write')],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      toolCallStepIds: new Map([['call_issue', 'step_issue']]),
+      toolDefinitions: new Map([
+        [
+          'issue_write',
+          {
+            name: 'issue_write',
+            parameters: {
+              type: 'object',
+              properties: { issue_number: { type: 'integer' } },
+            },
+          },
+        ],
+      ]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessage('call_issue', 'issue_write', {
+          issue_number: '2365',
+        }),
+      ],
+    });
+
+    expect(receivedHookInputs[0].toolInput).toEqual({ issue_number: 2365 });
+    expect(toolExecuteCalls[0].toolCalls[0].args).toEqual({
+      issue_number: 2365,
+    });
+  });
+
   it('uses a prestarted event result when final args are canonically equivalent', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();

--- a/src/tools/__tests__/eagerEventExecution.session.test.ts
+++ b/src/tools/__tests__/eagerEventExecution.session.test.ts
@@ -17,6 +17,10 @@ describe('coerceArgsForSchema', () => {
         type: 'object',
         properties: { delay_seconds: { type: 'number' } },
       },
+      metadata: {
+        type: 'object',
+        additionalProperties: { type: 'integer' },
+      },
     },
   };
 
@@ -28,6 +32,7 @@ describe('coerceArgsForSchema', () => {
           dry_run: 'false',
           retries: ['1', '2'],
           settings: { delay_seconds: '1.25' },
+          metadata: { attempt: '3' },
           label: '001',
         },
         issueSchema
@@ -37,6 +42,7 @@ describe('coerceArgsForSchema', () => {
       dry_run: false,
       retries: [1, 2],
       settings: { delay_seconds: 1.25 },
+      metadata: { attempt: 3 },
       label: '001',
     });
   });
@@ -48,6 +54,7 @@ describe('coerceArgsForSchema', () => {
           issue_number: '02365',
           dry_run: 'False',
           retries: ['9007199254740992'],
+          settings: { delay_seconds: '9007199254740993' },
         },
         issueSchema
       )
@@ -55,6 +62,7 @@ describe('coerceArgsForSchema', () => {
       issue_number: '02365',
       dry_run: 'False',
       retries: ['9007199254740992'],
+      settings: { delay_seconds: '9007199254740993' },
     });
   });
 });

--- a/src/tools/__tests__/eagerEventExecution.session.test.ts
+++ b/src/tools/__tests__/eagerEventExecution.session.test.ts
@@ -2,8 +2,62 @@ import { describe, it, expect } from '@jest/globals';
 import type * as t from '@/types';
 import {
   buildToolExecutionRequestPlan,
+  coerceArgsForSchema,
   resolveRuntimeSessionHint,
 } from '../eagerEventExecution';
+
+describe('coerceArgsForSchema', () => {
+  const issueSchema: t.JsonSchemaType = {
+    type: 'object',
+    properties: {
+      issue_number: { type: 'integer' },
+      dry_run: { type: 'boolean' },
+      retries: { type: 'array', items: { type: 'integer' } },
+      settings: {
+        type: 'object',
+        properties: { delay_seconds: { type: 'number' } },
+      },
+    },
+  };
+
+  it('repairs canonical scalar strings only where the schema permits it', () => {
+    expect(
+      coerceArgsForSchema(
+        {
+          issue_number: '2365',
+          dry_run: 'false',
+          retries: ['1', '2'],
+          settings: { delay_seconds: '1.25' },
+          label: '001',
+        },
+        issueSchema
+      )
+    ).toEqual({
+      issue_number: 2365,
+      dry_run: false,
+      retries: [1, 2],
+      settings: { delay_seconds: 1.25 },
+      label: '001',
+    });
+  });
+
+  it('does not coerce lossy, ambiguous, or unsafe numeric strings', () => {
+    expect(
+      coerceArgsForSchema(
+        {
+          issue_number: '02365',
+          dry_run: 'False',
+          retries: ['9007199254740992'],
+        },
+        issueSchema
+      )
+    ).toEqual({
+      issue_number: '02365',
+      dry_run: 'False',
+      retries: ['9007199254740992'],
+    });
+  });
+});
 
 describe('buildToolExecutionRequestPlan — runtimeSessionHint', () => {
   const usageCount = () => new Map<string, number>();
@@ -54,6 +108,24 @@ describe('buildToolExecutionRequestPlan — runtimeSessionHint', () => {
     });
     expect(plan?.allRequests[0].runtimeSessionHint).toBe('conv-9');
     expect(plan?.rejectedResults).toHaveLength(1);
+  });
+
+  it('normalizes arguments before event dispatch using the matching tool schema', () => {
+    const plan = buildToolExecutionRequestPlan({
+      toolCalls: [
+        {
+          id: 'c1',
+          name: 'issue_write',
+          args: { issue_number: '2365' },
+        },
+      ],
+      usageCount: usageCount(),
+      getToolSchema: () => ({
+        type: 'object',
+        properties: { issue_number: { type: 'integer' } },
+      }),
+    });
+    expect(plan?.requests[0].args).toEqual({ issue_number: 2365 });
   });
 });
 

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -19,6 +19,84 @@ export function coerceRecordArgs(
   return args as Record<string, unknown>;
 }
 
+const INTEGER_STRING = /^-?(?:0|[1-9]\d*)$/;
+const NUMBER_STRING = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+function coerceValueForSchema(
+  value: unknown,
+  schema: t.JsonSchemaType | undefined
+): unknown {
+  if (schema == null) {
+    return value;
+  }
+
+  if (schema.type === 'integer' && typeof value === 'string') {
+    if (!INTEGER_STRING.test(value)) {
+      return value;
+    }
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) ? parsed : value;
+  }
+
+  if (
+    (schema.type === 'number' || schema.type === 'float') &&
+    typeof value === 'string'
+  ) {
+    if (!NUMBER_STRING.test(value)) {
+      return value;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : value;
+  }
+
+  if (schema.type === 'boolean' && typeof value === 'string') {
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return value;
+  }
+
+  if (schema.type === 'array' && Array.isArray(value)) {
+    return value.map((item) => coerceValueForSchema(item, schema.items));
+  }
+
+  if (
+    schema.type !== 'object' ||
+    value == null ||
+    typeof value !== 'object' ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  const properties = schema.properties;
+  if (properties == null) {
+    return record;
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [
+      key,
+      coerceValueForSchema(entry, properties[key]),
+    ])
+  );
+}
+
+/**
+ * Applies only lossless, schema-directed repairs to model-generated arguments.
+ * The host remains responsible for full schema validation and all business rules.
+ */
+export function coerceArgsForSchema(
+  args: Record<string, unknown>,
+  schema: t.JsonSchemaType | undefined
+): Record<string, unknown> {
+  return coerceValueForSchema(args, schema) as Record<string, unknown>;
+}
+
 export function stableStringify(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map((item) => stableStringify(item)).join(',')}]`;
@@ -87,6 +165,7 @@ export function buildToolExecutionRequestPlan(args: {
   usageCount: Map<string, number>;
   invalidArgsBehavior?: 'abort' | 'error-result';
   recordTurn?: (toolName: string, turn: number, callId: string) => void;
+  getToolSchema?: (toolName: string) => t.JsonSchemaType | undefined;
 }): ToolExecutionRequestPlan | undefined {
   const invalidArgsBehavior = args.invalidArgsBehavior ?? 'abort';
   const prepared: Array<{
@@ -103,8 +182,8 @@ export function buildToolExecutionRequestPlan(args: {
     if (toolCall.id == null || toolCall.id === '' || toolCall.name === '') {
       return undefined;
     }
-    const coercedArgs = coerceRecordArgs(toolCall.args);
-    if (coercedArgs == null) {
+    const recordArgs = coerceRecordArgs(toolCall.args);
+    if (recordArgs == null) {
       if (invalidArgsBehavior === 'abort') {
         return undefined;
       }
@@ -120,6 +199,10 @@ export function buildToolExecutionRequestPlan(args: {
       });
       continue;
     }
+    const coercedArgs = coerceArgsForSchema(
+      recordArgs,
+      args.getToolSchema?.(toolCall.name)
+    );
     prepared.push({
       id: toolCall.id,
       name: toolCall.name,

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -46,7 +46,9 @@ function coerceValueForSchema(
       return value;
     }
     const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : value;
+    return Number.isFinite(parsed) && String(parsed) === value
+      ? parsed
+      : value;
   }
 
   if (schema.type === 'boolean' && typeof value === 'string') {
@@ -73,15 +75,18 @@ function coerceValueForSchema(
   }
 
   const record = value as Record<string, unknown>;
-  const properties = schema.properties;
-  if (properties == null) {
-    return record;
-  }
+  const additionalProperties =
+    typeof schema.additionalProperties === 'object'
+      ? schema.additionalProperties
+      : undefined;
 
   return Object.fromEntries(
     Object.entries(record).map(([key, entry]) => [
       key,
-      coerceValueForSchema(entry, properties[key]),
+      coerceValueForSchema(
+        entry,
+        schema.properties?.[key] ?? additionalProperties
+      ),
     ])
   );
 }


### PR DESCRIPTION
## Summary

I added conservative schema-guided normalization for recoverable model-generated tool argument mistakes before event-driven tools reach their host handlers.

- Normalize canonical string integers, finite numeric strings, and exact boolean strings only when the matching JSON Schema field explicitly declares that type.
- Recurse through declared object properties and array item schemas while leaving unknown, ambiguous, and unsafe values untouched for host validation.
- Apply the same normalization to both regular event dispatch and speculative eager execution so they use identical arguments.
- Cover valid coercion, ambiguous-value preservation, nested schemas, and request-plan dispatch behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/__tests__/eagerEventExecution.session.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/tools/eagerEventExecution.ts src/tools/ToolNode.ts src/stream.ts src/tools/__tests__/eagerEventExecution.session.test.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.