### PR TITLE
perf: align compaction with provider cache prefixes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -146,8 +146,17 @@ older closed tool-call/result unit while retaining a token-priced recent tail.
 Open and parallel tool units are indivisible, and a lone user payload is never
 eligible for the intra-turn fallback.
 
+A **Cache-Aligned Compaction Request** reuses the normal provider request's
+cacheable tool prefix and anchors retained history before the one-off
+summarization instruction. Provider-specific cache markers and TTL resolution
+come from shared request-preparation functions; cache-read usage is the source
+of truth for whether reuse occurred. Compaction never predicts cache identity
+from a hand-maintained list of provider options or environment variables.
+
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.
+See [ADR 0006](docs/adr/0006-align-compaction-with-provider-cache-prefixes.md)
+for the prompt-cache boundary and rejected predictive replay design.
 
 ## Provider Tool Derivation
 

--- a/docs/adr/0006-align-compaction-with-provider-cache-prefixes.md
+++ b/docs/adr/0006-align-compaction-with-provider-cache-prefixes.md
@@ -1,0 +1,54 @@
+# ADR 0006: Align Compaction with Provider Cache Prefixes
+
+## Status
+
+Accepted
+
+## Context
+
+Normal agent requests already place provider-specific cache breakpoints on the
+stable tool prefix. The summarizer bound the same logical tools independently,
+so Anthropic, OpenRouter, and Bedrock compaction requests could omit or resolve
+those breakpoints differently. Compaction also placed its message breakpoint
+after the unique summarization instruction, preventing the retained history
+from matching a reusable prefix.
+
+An earlier design attempted to predict whether the normal and compaction
+requests had identical cache identities. It fingerprinted provider options,
+environment fallbacks, formatted tools, and message projections before the
+request was sent. That approach required a closed allowlist over provider SDK
+behavior and repeatedly admitted false eligibility when a new route input or
+resolution rule was discovered.
+
+## Decision
+
+Normal and summarization model construction use one live tool projection. It
+resolves local or Cloudflare execution tools, the discovered deferred-tool set,
+and provider cache preparation at invocation time. It preserves the existing
+static-before-deferred partition and applies the same cache marker and TTL
+rules for Anthropic, OpenRouter, and cache-capable Bedrock Claude models. Other
+providers and Bedrock model families receive their original tools unchanged.
+
+When self-summarization uses prompt caching, retained history receives the
+provider-specific tail breakpoint before the unique compaction instruction is
+appended. Bedrock history TTL resolution uses the configured model family even
+when the serving route is an opaque application inference profile. Fallback
+providers receive no marker intended for another provider.
+
+Cache reuse is established by provider-reported cache-creation and cache-read
+usage. The SDK does not retain request snapshots or predict eligibility from
+configuration and environment inputs. A live before-and-after benchmark primes
+the normal tool prefix, invokes the former unmarked compaction shape, and then
+invokes the aligned shape while recording cache reads and latency.
+
+## Consequences
+
+- Normal request preparation performs the same provider-specific tool work as
+  before; the logic moves behind a shared function rather than adding another
+  pass to the hot path.
+- Summarization performs one provider tool-prefix preparation pass only when
+  compaction runs and can reuse both stable tools and retained history.
+- Provider usage remains the authoritative cache receipt, so SDK routing and
+  serialization changes cannot silently make an eligibility predictor lie.
+- Exact serialized-request comparison remains available as a future diagnostic
+  seam, but is not required for cache reuse and is not part of this change.

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -59,14 +59,12 @@ import {
   addTailCacheControl,
   resolvePromptCacheTtl,
   resolveBedrockPromptCacheTtl,
-  supportsBedrockToolCache,
   isSyntheticProviderContextMessage,
   compactSyntheticProviderContextMessage,
   getMessageId,
   getMessageCreationContentMetadata,
   splitAssistantTextContentByPhase,
   makeIsDeferred,
-  partitionAndMarkAnthropicToolCache,
   DEFAULT_RETAIN_RECENT_TURNS,
   resolveIntraTurnRetainTokens,
   splitAtRecencyBoundary,
@@ -149,14 +147,13 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
-import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
@@ -2789,6 +2786,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     };
   }
 
