### PR TITLE
perf: evolve compaction index from warm deltas

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -201,7 +201,9 @@ Reconstruction snapshots the prior entries, admits them chronologically through
 the same coverage-balanced collector, and derives the delta during its existing
 content pass. Work is independent of unbounded conversation length: `O(B +
 delta)`, where `B` is capped at 256. Invalid prior state degrades to delta-only
-derivation rather than disabling new guidance.
+derivation rather than disabling new guidance. Ephemeral revision floors for
+the bounded base prevent coverage omissions from admitting stale delta labels;
+they never become serialized collector state.
 
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,12 +194,14 @@ The index is appended only after cacheable raw history; it never replaces raw
 messages or makes generated labels authoritative.
 
 An **Incremental Compaction Semantic Index** evolves a previously committed,
-bounded index with labels from only the current persisted payload. Model
-Context Reconstruction snapshots the prior index, admits it chronologically
-through the same coverage-balanced collector, and derives the delta during its
-existing content pass. Work is independent of unbounded conversation length:
-`O(B + delta)`, where `B` is capped at 256. Invalid prior state degrades to
-delta-only derivation rather than disabling new guidance.
+bounded index with labels from only the current persisted payload. Its
+serializable snapshot contains retained entries plus their cumulative supplied
+count so omission telemetry survives process boundaries. Model Context
+Reconstruction snapshots the prior entries, admits them chronologically through
+the same coverage-balanced collector, and derives the delta during its existing
+content pass. Work is independent of unbounded conversation length: `O(B +
+delta)`, where `B` is capped at 256. Invalid prior state degrades to delta-only
+derivation rather than disabling new guidance.
 
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,10 +193,20 @@ owns enablement and identifies which tool `intent` fields are semantic labels.
 The index is appended only after cacheable raw history; it never replaces raw
 messages or makes generated labels authoritative.
 
+An **Incremental Compaction Semantic Index** evolves a previously committed,
+bounded index with labels from only the current persisted payload. Model
+Context Reconstruction snapshots the prior index, admits it chronologically
+through the same coverage-balanced collector, and derives the delta during its
+existing content pass. Work is independent of unbounded conversation length:
+`O(B + delta)`, where `B` is capped at 256. Invalid prior state degrades to
+delta-only derivation rather than disabling new guidance.
+
 See [ADR 0005](docs/adr/0005-pairing-balanced-compaction-ranges.md) for the
 range-selection and retention trade-offs.
 See [ADR 0007](docs/adr/0007-guide-compaction-with-a-bounded-semantic-index.md)
 for the index trust, ordering, and latency boundaries.
+See [ADR 0008](docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md)
+for bounded warm-turn evolution and continuation ownership.
 See [ADR 0006](docs/adr/0006-align-compaction-with-provider-cache-prefixes.md)
 for the prompt-cache boundary and rejected predictive replay design.
 

--- a/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
+++ b/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
@@ -38,6 +38,13 @@ current payload is still derived. Newer revisions and tombstones in the delta
 renew their logical identity's recency and prevent stale labels from
 resurfacing once balanced admission is active.
 
+While an evolution is in progress, the collector keeps one private revision
+floor for every logical identity in the bounded base snapshot. Coverage
+retention may omit a base entry from output, but cannot therefore admit an
+older delta revision or resurrect guidance suppressed by a base tombstone.
+These floors are capped by the same 256-entry base and are not serialized as
+collector state.
+
 Evolution costs `O(B + delta)`, where `B` is the bounded prior snapshot and
 `delta` is the current payload. It is therefore independent of unbounded
 conversation length, but is not described as pure `O(delta)`. When semantic

--- a/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
+++ b/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
@@ -1,0 +1,59 @@
+# ADR 0008: Evolve Compaction Guidance from Warm-Turn Deltas
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0007 established a bounded Compaction Semantic Index derived while Model
+Context Reconstruction formats persisted history. A host can persist and
+replay that exact snapshot across Event Actor and human-in-the-loop
+continuations. Labels created by later warm turns are not present in the
+construction-time snapshot, however. Rebuilding the index from the complete
+conversation after every continuation would add an unbounded history scan and
+duplicate the formatter's semantic extraction policy in the host.
+
+A public mutable collector would avoid the scan but expose retention rings,
+identity hashes, and cursor state as a serialized compatibility surface. A
+separate public entry merge would still require the host to construct trusted
+source coordinates or perform another message pass.
+
+## Decision
+
+The existing `formatAgentMessages` compaction option accepts an optional
+`baseIndex`. Before formatting the current payload, the SDK snapshots and
+validates this caller-owned index. Valid prior entries enter the private
+coverage-balanced collector in chronological order; semantic entries derived
+from the current payload follow during the formatter's existing content pass.
+The returned `compactionSemanticIndex` is the evolved bounded snapshot.
+
+The public interface exposes no mutable accumulator or retention internals.
+The prior snapshot remains subject to ADR 0007's 256-entry input bound. An
+oversized or invalid prior snapshot fails closed, while valid guidance from the
+current payload is still derived. Newer revisions and tombstones in the delta
+renew their logical identity's recency and prevent stale labels from
+resurfacing once balanced admission is active.
+
+Evolution costs `O(B + delta)`, where `B` is the bounded prior snapshot and
+`delta` is the current payload. It is therefore independent of unbounded
+conversation length, but is not described as pure `O(delta)`. When semantic
+derivation is disabled, the formatter does not snapshot, allocate, or scan an
+index.
+
+The host remains responsible for deciding when a continuation is settled and
+durable, supplying the last committed snapshot, and persisting the evolved
+result through its existing compare-and-set continuation seam. Provider
+messages, compaction range selection, cache checkpoints, graph state, and
+Langfuse trace shaping are unchanged.
+
+## Consequences
+
+- Warm continuations can add tool intents, outcomes, activity phases, and
+  reasoning labels without rescanning historical messages.
+- Formatter ownership keeps source-coordinate extraction and retention policy
+  local to the module that already has the necessary context.
+- Persisted snapshots remain plain index entries and can cross process or actor
+  boundaries without serializing SDK implementation details.
+- LibreChat needs a focused adoption change after the SDK version containing
+  this interface is published.

--- a/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
+++ b/docs/adr/0008-evolve-compaction-guidance-from-warm-turn-deltas.md
@@ -22,11 +22,14 @@ source coordinates or perform another message pass.
 ## Decision
 
 The existing `formatAgentMessages` compaction option accepts an optional
-`baseIndex`. Before formatting the current payload, the SDK snapshots and
-validates this caller-owned index. Valid prior entries enter the private
-coverage-balanced collector in chronological order; semantic entries derived
-from the current payload follow during the formatter's existing content pass.
-The returned `compactionSemanticIndex` is the evolved bounded snapshot.
+`baseSnapshot`. This serializable envelope contains the retained entries and
+their cumulative producer-side entry count. Before formatting the current
+payload, the SDK snapshots and validates this caller-owned state. Valid prior
+entries enter the private coverage-balanced collector in chronological order;
+semantic entries derived from the current payload follow during the
+formatter's existing content pass. The returned
+`compactionSemanticIndexSnapshot` is the evolved bounded envelope; the
+existing `compactionSemanticIndex` result remains its entries-only projection.
 
 The public interface exposes no mutable accumulator or retention internals.
 The prior snapshot remains subject to ADR 0007's 256-entry input bound. An
@@ -53,7 +56,8 @@ Langfuse trace shaping are unchanged.
   reasoning labels without rescanning historical messages.
 - Formatter ownership keeps source-coordinate extraction and retention policy
   local to the module that already has the necessary context.
