### PR TITLE
v3.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.7.7",
+      "version": "3.7.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
## Summary

I bumped `@librechat/agents` to 3.7.8 so the completed runtime and compaction fixes can publish for LibreChat.

- Publish suspended event-actor invocation serialization from #478.
- Publish the bounded compaction semantic index from #476.
- Publish the empty-summary retry and recursion guard from #479.
- Publish plain-text output-truncation detection from #477, including the reviewed halt-reason and Stop-hook propagation fix.
- Update only the package manifest and lockfile versions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Verified `package.json`, the lockfile root version, and the lockfile package version are all 3.7.8.
- Ran `npx jest truncation outputTruncation --runInBand` against the final implementation stack: 29 passed and 1 skipped.
- Ran `npx tsc --noEmit`.
- Ran ESLint for every #477 source and test file.
- Ran `npm run build` against the final implementation stack.
- Completed an exact-head Codex review cycle for #477 with no remaining findings.

### **Test Configuration**:

- Node.js 24.16.0
- npm 10-compatible lockfile

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that the included changes are effective
- [x] Local unit tests pass with my changes