+  private getPreparedToolsForBinding(
+    agentContext: AgentContext,
+    provider: t.ProviderName = agentContext.provider,
+    clientOptions: t.ClientOptions | undefined = agentContext.clientOptions
+  ): t.GraphTools | undefined {
+    const tools = resolveLocalToolsForBinding({
+      tools: agentContext.getToolsForBinding(),
+      toolExecution: this.toolExecution,
+      toolRegistry: agentContext.toolRegistry,
+      discoveredToolNames: new Set(agentContext.getDiscoveredTools()),
+    });
+    return prepareToolsForPromptCache({
+      provider,
+      clientOptions,
+      tools,
+      isDeferred: makeIsDeferred(
+        agentContext.getEffectiveToolDefinitions()
+      ),
+    });
+  }
+
   createCallModel(agentId = 'default') {
     return async (
       state: t.AgentSubgraphState,
@@ -2846,13 +2864,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentContext.markToolsAsDiscovered(discoveredNames);
       }
 
-      const rawToolsForBinding = resolveLocalToolsForBinding({
-        tools: agentContext.getToolsForBinding(),
-        toolExecution: this.toolExecution,
-        toolRegistry: agentContext.toolRegistry,
-        discoveredToolNames: new Set(agentContext.getDiscoveredTools()),
-      });
-
       /**
        * Anthropic prompt-cache breakpoint on the tool definitions.
        *
@@ -2866,69 +2877,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * Discovered deferred tools that arrive across turns sit *after*
        * the breakpoint and don't invalidate the prefix.
        */
-      let toolsForBinding = rawToolsForBinding;
-      const isDeferredTool = makeIsDeferred(
-        agentContext.getEffectiveToolDefinitions()
-      );
-      if (
-        agentContext.provider === Providers.ANTHROPIC &&
-        (agentContext.clientOptions as t.AnthropicClientOptions | undefined)
-          ?.promptCache === true
-      ) {
-        toolsForBinding =
-          partitionAndMarkAnthropicToolCache(
-            rawToolsForBinding,
-            isDeferredTool,
-            resolvePromptCacheTtl(
-              (
-                agentContext.clientOptions as
-                  | t.AnthropicClientOptions
-                  | undefined
-              )?.promptCacheTtl
-            )
-          ) ?? rawToolsForBinding;
-      } else if (
-        agentContext.provider === Providers.OPENROUTER &&
-        (
-          agentContext.clientOptions as
-            | t.ProviderOptionsMap[Providers.OPENROUTER]
-            | undefined
-        )?.promptCache === true
-      ) {
-        toolsForBinding =
-          partitionAndMarkOpenRouterToolCache(
-            rawToolsForBinding,
-            isDeferredTool,
-            resolvePromptCacheTtl(
-              (
-                agentContext.clientOptions as
-                  | t.ProviderOptionsMap[Providers.OPENROUTER]
-                  | undefined
-              )?.promptCacheTtl
-            )
-          ) ?? rawToolsForBinding;
-      } else if (
-        agentContext.provider === Providers.BEDROCK &&
-        (
-          agentContext.clientOptions as
-            | t.BedrockAnthropicClientOptions
-            | undefined
-        )?.promptCache === true
-      ) {
-        const bedrockModel = (
-          agentContext.clientOptions as { model?: string } | undefined
-        )?.model;
-        // An omitted model falls back to LangChain's default Claude model (which
-        // supports tool caching); only an explicit non-Claude model (e.g. Nova)
-        // skips tool marking so its stray marker never leaks into toolConfig.
-        if (bedrockModel == null || supportsBedrockToolCache(bedrockModel)) {
-          toolsForBinding =
-            partitionAndMarkBedrockToolCache(
-              rawToolsForBinding,
-              isDeferredTool
-            ) ?? rawToolsForBinding;
-        }
-      }
+      const toolsForBinding = this.getPreparedToolsForBinding(agentContext);
 
       let model =
         this.overrideModel ??
@@ -4924,6 +4873,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             runId: this.runId,
             isMultiAgent: this.isMultiAgentGraph(),
             hookRegistry: this.hookRegistry,
+            getToolsForBinding: (
+              provider: t.ProviderName,
+              clientOptions: t.ClientOptions | undefined
+            ): t.GraphTools | undefined =>
+              this.getPreparedToolsForBinding(
+                agentContext,
+                provider,
+                clientOptions
+              ),
             /**
              * Live references (both maps are cleared in place, never
              * replaced), so summarization streams share the run's event

--- a/src/llm/promptCacheTools.test.ts
+++ b/src/llm/promptCacheTools.test.ts
@@ -1,0 +1,90 @@
+import type { GraphTools } from '@/types';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
+import { Providers } from '@/common';
+
+function createTool(name: string): {
+  name: string;
+  description: string;
+  schema: { type: 'object'; properties: Record<string, never> };
+} {
+  return {
+    name,
+    description: `${name} description`,
+    schema: { type: 'object', properties: {} },
+  };
+}
+
+describe('prepareToolsForPromptCache', () => {
+  const tools = [createTool('stable'), createTool('deferred')] as GraphTools;
+  const isDeferred = (name: string): boolean => name === 'deferred';
+
+  it('marks the same Anthropic static prefix for every caller', () => {
+    const prepared = prepareToolsForPromptCache({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { promptCache: true },
+      tools,
+      isDeferred,
+    }) as Array<{ name: string; extras?: Record<string, unknown> }>;
+
+    expect(prepared.map((tool) => tool.name)).toEqual(['stable', 'deferred']);
+    expect(prepared[0].extras?.cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+    expect(prepared[1].extras?.cache_control).toBeUndefined();
+  });
+
+  it('marks the same OpenRouter static prefix for every caller', () => {
+    const prepared = prepareToolsForPromptCache({
+      provider: Providers.OPENROUTER,
+      clientOptions: { promptCache: true },
+      tools,
+      isDeferred,
+    }) as Array<{
+      function: { name: string };
+      cache_control?: { type: string; ttl?: string };
+    }>;
+
+    expect(prepared.map((tool) => tool.function.name)).toEqual([
+      'stable',
+      'deferred',
+    ]);
+    expect(prepared[0].cache_control).toEqual({
+      type: 'ephemeral',
+      ttl: '1h',
+    });
+    expect(prepared[1].cache_control).toBeUndefined();
+  });
+
+  it('marks Claude Bedrock tools and leaves Nova tools unchanged', () => {
+    const claude = prepareToolsForPromptCache({
+      provider: Providers.BEDROCK,
+      clientOptions: {
+        promptCache: true,
+        model: 'anthropic.claude-sonnet',
+      },
+      tools,
+      isDeferred,
+    });
+    const nova = prepareToolsForPromptCache({
+      provider: Providers.BEDROCK,
+      clientOptions: { promptCache: true, model: 'amazon.nova-pro-v1:0' },
+      tools,
+      isDeferred,
+    });
+
+    expect(claude).not.toBe(tools);
+    expect(nova).toBe(tools);
+  });
+
+  it('returns the original tools when prompt caching is disabled', () => {
+    expect(
+      prepareToolsForPromptCache({
+        provider: Providers.ANTHROPIC,
+        clientOptions: { promptCache: false },
+        tools,
+        isDeferred,
+      })
+    ).toBe(tools);
+  });
+});

--- a/src/llm/promptCacheTools.ts
+++ b/src/llm/promptCacheTools.ts
@@ -1,0 +1,58 @@
+import type * as t from '@/types';
+import {
+  resolvePromptCacheTtl,
+  supportsBedrockToolCache,
+} from '@/messages/cache';
+import { partitionAndMarkAnthropicToolCache } from '@/messages/anthropicToolCache';
+import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
+import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
+import { Providers } from '@/common';
+
+export function prepareToolsForPromptCache(params: {
+  provider: t.ProviderName;
+  clientOptions?: t.ClientOptions;
+  tools?: t.GraphTools;
+  isDeferred: (toolName: string) => boolean;
+}): t.GraphTools | undefined {
+  const { provider, clientOptions, tools, isDeferred } = params;
+  if (provider === Providers.ANTHROPIC) {
+    const options = clientOptions as t.AnthropicClientOptions | undefined;
+    if (options?.promptCache !== true) {
+      return tools;
+    }
+    return (
+      partitionAndMarkAnthropicToolCache(
+        tools,
+        isDeferred,
+        resolvePromptCacheTtl(options.promptCacheTtl)
+      ) ?? tools
+    );
+  }
+  if (provider === Providers.OPENROUTER) {
+    const options = clientOptions as
+      | t.ProviderOptionsMap[Providers.OPENROUTER]
+      | undefined;
+    if (options?.promptCache !== true) {
+      return tools;
+    }
+    return (
+      partitionAndMarkOpenRouterToolCache(
+        tools,
+        isDeferred,
+        resolvePromptCacheTtl(options.promptCacheTtl)
+      ) ?? tools
+    );
+  }
+  if (provider !== Providers.BEDROCK) {
+    return tools;
+  }
+  const options = clientOptions as t.BedrockAnthropicClientOptions | undefined;
+  if (options?.promptCache !== true) {
+    return tools;
+  }
+  const model = (options as { model?: string }).model;
+  if (model != null && !supportsBedrockToolCache(model)) {
+    return tools;
+  }
+  return partitionAndMarkBedrockToolCache(tools, isDeferred) ?? tools;
+}

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { performance } from 'node:perf_hooks';
 import { config } from 'dotenv';
 config();
 import { Calculator } from '@/tools/Calculator';
@@ -19,6 +20,8 @@ import { createTokenCounter } from '@/utils/tokens';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { Run } from '@/run';
 import { formatAgentMessages } from '@/messages/format';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
+import { CustomAnthropic } from '@/llm/anthropic';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import * as providers from '@/llm/providers';
 import { hasAnyEnv, hasEnv, hasEveryEnv } from './spec.utils';
@@ -305,6 +308,82 @@ const hasAnthropic = hasEnv('ANTHROPIC_API_KEY');
     'never compute in your head. Keep explanations concise (2-3 sentences max).',
     'When summarizing prior work, list each calculation and its result.',
   ].join(' ');
+
+  test('cache-aligned summarization reuses the normal tool prefix', async () => {
+    const nonce = `${Date.now()}-${Math.random()}`;
+    const description = `${nonce} ${'stable cache benchmark token '.repeat(180)}`;
+    const tools = Array.from({ length: 8 }, (_, index) => ({
+      name: `cache_probe_${index}`,
+      description,
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          value: { type: 'string' },
+        },
+      },
+    })) as t.GraphTools;
+    const preparedTools = prepareToolsForPromptCache({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { promptCache: true },
+      tools,
+      isDeferred: () => false,
+    });
+    const createModel = (
+      boundTools: t.GraphTools
+    ): ReturnType<CustomAnthropic['bindTools']> =>
+      new CustomAnthropic({
+        model: 'claude-haiku-4-5',
+        anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+        maxTokens: 8,
+        temperature: 0,
+      }).bindTools(boundTools);
+
+    const prime = await createModel(preparedTools ?? tools).invoke([
+      new HumanMessage('Prime the normal request tool prefix. Reply OK.'),
+    ]);
+    const primeCacheCreation =
+      prime.usage_metadata?.input_token_details?.cache_creation ?? 0;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const baselineStartedAt = performance.now();
+    const baseline = await createModel(tools).invoke([
+      new HumanMessage('Baseline compaction request. Reply OK.'),
+    ]);
+    const baselineLatencyMs = performance.now() - baselineStartedAt;
+
+    const alignedStartedAt = performance.now();
+    const aligned = await createModel(preparedTools ?? tools).invoke([
+      new HumanMessage('Cache-aligned compaction request. Reply OK.'),
+    ]);
+    const alignedLatencyMs = performance.now() - alignedStartedAt;
+
+    const baselineCacheRead =
+      baseline.usage_metadata?.input_token_details?.cache_read ?? 0;
+    const alignedCacheRead =
+      aligned.usage_metadata?.input_token_details?.cache_read ?? 0;
+    console.log(
+      `  Compaction tool-prefix benchmark: ${JSON.stringify({
+        prime: {
+          cacheCreationInputTokens: primeCacheCreation,
+          inputTokens: prime.usage_metadata?.input_tokens,
+        },
+        baseline: {
+          cacheReadInputTokens: baselineCacheRead,
+          inputTokens: baseline.usage_metadata?.input_tokens,
+          latencyMs: Math.round(baselineLatencyMs),
+        },
+        aligned: {
+          cacheReadInputTokens: alignedCacheRead,
+          inputTokens: aligned.usage_metadata?.input_tokens,
+          latencyMs: Math.round(alignedLatencyMs),
+        },
+      })}`
+    );
+
+    expect(primeCacheCreation).toBeGreaterThan(0);
+    expect(alignedCacheRead).toBeGreaterThan(baselineCacheRead);
+    expect(alignedCacheRead).toBeGreaterThan(0);
+  }, 180_000);
 
   test('heavy multi-turn with tool calls triggers and survives summarization', async () => {
     const spies = createSpies();

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -3,9 +3,11 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
+  applySummarizationHistoryCache,
   createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  resolveBedrockCompactionCacheModel,
 } from '@/summarization/node';
 import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { convertInjectedMessages } from '@/messages/injected';
@@ -13,6 +15,74 @@ import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
+
+describe('applySummarizationHistoryCache', () => {
+  it('marks Anthropic history before the compaction instruction', () => {
+    const cached = applySummarizationHistoryCache({
+      messages: [new HumanMessage('history')],
+      provider: Providers.ANTHROPIC,
+      enabled: true,
+    });
+
+    expect(cached[0].content).toEqual([
+      {
+        type: 'text',
+        text: 'history',
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+      },
+    ]);
+  });
+
+  it('marks Bedrock history before the compaction instruction', () => {
+    const cached = applySummarizationHistoryCache({
+      messages: [new HumanMessage('history')],
+      provider: Providers.BEDROCK,
+      enabled: true,
+      bedrockModelId: 'anthropic.claude-sonnet',
+    });
+
+    expect(cached[0].content).toEqual([
+      { type: 'text', text: 'history' },
+      { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+  });
+
+  it('uses five minutes for an explicit non-Claude Bedrock model', () => {
+    const cached = applySummarizationHistoryCache({
+      messages: [new HumanMessage('history')],
+      provider: Providers.BEDROCK,
+      enabled: true,
+      bedrockModelId: 'amazon.nova-pro-v1:0',
+    });
+
+    expect(cached[0].content).toEqual([
+      { type: 'text', text: 'history' },
+      { cachePoint: { type: 'default' } },
+    ]);
+  });
+
+  it('keeps the configured model family for an opaque Bedrock profile', () => {
+    expect(
+      resolveBedrockCompactionCacheModel({
+        applicationInferenceProfile:
+          'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opaque',
+        model: 'anthropic.claude-sonnet',
+      })
+    ).toBe('anthropic.claude-sonnet');
+  });
+
+  it('does not add provider-specific markers to a fallback provider', () => {
+    const messages = [new HumanMessage('history')];
+
+    expect(
+      applySummarizationHistoryCache({
+        messages,
+        provider: Providers.OPENAI,
+        enabled: true,
+      })
+    ).toBe(messages);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -160,6 +230,51 @@ beforeEach(() => {
 });
 
 describe('createSummarizeNode', () => {
+  it('binds the live graph tool projection for cache-aligned compaction', async () => {
+    captureEvents();
+
+    const projectedTools = [{ name: 'projected-tool' }] as t.GraphTools;
+    const bindTools = jest
+      .fn()
+      .mockReturnValue(mockInvokeModel('Cache-aligned summary'));
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        bindTools = bindTools;
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { promptCache: true },
+    });
+    const graph = {
+      ...mockGraph(),
+      getToolsForBinding: jest.fn(() => projectedTools),
+    };
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(graph.getToolsForBinding).toHaveBeenCalledWith(
+      Providers.ANTHROPIC,
+      expect.objectContaining({ promptCache: true })
+    );
+    expect(bindTools).toHaveBeenCalledWith(projectedTools);
+  });
+
   it('emits ON_SUMMARIZE_START and ON_SUMMARIZE_COMPLETE on success', async () => {
     const events = captureEvents();
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -24,7 +24,9 @@ import {
 } from '@/llm/streamLimits';
 import {
   addTailCacheControl,
+  addBedrockTailCacheControl,
   resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
   type PromptCacheTtl,
 } from '@/messages/cache';
 import {
@@ -41,7 +43,9 @@ import {
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
+import { makeIsDeferred } from '@/messages/anthropicToolCache';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
@@ -623,7 +627,13 @@ async function executeSummarizationWithFallback(params: {
   usePromptCache: boolean;
   log: LogFn;
   /** Carries the run's stream limits so the event cap covers summary streams. */
-  graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
+  graph?: StreamLimitState & {
+    getBreakerSignal?: () => AbortSignal;
+    getToolsForBinding?: (
+      provider: t.ProviderName,
+      clientOptions: t.ClientOptions | undefined
+    ) => t.GraphTools | undefined;
+  };
 }): Promise<{
   text: string;
   usage?: Partial<UsageMetadata>;
@@ -657,10 +667,24 @@ async function executeSummarizationWithFallback(params: {
      * (e.g. an unrecognized summarization.provider) surfaces through the
      * `log('error', ...)` path below rather than bubbling up silently.
      */
+    const summarizationTools = usePromptCache
+      ? (graph?.getToolsForBinding?.(
+          clientConfig.provider as t.ProviderName,
+          clientConfig.clientOptions as t.ClientOptions
+      ) ??
+        prepareToolsForPromptCache({
+          provider: clientConfig.provider as t.ProviderName,
+          clientOptions: clientConfig.clientOptions as t.ClientOptions,
+          tools: agentContext.getToolsForBinding(),
+          isDeferred: makeIsDeferred(
+            agentContext.getEffectiveToolDefinitions()
+          ),
+        }))
+      : agentContext.getToolsForBinding();
     const summarizationModel = initializeModel({
       provider: clientConfig.provider,
       clientOptions: clientConfig.clientOptions as t.ClientOptions,
-      tools: agentContext.getToolsForBinding(),
+      tools: summarizationTools,
     }) as t.ChatModel;
 
     const result = await summarizeWithCacheHit({
@@ -677,13 +701,23 @@ async function executeSummarizationWithFallback(params: {
       usePromptCache,
       promptCacheTtl:
         clientConfig.provider === Providers.ANTHROPIC ||
-        clientConfig.provider === Providers.OPENROUTER
-          ? resolvePromptCacheTtl(
-            (
+        clientConfig.provider === Providers.OPENROUTER ||
+        clientConfig.provider === Providers.BEDROCK
+          ? (
                 clientConfig.clientOptions as {
                   promptCacheTtl?: PromptCacheTtl;
                 }
-            ).promptCacheTtl
+          ).promptCacheTtl
+          : undefined,
+      bedrockModelId:
+        clientConfig.provider === Providers.BEDROCK
+          ? resolveBedrockCompactionCacheModel(
+            clientConfig.clientOptions as
+              | {
+                applicationInferenceProfile?: string;
+                model?: string;
+              }
+              | undefined
           )
           : undefined,
       log,
@@ -900,6 +934,10 @@ interface CreateSummarizeNodeParams {
     runId?: string;
     isMultiAgent: boolean;
     hookRegistry?: HookRegistry;
+    getToolsForBinding?: (
+      provider: t.ProviderName,
+      clientOptions: t.ClientOptions | undefined
+    ) => t.GraphTools | undefined;
     dispatchRunStep: (
       runStep: t.RunStep,
       config?: RunnableConfig
@@ -1221,7 +1259,7 @@ export function createSummarizeNode({
       clientConfig.provider === (agentContext.provider as string);
     const hasPromptCache =
       isSelfSummarizeModel &&
-      (agentContext.clientOptions as Record<string, unknown> | undefined)
+      (clientConfig.clientOptions as Record<string, unknown> | undefined)
         ?.promptCache === true;
 
     const log: LogFn = (level, message, data) => {
@@ -1615,6 +1653,45 @@ function traceConfig(
   };
 }
 
+export function applySummarizationHistoryCache(params: {
+  messages: BaseMessage[];
+  provider: t.ProviderName;
+  enabled: boolean;
+  promptCacheTtl?: PromptCacheTtl;
+  bedrockModelId?: string;
+}): BaseMessage[] {
+  if (!params.enabled) {
+    return params.messages;
+  }
+  if (params.provider === Providers.BEDROCK) {
+    return addBedrockTailCacheControl(
+      [...params.messages],
+      resolveBedrockPromptCacheTtl(
+        params.promptCacheTtl,
+        params.bedrockModelId
+      )
+    );
+  }
+  if (
+    params.provider !== Providers.ANTHROPIC &&
+    params.provider !== Providers.OPENROUTER
+  ) {
+    return params.messages;
+  }
+  return addTailCacheControl(
+    [...params.messages],
+    resolvePromptCacheTtl(params.promptCacheTtl)
+  );
+}
+
+export function resolveBedrockCompactionCacheModel(
+  options:
+    | { applicationInferenceProfile?: string; model?: string }
+    | undefined
+): string | undefined {
+  return options?.model;
+}
+
 /**
  * Cache-friendly compaction: sends raw conversation messages with the
  * summarization instruction appended as the final HumanMessage. Bound tool
@@ -1635,6 +1712,7 @@ async function summarizeWithCacheHit({
   graph,
   usePromptCache,
   promptCacheTtl,
+  bedrockModelId,
   log,
 }: {
   model: t.ChatModel;
@@ -1649,6 +1727,7 @@ async function summarizeWithCacheHit({
   graph?: StreamLimitState & { getBreakerSignal?: () => AbortSignal };
   usePromptCache?: boolean;
   promptCacheTtl?: PromptCacheTtl;
+  bedrockModelId?: string;
   log?: LogFn;
 }): Promise<{ text: string; usage?: Partial<UsageMetadata> }> {
   const instruction = buildSummarizationInstruction(
@@ -1657,11 +1736,17 @@ async function summarizeWithCacheHit({
     priorSummaryText
   );
 
-  const fullMessages = [...messages, new HumanMessage(instruction)];
-  const invokeMessages =
-    usePromptCache === true
-      ? addTailCacheControl(fullMessages, promptCacheTtl)
-      : fullMessages;
+  const cachedHistory = applySummarizationHistoryCache({
+    messages,
+    provider,
+    enabled: usePromptCache === true,
+    promptCacheTtl,
+    bedrockModelId,
+  });
+  const invokeMessages = [
+    ...cachedHistory,
+    new HumanMessage(instruction),
+  ];
 
   const result = await attemptInvoke(
     {


### PR DESCRIPTION
## Summary

- centralize the live provider tool projection used by normal requests and self-compaction, including local/Cloudflare tool resolution and deferred-tool partitioning
- apply provider-correct Anthropic, OpenRouter, and Bedrock cache markers and TTLs to the compaction tool/history prefixes
- preserve the configured Bedrock model family behind opaque application inference profiles
- treat provider cache-creation/cache-read usage as the receipt instead of predicting eligibility from provider options or environment variables

## Performance proof

The normal model hot path still performs the same single tool-resolution/cache-preparation pass; the work is relocated behind a shared function. Compaction pays one live projection only when it fires.

The Anthropic E2E job now primes an isolated normal-request tool prefix, invokes the former unmarked compaction shape as the baseline, then invokes the aligned shape. It logs before/after cache-read tokens and request latency, asserts that the prime created cache tokens, and requires the aligned request to read more cached input than baseline.

## Verification

- npx tsc --noEmit
- npm run build
- 141 focused cache, graph-overflow, and summarization tests passed; 11 credential-gated tests skipped locally
- changed source lint passes; the summarization live-spec retains six pre-existing no-useless-assignment warnings

## Architecture

ADR 0006 records why the production path uses shared output preparation plus provider receipts and rejects the non-convergent predictive cache-identity allowlist.

Supersedes #472.