### PR TITLE
🔁 fix: Stop Empty Summaries From Looping Compaction

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -75,6 +75,14 @@ type ProgrammaticToolInstructionTarget = {
 };
 
 /**
+ * Consecutive summarization attempts that may return no usable summary before
+ * the run stops asking. Every such attempt spends a full model call over the
+ * whole history and leaves the message set exactly as it was, so the cap
+ * bounds spend as much as it bounds the compaction loop.
+ */
+const MAX_SUMMARIZATION_FAILURES = 3;
+
+/**
  * Encapsulates agent-specific state that can vary between agents in a multi-agent system
  */
 export class AgentContext {
@@ -376,6 +384,13 @@ export class AgentContext {
    * Summarization is allowed to fire again only when new messages appear.
    */
   private _lastSummarizationMsgCount: number = 0;
+  /**
+   * Consecutive summarization attempts that produced no usable summary.
+   * An empty or failed summary leaves the message set exactly as it was, so
+   * the next prune cycle would ask again on identical state. Cleared by
+   * `setSummary` and by `reset()`.
+   */
+  private _summarizationFailures: number = 0;
   /**
    * Forced compactions performed after a provider rejected a prompt as too
    * large. Bounds the recovery loop so a model that keeps refusing cannot
@@ -1209,6 +1224,7 @@ export class AgentContext {
     this.summaryTokenCount = this._durableSummaryTokenCount;
     this.summaryPrecedesMessages = this.durableSummaryPrecedesMessages;
     this._lastSummarizationMsgCount = 0;
+    this._summarizationFailures = 0;
     this.lastCallUsage = undefined;
     this.totalTokensFresh = false;
     this.restoreContextBudgetAfterOverflow();
@@ -1478,6 +1494,7 @@ export class AgentContext {
     this._durableSummaryTokenCount = tokenCount;
     this.durableSummaryPrecedesMessages = this.summaryPrecedesMessages;
     this._summaryVersion += 1;
+    this._summarizationFailures = 0;
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
   }
@@ -1545,6 +1562,31 @@ export class AgentContext {
    */
   markSummarizationTriggered(msgCount: number): void {
     this._lastSummarizationMsgCount = msgCount;
+  }
+
+  /**
+   * Records a summarization attempt that produced no usable summary — an
+   * empty model response, or a provider failure the run declined to paper
+   * over with a metadata stub. Cleared by the next successful summary.
+   */
+  recordSummarizationFailure(): void {
+    this._summarizationFailures += 1;
+  }
+
+  get summarizationFailures(): number {
+    return this._summarizationFailures;
+  }
+
+  /**
+   * True once consecutive no-progress attempts reach {@link MAX_SUMMARIZATION_FAILURES}.
+   * A summarizer that has returned nothing this many times in a row will keep
+   * returning nothing: each empty result leaves the history unchanged, so the
+   * next prune cycle re-triggers on the same state and the run burns its
+   * recursion budget on empty summary steps. Summarization stays off for the
+   * remainder of the run; `reset()` restores it for the next one.
+   */
+  get summarizationExhausted(): boolean {
+    return this._summarizationFailures >= MAX_SUMMARIZATION_FAILURES;
   }
 
   get overflowRecoveryAttempts(): number {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -153,10 +153,10 @@ import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
-import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
+import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
@@ -2801,9 +2801,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       provider,
       clientOptions,
       tools,
-      isDeferred: makeIsDeferred(
-        agentContext.getEffectiveToolDefinitions()
-      ),
+      isDeferred: makeIsDeferred(agentContext.getEffectiveToolDefinitions()),
     });
   }
 
