### PR TITLE
⏭️ feat: Discard-and-Restart Preemption for Turns With Nothing to Keep

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -19,6 +19,21 @@ export const DEFAULT_TOOL_TOKEN_MULTIPLIER = 1.4;
  * preemption-enabled run reserves.
  */
 export const DEFAULT_MAX_SEALS = 8;
+/**
+ * How long a preempt request waits for the turn to become sealable before it
+ * is allowed to discard the turn instead.
+ *
+ * Exists to keep a restart from stealing a seal that was about to happen: a
+ * model streaming reasoning is usually moments from its first text, and
+ * keeping that answer beats throwing the reasoning away. Only a request that
+ * outlives the window — a genuinely long thinking stretch — converts.
+ *
+ * Applies to a silent provider too. The accumulation a restart is judged
+ * against is what the consumer has seen, and the stream buffers a chunk ahead
+ * of it — so "nothing accumulated" can also mean "the first chunk is in
+ * flight", and converting on it would discard that chunk unseen.
+ */
+export const DEFAULT_PREEMPT_RESTART_GRACE_MS = 2_000;
 
 /**
  * Default ceiling on Stop-hook continuations within one Run. A blocking Stop

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1463,6 +1463,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * another's turn.
    */
   pendingPreemptReturn = new Set<string>();
+  /**
+   * Agent IDs whose model turn a preempt DISCARDED rather than sealed. A
+   * discard returns no message, so the node cannot read
+   * `response_metadata.preempted` to learn a boundary is owed — this set is
+   * the only carrier.
+   *
+   * Keyed by agent for the same reason {@link pendingPreemptReturn} is: one
+   * graph instance serves every parallel agent, and a single flag would let
+   * whichever lane finished first consume another lane's boundary.
+   *
+   * Not derivable from `preemptSealInFlight`: an ordinary seal holds that slot
+   * too, and a claim that never reached its boundary would be indistinguishable
+   * from a discard.
+   */
+  private preemptRestartPending = new Set<string>();
 
   constructor(
     {
@@ -1712,6 +1727,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   private resetPreemptTurnState(): void {
     this.preemptSealBudgetUsed = 0;
     this.preemptSealInFlight = false;
+    this.preemptRestartPending.clear();
     this.pendingPreemptReturn.clear();
   }
 
@@ -1808,6 +1824,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /** Releases the seal slot once its boundary has resolved, win or lose. */
   releasePreemptSeal(): void {
     this.preemptSealInFlight = false;
+  }
+
+  /** See {@link preemptRestartPending}. Called from the model attempt. */
+  notePreemptRestart(agentId: string): void {
+    this.preemptRestartPending.add(agentId);
+  }
+
+  /**
+   * Reads and clears the lane's mark in one step, so a boundary is dispatched
+   * exactly once per discard even though the model node runs again immediately
+   * after.
+   */
+  private consumePreemptRestart(agentId: string): boolean {
+    return this.preemptRestartPending.delete(agentId);
   }
 
   getPreemptStats(): t.PreemptStats {
@@ -3907,6 +3937,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               {
                 request: preparedRequest,
                 context: this,
+                preemptAgentId: agentId,
               },
               invokeConfig
             )
@@ -4105,6 +4136,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 config: invokeConfig,
                 primaryError,
                 context: this,
+                preemptAgentId: agentId,
                 /**
                  * Lets the chain recognise a fallback overflow whose signature
                  * carries no reason of its own (Vertex AI's bare 400) and
@@ -4392,7 +4424,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           { force: true }
         );
       }
+      const preemptRestarted = this.consumePreemptRestart(agentId);
       if (
+        preemptRestarted ||
         (responseMessage as AIMessageChunk | undefined)?.response_metadata
           .preempted === true
       ) {
@@ -4434,12 +4468,26 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           return { messages: [...(result.messages ?? []), ...injected] };
         }
         /**
-         * Nothing to inject — the host cancelled or already drained. Do NOT
-         * self-loop: a trailing model turn with no new input is dropped by
-         * some Gemini models and read as prefill by Anthropic. Do NOT pretend
-         * the turn completed either; the answer really was cut short.
+         * Nothing to inject — the host cancelled or already drained.
+         *
+         * After a SEAL, do not self-loop: a trailing model turn with no new
+         * input is dropped by some Gemini models and read as prefill by
+         * Anthropic. Do not pretend the turn completed either; the answer
+         * really was cut short.
+         *
+         * After a RESTART there is no such trailing turn. The discard left
+         * graph state exactly as the model node found it, so returning to the
+         * node re-issues the same call — the only way the run can still
+         * produce an answer, and the honest outcome of an interrupt whose
+         * words were withdrawn before they landed. Bounded by the same seal
+         * budget, so a host stuck arming and cancelling cannot loop forever.
          */
         this.preemptEmptyBoundaries += 1;
+        if (preemptRestarted) {
+          this.pendingPreemptReturn.add(agentId);
+          this.cleanupSignalListener();
+          return result;
+        }
         this.preemptIncomplete = true;
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2102,6 +2102,35 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * unreachable — each step registers its calls before any completion can
    * reference it — and the mechanism was removed.)
    */
+  /**
+   * Closes the lane's open message step as `cancelled` when a preempt discards
+   * the turn that step belongs to.
+   *
+   * Without it the step is closed `completed` by the discard's own model-end,
+   * so `getRunSteps()` and every run-step subscriber keep reasoning the
+   * replacement prompt does not contain — the graph state forgets the attempt
+   * while the step view still shows it as a finished one.
+   *
+   * Only for turns that were CUT SHORT. A turn whose stream reached its own
+   * end really did complete, and its step is already closed by then; the
+   * terminal-status guard in {@link closeRunStep} leaves that alone.
+   */
+  async cancelOpenMessageStep(
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    const stepId = this.openMessageStepByAgent.get(
+      this.getStepAgentKey(metadata)
+    );
+    if (stepId == null) {
+      return;
+    }
+    try {
+      await this.closeRunStep(stepId, 'cancelled', { metadata });
+    } catch (_e) {
+      /** A step-view detail must never take down the run it describes. */
+    }
+  }
+
   async closeRunStep(
     stepId: string,
     status: Exclude<t.RunStepStatus, 'in_progress'>,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4479,7 +4479,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
            * hosts use the counter for truncated-seal telemetry, and both
            * paths end the turn with nothing to resume from.
            */
-          if (injected.length === 0) {
+          /**
+           * Seals only. `emptyBoundaries` means a kept assistant turn that was
+           * truncated with nothing to resume from; a restart preserved no turn
+           * at all, so a halted one is not that — `preemptIncomplete` above
+           * already records that the answer never arrived.
+           */
+          if (injected.length === 0 && !preemptRestarted) {
             this.preemptEmptyBoundaries += 1;
           }
           this.cleanupSignalListener();

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1416,6 +1416,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * cleanup runs.
    */
   preemptSealCount = 0;
+  /** Discards honored, counted apart from seals — see
+   *  {@link claimPreemptRestart}. */
+  preemptRestartCount = 0;
   /** Boundaries that produced nothing to inject, so the turn stopped early. */
   preemptEmptyBoundaries = 0;
   /**
@@ -1740,6 +1743,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   private resetPreemptTotals(): void {
     this.preemptSealCount = 0;
+    this.preemptRestartCount = 0;
     this.preemptEmptyBoundaries = 0;
     this.preemptIncomplete = false;
     this.preemptHaltReason = undefined;
@@ -1812,12 +1816,32 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * rather than sealing for a message it would never receive.
    */
   claimPreemptSeal(): boolean {
+    return this.claimPreemptSlot('seal');
+  }
+
+  /**
+   * The restart twin. It takes the SAME slot and spends the SAME budget —
+   * both moves end one model turn and cost one extra superstep, and the
+   * mutual exclusion argument above applies identically — but it is counted
+   * apart: a restart preserved no partial assistant message, so reporting it
+   * as a seal would tell every consumer of `getPreemptStats().seals` and the
+   * boundary hook's `sealCount` that a turn was kept when it was discarded.
+   */
+  claimPreemptRestart(): boolean {
+    return this.claimPreemptSlot('restart');
+  }
+
+  private claimPreemptSlot(kind: 'seal' | 'restart'): boolean {
     if (!this.canClaimPreemptSeal()) {
       return false;
     }
     this.preemptSealInFlight = true;
     this.preemptSealBudgetUsed += 1;
-    this.preemptSealCount += 1;
+    if (kind === 'seal') {
+      this.preemptSealCount += 1;
+      return true;
+    }
+    this.preemptRestartCount += 1;
     return true;
   }
 
@@ -1843,6 +1867,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   getPreemptStats(): t.PreemptStats {
     return {
       seals: this.preemptSealCount,
+      restarts: this.preemptRestartCount,
       emptyBoundaries: this.preemptEmptyBoundaries,
     };
   }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4482,12 +4482,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * words were withdrawn before they landed. Bounded by the same seal
          * budget, so a host stuck arming and cancelling cannot loop forever.
          */
-        this.preemptEmptyBoundaries += 1;
         if (preemptRestarted) {
+          /**
+           * NOT counted as an empty boundary. That counter means a seal that
+           * ended the turn early with nothing to resume from — hosts read it
+           * as truncated-answer telemetry — and this branch is the opposite:
+           * the call is reissued and the run goes on to produce a complete
+           * answer. Counting it here would make a successful restart look like
+           * a truncated one in every host that persists on that signal.
+           */
           this.pendingPreemptReturn.add(agentId);
           this.cleanupSignalListener();
           return result;
         }
+        this.preemptEmptyBoundaries += 1;
         this.preemptIncomplete = true;
       }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -37,6 +37,21 @@ export const HOOK_PREEMPT_BOUNDARY_CAPABLE = true;
  * and continue within the same `Run.processStream` lifecycle.
  */
 export const HOOK_STOP_CONTINUATION_CAPABLE = true;
+/**
+ * Feature probe for hosts: a preempt request can also be honored BEFORE the
+ * turn has produced anything to keep — the in-flight model call is discarded
+ * and re-issued with the boundary's injection appended, and
+ * `StreamPreemption.subscribe` wakes the SDK during the silent window where
+ * the per-chunk poll cannot reach.
+ *
+ * Separate from {@link HOOK_PREEMPT_BOUNDARY_CAPABLE} because the two answer
+ * different questions for the user-facing control. An SDK with only the
+ * boundary can seal a turn that is already writing an answer, but an interrupt
+ * armed while the model is still thinking waits for the whole turn — so a host
+ * that probed the wrong flag would promise an interrupt it cannot deliver in
+ * exactly the window users reach for it most.
+ */
+export const HOOK_PREEMPT_RESTART_CAPABLE = true;
 export {
   matchesQuery,
   hasNestedQuantifier,

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -39,7 +39,10 @@ import {
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
-import { consumePreemptRestartedRun } from '@/llm/preempt';
+import {
+  consumePreemptRestartedRun,
+  PREEMPT_RESTART_CONTROL_FLOW,
+} from '@/llm/preempt';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 export {
@@ -54,9 +57,6 @@ const GRAPH_INTERRUPT_CONTROL_FLOW = { controlFlow: 'GraphInterrupt' } as const;
 const GRAPH_INTERRUPT_TOOL_OUTPUT = JSON.stringify(
   GRAPH_INTERRUPT_CONTROL_FLOW
 );
-const PREEMPT_RESTART_CONTROL_FLOW = {
-  controlFlow: 'PreemptRestart',
-} as const;
 
 export type LangfuseTraceMetadata = Record<string, string>;
 export type LangfuseTraceAttributes = Record<string, string | number | boolean>;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -692,9 +692,28 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleLLMError']>
   ): ReturnType<CallbackHandler['handleLLMError']> {
     const [, runId, parentRunId] = args;
-    if (consumePreemptRestartedRun(runId)) {
-      return super.handleLLMEnd(
-        { generations: [], llmOutput: PREEMPT_RESTART_CONTROL_FLOW },
+    const restarted = consumePreemptRestartedRun(runId);
+    if (restarted != null) {
+      /**
+       * Closed WITH the discarded turn, not as an empty end. The provider
+       * consumed the whole prompt and may have billed reasoning tokens before
+       * the tear-down, and this is the only close the generation will get —
+       * the synthetic `CHAT_MODEL_END` that follows is a host stream event and
+       * cannot reopen it. Routed through the override so Bedrock usage is
+       * normalized exactly as it is for an ordinary end.
+       *
+       * The generation text stays empty on purpose: a discarded turn produced
+       * no answer, and replaying its reasoning as output would read as one.
+       */
+      const generation: ChatGeneration = {
+        text: '',
+        message: restarted.message,
+      };
+      return this.handleLLMEnd(
+        {
+          generations: [[generation]],
+          llmOutput: PREEMPT_RESTART_CONTROL_FLOW,
+        },
         runId,
         parentRunId
       );

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -40,7 +40,7 @@ import {
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
 import {
-  consumePreemptRestartedRun,
+  readPreemptRestartedRun,
   PREEMPT_RESTART_CONTROL_FLOW,
 } from '@/llm/preempt';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
@@ -692,7 +692,7 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
     ...args: Parameters<CallbackHandler['handleLLMError']>
   ): ReturnType<CallbackHandler['handleLLMError']> {
     const [, runId, parentRunId] = args;
-    const restarted = consumePreemptRestartedRun(runId);
+    const restarted = readPreemptRestartedRun(runId);
     if (restarted != null) {
       /**
        * Closed WITH the discarded turn, not as an empty end. The provider
@@ -704,6 +704,10 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
        *
        * The generation text stays empty on purpose: a discarded turn produced
        * no answer, and replaying its reasoning as output would read as one.
+       *
+       * The lookup does not consume the record: a run can be closed through
+       * several handlers at once, and each must reach this branch rather than
+       * the first one leaving the others to export an error.
        */
       const generation: ChatGeneration = {
         text: '',

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -39,6 +39,7 @@ import {
   registerLangfuseManagedSpan,
   resolveLangfuseDestinationKey,
 } from '@/langfuseSpanRegistry';
+import { consumePreemptRestartedRun } from '@/llm/preempt';
 import { isPresent, parseBooleanEnv } from '@/utils/misc';
 
 export {
@@ -53,6 +54,9 @@ const GRAPH_INTERRUPT_CONTROL_FLOW = { controlFlow: 'GraphInterrupt' } as const;
 const GRAPH_INTERRUPT_TOOL_OUTPUT = JSON.stringify(
   GRAPH_INTERRUPT_CONTROL_FLOW
 );
+const PREEMPT_RESTART_CONTROL_FLOW = {
+  controlFlow: 'PreemptRestart',
+} as const;
 
 export type LangfuseTraceMetadata = Record<string, string>;
 export type LangfuseTraceAttributes = Record<string, string | number | boolean>;
@@ -670,6 +674,32 @@ class ScopedLangfuseCallbackHandler extends CallbackHandler {
       runId,
       parentRunId
     );
+  }
+
+  /**
+   * A cooperative restart tears the provider stream down mid-flight, so the
+   * adapter reports cancellation and LangChain closes the generation through
+   * this path. That is control flow, not a failure — the graph catches it,
+   * injects, and calls the model again — so it closes as a successful
+   * generation rather than polluting an otherwise healthy trace with a failed
+   * one.
+   *
+   * Keyed on the run id the tear-down recorded, not on the error's shape:
+   * every provider adapter raises its own cancellation error, and matching on
+   * those would make the invariant depend on which provider served the call.
+   */
+  override handleLLMError(
+    ...args: Parameters<CallbackHandler['handleLLMError']>
+  ): ReturnType<CallbackHandler['handleLLMError']> {
+    const [, runId, parentRunId] = args;
+    if (consumePreemptRestartedRun(runId)) {
+      return super.handleLLMEnd(
+        { generations: [], llmOutput: PREEMPT_RESTART_CONTROL_FLOW },
+        runId,
+        parentRunId
+      );
+    }
+    return super.handleLLMError(...args);
   }
 
   override handleToolStart(

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -16,6 +16,7 @@ import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type { PreparedProviderRequest } from '@/llm/prepareProviderRequest';
 import type { ContextOverflowContext } from '@/utils/errors';
 import type { StreamLimitState } from '@/llm/streamLimits';
+import type { PreemptAction } from '@/llm/preempt';
 import type * as t from '@/types';
 import {
   enforceStreamLimitsForWireChunk,
@@ -38,6 +39,11 @@ import {
   prepareProviderRequest,
 } from '@/llm/prepareProviderRequest';
 import {
+  canRestartPreempt,
+  resolvePreemptAction,
+  resolveRestartGraceMs,
+} from '@/llm/preempt';
+import {
   getProviderFamily,
   providerUsesManualToolStream,
 } from '@/llm/providers';
@@ -48,7 +54,7 @@ import { resolveClientOptionsModel } from '@/llm/request';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { getContextOverflowInfo } from '@/utils/errors';
 import { appendCallbacks } from '@/utils/callbacks';
-import { canSealPreempt } from '@/llm/preempt';
+import { composeAbortSignals } from '@/utils/misc';
 import { initializeModel } from '@/llm/init';
 
 export {
@@ -590,6 +596,17 @@ function appendStreamChunk({
 interface AttemptInvokeCommonParams {
   context?: InvokeContext;
   onChunk?: OnChunk;
+  /**
+   * The agent lane this attempt belongs to, as the model node names it. Only
+   * read to record a discarded turn, which the node cannot otherwise detect —
+   * a discard returns no message to carry `response_metadata.preempted`.
+   *
+   * Keyed rather than global for the same reason `pendingPreemptReturn` is:
+   * `MultiAgentGraph` routes every parallel agent through ONE graph instance,
+   * so a shared flag would let whichever lane finished first consume another
+   * lane's boundary — and inject that lane's words into the wrong turn.
+   */
+  preemptAgentId?: string;
   /** Accounting owner for callers that deliberately pass no `context`
    * (summarization) — used ONLY for the attempt's accounting lease, never
    * for charge claims. */
@@ -691,6 +708,7 @@ export async function attemptInvoke(
         request: resolveAttemptRequest(params, stampedConfig),
         context: params.context,
         onChunk: params.onChunk,
+        preemptAgentId: params.preemptAgentId,
       },
       stampedConfig
     );
@@ -706,7 +724,11 @@ async function attemptInvokeBody(
     request,
     context,
     onChunk,
-  }: Pick<AttemptInvokeCommonParams, 'context' | 'onChunk'> & {
+    preemptAgentId,
+  }: Pick<
+    AttemptInvokeCommonParams,
+    'context' | 'onChunk' | 'preemptAgentId'
+  > & {
     request: PreparedProviderRequest;
   },
   config: RunnableConfig
@@ -747,11 +769,124 @@ async function attemptInvokeBody(
      * survive the bound runnable. The same handler owns the opt-in projection
      * invariant so enabled diagnostics do not stack a second model callback.
      */
-    const stream = await model.stream(messagesForProvider, invocationConfig);
     let finalChunk: AIMessageChunk | undefined;
-    let preempted = false;
+    let preemptAction: PreemptAction = 'none';
     const registeredStreamHandler =
       getRegisteredDefaultChatStreamHandler(context);
+    /**
+     * The wake channel is armed for the seal-capable branch only. The other
+     * two consume through readers that lag the accumulation — the same reason
+     * the per-chunk poll lives in that branch alone — and an `onChunk`
+     * consumer owns the stream outright.
+     *
+     * An unnamed lane disarms it too. A caller that supplies a preemption
+     * source but no `preemptAgentId` cannot have its discard routed back to
+     * the right model node, so it keeps today's behavior — the request waits
+     * for a boundary — rather than ending a turn nothing will resume.
+     */
+    const restartLane =
+      onChunk == null &&
+      registeredStreamHandler == null &&
+      context?.preemption?.subscribe != null
+        ? preemptAgentId
+        : undefined;
+    const restartController =
+      restartLane == null ? undefined : new AbortController();
+    /**
+     * Composed, never replaced: the run's own signal must keep tearing this
+     * stream down. `composeAbortSignals` collapses back to a single signal
+     * when there is nothing to compose.
+     */
+    const streamConfig =
+      restartController == null
+        ? invocationConfig
+        : {
+          ...invocationConfig,
+          signal: composeAbortSignals(
+            invocationConfig.signal,
+            restartController.signal
+          ),
+        };
+    const restartGraceMs = resolveRestartGraceMs(
+      context?.preemption?.restartGraceMs
+    );
+    /**
+     * When THIS attempt first saw the request, which is what the grace window
+     * is measured against. Recorded on first observation rather than on arm:
+     * the host's flag is level-triggered and may already have been true for a
+     * previous attempt, and a retry inheriting an aged request would discard
+     * its very first chunk.
+     */
+    let preemptRequestedAt: number | undefined;
+    let restartGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    /**
+     * The wake is a hint; this is where the request is actually read. The
+     * shape is judged at the instant we look at it, and the teardown that
+     * follows is what makes any later chunk irrelevant — so a wake arriving
+     * once an answer has started, or one that loses the shared seal slot,
+     * leaves the stream untouched and waits for the ordinary boundary.
+     *
+     * A `seal` verdict is deliberately ignored here. Sealing KEEPS the
+     * accumulated turn, and only the chunk loop can hand it over intact; this
+     * path exists solely to end turns that have nothing to hand over.
+     *
+     * The self-rescheduling timer is what covers the silent window. Nothing
+     * else will look again — a provider that has gone quiet produces no chunk
+     * to poll on — so without it a request arriving mid-grace would wait out
+     * the whole turn, which is the stall this path exists to remove.
+     */
+    const evaluatePreemptRestart = (): boolean => {
+      if (restartController == null || preemptAction !== 'none') {
+        return false;
+      }
+      if (context?.shouldPreemptStream() !== true) {
+        return false;
+      }
+      preemptRequestedAt ??= Date.now();
+      const requestAgeMs = Date.now() - preemptRequestedAt;
+      const action = resolvePreemptAction({
+        chunk: finalChunk,
+        requestAgeMs,
+        graceMs: restartGraceMs,
+      });
+      if (action !== 'restart') {
+        if (
+          action === 'none' &&
+          restartGraceTimer == null &&
+          canRestartPreempt(finalChunk)
+        ) {
+          /**
+           * Scheduled for what is LEFT of the window, not a fresh one: the
+           * clock starts when the request is first seen, so a wake arriving
+           * mid-window must not push the conversion further out than a wake
+           * arriving at its start.
+           *
+           * The handle is released as the timer fires so a look that changes
+           * nothing — the shape moved, the host disarmed and re-armed — can
+           * still schedule the next one.
+           */
+          restartGraceTimer = setTimeout(() => {
+            restartGraceTimer = undefined;
+            evaluatePreemptRestart();
+          }, Math.max(0, restartGraceMs - requestAgeMs));
+          /** The grace is a fallback, never a reason to hold the process
+           *  open: a run that ends before the window elapses must not be kept
+           *  alive by a timer whose only job is to look again. */
+          restartGraceTimer.unref();
+        }
+        return false;
+      }
+      if (!context.claimPreemptSeal()) {
+        return false;
+      }
+      preemptAction = 'restart';
+      restartController.abort();
+      return true;
+    };
+    const unsubscribeWake =
+      restartController == null
+        ? undefined
+        : context?.preemption?.subscribe?.(evaluatePreemptRestart);
     /** A sibling's trip aborts the composed signal, but an adapter that
      * ignores cancellation keeps yielding — and text-only chunks with the
      * event cap off never throw in enforcement, so nothing else would stop
@@ -767,137 +902,181 @@ async function attemptInvokeBody(
       }
     };
 
-    if (onChunk) {
-      const attemptMetadata = config.metadata as
-        | Record<string, unknown>
-        | undefined;
-      for await (const chunk of stream) {
-        throwIfBreakerTripped();
-        /** An onChunk consumer replaces the stream handler entirely, so
-         * stream limits are enforced here for every such caller — public
-         * package consumers get no other accounting. The internal
-         * summarization onChunk charges producer-side itself and passes no
-         * context, precisely so this claim and its own never stack. */
-        if (context != null) {
-          enforceStreamLimitsForWireChunk({
-            graph: context,
-            metadata: attemptMetadata,
-            chunk,
-          });
-        }
-        await onChunk(chunk, attemptMetadata);
-        finalChunk = appendStreamChunk({
-          current: finalChunk,
-          next: chunk,
-          provider,
-        });
-      }
-    } else if (registeredStreamHandler == null) {
-      const metadata = config.metadata as Record<string, unknown> | undefined;
-      const streamHandler = new ChatModelStreamHandler();
-      for await (const chunk of stream) {
-        throwIfBreakerTripped();
-        const handlingChunk = getStreamHandlingChunk({
-          current: finalChunk,
-          next: chunk,
-          provider,
-        });
-        if (handlingChunk != null) {
-          await streamHandler.handle(
-            GraphEvents.CHAT_MODEL_STREAM,
-            { chunk: handlingChunk },
-            metadata,
-            context
-          );
-        } else if (context != null) {
-          /**
-           * A replay-skipped chunk yields no handling chunk, and in this
-           * local branch no `streamEvents` consumer judges the wire event
-           * either — yet a cumulative OpenRouter replay can still carry
-           * `tool_call_chunks` or complete `tool_calls` that are appended
-           * below. Charge the full limits (event budget and argument bytes)
-           * directly so neither cap can be bypassed. Consumer side: the
-           * local handler.handle call above claims as consumer, and one
-           * reused chunk object can alternate between these two arms.
-           */
-          enforceStreamLimitsForWireChunk({
-            graph: context,
-            metadata,
-            chunk,
-            side: 'consumer',
-          });
-        }
-        finalChunk = appendStreamChunk({
-          current: finalChunk,
-          next: chunk,
-          provider,
-        });
-        /**
-         * Only this loop may seal. The registered-handler branch below
-         * dispatches through `run.ts`'s decoupled `streamEvents` consumer,
-         * which can lag the accumulated chunk — sealing there would let the
-         * host index a content part the user has not been shown yet.
-         */
-        /**
-         * Cheap poll first, shape check second, budget claim last. The claim
-         * is what makes this safe under a parallel `MultiAgentGraph`: several
-         * agents share one graph and can each see the poll as true, but only
-         * one can take the slot, and a chunk that cannot seal never spends it.
-         */
-        if (
-          context?.shouldPreemptStream() === true &&
-          canSealPreempt(finalChunk) &&
-          context.claimPreemptSeal()
-        ) {
-          preempted = true;
-          break;
-        }
-      }
-    } else {
-      const metadata = config.metadata as Record<string, unknown> | undefined;
+    try {
       /**
-       * The original wire chunk still reaches the registered handler through
-       * `streamEvents` (where the late-reasoning skip discards it AFTER the
-       * event guard counts it), so this inline re-dispatch of the transformed
-       * chunk is marked to not consume a second event-budget slot. Allocated
-       * once per attempt, only when a transformation occurs.
+       * Subscribing is not enough on its own. `shouldPreempt` is
+       * level-triggered, so a request armed BEFORE this attempt began — during
+       * setup, or on a previous attempt a fallback replaced — is already true
+       * and will never produce another wake. Reading it once here is the
+       * difference between honoring that request and waiting out the turn.
+       *
+       * Read before the provider request is issued so the grace clock starts
+       * from the attempt's own beginning rather than from its first chunk. A
+       * host that set `restartGraceMs` to zero skips the call entirely here,
+       * having streamed nothing and opened no model run — which is why the
+       * close below is conditional.
        */
-      let redispatchMetadata: Record<string, unknown> | undefined;
-      for await (const chunk of stream) {
-        throwIfBreakerTripped();
-        /**
-         * Charged synchronously, ahead of the decoupled `streamEvents`
-         * reader that will echo this same chunk to the registered handler:
-         * a lagging reader would otherwise let an oversized complete call
-         * return to LangGraph and reach ToolNode before the queued handler
-         * throws. The chunk is marked so the echo skips accounting.
-         */
-        if (context != null) {
-          enforceStreamLimitsForWireChunk({ graph: context, metadata, chunk });
+      if (!evaluatePreemptRestart()) {
+        const stream = await model.stream(messagesForProvider, streamConfig);
+        if (onChunk) {
+          const attemptMetadata = config.metadata as
+            | Record<string, unknown>
+            | undefined;
+          for await (const chunk of stream) {
+            throwIfBreakerTripped();
+            /** An onChunk consumer replaces the stream handler entirely, so
+             * stream limits are enforced here for every such caller — public
+             * package consumers get no other accounting. The internal
+             * summarization onChunk charges producer-side itself and passes no
+             * context, precisely so this claim and its own never stack. */
+            if (context != null) {
+              enforceStreamLimitsForWireChunk({
+                graph: context,
+                metadata: attemptMetadata,
+                chunk,
+              });
+            }
+            await onChunk(chunk, attemptMetadata);
+            finalChunk = appendStreamChunk({
+              current: finalChunk,
+              next: chunk,
+              provider,
+            });
+          }
+        } else if (registeredStreamHandler == null) {
+          const metadata = config.metadata as Record<string, unknown> | undefined;
+          const streamHandler = new ChatModelStreamHandler();
+          for await (const chunk of stream) {
+            throwIfBreakerTripped();
+            const handlingChunk = getStreamHandlingChunk({
+              current: finalChunk,
+              next: chunk,
+              provider,
+            });
+            if (handlingChunk != null) {
+              await streamHandler.handle(
+                GraphEvents.CHAT_MODEL_STREAM,
+                { chunk: handlingChunk },
+                metadata,
+                context
+              );
+            } else if (context != null) {
+              /**
+               * A replay-skipped chunk yields no handling chunk, and in this
+               * local branch no `streamEvents` consumer judges the wire event
+               * either — yet a cumulative OpenRouter replay can still carry
+               * `tool_call_chunks` or complete `tool_calls` that are appended
+               * below. Charge the full limits (event budget and argument bytes)
+               * directly so neither cap can be bypassed. Consumer side: the
+               * local handler.handle call above claims as consumer, and one
+               * reused chunk object can alternate between these two arms.
+               */
+              enforceStreamLimitsForWireChunk({
+                graph: context,
+                metadata,
+                chunk,
+                side: 'consumer',
+              });
+            }
+            finalChunk = appendStreamChunk({
+              current: finalChunk,
+              next: chunk,
+              provider,
+            });
+            /**
+             * Only this loop may seal. The registered-handler branch below
+             * dispatches through `run.ts`'s decoupled `streamEvents` consumer,
+             * which can lag the accumulated chunk — sealing there would let the
+             * host index a content part the user has not been shown yet.
+             */
+            /**
+             * Cheap poll first, shape check second, budget claim last. The claim
+             * is what makes this safe under a parallel `MultiAgentGraph`: several
+             * agents share one graph and can each see the poll as true, but only
+             * one can take the slot, and a chunk that cannot seal never spends it.
+             *
+             * `resolvePreemptAction` prefers a seal wherever one is available,
+             * so a turn that already produced an answer keeps it. `restart` is
+             * reached only for an accumulation holding nothing but reasoning —
+             * the case a seal can never accept, and the reason an interrupt
+             * armed during a long thinking stretch used to wait for the whole
+             * turn.
+             */
+            if (context?.shouldPreemptStream() === true) {
+              preemptRequestedAt ??= Date.now();
+              const action = resolvePreemptAction({
+                chunk: finalChunk,
+                requestAgeMs: Date.now() - preemptRequestedAt,
+                graceMs: restartGraceMs,
+              });
+              if (action !== 'none' && context.claimPreemptSeal()) {
+                preemptAction = action;
+                break;
+              }
+            }
+          }
+        } else {
+          const metadata = config.metadata as Record<string, unknown> | undefined;
+          /**
+           * The original wire chunk still reaches the registered handler through
+           * `streamEvents` (where the late-reasoning skip discards it AFTER the
+           * event guard counts it), so this inline re-dispatch of the transformed
+           * chunk is marked to not consume a second event-budget slot. Allocated
+           * once per attempt, only when a transformation occurs.
+           */
+          let redispatchMetadata: Record<string, unknown> | undefined;
+          for await (const chunk of stream) {
+            throwIfBreakerTripped();
+            /**
+             * Charged synchronously, ahead of the decoupled `streamEvents`
+             * reader that will echo this same chunk to the registered handler:
+             * a lagging reader would otherwise let an oversized complete call
+             * return to LangGraph and reach ToolNode before the queued handler
+             * throws. The chunk is marked so the echo skips accounting.
+             */
+            if (context != null) {
+              enforceStreamLimitsForWireChunk({ graph: context, metadata, chunk });
+            }
+            const handlingChunk = getStreamHandlingChunk({
+              current: finalChunk,
+              next: chunk,
+              provider,
+            });
+            if (handlingChunk != null && handlingChunk !== chunk) {
+              redispatchMetadata ??= {
+                ...(metadata ?? {}),
+                [STREAM_LIMIT_REDISPATCH_KEY]: true,
+              };
+              await registeredStreamHandler.handle(
+                GraphEvents.CHAT_MODEL_STREAM,
+                { chunk: handlingChunk },
+                redispatchMetadata,
+                context
+              );
+            }
+            finalChunk = appendStreamChunk({
+              current: finalChunk,
+              next: chunk,
+              provider,
+            });
+          }
         }
-        const handlingChunk = getStreamHandlingChunk({
-          current: finalChunk,
-          next: chunk,
-          provider,
-        });
-        if (handlingChunk != null && handlingChunk !== chunk) {
-          redispatchMetadata ??= {
-            ...(metadata ?? {}),
-            [STREAM_LIMIT_REDISPATCH_KEY]: true,
-          };
-          await registeredStreamHandler.handle(
-            GraphEvents.CHAT_MODEL_STREAM,
-            { chunk: handlingChunk },
-            redispatchMetadata,
-            context
-          );
-        }
-        finalChunk = appendStreamChunk({
-          current: finalChunk,
-          next: chunk,
-          provider,
-        });
       }
+    } catch (error) {
+      /**
+       * A restart tears the provider stream down mid-flight, which surfaces
+       * as the composed signal's abort — from the iteration, or from stream
+       * creation when the request was already outstanding. Swallowed only when
+       * THIS attempt asked for it: `preemptAction` is set immediately before
+       * the abort and by nothing else, so a run-level abort, a tripped stream
+       * limit and every provider error still propagate.
+       */
+      if (preemptAction !== 'restart') {
+        throw error;
+      }
+    } finally {
+      unsubscribeWake?.();
+      clearTimeout(restartGraceTimer);
     }
 
     if (providerUsesManualToolStream(provider)) {
@@ -907,7 +1086,70 @@ async function attemptInvokeBody(
       );
     }
 
-    if (preempted && finalChunk != null) {
+    if (preemptAction === 'restart') {
+      /**
+       * The turn is thrown away, but a model run that OPENED still has to be
+       * closed:
+       * its callback span is open, and a host that renders from the stream
+       * has already drawn the reasoning that is about to vanish. The synthetic
+       * end carries `preemptDiscarded` so both can tell this apart from a seal
+       * — a seal's content survives into the next prompt, a discard's does
+       * not, and a host that keeps rendering it would show the user words the
+       * model no longer has.
+       *
+       * Usage is still synthesized from whatever accumulated. Those reasoning
+       * tokens were spent and billed; dropping them from the report would make
+       * an interrupted turn look free.
+       *
+       * Skipped entirely when the request never went out — a preempt already
+       * outstanding when the attempt began short-circuits above the provider
+       * call, so there is no open span and no stream for a host to unwind, and
+       * a synthetic end would announce a run that never started.
+       */
+      if (finalChunk != null || sealedRunId != null) {
+        const discardedChunk = finalChunk ?? new AIMessageChunk({ content: '' });
+        const responseMetadata = {
+          ...discardedChunk.response_metadata,
+          preempted: true,
+          preemptDiscarded: true,
+        };
+        discardedChunk.response_metadata = responseMetadata;
+        discardedChunk.lc_kwargs.response_metadata = responseMetadata;
+        /**
+         * No run id, deliberately. Tearing the stream down makes LangChain
+         * close the model run through its error path, so the native close a
+         * seal performs would find nothing to end and warn on every interrupt.
+         * The synthetic `CHAT_MODEL_END` is the right close here anyway: it is
+         * what tells a host rendering from the stream that the part it has been
+         * drawing is over, and `preemptDiscarded` on it is what says the part's
+         * content is gone rather than kept.
+         */
+        await endSealedModelRun(
+          context,
+          discardedChunk,
+          messagesForProvider,
+          undefined,
+          config,
+          model
+        );
+      }
+      /** Non-null on every path that can reach here: it is what armed the
+       *  controller in the first place. */
+      if (restartLane != null) {
+        context?.notePreemptRestart(restartLane);
+      }
+      /**
+       * No message reaches graph state, so the injected user turn lands
+       * directly after the previous one — which is what makes this safe on
+       * every provider: adjacent user turns are native on Anthropic, OpenAI
+       * and Gemini, and normalized by `coalesceAdjacentUserTurns` for the
+       * strict-alternation providers. A seal needs a non-empty assistant turn
+       * precisely because it leaves one behind; a discard leaves none.
+       */
+      return { messages: [] };
+    }
+
+    if (preemptAction === 'seal' && finalChunk != null) {
       const responseMetadata = {
         ...finalChunk.response_metadata,
         preempted: true,
@@ -1018,6 +1260,7 @@ export async function tryFallbackProviders({
   context,
   onChunk,
   streamLimitState,
+  preemptAgentId,
   overflowContext,
   prepareProviderRequest: prepareFallbackRequest,
   prepareProviderMessages,
@@ -1032,6 +1275,11 @@ export async function tryFallbackProviders({
   /** Accounting-lease owner forwarded to each fallback attempt (see
    * `AttemptInvokeParams.streamLimitState`). */
   streamLimitState?: StreamLimitState;
+  /** Forwarded so a fallback-served attempt records a discarded turn in the
+   * SAME lane the primary would have (see
+   * `AttemptInvokeParams.preemptAgentId`). Dropping it here would leave the
+   * node's boundary undispatched and the lane holding an empty turn. */
+  preemptAgentId?: string;
   /**
    * Prompt-size corroboration for signatures that are not self-describing.
    * Vertex AI's overflow is a bare `400` with no reason, so without this a
@@ -1147,6 +1395,7 @@ export async function tryFallbackProviders({
             context,
             onChunk,
             streamLimitState,
+            preemptAgentId,
           },
           fbConfig
         );
@@ -1159,6 +1408,7 @@ export async function tryFallbackProviders({
           context,
           onChunk,
           streamLimitState,
+          preemptAgentId,
         },
         fbConfig
       );

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -833,6 +833,17 @@ async function attemptInvokeBody(
      *  initializer, and would narrow the comparison away as unreachable. */
     const restartDecided = (): boolean => preemptAction === 'restart';
     /**
+     * Whether the tear-down actually happened. Only an ABORT makes LangChain
+     * close the model run, through its error path; breaking the iterator fires
+     * neither end nor error callbacks. The two restart routes therefore need
+     * opposite closes, and the controller's own state is the exact record of
+     * which one ran — nothing else aborts it, and the run's signal is composed
+     * INTO the stream rather than into this.
+     */
+    const restartToreDownStream = (): boolean =>
+      restartController?.signal.aborted === true;
+
+    /**
      * The wake is a hint; this is where the request is actually read. The
      * shape is judged at the instant we look at it, and the teardown that
      * follows is what makes any later chunk irrelevant — so a wake arriving
@@ -912,7 +923,7 @@ async function attemptInvokeBody(
         }
         return false;
       }
-      if (!context.claimPreemptSeal()) {
+      if (!context.claimPreemptRestart()) {
         return false;
       }
       preemptAction = 'restart';
@@ -1095,10 +1106,13 @@ async function attemptInvokeBody(
                * its turns discarded, so its request waits for a seal exactly
                * as it does today.
                */
-              const permitted =
-                action === 'seal' ||
-                (action === 'restart' && restartLane != null);
-              if (permitted && context.claimPreemptSeal()) {
+              const claimed =
+                action === 'seal'
+                  ? context.claimPreemptSeal()
+                  : action === 'restart' &&
+                    restartLane != null &&
+                    context.claimPreemptRestart();
+              if (claimed) {
                 preemptAction = action;
                 break;
               }
@@ -1149,6 +1163,24 @@ async function attemptInvokeBody(
               provider,
             });
           }
+        }
+        /**
+         * The stream reached its natural end while a request was still armed
+         * and the turn still holds nothing worth keeping. The grace exists to
+         * avoid stealing a seal that was about to become possible — and the
+         * final shape is proof none was: no text ever arrived. Converting here
+         * spends no extra provider call (the stream is over) and spares the
+         * host a reasoning-only turn followed by its own steer, which is the
+         * shape the seal gate refuses to build in the first place.
+         */
+        if (
+          preemptAction === 'none' &&
+          restartLane != null &&
+          context?.shouldPreemptStream() === true &&
+          canRestartPreempt(finalChunk) &&
+          context.claimPreemptRestart()
+        ) {
+          preemptAction = 'restart';
         }
       }
     } catch (error) {
@@ -1217,7 +1249,15 @@ async function attemptInvokeBody(
           context,
           discardedChunk,
           messagesForProvider,
-          undefined,
+          /**
+           * Only an aborted run is already closed — LangChain took it through
+           * its error path, and the marker recorded above carries its usage
+           * there. A restart that merely BROKE the iterator fired no callback
+           * at all, so it closes natively here exactly as a seal does; passing
+           * no run id would leave that generation open forever and lose the
+           * discarded attempt's usage.
+           */
+          restartToreDownStream() ? undefined : sealedRunId,
           config,
           model
         );

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -828,6 +828,10 @@ async function attemptInvokeBody(
      *  yet been folded into `finalChunk`. See the guard in
      *  {@link evaluatePreemptRestart}. */
     let dispatchingChunk = false;
+    /** Read through a call so the check sees the value the wake handler
+     *  writes: control-flow analysis at the loop head still holds the
+     *  initializer, and would narrow the comparison away as unreachable. */
+    const restartDecided = (): boolean => preemptAction === 'restart';
     /**
      * The wake is a hint; this is where the request is actually read. The
      * shape is judged at the instant we look at it, and the teardown that
@@ -912,11 +916,28 @@ async function attemptInvokeBody(
         return false;
       }
       preemptAction = 'restart';
-      /** Recorded BEFORE the abort: the adapter's cancellation error can reach
-       *  the tracing callback synchronously, and a run marked afterwards would
-       *  already have closed as a failure. */
+      /**
+       * Recorded BEFORE the abort: the adapter's cancellation error can reach
+       * the tracing callback synchronously, and a run marked afterwards would
+       * already have closed as a failure.
+       *
+       * `sealedRunId` being set is also what proves the request went OUT, so
+       * charging the prompt against it is honest. Usage is resolved here, onto
+       * the same chunk the discard reports later — the run closes through the
+       * error path, which carries no output, so a marker without it would make
+       * every restart look free. `synthesizeSealedUsage` no-ops when the
+       * provider already streamed usage, and again when the discard path runs,
+       * so this is one computation, not two.
+       */
       if (sealedRunId != null) {
-        notePreemptRestartedRun(sealedRunId);
+        finalChunk ??= new AIMessageChunk({ content: '' });
+        synthesizeSealedUsage(
+          context,
+          finalChunk,
+          messagesForProvider,
+          config.metadata as Record<string, unknown> | undefined
+        );
+        notePreemptRestartedRun(sealedRunId, finalChunk);
       }
       restartController.abort();
       return true;
@@ -986,6 +1007,18 @@ async function attemptInvokeBody(
           const streamHandler = new ChatModelStreamHandler();
           for await (const chunk of stream) {
             throwIfBreakerTripped();
+            /**
+             * The decision is final, so stop consuming here rather than
+             * trusting the adapter to honor the abort. An adapter that ignores
+             * cancellation — or one whose iterator hands over a chunk buffered
+             * before the abort landed — would otherwise keep dispatching text
+             * the host is about to be told was discarded, and in the ignoring
+             * case would hold the boundary until the whole response finished:
+             * exactly the stall a restart exists to end.
+             */
+            if (restartDecided()) {
+              break;
+            }
             const handlingChunk = getStreamHandlingChunk({
               current: finalChunk,
               next: chunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -516,7 +516,14 @@ async function endSealedModelRun(
    * the two restart routes reading alike in a trace — the aborted one is
    * relabelled through the tracing callback, and this is the manual twin.
    */
-  llmOutput: Record<string, unknown> = {}
+  llmOutput: Record<string, unknown> = {},
+  /**
+   * Set when the run was probably closed already, so a failed native close is
+   * the expected outcome rather than a fault. The synthetic fallback below is
+   * the real close in that case, and warning on every interrupt would bury the
+   * failures that do matter.
+   */
+  nativeCloseOptional = false
 ): Promise<void> {
   const metadata = config?.metadata as Record<string, unknown> | undefined;
   synthesizeSealedUsage(context, chunk, prompt, metadata);
@@ -565,11 +572,13 @@ async function endSealedModelRun(
        * A sealed answer that reaches the user is worth more than a tidy
        * trace. Fall through to the custom event rather than failing the run.
        */
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[attemptInvoke] Native close of the sealed model run failed; falling back to a custom event:',
-        e instanceof Error ? e.message : e
-      );
+      if (!nativeCloseOptional) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[attemptInvoke] Native close of the sealed model run failed; falling back to a custom event:',
+          e instanceof Error ? e.message : e
+        );
+      }
     }
   }
   await safeDispatchCustomEvent(
@@ -861,8 +870,24 @@ async function attemptInvokeBody(
      * every later preemption in the run.
      */
     let attemptActive = true;
-    /** Only `broke` leaves a run for this attempt to close itself. */
-    const restartNeedsNativeClose = (): boolean => restartRoute === 'broke';
+    /**
+     * Only an exhausted stream leaves nothing for this attempt to close: it
+     * emitted its own end. Both other routes attempt the native close, because
+     * whether the run is still open is NOT observable from here — an adapter
+     * that ignores the abort keeps it open, while one that honors it (or that
+     * simply hands over a chunk buffered before the abort landed) has already
+     * closed it through the error path. `endSealedModelRun` degrades to the
+     * synthetic event when the run is gone, which is what makes both right.
+     */
+    const restartNeedsNativeClose = (): boolean => restartRoute !== 'exhausted';
+    /**
+     * An aborted run is EXPECTED to be closed already, so a failed native
+     * close is the normal outcome there and must not warn on every interrupt.
+     * A broken iterator fired no callback at all, so a failure is worth
+     * hearing about.
+     */
+    const restartCloseMayHaveHappened = (): boolean =>
+      restartRoute === 'aborted';
 
     /**
      * The wake is a hint; this is where the request is actually read. The
@@ -1281,6 +1306,17 @@ async function attemptInvokeBody(
        * call, so there is no open span and no stream for a host to unwind, and
        * a synthetic end would announce a run that never started.
        */
+      if (restartRoute !== 'exhausted') {
+        /**
+         * The step really was cut short, so it closes `cancelled` before the
+         * model-end below can close it `completed`. An exhausted turn is left
+         * alone: its stream reached its own end, and the step describing it is
+         * already closed and honest — only the turn built on it is discarded.
+         */
+        await context?.cancelOpenMessageStep(
+          config.metadata as Record<string, unknown> | undefined
+        );
+      }
       if (finalChunk != null || sealedRunId != null) {
         const discardedChunk = finalChunk ?? new AIMessageChunk({ content: '' });
         const responseMetadata = {
@@ -1324,7 +1360,8 @@ async function attemptInvokeBody(
             restartNeedsNativeClose() ? sealedRunId : undefined,
             config,
             model,
-            PREEMPT_RESTART_CONTROL_FLOW
+            PREEMPT_RESTART_CONTROL_FLOW,
+            restartCloseMayHaveHappened()
           );
         }
       }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -1348,10 +1348,11 @@ async function attemptInvokeBody(
           );
         } else {
           /**
-           * See {@link restartRoute}: only the broken iterator leaves a run
-           * with no close of its own. An aborted run was closed through
-           * LangChain's error path, where the marker relabels it and supplies
-           * this usage, so it takes the synthetic close instead.
+           * Both cut-short routes come here and both pass the run id: see
+           * {@link restartNeedsNativeClose} for why the run's state is not
+           * observable and the close has to work either way. An aborted run
+           * that WAS already closed falls through to the synthetic event,
+           * where the marker relabels it and supplies this usage.
            */
           await endSealedModelRun(
             context,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -35,14 +35,15 @@ import {
   modifyDeltaProperties,
 } from '@/messages';
 import {
-  assertPreparedProviderRequestFor,
-  prepareProviderRequest,
-} from '@/llm/prepareProviderRequest';
-import {
   canRestartPreempt,
+  notePreemptRestartedRun,
   resolvePreemptAction,
   resolveRestartGraceMs,
 } from '@/llm/preempt';
+import {
+  assertPreparedProviderRequestFor,
+  prepareProviderRequest,
+} from '@/llm/prepareProviderRequest';
 import {
   getProviderFamily,
   providerUsesManualToolStream,
@@ -115,6 +116,10 @@ export type OnChunk = (
   chunk: AIMessageChunk,
   metadata?: Record<string, unknown>
 ) => void | Promise<void>;
+
+/** Node coerces a `setTimeout` delay past this to 1ms, so a longer grace is
+ *  reached by chaining rather than by one out-of-range timer. */
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 /** Unique per-model-attempt sequence; see the stamp in `attemptInvoke`. */
 let streamLimitAttemptSeq = 0;
@@ -819,6 +824,10 @@ async function attemptInvokeBody(
      */
     let preemptRequestedAt: number | undefined;
     let restartGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    /** True while a chunk is being handed to the stream handler and has not
+     *  yet been folded into `finalChunk`. See the guard in
+     *  {@link evaluatePreemptRestart}. */
+    let dispatchingChunk = false;
     /**
      * The wake is a hint; this is where the request is actually read. The
      * shape is judged at the instant we look at it, and the teardown that
@@ -836,10 +845,23 @@ async function attemptInvokeBody(
      * the whole turn, which is the stall this path exists to remove.
      */
     const evaluatePreemptRestart = (): boolean => {
+      /** Reports whether a restart IS decided, not whether this call decided
+       *  it. A synchronous wake during `subscribe` can settle the action
+       *  before the pre-call read runs, and a caller that only learned "I did
+       *  not convert" would go on to issue a provider request against an
+       *  already-aborted signal. */
       if (restartController == null || preemptAction !== 'none') {
-        return false;
+        return preemptAction === 'restart';
       }
       if (context?.shouldPreemptStream() !== true) {
+        return false;
+      }
+      /** A chunk is mid-dispatch to the host, so `finalChunk` describes only
+       *  the chunks BEFORE it. Judging the turn now could read a text chunk
+       *  the host has already been shown as an empty turn and discard it. The
+       *  per-chunk poll runs immediately after the append with the complete
+       *  accumulation, so nothing is lost by declining here. */
+      if (dispatchingChunk) {
         return false;
       }
       preemptRequestedAt ??= Date.now();
@@ -865,10 +887,20 @@ async function attemptInvokeBody(
            * nothing — the shape moved, the host disarmed and re-armed — can
            * still schedule the next one.
            */
-          restartGraceTimer = setTimeout(() => {
-            restartGraceTimer = undefined;
-            evaluatePreemptRestart();
-          }, Math.max(0, restartGraceMs - requestAgeMs));
+          restartGraceTimer = setTimeout(
+            () => {
+              restartGraceTimer = undefined;
+              evaluatePreemptRestart();
+            },
+            /**
+             * Clamped, then CHAINED: a delay past Node's ceiling silently
+             * becomes 1ms, and this timer reschedules itself, so an
+             * out-of-range grace would spin at ~1ms for the life of the
+             * stream. Each firing re-reads the real age, so the requested
+             * deadline survives being reached in several hops.
+             */
+            Math.min(MAX_TIMEOUT_MS, Math.max(0, restartGraceMs - requestAgeMs))
+          );
           /** The grace is a fallback, never a reason to hold the process
            *  open: a run that ends before the window elapses must not be kept
            *  alive by a timer whose only job is to look again. */
@@ -880,6 +912,12 @@ async function attemptInvokeBody(
         return false;
       }
       preemptAction = 'restart';
+      /** Recorded BEFORE the abort: the adapter's cancellation error can reach
+       *  the tracing callback synchronously, and a run marked afterwards would
+       *  already have closed as a failure. */
+      if (sealedRunId != null) {
+        notePreemptRestartedRun(sealedRunId);
+      }
       restartController.abort();
       return true;
     };
@@ -954,12 +992,17 @@ async function attemptInvokeBody(
               provider,
             });
             if (handlingChunk != null) {
-              await streamHandler.handle(
-                GraphEvents.CHAT_MODEL_STREAM,
-                { chunk: handlingChunk },
-                metadata,
-                context
-              );
+              dispatchingChunk = true;
+              try {
+                await streamHandler.handle(
+                  GraphEvents.CHAT_MODEL_STREAM,
+                  { chunk: handlingChunk },
+                  metadata,
+                  context
+                );
+              } finally {
+                dispatchingChunk = false;
+              }
             } else if (context != null) {
               /**
                * A replay-skipped chunk yields no handling chunk, and in this
@@ -1009,7 +1052,20 @@ async function attemptInvokeBody(
                 requestAgeMs: Date.now() - preemptRequestedAt,
                 graceMs: restartGraceMs,
               });
-              if (action !== 'none' && context.claimPreemptSeal()) {
+              /**
+               * A restart needs the lane that names where its boundary is
+               * owed. Without one — a host still on the seal-only contract,
+               * which supplies no `subscribe` — the discard would return no
+               * message AND record no lane, so the node would dispatch no
+               * boundary, inject nothing, and end the turn empty with the
+               * steer still queued. Such a host also never opted into having
+               * its turns discarded, so its request waits for a seal exactly
+               * as it does today.
+               */
+              const permitted =
+                action === 'seal' ||
+                (action === 'restart' && restartLane != null);
+              if (permitted && context.claimPreemptSeal()) {
                 preemptAction = action;
                 break;
               }
@@ -1133,8 +1189,9 @@ async function attemptInvokeBody(
           model
         );
       }
-      /** Non-null on every path that can reach here: it is what armed the
-       *  controller in the first place. */
+      /** Non-null on every path that can reach here: it arms the controller
+       *  the wake path needs, and the per-chunk path refuses a restart
+       *  without it. */
       if (restartLane != null) {
         context?.notePreemptRestart(restartLane);
       }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -853,6 +853,14 @@ async function attemptInvokeBody(
      *    was torn down; only the turn built on it is being discarded.
      */
     let restartRoute: 'aborted' | 'broke' | 'exhausted' | undefined;
+    /**
+     * Cleared when the attempt returns. A host may deliver its wake through a
+     * queue or a message bus, so one can already be in flight when the
+     * unsubscribe runs — and a late claim would take the seal slot, abort a
+     * finished controller, and never reach a boundary to release it, blocking
+     * every later preemption in the run.
+     */
+    let attemptActive = true;
     /** Only `broke` leaves a run for this attempt to close itself. */
     const restartNeedsNativeClose = (): boolean => restartRoute === 'broke';
 
@@ -878,6 +886,9 @@ async function attemptInvokeBody(
        *  before the pre-call read runs, and a caller that only learned "I did
        *  not convert" would go on to issue a provider request against an
        *  already-aborted signal. */
+      if (!attemptActive) {
+        return false;
+      }
       if (restartController == null || preemptAction !== 'none') {
         return preemptAction === 'restart';
       }
@@ -922,7 +933,19 @@ async function attemptInvokeBody(
           restartGraceTimer = setTimeout(
             () => {
               restartGraceTimer = undefined;
-              evaluatePreemptRestart();
+              /**
+               * Contained, because this frame has no invocation to reject
+               * into: a host predicate that throws here would surface as an
+               * uncaught exception and can take the process down, while the
+               * same throw from the per-chunk poll is held by the attempt's
+               * promise. The cost of swallowing is one missed look, and a
+               * predicate that throws has no request to honor anyway.
+               */
+              try {
+                evaluatePreemptRestart();
+              } catch {
+                /** empty */
+              }
             },
             /**
              * Clamped, then CHAINED: a delay past Node's ceiling silently
@@ -1218,10 +1241,15 @@ async function attemptInvokeBody(
        * the abort and by nothing else, so a run-level abort, a tripped stream
        * limit and every provider error still propagate.
        */
-      if (preemptAction !== 'restart') {
+      const ownAbort =
+        restartRoute === 'aborted' &&
+        !(error instanceof StreamLimitExceededError) &&
+        config.signal?.aborted !== true;
+      if (!ownAbort) {
         throw error;
       }
     } finally {
+      attemptActive = false;
       unsubscribeWake?.();
       clearTimeout(restartGraceTimer);
     }
@@ -1262,30 +1290,43 @@ async function attemptInvokeBody(
         };
         discardedChunk.response_metadata = responseMetadata;
         discardedChunk.lc_kwargs.response_metadata = responseMetadata;
-        /**
-         * No run id, deliberately. Tearing the stream down makes LangChain
-         * close the model run through its error path, so the native close a
-         * seal performs would find nothing to end and warn on every interrupt.
-         * The synthetic `CHAT_MODEL_END` is the right close here anyway: it is
-         * what tells a host rendering from the stream that the part it has been
-         * drawing is over, and `preemptDiscarded` on it is what says the part's
-         * content is gone rather than kept.
-         */
-        await endSealedModelRun(
-          context,
-          discardedChunk,
-          messagesForProvider,
+        if (restartRoute === 'exhausted') {
+          /**
+           * The stream finished on its own, so the host has ALREADY had this
+           * turn's model-end, with its usage. Replaying it through
+           * `endSealedModelRun` would charge the same tokens twice in any host
+           * accumulating usage from that event. What the host still needs is
+           * the one thing the natural end could not say — that the turn it
+           * just completed is being thrown away — so that notification carries
+           * the marker and nothing else.
+           */
+          await safeDispatchCustomEvent(
+            GraphEvents.CHAT_MODEL_END,
+            {
+              output: new AIMessageChunk({
+                content: '',
+                response_metadata: responseMetadata,
+              }),
+            },
+            config
+          );
+        } else {
           /**
            * See {@link restartRoute}: only the broken iterator leaves a run
-           * with no close of its own. An aborted run was closed through the
-           * error path and an exhausted one through its natural end, and
-           * closing either again would find nothing to end.
+           * with no close of its own. An aborted run was closed through
+           * LangChain's error path, where the marker relabels it and supplies
+           * this usage, so it takes the synthetic close instead.
            */
-          restartNeedsNativeClose() ? sealedRunId : undefined,
-          config,
-          model,
-          PREEMPT_RESTART_CONTROL_FLOW
-        );
+          await endSealedModelRun(
+            context,
+            discardedChunk,
+            messagesForProvider,
+            restartNeedsNativeClose() ? sealedRunId : undefined,
+            config,
+            model,
+            PREEMPT_RESTART_CONTROL_FLOW
+          );
+        }
       }
       /** Non-null on every path that can reach here: it arms the controller
        *  the wake path needs, and the per-chunk path refuses a restart

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -37,6 +37,7 @@ import {
 import {
   canRestartPreempt,
   notePreemptRestartedRun,
+  PREEMPT_RESTART_CONTROL_FLOW,
   resolvePreemptAction,
   resolveRestartGraceMs,
 } from '@/llm/preempt';
@@ -508,7 +509,14 @@ async function endSealedModelRun(
   prompt: BaseMessage[],
   llmRunId: string | undefined,
   config?: RunnableConfig,
-  model?: t.ChatModel
+  model?: t.ChatModel,
+  /**
+   * Shapes the close for a DISCARDED turn. A seal's output is the partial
+   * answer it kept; a restart kept nothing, and marking it here is what keeps
+   * the two restart routes reading alike in a trace — the aborted one is
+   * relabelled through the tracing callback, and this is the manual twin.
+   */
+  llmOutput: Record<string, unknown> = {}
 ): Promise<void> {
   const metadata = config?.metadata as Record<string, unknown> | undefined;
   synthesizeSealedUsage(context, chunk, prompt, metadata);
@@ -548,7 +556,7 @@ async function endSealedModelRun(
         };
         await runManager.handleLLMEnd({
           generations: [[generation]],
-          llmOutput: {},
+          llmOutput,
         });
         return;
       }
@@ -833,15 +841,20 @@ async function attemptInvokeBody(
      *  initializer, and would narrow the comparison away as unreachable. */
     const restartDecided = (): boolean => preemptAction === 'restart';
     /**
-     * Whether the tear-down actually happened. Only an ABORT makes LangChain
-     * close the model run, through its error path; breaking the iterator fires
-     * neither end nor error callbacks. The two restart routes therefore need
-     * opposite closes, and the controller's own state is the exact record of
-     * which one ran — nothing else aborts it, and the run's signal is composed
-     * INTO the stream rather than into this.
+     * How the stream ended when a restart was chosen, because each way leaves
+     * the model run in a different state and needs a different close:
+     *  - `aborted`: LangChain closed it through its error path, where the
+     *    marker relabels it and supplies the discarded attempt's usage.
+     *  - `broke`: the iterator was closed early, which fires NEITHER end nor
+     *    error callbacks, so this is the one route that must close natively.
+     *  - `exhausted`: the stream finished on its own, so LangChain already
+     *    emitted its end. Closing again would warn and change nothing — and
+     *    the generation is honestly an ordinary completed one, since nothing
+     *    was torn down; only the turn built on it is being discarded.
      */
-    const restartToreDownStream = (): boolean =>
-      restartController?.signal.aborted === true;
+    let restartRoute: 'aborted' | 'broke' | 'exhausted' | undefined;
+    /** Only `broke` leaves a run for this attempt to close itself. */
+    const restartNeedsNativeClose = (): boolean => restartRoute === 'broke';
 
     /**
      * The wake is a hint; this is where the request is actually read. The
@@ -869,6 +882,10 @@ async function attemptInvokeBody(
         return preemptAction === 'restart';
       }
       if (context?.shouldPreemptStream() !== true) {
+        /** The request was withdrawn. Forget when it arrived, or a NEW request
+         *  later in this same attempt would inherit the old clock and convert
+         *  without ever getting its grace. */
+        preemptRequestedAt = undefined;
         return false;
       }
       /** A chunk is mid-dispatch to the host, so `finalChunk` describes only
@@ -950,6 +967,7 @@ async function attemptInvokeBody(
         );
         notePreemptRestartedRun(sealedRunId, finalChunk);
       }
+      restartRoute = 'aborted';
       restartController.abort();
       return true;
     };
@@ -1089,7 +1107,11 @@ async function attemptInvokeBody(
              * armed during a long thinking stretch used to wait for the whole
              * turn.
              */
-            if (context?.shouldPreemptStream() === true) {
+            if (context?.shouldPreemptStream() !== true) {
+              /** Withdrawn: forget the clock, so a later request in this same
+               *  attempt still gets its own grace. */
+              preemptRequestedAt = undefined;
+            } else {
               preemptRequestedAt ??= Date.now();
               const action = resolvePreemptAction({
                 chunk: finalChunk,
@@ -1114,6 +1136,9 @@ async function attemptInvokeBody(
                     context.claimPreemptRestart();
               if (claimed) {
                 preemptAction = action;
+                if (action === 'restart') {
+                  restartRoute = 'broke';
+                }
                 break;
               }
             }
@@ -1181,6 +1206,7 @@ async function attemptInvokeBody(
           context.claimPreemptRestart()
         ) {
           preemptAction = 'restart';
+          restartRoute = 'exhausted';
         }
       }
     } catch (error) {
@@ -1250,16 +1276,15 @@ async function attemptInvokeBody(
           discardedChunk,
           messagesForProvider,
           /**
-           * Only an aborted run is already closed — LangChain took it through
-           * its error path, and the marker recorded above carries its usage
-           * there. A restart that merely BROKE the iterator fired no callback
-           * at all, so it closes natively here exactly as a seal does; passing
-           * no run id would leave that generation open forever and lose the
-           * discarded attempt's usage.
+           * See {@link restartRoute}: only the broken iterator leaves a run
+           * with no close of its own. An aborted run was closed through the
+           * error path and an exhausted one through its natural end, and
+           * closing either again would find nothing to end.
            */
-          restartToreDownStream() ? undefined : sealedRunId,
+          restartNeedsNativeClose() ? sealedRunId : undefined,
           config,
-          model
+          model,
+          PREEMPT_RESTART_CONTROL_FLOW
         );
       }
       /** Non-null on every path that can reach here: it arms the controller

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -577,7 +577,7 @@ describe('preempt-restarted run records', () => {
       const base = realNow();
       Date.now = () => base;
       notePreemptRestartedRun('stale', chunk({ content: '' }));
-      Date.now = () => base + 60_001;
+      Date.now = () => base + 300_001;
       notePreemptRestartedRun('fresh', chunk({ content: '' }));
 
       expect(consumePreemptRestartedRun('stale')).toBeUndefined();

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -2,6 +2,8 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import {
   canRestartPreempt,
   canSealPreempt,
+  consumePreemptRestartedRun,
+  notePreemptRestartedRun,
   resolveMaxSeals,
   resolvePreemptAction,
   resolveRestartGraceMs,
@@ -532,5 +534,37 @@ describe('resolvePreemptAction', () => {
         graceMs: 0,
       })
     ).toBe('none');
+  });
+});
+
+/**
+ * The tracing layer keys on the run id rather than the thrown error, because
+ * every provider adapter raises its own cancellation shape. That makes the
+ * record's lifecycle the whole contract: exactly once, and bounded for hosts
+ * that never consume it.
+ */
+describe('preempt-restarted run records', () => {
+  it('reports a recorded run exactly once', () => {
+    notePreemptRestartedRun('run-a');
+    expect(consumePreemptRestartedRun('run-a')).toBe(true);
+    expect(consumePreemptRestartedRun('run-a')).toBe(false);
+  });
+
+  it('does not claim a run it never recorded', () => {
+    expect(consumePreemptRestartedRun('run-never-restarted')).toBe(false);
+  });
+
+  /**
+   * Nothing consumes these when tracing is off, so the set must not grow
+   * without limit — and it must evict the OLDEST rather than refuse the
+   * newest, or a long-lived process would silently stop recognizing new
+   * restarts while holding stale ids forever.
+   */
+  it('evicts the oldest record rather than refusing new ones', () => {
+    for (let i = 0; i < 80; i++) {
+      notePreemptRestartedRun(`bulk-${i}`);
+    }
+    expect(consumePreemptRestartedRun('bulk-0')).toBe(false);
+    expect(consumePreemptRestartedRun('bulk-79')).toBe(true);
   });
 });

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -2,9 +2,10 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import {
   canRestartPreempt,
   canSealPreempt,
-  consumePreemptRestartedRun,
+  forgetPreemptRestartedRun,
   notePreemptRestartedRun,
   resolveMaxSeals,
+  readPreemptRestartedRun,
   resolvePreemptAction,
   resolveRestartGraceMs,
 } from './preempt';
@@ -369,6 +370,32 @@ describe('canRestartPreempt', () => {
       expect(canRestartPreempt(chunk({ content: '  \n' }))).toBe(true);
     });
 
+    /** The block form of the same thing, which several providers send. */
+    it('a blank text block opening the message', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            content: [
+              { type: 'text', text: '' },
+              { type: 'thinking', thinking: 'working' },
+            ],
+          })
+        )
+      ).toBe(true);
+    });
+
+    /**
+     * A reasoning-only Responses turn populates `output` too at natural
+     * completion, and that is exactly the turn a restart should discard.
+     */
+    it('a Responses turn whose authoritative output is reasoning only', () => {
+      const reasoningOnly = chunk({ content: [] });
+      reasoningOnly.response_metadata = {
+        output: [{ type: 'reasoning', id: 'rs_1' }],
+      };
+      expect(canRestartPreempt(reasoningOnly)).toBe(true);
+    });
+
     it('every provider spelling of a reasoning block', () => {
       expect(
         canRestartPreempt(
@@ -455,6 +482,26 @@ describe('canRestartPreempt', () => {
           })
         )
       ).toBe(false);
+    });
+
+    /**
+     * Responses reports its built-in tools nowhere the ordinary gates look:
+     * `content` stays empty and `tool_calls` is never populated, so without
+     * this the turn reads as disposable and reissuing would run a completed
+     * search — or a shell/apply-patch call — a second time.
+     */
+    it('a completed OpenAI Responses tool output', () => {
+      const withSidecar = chunk({ content: [] });
+      withSidecar.additional_kwargs.tool_outputs = [
+        { type: 'web_search_call', id: 'ws_1', status: 'completed' },
+      ];
+      expect(canRestartPreempt(withSidecar)).toBe(false);
+
+      const withAuthoritativeOutput = chunk({ content: [] });
+      withAuthoritativeOutput.response_metadata = {
+        output: [{ type: 'code_interpreter_call', id: 'ci_1' }],
+      };
+      expect(canRestartPreempt(withAuthoritativeOutput)).toBe(false);
     });
 
     it('an unrecognized block, rather than guessing it is disposable', () => {
@@ -544,16 +591,28 @@ describe('resolvePreemptAction', () => {
  * that never consume it.
  */
 describe('preempt-restarted run records', () => {
-  it('reports a recorded run exactly once, with its turn', () => {
+  /**
+   * A run can be closed through several tracing handlers at once, so every
+   * read must see the record — a consuming read would let the first handler
+   * recognize the restart and leave the rest exporting an error.
+   */
+  it('reports a recorded run to every reader, with its turn', () => {
     const message = chunk({ content: 'thinking' });
     notePreemptRestartedRun('run-a', message);
 
-    expect(consumePreemptRestartedRun('run-a')?.message).toBe(message);
-    expect(consumePreemptRestartedRun('run-a')).toBeUndefined();
+    expect(readPreemptRestartedRun('run-a')?.message).toBe(message);
+    expect(readPreemptRestartedRun('run-a')?.message).toBe(message);
   });
 
   it('does not claim a run it never recorded', () => {
-    expect(consumePreemptRestartedRun('run-never-restarted')).toBeUndefined();
+    expect(readPreemptRestartedRun('run-never-restarted')).toBeUndefined();
+  });
+
+  it('forgets a record whose run closed another way', () => {
+    notePreemptRestartedRun('run-manual', chunk({ content: '' }));
+    forgetPreemptRestartedRun('run-manual');
+
+    expect(readPreemptRestartedRun('run-manual')).toBeUndefined();
   });
 
   /**
@@ -566,8 +625,8 @@ describe('preempt-restarted run records', () => {
       notePreemptRestartedRun(`bulk-${i}`, chunk({ content: '' }));
     }
 
-    expect(consumePreemptRestartedRun('bulk-0')).toBeDefined();
-    expect(consumePreemptRestartedRun('bulk-499')).toBeDefined();
+    expect(readPreemptRestartedRun('bulk-0')).toBeDefined();
+    expect(readPreemptRestartedRun('bulk-499')).toBeDefined();
   });
 
   /** Age is what separates a queued callback from a leak. */
@@ -580,8 +639,8 @@ describe('preempt-restarted run records', () => {
       Date.now = () => base + 300_001;
       notePreemptRestartedRun('fresh', chunk({ content: '' }));
 
-      expect(consumePreemptRestartedRun('stale')).toBeUndefined();
-      expect(consumePreemptRestartedRun('fresh')).toBeDefined();
+      expect(readPreemptRestartedRun('stale')).toBeUndefined();
+      expect(readPreemptRestartedRun('fresh')).toBeDefined();
     } finally {
       Date.now = realNow;
     }

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -544,27 +544,46 @@ describe('resolvePreemptAction', () => {
  * that never consume it.
  */
 describe('preempt-restarted run records', () => {
-  it('reports a recorded run exactly once', () => {
-    notePreemptRestartedRun('run-a');
-    expect(consumePreemptRestartedRun('run-a')).toBe(true);
-    expect(consumePreemptRestartedRun('run-a')).toBe(false);
+  it('reports a recorded run exactly once, with its turn', () => {
+    const message = chunk({ content: 'thinking' });
+    notePreemptRestartedRun('run-a', message);
+
+    expect(consumePreemptRestartedRun('run-a')?.message).toBe(message);
+    expect(consumePreemptRestartedRun('run-a')).toBeUndefined();
   });
 
   it('does not claim a run it never recorded', () => {
-    expect(consumePreemptRestartedRun('run-never-restarted')).toBe(false);
+    expect(consumePreemptRestartedRun('run-never-restarted')).toBeUndefined();
   });
 
   /**
-   * Nothing consumes these when tracing is off, so the set must not grow
-   * without limit — and it must evict the OLDEST rather than refuse the
-   * newest, or a long-lived process would silently stop recognizing new
-   * restarts while holding stale ids forever.
+   * The consumer is a non-awaited callback, so a burst of concurrent restarts
+   * must NOT push each other out: an evicted marker closes its generation as
+   * an error, which is the failure the marker exists to prevent.
    */
-  it('evicts the oldest record rather than refusing new ones', () => {
-    for (let i = 0; i < 80; i++) {
-      notePreemptRestartedRun(`bulk-${i}`);
+  it('keeps every record while its callback could still fire', () => {
+    for (let i = 0; i < 500; i++) {
+      notePreemptRestartedRun(`bulk-${i}`, chunk({ content: '' }));
     }
-    expect(consumePreemptRestartedRun('bulk-0')).toBe(false);
-    expect(consumePreemptRestartedRun('bulk-79')).toBe(true);
+
+    expect(consumePreemptRestartedRun('bulk-0')).toBeDefined();
+    expect(consumePreemptRestartedRun('bulk-499')).toBeDefined();
+  });
+
+  /** Age is what separates a queued callback from a leak. */
+  it('expires a record nothing ever consumed', () => {
+    const realNow = Date.now;
+    try {
+      const base = realNow();
+      Date.now = () => base;
+      notePreemptRestartedRun('stale', chunk({ content: '' }));
+      Date.now = () => base + 60_001;
+      notePreemptRestartedRun('fresh', chunk({ content: '' }));
+
+      expect(consumePreemptRestartedRun('stale')).toBeUndefined();
+      expect(consumePreemptRestartedRun('fresh')).toBeDefined();
+    } finally {
+      Date.now = realNow;
+    }
   });
 });

--- a/src/llm/preempt.test.ts
+++ b/src/llm/preempt.test.ts
@@ -1,5 +1,11 @@
 import { AIMessageChunk } from '@langchain/core/messages';
-import { canSealPreempt, resolveMaxSeals } from './preempt';
+import {
+  canRestartPreempt,
+  canSealPreempt,
+  resolveMaxSeals,
+  resolvePreemptAction,
+  resolveRestartGraceMs,
+} from './preempt';
 
 /**
  * The budget is read by two consumers that interpret it differently — a
@@ -319,5 +325,212 @@ describe('canSealPreempt', () => {
         )
       ).toBe(true);
     });
+  });
+});
+
+describe('resolveRestartGraceMs', () => {
+  it('defaults when unset', () => {
+    expect(resolveRestartGraceMs(undefined)).toBe(2_000);
+  });
+
+  it('honors zero as a deliberate convert-immediately', () => {
+    expect(resolveRestartGraceMs(0)).toBe(0);
+  });
+
+  it('clamps a negative window rather than inverting the comparison', () => {
+    expect(resolveRestartGraceMs(-500)).toBe(0);
+  });
+
+  it('falls back rather than never converting', () => {
+    expect(resolveRestartGraceMs(NaN)).toBe(2_000);
+    expect(resolveRestartGraceMs(Infinity)).toBe(2_000);
+  });
+});
+
+/**
+ * The membership rule is a whitelist, so every case that is not recognizably
+ * reasoning must refuse. Refusing costs a slower interrupt; wrongly discarding
+ * destroys work the model already did.
+ */
+describe('canRestartPreempt', () => {
+  describe('discards', () => {
+    it('a stream that has produced nothing', () => {
+      expect(canRestartPreempt(undefined)).toBe(true);
+    });
+
+    it('an empty accumulation', () => {
+      expect(canRestartPreempt(chunk({ content: '' }))).toBe(true);
+      expect(canRestartPreempt(chunk({ content: [] }))).toBe(true);
+    });
+
+    it('whitespace a provider emitted before its first word', () => {
+      expect(canRestartPreempt(chunk({ content: '  \n' }))).toBe(true);
+    });
+
+    it('every provider spelling of a reasoning block', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            content: [
+              { type: 'thinking', thinking: 'anthropic' },
+              { type: 'redacted_thinking', data: 'ciphertext' },
+              { type: 'reasoning', reasoning: 'google' },
+              { type: 'reasoning_content', reasoningText: { text: 'bedrock' } },
+            ],
+          })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('refuses to discard', () => {
+    it('an answer the user can already read', () => {
+      expect(
+        canRestartPreempt(chunk({ content: [{ type: 'text', text: 'Hi' }] }))
+      ).toBe(false);
+    });
+
+    it('reasoning that has begun turning into text', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            content: [
+              { type: 'thinking', thinking: 'almost' },
+              { type: 'text', text: 'The answer is' },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('a tool call, whether complete or still streaming', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            tool_calls: [{ id: 't1', name: 'search', args: {} }],
+          })
+        )
+      ).toBe(false);
+      expect(
+        canRestartPreempt(
+          chunk({
+            tool_call_chunks: [{ id: 't1', name: 'search', args: '{"q"' }],
+          })
+        )
+      ).toBe(false);
+    });
+
+    /**
+     * Assigned after construction because `AIMessageChunk` derives
+     * `invalid_tool_calls` from `tool_call_chunks` and drops a directly
+     * supplied array — the same reason the seal gate's own case does it.
+     */
+    it('a tool call the provider malformed', () => {
+      const malformed = chunk({ content: '' });
+      malformed.invalid_tool_calls = [
+        { id: 't1', name: 'search', args: '{oops', error: 'bad json' },
+      ];
+      expect(canRestartPreempt(malformed)).toBe(false);
+    });
+
+    /**
+     * The one place this is STRICTER than the seal gate. A seal may treat a
+     * settled server tool call as harmless, because the answer stays on the
+     * message. Re-issuing the request would run — and bill — that search again.
+     */
+    it('a server-side search the provider already ran and answered', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            tool_calls: [{ id: 'srvtoolu_1', name: 'web_search', args: {} }],
+            content: [
+              {
+                type: 'web_search_tool_result',
+                tool_use_id: 'srvtoolu_1',
+                content: [],
+              },
+            ],
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('an unrecognized block, rather than guessing it is disposable', () => {
+      expect(
+        canRestartPreempt(
+          chunk({
+            content: [{ type: 'image_url', image_url: { url: 'https://x/y' } }],
+          })
+        )
+      ).toBe(false);
+    });
+  });
+});
+
+describe('resolvePreemptAction', () => {
+  const thinking = chunk({
+    content: [{ type: 'thinking', thinking: 'working on it' }],
+  });
+  const answering = chunk({ content: [{ type: 'text', text: 'The answer' }] });
+
+  it('prefers a seal over a restart whenever one is available', () => {
+    expect(
+      resolvePreemptAction({
+        chunk: answering,
+        requestAgeMs: 60_000,
+        graceMs: 0,
+      })
+    ).toBe('seal');
+  });
+
+  it('holds a thinking turn inside the window, in case text is moments away', () => {
+    expect(
+      resolvePreemptAction({ chunk: thinking, requestAgeMs: 500, graceMs: 2000 })
+    ).toBe('none');
+  });
+
+  it('converts a thinking turn that outlives the window', () => {
+    expect(
+      resolvePreemptAction({
+        chunk: thinking,
+        requestAgeMs: 2000,
+        graceMs: 2000,
+      })
+    ).toBe('restart');
+  });
+
+  /**
+   * An empty accumulation does not prove the provider produced nothing — the
+   * stream buffers a chunk ahead of the consumer. Only silence that outlives
+   * the window does.
+   */
+  it('holds a silent turn inside the window, in case a chunk is in flight', () => {
+    expect(
+      resolvePreemptAction({
+        chunk: undefined,
+        requestAgeMs: 0,
+        graceMs: 2000,
+      })
+    ).toBe('none');
+  });
+
+  it('converts a silent turn that outlives the window', () => {
+    expect(
+      resolvePreemptAction({
+        chunk: undefined,
+        requestAgeMs: 2001,
+        graceMs: 2000,
+      })
+    ).toBe('restart');
+  });
+
+  it('never converts a turn holding work a restart would destroy', () => {
+    expect(
+      resolvePreemptAction({
+        chunk: chunk({ tool_calls: [{ id: 't1', name: 'search', args: {} }] }),
+        requestAgeMs: 60_000,
+        graceMs: 0,
+      })
+    ).toBe('none');
   });
 });

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -338,13 +338,40 @@ export interface PreemptRestartedRun {
   recordedAt: number;
 }
 
+/**
+ * Armed while anything is recorded, so expiry does not depend on another
+ * restart arriving to trigger it. Without this the final burst before a quiet
+ * period would hold its messages for the life of the process — and a host that
+ * enables preemption without tracing never consumes a single record, so that
+ * burst is the common case, not the corner one.
+ *
+ * `unref`'d: reclaiming a few messages is never a reason to keep a process
+ * alive.
+ */
+let sweepTimer: ReturnType<typeof setTimeout> | undefined;
+
 function sweepExpiredRestartedRuns(now: number): void {
   for (const [runId, record] of preemptRestartedRuns) {
     if (now - record.recordedAt < PREEMPT_RESTARTED_RUN_TTL_MS) {
-      return;
+      break;
     }
     preemptRestartedRuns.delete(runId);
   }
+  if (preemptRestartedRuns.size === 0) {
+    if (sweepTimer != null) {
+      clearTimeout(sweepTimer);
+      sweepTimer = undefined;
+    }
+    return;
+  }
+  if (sweepTimer != null) {
+    return;
+  }
+  sweepTimer = setTimeout(() => {
+    sweepTimer = undefined;
+    sweepExpiredRestartedRuns(Date.now());
+  }, PREEMPT_RESTARTED_RUN_TTL_MS);
+  sweepTimer.unref();
 }
 
 /** Records a model run whose stream was torn down for a restart. */
@@ -353,8 +380,8 @@ export function notePreemptRestartedRun(
   message: AIMessageChunk
 ): void {
   const now = Date.now();
-  sweepExpiredRestartedRuns(now);
   preemptRestartedRuns.set(runId, { message, recordedAt: now });
+  sweepExpiredRestartedRuns(now);
 }
 
 /**
@@ -370,5 +397,9 @@ export function consumePreemptRestartedRun(
     return undefined;
   }
   preemptRestartedRuns.delete(runId);
+  if (preemptRestartedRuns.size === 0 && sweepTimer != null) {
+    clearTimeout(sweepTimer);
+    sweepTimer = undefined;
+  }
   return record;
 }

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -301,15 +301,19 @@ export function resolvePreemptAction({
 /**
  * How long a restarted model run stays recorded when nothing consumes it.
  *
- * The consumer is LangChain's error callback, which is dispatched on a
- * non-awaited queue, so a marker may legitimately sit unread for a moment. A
- * COUNT cap cannot tell that apart from a leak: a burst of concurrent restarts
- * would evict markers whose callbacks were still queued, and each eviction
- * turns an expected restart back into an error in the host's traces — the very
- * thing the marker exists to prevent. Age can tell them apart, so the bound is
- * time.
+ * The consumer is LangChain's error callback, dispatched on a non-awaited
+ * queue, so a marker may legitimately sit unread for a while. A COUNT cap
+ * cannot tell that apart from a leak: a burst of concurrent restarts would
+ * evict markers whose callbacks were still queued, and each eviction turns an
+ * expected restart back into an error in the host's traces — the very thing
+ * the marker exists to prevent. Age can tell them apart, so the bound is time.
+ *
+ * It is a LEAK bound, not a deadline: nothing here can observe when the
+ * callback queue drains, so the window is set far past any latency that queue
+ * exhibits rather than tuned to it. A stall long enough to outlast this has
+ * already broken every other time-based assumption in the run.
  */
-const PREEMPT_RESTARTED_RUN_TTL_MS = 60_000;
+const PREEMPT_RESTARTED_RUN_TTL_MS = 300_000;
 
 /**
  * Model runs whose provider stream was torn down for a restart, with the

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -331,6 +331,18 @@ const PREEMPT_RESTARTED_RUN_TTL_MS = 60_000;
  */
 const preemptRestartedRuns = new Map<string, PreemptRestartedRun>();
 
+/**
+ * The `llmOutput` a discarded attempt closes with, so a restart reads as
+ * control flow rather than as an ordinary generation — `AGENTS.md` states that
+ * control flow is not an error, and a discarded turn is not an answer either.
+ *
+ * Shared so every close route emits it: which trigger fired must not change
+ * how the run looks in a trace.
+ */
+export const PREEMPT_RESTART_CONTROL_FLOW = {
+  controlFlow: 'PreemptRestart',
+} as const;
+
 /** A torn-down model run awaiting its tracing close. */
 export interface PreemptRestartedRun {
   /** The accumulated turn, carrying whatever usage was resolved for it. */

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -125,6 +125,61 @@ function countOpenToolCalls(
 }
 
 /**
+ * True for a text block a provider emitted before it had anything to say.
+ *
+ * Whitespace-only string content is already accepted above, and the block form
+ * of the same thing must agree: several providers open their message with an
+ * empty text part, and rejecting it would leave a turn neither sealable nor
+ * discardable — an armed interrupt would then wait out the whole turn for the
+ * sake of a block carrying nothing.
+ */
+function isBlankTextBlock(block: { type?: string; text?: unknown }): boolean {
+  if (block.type !== ContentTypes.TEXT) {
+    return false;
+  }
+  return typeof block.text === 'string' && block.text.trim() === '';
+}
+
+/**
+ * True when an OpenAI Responses turn already carries provider-side tool output.
+ *
+ * Responses reports its built-in tools differently from every other shape this
+ * module checks: a completed web search, code interpreter run, or apply-patch
+ * lands in `additional_kwargs.tool_outputs` or the authoritative
+ * `response_metadata.output`, while `content` stays empty and the `tool_calls`
+ * arrays are never populated. The ordinary gates therefore see an empty turn
+ * and would call it disposable — and reissuing the prompt would run that tool
+ * a SECOND time, rebilling a search and repeating whatever a shell or
+ * apply-patch call already did to the world.
+ *
+ * `output` is inspected item by item rather than treated as fatal on sight,
+ * because a reasoning-only Responses turn populates it too at natural
+ * completion, and that turn is precisely the one a restart should be able to
+ * discard.
+ */
+function hasResponsesProviderOutput(chunk: AIMessageChunk): boolean {
+  if (chunk.additional_kwargs.tool_outputs != null) {
+    return true;
+  }
+  const metadata = chunk.response_metadata as {
+    tool_outputs?: unknown;
+    output?: unknown;
+  };
+  if (metadata.tool_outputs != null) {
+    return true;
+  }
+  if (!Array.isArray(metadata.output)) {
+    return false;
+  }
+  for (const item of metadata.output) {
+    if (!isReasoningContentBlock(item as { type?: string })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Cooperative mid-generation seal gate. Returns true ONLY when sealing here
  * yields a message sequence valid on EVERY supported provider:
  *  - non-whitespace TEXT content, so the FIRST injected user turn is preceded
@@ -207,7 +262,10 @@ export type PreemptAction = 'none' | 'seal' | 'restart';
  * Tool machinery of any kind refuses, and deliberately without the settled-id
  * allowance {@link canSealPreempt} makes: a settled `web_search_tool_result`
  * means the provider already ran and billed a search, and re-issuing the call
- * would run it again. A seal there is free; a restart is not.
+ * would run it again. A seal there is free; a restart is not. The same
+ * argument covers Responses' sidecar shapes — see
+ * {@link hasResponsesProviderOutput}, which the ordinary tool-call gates
+ * cannot see at all.
  *
  * An accumulation that carries visible text is not handled here at all — the
  * caller resolves `seal` first, because keeping the user's answer always beats
@@ -230,14 +288,18 @@ export function canRestartPreempt(chunk: AIMessageChunk | undefined): boolean {
   if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {
     return false;
   }
+  if (hasResponsesProviderOutput(chunk)) {
+    return false;
+  }
   const { content } = chunk;
   if (typeof content === 'string') {
     return content.trim() === '';
   }
   for (const block of content) {
-    if (!isReasoningContentBlock(block)) {
-      return false;
+    if (isReasoningContentBlock(block) || isBlankTextBlock(block)) {
+      continue;
     }
+    return false;
   }
   return true;
 }
@@ -402,20 +464,34 @@ export function notePreemptRestartedRun(
 
 /**
  * The record for a run that ended because a preempt discarded it, or
- * `undefined`. Consuming: the run closes exactly once, and a stale id must not
- * reclassify a later genuine failure on a reused id.
+ * `undefined`.
+ *
+ * Deliberately NON-consuming. A run can be closed through more than one
+ * tracing handler — a run-level one plus another supplied through the model's
+ * own `clientOptions.callbacks`, which `endSealedModelRun` already composes
+ * for exactly that reason — and each receives the same `handleLLMError`. A
+ * read that deleted the record would let only the first handler recognize the
+ * restart, and every other destination would export the same expected abort as
+ * an error. Reuse is not a concern the way it would be for a counter: run ids
+ * are UUIDs, and the sweep is what reclaims them.
  */
-export function consumePreemptRestartedRun(
+export function readPreemptRestartedRun(
   runId: string
 ): PreemptRestartedRun | undefined {
-  const record = preemptRestartedRuns.get(runId);
-  if (record == null) {
-    return undefined;
+  return preemptRestartedRuns.get(runId);
+}
+
+/**
+ * Drops a record whose run turned out not to need it — the adapter ignored the
+ * abort, so the tear-down never reached LangChain's error path and the close
+ * happens manually instead.
+ */
+export function forgetPreemptRestartedRun(runId: string): void {
+  if (!preemptRestartedRuns.delete(runId)) {
+    return;
   }
-  preemptRestartedRuns.delete(runId);
   if (preemptRestartedRuns.size === 0 && sweepTimer != null) {
     clearTimeout(sweepTimer);
     sweepTimer = undefined;
   }
-  return record;
 }

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -1,6 +1,11 @@
 // src/llm/preempt.ts
 import type { AIMessageChunk } from '@langchain/core/messages';
-import { ContentTypes, DEFAULT_MAX_SEALS } from '@/common';
+import {
+  ContentTypes,
+  DEFAULT_MAX_SEALS,
+  DEFAULT_PREEMPT_RESTART_GRACE_MS,
+} from '@/common';
+import { isReasoningContentBlock } from '@/messages/core';
 
 /**
  * Normalizes a host-supplied seal budget.
@@ -175,4 +180,120 @@ export function canSealPreempt(chunk: AIMessageChunk | undefined): boolean {
     return false;
   }
   return hasNonEmptyTextContent(chunk.content);
+}
+
+/**
+ * What a host's armed preempt request may do to the turn in flight.
+ *
+ * `seal` keeps the partial assistant turn and injects after it; `restart`
+ * throws the partial away and re-issues the model call with the injected turn
+ * appended to the prompt. They are not two flavors of the same move — one
+ * preserves work, the other deliberately discards it — so the decision is
+ * resolved once, here, rather than re-derived at each trigger.
+ */
+export type PreemptAction = 'none' | 'seal' | 'restart';
+
+/**
+ * True when the accumulated turn holds nothing a seal would have to preserve,
+ * so the whole model call can be thrown away and re-issued instead.
+ *
+ * The membership test is a WHITELIST: every content block must be a known
+ * reasoning block, and an unrecognized block refuses the restart. Blacklisting
+ * would silently discard whatever a future provider adds, and the failure is
+ * asymmetric — refusing costs the user a slower interrupt (exactly today's
+ * behavior), while wrongly discarding destroys work the model already did and
+ * the host may already have rendered.
+ *
+ * Tool machinery of any kind refuses, and deliberately without the settled-id
+ * allowance {@link canSealPreempt} makes: a settled `web_search_tool_result`
+ * means the provider already ran and billed a search, and re-issuing the call
+ * would run it again. A seal there is free; a restart is not.
+ *
+ * An accumulation that carries visible text is not handled here at all — the
+ * caller resolves `seal` first, because keeping the user's answer always beats
+ * discarding it.
+ *
+ * `undefined` — the provider has sent nothing at all — is the case this whole
+ * path exists for: it is the silent window between the request and the first
+ * chunk, where there is by definition nothing to lose.
+ */
+export function canRestartPreempt(chunk: AIMessageChunk | undefined): boolean {
+  if (chunk == null) {
+    return true;
+  }
+  if ((chunk.tool_calls?.length ?? 0) > 0) {
+    return false;
+  }
+  if ((chunk.tool_call_chunks?.length ?? 0) > 0) {
+    return false;
+  }
+  if ((chunk.invalid_tool_calls?.length ?? 0) > 0) {
+    return false;
+  }
+  const { content } = chunk;
+  if (typeof content === 'string') {
+    return content.trim() === '';
+  }
+  for (const block of content) {
+    if (!isReasoningContentBlock(block)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Normalizes a host-supplied restart grace, on the same rules as
+ * {@link resolveMaxSeals}: `0` is honored as "never wait", anything not finite
+ * falls back to the default. Negative values collapse to `0` rather than
+ * inverting the comparison in {@link resolvePreemptAction}.
+ */
+export function resolveRestartGraceMs(graceMs: number | undefined): number {
+  if (graceMs == null || !Number.isFinite(graceMs)) {
+    return DEFAULT_PREEMPT_RESTART_GRACE_MS;
+  }
+  return graceMs > 0 ? graceMs : 0;
+}
+
+/**
+ * The single decision point both preempt triggers share: the per-chunk poll in
+ * the stream loop, and the host wake-up that fires while the provider is
+ * silent.
+ *
+ * A SEAL is preferred wherever one is available, so a turn that has already
+ * produced an answer never loses it to a restart. A RESTART converts only once
+ * the request has outlived `graceMs`.
+ *
+ * The window is not politeness, it is correctness, and it applies to a silent
+ * provider exactly as it does to a reasoning one:
+ *  - reasoning usually precedes text by moments, and discarding a turn that
+ *    was about to become sealable trades a kept answer for a re-issued
+ *    request. Only a genuinely long thinking stretch — the one an interrupt
+ *    can otherwise wait out entirely — should convert.
+ *  - `chunk` is what the CONSUMER has accumulated, and the provider stream
+ *    buffers a chunk ahead of it. An empty accumulation therefore does not
+ *    prove the provider produced nothing; it can also mean the first chunk is
+ *    in flight. Converting on emptiness alone would discard that chunk — text
+ *    included — on a race no caller can see. A provider that is still silent a
+ *    window later has no such chunk outstanding.
+ *
+ * Non-mutating and allocation-free, like the poll that guards it: the seal
+ * budget is only spent once the caller acts on a non-`none` result.
+ */
+export function resolvePreemptAction({
+  chunk,
+  requestAgeMs,
+  graceMs,
+}: {
+  chunk: AIMessageChunk | undefined;
+  requestAgeMs: number;
+  graceMs: number;
+}): PreemptAction {
+  if (canSealPreempt(chunk)) {
+    return 'seal';
+  }
+  if (!canRestartPreempt(chunk)) {
+    return 'none';
+  }
+  return requestAgeMs >= graceMs ? 'restart' : 'none';
 }

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -297,3 +297,49 @@ export function resolvePreemptAction({
   }
   return requestAgeMs >= graceMs ? 'restart' : 'none';
 }
+
+/**
+ * How many restarted model-run ids stay recorded. Each entry lives only until
+ * the tracing callback for that run consumes it, so the cap is a leak bound
+ * for hosts that run no tracing at all — not a working-set size.
+ */
+const PREEMPT_RESTARTED_RUN_LIMIT = 64;
+
+/**
+ * Model-run ids whose provider stream was torn down for a restart.
+ *
+ * Recorded rather than inferred from the thrown error: aborting makes the
+ * provider adapter raise whatever IT raises for cancellation, and matching on
+ * that shape would bind the tracing layer to per-provider error identity. The
+ * run id is unambiguous and already captured for the seal path.
+ *
+ * Consumed by the tracing callback so an expected restart closes as control
+ * flow instead of a failed generation — `AGENTS.md` states plainly that
+ * control flow is not an error, and a run cannot both be the interrupt the
+ * user asked for and an error in their traces.
+ *
+ * Insertion-ordered eviction bounds it: the oldest entry goes rather than the
+ * newest being refused, so a long-lived process with tracing disabled cannot
+ * grow this without limit and cannot start silently dropping new ids either.
+ */
+const preemptRestartedRuns = new Set<string>();
+
+/** Records a model run whose stream was torn down for a restart. */
+export function notePreemptRestartedRun(runId: string): void {
+  if (preemptRestartedRuns.size >= PREEMPT_RESTARTED_RUN_LIMIT) {
+    const oldest = preemptRestartedRuns.values().next().value;
+    if (oldest != null) {
+      preemptRestartedRuns.delete(oldest);
+    }
+  }
+  preemptRestartedRuns.add(runId);
+}
+
+/**
+ * True when this model run ended because a preempt discarded it. Consuming:
+ * the run closes exactly once, and a stale id must not reclassify a later
+ * genuine failure on a reused id.
+ */
+export function consumePreemptRestartedRun(runId: string): boolean {
+  return preemptRestartedRuns.delete(runId);
+}

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -299,47 +299,76 @@ export function resolvePreemptAction({
 }
 
 /**
- * How many restarted model-run ids stay recorded. Each entry lives only until
- * the tracing callback for that run consumes it, so the cap is a leak bound
- * for hosts that run no tracing at all — not a working-set size.
+ * How long a restarted model run stays recorded when nothing consumes it.
+ *
+ * The consumer is LangChain's error callback, which is dispatched on a
+ * non-awaited queue, so a marker may legitimately sit unread for a moment. A
+ * COUNT cap cannot tell that apart from a leak: a burst of concurrent restarts
+ * would evict markers whose callbacks were still queued, and each eviction
+ * turns an expected restart back into an error in the host's traces — the very
+ * thing the marker exists to prevent. Age can tell them apart, so the bound is
+ * time.
  */
-const PREEMPT_RESTARTED_RUN_LIMIT = 64;
+const PREEMPT_RESTARTED_RUN_TTL_MS = 60_000;
 
 /**
- * Model-run ids whose provider stream was torn down for a restart.
+ * Model runs whose provider stream was torn down for a restart, with the
+ * accumulated turn so the close can carry its usage.
  *
  * Recorded rather than inferred from the thrown error: aborting makes the
  * provider adapter raise whatever IT raises for cancellation, and matching on
  * that shape would bind the tracing layer to per-provider error identity. The
  * run id is unambiguous and already captured for the seal path.
  *
- * Consumed by the tracing callback so an expected restart closes as control
- * flow instead of a failed generation — `AGENTS.md` states plainly that
- * control flow is not an error, and a run cannot both be the interrupt the
- * user asked for and an error in their traces.
+ * The message rides along because the run closes through the error path, which
+ * carries no output: without it a discarded attempt would report no usage at
+ * all, and the reasoning tokens the provider already billed would vanish from
+ * cost accounting. The later synthetic `CHAT_MODEL_END` cannot repair that —
+ * by then the generation is closed.
  *
- * Insertion-ordered eviction bounds it: the oldest entry goes rather than the
- * newest being refused, so a long-lived process with tracing disabled cannot
- * grow this without limit and cannot start silently dropping new ids either.
+ * Insertion-ordered, so expiry sweeps from the front and stops at the first
+ * live entry.
  */
-const preemptRestartedRuns = new Set<string>();
+const preemptRestartedRuns = new Map<string, PreemptRestartedRun>();
+
+/** A torn-down model run awaiting its tracing close. */
+export interface PreemptRestartedRun {
+  /** The accumulated turn, carrying whatever usage was resolved for it. */
+  message: AIMessageChunk;
+  recordedAt: number;
+}
+
+function sweepExpiredRestartedRuns(now: number): void {
+  for (const [runId, record] of preemptRestartedRuns) {
+    if (now - record.recordedAt < PREEMPT_RESTARTED_RUN_TTL_MS) {
+      return;
+    }
+    preemptRestartedRuns.delete(runId);
+  }
+}
 
 /** Records a model run whose stream was torn down for a restart. */
-export function notePreemptRestartedRun(runId: string): void {
-  if (preemptRestartedRuns.size >= PREEMPT_RESTARTED_RUN_LIMIT) {
-    const oldest = preemptRestartedRuns.values().next().value;
-    if (oldest != null) {
-      preemptRestartedRuns.delete(oldest);
-    }
-  }
-  preemptRestartedRuns.add(runId);
+export function notePreemptRestartedRun(
+  runId: string,
+  message: AIMessageChunk
+): void {
+  const now = Date.now();
+  sweepExpiredRestartedRuns(now);
+  preemptRestartedRuns.set(runId, { message, recordedAt: now });
 }
 
 /**
- * True when this model run ended because a preempt discarded it. Consuming:
- * the run closes exactly once, and a stale id must not reclassify a later
- * genuine failure on a reused id.
+ * The record for a run that ended because a preempt discarded it, or
+ * `undefined`. Consuming: the run closes exactly once, and a stale id must not
+ * reclassify a later genuine failure on a reused id.
  */
-export function consumePreemptRestartedRun(runId: string): boolean {
-  return preemptRestartedRuns.delete(runId);
+export function consumePreemptRestartedRun(
+  runId: string
+): PreemptRestartedRun | undefined {
+  const record = preemptRestartedRuns.get(runId);
+  if (record == null) {
+    return undefined;
+  }
+  preemptRestartedRuns.delete(runId);
+  return record;
 }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -224,6 +224,34 @@ function getAdditionalReasoningContent(
   return getReasoningDetailsText(additionalKwargs.reasoning_details);
 }
 
+/**
+ * True when a content block is a provider reasoning block: Anthropic
+ * `thinking` / `redacted_thinking`, Google `reasoning`, Bedrock
+ * `reasoning_content`, and the streamed delta variants that prefix each of
+ * those names.
+ *
+ * Shared rather than re-derived because two very different readers must agree
+ * on the same answer: the stream classifier, which decides what the host has
+ * been shown, and the preempt gate, which decides whether an accumulated turn
+ * holds anything worth keeping. A turn the host renders as thinking-only must
+ * never look like a visible answer to the gate.
+ *
+ * Prefix matching, not equality, because providers stream these as suffixed
+ * delta types. `reasoning_content` needs no clause of its own — it already
+ * carries the `reasoning` prefix.
+ */
+export function isReasoningContentBlock(block: { type?: string }): boolean {
+  const type = block.type;
+  if (type == null) {
+    return false;
+  }
+  return (
+    type.startsWith(ContentTypes.THINKING) ||
+    type.startsWith(ContentTypes.REASONING) ||
+    type === 'redacted_thinking'
+  );
+}
+
 function hasReasoningContent(content: BaseMessage['content']): boolean {
   if (!Array.isArray(content)) {
     return false;

--- a/src/run.ts
+++ b/src/run.ts
@@ -942,12 +942,20 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   /**
-   * Cooperative-seal counters for this run. `emptyBoundaries` is the one to
-   * watch: it counts seals whose `PreemptBoundary` produced nothing to
-   * inject, which ends the turn early and leaves the answer unfinished.
+   * Cooperative-preemption counters for this run. `emptyBoundaries` is the one
+   * to watch: it counts SEALS whose `PreemptBoundary` produced nothing to
+   * inject, which ends the turn early and leaves the answer unfinished. A
+   * restart that injects nothing simply reissues the call, so it is not
+   * counted there.
    */
   getPreemptStats(): t.PreemptStats {
-    return this.Graph?.getPreemptStats() ?? { seals: 0, emptyBoundaries: 0 };
+    return (
+      this.Graph?.getPreemptStats() ?? {
+        seals: 0,
+        restarts: 0,
+        emptyBoundaries: 0,
+      }
+    );
   }
 
   getToolCount(): number {

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -206,10 +206,13 @@ class UncooperativeModel extends PromptRecordingModel {
 class ThinkingOnlyModel extends PromptRecordingModel {
   override async *_streamResponseChunks(
     messages: BaseMessage[],
-    _options: this['ParsedCallOptions'],
-    _runManager?: CallbackManagerForLLMRun
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
-    this.recordPrompt(messages);
+    if (this.recordPrompt(messages) !== 1) {
+      yield* super._streamResponseChunks(messages, options, runManager);
+      return;
+    }
     yield thinkingChunk('first');
     this.onFirstStream();
     yield thinkingChunk('second');
@@ -550,6 +553,107 @@ describe('an adapter that ignores the abort', () => {
      *  not be. */
     expect(model.yielded).toBeLessThan(model.textChunks);
     expect(userTexts(model.prompts[1])).toEqual(['go', 'stop']);
+    expect(model.prompts[1].some((message) => message.getType() === 'ai')).toBe(
+      false
+    );
+  });
+});
+
+/**
+ * A restart preserves nothing, so reporting it as a seal would tell every
+ * consumer of these counters that a turn was kept when it was discarded.
+ */
+describe('preempt stats', () => {
+  it('counts a discard apart from a seal', async () => {
+    const host = createHost(0);
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-stats',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'be brief' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    const stats = run.getPreemptStats();
+    expect(stats.restarts).toBe(1);
+    expect(stats.seals).toBe(0);
+    /** A restart boundary that DID inject is not an empty boundary either. */
+    expect(stats.emptyBoundaries).toBe(0);
+  });
+
+  it('does not count a reissued empty boundary as truncated', async () => {
+    const host = createHost(0);
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-stats-empty',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {};
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    expect(run.getPreemptStats().emptyBoundaries).toBe(0);
+  });
+});
+
+/**
+ * The grace guards against stealing a seal that was about to become possible.
+ * A stream that ENDS while still discardable is proof none was coming, so the
+ * request must not be left for the terminal boundary — which would replay a
+ * reasoning-only turn followed by the steer, the very shape the seal gate
+ * refuses to build.
+ */
+describe('a discardable stream that ends inside the grace', () => {
+  it('still honors the armed request', async () => {
+    const host = createHost(60_000);
+    const model = new ThinkingOnlyModel({ responses: [RESTARTED_RESPONSE] });
+    const run = await createRestartRun({
+      runId: 'restart-natural-end',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop there' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think it through')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    expect(userTexts(model.prompts[1])).toEqual([
+      'think it through',
+      'stop there',
+    ]);
     expect(model.prompts[1].some((message) => message.getType() === 'ai')).toBe(
       false
     );

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -1,0 +1,374 @@
+// src/specs/preemptRestart.test.ts
+/**
+ * End-to-end discard-and-restart flow through a real `Run`.
+ *
+ * The companion to `preemptSeal.test.ts`: that file covers a preempt request
+ * that arrives once the turn has an answer worth keeping. This one covers the
+ * window BEFORE that — the model is silent, or streaming reasoning it has not
+ * turned into text yet — where a seal is impossible and the request used to
+ * wait out the whole turn. Here the in-flight call is torn down, its partial
+ * output dropped, and the model called again with the boundary's injection
+ * appended to the SAME prompt.
+ *
+ * Everything runs the dispatch-synchronous loop in `attemptInvoke` (no
+ * registered CHAT_MODEL_STREAM handler), which is the only loop allowed to
+ * seal or restart.
+ */
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { HookCallback } from '@/hooks/types';
+import type * as t from '@/types';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { FakeChatModel } from '@/llm/fake';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+const RESTARTED_RESPONSE = 'Answering the steer instead.';
+
+/**
+ * A reasoning-only chunk. The seal gate rejects these by design — several
+ * providers strip or sign reasoning, so it cannot stand in for the visible
+ * assistant turn a sealed sequence needs — which is exactly why a turn made of
+ * nothing else is discardable rather than sealable.
+ */
+function thinkingChunk(text: string): ChatGenerationChunk {
+  return new ChatGenerationChunk({
+    text: '',
+    message: new AIMessageChunk({
+      content: [{ type: 'thinking', thinking: text }],
+    }),
+  });
+}
+
+const streamConfig = {
+  configurable: { thread_id: 'preempt-restart-e2e' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+/**
+ * A host arming an interrupt, modelled the way a real one behaves: the flag is
+ * level-triggered and stays true until a boundary drains it, and `wake` is a
+ * hint the SDK may act on or ignore.
+ */
+function createHost(restartGraceMs: number): {
+  arm: () => void;
+  disarm: () => void;
+  preemption: t.StreamPreemption;
+} {
+  let armed = false;
+  const wakes = new Set<() => void>();
+  return {
+    arm: (): void => {
+      armed = true;
+      for (const wake of wakes) {
+        wake();
+      }
+    },
+    disarm: (): void => {
+      armed = false;
+    },
+    preemption: {
+      shouldPreempt: () => armed,
+      subscribe: (wake) => {
+        wakes.add(wake);
+        return () => {
+          wakes.delete(wake);
+        };
+      },
+      restartGraceMs,
+      maxSeals: 2,
+    },
+  };
+}
+
+/** Records every prompt the provider was actually asked to complete. */
+class PromptRecordingModel extends FakeChatModel {
+  prompts: BaseMessage[][] = [];
+  /**
+   * Fired from inside the first stream, so a test can arm the interrupt at a
+   * realistic moment: while the provider is already working. Arming before
+   * `processStream` instead exercises a different path entirely — the request
+   * is outstanding before the call is issued, and the call never goes out.
+   */
+  onFirstStream: () => void = () => {};
+
+  protected recordPrompt(messages: BaseMessage[]): number {
+    this.prompts.push(messages);
+    return this.prompts.length;
+  }
+}
+
+/**
+ * First call hangs without yielding anything — the silent window between a
+ * request and its first chunk, where no per-chunk poll can ever run. Later
+ * calls answer normally.
+ */
+class SilentThenAnsweringModel extends PromptRecordingModel {
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    if (this.recordPrompt(messages) === 1) {
+      this.onFirstStream();
+      await new Promise<never>((_resolve, reject) => {
+        const { signal } = options;
+        if (signal == null) {
+          reject(new Error('Expected the attempt to carry an abort signal'));
+          return;
+        }
+        signal.addEventListener(
+          'abort',
+          () => reject(new Error('provider stream aborted')),
+          { once: true }
+        );
+      });
+      return;
+    }
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+/**
+ * First call streams reasoning and nothing else, then hangs — the long
+ * thinking stretch. `thinkingChunkCount` is deliberately more than one so the
+ * per-chunk trigger is exercised repeatedly against the grace window.
+ */
+class ThinkingThenAnsweringModel extends PromptRecordingModel {
+  thinkingChunkCount = 3;
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    if (this.recordPrompt(messages) !== 1) {
+      yield* super._streamResponseChunks(messages, options, runManager);
+      return;
+    }
+    for (let i = 0; i < this.thinkingChunkCount; i++) {
+      yield thinkingChunk(`step ${i}`);
+      this.onFirstStream();
+    }
+    await new Promise<never>((_resolve, reject) => {
+      options.signal?.addEventListener(
+        'abort',
+        () => reject(new Error('provider stream aborted')),
+        { once: true }
+      );
+    });
+  }
+}
+
+/** Streams reasoning first, then real text — the turn a seal must win. */
+class ThinkingThenTextModel extends PromptRecordingModel {
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    if (this.recordPrompt(messages) !== 1) {
+      yield* super._streamResponseChunks(messages, options, runManager);
+      return;
+    }
+    yield thinkingChunk('almost there');
+    this.onFirstStream();
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
+
+async function createRestartRun(options: {
+  runId: string;
+  hook: HookCallback<'PreemptBoundary'>;
+  preemption: t.StreamPreemption;
+  model: FakeChatModel;
+}): Promise<Run<t.IState>> {
+  const registry = new HookRegistry();
+  registry.register('PreemptBoundary', { hooks: [options.hook] });
+  const run = await Run.create<t.IState>({
+    runId: options.runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-4o-mini',
+        apiKey: 'test-key',
+      },
+      instructions: 'Answer plainly.',
+    },
+    hooks: registry,
+    preemption: options.preemption,
+    returnContent: true,
+    skipCleanup: true,
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph to be initialized');
+  }
+  run.Graph.overrideModel = options.model;
+  return run;
+}
+
+function userTexts(messages: BaseMessage[]): string[] {
+  const texts: string[] = [];
+  for (const message of messages) {
+    if (message.getType() !== 'human') {
+      continue;
+    }
+    texts.push(
+      typeof message.content === 'string'
+        ? message.content
+        : JSON.stringify(message.content)
+    );
+  }
+  return texts;
+}
+
+describe('cooperative restart (end-to-end via Run)', () => {
+  it('discards a silent turn and re-issues it with the steer appended', async () => {
+    const host = createHost(0);
+    /**
+     * The screenshot case: the provider has accepted the request and gone
+     * quiet. No chunk will ever arrive to poll on, so the wake is the only
+     * thing that can reach this turn.
+     */
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-silent',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [
+            { role: 'user' as const, content: 'actually, be brief' },
+          ],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    /**
+     * The whole safety argument in one assertion: the discarded turn leaves no
+     * assistant message behind, so the injected turn sits directly after the
+     * original question. Adjacent user turns are native on Anthropic, OpenAI
+     * and Gemini, and normalized for the strict-alternation providers.
+     */
+    expect(userTexts(model.prompts[1])).toEqual([
+      'tell me a long story',
+      'actually, be brief',
+    ]);
+    expect(
+      model.prompts[1].some((message) => message.getType() === 'ai')
+    ).toBe(false);
+  });
+
+  it('discards a thinking-only turn once the request outlives the grace', async () => {
+    const host = createHost(0);
+    const model = new ThinkingThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-thinking',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop there' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think it through')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    expect(userTexts(model.prompts[1])).toEqual([
+      'think it through',
+      'stop there',
+    ]);
+  });
+
+  it('prefers a seal when text arrives inside the grace window', async () => {
+    const host = createHost(60_000);
+    const model = new ThinkingThenTextModel({
+      responses: ['Partial answer.', RESTARTED_RESPONSE],
+    });
+    const boundaryPrompts: number[] = [];
+    const run = await createRestartRun({
+      runId: 'restart-defers-to-seal',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        boundaryPrompts.push(model.prompts.length);
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'go on' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think then answer')] },
+      streamConfig
+    );
+
+    expect(boundaryPrompts).toHaveLength(1);
+    expect(model.prompts).toHaveLength(2);
+    /**
+     * A seal KEEPS the turn, so the resumed prompt carries the partial
+     * assistant answer. That is the whole difference from a restart, and the
+     * grace window is what guarantees it: reasoning alone must not convert a
+     * turn whose text was moments away.
+     */
+    expect(
+      model.prompts[1].some((message) => message.getType() === 'ai')
+    ).toBe(true);
+  });
+
+  it('re-issues the call when a restart boundary injects nothing', async () => {
+    const host = createHost(0);
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-empty-boundary',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {};
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    /**
+     * A cancelled interrupt must not cost the user their answer. A seal cannot
+     * self-loop here (it would leave a trailing model turn with no new input),
+     * but a discard left graph state untouched, so re-entering the node simply
+     * re-issues the original call.
+     */
+    expect(model.prompts).toHaveLength(2);
+    expect(userTexts(model.prompts[1])).toEqual(['tell me a long story']);
+  });
+});

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -18,6 +18,7 @@ import { ChatGenerationChunk } from '@langchain/core/outputs';
 import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { LLMResult } from '@langchain/core/outputs';
 import type { HookCallback } from '@/hooks/types';
 import type * as t from '@/types';
 import { HookRegistry } from '@/hooks/HookRegistry';
@@ -53,7 +54,17 @@ const streamConfig = {
  * level-triggered and stays true until a boundary drains it, and `wake` is a
  * hint the SDK may act on or ignore.
  */
-function createHost(restartGraceMs: number): {
+function createHost(
+  restartGraceMs: number,
+  /**
+   * When false the channel is registered but never fired. That is not a broken
+   * host — a wake that arrives while the shape is not yet discardable declines
+   * and never comes again — and it is the only deterministic way to reach the
+   * per-chunk trigger, which ends the stream by BREAKING the iterator rather
+   * than aborting it.
+   */
+  deliverWakes = true
+): {
   arm: () => void;
   disarm: () => void;
   preemption: t.StreamPreemption;
@@ -63,6 +74,9 @@ function createHost(restartGraceMs: number): {
   return {
     arm: (): void => {
       armed = true;
+      if (!deliverWakes) {
+        return;
+      }
       for (const wake of wakes) {
         wake();
       }
@@ -657,5 +671,126 @@ describe('a discardable stream that ends inside the grace', () => {
     expect(model.prompts[1].some((message) => message.getType() === 'ai')).toBe(
       false
     );
+  });
+});
+
+/**
+ * Each way a restart can end the stream leaves the model run in a different
+ * state, and closing one the way another needs either double-closes a finished
+ * run or leaves an open one behind.
+ */
+describe('restart close routes', () => {
+  it('does not close a run the stream already finished', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation();
+    try {
+      const host = createHost(60_000);
+      const model = new ThinkingOnlyModel({ responses: [RESTARTED_RESPONSE] });
+      const run = await createRestartRun({
+        runId: 'restart-no-double-close',
+        preemption: host.preemption,
+        model,
+        hook: () => {
+          host.disarm();
+          return {
+            injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+          };
+        },
+      });
+      model.onFirstStream = host.arm;
+
+      await run.processStream(
+        { messages: [new HumanMessage('think')] },
+        streamConfig
+      );
+
+      expect(model.prompts).toHaveLength(2);
+      /**
+       * The natural end already emitted its own close. A second attempt finds
+       * no run to end and falls back with this warning, which is the
+       * observable signature of getting the route wrong.
+       */
+      expect(
+        warn.mock.calls.filter(([message]) =>
+          String(message).includes('Native close of the sealed model run')
+        )
+      ).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('marks a manually closed restart as control flow', async () => {
+    const outputs: Array<Record<string, unknown> | undefined> = [];
+    const host = createHost(0, false);
+    const model = new ThinkingThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-control-flow-output',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think it through')] },
+      {
+        ...streamConfig,
+        callbacks: [
+          {
+            handleLLMEnd: (output: LLMResult): void => {
+              outputs.push(output.llmOutput as Record<string, unknown>);
+            },
+          },
+        ],
+      }
+    );
+
+    /**
+     * A discarded turn must not read as an ordinary generation just because
+     * the per-chunk trigger fired instead of the wake.
+     */
+    expect(outputs).toContainEqual(
+      expect.objectContaining({ controlFlow: 'PreemptRestart' })
+    );
+  });
+});
+
+/**
+ * A halted restart truncates nothing that was kept, so it is not the
+ * truncated-seal signal hosts persist on. `preemptIncomplete` already records
+ * that the answer never arrived.
+ */
+describe('a restart boundary that halts', () => {
+  it('is not counted as an empty boundary', async () => {
+    const host = createHost(0);
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-halted',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return { preventContinuation: true };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('tell me a long story')] },
+      streamConfig
+    );
+
+    const stats = run.getPreemptStats();
+    expect(stats.restarts).toBe(1);
+    expect(stats.emptyBoundaries).toBe(0);
   });
 });

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -22,8 +22,8 @@ import type { LLMResult } from '@langchain/core/outputs';
 import type { HookCallback } from '@/hooks/types';
 import type * as t from '@/types';
 import { HookRegistry } from '@/hooks/HookRegistry';
+import { GraphEvents, Providers } from '@/common';
 import { FakeChatModel } from '@/llm/fake';
-import { Providers } from '@/common';
 import { Run } from '@/run';
 
 const RESTARTED_RESPONSE = 'Answering the steer instead.';
@@ -289,6 +289,14 @@ async function createRestartRun(options: {
     },
     hooks: registry,
     preemption: options.preemption,
+    /**
+     * Required for a discarded turn to report usage at all: a turn that ends
+     * early never receives the provider's usage chunk, so the synthetic close
+     * falls back to this counter. Without one the whole usage path silently
+     * no-ops and any test watching it proves nothing.
+     */
+    tokenCounter: (message: BaseMessage): number =>
+      Math.ceil(JSON.stringify(message.content).length / 4),
     returnContent: true,
     skipCleanup: true,
   });
@@ -719,6 +727,66 @@ describe('restart close routes', () => {
     }
   });
 
+  /**
+   * A stream that finished on its own already gave the host its model-end,
+   * with usage. Replaying that event would charge the discarded attempt's
+   * tokens twice in any host accumulating from it.
+   */
+  it('does not replay model-end usage after natural exhaustion', async () => {
+    const modelEnds: Array<Record<string, unknown> | undefined> = [];
+    const host = createHost(60_000);
+    const model = new ThinkingOnlyModel({ responses: [RESTARTED_RESPONSE] });
+    const run = await createRestartRun({
+      runId: 'restart-no-duplicate-usage',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think')] },
+      {
+        ...streamConfig,
+        callbacks: [
+          {
+            /**
+             * The synthetic close is dispatched as a CUSTOM event, which is
+             * how hosts accumulating usage receive it — `handleLLMEnd` never
+             * sees it, so watching that channel would miss the duplicate
+             * entirely.
+             */
+            handleCustomEvent: (
+              event: string,
+              data: { output?: AIMessageChunk }
+            ): void => {
+              if (event === GraphEvents.CHAT_MODEL_END) {
+                modelEnds.push(
+                  data.output?.usage_metadata as unknown as Record<
+                    string,
+                    unknown
+                  >
+                );
+              }
+            },
+          },
+        ],
+      }
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    /**
+     * The natural end already reported this turn through LangChain. A
+     * synthetic close carrying usage on top of it is the duplicate charge.
+     */
+    expect(modelEnds.filter((usage) => usage != null)).toHaveLength(0);
+  });
+
   it('marks a manually closed restart as control flow', async () => {
     const outputs: Array<Record<string, unknown> | undefined> = [];
     const host = createHost(0, false);
@@ -792,5 +860,51 @@ describe('a restart boundary that halts', () => {
     const stats = run.getPreemptStats();
     expect(stats.restarts).toBe(1);
     expect(stats.emptyBoundaries).toBe(0);
+  });
+});
+
+/**
+ * A restart must never swallow a genuine failure that landed at the same
+ * moment. The catch exists for one thing — the abort this attempt issued —
+ * and a stream-limit trip or a real cancellation has to keep travelling.
+ */
+describe('a failure concurrent with a restart', () => {
+  it('propagates a run cancellation rather than restarting through it', async () => {
+    const host = createHost(0);
+    const controller = new AbortController();
+    let boundaries = 0;
+    const model = new SilentThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-concurrent-cancel',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        boundaries += 1;
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+        };
+      },
+    });
+    model.onFirstStream = (): void => {
+      controller.abort();
+      host.arm();
+    };
+
+    await expect(
+      run.processStream({ messages: [new HumanMessage('go')] }, {
+        ...streamConfig,
+        signal: controller.signal,
+      })
+    ).rejects.toBeDefined();
+
+    /**
+     * The discriminator: swallowing the cancellation lets the node reach its
+     * boundary and consume the queued injection on a run the caller already
+     * cancelled. Nothing downstream of the model node may run at all.
+     */
+    expect(boundaries).toBe(0);
+    expect(model.prompts).toHaveLength(1);
   });
 });

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -163,6 +163,45 @@ class ThinkingThenAnsweringModel extends PromptRecordingModel {
   }
 }
 
+/**
+ * Ignores cancellation entirely — `stream` is overridden so LangChain's own
+ * signal handling never runs, leaving the SDK's consumer loop as the only
+ * thing that can stop it. That is the adapter the abort cannot be trusted
+ * against, and the buffered-chunk case behaves the same way from the loop's
+ * side. `yielded` records how far it got before the consumer closed it.
+ */
+class UncooperativeModel extends PromptRecordingModel {
+  yielded = 0;
+  readonly textChunks = 40;
+
+  override stream(
+    input: Parameters<FakeChatModel['stream']>[0],
+    options?: Parameters<FakeChatModel['stream']>[1]
+  ): ReturnType<FakeChatModel['stream']> {
+    const messages = Array.isArray(input) ? (input as BaseMessage[]) : [];
+    if (this.recordPrompt(messages) !== 1) {
+      return super.stream(input, options);
+    }
+    const countYield = (): void => {
+      this.yielded += 1;
+    };
+    const arm = (): void => this.onFirstStream();
+    const { textChunks } = this;
+    async function* uncooperative(): AsyncGenerator<AIMessageChunk> {
+      yield new AIMessageChunk({
+        content: [{ type: 'thinking', thinking: 'deciding' }],
+      });
+      countYield();
+      arm();
+      for (let i = 0; i < textChunks; i++) {
+        yield new AIMessageChunk({ content: 'x' });
+        countYield();
+      }
+    }
+    return uncooperative() as unknown as ReturnType<FakeChatModel['stream']>;
+  }
+}
+
 /** Streams reasoning and then ends, never producing text. */
 class ThinkingOnlyModel extends PromptRecordingModel {
   override async *_streamResponseChunks(
@@ -475,5 +514,44 @@ describe('seal-only hosts', () => {
 
     expect(model.prompts).toHaveLength(1);
     expect(boundaries).toHaveLength(0);
+  });
+});
+
+/**
+ * The abort is a request, not a guarantee. An adapter that ignores it — or one
+ * whose iterator hands over a chunk buffered before it landed — would keep
+ * feeding the host text it is about to be told was discarded, and in the
+ * ignoring case would hold the boundary until the whole response finished.
+ */
+describe('an adapter that ignores the abort', () => {
+  it('stops being consumed as soon as the restart is decided', async () => {
+    const host = createHost(0);
+    const model = new UncooperativeModel({ responses: [RESTARTED_RESPONSE] });
+    const run = await createRestartRun({
+      runId: 'restart-uncooperative',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('go')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    /** A couple of chunks may already be in flight; the whole response must
+     *  not be. */
+    expect(model.yielded).toBeLessThan(model.textChunks);
+    expect(userTexts(model.prompts[1])).toEqual(['go', 'stop']);
+    expect(model.prompts[1].some((message) => message.getType() === 'ai')).toBe(
+      false
+    );
   });
 });

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -908,3 +908,49 @@ describe('a failure concurrent with a restart', () => {
     expect(model.prompts).toHaveLength(1);
   });
 });
+
+/**
+ * Graph state forgets a discarded attempt, but the run-step view is a separate
+ * projection: left alone it closes the attempt `completed`, so subscribers keep
+ * showing reasoning the replacement prompt does not contain.
+ */
+describe('run steps for a discarded attempt', () => {
+  it('leaves no step open behind it', async () => {
+    const host = createHost(0);
+    const model = new ThinkingThenAnsweringModel({
+      responses: [RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'restart-run-steps',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think it through')] },
+      streamConfig
+    );
+
+    /**
+     * The reachable invariant. A step the discard cut short must not stay
+     * `in_progress` — subscribers would show the withdrawn attempt as still
+     * running. Whether such a step exists at all depends on what the provider
+     * streamed before the interrupt, so this asserts the property rather than
+     * a particular step count.
+     */
+    const statuses = (run.Graph?.getRunSteps() ?? []).map(
+      (step) => step.status
+    );
+    expect(statuses.length).toBeGreaterThan(0);
+    expect(
+      statuses.filter((status) => status == null || status === 'in_progress')
+    ).toHaveLength(0);
+  });
+});

--- a/src/specs/preemptRestart.test.ts
+++ b/src/specs/preemptRestart.test.ts
@@ -163,6 +163,20 @@ class ThinkingThenAnsweringModel extends PromptRecordingModel {
   }
 }
 
+/** Streams reasoning and then ends, never producing text. */
+class ThinkingOnlyModel extends PromptRecordingModel {
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    _options: this['ParsedCallOptions'],
+    _runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.recordPrompt(messages);
+    yield thinkingChunk('first');
+    this.onFirstStream();
+    yield thinkingChunk('second');
+  }
+}
+
 /** Streams reasoning first, then real text — the turn a seal must win. */
 class ThinkingThenTextModel extends PromptRecordingModel {
   override async *_streamResponseChunks(
@@ -178,6 +192,24 @@ class ThinkingThenTextModel extends PromptRecordingModel {
     this.onFirstStream();
     yield* super._streamResponseChunks(messages, options, runManager);
   }
+}
+
+/** A host on the seal-only contract: armed, but with no wake channel. */
+function createSealOnlyHost(): {
+  arm: () => void;
+  disarm: () => void;
+  preemption: t.StreamPreemption;
+  } {
+  let armed = false;
+  return {
+    arm: (): void => {
+      armed = true;
+    },
+    disarm: (): void => {
+      armed = false;
+    },
+    preemption: { shouldPreempt: () => armed, maxSeals: 2 },
+  };
 }
 
 async function createRestartRun(options: {
@@ -370,5 +402,78 @@ describe('cooperative restart (end-to-end via Run)', () => {
      */
     expect(model.prompts).toHaveLength(2);
     expect(userTexts(model.prompts[1])).toEqual(['tell me a long story']);
+  });
+});
+
+/**
+ * Everything a restart depends on is opt-in through `subscribe`, and the lane
+ * it names is where the discard's boundary gets dispatched. Without it a
+ * discard would return no message AND record no lane, so the node would inject
+ * nothing and end the turn empty with the steer still queued.
+ */
+describe('seal-only hosts', () => {
+  it('never discards a thinking turn when no wake channel was supplied', async () => {
+    const host = createSealOnlyHost();
+    const model = new ThinkingThenTextModel({
+      responses: ['Partial answer.', RESTARTED_RESPONSE],
+    });
+    const run = await createRestartRun({
+      runId: 'seal-only-no-restart',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        host.disarm();
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'go on' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think then answer')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(2);
+    /**
+     * Sealed, not discarded: the resumed prompt carries the partial assistant
+     * answer. An empty `messages[1]` with no assistant turn would mean the
+     * turn was thrown away with no boundary to catch it.
+     */
+    expect(model.prompts[1].some((message) => message.getType() === 'ai')).toBe(
+      true
+    );
+  });
+
+  /**
+   * The turn a seal can never accept, on a host that cannot restart. It must
+   * end as an ordinary reasoning-only turn — one model call, no boundary — and
+   * NOT be discarded into an empty turn with the steer still queued.
+   */
+  it('lets a thinking-only turn finish rather than discarding it', async () => {
+    const host = createSealOnlyHost();
+    const model = new ThinkingOnlyModel({ responses: [RESTARTED_RESPONSE] });
+    const boundaries: number[] = [];
+    const run = await createRestartRun({
+      runId: 'seal-only-thinking-only',
+      preemption: host.preemption,
+      model,
+      hook: () => {
+        boundaries.push(model.prompts.length);
+        return {
+          injectedMessages: [{ role: 'user' as const, content: 'stop there' }],
+        };
+      },
+    });
+    model.onFirstStream = host.arm;
+
+    await run.processStream(
+      { messages: [new HumanMessage('think it through')] },
+      streamConfig
+    );
+
+    expect(model.prompts).toHaveLength(1);
+    expect(boundaries).toHaveLength(0);
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -56,6 +56,7 @@ import {
 } from '@/utils/truncation';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
+import { isReasoningContentBlock } from '@/messages/core';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { composeAbortSignals } from '@/utils/misc';
 import { isGoogleLike } from '@/utils/llm';
@@ -454,15 +455,6 @@ function isTextContentPart(contentPart: t.MessageContentComplex): boolean {
   return contentPart.type?.startsWith(ContentTypes.TEXT) ?? false;
 }
 
-function isReasoningContentPart(contentPart: t.MessageContentComplex): boolean {
-  return (
-    (contentPart.type?.startsWith(ContentTypes.THINKING) ?? false) ||
-    (contentPart.type?.startsWith(ContentTypes.REASONING) ?? false) ||
-    (contentPart.type?.startsWith(ContentTypes.REASONING_CONTENT) ?? false) ||
-    contentPart.type === 'redacted_thinking'
-  );
-}
-
 function getReasoningTextFromContentPart(
   contentPart: t.MessageContentComplex
 ): string {
@@ -532,7 +524,7 @@ function shouldStartFreshMessageStepAfterGoogleServerSideTool({
   }
   return (
     content.every((c) => isTextContentPart(c)) ||
-    content.every((c) => isReasoningContentPart(c))
+    content.every((c) => isReasoningContentBlock(c))
   );
 }
 
@@ -649,7 +641,7 @@ async function dispatchGoogleServerSideToolStreamContent({
   }
   reasoningContent.push(
     ...content
-      .filter((contentPart) => isReasoningContentPart(contentPart))
+      .filter((contentPart) => isReasoningContentBlock(contentPart))
       .map((contentPart) => ({
         type: ContentTypes.THINK,
         think: getReasoningTextFromContentPart(contentPart),
@@ -2034,7 +2026,7 @@ hasToolCallChunks: ${hasToolCallChunks}
         },
         metadata
       );
-    } else if (content.every((c) => isReasoningContentPart(c))) {
+    } else if (content.every((c) => isReasoningContentBlock(c))) {
       await graph.dispatchReasoningDelta(
         stepId,
         {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -217,9 +217,18 @@ export interface StreamPreemption {
   maxSeals?: number;
 }
 
-/** Seals honored and boundaries that had nothing to inject, per run. */
+/**
+ * Per run: seals honored, discards honored, and boundaries that had nothing to
+ * inject.
+ *
+ * `seals` counts only turns that were KEPT — a partial assistant message
+ * survived into the next prompt. `restarts` counts turns that were discarded
+ * and reissued, which preserve nothing, so a consumer classifying a run as
+ * "sealed" must not read them together.
+ */
 export type PreemptStats = {
   seals: number;
+  restarts: number;
   emptyBoundaries: number;
 };
 

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -123,15 +123,23 @@ export type StandardGraphConfig = Omit<
 > & { type?: 'standard'; signal?: AbortSignal };
 
 /**
- * Cooperative mid-generation preemption. Lets a host seal the live model
- * stream at the next provider-safe token boundary — the run is never
- * aborted, the partial assistant turn is kept, and the graph self-loops
- * into a fresh model call once the `PreemptBoundary` hook has injected
- * whatever the host queued.
+ * Cooperative mid-generation preemption. Lets a host end the live model stream
+ * early and inject whatever it queued, in one of two ways:
+ *
+ *  - a SEAL, at the next provider-safe token boundary: the run is never
+ *    aborted, the partial assistant turn is kept, and the graph self-loops into
+ *    a fresh model call once the `PreemptBoundary` hook has injected.
+ *  - a RESTART, when the turn holds nothing worth keeping — no text, no tool
+ *    call, at most reasoning. The provider request IS torn down, its output is
+ *    discarded, and the model is called again with the injection appended to
+ *    the same prompt. Requires `subscribe`; see it for why the per-chunk poll
+ *    alone cannot reach this case.
  *
  * Preconditions the host MUST satisfy:
  *   - `shouldPreempt` is polled once per streamed chunk on the top-level
- *     graph. It must be synchronous, allocation-free and O(1) — never I/O.
+ *     graph, and once more per model attempt if `subscribe` is supplied — at
+ *     the attempt's start and on each wake. It must be synchronous,
+ *     allocation-free and O(1) — never I/O.
  *     It must also be LEVEL-TRIGGERED (non-consuming): the SDK never clears
  *     the host's request, and a true result is only honored once the
  *     accumulated chunk is provider-safe, so the predicate may be polled
@@ -168,6 +176,40 @@ export interface StreamPreemption {
    * consumes the request; a self-clearing read loses it on an unsafe chunk.
    */
   shouldPreempt: () => boolean;
+  /**
+   * Optional wake-up channel for the window where the poll cannot reach: a
+   * provider that has sent nothing yet, or that is streaming reasoning the
+   * seal gate will never accept. `shouldPreempt` is only read per chunk, so a
+   * request armed during a long silent stretch would otherwise wait for the
+   * whole turn.
+   *
+   * The SDK subscribes once per model attempt and calls the returned
+   * unsubscribe when the attempt ends. `wake` is a HINT, never the request
+   * itself: it wakes the SDK, which then re-reads `shouldPreempt` as the sole
+   * authority. That keeps the level-triggered contract above intact and makes
+   * spurious wakes free — a host may call it on every arm without tracking
+   * which ones the SDK already saw.
+   *
+   * A wake is only honored when the accumulated turn holds nothing worth
+   * keeping, and it is honored by DISCARDING that turn: the in-flight provider
+   * request is torn down, its partial output is dropped, the `PreemptBoundary`
+   * hook injects, and the model is called again with the injection appended.
+   * Reasoning tokens already spent are billed and lost, which is the trade the
+   * host is asking for. A turn that has produced visible text seals instead,
+   * through the ordinary per-chunk path, and a wake never discards it.
+   */
+  subscribe?: (wake: () => void) => () => void;
+  /**
+   * How long a request waits for the turn to become sealable before it may
+   * discard it instead. Defaults to `DEFAULT_PREEMPT_RESTART_GRACE_MS`; `0`
+   * converts as soon as the shape allows.
+   *
+   * The window keeps a restart from stealing a seal that was moments away, and
+   * from discarding a first chunk still in flight between the provider and the
+   * consumer. Both are why it applies to a silent turn as well as a thinking
+   * one.
+   */
+  restartGraceMs?: number;
   /**
    * Max cooperative seals per run. Each seal costs one extra superstep, so
    * this also bounds the recursion-limit headroom the run reserves.


### PR DESCRIPTION
## Summary

A preempt request could only ever be honored by **sealing**, and `canSealPreempt` requires non-empty *text* on the accumulated chunk. Two consequences followed, both in the window users reach for an interrupt most:

- a turn streaming only reasoning never becomes sealable, so the request waits out the whole turn;
- a provider that has sent nothing at all is never even polled — the only `shouldPreempt` read lives inside the chunk loop (`src/llm/invoke.ts`), so silence means no read.

Either way the queued message lands as a terminal continuation *after* the answer it was meant to redirect.

Both cases now convert to a **restart**: the provider request is torn down, its partial output discarded, the `PreemptBoundary` hook injects, and the model is called again with the injection appended to the same prompt.

## Why a discard is safe where a seal is not

A seal *keeps* the partial assistant turn, which is exactly why it needs non-empty text — the injected user turn must not be preceded by an empty assistant message. A discard leaves **no** assistant turn behind, so the injected turn sits directly after the previous user turn. Adjacent user turns are native on Anthropic, OpenAI and Gemini, and already normalized by `coalesceAdjacentUserTurns` for the `strictAlternationProviders` set.

## Design notes

**Seal always wins.** `resolvePreemptAction` prefers a seal wherever one is available, so a turn that has already produced an answer never loses it to a restart.

**The grace window is correctness, not politeness.** A restart converts only once the request outlives `DEFAULT_PREEMPT_RESTART_GRACE_MS` (2s, per-run overridable via `StreamPreemption.restartGraceMs`), for two independent reasons:

- reasoning usually precedes text by moments, and discarding a turn that was about to become sealable trades a kept answer for a re-issued request. The existing `preemptSeal.test.ts` case that steers a multi-item reasoning turn caught this directly — an eager first cut turned that seal into a discard;
- the chunk a restart is judged against is what the **consumer** has accumulated, and the stream buffers a chunk ahead of it. An empty accumulation therefore does not prove the provider produced nothing; it can also mean the first chunk is in flight. Converting on emptiness alone would discard that chunk — text included — on a race no caller can see. This is why the window applies to a silent provider too.

**The discardable shape is a whitelist.** Every content block must be a recognizable reasoning block; an unrecognized block refuses. Blacklisting would silently discard whatever a future provider adds, and the failure is asymmetric — refusing costs a slower interrupt (today's behavior), while wrongly discarding destroys work the model already did and the host may already have rendered.

**Stricter than the seal gate about server-side tools.** A seal may treat a settled `web_search_tool_result` as harmless, since the answer stays on the message. A restart would re-run and re-bill that search, so any tool machinery refuses.

**The wake channel.** `StreamPreemption.subscribe` is a *hint*: it wakes the SDK, which re-reads `shouldPreempt` as the sole authority, so the level-triggered contract is unchanged and spurious wakes are free. It is also read once per attempt — before the provider request is issued — because a request armed during setup or on a fallback-replaced attempt is already true and will never produce another wake. A self-rescheduling `unref`'d timer covers the remainder of the grace, since a silent provider yields no chunk to poll on.

**Lane keying.** A discard returns no message, so the model node cannot read `response_metadata.preempted` to learn a boundary is owed. The carrier is keyed by agent for the same reason `pendingPreemptReturn` is — one graph instance serves every parallel agent, and a single flag would let whichever lane finished first consume another lane's boundary. Threaded through `tryFallbackProviders` too, so a fallback-served attempt records into the same lane.

**Empty boundary after a restart re-issues the call.** A seal cannot self-loop there (a trailing model turn with no new input is dropped by some Gemini models and read as prefill by Anthropic), but a discard left graph state exactly as the node found it, so returning to the node simply re-issues the original call. A cancelled interrupt must not cost the user their answer. Bounded by the same seal budget.

**Reasoning predicate deduplicated.** `isReasoningContentBlock` moves to `src/messages/core.ts` and is shared with `src/stream.ts`. The stream classifier and the preempt gate must agree on what counts as reasoning, or a turn the host renders as thinking-only could look like a visible answer to the gate.

## Host contract

Probe `HOOK_PREEMPT_RESTART_CAPABLE` — deliberately separate from `HOOK_PREEMPT_BOUNDARY_CAPABLE`. An SDK with only the boundary still accepts the request and still labels the chip "interrupting"; it simply cannot act until the model starts writing, which is the difference users actually feel.

A host rendering from the stream should watch for `preemptDiscarded` on the synthetic `CHAT_MODEL_END`: a seal's content survives into the next prompt, a discard's does not.

## Test plan

- `src/specs/preemptRestart.test.ts` — four end-to-end scenarios through a real `Run`: silent provider discarded and re-issued with the steer appended (asserting no assistant message between the two user turns), thinking-only turn past the window, seal preferred when text arrives inside it, and empty boundary re-issuing the call.
- `src/llm/preempt.test.ts` — 48 cases over the gate and the grace policy.
- `preemptSeal.test.ts`, `Graph.preemptSignal.test.ts`, `preemptBoundary.test.ts` unchanged and green.
- Full suite: 233 suites / 4646 tests green (live-provider `llm.spec.ts` suites excluded — they fail identically on `main` without credentials).
