### PR TITLE
🧺 fix: Filter Historical Tool Call History

### DIFF
--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -2771,6 +2771,15 @@ function extractSkillName(args: unknown): string | undefined {
   return typeof name === 'string' && name !== '' ? name : undefined;
 }
 
+function isSdkManagedToolName(name: unknown): name is string {
+  return (
+    typeof name === 'string' &&
+    (name === Constants.SUBAGENT ||
+      name === 'conditional_transfer' ||
+      name.startsWith(Constants.LC_TRANSFER_TO_))
+  );
+}
+
 /**
  * Formats an array of messages for LangChain, handling tool calls and creating ToolMessage instances.
  *
@@ -3028,11 +3037,10 @@ export const formatAgentMessages = (
             }
           }
 
-          const isSdkManagedTool =
-            toolName === Constants.SUBAGENT ||
-            (typeof toolName === 'string' &&
-              toolName.startsWith(Constants.LC_TRANSFER_TO_));
-          if (discoveredTools.has(toolName) || isSdkManagedTool) {
+          if (
+            discoveredTools.has(toolName) ||
+            isSdkManagedToolName(toolName)
+          ) {
             filteredContent.push(part);
             filteredSourceContentPartIndices.push(partSourceContentIndices);
             if (

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -2776,7 +2776,8 @@ function extractSkillName(args: unknown): string | undefined {
  *
  * @param payload - The array of messages to format.
  * @param indexTokenCountMap - Optional map of message indices to token counts.
- * @param tools - Optional set of tool names that are allowed in the request.
+ * @param tools - Optional set of host-managed tool names allowed in the request. SDK-managed tool
+ *   names are preserved independently.
  * @param skills - Optional map of skill name to body for reconstructing skill HumanMessages.
  * @param options - Optional formatting options (provider, skipSkillBodyNames).
  * @returns - Object containing formatted messages and updated indexTokenCountMap if provided.
@@ -2957,8 +2958,8 @@ export const formatAgentMessages = (
 
     /**
      * If tools set is provided, process tool_calls:
-     * - Keep valid tool_calls (tools in the set or dynamically discovered)
-     * - Convert invalid tool_calls to string representation for context preservation
+     * - Keep valid tool_calls (tools in the set, SDK-managed, or dynamically discovered)
+     * - Omit invalid tool_calls without exposing their output as assistant-authored text
      * - Dynamically expand the set when tool_search results are encountered
      */
     let processedMessage = message;
@@ -2977,8 +2978,6 @@ export const formatAgentMessages = (
         const filteredContent: typeof content = [];
         const filteredSourceContentPartIndices: SourceContentPartIndices[] = [];
         const invalidToolCallIds = new Set<string>();
-        const invalidToolStrings: string[] = [];
-        const invalidToolSourceContentPartIndices: number[] = [];
 
         for (let partIndex = 0; partIndex < content.length; partIndex++) {
           const part = content[partIndex] as
@@ -3029,7 +3028,11 @@ export const formatAgentMessages = (
             }
           }
 
-          if (discoveredTools.has(toolName)) {
+          const isSdkManagedTool =
+            toolName === Constants.SUBAGENT ||
+            (typeof toolName === 'string' &&
+              toolName.startsWith(Constants.LC_TRANSFER_TO_));
+          if (discoveredTools.has(toolName) || isSdkManagedTool) {
             filteredContent.push(part);
             filteredSourceContentPartIndices.push(partSourceContentIndices);
             if (
@@ -3042,20 +3045,11 @@ export const formatAgentMessages = (
                 (pendingSkillNames ??= new Set()).add(skillName);
               }
             }
-          } else {
-            /** Invalid tool - convert to string for context preservation */
-            if (
-              typeof part.tool_call.id === 'string' &&
-              part.tool_call.id !== ''
-            ) {
-              invalidToolCallIds.add(part.tool_call.id);
-            }
-            const output = part.tool_call.output ?? '';
-            invalidToolStrings.push(`Tool: ${toolName}, ${output}`);
-            appendSourceContentPartIndices(
-              invalidToolSourceContentPartIndices,
-              partSourceContentIndices
-            );
+          } else if (
+            typeof part.tool_call.id === 'string' &&
+            part.tool_call.id !== ''
+          ) {
+            invalidToolCallIds.add(part.tool_call.id);
           }
         }
 
@@ -3076,57 +3070,8 @@ export const formatAgentMessages = (
           }
         }
 