-- Persisted snapshots remain plain index entries and can cross process or actor
-  boundaries without serializing SDK implementation details.
+- Persisted snapshots remain plain entries plus one cumulative count and can
+  cross process or actor boundaries without serializing SDK implementation
+  details. The count preserves omission telemetry across JSON persistence.
 - LibreChat needs a focused adoption change after the SDK version containing
   this interface is published.

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -58,17 +58,20 @@ import {
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from '@/utils/toolContent';
-import { setCompactionSemanticIndexProvidedEntryCount } from '@/summarization/semanticIndex';
-import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
-import { toLangChainContent, toLangChainMessageFields } from './langchain';
-import { flattenLegacyContent, isLegacyConvertible } from './content';
-import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import {
+  snapshotCompactionSemanticIndex,
+  setCompactionSemanticIndexProvidedEntryCount,
+} from '@/summarization/semanticIndex';
 import {
   Providers,
   ContentTypes,
   Constants,
   COMPACTION_SEMANTIC_INDEX_LIMITS,
 } from '@/common';
+import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
+import { toLangChainContent, toLangChainMessageFields } from './langchain';
+import { flattenLegacyContent, isLegacyConvertible } from './content';
+import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { emitAgentLog } from '@/utils/events';
 
 interface MediaMessageParams {
@@ -389,7 +392,7 @@ interface FormatAssistantMessageOptions {
 
 type SourceContentPartIndices = number | readonly number[];
 
-interface FormatAgentMessagesOptions {
+export interface FormatAgentMessagesOptions {
   provider?: ProviderName;
   /** Emit flattenable text content as the joined string the legacy-content
    *  projection would produce, so the per-request `formatContentStrings` pass
@@ -410,6 +413,10 @@ interface FormatAgentMessagesOptions {
    *  the host identifies as semantic-label fields; business `intent`
    *  parameters must remain ordinary tool input. */
   compactionSemanticIndex?: {
+    /** Previously committed bounded guidance to evolve with entries derived
+     *  from this payload. The formatter snapshots and validates caller-owned
+     *  data before scanning the new messages. */
+    baseIndex?: CompactionSemanticIndex;
     intentToolNames?: ReadonlySet<string>;
   };
 }
@@ -554,11 +561,21 @@ const DERIVED_SEMANTIC_TYPE_HASH: Readonly<
   reasoning_label: 4,
 });
 
-function createDerivedCompactionSemanticIndexCollector(): DerivedCompactionSemanticIndexCollector {
-  return {
+function createDerivedCompactionSemanticIndexCollector(
+  baseIndex?: CompactionSemanticIndex
+): DerivedCompactionSemanticIndexCollector {
+  const collector: DerivedCompactionSemanticIndexCollector = {
     entries: [],
     entryCount: 0,
   };
+  const snapshot = snapshotCompactionSemanticIndex(baseIndex);
+  if (snapshot == null) {
+    return collector;
+  }
+  for (let index = 0; index < snapshot.length; index++) {
+    appendDerivedCompactionSemanticEntry(collector, snapshot[index]);
+  }
+  return collector;
 }
 
 function createCompactionSemanticCoverageState(): CompactionSemanticCoverageState {
@@ -888,8 +905,7 @@ function collectCompactionSemanticEntriesFromPart(
   parsedToolInput?: ToolCallPart['args']
 ): void {
   if (
-    sourceMessageId.length >
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxIdentityChars
+    sourceMessageId.length > COMPACTION_SEMANTIC_INDEX_LIMITS.maxIdentityChars
   ) {
     return;
   }
@@ -1017,14 +1033,14 @@ function collectCompactionSemanticEntriesFromPart(
     part.pending !== undefined && typeof part.pending !== 'boolean';
   const malformedText = typeof part.activity_label !== 'string';
   const malformedState = malformedPending || malformedText;
-  const text = typeof part.activity_label === 'string' ? part.activity_label : '';
+  const text =
+    typeof part.activity_label === 'string' ? part.activity_label : '';
   appendDerivedCompactionSemanticEntry(collector, {
     type: 'activity_phase',
     sourceMessageId,
     sourceContentIndex: activitySourceContentIndex,
     revision: revision ?? 0,
-    status:
-      part.pending === true || malformedPending ? 'pending' : 'committed',
+    status: part.pending === true || malformedPending ? 'pending' : 'committed',
     text,
     ...(malformedState ? { redacted: true } : {}),
   });
@@ -2643,7 +2659,9 @@ export const formatAgentMessages = (
   const legacyContentEnabled = options?.legacyContent === true;
   const compactionSemanticIndexCollector =
     options?.compactionSemanticIndex != null
-      ? createDerivedCompactionSemanticIndexCollector()
+      ? createDerivedCompactionSemanticIndexCollector(
+        options.compactionSemanticIndex.baseIndex
+      )
       : undefined;
   /** Emission choke point: every formatted message enters the result here, so
    *  the legacy flatten happens once per message with no closing rescan. The

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -30,6 +30,7 @@ import type {
   ProviderName,
   CompactionSemanticIndex,
   CompactionSemanticIndexEntry,
+  CompactionSemanticIndexSnapshot,
 } from '@/types';
 import type {
   ProviderMessageAttribution,
@@ -414,10 +415,10 @@ export interface FormatAgentMessagesOptions {
    *  the host identifies as semantic-label fields; business `intent`
    *  parameters must remain ordinary tool input. */
   compactionSemanticIndex?: {
-    /** Previously committed bounded guidance to evolve with entries derived
-     *  from this payload. The formatter snapshots and validates caller-owned
-     *  data before scanning the new messages. */
-    baseIndex?: CompactionSemanticIndex;
+    /** Previously committed, serializable guidance to evolve with entries
+     *  derived from this payload. The formatter snapshots and validates
+     *  caller-owned data before scanning the new messages. */
+    baseSnapshot?: CompactionSemanticIndexSnapshot;
     intentToolNames?: ReadonlySet<string>;
   };
 }
@@ -564,20 +565,39 @@ const DERIVED_SEMANTIC_TYPE_HASH: Readonly<
 });
 
 function createDerivedCompactionSemanticIndexCollector(
-  baseIndex?: CompactionSemanticIndex
+  baseSnapshot?: CompactionSemanticIndexSnapshot
 ): DerivedCompactionSemanticIndexCollector {
   const collector: DerivedCompactionSemanticIndexCollector = {
     entries: [],
     entryCount: 0,
     omittedBaseEntryCount: 0,
   };
-  const snapshot = snapshotCompactionSemanticIndex(baseIndex);
+  let baseEntries: CompactionSemanticIndex | undefined;
+  let serializedProvidedEntryCount: number | undefined;
+  try {
+    baseEntries = baseSnapshot?.entries;
+    serializedProvidedEntryCount = baseSnapshot?.providedEntryCount;
+  } catch {
+    return collector;
+  }
+  const snapshot = snapshotCompactionSemanticIndex(baseEntries);
   if (snapshot == null) {
     return collector;
   }
+  const snapshotProvidedEntryCount =
+    getCompactionSemanticIndexProvidedEntryCount(snapshot);
+  const validSerializedProvidedEntryCount =
+    typeof serializedProvidedEntryCount === 'number' &&
+    Number.isSafeInteger(serializedProvidedEntryCount) &&
+    serializedProvidedEntryCount >= snapshotProvidedEntryCount;
+  const providedEntryCount =
+    validSerializedProvidedEntryCount &&
+    serializedProvidedEntryCount != null
+      ? serializedProvidedEntryCount
+      : snapshotProvidedEntryCount;
   collector.omittedBaseEntryCount = Math.max(
     0,
-    getCompactionSemanticIndexProvidedEntryCount(snapshot) - snapshot.length
+    providedEntryCount - snapshot.length
   );
   for (let index = 0; index < snapshot.length; index++) {
     appendDerivedCompactionSemanticEntry(collector, snapshot[index]);
@@ -867,23 +887,25 @@ function appendCoverageBalancedCompactionSemanticEntry(
   );
 }
 
-function finalizeDerivedCompactionSemanticIndex(
+function finalizeDerivedCompactionSemanticIndexSnapshot(
   collector: DerivedCompactionSemanticIndexCollector | undefined
-): CompactionSemanticIndex | undefined {
+): CompactionSemanticIndexSnapshot | undefined {
   if (
     collector == null ||
     (collector.entryCount === 0 && collector.omittedBaseEntryCount === 0)
   ) {
     return undefined;
   }
-  const providedEntryCount =
-    collector.entryCount + collector.omittedBaseEntryCount;
+  const providedEntryCount = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    collector.entryCount + collector.omittedBaseEntryCount
+  );
   if (collector.coverage == null) {
     setCompactionSemanticIndexProvidedEntryCount(
       collector.entries,
       providedEntryCount
     );
-    return collector.entries;
+    return { entries: collector.entries, providedEntryCount };
   }
   const retained = new Map<number, CompactionSemanticIndexEntry>();
   const retain = (
@@ -903,7 +925,7 @@ function finalizeDerivedCompactionSemanticIndex(
     .sort(([left], [right]) => left - right)
     .map(([, entry]) => entry);
   setCompactionSemanticIndexProvidedEntryCount(result, providedEntryCount);
-  return result;
+  return { entries: result, providedEntryCount };
 }
 
 function collectCompactionSemanticEntriesFromPart(
@@ -2655,6 +2677,8 @@ export const formatAgentMessages = (
   boundaryTokenAdjustment?: SummaryTokenAdjustment;
   /** Bounded semantic guidance derived during persisted-content analysis. */
   compactionSemanticIndex?: CompactionSemanticIndex;
+  /** Serializable continuation state for incrementally evolving the index. */
+  compactionSemanticIndexSnapshot?: CompactionSemanticIndexSnapshot;
 } => {
   const messages: Array<
     | RoleBearingMessage<HumanMessage>
@@ -2672,7 +2696,7 @@ export const formatAgentMessages = (
   const compactionSemanticIndexCollector =
     options?.compactionSemanticIndex != null
       ? createDerivedCompactionSemanticIndexCollector(
-        options.compactionSemanticIndex.baseIndex
+        options.compactionSemanticIndex.baseSnapshot
       )
       : undefined;
   /** Emission choke point: every formatted message enters the result here, so
@@ -3276,6 +3300,10 @@ export const formatAgentMessages = (
     }
   }
 
+  const compactionSemanticIndexSnapshot =
+    finalizeDerivedCompactionSemanticIndexSnapshot(
+      compactionSemanticIndexCollector
+    );
   return {
     messages,
     indexTokenCountMap: indexTokenCountMap
@@ -3285,9 +3313,8 @@ export const formatAgentMessages = (
       ? { text: summaryBoundary.text, tokenCount: summaryBoundary.tokenCount }
       : undefined,
     boundaryTokenAdjustment,
-    compactionSemanticIndex: finalizeDerivedCompactionSemanticIndex(
-      compactionSemanticIndexCollector
-    ),
+    compactionSemanticIndex: compactionSemanticIndexSnapshot?.entries,
+    compactionSemanticIndexSnapshot,
   };
 };
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -53,15 +53,16 @@ import {
   setProviderMessageProvenance,
 } from './provenance';
 import {
+  snapshotCompactionSemanticIndex,
+  getCompactionSemanticIndexProvidedEntryCount,
+  setCompactionSemanticIndexProvidedEntryCount,
+} from '@/summarization/semanticIndex';
+import {
   compactToolContent,
   getToolContentCharLength,
   isAtomicToolContentBlock,
   serializeStructuredValueBounded,
 } from '@/utils/toolContent';
-import {
-  snapshotCompactionSemanticIndex,
-  setCompactionSemanticIndexProvidedEntryCount,
-} from '@/summarization/semanticIndex';
 import {
   Providers,
   ContentTypes,
@@ -543,6 +544,7 @@ type CompactionSemanticCoverageState = {
 type DerivedCompactionSemanticIndexCollector = {
   entries: CompactionSemanticIndexEntry[];
   entryCount: number;
+  omittedBaseEntryCount: number;
   coverage?: CompactionSemanticCoverageState;
 };
 
@@ -567,11 +569,16 @@ function createDerivedCompactionSemanticIndexCollector(
   const collector: DerivedCompactionSemanticIndexCollector = {
     entries: [],
     entryCount: 0,
+    omittedBaseEntryCount: 0,
   };
   const snapshot = snapshotCompactionSemanticIndex(baseIndex);
   if (snapshot == null) {
     return collector;
   }
+  collector.omittedBaseEntryCount = Math.max(
+    0,
+    getCompactionSemanticIndexProvidedEntryCount(snapshot) - snapshot.length
+  );
   for (let index = 0; index < snapshot.length; index++) {
     appendDerivedCompactionSemanticEntry(collector, snapshot[index]);
   }
@@ -863,13 +870,18 @@ function appendCoverageBalancedCompactionSemanticEntry(
 function finalizeDerivedCompactionSemanticIndex(
   collector: DerivedCompactionSemanticIndexCollector | undefined
 ): CompactionSemanticIndex | undefined {
-  if (collector == null || collector.entryCount === 0) {
+  if (
+    collector == null ||
+    (collector.entryCount === 0 && collector.omittedBaseEntryCount === 0)
+  ) {
     return undefined;
   }
+  const providedEntryCount =
+    collector.entryCount + collector.omittedBaseEntryCount;
   if (collector.coverage == null) {
     setCompactionSemanticIndexProvidedEntryCount(
       collector.entries,
-      collector.entryCount
+      providedEntryCount
     );
     return collector.entries;
   }
@@ -890,7 +902,7 @@ function finalizeDerivedCompactionSemanticIndex(
   const result = [...retained.entries()]
     .sort(([left], [right]) => left - right)
     .map(([, entry]) => entry);
-  setCompactionSemanticIndexProvidedEntryCount(result, collector.entryCount);
+  setCompactionSemanticIndexProvidedEntryCount(result, providedEntryCount);
   return result;
 }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -542,10 +542,17 @@ type CompactionSemanticCoverageState = {
   >;
 };
 
+type CompactionSemanticRevisionFloor = {
+  entry: CompactionSemanticIndexEntry;
+  order: number;
+};
+
 type DerivedCompactionSemanticIndexCollector = {
   entries: CompactionSemanticIndexEntry[];
   entryCount: number;
+  baseEntryCount: number;
   omittedBaseEntryCount: number;
+  baseRevisionFloors?: Map<number, CompactionSemanticRevisionFloor[]>;
   coverage?: CompactionSemanticCoverageState;
 };
 
@@ -570,6 +577,7 @@ function createDerivedCompactionSemanticIndexCollector(
   const collector: DerivedCompactionSemanticIndexCollector = {
     entries: [],
     entryCount: 0,
+    baseEntryCount: 0,
     omittedBaseEntryCount: 0,
   };
   let baseEntries: CompactionSemanticIndex | undefined;
@@ -600,8 +608,9 @@ function createDerivedCompactionSemanticIndexCollector(
     providedEntryCount - snapshot.length
   );
   for (let index = 0; index < snapshot.length; index++) {
-    appendDerivedCompactionSemanticEntry(collector, snapshot[index]);
+    appendDerivedCompactionSemanticEntry(collector, snapshot[index], true);
   }
+  collector.baseEntryCount = collector.entryCount;
   return collector;
 }
 
@@ -679,6 +688,86 @@ function entriesHaveConflictingSemanticState(
     left.text.replace(/\s+/g, ' ').trim() !==
       right.text.replace(/\s+/g, ' ').trim()
   );
+}
+
+function findCompactionSemanticRevisionFloor(
+  collector: DerivedCompactionSemanticIndexCollector,
+  entry: CompactionSemanticIndexEntry,
+  identityHash: number
+): CompactionSemanticRevisionFloor | undefined {
+  return collector.baseRevisionFloors
+    ?.get(identityHash)
+    ?.find((floor) =>
+      entriesShareDerivedCompactionSemanticIdentity(floor.entry, entry)
+    );
+}
+
+function seedCompactionSemanticRevisionFloor(
+  collector: DerivedCompactionSemanticIndexCollector,
+  entry: CompactionSemanticIndexEntry,
+  order: number
+): void {
+  collector.baseRevisionFloors ??= new Map();
+  const identityHash = hashDerivedCompactionSemanticIdentity(entry);
+  const existing = findCompactionSemanticRevisionFloor(
+    collector,
+    entry,
+    identityHash
+  );
+  if (existing != null) {
+    if (entry.revision > existing.entry.revision) {
+      existing.entry = entry;
+      existing.order = order;
+    }
+    return;
+  }
+  const floor = { entry, order };
+  const bucket = collector.baseRevisionFloors.get(identityHash);
+  if (bucket == null) {
+    collector.baseRevisionFloors.set(identityHash, [floor]);
+    return;
+  }
+  bucket.push(floor);
+}
+
+function updateCompactionSemanticRevisionFloor(
+  collector: DerivedCompactionSemanticIndexCollector,
+  orderedEntry: OrderedCompactionSemanticIndexEntry
+): void {
+  const floor = findCompactionSemanticRevisionFloor(
+    collector,
+    orderedEntry.entry,
+    orderedEntry.identityHash
+  );
+  if (floor == null || orderedEntry.entry.revision <= floor.entry.revision) {
+    return;
+  }
+  floor.entry = orderedEntry.entry;
+  floor.order = orderedEntry.order;
+}
+
+function shouldRejectCompactionSemanticEntryBelowBaseFloor(
+  collector: DerivedCompactionSemanticIndexCollector,
+  orderedEntry: OrderedCompactionSemanticIndexEntry
+): boolean {
+  const floor = findCompactionSemanticRevisionFloor(
+    collector,
+    orderedEntry.entry,
+    orderedEntry.identityHash
+  );
+  if (floor == null || orderedEntry.order === floor.order) {
+    return false;
+  }
+  const currentBucket = collector.coverage?.latestByIdentityHash.get(
+    orderedEntry.identityHash
+  );
+  const current = currentBucket?.find(({ entry }) =>
+    entriesShareDerivedCompactionSemanticIdentity(entry, orderedEntry.entry)
+  );
+  if (current != null) {
+    return false;
+  }
+  return orderedEntry.entry.revision <= floor.entry.revision;
 }
 
 function retainCompactionSemanticEntry(
@@ -782,7 +871,8 @@ function renewCoverageBalancedCompactionSemanticEntry(
 
 function appendDerivedCompactionSemanticEntry(
   collector: DerivedCompactionSemanticIndexCollector,
-  entry: CompactionSemanticIndexEntry
+  entry: CompactionSemanticIndexEntry,
+  baseEntry = false
 ): void {
   let boundedEntry = entry;
   if (entry.status === 'pending') {
@@ -799,6 +889,14 @@ function appendDerivedCompactionSemanticEntry(
     collector.entries.length < COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries
   ) {
     collector.entries.push(boundedEntry);
+    if (!baseEntry && collector.baseRevisionFloors != null) {
+      updateCompactionSemanticRevisionFloor(collector, {
+        entry: boundedEntry,
+        identityHash: hashDerivedCompactionSemanticIdentity(boundedEntry),
+        order,
+        retentionCount: 0,
+      });
+    }
     return;
   }
   const orderedEntry = {
@@ -808,23 +906,54 @@ function appendDerivedCompactionSemanticEntry(
     retentionCount: 0,
   };
   if (collector.coverage == null) {
+    for (let order = 0; order < collector.baseEntryCount; order++) {
+      seedCompactionSemanticRevisionFloor(
+        collector,
+        collector.entries[order],
+        order
+      );
+    }
     collector.coverage = createCompactionSemanticCoverageState();
     for (let order = 0; order < collector.entries.length; order++) {
-      appendCoverageBalancedCompactionSemanticEntry(collector.coverage, {
+      const bufferedEntry = {
         entry: collector.entries[order],
         identityHash: hashDerivedCompactionSemanticIdentity(
           collector.entries[order]
         ),
         order,
         retentionCount: 0,
-      });
+      };
+      if (
+        shouldRejectCompactionSemanticEntryBelowBaseFloor(
+          collector,
+          bufferedEntry
+        )
+      ) {
+        continue;
+      }
+      appendCoverageBalancedCompactionSemanticEntry(
+        collector.coverage,
+        bufferedEntry
+      );
+      if (order >= collector.baseEntryCount) {
+        updateCompactionSemanticRevisionFloor(collector, bufferedEntry);
+      }
     }
     collector.entries = [];
+  }
+  if (
+    !baseEntry &&
+    shouldRejectCompactionSemanticEntryBelowBaseFloor(collector, orderedEntry)
+  ) {
+    return;
   }
   appendCoverageBalancedCompactionSemanticEntry(
     collector.coverage,
     orderedEntry
   );
+  if (!baseEntry) {
+    updateCompactionSemanticRevisionFloor(collector, orderedEntry);
+  }
 }
 
 function appendCoverageBalancedCompactionSemanticEntry(

--- a/src/messages/formatAgentMessages.semanticIndex.test.ts
+++ b/src/messages/formatAgentMessages.semanticIndex.test.ts
@@ -484,6 +484,123 @@ describe('formatAgentMessages compaction semantic index', () => {
     ]);
   });
 
+  it.each([
+    { deltaRevision: 4, expectedRevision: undefined },
+    { deltaRevision: 5, expectedRevision: undefined },
+    { deltaRevision: 6, expectedRevision: 6 },
+  ])(
+    'preserves revision floors for coverage-omitted base identities at delta revision $deltaRevision',
+    ({ deltaRevision, expectedRevision }) => {
+      const baseIndex: CompactionSemanticIndex = Array.from(
+        { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+        (_, index) => ({
+          type: 'activity_phase' as const,
+          sourceMessageId:
+          index === 100 ? 'coverage-gap-source' : `floor-base-${index}`,
+          sourceContentIndex: 0,
+          revision: index === 100 ? 5 : 1,
+          status: 'committed' as const,
+          text: index === 100 ? 'newer base label' : `Floor base ${index}`,
+        })
+      );
+      const payload: TPayload = [
+        {
+          role: 'assistant',
+          messageId: 'coverage-gap-source',
+          content: [
+            { type: ContentTypes.TEXT, text: 'Current answer' },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'stale delta label',
+            activity_label_type: 'phase',
+            activity_label_revision: deltaRevision,
+            activity_start_index: 0,
+            pending: false,
+          } as MessageContentComplex,
+          ],
+        },
+      ];
+
+      const result = formatAgentMessages(
+        payload,
+        undefined,
+        undefined,
+        undefined,
+        { compactionSemanticIndex: { baseSnapshot: semanticSnapshot(baseIndex) } }
+      );
+
+      const retained =
+      result.compactionSemanticIndex?.filter(
+        ({ sourceMessageId }) => sourceMessageId === 'coverage-gap-source'
+      ) ?? [];
+      expect(retained).toEqual(
+        expectedRevision == null
+          ? []
+          : [expect.objectContaining({ revision: expectedRevision })]
+      );
+    }
+  );
+
+  it('applies revision floors while replaying the bounded base itself', () => {
+    const baseIndex: CompactionSemanticIndex = Array.from(
+      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+      (_, index) => {
+        const newer = index === 64;
+        const stale = index === 200;
+        let revision = 1;
+        let text = `Reordered base ${index}`;
+        if (newer) {
+          revision = 5;
+          text = 'newer base revision';
+        } else if (stale) {
+          revision = 4;
+          text = 'stale reordered base revision';
+        }
+        return {
+          type: 'activity_phase' as const,
+          sourceMessageId:
+            newer || stale
+              ? 'reordered-base-source'
+              : `reordered-base-${index}`,
+          sourceContentIndex: 0,
+          revision,
+          status: 'committed' as const,
+          text,
+        };
+      }
+    );
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        messageId: 'coverage-trigger',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Current answer' },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'Current phase',
+            activity_label_type: 'phase',
+            activity_start_index: 0,
+            pending: false,
+          } as MessageContentComplex,
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      { compactionSemanticIndex: { baseSnapshot: semanticSnapshot(baseIndex) } }
+    );
+
+    expect(
+      result.compactionSemanticIndex?.filter(
+        ({ sourceMessageId }) => sourceMessageId === 'reordered-base-source'
+      )
+    ).toEqual([]);
+  });
+
   it('reuses the formatter parse for string-backed tool arguments', () => {
     const args = JSON.stringify({
       intent: 'Inspect the projection',

--- a/src/messages/formatAgentMessages.semanticIndex.test.ts
+++ b/src/messages/formatAgentMessages.semanticIndex.test.ts
@@ -1,4 +1,8 @@
-import type { MessageContentComplex, TPayload } from '@/types';
+import type {
+  CompactionSemanticIndex,
+  MessageContentComplex,
+  TPayload,
+} from '@/types';
 import { renderCompactionSemanticIndex } from '@/summarization/semanticIndex';
 import { COMPACTION_SEMANTIC_INDEX_LIMITS, ContentTypes } from '@/common';
 import { formatAgentMessages } from './format';
@@ -146,6 +150,201 @@ describe('formatAgentMessages compaction semantic index', () => {
     );
   });
 
+  it('evolves a bounded prior snapshot without changing delta provider messages', () => {
+    const baseIndex: CompactionSemanticIndex = [
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'prior-source',
+        sourceContentIndex: 0,
+        revision: 1,
+        status: 'committed',
+        text: 'Completed the prior phase',
+      },
+    ];
+    const baseline = formatAgentMessages(
+      semanticPayload(),
+      undefined,
+      undefined,
+      undefined,
+      { preserveReasoningContent: true }
+    );
+    const evolved = formatAgentMessages(
+      semanticPayload(),
+      undefined,
+      undefined,
+      undefined,
+      {
+        preserveReasoningContent: true,
+        compactionSemanticIndex: {
+          baseIndex,
+          intentToolNames: new Set(['search_docs']),
+        },
+      }
+    );
+
+    baseIndex[0].text = 'caller mutation';
+
+    expect(evolved.messages.map((message) => message.toDict())).toEqual(
+      baseline.messages.map((message) => message.toDict())
+    );
+    expect(evolved.compactionSemanticIndex).toHaveLength(5);
+    expect(evolved.compactionSemanticIndex?.[0]).toEqual(
+      expect.objectContaining({
+        sourceMessageId: 'prior-source',
+        text: 'Completed the prior phase',
+      })
+    );
+    expect(evolved.compactionSemanticIndex).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceMessageId: 'assistant-semantic-source',
+          type: 'tool_intent',
+        }),
+      ])
+    );
+  });
+
+  it('fails an oversized prior snapshot closed while retaining the delta', () => {
+    const oversizedBase: CompactionSemanticIndex = Array.from(
+      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 1 },
+      (_, index) => ({
+        type: 'activity_phase' as const,
+        sourceMessageId: `oversized-source-${index}`,
+        sourceContentIndex: 0,
+        revision: 0,
+        status: 'committed' as const,
+        text: `Oversized prior phase ${index}`,
+      })
+    );
+
+    const result = formatAgentMessages(
+      semanticPayload(),
+      undefined,
+      undefined,
+      undefined,
+      {
+        compactionSemanticIndex: {
+          baseIndex: oversizedBase,
+          intentToolNames: new Set(['search_docs']),
+        },
+      }
+    );
+
+    expect(result.compactionSemanticIndex).toHaveLength(4);
+    expect(result.compactionSemanticIndex).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceMessageId: expect.stringContaining('oversized-source-'),
+        }),
+      ])
+    );
+  });
+
+  it('keeps serialized warm-turn evolution bounded and coverage balanced', () => {
+    let evolved: CompactionSemanticIndex = Array.from(
+      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+      (_, index) => ({
+        type: 'activity_phase' as const,
+        sourceMessageId: `base-source-${index}`,
+        sourceContentIndex: 0,
+        revision: 0,
+        status: 'committed' as const,
+        text: `Base phase ${index}`,
+      })
+    );
+
+    for (let turn = 0; turn < 24; turn++) {
+      const payload: TPayload = [
+        {
+          role: 'assistant',
+          messageId: `warm-source-${turn}`,
+          content: [
+            { type: ContentTypes.TEXT, text: `Warm answer ${turn}` },
+            {
+              type: ContentTypes.ACTIVITY_LABEL,
+              activity_label: `Warm phase ${turn}`,
+              activity_label_type: 'phase',
+              activity_start_index: 0,
+              pending: false,
+            } as MessageContentComplex,
+          ],
+        },
+      ];
+      const result = formatAgentMessages(
+        payload,
+        undefined,
+        undefined,
+        undefined,
+        { compactionSemanticIndex: { baseIndex: evolved } }
+      );
+      evolved = JSON.parse(
+        JSON.stringify(result.compactionSemanticIndex)
+      ) as CompactionSemanticIndex;
+      expect(evolved.length).toBeLessThanOrEqual(
+        COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries
+      );
+    }
+
+    expect(evolved).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceMessageId: 'base-source-0' }),
+        expect.objectContaining({ sourceMessageId: 'warm-source-23' }),
+      ])
+    );
+  });
+
+  it('applies newer delta tombstones over a full prior snapshot', () => {
+    const baseIndex: CompactionSemanticIndex = Array.from(
+      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+      (_, index) => ({
+        type: 'activity_phase' as const,
+        sourceMessageId:
+          index === 200 ? 'continued-source' : `revision-base-${index}`,
+        sourceContentIndex: 0,
+        revision: 1,
+        status: 'committed' as const,
+        text: index === 200 ? 'stale label' : `Base label ${index}`,
+      })
+    );
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        messageId: 'continued-source',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Continued answer' },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'new pending label',
+            activity_label_type: 'phase',
+            activity_label_revision: 2,
+            activity_start_index: 0,
+            pending: true,
+          } as MessageContentComplex,
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      { compactionSemanticIndex: { baseIndex } }
+    );
+
+    expect(
+      result.compactionSemanticIndex?.filter(
+        ({ sourceMessageId }) => sourceMessageId === 'continued-source'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        revision: 2,
+        status: 'pending',
+        text: '',
+      }),
+    ]);
+  });
+
   it('reuses the formatter parse for string-backed tool arguments', () => {
     const args = JSON.stringify({
       intent: 'Inspect the projection',
@@ -163,9 +362,9 @@ describe('formatAgentMessages compaction semantic index', () => {
         compactionSemanticIndex: { intentToolNames: new Set(['search_docs']) },
       });
 
-      expect(
-        parse.mock.calls.filter(([value]) => value === args)
-      ).toHaveLength(1);
+      expect(parse.mock.calls.filter(([value]) => value === args)).toHaveLength(
+        1
+      );
     } finally {
       parse.mockRestore();
     }
@@ -385,8 +584,7 @@ describe('formatAgentMessages compaction semantic index', () => {
   });
 
   it('retains newer suppressing revisions when balanced admission overflows', () => {
-    const messageCount =
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
+    const messageCount = COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
     const payload: TPayload = Array.from(
       { length: messageCount },
       (_, index) => {
@@ -446,8 +644,7 @@ describe('formatAgentMessages compaction semantic index', () => {
   });
 
   it('renews recent retention when an admitted identity advances', () => {
-    const messageCount =
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 100;
+    const messageCount = COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 100;
     const payload: TPayload = Array.from(
       { length: messageCount },
       (_, index) => {
@@ -490,8 +687,7 @@ describe('formatAgentMessages compaction semantic index', () => {
 
     expect(
       result.compactionSemanticIndex?.filter(
-        ({ sourceMessageId }) =>
-          sourceMessageId === 'recent-revision-source'
+        ({ sourceMessageId }) => sourceMessageId === 'recent-revision-source'
       )
     ).toEqual([
       expect.objectContaining({
@@ -502,8 +698,7 @@ describe('formatAgentMessages compaction semantic index', () => {
   });
 
   it('balances revisions with renderer-normalized identities', () => {
-    const messageCount =
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
+    const messageCount = COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
     const payload: TPayload = Array.from(
       { length: messageCount },
       (_, index) => {
@@ -531,9 +726,7 @@ describe('formatAgentMessages compaction semantic index', () => {
               reasoning_label: reasoningLabel,
               reasoning_label_step_id: reasoningStepId,
               reasoning_label_revision: isNewRevision ? 2 : 1,
-              reasoning_label_status: isNewRevision
-                ? 'streaming'
-                : 'complete',
+              reasoning_label_status: isNewRevision ? 'streaming' : 'complete',
             } as MessageContentComplex,
           ],
         };
@@ -548,8 +741,7 @@ describe('formatAgentMessages compaction semantic index', () => {
       { preserveReasoningContent: true, compactionSemanticIndex: {} }
     );
     const revisions = result.compactionSemanticIndex?.filter(
-      ({ sourceMessageId }) =>
-        sourceMessageId === 'normalized-revision-source'
+      ({ sourceMessageId }) => sourceMessageId === 'normalized-revision-source'
     );
 
     expect(revisions).toEqual([
@@ -568,8 +760,7 @@ describe('formatAgentMessages compaction semantic index', () => {
   });
 
   it('accepts renderer-equivalent text for an equal retained revision', () => {
-    const messageCount =
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
+    const messageCount = COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 80;
     const payload: TPayload = Array.from(
       { length: messageCount },
       (_, index) => {

--- a/src/messages/formatAgentMessages.semanticIndex.test.ts
+++ b/src/messages/formatAgentMessages.semanticIndex.test.ts
@@ -150,6 +150,55 @@ describe('formatAgentMessages compaction semantic index', () => {
     );
   });
 
+  it('rejects malformed base revisions before delta revision selection', () => {
+    const baseIndex: CompactionSemanticIndex = Array.from(
+      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+      (_, index) => ({
+        type: 'activity_phase' as const,
+        sourceMessageId:
+          index === 200 ? 'malformed-revision-source' : `valid-base-${index}`,
+        sourceContentIndex: 0,
+        revision: index === 200 ? Number.MAX_SAFE_INTEGER + 1 : 1,
+        status: 'committed' as const,
+        text: index === 200 ? 'invalid newer label' : `Valid base ${index}`,
+      })
+    );
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        messageId: 'malformed-revision-source',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Current answer' },
+          {
+            type: ContentTypes.ACTIVITY_LABEL,
+            activity_label: 'valid delta label',
+            activity_label_type: 'phase',
+            activity_label_revision: 2,
+            activity_start_index: 0,
+            pending: false,
+          } as MessageContentComplex,
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      { compactionSemanticIndex: { baseIndex } }
+    );
+
+    expect(
+      result.compactionSemanticIndex?.filter(
+        ({ sourceMessageId }) =>
+          sourceMessageId === 'malformed-revision-source'
+      )
+    ).toEqual([
+      expect.objectContaining({ revision: 2, text: 'valid delta label' }),
+    ]);
+  });
+
   it('evolves a bounded prior snapshot without changing delta provider messages', () => {
     const baseIndex: CompactionSemanticIndex = [
       {
@@ -237,6 +286,20 @@ describe('formatAgentMessages compaction semantic index', () => {
           sourceMessageId: expect.stringContaining('oversized-source-'),
         }),
       ])
+    );
+    expect(
+      renderCompactionSemanticIndex(
+        result.compactionSemanticIndex,
+        result.messages
+      )
+    ).toEqual(
+      expect.objectContaining({
+        providedEntryCount:
+          oversizedBase.length +
+          (result.compactionSemanticIndex?.length ?? 0),
+        entryCount: 3,
+        omittedEntryCount: oversizedBase.length + 1,
+      })
     );
   });
 

--- a/src/messages/formatAgentMessages.semanticIndex.test.ts
+++ b/src/messages/formatAgentMessages.semanticIndex.test.ts
@@ -1,5 +1,6 @@
 import type {
   CompactionSemanticIndex,
+  CompactionSemanticIndexSnapshot,
   MessageContentComplex,
   TPayload,
 } from '@/types';
@@ -53,6 +54,13 @@ type TestSemanticPart = MessageContentComplex & {
   pending?: boolean;
   reasoning_label_status?: string;
 };
+
+function semanticSnapshot(
+  entries: CompactionSemanticIndex,
+  providedEntryCount = entries.length
+): CompactionSemanticIndexSnapshot {
+  return { entries, providedEntryCount };
+}
 
 describe('formatAgentMessages compaction semantic index', () => {
   it('derives exact semantic guidance without changing provider messages', () => {
@@ -186,17 +194,77 @@ describe('formatAgentMessages compaction semantic index', () => {
       undefined,
       undefined,
       undefined,
-      { compactionSemanticIndex: { baseIndex } }
+      { compactionSemanticIndex: { baseSnapshot: semanticSnapshot(baseIndex) } }
     );
 
     expect(
       result.compactionSemanticIndex?.filter(
-        ({ sourceMessageId }) =>
-          sourceMessageId === 'malformed-revision-source'
+        ({ sourceMessageId }) => sourceMessageId === 'malformed-revision-source'
       )
     ).toEqual([
       expect.objectContaining({ revision: 2, text: 'valid delta label' }),
     ]);
+  });
+
+  it('fails malformed snapshot-envelope metadata closed without losing the delta', () => {
+    const baseIndex: CompactionSemanticIndex = [
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'base-one',
+        sourceContentIndex: 0,
+        revision: 0,
+        status: 'committed',
+        text: 'Base one',
+      },
+      {
+        type: 'activity_phase',
+        sourceMessageId: 'base-two',
+        sourceContentIndex: 0,
+        revision: 0,
+        status: 'committed',
+        text: 'Base two',
+      },
+    ];
+    const malformedCount = semanticSnapshot(baseIndex, 1);
+
+    const result = formatAgentMessages(
+      semanticPayload(),
+      undefined,
+      undefined,
+      undefined,
+      {
+        compactionSemanticIndex: {
+          baseSnapshot: malformedCount,
+          intentToolNames: new Set(['search_docs']),
+        },
+      }
+    );
+
+    expect(result.compactionSemanticIndexSnapshot?.providedEntryCount).toBe(6);
+
+    const throwingSnapshot = semanticSnapshot([]);
+    Object.defineProperty(throwingSnapshot, 'entries', {
+      get() {
+        throw new Error('caller-owned getter failed');
+      },
+    });
+    const deltaOnly = formatAgentMessages(
+      semanticPayload(),
+      undefined,
+      undefined,
+      undefined,
+      {
+        compactionSemanticIndex: {
+          baseSnapshot: throwingSnapshot,
+          intentToolNames: new Set(['search_docs']),
+        },
+      }
+    );
+
+    expect(deltaOnly.compactionSemanticIndex).toHaveLength(4);
+    expect(
+      deltaOnly.compactionSemanticIndexSnapshot?.providedEntryCount
+    ).toBe(4);
   });
 
   it('evolves a bounded prior snapshot without changing delta provider messages', () => {
@@ -225,7 +293,7 @@ describe('formatAgentMessages compaction semantic index', () => {
       {
         preserveReasoningContent: true,
         compactionSemanticIndex: {
-          baseIndex,
+          baseSnapshot: semanticSnapshot(baseIndex),
           intentToolNames: new Set(['search_docs']),
         },
       }
@@ -237,6 +305,10 @@ describe('formatAgentMessages compaction semantic index', () => {
       baseline.messages.map((message) => message.toDict())
     );
     expect(evolved.compactionSemanticIndex).toHaveLength(5);
+    expect(evolved.compactionSemanticIndexSnapshot).toEqual({
+      entries: evolved.compactionSemanticIndex,
+      providedEntryCount: 5,
+    });
     expect(evolved.compactionSemanticIndex?.[0]).toEqual(
       expect.objectContaining({
         sourceMessageId: 'prior-source',
@@ -273,7 +345,7 @@ describe('formatAgentMessages compaction semantic index', () => {
       undefined,
       {
         compactionSemanticIndex: {
-          baseIndex: oversizedBase,
+          baseSnapshot: semanticSnapshot(oversizedBase),
           intentToolNames: new Set(['search_docs']),
         },
       }
@@ -295,8 +367,7 @@ describe('formatAgentMessages compaction semantic index', () => {
     ).toEqual(
       expect.objectContaining({
         providedEntryCount:
-          oversizedBase.length +
-          (result.compactionSemanticIndex?.length ?? 0),
+          oversizedBase.length + (result.compactionSemanticIndex?.length ?? 0),
         entryCount: 3,
         omittedEntryCount: oversizedBase.length + 1,
       })
@@ -304,16 +375,18 @@ describe('formatAgentMessages compaction semantic index', () => {
   });
 
   it('keeps serialized warm-turn evolution bounded and coverage balanced', () => {
-    let evolved: CompactionSemanticIndex = Array.from(
-      { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
-      (_, index) => ({
-        type: 'activity_phase' as const,
-        sourceMessageId: `base-source-${index}`,
-        sourceContentIndex: 0,
-        revision: 0,
-        status: 'committed' as const,
-        text: `Base phase ${index}`,
-      })
+    let evolvedSnapshot = semanticSnapshot(
+      Array.from(
+        { length: COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries },
+        (_, index) => ({
+          type: 'activity_phase' as const,
+          sourceMessageId: `base-source-${index}`,
+          sourceContentIndex: 0,
+          revision: 0,
+          status: 'committed' as const,
+          text: `Base phase ${index}`,
+        })
+      )
     );
 
     for (let turn = 0; turn < 24; turn++) {
@@ -338,17 +411,20 @@ describe('formatAgentMessages compaction semantic index', () => {
         undefined,
         undefined,
         undefined,
-        { compactionSemanticIndex: { baseIndex: evolved } }
+        { compactionSemanticIndex: { baseSnapshot: evolvedSnapshot } }
       );
-      evolved = JSON.parse(
-        JSON.stringify(result.compactionSemanticIndex)
-      ) as CompactionSemanticIndex;
-      expect(evolved.length).toBeLessThanOrEqual(
+      evolvedSnapshot = JSON.parse(
+        JSON.stringify(result.compactionSemanticIndexSnapshot)
+      ) as CompactionSemanticIndexSnapshot;
+      expect(evolvedSnapshot.entries.length).toBeLessThanOrEqual(
         COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries
       );
     }
 
-    expect(evolved).toEqual(
+    expect(evolvedSnapshot.providedEntryCount).toBe(
+      COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputEntries + 24
+    );
+    expect(evolvedSnapshot.entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ sourceMessageId: 'base-source-0' }),
         expect.objectContaining({ sourceMessageId: 'warm-source-23' }),
@@ -392,7 +468,7 @@ describe('formatAgentMessages compaction semantic index', () => {
       undefined,
       undefined,
       undefined,
-      { compactionSemanticIndex: { baseIndex } }
+      { compactionSemanticIndex: { baseSnapshot: semanticSnapshot(baseIndex) } }
     );
 
     expect(

--- a/src/scripts/bench-compaction-semantic-index.ts
+++ b/src/scripts/bench-compaction-semantic-index.ts
@@ -16,6 +16,8 @@ const MEASURED_ITERATIONS = 25_000;
 const FORMAT_WARMUP_ITERATIONS = 500;
 const FORMAT_SAMPLE_ITERATIONS = 300;
 const FORMAT_SAMPLE_COUNT = 9;
+const INCREMENTAL_WARMUP_ITERATIONS = 300;
+const INCREMENTAL_SAMPLE_ITERATIONS = 300;
 const INTENT_TOOL_NAMES: ReadonlySet<string> = new Set(['search_docs']);
 
 const messages = Array.from({ length: 12 }, (_, index) => {
@@ -57,9 +59,8 @@ function run(
   return { elapsedMs: performance.now() - startedAt, checksum };
 }
 
-const persistedPayload: TPayload = Array.from(
-  { length: 32 },
-  (_, messageIndex) => ({
+function createPersistedMessage(messageIndex: number): TPayload[number] {
+  return {
     role: 'assistant',
     messageId: `persisted-${messageIndex}`,
     content: [
@@ -96,8 +97,46 @@ const persistedPayload: TPayload = Array.from(
         text: `Completed request analysis ${messageIndex}`,
       },
     ],
-  })
+  };
+}
+
+const persistedPayload: TPayload = Array.from(
+  { length: 32 },
+  (_, messageIndex) => createPersistedMessage(messageIndex)
 );
+const warmHistoryPayload: TPayload = Array.from(
+  { length: 100 },
+  (_, messageIndex) => createPersistedMessage(messageIndex)
+);
+const incrementalDeltaPayload: TPayload = [
+  {
+    role: 'assistant',
+    messageId: 'persisted-warm-delta',
+    content: [
+      {
+        type: ContentTypes.TOOL_CALL,
+        tool_call: {
+          id: 'tool-warm-delta',
+          name: 'search_docs',
+          args: {
+            intent: 'Locate the warm continuation implementation',
+            query: 'warm continuation',
+          },
+          output: 'result warm delta',
+          outcome: 'Located the warm continuation implementation',
+        },
+      },
+      {
+        type: ContentTypes.ACTIVITY_LABEL,
+        activity_label: 'Mapped the warm continuation phase',
+        activity_label_type: 'phase',
+        activity_start_index: 0,
+        pending: false,
+      },
+      { type: ContentTypes.TEXT, text: 'Completed the warm continuation' },
+    ],
+  },
+];
 
 function stripActivityLabelParts(payload: TPayload): TPayload {
   return payload.map((message) => {
@@ -136,9 +175,7 @@ function appendSeparateSemanticEntry(
     entries.push({ ...entry, text: '' });
     return;
   }
-  if (
-    entry.text.length > COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputTextChars
-  ) {
+  if (entry.text.length > COMPACTION_SEMANTIC_INDEX_LIMITS.maxInputTextChars) {
     entries.push({ ...entry, text: '', redacted: true });
     return;
   }
@@ -292,16 +329,64 @@ function runFormatting(
       undefined,
       mode === 'one-pass'
         ? {
-          preserveReasoningContent: true,
-          compactionSemanticIndex: {
-            intentToolNames: INTENT_TOOL_NAMES,
-          },
-        }
+            preserveReasoningContent: true,
+            compactionSemanticIndex: {
+              intentToolNames: INTENT_TOOL_NAMES,
+            },
+          }
         : { preserveReasoningContent: true }
     );
     checksum +=
       result.messages.length +
-      (result.compactionSemanticIndex?.length ?? separatelyDerived?.length ?? 0);
+      (result.compactionSemanticIndex?.length ??
+        separatelyDerived?.length ??
+        0);
+  }
+  return { elapsedMs: performance.now() - startedAt, checksum };
+}
+
+type IncrementalBenchmarkMode = 'full-history' | 'bounded-delta';
+
+const incrementalBaseIndex = formatAgentMessages(
+  warmHistoryPayload,
+  undefined,
+  undefined,
+  undefined,
+  {
+    preserveReasoningContent: true,
+    compactionSemanticIndex: { intentToolNames: INTENT_TOOL_NAMES },
+  }
+).compactionSemanticIndex;
+const fullWarmHistoryPayload = [
+  ...warmHistoryPayload,
+  ...incrementalDeltaPayload,
+];
+
+function runIncrementalEvolution(
+  iterations: number,
+  mode: IncrementalBenchmarkMode
+): { elapsedMs: number; checksum: number } {
+  let checksum = 0;
+  const startedAt = performance.now();
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const result = formatAgentMessages(
+      mode === 'full-history'
+        ? fullWarmHistoryPayload
+        : incrementalDeltaPayload,
+      undefined,
+      undefined,
+      undefined,
+      {
+        preserveReasoningContent: true,
+        compactionSemanticIndex: {
+          baseIndex:
+            mode === 'bounded-delta' ? incrementalBaseIndex : undefined,
+          intentToolNames: INTENT_TOOL_NAMES,
+        },
+      }
+    );
+    checksum +=
+      result.messages.length + (result.compactionSemanticIndex?.length ?? 0);
   }
   return { elapsedMs: performance.now() - startedAt, checksum };
 }
@@ -311,10 +396,12 @@ function median(values: number[]): number {
   return ordered[Math.floor(ordered.length / 2)];
 }
 
-function formatTiming(results: Array<{
-  elapsedMs: number;
-  checksum: number;
-}>): {
+function formatTiming(
+  results: Array<{
+    elapsedMs: number;
+    checksum: number;
+  }>
+): {
   medianTotalMs: number;
   microsecondsPerProjection: number;
   checksum: number;
@@ -357,13 +444,35 @@ for (let sample = 0; sample < FORMAT_SAMPLE_COUNT; sample++) {
   }
 }
 const formatDisabled = formatTiming(formatSamples.get('disabled') ?? []);
-const legacyPrestrip = formatTiming(
-  formatSamples.get('legacy-prestrip') ?? []
-);
+const legacyPrestrip = formatTiming(formatSamples.get('legacy-prestrip') ?? []);
 const separateProjection = formatTiming(
   formatSamples.get('separate-projection') ?? []
 );
 const onePass = formatTiming(formatSamples.get('one-pass') ?? []);
+runIncrementalEvolution(INCREMENTAL_WARMUP_ITERATIONS, 'full-history');
+runIncrementalEvolution(INCREMENTAL_WARMUP_ITERATIONS, 'bounded-delta');
+const incrementalModes: IncrementalBenchmarkMode[] = [
+  'full-history',
+  'bounded-delta',
+];
+const incrementalSamples = new Map<
+  IncrementalBenchmarkMode,
+  Array<{ elapsedMs: number; checksum: number }>
+>(incrementalModes.map((mode) => [mode, []]));
+for (let sample = 0; sample < FORMAT_SAMPLE_COUNT; sample++) {
+  for (let offset = 0; offset < incrementalModes.length; offset++) {
+    const mode = incrementalModes[(sample + offset) % incrementalModes.length];
+    incrementalSamples
+      .get(mode)
+      ?.push(runIncrementalEvolution(INCREMENTAL_SAMPLE_ITERATIONS, mode));
+  }
+}
+const fullHistoryEvolution = formatTiming(
+  incrementalSamples.get('full-history') ?? []
+);
+const boundedDeltaEvolution = formatTiming(
+  incrementalSamples.get('bounded-delta') ?? []
+);
 
 // eslint-disable-next-line no-console
 console.log(
@@ -399,6 +508,29 @@ console.log(
             ((onePass.microsecondsPerProjection -
               separateProjection.microsecondsPerProjection) /
               separateProjection.microsecondsPerProjection) *
+            100
+          ).toFixed(2)
+        ),
+      },
+      warmTurnEvolution: {
+        iterationsPerSample: INCREMENTAL_SAMPLE_ITERATIONS,
+        samples: FORMAT_SAMPLE_COUNT,
+        historicalMessages: warmHistoryPayload.length,
+        retainedBaseEntries: incrementalBaseIndex?.length ?? 0,
+        deltaMessages: incrementalDeltaPayload.length,
+        fullHistory: fullHistoryEvolution,
+        boundedDelta: boundedDeltaEvolution,
+        speedup: Number(
+          (
+            fullHistoryEvolution.microsecondsPerProjection /
+            boundedDeltaEvolution.microsecondsPerProjection
+          ).toFixed(2)
+        ),
+        latencyReductionPercent: Number(
+          (
+            ((fullHistoryEvolution.microsecondsPerProjection -
+              boundedDeltaEvolution.microsecondsPerProjection) /
+              fullHistoryEvolution.microsecondsPerProjection) *
             100
           ).toFixed(2)
         ),

--- a/src/scripts/bench-compaction-semantic-index.ts
+++ b/src/scripts/bench-compaction-semantic-index.ts
@@ -347,7 +347,7 @@ function runFormatting(
 
 type IncrementalBenchmarkMode = 'full-history' | 'bounded-delta';
 
-const incrementalBaseIndex = formatAgentMessages(
+const incrementalBaseSnapshot = formatAgentMessages(
   warmHistoryPayload,
   undefined,
   undefined,
@@ -356,7 +356,7 @@ const incrementalBaseIndex = formatAgentMessages(
     preserveReasoningContent: true,
     compactionSemanticIndex: { intentToolNames: INTENT_TOOL_NAMES },
   }
-).compactionSemanticIndex;
+).compactionSemanticIndexSnapshot;
 const fullWarmHistoryPayload = [
   ...warmHistoryPayload,
   ...incrementalDeltaPayload,
@@ -379,8 +379,8 @@ function runIncrementalEvolution(
       {
         preserveReasoningContent: true,
         compactionSemanticIndex: {
-          baseIndex:
-            mode === 'bounded-delta' ? incrementalBaseIndex : undefined,
+          baseSnapshot:
+            mode === 'bounded-delta' ? incrementalBaseSnapshot : undefined,
           intentToolNames: INTENT_TOOL_NAMES,
         },
       }
@@ -516,7 +516,7 @@ console.log(
         iterationsPerSample: INCREMENTAL_SAMPLE_ITERATIONS,
         samples: FORMAT_SAMPLE_COUNT,
         historicalMessages: warmHistoryPayload.length,
-        retainedBaseEntries: incrementalBaseIndex?.length ?? 0,
+        retainedBaseEntries: incrementalBaseSnapshot?.entries.length ?? 0,
         deltaMessages: incrementalDeltaPayload.length,
         fullHistory: fullHistoryEvolution,
         boundedDelta: boundedDeltaEvolution,

--- a/src/summarization/__tests__/semanticIndex.test.ts
+++ b/src/summarization/__tests__/semanticIndex.test.ts
@@ -156,6 +156,25 @@ describe('renderCompactionSemanticIndex', () => {
     });
   });
 
+  it('filters collector-unsafe identities and numeric coordinates while snapshotting', () => {
+    const valid = activityEntry({ text: 'valid snapshot entry' });
+    const snapshot = snapshotCompactionSemanticIndex([
+      activityEntry({ sourceMessageId: '   ' }),
+      activityEntry({ sourceContentIndex: -1 }),
+      activityEntry({ sourceContentIndex: Number.POSITIVE_INFINITY }),
+      activityEntry({ revision: -1 }),
+      activityEntry({ revision: Number.MAX_SAFE_INTEGER + 1 }),
+      valid,
+    ]);
+
+    expect(snapshot).toEqual([valid]);
+    expect(renderCompactionSemanticIndex(snapshot, messages)).toMatchObject({
+      providedEntryCount: 6,
+      entryCount: 1,
+      omittedEntryCount: 5,
+    });
+  });
+
   it('rejects malformed and out-of-range source references', () => {
     const index: CompactionSemanticIndex = [
       activityEntry({ sourceMessageId: '' }),

--- a/src/summarization/semanticIndex.ts
+++ b/src/summarization/semanticIndex.ts
@@ -50,6 +50,13 @@ export function setCompactionSemanticIndexProvidedEntryCount(
   snapshotProvidedEntryCounts.set(index, providedEntryCount);
 }
 
+/** Reads producer-side cardinality without exposing snapshot bookkeeping. */
+export function getCompactionSemanticIndexProvidedEntryCount(
+  index: CompactionSemanticIndex
+): number {
+  return snapshotProvidedEntryCounts.get(index) ?? index.length;
+}
+
 type SourceReference = {
   contentOrders: Map<number, number>;
 };
@@ -102,10 +109,13 @@ function snapshotEntry(
   } = entry;
   if (
     typeof sourceMessageId !== 'string' ||
-    sourceMessageId.length >
-      COMPACTION_SEMANTIC_INDEX_LIMITS.maxIdentityChars ||
-    typeof sourceContentIndex !== 'number' ||
-    typeof revision !== 'number' ||
+    normalizeIdentity(sourceMessageId) == null ||
+    !Number.isSafeInteger(sourceContentIndex) ||
+    sourceContentIndex < 0 ||
+    sourceContentIndex >
+      COMPACTION_SEMANTIC_INDEX_LIMITS.maxSourceContentIndex ||
+    !Number.isSafeInteger(revision) ||
+    revision < 0 ||
     !VALID_ENTRY_TYPES.has(type)
   ) {
     return undefined;
@@ -143,14 +153,13 @@ function snapshotEntry(
   if (type === 'reasoning_label') {
     const reasoningStepId = entry.reasoningStepId;
     return typeof reasoningStepId === 'string' &&
-      reasoningStepId.length <=
-        COMPACTION_SEMANTIC_INDEX_LIMITS.maxIdentityChars
+      normalizeIdentity(reasoningStepId) != null
       ? Object.freeze({ type, reasoningStepId, ...common })
       : undefined;
   }
   const toolCallId = entry.toolCallId;
   return typeof toolCallId === 'string' &&
-    toolCallId.length <= COMPACTION_SEMANTIC_INDEX_LIMITS.maxIdentityChars
+    normalizeIdentity(toolCallId) != null
     ? Object.freeze({ type, toolCallId, ...common })
     : undefined;
 }

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -82,6 +82,13 @@ export type CompactionSemanticIndexEntry =
 
 export type CompactionSemanticIndex = readonly CompactionSemanticIndexEntry[];
 
+/** Serializable continuation state for a bounded compaction semantic index. */
+export type CompactionSemanticIndexSnapshot = {
+  entries: CompactionSemanticIndex;
+  /** Cumulative entries supplied before validation and bounded retention. */
+  providedEntryCount: number;
+};
+
 export type SummarizationConfig = {
   provider?: ProviderName;
   model?: string;


### PR DESCRIPTION
## Summary

- extend `formatAgentMessages` with a serializable bounded `baseSnapshot` so warm continuations evolve semantic guidance from only the current persisted payload
- snapshot and validate prior entries, seed the existing private coverage-balanced collector, then derive the delta during the formatter’s existing single pass
- return retained entries plus cumulative supplied-entry count so omission telemetry survives JSON/process boundaries
- lazily retain at most 256 private base revision floors when balanced admission activates, preventing coverage gaps from admitting stale revisions or resurrecting tombstones
- preserve the 256-entry output bound, caller isolation, delta-only failure mode, provider-message output, and disabled-path behavior
- document continuation ownership and the `O(B + delta)`, `B <= 256` latency boundary in ADR 0008 and `CONTEXT.md`

## Performance

`npx tsx src/scripts/bench-compaction-semantic-index.ts` on a 100-message tool-rich warm history, one-message delta, nine samples of 300 iterations:

| Mode | Median latency / evolution |
| --- | ---: |
| Full-history re-derivation | 942.385 us |
| Bounded snapshot + delta | 29.450 us |

This is a **32.00x speedup** and **96.87% latency reduction**. The retained base contained 192 bounded entries.

## Verification

- `npx jest semanticIndex summarization --runInBand` — 185 passed, 11 skipped
- targeted semantic-index suite — 25 passed
- targeted ESLint and import-order checks for all touched source/test files
- `npx tsc --noEmit`
- `npm run build`
- repeated 24-turn JSON persistence verifies the cumulative count reaches 280 while retained entries remain capped at 256
- coverage-gap tests verify stale/equal revisions are suppressed and newer revisions advance

The repository-wide import check reports pre-existing unsorted files on current `main`; all touched, non-excluded TypeScript files pass the targeted check.