@@ -3030,9 +3028,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           messagesToRefine.length > 0;
 
         if (hasPrunedMessages) {
-          const shouldSkip = agentContext.shouldSkipSummarization(
-            messages.length
-          );
+          const shouldSkip =
+            agentContext.summarizationExhausted ||
+            agentContext.shouldSkipSummarization(messages.length);
           const triggerResult =
             !shouldSkip &&
             shouldTriggerSummarization({
@@ -3089,6 +3087,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 messageCount: messages.length,
                 messagesToRefineCount: messagesToRefine.length,
                 contextLength: context.length,
+                summarizationFailures: agentContext.summarizationFailures,
+                summarizationExhausted: agentContext.summarizationExhausted,
               },
               { runId: this.runId, agentId }
             );

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { performance } from 'node:perf_hooks';
 import { config } from 'dotenv';
+import { performance } from 'node:perf_hooks';
 config();
 import { Calculator } from '@/tools/Calculator';
 import {
@@ -3898,5 +3898,123 @@ describe('Large tool result surviving context — no double summarization (no AP
     console.log(
       `  Double-summarization prevented: ${startCalls <= 1 ? 'YES' : 'NO'}`
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty summarizer output must not loop (FakeListChatModel — no API keys)
+// ---------------------------------------------------------------------------
+
+describe('Empty summarizer output (no API keys)', () => {
+  jest.setTimeout(60_000);
+
+  const SUMMARIZER_MODEL = 'summarizer-that-returns-nothing';
+  const AGENT_REPLY = 'Here is the answer to your final question.';
+  const streamConfig = {
+    configurable: { thread_id: 'empty-summary-loop' },
+    recursionLimit: 25,
+    streamMode: 'values',
+    version: 'v2' as const,
+  };
+
+  let getChatModelClassSpy: jest.SpyInstance;
+  const originalGetChatModelClass = providers.getChatModelClass;
+  let summarizerCallCount = 0;
+
+  beforeEach(() => {
+    summarizerCallCount = 0;
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider !== Providers.OPENAI) {
+          return originalGetChatModelClass(provider);
+        }
+        return class extends FakeListChatModel {
+          constructor(options: any) {
+            const isSummarizer = options?.model === SUMMARIZER_MODEL;
+            if (isSummarizer) {
+              summarizerCallCount++;
+            }
+            super({ responses: [isSummarizer ? '' : AGENT_REPLY] });
+          }
+        } as any;
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  test('a summarizer returning nothing does not loop the run to its recursion cap', async () => {
+    const spies = createSpies();
+    const tokenCounter = await createTokenCounter();
+
+    const padding = 'x'.repeat(400);
+    const conversationHistory: BaseMessage[] = [];
+    for (let i = 0; i < 10; i++) {
+      conversationHistory.push(new HumanMessage(`Question ${i}${padding}`));
+      conversationHistory.push(new AIMessage(`Answer ${i}${padding}`));
+    }
+    conversationHistory.push(new HumanMessage('Final question'));
+
+    const indexTokenCountMap = buildIndexTokenCountMap(
+      conversationHistory,
+      tokenCounter
+    );
+
+    const { aggregateContent } = createContentAggregator();
+    const collectedUsage: UsageMetadata[] = [];
+
+    const run = await Run.create<t.IState>({
+      runId: `empty-summary-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: getLLMConfig(Providers.OPENAI),
+        instructions: 'You are a helpful assistant.',
+        maxContextTokens: 600,
+        summarizationEnabled: true,
+        summarizationConfig: {
+          provider: Providers.OPENAI,
+          model: SUMMARIZER_MODEL,
+        },
+      },
+      returnContent: true,
+      customHandlers: buildHandlers(collectedUsage, aggregateContent, spies),
+      tokenCounter,
+      indexTokenCountMap,
+    });
+
+    let error: Error | undefined;
+    try {
+      await run.processStream(
+        { messages: conversationHistory },
+        streamConfig as any
+      );
+    } catch (err) {
+      error = err as Error;
+    }
+
+    const startCalls = spies.onSummarizeStartSpy.mock.calls.length;
+    console.log(
+      `  Empty-summary attempts: ${startCalls}, summarizer model calls: ${summarizerCallCount}`
+    );
+
+    /**
+     * The regression: an empty summary compacts nothing, so the agent node
+     * saw the same unchanged state and re-triggered — the run spent its whole
+     * recursion budget on empty summary steps and died on GraphRecursionError.
+     */
+    expect(error?.message ?? '').not.toMatch(/[Rr]ecursion/);
+    expect(startCalls).toBeLessThanOrEqual(3);
+    expect(summarizerCallCount).toBeLessThanOrEqual(3);
+
+    /** Nothing empty was committed as the run's summary. */
+    const summarizedContent = spies.onSummarizeCompleteSpy.mock.calls.flat();
+    for (const data of summarizedContent) {
+      const summary = (data as t.SummarizeCompleteEvent).summary;
+      if (summary != null) {
+        expect(summary.content?.length ?? 0).toBeGreaterThan(0);
+      }
+    }
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1966,6 +1966,200 @@ describe('createSummarizeNode — overflow recovery', () => {
   });
 });
 
+describe('createSummarizeNode — empty summarizer output', () => {
+  /** Model whose response carries no text — the shape a reasoning-only
+   *  completion produces once `extractResponseText` drops thinking blocks. */
+  function mockReasoningOnlyModel(): { invoke: jest.Mock } {
+    return {
+      invoke: jest.fn().mockResolvedValue({
+        content: [{ type: 'thinking', thinking: 'deliberating' }],
+      }),
+    };
+  }
+
+  it('leaves the dedupe guard on the current message count', async () => {
+    const events = captureEvents();
+
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockReasoningOnlyModel();
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    const messages = [
+      new HumanMessage('older question'),
+      new AIMessage('older answer'),
+      new HumanMessage('latest question'),
+    ];
+
+    const result = await node(
+      {
+        messages,
+        summarizationRequest: { remainingContextTokens: 0, agentId: 'agent_0' },
+      },
+      {} as RunnableConfig
+    );
+
+    /** State is untouched: nothing was compacted, so nothing is removed. */
+    expect(result.messages).toBeUndefined();
+    expect(agentContext.hasSummary()).toBe(false);
+    /**
+     * The regression: the node used to mark `0` here, which made
+     * `shouldSkipSummarization` answer `false` for every later count. The
+     * agent node then re-triggered on this same unchanged state, and the run
+     * looped through empty summary steps until the graph's recursion cap.
+     */
+    expect(agentContext.shouldSkipSummarization(messages.length)).toBe(true);
+    expect(agentContext.summarizationFailures).toBe(1);
+
+    const completeEvent = events.find(
+      (e) => e.event === GraphEvents.ON_SUMMARIZE_COMPLETE
+    );
+    expect((completeEvent?.data as t.SummarizeCompleteEvent).error).toBe(
+      'Summarization produced empty output'
+    );
+    expect(
+      (completeEvent?.data as t.SummarizeCompleteEvent).summary
+    ).toBeUndefined();
+  });
+
+  it('stops spending model calls once consecutive empty attempts hit the cap', async () => {
+    captureEvents();
+
+    const invoke = jest.fn().mockResolvedValue({ content: '' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    /** Growing history: each attempt clears the message-count guard on its
+     *  own, so only the failure tally can stop the retries. */
+    const messages: BaseMessage[] = [];
+    for (let attempt = 0; attempt < 6; attempt++) {
+      messages.push(new HumanMessage(`question ${attempt}`));
+      messages.push(new AIMessage(`answer ${attempt}`));
+      await node(
+        {
+          messages: [...messages],
+          summarizationRequest: {
+            remainingContextTokens: 0,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      );
+    }
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(agentContext.summarizationExhausted).toBe(true);
+  });
+
+  it('clears the failure tally once a summary succeeds', async () => {
+    captureEvents();
+
+    let call = 0;
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          call++;
+          return mockInvokeModel(call === 1 ? '' : 'A real checkpoint');
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    const first = [new HumanMessage('q1'), new AIMessage('a1')];
+    await node(
+      {
+        messages: first,
+        summarizationRequest: { remainingContextTokens: 0, agentId: 'agent_0' },
+      },
+      {} as RunnableConfig
+    );
+    expect(agentContext.summarizationFailures).toBe(1);
+
+    await node(
+      {
+        messages: [...first, new HumanMessage('q2'), new AIMessage('a2')],
+        summarizationRequest: { remainingContextTokens: 0, agentId: 'agent_0' },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(agentContext.summarizationFailures).toBe(0);
+    expect(agentContext.summarizationExhausted).toBe(false);
+    expect(agentContext.getSummaryText()).toContain('A real checkpoint');
+  });
+
+  it('counts a preserved-history stub failure toward the cap', async () => {
+    captureEvents();
+
+    const invoke = jest.fn().mockRejectedValue(new Error('provider down'));
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext();
+    /** Escalated overflow recovery: the stub is refused so history survives,
+     *  which means the attempt made no progress either. */
+    const node = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    const messages: BaseMessage[] = [];
+    for (let attempt = 0; attempt < 5; attempt++) {
+      messages.push(new HumanMessage(`question ${attempt}`));
+      messages.push(new AIMessage(`answer ${attempt}`));
+      await node(
+        {
+          messages: [...messages],
+          summarizationRequest: {
+            remainingContextTokens: 0,
+            agentId: 'agent_0',
+            reason: 'overflow',
+            allowSummarization: true,
+          },
+        },
+        {} as RunnableConfig
+      );
+    }
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+    expect(agentContext.hasSummary()).toBe(false);
+  });
+});
+
 describe('summarize node breaker capture', () => {
   it('stamps the entry-captured breaker epoch into summary attempt metadata', async () => {
     captureEvents();

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -12,6 +12,13 @@ import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
 import {
+  addTailCacheControl,
+  addBedrockTailCacheControl,
+  resolvePromptCacheTtl,
+  resolveBedrockPromptCacheTtl,
+  type PromptCacheTtl,
+} from '@/messages/cache';
+import {
   cloneToolMessageWithContent,
   compactToolContent,
   isComputerCallOutputMessage,
@@ -22,13 +29,6 @@ import {
   StreamLimitExceededError,
   STREAM_LIMIT_EPOCH_KEY,
 } from '@/llm/streamLimits';
-import {
-  addTailCacheControl,
-  addBedrockTailCacheControl,
-  resolvePromptCacheTtl,
-  resolveBedrockPromptCacheTtl,
-  type PromptCacheTtl,
-} from '@/messages/cache';
 import {
   DEFAULT_RETAIN_RECENT_TURNS,
   resolveIntraTurnRetainTokens,
@@ -42,8 +42,8 @@ import {
   Providers,
 } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
+import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { makeIsDeferred } from '@/messages/anthropicToolCache';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -704,20 +704,20 @@ async function executeSummarizationWithFallback(params: {
         clientConfig.provider === Providers.OPENROUTER ||
         clientConfig.provider === Providers.BEDROCK
           ? (
-                clientConfig.clientOptions as {
-                  promptCacheTtl?: PromptCacheTtl;
-                }
+              clientConfig.clientOptions as {
+                promptCacheTtl?: PromptCacheTtl;
+              }
           ).promptCacheTtl
           : undefined,
       bedrockModelId:
         clientConfig.provider === Providers.BEDROCK
           ? resolveBedrockCompactionCacheModel(
-            clientConfig.clientOptions as
-              | {
-                applicationInferenceProfile?: string;
-                model?: string;
-              }
-              | undefined
+              clientConfig.clientOptions as
+                | {
+                    applicationInferenceProfile?: string;
+                    model?: string;
+                  }
+                | undefined
           )
           : undefined,
       log,
@@ -1092,6 +1092,29 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
+    /**
+     * A summarizer that has already returned nothing several times in a row
+     * keeps returning nothing, and every empty result leaves the message set
+     * exactly as it was — so the next prune cycle re-triggers on identical
+     * state. Stopping here bounds that loop instead of letting the run spend
+     * its recursion budget dispatching empty summary steps.
+     */
+    if (agentContext.summarizationExhausted) {
+      emitAgentLog(
+        config,
+        'warn',
+        'summarize',
+        'Summarization skipped — consecutive attempts produced no usable summary',
+        {
+          failures: agentContext.summarizationFailures,
+          reason: request.reason ?? 'trigger',
+        },
+        { runId: graph.runId, agentId: request.agentId }
+      );
+      agentContext.markSummarizationTriggered(state.messages.length);
+      return { summarizationRequest: undefined };
+    }
+
     const maxCtx = agentContext.maxContextTokens ?? 0;
     if (maxCtx > 0 && agentContext.instructionTokens >= maxCtx) {
       emitAgentLog(
@@ -1365,6 +1388,7 @@ export function createSummarizeNode({
         `Summarization failed during ${preservationReason}; keeping history rather than replacing it with a metadata stub`
       );
       agentContext.markSummarizationTriggered(state.messages.length);
+      agentContext.recordSummarizationFailure();
       /**
        * The run step was already dispatched, so it has to be resolved here or
        * consumers tracking step lifecycle keep an unfinished placeholder for
@@ -1393,7 +1417,22 @@ export function createSummarizeNode({
     }
 
     if (!rawText) {
-      agentContext.markSummarizationTriggered(0);
+      /**
+       * An empty summary compacts nothing, so the state the pruner sees next
+       * is byte-identical to the one that just triggered. Resetting the guard
+       * to `0` here made `shouldSkipSummarization` answer `false` forever,
+       * and the agent node re-triggered on that unchanged state until the
+       * graph hit its recursion cap — a loop of empty summary steps, each one
+       * a billed model call. Recording the current count keeps the guard
+       * honest; the failure tally bounds the retries once new messages do
+       * arrive and legitimately lift it.
+       */
+      agentContext.markSummarizationTriggered(state.messages.length);
+      agentContext.recordSummarizationFailure();
+      log('warn', 'Summarization produced empty output', {
+        failures: agentContext.summarizationFailures,
+        messagesToRefineCount: messagesToRefine.length,
+      });
       if (runnableConfig) {
         await safeDispatchCustomEvent(
           GraphEvents.ON_SUMMARIZE_COMPLETE,
@@ -1666,10 +1705,7 @@ export function applySummarizationHistoryCache(params: {
   if (params.provider === Providers.BEDROCK) {
     return addBedrockTailCacheControl(
       [...params.messages],
-      resolveBedrockPromptCacheTtl(
-        params.promptCacheTtl,
-        params.bedrockModelId
-      )
+      resolveBedrockPromptCacheTtl(params.promptCacheTtl, params.bedrockModelId)
     );
   }
   if (
@@ -1685,9 +1721,7 @@ export function applySummarizationHistoryCache(params: {
 }
 
 export function resolveBedrockCompactionCacheModel(
-  options:
-    | { applicationInferenceProfile?: string; model?: string }
-    | undefined
+  options: { applicationInferenceProfile?: string; model?: string } | undefined
 ): string | undefined {
   return options?.model;
 }
@@ -1743,10 +1777,7 @@ async function summarizeWithCacheHit({
     promptCacheTtl,
     bedrockModelId,
   });
-  const invokeMessages = [
-    ...cachedHistory,
-    new HumanMessage(instruction),
-  ];
+  const invokeMessages = [...cachedHistory, new HumanMessage(instruction)];
 
   const result = await attemptInvoke(
     {


### PR DESCRIPTION
## Summary

I fixed the summarization recursion loop reported in [LibreChat#15294](https://github.com/danny-avila/LibreChat/issues/15294), where a run emits `{type: "summary", content: []}` over and over until the graph hits its recursion cap. The loop originates here, not in LibreChat — nothing on that side re-enters summarization.

An empty summarizer response compacts nothing, so the state the pruner sees on the next pass is identical to the one that just triggered. The summarize node reset the dedupe guard to `0` on that path (`markSummarizationTriggered(0)`), which made `shouldSkipSummarization` answer `false` for *every* later message count — the guard is written as `_lastSummarizationMsgCount > 0 && …`. The agent node then re-triggered on that unchanged state, routed back into the summarize node, got another empty response, and reset the guard again. Every pass billed a full summarizer call over the whole history and persisted a content-less summary block, until LangGraph threw `GraphRecursionError`.

- Recorded the current message count on the empty-output path instead of resetting the guard to `0`, so the identical state stops re-triggering.
- Added a consecutive-failure tally to `AgentContext` (`recordSummarizationFailure`, `summarizationFailures`, `summarizationExhausted`, capped at 3), which bounds the retries once new messages legitimately lift the count guard.
- Returned from the summarize node before `dispatchRunStep` once the tally is exhausted, so no further empty summary blocks are produced, persisted, or billed.
- Counted a provider failure the run declined to paper over with a metadata stub (overflow recovery and intra-turn compaction, where history is preserved instead) toward the same tally — that attempt made no progress either.
- Cleared the tally on a successful `setSummary` and on `reset()`, so a transient empty response costs nothing beyond the run it happened in.
- Short-circuited the trigger evaluation in `StandardGraph` on `summarizationExhausted`, and surfaced the tally in the existing skip log.

## Provenance

`markSummarizationTriggered(0)` was introduced by `ca586de` (squash-merged as #72, *Staged Context Compaction Pipeline with LLM Summarization*, 2026-03-20), whose commit message states the intent plainly:

> Also fixes the empty-output early return path: resets the summarization baseline via `markSummarizationTriggered(0)` so the next overflow can retry compaction instead of being permanently blocked.

The intent was right — an empty summary should not permanently block later compaction. The mechanism was the problem: because `shouldSkipSummarization` reads `_lastSummarizationMsgCount > 0 && …`, `0` is a sentinel meaning "no baseline recorded", which doesn't express "retry when the situation changes" but "never skip again, ever". So instead of *retry later*, it produced *retry immediately, forever, on byte-identical state*.

This fix preserves the original goal. Marking the current count still lets a genuinely changed conversation re-trigger, because a growing message count clears the guard on its own; the failure tally is what stops an unchanged-but-broken summarizer from spending calls indefinitely.

Two existing tests in `AgentContext.test.ts` (`shouldSkipSummarization — re-trigger after summary`) assert the `0`-means-unblock semantics directly, which is a fair part of why this survived review — the sentinel behavior read as intentional. Those tests still pass: they exercise `rebuildTokenMapAfterSummarization({})`, whose `0` write is immediately corrected by `markSummarizationTriggered(messagesToRetain.length)` on the success path.

**Affected releases:** every release from **v3.1.63** (2026-03-31) through **v3.7.7** — 113 tagged versions. LibreChat pins `^3.7.7` on `main` and `^3.2.46` on `v0.8.7`; both ranges resolve only to affected versions.

## Why it fires in practice

`extractResponseText` deliberately skips `thinking` / `reasoning_content` / `redacted_thinking` blocks and collects only `type: 'text'`, so any summarizer turn that ends without a text block yields `''`. Two routes get there, both reachable since #72:

1. **Reasoning-only response.** With no `summarization:` block configured, the summarizer self-summarizes: `buildSummarizationClientConfig` spreads `agentContext.clientOptions` wholesale, so the agent's `thinking` config carries into the summarizer. A turn that spends its output allowance on thinking returns thinking blocks and no text. This matches the reporter's setup exactly — Anthropic, `claude-fable-5`, no `librechat.yaml` summarization config.
2. **Tool call instead of text.** The summarizer is bound with the agent's tools, so a response of `[tool_use]` (or `[thinking, tool_use]`) also extracts to `''`, despite the prompt's "Only the checkpoint" instruction.

Neither route was covered by the metadata-stub fallback, which only fires when the call *throws*.

Worth noting as a **follow-up I deliberately did not fold in**: route 1 could be cut off at the source by not inheriting `thinking` into the self-summarize client options — the summary is text-only by construction, so a thinking budget there is pure cost. I left it out because changing thinking parameters alters the Anthropic request shape and would likely invalidate the cache prefix that #473 just aligned. That trade deserves its own PR and your call, not a quiet rider on a loop fix.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added a regression spec that drives a real `Run` through `processStream` with a `FakeListChatModel` split by model name: the agent model answers normally while the dedicated summarizer returns `''`. Reverting only the `markSummarizationTriggered` line makes it fail with `Recursion limit of 25 reached without hitting a stop condition` — the same failure mode as the report. With the fix the run completes after a single summarization attempt.

Also added four unit tests against `createSummarizeNode` covering the dedupe guard on empty output, the failure cap halting model calls after three consecutive empties, the tally clearing on a successful summary, and a preserved-history stub failure counting toward the cap.

### **Test Configuration**:

No API keys required — every new test uses `FakeListChatModel`.

```
npx jest src/summarization src/specs/summarization.test.ts src/agents/__tests__
npx tsc --noEmit
npx eslint src/
npm run build
```

Full suite: 4746 passed. The 4 failing suites are pre-existing environment gaps unrelated to this change — three live provider specs (`llm/anthropic`, `llm/google`, `llm/vertexai`) need credentials, and `durability-checkpoint.integration.test.ts` fails identically on a clean `main` because `mongodb-memory-server` cannot download a MongoDB binary in this sandbox.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qnA9kToNcuJhX8VH4GBsH