### PR TITLE
🧳 fix: Keep Handoff Tools With Source Agents

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2620,6 +2620,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         // run_id); `executingAgentId` always identifies the owning agent.
         agentId: this.subagentScope ? agentContext?.agentId : undefined,
         executingAgentId: agentContext?.agentId,
+        executingAgentName: agentContext?.name,
+        rootAgentId: this.defaultAgentId,
+        rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
         getDiscoveredToolNames: (): readonly string[] =>
@@ -2697,6 +2700,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // hooks can attribute the batch even at the top level.
       agentId: this.subagentScope ? agentContext?.agentId : undefined,
       executingAgentId: agentContext?.agentId,
+      executingAgentName: agentContext?.name,
+      rootAgentId: this.defaultAgentId,
+      rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
       toolCallStepIds: this.toolCallStepIds,
       errorHandler: (data, metadata): Promise<boolean> =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3815,6 +3815,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         parentMessageId: config.configurable?.requestBody?.parentMessageId,
         agentId,
         agentName: agentContext.name,
+        rootAgentId: this.defaultAgentId,
+        rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
+        activeAgentId: agentId,
+        activeAgentName: agentContext.name,
       });
       let langfuseHandler: CallbackEntry | undefined;
       let invokeConfig = {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -602,14 +602,19 @@ export class MultiAgentGraph extends StandardGraph {
   private createHandoffTools(): void {
     // Group handoff edges by source agent(s)
     const handoffsByAgent = new Map<string, t.GraphEdge[]>();
+    const tokenAccountingRefresh = new Set<string>();
 
     /** Transfer tool names are SDK-reserved. Remove externally supplied or
      * stale transfer tools before deriving the source agent's allowed set
      * from the graph edges below. */
     for (const agentContext of this.agentContexts.values()) {
+      const originalTools = agentContext.graphTools;
       const retainedTools = agentContext.graphTools?.filter(
         (graphTool) => !isTransferToolName(graphToolName(graphTool))
       );
+      if (retainedTools?.length !== originalTools?.length) {
+        tokenAccountingRefresh.add(agentContext.agentId);
+      }
       agentContext.graphTools =
         retainedTools != null && retainedTools.length > 0
           ? retainedTools
@@ -664,6 +669,29 @@ export class MultiAgentGraph extends StandardGraph {
       for (const handoffTool of handoffTools) {
         agentContext.graphTools.push(handoffTool);
       }
+      if (handoffTools.length > 0) {
+        tokenAccountingRefresh.add(agentId);
+      }
+    }
+
+    for (const agentId of tokenAccountingRefresh) {
+      const agentContext = this.agentContexts.get(agentId);
+      if (agentContext?.tokenCounter == null) {
+        continue;
+      }
+      const { tokenCounter, baseIndexTokenCountMap } = agentContext;
+      agentContext.tokenCalculationPromise = agentContext
+        .calculateInstructionTokens(tokenCounter)
+        .then(() => {
+          agentContext.updateTokenMapWithInstructions(baseIndexTokenCountMap);
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error(
+            'Error recalculating instruction tokens after handoff tool updates:',
+            err
+          );
+        });
     }
   }
 

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -101,6 +101,14 @@ function isTransferToolName(name: unknown): boolean {
   );
 }
 
+function graphToolName(tool: unknown): string | undefined {
+  if (tool == null || typeof tool !== 'object' || !('name' in tool)) {
+    return undefined;
+  }
+  const { name } = tool;
+  return typeof name === 'string' ? name : undefined;
+}
+
 /**
  * Drop transfer `tool_use` content blocks from an AI message's array content.
  * Companion to the reception's tool-call filtering: array-content providers
@@ -594,6 +602,19 @@ export class MultiAgentGraph extends StandardGraph {
   private createHandoffTools(): void {
     // Group handoff edges by source agent(s)
     const handoffsByAgent = new Map<string, t.GraphEdge[]>();
+
+    /** Transfer tool names are SDK-reserved. Remove externally supplied or
+     * stale transfer tools before deriving the source agent's allowed set
+     * from the graph edges below. */
+    for (const agentContext of this.agentContexts.values()) {
+      const retainedTools = agentContext.graphTools?.filter(
+        (graphTool) => !isTransferToolName(graphToolName(graphTool))
+      );
+      agentContext.graphTools =
+        retainedTools != null && retainedTools.length > 0
+          ? retainedTools
+          : undefined;
+    }
 
     // Only process handoff edges for tool creation
     for (const edge of this.handoffEdges) {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -295,6 +295,21 @@ function withHandoffGroupMetadata(
   };
 }
 
+function withActiveAgentMetadata(
+  config: LangGraphRunnableConfig | undefined,
+  agentId: string,
+  agentName: string | undefined
+): LangGraphRunnableConfig {
+  return {
+    ...config,
+    metadata: {
+      ...config?.metadata,
+      activeAgentId: agentId,
+      ...(agentName == null ? {} : { activeAgentName: agentName }),
+    },
+  };
+}
+
 /**
  * MultiAgentGraph extends StandardGraph to support dynamic multi-agent workflows
  * with handoffs, fan-in/fan-out, and other composable patterns.
@@ -1288,10 +1303,16 @@ export class MultiAgentGraph extends StandardGraph {
       ): Promise<t.MultiAgentGraphState | Command> => {
         let result: t.MultiAgentGraphState;
         let inputMessages = state.messages;
-        const memberConfig =
+        const agentContext = this.agentContexts.get(agentId);
+        const recursionLimitedConfig =
           this.memberRecursionLimit == null
             ? config
             : { ...config, recursionLimit: this.memberRecursionLimit };
+        const memberConfig = withActiveAgentMetadata(
+          recursionLimitedConfig,
+          agentId,
+          agentContext?.name
+        );
 
         /**
          * Check if this agent is receiving a handoff.
@@ -1303,7 +1324,6 @@ export class MultiAgentGraph extends StandardGraph {
           state.messages,
           agentId
         );
-        const agentContext = this.agentContexts.get(agentId);
 
         if (
           handoffContext?.sourceAgentName != null &&

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -783,17 +783,29 @@ export function createLangfuseTraceMetadata({
   parentMessageId,
   agentId,
   agentName,
+  rootAgentId,
+  rootAgentName,
+  activeAgentId,
+  activeAgentName,
 }: {
   messageId?: unknown;
   parentMessageId?: unknown;
   agentId?: unknown;
   agentName?: unknown;
+  rootAgentId?: unknown;
+  rootAgentName?: unknown;
+  activeAgentId?: unknown;
+  activeAgentName?: unknown;
 }): LangfuseTraceMetadata {
   return createTraceMetadata({
     messageId,
     parentMessageId,
     agentId,
     agentName,
+    rootAgentId,
+    rootAgentName,
+    activeAgentId,
+    activeAgentName,
   });
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -1311,6 +1311,10 @@ export class Run<_T extends t.BaseGraphState> {
       parentMessageId: config.configurable?.requestBody?.parentMessageId,
       agentId: graph.defaultAgentId,
       agentName: primaryContext?.name,
+      rootAgentId: graph.defaultAgentId,
+      rootAgentName: primaryContext?.name,
+      activeAgentId: graph.defaultAgentId,
+      activeAgentName: primaryContext?.name,
     });
     const traceName = config.runName ?? getLangfuseTraceName(traceMetadata);
     const streamLangfuseConfig = this.getStreamLangfuseConfig(graph);

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -306,7 +306,10 @@ describe('Agent Handoffs Tests', () => {
         createBasicAgent('agent_a', 'You are agent A'),
         {
           ...createBasicAgent('agent_b', 'You are agent B'),
-          graphTools: [leakedTransferTool, retainedGraphTool],
+          graphTools: [
+            leakedTransferTool as unknown as t.GenericTool,
+            retainedGraphTool as unknown as t.GenericTool,
+          ],
         },
       ];
 

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -1,6 +1,7 @@
 // src/specs/agent-handoffs.test.ts
 import { MemorySaver } from '@langchain/langgraph';
 import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
 import {
   AIMessage,
   HumanMessage,
@@ -9,7 +10,11 @@ import {
 } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
-import type { RunnableConfig } from '@langchain/core/runnables';
+import {
+  RunnableLambda,
+  RunnableToolLike,
+  type RunnableConfig,
+} from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { Providers, GraphEvents, Constants } from '@/common';
@@ -50,6 +55,26 @@ const findToolByName = (
 ): t.GraphTools[0] | undefined => {
   return tools?.find((tool) => getToolName(tool) === name);
 };
+
+const createGraphTool = (name: string, output: string): t.GenericTool =>
+  new RunnableToolLike({
+    name,
+    description: `Test ${name} tool`,
+    schema: z.object({}),
+    bound: RunnableLambda.from(async (): Promise<string> => output),
+  });
+
+class MetadataCapturingToolNode extends ToolNode<t.BaseGraphState> {
+  observedConfig?: RunnableConfig;
+
+  protected override async run(
+    input: t.BaseGraphState,
+    config: RunnableConfig
+  ): Promise<t.BaseGraphState> {
+    this.observedConfig = config;
+    return input;
+  }
+}
 
 type HandoffModelScript = {
   promptMarker: string;
@@ -290,26 +315,19 @@ describe('Agent Handoffs Tests', () => {
     });
 
     it('should not expose an inbound handoff tool to its recipient', async () => {
-      const leakedTransferTool = new DynamicStructuredTool({
-        name: `${Constants.LC_TRANSFER_TO_}agent_b`,
-        description: 'Leaked transfer to agent B',
-        schema: { type: 'object', properties: {}, required: [] },
-        func: async (): Promise<string> => 'transferred',
-      });
-      const retainedGraphTool = new DynamicStructuredTool({
-        name: 'retained_graph_tool',
-        description: 'A non-handoff graph tool',
-        schema: { type: 'object', properties: {}, required: [] },
-        func: async (): Promise<string> => 'retained',
-      });
+      const leakedTransferTool = createGraphTool(
+        `${Constants.LC_TRANSFER_TO_}agent_b`,
+        'transferred'
+      );
+      const retainedGraphTool = createGraphTool(
+        'retained_graph_tool',
+        'retained'
+      );
       const agents: t.AgentInputs[] = [
         createBasicAgent('agent_a', 'You are agent A'),
         {
           ...createBasicAgent('agent_b', 'You are agent B'),
-          graphTools: [
-            leakedTransferTool as unknown as t.GenericTool,
-            retainedGraphTool as unknown as t.GenericTool,
-          ],
+          graphTools: [leakedTransferTool, retainedGraphTool],
         },
       ];
 
@@ -321,7 +339,9 @@ describe('Agent Handoffs Tests', () => {
         },
       ];
 
-      const run = await Run.create(createTestConfig(agents, edges));
+      const config = createTestConfig(agents, edges);
+      config.tokenCounter = () => 1;
+      const run = await Run.create(config);
 
       const agentBContext = (run.Graph as StandardGraph).agentContexts.get(
         'agent_b'
@@ -337,6 +357,37 @@ describe('Agent Handoffs Tests', () => {
       expect(
         findToolByName(agentBContext?.graphTools, 'retained_graph_tool')
       ).toBeDefined();
+      await agentBContext?.tokenCalculationPromise;
+      expect(agentBContext?.toolTokenCounts).not.toHaveProperty(
+        `${Constants.LC_TRANSFER_TO_}agent_b`
+      );
+      expect(agentBContext?.toolTokenCounts).toHaveProperty(
+        'retained_graph_tool'
+      );
+    });
+
+    it('stamps the owning agent on tool observation metadata', async () => {
+      const node = new MetadataCapturingToolNode({
+        tools: [],
+        executingAgentId: 'mateo',
+        executingAgentName: 'Mateo Serrano',
+        rootAgentId: 'leila',
+        rootAgentName: 'Leila Mensah',
+      });
+
+      await node.invoke(
+        { messages: [] },
+        { metadata: { requestId: 'request-1' } }
+      );
+
+      expect(node.observedConfig?.metadata).toMatchObject({
+        requestId: 'request-1',
+        agentId: 'mateo',
+        activeAgentId: 'mateo',
+        activeAgentName: 'Mateo Serrano',
+        rootAgentId: 'leila',
+        rootAgentName: 'Leila Mensah',
+      });
     });
   });
 

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -1,7 +1,11 @@
 // src/specs/agent-handoffs.test.ts
+import { z } from 'zod';
 import { MemorySaver } from '@langchain/langgraph';
 import { DynamicStructuredTool } from '@langchain/core/tools';
-import { z } from 'zod';
+import {
+  RunnableLambda,
+  RunnableToolLike,
+} from '@langchain/core/runnables';
 import {
   AIMessage,
   HumanMessage,
@@ -10,10 +14,6 @@ import {
 } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
-import {
-  RunnableLambda,
-  RunnableToolLike,
-} from '@langchain/core/runnables';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -13,8 +13,8 @@ import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import {
   RunnableLambda,
   RunnableToolLike,
-  type RunnableConfig,
 } from '@langchain/core/runnables';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { Providers, GraphEvents, Constants } from '@/common';

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -289,10 +289,25 @@ describe('Agent Handoffs Tests', () => {
       expect(handoffToolMessage?.content).toContain('transferred to agent_b');
     });
 
-    it('should not create handoff tool for agent without outgoing edges', async () => {
+    it('should not expose an inbound handoff tool to its recipient', async () => {
+      const leakedTransferTool = new DynamicStructuredTool({
+        name: `${Constants.LC_TRANSFER_TO_}agent_b`,
+        description: 'Leaked transfer to agent B',
+        schema: { type: 'object', properties: {}, required: [] },
+        func: async (): Promise<string> => 'transferred',
+      });
+      const retainedGraphTool = new DynamicStructuredTool({
+        name: 'retained_graph_tool',
+        description: 'A non-handoff graph tool',
+        schema: { type: 'object', properties: {}, required: [] },
+        func: async (): Promise<string> => 'retained',
+      });
       const agents: t.AgentInputs[] = [
         createBasicAgent('agent_a', 'You are agent A'),
-        createBasicAgent('agent_b', 'You are agent B'),
+        {
+          ...createBasicAgent('agent_b', 'You are agent B'),
+          graphTools: [leakedTransferTool, retainedGraphTool],
+        },
       ];
 
       const edges: t.GraphEdge[] = [
@@ -310,12 +325,15 @@ describe('Agent Handoffs Tests', () => {
       );
       expect(agentBContext).toBeDefined();
 
-      // Agent B should not have handoff tools (no outgoing edges)
+      // Agent B has no outgoing edge, so any inbound transfer is removed.
       const handoffTools = agentBContext?.graphTools?.filter((tool) => {
         const name = getToolName(tool);
         return name?.startsWith(Constants.LC_TRANSFER_TO_) ?? false;
       });
       expect(handoffTools?.length ?? 0).toBe(0);
+      expect(
+        findToolByName(agentBContext?.graphTools, 'retained_graph_tool')
+      ).toBeDefined();
     });
   });
 

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -104,6 +104,10 @@ describe('Langfuse trace metadata includes agentName', () => {
         parentMessageId: 'parent-789',
         agentId: 'agent_abc123',
         agentName: 'DWAINE',
+        rootAgentId: 'agent_abc123',
+        rootAgentName: 'DWAINE',
+        activeAgentId: 'agent_abc123',
+        activeAgentName: 'DWAINE',
       },
     });
   });
@@ -138,6 +142,10 @@ describe('Langfuse trace metadata includes agentName', () => {
         messageId: 'test-run-id',
         agentId: 'agent_abc123',
         agentName: 'DWAINE',
+        rootAgentId: 'agent_abc123',
+        rootAgentName: 'DWAINE',
+        activeAgentId: 'agent_abc123',
+        activeAgentName: 'DWAINE',
       },
       tags: ['librechat', 'agent', 'tenant:tenant-1'],
     });
@@ -148,6 +156,10 @@ describe('Langfuse trace metadata includes agentName', () => {
         messageId: 'test-run-id',
         agentId: 'agent_abc123',
         agentName: 'DWAINE',
+        rootAgentId: 'agent_abc123',
+        rootAgentName: 'DWAINE',
+        activeAgentId: 'agent_abc123',
+        activeAgentName: 'DWAINE',
       },
     });
   });

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -738,6 +738,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * even where `agentId` (the subagent-scope marker) is undefined.
    */
   private executingAgentId?: string;
+  private executingAgentName?: string;
+  private rootAgentId?: string;
+  private rootAgentName?: string;
   /** Tool names that bypass event dispatch and execute directly (e.g., graph-managed handoff tools) */
   private directToolNames?: Set<string>;
   /**
@@ -823,6 +826,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     eagerEventToolSuppressions,
     agentId,
     executingAgentId,
+    executingAgentName,
+    rootAgentId,
+    rootAgentName,
     directToolNames,
     interruptingToolNames,
     codeSessionToolNames,
@@ -902,6 +908,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // Default to agentId so callers constructing ToolNode directly (who pass the
     // existing agentId option) still get attribution without knowing the new option.
     this.executingAgentId = executingAgentId ?? agentId;
+    this.executingAgentName = executingAgentName;
+    this.rootAgentId = rootAgentId;
+    this.rootAgentName = rootAgentName;
     this.directToolNames = directToolNames;
     this.interruptingToolNames =
       interruptingToolNames != null && interruptingToolNames.size > 0
@@ -963,6 +972,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           metadata: {
             ...options?.metadata,
             agentId: this.executingAgentId,
+            activeAgentId: this.executingAgentId,
+            ...(this.executingAgentName == null
+              ? {}
+              : { activeAgentName: this.executingAgentName }),
+            ...(this.rootAgentId == null
+              ? {}
+              : { rootAgentId: this.rootAgentId }),
+            ...(this.rootAgentName == null
+              ? {}
+              : { rootAgentName: this.rootAgentName }),
           },
         };
     return withLangfuseRuntimeScope(

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -148,6 +148,11 @@ export type ToolNodeOptions = {
   /** ID of the agent that owns this tool node, surfaced to hooks as `executingAgentId`
    * so a batch can be attributed to a specific agent even where `agentId` is undefined. */
   executingAgentId?: string;
+  /** Name of the agent that owns this tool node, used for active Langfuse attribution. */
+  executingAgentName?: string;
+  /** Root graph-agent identity retained alongside the currently executing tool owner. */
+  rootAgentId?: string;
+  rootAgentName?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
   /**


### PR DESCRIPTION
## Summary

I prevented a transfer tool intended for one agent from being exposed to its handoff recipient, and made handoff execution observable by root and active agent.

- Remove reserved transfer tools supplied through graph tools before graph-derived handoffs are installed.
- Retain regular graph tools while only exposing outgoing handoffs to each source agent.
- Record root-agent and active-agent IDs and names in Langfuse metadata.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest --runInBand src/specs/agent-handoffs.test.ts src/specs/langfuse-metadata.test.ts`.
- Ran `npm run build`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes