### PR TITLE
fix: flag output-token-truncated turns that carry no tool call

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -153,10 +153,10 @@ import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
-import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
@@ -164,6 +164,7 @@ import { shouldTriggerSummarization } from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
+import { getTruncationStopReason } from '@/llm/truncation';
 import { messagesStateReducer } from '@/messages/reducer';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
@@ -1426,6 +1427,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   preemptIncomplete = false;
   /**
+   * True when `routeMessage` sent a turn to `END` because the last AI
+   * message carries no tool call, AND the provider reports it stopped for
+   * hitting the output token ceiling (`getTruncationStopReason`). Plain-text
+   * and reasoning turns cut off this way carry no tool call for
+   * `assertNotTruncatedToolCall` to catch, so `toolsCondition` reads them as
+   * an ordinary finished turn otherwise — hosts read this flag to persist
+   * the turn as unfinished instead of a silently truncated "complete" answer.
+   *
+   * Deliberately separate from `preemptIncomplete`/`preemptHaltReason`: this
+   * has no interaction with the preempt/seal machinery (in particular the
+   * `preemptHaltReason` check at each model node's entry), so setting it
+   * cannot suppress an unrelated agent's turn in a multi-agent graph.
+   */
+  outputTruncatedIncomplete = false;
+  /**
    * `stopReason` from a `PreemptBoundary` hook that halted the turn.
    *
    * Clearing the registry halt is what keeps the sealed turn alive, but the
@@ -1702,6 +1718,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.preemptEmptyBoundaries = 0;
     this.preemptIncomplete = false;
     this.preemptHaltReason = undefined;
+    this.outputTruncatedIncomplete = false;
   }
 
   /**
@@ -2801,9 +2818,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       provider,
       clientOptions,
       tools,
-      isDeferred: makeIsDeferred(
-        agentContext.getEffectiveToolDefinitions()
-      ),
+      isDeferred: makeIsDeferred(agentContext.getEffectiveToolDefinitions()),
     });
   }
 
@@ -4818,11 +4833,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (state.summarizationRequest != null) {
         return summarizeNode;
       }
-      return toolsCondition(
+      const decision = toolsCondition(
         state as t.BaseGraphState,
         toolNode,
         this.invokedToolIds
       );
+      /**
+       * `toolsCondition` only looks at `tool_calls` — a plain-text/reasoning
+       * turn cut off by the output token ceiling has none, so it reads as an
+       * ordinary finished turn and routes here to END. Flag it so hosts can
+       * tell a genuinely finished answer from one the model never got to
+       * complete. See `outputTruncatedIncomplete` for why this stays clear
+       * of the preempt/seal halt fields.
+       */
+      if (decision === END) {
+        const { messages } = state as t.BaseGraphState;
+        const lastMessage = messages[messages.length - 1];
+        if (getTruncationStopReason(lastMessage) != null) {
+          this.outputTruncatedIncomplete = true;
+        }
+      }
+      return decision;
     };
 
     const StateAnnotation = Annotation.Root({

--- a/src/llm/fake.ts
+++ b/src/llm/fake.ts
@@ -14,6 +14,15 @@ export class FakeChatModel extends FakeListChatModel {
   private splitStrategy: SplitStrategy;
   private toolCalls: ToolCall[] = [];
   private addedToolCalls: boolean = false;
+  /**
+   * Attached to the last streamed chunk of every response, mirroring a real
+   * provider's terminal `finish_reason`/`stop_reason` on `generationInfo`.
+   * Lets truncation-path tests (`getTruncationStopReason`) drive a genuine
+   * `Run`/`StandardGraph` without a live provider. `undefined` (the
+   * default) reproduces the previous behavior exactly: no metadata on any
+   * chunk.
+   */
+  private finalChunkGenerationInfo?: Record<string, unknown>;
 
   constructor({
     responses,
@@ -21,16 +30,19 @@ export class FakeChatModel extends FakeListChatModel {
     emitCustomEvent,
     splitStrategy = { type: 'regex', value: /(?<=\s+)|(?=\s+)/ },
     toolCalls = [],
+    finalChunkGenerationInfo,
   }: {
     responses: string[];
     sleep?: number;
     emitCustomEvent?: boolean;
     splitStrategy?: SplitStrategy;
     toolCalls?: ToolCall[];
+    finalChunkGenerationInfo?: Record<string, unknown>;
   }) {
     super({ responses, sleep, emitCustomEvent });
     this.splitStrategy = splitStrategy;
     this.toolCalls = toolCalls;
+    this.finalChunkGenerationInfo = finalChunkGenerationInfo;
   }
 
   private splitText(text: string): string[] {
@@ -47,14 +59,16 @@ export class FakeChatModel extends FakeListChatModel {
   }
   _createResponseChunk(
     text: string,
-    tool_call_chunks?: ToolCallChunk[]
+    tool_call_chunks?: ToolCallChunk[],
+    responseMetadata?: Record<string, unknown>
   ): ChatGenerationChunk {
     return new ChatGenerationChunk({
       text,
-      generationInfo: {},
+      generationInfo: responseMetadata ?? {},
       message: new AIMessageChunk({
         content: text,
         tool_call_chunks,
+        response_metadata: responseMetadata,
         additional_kwargs: tool_call_chunks
           ? {
             tool_calls: tool_call_chunks.map((toolCall) => ({
@@ -87,14 +101,31 @@ export class FakeChatModel extends FakeListChatModel {
     }
 
     const chunks = this.splitText(response);
-    for await (const chunk of chunks) {
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
       await this._sleepIfRequested();
 
       if (options.thrownErrorString != null && options.thrownErrorString) {
         throw new Error(options.thrownErrorString);
       }
 
-      const responseChunk = super._createResponseChunk(chunk);
+      /**
+       * Only the true terminal chunk of the response gets the metadata: when
+       * this response also appends a trailing tool-call chunk below, THAT
+       * chunk is terminal instead (not currently exercised by any test —
+       * a caller wanting truncated-tool-call metadata should attach it
+       * there).
+       */
+      const isTerminalChunk =
+        i === chunks.length - 1 && this.toolCalls.length === 0;
+      const responseChunk =
+        isTerminalChunk && this.finalChunkGenerationInfo != null
+          ? this._createResponseChunk(
+            chunk,
+            undefined,
+            this.finalChunkGenerationInfo
+          )
+          : super._createResponseChunk(chunk);
       yield responseChunk;
       void runManager?.handleLLMNewToken(chunk);
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1637,13 +1637,16 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   /**
-   * Returns the reason a hook halted the run via
-   * `preventContinuation: true`, or `undefined` if no hook halted.
+   * Returns why the run ended without a natural completion, or `undefined`
+   * when it completed normally. Reasons include hook- and prompt-driven
+   * halts, `preempt_incomplete` when a cooperative seal ended the turn
+   * without continuation content, and `output_truncated` when the provider
+   * stopped a plain-text/reasoning response at its output-token ceiling.
    *
    * Hosts inspect this after `processStream` returns to distinguish a
-   * natural completion (`undefined`) from a hook-driven halt (a
-   * truthy string). Independent from `getInterrupt()` — a halted run
-   * has no interrupt; an interrupted run has no halt reason.
+   * natural completion from a terminal partial response. Independent from
+   * `getInterrupt()` — a halted run has no interrupt; an interrupted run has
+   * no halt reason.
    */
   getHaltReason(): string | undefined {
     return this._haltedReason;

--- a/src/run.ts
+++ b/src/run.ts
@@ -130,6 +130,7 @@ export const defaultOmitOptions = new Set([
 const ACTIVITY_LABEL_TRACE_NAME = 'LibreChat Activity Label';
 const ACTIVITY_PHASE_TRACE_NAME = 'LibreChat Activity Phase';
 const REASONING_LABEL_TRACE_NAME = 'LibreChat Reasoning Label';
+const OUTPUT_TRUNCATED_HALT_REASON = 'output_truncated';
 
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_AGENT_UPDATE,
@@ -1374,6 +1375,13 @@ export class Run<_T extends t.BaseGraphState> {
         this._haltedReason == null &&
         this.hookRegistry?.hasHookFor('Stop', this.id) === true
       ) {
+        let stopReason = graph.preemptHaltReason;
+        if (stopReason == null && graph.preemptIncomplete) {
+          stopReason = 'preempt_incomplete';
+        }
+        if (stopReason == null && graph.outputTruncatedIncomplete) {
+          stopReason = OUTPUT_TRUNCATED_HALT_REASON;
+        }
         await executeHooks({
           registry: this.hookRegistry,
           input: {
@@ -1389,9 +1397,7 @@ export class Run<_T extends t.BaseGraphState> {
              * actual cause, not the generic label — and `preempt_incomplete`
              * is reserved for the boundary that simply had nothing to inject.
              */
-            stopReason:
-              graph.preemptHaltReason ??
-              (graph.preemptIncomplete ? 'preempt_incomplete' : undefined),
+            stopReason,
             stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
           },
           sessionId: this.id,
@@ -1421,6 +1427,11 @@ export class Run<_T extends t.BaseGraphState> {
         this._haltedReason = graph.preemptHaltReason;
       } else if (this._haltedReason == null && graph.preemptIncomplete) {
         this._haltedReason = 'preempt_incomplete';
+      } else if (
+        this._haltedReason == null &&
+        graph.outputTruncatedIncomplete
+      ) {
+        this._haltedReason = OUTPUT_TRUNCATED_HALT_REASON;
       }
     };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,7 +35,6 @@ import {
   ACTIVITY_PHASE_LABEL_RUN_NAME,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
-import { isBuiltRuntime } from '@/lazyRequire';
 import {
   requireValidSubagentResumeManifest,
   stripSubagentResumeManifest,
@@ -94,14 +93,15 @@ import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { stampSyntheticProviderMessage } from '@/messages/provenance';
+import { isOpenAILike, isLibreChatOpenAIModel } from '@/utils/llm';
 import { initializeLangfuseTracing } from './instrumentation';
 import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import { createGraph } from '@/graphs/createGraph';
 import { resolveMaxSeals } from '@/llm/preempt';
+import { isBuiltRuntime } from '@/lazyRequire';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
-import { isOpenAILike, isLibreChatOpenAIModel } from '@/utils/llm';
 import { executeHooks } from '@/hooks';
 
 /** Source-mode runs have no dist siblings for the lazy-loading seam, so every
@@ -792,6 +792,18 @@ export class Run<_T extends t.BaseGraphState> {
 
   getToolCount(): number {
     return this.Graph?.getToolCount() ?? 0;
+  }
+
+  /**
+   * True when the run's last turn ended at `END` because the provider hit
+   * its output token ceiling while producing plain text/reasoning — no tool
+   * call, so `assertNotTruncatedToolCall` never sees it and the graph reads
+   * the turn as an ordinary completion. Hosts check this alongside
+   * `getPreemptStats()` / `getHaltReason()` to decide whether to persist the
+   * response as unfinished instead of a silently truncated "complete" one.
+   */
+  getOutputTruncated(): boolean {
+    return this.Graph?.outputTruncatedIncomplete ?? false;
   }
 
   /**

--- a/src/specs/outputTruncation.test.ts
+++ b/src/specs/outputTruncation.test.ts
@@ -56,7 +56,7 @@ describe('output-token truncation without a tool call', () => {
     expect(run.getOutputTruncated()).toBe(true);
     expect(run.Graph?.outputTruncatedIncomplete).toBe(true);
     // Distinct from the preempt/seal machinery — this path never touches it.
-    expect(run.getHaltReason()).toBeUndefined();
+    expect(run.getHaltReason()).toBe('output_truncated');
     expect(run.Graph?.preemptIncomplete).toBe(false);
   });
 
@@ -74,6 +74,7 @@ describe('output-token truncation without a tool call', () => {
 
     expect(run.getOutputTruncated()).toBe(false);
     expect(run.Graph?.outputTruncatedIncomplete).toBe(false);
+    expect(run.getHaltReason()).toBeUndefined();
   });
 
   it('does not flag a turn with no finish-reason metadata at all', async () => {

--- a/src/specs/outputTruncation.test.ts
+++ b/src/specs/outputTruncation.test.ts
@@ -90,4 +90,31 @@ describe('output-token truncation without a tool call', () => {
 
     expect(run.getOutputTruncated()).toBe(false);
   });
+
+  it('clears truncation state before the next invocation on a reused run', async () => {
+    const run = await createPlainRun('reused-run');
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['First response is cut off'],
+      finalChunkGenerationInfo: { finish_reason: 'length' },
+    }) as unknown as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('First request')] },
+      streamConfig
+    );
+    expect(run.getOutputTruncated()).toBe(true);
+    expect(run.getHaltReason()).toBe('output_truncated');
+
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['Second response completes normally.'],
+      finalChunkGenerationInfo: { finish_reason: 'stop' },
+    }) as unknown as t.ChatModel;
+    await run.processStream(
+      { messages: [new HumanMessage('Second request')] },
+      streamConfig
+    );
+
+    expect(run.getOutputTruncated()).toBe(false);
+    expect(run.getHaltReason()).toBeUndefined();
+  });
 });

--- a/src/specs/outputTruncation.test.ts
+++ b/src/specs/outputTruncation.test.ts
@@ -1,0 +1,92 @@
+// src/specs/outputTruncation.test.ts
+/**
+ * A model turn cut off by the output token ceiling while producing plain
+ * text/reasoning carries no tool call, so `toolsCondition` reads it as an
+ * ordinary finished turn and routes to END exactly like a real completion.
+ * `getOutputTruncated()` is the channel that lets a host tell the two apart
+ * and persist the turn as unfinished instead of a silently truncated
+ * "complete" answer. See `outputTruncatedIncomplete` on `StandardGraph`.
+ */
+import { HumanMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { FakeChatModel } from '@/llm/fake';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+const streamConfig = {
+  configurable: { thread_id: 'output-truncation' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+async function createPlainRun(runId: string): Promise<Run<t.IState>> {
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-4o-mini',
+        apiKey: 'test-key',
+      },
+      instructions: 'Answer plainly.',
+    },
+    returnContent: true,
+    skipCleanup: true,
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph to be initialized');
+  }
+  return run;
+}
+
+describe('output-token truncation without a tool call', () => {
+  it('flags a plain-text turn cut off at the output token ceiling', async () => {
+    const run = await createPlainRun('truncated-plain-text');
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['The channel posts about three times a day and the'],
+      finalChunkGenerationInfo: { finish_reason: 'length' },
+    }) as unknown as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('Analyze this channel')] },
+      streamConfig
+    );
+
+    expect(run.getOutputTruncated()).toBe(true);
+    expect(run.Graph?.outputTruncatedIncomplete).toBe(true);
+    // Distinct from the preempt/seal machinery — this path never touches it.
+    expect(run.getHaltReason()).toBeUndefined();
+    expect(run.Graph?.preemptIncomplete).toBe(false);
+  });
+
+  it('does not flag a normal completed turn', async () => {
+    const run = await createPlainRun('normal-completion');
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['The channel posts about three times a day.'],
+      finalChunkGenerationInfo: { finish_reason: 'stop' },
+    }) as unknown as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('Analyze this channel')] },
+      streamConfig
+    );
+
+    expect(run.getOutputTruncated()).toBe(false);
+    expect(run.Graph?.outputTruncatedIncomplete).toBe(false);
+  });
+
+  it('does not flag a turn with no finish-reason metadata at all', async () => {
+    const run = await createPlainRun('no-metadata');
+    run.Graph!.overrideModel = new FakeChatModel({
+      responses: ['The channel posts about three times a day.'],
+    }) as unknown as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('Analyze this channel')] },
+      streamConfig
+    );
+
+    expect(run.getOutputTruncated()).toBe(false);
+  });
+});


### PR DESCRIPTION
toolsCondition only inspects tool_calls, so a plain-text/reasoning turn cut off at the provider's output token ceiling (finish_reason: length / stop_reason: max_tokens, etc.) has nothing for it to catch and routes to END exactly like an ordinary completion. assertNotTruncatedToolCall only guards the tool-call case, so this path was silently treated as finished — hosts persisted a genuinely cut-off answer as complete, with no error and no unfinished flag.

routeMessage now checks getTruncationStopReason on the last message when toolsCondition resolves to END, and sets a new outputTruncatedIncomplete flag on StandardGraph (exposed via Run.getOutputTruncated()). Kept separate from preemptIncomplete/preemptHaltReason since the latter has a side effect at each model node's entry (declining the call) that must stay scoped to the preempt/seal machinery.

FakeChatModel gains an opt-in finalChunkGenerationInfo so tests can drive a truncated finish through a real Run/StandardGraph instead of asserting against internals.