### PR TITLE
🪵 refactor: Aggregate Web Search Logging Into Per-Phase Summaries

### DIFF
--- a/src/tools/search/cohere-reranker.test.ts
+++ b/src/tools/search/cohere-reranker.test.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+
+import { CohereReranker } from './rerankers';
+import { createDefaultLogger } from './utils';
+
+describe('CohereReranker', () => {
+  const mockLogger = createDefaultLogger();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const spyOnLogger = (): { warn: jest.SpyInstance; error: jest.SpyInstance } => {
+    jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
+    return {
+      warn: jest.spyOn(mockLogger, 'warn').mockImplementation(() => mockLogger),
+      error: jest
+        .spyOn(mockLogger, 'error')
+        .mockImplementation(() => mockLogger),
+    };
+  };
+
+  it('should map results back to their source documents by index', async () => {
+    const reranker = new CohereReranker({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+    const spies = spyOnLogger();
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      data: {
+        id: 'req-1',
+        meta: { billed_units: { search_units: 1 } },
+        results: [
+          { index: 2, relevance_score: 0.91 },
+          { index: 0, relevance_score: 0.42 },
+        ],
+      },
+    });
+
+    const result = await reranker.rerank('query', ['a', 'b', 'c'], 2);
+
+    expect(result).toEqual([
+      { text: 'c', score: 0.91 },
+      { text: 'a', score: 0.42 },
+    ]);
+    expect(spies.warn).not.toHaveBeenCalled();
+    expect(spies.error).not.toHaveBeenCalled();
+  });
+
+  it('should keep a ranking when the response omits the billing telemetry', async () => {
+    const reranker = new CohereReranker({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+    const spies = spyOnLogger();
+    // Telemetry is not part of the ranking; a response without it is usable.
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({
+      data: { id: 'req-1', results: [{ index: 1, relevance_score: 0.77 }] },
+    });
+
+    const result = await reranker.rerank('query', ['a', 'b'], 1);
+
+    expect(result).toEqual([{ text: 'b', score: 0.77 }]);
+    expect(spies.warn).not.toHaveBeenCalled();
+    expect(spies.error).not.toHaveBeenCalled();
+  });
+
+  it('should report a payload with no results array as a bad response', async () => {
+    const reranker = new CohereReranker({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+    const spies = spyOnLogger();
+    jest.spyOn(axios, 'post').mockResolvedValueOnce({ data: { id: 'req-1' } });
+
+    const result = await reranker.rerank('query', ['a', 'b'], 2);
+
+    expect(result).toEqual([
+      { text: 'a', score: 0 },
+      { text: 'b', score: 0 },
+    ]);
+    /** A malformed payload is a bad response, not a thrown error. */
+    expect(spies.error).not.toHaveBeenCalled();
+    expect(spies.warn).toHaveBeenCalledWith(
+      expect.stringContaining('fallbacks=1 reasons={bad_response:1}')
+    );
+  });
+
+  it('should fall back to input order without a network call when no key is set', async () => {
+    const reranker = new CohereReranker({ apiKey: '', logger: mockLogger });
+    const spies = spyOnLogger();
+    const postSpy = jest.spyOn(axios, 'post');
+
+    const result = await reranker.rerank('query', ['a', 'b'], 2);
+
+    expect(result).toEqual([
+      { text: 'a', score: 0 },
+      { text: 'b', score: 0 },
+    ]);
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(spies.warn).toHaveBeenCalledWith(
+      expect.stringContaining('fallbacks=1 reasons={no_api_key:1}')
+    );
+  });
+});

--- a/src/tools/search/jina-reranker.test.ts
+++ b/src/tools/search/jina-reranker.test.ts
@@ -124,7 +124,7 @@ describe('JinaReranker', () => {
   });
 
   describe('rerank method', () => {
-    it('should log the API URL being used', async () => {
+    it('should post to the configured API URL', async () => {
       const customUrl = 'https://test-jina-endpoint.com/v1/rerank';
       const reranker = new JinaReranker({
         apiKey: 'test-key',
@@ -132,20 +132,18 @@ describe('JinaReranker', () => {
         logger: mockLogger,
       });
 
-      const logSpy = jest
-        .spyOn(mockLogger, 'debug')
-        .mockImplementation(() => mockLogger);
+      jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
       jest.spyOn(mockLogger, 'error').mockImplementation(() => mockLogger);
-      jest
+      const postSpy = jest
         .spyOn(axios, 'post')
         .mockRejectedValueOnce(new Error('Network error'));
 
       await reranker.rerank('test query', ['document1', 'document2'], 2);
 
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `Reranking 2 chunks with Jina using API URL: ${customUrl}`
-        )
+      expect(postSpy).toHaveBeenCalledWith(
+        customUrl,
+        expect.objectContaining({ top_n: 2 }),
+        expect.anything()
       );
     });
 
@@ -180,7 +178,7 @@ describe('JinaReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(errorSpy).toHaveBeenCalledWith(
-        'Error using Jina reranker',
+        expect.stringContaining('rerank=jina calls=1'),
         expect.objectContaining({
           code: 'ERR_BAD_RESPONSE',
           message: 'Request failed with status code 500',

--- a/src/tools/search/jina-reranker.test.ts
+++ b/src/tools/search/jina-reranker.test.ts
@@ -147,6 +147,43 @@ describe('JinaReranker', () => {
       );
     });
 
+    it('should keep a ranking when the response omits the usage telemetry', async () => {
+      const reranker = new JinaReranker({
+        apiKey: 'test-key',
+        logger: mockLogger,
+      });
+      jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
+      const warnSpy = jest
+        .spyOn(mockLogger, 'warn')
+        .mockImplementation(() => mockLogger);
+      const errorSpy = jest
+        .spyOn(mockLogger, 'error')
+        .mockImplementation(() => mockLogger);
+      // A Jina-compatible endpoint may return results with no `usage` block.
+      jest.spyOn(axios, 'post').mockResolvedValueOnce({
+        data: {
+          model: 'custom-reranker',
+          results: [
+            { index: 1, relevance_score: 0.9 },
+            { index: 0, relevance_score: 0.4 },
+          ],
+        },
+      });
+
+      const result = await reranker.rerank(
+        'test query',
+        ['document1', 'document2'],
+        2
+      );
+
+      expect(result).toEqual([
+        { text: 'document2', score: 0.9 },
+        { text: 'document1', score: 0.4 },
+      ]);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
     it('should log compact Axios errors without request internals', async () => {
       const customUrl =
         'https://test-jina-endpoint.com/v1/rerank?api_key=hidden';

--- a/src/tools/search/metrics.test.ts
+++ b/src/tools/search/metrics.test.ts
@@ -78,7 +78,7 @@ describe('createSearchMetrics', () => {
     expect(line).toContain('calls=8');
     expect(line).toContain('chunks=108 maxChunks=17');
     expect(line).toContain('results=40');
-    expect(line).toContain('model=rerank-v3.5');
+    expect(line).toContain('model="rerank-v3.5"');
     expect(line).toContain('units=8');
     expect(line).toContain('maxDur=107ms');
   });
@@ -246,6 +246,76 @@ describe('createSearchMetrics', () => {
     );
   });
 
+  it('strips control characters from a provider-supplied label', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordRerank({
+      provider: 'jina',
+      // A forged second entry, were the newline to survive into the message.
+      model: 'evil\n[web_search] scrape links=0 ok=0 chars=0 highlights=0',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+    });
+    metrics.flush();
+
+    /** The line it could have forged cannot exist: the record stays one
+     * physical line, and the label is bounded within it. */
+    const line = lineOf(logger.debug);
+    expect(line.split(/\r?\n|[\u2028\u2029]/)).toHaveLength(1);
+    /** Whatever survives truncation stays inside the delimited field. */
+    expect(/ model="[^"]*"$/.test(line)).toBe(true);
+  });
+
+  it('attaches the thrown query detail, not an earlier soft failure', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'news',
+      results: 0,
+      durationMs: 5,
+      error: 'Request failed with status code 429',
+    });
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'images',
+      results: 0,
+      durationMs: 5,
+      error: 'socket hang up',
+      thrown: true,
+    });
+    metrics.flush();
+
+    /** The exception raised the severity, so its message is the one worth
+     * carrying — not whichever failure happened to arrive first. */
+    const [, detail] = (logger.error as jest.Mock).mock.calls[0];
+    expect(detail).toBe('socket hang up');
+  });
+
+  it('labels a phase mixed rather than mislabeling it as the first provider', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordRerank({
+      provider: 'chunker',
+      chunks: 0,
+      results: 0,
+      durationMs: 1,
+    });
+    metrics.recordRerank({
+      provider: 'jina',
+      chunks: 10,
+      results: 5,
+      durationMs: 1,
+    });
+    metrics.flush();
+
+    expect(lineOf(logger.debug)).toContain('rerank=mixed calls=2');
+  });
+
   it('bounds a provider-supplied model name inside the summary line', () => {
     const logger = createMockLogger();
     const metrics = createSearchMetrics(logger);
@@ -260,7 +330,7 @@ describe('createSearchMetrics', () => {
     metrics.flush();
 
     const line = lineOf(logger.debug);
-    expect(line).toContain('model=');
+    expect(line).toContain('model="');
     expect(line.length).toBeLessThan(200);
   });
 

--- a/src/tools/search/metrics.test.ts
+++ b/src/tools/search/metrics.test.ts
@@ -316,6 +316,83 @@ describe('createSearchMetrics', () => {
     expect(lineOf(logger.debug)).toContain('rerank=mixed calls=2');
   });
 
+  it('keeps a placeholder reranker at debug, and real fallbacks at warn', () => {
+    const placeholder = createMockLogger();
+    const placeholderMetrics = createSearchMetrics(placeholder);
+    placeholderMetrics.recordRerank({
+      provider: 'infinity',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+      reason: 'placeholder',
+    });
+    placeholderMetrics.flush();
+    /** `infinity` is a supported setting that returns input order by design;
+     * choosing it must not read as a degradation. */
+    expect(placeholder.warn).not.toHaveBeenCalled();
+    expect(lineOf(placeholder.debug)).toContain('reasons={placeholder:1}');
+
+    const degraded = createMockLogger();
+    const degradedMetrics = createSearchMetrics(degraded);
+    degradedMetrics.recordRerank({
+      provider: 'infinity',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+      reason: 'placeholder',
+    });
+    degradedMetrics.recordRerank({
+      provider: 'infinity',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+      reason: 'no_api_key',
+    });
+    degradedMetrics.flush();
+    expect(degraded.debug).not.toHaveBeenCalled();
+    expect(lineOf(degraded.warn)).toContain('fallbacks=2');
+  });
+
+  it('marks the model mixed rather than crediting the first one seen', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordRerank({
+      provider: 'rag-api',
+      model: 'fast-v1-a',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+    });
+    metrics.recordRerank({
+      provider: 'rag-api',
+      model: 'fast-v1-b',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+    });
+    metrics.flush();
+
+    expect(lineOf(logger.debug)).toContain('model="mixed"');
+  });
+
+  it('reports a clamped result count so short highlights have an explanation', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordRerank({
+      provider: 'rag-api',
+      chunks: 40,
+      results: 25,
+      durationMs: 1,
+      topK: 40,
+      topKLimit: 25,
+    });
+    metrics.flush();
+
+    expect(lineOf(logger.debug)).toContain('topK=40 topKLimit=25');
+  });
+
   it('bounds a provider-supplied model name inside the summary line', () => {
     const logger = createMockLogger();
     const metrics = createSearchMetrics(logger);

--- a/src/tools/search/metrics.test.ts
+++ b/src/tools/search/metrics.test.ts
@@ -180,7 +180,7 @@ describe('createSearchMetrics', () => {
       type: 'news',
       results: 0,
       durationMs: 200,
-      error: 'timeout',
+      error: 'Serper API request failed: timeout of 10000ms exceeded',
     });
     metrics.flush();
 
@@ -188,7 +188,80 @@ describe('createSearchMetrics', () => {
     expect(line).toContain('search=serper queries=3');
     expect(line).toContain('results={web:8,images:10}');
     expect(line).toContain('dur=900ms');
+    /** Provider prose is classified, not copied into the summary verbatim. */
     expect(line).toContain('failed=1 reasons={news:timeout:1}');
+    expect(line).not.toContain('Serper API request failed');
+  });
+
+  it('collapses equivalent search failures into one classified reason', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    for (const message of [
+      'Images search failed: timeout of 10000ms exceeded',
+      'Images search failed: ETIMEDOUT connecting to provider',
+    ]) {
+      metrics.recordSearch({
+        provider: 'serper',
+        type: 'images',
+        results: 0,
+        durationMs: 10,
+        error: message,
+      });
+    }
+    metrics.flush();
+
+    expect(lineOf(logger.warn)).toContain('failed=2 reasons={images:timeout:2}');
+  });
+
+  it('raises the search phase to error only when a query rejected', () => {
+    const soft = createMockLogger();
+    const softMetrics = createSearchMetrics(soft);
+    softMetrics.recordSearch({
+      provider: 'serper',
+      type: 'news',
+      results: 0,
+      durationMs: 5,
+      error: 'Request failed with status code 429',
+    });
+    softMetrics.flush();
+    expect(soft.error).not.toHaveBeenCalled();
+    expect(lineOf(soft.warn)).toContain('failed=1 reasons={news:http_429:1}');
+
+    const thrown = createMockLogger();
+    const thrownMetrics = createSearchMetrics(thrown);
+    thrownMetrics.recordSearch({
+      provider: 'serper',
+      type: 'images',
+      results: 0,
+      durationMs: 5,
+      error: 'socket hang up',
+      thrown: true,
+    });
+    thrownMetrics.flush();
+    expect(thrown.warn).not.toHaveBeenCalled();
+    expect(thrown.error).toHaveBeenCalledWith(
+      expect.stringContaining('failed=1 reasons={images:connection:1}'),
+      'socket hang up'
+    );
+  });
+
+  it('bounds a provider-supplied model name inside the summary line', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordRerank({
+      provider: 'jina',
+      model: 'm'.repeat(500),
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+    });
+    metrics.flush();
+
+    const line = lineOf(logger.debug);
+    expect(line).toContain('model=');
+    expect(line.length).toBeLessThan(200);
   });
 
   it('resets after a flush so a reused collector never double-counts', () => {

--- a/src/tools/search/metrics.test.ts
+++ b/src/tools/search/metrics.test.ts
@@ -1,0 +1,231 @@
+import type * as t from './types';
+import { createSearchMetrics, classifyFailure } from './metrics';
+
+const createMockLogger = (): t.Logger =>
+  ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  }) as unknown as t.Logger;
+
+const lineOf = (fn: unknown): string =>
+  String((fn as jest.Mock).mock.calls[0][0]);
+
+describe('classifyFailure', () => {
+  it.each([
+    ['Request failed with status code 403', 'http_403'],
+    ['fastCRW API request failed: timeout of 7500ms exceeded', 'timeout'],
+    ['connect ECONNREFUSED 127.0.0.1:8080', 'connection'],
+    ['getaddrinfo ENOTFOUND example.com', 'dns'],
+    ['unable to verify the first certificate SSL', 'tls'],
+    ['canceled', 'aborted'],
+    ['something entirely novel', 'other'],
+    ['', 'unknown'],
+    [undefined, 'unknown'],
+  ])('maps %p to %p', (message, expected) => {
+    expect(classifyFailure(message)).toBe(expected);
+  });
+});
+
+describe('createSearchMetrics', () => {
+  it('emits nothing until flushed, then one line per phase that ran', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'web',
+      results: 8,
+      durationMs: 120,
+    });
+    metrics.recordScrape({ url: 'https://a.com', chars: 400, highlights: 5 });
+    metrics.recordRerank({
+      provider: 'cohere',
+      chunks: 40,
+      results: 5,
+      durationMs: 90,
+    });
+
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    metrics.flush();
+
+    expect(logger.debug).toHaveBeenCalledTimes(3);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('folds every rerank call into a single summary', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    for (let i = 0; i < 8; i++) {
+      metrics.recordRerank({
+        provider: 'cohere',
+        model: 'rerank-v3.5',
+        chunks: 10 + i,
+        results: 5,
+        units: 1,
+        durationMs: 100 + i,
+      });
+    }
+    metrics.flush();
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    const line = lineOf(logger.debug);
+    expect(line).toContain('rerank=cohere');
+    expect(line).toContain('calls=8');
+    expect(line).toContain('chunks=108 maxChunks=17');
+    expect(line).toContain('results=40');
+    expect(line).toContain('model=rerank-v3.5');
+    expect(line).toContain('units=8');
+    expect(line).toContain('maxDur=107ms');
+  });
+
+  it('reports rerank fallbacks at warn and rerank errors at error', () => {
+    const warnLogger = createMockLogger();
+    const warned = createSearchMetrics(warnLogger);
+    warned.recordRerank({
+      provider: 'cohere',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+      reason: 'no_api_key',
+    });
+    warned.flush();
+    expect(warnLogger.debug).not.toHaveBeenCalled();
+    expect(lineOf(warnLogger.warn)).toContain(
+      'fallbacks=1 reasons={no_api_key:1}'
+    );
+
+    const errorLogger = createMockLogger();
+    const errored = createSearchMetrics(errorLogger);
+    errored.recordRerank({
+      provider: 'jina',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+      reason: 'error',
+      error: { message: 'boom', status: 500 },
+    });
+    errored.flush();
+    expect(errorLogger.warn).not.toHaveBeenCalled();
+    expect(errorLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('fallbacks=1 reasons={error:1}'),
+      expect.objectContaining({ status: 500 })
+    );
+  });
+
+  it('classifies scrape failures and names a bounded sample of hosts', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordScrape({ url: 'https://ok.com', chars: 900, highlights: 3 });
+    metrics.recordScrape({ url: 'https://empty.com', chars: 0 });
+    for (let i = 0; i < 6; i++) {
+      metrics.recordScrape({
+        url: `https://fail${i}.com/page`,
+        error: 'Request failed with status code 403',
+      });
+    }
+    metrics.flush();
+
+    const [line, detail] = (logger.error as jest.Mock).mock.calls[0];
+    expect(line).toContain('links=8 ok=2');
+    expect(line).toContain('empty=1');
+    expect(line).toContain('failed=6 reasons={http_403:6}');
+    expect(line).toContain('sample=fail0.com:http_403');
+    expect(line.match(/http_403/g)).toHaveLength(4);
+    expect(detail).toBe('Request failed with status code 403');
+  });
+
+  it('bounds the reason map when failures never repeat a class', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    for (let i = 0; i < 40; i++) {
+      metrics.recordScrape({
+        url: `https://fail${i}.com`,
+        error: `Request failed with status code ${400 + i}`,
+      });
+    }
+    metrics.flush();
+
+    const line = lineOf(logger.error);
+    const reasons = /\{(.*?)\}/.exec(line)?.[1].split(',') ?? [];
+    expect(reasons.length).toBeLessThanOrEqual(7);
+    expect(line).toContain('other:');
+    expect(line).toContain('failed=40');
+  });
+
+  it('takes the search phase duration from its slowest concurrent query', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'web',
+      results: 8,
+      durationMs: 300,
+    });
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'images',
+      results: 10,
+      durationMs: 900,
+    });
+    metrics.recordSearch({
+      provider: 'serper',
+      type: 'news',
+      results: 0,
+      durationMs: 200,
+      error: 'timeout',
+    });
+    metrics.flush();
+
+    const line = lineOf(logger.warn);
+    expect(line).toContain('search=serper queries=3');
+    expect(line).toContain('results={web:8,images:10}');
+    expect(line).toContain('dur=900ms');
+    expect(line).toContain('failed=1 reasons={news:timeout:1}');
+  });
+
+  it('resets after a flush so a reused collector never double-counts', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger);
+
+    metrics.recordScrape({ url: 'https://a.com', chars: 10, highlights: 1 });
+    metrics.flush();
+    metrics.flush();
+    metrics.recordScrape({ url: 'https://b.com', chars: 20, highlights: 2 });
+    metrics.flush();
+
+    expect(logger.debug).toHaveBeenCalledTimes(2);
+    expect(lineOf(logger.debug)).toContain('links=1 ok=1 chars=10');
+    expect(String((logger.debug as jest.Mock).mock.calls[1][0])).toContain(
+      'links=1 ok=1 chars=20'
+    );
+  });
+
+  it('emits per record when auto-flushing for a caller with no run scope', () => {
+    const logger = createMockLogger();
+    const metrics = createSearchMetrics(logger, true);
+
+    metrics.recordRerank({
+      provider: 'jina',
+      chunks: 4,
+      results: 4,
+      durationMs: 1,
+    });
+    metrics.recordRerank({
+      provider: 'jina',
+      chunks: 6,
+      results: 6,
+      durationMs: 1,
+    });
+
+    expect(logger.debug).toHaveBeenCalledTimes(2);
+    expect(lineOf(logger.debug)).toContain('calls=1 chunks=4 maxChunks=4');
+  });
+});

