### PR TITLE
refactor: Observe cache-aligned compaction replay eligibility

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,35 @@ eligible for the intra-turn fallback.
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.
 
+A **Compaction Replay Recipe** is the run-local, constant-time record of the
+latest successful normal request's serving route, cache namespace, provider
+projection mode, prepared-message reference, and system/tool projection
+revisions. It contains no live model or provider stream. Source lineage is
+derived only when compaction is attempted, and reset releases the recipe.
+
+A **Compaction Request Projection** is the cache-compatible provider request
+used to summarize one Compaction Range. When the summarizer uses the same
+routed provider and model, the projection replays the normal request's stable
+system instructions, tool schemas, and compactable message prefix and appends
+only the compaction instruction. A different provider or model uses an
+independent projection and makes no cache-reuse claim.
+
+A **Compaction Semantic Index** is a bounded, source-addressed projection of
+committed tool intents, tool outcomes, activity phases, and user-visible
+reasoning labels. It guides checkpoint creation without becoming conversation
+truth: raw source messages remain authoritative, pending labels are excluded,
+and hidden reasoning is never eligible.
+
+A **Compaction Pin** is a bounded typed fact that must survive checkpoint
+generation, such as an exact path, identifier, URL, error, pending approval,
+user steer, or artifact reference. Pins retain source provenance and are
+merged mechanically rather than relying on generated checkpoint text.
+
+A **Compaction Transaction** is the durable attempt that selects and prices a
+Compaction Range, generates and validates its replacement, commits the
+checkpoint, and records either completion or failure. The selected source
+span must still be stable when asynchronous generation completes.
+
 ## Provider Tool Derivation
 
 A **Provider Tool Derivation** is the copy-on-write projection of retained

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,11 +149,12 @@ eligible for the intra-turn fallback.
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.
 
-A **Compaction Replay Recipe** is the run-local, constant-time record of the
+A **Compaction Replay Recipe** is the debug-only, run-local record of the
 latest successful normal request's serving route, cache namespace, provider
-projection mode, prepared-message reference, and system/tool projection
-revisions. It contains no live model or provider stream. Source lineage is
-derived only when compaction is attempted, and reset releases the recipe.
+projection mode, prepared-message reference, bounded source-content
+fingerprints, and system/tool projection revisions. It contains no live model
+or provider stream, is absent from ordinary production runs, and reset releases
+the recipe.
 
 A **Compaction Request Projection** is the cache-compatible provider request
 used to summarize one Compaction Range. When the summarizer uses the same

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,9 +151,9 @@ range-selection and retention trade-offs.
 
 A **Compaction Replay Recipe** is the debug-only, run-local record of the
 latest successful normal request's serving route, cache namespace, provider
-projection mode, prepared-message reference, bounded source-content
-fingerprints, and system/tool projection revisions. It contains no live model
-or provider stream, is absent from ordinary production runs, and reset releases
+projection mode, immutable prepared/source fingerprints and lineage, and
+system/tool projection revisions. It contains no live messages, model, or
+provider stream, is absent from ordinary production runs, and reset releases
 the recipe.
 
 A **Compaction Request Projection** is the cache-compatible provider request

--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "bench:cache": "tsx ./src/scripts/bench-prompt-cache.ts",
     "bench:context-pressure": "tsx ./src/scripts/bench-context-pressure-cache.ts",
     "bench:compaction-range": "tsx ./src/scripts/bench-compaction-range.ts",
+    "bench:compaction-replay": "tsx ./src/scripts/bench-compaction-replay.ts",
     "bench:provider-derivation": "tsx ./src/scripts/bench-provider-derivation.ts",
     "bench:provider-projection": "tsx ./src/scripts/bench-provider-request-projection.ts",
     "bench:execution-world": "tsx ./src/scripts/bench-execution-world.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -10,6 +10,7 @@ import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type {
   CompactionCacheNamespace,
   CompactionReplayEligibility,