-        /** Append invalid tool strings to the content for context preservation */
-        if (invalidToolStrings.length > 0) {
-          /** Find the last text part or create one */
-          let lastTextPartIndex = -1;
-          for (let j = filteredContent.length - 1; j >= 0; j--) {
-            if (filteredContent[j].type === ContentTypes.TEXT) {
-              lastTextPartIndex = j;
-              break;
-            }
-          }
-
-          const invalidToolText = invalidToolStrings.join('\n');
-          if (lastTextPartIndex >= 0) {
-            const lastTextPart = filteredContent[lastTextPartIndex] as {
-              type: string;
-              [ContentTypes.TEXT]?: string;
-              text?: string;
-            };
-            const existingText =
-              lastTextPart[ContentTypes.TEXT] ?? lastTextPart.text ?? '';
-            filteredContent[lastTextPartIndex] = {
-              ...lastTextPart,
-              [ContentTypes.TEXT]: existingText
-                ? `${existingText}\n${invalidToolText}`
-                : invalidToolText,
-            };
-            const lastTextSourceContentPartIndices =
-              filteredSourceContentPartIndices[lastTextPartIndex];
-            filteredSourceContentPartIndices[lastTextPartIndex] = [
-              ...(typeof lastTextSourceContentPartIndices === 'number'
-                ? [lastTextSourceContentPartIndices]
-                : lastTextSourceContentPartIndices),
-              ...invalidToolSourceContentPartIndices,
-            ];
-          } else {
-            /** No text part exists, create one */
-            filteredContent.push({
-              type: ContentTypes.TEXT,
-              [ContentTypes.TEXT]: invalidToolText,
-            });
-            filteredSourceContentPartIndices.push(
-              invalidToolSourceContentPartIndices
-            );
-          }
-        }
-
         /** Use filtered content if we made any changes */
