### PR TITLE
🧩 fix: Route Tool-Free Programmatic Calls to Plain Exec

### DIFF
--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -386,6 +386,7 @@ export function createBashProgrammaticToolCallingTool(
             baseUrl,
             lang: 'bash',
             code,
+            timeout,
             sessionId: session_id,
             files,
             runtimeSessionHint,

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -306,14 +306,14 @@ export function createBashProgrammaticToolCallingTool(
        * replays, and event-driven ToolNode configurations legitimately inject
        * an empty toolMap/toolDefs, so requiring them here would re-break the
        * tool-free call this route exists to serve. Injected context is still
-       * required to conclude that: with nothing injected at all, an empty
-       * selection means the host wired the tool up wrong, not that the code
-       * needs no tools. */
+       * required to conclude that — but an injected empty context counts:
+       * ToolNode legitimately yields no code-execution tools. Only a call with
+       * nothing injected at all is treated as a host wiring mistake. */
       const needsNoTools =
         effectiveTools.length === 0 &&
         (params.tool_manifest?.length === 0 ||
-          (toolDefs?.length ?? 0) > 0 ||
-          (disallowedToolDefs?.length ?? 0) > 0);
+          toolDefs != null ||
+          disallowedToolDefs != null);
 
       if (!needsNoTools) {
         if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -302,22 +302,37 @@ export function createBashProgrammaticToolCallingTool(
         programmaticToolName,
       });
 
-      if (toolMap == null || toolMap.size === 0) {
-        throw new Error(
-          'No toolMap provided. ' +
-            'ToolNode should inject this from AgentContext when invoked through the graph.'
-        );
-      }
+      /* These guard the replay path only. A call that selected no tools never
+       * replays, and event-driven ToolNode configurations legitimately inject
+       * an empty toolMap/toolDefs, so requiring them here would re-break the
+       * tool-free call this route exists to serve. Injected context is still
+       * required to conclude that: with nothing injected at all, an empty
+       * selection means the host wired the tool up wrong, not that the code
+       * needs no tools. */
+      const needsNoTools =
+        effectiveTools.length === 0 &&
+        (params.tool_manifest?.length === 0 ||
+          (toolDefs?.length ?? 0) > 0 ||
+          (disallowedToolDefs?.length ?? 0) > 0);
 
-      if (toolDefs == null || toolDefs.length === 0) {
-        throw new Error(
-          'No tool definitions provided. ' +
-            'Either pass tools in the input or ensure ToolNode injects toolDefs.'
-        );
+      if (!needsNoTools) {
+        if (toolMap == null || toolMap.size === 0) {
+          throw new Error(
+            'No toolMap provided. ' +
+              'ToolNode should inject this from AgentContext when invoked through the graph.'
+          );
+        }
+
+        if (toolDefs == null || toolDefs.length === 0) {
+          throw new Error(
+            'No tool definitions provided. ' +
+              'Either pass tools in the input or ensure ToolNode injects toolDefs.'
+          );
+        }
       }
 
       const effectiveToolMap = projectProgrammaticToolMap(
-        toolMap,
+        toolMap ?? new Map(),
         effectiveTools
       );
 
@@ -332,7 +347,7 @@ export function createBashProgrammaticToolCallingTool(
           // eslint-disable-next-line no-console
           console.log(
             `[BashPTC Debug] Sending ${effectiveTools.length} tools to API ` +
-              `(selected from ${toolDefs.length})`
+              `(selected from ${toolDefs?.length ?? 0})`
           );
         }
 
@@ -366,7 +381,7 @@ export function createBashProgrammaticToolCallingTool(
 
         /* Raw `code`, not `preparedCode`: the `$!` guard exists for the
          * programmatic replay wrapper, which plain `/exec` never applies. */
-        if (effectiveTools.length === 0) {
+        if (needsNoTools) {
           return await runPlainExecution({
             baseUrl,
             lang: 'bash',

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -14,11 +14,6 @@ import {
   selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
-  makeRequest,
-  executeTools,
-  formatCompletedResponse,
-} from './ProgrammaticToolCalling';
-import {
   projectProgrammaticToolMap,
   resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
@@ -29,10 +24,25 @@ import {
   createCodeApiRunTimeoutSchema,
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
+import {
+  makeRequest,
+  executeTools,
+  runPlainExecution,
+  formatCompletedResponse,
+} from './ProgrammaticToolCalling';
+import {
+  extractUsedBashToolNames,
+  normalizeToBashIdentifier,
+} from './toolIdentifiers';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();
+
+export {
+  extractUsedBashToolNames,
+  normalizeToBashIdentifier,
+} from './toolIdentifiers';
 
 // ============================================================================
 // Constants
@@ -41,33 +51,6 @@ config();
 const DEFAULT_MAX_ROUND_TRIPS = 20;
 const DEFAULT_RUN_TIMEOUT_MS = resolveCodeApiRunTimeoutMs();
 const BASH_LAST_BACKGROUND_PID_GUARD = ': &\nwait "$!"';
-
-/** Bash reserved words that get `_tool` suffix when used as function names */
-const BASH_RESERVED = new Set([
-  'if',
-  'then',
-  'else',
-  'elif',
-  'fi',
-  'case',
-  'esac',
-  'for',
-  'while',
-  'until',
-  'do',
-  'done',
-  'in',
-  'function',
-  'select',
-  'time',
-  'coproc',
-  'declare',
-  'typeset',
-  'local',
-  'readonly',
-  'export',
-  'unset',
-]);
 
 // ============================================================================
 // Description Components
@@ -116,8 +99,9 @@ ${EXAMPLES}
 ${CORE_RULES}`;
 
 const TOOL_MANIFEST_DESCRIPTION =
-  'Exact registered tool names used by the code. Required when direct-only tools are configured; ' +
-  'validated before execution starts.';
+  'Exact registered tool names used by the code, validated before execution starts. ' +
+  'Omit it to have the runtime derive the manifest from the code; pass [] when the code ' +
+  'calls no tools at all.';
 
 // ============================================================================
 // Schema
@@ -217,51 +201,6 @@ export function normalizeBashToolResultsForReplay(
 // ============================================================================
 
 /**
- * Normalizes a tool name to a valid bash function identifier.
- * 1. Replace hyphens, spaces, dots with underscores
- * 2. Remove any other invalid characters
- * 3. Prefix with underscore if starts with number
- * 4. Append `_tool` if it's a bash reserved word
- */
-export function normalizeToBashIdentifier(name: string): string {
-  let normalized = name.replace(/[-\s.]/g, '_');
-  normalized = normalized.replace(/[^a-zA-Z0-9_]/g, '');
-
-  if (/^[0-9]/.test(normalized)) {
-    normalized = '_' + normalized;
-  }
-
-  if (BASH_RESERVED.has(normalized)) {
-    normalized = normalized + '_tool';
-  }
-
-  return normalized;
-}
-
-/**
- * Extracts tool names that are actually called in the bash code.
- * Bash functions are invoked as commands (no parentheses), so we match
- * the normalized name as a word boundary.
- */
-export function extractUsedBashToolNames(
-  code: string,
-  toolNameMap: Map<string, string>
-): Set<string> {
-  const usedTools = new Set<string>();
-
-  for (const [bashName, originalName] of toolNameMap) {
-    const escapedName = bashName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
-
-    if (pattern.test(code)) {
-      usedTools.add(originalName);
-    }
-  }
-
-  return usedTools;
-}
-
-/**
  * Filters tool definitions to only include tools actually used in the bash code.
  */
 export function filterBashToolsByUsage(
@@ -355,6 +294,8 @@ export function createBashProgrammaticToolCallingTool(
           ? toolCall.name
           : Constants.BASH_PROGRAMMATIC_TOOL_CALLING);
       const effectiveTools = selectProgrammaticTools({
+        code,
+        runtime: 'bash',
         requestedToolNames: params.tool_manifest,
         allowedToolDefs: toolDefs,
         disallowedToolDefs,
@@ -422,6 +363,22 @@ export function createBashProgrammaticToolCallingTool(
           selectedRuntimeSessionHint !== ''
             ? selectedRuntimeSessionHint
             : undefined;
+
+        /* Raw `code`, not `preparedCode`: the `$!` guard exists for the
+         * programmatic replay wrapper, which plain `/exec` never applies. */
+        if (effectiveTools.length === 0) {
+          return await runPlainExecution({
+            baseUrl,
+            lang: 'bash',
+            code,
+            sessionId: session_id,
+            files,
+            runtimeSessionHint,
+            proxy,
+            authHeaders: initParams.authHeaders,
+            executionProfile: initParams.executionProfile,
+          });
+        }
 
         let response = await makeRequest(
           EXEC_ENDPOINT,

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -70,10 +70,25 @@ export function selectProgrammaticTools(args: {
   const requestedToolNames = args.requestedToolNames;
 
   if (requestedToolNames == null) {
-    if (disallowedToolDefs.length > 0) {
-      return deriveReferencedToolDefs(allowedToolDefs, args.code, args.runtime);
+    if (disallowedToolDefs.length === 0) {
+      return allowedToolDefs;
     }
-    return allowedToolDefs;
+
+    /* Derive over the disallowed set as well. A direct-only tool the code
+     * references must still be rejected: some runtimes define native tool
+     * functions unconditionally, so treating an unmatched name as absent would
+     * let the call reach one the caller may not use. */
+    const referencedDisallowed = deriveReferencedToolDefs(
+      disallowedToolDefs,
+      args.code,
+      args.runtime
+    );
+    assertDisallowedToolUsage(
+      new Set(referencedDisallowed.map((toolDef) => toolDef.name)),
+      args.programmaticToolName
+    );
+
+    return deriveReferencedToolDefs(allowedToolDefs, args.code, args.runtime);
   }
 
   const disallowedNames = new Set(

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -1,6 +1,9 @@
 import type { ProgrammaticRuntime } from './toolIdentifiers';
 import type * as t from '@/types';
-import { deriveReferencedToolDefs } from './toolIdentifiers';
+import {
+  deriveReferencedToolDefs,
+  findNormalizedIdentifierCollision,
+} from './toolIdentifiers';
 
 export type ProgrammaticInvocationParams = {
   code: string;
@@ -57,6 +60,23 @@ export function assertDisallowedToolUsage(
  * An empty result is meaningful, not an error: the code calls no tools, so it
  * needs no stubs. Remote callers route that to plain `/exec`.
  */
+function assertUnambiguousIdentifiers(
+  selectedToolDefs: readonly t.LCTool[],
+  runtime: ProgrammaticRuntime,
+  programmaticToolName: string
+): void {
+  const collision = findNormalizedIdentifierCollision(selectedToolDefs, runtime);
+  if (collision == null) {
+    return;
+  }
+
+  throw new Error(
+    `Tools "${collision.first}" and "${collision.second}" both become ` +
+      `"${collision.identifier}" in ${runtime}, so "${programmaticToolName}" ` +
+      'cannot tell which one the code means. Call them directly, or rename one.'
+  );
+}
+
 export function selectProgrammaticTools(args: {
   code: string;
   runtime: ProgrammaticRuntime;
@@ -103,7 +123,17 @@ export function selectProgrammaticTools(args: {
       args.programmaticToolName
     );
 
-    return deriveReferencedToolDefs(allowedToolDefs, args.code, args.runtime);
+    const derived = deriveReferencedToolDefs(
+      allowedToolDefs,
+      args.code,
+      args.runtime
+    );
+    assertUnambiguousIdentifiers(
+      derived,
+      args.runtime,
+      args.programmaticToolName
+    );
+    return derived;
   }
 
   const disallowedNames = new Set(
@@ -134,7 +164,13 @@ export function selectProgrammaticTools(args: {
     );
   }
 
-  return [...new Set(requestedToolNames)].map(
+  const selected = [...new Set(requestedToolNames)].map(
     (name) => allowedByName.get(name) as t.LCTool
   );
+  assertUnambiguousIdentifiers(
+    selected,
+    args.runtime,
+    args.programmaticToolName
+  );
+  return selected;
 }

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -64,6 +64,14 @@ export function selectProgrammaticTools(args: {
   allowedToolDefs?: t.LCTool[];
   disallowedToolDefs?: t.LCTool[];
   programmaticToolName: string;
+  /**
+   * Set when the runtime defines tool functions the selection does not control,
+   * so stub absence cannot enforce the caller boundary. Cloudflare's Python
+   * program prepends every native tool unconditionally, and an indirect
+   * reference (`globals()["write_file"]`) is beyond what derivation can see —
+   * so the manifest stays required rather than derived there.
+   */
+  runtimeExposesUnselectedTools?: boolean;
 }): t.LCTool[] {
   const allowedToolDefs = args.allowedToolDefs ?? [];
   const disallowedToolDefs = args.disallowedToolDefs ?? [];
@@ -72,6 +80,13 @@ export function selectProgrammaticTools(args: {
   if (requestedToolNames == null) {
     if (disallowedToolDefs.length === 0) {
       return allowedToolDefs;
+    }
+
+    if (args.runtimeExposesUnselectedTools === true) {
+      throw new Error(
+        `"${args.programmaticToolName}" requires a tool_manifest when direct-only tools are configured. ` +
+          'List every registered tool name used by the submitted code in the tool_manifest field.'
+      );
     }
 
     /* Derive over the disallowed set as well. A direct-only tool the code

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -1,4 +1,6 @@
+import type { ProgrammaticRuntime } from './toolIdentifiers';
 import type * as t from '@/types';
+import { deriveReferencedToolDefs } from './toolIdentifiers';
 
 export type ProgrammaticInvocationParams = {
   code: string;
@@ -19,10 +21,10 @@ export function projectProgrammaticToolMap(
   toolMap: t.ToolMap,
   selectedToolDefs: readonly t.LCTool[]
 ): t.ToolMap {
-  const selectedNames = new Set(selectedToolDefs.map((toolDef) => toolDef.name));
-  return new Map(
-    [...toolMap].filter(([name]) => selectedNames.has(name))
+  const selectedNames = new Set(
+    selectedToolDefs.map((toolDef) => toolDef.name)
   );
+  return new Map([...toolMap].filter(([name]) => selectedNames.has(name)));
 }
 
 export function assertDisallowedToolUsage(
@@ -43,7 +45,21 @@ export function assertDisallowedToolUsage(
   );
 }
 
+/**
+ * Resolves the tool manifest a programmatic call runs with.
+ *
+ * An omitted manifest is derived from the submitted code rather than rejected.
+ * Deriving can only narrow `allowedToolDefs`, so a direct-only tool still cannot
+ * be reached; the caller-facing invariant is unchanged. Rejecting instead cost a
+ * round trip on every call once any direct-only tool existed, and left tool-free
+ * code with no valid manifest to send at all.
+ *
+ * An empty result is meaningful, not an error: the code calls no tools, so it
+ * needs no stubs. Remote callers route that to plain `/exec`.
+ */
 export function selectProgrammaticTools(args: {
+  code: string;
+  runtime: ProgrammaticRuntime;
   requestedToolNames?: string[];
   allowedToolDefs?: t.LCTool[];
   disallowedToolDefs?: t.LCTool[];
@@ -55,10 +71,7 @@ export function selectProgrammaticTools(args: {
 
   if (requestedToolNames == null) {
     if (disallowedToolDefs.length > 0) {
-      throw new Error(
-        `"${args.programmaticToolName}" requires a tool_manifest when direct-only tools are configured. ` +
-          'List every registered tool name used by the submitted code in the tool_manifest field.'
-      );
+      return deriveReferencedToolDefs(allowedToolDefs, args.code, args.runtime);
     }
     return allowedToolDefs;
   }

--- a/src/tools/ProgrammaticCallerPolicy.ts
+++ b/src/tools/ProgrammaticCallerPolicy.ts
@@ -84,14 +84,6 @@ export function selectProgrammaticTools(args: {
   allowedToolDefs?: t.LCTool[];
   disallowedToolDefs?: t.LCTool[];
   programmaticToolName: string;
-  /**
-   * Set when the runtime defines tool functions the selection does not control,
-   * so stub absence cannot enforce the caller boundary. Cloudflare's Python
-   * program prepends every native tool unconditionally, and an indirect
-   * reference (`globals()["write_file"]`) is beyond what derivation can see —
-   * so the manifest stays required rather than derived there.
-   */
-  runtimeExposesUnselectedTools?: boolean;
 }): t.LCTool[] {
   const allowedToolDefs = args.allowedToolDefs ?? [];
   const disallowedToolDefs = args.disallowedToolDefs ?? [];
@@ -100,13 +92,6 @@ export function selectProgrammaticTools(args: {
   if (requestedToolNames == null) {
     if (disallowedToolDefs.length === 0) {
       return allowedToolDefs;
-    }
-
-    if (args.runtimeExposesUnselectedTools === true) {
-      throw new Error(
-        `"${args.programmaticToolName}" requires a tool_manifest when direct-only tools are configured. ` +
-          'List every registered tool name used by the submitted code in the tool_manifest field.'
-      );
     }
 
     /* Derive over the disallowed set as well. A direct-only tool the code

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -22,21 +22,30 @@ import {
   selectRuntimeSessionHint,
 } from './CodeExecutor';
 import {
-  clampCodeApiRunTimeoutMs,
-  createCodeApiRunTimeoutSchema,
-  resolveCodeApiRunTimeoutMs,
-} from './ptcTimeout';
-import {
   projectProgrammaticToolMap,
   resolveProgrammaticToolDefinitions,
   selectProgrammaticTools,
   type ProgrammaticInvocationParams,
 } from './ProgrammaticCallerPolicy';
+import {
+  clampCodeApiRunTimeoutMs,
+  createCodeApiRunTimeoutSchema,
+  resolveCodeApiRunTimeoutMs,
+} from './ptcTimeout';
+import {
+  extractUsedToolNames,
+  normalizeToPythonIdentifier,
+} from './toolIdentifiers';
 import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { Constants } from '@/common';
 
 config();
+
+export {
+  extractUsedToolNames,
+  normalizeToPythonIdentifier,
+} from './toolIdentifiers';
 
 /** Default max round-trips to prevent infinite loops */
 const DEFAULT_MAX_ROUND_TRIPS = 20;
@@ -94,8 +103,9 @@ ${EXAMPLES}
 ${CORE_RULES}`;
 
 const TOOL_MANIFEST_DESCRIPTION =
-  'Exact registered tool names used by the code. Required when direct-only tools are configured; ' +
-  'validated before execution starts.';
+  'Exact registered tool names used by the code, validated before execution starts. ' +
+  'Omit it to have the runtime derive the manifest from the code; pass [] when the code ' +
+  'calls no tools at all.';
 
 export function createProgrammaticToolCallingSchema(
   maxRunTimeoutMs = DEFAULT_RUN_TIMEOUT_MS
@@ -148,45 +158,6 @@ export const ProgrammaticToolCallingDefinition = {
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-/** Python reserved keywords that get `_tool` suffix in Code API */
-const PYTHON_KEYWORDS = new Set([
-  'False',
-  'None',
-  'True',
-  'and',
-  'as',
-  'assert',
-  'async',
-  'await',
-  'break',
-  'class',
-  'continue',
-  'def',
-  'del',
-  'elif',
-  'else',
-  'except',
-  'finally',
-  'for',
-  'from',
-  'global',
-  'if',
-  'import',
-  'in',
-  'is',
-  'lambda',
-  'nonlocal',
-  'not',
-  'or',
-  'pass',
-  'raise',
-  'return',
-  'try',
-  'while',
-  'with',
-  'yield',
-]);
 
 export type FetchSessionFilesScope =
   | { kind: 'skill'; id: string; version: number }
@@ -296,57 +267,6 @@ function normalizeSessionFile(
 }
 
 /**
- * Normalizes a tool name to Python identifier format.
- * Must match the Code API's `normalizePythonFunctionName` exactly:
- * 1. Replace hyphens and spaces with underscores
- * 2. Remove any other invalid characters
- * 3. Prefix with underscore if starts with number
- * 4. Append `_tool` if it's a Python keyword
- * @param name - The tool name to normalize
- * @returns Normalized Python-safe identifier
- */
-export function normalizeToPythonIdentifier(name: string): string {
-  let normalized = name.replace(/[-\s]/g, '_');
-
-  normalized = normalized.replace(/[^a-zA-Z0-9_]/g, '');
-
-  if (/^[0-9]/.test(normalized)) {
-    normalized = '_' + normalized;
-  }
-
-  if (PYTHON_KEYWORDS.has(normalized)) {
-    normalized = normalized + '_tool';
-  }
-
-  return normalized;
-}
-
-/**
- * Extracts tool names that are actually called in the Python code.
- * Handles hyphen/underscore conversion since Python identifiers use underscores.
- * @param code - The Python code to analyze
- * @param toolNameMap - Map from normalized Python name to original tool name
- * @returns Set of original tool names found in the code
- */
-export function extractUsedToolNames(
-  code: string,
-  toolNameMap: Map<string, string>
-): Set<string> {
-  const usedTools = new Set<string>();
-
-  for (const [pythonName, originalName] of toolNameMap) {
-    const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = new RegExp(`\\b${escapedName}\\s*\\(`, 'g');
-
-    if (pattern.test(code)) {
-      usedTools.add(originalName);
-    }
-  }
-
-  return usedTools;
-}
-
-/**
  * Filters tool definitions to only include tools actually used in the code.
  * Handles the hyphen-to-underscore conversion for Python compatibility.
  * @param toolDefs - All available tool definitions
@@ -361,8 +281,7 @@ export function filterToolsByUsage(
 ): t.LCTool[] {
   const toolNameMap = new Map<string, string>();
   for (const tool of toolDefs) {
-    const pythonName = normalizeToPythonIdentifier(tool.name);
-    toolNameMap.set(pythonName, tool.name);
+    toolNameMap.set(normalizeToPythonIdentifier(tool.name), tool.name);
   }
 
   const usedToolNames = extractUsedToolNames(code, toolNameMap);
@@ -874,6 +793,49 @@ export function formatCompletedResponse(
   ];
 }
 
+/**
+ * Runs code that references no tools through plain `/exec`.
+ *
+ * `/exec/programmatic` rejects an empty tool manifest outright, and the sandbox
+ * has nothing to inject for such a call anyway — no stubs, no replay round
+ * trips. Routing it here makes a tool-free programmatic call behave exactly like
+ * the equivalent `execute_code`, against every deployed Code API, instead of
+ * failing with a rejection the model cannot act on.
+ */
+export async function runPlainExecution(args: {
+  baseUrl: string;
+  lang: 'bash' | 'py';
+  code: string;
+  sessionId?: string;
+  files?: t.CodeEnvFile[];
+  runtimeSessionHint?: string;
+  proxy?: string;
+  authHeaders?: t.CodeApiAuthHeaders;
+  executionProfile?: t.CodeApiExecutionProfile;
+}): Promise<[string, t.ProgrammaticExecutionArtifact]> {
+  const response = await makeRequest(
+    buildCodeApiEndpoint(args.baseUrl, 'exec'),
+    {
+      lang: args.lang,
+      code: args.code,
+      ...(args.sessionId != null && args.sessionId !== ''
+        ? { session_id: args.sessionId }
+        : {}),
+      ...(args.files != null && args.files.length > 0
+        ? { files: args.files }
+        : {}),
+      ...(args.runtimeSessionHint != null
+        ? { runtime_session_hint: args.runtimeSessionHint }
+        : {}),
+    },
+    args.proxy,
+    args.authHeaders,
+    args.executionProfile
+  );
+
+  return formatCompletedResponse(response, args.code);
+}
+
 // ============================================================================
 // Tool Factory
 // ============================================================================
@@ -937,6 +899,8 @@ export function createProgrammaticToolCallingTool(
           ? toolCall.name
           : Constants.PROGRAMMATIC_TOOL_CALLING);
       const effectiveTools = selectProgrammaticTools({
+        code,
+        runtime: 'python',
         requestedToolNames: params.tool_manifest,
         allowedToolDefs: toolDefs,
         disallowedToolDefs,
@@ -1007,6 +971,20 @@ export function createProgrammaticToolCallingTool(
           selectedRuntimeSessionHint !== ''
             ? selectedRuntimeSessionHint
             : undefined;
+
+        if (effectiveTools.length === 0) {
+          return await runPlainExecution({
+            baseUrl,
+            lang: 'py',
+            code,
+            sessionId: session_id,
+            files,
+            runtimeSessionHint,
+            proxy,
+            authHeaders: initParams.authHeaders,
+            executionProfile: initParams.executionProfile,
+          });
+        }
 
         let response = await makeRequest(
           EXEC_ENDPOINT,

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -946,14 +946,14 @@ export function createProgrammaticToolCallingTool(
        * replays, and event-driven ToolNode configurations legitimately inject
        * an empty toolMap/toolDefs, so requiring them here would re-break the
        * tool-free call this route exists to serve. Injected context is still
-       * required to conclude that: with nothing injected at all, an empty
-       * selection means the host wired the tool up wrong, not that the code
-       * needs no tools. */
+       * required to conclude that — but an injected empty context counts:
+       * ToolNode legitimately yields no code-execution tools. Only a call with
+       * nothing injected at all is treated as a host wiring mistake. */
       const needsNoTools =
         effectiveTools.length === 0 &&
         (params.tool_manifest?.length === 0 ||
-          (toolDefs?.length ?? 0) > 0 ||
-          (disallowedToolDefs?.length ?? 0) > 0);
+          toolDefs != null ||
+          disallowedToolDefs != null);
 
       if (!needsNoTools) {
         if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -831,6 +831,12 @@ export async function runPlainExecution(args: {
   baseUrl: string;
   lang: 'bash' | 'py';
   code: string;
+  /**
+   * Forwarded so the model-supplied cap applies as soon as the Code API honors
+   * it on `/exec`; today that route reads only `user_id`, `lang`, `code` and
+   * `files`, leaving the sandbox's own run limit in force.
+   */
+  timeout?: number;
   sessionId?: string;
   files?: t.CodeEnvFile[];
   runtimeSessionHint?: string;
@@ -846,6 +852,7 @@ export async function runPlainExecution(args: {
         args.lang === 'py'
           ? wrapPythonForPlainExecution(args.code)
           : args.code,
+      ...(args.timeout != null ? { timeout: args.timeout } : {}),
       ...(args.sessionId != null && args.sessionId !== ''
         ? { session_id: args.sessionId }
         : {}),
@@ -1020,6 +1027,7 @@ export function createProgrammaticToolCallingTool(
             baseUrl,
             lang: 'py',
             code,
+            timeout,
             sessionId: session_id,
             files,
             runtimeSessionHint,

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -794,6 +794,31 @@ export function formatCompletedResponse(
 }
 
 /**
+ * Mirrors the Code API's programmatic Python wrapper (`wrapUserCodeInAsync`).
+ *
+ * The programmatic contract promises top-level `await` works; plain `/exec`
+ * applies no wrapper, so forwarding source unchanged would turn valid
+ * programmatic input into a SyntaxError. The wrapper is self-contained, so a
+ * later divergence in the Code API's own copy cannot break this path.
+ */
+export function wrapPythonForPlainExecution(userCode: string): string {
+  const indented = userCode
+    .split('\n')
+    .map((line) => (line.trim() === '' ? '' : `    ${line}`))
+    .join('\n');
+
+  return (
+    'async def __user_main__():\n' +
+    '    """Auto-generated wrapper for user code to support top-level await"""\n' +
+    `${indented}\n` +
+    '\n' +
+    'if __name__ == "__main__":\n' +
+    '    import asyncio\n' +
+    '    asyncio.run(__user_main__())\n'
+  );
+}
+
+/**
  * Runs code that references no tools through plain `/exec`.
  *
  * `/exec/programmatic` rejects an empty tool manifest outright, and the sandbox
@@ -817,7 +842,10 @@ export async function runPlainExecution(args: {
     buildCodeApiEndpoint(args.baseUrl, 'exec'),
     {
       lang: args.lang,
-      code: args.code,
+      code:
+        args.lang === 'py'
+          ? wrapPythonForPlainExecution(args.code)
+          : args.code,
       ...(args.sessionId != null && args.sessionId !== ''
         ? { session_id: args.sessionId }
         : {}),
@@ -907,22 +935,37 @@ export function createProgrammaticToolCallingTool(
         programmaticToolName,
       });
 
-      if (toolMap == null || toolMap.size === 0) {
-        throw new Error(
-          'No toolMap provided. ' +
-            'ToolNode should inject this from AgentContext when invoked through the graph.'
-        );
-      }
+      /* These guard the replay path only. A call that selected no tools never
+       * replays, and event-driven ToolNode configurations legitimately inject
+       * an empty toolMap/toolDefs, so requiring them here would re-break the
+       * tool-free call this route exists to serve. Injected context is still
+       * required to conclude that: with nothing injected at all, an empty
+       * selection means the host wired the tool up wrong, not that the code
+       * needs no tools. */
+      const needsNoTools =
+        effectiveTools.length === 0 &&
+        (params.tool_manifest?.length === 0 ||
+          (toolDefs?.length ?? 0) > 0 ||
+          (disallowedToolDefs?.length ?? 0) > 0);
 
-      if (toolDefs == null || toolDefs.length === 0) {
-        throw new Error(
-          'No tool definitions provided. ' +
-            'Either pass tools in the input or ensure ToolNode injects toolDefs.'
-        );
+      if (!needsNoTools) {
+        if (toolMap == null || toolMap.size === 0) {
+          throw new Error(
+            'No toolMap provided. ' +
+              'ToolNode should inject this from AgentContext when invoked through the graph.'
+          );
+        }
+
+        if (toolDefs == null || toolDefs.length === 0) {
+          throw new Error(
+            'No tool definitions provided. ' +
+              'Either pass tools in the input or ensure ToolNode injects toolDefs.'
+          );
+        }
       }
 
       const effectiveToolMap = projectProgrammaticToolMap(
-        toolMap,
+        toolMap ?? new Map(),
         effectiveTools
       );
 
@@ -937,7 +980,7 @@ export function createProgrammaticToolCallingTool(
           // eslint-disable-next-line no-console
           console.log(
             `[PTC Debug] Sending ${effectiveTools.length} tools to API ` +
-              `(selected from ${toolDefs.length})`
+              `(selected from ${toolDefs?.length ?? 0})`
           );
         }
 
@@ -972,7 +1015,7 @@ export function createProgrammaticToolCallingTool(
             ? selectedRuntimeSessionHint
             : undefined;
 
-        if (effectiveTools.length === 0) {
+        if (needsNoTools) {
           return await runPlainExecution({
             baseUrl,
             lang: 'py',

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -674,3 +674,53 @@ describe('bash comments after control operators', () => {
     ).toEqual(['write_file']);
   });
 });
+
+describe('single-quoted words in command position', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a quoted command name', () => {
+    expect(
+      deriveReferencedToolDefs(tools, '\'calculator\' \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps a quoted command name after a separator', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'echo ok; \'calculator\' \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('still treats a quoted argument as prose', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'echo \'calculator\'', 'bash')
+    ).toEqual([]);
+  });
+});
+
+describe('an injected empty tool context still runs tool-free code', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('routes to plain exec when ToolNode injects no nested tools', async () => {
+    await createBashProgrammaticToolCallingTool({ baseUrl: BASE_URL }).invoke(
+      {
+        name: 'run_tools_with_bash',
+        args: { code: 'ls /mnt/data' },
+        id: 'call-1',
+        type: 'tool_call',
+        toolMap: new Map(),
+        toolDefs: [],
+      } as never,
+      {} as never
+    );
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -724,3 +724,31 @@ describe('an injected empty tool context still runs tool-free code', () => {
     expect(requests[0].url).toBe(`${BASE_URL}/exec`);
   });
 });
+
+describe('assignment prefixes keep command position', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a quoted command after an assignment prefix', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'FOO=bar \'calculator\' \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps an unquoted command after several prefixes', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'A=1 B=2 calculator \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('does not treat a later quoted argument as a command', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'FOO=bar echo \'calculator\'', 'bash')
+    ).toEqual([]);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -55,6 +55,7 @@ import {
 } from '../ProgrammaticToolCalling';
 import {
   deriveReferencedToolDefs,
+  findNormalizedIdentifierCollision,
   stripNonCodeText,
 } from '../toolIdentifiers';
 import {
@@ -337,12 +338,56 @@ describe('ambiguous normalized identifiers', () => {
     { name: 'report_tool', allowed_callers: ['code_execution'] },
   ];
 
-  it('keeps every colliding definition rather than picking by order', () => {
+  it('surfaces every colliding definition rather than picking by order', () => {
     expect(
       deriveReferencedToolDefs(colliding, 'report_tool \'{}\'', 'bash').map(
         (def) => def.name
       )
     ).toEqual(['report-tool', 'report_tool']);
+  });
+
+  it('reports the pair that collapses to one identifier', () => {
+    expect(findNormalizedIdentifierCollision(colliding, 'bash')).toEqual({
+      first: 'report-tool',
+      second: 'report_tool',
+      identifier: 'report_tool',
+    });
+  });
+
+  it('rejects an ambiguous derived selection', () => {
+    expect(() =>
+      selectProgrammaticTools({
+        code: 'report_tool \'{}\'',
+        runtime: 'bash',
+        allowedToolDefs: colliding,
+        disallowedToolDefs: [{ name: 'send_email' }],
+        programmaticToolName: 'run_tools_with_bash',
+      })
+    ).toThrow('cannot tell which one the code means');
+  });
+
+  it('rejects an ambiguous explicit manifest the same way', () => {
+    expect(() =>
+      selectProgrammaticTools({
+        code: 'report_tool \'{}\'',
+        runtime: 'bash',
+        requestedToolNames: ['report-tool', 'report_tool'],
+        allowedToolDefs: colliding,
+        programmaticToolName: 'run_tools_with_bash',
+      })
+    ).toThrow('cannot tell which one the code means');
+  });
+
+  it('accepts an unambiguous manifest naming one of the pair', () => {
+    expect(
+      selectProgrammaticTools({
+        code: 'report_tool \'{}\'',
+        runtime: 'bash',
+        requestedToolNames: ['report-tool'],
+        allowedToolDefs: colliding,
+        programmaticToolName: 'run_tools_with_bash',
+      }).map((def) => def.name)
+    ).toEqual(['report-tool']);
   });
 
   it('does not widen selection for an unreferenced collision', () => {
@@ -469,5 +514,37 @@ describe('timeout on the plain route', () => {
 
     expect(requests[0].url).toBe(`${BASE_URL}/exec`);
     expect(requests[0].body.timeout).toBe(5000);
+  });
+});
+
+describe('f-string literals are prose, replacement fields are code', () => {
+  const tools: t.LCTool[] = [
+    { name: 'write_file', allowed_callers: ['code_execution'] },
+  ];
+
+  it('ignores a tool name in the literal text of an f-string', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"example: write_file(path)")',
+        'python'
+      )
+    ).toEqual([]);
+  });
+
+  it('still sees a call inside a replacement field', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{await write_file(path=1)}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['write_file']);
+  });
+
+  it('treats doubled braces as literal text', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'print(f"{{write_file(x)}}")', 'python')
+    ).toEqual([]);
   });
 });

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -48,7 +48,10 @@ jest.mock('node-fetch', () => ({
 }));
 
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
-import { createProgrammaticToolCallingTool } from '../ProgrammaticToolCalling';
+import {
+  createProgrammaticToolCallingTool,
+  wrapPythonForPlainExecution,
+} from '../ProgrammaticToolCalling';
 import { deriveReferencedToolDefs } from '../toolIdentifiers';
 import {
   createProgrammaticToolRegistry,
@@ -212,11 +215,12 @@ describe('omitted manifest with direct-only tools configured', () => {
     expect(requests).toHaveLength(0);
   });
 
-  it('never derives a direct-only tool from the code', async () => {
-    await invokeBash({ code: 'send_email \'{}\'' }, { disallowedToolDefs });
+  it('rejects a derived reference to a direct-only tool', async () => {
+    await expect(
+      invokeBash({ code: 'send_email \'{}\'' }, { disallowedToolDefs })
+    ).rejects.toThrow('not marked for code_execution');
 
-    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
-    expect(requests[0].body.tools).toBeUndefined();
+    expect(requests).toHaveLength(0);
   });
 });
 
@@ -259,5 +263,85 @@ describe('deriveReferencedToolDefs', () => {
         (def) => def.name
       )
     ).toEqual(['calculator']);
+  });
+});
+
+describe('python plain route keeps the programmatic contract', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('wraps top-level await so it stays valid python', async () => {
+    await invokePython({
+      code: 'import asyncio\nawait asyncio.sleep(0)\nprint("done")',
+      tool_manifest: [],
+    });
+
+    const sent = requests[0].body.code as string;
+    expect(sent).toContain('async def __user_main__():');
+    expect(sent).toContain('    await asyncio.sleep(0)');
+    expect(sent).toContain('asyncio.run(__user_main__())');
+  });
+
+  it('leaves bash source untouched', async () => {
+    await invokeBash({ code: 'echo hi', tool_manifest: [] });
+
+    expect(requests[0].body.code).toBe('echo hi');
+  });
+
+  it('preserves blank lines when indenting', () => {
+    expect(wrapPythonForPlainExecution('a = 1\n\nprint(a)')).toContain(
+      '    a = 1\n\n    print(a)'
+    );
+  });
+});
+
+describe('tool context is still required to conclude no tools are needed', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('still reports a missing toolMap when nothing was injected', async () => {
+    await expect(
+      createBashProgrammaticToolCallingTool({ baseUrl: BASE_URL }).invoke({
+        code: 'get_weather \'{"city":"SF"}\'',
+      } as never)
+    ).rejects.toThrow('No toolMap provided');
+
+    expect(requests).toHaveLength(0);
+  });
+
+  it('runs tool-free code when only disallowed defs were injected', async () => {
+    await createBashProgrammaticToolCallingTool({ baseUrl: BASE_URL }).invoke(
+      {
+        name: 'run_tools_with_bash',
+        args: { code: 'ls /mnt/data' },
+        id: 'call-1',
+        type: 'tool_call',
+        disallowedToolDefs: [{ name: 'send_email' }],
+      } as never,
+      {} as never
+    );
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+  });
+});
+
+describe('ambiguous normalized identifiers', () => {
+  const colliding: t.LCTool[] = [
+    { name: 'report-tool', allowed_callers: ['code_execution'] },
+    { name: 'report_tool', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps every colliding definition rather than picking by order', () => {
+    expect(
+      deriveReferencedToolDefs(colliding, 'report_tool \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['report-tool', 'report_tool']);
+  });
+
+  it('does not widen selection for an unreferenced collision', () => {
+    expect(deriveReferencedToolDefs(colliding, 'ls -la', 'bash')).toEqual([]);
   });
 });

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -260,7 +260,7 @@ describe('deriveReferencedToolDefs', () => {
     ).toEqual(['calculator']);
   });
 
-  it('requires a call expression for python', () => {
+  it('ignores a python name that only appears in a comment', () => {
     expect(
       deriveReferencedToolDefs(allToolDefs, '# calculator is unused', 'python')
     ).toEqual([]);
@@ -749,6 +749,41 @@ describe('assignment prefixes keep command position', () => {
   it('does not treat a later quoted argument as a command', () => {
     expect(
       deriveReferencedToolDefs(tools, 'FOO=bar echo \'calculator\'', 'bash')
+    ).toEqual([]);
+  });
+});
+
+describe('aliased and higher-order tool references', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('selects a tool bound to another name', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'fn = calculator\nawait fn(a=1)',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('selects a tool passed to a higher-order call', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'results = [await f(a=1) for f in (calculator,)]',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('still ignores the name in a comment or literal', () => {
+    expect(
+      deriveReferencedToolDefs(tools, '# calculator unused', 'python')
+    ).toEqual([]);
+    expect(
+      deriveReferencedToolDefs(tools, 'x = "calculator"', 'python')
     ).toEqual([]);
   });
 });

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -419,3 +419,55 @@ describe('runtimes that expose unselected tools keep requiring a manifest', () =
     ).toEqual([]);
   });
 });
+
+describe('interpolating constructs stay visible to derivation', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a python f-string expression', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{await calculator(1)}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps a bash command substitution', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'echo "$(calculator \'{}\')"', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('still blanks a non-interpolating python literal', () => {
+    expect(stripNonCodeText('x = b"calculator("', 'python')).not.toContain(
+      'calculator'
+    );
+  });
+
+  it('still blanks bash single quotes and comments', () => {
+    expect(stripNonCodeText('echo \'calculator\'', 'bash')).not.toContain(
+      'calculator'
+    );
+    expect(stripNonCodeText('ls # calculator', 'bash')).not.toContain(
+      'calculator'
+    );
+  });
+});
+
+describe('timeout on the plain route', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('forwards the clamped timeout so it applies once /exec honors it', async () => {
+    await invokeBash({ code: 'ls /mnt/data', tool_manifest: [], timeout: 5000 });
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+    expect(requests[0].body.timeout).toBe(5000);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -48,11 +48,15 @@ jest.mock('node-fetch', () => ({
 }));
 
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
+import { selectProgrammaticTools } from '../ProgrammaticCallerPolicy';
 import {
   createProgrammaticToolCallingTool,
   wrapPythonForPlainExecution,
 } from '../ProgrammaticToolCalling';
-import { deriveReferencedToolDefs } from '../toolIdentifiers';
+import {
+  deriveReferencedToolDefs,
+  stripNonCodeText,
+} from '../toolIdentifiers';
 import {
   createProgrammaticToolRegistry,
   createGetWeatherTool,
@@ -343,5 +347,75 @@ describe('ambiguous normalized identifiers', () => {
 
   it('does not widen selection for an unreferenced collision', () => {
     expect(deriveReferencedToolDefs(colliding, 'ls -la', 'bash')).toEqual([]);
+  });
+});
+
+describe('prose is not mistaken for a call', () => {
+  const colliding: t.LCTool[] = [
+    { name: 'write_file', allowed_callers: ['code_execution'] },
+  ];
+
+  it('ignores python comments and string literals', () => {
+    expect(
+      deriveReferencedToolDefs(colliding, 'print("write_file(")', 'python')
+    ).toEqual([]);
+    expect(
+      deriveReferencedToolDefs(colliding, '# calls write_file(x)', 'python')
+    ).toEqual([]);
+  });
+
+  it('ignores bash comments and quoted text', () => {
+    expect(
+      deriveReferencedToolDefs(colliding, 'echo \'write_file\'', 'bash')
+    ).toEqual([]);
+    expect(
+      deriveReferencedToolDefs(colliding, '# write_file here', 'bash')
+    ).toEqual([]);
+  });
+
+  it('still matches a real invocation', () => {
+    expect(
+      deriveReferencedToolDefs(colliding, 'write_file(path="a")', 'python').map(
+        (def) => def.name
+      )
+    ).toEqual(['write_file']);
+  });
+
+  it('keeps code that follows a docstring', () => {
+    expect(stripNonCodeText('"""doc"""\nwrite_file(1)', 'python')).toContain(
+      'write_file(1)'
+    );
+  });
+});
+
+describe('runtimes that expose unselected tools keep requiring a manifest', () => {
+  const allowedToolDefs: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+  const disallowedToolDefs: t.LCTool[] = [{ name: 'write_file' }];
+
+  it('refuses to derive when stubs are defined unconditionally', () => {
+    expect(() =>
+      selectProgrammaticTools({
+        code: 'fn = globals()["write_file"]',
+        runtime: 'python',
+        allowedToolDefs,
+        disallowedToolDefs,
+        programmaticToolName: 'run_tools_with_code',
+        runtimeExposesUnselectedTools: true,
+      })
+    ).toThrow('requires a tool_manifest');
+  });
+
+  it('derives normally when the runtime gates its stubs', () => {
+    expect(
+      selectProgrammaticTools({
+        code: 'fn = globals()["write_file"]',
+        runtime: 'python',
+        allowedToolDefs,
+        disallowedToolDefs,
+        programmaticToolName: 'run_tools_with_code',
+      })
+    ).toEqual([]);
   });
 });

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type * as t from '@/types';
+
+/* Mirrors codeapi's `/exec/programmatic` guard, which rejects an empty tool
+ * manifest outright: `if (!tools || tools.length === 0) -> 400`. Plain `/exec`
+ * has no such requirement. */
+type CapturedRequest = { url: string; body: Record<string, unknown> };
+const requests: CapturedRequest[] = [];
+
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: async (url: string, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? '{}') as { tools?: unknown[] };
+    requests.push({ url, body });
+
+    if (url.endsWith('/exec/programmatic')) {
+      const { tools } = body;
+      if (!Array.isArray(tools) || tools.length === 0) {
+        return {
+          ok: false,
+          status: 400,
+          text: async () =>
+            '{"error":"Missing required field: tools (must be a non-empty array)"}',
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          status: 'completed',
+          session_id: 'programmatic-session',
+          stdout: 'programmatic',
+          stderr: '',
+          files: [],
+        }),
+      };
+    }
+
+    return {
+      ok: true,
+      json: async () => ({
+        session_id: 'plain-session',
+        stdout: 'plain',
+        stderr: '',
+        files: [],
+      }),
+    };
+  },
+}));
+
+import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
+import { createProgrammaticToolCallingTool } from '../ProgrammaticToolCalling';
+import { deriveReferencedToolDefs } from '../toolIdentifiers';
+import {
+  createProgrammaticToolRegistry,
+  createGetWeatherTool,
+  createCalculatorTool,
+} from '@/test/mockTools';
+
+const BASE_URL = 'https://code.example.test';
+
+const allToolDefs = Array.from(createProgrammaticToolRegistry().values());
+const toolMap: t.ToolMap = new Map([
+  ['get_weather', createGetWeatherTool()],
+  ['calculator', createCalculatorTool()],
+]);
+
+type ToolResult = {
+  content: string;
+  artifact?: t.ProgrammaticExecutionArtifact;
+};
+
+function invokeBash(
+  args: Record<string, unknown>,
+  toolCallExtras: Record<string, unknown> = {}
+) {
+  return createBashProgrammaticToolCallingTool({ baseUrl: BASE_URL }).invoke(
+    {
+      name: 'run_tools_with_bash',
+      args,
+      id: 'call-1',
+      type: 'tool_call',
+      toolMap,
+      toolDefs: allToolDefs,
+      ...toolCallExtras,
+    } as never,
+    {} as never
+  );
+}
+
+function invokePython(
+  args: Record<string, unknown>,
+  toolCallExtras: Record<string, unknown> = {}
+) {
+  return createProgrammaticToolCallingTool({ baseUrl: BASE_URL }).invoke(
+    {
+      name: 'run_tools_with_code',
+      args,
+      id: 'call-1',
+      type: 'tool_call',
+      toolMap,
+      toolDefs: allToolDefs,
+      ...toolCallExtras,
+    } as never,
+    {} as never
+  );
+}
+
+describe('programmatic calls that reference no tools', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('routes an explicitly empty bash manifest to plain /exec', async () => {
+    const result = (await invokeBash({
+      code: 'ls /mnt/data',
+      tool_manifest: [],
+    })) as ToolResult;
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+    expect(requests[0].body).toMatchObject({
+      lang: 'bash',
+      code: 'ls /mnt/data',
+    });
+    expect(requests[0].body.tools).toBeUndefined();
+    expect(result.content).toContain('plain');
+  });
+
+  it('sends raw code on the plain path, without the replay `$!` guard', async () => {
+    await invokeBash({ code: 'set -u\necho hi', tool_manifest: [] });
+
+    expect(requests[0].body.code).toBe('set -u\necho hi');
+  });
+
+  it('routes an explicitly empty python manifest to plain /exec', async () => {
+    await invokePython({
+      code: 'import os\nprint(os.listdir("/mnt/data"))',
+      tool_manifest: [],
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+    expect(requests[0].body).toMatchObject({ lang: 'py' });
+  });
+
+  it('carries session, files and runtime hint onto the plain path', async () => {
+    const files: t.CodeEnvFile[] = [
+      {
+        kind: 'user',
+        id: 'file-1',
+        resource_id: 'user-1',
+        name: 'data.csv',
+        storage_session_id: 'prior',
+      },
+    ];
+
+    const result = (await invokeBash(
+      { code: 'wc -l /mnt/data/data.csv', tool_manifest: [] },
+      {
+        session_id: 'prior',
+        _injected_files: files,
+        _runtime_session_hint: 'hint-1',
+      }
+    )) as ToolResult;
+
+    expect(requests[0].body).toMatchObject({
+      session_id: 'prior',
+      files,
+      runtime_session_hint: 'hint-1',
+    });
+    expect(result.artifact?.session_id).toBe('plain-session');
+  });
+});
+
+describe('omitted manifest with direct-only tools configured', () => {
+  const disallowedToolDefs: t.LCTool[] = [{ name: 'send_email' }];
+
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('derives an empty manifest for tool-free code and runs it', async () => {
+    const result = (await invokeBash(
+      { code: 'jq ".[] | .name" /mnt/data/saved.json' },
+      { disallowedToolDefs }
+    )) as ToolResult;
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+    expect(result.content).toContain('plain');
+  });
+
+  it('derives the referenced tool and keeps the programmatic path', async () => {
+    await invokeBash(
+      { code: 'raw=$(get_weather \'{"city":"SF"}\'); echo "$raw"' },
+      { disallowedToolDefs }
+    );
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec/programmatic`);
+    expect(
+      (requests[0].body.tools as t.LCTool[]).map((def) => def.name)
+    ).toEqual(['get_weather']);
+  });
+
+  it('still refuses a manifest that names a direct-only tool', async () => {
+    await expect(
+      invokeBash(
+        { code: 'send_email \'{}\'', tool_manifest: ['send_email'] },
+        { disallowedToolDefs }
+      )
+    ).rejects.toThrow('not marked for code_execution');
+
+    expect(requests).toHaveLength(0);
+  });
+
+  it('never derives a direct-only tool from the code', async () => {
+    await invokeBash({ code: 'send_email \'{}\'' }, { disallowedToolDefs });
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec`);
+    expect(requests[0].body.tools).toBeUndefined();
+  });
+});
+
+describe('unchanged behavior when no direct-only tools exist', () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it('still sends the full manifest for an omitted tool_manifest', async () => {
+    await invokeBash({ code: 'ls /mnt/data' });
+
+    expect(requests[0].url).toBe(`${BASE_URL}/exec/programmatic`);
+    expect(
+      (requests[0].body.tools as t.LCTool[]).map((def) => def.name)
+    ).toEqual(allToolDefs.map((def) => def.name));
+  });
+});
+
+describe('deriveReferencedToolDefs', () => {
+  it('returns an empty set rather than falling back to every tool', () => {
+    expect(deriveReferencedToolDefs(allToolDefs, 'ls -la', 'bash')).toEqual([]);
+  });
+
+  it('matches bash invocations by word boundary', () => {
+    expect(
+      deriveReferencedToolDefs(
+        allToolDefs,
+        'calculator \'{"a":1}\'',
+        'bash'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('requires a call expression for python', () => {
+    expect(
+      deriveReferencedToolDefs(allToolDefs, '# calculator is unused', 'python')
+    ).toEqual([]);
+    expect(
+      deriveReferencedToolDefs(allToolDefs, 'calculator(a=1)', 'python').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -49,6 +49,7 @@ jest.mock('node-fetch', () => ({
 
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
 import { selectProgrammaticTools } from '../ProgrammaticCallerPolicy';
+import { createPythonProgram as createCloudflarePythonProgramForTest } from '../cloudflare/CloudflareProgrammaticToolCalling';
 import {
   createProgrammaticToolCallingTool,
   wrapPythonForPlainExecution,
@@ -433,38 +434,6 @@ describe('prose is not mistaken for a call', () => {
   });
 });
 
-describe('runtimes that expose unselected tools keep requiring a manifest', () => {
-  const allowedToolDefs: t.LCTool[] = [
-    { name: 'calculator', allowed_callers: ['code_execution'] },
-  ];
-  const disallowedToolDefs: t.LCTool[] = [{ name: 'write_file' }];
-
-  it('refuses to derive when stubs are defined unconditionally', () => {
-    expect(() =>
-      selectProgrammaticTools({
-        code: 'fn = globals()["write_file"]',
-        runtime: 'python',
-        allowedToolDefs,
-        disallowedToolDefs,
-        programmaticToolName: 'run_tools_with_code',
-        runtimeExposesUnselectedTools: true,
-      })
-    ).toThrow('requires a tool_manifest');
-  });
-
-  it('derives normally when the runtime gates its stubs', () => {
-    expect(
-      selectProgrammaticTools({
-        code: 'fn = globals()["write_file"]',
-        runtime: 'python',
-        allowedToolDefs,
-        disallowedToolDefs,
-        programmaticToolName: 'run_tools_with_code',
-      })
-    ).toEqual([]);
-  });
-});
-
 describe('interpolating constructs stay visible to derivation', () => {
   const tools: t.LCTool[] = [
     { name: 'calculator', allowed_callers: ['code_execution'] },
@@ -586,5 +555,89 @@ describe('nested replacement fields', () => {
     expect(
       deriveReferencedToolDefs(tools, 'print(f"{{calculator(x)}}")', 'python')
     ).toEqual([]);
+  });
+});
+
+describe('cloudflare python withholds unselected native tools', () => {
+  const build = (names: string[]): string =>
+    createCloudflarePythonProgramForTest(
+      'print(1)',
+      names.map((name) => ({ name })),
+      { shell: 'bash' } as never,
+      '/workspace'
+    );
+
+  it('pops every native tool the selection does not include', () => {
+    const program = build(['read_file']);
+
+    expect(program).toContain('globals().pop(_lc_withheld, None)');
+    expect(program).toContain('"write_file"');
+    expect(program).not.toMatch(/_lc_withheld in \[[^\]]*"read_file"/);
+  });
+
+  it('withholds all of them when nothing is selected', () => {
+    const program = build([]);
+
+    expect(program).toContain('"read_file"');
+    expect(program).toContain('"execute_code"');
+  });
+
+  it('emits no withdrawal when every native tool is selected', () => {
+    const program = build([
+      'read_file',
+      'write_file',
+      'edit_file',
+      'grep_search',
+      'glob_search',
+      'list_directory',
+      'compile_check',
+      'bash_tool',
+      'execute_code',
+    ]);
+
+    expect(program).not.toContain('_lc_withheld');
+  });
+});
+
+describe('quoting inside scanned regions', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a call after a quoted brace in a replacement field', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{\'}\' + await calculator()}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps a command substitution after a literal hash in double quotes', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'echo "label # $(calculator \'{}\')"',
+        'bash'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('still treats a real bash comment as prose', () => {
+    expect(deriveReferencedToolDefs(tools, 'ls # calculator', 'bash')).toEqual(
+      []
+    );
+    expect(
+      deriveReferencedToolDefs(tools, 'echo \'calculator\'', 'bash')
+    ).toEqual([]);
+  });
+
+  it('does not treat a hash inside a word as a comment', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'calculator#1', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
   });
 });

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -787,3 +787,57 @@ describe('aliased and higher-order tool references', () => {
     ).toEqual([]);
   });
 });
+
+describe('literals inside replacement fields are data', () => {
+  const tools: t.LCTool[] = [
+    { name: 'write_file', allowed_callers: ['code_execution'] },
+  ];
+
+  it('ignores a quoted tool name inside a replacement field', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'print(f"{\'write_file\'}")', 'python')
+    ).toEqual([]);
+  });
+
+  it('still sees the call around a quoted argument', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{await write_file(path=\'a\')}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['write_file']);
+  });
+});
+
+describe('bash control keywords keep command position', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a quoted command after if', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'if \'calculator\' \'{}\'; then echo ok; fi',
+        'bash'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps a quoted command after while and do', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'while \'calculator\' \'{}\'; do echo ok; done',
+        'bash'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('still treats a quoted argument after a keyword as prose', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'if echo \'calculator\'; then :; fi', 'bash')
+    ).toEqual([]);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -548,3 +548,43 @@ describe('f-string literals are prose, replacement fields are code', () => {
     ).toEqual([]);
   });
 });
+
+describe('nested replacement fields', () => {
+  const tools: t.LCTool[] = [
+    { name: 'calculator', allowed_callers: ['code_execution'] },
+  ];
+
+  it('keeps a call whose arguments contain a dict literal', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{await calculator(payload={\'x\': 1})}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps a call beside a separate replacement field', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'print(f"{name}: {await calculator({\'a\': [1, 2]})}")',
+        'python'
+      ).map((def) => def.name)
+    ).toEqual(['calculator']);
+  });
+
+  it('keeps an unterminated field rather than dropping a call', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'x = f"{calculator(1)"', 'python').map(
+        (def) => def.name
+      )
+    ).toEqual(['calculator']);
+  });
+
+  it('still blanks doubled braces around prose', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'print(f"{{calculator(x)}}")', 'python')
+    ).toEqual([]);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
+++ b/src/tools/__tests__/ProgrammaticEmptyManifest.test.ts
@@ -641,3 +641,36 @@ describe('quoting inside scanned regions', () => {
     ).toEqual(['calculator']);
   });
 });
+
+describe('bash comments after control operators', () => {
+  const tools: t.LCTool[] = [
+    { name: 'write_file', allowed_callers: ['code_execution'] },
+  ];
+
+  it('treats a comment straight after a semicolon as prose', () => {
+    expect(
+      deriveReferencedToolDefs(
+        tools,
+        'echo ok;# write_file is unavailable',
+        'bash'
+      )
+    ).toEqual([]);
+  });
+
+  it('treats a comment after a pipe or ampersand as prose', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'echo ok &# write_file here', 'bash')
+    ).toEqual([]);
+    expect(
+      deriveReferencedToolDefs(tools, 'echo ok |# write_file here', 'bash')
+    ).toEqual([]);
+  });
+
+  it('still keeps a call that follows a control operator', () => {
+    expect(
+      deriveReferencedToolDefs(tools, 'echo ok; write_file \'{}\'', 'bash').map(
+        (def) => def.name
+      )
+    ).toEqual(['write_file']);
+  });
+});

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -929,19 +929,47 @@ for member in team:
     ];
     const disallowedToolDefs = [{ name: 'send_email' }];
 
-    it('requires a manifest for mixed caller configurations', () => {
-      expect(() =>
+    it('derives the manifest from code for mixed caller configurations', () => {
+      expect(
         selectProgrammaticTools({
+          code: 'print(search(query="x"))',
+          runtime: 'python',
           allowedToolDefs,
           disallowedToolDefs,
           programmaticToolName: 'run_tools_with_code',
         })
-      ).toThrow('requires a tool_manifest');
+      ).toEqual([allowedToolDefs[0]]);
+    });
+
+    it('derives an empty manifest for code that calls no tools', () => {
+      expect(
+        selectProgrammaticTools({
+          code: 'import os\nprint(os.listdir("/mnt/data"))',
+          runtime: 'python',
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toEqual([]);
+    });
+
+    it('never derives a direct-only tool the caller may not use', () => {
+      expect(
+        selectProgrammaticTools({
+          code: 'send_email(to="a@b.c")',
+          runtime: 'python',
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_code',
+        })
+      ).toEqual([]);
     });
 
     it('rejects direct-only manifest entries before execution', () => {
       expect(() =>
         selectProgrammaticTools({
+          code: 'send_email(to="a@b.c")',
+          runtime: 'python',
           requestedToolNames: ['send_email'],
           allowedToolDefs,
           disallowedToolDefs,
@@ -953,6 +981,8 @@ for member in team:
     it('selects declared allowed tools without parsing code', () => {
       expect(
         selectProgrammaticTools({
+          code: '',
+          runtime: 'python',
           requestedToolNames: ['calculate', 'search', 'search'],
           allowedToolDefs,
           disallowedToolDefs,
@@ -961,9 +991,24 @@ for member in team:
       ).toEqual([allowedToolDefs[1], allowedToolDefs[0]]);
     });
 
+    it('honors an explicitly empty manifest', () => {
+      expect(
+        selectProgrammaticTools({
+          code: 'ls /mnt/data',
+          runtime: 'bash',
+          requestedToolNames: [],
+          allowedToolDefs,
+          disallowedToolDefs,
+          programmaticToolName: 'run_tools_with_bash',
+        })
+      ).toEqual([]);
+    });
+
     it('preserves the all-tools fallback when no direct-only tools exist', () => {
       expect(
         selectProgrammaticTools({
+          code: 'ls /mnt/data',
+          runtime: 'bash',
           allowedToolDefs,
           programmaticToolName: 'run_tools_with_code',
         })
@@ -984,9 +1029,9 @@ for member in team:
         ['send_email', emailTool],
       ]);
 
-      expect(
-        projectProgrammaticToolMap(toolMap, [{ name: 'search' }])
-      ).toEqual(new Map([['search', searchTool]]));
+      expect(projectProgrammaticToolMap(toolMap, [{ name: 'search' }])).toEqual(
+        new Map([['search', searchTool]])
+      );
     });
   });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -953,8 +953,8 @@ for member in team:
       ).toEqual([]);
     });
 
-    it('never derives a direct-only tool the caller may not use', () => {
-      expect(
+    it('rejects a derived reference to a direct-only tool', () => {
+      expect(() =>
         selectProgrammaticTools({
           code: 'send_email(to="a@b.c")',
           runtime: 'python',
@@ -962,7 +962,7 @@ for member in team:
           disallowedToolDefs,
           programmaticToolName: 'run_tools_with_code',
         })
-      ).toEqual([]);
+      ).toThrow('not marked for code_execution');
     });
 
     it('rejects direct-only manifest entries before execution', () => {

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1060,6 +1060,8 @@ async function runProgrammatic(args: {
       ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       : Constants.PROGRAMMATIC_TOOL_CALLING);
   const selectedTools = selectProgrammaticTools({
+    code: args.params.code,
+    runtime: args.runtime,
     requestedToolNames: args.params.tool_manifest,
     allowedToolDefs: toolDefs,
     disallowedToolDefs: toolCall.disallowedToolDefs,

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1066,6 +1066,7 @@ async function runProgrammatic(args: {
     allowedToolDefs: toolDefs,
     disallowedToolDefs: toolCall.disallowedToolDefs,
     programmaticToolName,
+    runtimeExposesUnselectedTools: args.runtime === 'python',
   });
   const effectiveTools = filterNativeTools(selectedTools);
   const timeoutMs = clampExecutionTimeout(

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1007,7 +1007,13 @@ export function createPythonProgram(
   /* The native source defines every tool unconditionally, so selection alone
    * does not bound what user code can reach. Withdraw the unselected names
    * after the aliases bind, which leaves each tool's private `_`-prefixed
-   * helpers intact — no native tool calls another by its public name. */
+   * helpers intact — no native tool calls another by its public name.
+   *
+   * This bounds accidental reach, not a determined caller: the generated module
+   * imports `subprocess` at top level and user code runs in its globals, so
+   * `allowed_callers` is advisory in this runtime no matter what names are
+   * removed. Containment needs a restricted execution namespace, which is a
+   * separate change to how the program is generated. */
   const selectedNativeNames = new Set(
     toolDefs
       .filter((def) => NATIVE_TOOL_NAMES.has(def.name))

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -989,7 +989,7 @@ main().catch((error) => {
 `.trim();
 }
 
-function createPythonProgram(
+export function createPythonProgram(
   userCode: string,
   toolDefs: t.LCTool[],
   config: t.CloudflareSandboxExecutionConfig,
@@ -1004,9 +1004,28 @@ function createPythonProgram(
     })
     .filter(Boolean)
     .join('\n');
+  /* The native source defines every tool unconditionally, so selection alone
+   * does not bound what user code can reach. Withdraw the unselected names
+   * after the aliases bind, which leaves each tool's private `_`-prefixed
+   * helpers intact — no native tool calls another by its public name. */
+  const selectedNativeNames = new Set(
+    toolDefs
+      .filter((def) => NATIVE_TOOL_NAMES.has(def.name))
+      .map((def) => def.name)
+  );
+  const withheldNativeNames = [...NATIVE_TOOL_NAMES].filter(
+    (name) => !selectedNativeNames.has(name)
+  );
+  const withholdNativeTools =
+    withheldNativeNames.length > 0
+      ? `for _lc_withheld in ${JSON.stringify(withheldNativeNames)}:\n` +
+        '    globals().pop(_lc_withheld, None)\n' +
+        'del _lc_withheld\n'
+      : '';
+
   return `${createPythonNativeToolSource(config, workspaceRoot)}
 ${aliases}
-
+${withholdNativeTools}
 async def __lc_user_main__():
 ${indent(userCode)}
 
@@ -1066,7 +1085,6 @@ async function runProgrammatic(args: {
     allowedToolDefs: toolDefs,
     disallowedToolDefs: toolCall.disallowedToolDefs,
     programmaticToolName,
-    runtimeExposesUnselectedTools: args.runtime === 'python',
   });
   const effectiveTools = filterNativeTools(selectedTools);
   const timeoutMs = clampExecutionTimeout(

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -598,8 +598,8 @@ async function runLocalProgrammaticTool(args: {
   const needsNoTools =
     selectedTools.length === 0 &&
     (args.params.tool_manifest?.length === 0 ||
-      (toolDefs?.length ?? 0) > 0 ||
-      (disallowedToolDefs?.length ?? 0) > 0);
+      toolDefs != null ||
+      disallowedToolDefs != null);
 
   if (!needsNoTools) {
     if (toolMap == null || toolMap.size === 0) {

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -583,6 +583,8 @@ async function runLocalProgrammaticTool(args: {
       ? Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       : Constants.PROGRAMMATIC_TOOL_CALLING);
   const selectedTools = selectProgrammaticTools({
+    code: args.params.code,
+    runtime: args.runtime === 'bash' ? 'bash' : 'python',
     requestedToolNames: args.params.tool_manifest,
     allowedToolDefs: toolDefs,
     disallowedToolDefs,

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -591,17 +591,29 @@ async function runLocalProgrammaticTool(args: {
     programmaticToolName: runnerName,
   });
 
-  if (toolMap == null || toolMap.size === 0) {
-    throw new Error('No toolMap provided for local programmatic execution.');
-  }
-  if (toolDefs == null || toolDefs.length === 0) {
-    throw new Error(
-      'No tool definitions provided for local programmatic execution.'
-    );
+  /* The local program builder supports zero stubs, so a call that selected no
+   * tools needs neither a toolMap nor toolDefs. Injected context is still
+   * required to conclude that: with nothing injected, an empty selection means
+   * the host wired the runner up wrong. */
+  const needsNoTools =
+    selectedTools.length === 0 &&
+    (args.params.tool_manifest?.length === 0 ||
+      (toolDefs?.length ?? 0) > 0 ||
+      (disallowedToolDefs?.length ?? 0) > 0);
+
+  if (!needsNoTools) {
+    if (toolMap == null || toolMap.size === 0) {
+      throw new Error('No toolMap provided for local programmatic execution.');
+    }
+    if (toolDefs == null || toolDefs.length === 0) {
+      throw new Error(
+        'No tool definitions provided for local programmatic execution.'
+      );
+    }
   }
 
   const { effectiveTools, effectiveMap } = createEffectiveToolMap(
-    toolMap,
+    toolMap ?? new Map(),
     selectedTools
   );
   const bridge = await createToolBridge(effectiveMap, hookContext);

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -1,0 +1,228 @@
+import type * as t from '@/types';
+
+export type ProgrammaticRuntime = 'python' | 'bash';
+
+const PYTHON_KEYWORDS = new Set([
+  'False',
+  'None',
+  'True',
+  'and',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'class',
+  'continue',
+  'def',
+  'del',
+  'elif',
+  'else',
+  'except',
+  'finally',
+  'for',
+  'from',
+  'global',
+  'if',
+  'import',
+  'in',
+  'is',
+  'lambda',
+  'nonlocal',
+  'not',
+  'or',
+  'pass',
+  'raise',
+  'return',
+  'try',
+  'while',
+  'with',
+  'yield',
+]);
+
+/** Bash reserved words that get `_tool` suffix when used as function names */
+const BASH_RESERVED = new Set([
+  'if',
+  'then',
+  'else',
+  'elif',
+  'fi',
+  'case',
+  'esac',
+  'for',
+  'while',
+  'until',
+  'do',
+  'done',
+  'in',
+  'function',
+  'select',
+  'time',
+  'coproc',
+  'declare',
+  'typeset',
+  'local',
+  'readonly',
+  'export',
+  'unset',
+]);
+
+/**
+ * Normalizes a tool name to a valid Python identifier.
+ * 1. Replace hyphens and spaces with underscores
+ * 2. Remove any other invalid characters
+ * 3. Prefix with underscore if starts with number
+ * 4. Append `_tool` if it's a Python keyword
+ */
+export function normalizeToPythonIdentifier(name: string): string {
+  let normalized = name.replace(/[-\s]/g, '_');
+
+  normalized = normalized.replace(/[^a-zA-Z0-9_]/g, '');
+
+  if (/^[0-9]/.test(normalized)) {
+    normalized = '_' + normalized;
+  }
+
+  if (PYTHON_KEYWORDS.has(normalized)) {
+    normalized = normalized + '_tool';
+  }
+
+  return normalized;
+}
+
+/**
+ * Normalizes a tool name to a valid bash function identifier.
+ * 1. Replace hyphens, spaces, dots with underscores
+ * 2. Remove any other invalid characters
+ * 3. Prefix with underscore if starts with number
+ * 4. Append `_tool` if it's a bash reserved word
+ */
+export function normalizeToBashIdentifier(name: string): string {
+  let normalized = name.replace(/[-\s.]/g, '_');
+  normalized = normalized.replace(/[^a-zA-Z0-9_]/g, '');
+
+  if (/^[0-9]/.test(normalized)) {
+    normalized = '_' + normalized;
+  }
+
+  if (BASH_RESERVED.has(normalized)) {
+    normalized = normalized + '_tool';
+  }
+
+  return normalized;
+}
+
+export function normalizeToRuntimeIdentifier(
+  name: string,
+  runtime: ProgrammaticRuntime
+): string {
+  return runtime === 'bash'
+    ? normalizeToBashIdentifier(name)
+    : normalizeToPythonIdentifier(name);
+}
+
+/**
+ * Extracts tool names that are actually called in the Python code.
+ * Handles hyphen/underscore conversion since Python identifiers use underscores.
+ * @param code - The Python code to analyze
+ * @param toolNameMap - Map from normalized Python name to original tool name
+ * @returns Set of original tool names found in the code
+ */
+export function extractUsedToolNames(
+  code: string,
+  toolNameMap: Map<string, string>
+): Set<string> {
+  const usedTools = new Set<string>();
+
+  for (const [pythonName, originalName] of toolNameMap) {
+    const escapedName = pythonName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\b${escapedName}\\s*\\(`, 'g');
+
+    if (pattern.test(code)) {
+      usedTools.add(originalName);
+    }
+  }
+
+  return usedTools;
+}
+
+/**
+ * Extracts tool names that are actually called in the bash code.
+ * Bash functions are invoked as commands (no parentheses), so we match
+ * the normalized name as a word boundary.
+ */
+export function extractUsedBashToolNames(
+  code: string,
+  toolNameMap: Map<string, string>
+): Set<string> {
+  const usedTools = new Set<string>();
+
+  for (const [bashName, originalName] of toolNameMap) {
+    const escapedName = bashName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
+
+    if (pattern.test(code)) {
+      usedTools.add(originalName);
+    }
+  }
+
+  return usedTools;
+}
+
+function buildToolNameMap(
+  toolDefs: readonly t.LCTool[],
+  runtime: ProgrammaticRuntime
+): Map<string, string> {
+  const toolNameMap = new Map<string, string>();
+  for (const toolDef of toolDefs) {
+    toolNameMap.set(
+      normalizeToRuntimeIdentifier(toolDef.name, runtime),
+      toolDef.name
+    );
+  }
+  return toolNameMap;
+}
+
+export function extractUsedRuntimeToolNames(
+  code: string,
+  toolNameMap: Map<string, string>,
+  runtime: ProgrammaticRuntime
+): Set<string> {
+  return runtime === 'bash'
+    ? extractUsedBashToolNames(code, toolNameMap)
+    : extractUsedToolNames(code, toolNameMap);
+}
+
+/**
+ * Narrows `toolDefs` to the tools the submitted code actually references.
+ *
+ * Deliberately returns an EMPTY array when the code references nothing, unlike
+ * `filterToolsByUsage`, which falls back to the full set. Callers use the empty
+ * result to recognize a call that needs no tool stubs at all.
+ *
+ * Detection is a conservative regex over normalized identifiers, so it can only
+ * ever narrow the caller's own allowed set — a miss drops a stub and surfaces as
+ * a plain "not defined"/"command not found" inside the sandbox, never as access
+ * to a tool the caller was not already permitted to use.
+ */
+export function deriveReferencedToolDefs(
+  toolDefs: readonly t.LCTool[],
+  code: string,
+  runtime: ProgrammaticRuntime
+): t.LCTool[] {
+  if (toolDefs.length === 0) {
+    return [];
+  }
+
+  const usedToolNames = extractUsedRuntimeToolNames(
+    code,
+    buildToolNameMap(toolDefs, runtime),
+    runtime
+  );
+
+  if (usedToolNames.size === 0) {
+    return [];
+  }
+
+  return toolDefs.filter((toolDef) => usedToolNames.has(toolDef.name));
+}

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -169,6 +169,25 @@ export function extractUsedBashToolNames(
   return usedTools;
 }
 
+const PYTHON_NON_CODE =
+  /("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|#[^\n]*)/g;
+const BASH_NON_CODE = /("(?:[^"\\]|\\.)*"|'[^']*'|(?:^|\s)#[^\n]*)/g;
+
+/**
+ * Blanks comments and string literals so prose cannot be mistaken for a call.
+ *
+ * Only reduces false positives — a name that survives may still not be a real
+ * invocation. Runtimes enforce the caller boundary by defining stubs for the
+ * selected tools alone, so a residual miss costs a stub, not a permission.
+ */
+export function stripNonCodeText(
+  code: string,
+  runtime: ProgrammaticRuntime
+): string {
+  const pattern = runtime === 'bash' ? BASH_NON_CODE : PYTHON_NON_CODE;
+  return code.replace(pattern, (match) => ' '.repeat(match.length));
+}
+
 function matchesRuntimeIdentifier(
   code: string,
   identifier: string,
@@ -219,9 +238,10 @@ export function deriveReferencedToolDefs(
     namesByIdentifier.set(identifier, [toolDef.name]);
   }
 
+  const executableCode = stripNonCodeText(code, runtime);
   const usedToolNames = new Set<string>();
   for (const [identifier, names] of namesByIdentifier) {
-    if (!matchesRuntimeIdentifier(code, identifier, runtime)) {
+    if (!matchesRuntimeIdentifier(executableCode, identifier, runtime)) {
       continue;
     }
     for (const name of names) {

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -169,12 +169,18 @@ export function extractUsedBashToolNames(
   return usedTools;
 }
 
-const PYTHON_NON_CODE =
-  /("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*'|#[^\n]*)/g;
-const BASH_NON_CODE = /("(?:[^"\\]|\\.)*"|'[^']*'|(?:^|\s)#[^\n]*)/g;
+/* Interpolating constructs stay visible: an f-string expression and a bash
+ * command substitution are executable code, and blanking them would hide a real
+ * tool call. Bash double quotes interpolate, so only single quotes are erased. */
+const PYTHON_STRING_OR_COMMENT =
+  /([A-Za-z]*)("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')|#[^\n]*/g;
+const BASH_STRING_OR_COMMENT = /'[^']*'|(?:^|\s)#[^\n]*/gm;
+
+const blankOut = (match: string): string => ' '.repeat(match.length);
 
 /**
- * Blanks comments and string literals so prose cannot be mistaken for a call.
+ * Blanks comments and non-interpolating string literals so prose cannot be
+ * mistaken for a call.
  *
  * Only reduces false positives — a name that survives may still not be a real
  * invocation. Runtimes enforce the caller boundary by defining stubs for the
@@ -184,8 +190,19 @@ export function stripNonCodeText(
   code: string,
   runtime: ProgrammaticRuntime
 ): string {
-  const pattern = runtime === 'bash' ? BASH_NON_CODE : PYTHON_NON_CODE;
-  return code.replace(pattern, (match) => ' '.repeat(match.length));
+  if (runtime === 'bash') {
+    return code.replace(BASH_STRING_OR_COMMENT, blankOut);
+  }
+
+  return code.replace(
+    PYTHON_STRING_OR_COMMENT,
+    (match: string, prefix?: string, literal?: string) => {
+      if (literal == null) {
+        return blankOut(match);
+      }
+      return prefix != null && /[fF]/.test(prefix) ? match : blankOut(match);
+    }
+  );
 }
 
 function matchesRuntimeIdentifier(

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -250,6 +250,7 @@ function blankOutsideReplacementFields(literal: string): string {
 
 /* A bash comment opens only at the start of a word: after whitespace, or after
  * a control operator that ends the previous one. */
+const BASH_ASSIGNMENT_PREFIX = /^[A-Za-z_][A-Za-z0-9_]*=/;
 const BASH_COMMAND_SEPARATOR = /[;&|()`\n]/;
 const BASH_WORD_START = /[\s;&|()`]/;
 
@@ -265,6 +266,7 @@ const BASH_WORD_START = /[\s;&|()`]/;
 function stripBashNonCodeText(code: string): string {
   const kept = code.split('');
   let atCommandStart = true;
+  let inAssignmentValue = false;
 
   const blankRange = (from: number, to: number): void => {
     for (let i = from; i < to; i++) {
@@ -318,9 +320,28 @@ function stripBashNonCodeText(code: string): string {
       continue;
     }
 
-    if (!/\s/.test(char)) {
-      atCommandStart = false;
+    if (/\s/.test(char)) {
+      if (inAssignmentValue) {
+        atCommandStart = true;
+        inAssignmentValue = false;
+      }
+      continue;
     }
+
+    /* Assignment words are prefixes, not the command: in `FOO=bar cmd`, the
+     * command position resumes once the value ends. The value is scanned
+     * normally — it can hold a substitution, as in `out=$(tool ...)`. */
+    if (atCommandStart) {
+      const assignment = BASH_ASSIGNMENT_PREFIX.exec(code.slice(i));
+      if (assignment != null) {
+        i += assignment[0].length - 1;
+        atCommandStart = false;
+        inAssignmentValue = true;
+        continue;
+      }
+    }
+
+    atCommandStart = false;
   }
 
   return kept.join('');

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -400,17 +400,13 @@ export function findNormalizedIdentifierCollision(
   return null;
 }
 
-function matchesRuntimeIdentifier(
-  code: string,
-  identifier: string,
-  runtime: ProgrammaticRuntime
-): boolean {
+function referencesIdentifier(code: string, identifier: string): boolean {
   const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern =
-    runtime === 'bash'
-      ? new RegExp(`\\b${escaped}\\b`)
-      : new RegExp(`\\b${escaped}\\s*\\(`);
-  return pattern.test(code);
+  /* A bare word, not a call expression: a tool can be aliased or passed on
+   * (`fn = calculator; await fn(a=1)`), and requiring `(` would drop the stub
+   * and break the run. Comments and literal text are already blanked, so what
+   * remains is code. Over-matching only adds a stub the sandbox ignores. */
+  return new RegExp(`\\b${escaped}\\b`).test(code);
 }
 
 /**
@@ -453,7 +449,7 @@ export function deriveReferencedToolDefs(
   const executableCode = stripNonCodeText(code, runtime);
   const usedToolNames = new Set<string>();
   for (const [identifier, names] of namesByIdentifier) {
-    if (!matchesRuntimeIdentifier(executableCode, identifier, runtime)) {
+    if (!referencesIdentifier(executableCode, identifier)) {
       continue;
     }
     for (const name of names) {

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -177,25 +177,61 @@ export function extractUsedBashToolNames(
 const PYTHON_STRING_OR_COMMENT =
   /([A-Za-z]*)("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')|#[^\n]*/g;
 const BASH_STRING_OR_COMMENT = /'[^']*'|(?:^|\s)#[^\n]*/gm;
-const PYTHON_REPLACEMENT_FIELD = /\{\{|\}\}|\{[^{}]*\}/g;
 
 const blankOut = (match: string): string => ' '.repeat(match.length);
 
-/** Blanks an f-string literal except for its `{...}` replacement fields. */
+/**
+ * Blanks an f-string literal except for its `{...}` replacement fields.
+ *
+ * Scans for balanced braces rather than matching a pattern: a replacement field
+ * can contain dict and set literals, and a regex that stops at the first inner
+ * brace would blank the surrounding call. Doubled braces are literal text. An
+ * unterminated field is preserved — keeping too much only risks a loud
+ * rejection, while dropping a real call breaks the run.
+ */
 function blankOutsideReplacementFields(literal: string): string {
-  let result = blankOut(literal);
-  let match: RegExpExecArray | null;
-  PYTHON_REPLACEMENT_FIELD.lastIndex = 0;
-  while ((match = PYTHON_REPLACEMENT_FIELD.exec(literal)) != null) {
-    if (match[0].length === 2) {
+  const kept = literal.split('').map(() => ' ');
+  let depth = 0;
+  let fieldStart = -1;
+
+  for (let i = 0; i < literal.length; i++) {
+    const char = literal[i];
+
+    if (depth === 0 && char === '{' && literal[i + 1] === '{') {
+      i++;
       continue;
     }
-    result =
-      result.slice(0, match.index) +
-      match[0] +
-      result.slice(match.index + match[0].length);
+    if (depth === 0 && char === '}' && literal[i + 1] === '}') {
+      i++;
+      continue;
+    }
+
+    if (char === '{') {
+      if (depth === 0) {
+        fieldStart = i;
+      }
+      depth++;
+      continue;
+    }
+
+    if (char === '}' && depth > 0) {
+      depth--;
+      if (depth === 0 && fieldStart >= 0) {
+        for (let j = fieldStart; j <= i; j++) {
+          kept[j] = literal[j];
+        }
+        fieldStart = -1;
+      }
+    }
   }
-  return result;
+
+  if (depth > 0 && fieldStart >= 0) {
+    for (let j = fieldStart; j < literal.length; j++) {
+      kept[j] = literal[j];
+    }
+  }
+
+  return kept.join('');
 }
 
 /**

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -193,6 +193,8 @@ function blankOutsideReplacementFields(literal: string): string {
   let depth = 0;
   let fieldStart = -1;
   let quote = '';
+  let quoteStart = -1;
+  const quotedSpans: Array<[number, number]> = [];
 
   const keepRange = (from: number, to: number): void => {
     for (let i = from; i < to; i++) {
@@ -209,6 +211,7 @@ function blankOutsideReplacementFields(literal: string): string {
         continue;
       }
       if (char === quote) {
+        quotedSpans.push([quoteStart, i + 1]);
         quote = '';
       }
       continue;
@@ -216,6 +219,7 @@ function blankOutsideReplacementFields(literal: string): string {
 
     if (depth > 0 && (char === '"' || char === '\'')) {
       quote = char;
+      quoteStart = i;
       continue;
     }
 
@@ -245,12 +249,22 @@ function blankOutsideReplacementFields(literal: string): string {
     keepRange(fieldStart, literal.length);
   }
 
+  /* A quoted token inside a replacement field is data, not a call. */
+  for (const [from, to] of quotedSpans) {
+    for (let i = from; i < to; i++) {
+      kept[i] = ' ';
+    }
+  }
+
   return kept.join('');
 }
 
 /* A bash comment opens only at the start of a word: after whitespace, or after
  * a control operator that ends the previous one. */
 const BASH_ASSIGNMENT_PREFIX = /^[A-Za-z_][A-Za-z0-9_]*=/;
+/* Keywords that precede a command rather than being one. */
+const BASH_COMMAND_KEYWORD =
+  /^(?:if|then|elif|else|while|until|do|time|coproc|!)(?=\s|$)/;
 const BASH_COMMAND_SEPARATOR = /[;&|()`\n]/;
 const BASH_WORD_START = /[\s;&|()`]/;
 
@@ -332,6 +346,12 @@ function stripBashNonCodeText(code: string): string {
      * command position resumes once the value ends. The value is scanned
      * normally — it can hold a substitution, as in `out=$(tool ...)`. */
     if (atCommandStart) {
+      const keyword = BASH_COMMAND_KEYWORD.exec(code.slice(i));
+      if (keyword != null) {
+        i += keyword[0].length - 1;
+        continue;
+      }
+
       const assignment = BASH_ASSIGNMENT_PREFIX.exec(code.slice(i));
       if (assignment != null) {
         i += assignment[0].length - 1;

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -169,18 +169,38 @@ export function extractUsedBashToolNames(
   return usedTools;
 }
 
-/* Interpolating constructs stay visible: an f-string expression and a bash
- * command substitution are executable code, and blanking them would hide a real
- * tool call. Bash double quotes interpolate, so only single quotes are erased. */
+/* Interpolating constructs stay visible: an f-string replacement field and a
+ * bash command substitution are executable code, and blanking them would hide a
+ * real tool call. Everything else in the literal is prose and is erased, so
+ * `f"example: write_file(path)"` does not read as a call. Bash double quotes
+ * interpolate, so only single quotes are erased. */
 const PYTHON_STRING_OR_COMMENT =
   /([A-Za-z]*)("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')|#[^\n]*/g;
 const BASH_STRING_OR_COMMENT = /'[^']*'|(?:^|\s)#[^\n]*/gm;
+const PYTHON_REPLACEMENT_FIELD = /\{\{|\}\}|\{[^{}]*\}/g;
 
 const blankOut = (match: string): string => ' '.repeat(match.length);
 
+/** Blanks an f-string literal except for its `{...}` replacement fields. */
+function blankOutsideReplacementFields(literal: string): string {
+  let result = blankOut(literal);
+  let match: RegExpExecArray | null;
+  PYTHON_REPLACEMENT_FIELD.lastIndex = 0;
+  while ((match = PYTHON_REPLACEMENT_FIELD.exec(literal)) != null) {
+    if (match[0].length === 2) {
+      continue;
+    }
+    result =
+      result.slice(0, match.index) +
+      match[0] +
+      result.slice(match.index + match[0].length);
+  }
+  return result;
+}
+
 /**
- * Blanks comments and non-interpolating string literals so prose cannot be
- * mistaken for a call.
+ * Blanks comments and the literal text of strings so prose cannot be mistaken
+ * for a call, while leaving interpolated expressions visible.
  *
  * Only reduces false positives — a name that survives may still not be a real
  * invocation. Runtimes enforce the caller boundary by defining stubs for the
@@ -200,9 +220,35 @@ export function stripNonCodeText(
       if (literal == null) {
         return blankOut(match);
       }
-      return prefix != null && /[fF]/.test(prefix) ? match : blankOut(match);
+      if (prefix == null || !/[fF]/.test(prefix)) {
+        return blankOut(match);
+      }
+      return blankOut(prefix) + blankOutsideReplacementFields(literal);
     }
   );
+}
+
+/**
+ * Returns the first pair of tool names that collapse to one runtime identifier.
+ *
+ * Stub generation binds by identifier, so two such tools are indistinguishable
+ * once emitted — the local Python wrapper defines both and the later one wins.
+ * Callers reject the selection rather than dispatch by declaration order.
+ */
+export function findNormalizedIdentifierCollision(
+  toolDefs: readonly t.LCTool[],
+  runtime: ProgrammaticRuntime
+): { first: string; second: string; identifier: string } | null {
+  const seen = new Map<string, string>();
+  for (const toolDef of toolDefs) {
+    const identifier = normalizeToRuntimeIdentifier(toolDef.name, runtime);
+    const prior = seen.get(identifier);
+    if (prior != null && prior !== toolDef.name) {
+      return { first: prior, second: toolDef.name, identifier };
+    }
+    seen.set(identifier, toolDef.name);
+  }
+  return null;
 }
 
 function matchesRuntimeIdentifier(

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -176,7 +176,6 @@ export function extractUsedBashToolNames(
  * interpolate, so only single quotes are erased. */
 const PYTHON_STRING_OR_COMMENT =
   /([A-Za-z]*)("""[\s\S]*?"""|'''[\s\S]*?'''|"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')|#[^\n]*/g;
-const BASH_STRING_OR_COMMENT = /'[^']*'|(?:^|\s)#[^\n]*/gm;
 
 const blankOut = (match: string): string => ' '.repeat(match.length);
 
@@ -184,24 +183,43 @@ const blankOut = (match: string): string => ' '.repeat(match.length);
  * Blanks an f-string literal except for its `{...}` replacement fields.
  *
  * Scans for balanced braces rather than matching a pattern: a replacement field
- * can contain dict and set literals, and a regex that stops at the first inner
- * brace would blank the surrounding call. Doubled braces are literal text. An
- * unterminated field is preserved — keeping too much only risks a loud
- * rejection, while dropping a real call breaks the run.
+ * can contain dict and set literals, and quoted braces inside it are text, not
+ * delimiters. Doubled braces are literal. An unterminated field is preserved —
+ * keeping too much only risks a loud rejection, while dropping a real call
+ * breaks the run.
  */
 function blankOutsideReplacementFields(literal: string): string {
   const kept = literal.split('').map(() => ' ');
   let depth = 0;
   let fieldStart = -1;
+  let quote = '';
+
+  const keepRange = (from: number, to: number): void => {
+    for (let i = from; i < to; i++) {
+      kept[i] = literal[i];
+    }
+  };
 
   for (let i = 0; i < literal.length; i++) {
     const char = literal[i];
 
-    if (depth === 0 && char === '{' && literal[i + 1] === '{') {
-      i++;
+    if (quote !== '') {
+      if (char === '\\') {
+        i++;
+        continue;
+      }
+      if (char === quote) {
+        quote = '';
+      }
       continue;
     }
-    if (depth === 0 && char === '}' && literal[i + 1] === '}') {
+
+    if (depth > 0 && (char === '"' || char === '\'')) {
+      quote = char;
+      continue;
+    }
+
+    if (depth === 0 && (char === '{' || char === '}') && literal[i + 1] === char) {
       i++;
       continue;
     }
@@ -217,17 +235,71 @@ function blankOutsideReplacementFields(literal: string): string {
     if (char === '}' && depth > 0) {
       depth--;
       if (depth === 0 && fieldStart >= 0) {
-        for (let j = fieldStart; j <= i; j++) {
-          kept[j] = literal[j];
-        }
+        keepRange(fieldStart, i + 1);
         fieldStart = -1;
       }
     }
   }
 
   if (depth > 0 && fieldStart >= 0) {
-    for (let j = fieldStart; j < literal.length; j++) {
-      kept[j] = literal[j];
+    keepRange(fieldStart, literal.length);
+  }
+
+  return kept.join('');
+}
+
+/**
+ * Blanks bash comments and single-quoted text.
+ *
+ * Double quotes interpolate, so their contents stay visible — including a
+ * command substitution that follows a literal `#`, which is text there rather
+ * than the start of a comment. A `#` only opens a comment at the start of a
+ * word outside quotes.
+ */
+function stripBashNonCodeText(code: string): string {
+  const kept = code.split('');
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < code.length; i++) {
+    const char = code[i];
+
+    if (inSingle) {
+      kept[i] = ' ';
+      if (char === '\'') {
+        inSingle = false;
+      }
+      continue;
+    }
+
+    if (char === '\\') {
+      i++;
+      continue;
+    }
+
+    if (inDouble) {
+      if (char === '"') {
+        inDouble = false;
+      }
+      continue;
+    }
+
+    if (char === '\'') {
+      inSingle = true;
+      kept[i] = ' ';
+      continue;
+    }
+
+    if (char === '"') {
+      inDouble = true;
+      continue;
+    }
+
+    if (char === '#' && (i === 0 || /\s/.test(code[i - 1]))) {
+      while (i < code.length && code[i] !== '\n') {
+        kept[i] = ' ';
+        i++;
+      }
     }
   }
 
@@ -247,7 +319,7 @@ export function stripNonCodeText(
   runtime: ProgrammaticRuntime
 ): string {
   if (runtime === 'bash') {
-    return code.replace(BASH_STRING_OR_COMMENT, blankOut);
+    return stripBashNonCodeText(code);
   }
 
   return code.replace(

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -248,6 +248,10 @@ function blankOutsideReplacementFields(literal: string): string {
   return kept.join('');
 }
 
+/* A bash comment opens only at the start of a word: after whitespace, or after
+ * a control operator that ends the previous one. */
+const BASH_WORD_START = /[\s;&|()`]/;
+
 /**
  * Blanks bash comments and single-quoted text.
  *
@@ -295,7 +299,7 @@ function stripBashNonCodeText(code: string): string {
       continue;
     }
 
-    if (char === '#' && (i === 0 || /\s/.test(code[i - 1]))) {
+    if (char === '#' && (i === 0 || BASH_WORD_START.test(code[i - 1]))) {
       while (i < code.length && code[i] !== '\n') {
         kept[i] = ' ';
         i++;

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -169,28 +169,17 @@ export function extractUsedBashToolNames(
   return usedTools;
 }
 
-function buildToolNameMap(
-  toolDefs: readonly t.LCTool[],
-  runtime: ProgrammaticRuntime
-): Map<string, string> {
-  const toolNameMap = new Map<string, string>();
-  for (const toolDef of toolDefs) {
-    toolNameMap.set(
-      normalizeToRuntimeIdentifier(toolDef.name, runtime),
-      toolDef.name
-    );
-  }
-  return toolNameMap;
-}
-
-export function extractUsedRuntimeToolNames(
+function matchesRuntimeIdentifier(
   code: string,
-  toolNameMap: Map<string, string>,
+  identifier: string,
   runtime: ProgrammaticRuntime
-): Set<string> {
-  return runtime === 'bash'
-    ? extractUsedBashToolNames(code, toolNameMap)
-    : extractUsedToolNames(code, toolNameMap);
+): boolean {
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern =
+    runtime === 'bash'
+      ? new RegExp(`\\b${escaped}\\b`)
+      : new RegExp(`\\b${escaped}\\s*\\(`);
+  return pattern.test(code);
 }
 
 /**
@@ -200,10 +189,11 @@ export function extractUsedRuntimeToolNames(
  * `filterToolsByUsage`, which falls back to the full set. Callers use the empty
  * result to recognize a call that needs no tool stubs at all.
  *
- * Detection is a conservative regex over normalized identifiers, so it can only
- * ever narrow the caller's own allowed set — a miss drops a stub and surfaces as
- * a plain "not defined"/"command not found" inside the sandbox, never as access
- * to a tool the caller was not already permitted to use.
+ * Detection is a conservative regex over normalized identifiers, so a miss only
+ * ever drops a stub and surfaces as a plain "not defined"/"command not found"
+ * inside the sandbox. Callers stay responsible for the caller-capability
+ * boundary: derive over the allowed and disallowed sets separately rather than
+ * treating an unmatched name as absent.
  */
 export function deriveReferencedToolDefs(
   toolDefs: readonly t.LCTool[],
@@ -214,11 +204,30 @@ export function deriveReferencedToolDefs(
     return [];
   }
 
-  const usedToolNames = extractUsedRuntimeToolNames(
-    code,
-    buildToolNameMap(toolDefs, runtime),
-    runtime
-  );
+  /* Names that normalize to the same identifier are kept together: the
+   * reference is genuinely ambiguous, and dropping one would silently dispatch
+   * by insertion order where sending both preserves existing behavior — the
+   * Code API rejects bash collisions outright. */
+  const namesByIdentifier = new Map<string, string[]>();
+  for (const toolDef of toolDefs) {
+    const identifier = normalizeToRuntimeIdentifier(toolDef.name, runtime);
+    const names = namesByIdentifier.get(identifier);
+    if (names != null) {
+      names.push(toolDef.name);
+      continue;
+    }
+    namesByIdentifier.set(identifier, [toolDef.name]);
+  }
+
+  const usedToolNames = new Set<string>();
+  for (const [identifier, names] of namesByIdentifier) {
+    if (!matchesRuntimeIdentifier(code, identifier, runtime)) {
+      continue;
+    }
+    for (const name of names) {
+      usedToolNames.add(name);
+    }
+  }
 
   if (usedToolNames.size === 0) {
     return [];

--- a/src/tools/toolIdentifiers.ts
+++ b/src/tools/toolIdentifiers.ts
@@ -250,60 +250,76 @@ function blankOutsideReplacementFields(literal: string): string {
 
 /* A bash comment opens only at the start of a word: after whitespace, or after
  * a control operator that ends the previous one. */
+const BASH_COMMAND_SEPARATOR = /[;&|()`\n]/;
 const BASH_WORD_START = /[\s;&|()`]/;
 
 /**
  * Blanks bash comments and single-quoted text.
  *
- * Double quotes interpolate, so their contents stay visible — including a
- * command substitution that follows a literal `#`, which is text there rather
- * than the start of a comment. A `#` only opens a comment at the start of a
- * word outside quotes.
+ * Double quotes interpolate, so their contents stay visible — including a `#`
+ * inside them, which is literal text. A comment opens only at the start of a
+ * word outside quotes. Single-quoted text is prose in argument position but
+ * executable in command position, where quote removal happens before command
+ * lookup, so `'calculator' '{}'` still calls `calculator`.
  */
 function stripBashNonCodeText(code: string): string {
   const kept = code.split('');
-  let inSingle = false;
-  let inDouble = false;
+  let atCommandStart = true;
+
+  const blankRange = (from: number, to: number): void => {
+    for (let i = from; i < to; i++) {
+      kept[i] = ' ';
+    }
+  };
 
   for (let i = 0; i < code.length; i++) {
     const char = code[i];
 
-    if (inSingle) {
-      kept[i] = ' ';
-      if (char === '\'') {
-        inSingle = false;
-      }
-      continue;
-    }
-
     if (char === '\\') {
       i++;
-      continue;
-    }
-
-    if (inDouble) {
-      if (char === '"') {
-        inDouble = false;
-      }
-      continue;
-    }
-
-    if (char === '\'') {
-      inSingle = true;
-      kept[i] = ' ';
+      atCommandStart = false;
       continue;
     }
 
     if (char === '"') {
-      inDouble = true;
+      i++;
+      while (i < code.length && code[i] !== '"') {
+        i += code[i] === '\\' ? 2 : 1;
+      }
+      atCommandStart = false;
+      continue;
+    }
+
+    if (char === '\'') {
+      const start = i;
+      i++;
+      while (i < code.length && code[i] !== '\'') {
+        i++;
+      }
+      if (!atCommandStart) {
+        blankRange(start, Math.min(i + 1, code.length));
+      }
+      atCommandStart = false;
       continue;
     }
 
     if (char === '#' && (i === 0 || BASH_WORD_START.test(code[i - 1]))) {
+      const start = i;
       while (i < code.length && code[i] !== '\n') {
-        kept[i] = ' ';
         i++;
       }
+      blankRange(start, i);
+      atCommandStart = true;
+      continue;
+    }
+
+    if (BASH_COMMAND_SEPARATOR.test(char)) {
+      atCommandStart = true;
+      continue;
+    }
+
+    if (!/\s/.test(char)) {
+      atCommandStart = false;
     }
   }
 


### PR DESCRIPTION
Fixes #488

## Problem

`run_tools_with_bash` / `run_tools_with_code` had **no valid call** for code that references no tools.

- Omit `tool_manifest` → `selectProgrammaticTools` throws *"requires a tool_manifest when direct-only tools are configured"*.
- Send the honest answer, `[]` → codeapi's `/exec/programmatic` rejects it (`tools` must be a non-empty array), and `buildCodeApiHttpErrorMessage` maps that 400 to the generic `CODE_API_INVALID_REQUEST_ERROR_MESSAGE`. Nothing in that message names the cause, so the model retries the identical call instead of switching tools.

That genericization is deliberate (cc362b2b, #329), so the fix belongs on the client, not in un-sanitizing the upstream body.

**This is the default configuration, not an edge case.** `getAllowedCallers` falls back to `['direct']`, and hosts register action and built-in tools that way unconditionally — so an agent with both a code tool and any ordinary tool (exactly what #488 describes) always has a non-empty `directOnlyTools`, and could not run `ls` through the programmatic caller at all.

## Fix

Resolve the manifest in the runtime instead of making the model guess it.

**Derive an omitted manifest from the code rather than rejecting it.** Derivation intersects with the caller's allowed set, so a direct-only tool still cannot be reached — the caller-facing invariant is unchanged, and detection can only ever *narrow*. A miss drops a stub and surfaces as `not defined` / `command not found` inside the sandbox, never as access to something the caller wasn't already permitted to use.

**Treat an empty manifest as meaningful, not an error.** Code that calls no tools needs no stubs and no replay round trips, so remote callers route it to plain `/exec`, where it behaves exactly like the equivalent `execute_code` — against every deployed Code API, with no server change and no version skew. Bash sends raw code on that path: the `: &\nwait "$!"` guard exists for the programmatic replay wrapper (`preamble-bash.ts`), which `/exec` never applies.

Identifier normalization and usage extraction move to `toolIdentifiers.ts`, a leaf module both runtimes share, so the policy can derive without importing its own callers. `normalizeToPythonIdentifier`, `normalizeToBashIdentifier`, `extractUsedToolNames` and `extractUsedBashToolNames` are re-exported from their previous homes, so the package's public API is unchanged.

## Behavior

| call | before | after |
|---|---|---|
| `tool_manifest: []`, tool-free code | 400 → opaque "request was rejected" | runs via `/exec` |
| manifest omitted, direct-only tools present, tool-free code | throws "requires a tool_manifest" | runs via `/exec` |
| manifest omitted, direct-only tools present, code calls `get_weather` | throws "requires a tool_manifest" | `/exec/programmatic` with just `get_weather` |
| manifest names a direct-only tool | rejected | rejected (unchanged) |
| manifest omitted, no direct-only tools | full manifest sent | full manifest sent (unchanged) |

## Notes

- `/exec` ignores `timeout` (it destructures `{ user_id, lang, code, files }`), so a model-supplied timeout drops on the plain path. That matches `execute_code`, which has no timeout param at all, so it is not a regression against the tool that should have been called — honoring it is a separate one-line codeapi change.
- Cloudflare and local backends already tolerated an empty tool set and build a program with zero stubs; they get the derivation but need no routing change.
- Scope note for the issue: there are four sandbox entry points, not two — `execute_code`, `bash_tool`, `run_tools_with_code`, `run_tools_with_bash`. This makes the routing choice between them stop mattering for the failing case without merging them.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint src/tools/` — 0 errors, 16 warnings (identical to `main`)
- `npx jest src/tools/` — 1550 passed, 59 suites
- Full suite: only `src/llm/{anthropic,google,vertexai}/llm.spec.ts` fail, identically on `main` (live provider credentials / ESM)
- `npm run check:circular-deps` — no circular dependencies
- 12 new tests in `ProgrammaticEmptyManifest.test.ts` covering both routes, the derivation safety property, session/file/runtime-hint propagation, and the unchanged paths