### PR TITLE
feat: continue runs from blocking stop hooks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,26 @@ Hosts may translate a durable LangGraph pause into the structured suspension
 result. Untranslated LangGraph interrupts and parent commands retain the fork
 and propagate as control flow for compatibility and routing.
 
+## Terminal Run Continuation
+
+A **Terminal Run Continuation** keeps one naturally completed `Run` alive when
+its terminal hooks admit queued host input. Ordinary Stop hooks execute in
+parallel and fold policy/notification requests first; the serialized
+StopFinalize phase then observes whether they already planned or prevented a
+continuation, allowing a durable host to make one atomic claim-or-seal decision.
+A `block` result with injected messages starts another graph segment before Run
+cleanup, hook-session teardown, or final content extraction. The continuation
+retains the same public run, trace scope, event handlers, graph sidecars, and
+content accumulator; it does not replay RunStart or UserPromptSubmit hooks.
+
+Continuation is bounded. Both terminal phases report the admitted count and
+remaining budget. StopFinalize additionally reports the folded planned and
+prevented state so unrelated continuation sources cannot close each other's
+admission. HITL pauses, aborts, hook halts, output truncation, and empty
+Stop injections remain terminal and never enter this path. With a checkpointer,
+the next segment submits only its injected delta; without one, it seeds the new
+graph invocation from the live in-process transcript.
+
 ## Tool Caller Capabilities
 
 A **Caller Capability Projection** is the effective classification of tool

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -21,6 +21,14 @@ export const DEFAULT_TOOL_TOKEN_MULTIPLIER = 1.4;
 export const DEFAULT_MAX_SEALS = 8;
 
 /**
+ * Default ceiling on Stop-hook continuations within one Run. A blocking Stop
+ * hook can keep a naturally terminal run warm by injecting another user turn;
+ * the ceiling prevents a faulty hook or continuously arriving input from
+ * keeping one processStream call alive forever.
+ */
+export const DEFAULT_MAX_STOP_CONTINUATIONS = 8;
+
+/**
  * Per-hook timeout for `PreemptBoundary`, deliberately far above
  * `DEFAULT_HOOK_TIMEOUT_MS`. A host drain has already popped its queue and
  * persisted content by the time this fires, so a timeout does not cancel the

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -772,6 +772,7 @@ export abstract class Graph<
   protected nextContentIndex = 0;
   protected runStepStateRevision = 0;
   protected stopContinuationCount = 0;
+  protected stopContinuationExecutionId = '';
   protected streamSegment = 0;
   stepKeyIds: Map<string, string[]> = new Map<string, string[]>();
   contentIndexMap: Map<string, number> = new Map();
@@ -903,6 +904,7 @@ export abstract class Graph<
     this.nextContentIndex = 0;
     this.runStepStateRevision = 0;
     this.stopContinuationCount = 0;
+    this.stopContinuationExecutionId = '';
     this.streamSegment = 0;
     this.contentIndexMap = new Map();
     this.stepKeyIds = new Map();
@@ -1542,6 +1544,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.cachedDiscoveredTools = undefined;
     this.config = resetIfNotEmpty(this.config, undefined);
     this.stopContinuationCount = 0;
+    this.stopContinuationExecutionId = '';
     this.streamSegment = 0;
     if (keepContent !== true) {
       this.contentData = resetIfNotEmpty(this.contentData, []);
@@ -1842,6 +1845,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       revision: this.runStepStateRevision,
       nextIndex: this.nextContentIndex,
       stopContinuationCount: this.stopContinuationCount,
+      ...(this.stopContinuationExecutionId === ''
+        ? {}
+        : {
+          stopContinuationExecutionId: this.stopContinuationExecutionId,
+        }),
       streamSegment: this.streamSegment,
       toolCallSteps: [...this.toolCallStepIds].map(([toolCallId, stepId]) => ({
         toolCallId,
@@ -1863,6 +1871,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.nextContentIndex = state.nextIndex;
     this.runStepStateRevision = state.revision;
     this.stopContinuationCount = state.stopContinuationCount ?? 0;
+    this.stopContinuationExecutionId =
+      state.stopContinuationExecutionId ?? '';
     this.streamSegment = state.streamSegment ?? 0;
     for (const { toolCallId, stepId } of state.toolCallSteps) {
       this.toolCallStepIds.set(toolCallId, stepId);
@@ -1904,6 +1914,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   setStopContinuationCount(count: number): void {
     this.stopContinuationCount = count;
+  }
+
+  getStopContinuationExecutionId(): string {
+    return this.stopContinuationExecutionId;
+  }
+
+  startStopContinuationExecution(executionId: string): void {
+    this.stopContinuationExecutionId = executionId;
+  }
+
+  getStreamSegment(): number {
+    return this.streamSegment;
   }
 
   advanceStreamSegment(): void {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -771,6 +771,8 @@ export abstract class Graph<
   contentData: t.RunStep[] = [];
   protected nextContentIndex = 0;
   protected runStepStateRevision = 0;
+  protected stopContinuationCount = 0;
+  protected streamSegment = 0;
   stepKeyIds: Map<string, string[]> = new Map<string, string[]>();
   contentIndexMap: Map<string, number> = new Map();
   toolCallStepIds: Map<string, string> = new Map();
@@ -900,6 +902,8 @@ export abstract class Graph<
     this.contentData = [];
     this.nextContentIndex = 0;
     this.runStepStateRevision = 0;
+    this.stopContinuationCount = 0;
+    this.streamSegment = 0;
     this.contentIndexMap = new Map();
     this.stepKeyIds = new Map();
     this.toolCallStepIds.clear();
@@ -1537,6 +1541,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.cachedRunMessages = undefined;
     this.cachedDiscoveredTools = undefined;
     this.config = resetIfNotEmpty(this.config, undefined);
+    this.stopContinuationCount = 0;
+    this.streamSegment = 0;
     if (keepContent !== true) {
       this.contentData = resetIfNotEmpty(this.contentData, []);
       this.nextContentIndex = 0;
@@ -1835,6 +1841,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       version: 1,
       revision: this.runStepStateRevision,
       nextIndex: this.nextContentIndex,
+      stopContinuationCount: this.stopContinuationCount,
+      streamSegment: this.streamSegment,
       toolCallSteps: [...this.toolCallStepIds].map(([toolCallId, stepId]) => ({
         toolCallId,
         stepId,
@@ -1854,6 +1862,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
     this.nextContentIndex = state.nextIndex;
     this.runStepStateRevision = state.revision;
+    this.stopContinuationCount = state.stopContinuationCount ?? 0;
+    this.streamSegment = state.streamSegment ?? 0;
     for (const { toolCallId, stepId } of state.toolCallSteps) {
       this.toolCallStepIds.set(toolCallId, stepId);
     }
@@ -1886,6 +1896,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       return this.contentData[index];
     }
     return undefined;
+  }
+
+  getStopContinuationCount(): number {
+    return this.stopContinuationCount;
+  }
+
+  setStopContinuationCount(count: number): void {
+    this.stopContinuationCount = count;
+  }
+
+  advanceStreamSegment(): void {
+    this.streamSegment += 1;
   }
 
   /**
@@ -2336,6 +2358,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       metadata.langgraph_node as string,
       metadata.langgraph_step as number,
       checkpointNs,
+      this.streamSegment,
     ];
 
     return keyList;

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -43,7 +43,9 @@ type MatcherBucket = Partial<Record<HookEvent, HookMatcher<HookEvent>[]>>;
 /**
  * Events whose hooks can change a tool call's input or output. Presence of
  * any of these disables eager tool execution and early completion emission;
- * observation-only events (`PostToolBatch`, `Stop`, telemetry hooks) do not.
+ * hooks that cannot rewrite a tool result (`PostToolBatch`, `Stop`, telemetry
+ * hooks) do not. A Stop hook may continue the Run, but only after every tool
+ * result in the terminal graph segment is already authoritative.
  */
 const RESULT_ALTERING_HOOK_EVENTS = [
   'PreToolUse',

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -311,7 +311,7 @@ describe('HookRegistry', () => {
       expect(registry.hasResultAlteringHooks('run-1')).toBe(false);
     });
 
-    it('returns false when only observation hooks are registered', () => {
+    it('returns false when hooks cannot rewrite tool results', () => {
       const registry = new HookRegistry();
       registry.register('PostToolBatch', { hooks: [async () => ({})] });
       registry.register('Stop', { hooks: [async () => ({})] });

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -1211,6 +1211,7 @@ describe('executeHooks', () => {
         matchQuery: 'Bash',
       });
       expect(result.errors).toHaveLength(0);
+      expect(result.hasHookFailures).toBe(true);
     });
 
     it('routes non-internal errors through an optional logger instead of console', async () => {

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -51,6 +51,8 @@ function stopInput(overrides: Partial<StopHookInput> = {}): StopHookInput {
     runId: 'run-1',
     messages: [],
     stopHookActive: false,
+    continuationCount: 0,
+    continuationBudgetRemaining: 8,
     ...overrides,
   };
 }

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -379,6 +379,30 @@ describe('Run-level hook integration', () => {
       );
     });
 
+    it('fails closed when an internal finalizer suppresses diagnostics', async () => {
+      const registry = new HookRegistry();
+      registry.register('StopFinalize', {
+        internal: true,
+        hooks: [
+          async (): Promise<StopHookOutput> => {
+            throw new Error('private claim failure');
+          },
+        ],
+      });
+
+      const run = await createRun(registry, 'failed-internal-admission');
+      run.Graph!.overrideTestModel(['first answer']);
+
+      await expect(
+        run.processStream(
+          { messages: [new HumanMessage('initial prompt')] },
+          callerConfig
+        )
+      ).rejects.toThrow(
+        'StopFinalize terminal admission failed: one or more internal finalizers failed'
+      );
+    });
+
     it('does not self-loop when Stop blocks without injectable content', async () => {
       const registry = new HookRegistry();
       let calls = 0;

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -1,4 +1,5 @@
 // src/hooks/__tests__/integration.test.ts
+import { MemorySaver } from '@langchain/langgraph';
 import { HumanMessage } from '@langchain/core/messages';
 import type {
   HookCallback,
@@ -6,6 +7,7 @@ import type {
   RunStartHookOutput,
   UserPromptSubmitHookOutput,
   StopHookInput,
+  StopFinalizeHookInput,
   StopHookOutput,
   StopFailureHookOutput,
 } from '../types';
@@ -227,7 +229,244 @@ describe('Run-level hook integration', () => {
       expect(captured!.hook_event_name).toBe('Stop');
       expect(captured!.runId).toBe('test-run');
       expect(captured!.stopHookActive).toBe(false);
+      expect(captured!.continuationCount).toBe(0);
+      expect(captured!.continuationBudgetRemaining).toBe(8);
       expect(captured!.messages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('keeps the same Run warm when Stop blocks with injected messages', async () => {
+      const registry = new HookRegistry();
+      const captured: StopHookInput[] = [];
+      let runStarts = 0;
+      let promptSubmissions = 0;
+      registry.register('RunStart', {
+        hooks: [
+          async (): Promise<RunStartHookOutput> => {
+            runStarts += 1;
+            return {};
+          },
+        ],
+      });
+      registry.register('UserPromptSubmit', {
+        hooks: [
+          async (): Promise<UserPromptSubmitHookOutput> => {
+            promptSubmissions += 1;
+            return {};
+          },
+        ],
+      });
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> => {
+            captured.push(input);
+            if (input.continuationCount > 0) {
+              return { decision: 'continue' };
+            }
+            return {
+              decision: 'block',
+              injectedMessages: [
+                { role: 'user', content: 'late steer', source: 'steer' },
+              ],
+            };
+          },
+        ],
+      });
+
+      const run = await createRun(registry, 'warm-run');
+      run.Graph!.overrideTestModel(['first answer', 'continued answer']);
+      await run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      );
+
+      expect(captured).toHaveLength(2);
+      expect(captured.map((input) => input.stopHookActive)).toEqual([
+        false,
+        true,
+      ]);
+      expect(captured.map((input) => input.continuationCount)).toEqual([0, 1]);
+      expect(
+        captured.map((input) => input.continuationBudgetRemaining)
+      ).toEqual([8, 7]);
+      expect(runStarts).toBe(1);
+      expect(promptSubmissions).toBe(1);
+      expect(run.Graph!.messages.map((message) => message.content)).toEqual([
+        'initial prompt',
+        'first answer',
+        'late steer',
+        'continued answer',
+      ]);
+      expect(run.Graph!.messages[2].additional_kwargs).toMatchObject({
+        role: 'user',
+        source: 'steer',
+      });
+    });
+
+    it('serializes StopFinalize after ordinary Stop decisions are folded', async () => {
+      const registry = new HookRegistry();
+      const finalized: StopFinalizeHookInput[] = [];
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> =>
+            input.continuationCount === 0
+              ? {
+                decision: 'block',
+                injectedMessages: [
+                  { role: 'user', content: 'plugin continuation' },
+                ],
+              }
+              : { decision: 'continue' },
+        ],
+      });
+      registry.register('StopFinalize', {
+        hooks: [
+          async (input): Promise<StopHookOutput> => {
+            finalized.push(input);
+            return { decision: 'continue' };
+          },
+        ],
+      });
+
+      const run = await createRun(registry, 'finalized-warm-run');
+      run.Graph!.overrideTestModel(['first answer', 'continued answer']);
+      await run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      );
+
+      expect(finalized).toHaveLength(2);
+      expect(finalized.map((input) => input.continuationPlanned)).toEqual([
+        true,
+        false,
+      ]);
+      expect(finalized.map((input) => input.continuationPrevented)).toEqual([
+        false,
+        false,
+      ]);
+      expect(run.Graph!.messages.map((message) => message.content)).toEqual([
+        'initial prompt',
+        'first answer',
+        'plugin continuation',
+        'continued answer',
+      ]);
+    });
+
+    it('does not self-loop when Stop blocks without injectable content', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      registry.register('Stop', {
+        hooks: [
+          async (): Promise<StopHookOutput> => {
+            calls += 1;
+            return { decision: 'block' };
+          },
+        ],
+      });
+
+      const run = await createRun(registry, 'empty-warm-run');
+      run.Graph!.overrideTestModel(['only answer']);
+      await run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      );
+
+      expect(calls).toBe(1);
+      expect(run.Graph!.messages.map((message) => message.content)).toEqual([
+        'initial prompt',
+        'only answer',
+      ]);
+    });
+
+    it('submits only the injected delta when a checkpointer owns prior state', async () => {
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> =>
+            input.continuationCount === 0
+              ? {
+                decision: 'block',
+                injectedMessages: [
+                  {
+                    role: 'user',
+                    content: 'checkpoint steer',
+                    source: 'steer',
+                  },
+                ],
+              }
+              : { decision: 'continue' },
+        ],
+      });
+      const run = await Run.create<t.IState>({
+        runId: 'checkpoint-warm-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          compileOptions: { checkpointer: new MemorySaver() },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        hooks: registry,
+      });
+      run.Graph!.overrideTestModel(['first answer', 'continued answer']);
+
+      await run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      );
+
+      expect(run.Graph!.messages.map((message) => message.content)).toEqual([
+        'initial prompt',
+        'first answer',
+        'checkpoint steer',
+        'continued answer',
+      ]);
+    });
+
+    it('reports a zero budget and refuses continuation past the configured cap', async () => {
+      const registry = new HookRegistry();
+      const remaining: number[] = [];
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> => {
+            remaining.push(input.continuationBudgetRemaining);
+            if (input.continuationBudgetRemaining === 0) {
+              return { decision: 'continue' };
+            }
+            return {
+              decision: 'block',
+              injectedMessages: [
+                {
+                  role: 'user',
+                  content: `steer ${input.continuationCount + 1}`,
+                  source: 'steer',
+                },
+              ],
+            };
+          },
+        ],
+      });
+      const run = await Run.create<t.IState>({
+        runId: 'capped-warm-run',
+        graphConfig: { type: 'standard', llmConfig },
+        returnContent: true,
+        skipCleanup: true,
+        hooks: registry,
+        maxStopContinuations: 1,
+      });
+      run.Graph!.overrideTestModel(['first answer', 'second answer']);
+
+      await run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      );
+
+      expect(remaining).toEqual([1, 0]);
+      expect(run.Graph!.messages.map((message) => message.content)).toEqual([
+        'initial prompt',
+        'first answer',
+        'steer 1',
+        'second answer',
+      ]);
     });
 
     it('does not fire when the stream throws an error', async () => {

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -12,8 +12,8 @@ import type {
   StopFailureHookOutput,
 } from '../types';
 import type * as t from '@/types';
-import { HookRegistry } from '../HookRegistry';
 import { Providers, StepTypes } from '@/common';
+import { HookRegistry } from '../HookRegistry';
 import { Run } from '@/run';
 
 const llmConfig: t.LLMConfig = {
@@ -476,17 +476,36 @@ describe('Run-level hook integration', () => {
       expect(typeof checkpointId).toBe('string');
 
       const registry = new HookRegistry();
+      let siblingCompleted = false;
       registry.register('Stop', {
         hooks: [
-          async (input): Promise<StopHookOutput> =>
-            input.continuationCount === 0
-              ? {
-                decision: 'block',
-                injectedMessages: [
-                  { role: 'user', content: 'branch steer', source: 'steer' },
-                ],
-              }
-              : { decision: 'continue' },
+          async (input): Promise<StopHookOutput> => {
+            if (input.continuationCount > 0) {
+              return { decision: 'continue' };
+            }
+            const siblingRun = await Run.create<t.IState>({
+              runId: 'pinned-warm-sibling',
+              graphConfig: {
+                type: 'standard',
+                llmConfig,
+                compileOptions: { checkpointer },
+              },
+              returnContent: true,
+              skipCleanup: true,
+            });
+            siblingRun.Graph!.overrideTestModel(['sibling answer']);
+            await siblingRun.processStream(
+              { messages: [new HumanMessage('sibling prompt')] },
+              threadConfig
+            );
+            siblingCompleted = true;
+            return {
+              decision: 'block',
+              injectedMessages: [
+                { role: 'user', content: 'branch steer', source: 'steer' },
+              ],
+            };
+          },
         ],
       });
       const branchRun = await Run.create<t.IState>({
@@ -515,6 +534,7 @@ describe('Run-level hook integration', () => {
         }
       );
 
+      expect(siblingCompleted).toBe(true);
       expect(
         branchRun.Graph!.messages.map((message) => message.content)
       ).toEqual([
@@ -525,6 +545,59 @@ describe('Run-level hook integration', () => {
         'branch steer',
         'continued branch answer',
       ]);
+    });
+
+    it('resets persisted continuation admission for the next fresh turn', async () => {
+      const checkpointer = new MemorySaver();
+      const counts: number[] = [];
+      let admitted = false;
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> => {
+            counts.push(input.continuationCount);
+            if (admitted) {
+              return { decision: 'continue' };
+            }
+            admitted = true;
+            return {
+              decision: 'block',
+              injectedMessages: [
+                { role: 'user', content: 'first-turn steer', source: 'steer' },
+              ],
+            };
+          },
+        ],
+      });
+      const run = await Run.create<t.IState>({
+        runId: 'fresh-turn-continuation-reset',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        hooks: registry,
+        maxStopContinuations: 1,
+      });
+      const config = {
+        ...callerConfig,
+        configurable: { thread_id: 'fresh-turn-continuation-reset-thread' },
+      };
+      run.Graph!.overrideTestModel(['first answer', 'continued answer']);
+      await run.processStream(
+        { messages: [new HumanMessage('first prompt')] },
+        config
+      );
+
+      run.Graph!.overrideTestModel(['next answer']);
+      await run.processStream(
+        { messages: [new HumanMessage('next prompt')] },
+        config
+      );
+
+      expect(counts).toEqual([0, 1, 0]);
     });
 
     it('reports a zero budget and refuses continuation past the configured cap', async () => {

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -13,7 +13,7 @@ import type {
 } from '../types';
 import type * as t from '@/types';
 import { HookRegistry } from '../HookRegistry';
-import { Providers } from '@/common';
+import { Providers, StepTypes } from '@/common';
 import { Run } from '@/run';
 
 const llmConfig: t.LLMConfig = {
@@ -300,6 +300,11 @@ describe('Run-level hook integration', () => {
         role: 'user',
         source: 'steer',
       });
+      const messageSteps = run.Graph!.contentData.filter(
+        (step) => step.type === StepTypes.MESSAGE_CREATION
+      );
+      expect(messageSteps).toHaveLength(2);
+      expect(new Set(messageSteps.map((step) => step.id)).size).toBe(2);
     });
 
     it('serializes StopFinalize after ordinary Stop decisions are folded', async () => {
@@ -349,6 +354,29 @@ describe('Run-level hook integration', () => {
         'plugin continuation',
         'continued answer',
       ]);
+    });
+
+    it('fails the run when final continuation admission is indeterminate', async () => {
+      const registry = new HookRegistry();
+      registry.register('StopFinalize', {
+        hooks: [
+          async (): Promise<StopHookOutput> => {
+            throw new Error('claim response unavailable');
+          },
+        ],
+      });
+
+      const run = await createRun(registry, 'failed-final-admission');
+      run.Graph!.overrideTestModel(['first answer']);
+
+      await expect(
+        run.processStream(
+          { messages: [new HumanMessage('initial prompt')] },
+          callerConfig
+        )
+      ).rejects.toThrow(
+        'StopFinalize terminal admission failed: claim response unavailable'
+      );
     });
 
     it('does not self-loop when Stop blocks without injectable content', async () => {
@@ -419,6 +447,83 @@ describe('Run-level hook integration', () => {
         'first answer',
         'checkpoint steer',
         'continued answer',
+      ]);
+    });
+
+    it('advances an explicitly pinned checkpoint before the warm segment', async () => {
+      const checkpointer = new MemorySaver();
+      const threadConfig = {
+        ...callerConfig,
+        configurable: { thread_id: 'pinned-warm-thread' },
+      };
+      const seedRun = await Run.create<t.IState>({
+        runId: 'pinned-warm-seed',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+      });
+      seedRun.Graph!.overrideTestModel(['seed answer']);
+      await seedRun.processStream(
+        { messages: [new HumanMessage('seed prompt')] },
+        threadConfig
+      );
+      const seedTuple = await checkpointer.getTuple(threadConfig);
+      const checkpointId = seedTuple?.config.configurable?.checkpoint_id;
+      expect(typeof checkpointId).toBe('string');
+
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          async (input): Promise<StopHookOutput> =>
+            input.continuationCount === 0
+              ? {
+                decision: 'block',
+                injectedMessages: [
+                  { role: 'user', content: 'branch steer', source: 'steer' },
+                ],
+              }
+              : { decision: 'continue' },
+        ],
+      });
+      const branchRun = await Run.create<t.IState>({
+        runId: 'pinned-warm-branch',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          compileOptions: { checkpointer },
+        },
+        returnContent: true,
+        skipCleanup: true,
+        hooks: registry,
+      });
+      branchRun.Graph!.overrideTestModel([
+        'branch answer',
+        'continued branch answer',
+      ]);
+      await branchRun.processStream(
+        { messages: [new HumanMessage('branch prompt')] },
+        {
+          ...threadConfig,
+          configurable: {
+            ...threadConfig.configurable,
+            checkpoint_id: checkpointId,
+          },
+        }
+      );
+
+      expect(
+        branchRun.Graph!.messages.map((message) => message.content)
+      ).toEqual([
+        'seed prompt',
+        'seed answer',
+        'branch prompt',
+        'branch answer',
+        'branch steer',
+        'continued branch answer',
       ]);
     });
 

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -347,6 +347,19 @@ function combineAggregatedResults(
   return combined;
 }
 
+/** Deterministically fold results from serialized hook phases. */
+export function mergeAggregatedHookResults(
+  ...results: Array<AggregatedHookResult | undefined>
+): AggregatedHookResult | undefined {
+  let combined: AggregatedHookResult | undefined;
+  for (const result of results) {
+    if (result != null) {
+      combined = combineAggregatedResults(combined, result);
+    }
+  }
+  return combined;
+}
+
 function createPendingApprovalReplay(
   approvalResult: AggregatedHookResult,
   pendingApproval: AggregatedHookResult | undefined,

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -313,6 +313,9 @@ function applyAggregatedResult(
   target.additionalContexts.push(...source.additionalContexts);
   target.injectedMessages.push(...source.injectedMessages);
   target.errors.push(...source.errors);
+  if (source.hasHookFailures === true) {
+    target.hasHookFailures = true;
+  }
   if (source.decision != null) {
     applyToolDecision(target, source.decision, source.reason);
   }
@@ -390,6 +393,7 @@ function fold(outcomes: readonly HookOutcome[]): {
   for (const outcome of outcomes) {
     const isOnceMatcher = outcome.matcher.once === true;
     if (outcome.error !== null) {
+      aggregated.hasHookFailures = true;
       if (outcome.matcher.internal !== true) {
         aggregated.errors.push(outcome.error);
       }
@@ -468,8 +472,9 @@ function fold(outcomes: readonly HookOutcome[]): {
  * ## Internal matchers
  *
  * A matcher with `internal: true` is excluded from both the `errors` array
- * and the logger output. Use it for infrastructure hooks whose failures
- * should not pollute user-visible diagnostics.
+ * and the logger output. `hasHookFailures` still records that the call was
+ * not fully successful, so fail-closed infrastructure boundaries can reject
+ * without exposing the suppressed diagnostic.
  *
  * ## Once semantics — atomic at-most-once
  *

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,7 +9,11 @@
 // `StandardGraph.createCallModel` (PreemptBoundary).
 export { HookRegistry } from './HookRegistry';
 export type { HookHaltSignal } from './HookRegistry';
-export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
+export {
+  executeHooks,
+  mergeAggregatedHookResults,
+  DEFAULT_HOOK_TIMEOUT_MS,
+} from './executeHooks';
 /**
  * Feature probe for hosts: hook outputs support `injectedMessages`
  * (per-message graph-state injection at the `PostToolBatch` boundary).
@@ -28,6 +32,11 @@ export const HOOK_INJECTED_MESSAGES_CAPABLE = true;
  * the user as a dead button rather than as an unsupported feature.
  */
 export const HOOK_PREEMPT_BOUNDARY_CAPABLE = true;
+/**
+ * Feature probe for hosts: a blocking `Stop` hook can inject queued messages
+ * and continue within the same `Run.processStream` lifecycle.
+ */
+export const HOOK_STOP_CONTINUATION_CAPABLE = true;
 export {
   matchesQuery,
   hasNestedQuantifier,
@@ -71,6 +80,7 @@ export type {
   SubagentStartHookInput,
   SubagentStopHookInput,
   StopHookInput,
+  StopFinalizeHookInput,
   StopFailureHookInput,
   PreCompactHookInput,
   PostCompactHookInput,
@@ -85,6 +95,7 @@ export type {
   SubagentStartHookOutput,
   SubagentStopHookOutput,
   StopHookOutput,
+  StopFinalizeHookOutput,
   StopFailureHookOutput,
   PreCompactHookOutput,
   PostCompactHookOutput,

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -634,6 +634,8 @@ export interface AggregatedHookResult {
    * `preventContinuation` do not overwrite the reason.
    */
   stopReason?: string;
+  /** True when any hook failed, including internal hooks with hidden diagnostics. */
+  hasHookFailures?: true;
   /** Error messages from hooks that threw; always present (possibly empty). */
   errors: string[];
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -22,6 +22,7 @@ export const HOOK_EVENTS = [
   'SubagentStart',
   'SubagentStop',
   'Stop',
+  'StopFinalize',
   'StopFailure',
   'PreCompact',
   'PostCompact',
@@ -209,7 +210,34 @@ export interface StopHookInput extends BaseHookInput {
   hook_event_name: 'Stop';
   messages: BaseMessage[];
   stopReason?: string;
+  /** True after this hook has already kept the current Run warm once. */
   stopHookActive: boolean;
+  /** Number of terminal continuations already admitted in this Run. */
+  continuationCount: number;
+  /**
+   * Remaining continuations the SDK can honor. A host that durably claims
+   * queued work MUST seal admission instead when this reaches zero.
+   */
+  continuationBudgetRemaining: number;
+}
+
+/**
+ * Serialized terminal admission phase. Unlike ordinary `Stop` hooks (which
+ * execute in parallel), this fires after their outputs have been folded so a
+ * durable host can make one final claim-or-seal decision with full knowledge
+ * of whether another hook already kept the Run warm.
+ */
+export interface StopFinalizeHookInput extends BaseHookInput {
+  hook_event_name: 'StopFinalize';
+  messages: BaseMessage[];
+  stopReason?: string;
+  stopHookActive: boolean;
+  continuationCount: number;
+  continuationBudgetRemaining: number;
+  /** A regular Stop hook already supplied a valid warm continuation. */
+  continuationPlanned: boolean;
+  /** A halt reason or Stop output forbids another graph segment. */
+  continuationPrevented: boolean;
 }
 
 export interface StopFailureHookInput extends BaseHookInput {
@@ -259,6 +287,7 @@ export type HookInput =
   | SubagentStartHookInput
   | SubagentStopHookInput
   | StopHookInput
+  | StopFinalizeHookInput
   | StopFailureHookInput
   | PreCompactHookInput
   | PostCompactHookInput;
@@ -276,6 +305,7 @@ export type HookInputByEvent = {
   SubagentStart: SubagentStartHookInput;
   SubagentStop: SubagentStopHookInput;
   Stop: StopHookInput;
+  StopFinalize: StopFinalizeHookInput;
   StopFailure: StopFailureHookInput;
   PreCompact: PreCompactHookInput;
   PostCompact: PostCompactHookInput;
@@ -298,10 +328,11 @@ export interface BaseHookOutput {
    * mid-run steering message). Accumulated across hooks in registration
    * order.
    *
-   * Consumed at exactly two dispatch sites, both of which run the same
-   * converter so the emitted shapes cannot drift: `PostToolBatch` (the tool
-   * boundary) and `PreemptBoundary` (a cooperative mid-generation seal).
-   * Every other event ignores the field.
+   * Consumed at three dispatch sites, all of which run the same converter so
+   * the emitted shapes cannot drift: `PostToolBatch` (the tool boundary),
+   * `PreemptBoundary` (a cooperative mid-generation seal), and a blocking
+   * `Stop` hook (terminal Run continuation). Every other event ignores the
+   * field.
    */
   injectedMessages?: InjectedMessage[];
   /** True to prevent the next model turn. Any hook can set this. */
@@ -435,9 +466,17 @@ export interface SubagentStartHookOutput extends BaseHookOutput {
 export type SubagentStopHookOutput = BaseHookOutput;
 
 export interface StopHookOutput extends BaseHookOutput {
+  /**
+   * `block` keeps a naturally terminal Run warm only when the output also
+   * supplies non-empty `injectedMessages` or `additionalContext`. The SDK
+   * starts another graph segment inside the same `processStream` call; no
+   * RunStart/UserPromptSubmit hooks or terminal cleanup occur between them.
+   */
   decision?: StopDecision;
   reason?: string;
 }
+
+export type StopFinalizeHookOutput = StopHookOutput;
 
 export type StopFailureHookOutput = BaseHookOutput;
 
@@ -458,6 +497,7 @@ export type HookOutputByEvent = {
   SubagentStart: SubagentStartHookOutput;
   SubagentStop: SubagentStopHookOutput;
   Stop: StopHookOutput;
+  StopFinalize: StopFinalizeHookOutput;
   StopFailure: StopFailureHookOutput;
   PreCompact: PreCompactHookOutput;
   PostCompact: PostCompactHookOutput;
@@ -476,6 +516,7 @@ export type HookOutput =
   | SubagentStartHookOutput
   | SubagentStopHookOutput
   | StopHookOutput
+  | StopFinalizeHookOutput
   | StopFailureHookOutput
   | PreCompactHookOutput
   | PostCompactHookOutput;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -79,6 +79,8 @@ type LangfuseHandlerParams = {
    *  only adopted when stamped with the same run (see
    *  `LangfuseRuntimeContext.runId`). */
   runId?: string;
+  /** Keep this root open while one processStream call executes graph segments. */
+  deferRootRunId?: string;
   /** The run's resolved tool-output policy — for multi-agent streams the
    *  conservative aggregate across agents, which `this.langfuse` (the
    *  primary agent's config) cannot reproduce. Applied when a foreign
@@ -293,9 +295,19 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   private readonly agentId?: string;
   private readonly parentSpanContext?: SpanContext;
   private readonly runId?: string;
+  private readonly deferredRootRunId?: string;
   private readonly identity: HandlerIdentity;
   private readonly toolOutputTracing?: ResolvedLangfuseToolOutputTracingConfig;
   private readonly trackedRunIds = new Set<string>();
+  private deferredRootStarted = false;
+  private deferredRootOutcome:
+    | {
+      type: 'end';
+      output: Parameters<CallbackHandler['handleChainEnd']>[0];
+      parentRunId?: string;
+    }
+    | { type: 'error'; error: Error; parentRunId?: string }
+    | undefined;
 
   constructor(params?: AgentLangfuseHandlerParams) {
     const {
@@ -306,6 +318,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
       parentSpanContext,
       inheritTraceIdentity,
       runId,
+      deferRootRunId,
       toolOutputTracing,
       traceName,
       ...handlerParams
@@ -326,6 +339,10 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     this.agentId = agentId;
     this.parentSpanContext = parentSpanContext;
     this.runId = runId;
+    this.deferredRootRunId = deferRootRunId;
+    if (deferRootRunId != null) {
+      this.awaitHandlers = true;
+    }
     this.toolOutputTracing = toolOutputTracing;
     this.identity = {
       userId: inheritTraceIdentity === true ? undefined : handlerParams.userId,
@@ -528,6 +545,17 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
   override handleChainStart(
     ...args: Parameters<CallbackHandler['handleChainStart']>
   ): ReturnType<CallbackHandler['handleChainStart']> {
+    const [, , runId, parentRunId] = args;
+    if (
+      runId === this.deferredRootRunId &&
+      parentRunId == null &&
+      this.deferredRootStarted
+    ) {
+      return Promise.resolve();
+    }
+    if (runId === this.deferredRootRunId && parentRunId == null) {
+      this.deferredRootStarted = true;
+    }
     return this.withRuntimeContext(
       () => super.handleChainStart(...args),
       this.startsDetachedRun(args[2], args[3]),
@@ -539,6 +567,13 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleChainError']>
   ): ReturnType<CallbackHandler['handleChainError']> {
     const [error, runId, parentRunId] = args;
+    if (runId === this.deferredRootRunId && parentRunId == null) {
+      this.deferredRootOutcome = {
+        type: 'error',
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+      return Promise.resolve();
+    }
     if (error != null && parentRunId != null && isGraphInterrupt(error)) {
       return super.handleChainEnd(
         GRAPH_INTERRUPT_CONTROL_FLOW,
@@ -554,6 +589,36 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
       );
     }
     return super.handleChainError(...args);
+  }
+
+  override handleChainEnd(
+    ...args: Parameters<CallbackHandler['handleChainEnd']>
+  ): ReturnType<CallbackHandler['handleChainEnd']> {
+    const [output, runId, parentRunId] = args;
+    if (runId === this.deferredRootRunId && parentRunId == null) {
+      this.deferredRootOutcome = { type: 'end', output };
+      return Promise.resolve();
+    }
+    return super.handleChainEnd(...args);
+  }
+
+  async finishDeferredRoot(): Promise<void> {
+    const runId = this.deferredRootRunId;
+    const outcome = this.deferredRootOutcome;
+    if (!this.deferredRootStarted || runId == null || outcome == null) {
+      return;
+    }
+    this.deferredRootStarted = false;
+    this.deferredRootOutcome = undefined;
+    if (outcome.type === 'error') {
+      await super.handleChainError(
+        outcome.error,
+        runId,
+        outcome.parentRunId
+      );
+      return;
+    }
+    await super.handleChainEnd(outcome.output, runId, outcome.parentRunId);
   }
 
   override handleAgentAction(
@@ -792,6 +857,7 @@ export function createLangfuseHandler({
   parentSpanContext,
   inheritTraceIdentity,
   runId,
+  deferRootRunId,
   toolOutputTracing,
   traceName,
 }: AgentLangfuseHandlerParams): CallbackHandler | undefined {
@@ -813,6 +879,7 @@ export function createLangfuseHandler({
     parentSpanContext,
     inheritTraceIdentity,
     runId,
+    deferRootRunId,
     toolOutputTracing,
     traceName,
   });
@@ -865,6 +932,9 @@ export function isLangfuseCallbackHandler(value: unknown): boolean {
 }
 
 export async function disposeLangfuseHandler(value: unknown): Promise<void> {
+  if (value instanceof ScopedLangfuseCallbackHandler) {
+    await value.finishDeferredRoot();
+  }
   if (
     value == null ||
     parseBooleanEnv(process.env[LANGFUSE_FORCE_FLUSH_ON_DISPOSE]) !== true

--- a/src/run.ts
+++ b/src/run.ts
@@ -166,6 +166,24 @@ function materializeStopContinuation(
   return messages;
 }
 
+function advanceCheckpointCursor(
+  config: t.RunStreamConfig
+): t.RunStreamConfig {
+  const configurable = { ...config.configurable };
+  delete configurable.checkpoint_id;
+  delete configurable.checkpoint_map;
+  return { ...config, configurable };
+}
+
+function assertFinalAdmissionSucceeded(result: AggregatedHookResult): void {
+  if (result.errors.length === 0) {
+    return;
+  }
+  throw new Error(
+    `StopFinalize terminal admission failed: ${result.errors.join('; ')}`
+  );
+}
+
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_AGENT_UPDATE,
   GraphEvents.ON_RUN_STEP,
@@ -262,7 +280,10 @@ function getInterruptHookSessionId(payload: unknown): string | undefined {
 
 type InterruptStateSnapshot = {
   config?: RunnableConfig;
-  values?: { messages?: BaseMessage[] };
+  values?: {
+    messages?: BaseMessage[];
+    runStepState?: t.RunStepResumeState;
+  };
   tasks?: Array<{
     interrupts?: Array<{ id?: string; value?: unknown }>;
     state?: RunnableConfig | InterruptStateSnapshot;
@@ -1213,6 +1234,7 @@ export class Run<_T extends t.BaseGraphState> {
           : undefined,
       traceAnchor: graph.langfuseTraceAnchor,
       runId: graph.langfuseScopeRunId,
+      deferRootRunId: this.id,
       // The aggregate multi-agent policy from the runtime scope — the
       // handler must restore THIS (not the primary agent's config-derived
       // policy) when rejecting a foreign scope.
@@ -1227,6 +1249,7 @@ export class Run<_T extends t.BaseGraphState> {
       throw new Error('Run ID not provided');
     }
 
+    config.runId = this.id;
     config.run_id = this.id;
     config.configurable = Object.assign(config.configurable ?? {}, {
       run_id: this.id,
@@ -1276,7 +1299,7 @@ export class Run<_T extends t.BaseGraphState> {
 
     const consumeStream = async (): Promise<void> => {
       let streamInputs: t.IState | Command = inputs;
-      let stopContinuationCount = 0;
+      let streamConfig = config;
 
       for (;;) {
         /**
@@ -1287,7 +1310,7 @@ export class Run<_T extends t.BaseGraphState> {
          */
         const stream = graphRunnable.streamEvents(
           streamInputs as t.IState,
-          { ...config, runName: graph.runName },
+          { ...streamConfig, runName: graph.runName },
           {
             raiseError: true,
             /** Custom events are handled by createCustomEventCallback(). */
@@ -1356,6 +1379,7 @@ export class Run<_T extends t.BaseGraphState> {
         }
 
         const stopMessages = graph.getRunMessages() ?? stateInputs?.messages ?? [];
+        const stopContinuationCount = graph.getStopContinuationCount();
         const continuationBudgetRemaining = Math.max(
           0,
           this.maxStopContinuations - stopContinuationCount
@@ -1406,7 +1430,8 @@ export class Run<_T extends t.BaseGraphState> {
             },
             sessionId: this.id,
             signal: config.signal,
-          }).catch((): undefined => undefined);
+          });
+          assertFinalAdmissionSucceeded(finalized);
           stopResult = mergeAggregatedHookResults(stopResult, finalized);
         }
 
@@ -1426,7 +1451,9 @@ export class Run<_T extends t.BaseGraphState> {
                 'Stop hook attempted to inject messages after the terminal continuation budget was exhausted.'
               );
             }
-            stopContinuationCount += 1;
+            const nextContinuationCount = stopContinuationCount + 1;
+            graph.setStopContinuationCount(nextContinuationCount);
+            graph.advanceStreamSegment();
             /**
              * A checkpointer already owns the completed graph state, so only
              * the delta is submitted. Without one, each invocation starts from
@@ -1437,7 +1464,11 @@ export class Run<_T extends t.BaseGraphState> {
               messages: this.hasCheckpointer
                 ? injected
                 : [...graph.messages, ...injected],
+              runStepState: graph.createRunStepResumeState(),
             };
+            if (this.hasCheckpointer) {
+              streamConfig = advanceCheckpointCursor(streamConfig);
+            }
             continue;
           }
         }
@@ -1877,7 +1908,8 @@ export class Run<_T extends t.BaseGraphState> {
       return;
     }
     this.Graph?.restoreRunStepResumeState(
-      getRunStepResumeState(persistedInterrupt.value)
+      getRunStepResumeState(persistedInterrupt.value) ??
+        snapshot.values?.runStepState
     );
     const persistedMessages = getPersistedMessages(snapshot);
     if (persistedMessages != null) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,9 +21,9 @@ import type {
 } from '@langchain/core/messages';
 import type { StringPromptValue } from '@langchain/core/prompt_values';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import type { StandardGraph } from '@/graphs/Graph';
-import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import {
   Callback,
@@ -33,6 +33,7 @@ import {
   REASONING_LABEL_RUN_NAME,
   ACTIVITY_PHASE_RUN_NAME,
   ACTIVITY_PHASE_LABEL_RUN_NAME,
+  DEFAULT_MAX_STOP_CONTINUATIONS,
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
 import {
@@ -94,6 +95,8 @@ import { LANGFUSE_OPERATION_METADATA_KEY } from '@/langfuseOperation';
 import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 import { stampSyntheticProviderMessage } from '@/messages/provenance';
 import { isOpenAILike, isLibreChatOpenAIModel } from '@/utils/llm';
+import { executeHooks, mergeAggregatedHookResults } from '@/hooks';
+import { convertInjectedMessages } from '@/messages/injected';
 import { initializeLangfuseTracing } from './instrumentation';
 import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
@@ -102,7 +105,6 @@ import { resolveMaxSeals } from '@/llm/preempt';
 import { isBuiltRuntime } from '@/lazyRequire';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
-import { executeHooks } from '@/hooks';
 
 /** Source-mode runs have no dist siblings for the lazy-loading seam, so every
  *  lazily loadable module is imported through the active loader before the
@@ -131,6 +133,38 @@ const ACTIVITY_LABEL_TRACE_NAME = 'LibreChat Activity Label';
 const ACTIVITY_PHASE_TRACE_NAME = 'LibreChat Activity Phase';
 const REASONING_LABEL_TRACE_NAME = 'LibreChat Reasoning Label';
 const OUTPUT_TRUNCATED_HALT_REASON = 'output_truncated';
+
+function resolveMaxStopContinuations(value: number | undefined): number {
+  if (value == null || !Number.isFinite(value)) {
+    return DEFAULT_MAX_STOP_CONTINUATIONS;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function materializeStopContinuation(
+  result: AggregatedHookResult
+): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  const contexts = result.additionalContexts.filter(
+    (context) => context.trim() !== ''
+  );
+  if (contexts.length > 0) {
+    messages.push(
+      stampSyntheticProviderMessage(
+        new HumanMessage({
+          content: contexts.join('\n\n'),
+          additional_kwargs: {
+            role: 'system',
+            isMeta: true,
+            source: 'hook',
+          },
+        })
+      )
+    );
+  }
+  messages.push(...convertInjectedMessages(result.injectedMessages));
+  return messages;
+}
 
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_AGENT_UPDATE,
@@ -316,6 +350,7 @@ export class Run<_T extends t.BaseGraphState> {
   private toolExecution?: t.ToolExecutionConfig;
   private subagentUsageSink?: t.SubagentUsageSink;
   private preemption?: t.StreamPreemption;
+  private maxStopContinuations: number;
   private streamLimits?: t.StreamLimits;
   private subagentTasks?: t.SubagentTaskConfig;
   private indexTokenCountMap?: Record<string, number>;
@@ -387,6 +422,9 @@ export class Run<_T extends t.BaseGraphState> {
     this.subagentUsageSink = config.subagentUsageSink;
     this.subagentTasks = config.subagentTasks;
     this.preemption = config.preemption;
+    this.maxStopContinuations = resolveMaxStopContinuations(
+      config.maxStopContinuations
+    );
     this.streamLimits = config.streamLimits;
 
     if (!config.graphConfig) {
@@ -1237,144 +1275,78 @@ export class Run<_T extends t.BaseGraphState> {
     let terminalAt: number | undefined;
 
     const consumeStream = async (): Promise<void> => {
-      /**
-       * `streamEvents` accepts both state inputs and `Command` (resume) at
-       * runtime, but our `CompiledStateWorkflow` type narrows the first
-       * arg to `BaseGraphState`. Cast on the call so the resume path
-       * type-checks without widening the wrapper for every caller.
-       */
-      const stream = graphRunnable.streamEvents(
-        inputs as t.IState,
-        { ...config, runName: graph.runName },
-        {
-          raiseError: true,
-          /**
-           * Prevent EventStreamCallbackHandler from processing custom events.
-           * Custom events are already handled via our createCustomEventCallback()
-           * which routes them through the handlerRegistry.
-           * Without this flag, EventStreamCallbackHandler throws errors when
-           * custom events are dispatched for run IDs not in its internal map
-           * (due to timing issues in parallel execution or after run cleanup).
-           */
-          ignoreCustomEvent: true,
-        }
-      );
+      let streamInputs: t.IState | Command = inputs;
+      let stopContinuationCount = 0;
 
-      for await (const event of stream) {
-        const { data, metadata, ...info } = event;
-
-        const eventName: t.EventName = info.event;
-
-        /** Skip custom events as they're handled by our callback */
-        if (CUSTOM_GRAPH_EVENTS.has(eventName)) {
-          continue;
-        }
-
+      for (;;) {
         /**
-         * Detect interrupts surfaced by LangGraph as a synthetic
-         * `__interrupt__` field on the streamed chunk and stash the
-         * first one for the host to read via `run.getInterrupt()`
-         * once the stream drains. Captured as `unknown` because the
-         * SDK does not validate the runtime payload shape — the
-         * built-in ToolNode raises a `HumanInterruptPayload`
-         * (`tool_approval` / `ask_user_question`), but custom nodes
-         * can pass any payload to `interrupt()`. Callers narrow with
-         * the `isToolApprovalInterrupt` / `isAskUserQuestionInterrupt`
-         * guards or assert via `getInterrupt<T>()`.
+         * `streamEvents` accepts both state inputs and `Command` (resume) at
+         * runtime, but our `CompiledStateWorkflow` type narrows the first
+         * arg to `BaseGraphState`. Cast on the call so the resume path
+         * type-checks without widening the wrapper for every caller.
          */
-        if (
-          this._interrupt == null &&
-          data.chunk != null &&
-          isInterrupted<unknown>(data.chunk)
-        ) {
-          const interrupts = data.chunk[INTERRUPT];
-          if (interrupts.length > 0) {
-            const first = interrupts[0];
-            /**
-             * Capture the interrupt unconditionally — `interrupt(null)`
-             * and `interrupt(undefined)` are valid pauses (a custom
-             * node may want to pause without metadata) and the host
-             * still needs to know the run is awaiting resume. Gating
-             * on `payload != null` would silently downgrade a paused
-             * run to "completed" and let the `Stop` hook fire,
-             * breaking host resume handling.
-             */
-            this._interrupt = {
-              interruptId: first.id ?? '',
-              threadId,
-              payload: first.value,
-            };
+        const stream = graphRunnable.streamEvents(
+          streamInputs as t.IState,
+          { ...config, runName: graph.runName },
+          {
+            raiseError: true,
+            /** Custom events are handled by createCustomEventCallback(). */
+            ignoreCustomEvent: true,
+          }
+        );
+
+        for await (const event of stream) {
+          const { data, metadata, ...info } = event;
+          const eventName: t.EventName = info.event;
+
+          if (CUSTOM_GRAPH_EVENTS.has(eventName)) {
+            continue;
+          }
+
+          if (
+            this._interrupt == null &&
+            data.chunk != null &&
+            isInterrupted<unknown>(data.chunk)
+          ) {
+            const interrupts = data.chunk[INTERRUPT];
+            if (interrupts.length > 0) {
+              const first = interrupts[0];
+              this._interrupt = {
+                interruptId: first.id ?? '',
+                threadId,
+                payload: first.value,
+              };
+            }
+          }
+
+          const modelEndAt =
+            eventName === GraphEvents.CHAT_MODEL_END ? Date.now() : undefined;
+          const handler = this.handlerRegistry?.getHandler(eventName);
+          if (handler) {
+            await handler.handle(eventName, data, metadata, this.Graph);
+          }
+
+          if (eventName === GraphEvents.CHAT_MODEL_END && this.Graph != null) {
+            await this.Graph.closeOpenMessageStep(metadata, modelEndAt);
+          }
+
+          const haltSignal = this.hookRegistry?.getHaltSignal(this.id);
+          if (haltSignal != null) {
+            this._haltedReason = haltSignal.reason;
+            break;
           }
         }
 
-        /**
-         * Stamped before the handler runs: the close below happens after an
-         * arbitrarily slow host handler resolves, and the step's duration
-         * should end when the model did, not when the host finished with it.
-         */
-        const modelEndAt =
-          eventName === GraphEvents.CHAT_MODEL_END ? Date.now() : undefined;
-        const handler = this.handlerRegistry?.getHandler(eventName);
-        if (handler) {
-          await handler.handle(eventName, data, metadata, this.Graph);
+        terminalAt = Date.now();
+
+        if (this._interrupt != null) {
+          await this.resolveInterruptResumeConfig(config);
+          return;
+        }
+        if (this._haltedReason != null) {
+          return;
         }
 
-        /**
-         * A finished model call ends its lane's open message step. Placed
-         * here — not in `ModelEndHandler` — because hosts replace the
-         * CHAT_MODEL_END handler with their own instance, which would
-         * silently drop the close.
-         */
-        if (eventName === GraphEvents.CHAT_MODEL_END && this.Graph != null) {
-          await this.Graph.closeOpenMessageStep(metadata, modelEndAt);
-        }
-
-        /**
-         * Mid-flight halt: any hook (PreToolUse, PostToolUse,
-         * PostToolBatch, SubagentStart/Stop, PreCompact, PostCompact)
-         * that returned `preventContinuation: true` raises a halt
-         * signal on the registry via `executeHooks`. We poll between
-         * stream events and break out as soon as one is set so the
-         * graph doesn't take another model turn after the halting
-         * operation completes.
-         *
-         * This `break` is NOT graceful, despite what a `continue: false`
-         * reading suggests. Leaving the `for await` calls the iterator's
-         * `return()`, which cancels the reader
-         * (`@langchain/core/utils/stream`), and langgraph's stream wrapper
-         * turns that cancel into `_abortController.abort()`
-         * (`pregel/stream.js`). The in-flight model call or tool batch is
-         * torn down where it stands — it does not finish first.
-         *
-         * A halt is therefore the wrong tool for "stop generating but keep
-         * what you have". That is what `RunConfig.preemption` is for: it
-         * seals the stream at a provider-safe boundary and keeps the run.
-         */
-        const haltSignal = this.hookRegistry?.getHaltSignal(this.id);
-        if (haltSignal != null) {
-          this._haltedReason = haltSignal.reason;
-          break;
-        }
-      }
-
-      terminalAt = Date.now();
-
-      if (this._interrupt != null) {
-        await this.resolveInterruptResumeConfig(config);
-      }
-
-      /**
-       * Skip the Stop hook when the run paused on a HITL interrupt
-       * (still pending human input) or was halted by a hook (the host
-       * already chose to stop, so a Stop hook firing now would be
-       * misleading). The host fires Stop on the resumed-and-completed
-       * run instead.
-       */
-      if (
-        this._interrupt == null &&
-        this._haltedReason == null &&
-        this.hookRegistry?.hasHookFor('Stop', this.id) === true
-      ) {
         let stopReason = graph.preemptHaltReason;
         if (stopReason == null && graph.preemptIncomplete) {
           stopReason = 'preempt_incomplete';
@@ -1382,56 +1354,102 @@ export class Run<_T extends t.BaseGraphState> {
         if (stopReason == null && graph.outputTruncatedIncomplete) {
           stopReason = OUTPUT_TRUNCATED_HALT_REASON;
         }
-        await executeHooks({
-          registry: this.hookRegistry,
-          input: {
-            hook_event_name: 'Stop',
-            runId: this.id,
-            threadId,
-            agentId: graph.defaultAgentId,
-            messages: graph.getRunMessages() ?? stateInputs?.messages ?? [],
-            /**
-             * A seal whose boundary ended the turn early must say so. The
-             * hook-supplied reason wins when a `PreemptBoundary` hook halted
-             * with one — a persistence/audit `Stop` hook should record the
-             * actual cause, not the generic label — and `preempt_incomplete`
-             * is reserved for the boundary that simply had nothing to inject.
-             */
-            stopReason,
-            stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
-          },
-          sessionId: this.id,
-        }).catch(() => {
-          /* Stop hook errors must not masquerade as stream failures */
-        });
-      }
 
-      /**
-       * A `PreemptBoundary` hook that returned `preventContinuation` has its
-       * registry halt cleared by the graph — that is what stops the halt from
-       * cancelling the stream before the sealed turn commits — so the reason
-       * is carried across on the graph instead. Surfaced here, AFTER the
-       * `Stop` dispatch above, so the host still receives a completion signal
-       * to persist the partial answer with while `getHaltReason()` correctly
-       * reports that a hook stopped the run rather than the model finishing.
-       *
-       * An empty boundary — sealed, but nothing to inject because the host's
-       * queue was drained or cancelled in the meantime — cut the answer short
-       * just as surely, only without a hook-supplied reason. It surfaces
-       * through the same channel under the same name the `Stop` dispatch
-       * already used for its `stopReason`, so terminal consumers
-       * (`AgentSession` emits `run.halted`, not `run.completed`) cannot
-       * finalize a truncated answer as a natural finish.
-       */
-      if (this._haltedReason == null && graph.preemptHaltReason != null) {
-        this._haltedReason = graph.preemptHaltReason;
-      } else if (this._haltedReason == null && graph.preemptIncomplete) {
-        this._haltedReason = 'preempt_incomplete';
-      } else if (
-        this._haltedReason == null &&
-        graph.outputTruncatedIncomplete
-      ) {
-        this._haltedReason = OUTPUT_TRUNCATED_HALT_REASON;
+        const stopMessages = graph.getRunMessages() ?? stateInputs?.messages ?? [];
+        const continuationBudgetRemaining = Math.max(
+          0,
+          this.maxStopContinuations - stopContinuationCount
+        );
+        let stopResult: AggregatedHookResult | undefined;
+        if (this.hookRegistry?.hasHookFor('Stop', this.id) === true) {
+          stopResult = await executeHooks({
+            registry: this.hookRegistry,
+            input: {
+              hook_event_name: 'Stop',
+              runId: this.id,
+              threadId,
+              agentId: graph.defaultAgentId,
+              messages: stopMessages,
+              stopReason,
+              stopHookActive: stopContinuationCount > 0,
+              continuationCount: stopContinuationCount,
+              continuationBudgetRemaining,
+            },
+            sessionId: this.id,
+            signal: config.signal,
+          }).catch((): undefined => undefined);
+        }
+
+        if (this.hookRegistry?.hasHookFor('StopFinalize', this.id) === true) {
+          const stopInjected =
+            stopResult == null ? [] : materializeStopContinuation(stopResult);
+          const continuationPrevented =
+            stopReason != null || stopResult?.preventContinuation === true;
+          const finalized = await executeHooks({
+            registry: this.hookRegistry,
+            input: {
+              hook_event_name: 'StopFinalize',
+              runId: this.id,
+              threadId,
+              agentId: graph.defaultAgentId,
+              messages: stopMessages,
+              stopReason,
+              stopHookActive: stopContinuationCount > 0,
+              continuationCount: stopContinuationCount,
+              continuationBudgetRemaining,
+              continuationPlanned:
+                !continuationPrevented &&
+                stopResult?.stopDecision === 'block' &&
+                stopInjected.length > 0 &&
+                continuationBudgetRemaining > 0,
+              continuationPrevented,
+            },
+            sessionId: this.id,
+            signal: config.signal,
+          }).catch((): undefined => undefined);
+          stopResult = mergeAggregatedHookResults(stopResult, finalized);
+        }
+
+        if (stopResult?.preventContinuation === true) {
+          this._haltedReason =
+            stopResult.stopReason ?? stopResult.reason ?? 'preventContinuation';
+          return;
+        }
+
+        const requestsContinuation =
+          stopReason == null && stopResult?.stopDecision === 'block';
+        if (requestsContinuation && stopResult != null) {
+          const injected = materializeStopContinuation(stopResult);
+          if (injected.length > 0) {
+            if (stopContinuationCount >= this.maxStopContinuations) {
+              throw new Error(
+                'Stop hook attempted to inject messages after the terminal continuation budget was exhausted.'
+              );
+            }
+            stopContinuationCount += 1;
+            /**
+             * A checkpointer already owns the completed graph state, so only
+             * the delta is submitted. Without one, each invocation starts from
+             * empty state and must be seeded with the live full transcript.
+             * Graph sidecars and the outer Run stay intact in both cases.
+             */
+            streamInputs = {
+              messages: this.hasCheckpointer
+                ? injected
+                : [...graph.messages, ...injected],
+            };
+            continue;
+          }
+        }
+
+        if (graph.preemptHaltReason != null) {
+          this._haltedReason = graph.preemptHaltReason;
+        } else if (graph.preemptIncomplete) {
+          this._haltedReason = 'preempt_incomplete';
+        } else if (graph.outputTruncatedIncomplete) {
+          this._haltedReason = OUTPUT_TRUNCATED_HALT_REASON;
+        }
+        return;
       }
     };
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,17 +4,18 @@ import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import {
-  Command,
-  INTERRUPT,
-  MemorySaver,
-  isInterrupted,
-} from '@langchain/langgraph';
-import {
   AIMessage,
   BaseMessage,
   HumanMessage,
   SystemMessage,
 } from '@langchain/core/messages';
+import {
+  Command,
+  INTERRUPT,
+  MemorySaver,
+  Overwrite,
+  isInterrupted,
+} from '@langchain/langgraph';
 import type {
   MessageContentComplex,
   UsageMetadata,
@@ -296,9 +297,78 @@ type WorkflowWithStateHistory = {
     options?: { subgraphs?: boolean }
   ): Promise<InterruptStateSnapshot>;
   getStateHistory?(
-    config: RunnableConfig
+    config: RunnableConfig,
+    options?: { filter?: Record<string, unknown>; limit?: number }
   ): AsyncIterableIterator<InterruptStateSnapshot>;
 };
+
+async function resolveCompletedSegmentConfig(
+  workflow: t.CompiledStateWorkflow,
+  config: t.RunStreamConfig,
+  executionId: string,
+  streamSegment: number
+): Promise<t.RunStreamConfig> {
+  const stateWorkflow = workflow as t.CompiledStateWorkflow &
+    WorkflowWithStateHistory;
+  const stateHistory = stateWorkflow.getStateHistory;
+  if (typeof stateHistory !== 'function') {
+    throw new Error(
+      'Cannot continue a checkpointed run without exact state history.'
+    );
+  }
+  const lookup = advanceCheckpointCursor(config);
+
+  const resolveSnapshot = (
+    snapshot: InterruptStateSnapshot | undefined
+  ): t.RunStreamConfig | undefined => {
+    if (snapshot == null) {
+      return undefined;
+    }
+    const runStepState =
+      snapshot.values?.runStepState ??
+      snapshot.tasks
+        ?.flatMap((task) => task.interrupts ?? [])
+        .map((pendingInterrupt) =>
+          getRunStepResumeState(pendingInterrupt.value)
+        )
+        .find((state): state is t.RunStepResumeState => state != null);
+    if (
+      runStepState?.stopContinuationExecutionId !== executionId ||
+      runStepState.streamSegment !== streamSegment
+    ) {
+      return undefined;
+    }
+    const checkpointId = snapshot.config?.configurable?.checkpoint_id;
+    if (typeof checkpointId !== 'string' || checkpointId.length === 0) {
+      return undefined;
+    }
+    return {
+      ...config,
+      configurable: {
+        ...config.configurable,
+        ...snapshot.config?.configurable,
+      },
+    };
+  };
+
+  if (typeof stateWorkflow.getState === 'function') {
+    const latest = await stateWorkflow.getState(lookup);
+    const latestConfig = resolveSnapshot(latest);
+    if (latestConfig != null) {
+      return latestConfig;
+    }
+  }
+
+  for await (const snapshot of stateHistory.call(workflow, lookup)) {
+    const snapshotConfig = resolveSnapshot(snapshot);
+    if (snapshotConfig != null) {
+      return snapshotConfig;
+    }
+  }
+  throw new Error(
+    'Cannot identify the checkpoint committed by the completed graph segment.'
+  );
+}
 
 function getFirstPersistedInterrupt(
   snapshot: InterruptStateSnapshot
@@ -1169,6 +1239,7 @@ export class Run<_T extends t.BaseGraphState> {
             checkpointId === '' ? 0 : ++this.checkpointForkSeq,
           ]);
       graph.resetValues(streamOptions?.keepContent, checkpointScope);
+      graph.startStopContinuationExecution(nanoid());
     }
     this._interrupt = undefined;
     this._haltedReason = undefined;
@@ -1298,7 +1369,13 @@ export class Run<_T extends t.BaseGraphState> {
     let terminalAt: number | undefined;
 
     const consumeStream = async (): Promise<void> => {
-      let streamInputs: t.IState | Command = inputs;
+      let streamInputs: t.IState | Command =
+        !isResume && this.hasCheckpointer
+          ? ({
+            ...(inputs as t.IState),
+            runStepState: new Overwrite(graph.createRunStepResumeState()),
+          } as unknown as t.IState)
+          : inputs;
       let streamConfig = config;
 
       for (;;) {
@@ -1363,7 +1440,10 @@ export class Run<_T extends t.BaseGraphState> {
         terminalAt = Date.now();
 
         if (this._interrupt != null) {
-          await this.resolveInterruptResumeConfig(config);
+          const interruptConfig = this.hasCheckpointer
+            ? advanceCheckpointCursor(streamConfig)
+            : streamConfig;
+          await this.resolveInterruptResumeConfig(interruptConfig);
           return;
         }
         if (this._haltedReason != null) {
@@ -1451,6 +1531,14 @@ export class Run<_T extends t.BaseGraphState> {
                 'Stop hook attempted to inject messages after the terminal continuation budget was exhausted.'
               );
             }
+            const completedSegmentConfig = this.hasCheckpointer
+              ? await resolveCompletedSegmentConfig(
+                graphRunnable,
+                streamConfig,
+                graph.getStopContinuationExecutionId(),
+                graph.getStreamSegment()
+              )
+              : streamConfig;
             const nextContinuationCount = stopContinuationCount + 1;
             graph.setStopContinuationCount(nextContinuationCount);
             graph.advanceStreamSegment();
@@ -1466,9 +1554,7 @@ export class Run<_T extends t.BaseGraphState> {
                 : [...graph.messages, ...injected],
               runStepState: graph.createRunStepResumeState(),
             };
-            if (this.hasCheckpointer) {
-              streamConfig = advanceCheckpointCursor(streamConfig);
-            }
+            streamConfig = completedSegmentConfig;
             continue;
           }
         }
@@ -1504,6 +1590,10 @@ export class Run<_T extends t.BaseGraphState> {
     } catch (err) {
       terminalAt = Date.now();
       streamThrew = true;
+      await langfuseHandler?.handleChainError(
+        err instanceof Error ? err : new Error(String(err)),
+        this.id
+      );
       /**
        * Corroborate cancellation against an actually-aborted signal. A
        * provider SDK or host handler can reject with an `AbortError` while

--- a/src/run.ts
+++ b/src/run.ts
@@ -177,11 +177,15 @@ function advanceCheckpointCursor(
 }
 
 function assertFinalAdmissionSucceeded(result: AggregatedHookResult): void {
-  if (result.errors.length === 0) {
+  if (result.hasHookFailures !== true && result.errors.length === 0) {
     return;
   }
+  const detail =
+    result.errors.length > 0
+      ? result.errors.join('; ')
+      : 'one or more internal finalizers failed';
   throw new Error(
-    `StopFinalize terminal admission failed: ${result.errors.join('; ')}`
+    `StopFinalize terminal admission failed: ${detail}`
   );
 }
 
@@ -408,6 +412,27 @@ function getPersistedMessages(
 }
 
 type ResumeCommandUpdate = ConstructorParameters<typeof Command>[0]['update'];
+
+function overwriteResumeRunStepState(
+  command: Command,
+  state: t.RunStepResumeState
+): Command {
+  const overwrite = new Overwrite(state);
+  const update = Array.isArray(command.update)
+    ? [
+      ...command.update.filter(([key]) => key !== 'runStepState'),
+      ['runStepState', overwrite] as [string, unknown],
+    ]
+    : { ...(command.update ?? {}), runStepState: overwrite };
+  const resumed = new Command({
+    ...(command.graph == null ? {} : { graph: command.graph }),
+    ...(command.resume === undefined ? {} : { resume: command.resume }),
+    update,
+    ...(command.goto === undefined ? {} : { goto: command.goto }),
+  });
+  resumed.lc_direct_tool_output = command.lc_direct_tool_output;
+  return resumed;
+}
 
 function getResumeUpdateMessages(
   update: ResumeCommandUpdate
@@ -1184,11 +1209,16 @@ export class Run<_T extends t.BaseGraphState> {
       delete config.configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
       delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
     }
+    let overwriteLegacyResumeState = false;
     if (isResume) {
       await this.restoreInterruptFromCheckpoint(
         config,
         (inputs as Command).update
       );
+      if (graph.getStopContinuationExecutionId() === '') {
+        graph.startStopContinuationExecution(nanoid());
+        overwriteLegacyResumeState = this.hasCheckpointer;
+      }
     }
 
     /**
@@ -1369,13 +1399,18 @@ export class Run<_T extends t.BaseGraphState> {
     let terminalAt: number | undefined;
 
     const consumeStream = async (): Promise<void> => {
-      let streamInputs: t.IState | Command =
-        !isResume && this.hasCheckpointer
-          ? ({
-            ...(inputs as t.IState),
-            runStepState: new Overwrite(graph.createRunStepResumeState()),
-          } as unknown as t.IState)
-          : inputs;
+      let streamInputs: t.IState | Command = inputs;
+      if (!isResume && this.hasCheckpointer) {
+        streamInputs = {
+          ...(inputs as t.IState),
+          runStepState: new Overwrite(graph.createRunStepResumeState()),
+        } as unknown as t.IState;
+      } else if (overwriteLegacyResumeState) {
+        streamInputs = overwriteResumeRunStepState(
+          inputs as Command,
+          graph.createRunStepResumeState()
+        );
+      }
       let streamConfig = config;
 
       for (;;) {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
 import { HumanMessage } from '@langchain/core/messages';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import { context as otelContext, trace as otelTrace } from '@opentelemetry/api';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
@@ -19,8 +20,8 @@ import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
 import { initializeLangfuseTracing } from '@/instrumentation';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { createLangfuseHandler } from '@/langfuse';
-import { HookRegistry } from '@/hooks';
 import * as providers from '@/llm/providers';
+import { HookRegistry } from '@/hooks';
 import { Run } from '@/run';
 
 type ProcessorParams = {
@@ -38,6 +39,7 @@ type SpanStartRecord = {
 };
 
 const spanStarts: SpanStartRecord[] = [];
+const endedSpans: MockSpan[] = [];
 let providerInput:
   | {
       spanProcessors?: SpanProcessor[];
@@ -87,6 +89,7 @@ function createMockSpan(
     attributes,
     addEvent: jest.fn(),
     end: jest.fn(() => {
+      endedSpans.push(span);
       for (const processor of providerInput?.spanProcessors ?? []) {
         processor.onEnd(span as never);
       }
@@ -541,6 +544,7 @@ describe('Langfuse per-run routing integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     spanStarts.length = 0;
+    endedSpans.length = 0;
     delete process.env.LANGFUSE_PUBLIC_KEY;
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_BASE_URL;
@@ -1032,6 +1036,52 @@ describe('Langfuse per-run routing integration', () => {
         (record) => record.parentSpanId === roots[0].spanId
       ).length
     ).toBeGreaterThan(0);
+  });
+
+  it('marks the deferred root as failed when terminal admission fails', async () => {
+    const tenantId = 'tenant-terminal-admission-failure';
+    const registry = new HookRegistry();
+    registry.register('StopFinalize', {
+      hooks: [
+        async (): Promise<StopHookOutput> => {
+          throw new Error('terminal admission unavailable');
+        },
+      ],
+    });
+    const run = await Run.create<t.IState>({
+      runId: `routing-${tenantId}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createAgent(tenantId)],
+      },
+      langfuse: tenantLangfuse(tenantId),
+      hooks: registry,
+      returnContent: true,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(['first answer']);
+
+    await expect(
+      run.processStream(
+        { messages: [new HumanMessage('initial prompt')] },
+        callerConfig
+      )
+    ).rejects.toThrow(
+      'StopFinalize terminal admission failed: terminal admission unavailable'
+    );
+
+    const root = endedSpans.find(
+      (span) =>
+        span.name === 'AgentGraph' &&
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_LEVEL] ===
+          'ERROR'
+    );
+    expect(root).toBeDefined();
+    expect(
+      root?.attributes[
+        LangfuseOtelSpanAttributes.OBSERVATION_STATUS_MESSAGE
+      ]
+    ).toContain('terminal admission unavailable');
   });
 
   it('generates a scope stamp for directly-constructed graphs without a run id', async () => {

--- a/src/specs/langfuse-routing.integration.test.ts
+++ b/src/specs/langfuse-routing.integration.test.ts
@@ -7,6 +7,7 @@ import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { Context } from '@opentelemetry/api';
+import type { StopHookOutput } from '@/hooks';
 import type * as t from '@/types';
 import {
   registerLangfuseManagedSpan,
@@ -18,6 +19,7 @@ import { withLangfuseRuntimeScope } from '@/langfuseRuntimeScope';
 import { initializeLangfuseTracing } from '@/instrumentation';
 import { traceIdFromSeed } from '@/langfuseRuntimeContext';
 import { createLangfuseHandler } from '@/langfuse';
+import { HookRegistry } from '@/hooks';
 import * as providers from '@/llm/providers';
 import { Run } from '@/run';
 
@@ -985,6 +987,51 @@ describe('Langfuse per-run routing integration', () => {
     expect(secondParent?.spanId).not.toBe(firstParent?.spanId);
     expect(secondTraceAnchor).not.toBe(firstTraceAnchor);
     expect(secondScopeRunId).not.toBe(firstScopeRunId);
+  });
+
+  it('keeps warm terminal continuations under one trace root', async () => {
+    const tenantId = 'tenant-warm-continuation';
+    const registry = new HookRegistry();
+    registry.register('Stop', {
+      hooks: [
+        async (input): Promise<StopHookOutput> =>
+          input.continuationCount === 0
+            ? {
+              decision: 'block',
+              injectedMessages: [
+                { role: 'user', content: 'late steer', source: 'steer' },
+              ],
+            }
+            : { decision: 'continue' },
+      ],
+    });
+    const run = await Run.create<t.IState>({
+      runId: `routing-${tenantId}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createAgent(tenantId)],
+      },
+      langfuse: tenantLangfuse(tenantId),
+      hooks: registry,
+      returnContent: true,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(['first answer', 'continued answer']);
+
+    await run.processStream(
+      { messages: [new HumanMessage('initial prompt')] },
+      callerConfig
+    );
+
+    const roots = startsForTenant(tenantId).filter(
+      (record) => record.name === 'AgentGraph' && record.parentSpanId == null
+    );
+    expect(roots).toHaveLength(1);
+    expect(
+      startsForTenant(tenantId).filter(
+        (record) => record.parentSpanId === roots[0].spanId
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it('generates a scope stamp for directly-constructed graphs without a run id', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import {
   describe,
   it,
@@ -29,6 +33,8 @@ import type {
   PostToolBatchHookInput,
   PostToolBatchHookOutput,
   RunStartHookOutput,
+  StopHookInput,
+  StopHookOutput,
   UserPromptSubmitHookOutput,
 } from '@/hooks';
 import type * as t from '@/types';
@@ -1327,6 +1333,114 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
      * reason carried over from the previous pass. */
     expect(run.getInterrupt()).toBeUndefined();
     expect(run.getHaltReason()).toBeUndefined();
+  });
+
+  it('preserves the warm continuation budget across a HITL resume', async () => {
+    const { Run: RunClass } = await import('@/run');
+    const registry = new HookRegistry();
+    const stopInputs: StopHookInput[] = [];
+    let run: Awaited<ReturnType<typeof RunClass.create<t.IState>>>;
+    const checkpointer = new MemorySaver();
+    const toolCallId = 'abcdef0123456789abcdef0123456789';
+    registry.register('PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review',
+        }),
+      ],
+    });
+    registry.register('Stop', {
+      hooks: [
+        async (input): Promise<StopHookOutput> => {
+          stopInputs.push(input);
+          if (input.continuationCount > 0) {
+            return { decision: 'continue' };
+          }
+          run.Graph?.overrideTestModel(
+            ['tool request', 'final answer'],
+            undefined,
+            [
+              {
+                id: toolCallId,
+                name: 'echo',
+                args: { command: 'continue' },
+                type: 'tool_call',
+              },
+            ]
+          );
+          return {
+            decision: 'block',
+            injectedMessages: [
+              { role: 'user', content: 'late steer', source: 'steer' },
+            ],
+          };
+        },
+      ],
+    });
+    run = await RunClass.create<t.IState>({
+      runId: 'warm-hitl-budget',
+      graphConfig: {
+        type: 'standard',
+        compileOptions: { checkpointer },
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+            tools: [createSchemaStub('echo')],
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+      maxStopContinuations: 1,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(['first answer']);
+    const config = {
+      configurable: { thread_id: 'warm-hitl-budget-thread' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream(
+      { messages: [new HumanMessage('initial prompt')] },
+      config
+    );
+    expect(run.getInterrupt()).toBeDefined();
+    expect(stopInputs.map((input) => input.continuationCount)).toEqual([0]);
+
+    run = await RunClass.create<t.IState>({
+      runId: 'warm-hitl-budget',
+      graphConfig: {
+        type: 'standard',
+        compileOptions: { checkpointer },
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+            tools: [createSchemaStub('echo')],
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+      maxStopContinuations: 1,
+      skipCleanup: true,
+    });
+    run.Graph?.overrideTestModel(['final answer']);
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(run.getInterrupt()).toBeUndefined();
+    expect(stopInputs.map((input) => input.continuationCount)).toEqual([0, 1]);
+    expect(
+      stopInputs.map((input) => input.continuationBudgetRemaining)
+    ).toEqual([1, 0]);
   });
 
   it('Run.resume() forwards `update` so langgraph applies the channel edit through streamEvents', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -40,6 +40,7 @@ import type {
 import type * as t from '@/types';
 import { Constants, Providers as providers, GraphEvents } from '@/common';
 import { getProviderMessageProvenance } from '@/messages/provenance';
+import { getRunStepResumeState } from '@/tools/runStepResume';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
@@ -90,6 +91,48 @@ function mockEventDispatch(mockResults: t.ToolExecuteResult[]): void {
         (request.resolve as (r: t.ToolExecuteResult[]) => void)(mockResults);
       }
     });
+}
+
+async function stripStopContinuationExecutionIds(
+  checkpointer: MemorySaver,
+  threadId: string
+): Promise<void> {
+  for (const checkpoints of Object.values(
+    checkpointer.storage[threadId] ?? {}
+  )) {
+    for (const stored of Object.values(checkpoints)) {
+      const checkpoint = await checkpointer.serde.loadsTyped(
+        'json',
+        stored[0]
+      );
+      const runStepState = (
+        checkpoint as {
+          channel_values?: { runStepState?: t.RunStepResumeState };
+        }
+      ).channel_values?.runStepState;
+      if (runStepState != null) {
+        delete runStepState.stopContinuationExecutionId;
+        const [, serialized] = await checkpointer.serde.dumpsTyped(checkpoint);
+        stored[0] = serialized;
+      }
+    }
+  }
+  for (const [key, writes] of Object.entries(checkpointer.writes)) {
+    const [storedThreadId] = JSON.parse(key) as [string, string, string];
+    if (storedThreadId !== threadId) {
+      continue;
+    }
+    for (const stored of Object.values(writes)) {
+      const value = await checkpointer.serde.loadsTyped('json', stored[2]);
+      const runStepState = getRunStepResumeState(value);
+      if (runStepState == null) {
+        continue;
+      }
+      delete runStepState.stopContinuationExecutionId;
+      const [, serialized] = await checkpointer.serde.dumpsTyped(value);
+      stored[2] = serialized;
+    }
+  }
 }
 
 type MessagesUpdate = { messages: BaseMessage[] };
@@ -1391,8 +1434,20 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       hooks: [
         async (input): Promise<StopHookOutput> => {
           stopInputs.push(input);
-          if (input.continuationCount > 0) {
+          if (input.continuationCount > 1) {
             return { decision: 'continue' };
+          }
+          if (input.continuationCount === 1) {
+            return {
+              decision: 'block',
+              injectedMessages: [
+                {
+                  role: 'user',
+                  content: 'post-upgrade steer',
+                  source: 'steer',
+                },
+              ],
+            };
           }
           run.Graph?.overrideTestModel(
             ['tool request', 'final answer'],
@@ -1433,7 +1488,7 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       },
       hooks: registry,
       humanInTheLoop: { enabled: true },
-      maxStopContinuations: 1,
+      maxStopContinuations: 2,
       skipCleanup: true,
     });
     run.Graph?.overrideTestModel(['first answer']);
@@ -1447,6 +1502,10 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     expect(interrupt?.checkpointId).toEqual(expect.any(String));
     expect(interrupt?.checkpointId).not.toBe(seedCheckpointId);
     expect(stopInputs.map((input) => input.continuationCount)).toEqual([0]);
+    await stripStopContinuationExecutionIds(
+      checkpointer,
+      threadConfig.configurable.thread_id
+    );
 
     run = await RunClass.create<t.IState>({
       runId: 'warm-hitl-budget',
@@ -1466,10 +1525,13 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       },
       hooks: registry,
       humanInTheLoop: { enabled: true },
-      maxStopContinuations: 1,
+      maxStopContinuations: 2,
       skipCleanup: true,
     });
-    run.Graph?.overrideTestModel(['final answer']);
+    run.Graph?.overrideTestModel([
+      'final answer',
+      'post-upgrade continued answer',
+    ]);
     await run.resume([{ type: 'approve' }], {
       ...config,
       configurable: {
@@ -1479,10 +1541,12 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     });
 
     expect(run.getInterrupt()).toBeUndefined();
-    expect(stopInputs.map((input) => input.continuationCount)).toEqual([0, 1]);
+    expect(stopInputs.map((input) => input.continuationCount)).toEqual([
+      0, 1, 2,
+    ]);
     expect(
       stopInputs.map((input) => input.continuationBudgetRemaining)
-    ).toEqual([1, 0]);
+    ).toEqual([2, 1, 0]);
   });
 
   it('Run.resume() forwards `update` so langgraph applies the channel edit through streamEvents', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1342,6 +1342,43 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     let run: Awaited<ReturnType<typeof RunClass.create<t.IState>>>;
     const checkpointer = new MemorySaver();
     const toolCallId = 'abcdef0123456789abcdef0123456789';
+    const threadConfig = {
+      configurable: { thread_id: 'warm-hitl-budget-thread' },
+      version: 'v2' as const,
+    };
+    const seedRun = await RunClass.create<t.IState>({
+      runId: 'warm-hitl-budget-seed',
+      graphConfig: {
+        type: 'standard',
+        compileOptions: { checkpointer },
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+            tools: [createSchemaStub('echo')],
+          },
+        ],
+      },
+      skipCleanup: true,
+    });
+    seedRun.Graph?.overrideTestModel(['seed answer']);
+    await seedRun.processStream(
+      { messages: [new HumanMessage('seed prompt')] },
+      threadConfig
+    );
+    const seedTuple = await checkpointer.getTuple(threadConfig);
+    const seedCheckpointId = seedTuple?.config.configurable?.checkpoint_id;
+    expect(typeof seedCheckpointId).toBe('string');
+    const config = {
+      ...threadConfig,
+      configurable: {
+        ...threadConfig.configurable,
+        checkpoint_id: seedCheckpointId,
+      },
+    };
     registry.register('PreToolUse', {
       hooks: [
         async (): Promise<PreToolUseHookOutput> => ({
@@ -1400,16 +1437,15 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       skipCleanup: true,
     });
     run.Graph?.overrideTestModel(['first answer']);
-    const config = {
-      configurable: { thread_id: 'warm-hitl-budget-thread' },
-      version: 'v2' as const,
-    };
 
     await run.processStream(
       { messages: [new HumanMessage('initial prompt')] },
       config
     );
-    expect(run.getInterrupt()).toBeDefined();
+    const interrupt = run.getInterrupt();
+    expect(interrupt).toBeDefined();
+    expect(interrupt?.checkpointId).toEqual(expect.any(String));
+    expect(interrupt?.checkpointId).not.toBe(seedCheckpointId);
     expect(stopInputs.map((input) => input.continuationCount)).toEqual([0]);
 
     run = await RunClass.create<t.IState>({
@@ -1434,7 +1470,13 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       skipCleanup: true,
     });
     run.Graph?.overrideTestModel(['final answer']);
-    await run.resume([{ type: 'approve' }], config);
+    await run.resume([{ type: 'approve' }], {
+      ...config,
+      configurable: {
+        ...config.configurable,
+        checkpoint_id: interrupt?.checkpointId,
+      },
+    });
 
     expect(run.getInterrupt()).toBeUndefined();
     expect(stopInputs.map((input) => input.continuationCount)).toEqual([0, 1]);

--- a/src/tools/runStepResume.ts
+++ b/src/tools/runStepResume.ts
@@ -26,6 +26,9 @@ export function isRunStepResumeState(
     (state.stopContinuationCount != null &&
       (!Number.isSafeInteger(state.stopContinuationCount) ||
         state.stopContinuationCount < 0)) ||
+    (state.stopContinuationExecutionId != null &&
+      (typeof state.stopContinuationExecutionId !== 'string' ||
+        state.stopContinuationExecutionId.length === 0)) ||
     (state.streamSegment != null &&
       (!Number.isSafeInteger(state.streamSegment) ||
         state.streamSegment < 0)) ||

--- a/src/tools/runStepResume.ts
+++ b/src/tools/runStepResume.ts
@@ -23,6 +23,12 @@ export function isRunStepResumeState(
     (state.revision ?? -1) < 0 ||
     !Number.isSafeInteger(state.nextIndex) ||
     (state.nextIndex ?? -1) < 0 ||
+    (state.stopContinuationCount != null &&
+      (!Number.isSafeInteger(state.stopContinuationCount) ||
+        state.stopContinuationCount < 0)) ||
+    (state.streamSegment != null &&
+      (!Number.isSafeInteger(state.streamSegment) ||
+        state.streamSegment < 0)) ||
     !Array.isArray(state.toolCallSteps) ||
     !Array.isArray(state.steps)
   ) {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -253,6 +253,14 @@ export type RunConfig = {
    */
   hooks?: HookRegistry;
   /**
+   * Maximum number of times a `Stop` hook may keep this Run warm by returning
+   * `decision: 'block'` with messages to inject. Defaults to
+   * `DEFAULT_MAX_STOP_CONTINUATIONS`; non-finite values use the default and
+   * values at or below zero disable terminal continuation while preserving the
+   * final Stop notification.
+   */
+  maxStopContinuations?: number;
+  /**
    * Opt-in cooperative preemption for this run. Requires a `hooks` registry
    * with a `PreemptBoundary` matcher — the seal only stops the stream, the
    * hook is what supplies the messages to resume with. Omit to keep the

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -118,6 +118,8 @@ export interface RunStepResumeState {
   nextIndex: number;
   /** Warm terminal continuations already admitted for this execution. */
   stopContinuationCount?: number;
+  /** Identifies the fresh execution that owns this continuation lifecycle. */
+  stopContinuationExecutionId?: string;
   /** Distinguishes LangGraph event keys when a warm continuation restarts steps. */
   streamSegment?: number;
   toolCallSteps: Array<{ toolCallId: string; stepId: string }>;

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -116,6 +116,10 @@ export interface RunStepResumeState {
   version: 1;
   revision: number;
   nextIndex: number;
+  /** Warm terminal continuations already admitted for this execution. */
+  stopContinuationCount?: number;
+  /** Distinguishes LangGraph event keys when a warm continuation restarts steps. */
+  streamSegment?: number;
   toolCallSteps: Array<{ toolCallId: string; stepId: string }>;
   steps: RunStepResumeEntry[];
 }


### PR DESCRIPTION
## Summary

- complete the existing `StopDecision: block` contract by admitting injected messages into another graph segment inside the same `Run.processStream` lifecycle
- preserve one public run, trace scope, handlers, graph sidecars, content accumulator, and hook session across terminal continuation
- add a serialized `StopFinalize` admission phase after parallel `Stop` hooks are folded, so durable hosts can atomically claim or seal with full knowledge of other continuation sources
- expose a bounded continuation budget plus an SDK capability probe
- support both checkpointed (delta input) and non-checkpointed (live transcript) execution without replaying `RunStart` or `UserPromptSubmit`
- bypass warm continuation for HITL pauses, hook halts, preemption-incomplete turns, and output truncation

## Why

LibreChat needs an atomic terminal steer handoff: a steer accepted immediately before natural completion should either continue the already-warm run or remain an ordinary follow-up after terminal admission is sealed. The SDK must own the in-run continuation lifecycle and serialize final admission after notification/plugin Stop hooks before the host can implement that storage transition safely.

## Validation

- `tsc --noEmit`
- scoped ESLint and import-order checks
- 83 hook/continuation tests
- preemption and output-truncation regression tests
- circular dependency check
- full package build