+  CompactionReplayRouteSnapshot,
   CompactionReplayState,
 } from '@/llm/compactionReplay';
 import type {
@@ -1998,34 +1999,42 @@ export class AgentContext {
     request: PreparedProviderRequest,
     sourceMessages: readonly BaseMessage[],
     servingRouteKnown = true,
-    tools?: t.GraphTools
+    tools?: t.GraphTools,
+    routeSnapshot = this.createCompactionReplayRouteSnapshot(servingRouteKnown)
   ): void {
-    const promptCacheEnabled = isCompactionPromptCacheEnabled(
-      this.provider,
-      this.clientOptions
-    );
     this.compactionReplayState = createCompactionReplayRecipe({
       provider: request.provider,
       modelId: request.modelId,
       projectionMode: request.projectionMode,
+      cacheNamespace: routeSnapshot.cacheNamespace,
+      promptCacheEnabled: routeSnapshot.promptCacheEnabled,
+      systemProjectionFingerprint:
+        this.systemRunnable == null
+          ? EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT
+          : undefined,
+      toolProjectionFingerprint: routeSnapshot.promptCacheEnabled
+        ? createCompactionToolProjectionFingerprint(tools)
+        : undefined,
+      systemRevision: this.compactionSystemRevision,
+      toolRevision: this.compactionToolRevision,
+      messages: request.messages,
+      sourceMessages,
+    });
+  }
+
+  createCompactionReplayRouteSnapshot(
+    servingRouteKnown = true
+  ): CompactionReplayRouteSnapshot {
+    return Object.freeze({
       cacheNamespace: createCompactionCacheNamespace(
         this.provider,
         this.clientOptions,
         servingRouteKnown
       ),
-      promptCacheEnabled,
-      systemProjectionFingerprint:
-        this.systemRunnable == null
-          ? EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT
-          : undefined,
-      toolProjectionFingerprint:
-        promptCacheEnabled
-          ? createCompactionToolProjectionFingerprint(tools)
-          : undefined,
-      systemRevision: this.compactionSystemRevision,
-      toolRevision: this.compactionToolRevision,
-      messages: request.messages,
-      sourceMessages,
+      promptCacheEnabled: isCompactionPromptCacheEnabled(
+        this.provider,
+        this.clientOptions
+      ),
     });
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -2052,6 +2052,7 @@ export class AgentContext {
     systemProjectionFingerprint?: string;
     toolProjectionFingerprint?: string;
     messages: readonly BaseMessage[];
+    projectedMessages?: readonly BaseMessage[];
     restoredToolSubstitution: boolean;
     summarizerFallbackServed?: boolean;
   }): CompactionReplayEligibility {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -63,6 +63,7 @@ import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
+  EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   isCompactionPromptCacheEnabled,
   inspectCompactionReplayEligibility,
 } from '@/llm/compactionReplay';
@@ -2013,6 +2014,10 @@ export class AgentContext {
         servingRouteKnown
       ),
       promptCacheEnabled,
+      systemProjectionFingerprint:
+        this.systemRunnable == null
+          ? EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT
+          : undefined,
       toolProjectionFingerprint:
         promptCacheEnabled
           ? createCompactionToolProjectionFingerprint(tools)
@@ -2035,6 +2040,7 @@ export class AgentContext {
     projectionMode?: ProviderMessageProjectionMode;
     cacheNamespace: CompactionCacheNamespace;
     promptCacheEnabled: boolean;
+    systemProjectionFingerprint?: string;
     toolProjectionFingerprint?: string;
     messages: readonly BaseMessage[];
     restoredToolSubstitution: boolean;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -10,6 +10,7 @@ import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type {
   CompactionCacheNamespace,
   CompactionReplayEligibility,
+  CompactionReplayRecipe,
   CompactionReplayRouteSnapshot,
   CompactionReplayState,
 } from '@/llm/compactionReplay';
@@ -1995,14 +1996,14 @@ export class AgentContext {
     return hasNewDiscoveries;
   }
 
-  captureCompactionReplayRecipe(
+  createCompactionReplayRecipeSnapshot(
     request: PreparedProviderRequest,
     sourceMessages: readonly BaseMessage[],
     servingRouteKnown = true,
     tools?: t.GraphTools,
     routeSnapshot = this.createCompactionReplayRouteSnapshot(servingRouteKnown)
-  ): void {
-    this.compactionReplayState = createCompactionReplayRecipe({
+  ): CompactionReplayRecipe {
+    return createCompactionReplayRecipe({
       provider: request.provider,
       modelId: request.modelId,
       projectionMode: request.projectionMode,
@@ -2020,6 +2021,10 @@ export class AgentContext {
       messages: request.messages,
       sourceMessages,
     });
+  }
+
+  captureCompactionReplayRecipe(recipe: CompactionReplayRecipe): void {
+    this.compactionReplayState = recipe;
   }
 
   createCompactionReplayRouteSnapshot(

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -357,8 +357,6 @@ export class AgentContext {
   private compactionToolRevision = 0;
   /** Latest successful normal-request recipe, or a fallback-served marker. */
   private compactionReplayState?: CompactionReplayState;
-  /** Lazily derived because contexts without summarization never need it. */
-  private compactionCacheNamespace?: CompactionCacheNamespace;
   /** Promise for token calculation initialization */
   tokenCalculationPromise?: Promise<void>;
   /** Format content blocks as strings (for legacy compatibility) */
@@ -2001,7 +1999,10 @@ export class AgentContext {
       provider: request.provider,
       modelId: request.modelId,
       projectionMode: request.projectionMode,
-      cacheNamespace: this.getCompactionCacheNamespace(),
+      cacheNamespace: createCompactionCacheNamespace(
+        this.provider,
+        this.clientOptions
+      ),
       systemRevision: this.compactionSystemRevision,
       toolRevision: this.compactionToolRevision,
       messages: request.messages,
@@ -2014,14 +2015,6 @@ export class AgentContext {
     this.compactionReplayState = 'fallback';
   }
 
-  private getCompactionCacheNamespace(): CompactionCacheNamespace {
-    this.compactionCacheNamespace ??= createCompactionCacheNamespace(
-      this.provider,
-      this.clientOptions
-    );
-    return this.compactionCacheNamespace;
-  }
-
   inspectCompactionReplay(params: {
     provider: t.ProviderName;
     modelId?: string;
@@ -2029,6 +2022,7 @@ export class AgentContext {
     cacheNamespace: CompactionCacheNamespace;
     messages: readonly BaseMessage[];
     restoredToolSubstitution: boolean;
+    summarizerFallbackServed?: boolean;
   }): CompactionReplayEligibility {
     return inspectCompactionReplayEligibility(this.compactionReplayState, {
       ...params,

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -62,6 +62,8 @@ import { isTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibil
 import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
+  createCompactionToolProjectionFingerprint,
+  isCompactionPromptCacheEnabled,
   inspectCompactionReplayEligibility,
 } from '@/llm/compactionReplay';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
@@ -1994,8 +1996,13 @@ export class AgentContext {
   captureCompactionReplayRecipe(
     request: PreparedProviderRequest,
     sourceMessages: readonly BaseMessage[],
-    servingRouteKnown = true
+    servingRouteKnown = true,
+    tools?: t.GraphTools
   ): void {
+    const promptCacheEnabled = isCompactionPromptCacheEnabled(
+      this.provider,
+      this.clientOptions
+    );
     this.compactionReplayState = createCompactionReplayRecipe({
       provider: request.provider,
       modelId: request.modelId,
@@ -2005,6 +2012,11 @@ export class AgentContext {
         this.clientOptions,
         servingRouteKnown
       ),
+      promptCacheEnabled,
+      toolProjectionFingerprint:
+        promptCacheEnabled
+          ? createCompactionToolProjectionFingerprint(tools)
+          : undefined,
       systemRevision: this.compactionSystemRevision,
       toolRevision: this.compactionToolRevision,
       messages: request.messages,
@@ -2022,6 +2034,8 @@ export class AgentContext {
     modelId?: string;
     projectionMode?: ProviderMessageProjectionMode;
     cacheNamespace: CompactionCacheNamespace;
+    promptCacheEnabled: boolean;
+    toolProjectionFingerprint?: string;
     messages: readonly BaseMessage[];
     restoredToolSubstitution: boolean;
     summarizerFallbackServed?: boolean;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -2052,7 +2052,7 @@ export class AgentContext {
     systemProjectionFingerprint?: string;
     toolProjectionFingerprint?: string;
     messages: readonly BaseMessage[];
-    projectedMessages?: readonly BaseMessage[];
+    projectedMessages?: readonly BaseMessage[] | null;
     restoredToolSubstitution: boolean;
     summarizerFallbackServed?: boolean;
   }): CompactionReplayEligibility {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1993,7 +1993,10 @@ export class AgentContext {
     return hasNewDiscoveries;
   }
 
-  captureCompactionReplayRecipe(request: PreparedProviderRequest): void {
+  captureCompactionReplayRecipe(
+    request: PreparedProviderRequest,
+    sourceMessages: readonly BaseMessage[]
+  ): void {
     this.compactionReplayState = createCompactionReplayRecipe({
       provider: request.provider,
       modelId: request.modelId,
@@ -2002,6 +2005,7 @@ export class AgentContext {
       systemRevision: this.compactionSystemRevision,
       toolRevision: this.compactionToolRevision,
       messages: request.messages,
+      sourceMessages,
     });
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -7,6 +7,15 @@ import type {
   BaseMessageFields,
 } from '@langchain/core/messages';
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
+import type {
+  CompactionCacheNamespace,
+  CompactionReplayEligibility,
+  CompactionReplayState,
+} from '@/llm/compactionReplay';
+import type {
+  PreparedProviderRequest,
+  ProviderMessageProjectionMode,
+} from '@/llm/prepareProviderRequest';
 import type { ExactTokenCountCache } from '@/llm/contextPressureMeter';
 import type * as t from '@/types';
 import {
@@ -50,6 +59,11 @@ import {
   Providers,
 } from '@/common';
 import { isTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
+import {
+  createCompactionCacheNamespace,
+  createCompactionReplayRecipe,
+  inspectCompactionReplayEligibility,
+} from '@/llm/compactionReplay';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
@@ -338,6 +352,13 @@ export class AgentContext {
   >;
   /** Whether system runnable needs rebuild (set when discovered tools change) */
   private systemRunnableStale: boolean = true;
+  /** Monotonic identities for cache-relevant system and tool projections. */
+  private compactionSystemRevision = 0;
+  private compactionToolRevision = 0;
+  /** Latest successful normal-request recipe, or a fallback-served marker. */
+  private compactionReplayState?: CompactionReplayState;
+  /** Lazily derived because contexts without summarization never need it. */
+  private compactionCacheNamespace?: CompactionCacheNamespace;
   /** Promise for token calculation initialization */
   tokenCalculationPromise?: Promise<void>;
   /** Format content blocks as strings (for legacy compatibility) */
@@ -1191,6 +1212,9 @@ export class AgentContext {
     this.deferredToolNames = [];
     this.cachedSystemRunnable = undefined;
     this.systemRunnableStale = true;
+    this.compactionSystemRevision += 1;
+    this.compactionToolRevision += 1;
+    this.compactionReplayState = undefined;
     this.lastToken = undefined;
     this.indexTokenCountMap = { ...this.baseIndexTokenCountMap };
     this.currentUsage = undefined;
@@ -1452,6 +1476,7 @@ export class AgentContext {
   setHandoffContext(sourceAgentName: string, parallelSiblings: string[]): void {
     this.handoffContext = { sourceAgentName, parallelSiblings };
     this.systemRunnableStale = true;
+    this.compactionSystemRevision += 1;
   }
 
   /**
@@ -1462,6 +1487,7 @@ export class AgentContext {
     if (this.handoffContext) {
       this.handoffContext = undefined;
       this.systemRunnableStale = true;
+      this.compactionSystemRevision += 1;
     }
   }
 
@@ -1479,6 +1505,7 @@ export class AgentContext {
     this.durableSummaryPrecedesMessages = this.summaryPrecedesMessages;
     this._summaryVersion += 1;
     this.systemRunnableStale = true;
+    this.compactionSystemRevision += 1;
     this.pruneMessages = undefined;
   }
 
@@ -1493,6 +1520,7 @@ export class AgentContext {
     this.durableSummaryPrecedesMessages = false;
     this._summaryVersion += 1;
     this.systemRunnableStale = true;
+    this.compactionSystemRevision += 1;
   }
 
   /**
@@ -1699,6 +1727,7 @@ export class AgentContext {
       this.durableSummaryPrecedesMessages = false;
       this._summaryLocation = 'none';
       this.systemRunnableStale = true;
+      this.compactionSystemRevision += 1;
     }
   }
 
@@ -1950,6 +1979,8 @@ export class AgentContext {
     }
     if (hasNewDiscoveries) {
       this.systemRunnableStale = true;
+      this.compactionSystemRevision += 1;
+      this.compactionToolRevision += 1;
       /** Refresh schema token accounting so the next call's budget and
        *  per-tool breakdown include the newly discovered tools; awaited
        *  via tokenCalculationPromise before the next model call */
@@ -1960,6 +1991,46 @@ export class AgentContext {
       }
     }
     return hasNewDiscoveries;
+  }
+
+  captureCompactionReplayRecipe(request: PreparedProviderRequest): void {
+    this.compactionReplayState = createCompactionReplayRecipe({
+      provider: request.provider,
+      modelId: request.modelId,
+      projectionMode: request.projectionMode,
+      cacheNamespace: this.getCompactionCacheNamespace(),
+      systemRevision: this.compactionSystemRevision,
+      toolRevision: this.compactionToolRevision,
+      messages: request.messages,
+    });
+  }
+
+  /** Prevents a later compaction from attributing a fallback call to primary. */
+  markCompactionReplayFallbackServed(): void {
+    this.compactionReplayState = 'fallback';
+  }
+
+  private getCompactionCacheNamespace(): CompactionCacheNamespace {
+    this.compactionCacheNamespace ??= createCompactionCacheNamespace(
+      this.provider,
+      this.clientOptions
+    );
+    return this.compactionCacheNamespace;
+  }
+
+  inspectCompactionReplay(params: {
+    provider: t.ProviderName;
+    modelId?: string;
+    projectionMode?: ProviderMessageProjectionMode;
+    cacheNamespace: CompactionCacheNamespace;
+    messages: readonly BaseMessage[];
+    restoredToolSubstitution: boolean;
+  }): CompactionReplayEligibility {
+    return inspectCompactionReplayEligibility(this.compactionReplayState, {
+      ...params,
+      systemRevision: this.compactionSystemRevision,
+      toolRevision: this.compactionToolRevision,
+    });
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1993,7 +1993,8 @@ export class AgentContext {
 
   captureCompactionReplayRecipe(
     request: PreparedProviderRequest,
-    sourceMessages: readonly BaseMessage[]
+    sourceMessages: readonly BaseMessage[],
+    servingRouteKnown = true
   ): void {
     this.compactionReplayState = createCompactionReplayRecipe({
       provider: request.provider,
@@ -2001,7 +2002,8 @@ export class AgentContext {
       projectionMode: request.projectionMode,
       cacheNamespace: createCompactionCacheNamespace(
         this.provider,
-        this.clientOptions
+        this.clientOptions,
+        servingRouteKnown
       ),
       systemRevision: this.compactionSystemRevision,
       toolRevision: this.compactionToolRevision,

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -9,6 +9,7 @@ import type {
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type {
   CompactionCacheNamespace,
+  CompactionReplayCandidateSnapshot,
   CompactionReplayEligibility,
   CompactionReplayRecipe,
   CompactionReplayRouteSnapshot,
@@ -2058,6 +2059,7 @@ export class AgentContext {
     toolProjectionFingerprint?: string;
     messages: readonly BaseMessage[];
     projectedMessages?: readonly BaseMessage[] | null;
+    snapshot?: CompactionReplayCandidateSnapshot;
     restoredToolSubstitution: boolean;
     summarizerFallbackServed?: boolean;
   }): CompactionReplayEligibility {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -2002,8 +2002,16 @@ export class AgentContext {
     sourceMessages: readonly BaseMessage[],
     servingRouteKnown = true,
     tools?: t.GraphTools,
-    routeSnapshot = this.createCompactionReplayRouteSnapshot(servingRouteKnown)
+    routeSnapshot = this.createCompactionReplayRouteSnapshot(servingRouteKnown),
+    toolProjectionSnapshot?: { readonly fingerprint?: string }
   ): CompactionReplayRecipe {
+    let toolProjectionFingerprint: string | undefined;
+    if (routeSnapshot.promptCacheEnabled) {
+      toolProjectionFingerprint =
+        toolProjectionSnapshot == null
+          ? createCompactionToolProjectionFingerprint(tools)
+          : toolProjectionSnapshot.fingerprint;
+    }
     return createCompactionReplayRecipe({
       provider: request.provider,
       modelId: request.modelId,
@@ -2014,9 +2022,7 @@ export class AgentContext {
         this.systemRunnable == null
           ? EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT
           : undefined,
-      toolProjectionFingerprint: routeSnapshot.promptCacheEnabled
-        ? createCompactionToolProjectionFingerprint(tools)
-        : undefined,
+      toolProjectionFingerprint,
       systemRevision: this.compactionSystemRevision,
       toolRevision: this.compactionToolRevision,
       messages: request.messages,

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -234,6 +234,35 @@ describe('AgentContext', () => {
       });
     });
 
+    it('retains the tool projection captured when the model was bound', () => {
+      const ctx = createReplayContext();
+      const message = new HumanMessage({ content: 'hello', id: 'source-1' });
+      const tools = [createMockTool('stable-tool')];
+      const fingerprint = createCompactionToolProjectionFingerprint(tools);
+      const toolProjectionSnapshot = Object.freeze({ fingerprint });
+      const routeSnapshot = ctx.createCompactionReplayRouteSnapshot();
+      const request = prepareProviderRequest({
+        model: new FakeListChatModel({ responses: ['ok'] }) as t.ChatModel,
+        messages: [message],
+        provider: Providers.OPENAI,
+      });
+
+      tools[0].description = 'Mutated after model binding';
+      const recipe = ctx.createCompactionReplayRecipeSnapshot(
+        request,
+        [message],
+        true,
+        tools,
+        routeSnapshot,
+        toolProjectionSnapshot
+      );
+
+      expect(recipe.toolProjectionFingerprint).toBe(fingerprint);
+      expect(recipe.toolProjectionFingerprint).not.toBe(
+        createCompactionToolProjectionFingerprint(tools)
+      );
+    });
+
     it('distinguishes tool discovery from system-only projection changes', () => {
       const createRecordedContext = (): {
         ctx: AgentContext;

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1,7 +1,10 @@
 // src/agents/__tests__/AgentContext.test.ts
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type * as t from '@/types';
+import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
 import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
+import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { addBedrockCacheControl } from '@/messages/cache';
 import { createTokenCounter } from '@/utils/tokens';
 import { Constants, Providers } from '@/common';
@@ -88,6 +91,85 @@ describe('AgentContext', () => {
       const names = (bound as Array<{ name?: string }>).map((t) => t.name);
       expect(names).toContain('ask_user_question');
       expect(names).toContain('echo');
+    });
+  });
+
+  describe('compaction replay recipe lifecycle', () => {
+    const captureRecipe = (
+      ctx: AgentContext,
+      message: HumanMessage
+    ): ReturnType<typeof createCompactionCacheNamespace> => {
+      const request = prepareProviderRequest({
+        model: new FakeListChatModel({ responses: ['ok'] }) as t.ChatModel,
+        messages: [message],
+        provider: Providers.OPENAI,
+      });
+      ctx.captureCompactionReplayRecipe(request);
+      return createCompactionCacheNamespace(Providers.OPENAI);
+    };
+
+    it('releases the run-local recipe on reset', () => {
+      const ctx = createBasicContext();
+      const message = new HumanMessage({ content: 'hello', id: 'source-1' });
+      const cacheNamespace = captureRecipe(ctx, message);
+
+      expect(
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace,
+          messages: [message],
+          restoredToolSubstitution: false,
+        })
+      ).toMatchObject({ eligible: true });
+
+      ctx.reset();
+
+      expect(
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace,
+          messages: [message],
+          restoredToolSubstitution: false,
+        })
+      ).toMatchObject({ eligible: false, reason: 'no_request_snapshot' });
+    });
+
+    it('distinguishes tool discovery from system-only projection changes', () => {
+      const createRecordedContext = (): {
+        ctx: AgentContext;
+        message: HumanMessage;
+        cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
+      } => {
+        const ctx = createBasicContext();
+        const message = new HumanMessage({ content: 'hello', id: 'source-1' });
+        const cacheNamespace = captureRecipe(ctx, message);
+        return { ctx, message, cacheNamespace };
+      };
+      const inspect = ({
+        ctx,
+        message,
+        cacheNamespace,
+      }: ReturnType<typeof createRecordedContext>) =>
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace,
+          messages: [message],
+          restoredToolSubstitution: false,
+        });
+
+      const toolChanged = createRecordedContext();
+      toolChanged.ctx.markToolsAsDiscovered(['deferred-tool']);
+      expect(inspect(toolChanged)).toMatchObject({
+        eligible: false,
+        reason: 'tool_projection_changed',
+      });
+
+      const systemChanged = createRecordedContext();
+      systemChanged.ctx.setHandoffContext('parent', []);
+      expect(inspect(systemChanged)).toMatchObject({
+        eligible: false,
+        reason: 'system_projection_changed',
+      });
     });
   });
 

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -105,7 +105,10 @@ describe('AgentContext', () => {
         provider: Providers.OPENAI,
       });
       ctx.captureCompactionReplayRecipe(request, [message]);
-      return createCompactionCacheNamespace(Providers.OPENAI);
+      return createCompactionCacheNamespace(
+        Providers.OPENAI,
+        ctx.clientOptions
+      );
     };
 
     it('releases the run-local recipe on reset', () => {
@@ -132,6 +135,24 @@ describe('AgentContext', () => {
           restoredToolSubstitution: false,
         })
       ).toMatchObject({ eligible: false, reason: 'no_request_snapshot' });
+    });
+
+    it('snapshots the current cache route on every capture', () => {
+      const ctx = createBasicContext();
+      const message = new HumanMessage({ content: 'hello', id: 'source-1' });
+      ctx.clientOptions = { apiKey: 'first-key' } as t.ClientOptions;
+      captureRecipe(ctx, message);
+      ctx.clientOptions = { apiKey: 'second-key' } as t.ClientOptions;
+      const currentNamespace = captureRecipe(ctx, message);
+
+      expect(
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace: currentNamespace,
+          messages: [message],
+          restoredToolSubstitution: false,
+        })
+      ).toMatchObject({ eligible: true });
     });
 
     it('distinguishes tool discovery from system-only projection changes', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -5,6 +5,7 @@ import type * as t from '@/types';
 import {
   createCompactionCacheNamespace,
   createCompactionToolProjectionFingerprint,
+  EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
 } from '@/llm/compactionReplay';
 import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
@@ -98,8 +99,17 @@ describe('AgentContext', () => {
   });
 
   describe('compaction replay recipe lifecycle', () => {
+    const createReplayContext = (): AgentContext =>
+      createBasicContext({
+        agentConfig: {
+          instructions: undefined,
+          additional_instructions: undefined,
+        },
+      });
     const replayIdentity = {
       promptCacheEnabled: true,
+      systemProjectionFingerprint:
+        EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
       toolProjectionFingerprint:
         createCompactionToolProjectionFingerprint(undefined),
     };
@@ -128,7 +138,7 @@ describe('AgentContext', () => {
     };
 
     it('releases the run-local recipe on reset', () => {
-      const ctx = createBasicContext();
+      const ctx = createReplayContext();
       const message = new HumanMessage({ content: 'hello', id: 'source-1' });
       const cacheNamespace = captureRecipe(ctx, message);
 
@@ -156,7 +166,7 @@ describe('AgentContext', () => {
     });
 
     it('snapshots the current cache route on every capture', () => {
-      const ctx = createBasicContext();
+      const ctx = createReplayContext();
       const message = new HumanMessage({ content: 'hello', id: 'source-1' });
       ctx.clientOptions = { apiKey: 'first-key' } as t.ClientOptions;
       captureRecipe(ctx, message);
@@ -180,7 +190,7 @@ describe('AgentContext', () => {
         message: HumanMessage;
         cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
       } => {
-        const ctx = createBasicContext();
+        const ctx = createReplayContext();
         const message = new HumanMessage({ content: 'hello', id: 'source-1' });
         const cacheNamespace = captureRecipe(ctx, message);
         return { ctx, message, cacheNamespace };

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -104,7 +104,7 @@ describe('AgentContext', () => {
         messages: [message],
         provider: Providers.OPENAI,
       });
-      ctx.captureCompactionReplayRecipe(request);
+      ctx.captureCompactionReplayRecipe(request, [message]);
       return createCompactionCacheNamespace(Providers.OPENAI);
     };
 

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -130,7 +130,9 @@ describe('AgentContext', () => {
         messages: [message],
         provider: Providers.OPENAI,
       });
-      ctx.captureCompactionReplayRecipe(request, [message]);
+      ctx.captureCompactionReplayRecipe(
+        ctx.createCompactionReplayRecipeSnapshot(request, [message])
+      );
       return createCompactionCacheNamespace(
         Providers.OPENAI,
         ctx.clientOptions
@@ -197,11 +199,13 @@ describe('AgentContext', () => {
       });
 
       ctx.captureCompactionReplayRecipe(
-        request,
-        [message],
-        true,
-        undefined,
-        servingRoute
+        ctx.createCompactionReplayRecipeSnapshot(
+          request,
+          [message],
+          true,
+          undefined,
+          servingRoute
+        )
       );
 
       expect(

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -107,6 +107,14 @@ describe('AgentContext', () => {
       ctx: AgentContext,
       message: HumanMessage
     ): ReturnType<typeof createCompactionCacheNamespace> => {
+      if (
+        (ctx.clientOptions as { apiKey?: unknown } | undefined)?.apiKey == null
+      ) {
+        ctx.clientOptions = {
+          ...ctx.clientOptions,
+          apiKey: 'test-key',
+        } as t.ClientOptions;
+      }
       const request = prepareProviderRequest({
         model: new FakeListChatModel({ responses: ['ok'] }) as t.ChatModel,
         messages: [message],

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2,7 +2,10 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type * as t from '@/types';
-import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
+import {
+  createCompactionCacheNamespace,
+  createCompactionToolProjectionFingerprint,
+} from '@/llm/compactionReplay';
 import { markTokenCounterCacheCompatible } from '@/llm/tokenCounterCacheCompatibility';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { addBedrockCacheControl } from '@/messages/cache';
@@ -95,6 +98,11 @@ describe('AgentContext', () => {
   });
 
   describe('compaction replay recipe lifecycle', () => {
+    const replayIdentity = {
+      promptCacheEnabled: true,
+      toolProjectionFingerprint:
+        createCompactionToolProjectionFingerprint(undefined),
+    };
     const captureRecipe = (
       ctx: AgentContext,
       message: HumanMessage
@@ -120,6 +128,7 @@ describe('AgentContext', () => {
         ctx.inspectCompactionReplay({
           provider: Providers.OPENAI,
           cacheNamespace,
+          ...replayIdentity,
           messages: [message],
           restoredToolSubstitution: false,
         })
@@ -131,6 +140,7 @@ describe('AgentContext', () => {
         ctx.inspectCompactionReplay({
           provider: Providers.OPENAI,
           cacheNamespace,
+          ...replayIdentity,
           messages: [message],
           restoredToolSubstitution: false,
         })
@@ -149,6 +159,7 @@ describe('AgentContext', () => {
         ctx.inspectCompactionReplay({
           provider: Providers.OPENAI,
           cacheNamespace: currentNamespace,
+          ...replayIdentity,
           messages: [message],
           restoredToolSubstitution: false,
         })
@@ -174,6 +185,7 @@ describe('AgentContext', () => {
         ctx.inspectCompactionReplay({
           provider: Providers.OPENAI,
           cacheNamespace,
+          ...replayIdentity,
           messages: [message],
           restoredToolSubstitution: false,
         });

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -184,6 +184,52 @@ describe('AgentContext', () => {
       ).toMatchObject({ eligible: true });
     });
 
+    it('retains the route snapshot taken before an in-flight mutation', () => {
+      const ctx = createReplayContext();
+      const message = new HumanMessage({ content: 'hello', id: 'source-1' });
+      ctx.clientOptions = { apiKey: 'serving-key' } as t.ClientOptions;
+      const servingRoute = ctx.createCompactionReplayRouteSnapshot();
+      ctx.clientOptions = { apiKey: 'next-key' } as t.ClientOptions;
+      const request = prepareProviderRequest({
+        model: new FakeListChatModel({ responses: ['ok'] }) as t.ChatModel,
+        messages: [message],
+        provider: Providers.OPENAI,
+      });
+
+      ctx.captureCompactionReplayRecipe(
+        request,
+        [message],
+        true,
+        undefined,
+        servingRoute
+      );
+
+      expect(
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace: servingRoute.cacheNamespace,
+          ...replayIdentity,
+          messages: [message],
+          restoredToolSubstitution: false,
+        })
+      ).toMatchObject({ eligible: true });
+      expect(
+        ctx.inspectCompactionReplay({
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.OPENAI,
+            ctx.clientOptions
+          ),
+          ...replayIdentity,
+          messages: [message],
+          restoredToolSubstitution: false,
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    });
+
     it('distinguishes tool discovery from system-only projection changes', () => {
       const createRecordedContext = (): {
         ctx: AgentContext;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3896,7 +3896,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         ) {
           agentContext.captureCompactionReplayRecipe(
             preparedRequest,
-            messagesToUse
+            messagesToUse,
+            this.overrideModel == null
           );
         }
       } catch (primaryError) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3890,8 +3890,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               invokeConfig
             )
         );
-        if (agentContext.summarizationEnabled === true) {
-          agentContext.captureCompactionReplayRecipe(preparedRequest);
+        if (
+          agentContext.summarizationEnabled === true &&
+          process.env.AGENT_DEBUG_LOGGING === 'true'
+        ) {
+          agentContext.captureCompactionReplayRecipe(
+            preparedRequest,
+            messagesToUse
+          );
         }
       } catch (primaryError) {
         clearCurrentDeltaStepMarkers({
@@ -4153,7 +4159,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 },
               })
           );
-          if (agentContext.summarizationEnabled === true) {
+          if (
+            agentContext.summarizationEnabled === true &&
+            process.env.AGENT_DEBUG_LOGGING === 'true'
+          ) {
             agentContext.markCompactionReplayFallbackServed();
           }
         } catch (fallbackError) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3890,6 +3890,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               invokeConfig
             )
         );
+        if (agentContext.summarizationEnabled === true) {
+          agentContext.captureCompactionReplayRecipe(preparedRequest);
+        }
       } catch (primaryError) {
         clearCurrentDeltaStepMarkers({
           graph: this,
@@ -4150,6 +4153,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 },
               })
           );
+          if (agentContext.summarizationEnabled === true) {
+            agentContext.markCompactionReplayFallbackServed();
+          }
         } catch (fallbackError) {
           if (fallbackError instanceof StreamLimitExceededError) {
             /** Same treatment as the primary path: a fallback stream that

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -59,7 +59,6 @@ import {
   addTailCacheControl,
   resolvePromptCacheTtl,
   resolveBedrockPromptCacheTtl,
-  supportsBedrockToolCache,
   isSyntheticProviderContextMessage,
   compactSyntheticProviderContextMessage,
   getMessageId,
@@ -155,7 +154,7 @@ import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
-import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
+import { prepareBedrockToolsForPromptCache } from '@/llm/bedrock/toolCache';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
@@ -2918,16 +2917,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const bedrockModel = (
           agentContext.clientOptions as { model?: string } | undefined
         )?.model;
-        // An omitted model falls back to LangChain's default Claude model (which
-        // supports tool caching); only an explicit non-Claude model (e.g. Nova)
-        // skips tool marking so its stray marker never leaks into toolConfig.
-        if (bedrockModel == null || supportsBedrockToolCache(bedrockModel)) {
-          toolsForBinding =
-            partitionAndMarkBedrockToolCache(
-              rawToolsForBinding,
-              isDeferredTool
-            ) ?? rawToolsForBinding;
-        }
+        toolsForBinding = prepareBedrockToolsForPromptCache(
+          rawToolsForBinding,
+          isDeferredTool,
+          true,
+          bedrockModel
+        );
       }
 
       let model =
@@ -3881,6 +3876,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             throw preInvokeTrip;
           }
         }
+        const compactionReplayRecipeSnapshot =
+          agentContext.summarizationEnabled === true &&
+          process.env.AGENT_DEBUG_LOGGING === 'true'
+            ? agentContext.createCompactionReplayRecipeSnapshot(
+              preparedRequest,
+              messagesToUse,
+              this.overrideModel == null,
+              toolsForBinding,
+              compactionReplayRouteSnapshot
+            )
+            : undefined;
         result = await withLangfuseRuntimeScope(
           resolveLangfuseRuntimeScope({
             runLangfuse: this.langfuse,
@@ -3898,16 +3904,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               invokeConfig
             )
         );
-        if (
-          agentContext.summarizationEnabled === true &&
-          process.env.AGENT_DEBUG_LOGGING === 'true'
-        ) {
+        if (compactionReplayRecipeSnapshot != null) {
           agentContext.captureCompactionReplayRecipe(
-            preparedRequest,
-            messagesToUse,
-            this.overrideModel == null,
-            toolsForBinding,
-            compactionReplayRouteSnapshot
+            compactionReplayRecipeSnapshot
           );
         }
       } catch (primaryError) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3897,7 +3897,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.captureCompactionReplayRecipe(
             preparedRequest,
             messagesToUse,
-            this.overrideModel == null
+            this.overrideModel == null,
+            toolsForBinding
           );
         }
       } catch (primaryError) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -155,6 +155,7 @@ import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { prepareBedrockToolsForPromptCache } from '@/llm/bedrock/toolCache';
+import { createCompactionToolProjectionFingerprint } from '@/llm/compactionReplay';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
@@ -2925,6 +2926,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
+      const compactionReplayRouteSnapshot =
+        agentContext.summarizationEnabled === true &&
+        process.env.AGENT_DEBUG_LOGGING === 'true'
+          ? agentContext.createCompactionReplayRouteSnapshot(
+            this.overrideModel == null
+          )
+          : undefined;
+      const compactionReplayToolProjectionSnapshot =
+        compactionReplayRouteSnapshot?.promptCacheEnabled === true
+          ? Object.freeze({
+            fingerprint: createCompactionToolProjectionFingerprint(
+              toolsForBinding
+            ),
+          })
+          : undefined;
+
       let model =
         this.overrideModel ??
         initializeModel({
@@ -2938,14 +2955,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           .pipe(model as Runnable)
           .withConfig({ runName: AGENT_MODEL_CALL_RUN_NAME });
       }
-
-      const compactionReplayRouteSnapshot =
-        agentContext.summarizationEnabled === true &&
-        process.env.AGENT_DEBUG_LOGGING === 'true'
-          ? agentContext.createCompactionReplayRouteSnapshot(
-            this.overrideModel == null
-          )
-          : undefined;
 
       if (agentContext.tokenCalculationPromise) {
         await agentContext.tokenCalculationPromise;
@@ -3884,7 +3893,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               messagesToUse,
               this.overrideModel == null,
               toolsForBinding,
-              compactionReplayRouteSnapshot
+              compactionReplayRouteSnapshot,
+              compactionReplayToolProjectionSnapshot
             )
             : undefined;
         result = await withLangfuseRuntimeScope(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2944,6 +2944,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           .withConfig({ runName: AGENT_MODEL_CALL_RUN_NAME });
       }
 
+      const compactionReplayRouteSnapshot =
+        agentContext.summarizationEnabled === true &&
+        process.env.AGENT_DEBUG_LOGGING === 'true'
+          ? agentContext.createCompactionReplayRouteSnapshot(
+            this.overrideModel == null
+          )
+          : undefined;
+
       if (agentContext.tokenCalculationPromise) {
         await agentContext.tokenCalculationPromise;
       }
@@ -3898,7 +3906,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             preparedRequest,
             messagesToUse,
             this.overrideModel == null,
-            toolsForBinding
+            toolsForBinding,
+            compactionReplayRouteSnapshot
           );
         }
       } catch (primaryError) {

--- a/src/llm/bedrock/toolCache.test.ts
+++ b/src/llm/bedrock/toolCache.test.ts
@@ -4,6 +4,7 @@ import type { GraphTools } from '@/types';
 import {
   insertBedrockToolCachePoint,
   partitionAndMarkBedrockToolCache,
+  prepareBedrockToolsForPromptCache,
 } from './toolCache';
 
 type OpenAITool = {
@@ -59,6 +60,48 @@ function getToolSpec(entry: Tool): Tool.ToolSpecMember['toolSpec'] {
 }
 
 describe('partitionAndMarkBedrockToolCache', () => {
+  it('uses the same formatted tools for cache-aware model projections', () => {
+    const tools = [
+      createOpenAITool('static_tool'),
+      createOpenAITool('dynamic_tool'),
+    ] as GraphTools;
+
+    const prepared = prepareBedrockToolsForPromptCache(
+      tools,
+      (name) => name === 'dynamic_tool',
+      true,
+      'anthropic.claude-sonnet'
+    ) as Tool[];
+    const result = insertBedrockToolCachePoint({ tools: prepared }, false);
+
+    expect(toolNames(result?.tools)).toEqual([
+      'static_tool',
+      'cachePoint',
+      'dynamic_tool',
+    ]);
+  });
+
+  it('leaves tools untouched when effective prompt caching is disabled', () => {
+    const tools = [createOpenAITool('static_tool')] as GraphTools;
+
+    expect(prepareBedrockToolsForPromptCache(tools, () => false, false)).toBe(
+      tools
+    );
+  });
+
+  it('leaves tools untouched for an explicit non-Claude Bedrock model', () => {
+    const tools = [createOpenAITool('static_tool')] as GraphTools;
+
+    expect(
+      prepareBedrockToolsForPromptCache(
+        tools,
+        () => false,
+        true,
+        'amazon.nova-pro-v1:0'
+      )
+    ).toBe(tools);
+  });
+
   it('inserts the Bedrock cache point after the last static tool', () => {
     const tools = [
       createOpenAITool('static_one'),

--- a/src/llm/bedrock/toolCache.ts
+++ b/src/llm/bedrock/toolCache.ts
@@ -3,7 +3,11 @@ import type { Tool, ToolConfiguration } from '@aws-sdk/client-bedrock-runtime';
 import type { OpenAIClient } from '@langchain/openai';
 import type { DocumentType } from '@smithy/types';
 import type { GraphTools } from '@/types';
-import { buildBedrockCachePoint, type PromptCacheTtl } from '@/messages/cache';
+import {
+  buildBedrockCachePoint,
+  supportsBedrockToolCache,
+  type PromptCacheTtl,
+} from '@/messages/cache';
 import { requireInternalModule } from '@/lazyRequire';
 
 /** Loads with the first Bedrock request rather than alongside every graph. */
@@ -145,6 +149,21 @@ export function partitionAndMarkBedrockToolCache(
   );
 
   return [...staticTools, ...deferredTools] as GraphTools;
+}
+
+export function prepareBedrockToolsForPromptCache(
+  tools: GraphTools | undefined,
+  isDeferred: (toolName: string) => boolean,
+  promptCacheEnabled: boolean,
+  model?: string
+): GraphTools | undefined {
+  if (
+    !promptCacheEnabled ||
+    (model != null && !supportsBedrockToolCache(model))
+  ) {
+    return tools;
+  }
+  return partitionAndMarkBedrockToolCache(tools, isDeferred) ?? tools;
 }
 
 export function insertBedrockToolCachePoint(

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -1,0 +1,335 @@
+import {
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import {
+  createCompactionCacheNamespace,
+  createCompactionReplayRecipe,
+  inspectCompactionReplayEligibility,
+  type CompactionReplayRecipe,
+  type CompactionReplayState,
+} from '@/llm/compactionReplay';
+import type * as t from '@/types';
+import { setProviderMessageProvenance } from '@/messages/provenance';
+import { Providers } from '@/common';
+
+function sourceMessage(id: string): HumanMessage {
+  const message = new HumanMessage({ content: id, id });
+  setProviderMessageProvenance(message, [
+    { attribution: 'user', sourceMessageId: id },
+  ]);
+  return message;
+}
+
+function createEnvelope(
+  overrides: Partial<{
+    provider: t.ProviderName;
+    modelId: string;
+    projectionMode: 'chat-messages' | 'openai-responses';
+    cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
+    systemRevision: number;
+    toolRevision: number;
+    messages: BaseMessage[];
+  }> = {}
+): CompactionReplayRecipe {
+  const envelope = createCompactionReplayRecipe({
+    provider: overrides.provider ?? Providers.ANTHROPIC,
+    modelId: overrides.modelId ?? 'claude-sonnet',
+    projectionMode: overrides.projectionMode ?? 'chat-messages',
+    cacheNamespace:
+      overrides.cacheNamespace ??
+      createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        baseURL: 'https://provider.test',
+      }),
+    systemRevision: overrides.systemRevision ?? 2,
+    toolRevision: overrides.toolRevision ?? 3,
+    messages: overrides.messages ?? [
+      new SystemMessage('stable'),
+      sourceMessage('a'),
+      sourceMessage('b'),
+      sourceMessage('c'),
+    ],
+  });
+  return envelope;
+}
+
+function inspect(
+  state: CompactionReplayState | undefined,
+  overrides: Partial<{
+    provider: t.ProviderName;
+    modelId: string;
+    projectionMode: 'chat-messages' | 'openai-responses';
+    cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
+    systemRevision: number;
+    toolRevision: number;
+    messages: BaseMessage[];
+    restoredToolSubstitution: boolean;
+  }> = {}
+) {
+  return inspectCompactionReplayEligibility(state, {
+    provider: overrides.provider ?? Providers.ANTHROPIC,
+    modelId: overrides.modelId,
+    projectionMode: overrides.projectionMode,
+    cacheNamespace:
+      overrides.cacheNamespace ??
+      createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        baseURL: 'https://provider.test',
+      }),
+    systemRevision: overrides.systemRevision ?? 2,
+    toolRevision: overrides.toolRevision ?? 3,
+    messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
+    restoredToolSubstitution:
+      overrides.restoredToolSubstitution ?? false,
+  });
+}
+
+describe('compaction replay eligibility', () => {
+  it.each([
+    Providers.ANTHROPIC,
+    Providers.BEDROCK,
+    Providers.OPENROUTER,
+  ])('finds the exact source prefix for %s', (provider) => {
+    const envelope = createEnvelope({ provider });
+    const result = inspect(envelope, { provider });
+
+    expect(result).toEqual({
+      eligible: true,
+      replayMessageCount: 3,
+      replaySourceCount: 2,
+      requestSourceCount: 3,
+    });
+  });
+
+  it('inherits the captured model when no dedicated summary model is set', () => {
+    const envelope = createEnvelope();
+    expect(inspect(envelope)).toMatchObject({
+      eligible: true,
+    });
+  });
+
+  it('treats a changed prompt-cache marker policy as a namespace mismatch', () => {
+    const envelope = createEnvelope({
+      cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        promptCache: true,
+        promptCacheTtl: '1h',
+      }),
+    });
+
+    expect(
+      inspect(
+        envelope,
+        {
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.ANTHROPIC,
+            {
+              promptCache: true,
+              promptCacheTtl: '5m',
+            }
+          ),
+        }
+      )
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('fails closed when a runtime provider cannot prove its cache namespace', () => {
+    const provider = 'runtime-provider' as t.ProviderName;
+    const cacheNamespace = createCompactionCacheNamespace(provider, {
+      baseURL: 'https://runtime-provider.test',
+    });
+    const recipe = createEnvelope({ provider, cacheNamespace });
+
+    expect(inspect(recipe, { provider, cacheNamespace })).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_unknown',
+    });
+  });
+
+  it('fails closed when cache identity contains an unsupported value', () => {
+    const cacheNamespace = createCompactionCacheNamespace(
+      Providers.ANTHROPIC,
+      { apiKey: () => 'dynamic-key' }
+    );
+    const recipe = createEnvelope({ cacheNamespace });
+
+    expect(inspect(recipe, { cacheNamespace })).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_unknown',
+    });
+  });
+
+  it.each([
+    ['no_request_snapshot', undefined, {}],
+    ['fallback_served_request', 'fallback', {}],
+    [
+      'provider_mismatch',
+      createEnvelope(),
+      { provider: Providers.OPENAI },
+    ],
+    [
+      'model_mismatch',
+      createEnvelope(),
+      { modelId: 'different-model' },
+    ],
+    [
+      'cache_namespace_mismatch',
+      createEnvelope(),
+      {
+        cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          baseURL: 'https://other.test',
+        }),
+      },
+    ],
+    [
+      'system_projection_changed',
+      createEnvelope(),
+      { systemRevision: 4 },
+    ],
+    [
+      'tool_projection_changed',
+      createEnvelope(),
+      { toolRevision: 4 },
+    ],
+    [
+      'projection_mode_mismatch',
+      createEnvelope(),
+      { projectionMode: 'openai-responses' },
+    ],
+    [
+      'restored_tool_substitution',
+      createEnvelope(),
+      { restoredToolSubstitution: true },
+    ],
+    [
+      'source_not_prefix',
+      createEnvelope(),
+      { messages: [sourceMessage('b')] },
+    ],
+    [
+      'ambiguous_lineage',
+      createEnvelope(),
+      { messages: [new HumanMessage('missing id')] },
+    ],
+  ] as const)(
+    'fails closed with %s',
+    (reason, state, overrides) => {
+      expect(
+        inspect(
+          state as CompactionReplayState | undefined,
+          overrides as Parameters<typeof inspect>[1]
+        )
+      ).toMatchObject({ eligible: false, reason });
+    }
+  );
+
+  it('rejects a cut through one coalesced provider message', () => {
+    const coalesced = new HumanMessage({
+      content: 'a then b',
+      additional_kwargs: { sourceMessageIds: ['a', 'b'] },
+    });
+    const envelope = createEnvelope({
+      messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
+    });
+
+    expect(inspect(envelope, { messages: [sourceMessage('a')] })).toMatchObject(
+      { eligible: false, reason: 'ambiguous_lineage' }
+    );
+  });
+
+  it('accepts a complete strict-alternation coalesced prefix', () => {
+    const coalesced = new HumanMessage({
+      content: 'a then b',
+      additional_kwargs: { sourceMessageIds: ['a', 'b'] },
+    });
+    const envelope = createEnvelope({
+      messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
+    });
+
+    expect(
+      inspect(envelope, {
+        messages: [sourceMessage('a'), sourceMessage('b')],
+      })
+    ).toEqual({
+      eligible: true,
+      replayMessageCount: 2,
+      replaySourceCount: 2,
+      requestSourceCount: 3,
+    });
+  });
+
+  it('ignores a synthetic prior checkpoint when proving source order', () => {
+    const priorCheckpoint = new HumanMessage({
+      content: '<summary>prior checkpoint</summary>',
+      additional_kwargs: { injected: true, source: 'summary' },
+    });
+    const envelope = createEnvelope({
+      messages: [
+        new SystemMessage('stable'),
+        priorCheckpoint,
+        sourceMessage('a'),
+        sourceMessage('b'),
+        sourceMessage('c'),
+      ],
+    });
+
+    expect(
+      inspect(
+        envelope,
+        { messages: [priorCheckpoint, sourceMessage('a'), sourceMessage('b')] }
+      )
+    ).toEqual({
+      eligible: true,
+      replayMessageCount: 4,
+      replaySourceCount: 2,
+      requestSourceCount: 3,
+    });
+  });
+
+  it('retains only a frozen recipe container, not the live model', () => {
+    const envelope = createEnvelope();
+
+    expect(Object.isFrozen(envelope)).toBe(true);
+    expect('model' in envelope).toBe(false);
+  });
+
+  it('retains the prepared-message reference without mutating its messages', () => {
+    const messages = [sourceMessage('a'), sourceMessage('b')];
+    const before = [...messages];
+    const recipe = createEnvelope({ messages });
+
+    expect(recipe.messages).toBe(messages);
+    inspect(recipe, { messages: [sourceMessage('a')] });
+    expect(messages).toEqual(before);
+  });
+
+  it('treats a restored tool result as ineligible even with exact lineage', () => {
+    const tool = new ToolMessage({
+      content: 'result',
+      tool_call_id: 'call_1',
+      id: 'tool-source',
+    });
+    setProviderMessageProvenance(tool, [
+      { attribution: 'tool', sourceMessageId: 'tool-source' },
+    ]);
+    const envelope = createEnvelope({
+      messages: [new SystemMessage('stable'), sourceMessage('a'), tool],
+    });
+
+    expect(
+      inspect(
+        envelope,
+        {
+          messages: [sourceMessage('a'), tool],
+          restoredToolSubstitution: true,
+        }
+      )
+    ).toMatchObject({
+      eligible: false,
+      reason: 'restored_tool_substitution',
+    });
+  });
+});

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -9,6 +9,7 @@ import {
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
   EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
+  extractCompactionReplayPrefixProjection,
   inspectCompactionReplayEligibility,
   type CompactionReplayRecipe,
   type CompactionReplayState,
@@ -88,6 +89,7 @@ function inspect(
     systemRevision: number;
     toolRevision: number;
     messages: BaseMessage[];
+    projectedMessages: BaseMessage[];
     restoredToolSubstitution: boolean;
     summarizerFallbackServed: boolean;
   }> = {}
@@ -112,6 +114,7 @@ function inspect(
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
     messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
+    projectedMessages: overrides.projectedMessages,
     restoredToolSubstitution: overrides.restoredToolSubstitution ?? false,
     summarizerFallbackServed: overrides.summarizerFallbackServed,
   });
@@ -406,6 +409,27 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it('includes Anthropic inference geography in cache identity', () => {
+    const recipe = createEnvelope({
+      cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        apiKey: 'test-key',
+        inferenceGeo: 'us',
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          apiKey: 'test-key',
+          inferenceGeo: 'eu',
+        }),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
   it('fails closed when credentials come from an opaque external source', () => {
     const cacheNamespace = createCompactionCacheNamespace(Providers.ANTHROPIC, {
       baseURL: 'https://provider.test',
@@ -690,6 +714,45 @@ describe('compaction replay eligibility', () => {
       replaySourceCount: 2,
       requestSourceCount: 2,
     });
+  });
+
+  it('rejects a changed prepared summarizer projection', () => {
+    const sourceMessages = [sourceMessage('a'), sourceMessage('b')];
+    const changed = sourceMessage('b');
+    changed.content = 'provider-truncated';
+    const envelope = createEnvelope({
+      messages: sourceMessages,
+      sourceMessages,
+    });
+
+    expect(
+      inspect(envelope, {
+        messages: sourceMessages,
+        projectedMessages: [sourceMessages[0], changed],
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'provider_projection_changed',
+    });
+  });
+
+  it('extracts only a provenance-proven projection before summary instructions', () => {
+    const source = sourceMessage('a');
+    const instruction = new HumanMessage('summarize');
+    setProviderMessageProvenance(instruction, [
+      { attribution: 'synthetic' },
+    ]);
+
+    expect(
+      extractCompactionReplayPrefixProjection([source, instruction])
+    ).toEqual([source]);
+
+    const merged = new HumanMessage('source then summarize');
+    setProviderMessageProvenance(merged, [
+      { attribution: 'user', sourceMessageId: 'a' },
+      { attribution: 'synthetic' },
+    ]);
+    expect(extractCompactionReplayPrefixProjection([merged])).toBeUndefined();
   });
 
   it('ignores a synthetic prior checkpoint when proving source order', () => {

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -550,6 +550,28 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it.each([
+    [{ strict: true }, { strict: false }],
+    [{ extras: { strict: true } }, { extras: { strict: false } }],
+  ])('includes provider-facing strict tool settings', (primary, summary) => {
+    const recipe = createEnvelope({
+      toolProjectionFingerprint: createCompactionToolProjectionFingerprint([
+        { name: 'stable', ...primary },
+      ]),
+    });
+
+    expect(
+      inspect(recipe, {
+        toolProjectionFingerprint: createCompactionToolProjectionFingerprint([
+          { name: 'stable', ...summary },
+        ]),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'tool_projection_changed',
+    });
+  });
+
   it('fails closed when a runtime provider cannot prove its cache namespace', () => {
     const provider = 'runtime-provider' as t.ProviderName;
     const cacheNamespace = createCompactionCacheNamespace(provider, {

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -7,6 +7,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
+  createCompactionToolProjectionFingerprint,
   inspectCompactionReplayEligibility,
   type CompactionReplayRecipe,
   type CompactionReplayState,
@@ -29,6 +30,8 @@ function createEnvelope(
     modelId: string;
     projectionMode: 'chat-messages' | 'openai-responses';
     cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
+    promptCacheEnabled: boolean;
+    toolProjectionFingerprint: string;
     systemRevision: number;
     toolRevision: number;
     messages: BaseMessage[];
@@ -49,6 +52,10 @@ function createEnvelope(
       createCompactionCacheNamespace(Providers.ANTHROPIC, {
         baseURL: 'https://provider.test',
       }),
+    promptCacheEnabled: overrides.promptCacheEnabled ?? true,
+    toolProjectionFingerprint:
+      overrides.toolProjectionFingerprint ??
+      createCompactionToolProjectionFingerprint(undefined),
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
     messages: overrides.messages ?? [new SystemMessage('stable'), ...sourceMessages],
@@ -64,6 +71,8 @@ function inspect(
     modelId: string;
     projectionMode: 'chat-messages' | 'openai-responses';
     cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
+    promptCacheEnabled: boolean;
+    toolProjectionFingerprint: string;
     systemRevision: number;
     toolRevision: number;
     messages: BaseMessage[];
@@ -80,6 +89,10 @@ function inspect(
       createCompactionCacheNamespace(Providers.ANTHROPIC, {
         baseURL: 'https://provider.test',
       }),
+    promptCacheEnabled: overrides.promptCacheEnabled ?? true,
+    toolProjectionFingerprint:
+      overrides.toolProjectionFingerprint ??
+      createCompactionToolProjectionFingerprint(undefined),
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
     messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
@@ -163,7 +176,7 @@ describe('compaction replay eligibility', () => {
     }
   );
 
-  it.each(['openAIApiKey', 'openAIBasePath'] as const)(
+  it.each(['openAIApiKey', 'openAIBasePath', 'openAIApiVersion'] as const)(
     'includes the Azure %s routing alias in cache identity',
     (key) => {
       const recipe = createEnvelope({
@@ -264,6 +277,36 @@ describe('compaction replay eligibility', () => {
     expect(inspect(recipe, { cacheNamespace })).toMatchObject({
       eligible: false,
       reason: 'cache_namespace_unknown',
+    });
+  });
+
+  it('requires explicit prompt caching for gated providers', () => {
+    const recipe = createEnvelope({ promptCacheEnabled: false });
+
+    expect(inspect(recipe)).toMatchObject({
+      eligible: false,
+      reason: 'prompt_cache_disabled',
+    });
+  });
+
+  it('compares the actual ordered tool projection', () => {
+    const primaryTools = createCompactionToolProjectionFingerprint([
+      { name: 'stable', extras: { cache_control: { type: 'ephemeral' } } },
+      { name: 'deferred', defer_loading: true },
+    ]);
+    const summaryTools = createCompactionToolProjectionFingerprint([
+      { name: 'stable' },
+      { name: 'deferred', defer_loading: true },
+    ]);
+    const recipe = createEnvelope({
+      toolProjectionFingerprint: primaryTools,
+    });
+
+    expect(
+      inspect(recipe, { toolProjectionFingerprint: summaryTools })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'tool_projection_changed',
     });
   });
 

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -8,6 +8,7 @@ import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
+  EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   inspectCompactionReplayEligibility,
   type CompactionReplayRecipe,
   type CompactionReplayState,
@@ -31,6 +32,7 @@ function createEnvelope(
     projectionMode: 'chat-messages' | 'openai-responses';
     cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
     promptCacheEnabled: boolean;
+    systemProjectionFingerprint: string | null;
     toolProjectionFingerprint: string;
     systemRevision: number;
     toolRevision: number;
@@ -54,6 +56,11 @@ function createEnvelope(
         baseURL: 'https://provider.test',
       }),
     promptCacheEnabled: overrides.promptCacheEnabled ?? true,
+    systemProjectionFingerprint:
+      overrides.systemProjectionFingerprint === null
+        ? undefined
+        : (overrides.systemProjectionFingerprint ??
+          EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT),
     toolProjectionFingerprint:
       overrides.toolProjectionFingerprint ??
       createCompactionToolProjectionFingerprint(undefined),
@@ -73,6 +80,7 @@ function inspect(
     projectionMode: 'chat-messages' | 'openai-responses';
     cacheNamespace: ReturnType<typeof createCompactionCacheNamespace>;
     promptCacheEnabled: boolean;
+    systemProjectionFingerprint: string;
     toolProjectionFingerprint: string;
     systemRevision: number;
     toolRevision: number;
@@ -92,6 +100,9 @@ function inspect(
         baseURL: 'https://provider.test',
       }),
     promptCacheEnabled: overrides.promptCacheEnabled ?? true,
+    systemProjectionFingerprint:
+      overrides.systemProjectionFingerprint ??
+      EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
     toolProjectionFingerprint:
       overrides.toolProjectionFingerprint ??
       createCompactionToolProjectionFingerprint(undefined),
@@ -299,6 +310,69 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it('fails closed when the normal system projection is not replayed', () => {
+    const recipe = createEnvelope({
+      systemProjectionFingerprint: null,
+    });
+
+    expect(inspect(recipe)).toMatchObject({
+      eligible: false,
+      reason: 'system_projection_unknown',
+    });
+  });
+
+  it('includes Google API version in cache identity', () => {
+    const credentials = { apiKey: 'test-key' };
+    const recipe = createEnvelope({
+      provider: Providers.GOOGLE,
+      cacheNamespace: createCompactionCacheNamespace(Providers.GOOGLE, {
+        ...credentials,
+        apiVersion: 'v1',
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.GOOGLE,
+        cacheNamespace: createCompactionCacheNamespace(Providers.GOOGLE, {
+          ...credentials,
+          apiVersion: 'v1beta',
+        }),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('includes OpenRouter upstream routing in cache identity', () => {
+    const recipe = createEnvelope({
+      provider: Providers.OPENROUTER,
+      cacheNamespace: createCompactionCacheNamespace(Providers.OPENROUTER, {
+        apiKey: 'test-key',
+        modelKwargs: { provider: { order: ['anthropic'] } },
+        promptCache: true,
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.OPENROUTER,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.OPENROUTER,
+          {
+            apiKey: 'test-key',
+            modelKwargs: { provider: { order: ['google'] } },
+            promptCache: true,
+          }
+        ),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
   it('fails closed when credentials come from an opaque external source', () => {
     const cacheNamespace = createCompactionCacheNamespace(
       Providers.ANTHROPIC,
@@ -335,6 +409,37 @@ describe('compaction replay eligibility', () => {
         eligible: false,
         reason: 'cache_namespace_mismatch',
       });
+    } finally {
+      if (originalBaseURL == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalBaseURL;
+      }
+    }
+  });
+
+  it('ignores an environment endpoint overridden by explicit options', () => {
+    const originalBaseURL = process.env.OPENAI_BASE_URL;
+    try {
+      process.env.OPENAI_BASE_URL = 'https://ignored-primary.test';
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'test-key',
+          baseURL: 'https://explicit.test',
+        }),
+      });
+      process.env.OPENAI_BASE_URL = 'https://ignored-summary.test';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+            apiKey: 'test-key',
+            baseURL: 'https://explicit.test',
+          }),
+        })
+      ).toMatchObject({ eligible: true });
     } finally {
       if (originalBaseURL == null) {
         delete process.env.OPENAI_BASE_URL;

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -506,6 +506,90 @@ describe('compaction replay eligibility', () => {
     }
   });
 
+  it('snapshots environment-derived OpenAI organization and project routing', () => {
+    const originalOrgId = process.env.OPENAI_ORG_ID;
+    const originalProjectId = process.env.OPENAI_PROJECT_ID;
+    try {
+      process.env.OPENAI_ORG_ID = 'org-primary';
+      process.env.OPENAI_PROJECT_ID = 'project-primary';
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'test-key',
+        }),
+      });
+      process.env.OPENAI_ORG_ID = 'org-summary';
+      process.env.OPENAI_PROJECT_ID = 'project-summary';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+            apiKey: 'test-key',
+          }),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    } finally {
+      if (originalOrgId == null) {
+        delete process.env.OPENAI_ORG_ID;
+      } else {
+        process.env.OPENAI_ORG_ID = originalOrgId;
+      }
+      if (originalProjectId == null) {
+        delete process.env.OPENAI_PROJECT_ID;
+      } else {
+        process.env.OPENAI_PROJECT_ID = originalProjectId;
+      }
+    }
+  });
+
+  it('prefers explicit OpenAI organization and project routing', () => {
+    const originalOrgId = process.env.OPENAI_ORG_ID;
+    const originalProjectId = process.env.OPENAI_PROJECT_ID;
+    try {
+      process.env.OPENAI_ORG_ID = 'org-environment-primary';
+      process.env.OPENAI_PROJECT_ID = 'project-environment-primary';
+      const explicitRoute = {
+        apiKey: 'test-key',
+        organization: 'org-explicit',
+        project: 'project-explicit',
+      };
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.OPENAI,
+          explicitRoute
+        ),
+      });
+      process.env.OPENAI_ORG_ID = 'org-environment-summary';
+      process.env.OPENAI_PROJECT_ID = 'project-environment-summary';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.OPENAI,
+            explicitRoute
+          ),
+        })
+      ).toMatchObject({ eligible: true });
+    } finally {
+      if (originalOrgId == null) {
+        delete process.env.OPENAI_ORG_ID;
+      } else {
+        process.env.OPENAI_ORG_ID = originalOrgId;
+      }
+      if (originalProjectId == null) {
+        delete process.env.OPENAI_PROJECT_ID;
+      } else {
+        process.env.OPENAI_PROJECT_ID = originalProjectId;
+      }
+    }
+  });
+
   it('fails closed when the serving model owns an unknown route', () => {
     const cacheNamespace = createCompactionCacheNamespace(
       Providers.ANTHROPIC,
@@ -787,9 +871,7 @@ describe('compaction replay eligibility', () => {
   it('extracts only a provenance-proven projection before summary instructions', () => {
     const source = sourceMessage('a');
     const instruction = new HumanMessage('summarize');
-    setProviderMessageProvenance(instruction, [
-      { attribution: 'synthetic' },
-    ]);
+    setProviderMessageProvenance(instruction, [{ attribution: 'synthetic' }]);
 
     expect(
       extractCompactionReplayPrefixProjection([source, instruction])
@@ -843,14 +925,19 @@ describe('compaction replay eligibility', () => {
     expect('model' in envelope).toBe(false);
   });
 
-  it('retains the prepared-message reference without mutating its messages', () => {
+  it('snapshots prepared messages without retaining their mutable objects', () => {
     const messages = [sourceMessage('a'), sourceMessage('b')];
-    const before = [...messages];
     const recipe = createEnvelope({ messages, sourceMessages: messages });
 
-    expect(recipe.messages).toBe(messages);
-    inspect(recipe, { messages: [sourceMessage('a')] });
-    expect(messages).toEqual(before);
+    messages[0].content = 'mutated after snapshot';
+
+    expect('messages' in recipe).toBe(false);
+    expect(
+      inspect(recipe, {
+        messages: [sourceMessage('a')],
+        projectedMessages: [sourceMessage('a')],
+      })
+    ).toMatchObject({ eligible: true });
   });
 
   it('treats a restored tool result as ineligible even with exact lineage', () => {

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -68,6 +68,7 @@ function inspect(
     toolRevision: number;
     messages: BaseMessage[];
     restoredToolSubstitution: boolean;
+    summarizerFallbackServed: boolean;
   }> = {}
 ) {
   return inspectCompactionReplayEligibility(state, {
@@ -84,6 +85,7 @@ function inspect(
     messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
     restoredToolSubstitution:
       overrides.restoredToolSubstitution ?? false,
+    summarizerFallbackServed: overrides.summarizerFallbackServed,
   });
 }
 
@@ -203,6 +205,11 @@ describe('compaction replay eligibility', () => {
   it.each([
     ['no_request_snapshot', undefined, {}],
     ['fallback_served_request', 'fallback', {}],
+    [
+      'summarizer_fallback_served_request',
+      createEnvelope(),
+      { summarizerFallbackServed: true },
+    ],
     [
       'provider_mismatch',
       createEnvelope(),

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -21,6 +21,12 @@ import { addTailCacheControl } from '@/messages/cache';
 import { setProviderMessageProvenance } from '@/messages/provenance';
 import { Providers } from '@/common';
 
+const AZURE_ENVIRONMENT_ROUTE_CASES = [
+  ['AZURE_OPENAI_API_INSTANCE_NAME', 'azureOpenAIApiInstanceName'],
+  ['AZURE_OPENAI_API_DEPLOYMENT_NAME', 'azureOpenAIApiDeploymentName'],
+  ['AZURE_OPENAI_API_VERSION', 'azureOpenAIApiVersion'],
+] as const;
+
 function sourceMessage(id: string): HumanMessage {
   const message = new HumanMessage({ content: id, id });
   setProviderMessageProvenance(message, [
@@ -509,6 +515,79 @@ describe('compaction replay eligibility', () => {
       }
     }
   });
+
+  it.each(AZURE_ENVIRONMENT_ROUTE_CASES)(
+    'snapshots the Azure %s route fallback',
+    (environmentKey, _optionKey) => {
+      const originalValue = process.env[environmentKey];
+      try {
+        process.env[environmentKey] = 'primary';
+        const recipe = createEnvelope({
+          provider: Providers.AZURE,
+          cacheNamespace: createCompactionCacheNamespace(Providers.AZURE, {
+            azureOpenAIApiKey: 'shared-key',
+          }),
+        });
+        process.env[environmentKey] = 'summary';
+
+        expect(
+          inspect(recipe, {
+            provider: Providers.AZURE,
+            cacheNamespace: createCompactionCacheNamespace(Providers.AZURE, {
+              azureOpenAIApiKey: 'shared-key',
+            }),
+          })
+        ).toMatchObject({
+          eligible: false,
+          reason: 'cache_namespace_mismatch',
+        });
+      } finally {
+        if (originalValue == null) {
+          delete process.env[environmentKey];
+        } else {
+          process.env[environmentKey] = originalValue;
+        }
+      }
+    }
+  );
+
+  it.each(AZURE_ENVIRONMENT_ROUTE_CASES)(
+    'ignores Azure %s when %s is explicit',
+    (environmentKey, optionKey) => {
+      const originalValue = process.env[environmentKey];
+      const options = {
+        azureOpenAIApiKey: 'shared-key',
+        [optionKey]: 'explicit',
+      };
+      try {
+        process.env[environmentKey] = 'ignored-primary';
+        const recipe = createEnvelope({
+          provider: Providers.AZURE,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.AZURE,
+            options
+          ),
+        });
+        process.env[environmentKey] = 'ignored-summary';
+
+        expect(
+          inspect(recipe, {
+            provider: Providers.AZURE,
+            cacheNamespace: createCompactionCacheNamespace(
+              Providers.AZURE,
+              options
+            ),
+          })
+        ).toMatchObject({ eligible: true });
+      } finally {
+        if (originalValue == null) {
+          delete process.env[environmentKey];
+        } else {
+          process.env[environmentKey] = originalValue;
+        }
+      }
+    }
+  );
 
   it('snapshots environment-derived OpenAI organization and project routing', () => {
     const originalOrgId = process.env.OPENAI_ORG_ID;

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -163,6 +163,71 @@ describe('compaction replay eligibility', () => {
     }
   );
 
+  it.each(['openAIApiKey', 'openAIBasePath'] as const)(
+    'includes the Azure %s routing alias in cache identity',
+    (key) => {
+      const recipe = createEnvelope({
+        provider: Providers.AZURE,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.AZURE,
+          { [key]: 'primary' }
+        ),
+      });
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.AZURE,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.AZURE,
+            { [key]: 'summary' }
+          ),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    }
+  );
+
+  it('snapshots nested cache identity before host mutation', () => {
+    const options = {
+      configuration: { baseURL: 'https://primary.test' },
+    };
+    const recipe = createEnvelope({
+      cacheNamespace: createCompactionCacheNamespace(
+        Providers.ANTHROPIC,
+        options
+      ),
+    });
+    options.configuration.baseURL = 'https://summary.test';
+
+    expect(
+      inspect(recipe, {
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.ANTHROPIC,
+          options
+        ),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('fails closed when the serving model owns an unknown route', () => {
+    const cacheNamespace = createCompactionCacheNamespace(
+      Providers.ANTHROPIC,
+      { baseURL: 'https://configured.test' },
+      false
+    );
+    const recipe = createEnvelope({ cacheNamespace });
+
+    expect(inspect(recipe, { cacheNamespace })).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_unknown',
+    });
+  });
+
   it('fails closed when a runtime provider cannot prove its cache namespace', () => {
     const provider = 'runtime-provider' as t.ProviderName;
     const cacheNamespace = createCompactionCacheNamespace(provider, {

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -50,6 +50,7 @@ function createEnvelope(
     cacheNamespace:
       overrides.cacheNamespace ??
       createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        apiKey: 'test-key',
         baseURL: 'https://provider.test',
       }),
     promptCacheEnabled: overrides.promptCacheEnabled ?? true,
@@ -87,6 +88,7 @@ function inspect(
     cacheNamespace:
       overrides.cacheNamespace ??
       createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        apiKey: 'test-key',
         baseURL: 'https://provider.test',
       }),
     promptCacheEnabled: overrides.promptCacheEnabled ?? true,
@@ -129,6 +131,7 @@ describe('compaction replay eligibility', () => {
   it('treats a changed prompt-cache marker policy as a namespace mismatch', () => {
     const envelope = createEnvelope({
       cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        apiKey: 'test-key',
         promptCache: true,
         promptCacheTtl: '1h',
       }),
@@ -141,6 +144,7 @@ describe('compaction replay eligibility', () => {
           cacheNamespace: createCompactionCacheNamespace(
             Providers.ANTHROPIC,
             {
+              apiKey: 'test-key',
               promptCache: true,
               promptCacheTtl: '5m',
             }
@@ -158,6 +162,7 @@ describe('compaction replay eligibility', () => {
     (key) => {
       const recipe = createEnvelope({
         cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          apiKey: 'shared-key',
           [key]: 'primary',
         }),
       });
@@ -166,7 +171,7 @@ describe('compaction replay eligibility', () => {
         inspect(recipe, {
           cacheNamespace: createCompactionCacheNamespace(
             Providers.ANTHROPIC,
-            { [key]: 'summary' }
+            { apiKey: 'shared-key', [key]: 'summary' }
           ),
         })
       ).toMatchObject({
@@ -183,7 +188,7 @@ describe('compaction replay eligibility', () => {
         provider: Providers.AZURE,
         cacheNamespace: createCompactionCacheNamespace(
           Providers.AZURE,
-          { [key]: 'primary' }
+          { azureOpenAIApiKey: 'shared-key', [key]: 'primary' }
         ),
       });
 
@@ -192,7 +197,7 @@ describe('compaction replay eligibility', () => {
           provider: Providers.AZURE,
           cacheNamespace: createCompactionCacheNamespace(
             Providers.AZURE,
-            { [key]: 'summary' }
+            { azureOpenAIApiKey: 'shared-key', [key]: 'summary' }
           ),
         })
       ).toMatchObject({
@@ -205,6 +210,7 @@ describe('compaction replay eligibility', () => {
   it('snapshots nested cache identity before host mutation', () => {
     const options = {
       configuration: { baseURL: 'https://primary.test' },
+      apiKey: 'test-key',
     };
     const recipe = createEnvelope({
       cacheNamespace: createCompactionCacheNamespace(
@@ -232,7 +238,10 @@ describe('compaction replay eligibility', () => {
       provider: Providers.VERTEXAI,
       cacheNamespace: createCompactionCacheNamespace(
         Providers.VERTEXAI,
-        { projectId: 'primary-project' }
+        {
+          credentials: { client_email: 'test@example.test' },
+          projectId: 'primary-project',
+        }
       ),
     });
 
@@ -241,7 +250,10 @@ describe('compaction replay eligibility', () => {
         provider: Providers.VERTEXAI,
         cacheNamespace: createCompactionCacheNamespace(
           Providers.VERTEXAI,
-          { projectId: 'summary-project' }
+          {
+            credentials: { client_email: 'test@example.test' },
+            projectId: 'summary-project',
+          }
         ),
       })
     ).toMatchObject({
@@ -264,6 +276,72 @@ describe('compaction replay eligibility', () => {
         configuration: revocable.proxy,
       })
     ).toMatchObject({ complete: false });
+  });
+
+  it('fingerprints the effective thinking mode', () => {
+    const recipe = createEnvelope({
+      cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        apiKey: 'test-key',
+        thinking: { type: 'enabled', budget_tokens: 1_024 },
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.ANTHROPIC,
+          { apiKey: 'test-key' }
+        ),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('fails closed when credentials come from an opaque external source', () => {
+    const cacheNamespace = createCompactionCacheNamespace(
+      Providers.ANTHROPIC,
+      { baseURL: 'https://provider.test' }
+    );
+    const recipe = createEnvelope({ cacheNamespace });
+
+    expect(inspect(recipe, { cacheNamespace })).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_unknown',
+    });
+  });
+
+  it('snapshots environment-derived endpoint routing', () => {
+    const originalBaseURL = process.env.OPENAI_BASE_URL;
+    try {
+      process.env.OPENAI_BASE_URL = 'https://primary.test';
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'test-key',
+        }),
+      });
+      process.env.OPENAI_BASE_URL = 'https://summary.test';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+            apiKey: 'test-key',
+          }),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    } finally {
+      if (originalBaseURL == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalBaseURL;
+      }
+    }
   });
 
   it('fails closed when the serving model owns an unknown route', () => {
@@ -372,6 +450,7 @@ describe('compaction replay eligibility', () => {
       createEnvelope(),
       {
         cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          apiKey: 'test-key',
           baseURL: 'https://other.test',
         }),
       },

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -66,7 +66,10 @@ function createEnvelope(
       createCompactionToolProjectionFingerprint(undefined),
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
-    messages: overrides.messages ?? [new SystemMessage('stable'), ...sourceMessages],
+    messages: overrides.messages ?? [
+      new SystemMessage('stable'),
+      ...sourceMessages,
+    ],
     sourceMessages,
   });
   return envelope;
@@ -109,28 +112,26 @@ function inspect(
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
     messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
-    restoredToolSubstitution:
-      overrides.restoredToolSubstitution ?? false,
+    restoredToolSubstitution: overrides.restoredToolSubstitution ?? false,
     summarizerFallbackServed: overrides.summarizerFallbackServed,
   });
 }
 
 describe('compaction replay eligibility', () => {
-  it.each([
-    Providers.ANTHROPIC,
-    Providers.BEDROCK,
-    Providers.OPENROUTER,
-  ])('finds the exact source prefix for %s', (provider) => {
-    const envelope = createEnvelope({ provider });
-    const result = inspect(envelope, { provider });
+  it.each([Providers.ANTHROPIC, Providers.BEDROCK, Providers.OPENROUTER])(
+    'finds the exact source prefix for %s',
+    (provider) => {
+      const envelope = createEnvelope({ provider });
+      const result = inspect(envelope, { provider });
 
-    expect(result).toEqual({
-      eligible: true,
-      replayMessageCount: 3,
-      replaySourceCount: 2,
-      requestSourceCount: 3,
-    });
-  });
+      expect(result).toEqual({
+        eligible: true,
+        replayMessageCount: 3,
+        replaySourceCount: 2,
+        requestSourceCount: 3,
+      });
+    }
+  );
 
   it('inherits the captured model when no dedicated summary model is set', () => {
     const envelope = createEnvelope();
@@ -149,19 +150,13 @@ describe('compaction replay eligibility', () => {
     });
 
     expect(
-      inspect(
-        envelope,
-        {
-          cacheNamespace: createCompactionCacheNamespace(
-            Providers.ANTHROPIC,
-            {
-              apiKey: 'test-key',
-              promptCache: true,
-              promptCacheTtl: '5m',
-            }
-          ),
-        }
-      )
+      inspect(envelope, {
+        cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          apiKey: 'test-key',
+          promptCache: true,
+          promptCacheTtl: '5m',
+        }),
+      })
     ).toMatchObject({
       eligible: false,
       reason: 'cache_namespace_mismatch',
@@ -180,10 +175,10 @@ describe('compaction replay eligibility', () => {
 
       expect(
         inspect(recipe, {
-          cacheNamespace: createCompactionCacheNamespace(
-            Providers.ANTHROPIC,
-            { apiKey: 'shared-key', [key]: 'summary' }
-          ),
+          cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+            apiKey: 'shared-key',
+            [key]: 'summary',
+          }),
         })
       ).toMatchObject({
         eligible: false,
@@ -197,19 +192,19 @@ describe('compaction replay eligibility', () => {
     (key) => {
       const recipe = createEnvelope({
         provider: Providers.AZURE,
-        cacheNamespace: createCompactionCacheNamespace(
-          Providers.AZURE,
-          { azureOpenAIApiKey: 'shared-key', [key]: 'primary' }
-        ),
+        cacheNamespace: createCompactionCacheNamespace(Providers.AZURE, {
+          azureOpenAIApiKey: 'shared-key',
+          [key]: 'primary',
+        }),
       });
 
       expect(
         inspect(recipe, {
           provider: Providers.AZURE,
-          cacheNamespace: createCompactionCacheNamespace(
-            Providers.AZURE,
-            { azureOpenAIApiKey: 'shared-key', [key]: 'summary' }
-          ),
+          cacheNamespace: createCompactionCacheNamespace(Providers.AZURE, {
+            azureOpenAIApiKey: 'shared-key',
+            [key]: 'summary',
+          }),
         })
       ).toMatchObject({
         eligible: false,
@@ -247,25 +242,19 @@ describe('compaction replay eligibility', () => {
   it('includes the Vertex project ID in cache identity', () => {
     const recipe = createEnvelope({
       provider: Providers.VERTEXAI,
-      cacheNamespace: createCompactionCacheNamespace(
-        Providers.VERTEXAI,
-        {
-          credentials: { client_email: 'test@example.test' },
-          projectId: 'primary-project',
-        }
-      ),
+      cacheNamespace: createCompactionCacheNamespace(Providers.VERTEXAI, {
+        credentials: { client_email: 'test@example.test' },
+        projectId: 'primary-project',
+      }),
     });
 
     expect(
       inspect(recipe, {
         provider: Providers.VERTEXAI,
-        cacheNamespace: createCompactionCacheNamespace(
-          Providers.VERTEXAI,
-          {
-            credentials: { client_email: 'test@example.test' },
-            projectId: 'summary-project',
-          }
-        ),
+        cacheNamespace: createCompactionCacheNamespace(Providers.VERTEXAI, {
+          credentials: { client_email: 'test@example.test' },
+          projectId: 'summary-project',
+        }),
       })
     ).toMatchObject({
       eligible: false,
@@ -299,10 +288,9 @@ describe('compaction replay eligibility', () => {
 
     expect(
       inspect(recipe, {
-        cacheNamespace: createCompactionCacheNamespace(
-          Providers.ANTHROPIC,
-          { apiKey: 'test-key' }
-        ),
+        cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          apiKey: 'test-key',
+        }),
       })
     ).toMatchObject({
       eligible: false,
@@ -358,14 +346,59 @@ describe('compaction replay eligibility', () => {
     expect(
       inspect(recipe, {
         provider: Providers.OPENROUTER,
-        cacheNamespace: createCompactionCacheNamespace(
-          Providers.OPENROUTER,
-          {
-            apiKey: 'test-key',
-            modelKwargs: { provider: { order: ['google'] } },
-            promptCache: true,
-          }
-        ),
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENROUTER, {
+          apiKey: 'test-key',
+          modelKwargs: { provider: { order: ['google'] } },
+          promptCache: true,
+        }),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('includes the Bedrock application inference profile in cache identity', () => {
+    const recipe = createEnvelope({
+      provider: Providers.BEDROCK,
+      cacheNamespace: createCompactionCacheNamespace(Providers.BEDROCK, {
+        credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+        applicationInferenceProfile: 'arn:primary',
+        promptCache: true,
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.BEDROCK,
+        cacheNamespace: createCompactionCacheNamespace(Providers.BEDROCK, {
+          credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+          applicationInferenceProfile: 'arn:summary',
+          promptCache: true,
+        }),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('includes OpenAI explicit cache projection mode in cache identity', () => {
+    const recipe = createEnvelope({
+      provider: Providers.OPENAI,
+      cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+        apiKey: 'test-key',
+        promptCacheExplicit: true,
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'test-key',
+          promptCacheExplicit: false,
+        }),
       })
     ).toMatchObject({
       eligible: false,
@@ -374,10 +407,9 @@ describe('compaction replay eligibility', () => {
   });
 
   it('fails closed when credentials come from an opaque external source', () => {
-    const cacheNamespace = createCompactionCacheNamespace(
-      Providers.ANTHROPIC,
-      { baseURL: 'https://provider.test' }
-    );
+    const cacheNamespace = createCompactionCacheNamespace(Providers.ANTHROPIC, {
+      baseURL: 'https://provider.test',
+    });
     const recipe = createEnvelope({ cacheNamespace });
 
     expect(inspect(recipe, { cacheNamespace })).toMatchObject({
@@ -507,10 +539,9 @@ describe('compaction replay eligibility', () => {
   });
 
   it('fails closed when cache identity contains an unsupported value', () => {
-    const cacheNamespace = createCompactionCacheNamespace(
-      Providers.ANTHROPIC,
-      { apiKey: () => 'dynamic-key' }
-    );
+    const cacheNamespace = createCompactionCacheNamespace(Providers.ANTHROPIC, {
+      apiKey: () => 'dynamic-key',
+    });
     const recipe = createEnvelope({ cacheNamespace });
 
     expect(inspect(recipe, { cacheNamespace })).toMatchObject({
@@ -524,7 +555,10 @@ describe('compaction replay eligibility', () => {
 
     expect(
       inspect(recipe, {
-        messages: [sourceMessage('a'), new HumanMessage({ content: 'changed', id: 'b' })],
+        messages: [
+          sourceMessage('a'),
+          new HumanMessage({ content: 'changed', id: 'b' }),
+        ],
       })
     ).toMatchObject({
       eligible: false,
@@ -540,16 +574,8 @@ describe('compaction replay eligibility', () => {
       createEnvelope(),
       { summarizerFallbackServed: true },
     ],
-    [
-      'provider_mismatch',
-      createEnvelope(),
-      { provider: Providers.OPENAI },
-    ],
-    [
-      'model_mismatch',
-      createEnvelope(),
-      { modelId: 'different-model' },
-    ],
+    ['provider_mismatch', createEnvelope(), { provider: Providers.OPENAI }],
+    ['model_mismatch', createEnvelope(), { modelId: 'different-model' }],
     [
       'cache_namespace_mismatch',
       createEnvelope(),
@@ -560,16 +586,8 @@ describe('compaction replay eligibility', () => {
         }),
       },
     ],
-    [
-      'system_projection_changed',
-      createEnvelope(),
-      { systemRevision: 4 },
-    ],
-    [
-      'tool_projection_changed',
-      createEnvelope(),
-      { toolRevision: 4 },
-    ],
+    ['system_projection_changed', createEnvelope(), { systemRevision: 4 }],
+    ['tool_projection_changed', createEnvelope(), { toolRevision: 4 }],
     [
       'projection_mode_mismatch',
       createEnvelope(),
@@ -580,27 +598,20 @@ describe('compaction replay eligibility', () => {
       createEnvelope(),
       { restoredToolSubstitution: true },
     ],
-    [
-      'source_not_prefix',
-      createEnvelope(),
-      { messages: [sourceMessage('b')] },
-    ],
+    ['source_not_prefix', createEnvelope(), { messages: [sourceMessage('b')] }],
     [
       'ambiguous_lineage',
       createEnvelope(),
       { messages: [new HumanMessage('missing id')] },
     ],
-  ] as const)(
-    'fails closed with %s',
-    (reason, state, overrides) => {
-      expect(
-        inspect(
-          state as CompactionReplayState | undefined,
-          overrides as Parameters<typeof inspect>[1]
-        )
-      ).toMatchObject({ eligible: false, reason });
-    }
-  );
+  ] as const)('fails closed with %s', (reason, state, overrides) => {
+    expect(
+      inspect(
+        state as CompactionReplayState | undefined,
+        overrides as Parameters<typeof inspect>[1]
+      )
+    ).toMatchObject({ eligible: false, reason });
+  });
 
   it('rejects a cut through one coalesced provider message', () => {
     const coalesced = new HumanMessage({
@@ -609,7 +620,11 @@ describe('compaction replay eligibility', () => {
     });
     const envelope = createEnvelope({
       messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
-      sourceMessages: [sourceMessage('a'), sourceMessage('b'), sourceMessage('c')],
+      sourceMessages: [
+        sourceMessage('a'),
+        sourceMessage('b'),
+        sourceMessage('c'),
+      ],
     });
 
     expect(inspect(envelope, { messages: [sourceMessage('a')] })).toMatchObject(
@@ -624,7 +639,11 @@ describe('compaction replay eligibility', () => {
     });
     const envelope = createEnvelope({
       messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
-      sourceMessages: [sourceMessage('a'), sourceMessage('b'), sourceMessage('c')],
+      sourceMessages: [
+        sourceMessage('a'),
+        sourceMessage('b'),
+        sourceMessage('c'),
+      ],
     });
 
     expect(
@@ -636,6 +655,40 @@ describe('compaction replay eligibility', () => {
       replayMessageCount: 2,
       replaySourceCount: 2,
       requestSourceCount: 3,
+    });
+  });
+
+  it('includes every repeated artifact projection at the replay boundary', () => {
+    const firstArtifact = new ToolMessage({
+      content: 'first placeholder',
+      tool_call_id: 'call_1',
+      additional_kwargs: { sourceMessageIds: ['a'] },
+    });
+    const secondArtifact = new ToolMessage({
+      content: 'second placeholder',
+      tool_call_id: 'call_2',
+      additional_kwargs: { sourceMessageIds: ['b'] },
+    });
+    const aggregate = new HumanMessage({
+      content: 'expanded artifacts',
+      additional_kwargs: { sourceMessageIds: ['a', 'b'] },
+    });
+    const sourceMessages = [sourceMessage('a'), sourceMessage('b')];
+    const envelope = createEnvelope({
+      messages: [
+        new SystemMessage('stable'),
+        firstArtifact,
+        secondArtifact,
+        aggregate,
+      ],
+      sourceMessages,
+    });
+
+    expect(inspect(envelope, { messages: sourceMessages })).toEqual({
+      eligible: true,
+      replayMessageCount: 4,
+      replaySourceCount: 2,
+      requestSourceCount: 2,
     });
   });
 
@@ -661,10 +714,9 @@ describe('compaction replay eligibility', () => {
     });
 
     expect(
-      inspect(
-        envelope,
-        { messages: [priorCheckpoint, sourceMessage('a'), sourceMessage('b')] }
-      )
+      inspect(envelope, {
+        messages: [priorCheckpoint, sourceMessage('a'), sourceMessage('b')],
+      })
     ).toEqual({
       eligible: true,
       replayMessageCount: 4,
@@ -705,13 +757,10 @@ describe('compaction replay eligibility', () => {
     });
 
     expect(
-      inspect(
-        envelope,
-        {
-          messages: [sourceMessage('a'), tool],
-          restoredToolSubstitution: true,
-        }
-      )
+      inspect(envelope, {
+        messages: [sourceMessage('a'), tool],
+        restoredToolSubstitution: true,
+      })
     ).toMatchObject({
       eligible: false,
       reason: 'restored_tool_substitution',

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -6,11 +6,13 @@ import {
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   createCompactionCacheNamespace,
+  createCompactionReplayCandidateSnapshot,
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
   EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   extractCompactionReplayPrefixProjection,
   inspectCompactionReplayEligibility,
+  type CompactionReplayCandidateSnapshot,
   type CompactionReplayRecipe,
   type CompactionReplayState,
 } from '@/llm/compactionReplay';
@@ -91,6 +93,7 @@ function inspect(
     toolRevision: number;
     messages: BaseMessage[];
     projectedMessages: BaseMessage[] | null;
+    snapshot: CompactionReplayCandidateSnapshot;
     restoredToolSubstitution: boolean;
     summarizerFallbackServed: boolean;
   }> = {}
@@ -116,6 +119,7 @@ function inspect(
     toolRevision: overrides.toolRevision ?? 3,
     messages: overrides.messages ?? [sourceMessage('a'), sourceMessage('b')],
     projectedMessages: overrides.projectedMessages,
+    snapshot: overrides.snapshot,
     restoredToolSubstitution: overrides.restoredToolSubstitution ?? false,
     summarizerFallbackServed: overrides.summarizerFallbackServed,
   });
@@ -938,6 +942,32 @@ describe('compaction replay eligibility', () => {
         projectedMessages: [sourceMessage('a')],
       })
     ).toMatchObject({ eligible: true });
+  });
+
+  it('uses the pre-invoke candidate snapshot after live messages mutate', () => {
+    const sourceMessages = [sourceMessage('a'), sourceMessage('b')];
+    const projectedMessages = [...sourceMessages];
+    const recipe = createEnvelope({
+      messages: projectedMessages,
+      sourceMessages,
+    });
+    const candidateMessages = [sourceMessage('a')];
+    const candidateProjection = [...candidateMessages];
+    const snapshot = createCompactionReplayCandidateSnapshot(
+      candidateMessages,
+      candidateProjection
+    );
+
+    candidateMessages[0].content = 'mutated source';
+    candidateProjection[0].content = 'mutated projection';
+
+    expect(
+      inspect(recipe, {
+        messages: candidateMessages,
+        projectedMessages: candidateProjection,
+        snapshot,
+      })
+    ).toMatchObject({ eligible: true, replayMessageCount: 1 });
   });
 
   it('treats a restored tool result as ineligible even with exact lineage', () => {

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -314,6 +314,35 @@ describe('compaction replay eligibility', () => {
     }
   });
 
+  it('ignores OPENAI_BASE_URL for the fixed default xAI endpoint', () => {
+    const originalBaseURL = process.env.OPENAI_BASE_URL;
+    try {
+      process.env.OPENAI_BASE_URL = 'https://ignored-primary.x.ai';
+      const recipe = createEnvelope({
+        provider: Providers.XAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.XAI, {
+          apiKey: 'shared-key',
+        }),
+      });
+      process.env.OPENAI_BASE_URL = 'https://ignored-summary.x.ai';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.XAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.XAI, {
+            apiKey: 'shared-key',
+          }),
+        })
+      ).toMatchObject({ eligible: true });
+    } finally {
+      if (originalBaseURL == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalBaseURL;
+      }
+    }
+  });
+
   it('snapshots nested cache identity before host mutation', () => {
     const options = {
       configuration: { baseURL: 'https://primary.test' },
@@ -484,6 +513,44 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it('snapshots the AWS_REGION Bedrock route fallback', () => {
+    const originalRegion = process.env.AWS_REGION;
+    const options = {
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+      promptCache: true,
+    };
+    try {
+      process.env.AWS_REGION = 'us-east-1';
+      const recipe = createEnvelope({
+        provider: Providers.BEDROCK,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.BEDROCK,
+          options
+        ),
+      });
+      process.env.AWS_REGION = 'us-west-2';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.BEDROCK,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.BEDROCK,
+            options
+          ),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    } finally {
+      if (originalRegion == null) {
+        delete process.env.AWS_REGION;
+      } else {
+        process.env.AWS_REGION = originalRegion;
+      }
+    }
+  });
+
   it('includes OpenAI explicit cache projection mode in cache identity', () => {
     const recipe = createEnvelope({
       provider: Providers.OPENAI,
@@ -557,6 +624,40 @@ describe('compaction replay eligibility', () => {
           provider: Providers.OPENAI,
           cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
             apiKey: 'test-key',
+          }),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    } finally {
+      if (originalBaseURL == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalBaseURL;
+      }
+    }
+  });
+
+  it('treats a null route option as an environment fallback', () => {
+    const originalBaseURL = process.env.OPENAI_BASE_URL;
+    try {
+      process.env.OPENAI_BASE_URL = 'https://primary.test';
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'test-key',
+          baseURL: null,
+        }),
+      });
+      process.env.OPENAI_BASE_URL = 'https://summary.test';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+            apiKey: 'test-key',
+            baseURL: null,
           }),
         })
       ).toMatchObject({
@@ -820,6 +921,35 @@ describe('compaction replay eligibility', () => {
           { name: 'stable', ...summary },
         ]),
       })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'tool_projection_changed',
+    });
+  });
+
+  it('includes every Anthropic built-in provider field', () => {
+    const primaryTools = createCompactionToolProjectionFingerprint([
+      {
+        type: 'web_search_20250305',
+        name: 'web_search',
+        max_uses: 3,
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    const summaryTools = createCompactionToolProjectionFingerprint([
+      {
+        type: 'web_search_20250305',
+        name: 'web_search',
+        max_uses: 5,
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    const recipe = createEnvelope({
+      toolProjectionFingerprint: primaryTools,
+    });
+
+    expect(
+      inspect(recipe, { toolProjectionFingerprint: summaryTools })
     ).toMatchObject({
       eligible: false,
       reason: 'tool_projection_changed',

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -32,8 +32,14 @@ function createEnvelope(
     systemRevision: number;
     toolRevision: number;
     messages: BaseMessage[];
+    sourceMessages: BaseMessage[];
   }> = {}
 ): CompactionReplayRecipe {
+  const sourceMessages = overrides.sourceMessages ?? [
+    sourceMessage('a'),
+    sourceMessage('b'),
+    sourceMessage('c'),
+  ];
   const envelope = createCompactionReplayRecipe({
     provider: overrides.provider ?? Providers.ANTHROPIC,
     modelId: overrides.modelId ?? 'claude-sonnet',
@@ -45,12 +51,8 @@ function createEnvelope(
       }),
     systemRevision: overrides.systemRevision ?? 2,
     toolRevision: overrides.toolRevision ?? 3,
-    messages: overrides.messages ?? [
-      new SystemMessage('stable'),
-      sourceMessage('a'),
-      sourceMessage('b'),
-      sourceMessage('c'),
-    ],
+    messages: overrides.messages ?? [new SystemMessage('stable'), ...sourceMessages],
+    sourceMessages,
   });
   return envelope;
 }
@@ -136,6 +138,29 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it.each(['anthropicApiKey', 'anthropicApiUrl'] as const)(
+    'includes the Anthropic %s routing alias in cache identity',
+    (key) => {
+      const recipe = createEnvelope({
+        cacheNamespace: createCompactionCacheNamespace(Providers.ANTHROPIC, {
+          [key]: 'primary',
+        }),
+      });
+
+      expect(
+        inspect(recipe, {
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.ANTHROPIC,
+            { [key]: 'summary' }
+          ),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    }
+  );
+
   it('fails closed when a runtime provider cannot prove its cache namespace', () => {
     const provider = 'runtime-provider' as t.ProviderName;
     const cacheNamespace = createCompactionCacheNamespace(provider, {
@@ -159,6 +184,19 @@ describe('compaction replay eligibility', () => {
     expect(inspect(recipe, { cacheNamespace })).toMatchObject({
       eligible: false,
       reason: 'cache_namespace_unknown',
+    });
+  });
+
+  it('rejects changed content even when source lineage is unchanged', () => {
+    const recipe = createEnvelope();
+
+    expect(
+      inspect(recipe, {
+        messages: [sourceMessage('a'), new HumanMessage({ content: 'changed', id: 'b' })],
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'source_content_mismatch',
     });
   });
 
@@ -233,6 +271,7 @@ describe('compaction replay eligibility', () => {
     });
     const envelope = createEnvelope({
       messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
+      sourceMessages: [sourceMessage('a'), sourceMessage('b'), sourceMessage('c')],
     });
 
     expect(inspect(envelope, { messages: [sourceMessage('a')] })).toMatchObject(
@@ -247,6 +286,7 @@ describe('compaction replay eligibility', () => {
     });
     const envelope = createEnvelope({
       messages: [new SystemMessage('stable'), coalesced, sourceMessage('c')],
+      sourceMessages: [sourceMessage('a'), sourceMessage('b'), sourceMessage('c')],
     });
 
     expect(
@@ -269,6 +309,12 @@ describe('compaction replay eligibility', () => {
     const envelope = createEnvelope({
       messages: [
         new SystemMessage('stable'),
+        priorCheckpoint,
+        sourceMessage('a'),
+        sourceMessage('b'),
+        sourceMessage('c'),
+      ],
+      sourceMessages: [
         priorCheckpoint,
         sourceMessage('a'),
         sourceMessage('b'),
@@ -299,7 +345,7 @@ describe('compaction replay eligibility', () => {
   it('retains the prepared-message reference without mutating its messages', () => {
     const messages = [sourceMessage('a'), sourceMessage('b')];
     const before = [...messages];
-    const recipe = createEnvelope({ messages });
+    const recipe = createEnvelope({ messages, sourceMessages: messages });
 
     expect(recipe.messages).toBe(messages);
     inspect(recipe, { messages: [sourceMessage('a')] });
@@ -317,6 +363,7 @@ describe('compaction replay eligibility', () => {
     ]);
     const envelope = createEnvelope({
       messages: [new SystemMessage('stable'), sourceMessage('a'), tool],
+      sourceMessages: [sourceMessage('a'), tool],
     });
 
     expect(

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -15,6 +15,7 @@ import {
   type CompactionReplayState,
 } from '@/llm/compactionReplay';
 import type * as t from '@/types';
+import { addTailCacheControl } from '@/messages/cache';
 import { setProviderMessageProvenance } from '@/messages/provenance';
 import { Providers } from '@/common';
 
@@ -89,7 +90,7 @@ function inspect(
     systemRevision: number;
     toolRevision: number;
     messages: BaseMessage[];
-    projectedMessages: BaseMessage[];
+    projectedMessages: BaseMessage[] | null;
     restoredToolSubstitution: boolean;
     summarizerFallbackServed: boolean;
   }> = {}
@@ -733,6 +734,31 @@ describe('compaction replay eligibility', () => {
     ).toMatchObject({
       eligible: false,
       reason: 'provider_projection_changed',
+    });
+  });
+
+  it('accepts a prepared prefix after restoring its history cache marker', () => {
+    const sourceMessages = [sourceMessage('a'), sourceMessage('b')];
+    const normalProjection = addTailCacheControl([...sourceMessages]);
+    const envelope = createEnvelope({
+      messages: normalProjection,
+      sourceMessages,
+    });
+
+    expect(
+      inspect(envelope, {
+        messages: sourceMessages,
+        projectedMessages: addTailCacheControl([...sourceMessages]),
+      })
+    ).toMatchObject({ eligible: true, replayMessageCount: 2 });
+  });
+
+  it('fails closed when prepared-prefix extraction is inconclusive', () => {
+    const envelope = createEnvelope();
+
+    expect(inspect(envelope, { projectedMessages: null })).toMatchObject({
+      eligible: false,
+      reason: 'provider_projection_unknown',
     });
   });
 

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -227,6 +227,93 @@ describe('compaction replay eligibility', () => {
     }
   );
 
+  it.each([
+    ['responsesPromptCache', true, false],
+    ['responsesPromptCacheTtl', '1h', '5m'],
+  ] as const)(
+    'includes the OpenAI Responses %s setting in cache identity',
+    (key, primary, summary) => {
+      const recipe = createEnvelope({
+        provider: Providers.OPENAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+          apiKey: 'shared-key',
+          [key]: primary,
+        }),
+      });
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.OPENAI,
+          cacheNamespace: createCompactionCacheNamespace(Providers.OPENAI, {
+            apiKey: 'shared-key',
+            [key]: summary,
+          }),
+        })
+      ).toMatchObject({
+        eligible: false,
+        reason: 'cache_namespace_mismatch',
+      });
+    }
+  );
+
+  it('includes the xAI clientConfig endpoint in cache identity', () => {
+    const recipe = createEnvelope({
+      provider: Providers.XAI,
+      cacheNamespace: createCompactionCacheNamespace(Providers.XAI, {
+        apiKey: 'shared-key',
+        clientConfig: { baseURL: 'https://primary.x.ai' },
+      }),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.XAI,
+        cacheNamespace: createCompactionCacheNamespace(Providers.XAI, {
+          apiKey: 'shared-key',
+          clientConfig: { baseURL: 'https://summary.x.ai' },
+        }),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('lets an explicit xAI clientConfig endpoint override the environment', () => {
+    const originalBaseURL = process.env.OPENAI_BASE_URL;
+    const options = {
+      apiKey: 'shared-key',
+      clientConfig: { baseURL: 'https://explicit.x.ai' },
+    };
+    try {
+      process.env.OPENAI_BASE_URL = 'https://ignored-primary.x.ai';
+      const recipe = createEnvelope({
+        provider: Providers.XAI,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.XAI,
+          options
+        ),
+      });
+      process.env.OPENAI_BASE_URL = 'https://ignored-summary.x.ai';
+
+      expect(
+        inspect(recipe, {
+          provider: Providers.XAI,
+          cacheNamespace: createCompactionCacheNamespace(
+            Providers.XAI,
+            options
+          ),
+        })
+      ).toMatchObject({ eligible: true });
+    } finally {
+      if (originalBaseURL == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = originalBaseURL;
+      }
+    }
+  });
+
   it('snapshots nested cache identity before host mutation', () => {
     const options = {
       configuration: { baseURL: 'https://primary.test' },

--- a/src/llm/compactionReplay.test.ts
+++ b/src/llm/compactionReplay.test.ts
@@ -214,6 +214,45 @@ describe('compaction replay eligibility', () => {
     });
   });
 
+  it('includes the Vertex project ID in cache identity', () => {
+    const recipe = createEnvelope({
+      provider: Providers.VERTEXAI,
+      cacheNamespace: createCompactionCacheNamespace(
+        Providers.VERTEXAI,
+        { projectId: 'primary-project' }
+      ),
+    });
+
+    expect(
+      inspect(recipe, {
+        provider: Providers.VERTEXAI,
+        cacheNamespace: createCompactionCacheNamespace(
+          Providers.VERTEXAI,
+          { projectId: 'summary-project' }
+        ),
+      })
+    ).toMatchObject({
+      eligible: false,
+      reason: 'cache_namespace_mismatch',
+    });
+  });
+
+  it('fails closed instead of throwing on an opaque route object', () => {
+    const revocable = Proxy.revocable({}, {});
+    revocable.revoke();
+
+    expect(() =>
+      createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        configuration: revocable.proxy,
+      })
+    ).not.toThrow();
+    expect(
+      createCompactionCacheNamespace(Providers.ANTHROPIC, {
+        configuration: revocable.proxy,
+      })
+    ).toMatchObject({ complete: false });
+  });
+
   it('fails closed when the serving model owns an unknown route', () => {
     const cacheNamespace = createCompactionCacheNamespace(
       Providers.ANTHROPIC,

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -214,6 +214,24 @@ const PROVIDER_ENVIRONMENT_ROUTES: Partial<
         ['configuration', 'baseURL'],
       ],
     },
+    {
+      environmentKey: 'AZURE_OPENAI_API_INSTANCE_NAME',
+      optionPaths: [['azureOpenAIApiInstanceName']],
+    },
+    {
+      environmentKey: 'AZURE_OPENAI_API_DEPLOYMENT_NAME',
+      optionPaths: [
+        ['azureOpenAIApiDeploymentName'],
+        ['deploymentName'],
+      ],
+    },
+    {
+      environmentKey: 'AZURE_OPENAI_API_VERSION',
+      optionPaths: [
+        ['azureOpenAIApiVersion'],
+        ['openAIApiVersion'],
+      ],
+    },
   ],
   [Providers.BEDROCK]: [
     {

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -111,9 +111,73 @@ const CACHE_NAMESPACE_KEYS = [
   'defaultHeaders',
   'configuration',
   'useResponsesApi',
+  'thinking',
+  'thinkingBudget',
+  'additionalModelRequestFields',
+  'azureADTokenProvider',
 ] as const;
 
 const BUILT_IN_PROVIDER_NAMES = new Set<string>(Object.values(Providers));
+
+const PROVIDER_CREDENTIAL_KEYS: Partial<
+  Record<Providers, readonly string[]>
+> = {
+  [Providers.OPENAI]: ['apiKey', 'openAIApiKey'],
+  [Providers.AZURE]: [
+    'apiKey',
+    'openAIApiKey',
+    'azureOpenAIApiKey',
+    'azureADTokenProvider',
+  ],
+  [Providers.ANTHROPIC]: ['apiKey', 'anthropicApiKey'],
+  [Providers.BEDROCK]: [
+    'credentials',
+    'awsAccessKeyId',
+    'awsSecretAccessKey',
+  ],
+  [Providers.VERTEXAI]: ['credentials'],
+  [Providers.GOOGLE]: ['apiKey', 'googleApiKey'],
+  [Providers.MISTRALAI]: ['apiKey'],
+  [Providers.MISTRAL]: ['apiKey'],
+  [Providers.DEEPSEEK]: ['apiKey'],
+  [Providers.OPENROUTER]: ['apiKey', 'openAIApiKey'],
+  [Providers.XAI]: ['apiKey'],
+  [Providers.MOONSHOT]: ['apiKey', 'openAIApiKey'],
+};
+
+const PROVIDER_ENVIRONMENT_ROUTE_KEYS: Partial<
+  Record<Providers, readonly string[]>
+> = {
+  [Providers.OPENAI]: ['OPENAI_BASE_URL'],
+  [Providers.AZURE]: [
+    'OPENAI_BASE_URL',
+    'AZURE_OPENAI_ENDPOINT',
+    'AZURE_OPENAI_BASE_PATH',
+  ],
+  [Providers.BEDROCK]: ['BEDROCK_AWS_REGION', 'AWS_DEFAULT_REGION'],
+  [Providers.VERTEXAI]: ['GOOGLE_CLOUD_PROJECT', 'GCLOUD_PROJECT'],
+  [Providers.DEEPSEEK]: ['OPENAI_BASE_URL'],
+  [Providers.XAI]: ['OPENAI_BASE_URL'],
+  [Providers.MOONSHOT]: ['OPENAI_BASE_URL'],
+};
+
+function hasExplicitCredentialIdentity(
+  provider: t.ProviderName,
+  options?: t.ClientOptions | Record<string, unknown>
+): boolean {
+  const keys = PROVIDER_CREDENTIAL_KEYS[provider as Providers];
+  if (keys == null) {
+    return false;
+  }
+  try {
+    return keys.some(
+      (key) =>
+        (options as Record<string, unknown> | undefined)?.[key] !== undefined
+    );
+  } catch {
+    return false;
+  }
+}
 
 function serializeCacheNamespaceValue(
   value: unknown,
@@ -301,7 +365,7 @@ export function createCompactionCacheNamespace(
     });
   }
   const entries: Array<readonly [string, CacheNamespaceValue]> = [];
-  let complete = true;
+  let complete = hasExplicitCredentialIdentity(provider, options);
   for (const key of CACHE_NAMESPACE_KEYS) {
     let value: unknown;
     try {
@@ -319,6 +383,25 @@ export function createCompactionCacheNamespace(
       continue;
     }
     entries.push(Object.freeze([key, fingerprint] as const));
+  }
+  for (const key of
+    PROVIDER_ENVIRONMENT_ROUTE_KEYS[provider as Providers] ?? []) {
+    let value: string | undefined;
+    try {
+      value = process.env[key];
+    } catch {
+      complete = false;
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    const fingerprint = fingerprintCacheNamespaceValue(value);
+    if (fingerprint == null) {
+      complete = false;
+      continue;
+    }
+    entries.push(Object.freeze([`env:${key}`, fingerprint] as const));
   }
   return Object.freeze({
     complete,

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -64,6 +64,11 @@ export interface CompactionCacheNamespace {
   >;
 }
 
+export interface CompactionReplayRouteSnapshot {
+  readonly cacheNamespace: CompactionCacheNamespace;
+  readonly promptCacheEnabled: boolean;
+}
+
 interface CompactionReplayCandidate {
   readonly provider: t.ProviderName;
   readonly modelId?: string;
@@ -111,6 +116,7 @@ const CACHE_NAMESPACE_KEYS = [
   'authOptions',
   'profile',
   'promptCache',
+  'promptCacheExplicit',
   'promptCacheTtl',
   'customHeaders',
   'defaultHeaders',
@@ -120,36 +126,36 @@ const CACHE_NAMESPACE_KEYS = [
   'thinkingBudget',
   'additionalModelRequestFields',
   'modelKwargs',
+  'applicationInferenceProfile',
   'azureADTokenProvider',
 ] as const;
 
 const BUILT_IN_PROVIDER_NAMES = new Set<string>(Object.values(Providers));
 
-const PROVIDER_CREDENTIAL_KEYS: Partial<
-  Record<Providers, readonly string[]>
-> = {
-  [Providers.OPENAI]: ['apiKey', 'openAIApiKey'],
-  [Providers.AZURE]: [
-    'apiKey',
-    'openAIApiKey',
-    'azureOpenAIApiKey',
-    'azureADTokenProvider',
-  ],
-  [Providers.ANTHROPIC]: ['apiKey', 'anthropicApiKey'],
-  [Providers.BEDROCK]: [
-    'credentials',
-    'awsAccessKeyId',
-    'awsSecretAccessKey',
-  ],
-  [Providers.VERTEXAI]: ['credentials'],
-  [Providers.GOOGLE]: ['apiKey', 'googleApiKey'],
-  [Providers.MISTRALAI]: ['apiKey'],
-  [Providers.MISTRAL]: ['apiKey'],
-  [Providers.DEEPSEEK]: ['apiKey'],
-  [Providers.OPENROUTER]: ['apiKey', 'openAIApiKey'],
-  [Providers.XAI]: ['apiKey'],
-  [Providers.MOONSHOT]: ['apiKey', 'openAIApiKey'],
-};
+const PROVIDER_CREDENTIAL_KEYS: Partial<Record<Providers, readonly string[]>> =
+  {
+    [Providers.OPENAI]: ['apiKey', 'openAIApiKey'],
+    [Providers.AZURE]: [
+      'apiKey',
+      'openAIApiKey',
+      'azureOpenAIApiKey',
+      'azureADTokenProvider',
+    ],
+    [Providers.ANTHROPIC]: ['apiKey', 'anthropicApiKey'],
+    [Providers.BEDROCK]: [
+      'credentials',
+      'awsAccessKeyId',
+      'awsSecretAccessKey',
+    ],
+    [Providers.VERTEXAI]: ['credentials'],
+    [Providers.GOOGLE]: ['apiKey', 'googleApiKey'],
+    [Providers.MISTRALAI]: ['apiKey'],
+    [Providers.MISTRAL]: ['apiKey'],
+    [Providers.DEEPSEEK]: ['apiKey'],
+    [Providers.OPENROUTER]: ['apiKey', 'openAIApiKey'],
+    [Providers.XAI]: ['apiKey'],
+    [Providers.MOONSHOT]: ['apiKey', 'openAIApiKey'],
+  };
 
 interface EnvironmentRouteIdentity {
   readonly environmentKey: string;
@@ -467,8 +473,8 @@ export function createCompactionCacheNamespace(
     }
     entries.push(Object.freeze([key, fingerprint] as const));
   }
-  for (const route of
-    PROVIDER_ENVIRONMENT_ROUTES[provider as Providers] ?? []) {
+  for (const route of PROVIDER_ENVIRONMENT_ROUTES[provider as Providers] ??
+    []) {
     let overridden = false;
     for (const path of route.optionPaths) {
       const defined = hasDefinedOptionPath(options, path);
@@ -568,12 +574,15 @@ interface SourceLineage {
 
 function appendUniqueSourceIds(
   target: string[],
-  sourceIds: readonly string[]
+  sourceIds: readonly string[],
+  seen: Set<string>
 ): void {
   for (const sourceId of sourceIds) {
-    if (target[target.length - 1] !== sourceId) {
-      target.push(sourceId);
+    if (seen.has(sourceId)) {
+      continue;
     }
+    seen.add(sourceId);
+    target.push(sourceId);
   }
 }
 
@@ -582,6 +591,7 @@ function inspectSourceLineage(
 ): SourceLineage | undefined {
   const sourceMessageIds: string[] = [];
   const messageSourceCounts: number[] = [];
+  const seenSourceMessageIds = new Set<string>();
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
@@ -601,7 +611,7 @@ function inspectSourceLineage(
       messageSourceCounts.push(sourceMessageIds.length);
       continue;
     }
-    appendUniqueSourceIds(sourceMessageIds, ids);
+    appendUniqueSourceIds(sourceMessageIds, ids, seenSourceMessageIds);
     messageSourceCounts.push(sourceMessageIds.length);
   }
 
@@ -681,10 +691,7 @@ export function inspectCompactionReplayEligibility(
       requestSourceCount
     );
   }
-  if (
-    candidate.modelId != null &&
-    recipe.modelId !== candidate.modelId
-  ) {
+  if (candidate.modelId != null && recipe.modelId !== candidate.modelId) {
     return ineligible('model_mismatch', replaySourceCount, requestSourceCount);
   }
   if (!recipe.cacheNamespace.complete || !candidate.cacheNamespace.complete) {
@@ -719,8 +726,7 @@ export function inspectCompactionReplayEligibility(
     );
   }
   if (
-    recipe.systemProjectionFingerprint !==
-    candidate.systemProjectionFingerprint
+    recipe.systemProjectionFingerprint !== candidate.systemProjectionFingerprint
   ) {
     return ineligible(
       'system_projection_changed',

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -5,6 +5,7 @@ import {
   inspectProviderMessageProvenance,
   inspectProviderSourceMessageIds,
 } from '@/messages/provenance';
+import { isAnthropicBuiltInTool } from '@/messages/anthropicToolCache';
 import { toJsonSchema } from '@/utils/schema';
 import { Providers } from '@/common';
 
@@ -242,6 +243,10 @@ const PROVIDER_ENVIRONMENT_ROUTES: Partial<
       optionPaths: [['region'], ['region_name']],
     },
     {
+      environmentKey: 'AWS_REGION',
+      optionPaths: [['region'], ['region_name']],
+    },
+    {
       environmentKey: 'AWS_DEFAULT_REGION',
       optionPaths: [['region'], ['region_name']],
     },
@@ -260,17 +265,6 @@ const PROVIDER_ENVIRONMENT_ROUTES: Partial<
     {
       environmentKey: 'OPENAI_BASE_URL',
       optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
-    },
-  ],
-  [Providers.XAI]: [
-    {
-      environmentKey: 'OPENAI_BASE_URL',
-      optionPaths: [
-        ['baseURL'],
-        ['baseUrl'],
-        ['configuration', 'baseURL'],
-        ['clientConfig', 'baseURL'],
-      ],
     },
   ],
   [Providers.MOONSHOT]: [
@@ -311,7 +305,7 @@ function hasDefinedOptionPath(
       }
       current = (current as Record<string, unknown>)[key];
     }
-    return current !== undefined;
+    return current != null;
   } catch {
     return undefined;
   }
@@ -414,6 +408,11 @@ function projectToolForFingerprint(tool: unknown): object | undefined {
       return undefined;
     }
     const candidate = tool as Record<string, unknown>;
+    if (isAnthropicBuiltInTool(candidate)) {
+      const providerDefinition = { ...candidate };
+      delete providerDefinition.extras;
+      return providerDefinition;
+    }
     const projection: Record<string, unknown> = {};
     const name =
       typeof candidate.name === 'string' ? candidate.name : undefined;

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -391,6 +391,7 @@ function projectToolForFingerprint(tool: unknown): object | undefined {
       'parameters',
       'function',
       'toolSpec',
+      'strict',
       'cache_control',
       'cachePoint',
       'defer_loading',
@@ -404,6 +405,9 @@ function projectToolForFingerprint(tool: unknown): object | undefined {
     const extras = candidate.extras as Record<string, unknown> | undefined;
     if (extras?.cache_control !== undefined) {
       projection.extrasCacheControl = extras.cache_control;
+    }
+    if (extras?.strict !== undefined) {
+      projection.extrasStrict = extras.strict;
     }
     if (extras?.providerToolDefinition !== undefined) {
       projection.providerToolDefinition = extras.providerToolDefinition;

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -20,7 +20,8 @@ export interface CompactionReplayRecipe {
   readonly toolProjectionFingerprint?: string;
   readonly systemRevision: number;
   readonly toolRevision: number;
-  readonly messages: readonly BaseMessage[];
+  readonly messageFingerprints?: readonly string[];
+  readonly sourceLineage?: SourceLineage;
   readonly sourceMessageFingerprints?: readonly string[];
 }
 
@@ -176,6 +177,14 @@ const PROVIDER_ENVIRONMENT_ROUTES: Partial<
     {
       environmentKey: 'OPENAI_BASE_URL',
       optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
+    {
+      environmentKey: 'OPENAI_ORG_ID',
+      optionPaths: [['organization']],
+    },
+    {
+      environmentKey: 'OPENAI_PROJECT_ID',
+      optionPaths: [['project']],
     },
   ],
   [Providers.AZURE]: [
@@ -658,10 +667,10 @@ function inspectSourceLineage(
     messageSourceCounts.push(sourceMessageIds.length);
   }
 
-  return {
+  return Object.freeze({
     sourceMessageIds: Object.freeze(sourceMessageIds),
     messageSourceCounts: Object.freeze(messageSourceCounts),
-  };
+  });
 }
 
 export function createCompactionReplayRecipe(params: {
@@ -687,7 +696,8 @@ export function createCompactionReplayRecipe(params: {
     toolProjectionFingerprint: params.toolProjectionFingerprint,
     systemRevision: params.systemRevision,
     toolRevision: params.toolRevision,
-    messages: params.messages,
+    messageFingerprints: fingerprintMessages(params.messages),
+    sourceLineage: inspectSourceLineage(params.messages),
     sourceMessageFingerprints: fingerprintMessages(params.sourceMessages),
   });
 }
@@ -727,7 +737,7 @@ export function inspectCompactionReplayEligibility(
     return ineligible('fallback_served_request', replaySourceCount, 0);
   }
   const recipe = state;
-  const requestLineage = inspectSourceLineage(recipe.messages);
+  const requestLineage = recipe.sourceLineage;
   const requestSourceCount = requestLineage?.sourceMessageIds.length ?? 0;
   if (recipe.provider !== candidate.provider) {
     return ineligible(
@@ -938,7 +948,7 @@ export function inspectCompactionReplayEligibility(
       );
     }
     for (let i = 0; i < replayMessageCount; i++) {
-      const requestFingerprint = fingerprintMessage(recipe.messages[i]);
+      const requestFingerprint = recipe.messageFingerprints?.[i];
       const candidateFingerprint = fingerprintMessage(
         candidate.projectedMessages[i]
       );

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -75,6 +75,15 @@ export interface CompactionReplayRouteSnapshot {
   readonly promptCacheEnabled: boolean;
 }
 
+export interface CompactionReplayCandidateSnapshot {
+  readonly sourceMessageCount: number;
+  readonly sourceMessageFingerprints?: readonly string[];
+  readonly projection: 'unknown' | 'source' | 'projected';
+  readonly lineage?: SourceLineage;
+  readonly projectedMessageCount?: number;
+  readonly projectedMessageFingerprints?: readonly string[];
+}
+
 interface CompactionReplayCandidate {
   readonly provider: t.ProviderName;
   readonly modelId?: string;
@@ -87,6 +96,7 @@ interface CompactionReplayCandidate {
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
   readonly projectedMessages?: readonly BaseMessage[] | null;
+  readonly snapshot?: CompactionReplayCandidateSnapshot;
   readonly restoredToolSubstitution: boolean;
   readonly summarizerFallbackServed?: boolean;
 }
@@ -702,6 +712,37 @@ export function createCompactionReplayRecipe(params: {
   });
 }
 
+export function createCompactionReplayCandidateSnapshot(
+  messages: readonly BaseMessage[],
+  projectedMessages?: readonly BaseMessage[] | null
+): CompactionReplayCandidateSnapshot {
+  const sourceMessageFingerprints = fingerprintMessages(messages);
+  if (projectedMessages === null) {
+    return Object.freeze({
+      sourceMessageCount: messages.length,
+      sourceMessageFingerprints,
+      projection: 'unknown',
+      lineage: inspectSourceLineage(messages),
+    });
+  }
+  if (projectedMessages === undefined) {
+    return Object.freeze({
+      sourceMessageCount: messages.length,
+      sourceMessageFingerprints,
+      projection: 'source',
+      lineage: inspectSourceLineage(messages),
+    });
+  }
+  return Object.freeze({
+    sourceMessageCount: messages.length,
+    sourceMessageFingerprints,
+    projection: 'projected',
+    lineage: inspectSourceLineage(projectedMessages),
+    projectedMessageCount: projectedMessages.length,
+    projectedMessageFingerprints: fingerprintMessages(projectedMessages),
+  });
+}
+
 function ineligible(
   reason: CompactionReplayIneligibilityReason,
   replaySourceCount: number,
@@ -719,9 +760,12 @@ export function inspectCompactionReplayEligibility(
   state: CompactionReplayState | undefined,
   candidate: CompactionReplayCandidate
 ): CompactionReplayEligibility {
-  const candidateLineage = inspectSourceLineage(
-    candidate.projectedMessages ?? candidate.messages
-  );
+  const candidateLineage =
+    candidate.snapshot != null
+      ? candidate.snapshot.lineage
+      : inspectSourceLineage(
+        candidate.projectedMessages ?? candidate.messages
+      );
   const replaySourceCount = candidateLineage?.sourceMessageIds.length ?? 0;
   if (candidate.summarizerFallbackServed === true) {
     return ineligible(
@@ -839,7 +883,10 @@ export function inspectCompactionReplayEligibility(
       requestSourceCount
     );
   }
-  if (candidate.projectedMessages === null) {
+  if (
+    candidate.snapshot?.projection === 'unknown' ||
+    (candidate.snapshot == null && candidate.projectedMessages === null)
+  ) {
     return ineligible(
       'provider_projection_unknown',
       replaySourceCount,
@@ -886,15 +933,20 @@ export function inspectCompactionReplayEligibility(
       requestSourceCount
     );
   }
-  if (candidate.messages.length > recipe.sourceMessageFingerprints.length) {
+  const candidateSourceMessageCount =
+    candidate.snapshot?.sourceMessageCount ?? candidate.messages.length;
+  if (candidateSourceMessageCount > recipe.sourceMessageFingerprints.length) {
     return ineligible(
       'source_content_mismatch',
       replaySourceCount,
       requestSourceCount
     );
   }
-  for (let i = 0; i < candidate.messages.length; i++) {
-    const fingerprint = fingerprintMessage(candidate.messages[i]);
+  for (let i = 0; i < candidateSourceMessageCount; i++) {
+    const fingerprint =
+      candidate.snapshot != null
+        ? candidate.snapshot.sourceMessageFingerprints?.[i]
+        : fingerprintMessage(candidate.messages[i]);
     if (fingerprint == null) {
       return ineligible(
         'source_content_unknown',
@@ -939,8 +991,18 @@ export function inspectCompactionReplayEligibility(
     );
   }
 
-  if (candidate.projectedMessages != null) {
-    if (candidate.projectedMessages.length !== replayMessageCount) {
+  const projectedSnapshot =
+    candidate.snapshot?.projection === 'projected'
+      ? candidate.snapshot
+      : undefined;
+  const candidateProjectedMessages =
+    candidate.snapshot == null ? candidate.projectedMessages : undefined;
+  if (projectedSnapshot != null || candidateProjectedMessages != null) {
+    const projectedMessageCount =
+      projectedSnapshot != null
+        ? projectedSnapshot.projectedMessageCount
+        : candidateProjectedMessages?.length;
+    if (projectedMessageCount !== replayMessageCount) {
       return ineligible(
         'provider_projection_changed',
         replaySourceCount,
@@ -949,9 +1011,15 @@ export function inspectCompactionReplayEligibility(
     }
     for (let i = 0; i < replayMessageCount; i++) {
       const requestFingerprint = recipe.messageFingerprints?.[i];
-      const candidateFingerprint = fingerprintMessage(
-        candidate.projectedMessages[i]
-      );
+      let candidateFingerprint: string | undefined;
+      if (projectedSnapshot != null) {
+        candidateFingerprint =
+          projectedSnapshot.projectedMessageFingerprints?.[i];
+      } else if (candidateProjectedMessages != null) {
+        candidateFingerprint = fingerprintMessage(
+          candidateProjectedMessages[i]
+        );
+      }
       if (requestFingerprint == null || candidateFingerprint == null) {
         return ineligible(
           'provider_projection_unknown',

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -2,6 +2,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { ProviderMessageProjectionMode } from '@/llm/prepareProviderRequest';
 import type * as t from '@/types';
 import { inspectProviderSourceMessageIds } from '@/messages/provenance';
+import { toJsonSchema } from '@/utils/schema';
 import { Providers } from '@/common';
 
 type CacheNamespaceValue = string;
@@ -11,6 +12,8 @@ export interface CompactionReplayRecipe {
   readonly modelId?: string;
   readonly projectionMode: ProviderMessageProjectionMode;
   readonly cacheNamespace: CompactionCacheNamespace;
+  readonly promptCacheEnabled: boolean;
+  readonly toolProjectionFingerprint?: string;
   readonly systemRevision: number;
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
@@ -27,8 +30,10 @@ export type CompactionReplayIneligibilityReason =
   | 'model_mismatch'
   | 'cache_namespace_unknown'
   | 'cache_namespace_mismatch'
+  | 'prompt_cache_disabled'
   | 'system_projection_changed'
   | 'tool_projection_changed'
+  | 'tool_projection_unknown'
   | 'projection_mode_mismatch'
   | 'restored_tool_substitution'
   | 'source_content_unknown'
@@ -62,6 +67,8 @@ interface CompactionReplayCandidate {
   readonly modelId?: string;
   readonly projectionMode?: ProviderMessageProjectionMode;
   readonly cacheNamespace: CompactionCacheNamespace;
+  readonly promptCacheEnabled: boolean;
+  readonly toolProjectionFingerprint?: string;
   readonly systemRevision: number;
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
@@ -89,6 +96,7 @@ const CACHE_NAMESPACE_KEYS = [
   'azureOpenAIBasePath',
   'openAIApiKey',
   'openAIBasePath',
+  'openAIApiVersion',
   'googleApiKey',
   'location',
   'credentials',
@@ -192,6 +200,91 @@ function fingerprintCacheNamespaceValue(value: unknown): string | undefined {
       : fingerprintSerializedValue(serialized);
   } catch {
     return undefined;
+  }
+}
+
+function projectToolForFingerprint(tool: unknown): object | undefined {
+  try {
+    if (tool == null || typeof tool !== 'object') {
+      return undefined;
+    }
+    const candidate = tool as Record<string, unknown>;
+    const projection: Record<string, unknown> = {};
+    const name =
+      typeof candidate.name === 'string' ? candidate.name : undefined;
+    const description =
+      typeof candidate.description === 'string'
+        ? candidate.description
+        : undefined;
+    if (name != null) {
+      projection.name = name;
+    }
+    if (description != null) {
+      projection.description = description;
+    }
+    if (candidate.schema != null) {
+      projection.schema = toJsonSchema(candidate.schema, name, description);
+    }
+    for (const key of [
+      'type',
+      'input_schema',
+      'parameters',
+      'function',
+      'toolSpec',
+      'cache_control',
+      'cachePoint',
+      'defer_loading',
+      '__lc_bedrock_cache_point_after',
+      '__lc_bedrock_skip_tool_cache',
+    ] as const) {
+      if (candidate[key] !== undefined) {
+        projection[key] = candidate[key];
+      }
+    }
+    const extras = candidate.extras as Record<string, unknown> | undefined;
+    if (extras?.cache_control !== undefined) {
+      projection.extrasCacheControl = extras.cache_control;
+    }
+    if (extras?.providerToolDefinition !== undefined) {
+      projection.providerToolDefinition = extras.providerToolDefinition;
+    }
+    return Object.keys(projection).length === 0 ? undefined : projection;
+  } catch {
+    return undefined;
+  }
+}
+
+export function createCompactionToolProjectionFingerprint(
+  tools: readonly unknown[] | undefined
+): string | undefined {
+  const projections: object[] = [];
+  for (const tool of tools ?? []) {
+    const projection = projectToolForFingerprint(tool);
+    if (projection == null) {
+      return undefined;
+    }
+    projections.push(projection);
+  }
+  return fingerprintCacheNamespaceValue(projections);
+}
+
+export function isCompactionPromptCacheEnabled(
+  provider: t.ProviderName,
+  options?: t.ClientOptions | Record<string, unknown>
+): boolean {
+  if (
+    provider !== Providers.ANTHROPIC &&
+    provider !== Providers.BEDROCK &&
+    provider !== Providers.OPENROUTER
+  ) {
+    return true;
+  }
+  try {
+    return (
+      (options as Record<string, unknown> | undefined)?.promptCache === true
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -339,6 +432,8 @@ export function createCompactionReplayRecipe(params: {
   modelId?: string;
   projectionMode: ProviderMessageProjectionMode;
   cacheNamespace: CompactionCacheNamespace;
+  promptCacheEnabled: boolean;
+  toolProjectionFingerprint?: string;
   systemRevision: number;
   toolRevision: number;
   messages: readonly BaseMessage[];
@@ -349,6 +444,8 @@ export function createCompactionReplayRecipe(params: {
     modelId: params.modelId,
     projectionMode: params.projectionMode,
     cacheNamespace: params.cacheNamespace,
+    promptCacheEnabled: params.promptCacheEnabled,
+    toolProjectionFingerprint: params.toolProjectionFingerprint,
     systemRevision: params.systemRevision,
     toolRevision: params.toolRevision,
     messages: params.messages,
@@ -414,6 +511,32 @@ export function inspectCompactionReplayEligibility(
   if (!cacheNamespacesEqual(recipe.cacheNamespace, candidate.cacheNamespace)) {
     return ineligible(
       'cache_namespace_mismatch',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (!recipe.promptCacheEnabled || !candidate.promptCacheEnabled) {
+    return ineligible(
+      'prompt_cache_disabled',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    recipe.toolProjectionFingerprint == null ||
+    candidate.toolProjectionFingerprint == null
+  ) {
+    return ineligible(
+      'tool_projection_unknown',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    recipe.toolProjectionFingerprint !== candidate.toolProjectionFingerprint
+  ) {
+    return ineligible(
+      'tool_projection_changed',
       replaySourceCount,
       requestSourceCount
     );

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -6,11 +6,6 @@ import { Providers } from '@/common';
 
 type CacheNamespaceValue = string | number | boolean | object | null;
 
-export interface CompactionProjectionRevisions {
-  readonly systemRevision: number;
-  readonly toolRevision: number;
-}
-
 export interface CompactionReplayRecipe {
   readonly provider: t.ProviderName;
   readonly modelId?: string;
@@ -27,6 +22,7 @@ export type CompactionReplayState = CompactionReplayRecipe | 'fallback';
 export type CompactionReplayIneligibilityReason =
   | 'no_request_snapshot'
   | 'fallback_served_request'
+  | 'summarizer_fallback_served_request'
   | 'provider_mismatch'
   | 'model_mismatch'
   | 'cache_namespace_unknown'
@@ -70,6 +66,7 @@ interface CompactionReplayCandidate {
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
   readonly restoredToolSubstitution: boolean;
+  readonly summarizerFallbackServed?: boolean;
 }
 
 const CACHE_NAMESPACE_KEYS = [
@@ -294,6 +291,13 @@ export function inspectCompactionReplayEligibility(
 ): CompactionReplayEligibility {
   const candidateLineage = inspectSourceLineage(candidate.messages);
   const replaySourceCount = candidateLineage?.sourceMessageIds.length ?? 0;
+  if (candidate.summarizerFallbackServed === true) {
+    return ineligible(
+      'summarizer_fallback_served_request',
+      replaySourceCount,
+      0
+    );
+  }
   if (state == null) {
     return ineligible('no_request_snapshot', replaySourceCount, 0);
   }

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -135,8 +135,11 @@ const CACHE_NAMESPACE_KEYS = [
   'promptCache',
   'promptCacheExplicit',
   'promptCacheTtl',
+  'responsesPromptCache',
+  'responsesPromptCacheTtl',
   'customHeaders',
   'defaultHeaders',
+  'clientConfig',
   'configuration',
   'useResponsesApi',
   'thinking',
@@ -262,7 +265,12 @@ const PROVIDER_ENVIRONMENT_ROUTES: Partial<
   [Providers.XAI]: [
     {
       environmentKey: 'OPENAI_BASE_URL',
-      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+      optionPaths: [
+        ['baseURL'],
+        ['baseUrl'],
+        ['configuration', 'baseURL'],
+        ['clientConfig', 'baseURL'],
+      ],
     },
   ],
   [Providers.MOONSHOT]: [

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -1,0 +1,394 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ProviderMessageProjectionMode } from '@/llm/prepareProviderRequest';
+import type * as t from '@/types';
+import { inspectProviderSourceMessageIds } from '@/messages/provenance';
+import { Providers } from '@/common';
+
+type CacheNamespaceValue = string | number | boolean | object | null;
+
+export interface CompactionProjectionRevisions {
+  readonly systemRevision: number;
+  readonly toolRevision: number;
+}
+
+export interface CompactionReplayRecipe {
+  readonly provider: t.ProviderName;
+  readonly modelId?: string;
+  readonly projectionMode: ProviderMessageProjectionMode;
+  readonly cacheNamespace: CompactionCacheNamespace;
+  readonly systemRevision: number;
+  readonly toolRevision: number;
+  readonly messages: readonly BaseMessage[];
+}
+
+export type CompactionReplayState = CompactionReplayRecipe | 'fallback';
+
+export type CompactionReplayIneligibilityReason =
+  | 'no_request_snapshot'
+  | 'fallback_served_request'
+  | 'provider_mismatch'
+  | 'model_mismatch'
+  | 'cache_namespace_unknown'
+  | 'cache_namespace_mismatch'
+  | 'system_projection_changed'
+  | 'tool_projection_changed'
+  | 'projection_mode_mismatch'
+  | 'restored_tool_substitution'
+  | 'ambiguous_lineage'
+  | 'source_not_prefix';
+
+export type CompactionReplayEligibility =
+  | {
+      readonly eligible: true;
+      readonly replayMessageCount: number;
+      readonly replaySourceCount: number;
+      readonly requestSourceCount: number;
+    }
+  | {
+      readonly eligible: false;
+      readonly reason: CompactionReplayIneligibilityReason;
+      readonly replaySourceCount: number;
+      readonly requestSourceCount: number;
+    };
+
+export interface CompactionCacheNamespace {
+  readonly complete: boolean;
+  readonly entries: ReadonlyArray<
+    readonly [key: string, value: CacheNamespaceValue]
+  >;
+}
+
+interface CompactionReplayCandidate {
+  readonly provider: t.ProviderName;
+  readonly modelId?: string;
+  readonly projectionMode?: ProviderMessageProjectionMode;
+  readonly cacheNamespace: CompactionCacheNamespace;
+  readonly systemRevision: number;
+  readonly toolRevision: number;
+  readonly messages: readonly BaseMessage[];
+  readonly restoredToolSubstitution: boolean;
+}
+
+const CACHE_NAMESPACE_KEYS = [
+  'apiKey',
+  'baseURL',
+  'baseUrl',
+  'organization',
+  'project',
+  'region',
+  'region_name',
+  'endpoint',
+  'deploymentName',
+  'azureOpenAIApiDeploymentName',
+  'azureOpenAIApiInstanceName',
+  'azureOpenAIApiVersion',
+  'azureOpenAIApiKey',
+  'azureOpenAIBasePath',
+  'googleApiKey',
+  'location',
+  'credentials',
+  'awsAccessKeyId',
+  'awsSecretAccessKey',
+  'awsSessionToken',
+  'authOptions',
+  'profile',
+  'promptCache',
+  'promptCacheTtl',
+  'customHeaders',
+  'defaultHeaders',
+  'configuration',
+  'useResponsesApi',
+] as const;
+
+const BUILT_IN_PROVIDER_NAMES = new Set<string>(Object.values(Providers));
+
+function isCacheNamespaceValue(value: unknown): value is CacheNamespaceValue {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null ||
+    typeof value === 'object'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Captures only routing identity; values are never emitted in diagnostics. */
+export function createCompactionCacheNamespace(
+  provider: t.ProviderName,
+  options?: t.ClientOptions | Record<string, unknown>
+): CompactionCacheNamespace {
+  const entries: Array<readonly [string, CacheNamespaceValue]> = [];
+  let complete = BUILT_IN_PROVIDER_NAMES.has(provider);
+  for (const key of CACHE_NAMESPACE_KEYS) {
+    const value = (options as Record<string, unknown> | undefined)?.[key];
+    if (value === undefined) {
+      continue;
+    }
+    if (!isCacheNamespaceValue(value)) {
+      complete = false;
+      continue;
+    }
+    entries.push(Object.freeze([key, value] as const));
+  }
+  return Object.freeze({
+    complete,
+    entries: Object.freeze(entries),
+  });
+}
+
+function cacheNamespacesEqual(
+  left: CompactionCacheNamespace,
+  right: CompactionCacheNamespace
+): boolean {
+  if (left.entries.length !== right.entries.length) {
+    return false;
+  }
+  for (let i = 0; i < left.entries.length; i++) {
+    const [leftKey, leftValue] = left.entries[i];
+    const [rightKey, rightValue] = right.entries[i];
+    if (leftKey !== rightKey || !Object.is(leftValue, rightValue)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isSyntheticMessage(message: BaseMessage): boolean {
+  if (message.getType() === 'system') {
+    return true;
+  }
+  const kwargs = message.additional_kwargs;
+  if (kwargs.injected === true || kwargs.isMeta === true) {
+    return true;
+  }
+  return kwargs.source != null && kwargs.source !== 'steer';
+}
+
+interface SourceLineage {
+  readonly sourceMessageIds: readonly string[];
+  readonly messageSourceCounts: readonly number[];
+}
+
+function appendUniqueSourceIds(
+  target: string[],
+  sourceIds: readonly string[]
+): void {
+  for (const sourceId of sourceIds) {
+    if (target[target.length - 1] !== sourceId) {
+      target.push(sourceId);
+    }
+  }
+}
+
+function inspectSourceLineage(
+  messages: readonly BaseMessage[]
+): SourceLineage | undefined {
+  const sourceMessageIds: string[] = [];
+  const messageSourceCounts: number[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const inspected = inspectProviderSourceMessageIds(message);
+    if (inspected.status === 'invalid') {
+      return undefined;
+    }
+    let ids = inspected.status === 'valid' ? inspected.sourceMessageIds : [];
+    if (ids.length === 0 && !isSyntheticMessage(message)) {
+      const fallbackId = message.id?.trim();
+      if (fallbackId == null || fallbackId === '') {
+        return undefined;
+      }
+      ids = [fallbackId];
+    }
+    if (ids.length === 0) {
+      messageSourceCounts.push(sourceMessageIds.length);
+      continue;
+    }
+    appendUniqueSourceIds(sourceMessageIds, ids);
+    messageSourceCounts.push(sourceMessageIds.length);
+  }
+
+  return {
+    sourceMessageIds: Object.freeze(sourceMessageIds),
+    messageSourceCounts: Object.freeze(messageSourceCounts),
+  };
+}
+
+export function createCompactionReplayRecipe(params: {
+  provider: t.ProviderName;
+  modelId?: string;
+  projectionMode: ProviderMessageProjectionMode;
+  cacheNamespace: CompactionCacheNamespace;
+  systemRevision: number;
+  toolRevision: number;
+  messages: readonly BaseMessage[];
+}): CompactionReplayRecipe {
+  return Object.freeze({
+    provider: params.provider,
+    modelId: params.modelId,
+    projectionMode: params.projectionMode,
+    cacheNamespace: params.cacheNamespace,
+    systemRevision: params.systemRevision,
+    toolRevision: params.toolRevision,
+    messages: params.messages,
+  });
+}
+
+function ineligible(
+  reason: CompactionReplayIneligibilityReason,
+  replaySourceCount: number,
+  requestSourceCount: number
+): CompactionReplayEligibility {
+  return {
+    eligible: false,
+    reason,
+    replaySourceCount,
+    requestSourceCount,
+  };
+}
+
+export function inspectCompactionReplayEligibility(
+  state: CompactionReplayState | undefined,
+  candidate: CompactionReplayCandidate
+): CompactionReplayEligibility {
+  const candidateLineage = inspectSourceLineage(candidate.messages);
+  const replaySourceCount = candidateLineage?.sourceMessageIds.length ?? 0;
+  if (state == null) {
+    return ineligible('no_request_snapshot', replaySourceCount, 0);
+  }
+  if (state === 'fallback') {
+    return ineligible('fallback_served_request', replaySourceCount, 0);
+  }
+  const recipe = state;
+  const requestLineage = inspectSourceLineage(recipe.messages);
+  const requestSourceCount = requestLineage?.sourceMessageIds.length ?? 0;
+  if (recipe.provider !== candidate.provider) {
+    return ineligible(
+      'provider_mismatch',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    candidate.modelId != null &&
+    recipe.modelId !== candidate.modelId
+  ) {
+    return ineligible('model_mismatch', replaySourceCount, requestSourceCount);
+  }
+  if (!recipe.cacheNamespace.complete || !candidate.cacheNamespace.complete) {
+    return ineligible(
+      'cache_namespace_unknown',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (!cacheNamespacesEqual(recipe.cacheNamespace, candidate.cacheNamespace)) {
+    return ineligible(
+      'cache_namespace_mismatch',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (recipe.toolRevision !== candidate.toolRevision) {
+    return ineligible(
+      'tool_projection_changed',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (recipe.systemRevision !== candidate.systemRevision) {
+    return ineligible(
+      'system_projection_changed',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    candidate.projectionMode != null &&
+    recipe.projectionMode !== candidate.projectionMode
+  ) {
+    return ineligible(
+      'projection_mode_mismatch',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (candidate.restoredToolSubstitution) {
+    return ineligible(
+      'restored_tool_substitution',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (candidateLineage == null || replaySourceCount === 0) {
+    return ineligible(
+      'ambiguous_lineage',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (requestLineage == null || requestSourceCount === 0) {
+    return ineligible(
+      'ambiguous_lineage',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (replaySourceCount > requestSourceCount) {
+    return ineligible(
+      'source_not_prefix',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  for (let i = 0; i < replaySourceCount; i++) {
+    if (
+      candidateLineage.sourceMessageIds[i] !==
+      requestLineage.sourceMessageIds[i]
+    ) {
+      return ineligible(
+        'source_not_prefix',
+        replaySourceCount,
+        requestSourceCount
+      );
+    }
+  }
+
+  let replayMessageCount = 0;
+  let reachedCandidateEnd = false;
+  for (let i = 0; i < requestLineage.messageSourceCounts.length; i++) {
+    const sourceCount = requestLineage.messageSourceCounts[i];
+    if (sourceCount > replaySourceCount) {
+      if (!reachedCandidateEnd) {
+        return ineligible(
+          'ambiguous_lineage',
+          replaySourceCount,
+          requestSourceCount
+        );
+      }
+      break;
+    }
+    replayMessageCount = i + 1;
+    if (sourceCount < replaySourceCount) {
+      continue;
+    }
+    reachedCandidateEnd = true;
+  }
+  if (!reachedCandidateEnd) {
+    return ineligible(
+      'ambiguous_lineage',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+
+  return {
+    eligible: true,
+    replayMessageCount,
+    replaySourceCount,
+    requestSourceCount,
+  };
+}

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -13,6 +13,7 @@ export interface CompactionReplayRecipe {
   readonly projectionMode: ProviderMessageProjectionMode;
   readonly cacheNamespace: CompactionCacheNamespace;
   readonly promptCacheEnabled: boolean;
+  readonly systemProjectionFingerprint?: string;
   readonly toolProjectionFingerprint?: string;
   readonly systemRevision: number;
   readonly toolRevision: number;
@@ -32,6 +33,7 @@ export type CompactionReplayIneligibilityReason =
   | 'cache_namespace_mismatch'
   | 'prompt_cache_disabled'
   | 'system_projection_changed'
+  | 'system_projection_unknown'
   | 'tool_projection_changed'
   | 'tool_projection_unknown'
   | 'projection_mode_mismatch'
@@ -68,6 +70,7 @@ interface CompactionReplayCandidate {
   readonly projectionMode?: ProviderMessageProjectionMode;
   readonly cacheNamespace: CompactionCacheNamespace;
   readonly promptCacheEnabled: boolean;
+  readonly systemProjectionFingerprint?: string;
   readonly toolProjectionFingerprint?: string;
   readonly systemRevision: number;
   readonly toolRevision: number;
@@ -97,6 +100,8 @@ const CACHE_NAMESPACE_KEYS = [
   'openAIApiKey',
   'openAIBasePath',
   'openAIApiVersion',
+  'apiVersion',
+  'azureOpenAIEndpoint',
   'googleApiKey',
   'location',
   'credentials',
@@ -114,6 +119,7 @@ const CACHE_NAMESPACE_KEYS = [
   'thinking',
   'thinkingBudget',
   'additionalModelRequestFields',
+  'modelKwargs',
   'azureADTokenProvider',
 ] as const;
 
@@ -145,20 +151,76 @@ const PROVIDER_CREDENTIAL_KEYS: Partial<
   [Providers.MOONSHOT]: ['apiKey', 'openAIApiKey'],
 };
 
-const PROVIDER_ENVIRONMENT_ROUTE_KEYS: Partial<
-  Record<Providers, readonly string[]>
+interface EnvironmentRouteIdentity {
+  readonly environmentKey: string;
+  readonly optionPaths: readonly (readonly string[])[];
+}
+
+const PROVIDER_ENVIRONMENT_ROUTES: Partial<
+  Record<Providers, readonly EnvironmentRouteIdentity[]>
 > = {
-  [Providers.OPENAI]: ['OPENAI_BASE_URL'],
-  [Providers.AZURE]: [
-    'OPENAI_BASE_URL',
-    'AZURE_OPENAI_ENDPOINT',
-    'AZURE_OPENAI_BASE_PATH',
+  [Providers.OPENAI]: [
+    {
+      environmentKey: 'OPENAI_BASE_URL',
+      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
   ],
-  [Providers.BEDROCK]: ['BEDROCK_AWS_REGION', 'AWS_DEFAULT_REGION'],
-  [Providers.VERTEXAI]: ['GOOGLE_CLOUD_PROJECT', 'GCLOUD_PROJECT'],
-  [Providers.DEEPSEEK]: ['OPENAI_BASE_URL'],
-  [Providers.XAI]: ['OPENAI_BASE_URL'],
-  [Providers.MOONSHOT]: ['OPENAI_BASE_URL'],
+  [Providers.AZURE]: [
+    {
+      environmentKey: 'OPENAI_BASE_URL',
+      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
+    {
+      environmentKey: 'AZURE_OPENAI_ENDPOINT',
+      optionPaths: [['azureOpenAIEndpoint'], ['endpoint']],
+    },
+    {
+      environmentKey: 'AZURE_OPENAI_BASE_PATH',
+      optionPaths: [
+        ['azureOpenAIBasePath'],
+        ['openAIBasePath'],
+        ['configuration', 'baseURL'],
+      ],
+    },
+  ],
+  [Providers.BEDROCK]: [
+    {
+      environmentKey: 'BEDROCK_AWS_REGION',
+      optionPaths: [['region'], ['region_name']],
+    },
+    {
+      environmentKey: 'AWS_DEFAULT_REGION',
+      optionPaths: [['region'], ['region_name']],
+    },
+  ],
+  [Providers.VERTEXAI]: [
+    {
+      environmentKey: 'GOOGLE_CLOUD_PROJECT',
+      optionPaths: [['projectId'], ['project']],
+    },
+    {
+      environmentKey: 'GCLOUD_PROJECT',
+      optionPaths: [['projectId'], ['project']],
+    },
+  ],
+  [Providers.DEEPSEEK]: [
+    {
+      environmentKey: 'OPENAI_BASE_URL',
+      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
+  ],
+  [Providers.XAI]: [
+    {
+      environmentKey: 'OPENAI_BASE_URL',
+      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
+  ],
+  [Providers.MOONSHOT]: [
+    {
+      environmentKey: 'OPENAI_BASE_URL',
+      optionPaths: [['baseURL'], ['baseUrl'], ['configuration', 'baseURL']],
+    },
+  ],
 };
 
 function hasExplicitCredentialIdentity(
@@ -176,6 +238,24 @@ function hasExplicitCredentialIdentity(
     );
   } catch {
     return false;
+  }
+}
+
+function hasDefinedOptionPath(
+  options: t.ClientOptions | Record<string, unknown> | undefined,
+  path: readonly string[]
+): boolean | undefined {
+  try {
+    let current: unknown = options;
+    for (const key of path) {
+      if (current == null || typeof current !== 'object') {
+        return false;
+      }
+      current = (current as Record<string, unknown>)[key];
+    }
+    return current !== undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -255,6 +335,9 @@ function fingerprintSerializedValue(serialized: string): string {
   }
   return `${serialized.length}:${hashA >>> 0}:${hashB >>> 0}`;
 }
+
+export const EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT =
+  fingerprintSerializedValue('system:empty');
 
 function fingerprintCacheNamespaceValue(value: unknown): string | undefined {
   try {
@@ -384,11 +467,27 @@ export function createCompactionCacheNamespace(
     }
     entries.push(Object.freeze([key, fingerprint] as const));
   }
-  for (const key of
-    PROVIDER_ENVIRONMENT_ROUTE_KEYS[provider as Providers] ?? []) {
+  for (const route of
+    PROVIDER_ENVIRONMENT_ROUTES[provider as Providers] ?? []) {
+    let overridden = false;
+    for (const path of route.optionPaths) {
+      const defined = hasDefinedOptionPath(options, path);
+      if (defined == null) {
+        complete = false;
+        overridden = true;
+        break;
+      }
+      if (defined) {
+        overridden = true;
+        break;
+      }
+    }
+    if (overridden) {
+      continue;
+    }
     let value: string | undefined;
     try {
-      value = process.env[key];
+      value = process.env[route.environmentKey];
     } catch {
       complete = false;
       continue;
@@ -401,7 +500,9 @@ export function createCompactionCacheNamespace(
       complete = false;
       continue;
     }
-    entries.push(Object.freeze([`env:${key}`, fingerprint] as const));
+    entries.push(
+      Object.freeze([`env:${route.environmentKey}`, fingerprint] as const)
+    );
   }
   return Object.freeze({
     complete,
@@ -516,6 +617,7 @@ export function createCompactionReplayRecipe(params: {
   projectionMode: ProviderMessageProjectionMode;
   cacheNamespace: CompactionCacheNamespace;
   promptCacheEnabled: boolean;
+  systemProjectionFingerprint?: string;
   toolProjectionFingerprint?: string;
   systemRevision: number;
   toolRevision: number;
@@ -528,6 +630,7 @@ export function createCompactionReplayRecipe(params: {
     projectionMode: params.projectionMode,
     cacheNamespace: params.cacheNamespace,
     promptCacheEnabled: params.promptCacheEnabled,
+    systemProjectionFingerprint: params.systemProjectionFingerprint,
     toolProjectionFingerprint: params.toolProjectionFingerprint,
     systemRevision: params.systemRevision,
     toolRevision: params.toolRevision,
@@ -601,6 +704,26 @@ export function inspectCompactionReplayEligibility(
   if (!recipe.promptCacheEnabled || !candidate.promptCacheEnabled) {
     return ineligible(
       'prompt_cache_disabled',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    recipe.systemProjectionFingerprint == null ||
+    candidate.systemProjectionFingerprint == null
+  ) {
+    return ineligible(
+      'system_projection_unknown',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (
+    recipe.systemProjectionFingerprint !==
+    candidate.systemProjectionFingerprint
+  ) {
+    return ineligible(
+      'system_projection_changed',
       replaySourceCount,
       requestSourceCount
     );

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -4,7 +4,7 @@ import type * as t from '@/types';
 import { inspectProviderSourceMessageIds } from '@/messages/provenance';
 import { Providers } from '@/common';
 
-type CacheNamespaceValue = string | number | boolean | object | null;
+type CacheNamespaceValue = string;
 
 export interface CompactionReplayRecipe {
   readonly provider: t.ProviderName;
@@ -86,6 +86,8 @@ const CACHE_NAMESPACE_KEYS = [
   'azureOpenAIApiVersion',
   'azureOpenAIApiKey',
   'azureOpenAIBasePath',
+  'openAIApiKey',
+  'openAIBasePath',
   'googleApiKey',
   'location',
   'credentials',
@@ -104,36 +106,113 @@ const CACHE_NAMESPACE_KEYS = [
 
 const BUILT_IN_PROVIDER_NAMES = new Set<string>(Object.values(Providers));
 
-function isCacheNamespaceValue(value: unknown): value is CacheNamespaceValue {
-  if (
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean' ||
-    value === null ||
-    typeof value === 'object'
-  ) {
-    return true;
+function serializeCacheNamespaceValue(
+  value: unknown,
+  seen: Set<object>
+): string | undefined {
+  if (value === null) {
+    return 'null';
   }
-  return false;
+  if (typeof value === 'string') {
+    return `string:${JSON.stringify(value)}`;
+  }
+  if (typeof value === 'boolean') {
+    return `boolean:${value}`;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+    return `number:${Object.is(value, -0) ? '-0' : value}`;
+  }
+  if (typeof value !== 'object' || seen.has(value)) {
+    return undefined;
+  }
+
+  seen.add(value);
+  const parts: string[] = [];
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const serialized = serializeCacheNamespaceValue(value[i], seen);
+      if (serialized == null) {
+        seen.delete(value);
+        return undefined;
+      }
+      parts.push(serialized);
+    }
+    seen.delete(value);
+    return `array:[${parts.join(',')}]`;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    seen.delete(value);
+    return undefined;
+  }
+  if (Object.getOwnPropertySymbols(value).length > 0) {
+    seen.delete(value);
+    return undefined;
+  }
+  const keys = Object.getOwnPropertyNames(value).sort();
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor == null || !('value' in descriptor)) {
+      seen.delete(value);
+      return undefined;
+    }
+    const serialized = serializeCacheNamespaceValue(descriptor.value, seen);
+    if (serialized == null) {
+      seen.delete(value);
+      return undefined;
+    }
+    parts.push(`${JSON.stringify(key)}:${serialized}`);
+  }
+  seen.delete(value);
+  return `object:{${parts.join(',')}}`;
+}
+
+function fingerprintSerializedValue(serialized: string): string {
+  let hashA = 0x811c9dc5;
+  let hashB = 0x9e3779b9;
+  for (let i = 0; i < serialized.length; i++) {
+    const code = serialized.charCodeAt(i);
+    hashA = Math.imul(hashA ^ code, 0x01000193);
+    hashB = Math.imul(hashB ^ code, 0x5bd1e995);
+    hashB ^= hashB >>> 13;
+  }
+  return `${serialized.length}:${hashA >>> 0}:${hashB >>> 0}`;
+}
+
+function fingerprintCacheNamespaceValue(value: unknown): string | undefined {
+  const serialized = serializeCacheNamespaceValue(value, new Set<object>());
+  return serialized == null ? undefined : fingerprintSerializedValue(serialized);
 }
 
 /** Captures only routing identity; values are never emitted in diagnostics. */
 export function createCompactionCacheNamespace(
   provider: t.ProviderName,
-  options?: t.ClientOptions | Record<string, unknown>
+  options?: t.ClientOptions | Record<string, unknown>,
+  servingRouteKnown = true
 ): CompactionCacheNamespace {
+  if (!BUILT_IN_PROVIDER_NAMES.has(provider) || !servingRouteKnown) {
+    return Object.freeze({
+      complete: false,
+      entries: Object.freeze([]),
+    });
+  }
   const entries: Array<readonly [string, CacheNamespaceValue]> = [];
-  let complete = BUILT_IN_PROVIDER_NAMES.has(provider);
+  let complete = true;
   for (const key of CACHE_NAMESPACE_KEYS) {
     const value = (options as Record<string, unknown> | undefined)?.[key];
     if (value === undefined) {
       continue;
     }
-    if (!isCacheNamespaceValue(value)) {
+    const fingerprint = fingerprintCacheNamespaceValue(value);
+    if (fingerprint == null) {
       complete = false;
       continue;
     }
-    entries.push(Object.freeze([key, value] as const));
+    entries.push(Object.freeze([key, fingerprint] as const));
   }
   return Object.freeze({
     complete,
@@ -172,15 +251,7 @@ function isSyntheticMessage(message: BaseMessage): boolean {
 function fingerprintMessage(message: BaseMessage): string | undefined {
   try {
     const serialized = JSON.stringify(message.toDict());
-    let hashA = 0x811c9dc5;
-    let hashB = 0x9e3779b9;
-    for (let i = 0; i < serialized.length; i++) {
-      const code = serialized.charCodeAt(i);
-      hashA = Math.imul(hashA ^ code, 0x01000193);
-      hashB = Math.imul(hashB ^ code, 0x5bd1e995);
-      hashB ^= hashB >>> 13;
-    }
-    return `${serialized.length}:${hashA >>> 0}:${hashB >>> 0}`;
+    return fingerprintSerializedValue(serialized);
   } catch {
     return undefined;
   }

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -85,7 +85,7 @@ interface CompactionReplayCandidate {
   readonly systemRevision: number;
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
-  readonly projectedMessages?: readonly BaseMessage[];
+  readonly projectedMessages?: readonly BaseMessage[] | null;
   readonly restoredToolSubstitution: boolean;
   readonly summarizerFallbackServed?: boolean;
 }
@@ -821,6 +821,13 @@ export function inspectCompactionReplayEligibility(
   if (candidate.restoredToolSubstitution) {
     return ineligible(
       'restored_tool_substitution',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (candidate.projectedMessages === null) {
+    return ineligible(
+      'provider_projection_unknown',
       replaySourceCount,
       requestSourceCount
     );

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -1,7 +1,10 @@
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ProviderMessageProjectionMode } from '@/llm/prepareProviderRequest';
 import type * as t from '@/types';
-import { inspectProviderSourceMessageIds } from '@/messages/provenance';
+import {
+  inspectProviderMessageProvenance,
+  inspectProviderSourceMessageIds,
+} from '@/messages/provenance';
 import { toJsonSchema } from '@/utils/schema';
 import { Providers } from '@/common';
 
@@ -40,6 +43,8 @@ export type CompactionReplayIneligibilityReason =
   | 'restored_tool_substitution'
   | 'source_content_unknown'
   | 'source_content_mismatch'
+  | 'provider_projection_unknown'
+  | 'provider_projection_changed'
   | 'ambiguous_lineage'
   | 'source_not_prefix';
 
@@ -80,6 +85,7 @@ interface CompactionReplayCandidate {
   readonly systemRevision: number;
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
+  readonly projectedMessages?: readonly BaseMessage[];
   readonly restoredToolSubstitution: boolean;
   readonly summarizerFallbackServed?: boolean;
 }
@@ -124,6 +130,7 @@ const CACHE_NAMESPACE_KEYS = [
   'useResponsesApi',
   'thinking',
   'thinkingBudget',
+  'inferenceGeo',
   'additionalModelRequestFields',
   'modelKwargs',
   'applicationInferenceProfile',
@@ -567,6 +574,38 @@ function fingerprintMessages(
   return Object.freeze(fingerprints);
 }
 
+/** Removes only trailing, provenance-proven synthetic request instructions. */
+export function extractCompactionReplayPrefixProjection(
+  messages: readonly BaseMessage[]
+): readonly BaseMessage[] | undefined {
+  let end = messages.length;
+  while (end > 0) {
+    const inspected = inspectProviderMessageProvenance(messages[end - 1]);
+    if (inspected.status !== 'valid') {
+      return undefined;
+    }
+    const parts = inspected.provenance.parts;
+    let hasSource = false;
+    let hasSynthetic = false;
+    for (const part of parts) {
+      if (part.sourceMessageId != null) {
+        hasSource = true;
+      }
+      if (part.attribution === 'synthetic') {
+        hasSynthetic = true;
+      }
+    }
+    if (hasSource) {
+      return hasSynthetic ? undefined : messages.slice(0, end);
+    }
+    if (!hasSynthetic) {
+      return undefined;
+    }
+    end--;
+  }
+  return [];
+}
+
 interface SourceLineage {
   readonly sourceMessageIds: readonly string[];
   readonly messageSourceCounts: readonly number[];
@@ -666,7 +705,9 @@ export function inspectCompactionReplayEligibility(
   state: CompactionReplayState | undefined,
   candidate: CompactionReplayCandidate
 ): CompactionReplayEligibility {
-  const candidateLineage = inspectSourceLineage(candidate.messages);
+  const candidateLineage = inspectSourceLineage(
+    candidate.projectedMessages ?? candidate.messages
+  );
   const replaySourceCount = candidateLineage?.sourceMessageIds.length ?? 0;
   if (candidate.summarizerFallbackServed === true) {
     return ineligible(
@@ -875,6 +916,36 @@ export function inspectCompactionReplayEligibility(
       replaySourceCount,
       requestSourceCount
     );
+  }
+
+  if (candidate.projectedMessages != null) {
+    if (candidate.projectedMessages.length !== replayMessageCount) {
+      return ineligible(
+        'provider_projection_changed',
+        replaySourceCount,
+        requestSourceCount
+      );
+    }
+    for (let i = 0; i < replayMessageCount; i++) {
+      const requestFingerprint = fingerprintMessage(recipe.messages[i]);
+      const candidateFingerprint = fingerprintMessage(
+        candidate.projectedMessages[i]
+      );
+      if (requestFingerprint == null || candidateFingerprint == null) {
+        return ineligible(
+          'provider_projection_unknown',
+          replaySourceCount,
+          requestSourceCount
+        );
+      }
+      if (requestFingerprint !== candidateFingerprint) {
+        return ineligible(
+          'provider_projection_changed',
+          replaySourceCount,
+          requestSourceCount
+        );
+      }
+    }
   }
 
   return {

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -77,6 +77,7 @@ const CACHE_NAMESPACE_KEYS = [
   'baseUrl',
   'organization',
   'project',
+  'projectId',
   'region',
   'region_name',
   'endpoint',
@@ -184,8 +185,14 @@ function fingerprintSerializedValue(serialized: string): string {
 }
 
 function fingerprintCacheNamespaceValue(value: unknown): string | undefined {
-  const serialized = serializeCacheNamespaceValue(value, new Set<object>());
-  return serialized == null ? undefined : fingerprintSerializedValue(serialized);
+  try {
+    const serialized = serializeCacheNamespaceValue(value, new Set<object>());
+    return serialized == null
+      ? undefined
+      : fingerprintSerializedValue(serialized);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Captures only routing identity; values are never emitted in diagnostics. */
@@ -203,7 +210,13 @@ export function createCompactionCacheNamespace(
   const entries: Array<readonly [string, CacheNamespaceValue]> = [];
   let complete = true;
   for (const key of CACHE_NAMESPACE_KEYS) {
-    const value = (options as Record<string, unknown> | undefined)?.[key];
+    let value: unknown;
+    try {
+      value = (options as Record<string, unknown> | undefined)?.[key];
+    } catch {
+      complete = false;
+      continue;
+    }
     if (value === undefined) {
       continue;
     }

--- a/src/llm/compactionReplay.ts
+++ b/src/llm/compactionReplay.ts
@@ -19,6 +19,7 @@ export interface CompactionReplayRecipe {
   readonly systemRevision: number;
   readonly toolRevision: number;
   readonly messages: readonly BaseMessage[];
+  readonly sourceMessageFingerprints?: readonly string[];
 }
 
 export type CompactionReplayState = CompactionReplayRecipe | 'fallback';
@@ -34,6 +35,8 @@ export type CompactionReplayIneligibilityReason =
   | 'tool_projection_changed'
   | 'projection_mode_mismatch'
   | 'restored_tool_substitution'
+  | 'source_content_unknown'
+  | 'source_content_mismatch'
   | 'ambiguous_lineage'
   | 'source_not_prefix';
 
@@ -71,6 +74,8 @@ interface CompactionReplayCandidate {
 
 const CACHE_NAMESPACE_KEYS = [
   'apiKey',
+  'anthropicApiKey',
+  'anthropicApiUrl',
   'baseURL',
   'baseUrl',
   'organization',
@@ -167,6 +172,37 @@ function isSyntheticMessage(message: BaseMessage): boolean {
   return kwargs.source != null && kwargs.source !== 'steer';
 }
 
+function fingerprintMessage(message: BaseMessage): string | undefined {
+  try {
+    const serialized = JSON.stringify(message.toDict());
+    let hashA = 0x811c9dc5;
+    let hashB = 0x9e3779b9;
+    for (let i = 0; i < serialized.length; i++) {
+      const code = serialized.charCodeAt(i);
+      hashA = Math.imul(hashA ^ code, 0x01000193);
+      hashB = Math.imul(hashB ^ code, 0x5bd1e995);
+      hashB ^= hashB >>> 13;
+    }
+    return `${serialized.length}:${hashA >>> 0}:${hashB >>> 0}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function fingerprintMessages(
+  messages: readonly BaseMessage[]
+): readonly string[] | undefined {
+  const fingerprints: string[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const fingerprint = fingerprintMessage(messages[i]);
+    if (fingerprint == null) {
+      return undefined;
+    }
+    fingerprints.push(fingerprint);
+  }
+  return Object.freeze(fingerprints);
+}
+
 interface SourceLineage {
   readonly sourceMessageIds: readonly string[];
   readonly messageSourceCounts: readonly number[];
@@ -225,6 +261,7 @@ export function createCompactionReplayRecipe(params: {
   systemRevision: number;
   toolRevision: number;
   messages: readonly BaseMessage[];
+  sourceMessages: readonly BaseMessage[];
 }): CompactionReplayRecipe {
   return Object.freeze({
     provider: params.provider,
@@ -234,6 +271,7 @@ export function createCompactionReplayRecipe(params: {
     systemRevision: params.systemRevision,
     toolRevision: params.toolRevision,
     messages: params.messages,
+    sourceMessageFingerprints: fingerprintMessages(params.sourceMessages),
   });
 }
 
@@ -351,6 +389,37 @@ export function inspectCompactionReplayEligibility(
     ) {
       return ineligible(
         'source_not_prefix',
+        replaySourceCount,
+        requestSourceCount
+      );
+    }
+  }
+  if (recipe.sourceMessageFingerprints == null) {
+    return ineligible(
+      'source_content_unknown',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  if (candidate.messages.length > recipe.sourceMessageFingerprints.length) {
+    return ineligible(
+      'source_content_mismatch',
+      replaySourceCount,
+      requestSourceCount
+    );
+  }
+  for (let i = 0; i < candidate.messages.length; i++) {
+    const fingerprint = fingerprintMessage(candidate.messages[i]);
+    if (fingerprint == null) {
+      return ineligible(
+        'source_content_unknown',
+        replaySourceCount,
+        requestSourceCount
+      );
+    }
+    if (fingerprint !== recipe.sourceMessageFingerprints[i]) {
+      return ineligible(
+        'source_content_mismatch',
         replaySourceCount,
         requestSourceCount
       );

--- a/src/messages/anthropicToolCache.ts
+++ b/src/messages/anthropicToolCache.ts
@@ -52,7 +52,7 @@ type AnthropicToolCacheCandidate = {
   cache_control?: unknown;
 };
 
-function isAnthropicBuiltInTool(
+export function isAnthropicBuiltInTool(
   tool: AnthropicToolCacheCandidate
 ): tool is AnthropicToolCacheCandidate & { type: string } {
   const { type } = tool;

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -84,6 +84,7 @@ for (const toolSteps of [20, 50, 100]) {
     const cacheNamespace = createCompactionCacheNamespace(
       Providers.ANTHROPIC,
       {
+        apiKey: 'benchmark-key',
         baseURL: 'https://benchmark.invalid',
       }
     );

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -11,6 +11,7 @@ import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
+  EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   inspectCompactionReplayEligibility,
 } from '@/llm/compactionReplay';
 import { setProviderMessageProvenance } from '@/messages/provenance';
@@ -95,6 +96,8 @@ for (const toolSteps of [20, 50, 100]) {
         projectionMode: 'chat-messages',
         cacheNamespace,
         promptCacheEnabled: true,
+        systemProjectionFingerprint:
+          EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
         toolProjectionFingerprint:
           createCompactionToolProjectionFingerprint(undefined),
         systemRevision: 0,
@@ -116,6 +119,8 @@ for (const toolSteps of [20, 50, 100]) {
           projectionMode: 'chat-messages',
           cacheNamespace,
           promptCacheEnabled: true,
+          systemProjectionFingerprint:
+            EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
           toolProjectionFingerprint:
             createCompactionToolProjectionFingerprint(undefined),
           systemRevision: 0,
@@ -133,6 +138,8 @@ for (const toolSteps of [20, 50, 100]) {
         projectionMode: 'chat-messages',
         cacheNamespace,
         promptCacheEnabled: true,
+        systemProjectionFingerprint:
+          EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
         toolProjectionFingerprint:
           createCompactionToolProjectionFingerprint(undefined),
         systemRevision: 0,

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -15,7 +15,7 @@ import {
 import { setProviderMessageProvenance } from '@/messages/provenance';
 import { Providers } from '@/common';
 
-const CAPTURE_ITERATIONS = 100_000;
+const CAPTURE_ITERATIONS = 2_000;
 const INSPECTION_ITERATIONS = 2_000;
 
 function stamp<T extends BaseMessage>(message: T, sourceId: string): T {
@@ -95,6 +95,7 @@ for (const toolSteps of [20, 50, 100]) {
         systemRevision: 0,
         toolRevision: 0,
         messages,
+        sourceMessages: messages,
       });
     const envelope = createEnvelope();
     const compactableMessages = messages.slice(0, messages.length - 4);

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -10,6 +10,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import {
   createCompactionCacheNamespace,
   createCompactionReplayRecipe,
+  createCompactionToolProjectionFingerprint,
   inspectCompactionReplayEligibility,
 } from '@/llm/compactionReplay';
 import { setProviderMessageProvenance } from '@/messages/provenance';
@@ -92,6 +93,9 @@ for (const toolSteps of [20, 50, 100]) {
         modelId: 'benchmark-model',
         projectionMode: 'chat-messages',
         cacheNamespace,
+        promptCacheEnabled: true,
+        toolProjectionFingerprint:
+          createCompactionToolProjectionFingerprint(undefined),
         systemRevision: 0,
         toolRevision: 0,
         messages,
@@ -110,6 +114,9 @@ for (const toolSteps of [20, 50, 100]) {
           modelId: 'benchmark-model',
           projectionMode: 'chat-messages',
           cacheNamespace,
+          promptCacheEnabled: true,
+          toolProjectionFingerprint:
+            createCompactionToolProjectionFingerprint(undefined),
           systemRevision: 0,
           toolRevision: 0,
           messages: compactableMessages,
@@ -124,6 +131,9 @@ for (const toolSteps of [20, 50, 100]) {
         modelId: 'benchmark-model',
         projectionMode: 'chat-messages',
         cacheNamespace,
+        promptCacheEnabled: true,
+        toolProjectionFingerprint:
+          createCompactionToolProjectionFingerprint(undefined),
         systemRevision: 0,
         toolRevision: 0,
         messages: compactableMessages,

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -1,0 +1,147 @@
+/* eslint-disable no-console */
+import { performance } from 'node:perf_hooks';
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+
+import type { BaseMessage } from '@langchain/core/messages';
+import {
+  createCompactionCacheNamespace,
+  createCompactionReplayRecipe,
+  inspectCompactionReplayEligibility,
+} from '@/llm/compactionReplay';
+import { setProviderMessageProvenance } from '@/messages/provenance';
+import { Providers } from '@/common';
+
+const CAPTURE_ITERATIONS = 100_000;
+const INSPECTION_ITERATIONS = 2_000;
+
+function stamp<T extends BaseMessage>(message: T, sourceId: string): T {
+  setProviderMessageProvenance(message, [
+    { attribution: 'user', sourceMessageId: sourceId },
+  ]);
+  return message;
+}
+
+function createToolHistory(
+  toolSteps: number,
+  priorCheckpoint: boolean
+): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  if (priorCheckpoint) {
+    messages.push(
+      new HumanMessage({
+        content: '<summary>prior checkpoint</summary>',
+        additional_kwargs: { injected: true, source: 'summary' },
+      })
+    );
+  }
+  messages.push(stamp(new HumanMessage('complete the task'), 'user-0'));
+  for (let i = 0; i < toolSteps; i++) {
+    const callId = `call-${i}`;
+    const assistant = new AIMessage({
+      id: `assistant-${i}`,
+      content: '',
+      tool_calls: [
+        {
+          id: callId,
+          name: 'exec_command',
+          args: { cmd: `rg pattern-${i}` },
+        },
+      ],
+    });
+    const tool = new ToolMessage({
+      id: `tool-${i}`,
+      content: `result-${i}`,
+      tool_call_id: callId,
+      name: 'exec_command',
+    });
+    setProviderMessageProvenance(assistant, [
+      { attribution: 'model', sourceMessageId: `assistant-${i}` },
+    ]);
+    setProviderMessageProvenance(tool, [
+      { attribution: 'tool', sourceMessageId: `tool-${i}` },
+    ]);
+    messages.push(assistant, tool);
+  }
+  return messages;
+}
+
+function measure(iterations: number, operation: () => void): number {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    operation();
+  }
+  return (performance.now() - start) / iterations;
+}
+
+for (const toolSteps of [20, 50, 100]) {
+  for (const priorCheckpoint of [false, true]) {
+    const messages = createToolHistory(toolSteps, priorCheckpoint);
+    const cacheNamespace = createCompactionCacheNamespace(
+      Providers.ANTHROPIC,
+      {
+        baseURL: 'https://benchmark.invalid',
+      }
+    );
+    const createEnvelope = () =>
+      createCompactionReplayRecipe({
+        provider: Providers.ANTHROPIC,
+        modelId: 'benchmark-model',
+        projectionMode: 'chat-messages',
+        cacheNamespace,
+        systemRevision: 0,
+        toolRevision: 0,
+        messages,
+      });
+    const envelope = createEnvelope();
+    const compactableMessages = messages.slice(0, messages.length - 4);
+    const captureMs = measure(CAPTURE_ITERATIONS, () => {
+      createEnvelope();
+    });
+    const inspectionMs = measure(INSPECTION_ITERATIONS, () => {
+      inspectCompactionReplayEligibility(
+        envelope,
+        {
+          provider: Providers.ANTHROPIC,
+          modelId: 'benchmark-model',
+          projectionMode: 'chat-messages',
+          cacheNamespace,
+          systemRevision: 0,
+          toolRevision: 0,
+          messages: compactableMessages,
+          restoredToolSubstitution: false,
+        }
+      );
+    });
+    const eligibility = inspectCompactionReplayEligibility(
+      envelope,
+      {
+        provider: Providers.ANTHROPIC,
+        modelId: 'benchmark-model',
+        projectionMode: 'chat-messages',
+        cacheNamespace,
+        systemRevision: 0,
+        toolRevision: 0,
+        messages: compactableMessages,
+        restoredToolSubstitution: false,
+      }
+    );
+
+    console.log(
+      JSON.stringify({
+        toolSteps,
+        priorCheckpoint,
+        requestMessages: messages.length,
+        compactableMessages: compactableMessages.length,
+        captureMicrosecondsPerRequest: Number((captureMs * 1_000).toFixed(3)),
+        inspectionMicrosecondsPerCompaction: Number(
+          (inspectionMs * 1_000).toFixed(3)
+        ),
+        eligibility,
+      })
+    );
+  }
+}

--- a/src/scripts/bench-compaction-replay.ts
+++ b/src/scripts/bench-compaction-replay.ts
@@ -9,6 +9,7 @@ import {
 import type { BaseMessage } from '@langchain/core/messages';
 import {
   createCompactionCacheNamespace,
+  createCompactionReplayCandidateSnapshot,
   createCompactionReplayRecipe,
   createCompactionToolProjectionFingerprint,
   EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
@@ -111,6 +112,10 @@ for (const toolSteps of [20, 50, 100]) {
       createEnvelope();
     });
     const inspectionMs = measure(INSPECTION_ITERATIONS, () => {
+      const snapshot = createCompactionReplayCandidateSnapshot(
+        compactableMessages,
+        compactableMessages
+      );
       inspectCompactionReplayEligibility(
         envelope,
         {
@@ -126,10 +131,15 @@ for (const toolSteps of [20, 50, 100]) {
           systemRevision: 0,
           toolRevision: 0,
           messages: compactableMessages,
+          snapshot,
           restoredToolSubstitution: false,
         }
       );
     });
+    const snapshot = createCompactionReplayCandidateSnapshot(
+      compactableMessages,
+      compactableMessages
+    );
     const eligibility = inspectCompactionReplayEligibility(
       envelope,
       {
@@ -145,6 +155,7 @@ for (const toolSteps of [20, 50, 100]) {
         systemRevision: 0,
         toolRevision: 0,
         messages: compactableMessages,
+        snapshot,
         restoredToolSubstitution: false,
       }
     );
@@ -156,7 +167,7 @@ for (const toolSteps of [20, 50, 100]) {
         requestMessages: messages.length,
         compactableMessages: compactableMessages.length,
         captureMicrosecondsPerRequest: Number((captureMs * 1_000).toFixed(3)),
-        inspectionMicrosecondsPerCompaction: Number(
+        candidateCaptureAndInspectionMicrosecondsPerCompaction: Number(
           (inspectionMs * 1_000).toFixed(3)
         ),
         eligibility,

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -284,6 +284,16 @@ const SCENARIOS: Array<{
   },
 ];
 
+function isolateCacheNamespace(
+  steps: BaseMessage[][],
+  marker: 'A' | 'B'
+): BaseMessage[][] {
+  return steps.map((messages) => [
+    new SystemMessage(`Benchmark cache namespace ${marker}.`),
+    ...messages,
+  ]);
+}
+
 // ---------------------------------------------------------------------------
 // Provider plumbing.
 // ---------------------------------------------------------------------------
@@ -516,17 +526,22 @@ async function collectTimedStream(
 }
 
 async function runCompactionSummaryProbe(params: {
-  nonce: string;
+  conversationId: string;
+  cacheMarker: 'A' | 'B';
   replay: boolean;
   apply: (m: BaseMessage[]) => BaseMessage[];
   invokeTimed: (m: BaseMessage[]) => Promise<TimedUsage>;
 }): Promise<{ prime: TimedUsage; summary: TimedUsage; totals: Totals }> {
-  const history = toolLoopScenario(params.nonce, 5).at(-1) ?? [];
+  const history = toolLoopScenario(params.conversationId, 5).at(-1) ?? [];
+  const cacheNamespace = new SystemMessage(
+    `Benchmark cache namespace ${params.cacheMarker}.`
+  );
   const normalRequest = params.apply([
+    cacheNamespace,
     new SystemMessage(
-      `Stable agent instructions for ${params.nonce}. ${filler(
+      `Stable agent instructions for ${params.conversationId}. ${filler(
         STABLE_TOKENS,
-        `sys${params.nonce}`
+        `sys${params.conversationId}`
       )}`
     ),
     ...history,
@@ -537,7 +552,7 @@ async function runCompactionSummaryProbe(params: {
   );
   const summaryRequest = params.replay
     ? [...normalRequest, compactionInstruction]
-    : params.apply([...history, compactionInstruction]);
+    : params.apply([cacheNamespace, ...history, compactionInstruction]);
   const summary = await params.invokeTimed(summaryRequest);
   const totals = emptyTotals();
   addUsage(totals, summary.usage);
@@ -577,10 +592,11 @@ async function main(): Promise<void> {
   let scenarioCount = 0;
 
   for (const scenario of SCENARIOS) {
-    // Distinct nonce per strategy run so legacy and tail never share a cache.
-    const legacySteps = scenario.build(uniqueNonce('legacy'), args.rounds);
+    const conversationId = uniqueNonce('comparison');
+    const conversation = scenario.build(conversationId, args.rounds);
+    const legacySteps = isolateCacheNamespace(conversation, 'A');
     const legacy = await runStrategy(legacySteps, strategies.legacy, invoke);
-    const tailSteps = scenario.build(uniqueNonce('tail'), args.rounds);
+    const tailSteps = isolateCacheNamespace(conversation, 'B');
     const tail = await runStrategy(tailSteps, strategies.tail, invoke);
 
     console.log(`SCENARIO: ${scenario.name}  (${legacySteps.length} calls)`);
@@ -609,14 +625,17 @@ async function main(): Promise<void> {
     if (better) tailWins++;
   }
 
+  const compactionConversationId = uniqueNonce('compaction-comparison');
   const independent = await runCompactionSummaryProbe({
-    nonce: uniqueNonce('independent-summary'),
+    conversationId: compactionConversationId,
+    cacheMarker: 'A',
     replay: false,
     apply: strategies.tail,
     invokeTimed,
   });
   const replay = await runCompactionSummaryProbe({
-    nonce: uniqueNonce('replayed-summary'),
+    conversationId: compactionConversationId,
+    cacheMarker: 'B',
     replay: true,
     apply: strategies.tail,
     invokeTimed,

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -550,9 +550,13 @@ async function runCompactionSummaryProbe(params: {
   const compactionInstruction = new HumanMessage(
     'Write a checkpoint that preserves completed work, exact identifiers, failures, and next actions.'
   );
+  const independentlyCachedHistory = params.apply([
+    cacheNamespace,
+    ...history,
+  ]);
   const summaryRequest = params.replay
     ? [...normalRequest, compactionInstruction]
-    : params.apply([cacheNamespace, ...history, compactionInstruction]);
+    : [...independentlyCachedHistory, compactionInstruction];
   const summary = await params.invokeTimed(summaryRequest);
   const totals = emptyTotals();
   addUsage(totals, summary.usage);

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -422,11 +422,73 @@ interface UsageChunk {
   usage_metadata?: Usage;
 }
 
+function hasStreamPayload(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value !== '';
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasStreamPayload);
+  }
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).some(
+    hasStreamPayload
+  );
+}
+
 function hasStreamContent(content: unknown): boolean {
   if (typeof content === 'string') {
     return content !== '';
   }
-  return Array.isArray(content) ? content.length > 0 : content != null;
+  if (Array.isArray(content)) {
+    return content.some(hasStreamContent);
+  }
+  if (content == null || typeof content !== 'object') {
+    return false;
+  }
+  const block = content as Record<string, unknown>;
+  for (const key of [
+    'text',
+    'thinking',
+    'reasoning',
+    'partial_json',
+    'input',
+    'args',
+    'content',
+  ] as const) {
+    if (hasStreamPayload(block[key])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sumUsage(
+  accumulated: Usage | undefined,
+  chunk: Usage
+): Usage {
+  const previousDetails = accumulated?.input_token_details;
+  const chunkDetails = chunk.input_token_details;
+  return {
+    input_tokens:
+      (accumulated?.input_tokens ?? 0) + (chunk.input_tokens ?? 0),
+    output_tokens:
+      (accumulated?.output_tokens ?? 0) + (chunk.output_tokens ?? 0),
+    total_tokens:
+      (accumulated?.total_tokens ?? 0) + (chunk.total_tokens ?? 0),
+    input_token_details: {
+      cache_creation:
+        (previousDetails?.cache_creation ?? 0) +
+        (chunkDetails?.cache_creation ?? 0),
+      cache_read:
+        (previousDetails?.cache_read ?? 0) +
+        (chunkDetails?.cache_read ?? 0),
+    },
+  };
 }
 
 async function collectTimedStream(
@@ -443,7 +505,7 @@ async function collectTimedStream(
       timeToFirstTokenMs = performance.now() - startedAt;
     }
     if (chunk.usage_metadata != null) {
-      usage = chunk.usage_metadata;
+      usage = sumUsage(usage, chunk.usage_metadata);
     }
   }
   return {

--- a/src/scripts/bench-prompt-cache.ts
+++ b/src/scripts/bench-prompt-cache.ts
@@ -18,6 +18,8 @@
  *  - Multi-turn chat (frequent user messages): legacy's two rolling markers do
  *    fine here; the tail strategy ties (never worse).
  *  - Realistic agent (user turns interleaved with tool rounds): tail wins.
+ *  - Compaction summary: compares today's independent summary projection with
+ *    exact replay of the already-cached normal request plus one instruction.
  *
  * Metrics (per strategy, summed over all calls in a scenario)
  *  - cache_read   : tokens served from cache (HIGHER is better).
@@ -39,12 +41,14 @@
  * Not a unit test (no `.test.` suffix) so CI never runs it; it makes real,
  * paid API calls.
  */
+import { performance } from 'node:perf_hooks';
 import { config } from 'dotenv';
 config({ path: process.env.BENCH_ENV_FILE || '.env' });
 
 import {
   HumanMessage,
   AIMessage,
+  SystemMessage,
   ToolMessage,
   type BaseMessage,
 } from '@langchain/core/messages';
@@ -303,6 +307,7 @@ interface StrategyPair {
 
 function makeProvider(args: Args): {
   invoke: (messages: BaseMessage[]) => Promise<Usage | undefined>;
+  invokeTimed: (messages: BaseMessage[]) => Promise<TimedUsage>;
   strategies: StrategyPair;
   label: string;
 } {
@@ -327,6 +332,8 @@ function makeProvider(args: Args): {
       label: `bedrock:${model}`,
       invoke: async (messages) =>
         (await llm.invoke(messages)).usage_metadata as Usage,
+      invokeTimed: async (messages) =>
+        collectTimedStream(llm.stream(messages)),
       strategies: {
         legacy: (m) => addBedrockCacheControl<BaseMessage>(m),
         tail: (m) => addBedrockTailCacheControl<BaseMessage>(m),
@@ -347,6 +354,7 @@ function makeProvider(args: Args): {
     label: `anthropic:${model}`,
     invoke: async (messages) =>
       (await llm.invoke(messages)).usage_metadata as Usage,
+    invokeTimed: async (messages) => collectTimedStream(llm.stream(messages)),
     strategies: {
       legacy: (m) => addCacheControl<BaseMessage>(m),
       tail: (m) => addTailCacheControl<BaseMessage>(m),
@@ -403,6 +411,77 @@ async function runStrategy(
   return totals;
 }
 
+interface TimedUsage {
+  usage?: Usage;
+  timeToFirstTokenMs?: number;
+  latencyMs: number;
+}
+
+interface UsageChunk {
+  content?: unknown;
+  usage_metadata?: Usage;
+}
+
+function hasStreamContent(content: unknown): boolean {
+  if (typeof content === 'string') {
+    return content !== '';
+  }
+  return Array.isArray(content) ? content.length > 0 : content != null;
+}
+
+async function collectTimedStream(
+  streamPromise:
+    | AsyncIterable<UsageChunk>
+    | Promise<AsyncIterable<UsageChunk>>
+): Promise<TimedUsage> {
+  const startedAt = performance.now();
+  const stream = await streamPromise;
+  let usage: Usage | undefined;
+  let timeToFirstTokenMs: number | undefined;
+  for await (const chunk of stream) {
+    if (timeToFirstTokenMs == null && hasStreamContent(chunk.content)) {
+      timeToFirstTokenMs = performance.now() - startedAt;
+    }
+    if (chunk.usage_metadata != null) {
+      usage = chunk.usage_metadata;
+    }
+  }
+  return {
+    usage,
+    timeToFirstTokenMs,
+    latencyMs: performance.now() - startedAt,
+  };
+}
+
+async function runCompactionSummaryProbe(params: {
+  nonce: string;
+  replay: boolean;
+  apply: (m: BaseMessage[]) => BaseMessage[];
+  invokeTimed: (m: BaseMessage[]) => Promise<TimedUsage>;
+}): Promise<{ prime: TimedUsage; summary: TimedUsage; totals: Totals }> {
+  const history = toolLoopScenario(params.nonce, 5).at(-1) ?? [];
+  const normalRequest = params.apply([
+    new SystemMessage(
+      `Stable agent instructions for ${params.nonce}. ${filler(
+        STABLE_TOKENS,
+        `sys${params.nonce}`
+      )}`
+    ),
+    ...history,
+  ]);
+  const prime = await params.invokeTimed(normalRequest);
+  const compactionInstruction = new HumanMessage(
+    'Write a checkpoint that preserves completed work, exact identifiers, failures, and next actions.'
+  );
+  const summaryRequest = params.replay
+    ? [...normalRequest, compactionInstruction]
+    : params.apply([...history, compactionInstruction]);
+  const summary = await params.invokeTimed(summaryRequest);
+  const totals = emptyTotals();
+  addUsage(totals, summary.usage);
+  return { prime, summary, totals };
+}
+
 function pct(legacy: number, tail: number): string {
   if (legacy === 0) return tail === 0 ? '0%' : 'n/a';
   const delta = ((tail - legacy) / legacy) * 100;
@@ -426,7 +505,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const { invoke, strategies, label } = makeProvider(args);
+  const { invoke, invokeTimed, strategies, label } = makeProvider(args);
   console.log(`\nProvider: ${label}   rounds=${args.rounds}`);
   console.log(
     'Metrics summed over all calls in a scenario. read↑ better; fresh↓ and effective↓ better.\n'
@@ -467,6 +546,43 @@ async function main(): Promise<void> {
     scenarioCount++;
     if (better) tailWins++;
   }
+
+  const independent = await runCompactionSummaryProbe({
+    nonce: uniqueNonce('independent-summary'),
+    replay: false,
+    apply: strategies.tail,
+    invokeTimed,
+  });
+  const replay = await runCompactionSummaryProbe({
+    nonce: uniqueNonce('replayed-summary'),
+    replay: true,
+    apply: strategies.tail,
+    invokeTimed,
+  });
+  console.log('SCENARIO: Compaction summary request (2 calls per variant)');
+  console.log(
+    JSON.stringify({
+      independent: {
+        summaryUsage: independent.summary.usage,
+        summaryEffectiveInput: Math.round(independent.totals.effective),
+        summaryTimeToFirstTokenMs:
+          independent.summary.timeToFirstTokenMs == null
+            ? undefined
+            : Math.round(independent.summary.timeToFirstTokenMs),
+        summaryLatencyMs: Math.round(independent.summary.latencyMs),
+      },
+      exactReplay: {
+        summaryUsage: replay.summary.usage,
+        summaryEffectiveInput: Math.round(replay.totals.effective),
+        summaryTimeToFirstTokenMs:
+          replay.summary.timeToFirstTokenMs == null
+            ? undefined
+            : Math.round(replay.summary.timeToFirstTokenMs),
+        summaryLatencyMs: Math.round(replay.summary.latencyMs),
+      },
+      note: 'Each variant uses an isolated nonce and primes its own normal request before the measured summary call.',
+    })
+  );
 
   console.log(
     `RESULT: tail strategy is better-or-equal in ${tailWins}/${scenarioCount} scenarios.`

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -578,6 +578,54 @@ describe('createSummarizeNode', () => {
     }
   });
 
+  it('routes Bedrock tool preparation errors through fallback recovery', async () => {
+    const invalidTools = [{}] as t.GraphTools;
+    const fallback = jest
+      .spyOn(invokeUtils, 'tryFallbackProviders')
+      .mockResolvedValue({
+        messages: [new AIMessage('Fallback summary')],
+      } as never);
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      provider: Providers.BEDROCK,
+      clientOptions: {
+        model: 'anthropic.claude-sonnet',
+        promptCache: true,
+        fallbacks: [{ provider: Providers.ANTHROPIC, model: 'fallback' }],
+      },
+      setSummary,
+    });
+    jest
+      .spyOn(agentContext, 'getToolsForBinding')
+      .mockReturnValue(invalidTools);
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph(),
+      generateStepId,
+    });
+
+    await expect(
+      node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      )
+    ).resolves.not.toThrow();
+
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ tools: invalidTools })
+    );
+    expect(setSummary).toHaveBeenCalledWith(
+      'Fallback summary',
+      expect.any(Number)
+    );
+  });
+
   it('marks a successfully served summarizer fallback ineligible', async () => {
     const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
     process.env.AGENT_DEBUG_LOGGING = 'true';

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -13,6 +13,7 @@ import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
+import * as invokeUtils from '@/llm/invoke';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -227,6 +228,7 @@ describe('createSummarizeNode', () => {
         class {
           constructor() {
             return {
+              model: 'actual-summary-model',
               _useResponsesApi: (): boolean => true,
               invoke: jest.fn().mockResolvedValue({ content: 'Summary text' }),
             };
@@ -261,7 +263,72 @@ describe('createSummarizeNode', () => {
       );
 
       expect(inspect).toHaveBeenCalledWith(
-        expect.objectContaining({ projectionMode: 'openai-responses' })
+        expect.objectContaining({
+          modelId: 'actual-summary-model',
+          projectionMode: 'openai-responses',
+          summarizerFallbackServed: false,
+        })
+      );
+    } finally {
+      if (previousDebugLogging == null) {
+        delete process.env.AGENT_DEBUG_LOGGING;
+      } else {
+        process.env.AGENT_DEBUG_LOGGING = previousDebugLogging;
+      }
+    }
+  });
+
+  it('marks a successfully served summarizer fallback ineligible', async () => {
+    const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
+    process.env.AGENT_DEBUG_LOGGING = 'true';
+    try {
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return {
+              model: 'primary-summary-model',
+              invoke: jest.fn().mockRejectedValue(new Error('primary failed')),
+            };
+          }
+        } as never
+      );
+      jest.spyOn(invokeUtils, 'tryFallbackProviders').mockResolvedValue({
+        messages: [new AIMessage('Fallback summary')],
+      } as never);
+
+      const agentContext = createAgentContext({
+        clientOptions: {
+          fallbacks: [{ provider: Providers.ANTHROPIC, model: 'fallback' }],
+        },
+      });
+      const inspect = jest
+        .spyOn(agentContext, 'inspectCompactionReplay')
+        .mockReturnValue({
+          eligible: false,
+          reason: 'summarizer_fallback_served_request',
+          replaySourceCount: 0,
+          requestSourceCount: 0,
+        });
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      expect(inspect).toHaveBeenCalledTimes(1);
+      expect(inspect).toHaveBeenCalledWith(
+        expect.objectContaining({ summarizerFallbackServed: true })
       );
     } finally {
       if (previousDebugLogging == null) {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -10,6 +10,7 @@ import {
   resolveBedrockCompactionCacheModel,
 } from '@/summarization/node';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
+import { createCompactionToolProjectionFingerprint } from '@/llm/compactionReplay';
 import { convertInjectedMessages } from '@/messages/injected';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
@@ -327,6 +328,167 @@ describe('createSummarizeNode', () => {
           modelId: 'actual-summary-model',
           projectionMode: 'openai-responses',
           summarizerFallbackServed: false,
+        })
+      );
+    } finally {
+      if (previousDebugLogging == null) {
+        delete process.env.AGENT_DEBUG_LOGGING;
+      } else {
+        process.env.AGENT_DEBUG_LOGGING = previousDebugLogging;
+      }
+    }
+  });
+
+  it('honors an effective summarization prompt-cache override', async () => {
+    const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
+    process.env.AGENT_DEBUG_LOGGING = 'true';
+    try {
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return mockInvokeModel('Summary text');
+          }
+        } as never
+      );
+
+      const agentContext = createAgentContext({
+        provider: Providers.BEDROCK,
+        clientOptions: {
+          model: 'anthropic.claude-sonnet',
+          promptCache: true,
+        },
+        summarizationConfig: {
+          retainRecent: { turns: 0 },
+          parameters: { promptCache: false },
+        },
+      });
+      const inspect = jest
+        .spyOn(agentContext, 'inspectCompactionReplay')
+        .mockReturnValue({
+          eligible: false,
+          reason: 'prompt_cache_disabled',
+          replaySourceCount: 0,
+          requestSourceCount: 0,
+        });
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      expect(inspect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptCacheEnabled: false,
+          toolProjectionFingerprint: undefined,
+        })
+      );
+    } finally {
+      if (previousDebugLogging == null) {
+        delete process.env.AGENT_DEBUG_LOGGING;
+      } else {
+        process.env.AGENT_DEBUG_LOGGING = previousDebugLogging;
+      }
+    }
+  });
+
+  it('fingerprints the Bedrock tools actually bound by the summarizer', async () => {
+    const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
+    process.env.AGENT_DEBUG_LOGGING = 'true';
+    try {
+      let boundTools: t.GraphTools | undefined;
+      const model: {
+        model: string;
+        invoke: jest.Mock;
+        bindTools: (tools: t.GraphTools) => object;
+      } = {
+        model: 'anthropic.claude-sonnet',
+        invoke: jest.fn().mockResolvedValue({ content: 'Summary text' }),
+        bindTools: (tools: t.GraphTools): object => {
+          boundTools = tools;
+          return model;
+        },
+      };
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return model;
+          }
+        } as never
+      );
+
+      const rawTools = [
+        {
+          type: 'function',
+          function: {
+            name: 'static_tool',
+            description: 'Static tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'dynamic_tool',
+            description: 'Dynamic tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      ] as t.GraphTools;
+      const agentContext = createAgentContext({
+        provider: Providers.BEDROCK,
+        clientOptions: {
+          model: 'anthropic.claude-sonnet',
+          promptCache: true,
+        },
+      });
+      jest.spyOn(agentContext, 'getToolsForBinding').mockReturnValue(rawTools);
+      jest
+        .spyOn(agentContext, 'getEffectiveToolDefinitions')
+        .mockReturnValue([
+          { name: 'static_tool' },
+          { name: 'dynamic_tool', defer_loading: true },
+        ]);
+      const inspect = jest
+        .spyOn(agentContext, 'inspectCompactionReplay')
+        .mockReturnValue({
+          eligible: false,
+          reason: 'no_request_snapshot',
+          replaySourceCount: 0,
+          requestSourceCount: 0,
+        });
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      expect(boundTools).toBeDefined();
+      expect(inspect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolProjectionFingerprint:
+            createCompactionToolProjectionFingerprint(boundTools),
         })
       );
     } finally {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -219,6 +219,59 @@ describe('createSummarizeNode', () => {
     ).toBeUndefined();
   });
 
+  it('observes the actual summarizer projection mode in debug logging', async () => {
+    const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
+    process.env.AGENT_DEBUG_LOGGING = 'true';
+    try {
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return {
+              _useResponsesApi: (): boolean => true,
+              invoke: jest.fn().mockResolvedValue({ content: 'Summary text' }),
+            };
+          }
+        } as never
+      );
+
+      const agentContext = createAgentContext();
+      const inspect = jest
+        .spyOn(agentContext, 'inspectCompactionReplay')
+        .mockReturnValue({
+          eligible: false,
+          reason: 'no_request_snapshot',
+          replaySourceCount: 0,
+          requestSourceCount: 0,
+        });
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      expect(inspect).toHaveBeenCalledWith(
+        expect.objectContaining({ projectionMode: 'openai-responses' })
+      );
+    } finally {
+      if (previousDebugLogging == null) {
+        delete process.env.AGENT_DEBUG_LOGGING;
+      } else {
+        process.env.AGENT_DEBUG_LOGGING = previousDebugLogging;
+      }
+    }
+  });
+
   it('stamps INVOKED_MODEL/INVOKED_PROVIDER metadata for a dedicated summarizer model', async () => {
     captureEvents();
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -10,8 +10,12 @@ import {
   resolveBedrockCompactionCacheModel,
 } from '@/summarization/node';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
-import { createCompactionToolProjectionFingerprint } from '@/llm/compactionReplay';
+import {
+  createCompactionReplayCandidateSnapshot,
+  createCompactionToolProjectionFingerprint,
+} from '@/llm/compactionReplay';
 import { convertInjectedMessages } from '@/messages/injected';
+import { setProviderMessageProvenance } from '@/messages/provenance';
 import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
@@ -328,6 +332,80 @@ describe('createSummarizeNode', () => {
           modelId: 'actual-summary-model',
           projectionMode: 'openai-responses',
           summarizerFallbackServed: false,
+        })
+      );
+    } finally {
+      if (previousDebugLogging == null) {
+        delete process.env.AGENT_DEBUG_LOGGING;
+      } else {
+        process.env.AGENT_DEBUG_LOGGING = previousDebugLogging;
+      }
+    }
+  });
+
+  it('observes the summarizer projection captured before provider mutation', async () => {
+    const previousDebugLogging = process.env.AGENT_DEBUG_LOGGING;
+    process.env.AGENT_DEBUG_LOGGING = 'true';
+    try {
+      jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+        class {
+          constructor() {
+            return {
+              invoke: jest.fn().mockImplementation(
+                async (messages: BaseMessage[]) => {
+                  messages[0].content = 'mutated during invocation';
+                  return { content: 'Summary text' };
+                }
+              ),
+            };
+          }
+        } as never
+      );
+
+      const messages = [
+        new HumanMessage({ content: 'Hello', id: 'source-1' }),
+        new AIMessage({ content: 'World', id: 'source-2' }),
+      ];
+      setProviderMessageProvenance(messages[0], [
+        { attribution: 'user', sourceMessageId: 'source-1' },
+      ]);
+      setProviderMessageProvenance(messages[1], [
+        { attribution: 'model', sourceMessageId: 'source-2' },
+      ]);
+      const sourceSnapshot = createCompactionReplayCandidateSnapshot(messages);
+      const agentContext = createAgentContext();
+      const inspect = jest
+        .spyOn(agentContext, 'inspectCompactionReplay')
+        .mockReturnValue({
+          eligible: false,
+          reason: 'no_request_snapshot',
+          replaySourceCount: 0,
+          requestSourceCount: 0,
+        });
+      const node = createSummarizeNode({
+        agentContext,
+        graph: mockGraph(),
+        generateStepId,
+      });
+
+      await node(
+        {
+          messages,
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+
+      expect(inspect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snapshot: expect.objectContaining({
+            sourceMessageFingerprints:
+              sourceSnapshot.sourceMessageFingerprints,
+            projection: 'projected',
+          }),
         })
       );
     } finally {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -17,6 +17,22 @@ import * as eventUtils from '@/utils/events';
 import * as invokeUtils from '@/llm/invoke';
 
 describe('applySummarizationHistoryCache', () => {
+  it('uses the one-hour default for Anthropic history', () => {
+    const cached = applySummarizationHistoryCache({
+      messages: [new HumanMessage('history')],
+      provider: Providers.ANTHROPIC,
+      enabled: true,
+    });
+
+    expect(cached[0].content).toEqual([
+      {
+        type: 'text',
+        text: 'history',
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+      },
+    ]);
+  });
+
   it('places a Bedrock cache point on history before the instruction is appended', () => {
     const history = [new HumanMessage('history')];
     const cached = applySummarizationHistoryCache({
@@ -30,6 +46,21 @@ describe('applySummarizationHistoryCache', () => {
     expect(cached[0].content).toEqual([
       { type: 'text', text: 'history' },
       { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+  });
+
+  it('uses five minutes for an unknown Bedrock inference profile family', () => {
+    const cached = applySummarizationHistoryCache({
+      messages: [new HumanMessage('history')],
+      provider: Providers.BEDROCK,
+      enabled: true,
+      bedrockModelId:
+        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/nova',
+    });
+
+    expect(cached[0].content).toEqual([
+      { type: 'text', text: 'history' },
+      { cachePoint: { type: 'default' } },
     ]);
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -7,6 +7,7 @@ import {
   createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  resolveBedrockCompactionCacheModel,
 } from '@/summarization/node';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
@@ -49,19 +50,28 @@ describe('applySummarizationHistoryCache', () => {
     ]);
   });
 
-  it('uses five minutes for an unknown Bedrock inference profile family', () => {
+  it('uses five minutes for a configured non-Claude Bedrock model', () => {
     const cached = applySummarizationHistoryCache({
       messages: [new HumanMessage('history')],
       provider: Providers.BEDROCK,
       enabled: true,
-      bedrockModelId:
-        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/nova',
+      bedrockModelId: 'amazon.nova-pro-v1:0',
     });
 
     expect(cached[0].content).toEqual([
       { type: 'text', text: 'history' },
       { cachePoint: { type: 'default' } },
     ]);
+  });
+
+  it('keeps the configured Claude cache family for an opaque profile ARN', () => {
+    expect(
+      resolveBedrockCompactionCacheModel({
+        applicationInferenceProfile:
+          'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opaque',
+        model: 'anthropic.claude-sonnet',
+      })
+    ).toBe('anthropic.claude-sonnet');
   });
 });
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -3,6 +3,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
+  applySummarizationHistoryCache,
   createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
@@ -14,6 +15,24 @@ import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
 import * as invokeUtils from '@/llm/invoke';
+
+describe('applySummarizationHistoryCache', () => {
+  it('places a Bedrock cache point on history before the instruction is appended', () => {
+    const history = [new HumanMessage('history')];
+    const cached = applySummarizationHistoryCache({
+      messages: history,
+      provider: Providers.BEDROCK,
+      enabled: true,
+      bedrockModelId: 'anthropic.claude-sonnet',
+    });
+
+    expect(cached).toHaveLength(1);
+    expect(cached[0].content).toEqual([
+      { type: 'text', text: 'history' },
+      { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -785,17 +785,14 @@ async function executeSummarizationWithFallback(params: {
           : undefined,
       bedrockModelId:
         clientConfig.provider === Providers.BEDROCK
-          ? (
-              clientConfig.clientOptions as
-                | {
-                  applicationInferenceProfile?: string;
-                  model?: string;
-                }
-                | undefined
-          )?.applicationInferenceProfile ??
-            (
-              clientConfig.clientOptions as { model?: string } | undefined
-            )?.model
+          ? resolveBedrockCompactionCacheModel(
+            clientConfig.clientOptions as
+              | {
+                applicationInferenceProfile?: string;
+                model?: string;
+              }
+              | undefined
+          )
           : undefined,
       log,
     });
@@ -1776,6 +1773,14 @@ export function applySummarizationHistoryCache(params: {
     [...params.messages],
     resolvePromptCacheTtl(params.promptCacheTtl)
   );
+}
+
+export function resolveBedrockCompactionCacheModel(
+  options:
+    | { applicationInferenceProfile?: string; model?: string }
+    | undefined
+): string | undefined {
+  return options?.model;
 }
 
 /**

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -26,7 +26,6 @@ import {
 import {
   addTailCacheControl,
   addBedrockTailCacheControl,
-  resolvePromptCacheTtl,
   resolveBedrockPromptCacheTtl,
   type PromptCacheTtl,
 } from '@/messages/cache';
@@ -775,55 +774,28 @@ async function executeSummarizationWithFallback(params: {
       usePromptCache,
       promptCacheTtl:
         clientConfig.provider === Providers.ANTHROPIC ||
-        clientConfig.provider === Providers.OPENROUTER
-          ? resolvePromptCacheTtl(
-            (
+        clientConfig.provider === Providers.OPENROUTER ||
+        clientConfig.provider === Providers.BEDROCK
+          ? (
                 clientConfig.clientOptions as {
                   promptCacheTtl?: PromptCacheTtl;
                 }
-            ).promptCacheTtl
-          )
+          ).promptCacheTtl
+          : undefined,
+      bedrockModelId:
+        clientConfig.provider === Providers.BEDROCK
+          ? (
+              clientConfig.clientOptions as { model?: string } | undefined
+          )?.model
           : undefined,
       log,
     });
     summaryText = result.text;
     summaryUsage = result.usage;
     if (process.env.AGENT_DEBUG_LOGGING === 'true') {
-      const projectedPrefix = extractCompactionReplayPrefixProjection(
-        result.preparedMessages
-      );
-      if (projectedPrefix == null) {
-        compactionReplayProjectedMessages = null;
-      } else if (!usePromptCache) {
-        compactionReplayProjectedMessages = projectedPrefix;
-      } else if (clientConfig.provider === Providers.BEDROCK) {
-        const clientOptions = clientConfig.clientOptions as
-          | t.BedrockAnthropicClientOptions
-          | undefined;
-        compactionReplayProjectedMessages = addBedrockTailCacheControl(
-          [...projectedPrefix],
-          resolveBedrockPromptCacheTtl(
-            clientOptions?.promptCacheTtl,
-            (clientOptions as { model?: string } | undefined)?.model
-          )
-        );
-      } else if (
-        clientConfig.provider === Providers.ANTHROPIC ||
-        clientConfig.provider === Providers.OPENROUTER
-      ) {
-        compactionReplayProjectedMessages = addTailCacheControl(
-          [...projectedPrefix],
-          resolvePromptCacheTtl(
-            (
-                  clientConfig.clientOptions as {
-                    promptCacheTtl?: PromptCacheTtl;
-                  }
-            ).promptCacheTtl
-          )
-        );
-      } else {
-        compactionReplayProjectedMessages = projectedPrefix;
-      }
+      compactionReplayProjectedMessages =
+        extractCompactionReplayPrefixProjection(result.preparedMessages) ??
+        null;
     }
     observeCompactionReplay(false);
   } catch (primaryError) {
@@ -1772,6 +1744,28 @@ function traceConfig(
   };
 }
 
+export function applySummarizationHistoryCache(params: {
+  messages: BaseMessage[];
+  provider: t.ProviderName;
+  enabled: boolean;
+  promptCacheTtl?: PromptCacheTtl;
+  bedrockModelId?: string;
+}): BaseMessage[] {
+  if (!params.enabled) {
+    return params.messages;
+  }
+  if (params.provider === Providers.BEDROCK) {
+    return addBedrockTailCacheControl(
+      [...params.messages],
+      resolveBedrockPromptCacheTtl(
+        params.promptCacheTtl,
+        params.bedrockModelId
+      )
+    );
+  }
+  return addTailCacheControl([...params.messages], params.promptCacheTtl);
+}
+
 /**
  * Cache-friendly compaction: sends raw conversation messages with the
  * summarization instruction appended as the final HumanMessage. Bound tool
@@ -1792,6 +1786,7 @@ async function summarizeWithCacheHit({
   graph,
   usePromptCache,
   promptCacheTtl,
+  bedrockModelId,
   log,
 }: {
   model: t.ChatModel;
@@ -1806,6 +1801,7 @@ async function summarizeWithCacheHit({
   graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
   usePromptCache?: boolean;
   promptCacheTtl?: PromptCacheTtl;
+  bedrockModelId?: string;
   log?: LogFn;
 }): Promise<{
   text: string;
@@ -1824,11 +1820,14 @@ async function summarizeWithCacheHit({
       { attribution: 'synthetic' },
     ]);
   }
-  const fullMessages = [...messages, instructionMessage];
-  const invokeMessages =
-    usePromptCache === true
-      ? addTailCacheControl(fullMessages, promptCacheTtl)
-      : fullMessages;
+  const cachedHistory = applySummarizationHistoryCache({
+    messages,
+    provider,
+    enabled: usePromptCache === true,
+    promptCacheTtl,
+    bedrockModelId,
+  });
+  const invokeMessages = [...cachedHistory, instructionMessage];
 
   const invokeConfig = withBreakerSignal(
     traceConfig(config, 'cache_hit_compaction'),

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -44,12 +44,15 @@ import {
   createCompactionCacheNamespace,
   createCompactionToolProjectionFingerprint,
   EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
+  extractCompactionReplayPrefixProjection,
   isCompactionPromptCacheEnabled,
 } from '@/llm/compactionReplay';
 import {
+  prepareProviderRequest,
   resolveServingModelId,
   usesNativeOpenAIResponses,
 } from '@/llm/prepareProviderRequest';
+import { setProviderMessageProvenance } from '@/messages/provenance';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -683,6 +686,7 @@ async function executeSummarizationWithFallback(params: {
   let usedMetadataStub = false;
   let summarizationModel: t.ChatModel | undefined;
   let compactionReplayRouteSnapshot: CompactionReplayRouteSnapshot | undefined;
+  let compactionReplayProjectedMessages: readonly BaseMessage[] | undefined;
   const summarizationTools = agentContext.getToolsForBinding();
 
   const observeCompactionReplay = (summarizerFallbackServed: boolean): void => {
@@ -721,6 +725,7 @@ async function executeSummarizationWithFallback(params: {
         ? createCompactionToolProjectionFingerprint(summarizationTools)
         : undefined,
       messages,
+      projectedMessages: compactionReplayProjectedMessages,
       restoredToolSubstitution,
       summarizerFallbackServed,
     });
@@ -778,6 +783,8 @@ async function executeSummarizationWithFallback(params: {
     });
     summaryText = result.text;
     summaryUsage = result.usage;
+    compactionReplayProjectedMessages =
+      extractCompactionReplayPrefixProjection(result.preparedMessages);
     observeCompactionReplay(false);
   } catch (primaryError) {
     const primaryDescribed = describeProviderError(
@@ -1760,24 +1767,40 @@ async function summarizeWithCacheHit({
   usePromptCache?: boolean;
   promptCacheTtl?: PromptCacheTtl;
   log?: LogFn;
-}): Promise<{ text: string; usage?: Partial<UsageMetadata> }> {
+}): Promise<{
+  text: string;
+  usage?: Partial<UsageMetadata>;
+  preparedMessages: readonly BaseMessage[];
+}> {
   const instruction = buildSummarizationInstruction(
     promptText,
     updatePromptText,
     priorSummaryText
   );
 
-  const fullMessages = [...messages, new HumanMessage(instruction)];
+  const instructionMessage = new HumanMessage(instruction);
+  setProviderMessageProvenance(instructionMessage, [
+    { attribution: 'synthetic' },
+  ]);
+  const fullMessages = [...messages, instructionMessage];
   const invokeMessages =
     usePromptCache === true
       ? addTailCacheControl(fullMessages, promptCacheTtl)
       : fullMessages;
 
+  const invokeConfig = withBreakerSignal(
+    traceConfig(config, 'cache_hit_compaction'),
+    graph
+  );
+  const preparedRequest = prepareProviderRequest({
+    model,
+    messages: invokeMessages,
+    provider,
+    config: invokeConfig,
+  });
   const result = await attemptInvoke(
     {
-      model,
-      messages: invokeMessages,
-      provider,
+      request: preparedRequest,
       onChunk: createSummarizationChunkHandler({
         stepId,
         config: traceConfig(config, 'cache_hit_compaction'),
@@ -1789,7 +1812,7 @@ async function summarizeWithCacheHit({
        * producer claim never stacks with the onChunk handler's). */
       streamLimitState: graph,
     },
-    withBreakerSignal(traceConfig(config, 'cache_hit_compaction'), graph)
+    invokeConfig
   );
 
   const responseMsg = result.messages?.[0];
@@ -1840,5 +1863,5 @@ async function summarizeWithCacheHit({
       }
       : {}),
   });
-  return { text, usage };
+  return { text, usage, preparedMessages: preparedRequest.messages };
 }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -39,7 +39,11 @@ import {
   StepTypes,
   Providers,
 } from '@/common';
-import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
+import {
+  createCompactionCacheNamespace,
+  createCompactionToolProjectionFingerprint,
+  isCompactionPromptCacheEnabled,
+} from '@/llm/compactionReplay';
 import {
   resolveServingModelId,
   usesNativeOpenAIResponses,
@@ -676,6 +680,7 @@ async function executeSummarizationWithFallback(params: {
   let summaryUsage: Partial<UsageMetadata> | undefined;
   let usedMetadataStub = false;
   let summarizationModel: t.ChatModel | undefined;
+  const summarizationTools = agentContext.getToolsForBinding();
 
   const observeCompactionReplay = (
     summarizerFallbackServed: boolean
@@ -693,6 +698,10 @@ async function executeSummarizationWithFallback(params: {
         ? 'openai-responses'
         : 'chat-messages';
     }
+    const promptCacheEnabled = isCompactionPromptCacheEnabled(
+      clientConfig.provider as t.ProviderName,
+      clientConfig.clientOptions
+    );
     const compactionReplay = agentContext.inspectCompactionReplay({
       provider: clientConfig.provider as t.ProviderName,
       modelId:
@@ -703,6 +712,11 @@ async function executeSummarizationWithFallback(params: {
         clientConfig.provider as t.ProviderName,
         clientConfig.clientOptions
       ),
+      promptCacheEnabled,
+      toolProjectionFingerprint:
+        promptCacheEnabled
+          ? createCompactionToolProjectionFingerprint(summarizationTools)
+          : undefined,
       messages,
       restoredToolSubstitution,
       summarizerFallbackServed,
@@ -719,7 +733,7 @@ async function executeSummarizationWithFallback(params: {
     summarizationModel = initializeModel({
       provider: clientConfig.provider,
       clientOptions: clientConfig.clientOptions as t.ClientOptions,
-      tools: agentContext.getToolsForBinding(),
+      tools: summarizationTools,
     }) as t.ChatModel;
 
     const result = await summarizeWithCacheHit({

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -39,6 +39,7 @@ import {
   StepTypes,
   Providers,
 } from '@/common';
+import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -367,6 +368,24 @@ function buildSummarizationClientConfig(
     promptText,
     updatePromptText,
   };
+}
+
+function resolveSummarizationModelId(
+  clientConfig: SummarizationClientConfig
+): string | undefined {
+  if (clientConfig.modelName != null && clientConfig.modelName !== '') {
+    return clientConfig.modelName;
+  }
+  const options = clientConfig.clientOptions as {
+    model?: unknown;
+    modelName?: unknown;
+  };
+  if (typeof options.model === 'string' && options.model !== '') {
+    return options.model;
+  }
+  return typeof options.modelName === 'string' && options.modelName !== ''
+    ? options.modelName
+    : undefined;
 }
 
 /** Computes the token count for a summary, preferring provider output tokens when available. */
@@ -1230,6 +1249,32 @@ export function createSummarizeNode({
         agentId: request.agentId,
       });
     };
+
+    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
+      let restoredToolSubstitution = false;
+      if (restoredMessages !== state.messages && originalPending != null) {
+        for (const index of originalPending.keys()) {
+          if (
+            index < tailStartIndex &&
+            restoredMessages[index] !== state.messages[index]
+          ) {
+            restoredToolSubstitution = true;
+            break;
+          }
+        }
+      }
+      const compactionReplay = agentContext.inspectCompactionReplay({
+        provider: clientConfig.provider as t.ProviderName,
+        modelId: resolveSummarizationModelId(clientConfig),
+        cacheNamespace: createCompactionCacheNamespace(
+          clientConfig.provider as t.ProviderName,
+          clientConfig.clientOptions
+        ),
+        messages: messagesToRefine,
+        restoredToolSubstitution,
+      });
+      log('debug', 'Compaction replay eligibility', { ...compactionReplay });
+    }
 
     log('debug', 'Summarization starting', {
       messagesToRefineCount: messagesToRefine.length,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -40,7 +40,10 @@ import {
   Providers,
 } from '@/common';
 import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
-import { usesNativeOpenAIResponses } from '@/llm/prepareProviderRequest';
+import {
+  resolveServingModelId,
+  usesNativeOpenAIResponses,
+} from '@/llm/prepareProviderRequest';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -672,6 +675,40 @@ async function executeSummarizationWithFallback(params: {
   let summaryText = '';
   let summaryUsage: Partial<UsageMetadata> | undefined;
   let usedMetadataStub = false;
+  let summarizationModel: t.ChatModel | undefined;
+
+  const observeCompactionReplay = (
+    summarizerFallbackServed: boolean
+  ): void => {
+    if (process.env.AGENT_DEBUG_LOGGING !== 'true') {
+      return;
+    }
+    let projectionMode: 'chat-messages' | 'openai-responses' | undefined;
+    if (summarizationModel != null) {
+      projectionMode = usesNativeOpenAIResponses(
+        summarizationModel,
+        clientConfig.provider as t.ProviderName,
+        summarizeConfig
+      )
+        ? 'openai-responses'
+        : 'chat-messages';
+    }
+    const compactionReplay = agentContext.inspectCompactionReplay({
+      provider: clientConfig.provider as t.ProviderName,
+      modelId:
+        resolveServingModelId(summarizationModel) ??
+        resolveSummarizationModelId(clientConfig),
+      projectionMode,
+      cacheNamespace: createCompactionCacheNamespace(
+        clientConfig.provider as t.ProviderName,
+        clientConfig.clientOptions
+      ),
+      messages,
+      restoredToolSubstitution,
+      summarizerFallbackServed,
+    });
+    log('debug', 'Compaction replay eligibility', { ...compactionReplay });
+  };
 
   try {
     /**
@@ -679,32 +716,11 @@ async function executeSummarizationWithFallback(params: {
      * (e.g. an unrecognized summarization.provider) surfaces through the
      * `log('error', ...)` path below rather than bubbling up silently.
      */
-    const summarizationModel = initializeModel({
+    summarizationModel = initializeModel({
       provider: clientConfig.provider,
       clientOptions: clientConfig.clientOptions as t.ClientOptions,
       tools: agentContext.getToolsForBinding(),
     }) as t.ChatModel;
-
-    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
-      const compactionReplay = agentContext.inspectCompactionReplay({
-        provider: clientConfig.provider as t.ProviderName,
-        modelId: resolveSummarizationModelId(clientConfig),
-        projectionMode: usesNativeOpenAIResponses(
-          summarizationModel,
-          clientConfig.provider as t.ProviderName,
-          summarizeConfig
-        )
-          ? 'openai-responses'
-          : 'chat-messages',
-        cacheNamespace: createCompactionCacheNamespace(
-          clientConfig.provider as t.ProviderName,
-          clientConfig.clientOptions
-        ),
-        messages,
-        restoredToolSubstitution,
-      });
-      log('debug', 'Compaction replay eligibility', { ...compactionReplay });
-    }
 
     const result = await summarizeWithCacheHit({
       model: summarizationModel,
@@ -733,6 +749,7 @@ async function executeSummarizationWithFallback(params: {
     });
     summaryText = result.text;
     summaryUsage = result.usage;
+    observeCompactionReplay(false);
   } catch (primaryError) {
     const primaryDescribed = describeProviderError(
       primaryError,
@@ -811,6 +828,9 @@ async function executeSummarizationWithFallback(params: {
           summaryText = extractResponseText(
             fbMsg as { content: string | object }
           );
+          if (summaryText !== '') {
+            observeCompactionReplay(true);
+          }
         }
       } catch (fbErr) {
         if (fbErr instanceof StreamLimitExceededError) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -42,6 +42,7 @@ import {
 import {
   createCompactionCacheNamespace,
   createCompactionToolProjectionFingerprint,
+  EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   isCompactionPromptCacheEnabled,
 } from '@/llm/compactionReplay';
 import {
@@ -713,6 +714,8 @@ async function executeSummarizationWithFallback(params: {
         clientConfig.clientOptions
       ),
       promptCacheEnabled,
+      systemProjectionFingerprint:
+        EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
       toolProjectionFingerprint:
         promptCacheEnabled
           ? createCompactionToolProjectionFingerprint(summarizationTools)

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -26,6 +26,7 @@ import {
 import {
   addTailCacheControl,
   addBedrockTailCacheControl,
+  resolvePromptCacheTtl,
   resolveBedrockPromptCacheTtl,
   type PromptCacheTtl,
 } from '@/messages/cache';
@@ -785,8 +786,16 @@ async function executeSummarizationWithFallback(params: {
       bedrockModelId:
         clientConfig.provider === Providers.BEDROCK
           ? (
+              clientConfig.clientOptions as
+                | {
+                  applicationInferenceProfile?: string;
+                  model?: string;
+                }
+                | undefined
+          )?.applicationInferenceProfile ??
+            (
               clientConfig.clientOptions as { model?: string } | undefined
-          )?.model
+            )?.model
           : undefined,
       log,
     });
@@ -1763,7 +1772,10 @@ export function applySummarizationHistoryCache(params: {
       )
     );
   }
-  return addTailCacheControl([...params.messages], params.promptCacheTtl);
+  return addTailCacheControl(
+    [...params.messages],
+    resolvePromptCacheTtl(params.promptCacheTtl)
+  );
 }
 
 /**

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -40,6 +40,7 @@ import {
   Providers,
 } from '@/common';
 import { createCompactionCacheNamespace } from '@/llm/compactionReplay';
+import { usesNativeOpenAIResponses } from '@/llm/prepareProviderRequest';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -643,6 +644,7 @@ async function executeSummarizationWithFallback(params: {
   log: LogFn;
   /** Carries the run's stream limits so the event cap covers summary streams. */
   graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
+  restoredToolSubstitution: boolean;
 }): Promise<{
   text: string;
   usage?: Partial<UsageMetadata>;
@@ -662,6 +664,7 @@ async function executeSummarizationWithFallback(params: {
     usePromptCache,
     log,
     graph,
+    restoredToolSubstitution,
   } = params;
 
   const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
@@ -681,6 +684,27 @@ async function executeSummarizationWithFallback(params: {
       clientOptions: clientConfig.clientOptions as t.ClientOptions,
       tools: agentContext.getToolsForBinding(),
     }) as t.ChatModel;
+
+    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
+      const compactionReplay = agentContext.inspectCompactionReplay({
+        provider: clientConfig.provider as t.ProviderName,
+        modelId: resolveSummarizationModelId(clientConfig),
+        projectionMode: usesNativeOpenAIResponses(
+          summarizationModel,
+          clientConfig.provider as t.ProviderName,
+          summarizeConfig
+        )
+          ? 'openai-responses'
+          : 'chat-messages',
+        cacheNamespace: createCompactionCacheNamespace(
+          clientConfig.provider as t.ProviderName,
+          clientConfig.clientOptions
+        ),
+        messages,
+        restoredToolSubstitution,
+      });
+      log('debug', 'Compaction replay eligibility', { ...compactionReplay });
+    }
 
     const result = await summarizeWithCacheHit({
       model: summarizationModel,
@@ -1250,30 +1274,21 @@ export function createSummarizeNode({
       });
     };
 
-    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
-      let restoredToolSubstitution = false;
-      if (restoredMessages !== state.messages && originalPending != null) {
-        for (const index of originalPending.keys()) {
-          if (
-            index < tailStartIndex &&
-            restoredMessages[index] !== state.messages[index]
-          ) {
-            restoredToolSubstitution = true;
-            break;
-          }
+    let restoredToolSubstitution = false;
+    if (
+      process.env.AGENT_DEBUG_LOGGING === 'true' &&
+      restoredMessages !== state.messages &&
+      originalPending != null
+    ) {
+      for (const index of originalPending.keys()) {
+        if (
+          index < tailStartIndex &&
+          restoredMessages[index] !== state.messages[index]
+        ) {
+          restoredToolSubstitution = true;
+          break;
         }
       }
-      const compactionReplay = agentContext.inspectCompactionReplay({
-        provider: clientConfig.provider as t.ProviderName,
-        modelId: resolveSummarizationModelId(clientConfig),
-        cacheNamespace: createCompactionCacheNamespace(
-          clientConfig.provider as t.ProviderName,
-          clientConfig.clientOptions
-        ),
-        messages: messagesToRefine,
-        restoredToolSubstitution,
-      });
-      log('debug', 'Compaction replay eligibility', { ...compactionReplay });
     }
 
     log('debug', 'Summarization starting', {
@@ -1349,6 +1364,7 @@ export function createSummarizeNode({
       usePromptCache: isSelfSummarizeModel && hasPromptCache,
       log,
       graph,
+      restoredToolSubstitution,
     });
 
     /**

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -25,7 +25,9 @@ import {
 } from '@/llm/streamLimits';
 import {
   addTailCacheControl,
+  addBedrockTailCacheControl,
   resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   type PromptCacheTtl,
 } from '@/messages/cache';
 import {
@@ -686,7 +688,10 @@ async function executeSummarizationWithFallback(params: {
   let usedMetadataStub = false;
   let summarizationModel: t.ChatModel | undefined;
   let compactionReplayRouteSnapshot: CompactionReplayRouteSnapshot | undefined;
-  let compactionReplayProjectedMessages: readonly BaseMessage[] | undefined;
+  let compactionReplayProjectedMessages:
+    | readonly BaseMessage[]
+    | null
+    | undefined;
   const summarizationTools = agentContext.getToolsForBinding();
 
   const observeCompactionReplay = (summarizerFallbackServed: boolean): void => {
@@ -783,8 +788,43 @@ async function executeSummarizationWithFallback(params: {
     });
     summaryText = result.text;
     summaryUsage = result.usage;
-    compactionReplayProjectedMessages =
-      extractCompactionReplayPrefixProjection(result.preparedMessages);
+    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
+      const projectedPrefix = extractCompactionReplayPrefixProjection(
+        result.preparedMessages
+      );
+      if (projectedPrefix == null) {
+        compactionReplayProjectedMessages = null;
+      } else if (!usePromptCache) {
+        compactionReplayProjectedMessages = projectedPrefix;
+      } else if (clientConfig.provider === Providers.BEDROCK) {
+        const clientOptions = clientConfig.clientOptions as
+          | t.BedrockAnthropicClientOptions
+          | undefined;
+        compactionReplayProjectedMessages = addBedrockTailCacheControl(
+          [...projectedPrefix],
+          resolveBedrockPromptCacheTtl(
+            clientOptions?.promptCacheTtl,
+            (clientOptions as { model?: string } | undefined)?.model
+          )
+        );
+      } else if (
+        clientConfig.provider === Providers.ANTHROPIC ||
+        clientConfig.provider === Providers.OPENROUTER
+      ) {
+        compactionReplayProjectedMessages = addTailCacheControl(
+          [...projectedPrefix],
+          resolvePromptCacheTtl(
+            (
+                  clientConfig.clientOptions as {
+                    promptCacheTtl?: PromptCacheTtl;
+                  }
+            ).promptCacheTtl
+          )
+        );
+      } else {
+        compactionReplayProjectedMessages = projectedPrefix;
+      }
+    }
     observeCompactionReplay(false);
   } catch (primaryError) {
     const primaryDescribed = describeProviderError(
@@ -1779,9 +1819,11 @@ async function summarizeWithCacheHit({
   );
 
   const instructionMessage = new HumanMessage(instruction);
-  setProviderMessageProvenance(instructionMessage, [
-    { attribution: 'synthetic' },
-  ]);
+  if (process.env.AGENT_DEBUG_LOGGING === 'true') {
+    setProviderMessageProvenance(instructionMessage, [
+      { attribution: 'synthetic' },
+    ]);
+  }
   const fullMessages = [...messages, instructionMessage];
   const invokeMessages =
     usePromptCache === true

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -6,6 +6,7 @@ import {
 } from '@langchain/core/messages';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { CompactionReplayRouteSnapshot } from '@/llm/compactionReplay';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
@@ -681,11 +682,10 @@ async function executeSummarizationWithFallback(params: {
   let summaryUsage: Partial<UsageMetadata> | undefined;
   let usedMetadataStub = false;
   let summarizationModel: t.ChatModel | undefined;
+  let compactionReplayRouteSnapshot: CompactionReplayRouteSnapshot | undefined;
   const summarizationTools = agentContext.getToolsForBinding();
 
-  const observeCompactionReplay = (
-    summarizerFallbackServed: boolean
-  ): void => {
+  const observeCompactionReplay = (summarizerFallbackServed: boolean): void => {
     if (process.env.AGENT_DEBUG_LOGGING !== 'true') {
       return;
     }
@@ -699,27 +699,27 @@ async function executeSummarizationWithFallback(params: {
         ? 'openai-responses'
         : 'chat-messages';
     }
-    const promptCacheEnabled = isCompactionPromptCacheEnabled(
-      clientConfig.provider as t.ProviderName,
-      clientConfig.clientOptions
-    );
+    const promptCacheEnabled =
+      compactionReplayRouteSnapshot?.promptCacheEnabled ?? false;
     const compactionReplay = agentContext.inspectCompactionReplay({
       provider: clientConfig.provider as t.ProviderName,
       modelId:
         resolveServingModelId(summarizationModel) ??
         resolveSummarizationModelId(clientConfig),
       projectionMode,
-      cacheNamespace: createCompactionCacheNamespace(
-        clientConfig.provider as t.ProviderName,
-        clientConfig.clientOptions
-      ),
+      cacheNamespace:
+        compactionReplayRouteSnapshot?.cacheNamespace ??
+        createCompactionCacheNamespace(
+          clientConfig.provider as t.ProviderName,
+          undefined,
+          false
+        ),
       promptCacheEnabled,
       systemProjectionFingerprint:
         EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
-      toolProjectionFingerprint:
-        promptCacheEnabled
-          ? createCompactionToolProjectionFingerprint(summarizationTools)
-          : undefined,
+      toolProjectionFingerprint: promptCacheEnabled
+        ? createCompactionToolProjectionFingerprint(summarizationTools)
+        : undefined,
       messages,
       restoredToolSubstitution,
       summarizerFallbackServed,
@@ -738,6 +738,18 @@ async function executeSummarizationWithFallback(params: {
       clientOptions: clientConfig.clientOptions as t.ClientOptions,
       tools: summarizationTools,
     }) as t.ChatModel;
+    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
+      compactionReplayRouteSnapshot = Object.freeze({
+        cacheNamespace: createCompactionCacheNamespace(
+          clientConfig.provider as t.ProviderName,
+          clientConfig.clientOptions
+        ),
+        promptCacheEnabled: isCompactionPromptCacheEnabled(
+          clientConfig.provider as t.ProviderName,
+          clientConfig.clientOptions
+        ),
+      });
+    }
 
     const result = await summarizeWithCacheHit({
       model: summarizationModel,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -6,7 +6,10 @@ import {
 } from '@langchain/core/messages';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import type { CompactionReplayRouteSnapshot } from '@/llm/compactionReplay';
+import type {
+  CompactionReplayCandidateSnapshot,
+  CompactionReplayRouteSnapshot,
+} from '@/llm/compactionReplay';
 import type { StreamLimitState } from '@/llm/streamLimits';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
@@ -44,6 +47,7 @@ import {
 } from '@/common';
 import {
   createCompactionCacheNamespace,
+  createCompactionReplayCandidateSnapshot,
   createCompactionToolProjectionFingerprint,
   EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
   extractCompactionReplayPrefixProjection,
@@ -690,10 +694,10 @@ async function executeSummarizationWithFallback(params: {
   let usedMetadataStub = false;
   let summarizationModel: t.ChatModel | undefined;
   let compactionReplayRouteSnapshot: CompactionReplayRouteSnapshot | undefined;
-  let compactionReplayProjectedMessages:
-    | readonly BaseMessage[]
-    | null
+  let compactionReplayCandidateSnapshot:
+    | CompactionReplayCandidateSnapshot
     | undefined;
+  let compactionReplayToolProjectionFingerprint: string | undefined;
   const rawSummarizationTools = agentContext.getToolsForBinding();
   const bedrockOptions = clientConfig.clientOptions as
     | t.BedrockAnthropicClientOptions
@@ -741,10 +745,10 @@ async function executeSummarizationWithFallback(params: {
       systemProjectionFingerprint:
         EMPTY_COMPACTION_SYSTEM_PROJECTION_FINGERPRINT,
       toolProjectionFingerprint: promptCacheEnabled
-        ? createCompactionToolProjectionFingerprint(summarizationTools)
+        ? compactionReplayToolProjectionFingerprint
         : undefined,
       messages,
-      projectedMessages: compactionReplayProjectedMessages,
+      snapshot: compactionReplayCandidateSnapshot,
       restoredToolSubstitution,
       summarizerFallbackServed,
     });
@@ -757,11 +761,6 @@ async function executeSummarizationWithFallback(params: {
      * (e.g. an unrecognized summarization.provider) surfaces through the
      * `log('error', ...)` path below rather than bubbling up silently.
      */
-    summarizationModel = initializeModel({
-      provider: clientConfig.provider,
-      clientOptions: clientConfig.clientOptions as t.ClientOptions,
-      tools: summarizationTools,
-    }) as t.ChatModel;
     if (process.env.AGENT_DEBUG_LOGGING === 'true') {
       compactionReplayRouteSnapshot = Object.freeze({
         cacheNamespace: createCompactionCacheNamespace(
@@ -773,7 +772,17 @@ async function executeSummarizationWithFallback(params: {
           clientConfig.clientOptions
         ),
       });
+      if (compactionReplayRouteSnapshot.promptCacheEnabled) {
+        compactionReplayToolProjectionFingerprint =
+          createCompactionToolProjectionFingerprint(summarizationTools);
+      }
     }
+
+    summarizationModel = initializeModel({
+      provider: clientConfig.provider,
+      clientOptions: clientConfig.clientOptions as t.ClientOptions,
+      tools: summarizationTools,
+    }) as t.ChatModel;
 
     const result = await summarizeWithCacheHit({
       model: summarizationModel,
@@ -812,11 +821,8 @@ async function executeSummarizationWithFallback(params: {
     });
     summaryText = result.text;
     summaryUsage = result.usage;
-    if (process.env.AGENT_DEBUG_LOGGING === 'true') {
-      compactionReplayProjectedMessages =
-        extractCompactionReplayPrefixProjection(result.preparedMessages) ??
-        null;
-    }
+    compactionReplayCandidateSnapshot =
+      result.compactionReplayCandidateSnapshot;
     observeCompactionReplay(false);
   } catch (primaryError) {
     const primaryDescribed = describeProviderError(
@@ -1837,7 +1843,7 @@ async function summarizeWithCacheHit({
 }): Promise<{
   text: string;
   usage?: Partial<UsageMetadata>;
-  preparedMessages: readonly BaseMessage[];
+  compactionReplayCandidateSnapshot?: CompactionReplayCandidateSnapshot;
 }> {
   const instruction = buildSummarizationInstruction(
     promptText,
@@ -1870,6 +1876,14 @@ async function summarizeWithCacheHit({
     provider,
     config: invokeConfig,
   });
+  const compactionReplayCandidateSnapshot =
+    process.env.AGENT_DEBUG_LOGGING === 'true'
+      ? createCompactionReplayCandidateSnapshot(
+        messages,
+        extractCompactionReplayPrefixProjection(preparedRequest.messages) ??
+            null
+      )
+      : undefined;
   const result = await attemptInvoke(
     {
       request: preparedRequest,
@@ -1935,5 +1949,9 @@ async function summarizeWithCacheHit({
       }
       : {}),
   });
-  return { text, usage, preparedMessages: preparedRequest.messages };
+  return {
+    text,
+    usage,
+    compactionReplayCandidateSnapshot,
+  };
 }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -698,19 +698,6 @@ async function executeSummarizationWithFallback(params: {
     | CompactionReplayCandidateSnapshot
     | undefined;
   let compactionReplayToolProjectionFingerprint: string | undefined;
-  const rawSummarizationTools = agentContext.getToolsForBinding();
-  const bedrockOptions = clientConfig.clientOptions as
-    | t.BedrockAnthropicClientOptions
-    | undefined;
-  const summarizationTools =
-    clientConfig.provider === Providers.BEDROCK
-      ? prepareBedrockToolsForPromptCache(
-        rawSummarizationTools,
-        makeIsDeferred(agentContext.getEffectiveToolDefinitions()),
-        bedrockOptions?.promptCache === true,
-        (bedrockOptions as { model?: string } | undefined)?.model
-      )
-      : rawSummarizationTools;
 
   const observeCompactionReplay = (summarizerFallbackServed: boolean): void => {
     if (process.env.AGENT_DEBUG_LOGGING !== 'true') {
@@ -761,6 +748,19 @@ async function executeSummarizationWithFallback(params: {
      * (e.g. an unrecognized summarization.provider) surfaces through the
      * `log('error', ...)` path below rather than bubbling up silently.
      */
+    const rawSummarizationTools = agentContext.getToolsForBinding();
+    const bedrockOptions = clientConfig.clientOptions as
+      | t.BedrockAnthropicClientOptions
+      | undefined;
+    const summarizationTools =
+      clientConfig.provider === Providers.BEDROCK
+        ? prepareBedrockToolsForPromptCache(
+          rawSummarizationTools,
+          makeIsDeferred(agentContext.getEffectiveToolDefinitions()),
+          bedrockOptions?.promptCache === true,
+          (bedrockOptions as { model?: string } | undefined)?.model
+        )
+        : rawSummarizationTools;
     if (process.env.AGENT_DEBUG_LOGGING === 'true') {
       compactionReplayRouteSnapshot = Object.freeze({
         cacheNamespace: createCompactionCacheNamespace(

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -58,7 +58,9 @@ import { setProviderMessageProvenance } from '@/messages/provenance';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
+import { prepareBedrockToolsForPromptCache } from '@/llm/bedrock/toolCache';
 import { createRemoveAllMessage } from '@/messages/reducer';
+import { makeIsDeferred } from '@/messages';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
@@ -692,7 +694,19 @@ async function executeSummarizationWithFallback(params: {
     | readonly BaseMessage[]
     | null
     | undefined;
-  const summarizationTools = agentContext.getToolsForBinding();
+  const rawSummarizationTools = agentContext.getToolsForBinding();
+  const bedrockOptions = clientConfig.clientOptions as
+    | t.BedrockAnthropicClientOptions
+    | undefined;
+  const summarizationTools =
+    clientConfig.provider === Providers.BEDROCK
+      ? prepareBedrockToolsForPromptCache(
+        rawSummarizationTools,
+        makeIsDeferred(agentContext.getEffectiveToolDefinitions()),
+        bedrockOptions?.promptCache === true,
+        (bedrockOptions as { model?: string } | undefined)?.model
+      )
+      : rawSummarizationTools;
 
   const observeCompactionReplay = (summarizerFallbackServed: boolean): void => {
     if (process.env.AGENT_DEBUG_LOGGING !== 'true') {
@@ -1338,7 +1352,7 @@ export function createSummarizeNode({
       clientConfig.provider === (agentContext.provider as string);
     const hasPromptCache =
       isSelfSummarizeModel &&
-      (agentContext.clientOptions as Record<string, unknown> | undefined)
+      (clientConfig.clientOptions as Record<string, unknown> | undefined)
         ?.promptCache === true;
 
     const log: LogFn = (level, message, data) => {


### PR DESCRIPTION
## Summary
- capture a debug-only, run-local replay recipe after successful normal requests
- report fail-closed replay eligibility without changing summarization inputs or calls
- prove serving route, model, projection mode, source lineage, and source-content identity
- classify normal-request and summarizer fallbacks without false cache-reuse claims
- add deterministic and live prompt-cache benchmark coverage for the follow-up replay PR

## Performance
- rejected a LangChain callback prototype after it added about 56.9 microseconds per invocation
- debug logging disabled: zero replay-snapshot capture, fingerprinting, message retention, or lineage work
- debug logging enabled: repeated 100-tool-step runs measured 0.56–0.84 milliseconds for capture and 0.61–0.90 milliseconds for inspection
- runtime providers, opaque/dynamic identities, and override-model routes fail closed until they expose a provable namespace

## Verification
- `npx tsc --noEmit`
- 239 focused compaction, context, summarization, and overflow tests
- 187 Langfuse and deterministic trace ID tests
- `npm run build`
- `npm run bench:compaction-replay`
- `git diff --check`

Live paid-provider benchmark support is included, but was not executed locally because Anthropic and Bedrock credentials were unavailable.