-        if (
-          filteredContent.length !== content.length ||
-          invalidToolStrings.length > 0
-        ) {
+        if (filteredContent.length !== content.length) {
           processedMessage = { ...message, content: filteredContent };
           processedSourceContentPartIndices = filteredSourceContentPartIndices;
         }

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5484,12 +5484,11 @@ describe('formatAgentMessages', () => {
     expect(toolMessages[2].name).toBe('list_commits_mcp_github');
   });
 
-  it('should convert invalid tools to string while keeping valid tools as ToolMessages', () => {
+  it('omits invalid tools while keeping valid tools as ToolMessages', () => {
     /**
      * This test documents the hybrid behavior:
      * - Valid tools remain as proper AIMessage + ToolMessage structures
-     * - Invalid tools are converted to string and appended to text content
-     *   (preserving context without losing information)
+     * - Invalid tools and their outputs are omitted from model context
      */
     const tools = new Set(['calculator']);
     const payload = [
@@ -5538,19 +5537,19 @@ describe('formatAgentMessages', () => {
     );
     expect((result.messages[1] as ToolMessage).name).toBe('calculator');
 
-    /** The invalid tool should be converted to string in the content */
+    /** The invalid tool output must not become assistant-authored content */
     const aiContent = result.messages[0].content;
     const aiContentStr =
       typeof aiContent === 'string' ? aiContent : JSON.stringify(aiContent);
-    expect(aiContentStr).toContain('some_unknown_tool');
-    expect(aiContentStr).toContain('This is the result from unknown tool');
+    expect(aiContentStr).not.toContain('some_unknown_tool');
+    expect(aiContentStr).not.toContain('This is the result from unknown tool');
     expect(result.messages[0].additional_kwargs.provenance).toEqual({
       version: 1,
       parts: [
         {
           attribution: 'model',
           sourceMessageId: 'filtered-tool-row',
-          sourceContentPartIndices: [0, 2, 1],
+          sourceContentPartIndices: [0, 1],
         },
       ],
     });
@@ -5566,7 +5565,7 @@ describe('formatAgentMessages', () => {
     });
   });
 
-  it('keeps an output-less unavailable tool call model-attributed when flattened', () => {
+  it('omits an output-less unavailable tool call', () => {
     const { messages } = formatAgentMessages(
       [
         {
@@ -5589,17 +5588,7 @@ describe('formatAgentMessages', () => {
       new Set(['available_tool'])
     );
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0].content).toEqual([
-      { type: ContentTypes.TEXT, text: 'Tool: unavailable_tool, ' },
-    ]);
-    expect(getProviderMessageProvenance(messages[0])?.parts).toEqual([
-      {
-        attribution: 'model',
-        sourceMessageId: 'output-less-filtered-tool-row',
-        sourceContentPartIndices: [0],
-      },
-    ]);
+    expect(messages).toHaveLength(0);
   });
 
   it('should simulate realistic deferred tools flow with tool_search', () => {

--- a/src/messages/formatAgentMessages.tools.test.ts
+++ b/src/messages/formatAgentMessages.tools.test.ts
@@ -2,7 +2,7 @@ import { HumanMessage, AIMessage, ToolMessage } from '@langchain/core/messages';
 import type { TPayload } from '@/types';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { formatAgentMessages } from './format';
-import { ContentTypes } from '@/common';
+import { Constants, ContentTypes } from '@/common';
 
 describe('formatAgentMessages with tools parameter', () => {
   it('should process messages normally when tools is not provided', () => {
@@ -299,7 +299,7 @@ describe('formatAgentMessages with tools parameter', () => {
 
     const result = formatAgentMessages(payload, undefined, allowedTools);
 
-    // Should keep valid tool (calculator) and convert invalid (check_weather) to string
+    // Should keep the valid tool and omit the invalid tool without rewriting its output as text
     expect(result.messages).toHaveLength(3);
     expect(result.messages[0]).toBeInstanceOf(HumanMessage);
     expect(result.messages[1]).toBeInstanceOf(AIMessage);
@@ -311,9 +311,8 @@ describe('formatAgentMessages with tools parameter', () => {
       'calculator'
     );
 
-    // The content should include invalid tool as string
-    expect(result.messages[1].content).toContain('check_weather');
-    expect(result.messages[1].content).toContain('Sunny, 75°F');
+    expect(result.messages[1].content).not.toContain('check_weather');
+    expect(result.messages[1].content).not.toContain('Sunny, 75°F');
 
     // The ToolMessage should be for calculator
     expect((result.messages[2] as ToolMessage).name).toBe('calculator');
@@ -369,7 +368,7 @@ describe('formatAgentMessages with tools parameter', () => {
     expect(result.indexTokenCountMap?.[1]).toBe(40);
   });
 
-  it('should convert invalid tool to text content when no other content exists', () => {
+  it('omits an invalid tool and its output when no other content exists', () => {
     const payload: TPayload = [
       {
         role: 'assistant',
@@ -392,19 +391,41 @@ describe('formatAgentMessages with tools parameter', () => {
 
     const result = formatAgentMessages(payload, undefined, allowedTools);
 
-    // Should create an AIMessage with the invalid tool converted to text
-    expect(result.messages).toHaveLength(1);
-    expect(result.messages[0]).toBeInstanceOf(AIMessage);
+    expect(result.messages).toHaveLength(0);
+  });
 
-    // The AIMessage should have no tool_calls (all were invalid)
-    expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(0);
+  it.each([
+    ['subagent', Constants.SUBAGENT],
+    ['handoff', `${Constants.LC_TRANSFER_TO_}researcher`],
+  ])('preserves an SDK-managed %s call as structured history', (_, toolName) => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Delegate this task' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'managed_1',
+              name: toolName,
+              args: '{}',
+              output: 'completed',
+            },
+          },
+        ],
+      },
+    ];
 
-    // The content should contain the invalid tool info
-    const content = result.messages[0].content;
-    const contentStr =
-      typeof content === 'string' ? content : JSON.stringify(content);
-    expect(contentStr).toContain('check_weather');
-    expect(contentStr).toContain('Sunny, 75°F');
+    const result = formatAgentMessages(payload, undefined, new Set());
+
+    expect(result.messages).toHaveLength(3);
+    expect((result.messages[1] as AIMessage).tool_calls).toEqual([
+      expect.objectContaining({ id: 'managed_1', name: toolName }),
+    ]);
+    expect(result.messages[1].content).not.toContain(`Tool: ${toolName}`);
+    expect(result.messages[2]).toBeInstanceOf(ToolMessage);
+    expect((result.messages[2] as ToolMessage).name).toBe(toolName);
+    expect(result.messages[2].content).toBe('completed');
   });
 
   it('should handle complex sequences with multiple tool calls', () => {
@@ -478,11 +499,11 @@ describe('formatAgentMessages with tools parameter', () => {
 
     const result = formatAgentMessages(payload, undefined, allowedTools);
 
-    // With selective filtering: valid tools are kept, invalid tools are converted to string
+    // With selective filtering, valid tools are kept and invalid tools are omitted
     // 1. HumanMessage
     // 2. AIMessage (search tool_call)
     // 3. ToolMessage (search result)
-    // 4. AIMessage (text + invalid weather tool as string, no tool_calls)
+    // 4. AIMessage (text only; invalid weather tool omitted)
     // 5. AIMessage (calculator tool_call)
     // 6. ToolMessage (calculator result)
     // 7. AIMessage (final text)
@@ -492,7 +513,7 @@ describe('formatAgentMessages with tools parameter', () => {
     expect(result.messages[0]).toBeInstanceOf(HumanMessage);
     expect(result.messages[1]).toBeInstanceOf(AIMessage); // Search message
     expect(result.messages[2]).toBeInstanceOf(ToolMessage); // Search tool response
-    expect(result.messages[3]).toBeInstanceOf(AIMessage); // Weather message (tool converted to string)
+    expect(result.messages[3]).toBeInstanceOf(AIMessage); // Weather text
     expect(result.messages[4]).toBeInstanceOf(AIMessage); // Calculator message
     expect(result.messages[5]).toBeInstanceOf(ToolMessage); // Calculator tool response
     expect(result.messages[6]).toBeInstanceOf(AIMessage); // Final message
@@ -503,15 +524,15 @@ describe('formatAgentMessages with tools parameter', () => {
       'search'
     );
 
-    // Check that weather message has no tool_calls but contains the invalid tool as text
+    // Check that weather output is not rewritten as assistant-authored text
     expect((result.messages[3] as AIMessage).tool_calls).toHaveLength(0);
     const weatherContent = result.messages[3].content;
     const weatherContentStr =
       typeof weatherContent === 'string'
         ? weatherContent
         : JSON.stringify(weatherContent);
-    expect(weatherContentStr).toContain('check_weather');
-    expect(weatherContentStr).toContain('Sunny');
+    expect(weatherContentStr).not.toContain('check_weather');
+    expect(weatherContentStr).not.toContain('Sunny');
 
     // Check that calculator tool was kept
     expect((result.messages[4] as AIMessage).tool_calls).toHaveLength(1);

--- a/src/messages/formatAgentMessages.tools.test.ts
+++ b/src/messages/formatAgentMessages.tools.test.ts
@@ -397,6 +397,7 @@ describe('formatAgentMessages with tools parameter', () => {
   it.each([
     ['subagent', Constants.SUBAGENT],
     ['handoff', `${Constants.LC_TRANSFER_TO_}researcher`],
+    ['conditional handoff', 'conditional_transfer'],
   ])('preserves an SDK-managed %s call as structured history', (_, toolName) => {
     const payload: TPayload = [
       { role: 'user', content: 'Delegate this task' },


### PR DESCRIPTION
I fixed historical tool serialization so SDK-managed control calls remain structured while unavailable tool outputs can no longer become assistant-authored prompt content.

- Preserve `subagent` and `lc_transfer_to_*` call/result pairs even when a host-provided tool allowlist omits SDK-managed tools.
- Omit genuinely unavailable historical tool calls and outputs instead of flattening them into imitable `Tool: <name>, <output>` assistant text.
- Remove invalid tool-call references from retained text parts while keeping provider provenance limited to retained content.
- Add regression coverage for subagent history, handoff history, mixed valid and invalid tools, output-less unavailable calls, deferred tool discovery, and provenance.
- Address the SDK defense-in-depth portion of [LibreChat #14623](https://github.com/danny-avila/LibreChat/issues/14623). The LibreChat host still needs its run-wide reachable-agent tool allowlist fix to preserve ordinary handoff-agent tool history.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused message-formatting suites, TypeScript typechecking, targeted ESLint, and whitespace validation.

### **Test Configuration**:

- Node.js: repository-configured local runtime
- `npm test -- --runInBand src/messages/formatAgentMessages.tools.test.ts src/messages/formatAgentMessages.reducer.test.ts src/messages/formatAgentMessages.test.ts src/messages/formatAgentMessages.skills.test.ts` — 264 passed, 1 skipped
- `npx tsc --noEmit`
- `npx eslint src/messages/format.ts src/messages/formatAgentMessages.tools.test.ts src/messages/formatAgentMessages.test.ts`
- `git diff --check`

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes