### PR TITLE
🔎 fix: Emit Empty topStories From the Keenable Provider

### DIFF
--- a/src/tools/search/keenable-search.ts
+++ b/src/tools/search/keenable-search.ts
@@ -105,7 +105,7 @@ export const createKeenableAPI = (
         date: result.published_at,
       }));
 
-      return { success: true, data: { organic } };
+      return { success: true, data: { organic, topStories: [] } };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/src/tools/search/keenable.test.ts
+++ b/src/tools/search/keenable.test.ts
@@ -101,6 +101,15 @@ describe('Keenable search API', () => {
     ]);
   });
 
+  it('emits an empty topStories array so shape-consuming callers do not crash', async () => {
+    mockedAxios.post.mockResolvedValueOnce(sampleResponse);
+
+    const searchAPI = createSearchAPI({ searchProvider: 'keenable' });
+    const result = await searchAPI.getSources({ query: 'typescript' });
+
+    expect(result.data?.topStories).toEqual([]);
+  });
+
   it('falls back to the description when the snippet is present but empty', async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {


### PR DESCRIPTION
## Problem

The Keenable provider returns `{ organic }` without `topStories`. Every consumer that
reads the field positionally — rather than defensively — throws on the first search.

Observed in production against a live LibreChat instance: Keenable itself works fine,

```
[web_search] search=keenable queries=1 results={web:8} dur=212ms
```

but the result handler crashes immediately after, eight times over:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at onSearchResults (/app/api/server/services/Tools/search.js:74:41)
```

`search.js:74` is `for (let i = 0; i < data.topStories.length; i++)`. Net effect: web
search is completely non-functional on Keenable — results are fetched, then discarded
by an exception.

## Cause

`topStories` is optional in `SearchResultData`, but the established provider convention
in this package is to always emit it, so that shape-consuming callers can iterate
without a guard:

| Provider | emits `topStories` |
|---|---|
| `tavily-search.ts:405-407` | ✅ `topStories: []` |
| `crw-search.ts:154` | ✅ `topStories: []` |
| `keenable-search.ts:108` | ❌ omitted |

Keenable is the sole outlier. This package's own consumers happen to guard
(`format.ts:253`, `search.ts:290` both use `?? []`), which is why it went unnoticed
here — but downstream consumers do not, and the contract Tavily and CRW establish is
that the key is present.

## Fix

One line, bringing Keenable in line with the other two providers:

```diff
-return { success: true, data: { organic } };
+return { success: true, data: { organic, topStories: [] } };
```

Keenable is organic-only — it has no news vertical, and the capability-gating test
already asserts it skips news sub-searches — so an empty array is the semantically
correct value, not a placeholder.

## Tests

Added a regression test asserting the provider emits the key. The gap was that no
existing test looked at anything but `data.organic`, so an absent `topStories` was
invisible.

`npx jest --runTestsByPath src/tools/search/keenable.test.ts`

- before: `1 failed, 10 passed`
- after: `1 failed, 11 passed`

The single failure is pre-existing and unrelated — `ReferenceError: crypto is not
defined` from `langsmith`'s uuid v7 in the Jest environment, which affects 12 tests
across the search suite on `main` before this change (`12 failed, 229 passed` →
`12 failed, 230 passed`, the delta being the new test).

`npm run build` passes; ESLint clean on both files.
