### PR TITLE
v3.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.7.8",
+      "version": "3.7.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
## Summary

I bumped `@librechat/agents` to `3.7.9` so the merged StopFinalize continuation support can be published for LibreChat.

- Updated the package version to `3.7.9`.
- Kept the package lock metadata aligned with the manifest.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Verified manifest and lockfile versions are identical.
- Ran `git diff --check`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.