### PR TITLE
fix(stream): reject incomplete OpenAI-compatible responses

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1182,12 +1182,19 @@ function getOpenAIChatCompletionChunk(
 async function* filterOpenAIChatCompletionStream(
   stream: AsyncIterable<OpenAIChatCompletionStreamItem>
 ): AsyncGenerator<OpenAIChatCompletionChunk> {
+  let sawFinishReason = false;
   for await (const item of stream) {
     const chunk = getOpenAIChatCompletionChunk(item);
     if (chunk == null) {
       continue;
     }
+    if (chunk.choices.some((choice) => choice.finish_reason != null)) {
+      sawFinishReason = true;
+    }
     yield chunk;
+  }
+  if (!sawFinishReason) {
+    throw new Error('OpenAI-compatible stream ended before completion');
   }
 }
 

--- a/src/llm/openai/streamCompletion.test.ts
+++ b/src/llm/openai/streamCompletion.test.ts
@@ -1,0 +1,93 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, test } from '@jest/globals';
+import { HumanMessage } from '@langchain/core/messages';
+import { ChatOpenAI } from './index';
+
+type StreamFrame = {
+  choices: Array<{
+    index: number;
+    delta: { role?: 'assistant'; content?: string };
+    finish_reason: string | null;
+  }>;
+};
+
+async function startCompletionServer(frames: StreamFrame[]): Promise<{
+  baseURL: string;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    for (const frame of frames) {
+      res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    }
+    if (frames.some((frame) => frame.choices.some((choice) => choice.finish_reason != null))) {
+      res.write('data: [DONE]\n\n');
+    }
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseURL: `http://127.0.0.1:${port}/v1`,
+    close: () => new Promise((resolve, reject) => server.close((error) => error == null ? resolve() : reject(error))),
+  };
+}
+
+function streamFrame(content: string, finishReason: string | null): StreamFrame {
+  return {
+    choices: [
+      {
+        index: 0,
+        delta: { role: 'assistant', content },
+        finish_reason: finishReason,
+      },
+    ],
+  };
+}
+
+describe('ChatOpenAI stream completion', () => {
+  test('rejects a partial OpenAI-compatible stream without a terminal finish reason', async () => {
+    const server = await startCompletionServer([streamFrame('partial', null)]);
+    const model = new ChatOpenAI({
+      model: 'test-model',
+      apiKey: 'test-key',
+      configuration: { baseURL: server.baseURL },
+    });
+    const received: string[] = [];
+
+    try {
+      await expect(async () => {
+        for await (const chunk of await model.stream([new HumanMessage('test')])) {
+          received.push(String(chunk.content));
+        }
+      }).rejects.toThrow('OpenAI-compatible stream ended before completion');
+      expect(received).toContain('partial');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('accepts a stream with a terminal finish reason', async () => {
+    const server = await startCompletionServer([
+      streamFrame('complete', null),
+      streamFrame('', 'stop'),
+    ]);
+    const model = new ChatOpenAI({
+      model: 'test-model',
+      apiKey: 'test-key',
+      configuration: { baseURL: server.baseURL },
+    });
+    const received: string[] = [];
+
+    try {
+      for await (const chunk of await model.stream([new HumanMessage('test')])) {
+        received.push(String(chunk.content));
+      }
+      expect(received).toContain('complete');
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- reject OpenAI-compatible streams that end without a terminal `finish_reason`
- cover the real loopback HTTP/SSE shape: a partial chunk followed by EOF must fail, while a completed stream succeeds
- apply the guard to the shared completions wrapper used by both standard and Azure OpenAI-compatible clients

## Why
A provider or gateway can close an SSE response after producing partial text. The OpenAI/LangChain client treats that as a successful iteration unless an in-band error is sent. This guard prevents the agent graph from accepting incomplete model output as a completed assistant turn.

## Validation
- `npx jest src/llm/openai/streamCompletion.test.ts src/llm/openai/llm.spec.ts --runInBand`
- `npx jest src/hooks/__tests__/integration.test.ts src/graphs/__tests__/Graph.closeRunStep.test.ts --runInBand`
- `npx eslint src/llm/openai/index.ts src/llm/openai/streamCompletion.test.ts`
- `git diff --check`

## Related
Complements ClickHouse/ai#3427, which makes Anthropic gateway read failures and missing terminal events explicit in-band SSE errors.