--- a/src/tools/search/metrics.ts
+++ b/src/tools/search/metrics.ts
@@ -133,6 +133,8 @@ interface RerankPhase {
   chunks: number;
   maxChunks: number;
   dropped: number;
+  topK?: number;
+  topKLimit?: number;
   results: number;
   units: number;
   durationMs: number;
@@ -228,11 +230,22 @@ export const createSearchMetrics = (
     if (phase.dropped > 0) {
       line += ` dropped=${phase.dropped}`;
     }
+    if (phase.topKLimit != null) {
+      line += ` topK=${phase.topK} topKLimit=${phase.topKLimit}`;
+    }
     if (phase.fallbacks === 0) {
       logger.debug(line);
       return;
     }
     line += ` fallbacks=${phase.fallbacks} reasons=${formatMap(phase.reasons)}`;
+    /** A placeholder reranker returns input order by design, so a phase whose
+     * only fallbacks are placeholders is the configuration working — it stays
+     * at the debug level it had before these counters existed. */
+    const degraded = phase.fallbacks - (phase.reasons.get('placeholder') ?? 0);
+    if (degraded === 0 && phase.errors === 0) {
+      logger.debug(line);
+      return;
+    }
     if (phase.errors === 0) {
       logger.warn(line);
       return;
@@ -356,13 +369,20 @@ export const createSearchMetrics = (
     rerank.maxChunks = Math.max(rerank.maxChunks, observation.chunks);
     rerank.results += observation.results;
     rerank.dropped += observation.dropped ?? 0;
+    rerank.topK ??= observation.topK;
+    rerank.topKLimit ??= observation.topKLimit;
     rerank.units += observation.units ?? 0;
     rerank.durationMs += observation.durationMs;
     rerank.maxDurationMs = Math.max(
       rerank.maxDurationMs,
       observation.durationMs
     );
-    rerank.model ??= observation.model;
+    if (observation.model != null) {
+      rerank.model =
+        rerank.model == null
+          ? observation.model
+          : mergeProvider(rerank.model, observation.model);
+    }
     if (observation.reason != null) {
       rerank.fallbacks += 1;
       bump(rerank.reasons, observation.reason);

--- a/src/tools/search/metrics.ts
+++ b/src/tools/search/metrics.ts
@@ -80,10 +80,26 @@ const formatMap = (counts: Map<string, number>): string => {
 const truncate = (value: string, max: number): string =>
   value.length <= max ? value : `${value.slice(0, max)}…`;
 
+/** Newlines, bidi overrides, and other non-printing characters let a remote
+ * payload split one summary into several physical lines or forge a second
+ * apparent entry, so they never survive into a log message. */
+const UNPRINTABLE = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}"]+/gu;
+
+const sanitize = (value: string): string => value.replace(UNPRINTABLE, ' ');
+
 /** Every provider-supplied string that reaches a summary line or a map key
- * goes through here: the phases promise a fixed-width line, and neither a
- * remote payload nor an external caller's label is bounded on its own. */
-const label = (value: string): string => truncate(value, MAX_LABEL_LENGTH);
+ * goes through here: the phases promise one bounded line, and neither a
+ * remote payload nor an external caller's label is safe on its own. */
+const label = (value: string): string =>
+  truncate(sanitize(value), MAX_LABEL_LENGTH);
+
+const detailOf = (value: string): string =>
+  truncate(sanitize(value), MAX_DETAIL_LENGTH);
+
+/** A phase carries one provider label. Nothing in this package mixes them,
+ * but a wrong label is worse than an honest one if that ever changes. */
+const mergeProvider = (current: string, incoming: string): string =>
+  current === incoming ? current : 'mixed';
 
 interface SearchPhase {
   provider: string;
@@ -201,7 +217,10 @@ export const createSearchMetrics = (
       ` dur=${formatMs(phase.durationMs)}` +
       ` maxDur=${formatMs(phase.maxDurationMs)}`;
     if (phase.model != null) {
-      line += ` model=${label(phase.model)}`;
+      /** The only free-form remote value in the line, so it is the one field
+       * that gets delimited — a truncated payload cannot then read as
+       * further fields. */
+      line += ` model="${label(phase.model)}"`;
     }
     if (phase.units > 0) {
       line += ` units=${phase.units}`;
@@ -250,6 +269,7 @@ export const createSearchMetrics = (
       types: new Map(),
       reasons: new Map(),
     };
+    search.provider = mergeProvider(search.provider, observation.provider);
     search.queries += 1;
     /** Sub-searches run concurrently, so the phase lasts as long as its
      * slowest query rather than the sum of all of them. */
@@ -262,9 +282,13 @@ export const createSearchMetrics = (
         search.reasons,
         `${observation.type}:${classifyFailure(observation.error)}`
       );
-      search.detail ??= truncate(observation.error, MAX_DETAIL_LENGTH);
+      /** `detail` is only ever logged on the error path, so it is captured
+       * only from a thrown observation — otherwise an earlier soft failure's
+       * message would be attached to an exception it has nothing to do
+       * with, and the real one dropped. */
       if (observation.thrown === true) {
         search.errors += 1;
+        search.detail ??= detailOf(observation.error);
       }
     } else if (observation.results > 0) {
       const type = label(observation.type);
@@ -294,9 +318,9 @@ export const createSearchMetrics = (
       const reason = classifyFailure(observation.error);
       bump(scrape.reasons, reason);
       if (scrape.samples.length < MAX_FAILURE_SAMPLES) {
-        scrape.samples.push(`${hostOf(observation.url)}:${reason}`);
+        scrape.samples.push(label(`${hostOf(observation.url)}:${reason}`));
       }
-      scrape.detail ??= truncate(observation.error, MAX_DETAIL_LENGTH);
+      scrape.detail ??= detailOf(observation.error);
     } else {
       scrape.ok += 1;
       const chars = observation.chars ?? 0;
@@ -326,6 +350,7 @@ export const createSearchMetrics = (
       maxDurationMs: 0,
       reasons: new Map(),
     };
+    rerank.provider = mergeProvider(rerank.provider, observation.provider);
     rerank.calls += 1;
     rerank.chunks += observation.chunks;
     rerank.maxChunks = Math.max(rerank.maxChunks, observation.chunks);

--- a/src/tools/search/metrics.ts
+++ b/src/tools/search/metrics.ts
@@ -1,0 +1,324 @@
+import type * as t from './types';
+
+/** Distinct failure reasons kept per phase before the tail folds into
+ * `other`: enough to characterize a mixed failure without letting a
+ * pathological run grow one map entry per source. */
+const MAX_REASON_KEYS = 6;
+/** Failing hosts named in a summary before the rest are counted only. */
+const MAX_FAILURE_SAMPLES = 3;
+/** Cap on the raw provider message carried alongside a summary. */
+const MAX_DETAIL_LENGTH = 200;
+const OTHER_REASON = 'other';
+
+const HTTP_STATUS_REGEX = /\b(?:status(?:\scode)?|http)\D{0,3}(\d{3})\b/i;
+
+/** Free-form provider messages have unbounded cardinality; the aggregate only
+ * keeps a normalized class so the reason map stays small and comparable. */
+const REASON_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/ECONNABORTED|ETIMEDOUT|timeout|timed out/i, 'timeout'],
+  [/ENOTFOUND|EAI_AGAIN|getaddrinfo/i, 'dns'],
+  [/ECONNREFUSED|ECONNRESET|EPIPE|socket hang up/i, 'connection'],
+  [/CERT_|SSL|TLS|self[- ]signed/i, 'tls'],
+  [/abort|cancel/i, 'aborted'],
+];
+
+export const classifyFailure = (message?: string): string => {
+  if (message == null || message === '') {
+    return 'unknown';
+  }
+  const status = HTTP_STATUS_REGEX.exec(message);
+  if (status != null) {
+    return `http_${status[1]}`;
+  }
+  for (const [pattern, reason] of REASON_PATTERNS) {
+    if (pattern.test(message)) {
+      return reason;
+    }
+  }
+  return OTHER_REASON;
+};
+
+const bump = (counts: Map<string, number>, key: string): void => {
+  const existing = counts.get(key);
+  if (existing != null) {
+    counts.set(key, existing + 1);
+    return;
+  }
+  if (counts.size >= MAX_REASON_KEYS) {
+    counts.set(OTHER_REASON, (counts.get(OTHER_REASON) ?? 0) + 1);
+    return;
+  }
+  counts.set(key, 1);
+};
+
+const hostOf = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url.slice(0, 60);
+  }
+};
+
+const formatCount = (value: number): string =>
+  value < 10000 ? String(value) : `${(value / 1000).toFixed(1)}k`;
+
+const formatMs = (ms: number): string =>
+  ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+
+const formatMap = (counts: Map<string, number>): string => {
+  let out = '';
+  for (const [key, count] of counts) {
+    out += `${out === '' ? '' : ','}${key}:${count}`;
+  }
+  return `{${out}}`;
+};
+
+const truncateDetail = (detail: string): string =>
+  detail.length <= MAX_DETAIL_LENGTH
+    ? detail
+    : `${detail.slice(0, MAX_DETAIL_LENGTH)}…`;
+
+interface SearchPhase {
+  provider: string;
+  queries: number;
+  failed: number;
+  durationMs: number;
+  types: Map<string, number>;
+  reasons: Map<string, number>;
+}
+
+interface ScrapePhase {
+  links: number;
+  ok: number;
+  empty: number;
+  chars: number;
+  highlights: number;
+  failed: number;
+  reasons: Map<string, number>;
+  samples: string[];
+  detail?: string;
+}
+
+interface RerankPhase {
+  provider: string;
+  model?: string;
+  calls: number;
+  fallbacks: number;
+  errors: number;
+  chunks: number;
+  maxChunks: number;
+  dropped: number;
+  results: number;
+  units: number;
+  durationMs: number;
+  maxDurationMs: number;
+  reasons: Map<string, number>;
+  error?: t.SafeErrorLog;
+}
+
+/**
+ * Creates the counter set for one `web_search` call.
+ *
+ * The pipeline reranks once per scraped source and scrapes once per link, so
+ * logging at those points scales the log with the result count. Every phase
+ * records into fixed-width counters instead and {@link t.SearchMetrics.flush}
+ * emits one line per phase, at the highest severity that phase reached.
+ *
+ * @param autoFlush emit on every record, for a caller with no enclosing search
+ * to fold into (a reranker used directly). Recording is synchronous, so the
+ * record/flush/reset cycle can never interleave with a concurrent call.
+ */
+export const createSearchMetrics = (
+  logger: t.Logger,
+  autoFlush = false
+): t.SearchMetrics => {
+  let search: SearchPhase | undefined;
+  let scrape: ScrapePhase | undefined;
+  let rerank: RerankPhase | undefined;
+
+  const flushSearch = (phase: SearchPhase): void => {
+    let line = `[web_search] search=${phase.provider} queries=${phase.queries}`;
+    if (phase.types.size > 0) {
+      line += ` results=${formatMap(phase.types)}`;
+    }
+    line += ` dur=${formatMs(phase.durationMs)}`;
+    if (phase.failed === 0) {
+      logger.debug(line);
+      return;
+    }
+    logger.warn(
+      `${line} failed=${phase.failed} reasons=${formatMap(phase.reasons)}`
+    );
+  };
+
+  const flushScrape = (phase: ScrapePhase): void => {
+    let line =
+      `[web_search] scrape links=${phase.links} ok=${phase.ok}` +
+      ` chars=${formatCount(phase.chars)} highlights=${phase.highlights}`;
+    if (phase.empty > 0) {
+      line += ` empty=${phase.empty}`;
+    }
+    if (phase.failed === 0) {
+      logger.debug(line);
+      return;
+    }
+    line += ` failed=${phase.failed} reasons=${formatMap(phase.reasons)}`;
+    if (phase.samples.length > 0) {
+      line += ` sample=${phase.samples.join(',')}`;
+    }
+    if (phase.detail == null) {
+      logger.error(line);
+      return;
+    }
+    logger.error(line, phase.detail);
+  };
+
+  const flushRerank = (phase: RerankPhase): void => {
+    let line =
+      `[web_search] rerank=${phase.provider} calls=${phase.calls}` +
+      ` chunks=${phase.chunks} maxChunks=${phase.maxChunks}` +
+      ` results=${phase.results}` +
+      ` dur=${formatMs(phase.durationMs)}` +
+      ` maxDur=${formatMs(phase.maxDurationMs)}`;
+    if (phase.model != null) {
+      line += ` model=${phase.model}`;
+    }
+    if (phase.units > 0) {
+      line += ` units=${phase.units}`;
+    }
+    if (phase.dropped > 0) {
+      line += ` dropped=${phase.dropped}`;
+    }
+    if (phase.fallbacks === 0) {
+      logger.debug(line);
+      return;
+    }
+    line += ` fallbacks=${phase.fallbacks} reasons=${formatMap(phase.reasons)}`;
+    if (phase.errors === 0) {
+      logger.warn(line);
+      return;
+    }
+    if (phase.error == null) {
+      logger.error(line);
+      return;
+    }
+    logger.error(line, phase.error);
+  };
+
+  const flush = (): void => {
+    if (search != null) {
+      flushSearch(search);
+      search = undefined;
+    }
+    if (scrape != null) {
+      flushScrape(scrape);
+      scrape = undefined;
+    }
+    if (rerank != null) {
+      flushRerank(rerank);
+      rerank = undefined;
+    }
+  };
+
+  const recordSearch = (observation: t.SearchObservation): void => {
+    search ??= {
+      provider: observation.provider,
+      queries: 0,
+      failed: 0,
+      durationMs: 0,
+      types: new Map(),
+      reasons: new Map(),
+    };
+    search.queries += 1;
+    /** Sub-searches run concurrently, so the phase lasts as long as its
+     * slowest query rather than the sum of all of them. */
+    search.durationMs = Math.max(search.durationMs, observation.durationMs);
+    if (observation.error != null) {
+      search.failed += 1;
+      bump(search.reasons, `${observation.type}:${observation.error}`);
+    } else if (observation.results > 0) {
+      const seen = search.types.get(observation.type) ?? 0;
+      search.types.set(observation.type, seen + observation.results);
+    }
+    if (autoFlush) {
+      flush();
+    }
+  };
+
+  const recordScrape = (observation: t.ScrapeObservation): void => {
+    scrape ??= {
+      links: 0,
+      ok: 0,
+      empty: 0,
+      chars: 0,
+      highlights: 0,
+      failed: 0,
+      reasons: new Map(),
+      samples: [],
+      detail: undefined,
+    };
+    scrape.links += 1;
+    if (observation.error != null) {
+      scrape.failed += 1;
+      const reason = classifyFailure(observation.error);
+      bump(scrape.reasons, reason);
+      if (scrape.samples.length < MAX_FAILURE_SAMPLES) {
+        scrape.samples.push(`${hostOf(observation.url)}:${reason}`);
+      }
+      scrape.detail ??= truncateDetail(observation.error);
+    } else {
+      scrape.ok += 1;
+      const chars = observation.chars ?? 0;
+      scrape.chars += chars;
+      scrape.highlights += observation.highlights ?? 0;
+      if (chars === 0) {
+        scrape.empty += 1;
+      }
+    }
+    if (autoFlush) {
+      flush();
+    }
+  };
+
+  const recordRerank = (observation: t.RerankObservation): void => {
+    rerank ??= {
+      provider: observation.provider,
+      calls: 0,
+      fallbacks: 0,
+      errors: 0,
+      chunks: 0,
+      maxChunks: 0,
+      dropped: 0,
+      results: 0,
+      units: 0,
+      durationMs: 0,
+      maxDurationMs: 0,
+      reasons: new Map(),
+    };
+    rerank.calls += 1;
+    rerank.chunks += observation.chunks;
+    rerank.maxChunks = Math.max(rerank.maxChunks, observation.chunks);
+    rerank.results += observation.results;
+    rerank.dropped += observation.dropped ?? 0;
+    rerank.units += observation.units ?? 0;
+    rerank.durationMs += observation.durationMs;
+    rerank.maxDurationMs = Math.max(
+      rerank.maxDurationMs,
+      observation.durationMs
+    );
+    rerank.model ??= observation.model;
+    if (observation.reason != null) {
+      rerank.fallbacks += 1;
+      bump(rerank.reasons, observation.reason);
+    }
+    if (observation.error != null) {
+      rerank.errors += 1;
+      rerank.error ??= observation.error;
+    }
+    if (autoFlush) {
+      flush();
+    }
+  };
+
+  return { recordSearch, recordScrape, recordRerank, flush };
+};

--- a/src/tools/search/metrics.ts
+++ b/src/tools/search/metrics.ts
@@ -8,6 +8,9 @@ const MAX_REASON_KEYS = 6;
 const MAX_FAILURE_SAMPLES = 3;
 /** Cap on the raw provider message carried alongside a summary. */
 const MAX_DETAIL_LENGTH = 200;
+/** Cap on a provider-supplied label placed inside a summary line, so a
+ * malformed response cannot stretch a fixed-width line without bound. */
+const MAX_LABEL_LENGTH = 48;
 const OTHER_REASON = 'other';
 
 const HTTP_STATUS_REGEX = /\b(?:status(?:\scode)?|http)\D{0,3}(\d{3})\b/i;
@@ -38,7 +41,8 @@ export const classifyFailure = (message?: string): string => {
   return OTHER_REASON;
 };
 
-const bump = (counts: Map<string, number>, key: string): void => {
+const bump = (counts: Map<string, number>, rawKey: string): void => {
+  const key = label(rawKey);
   const existing = counts.get(key);
   if (existing != null) {
     counts.set(key, existing + 1);
@@ -73,18 +77,23 @@ const formatMap = (counts: Map<string, number>): string => {
   return `{${out}}`;
 };
 
-const truncateDetail = (detail: string): string =>
-  detail.length <= MAX_DETAIL_LENGTH
-    ? detail
-    : `${detail.slice(0, MAX_DETAIL_LENGTH)}…`;
+const truncate = (value: string, max: number): string =>
+  value.length <= max ? value : `${value.slice(0, max)}…`;
+
+/** Every provider-supplied string that reaches a summary line or a map key
+ * goes through here: the phases promise a fixed-width line, and neither a
+ * remote payload nor an external caller's label is bounded on its own. */
+const label = (value: string): string => truncate(value, MAX_LABEL_LENGTH);
 
 interface SearchPhase {
   provider: string;
   queries: number;
   failed: number;
+  errors: number;
   durationMs: number;
   types: Map<string, number>;
   reasons: Map<string, number>;
+  detail?: string;
 }
 
 interface ScrapePhase {
@@ -137,7 +146,9 @@ export const createSearchMetrics = (
   let rerank: RerankPhase | undefined;
 
   const flushSearch = (phase: SearchPhase): void => {
-    let line = `[web_search] search=${phase.provider} queries=${phase.queries}`;
+    let line =
+      `[web_search] search=${label(phase.provider)}` +
+      ` queries=${phase.queries}`;
     if (phase.types.size > 0) {
       line += ` results=${formatMap(phase.types)}`;
     }
@@ -146,9 +157,18 @@ export const createSearchMetrics = (
       logger.debug(line);
       return;
     }
-    logger.warn(
-      `${line} failed=${phase.failed} reasons=${formatMap(phase.reasons)}`
-    );
+    line += ` failed=${phase.failed} reasons=${formatMap(phase.reasons)}`;
+    /** A rejected query was an error-level event before it was aggregated;
+     * a provider that merely reported failure was not. */
+    if (phase.errors === 0) {
+      logger.warn(line);
+      return;
+    }
+    if (phase.detail == null) {
+      logger.error(line);
+      return;
+    }
+    logger.error(line, phase.detail);
   };
 
   const flushScrape = (phase: ScrapePhase): void => {
@@ -175,13 +195,13 @@ export const createSearchMetrics = (
 
   const flushRerank = (phase: RerankPhase): void => {
     let line =
-      `[web_search] rerank=${phase.provider} calls=${phase.calls}` +
+      `[web_search] rerank=${label(phase.provider)} calls=${phase.calls}` +
       ` chunks=${phase.chunks} maxChunks=${phase.maxChunks}` +
       ` results=${phase.results}` +
       ` dur=${formatMs(phase.durationMs)}` +
       ` maxDur=${formatMs(phase.maxDurationMs)}`;
     if (phase.model != null) {
-      line += ` model=${phase.model}`;
+      line += ` model=${label(phase.model)}`;
     }
     if (phase.units > 0) {
       line += ` units=${phase.units}`;
@@ -225,6 +245,7 @@ export const createSearchMetrics = (
       provider: observation.provider,
       queries: 0,
       failed: 0,
+      errors: 0,
       durationMs: 0,
       types: new Map(),
       reasons: new Map(),
@@ -235,10 +256,20 @@ export const createSearchMetrics = (
     search.durationMs = Math.max(search.durationMs, observation.durationMs);
     if (observation.error != null) {
       search.failed += 1;
-      bump(search.reasons, `${observation.type}:${observation.error}`);
+      /** Provider messages are prose: classify before counting, or equivalent
+       * failures never collapse and the raw text lands in the summary. */
+      bump(
+        search.reasons,
+        `${observation.type}:${classifyFailure(observation.error)}`
+      );
+      search.detail ??= truncate(observation.error, MAX_DETAIL_LENGTH);
+      if (observation.thrown === true) {
+        search.errors += 1;
+      }
     } else if (observation.results > 0) {
-      const seen = search.types.get(observation.type) ?? 0;
-      search.types.set(observation.type, seen + observation.results);
+      const type = label(observation.type);
+      const seen = search.types.get(type) ?? 0;
+      search.types.set(type, seen + observation.results);
     }
     if (autoFlush) {
       flush();
@@ -265,7 +296,7 @@ export const createSearchMetrics = (
       if (scrape.samples.length < MAX_FAILURE_SAMPLES) {
         scrape.samples.push(`${hostOf(observation.url)}:${reason}`);
       }
-      scrape.detail ??= truncateDetail(observation.error);
+      scrape.detail ??= truncate(observation.error, MAX_DETAIL_LENGTH);
     } else {
       scrape.ok += 1;
       const chars = observation.chars ?? 0;

--- a/src/tools/search/rag-api-reranker.test.ts
+++ b/src/tools/search/rag-api-reranker.test.ts
@@ -166,7 +166,10 @@ describe('RagApiReranker', () => {
       ]);
       expect(postSpy).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(
-        'RAG_API_URL is not set. Using default ranking.'
+        expect.stringContaining('rerank=rag-api calls=1')
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fallbacks=1 reasons={no_base_url:1}')
       );
 
       if (typeof originalEnv === 'string') {
@@ -193,7 +196,7 @@ describe('RagApiReranker', () => {
       ]);
       expect(postSpy).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(
-        'No rag_api token supplier configured. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={no_token_supplier:1}')
       );
     });
 
@@ -390,7 +393,7 @@ describe('RagApiReranker', () => {
       ]);
     });
 
-    it('should truncate candidates beyond the 50-candidate contract limit with a debug log', async () => {
+    it('should truncate candidates beyond the 50-candidate contract limit and report the overflow', async () => {
       const tokenSupplier = jest.fn().mockResolvedValue('token');
       const reranker = new RagApiReranker({
         baseUrl,
@@ -418,22 +421,18 @@ describe('RagApiReranker', () => {
         (requestBody as t.RagApiRerankRequestBody).candidates
       ).toHaveLength(50);
       expect(debugSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'accepts at most 50 candidates; truncating 60 to 50'
-        )
+        expect.stringContaining('dropped=10')
       );
     });
 
-    it('should clamp top_n beyond the 25-result contract limit with a debug log', async () => {
+    it('should clamp top_n beyond the 25-result contract limit', async () => {
       const tokenSupplier = jest.fn().mockResolvedValue('token');
       const reranker = new RagApiReranker({
         baseUrl,
         tokenSupplier,
         logger: mockLogger,
       });
-      const debugSpy = jest
-        .spyOn(mockLogger, 'debug')
-        .mockImplementation(() => mockLogger);
+      jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
       const documents = Array.from({ length: 30 }, (_, i) => `document${i}`);
       const postSpy = jest.spyOn(axios, 'post').mockResolvedValueOnce({
         data: {
@@ -450,9 +449,6 @@ describe('RagApiReranker', () => {
       const [, requestBody] = postSpy.mock.calls[0];
       expect((requestBody as t.RagApiRerankRequestBody).top_n).toBe(25);
       expect(result).toHaveLength(25);
-      expect(debugSpy).toHaveBeenCalledWith(
-        expect.stringContaining('accepts top_n <= 25; clamping 40 to 25')
-      );
     });
 
     it('should fall back to the candidates original order on a request timeout', async () => {
@@ -485,7 +481,7 @@ describe('RagApiReranker', () => {
         { text: 'document3', score: 0 },
       ]);
       expect(errorSpy).toHaveBeenCalledWith(
-        'Error using rag_api reranker',
+        expect.stringContaining('rerank=rag-api'),
         expect.objectContaining({ code: 'ECONNABORTED' })
       );
     });
@@ -513,7 +509,7 @@ describe('RagApiReranker', () => {
 
       expect(result).toEqual([{ text: 'document1', score: 0 }]);
       expect(errorSpy).toHaveBeenCalledWith(
-        'Error using rag_api reranker',
+        expect.stringContaining('rerank=rag-api'),
         expect.objectContaining({ status: 500 })
       );
 
@@ -547,7 +543,7 @@ describe('RagApiReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
-        'Unexpected response format from rag_api rerank. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={bad_response:1}')
       );
     });
 
@@ -582,7 +578,7 @@ describe('RagApiReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
-        'rag_api rerank response contained no valid results. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={invalid_results:1}')
       );
     });
 
@@ -632,7 +628,7 @@ describe('RagApiReranker', () => {
       expect(Date.now() - startedAt).toBeLessThan(2000);
       expect(postSpy).not.toHaveBeenCalled();
       expect(errorSpy).toHaveBeenCalledWith(
-        'Error using rag_api reranker',
+        expect.stringContaining('rerank=rag-api'),
         expect.objectContaining({
           message: 'rag_api rerank exceeded its 50ms timeout.',
         })
@@ -750,7 +746,7 @@ describe('RagApiReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
-        'rag_api rerank response contained no valid results. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={invalid_results:1}')
       );
     });
 
@@ -785,7 +781,7 @@ describe('RagApiReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
-        'rag_api rerank response contained no valid results. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={invalid_results:1}')
       );
     });
 
@@ -820,7 +816,7 @@ describe('RagApiReranker', () => {
         { text: 'document2', score: 0 },
       ]);
       expect(warnSpy).toHaveBeenCalledWith(
-        'rag_api rerank response contained no valid results. Using default ranking.'
+        expect.stringContaining('fallbacks=1 reasons={invalid_results:1}')
       );
     });
 

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -18,7 +18,9 @@ const getDefaultJinaApiUrl = (): string =>
 export abstract class BaseReranker {
   protected apiKey: string | undefined;
   protected logger: t.Logger;
-  protected abstract readonly provider: string;
+  /** Public so a caller that fails before reaching `rerank` can still
+   * attribute the attempt to the configured reranker. */
+  abstract readonly provider: string;
   private ownMetrics?: t.SearchMetrics;
 
   constructor(logger?: t.Logger) {
@@ -114,7 +116,7 @@ export abstract class BaseReranker {
 }
 
 export class JinaReranker extends BaseReranker {
-  protected readonly provider = 'jina';
+  readonly provider = 'jina';
   private apiUrl: string;
   private timeout: number;
   private httpAgent?: t.HttpAgent;
@@ -214,7 +216,7 @@ export class JinaReranker extends BaseReranker {
 }
 
 export class CohereReranker extends BaseReranker {
-  protected readonly provider = 'cohere';
+  readonly provider = 'cohere';
   private timeout: number;
   private httpAgent?: t.HttpAgent;
   private httpsAgent?: t.HttpsAgent;
@@ -407,7 +409,7 @@ const withRerankDeadline = <T>(
  * to the candidates' original order via {@link BaseReranker.getDefaultRanking}.
  */
 export class RagApiReranker extends BaseReranker {
-  protected readonly provider = 'rag-api';
+  readonly provider = 'rag-api';
   private baseUrl?: string;
   private tokenSupplier?: t.RagApiTokenSupplier;
   private profile: string;
@@ -518,7 +520,7 @@ export class RagApiReranker extends BaseReranker {
 }
 
 export class InfinityReranker extends BaseReranker {
-  protected readonly provider = 'infinity';
+  readonly provider = 'infinity';
 
   constructor(logger?: t.Logger) {
     super(logger);

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type * as t from './types';
 import { createDefaultLogger, formatErrorForLog } from './utils';
+import { createSearchMetrics } from './metrics';
 
 const DEFAULT_JINA_API_URL = 'https://api.jina.ai/v1/rerank';
 
@@ -17,16 +18,25 @@ const getDefaultJinaApiUrl = (): string =>
 export abstract class BaseReranker {
   protected apiKey: string | undefined;
   protected logger: t.Logger;
+  protected abstract readonly provider: string;
+  private ownMetrics?: t.SearchMetrics;
 
   constructor(logger?: t.Logger) {
     // Each specific reranker will set its API key
     this.logger = logger || createDefaultLogger();
   }
 
+  /**
+   * A search reranks once per scraped source, so nothing here logs per call:
+   * every exit records one observation through `metrics` and the enclosing
+   * search emits a single summary. `metrics` is optional only for direct use
+   * of a reranker, which falls back to an auto-flushing collector.
+   */
   abstract rerank(
     query: string,
     documents: string[],
-    topK?: number
+    topK?: number,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]>;
 
   protected getDefaultRanking(
@@ -37,9 +47,74 @@ export abstract class BaseReranker {
       .slice(0, Math.min(topK, documents.length))
       .map((doc) => ({ text: doc, score: 0 }));
   }
+
+  /** A direct caller has no enclosing search to fold into, so one
+   * auto-flushing collector per instance emits that call's summary on its
+   * own; record and flush run synchronously, so concurrent calls on the same
+   * instance cannot share a total. */
+  private localMetrics(): t.SearchMetrics {
+    this.ownMetrics ??= createSearchMetrics(this.logger, true);
+    return this.ownMetrics;
+  }
+
+  /** Opens the per-call state every exit path records against. */
+  protected beginRerank(
+    documents: string[],
+    topK: number,
+    metrics?: t.SearchMetrics
+  ): t.RerankRun {
+    return {
+      metrics: metrics ?? this.localMetrics(),
+      documents,
+      topK,
+      startedAt: Date.now(),
+    };
+  }
+
+  private record(
+    run: t.RerankRun,
+    highlights: t.Highlight[],
+    reason?: t.RerankFallback,
+    error?: t.SafeErrorLog
+  ): t.Highlight[] {
+    run.metrics.recordRerank({
+      provider: this.provider,
+      chunks: run.documents.length,
+      results: highlights.length,
+      durationMs: Date.now() - run.startedAt,
+      model: run.model,
+      units: run.units,
+      dropped: run.dropped,
+      reason,
+      error,
+    });
+    return highlights;
+  }
+
+  protected complete(
+    run: t.RerankRun,
+    highlights: t.Highlight[]
+  ): t.Highlight[] {
+    return this.record(run, highlights);
+  }
+
+  /** Records the call as a fallback and returns the candidates' input order. */
+  protected fallback(
+    run: t.RerankRun,
+    reason: t.RerankFallback,
+    error?: t.SafeErrorLog
+  ): t.Highlight[] {
+    return this.record(
+      run,
+      this.getDefaultRanking(run.documents, run.topK),
+      reason,
+      error
+    );
+  }
 }
 
 export class JinaReranker extends BaseReranker {
+  protected readonly provider = 'jina';
   private apiUrl: string;
   private timeout: number;
   private httpAgent?: t.HttpAgent;
@@ -69,16 +144,14 @@ export class JinaReranker extends BaseReranker {
   async rerank(
     query: string,
     documents: string[],
-    topK: number = 5
+    topK: number = 5,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]> {
-    this.logger.debug(
-      `Reranking ${documents.length} chunks with Jina using API URL: ${this.apiUrl}`
-    );
+    const run = this.beginRerank(documents, topK, metrics);
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
-        this.logger.warn('JINA_API_KEY is not set. Using default ranking.');
-        return this.getDefaultRanking(documents, topK);
+        return this.fallback(run, 'no_api_key');
       }
 
       const requestData = {
@@ -103,11 +176,16 @@ export class JinaReranker extends BaseReranker {
         }
       );
 
-      this.logger.debug('Jina API Model:', response.data?.model);
-      this.logger.debug('Jina API Usage:', response.data?.usage);
+      run.model = response.data?.model;
+      run.units = response.data?.usage.total_tokens;
 
-      if (response.data && response.data.results.length) {
-        return response.data.results.map((result) => {
+      if (!response.data || !response.data.results.length) {
+        return this.fallback(run, 'bad_response');
+      }
+
+      return this.complete(
+        run,
+        response.data.results.map((result) => {
           const docIndex = result.index;
           const score = result.relevance_score;
           let text = '';
@@ -126,22 +204,16 @@ export class JinaReranker extends BaseReranker {
           }
 
           return { text, score };
-        });
-      } else {
-        this.logger.warn(
-          'Unexpected response format from Jina API. Using default ranking.'
-        );
-        return this.getDefaultRanking(documents, topK);
-      }
+        })
+      );
     } catch (error) {
-      this.logger.error('Error using Jina reranker', formatErrorForLog(error));
-      // Fallback to default ranking on error
-      return this.getDefaultRanking(documents, topK);
+      return this.fallback(run, 'error', formatErrorForLog(error));
     }
   }
 }
 
 export class CohereReranker extends BaseReranker {
+  protected readonly provider = 'cohere';
   private timeout: number;
   private httpAgent?: t.HttpAgent;
   private httpsAgent?: t.HttpsAgent;
@@ -167,18 +239,19 @@ export class CohereReranker extends BaseReranker {
   async rerank(
     query: string,
     documents: string[],
-    topK: number = 5
+    topK: number = 5,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]> {
-    this.logger.debug(`Reranking ${documents.length} chunks with Cohere`);
+    const run = this.beginRerank(documents, topK, metrics);
 
     try {
       if (this.apiKey == null || this.apiKey === '') {
-        this.logger.warn('COHERE_API_KEY is not set. Using default ranking.');
-        return this.getDefaultRanking(documents, topK);
+        return this.fallback(run, 'no_api_key');
       }
 
+      const model = 'rerank-v3.5';
       const requestData = {
-        model: 'rerank-v3.5',
+        model,
         query: query,
         top_n: topK,
         documents: documents,
@@ -198,29 +271,24 @@ export class CohereReranker extends BaseReranker {
         }
       );
 
-      this.logger.debug('Cohere API ID:', response.data?.id);
-      this.logger.debug('Cohere API Meta:', response.data?.meta);
+      run.model = model;
+      run.units = response.data?.meta.billed_units.search_units;
 
-      if (response.data && response.data.results.length) {
-        return response.data.results.map((result) => {
+      if (!response.data || !response.data.results.length) {
+        return this.fallback(run, 'bad_response');
+      }
+
+      return this.complete(
+        run,
+        response.data.results.map((result) => {
           const docIndex = result.index;
           const score = result.relevance_score;
           const text = documents[docIndex];
           return { text, score };
-        });
-      } else {
-        this.logger.warn(
-          'Unexpected response format from Cohere API. Using default ranking.'
-        );
-        return this.getDefaultRanking(documents, topK);
-      }
-    } catch (error) {
-      this.logger.error(
-        'Error using Cohere reranker',
-        formatErrorForLog(error)
+        })
       );
-      // Fallback to default ranking on error
-      return this.getDefaultRanking(documents, topK);
+    } catch (error) {
+      return this.fallback(run, 'error', formatErrorForLog(error));
     }
   }
 }
@@ -244,29 +312,17 @@ const toRagApiCandidate = (
 
 /** A single source split into overlapping chunks routinely exceeds the
  * contract limit, so documents are capped before any candidate is built:
- * only the submittable window is ever allocated. */
+ * only the submittable window is ever allocated. The overflow is reported
+ * through the run's `dropped` counter rather than a per-call log. */
 const buildRagApiCandidates = (
-  documents: string[],
-  logger: t.Logger
-): t.RagApiRerankCandidate[] => {
-  if (documents.length <= RAG_API_MAX_CANDIDATES) {
-    return documents.map(toRagApiCandidate);
-  }
-  logger.debug(
-    `rag_api fast-v1 accepts at most ${RAG_API_MAX_CANDIDATES} candidates; truncating ${documents.length} to ${RAG_API_MAX_CANDIDATES}.`
-  );
-  return documents.slice(0, RAG_API_MAX_CANDIDATES).map(toRagApiCandidate);
-};
+  documents: string[]
+): t.RagApiRerankCandidate[] =>
+  documents.length <= RAG_API_MAX_CANDIDATES
+    ? documents.map(toRagApiCandidate)
+    : documents.slice(0, RAG_API_MAX_CANDIDATES).map(toRagApiCandidate);
 
-const clampRagApiTopN = (topN: number, logger: t.Logger): number => {
-  if (topN <= RAG_API_MAX_TOP_N) {
-    return topN;
-  }
-  logger.debug(
-    `rag_api fast-v1 accepts top_n <= ${RAG_API_MAX_TOP_N}; clamping ${topN} to ${RAG_API_MAX_TOP_N}.`
-  );
-  return RAG_API_MAX_TOP_N;
-};
+const clampRagApiTopN = (topN: number): number =>
+  Math.min(topN, RAG_API_MAX_TOP_N);
 
 /** Deterministic tie ordering: rank by score descending, breaking ties on
  * original candidate index rather than relying on rag_api's response order. */
@@ -349,6 +405,7 @@ const withRerankDeadline = <T>(
  * to the candidates' original order via {@link BaseReranker.getDefaultRanking}.
  */
 export class RagApiReranker extends BaseReranker {
+  protected readonly provider = 'rag-api';
   private baseUrl?: string;
   private tokenSupplier?: t.RagApiTokenSupplier;
   private profile: string;
@@ -383,32 +440,28 @@ export class RagApiReranker extends BaseReranker {
   async rerank(
     query: string,
     documents: string[],
-    topK: number = 5
+    topK: number = 5,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]> {
     if (documents.length === 0) {
       return [];
     }
 
-    this.logger.debug(
-      `Reranking ${documents.length} chunks with rag_api (${this.profile}) using base URL: ${this.baseUrl}`
-    );
+    const run = this.beginRerank(documents, topK, metrics);
 
     const baseUrl = this.baseUrl;
     if (baseUrl == null || baseUrl === '') {
-      this.logger.warn('RAG_API_URL is not set. Using default ranking.');
-      return this.getDefaultRanking(documents, topK);
+      return this.fallback(run, 'no_base_url');
     }
 
     const tokenSupplier = this.tokenSupplier;
     if (tokenSupplier == null) {
-      this.logger.warn(
-        'No rag_api token supplier configured. Using default ranking.'
-      );
-      return this.getDefaultRanking(documents, topK);
+      return this.fallback(run, 'no_token_supplier');
     }
 
-    const candidates = buildRagApiCandidates(documents, this.logger);
-    const topN = clampRagApiTopN(Math.max(0, topK), this.logger);
+    const candidates = buildRagApiCandidates(documents);
+    const topN = clampRagApiTopN(Math.max(0, topK));
+    run.dropped = documents.length - candidates.length;
     const requestData: t.RagApiRerankRequestBody = {
       profile: this.profile,
       query,
@@ -436,40 +489,35 @@ export class RagApiReranker extends BaseReranker {
         return response.data;
       }, this.timeout);
 
-      this.logger.debug('rag_api rerank model:', data?.model);
+      run.model = data?.model;
 
       const rawResults = data?.results;
       if (!Array.isArray(rawResults) || rawResults.length === 0) {
-        this.logger.warn(
-          'Unexpected response format from rag_api rerank. Using default ranking.'
-        );
-        return this.getDefaultRanking(documents, topK);
+        return this.fallback(run, 'bad_response');
       }
 
       if (!isValidRagApiBatch(rawResults, candidates.length)) {
-        this.logger.warn(
-          'rag_api rerank response contained no valid results. Using default ranking.'
-        );
-        return this.getDefaultRanking(documents, topK);
+        return this.fallback(run, 'invalid_results');
       }
 
-      return sortRagApiResults(rawResults)
-        .slice(0, topN)
-        .map((result) => ({
-          text: documents[result.index],
-          score: result.score,
-        }));
-    } catch (error) {
-      this.logger.error(
-        'Error using rag_api reranker',
-        formatErrorForLog(error)
+      return this.complete(
+        run,
+        sortRagApiResults(rawResults)
+          .slice(0, topN)
+          .map((result) => ({
+            text: documents[result.index],
+            score: result.score,
+          }))
       );
-      return this.getDefaultRanking(documents, topK);
+    } catch (error) {
+      return this.fallback(run, 'error', formatErrorForLog(error));
     }
   }
 }
 
 export class InfinityReranker extends BaseReranker {
+  protected readonly provider = 'infinity';
+
   constructor(logger?: t.Logger) {
     super(logger);
     // No API key needed for the placeholder implementation
@@ -478,13 +526,14 @@ export class InfinityReranker extends BaseReranker {
   async rerank(
     query: string,
     documents: string[],
-    topK: number = 5
+    topK: number = 5,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]> {
-    this.logger.debug(
-      `Reranking ${documents.length} chunks with Infinity (placeholder)`
-    );
     // This would be replaced with actual Infinity reranker implementation
-    return this.getDefaultRanking(documents, topK);
+    return this.fallback(
+      this.beginRerank(documents, topK, metrics),
+      'placeholder'
+    );
   }
 }
 

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -87,6 +87,8 @@ export abstract class BaseReranker {
       model: run.model,
       units: run.units,
       dropped: run.dropped,
+      topK: run.topKLimit != null ? run.topK : undefined,
+      topKLimit: run.topKLimit,
       reason,
       error,
     });
@@ -325,8 +327,16 @@ const buildRagApiCandidates = (
     ? documents.map(toRagApiCandidate)
     : documents.slice(0, RAG_API_MAX_CANDIDATES).map(toRagApiCandidate);
 
-const clampRagApiTopN = (topN: number): number =>
-  Math.min(topN, RAG_API_MAX_TOP_N);
+/** Reports the clamp on `run` rather than logging it per call: a search
+ * configured above the contract limit returns fewer highlights than asked
+ * for, and the summary is the only place that now says so. */
+const clampRagApiTopN = (topN: number, run: t.RerankRun): number => {
+  if (topN <= RAG_API_MAX_TOP_N) {
+    return topN;
+  }
+  run.topKLimit = RAG_API_MAX_TOP_N;
+  return RAG_API_MAX_TOP_N;
+};
 
 /** Deterministic tie ordering: rank by score descending, breaking ties on
  * original candidate index rather than relying on rag_api's response order. */
@@ -464,7 +474,7 @@ export class RagApiReranker extends BaseReranker {
     }
 
     const candidates = buildRagApiCandidates(documents);
-    const topN = clampRagApiTopN(Math.max(0, topK));
+    const topN = clampRagApiTopN(Math.max(0, topK), run);
     run.dropped = documents.length - candidates.length;
     const requestData: t.RagApiRerankRequestBody = {
       profile: this.profile,

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -177,15 +177,16 @@ export class JinaReranker extends BaseReranker {
       );
 
       run.model = response.data?.model;
-      run.units = response.data?.usage.total_tokens;
+      run.units = response.data?.usage?.total_tokens;
 
-      if (!response.data || !response.data.results.length) {
+      const results = response.data?.results;
+      if (!Array.isArray(results) || results.length === 0) {
         return this.fallback(run, 'bad_response');
       }
 
       return this.complete(
         run,
-        response.data.results.map((result) => {
+        results.map((result) => {
           const docIndex = result.index;
           const score = result.relevance_score;
           let text = '';
@@ -272,15 +273,16 @@ export class CohereReranker extends BaseReranker {
       );
 
       run.model = model;
-      run.units = response.data?.meta.billed_units.search_units;
+      run.units = response.data?.meta?.billed_units?.search_units;
 
-      if (!response.data || !response.data.results.length) {
+      const results = response.data?.results;
+      if (!Array.isArray(results) || results.length === 0) {
         return this.fallback(run, 'bad_response');
       }
 
       return this.complete(
         run,
-        response.data.results.map((result) => {
+        results.map((result) => {
           const docIndex = result.index;
           const score = result.relevance_score;
           const text = documents[docIndex];

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -1,9 +1,14 @@
 import axios from 'axios';
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
-import { getAttribution, createDefaultLogger } from './utils';
+import {
+  getAttribution,
+  createDefaultLogger,
+  formatErrorForLog,
+} from './utils';
 import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
+import { createSearchMetrics } from './metrics';
 import { createCrwAPI } from './crw-search';
 import { BaseReranker } from './rerankers';
 
@@ -139,50 +144,46 @@ function createSourceUpdateCallback(sourceMap: Map<string, t.ValidSource>) {
   };
 }
 
+/** Returns undefined without logging when there is nothing to rank: an empty
+ * scrape is already counted by the scrape summary, and a missing reranker is
+ * reported once at tool construction rather than once per source. */
 const getHighlights = async ({
   query,
   content,
   reranker,
+  metrics,
   topResults = 5,
   maxContentLength = DEFAULT_MAX_CONTENT_LENGTH,
   chunkOptions,
-  logger,
 }: {
   content: string;
   query: string;
   reranker?: BaseReranker;
+  metrics: t.SearchMetrics;
   topResults?: number;
   maxContentLength?: number;
   chunkOptions?: { chunkSize: number; chunkOverlap: number };
-  logger?: t.Logger;
 }): Promise<t.Highlight[] | undefined> => {
-  const logger_ = logger || createDefaultLogger();
-
-  if (!content) {
-    logger_.warn('No content provided for highlights');
-    return;
-  }
-  if (!reranker) {
-    logger_.warn('No reranker provided for highlights');
+  if (!content || !reranker) {
     return;
   }
 
+  const startedAt = Date.now();
   try {
     const documents = await chunker.splitText(
       truncateContent(content, maxContentLength),
       chunkOptions
     );
-    if (Array.isArray(documents)) {
-      return await reranker.rerank(query, documents, topResults);
-    } else {
-      logger_.error(
-        'Expected documents to be an array, got:',
-        typeof documents
-      );
-      return;
-    }
+    return await reranker.rerank(query, documents, topResults, metrics);
   } catch (error) {
-    logger_.error('Error in content processing:', error);
+    metrics.recordRerank({
+      provider: 'chunker',
+      chunks: 0,
+      results: 0,
+      durationMs: Date.now() - startedAt,
+      reason: 'chunk_error',
+      error: formatErrorForLog(error),
+    });
     return;
   }
 };
@@ -598,51 +599,77 @@ export const createSourceProcessor = (
       };
     }
 
-    logger_.error(
-      `Error scraping ${url}: ${response.error ?? 'Unknown error'}`
-    );
     return { url, attribution, error: true, content: '' };
   };
 
   const addHighlights = async (
     result: t.ScrapeResult,
     query: string,
+    metrics: t.SearchMetrics,
     onGetHighlights: t.SearchToolConfig['onGetHighlights']
   ): Promise<t.ScrapeResult> => {
-    if (result.error != null) {
-      return result;
+    const highlights = await getHighlights({
+      query,
+      reranker,
+      metrics,
+      topResults,
+      content: result.content,
+      maxContentLength,
+      chunkOptions,
+    });
+    if (onGetHighlights) {
+      onGetHighlights(result.url);
     }
-    try {
-      const highlights = await getHighlights({
-        query,
-        reranker,
-        topResults,
-        content: result.content,
-        maxContentLength,
-        chunkOptions,
-        logger: logger_,
-      });
-      if (onGetHighlights) {
-        onGetHighlights(result.url);
-      }
-      return { ...result, highlights };
-    } catch (error) {
+    return { ...result, highlights };
+  };
+
+  /** Scrape and rerank one link, recording the single observation that link
+   * contributes to the run summary — the only place a per-link outcome is
+   * reported, so nothing here logs per link. */
+  const processLink = async (
+    url: string,
+    response: t.AnyScraperResponse,
+    query: string,
+    metrics: t.SearchMetrics,
+    onGetHighlights: t.SearchToolConfig['onGetHighlights']
+  ): Promise<t.ScrapeResult> => {
+    const scraped = processResponse(url, response);
+    if (scraped.error === true) {
+      metrics.recordScrape({ url, error: response.error ?? 'Unknown error' });
+      return scraped;
+    }
+    /** `getHighlights` absorbs its own failures, so only a throwing
+     * `onGetHighlights` consumer reaches here; one bad callback must not
+     * discard the sibling links awaiting alongside it. */
+    const result = await addHighlights(
+      scraped,
+      query,
+      metrics,
+      onGetHighlights
+    ).catch((error) => {
       logger_.error('Error processing scraped content:', error);
-      return result;
-    }
+      return scraped;
+    });
+    metrics.recordScrape({
+      url,
+      chars: result.content.length,
+      highlights: result.highlights?.length ?? 0,
+    });
+    return result;
   };
 
   const webScraper = {
     scrapeMany: async ({
       query,
       links,
+      metrics,
       onGetHighlights,
     }: {
       query: string;
       links: string[];
+      metrics: t.SearchMetrics;
       onGetHighlights: t.SearchToolConfig['onGetHighlights'];
     }): Promise<Array<t.ScrapeResult>> => {
-      logger_.debug(`Scraping ${links.length} links`);
       try {
         let responses: Array<[string, t.AnyScraperResponse]>;
 
@@ -653,24 +680,19 @@ export const createSourceProcessor = (
             links.map((link) =>
               scraper
                 .scrapeUrl(link, {})
-                .catch((error): [string, t.AnyScraperResponse] => {
-                  logger_.error(`Error scraping ${link}:`, error);
-                  return [link, { success: false, error: String(error) }];
-                })
+                .catch((error): [string, t.AnyScraperResponse] => [
+                  link,
+                  { success: false, error: String(error) },
+                ])
             )
           );
         }
 
-        const withHighlights = await Promise.all(
+        return await Promise.all(
           responses.map(([url, response]) =>
-            addHighlights(
-              processResponse(url, response),
-              query,
-              onGetHighlights
-            )
+            processLink(url, response, query, metrics, onGetHighlights)
           )
         );
-        return withHighlights;
       } catch (error) {
         logger_.error('Error in scrapeMany:', error);
         return [];
@@ -682,12 +704,14 @@ export const createSourceProcessor = (
     links,
     query,
     target,
+    metrics,
     onGetHighlights,
     onContentScraped,
   }: {
     links: string[];
     query: string;
     target: number;
+    metrics: t.SearchMetrics;
     onGetHighlights: t.SearchToolConfig['onGetHighlights'];
     onContentScraped?: (link: string, update?: Partial<t.ValidSource>) => void;
   }): Promise<void> => {
@@ -695,6 +719,7 @@ export const createSourceProcessor = (
     // const remainingLinks = links.slice(target).reverse();
     const results = await webScraper.scrapeMany({
       query,
+      metrics,
       links: initialLinks,
       onGetHighlights,
     });
@@ -719,7 +744,11 @@ export const createSourceProcessor = (
     news,
     proMode = true,
     onGetHighlights,
+    metrics: ownerMetrics,
   }: t.ProcessSourcesFields): Promise<t.SearchResultData> => {
+    /** The caller owns the collector when it supplies one — it has phases of
+     * its own to fold in and flushes them together. */
+    const metrics = ownerMetrics ?? createSearchMetrics(logger_);
     try {
       if (!result.data) {
         return {
@@ -759,6 +788,7 @@ export const createSourceProcessor = (
         const onContentScraped = createSourceUpdateCallback(wikiSourceMap);
         await fetchContents({
           query,
+          metrics,
           target: 1,
           onGetHighlights,
           onContentScraped,
@@ -809,6 +839,7 @@ export const createSourceProcessor = (
         promises.push(
           fetchContents({
             query,
+            metrics,
             onGetHighlights,
             onContentScraped,
             links: organicLinks,
@@ -822,6 +853,7 @@ export const createSourceProcessor = (
         promises.push(
           fetchContents({
             query,
+            metrics,
             onGetHighlights,
             onContentScraped,
             links: topStoryLinks,
@@ -851,6 +883,10 @@ export const createSourceProcessor = (
         ...result.data,
         error: error instanceof Error ? error.message : String(error),
       };
+    } finally {
+      if (ownerMetrics == null) {
+        metrics.flush();
+      }
     }
   };
 

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -176,8 +176,12 @@ const getHighlights = async ({
     );
     return await reranker.rerank(query, documents, topResults, metrics);
   } catch (error) {
+    /** Chunking failed before the reranker was reached, but this was still
+     * that reranker's attempt for this source — labelling it with the real
+     * provider keeps one coherent phase, and `chunk_error` says where it
+     * broke. */
     metrics.recordRerank({
-      provider: 'chunker',
+      provider: reranker.provider,
       chunks: 0,
       results: 0,
       durationMs: Date.now() - startedAt,
@@ -633,7 +637,16 @@ export const createSourceProcessor = (
     metrics: t.SearchMetrics,
     onGetHighlights: t.SearchToolConfig['onGetHighlights']
   ): Promise<t.ScrapeResult> => {
-    const scraped = processResponse(url, response);
+    /** `extractContent`/`extractMetadata` are the scraper implementation's
+     * code: one malformed response must not reject alongside its siblings,
+     * which would discard their results and their observations with them. */
+    let scraped: t.ScrapeResult;
+    try {
+      scraped = processResponse(url, response);
+    } catch (error) {
+      metrics.recordScrape({ url, error: String(error) });
+      return { url, error: true, content: '' };
+    }
     if (scraped.error === true) {
       metrics.recordScrape({ url, error: response.error ?? 'Unknown error' });
       return scraped;

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -168,24 +168,41 @@ const getHighlights = async ({
     return;
   }
 
-  const startedAt = Date.now();
+  /** Both failures are this reranker's attempt for this source, so they stay
+   * in its phase — but they are caught separately: sharing one `catch` would
+   * report a reranker that threw as a chunking failure, with a chunk count
+   * of zero for text that split fine. */
+  const chunkStartedAt = Date.now();
+  let documents: string[];
   try {
-    const documents = await chunker.splitText(
+    documents = await chunker.splitText(
       truncateContent(content, maxContentLength),
       chunkOptions
     );
-    return await reranker.rerank(query, documents, topResults, metrics);
   } catch (error) {
-    /** Chunking failed before the reranker was reached, but this was still
-     * that reranker's attempt for this source — labelling it with the real
-     * provider keeps one coherent phase, and `chunk_error` says where it
-     * broke. */
     metrics.recordRerank({
       provider: reranker.provider,
       chunks: 0,
       results: 0,
-      durationMs: Date.now() - startedAt,
+      durationMs: Date.now() - chunkStartedAt,
       reason: 'chunk_error',
+      error: formatErrorForLog(error),
+    });
+    return;
+  }
+
+  const rerankStartedAt = Date.now();
+  try {
+    return await reranker.rerank(query, documents, topResults, metrics);
+  } catch (error) {
+    /** The bundled rerankers absorb their own failures and record the
+     * observation themselves; a custom implementation may reject instead. */
+    metrics.recordRerank({
+      provider: reranker.provider,
+      chunks: documents.length,
+      results: 0,
+      durationMs: Date.now() - rerankStartedAt,
+      reason: 'error',
       error: formatErrorForLog(error),
     });
     return;
@@ -683,9 +700,14 @@ export const createSourceProcessor = (
       metrics: t.SearchMetrics;
       onGetHighlights: t.SearchToolConfig['onGetHighlights'];
     }): Promise<Array<t.ScrapeResult>> => {
-      try {
-        let responses: Array<[string, t.AnyScraperResponse]>;
+      let responses: Array<[string, t.AnyScraperResponse]>;
 
+      /** Scoped to acquisition alone. A batch `scrapeUrls` that rejects
+       * yields no per-link responses, so nothing downstream will ever report
+       * these links — without recording them here a total outage would flush
+       * no scrape summary at all, reading exactly like a search that never
+       * scraped anything. */
+      try {
         if (scraper.scrapeUrls) {
           responses = await scraper.scrapeUrls(links);
         } else {
@@ -700,13 +722,25 @@ export const createSourceProcessor = (
             )
           );
         }
+      } catch (error) {
+        logger_.error('Error in scrapeMany:', error);
+        const message = String(error);
+        for (const link of links) {
+          metrics.recordScrape({ url: link, error: message });
+        }
+        return [];
+      }
 
+      try {
         return await Promise.all(
           responses.map(([url, response]) =>
             processLink(url, response, query, metrics, onGetHighlights)
           )
         );
       } catch (error) {
+        /** `processLink` absorbs its own failures and has already recorded
+         * whatever it reached, so this only preserves the soft failure the
+         * caller has always seen — it must not re-count these links. */
         logger_.error('Error in scrapeMany:', error);
         return [];
       }

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -503,12 +503,13 @@ describe('executeParallelSearches topStories dedupe', () => {
 
     const merged = await executeParallelSearches({
       searchAPI,
-      provider: 'serper',
       query: 'test query',
       safeSearch: 1,
       images: false,
       videos: false,
       news: true,
+      logger: silentLogger,
+      provider: 'serper',
       metrics: createSearchMetrics(silentLogger),
     });
 
@@ -621,5 +622,98 @@ describe('createSourceProcessor log volume', () => {
 
     metrics.flush();
     expect(logger.debug).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('executeParallelSearches call contract', () => {
+  const createMockLogger = (): t.Logger =>
+    ({
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    }) as unknown as t.Logger;
+
+  const okResult: t.SearchResult = {
+    success: true,
+    data: { organic: [makeOrganic('https://a.com')] },
+  };
+
+  test('summarizes itself when called with only the legacy arguments', async () => {
+    const logger = createMockLogger();
+    const searchAPI = { getSources: async (): Promise<t.SearchResult> => okResult };
+
+    const merged = await executeParallelSearches({
+      searchAPI,
+      query: 'test query',
+      safeSearch: 1,
+      images: false,
+      videos: false,
+      news: false,
+      logger,
+    });
+
+    expect(merged.success).toBe(true);
+    /** No collector supplied, so this call owns and flushes its own. */
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(String((logger.debug as jest.Mock).mock.calls[0][0])).toContain(
+      'search=unknown queries=1'
+    );
+  });
+
+  test('rethrows the main search error object rather than a wrapped copy', async () => {
+    const logger = createMockLogger();
+    class ProviderError extends Error {}
+    const failure = new ProviderError('provider exploded');
+    const searchAPI = {
+      getSources: async (): Promise<t.SearchResult> => {
+        throw failure;
+      },
+    };
+
+    await expect(
+      executeParallelSearches({
+        searchAPI,
+        query: 'test query',
+        safeSearch: 1,
+        images: false,
+        videos: false,
+        news: false,
+        logger,
+      })
+    ).rejects.toBe(failure);
+
+    /** A rejected query was error-level before it was aggregated. */
+    expect(logger.warn).not.toHaveBeenCalled();
+    const [line, detail] = (logger.error as jest.Mock).mock.calls[0];
+    expect(String(line)).toContain('failed=1 reasons={web:other:1}');
+    expect(detail).toBe('provider exploded');
+  });
+
+  test('keeps a sub-search failure off the error channel', async () => {
+    const logger = createMockLogger();
+    const searchAPI = {
+      getSources: async (params: t.GetSourcesParams): Promise<t.SearchResult> =>
+        params.type === 'news'
+          ? { success: false, error: 'timeout of 10000ms exceeded' }
+          : okResult,
+    };
+
+    const merged = await executeParallelSearches({
+      searchAPI,
+      query: 'test query',
+      safeSearch: 1,
+      images: false,
+      videos: false,
+      news: true,
+      logger,
+      provider: 'serper',
+    });
+
+    expect(merged.success).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(String((logger.warn as jest.Mock).mock.calls[0][0])).toContain(
+      'failed=1 reasons={news:timeout:1}'
+    );
   });
 });

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -14,7 +14,7 @@ const silentLogger = {
 } as t.Logger;
 
 class RecordingReranker extends BaseReranker {
-  protected readonly provider = 'recording';
+  readonly provider = 'recording';
   public rerankCalls: string[][] = [];
   public topKCalls: number[] = [];
 
@@ -688,6 +688,44 @@ describe('executeParallelSearches call contract', () => {
     const [line, detail] = (logger.error as jest.Mock).mock.calls[0];
     expect(String(line)).toContain('failed=1 reasons={web:other:1}');
     expect(detail).toBe('provider exploded');
+  });
+
+  test('records a slow sibling failure even when the main search rejects first', async () => {
+    const logger = createMockLogger();
+    const failure = new Error('main provider exploded');
+    const searchAPI = {
+      getSources: async (
+        params: t.GetSourcesParams
+      ): Promise<t.SearchResult> => {
+        if (params.type !== 'images') {
+          throw failure;
+        }
+        // Settles well after the main search has already rejected.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { success: false, error: 'timeout of 10000ms exceeded' };
+      },
+    };
+
+    await expect(
+      executeParallelSearches({
+        searchAPI,
+        query: 'test query',
+        safeSearch: 1,
+        images: true,
+        videos: false,
+        news: false,
+        logger,
+        provider: 'serper',
+      })
+    ).rejects.toBe(failure);
+
+    /** The summary must not be flushed while a sibling is still in flight,
+     * or that provider's failure is lost from the aggregate entirely. */
+    const line = String((logger.error as jest.Mock).mock.calls[0][0]);
+    expect(line).toContain('queries=2');
+    expect(line).toContain('failed=2');
+    expect(line).toContain('images:timeout:1');
+    expect(line).toContain('web:other:1');
   });
 
   test('keeps a sub-search failure off the error channel', async () => {

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -599,6 +599,83 @@ describe('createSourceProcessor log volume', () => {
     expect(rerankLine).toContain('rerank=recording calls=6');
   });
 
+  test('attributes a rejecting reranker to the reranker, not the chunker', async () => {
+    const logger = createCountingLogger();
+    class RejectingReranker extends BaseReranker {
+      readonly provider = 'custom';
+      constructor() {
+        super(silentLogger);
+      }
+      async rerank(): Promise<t.Highlight[]> {
+        throw new Error('custom reranker exploded');
+      }
+    }
+    const link = 'https://a.com';
+    const processor = createSourceProcessor(
+      { reranker: new RejectingReranker(), logger },
+      createFakeScraper({ [link]: makeLongContent(2000) })
+    );
+
+    await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 1,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+    });
+
+    /** Splitting succeeded, so the chunk count is real and the reason must
+     * point at the reranker rather than the chunker. */
+    const summary = (logger.error as jest.Mock).mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.includes('[web_search] rerank'));
+    expect(summary).toContain('rerank=custom calls=1');
+    expect(summary).toContain('reasons={error:1}');
+    expect(summary).not.toContain('chunk_error');
+    expect(summary).not.toContain('chunks=0');
+  });
+
+  test('counts every link of a batch scrape that never returned responses', async () => {
+    const logger = createCountingLogger();
+    const links = ['https://a.com', 'https://b.com', 'https://c.com'];
+    const scraper: t.BaseScraper = {
+      scrapeUrl: async (url: string): Promise<[string, t.AnyScraperResponse]> => [
+        url,
+        { success: true, data: { markdown: 'unused' } },
+      ],
+      scrapeUrls: async (): Promise<Array<[string, t.AnyScraperResponse]>> => {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:3002');
+      },
+      extractContent: (): [string, undefined] => ['', undefined],
+      extractMetadata: (): t.GenericScrapeMetadata => ({}),
+    };
+    const processor = createSourceProcessor(
+      { reranker: new RecordingReranker(), logger },
+      scraper
+    );
+
+    await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: links.length,
+      result: {
+        success: true,
+        data: { organic: links.map((link) => makeOrganic(link)) },
+      },
+    });
+
+    /** A wholly failed batch must not read like a search that scraped
+     * nothing: the summary has to show the attempt and the outage. */
+    const summary = (logger.error as jest.Mock).mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.includes('[web_search] scrape'));
+    expect(summary).toContain('links=3 ok=0');
+    expect(summary).toContain('failed=3 reasons={connection:3}');
+  });
+
   test('flushes to the owning collector instead of logging itself', async () => {
     const logger = createCountingLogger();
     const metrics = createSearchMetrics(logger);

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -1,6 +1,7 @@
 import type * as t from './types';
 import { executeParallelSearches } from './tool';
 import { createSourceProcessor } from './search';
+import { createSearchMetrics } from './metrics';
 import { expandHighlights } from './highlights';
 import { BaseReranker } from './rerankers';
 
@@ -13,6 +14,7 @@ const silentLogger = {
 } as t.Logger;
 
 class RecordingReranker extends BaseReranker {
+  protected readonly provider = 'recording';
   public rerankCalls: string[][] = [];
   public topKCalls: number[] = [];
 
@@ -23,11 +25,15 @@ class RecordingReranker extends BaseReranker {
   async rerank(
     _query: string,
     documents: string[],
-    topK: number = 5
+    topK: number = 5,
+    metrics?: t.SearchMetrics
   ): Promise<t.Highlight[]> {
     this.rerankCalls.push(documents);
     this.topKCalls.push(topK);
-    return this.getDefaultRanking(documents, topK);
+    return this.complete(
+      this.beginRerank(documents, topK, metrics),
+      this.getDefaultRanking(documents, topK)
+    );
   }
 }
 
@@ -497,12 +503,13 @@ describe('executeParallelSearches topStories dedupe', () => {
 
     const merged = await executeParallelSearches({
       searchAPI,
+      provider: 'serper',
       query: 'test query',
       safeSearch: 1,
       images: false,
       videos: false,
       news: true,
-      logger: silentLogger,
+      metrics: createSearchMetrics(silentLogger),
     });
 
     expect(merged.data?.topStories?.map((story) => story.link)).toEqual([
@@ -512,5 +519,107 @@ describe('executeParallelSearches topStories dedupe', () => {
     ]);
     expect(merged.data?.topStories?.[0].title).toBe('Story for https://n1.com');
     expect(merged.data?.news).toBeUndefined();
+  });
+});
+
+describe('createSourceProcessor log volume', () => {
+  const createCountingLogger = (): t.Logger =>
+    ({
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    }) as unknown as t.Logger;
+
+  const createMixedScraper = (
+    okLinks: string[],
+    failingLinks: Map<string, string>
+  ): t.BaseScraper => ({
+    scrapeUrl: async (url: string): Promise<[string, t.AnyScraperResponse]> => {
+      const failure = failingLinks.get(url);
+      if (failure != null) {
+        return [url, { success: false, error: failure }];
+      }
+      return [
+        url,
+        {
+          success: true,
+          data: { markdown: okLinks.includes(url) ? makeLongContent(4000) : '' },
+        },
+      ];
+    },
+    extractContent: (
+      response: t.AnyScraperResponse
+    ): [string, undefined | t.References] => [
+      (response as t.FirecrawlScrapeResponse).data?.markdown ?? '',
+      undefined,
+    ],
+    extractMetadata: (): t.GenericScrapeMetadata => ({}),
+  });
+
+  test('summarizes an eight-source search in one line per phase', async () => {
+    const logger = createCountingLogger();
+    const okLinks = Array.from({ length: 6 }, (_, i) => `https://ok${i}.com`);
+    const failing = new Map([
+      ['https://bad0.com', 'Request failed with status code 403'],
+      ['https://bad1.com', 'timeout of 7500ms exceeded'],
+    ]);
+    const links = [...okLinks, ...failing.keys()];
+    const processor = createSourceProcessor(
+      { reranker: new RecordingReranker(), logger },
+      createMixedScraper(okLinks, failing)
+    );
+
+    await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: links.length,
+      result: {
+        success: true,
+        data: { organic: links.map((link) => makeOrganic(link)) },
+      },
+    });
+
+    /** Eight links formerly logged a scrape line plus three reranker lines
+     * each; the whole call must now cost one line per phase. */
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    const scrapeLine = String((logger.error as jest.Mock).mock.calls[0][0]);
+    expect(scrapeLine).toContain('links=8 ok=6');
+    expect(scrapeLine).toContain(
+      'failed=2 reasons={http_403:1,timeout:1}'
+    );
+
+    const rerankLine = String((logger.debug as jest.Mock).mock.calls[0][0]);
+    expect(rerankLine).toContain('rerank=recording calls=6');
+  });
+
+  test('flushes to the owning collector instead of logging itself', async () => {
+    const logger = createCountingLogger();
+    const metrics = createSearchMetrics(logger);
+    const link = 'https://a.com';
+    const processor = createSourceProcessor(
+      { reranker: new RecordingReranker(), logger },
+      createFakeScraper({ [link]: makeLongContent(2000) })
+    );
+
+    await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 1,
+      metrics,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+    });
+
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    metrics.flush();
+    expect(logger.debug).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -767,6 +767,38 @@ describe('executeParallelSearches call contract', () => {
     expect(detail).toBe('provider exploded');
   });
 
+  test('counts a row shared by organic and topStories once', async () => {
+    const logger = createMockLogger();
+    /** The SearXNG shape: both collections built from the same rows. */
+    const shared: t.SearchResult = {
+      success: true,
+      data: {
+        organic: [
+          makeOrganic('https://a.com'),
+          makeOrganic('https://news.com'),
+          makeOrganic('https://c.com'),
+        ],
+        topStories: [makeStory('https://news.com')],
+      },
+    };
+    const searchAPI = { getSources: async (): Promise<t.SearchResult> => shared };
+
+    await executeParallelSearches({
+      searchAPI,
+      query: 'test query',
+      safeSearch: 1,
+      images: false,
+      videos: false,
+      news: false,
+      logger,
+      provider: 'searxng',
+    });
+
+    expect(String((logger.debug as jest.Mock).mock.calls[0][0])).toContain(
+      'results={web:3}'
+    );
+  });
+
   test('records a slow sibling failure even when the main search rejects first', async () => {
     const logger = createMockLogger();
     const failure = new Error('main provider exploded');

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -21,6 +21,7 @@ import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
 import { formatResultsForLLM } from './format';
+import { createSearchMetrics } from './metrics';
 import { createDefaultLogger } from './utils';
 import { createReranker } from './rerankers';
 import { Constants } from '@/common';
@@ -65,12 +66,33 @@ export function resolveSearchOutcome(
   return `Found ${count} result${count === 1 ? '' : 's'} for "${query}"`;
 }
 
+/** Rows a sub-search contributed, for the run summary's per-type breakdown. */
+const countResults = (
+  type: t.SubSearchType,
+  data?: t.SearchResultData
+): number => {
+  if (data == null) {
+    return 0;
+  }
+  if (type === 'images') {
+    return data.images?.length ?? 0;
+  }
+  if (type === 'videos') {
+    return data.videos?.length ?? 0;
+  }
+  if (type === 'news') {
+    return data.news?.length ?? 0;
+  }
+  return (data.organic?.length ?? 0) + (data.topStories?.length ?? 0);
+};
+
 /**
  * Executes parallel searches and merges the results,
  * deduplicating top stories by link
  */
 export async function executeParallelSearches({
   searchAPI,
+  provider,
   query,
   date,
   country,
@@ -78,9 +100,10 @@ export async function executeParallelSearches({
   images,
   videos,
   news,
-  logger,
+  metrics,
 }: {
   searchAPI: ReturnType<typeof createSearchAPI>;
+  provider: string;
   query: string;
   date?: DATE_RANGE;
   country?: string;
@@ -88,75 +111,53 @@ export async function executeParallelSearches({
   images: boolean;
   videos: boolean;
   news: boolean;
-  logger: t.Logger;
+  metrics: t.SearchMetrics;
 }): Promise<t.SearchResult> {
+  /** Every sub-search shares this shape, and a failed one must resolve rather
+   * than reject so the siblings still merge; only the main search's failure
+   * is fatal, and that is raised from its `success` flag below. */
+  const runSearch = async (type: t.SubSearchType): Promise<t.SearchResult> => {
+    const startedAt = Date.now();
+    try {
+      const result = await searchAPI.getSources({
+        query,
+        date,
+        country,
+        safeSearch,
+        ...(type !== 'web' && { type }),
+      });
+      metrics.recordSearch({
+        provider,
+        type,
+        results: countResults(type, result.data),
+        durationMs: Date.now() - startedAt,
+        error: result.success ? undefined : (result.error ?? 'Search failed'),
+      });
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      metrics.recordSearch({
+        provider,
+        type,
+        results: 0,
+        durationMs: Date.now() - startedAt,
+        error: message,
+      });
+      return { success: false, error: `${type} search failed: ${message}` };
+    }
+  };
+
   // Prepare all search tasks to run in parallel
-  const searchTasks: Promise<t.SearchResult>[] = [
-    // Main search
-    searchAPI.getSources({
-      query,
-      date,
-      country,
-      safeSearch,
-    }),
-  ];
+  const searchTasks: Promise<t.SearchResult>[] = [runSearch('web')];
 
   if (images) {
-    searchTasks.push(
-      searchAPI
-        .getSources({
-          query,
-          date,
-          country,
-          safeSearch,
-          type: 'images',
-        })
-        .catch((error) => {
-          logger.error('Error fetching images:', error);
-          return {
-            success: false,
-            error: `Images search failed: ${error instanceof Error ? error.message : String(error)}`,
-          };
-        })
-    );
+    searchTasks.push(runSearch('images'));
   }
   if (videos) {
-    searchTasks.push(
-      searchAPI
-        .getSources({
-          query,
-          date,
-          country,
-          safeSearch,
-          type: 'videos',
-        })
-        .catch((error) => {
-          logger.error('Error fetching videos:', error);
-          return {
-            success: false,
-            error: `Videos search failed: ${error instanceof Error ? error.message : String(error)}`,
-          };
-        })
-    );
+    searchTasks.push(runSearch('videos'));
   }
   if (news) {
-    searchTasks.push(
-      searchAPI
-        .getSources({
-          query,
-          date,
-          country,
-          safeSearch,
-          type: 'news',
-        })
-        .catch((error) => {
-          logger.error('Error fetching news:', error);
-          return {
-            success: false,
-            error: `News search failed: ${error instanceof Error ? error.message : String(error)}`,
-          };
-        })
-    );
+    searchTasks.push(runSearch('news'));
   }
 
   // Run all searches in parallel
@@ -239,6 +240,7 @@ export async function executeParallelSearches({
 
 function createSearchProcessor({
   searchAPI,
+  provider,
   safeSearch,
   supportsImages,
   supportsVideos,
@@ -249,6 +251,7 @@ function createSearchProcessor({
   separatorExpandBy,
   logger,
 }: {
+  provider: string;
   safeSearch: t.SearchToolConfig['safeSearch'];
   supportsImages: boolean;
   supportsVideos: boolean;
@@ -281,10 +284,15 @@ function createSearchProcessor({
     videos?: boolean;
     news?: boolean;
   }): Promise<t.SearchResultData> {
+    /** One collector for the whole call: the provider, scrape, and rerank
+     * phases each fold into counters and flush together, so a search costs a
+     * bounded handful of lines instead of a few per source. */
+    const metrics = createSearchMetrics(logger);
     try {
       // Execute parallel searches and merge results
       const searchResult = await executeParallelSearches({
         searchAPI,
+        provider,
         query,
         date,
         country,
@@ -292,7 +300,7 @@ function createSearchProcessor({
         images: supportsImages && images,
         videos: supportsVideos && videos,
         news: supportsNews && news,
-        logger,
+        metrics,
       });
 
       onSearchResults?.(searchResult);
@@ -300,6 +308,7 @@ function createSearchProcessor({
       const processedSources = await sourceProcessor.processSources({
         query,
         news,
+        metrics,
         result: searchResult,
         proMode,
         onGetHighlights,
@@ -322,6 +331,8 @@ function createSearchProcessor({
         relatedSearches: [],
         error: error instanceof Error ? error.message : String(error),
       };
+    } finally {
+      metrics.flush();
     }
   };
 }
@@ -585,7 +596,9 @@ export const createSearchTool = (
     logger,
   });
 
-  if (!selectedReranker) {
+  /** `none` is a deliberate opt-out that `createReranker` already reports;
+   * only an unusable configuration warrants a warning here. */
+  if (!selectedReranker && rerankerType !== 'none') {
     logger.warn('No reranker selected. Using default ranking.');
   }
 
@@ -605,6 +618,7 @@ export const createSearchTool = (
 
   const search = createSearchProcessor({
     searchAPI,
+    provider: searchProvider,
     safeSearch,
     // Keenable is organic-only: its API ignores `type`, so image/news
     // sub-searches would spend rate limit and merge nothing.

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -92,7 +92,6 @@ const countResults = (
  */
 export async function executeParallelSearches({
   searchAPI,
-  provider,
   query,
   date,
   country,
@@ -100,10 +99,11 @@ export async function executeParallelSearches({
   images,
   videos,
   news,
+  logger,
+  provider = 'unknown',
   metrics,
 }: {
   searchAPI: ReturnType<typeof createSearchAPI>;
-  provider: string;
   query: string;
   date?: DATE_RANGE;
   country?: string;
@@ -111,11 +111,19 @@ export async function executeParallelSearches({
   images: boolean;
   videos: boolean;
   news: boolean;
-  metrics: t.SearchMetrics;
+  logger: t.Logger;
+  /** Labels the provider in the run summary. Optional so the pre-existing
+   * call contract still holds for callers outside this package. */
+  provider?: string;
+  /** Collector owned by the caller. Without one, this call opens and flushes
+   * its own, so a direct caller still gets the single summary line. */
+  metrics?: t.SearchMetrics;
 }): Promise<t.SearchResult> {
-  /** Every sub-search shares this shape, and a failed one must resolve rather
-   * than reject so the siblings still merge; only the main search's failure
-   * is fatal, and that is raised from its `success` flag below. */
+  const collector = metrics ?? createSearchMetrics(logger);
+
+  /** Sub-searches resolve rather than reject so their siblings still merge.
+   * A rejected MAIN search stays fatal and rethrows the provider's own error
+   * — callers have always seen that error object, not a wrapped copy. */
   const runSearch = async (type: t.SubSearchType): Promise<t.SearchResult> => {
     const startedAt = Date.now();
     try {
@@ -126,7 +134,7 @@ export async function executeParallelSearches({
         safeSearch,
         ...(type !== 'web' && { type }),
       });
-      metrics.recordSearch({
+      collector.recordSearch({
         provider,
         type,
         results: countResults(type, result.data),
@@ -136,14 +144,18 @@ export async function executeParallelSearches({
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      metrics.recordSearch({
+      collector.recordSearch({
         provider,
         type,
         results: 0,
         durationMs: Date.now() - startedAt,
         error: message,
+        thrown: true,
       });
-      return { success: false, error: `${type} search failed: ${message}` };
+      if (type === 'web') {
+        throw error;
+      }
+      return { success: false, error: message };
     }
   };
 
@@ -161,7 +173,11 @@ export async function executeParallelSearches({
   }
 
   // Run all searches in parallel
-  const results = await Promise.all(searchTasks);
+  const results = await Promise.all(searchTasks).finally(() => {
+    if (metrics == null) {
+      collector.flush();
+    }
+  });
 
   // Get the main search result (first result)
   const mainResult = results[0];
@@ -292,7 +308,6 @@ function createSearchProcessor({
       // Execute parallel searches and merge results
       const searchResult = await executeParallelSearches({
         searchAPI,
-        provider,
         query,
         date,
         country,
@@ -300,6 +315,8 @@ function createSearchProcessor({
         images: supportsImages && images,
         videos: supportsVideos && videos,
         news: supportsNews && news,
+        logger,
+        provider,
         metrics,
       });
 

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -66,6 +66,30 @@ export function resolveSearchOutcome(
   return `Found ${count} result${count === 1 ? '' : 's'} for "${query}"`;
 }
 
+/** Distinct rows across the main search's two collections. SearXNG derives
+ * both from one result array — a row matching its news heuristic lands in
+ * `organic` and `topStories` alike — so summing the lengths would report
+ * more rows than the provider actually returned. */
+const countWebResults = (data: t.SearchResultData): number => {
+  const organic = data.organic ?? [];
+  const topStories = data.topStories ?? [];
+  if (organic.length === 0 || topStories.length === 0) {
+    return organic.length + topStories.length;
+  }
+
+  const links = new Set<string>();
+  let unlinked = 0;
+  for (const row of [...organic, ...topStories]) {
+    if (row.link) {
+      links.add(row.link);
+      continue;
+    }
+    /** Nothing to dedupe a blank link against, so it counts on its own. */
+    unlinked += 1;
+  }
+  return links.size + unlinked;
+};
+
 /** Rows a sub-search contributed, for the run summary's per-type breakdown. */
 const countResults = (
   type: t.SubSearchType,
@@ -83,7 +107,7 @@ const countResults = (
   if (type === 'news') {
     return data.news?.length ?? 0;
   }
-  return (data.organic?.length ?? 0) + (data.topStories?.length ?? 0);
+  return countWebResults(data);
 };
 
 /**

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -120,10 +120,15 @@ export async function executeParallelSearches({
   metrics?: t.SearchMetrics;
 }): Promise<t.SearchResult> {
   const collector = metrics ?? createSearchMetrics(logger);
+  /** A rejected main search is fatal, but rethrowing it from the task itself
+   * would settle `Promise.all` while its siblings are still in flight, and
+   * their observations would then land in an already-flushed phase. Every
+   * task resolves; the failure is held here and raised once all have run. */
+  let mainFailure: { error: unknown } | undefined;
 
   /** Sub-searches resolve rather than reject so their siblings still merge.
-   * A rejected MAIN search stays fatal and rethrows the provider's own error
-   * — callers have always seen that error object, not a wrapped copy. */
+   * A rejected MAIN search rethrows the provider's own error below — callers
+   * have always seen that error object, not a wrapped copy. */
   const runSearch = async (type: t.SubSearchType): Promise<t.SearchResult> => {
     const startedAt = Date.now();
     try {
@@ -153,7 +158,7 @@ export async function executeParallelSearches({
         thrown: true,
       });
       if (type === 'web') {
-        throw error;
+        mainFailure = { error };
       }
       return { success: false, error: message };
     }
@@ -172,12 +177,16 @@ export async function executeParallelSearches({
     searchTasks.push(runSearch('news'));
   }
 
-  // Run all searches in parallel
-  const results = await Promise.all(searchTasks).finally(() => {
-    if (metrics == null) {
-      collector.flush();
-    }
-  });
+  // Run all searches in parallel. No task rejects, so every observation is
+  // recorded before the collector is flushed or a failure is raised.
+  const results = await Promise.all(searchTasks);
+  if (metrics == null) {
+    collector.flush();
+  }
+
+  if (mainFailure != null) {
+    throw mainFailure.error;
+  }
 
   // Get the main search result (first result)
   const mainResult = results[0];

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -468,6 +468,10 @@ export interface RerankObservation {
   units?: number;
   /** Chunks a provider candidate cap dropped before submission. */
   dropped?: number;
+  /** Set only when a provider cap reduced the requested result count, so a
+   * search returning fewer highlights than configured says why. */
+  topK?: number;
+  topKLimit?: number;
   reason?: RerankFallback;
   error?: SafeErrorLog;
 }
@@ -482,6 +486,7 @@ export interface RerankRun {
   model?: string;
   units?: number;
   dropped?: number;
+  topKLimit?: number;
 }
 
 /**

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -407,6 +407,87 @@ export interface RagApiRerankResponse {
 export type SafeSearchLevel = 0 | 1 | 2;
 
 export type Logger = WinstonLogger;
+
+/** Compact, redacted view of a thrown error, safe to hand to a logger. */
+export interface SafeErrorLog {
+  message: string;
+  name?: string;
+  code?: string;
+  status?: number;
+  method?: string;
+  url?: string;
+  responseDataSummary?: string;
+  value?: string;
+}
+
+/** Why a rerank returned the candidates' original order instead of a ranking. */
+export type RerankFallback =
+  | 'no_api_key'
+  | 'no_base_url'
+  | 'no_token_supplier'
+  | 'bad_response'
+  | 'invalid_results'
+  | 'chunk_error'
+  | 'placeholder'
+  | 'error';
+
+/** One provider query. `results` is the row count that query contributed. */
+export interface SearchObservation {
+  provider: string;
+  type: string;
+  results: number;
+  durationMs: number;
+  error?: string;
+}
+
+/** One scraped link. A failure carries `error`; a success carries the sizes
+ * the scrape produced, so the summary can report both without a second pass. */
+export interface ScrapeObservation {
+  url: string;
+  chars?: number;
+  highlights?: number;
+  error?: string;
+}
+
+/** One reranker round trip. A search reranks once per scraped source, so
+ * these fold into a single summary rather than logging per source. */
+export interface RerankObservation {
+  provider: string;
+  chunks: number;
+  results: number;
+  durationMs: number;
+  model?: string;
+  /** Provider-reported usage: Jina tokens, Cohere billed search units. */
+  units?: number;
+  /** Chunks a provider candidate cap dropped before submission. */
+  dropped?: number;
+  reason?: RerankFallback;
+  error?: SafeErrorLog;
+}
+
+/** Per-rerank state threaded from the start of a call to whichever exit it
+ * takes, so every path records exactly one observation. */
+export interface RerankRun {
+  metrics: SearchMetrics;
+  documents: string[];
+  topK: number;
+  startedAt: number;
+  model?: string;
+  units?: number;
+  dropped?: number;
+}
+
+/**
+ * Fold-as-you-go counters for one `web_search` call. Recording is O(1) and
+ * allocation-free past a bounded reason map; {@link SearchMetrics.flush}
+ * emits at most one line per phase that actually ran.
+ */
+export interface SearchMetrics {
+  recordSearch(observation: SearchObservation): void;
+  recordScrape(observation: ScrapeObservation): void;
+  recordRerank(observation: RerankObservation): void;
+  flush(): void;
+}
 export interface SearchToolConfig
   extends SearchConfig,
     ProcessSourcesConfig,
@@ -701,6 +782,10 @@ export interface FirecrawlScraperConfig extends BaseSearchProviderConfig {
   onlyMainContent?: boolean;
   changeTrackingOptions?: object;
 }
+
+/** Result kind a parallel sub-search covers; `web` is the untyped main
+ * search, which every provider serves without a `type` parameter. */
+export type SubSearchType = 'web' | 'images' | 'videos' | 'news';
 
 export type GetSourcesParams = {
   query: string;
@@ -1038,6 +1123,9 @@ export type ProcessSourcesFields = {
   news: boolean;
   proMode: boolean;
   onGetHighlights: SearchToolConfig['onGetHighlights'];
+  /** Collector owned by the caller; when omitted, one is created and flushed
+   * for this call so a direct `processSources` still summarizes itself. */
+  metrics?: SearchMetrics;
 };
 
 export interface SearchToolSchema {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -344,7 +344,9 @@ export interface JinaRerankerResult {
 
 export interface JinaRerankerResponse {
   model: string;
-  usage: {
+  /** Telemetry only, and absent from some Jina-compatible endpoints — never
+   * dereference it on a path that would discard a usable ranking. */
+  usage?: {
     total_tokens: number;
   };
   results: JinaRerankerResult[];
@@ -358,12 +360,13 @@ export interface CohereRerankerResult {
 export interface CohereRerankerResponse {
   results: CohereRerankerResult[];
   id: string;
-  meta: {
-    api_version: {
+  /** Telemetry only; see {@link JinaRerankerResponse.usage}. */
+  meta?: {
+    api_version?: {
       version: string;
       is_experimental: boolean;
     };
-    billed_units: {
+    billed_units?: {
       search_units: number;
     };
   };
@@ -438,6 +441,10 @@ export interface SearchObservation {
   results: number;
   durationMs: number;
   error?: string;
+  /** The query rejected rather than reporting failure in its response. Those
+   * were logged at error level before they were aggregated, so the summary
+   * has to carry the distinction to keep that severity. */
+  thrown?: boolean;
 }
 
 /** One scraped link. A failure carries `error`; a success carries the sizes

--- a/src/tools/search/utils.ts
+++ b/src/tools/search/utils.ts
@@ -2,21 +2,13 @@
 
 import { isAxiosError } from 'axios';
 
+import type { SafeErrorLog } from './types';
 import type { AxiosError } from 'axios';
 import type * as t from './types';
 
 const LOG_VALUE_MAX_LENGTH = 2048;
 
-export interface SafeErrorLog {
-  message: string;
-  name?: string;
-  code?: string;
-  status?: number;
-  method?: string;
-  url?: string;
-  responseDataSummary?: string;
-  value?: string;
-}
+export type { SafeErrorLog } from './types';
 
 /**
  * Singleton instance of the default logger


### PR DESCRIPTION
## Summary

The web search pipeline logged once per source. A reranker emitted three lines per scraped link (chunk count, model, usage/meta), scrapes logged per link, and a missing API key warned once per source — so log volume scaled with the result count. An eight-source search cost 25+ lines.

Every phase now folds into fixed-width counters and emits **one line per phase** at flush.

### Before

```
Scraping 5 links
Error scraping https://bad1.com: Request failed with status code 403
Error scraping https://bad2.com: Request failed with status code 403
Reranking 200 chunks with Cohere
COHERE_API_KEY is not set. Using default ranking.
Reranking 200 chunks with Cohere
COHERE_API_KEY is not set. Using default ranking.
Reranking 200 chunks with Cohere
COHERE_API_KEY is not set. Using default ranking.
```

### After

```
ERROR [web_search] scrape links=5 ok=3 chars=54.0k highlights=15 failed=2 reasons={http_403:2} sample=bad1.com:http_403,bad2.com:http_403
WARN  [web_search] rerank=cohere calls=3 chunks=600 maxChunks=200 results=15 dur=0ms maxDur=0ms fallbacks=3 reasons={no_api_key:3}
```

A healthy search reads:

```
DEBUG [web_search] search=serper queries=3 results={web:8,images:10} dur=820ms
DEBUG [web_search] scrape links=8 ok=8 chars=182.4k highlights=40
DEBUG [web_search] rerank=cohere calls=8 chunks=412 maxChunks=96 results=40 dur=1.2s maxDur=390ms model=rerank-v3.5 units=8
```

## Design

**`src/tools/search/metrics.ts`** — one counter set per `web_search` call (`createSearchMetrics`), three record methods, one `flush()`.

- Recording is O(1) and allocation-free past a bounded reason map — sums, maxes, and counts only, never a per-item array.
- Failure messages are free-form and unbounded, so they are normalized to a class (`http_403`, `timeout`, `dns`, `connection`, `tls`, `aborted`, `other`) before counting. The map is capped at 6 keys plus `other`, so cardinality cannot grow with source count.
- Debuggability is preserved without volume: 3 failing hosts are sampled into the line, and the first raw provider message rides along as log metadata (truncated to 200 chars).
- **Severity is preserved.** `debug` when the phase is clean, `warn` on fallbacks, `error` on real failures — aggregation never hides a problem behind a lower level.
- Lines are pure `key=value`, greppable and parseable.

**Concurrency.** The collector is created per call in `createSearchProcessor` and flushed in `finally`, so concurrent searches never share counters. Records are synchronous, so a phase's three lines are always adjacent in the log with no interleaving.

**Rerankers.** `BaseReranker` gained `beginRerank` / `complete` / `fallback`, so every exit path records exactly one observation — the concrete rerankers got shorter as a result. `rerank()` takes an optional metrics sink; a reranker used directly falls back to an auto-flushing collector, so standalone use still emits one line per call instead of three.

**Incidental cleanups**
- The four copy-pasted sub-search blocks in `executeParallelSearches` collapsed into one timed `runSearch` helper.
- A scrape failure was logged twice on the non-batch path (once in the `catch`, once in `processResponse`); now recorded once.
- Dropped the misleading `No reranker selected` warning when `rerankerType: 'none'` is set deliberately — `createReranker` already reports that opt-in.

## API note

`BaseReranker.rerank` gained a 4th optional parameter, and subclasses must now declare a `provider` field. Rerankers are **not** in the package's public exports (`src/tools/search/index.ts` exports only `tool`, `schema`, and types), so this is internal; an out-of-tree subclass would need the one-line `provider` field.

## Verification

- `npx tsc --noEmit` clean.
- `npx eslint src/tools/search/` clean — the 2 remaining warnings are pre-existing, in untouched SearXNG mapping code.
- 220 search tests pass, including a new `metrics.test.ts` (classification, bounded cardinality, severity routing, flush/reset) and a log-volume regression test asserting an 8-link search costs one line per phase.
- Full suite: only the pre-existing `src/llm/{google,anthropic,vertexai}` specs fail, which need live provider credentials.
