### PR TITLE
🧊 fix: Keep Historical Tool Result Truncation Byte-Stable Across Turns

### DIFF
--- a/docs/summarization-behavior.md
+++ b/docs/summarization-behavior.md
@@ -44,6 +44,16 @@ Updated each turn from `usageMetadata.input_tokens` returned by the provider. Th
 
 All budget comparisons multiply raw counts by `calibrationRatio` to approximate provider space, while the `indexTokenCountMap` stays in raw-token space for stability.
 
+### Fading Tier
+
+Every character cap applied to historical tool results (masking, pre-flight truncation, fit-to-budget) derives from one latched **fading tier** (`src/messages/fading.ts`): `{ budgetTokens, masked }`. The budget sits on a ladder that halves the context window per rung; the tier only ever shrinks and masking only ever activates. Because truncation is a pure function of (content, cap), a historical tool result maps to identical bytes on every call within a tier — which is what keeps prefix-based provider prompt caches (Anthropic's single tail breakpoint) valid from turn to turn. Only escalation and compaction rewrite the prefix.
+
+- **Fit rung**: the shallowest rung whose fresh-result cap fits within half the effective budget, so a single tool result can never leave the context empty.
+- **Pressure-band rungs** (summarization disabled only): +1 rung at 85 %, +2 at 90 %, +4 at 99 %.
+- **Masking** latches at 80 % pressure; consumed results then keep 10 % of the fresh cap (floor 300 chars).
+
+The tier is returned from every prune call and exposed as `Run.getFadingTier()`; hosts should persist it beside `calibrationRatio` and pass it back as `RunConfig.fadingTier` so stability holds across runs. The budget is absolute, so a mid-run budget correction or a return to the normal window keeps the tier; only compaction resets it.
+
 **Instruction overhead calibration**: The pruner also tracks `bestInstructionOverhead` — the best observed instruction token count from provider feedback. When the variance between the estimated and calibrated `toolSchemaTokens` exceeds 15% (`CALIBRATION_VARIANCE_THRESHOLD`), the calibrated value is applied to `AgentContext.toolSchemaTokens`. This corrects the local tool-schema estimate (which uses a static multiplier) against real provider behavior. After intra-run summarization, the calibrated overhead is preserved and seeded into the recreated pruner.
 
 ---
@@ -52,11 +62,11 @@ All budget comparisons multiply raw counts by `calibrationRatio` to approximate 
 
 ### Pipeline (every agent node turn)
 
-1. **< 80% pressure**: No modifications. Messages pass through untouched.
+1. **Fit-to-budget truncation** (every turn): the fading tier's fit rung caps any individual tool result and tool-call input so it fits within half the effective budget. The cap is latched, so a historical result keeps the same bytes on later turns.
 
-2. **80%+ pressure — Observation masking**: Consumed ToolMessages masked to ~300 char placeholders. Pre-masking snapshot saved so the summarizer can access un-masked originals later.
+2. **80%+ pressure — Observation masking**: Masking latches on the tier; consumed ToolMessages shrink to 10 % of the fresh cap (floor ~300 chars). Pre-masking snapshot saved so the summarizer can access un-masked originals later.
 
-3. **Fit-to-budget truncation**: Any individual message still exceeding `effectiveMaxTokens` is truncated via `preFlightTruncateToolResults` / `preFlightTruncateToolCallInputs`. Uses 30% of effective budget as per-result cap with recency weighting.
+3. **Apply pass**: `applyFadingCaps` walks only the messages that arrived since the last call (or everything after an escalation) and rewrites the ones above their cap.
 
 4. **Pruning split**: `getMessagesWithinTokenLimit` determines which messages fit (`context`) and which overflow (`messagesToRefine`). Messages are kept newest-first.
 
@@ -94,9 +104,9 @@ The prompt is written in the tone of a user directing the assistant — assertiv
 
 This prevents the model from continuing to roleplay or respond to the conversation instead of producing a structured checkpoint.
 
-### Fallback Fading
+### Emergency Truncation
 
-If observation masking + fit-to-budget still produce an **empty context** (no messages fit at all), context pressure fading is applied as a fallback before emergency truncation. This uses the same pressure-band graduated truncation from the disabled path.
+If masking + fit-to-budget still produce an **empty context** (no messages fit at all), a deeper, temporary tier is derived from a per-message share of the effective budget and applied to a clone of the messages before pruning is retried. The latched tier is left alone: that share depends on the message count, and latching it would pin every future result to one transient event.
 
 ### Cross-Run Behavior
 
@@ -115,22 +125,22 @@ If observation masking + fit-to-budget still produce an **empty context** (no me
 
 2. **80%+ pressure — Observation masking**: Same consumed-only masking as the summarization-enabled path. Consumed ToolMessages masked, unconsumed left intact, AI messages untouched.
 
-3. **80%+ pressure — Context pressure fading**: Additional progressive truncation of remaining oversized tool results based on graduated pressure bands:
+3. **80%+ pressure — Context pressure fading**: The fading tier deepens by extra rungs on top of the fit rung, halving the cap budget per rung:
 
-   | Pressure | Budget factor | Effect                                        |
-   | -------- | ------------- | --------------------------------------------- |
-   | 80%      | 1.0           | Gentle — oldest results get light truncation  |
-   | 85%      | 0.5           | Moderate — older results shrink significantly |
-   | 90%      | 0.2           | Aggressive — most results heavily truncated   |
-   | 99%      | 0.05          | Emergency — effectively one-line placeholders |
+   | Pressure | Extra rungs | Budget factor |
+   | -------- | ----------- | ------------- |
+   | 80%      | 0           | 1.0           |
+   | 85%      | 1           | 0.5           |
+   | 90%      | 2           | 0.25          |
+   | 99%      | 4           | 0.0625        |
 
-   Recency weighting: oldest tool results get 20% of the budget factor, newest get 100%.
+   Every tool result shares one cap at a given tier; the consumed/fresh distinction from masking is the only per-message difference. The tier never relaxes, so a conversation hovering around a threshold does not flip between bands.
 
 4. **Position-based context pruning** (if `contextPruningConfig.enabled`): Additional position-based degradation of old tool results.
 
 5. **Pruning**: `getMessagesWithinTokenLimit` drops oldest messages to fit budget. Orphan repair strips unpaired tool_use/tool_result blocks.
 
-6. **Emergency truncation** (if pruning produces empty context): Proportional budget divided across all messages, aggressive head+tail truncation, retry pruning.
+6. **Emergency truncation** (if pruning produces empty context): A temporary tier derived from the per-message share of the effective budget is applied to a clone, then pruning is retried. The latched tier is not changed.
 
 ### Key Difference from Enabled Path
 

--- a/docs/summarization-behavior.md
+++ b/docs/summarization-behavior.md
@@ -52,7 +52,7 @@ Every character cap applied to historical tool results (masking, pre-flight trun
 - **Pressure-band rungs** (summarization disabled only): +1 rung at 85 %, +2 at 90 %, +4 at 99 %.
 - **Masking** latches at 80 % pressure; consumed results then keep 10 % of the fresh cap (floor 300 chars).
 
-The tier is returned from every prune call and exposed as `Run.getFadingTier()`; hosts should persist it beside `calibrationRatio` and pass it back as `RunConfig.fadingTier` so stability holds across runs. The budget is absolute, so a mid-run budget correction or a return to the normal window keeps the tier; only compaction resets it.
+The tier is returned from every prune call. Single-agent hosts can use `Run.getFadingTier()` and `RunConfig.fadingTier`; multi-agent hosts should persist `Run.getFadingTiers()` and restore `RunConfig.fadingTiers` so each agent keeps its independent tier. The budget is absolute, so a mid-run budget correction or a return to the normal window keeps the tier; only compaction resets it.
 
 **Instruction overhead calibration**: The pruner also tracks `bestInstructionOverhead` — the best observed instruction token count from provider feedback. When the variance between the estimated and calibrated `toolSchemaTokens` exceeds 15% (`CALIBRATION_VARIANCE_THRESHOLD`), the calibrated value is applied to `AgentContext.toolSchemaTokens`. This corrects the local tool-schema estimate (which uses a static multiplier) against real provider behavior. After intra-run summarization, the calibrated overhead is preserved and seeded into the recreated pruner.
 

--- a/docs/summarization-behavior.md
+++ b/docs/summarization-behavior.md
@@ -46,13 +46,15 @@ All budget comparisons multiply raw counts by `calibrationRatio` to approximate 
 
 ### Fading Tier
 
-Every character cap applied to historical tool results (masking, pre-flight truncation, fit-to-budget) derives from one latched **fading tier** (`src/messages/fading.ts`): `{ budgetTokens, masked }`. The budget sits on a ladder that halves the context window per rung; the tier only ever shrinks and masking only ever activates. Because truncation is a pure function of (content, cap), a historical tool result maps to identical bytes on every call within a tier — which is what keeps prefix-based provider prompt caches (Anthropic's single tail breakpoint) valid from turn to turn. Only escalation and compaction rewrite the prefix.
+Every character cap applied to historical tool results (masking, pre-flight truncation, fit-to-budget) derives from one latched **fading tier** (`src/messages/fading.ts`): `{ v, budgetTokens, masked }`. The budget sits on a ladder that halves the context window per rung; the tier only ever shrinks and masking only ever activates. Because truncation is a pure function of (content, cap), a historical tool result maps to identical bytes on every call within a tier — which is what keeps prefix-based provider prompt caches (Anthropic's single tail breakpoint) valid from turn to turn. Only escalation and compaction rewrite the prefix.
 
-- **Fit rung**: the shallowest rung whose fresh-result cap fits within half the effective budget, so a single tool result can never leave the context empty.
+- **Fit rung**: the shallowest rung at which the widest observed parallel tool exchange (call inputs plus fresh results) fits within the effective budget, so a complete exchange can never leave the context empty or lose its results to orphan repair.
 - **Pressure-band rungs** (summarization disabled only): +1 rung at 85 %, +2 at 90 %, +4 at 99 %.
 - **Masking** latches at 80 % pressure; consumed results then keep 10 % of the fresh cap (floor 300 chars).
 
-The tier is returned from every prune call. Single-agent hosts can use `Run.getFadingTier()` and `RunConfig.fadingTier`; multi-agent hosts should persist `Run.getFadingTiers()` and restore `RunConfig.fadingTiers` so each agent keeps its independent tier. The budget is absolute, so a mid-run budget correction or a return to the normal window keeps the tier; only compaction resets it.
+Graph history stays canonical. The pruner keeps the original bytes of every capped tool result and input-capped AI message and builds a provider-facing projection per Run from them, so a deeper tier or masking re-derives from the original content and matches what a fresh Run seeded with the same tier derives from the host's stored messages. Restored tiers are validated at every boundary (`Run`, `StandardGraph`, `AgentSession`); an invalid or fresh seed starts fresh.
+
+The tier is returned from every prune call. Single-agent hosts can use `Run.getFadingTier()` and `RunConfig.fadingTier`; multi-agent hosts should persist `Run.getFadingTiers()` and restore `RunConfig.fadingTiers` so each agent keeps its independent tier. The budget is absolute, so a mid-run budget correction or a return to the normal window keeps the tier; only compaction resets it, and `Run.didResetFadingTier()` / `Run.getFadingTierResetAgentIds()` report that reset to hosts that merge tiers.
 
 **Instruction overhead calibration**: The pruner also tracks `bestInstructionOverhead` — the best observed instruction token count from provider feedback. When the variance between the estimated and calibrated `toolSchemaTokens` exceeds 15% (`CALIBRATION_VARIANCE_THRESHOLD`), the calibrated value is applied to `AgentContext.toolSchemaTokens`. This corrects the local tool-schema estimate (which uses a static multiplier) against real provider behavior. After intra-run summarization, the calibrated overhead is preserved and seeded into the recreated pruner.
 
@@ -62,7 +64,7 @@ The tier is returned from every prune call. Single-agent hosts can use `Run.getF
 
 ### Pipeline (every agent node turn)
 
-1. **Fit-to-budget truncation** (every turn): the fading tier's fit rung caps any individual tool result and tool-call input so it fits within half the effective budget. The cap is latched, so a historical result keeps the same bytes on later turns.
+1. **Fit-to-budget truncation** (every turn): the fading tier's fit rung caps every tool result and tool-call input so the widest observed parallel exchange fits within the effective budget. The cap is latched, so a historical result keeps the same bytes on later turns.
 
 2. **80%+ pressure — Observation masking**: Masking latches on the tier; consumed ToolMessages shrink to 10 % of the fresh cap (floor ~300 chars). Pre-masking snapshot saved so the summarizer can access un-masked originals later.
 
@@ -106,7 +108,7 @@ This prevents the model from continuing to roleplay or respond to the conversati
 
 ### Emergency Truncation
 
-If masking + fit-to-budget still produce an **empty context** (no messages fit at all), a deeper, temporary tier is derived from a per-message share of the effective budget and applied to a clone of the messages before pruning is retried. The latched tier is left alone: that share depends on the message count, and latching it would pin every future result to one transient event.
+If masking + fit-to-budget still produce an **empty context** (no messages fit at all), a deeper, temporary tier at which one complete tool exchange (result plus call input) fits within a per-message share of the effective budget is applied to a clone of the messages before pruning is retried. The latched tier is left alone: that share depends on the message count, and latching it would pin every future result to one transient event.
 
 ### Cross-Run Behavior
 
@@ -140,7 +142,7 @@ If masking + fit-to-budget still produce an **empty context** (no messages fit a
 
 5. **Pruning**: `getMessagesWithinTokenLimit` drops oldest messages to fit budget. Orphan repair strips unpaired tool_use/tool_result blocks.
 
-6. **Emergency truncation** (if pruning produces empty context): A temporary tier derived from the per-message share of the effective budget is applied to a clone, then pruning is retried. The latched tier is not changed.
+6. **Emergency truncation** (if pruning produces empty context): A temporary tier at which one complete tool exchange fits within the per-message share of the effective budget is applied to a clone, then pruning is retried. The latched tier is not changed.
 
 ### Key Difference from Enabled Path
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1233,6 +1233,7 @@ export class AgentContext {
    * Reset context for a new run
    */
   reset(options?: { preserveOriginalToolContent?: boolean }): void {
+    this._fadingTierReset = false;
     this.systemMessageTokens = 0;
     this.dynamicInstructionTokens = 0;
     this.toolSchemaTokens = 0;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1739,6 +1739,9 @@ export class AgentContext {
     if (projection == null || sources == null || prefixChanged) {
       if (prefixChanged) {
         this.pruneMessages = undefined;
+        /** The originals map is keyed by index; a rewritten prefix would let
+         * the summarizer restore one tool's bytes onto another message. */
+        this.pendingOriginalToolContent = undefined;
         this.prepareProviderProjectionRecount(sources);
       }
       projection = messages.map((message) =>

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -277,6 +277,8 @@ export class AgentContext {
   resolvedInstructionOverhead?: number;
   private _pendingOriginalToolContent?: Map<number, string>;
   private pendingOriginalToolContentChars = 0;
+  /** Bounded pre-fading results retained when overflow recreates the pruner. */
+  canonicalToolContent = new Map<number, BaseMessage['content']>();
   /** Pre-masking tool content keyed by message index, consumed by the summarize node. */
   get pendingOriginalToolContent(): Map<number, string> | undefined {
     return this._pendingOriginalToolContent;
@@ -1515,6 +1517,7 @@ export class AgentContext {
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
     this.fadingTier = undefined;
+    this.canonicalToolContent.clear();
   }
 
   /** Sets a cross-run summary that is injected into the system prompt. */
@@ -1528,6 +1531,9 @@ export class AgentContext {
     this.durableSummaryPrecedesMessages = false;
     this._summaryVersion += 1;
     this.systemRunnableStale = true;
+    this.pruneMessages = undefined;
+    this.fadingTier = undefined;
+    this.canonicalToolContent.clear();
   }
 
   /**

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1714,8 +1714,10 @@ export class AgentContext {
     const prefixChanged =
       sources != null &&
       (messages.length < sources.length ||
-        (priorLength > 0 &&
-          messages[priorLength - 1] !== sources[priorLength - 1]));
+        (messages.length === priorLength
+          ? sources.some((source, index) => messages[index] !== source)
+          : priorLength > 0 &&
+            messages[priorLength - 1] !== sources[priorLength - 1]));
 
     if (projection == null || sources == null || prefixChanged) {
       if (prefixChanged) {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -277,8 +277,12 @@ export class AgentContext {
   resolvedInstructionOverhead?: number;
   private _pendingOriginalToolContent?: Map<number, string>;
   private pendingOriginalToolContentChars = 0;
-  /** Bounded pre-fading results retained when overflow recreates the pruner. */
-  canonicalToolContent = new Map<number, BaseMessage['content']>();
+  /** Provider-bound projection for this Run; graph messages remain canonical. */
+  private providerProjectedMessages?: BaseMessage[];
+  /** Canonical object identities corresponding to the projected slots. */
+  private providerProjectionSources?: BaseMessage[];
+  /** Recount after discarding a projection whose token map contains capped sizes. */
+  private providerProjectionRequiresRecount = false;
   /** Pre-masking tool content keyed by message index, consumed by the summarize node. */
   get pendingOriginalToolContent(): Map<number, string> | undefined {
     return this._pendingOriginalToolContent;
@@ -1229,6 +1233,7 @@ export class AgentContext {
     this.indexTokenCountMap = { ...this.baseIndexTokenCountMap };
     this.currentUsage = undefined;
     this.pruneMessages = undefined;
+    this.clearProviderProjection(false);
     this.lastStreamCall = undefined;
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
@@ -1517,7 +1522,7 @@ export class AgentContext {
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
     this.fadingTier = undefined;
-    this.canonicalToolContent.clear();
+    this.clearProviderProjection(false);
   }
 
   /** Sets a cross-run summary that is injected into the system prompt. */
@@ -1533,7 +1538,7 @@ export class AgentContext {
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
     this.fadingTier = undefined;
-    this.canonicalToolContent.clear();
+    this.clearProviderProjection(false);
   }
 
   /**
@@ -1687,12 +1692,68 @@ export class AgentContext {
       this.maxContextTokens = budgetTokens;
     }
     this.pruneMessages = undefined;
+    this.clearProviderProjection(true);
     this._lastSummarizationMsgCount = 0;
     this._lastOverflowPromptTokens =
       promptTokens != null
         ? this.normalizePromptTokens(promptTokens)
         : promptTokens;
     this._overflowRecoveryAttempts += 1;
+  }
+
+  /**
+   * Returns the mutable provider projection for this Run while preserving the
+   * graph-owned messages as the canonical history. Appends are synchronized
+   * incrementally so the pruner's watermarks remain valid. Any rewritten or
+   * compacted canonical prefix starts a fresh projection and pruner.
+   */
+  getProviderProjectedMessages(messages: BaseMessage[]): BaseMessage[] {
+    const sources = this.providerProjectionSources;
+    let projection = this.providerProjectedMessages;
+    const prefixChanged =
+      sources != null &&
+      (messages.length < sources.length ||
+        sources.some((source, index) => messages[index] !== source));
+
+    if (projection == null || sources == null || prefixChanged) {
+      if (prefixChanged) {
+        this.pruneMessages = undefined;
+        this.providerProjectionRequiresRecount = true;
+      }
+      projection = messages.map((message) =>
+        Array.isArray(message.content)
+          ? cloneMessage(message, [...message.content])
+          : message
+      );
+      this.providerProjectedMessages = projection;
+      this.providerProjectionSources = [...messages];
+      if (this.providerProjectionRequiresRecount && this.tokenCounter != null) {
+        const recounted: Record<string, number> = {};
+        for (let i = 0; i < messages.length; i++) {
+          recounted[i] = this.tokenCounter(messages[i]);
+        }
+        this.indexTokenCountMap = recounted;
+        this.providerProjectionRequiresRecount = false;
+      }
+      return projection;
+    }
+
+    for (let i = sources.length; i < messages.length; i++) {
+      const message = messages[i];
+      sources.push(message);
+      projection.push(
+        Array.isArray(message.content)
+          ? cloneMessage(message, [...message.content])
+          : message
+      );
+    }
+    return projection;
+  }
+
+  private clearProviderProjection(recountOnNextUse: boolean): void {
+    this.providerProjectedMessages = undefined;
+    this.providerProjectionSources = undefined;
+    this.providerProjectionRequiresRecount = recountOnNextUse;
   }
 
   /** Applies token calibration only when the observation came from this provider. */

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1793,7 +1793,9 @@ export class AgentContext {
     if (this.providerProjectionSources == null) {
       return;
     }
-    const updateList = Array.isArray(updates) ? updates : [updates];
+    const updateList = (Array.isArray(updates) ? updates : [updates]) as Array<
+      BaseMessageLike | null | undefined
+    >;
     for (const rawUpdate of updateList) {
       if (rawUpdate == null) {
         continue;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -283,6 +283,8 @@ export class AgentContext {
   private providerProjectionSources?: BaseMessage[];
   /** Canonical message IDs used to recognize reducer replacements in O(update). */
   private providerProjectionSourceIds?: Set<string>;
+  /** Conservative counts retained by canonical identity across a rebuild. */
+  private providerProjectionRecountFloors?: WeakMap<BaseMessage, number>;
   /** Recount after discarding a projection whose token map contains capped sizes. */
   private providerProjectionRequiresRecount = false;
   /** Pre-masking tool content keyed by message index, consumed by the summarize node. */
@@ -1724,7 +1726,7 @@ export class AgentContext {
     if (projection == null || sources == null || prefixChanged) {
       if (prefixChanged) {
         this.pruneMessages = undefined;
-        this.providerProjectionRequiresRecount = true;
+        this.prepareProviderProjectionRecount(sources);
       }
       projection = messages.map((message) =>
         Array.isArray(message.content)
@@ -1739,10 +1741,17 @@ export class AgentContext {
       if (this.providerProjectionRequiresRecount && this.tokenCounter != null) {
         const recounted: Record<string, number> = {};
         for (let i = 0; i < messages.length; i++) {
-          recounted[i] = this.tokenCounter(messages[i]);
+          const localCount = this.tokenCounter(messages[i]);
+          const conservativeFloor =
+            this.providerProjectionRecountFloors?.get(messages[i]);
+          recounted[i] =
+            conservativeFloor == null
+              ? localCount
+              : Math.max(localCount, conservativeFloor);
         }
         this.indexTokenCountMap = recounted;
         this.providerProjectionRequiresRecount = false;
+        this.providerProjectionRecountFloors = undefined;
       }
       return projection;
     }
@@ -1789,10 +1798,32 @@ export class AgentContext {
   }
 
   private clearProviderProjection(recountOnNextUse: boolean): void {
+    if (recountOnNextUse) {
+      this.prepareProviderProjectionRecount(this.providerProjectionSources);
+    } else {
+      this.providerProjectionRequiresRecount = false;
+      this.providerProjectionRecountFloors = undefined;
+    }
     this.providerProjectedMessages = undefined;
     this.providerProjectionSources = undefined;
     this.providerProjectionSourceIds = undefined;
-    this.providerProjectionRequiresRecount = recountOnNextUse;
+  }
+
+  private prepareProviderProjectionRecount(
+    sources: BaseMessage[] | undefined
+  ): void {
+    this.providerProjectionRequiresRecount = true;
+    if (sources == null) {
+      return;
+    }
+    const floors = new WeakMap<BaseMessage, number>();
+    for (let i = 0; i < sources.length; i++) {
+      const count = this.indexTokenCountMap[i];
+      if (count != null && Number.isFinite(count) && count >= 0) {
+        floors.set(sources[i], count);
+      }
+    }
+    this.providerProjectionRecountFloors = floors;
   }
 
   /** Applies token calibration only when the observation came from this provider. */

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -286,8 +286,8 @@ export class AgentContext {
   private providerProjectedMessages?: BaseMessage[];
   /** Canonical object identities corresponding to the projected slots. */
   private providerProjectionSources?: BaseMessage[];
-  /** Canonical message IDs used to recognize reducer replacements in O(update). */
-  private providerProjectionSourceIds?: Set<string>;
+  /** Canonical messages by ID, used to distinguish identity replay from replacement. */
+  private providerProjectionSourcesById?: Map<string, BaseMessage>;
   /** Conservative counts retained by canonical identity across a rebuild. */
   private providerProjectionRecountFloors?: WeakMap<BaseMessage, number>;
   /** Recount after discarding a projection whose token map contains capped sizes. */
@@ -1740,8 +1740,10 @@ export class AgentContext {
       );
       this.providerProjectedMessages = projection;
       this.providerProjectionSources = [...messages];
-      this.providerProjectionSourceIds = new Set(
-        messages.flatMap((message) => (message.id == null ? [] : [message.id]))
+      this.providerProjectionSourcesById = new Map(
+        messages.flatMap((message) =>
+          message.id == null ? [] : [[message.id, message] as const]
+        )
       );
       if (this.providerProjectionRequiresRecount && this.tokenCounter != null) {
         const recounted: Record<string, number> = {};
@@ -1765,7 +1767,7 @@ export class AgentContext {
       const message = messages[i];
       sources.push(message);
       if (message.id != null) {
-        this.providerProjectionSourceIds?.add(message.id);
+        this.providerProjectionSourcesById?.set(message.id, message);
       }
       projection.push(
         Array.isArray(message.content)
@@ -1801,10 +1803,13 @@ export class AgentContext {
         continue;
       }
       const update = coerceMessageLikeToMessage(rawUpdate);
+      const priorSource =
+        update.id == null
+          ? undefined
+          : this.providerProjectionSourcesById?.get(update.id);
       if (
         update.getType() === 'remove' ||
-        (update.id != null &&
-          this.providerProjectionSourceIds?.has(update.id) === true)
+        (priorSource != null && priorSource !== update)
       ) {
         this.pruneMessages = undefined;
         this.pendingOriginalToolContent = undefined;
@@ -1823,7 +1828,7 @@ export class AgentContext {
     }
     this.providerProjectedMessages = undefined;
     this.providerProjectionSources = undefined;
-    this.providerProjectionSourceIds = undefined;
+    this.providerProjectionSourcesById = undefined;
   }
 
   private prepareProviderProjectionRecount(

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -281,6 +281,8 @@ export class AgentContext {
   private providerProjectedMessages?: BaseMessage[];
   /** Canonical object identities corresponding to the projected slots. */
   private providerProjectionSources?: BaseMessage[];
+  /** Canonical message IDs used to recognize reducer replacements in O(update). */
+  private providerProjectionSourceIds?: Set<string>;
   /** Recount after discarding a projection whose token map contains capped sizes. */
   private providerProjectionRequiresRecount = false;
   /** Pre-masking tool content keyed by message index, consumed by the summarize node. */
@@ -1731,6 +1733,9 @@ export class AgentContext {
       );
       this.providerProjectedMessages = projection;
       this.providerProjectionSources = [...messages];
+      this.providerProjectionSourceIds = new Set(
+        messages.flatMap((message) => (message.id == null ? [] : [message.id]))
+      );
       if (this.providerProjectionRequiresRecount && this.tokenCounter != null) {
         const recounted: Record<string, number> = {};
         for (let i = 0; i < messages.length; i++) {
@@ -1745,6 +1750,9 @@ export class AgentContext {
     for (let i = sources.length; i < messages.length; i++) {
       const message = messages[i];
       sources.push(message);
+      if (message.id != null) {
+        this.providerProjectionSourceIds?.add(message.id);
+      }
       projection.push(
         Array.isArray(message.content)
           ? cloneMessage(message, [...message.content])
@@ -1754,9 +1762,36 @@ export class AgentContext {
     return projection;
   }
 
+  /**
+   * Invalidates the provider projection when a graph reducer update rewrites
+   * canonical history. Reducer updates expose replacements and removals before
+   * they are folded into a potentially longer array, avoiding a prefix scan on
+   * the normal append-only path.
+   */
+  invalidateProviderProjectionForMessageUpdates(
+    updates: BaseMessage | BaseMessage[]
+  ): void {
+    if (this.providerProjectionSources == null) {
+      return;
+    }
+    const updateList = Array.isArray(updates) ? updates : [updates];
+    for (const update of updateList) {
+      if (
+        update.getType() === 'remove' ||
+        (update.id != null &&
+          this.providerProjectionSourceIds?.has(update.id) === true)
+      ) {
+        this.pruneMessages = undefined;
+        this.clearProviderProjection(true);
+        return;
+      }
+    }
+  }
+
   private clearProviderProjection(recountOnNextUse: boolean): void {
     this.providerProjectedMessages = undefined;
     this.providerProjectionSources = undefined;
+    this.providerProjectionSourceIds = undefined;
     this.providerProjectionRequiresRecount = recountOnNextUse;
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -271,6 +271,8 @@ export class AgentContext {
   deferredToolNames: string[] = [];
   /** Running calibration ratio from the pruner — persisted across runs via contextMeta. */
   calibrationRatio: number = 1;
+  /** Latched context-fading tier from the pruner — persisted across runs via contextMeta. */
+  fadingTier?: t.FadingTier;
   /** Provider-observed instruction overhead from the pruner's best-variance turn. */
   resolvedInstructionOverhead?: number;
   private _pendingOriginalToolContent?: Map<number, string>;
@@ -1512,6 +1514,7 @@ export class AgentContext {
     this._summarizationFailures = 0;
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
+    this.fadingTier = undefined;
   }
 
   /** Sets a cross-run summary that is injected into the system prompt. */
@@ -1904,6 +1907,7 @@ export class AgentContext {
       summarizationEnabled: this.summarizationEnabled,
       reserveRatio: this.summarizationConfig?.reserveRatio,
       calibrationRatio: opts?.calibrationRatio ?? this.calibrationRatio,
+      fadingTier: this.fadingTier,
       getInstructionTokens: () => this.instructionTokens,
     });
     const {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1805,6 +1805,7 @@ export class AgentContext {
           this.providerProjectionSourceIds?.has(update.id) === true)
       ) {
         this.pruneMessages = undefined;
+        this.pendingOriginalToolContent = undefined;
         this.clearProviderProjection(true);
         return;
       }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1,10 +1,15 @@
 /* eslint-disable no-console */
 import { RunnableLambda } from '@langchain/core/runnables';
-import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import {
+  HumanMessage,
+  SystemMessage,
+  coerceMessageLikeToMessage,
+} from '@langchain/core/messages';
 import type {
   UsageMetadata,
   BaseMessage,
   BaseMessageFields,
+  BaseMessageLike,
 } from '@langchain/core/messages';
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type { ExactTokenCountCache } from '@/llm/contextPressureMeter';
@@ -1778,13 +1783,22 @@ export class AgentContext {
    * the normal append-only path.
    */
   invalidateProviderProjectionForMessageUpdates(
-    updates: BaseMessage | BaseMessage[]
+    updates:
+      | BaseMessage
+      | BaseMessageLike
+      | Array<BaseMessage | BaseMessageLike | null | undefined>
+      | null
+      | undefined
   ): void {
     if (this.providerProjectionSources == null) {
       return;
     }
     const updateList = Array.isArray(updates) ? updates : [updates];
-    for (const update of updateList) {
+    for (const rawUpdate of updateList) {
+      if (rawUpdate == null) {
+        continue;
+      }
+      const update = coerceMessageLikeToMessage(rawUpdate);
       if (
         update.getType() === 'remove' ||
         (update.id != null &&

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1710,10 +1710,12 @@ export class AgentContext {
   getProviderProjectedMessages(messages: BaseMessage[]): BaseMessage[] {
     const sources = this.providerProjectionSources;
     let projection = this.providerProjectedMessages;
+    const priorLength = sources?.length ?? 0;
     const prefixChanged =
       sources != null &&
       (messages.length < sources.length ||
-        sources.some((source, index) => messages[index] !== source));
+        (priorLength > 0 &&
+          messages[priorLength - 1] !== sources[priorLength - 1]));
 
     if (projection == null || sources == null || prefixChanged) {
       if (prefixChanged) {

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -407,6 +407,8 @@ export class AgentContext {
   private durableSummaryPrecedesMessages: boolean = false;
   /** Number of summarization cycles that have occurred for this agent context */
   private _summaryVersion: number = 0;
+  /** Whether this run compacted canonical history and reset its fading tier. */
+  private _fadingTierReset: boolean = false;
   /**
    * Message count at the time summarization was last triggered.
    * Used to prevent re-summarizing the same unchanged message set.
@@ -1527,6 +1529,7 @@ export class AgentContext {
     this._durableSummaryTokenCount = tokenCount;
     this.durableSummaryPrecedesMessages = this.summaryPrecedesMessages;
     this._summaryVersion += 1;
+    this._fadingTierReset = true;
     this._summarizationFailures = 0;
     this.systemRunnableStale = true;
     this.pruneMessages = undefined;
@@ -1579,6 +1582,10 @@ export class AgentContext {
 
   get summaryVersion(): number {
     return this._summaryVersion;
+  }
+
+  get fadingTierReset(): boolean {
+    return this._fadingTierReset;
   }
 
   /**

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -88,6 +88,9 @@ describe('AgentContext overflow recovery state', () => {
     });
     const appended = new HumanMessage({ id: 'human-2', content: 'next' });
 
+    context.invalidateProviderProjectionForMessageUpdates(canonical);
+    expect(context.getProviderProjectedMessages(canonical)).toBe(projection);
+
     const updates = [replacement, appended];
     context.pendingOriginalToolContent = new Map([[0, 'full original']]);
     context.invalidateProviderProjectionForMessageUpdates(updates);

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -89,6 +89,7 @@ describe('AgentContext overflow recovery state', () => {
     const appended = new HumanMessage({ id: 'human-2', content: 'next' });
 
     const updates = [replacement, appended];
+    context.pendingOriginalToolContent = new Map([[0, 'full original']]);
     context.invalidateProviderProjectionForMessageUpdates(updates);
     const nextCanonical = messagesStateReducer(canonical, updates);
     const rebuilt = context.getProviderProjectedMessages(nextCanonical);
@@ -100,6 +101,7 @@ describe('AgentContext overflow recovery state', () => {
       'next',
     ]);
     expect(context.indexTokenCountMap).toEqual({ 0: 1, 1: 200, 2: 1 });
+    expect(context.pendingOriginalToolContent).toBeUndefined();
   });
 
   it('accepts reducer message-like and empty updates during invalidation', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -1,3 +1,4 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { AgentContext } from '@/agents/AgentContext';
 import { Providers } from '@/common';
@@ -24,6 +25,41 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.overflowRecoveryAttempts).toBe(1);
     /** Forces the pruner to be rebuilt against the corrected budget. */
     expect(context.pruneMessages).toBeUndefined();
+  });
+
+  it('keeps one provider projection per run and rebuilds it after overflow', () => {
+    const context = AgentContext.fromConfig(
+      {
+        agentId: 'overflow-agent',
+        provider: Providers.ANTHROPIC,
+        instructions: 'Test instructions',
+        maxContextTokens: 1_000_000,
+      } as Partial<t.AgentInputs> as t.AgentInputs,
+      () => 1
+    );
+    const canonical = [
+      new HumanMessage('canonical'),
+      new AIMessage({ content: [{ type: 'text', text: 'answer' }] }),
+    ];
+
+    const projection = context.getProviderProjectedMessages(canonical);
+    projection[0] = new HumanMessage('projected');
+    (projection[1].content as Array<{ text: string }>).unshift({
+      text: 'provider-only',
+    });
+    canonical.push(new HumanMessage('next'));
+
+    expect(context.getProviderProjectedMessages(canonical)).toBe(projection);
+    expect(projection).toHaveLength(3);
+    expect(canonical[0].content).toBe('canonical');
+    expect(canonical[1].content).toEqual([{ type: 'text', text: 'answer' }]);
+
+    context.applyContextBudgetCorrection(190_000, 274_468);
+    const rebuilt = context.getProviderProjectedMessages(canonical);
+
+    expect(rebuilt).not.toBe(projection);
+    expect(rebuilt[0]).toBe(canonical[0]);
+    expect(rebuilt[1].content).toEqual([{ type: 'text', text: 'answer' }]);
   });
 
   it('summarizes the first overflow when deterministic pruning is unavailable', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -102,6 +102,39 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.indexTokenCountMap).toEqual({ 0: 1, 1: 200, 2: 1 });
   });
 
+  it('accepts reducer message-like and empty updates during invalidation', () => {
+    const context = AgentContext.fromConfig(
+      {
+        agentId: 'overflow-agent',
+        provider: Providers.ANTHROPIC,
+        instructions: 'Test instructions',
+        maxContextTokens: 1_000_000,
+      } as Partial<t.AgentInputs> as t.AgentInputs,
+      () => 1
+    );
+    const canonical = [
+      new HumanMessage({ id: 'human-1', content: 'original' }),
+    ];
+    const projection = context.getProviderProjectedMessages(canonical);
+    const replacement = {
+      id: 'human-1',
+      role: 'user' as const,
+      content: 'replacement',
+    };
+
+    expect(() =>
+      context.invalidateProviderProjectionForMessageUpdates([
+        undefined,
+        replacement,
+      ])
+    ).not.toThrow();
+    const nextCanonical = messagesStateReducer(canonical, replacement);
+
+    expect(context.getProviderProjectedMessages(nextCanonical)).not.toBe(
+      projection
+    );
+  });
+
   it('summarizes the first overflow when deterministic pruning is unavailable', () => {
     const context = createContext(1_000_000);
     context.summarizationEnabled = true;

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -66,8 +66,18 @@ describe('AgentContext overflow recovery state', () => {
     expect(context.getProviderProjectedMessages(canonical)).not.toBe(rebuilt);
   });
 
-  it('invalidates a projection when a reducer replacement also appends', () => {
-    const context = createContext(1_000_000);
+  it('invalidates a projection when a reducer replacement also appends', async () => {
+    const context = AgentContext.fromConfig(
+      {
+        agentId: 'overflow-agent',
+        provider: Providers.ANTHROPIC,
+        instructions: 'Test instructions',
+        maxContextTokens: 1_000_000,
+      } as Partial<t.AgentInputs> as t.AgentInputs,
+      () => 1,
+      { 0: 100, 1: 200 }
+    );
+    await context.tokenCalculationPromise;
     const original = new HumanMessage({ id: 'human-1', content: 'original' });
     const existingReply = new AIMessage({ id: 'ai-1', content: 'reply' });
     const canonical = [original, existingReply];
@@ -89,6 +99,7 @@ describe('AgentContext overflow recovery state', () => {
       'reply',
       'next',
     ]);
+    expect(context.indexTokenCountMap).toEqual({ 0: 1, 1: 200, 2: 1 });
   });
 
   it('summarizes the first overflow when deterministic pruning is unavailable', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -60,6 +60,9 @@ describe('AgentContext overflow recovery state', () => {
     expect(rebuilt).not.toBe(projection);
     expect(rebuilt[0]).toBe(canonical[0]);
     expect(rebuilt[1].content).toEqual([{ type: 'text', text: 'answer' }]);
+
+    canonical[canonical.length - 1] = new HumanMessage('rewritten tail');
+    expect(context.getProviderProjectedMessages(canonical)).not.toBe(rebuilt);
   });
 
   it('summarizes the first overflow when deterministic pruning is unavailable', () => {

--- a/src/agents/__tests__/AgentContext.overflow.test.ts
+++ b/src/agents/__tests__/AgentContext.overflow.test.ts
@@ -2,6 +2,7 @@ import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { AgentContext } from '@/agents/AgentContext';
 import { Providers } from '@/common';
+import { messagesStateReducer } from '@/messages/reducer';
 
 /**
  * The overflow-recovery bookkeeping on AgentContext: the budget correction,
@@ -63,6 +64,31 @@ describe('AgentContext overflow recovery state', () => {
 
     canonical[canonical.length - 1] = new HumanMessage('rewritten tail');
     expect(context.getProviderProjectedMessages(canonical)).not.toBe(rebuilt);
+  });
+
+  it('invalidates a projection when a reducer replacement also appends', () => {
+    const context = createContext(1_000_000);
+    const original = new HumanMessage({ id: 'human-1', content: 'original' });
+    const existingReply = new AIMessage({ id: 'ai-1', content: 'reply' });
+    const canonical = [original, existingReply];
+    const projection = context.getProviderProjectedMessages(canonical);
+    const replacement = new HumanMessage({
+      id: 'human-1',
+      content: 'replacement',
+    });
+    const appended = new HumanMessage({ id: 'human-2', content: 'next' });
+
+    const updates = [replacement, appended];
+    context.invalidateProviderProjectionForMessageUpdates(updates);
+    const nextCanonical = messagesStateReducer(canonical, updates);
+    const rebuilt = context.getProviderProjectedMessages(nextCanonical);
+
+    expect(rebuilt).not.toBe(projection);
+    expect(rebuilt.map((message) => message.content)).toEqual([
+      'replacement',
+      'reply',
+      'next',
+    ]);
   });
 
   it('summarizes the first overflow when deterministic pruning is unavailable', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2096,6 +2096,29 @@ describe('AgentContext', () => {
     });
   });
 
+  describe('provider projection rebuild', () => {
+    it('drops the index-keyed original tool content when the canonical prefix changes', () => {
+      const context = createBasicContext();
+      const tool = new ToolMessage({
+        content: 'result',
+        tool_call_id: 'call-1',
+        name: 'tool',
+      });
+      const first = [new HumanMessage('a'), tool];
+      context.getProviderProjectedMessages(first);
+      context.preserveOriginalToolContent(new Map([[1, 'original result']]));
+      expect(context.pendingOriginalToolContent?.get(1)).toBe('original result');
+
+      const shifted = [new HumanMessage('inserted'), ...first];
+      context.getProviderProjectedMessages(shifted);
+      expect(context.pendingOriginalToolContent).toBeUndefined();
+
+      context.preserveOriginalToolContent(new Map([[2, 'original result']]));
+      context.getProviderProjectedMessages([...shifted, new AIMessage('done')]);
+      expect(context.pendingOriginalToolContent?.get(2)).toBe('original result');
+    });
+  });
+
   describe('reset()', () => {
     it('retains the stable-message token cache across resets', async () => {
       const tokenCounter = await createTokenCounter();

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -93,6 +93,16 @@ describe('AgentContext', () => {
   });
 
   describe('Summary carrier', () => {
+    it('clears the per-run fading reset signal on a fresh reset', () => {
+      const ctx = createBasicContext();
+
+      ctx.setSummary('compacted history', 10);
+      expect(ctx.fadingTierReset).toBe(true);
+
+      ctx.reset();
+      expect(ctx.fadingTierReset).toBe(false);
+    });
+
     /** The summary's stored token count is a measurement of the carrier built
      *  by `buildSummaryCarrierText`. If this context ever injected different
      *  text, every budget read against a persisted summary would be wrong by

--- a/src/agents/__tests__/projection.test.ts
+++ b/src/agents/__tests__/projection.test.ts
@@ -1,4 +1,4 @@
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { projectAgentContextUsage } from '../projection';
 import { Providers } from '@/common';
@@ -95,6 +95,43 @@ describe('projectAgentContextUsage', () => {
 
     expect(withExecution!.breakdown.instructionTokens).toBeGreaterThan(
       withoutExecution!.breakdown.instructionTokens
+    );
+  });
+
+  it('applies a persisted fading tier to the projected branch', async () => {
+    const messages = [
+      new HumanMessage('fetch the report'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call-1', name: 'fetch', args: {}, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'x'.repeat(60_000),
+        tool_call_id: 'call-1',
+      }),
+      new AIMessage('report received'),
+    ];
+    const withoutTier = await projectAgentContextUsage({
+      agent: agent(100_000),
+      messages,
+      tokenCounter: countByChars,
+    });
+    const withTier = await projectAgentContextUsage({
+      agent: agent(100_000),
+      messages,
+      tokenCounter: countByChars,
+      fadingTier: {
+        v: 1,
+        budgetTokens: 10_000,
+        masked: true,
+        latched: true,
+      },
+    });
+
+    expect(withTier!.remainingContextTokens).toBeGreaterThan(
+      withoutTier!.remainingContextTokens!
     );
   });
 });

--- a/src/agents/projection.ts
+++ b/src/agents/projection.ts
@@ -13,6 +13,8 @@ export interface ProjectAgentContextUsageParams {
   indexTokenCountMap?: Record<string, number>;
   /** Provider-calibrated ratio from a prior snapshot, applied as a static seed. */
   calibrationRatio?: number;
+  /** Persisted fading tier for this agent, applied to the projected branch. */
+  fadingTier?: t.FadingTier;
   /** Execution backend used to synthesize the live effective tool registry. */
   toolExecution?: t.ToolExecutionConfig;
   runId?: string;
@@ -34,6 +36,7 @@ export async function projectAgentContextUsage({
   tokenCounter,
   indexTokenCountMap,
   calibrationRatio,
+  fadingTier,
   toolExecution,
   runId,
   agentId,
@@ -44,6 +47,7 @@ export async function projectAgentContextUsage({
     indexTokenCountMap,
     toolExecution
   );
+  context.fadingTier = fadingTier;
   await context.tokenCalculationPromise;
   return context.projectContextUsage(messages, {
     runId,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3175,6 +3175,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         } = agentContext.pruneMessages({
           messages: providerMessages,
           canonicalMessages: messages,
+          canonicalPrefixStable: true,
           usageMetadata: agentContext.currentUsage,
           lastCallUsage: agentContext.lastCallUsage,
           totalTokensFresh: agentContext.totalTokensFresh,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2602,6 +2602,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return Object.fromEntries(tiers);
   }
 
+  /** Agent IDs whose canonical history was compacted during this run. */
+  getFadingTierResetAgentIds(): string[] {
+    return Array.from(this.agentContexts)
+      .filter(([, context]) => context.fadingTierReset)
+      .map(([agentId]) => agentId);
+  }
+
+  /** Whether the default agent compacted canonical history during this run. */
+  didResetFadingTier(): boolean {
+    return (
+      this.agentContexts.get(this.defaultAgentId)?.fadingTierReset === true
+    );
+  }
+
   protected override createSubagentFadingResumeState(): Pick<
     SubagentGraphResumeState,
     'fadingTier' | 'fadingTiers'

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1545,8 +1545,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const restoredFadingTier =
         fadingTiers?.[agentConfig.agentId] ??
         (agentConfig.agentId === agents[0].agentId ? fadingTier : undefined);
-      if (restoredFadingTier != null) {
-        agentContext.fadingTier = restoredFadingTier;
+      if (
+        restoredFadingTier != null &&
+        (agentConfig.initialSummary?.text == null ||
+          agentConfig.initialSummary.text === '')
+      ) {
+        agentContext.fadingTier = { ...restoredFadingTier };
       }
 
       this.agentContexts.set(agentConfig.agentId, agentContext);
@@ -2568,7 +2572,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const context = this.agentContexts.get(this.defaultAgentId);
     const tier = context?.fadingTier;
     return isInformativeFadingTier(tier, context?.maxContextTokens)
-      ? tier
+      ? { ...tier }
       : undefined;
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -5079,7 +5079,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
-        reducer: messagesStateReducer,
+        reducer: (a, b) => {
+          agentContext.invalidateProviderProjectionForMessageUpdates(b);
+          return messagesStateReducer(a, b);
+        },
         default: () => [],
       }),
       summarizationRequest: Annotation<t.SummarizationNodeInput | undefined>({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -54,7 +54,6 @@ import {
   CALIBRATION_RATIO_MAX,
   createPruneMessages,
   projectToolMessagesForProvider,
-  calculateMaxToolCallInputChars,
   syncBudgetDerivedFields,
   addTailCacheControl,
   resolvePromptCacheTtl,
@@ -156,6 +155,7 @@ import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
+import { calculateMaxToolCallInputChars } from '@/utils/truncation';
 import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
@@ -1493,6 +1493,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       indexTokenCountMap,
       calibrationRatio,
       fadingTier,
+      fadingTiers,
       subagentUsageSink,
       subagentTasks,
       subagentScope,
@@ -1541,8 +1542,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
       }
-      if (fadingTier != null) {
-        agentContext.fadingTier = fadingTier;
+      const restoredFadingTier =
+        fadingTiers?.[agentConfig.agentId] ??
+        (agentConfig.agentId === agents[0].agentId ? fadingTier : undefined);
+      if (restoredFadingTier != null) {
+        agentContext.fadingTier = restoredFadingTier;
       }
 
       this.agentContexts.set(agentConfig.agentId, agentContext);
@@ -2563,7 +2567,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   getFadingTier(): t.FadingTier | undefined {
     const context = this.agentContexts.get(this.defaultAgentId);
     const tier = context?.fadingTier;
-    return isInformativeFadingTier(tier, context?.maxContextTokens) ? tier : undefined;
+    return isInformativeFadingTier(tier, context?.maxContextTokens)
+      ? tier
+      : undefined;
+  }
+
+  /** Latched context-fading tiers keyed by agent ID. */
+  getFadingTiers(): t.FadingTiers {
+    const tiers: t.FadingTiers = {};
+    for (const [agentId, context] of this.agentContexts) {
+      if (
+        isInformativeFadingTier(context.fadingTier, context.maxContextTokens)
+      ) {
+        tiers[agentId] = context.fadingTier;
+      }
+    }
+    return tiers;
   }
 
   getResolvedInstructionOverhead(): number | undefined {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1491,6 +1491,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       tokenCounter,
       indexTokenCountMap,
       calibrationRatio,
+      fadingTier,
       subagentUsageSink,
       subagentTasks,
       subagentScope,
@@ -1538,6 +1539,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       );
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
+      }
+      if (fadingTier != null) {
+        agentContext.fadingTier = fadingTier;
       }
 
       this.agentContexts.set(agentConfig.agentId, agentContext);
@@ -2551,6 +2555,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return context?.calibrationRatio ?? 1;
   }
 
+  /** Latched context-fading tier for the default agent; hosts persist it with the calibration ratio. */
+  getFadingTier(): t.FadingTier | undefined {
+    return this.agentContexts.get(this.defaultAgentId)?.fadingTier;
+  }
+
   getResolvedInstructionOverhead(): number | undefined {
     const context = this.agentContexts.get(this.defaultAgentId);
     return context?.resolvedInstructionOverhead;
@@ -3080,6 +3089,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           summarizationEnabled: agentContext.summarizationEnabled,
           reserveRatio: agentContext.summarizationConfig?.reserveRatio,
           calibrationRatio: agentContext.calibrationRatio,
+          fadingTier: agentContext.fadingTier,
           getInstructionTokens: () => agentContext.instructionTokens,
           log: (level, message, data) => {
             emitAgentLog(config, level, 'prune', message, data, {
@@ -3098,6 +3108,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           remainingContextTokens,
           newOriginalToolContent,
           calibrationRatio,
+          fadingTier,
           resolvedInstructionOverhead,
           contextBudget,
           effectiveInstructionTokens,
@@ -3121,6 +3132,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (calibrationRatio != null && calibrationRatio > 0) {
           agentContext.calibrationRatio = calibrationRatio;
         }
+        agentContext.fadingTier = fadingTier;
         if (resolvedInstructionOverhead != null) {
           agentContext.resolvedInstructionOverhead =
             resolvedInstructionOverhead;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3103,6 +3103,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * same masking record the configured trigger preserves.
        */
       let prunedOriginalToolContent: Map<number, string> | undefined;
+      const canProjectContext =
+        agentContext.tokenCounter != null &&
+        agentContext.maxContextTokens != null;
+      const providerMessages = canProjectContext
+        ? agentContext.getProviderProjectedMessages(messages)
+        : messages;
       if (
         !agentContext.pruneMessages &&
         agentContext.tokenCounter &&
@@ -3125,7 +3131,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           reserveRatio: agentContext.summarizationConfig?.reserveRatio,
           calibrationRatio: agentContext.calibrationRatio,
           fadingTier: agentContext.fadingTier,
-          canonicalToolContent: agentContext.canonicalToolContent,
           getInstructionTokens: () => agentContext.instructionTokens,
           log: (level, message, data) => {
             emitAgentLog(config, level, 'prune', message, data, {
@@ -3149,20 +3154,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           contextBudget,
           effectiveInstructionTokens,
         } = agentContext.pruneMessages({
-          messages,
+          messages: providerMessages,
+          canonicalMessages: messages,
           usageMetadata: agentContext.currentUsage,
           lastCallUsage: agentContext.lastCallUsage,
           totalTokensFresh: agentContext.totalTokensFresh,
         });
         prunedOriginalToolContent = newOriginalToolContent;
-        /**
-         * Masking rewrites tool content in `state.messages` in place, so this
-         * map is the only surviving copy of the full output. Persist it on
-         * every prune, not just when a summary is about to be written — the
-         * pruner closure that produced it is discarded on the next reset, and
-         * with it any chance of a later summary restoring the real content.
-         * AgentContext bounds what accumulates.
-         */
+        /** Preserve the masking record for the existing overflow/summarization
+         * path. The graph history itself remains canonical; only the provider
+         * projection above is rewritten by fading. */
         agentContext.preserveOriginalToolContent(newOriginalToolContent);
         agentContext.indexTokenCountMap = indexTokenCountMap;
         if (calibrationRatio != null && calibrationRatio > 0) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -163,7 +163,7 @@ import { initializeLangfuseTracing } from '@/instrumentation';
 import { shouldTriggerSummarization } from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
-import { isInformativeFadingTier } from '@/messages/fading';
+import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createSummarizeNode } from '@/summarization/node';
 import { getTruncationStopReason } from '@/llm/truncation';
 import { messagesStateReducer } from '@/messages/reducer';
@@ -1562,7 +1562,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       /** A supplied tier is assumed to describe the supplied history. Hosts
        * must clear it when they create a new summary; this also permits tiers
        * learned on turns after a durable summary to survive subsequent Runs. */
-      if (restoredFadingTier != null) {
+      if (isFadingTier(restoredFadingTier)) {
         agentContext.fadingTier = { ...restoredFadingTier };
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1542,9 +1542,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
       }
-      const restoredFadingTier =
-        fadingTiers?.[agentConfig.agentId] ??
-        (agentConfig.agentId === agents[0].agentId ? fadingTier : undefined);
+      let restoredFadingTier: t.FadingTier | null | undefined;
+      if (
+        fadingTiers != null &&
+        Object.prototype.hasOwnProperty.call(fadingTiers, agentConfig.agentId)
+      ) {
+        restoredFadingTier = fadingTiers[agentConfig.agentId];
+      } else if (agentConfig.agentId === agents[0].agentId) {
+        restoredFadingTier = fadingTier;
+      }
       if (
         restoredFadingTier != null &&
         (agentConfig.initialSummary?.text == null ||
@@ -2578,15 +2584,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /** Latched context-fading tiers keyed by agent ID. */
   getFadingTiers(): t.FadingTiers {
-    const tiers: t.FadingTiers = {};
+    const tiers: Array<[string, t.FadingTier]> = [];
     for (const [agentId, context] of this.agentContexts) {
       if (
         isInformativeFadingTier(context.fadingTier, context.maxContextTokens)
       ) {
-        tiers[agentId] = { ...context.fadingTier };
+        tiers.push([agentId, { ...context.fadingTier }]);
       }
     }
-    return tiers;
+    return Object.fromEntries(tiers);
   }
 
   getResolvedInstructionOverhead(): number | undefined {
@@ -3119,6 +3125,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           reserveRatio: agentContext.summarizationConfig?.reserveRatio,
           calibrationRatio: agentContext.calibrationRatio,
           fadingTier: agentContext.fadingTier,
+          canonicalToolContent: agentContext.canonicalToolContent,
           getInstructionTokens: () => agentContext.instructionTokens,
           log: (level, message, data) => {
             emitAgentLog(config, level, 'prune', message, data, {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2579,7 +2579,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (
         isInformativeFadingTier(context.fadingTier, context.maxContextTokens)
       ) {
-        tiers[agentId] = context.fadingTier;
+        tiers[agentId] = { ...context.fadingTier };
       }
     }
     return tiers;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1551,11 +1551,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       } else if (agentConfig.agentId === agents[0].agentId) {
         restoredFadingTier = fadingTier;
       }
-      if (
-        restoredFadingTier != null &&
-        (agentConfig.initialSummary?.text == null ||
-          agentConfig.initialSummary.text === '')
-      ) {
+      /** A supplied tier is assumed to describe the supplied history. Hosts
+       * must clear it when they create a new summary; this also permits tiers
+       * learned on turns after a durable summary to survive subsequent Runs. */
+      if (restoredFadingTier != null) {
         agentContext.fadingTier = { ...restoredFadingTier };
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1071,6 +1071,13 @@ export abstract class Graph<
     return [...threadIds];
   }
 
+  protected createSubagentFadingResumeState(): Pick<
+    SubagentGraphResumeState,
+    'fadingTier' | 'fadingTiers'
+    > {
+    return {};
+  }
+
   createSubagentResumeState(runId: string): SubagentGraphResumeState {
     return {
       toolCallSteps: [...this.toolCallStepIds].map(([toolCallId, stepId]) => ({
@@ -1108,6 +1115,7 @@ export abstract class Graph<
       ],
       eagerToolSuppressions: [...this.eagerEventToolSuppressions],
       runStepState: this.createRunStepResumeState(),
+      ...this.createSubagentFadingResumeState(),
       ...(this._toolOutputRegistry == null
         ? {}
         : {
@@ -2592,6 +2600,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
     }
     return Object.fromEntries(tiers);
+  }
+
+  protected override createSubagentFadingResumeState(): Pick<
+    SubagentGraphResumeState,
+    'fadingTier' | 'fadingTiers'
+    > {
+    const fadingTier = this.getFadingTier();
+    const fadingTiers = this.getFadingTiers();
+    return {
+      ...(fadingTier == null ? {} : { fadingTier }),
+      ...(Object.keys(fadingTiers).length === 0 ? {} : { fadingTiers }),
+    };
   }
 
   getResolvedInstructionOverhead(): number | undefined {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -163,6 +163,7 @@ import { initializeLangfuseTracing } from '@/instrumentation';
 import { shouldTriggerSummarization } from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
+import { isInformativeFadingTier } from '@/messages/fading';
 import { createSummarizeNode } from '@/summarization/node';
 import { getTruncationStopReason } from '@/llm/truncation';
 import { messagesStateReducer } from '@/messages/reducer';
@@ -2555,9 +2556,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return context?.calibrationRatio ?? 1;
   }
 
-  /** Latched context-fading tier for the default agent; hosts persist it with the calibration ratio. */
+  /**
+   * Latched context-fading tier for the default agent, or undefined while it
+   * is still fresh. Hosts persist it beside the calibration ratio.
+   */
   getFadingTier(): t.FadingTier | undefined {
-    return this.agentContexts.get(this.defaultAgentId)?.fadingTier;
+    const context = this.agentContexts.get(this.defaultAgentId);
+    const tier = context?.fadingTier;
+    return isInformativeFadingTier(tier, context?.maxContextTokens) ? tier : undefined;
   }
 
   getResolvedInstructionOverhead(): number | undefined {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1586,17 +1586,21 @@ export class MultiAgentGraph extends StandardGraph {
             if (prompt.includes('{results}')) {
               const resultsMessages = state.messages.slice(this.startIndex);
               const destinationContext = this.agentContexts.get(destination);
+              const maxRoutingPromptChars = calculateMaxToolResultChars(
+                destinationContext?.maxContextTokens
+              );
               const resultsString = serializeToolContentBounded(
                 getBufferString(resultsMessages),
-                calculateMaxToolResultChars(
-                  destinationContext?.maxContextTokens
-                )
+                maxRoutingPromptChars
               );
               const promptTemplate = PromptTemplate.fromTemplate(prompt);
               const result = await promptTemplate.invoke({
                 results: resultsString,
               });
-              promptText = result.value;
+              promptText = serializeToolContentBounded(
+                result.value,
+                maxRoutingPromptChars
+              );
               effectiveExcludeResults =
                 excludeResults !== false && promptText !== '';
             } else {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1598,10 +1598,14 @@ export class MultiAgentGraph extends StandardGraph {
           };
 
           if (typeof prompt === 'function') {
-            promptText = serializeToolContentBounded(
-              await prompt(state.messages, this.startIndex),
-              await getMaxRoutingPromptChars()
-            );
+            const resolvedPrompt = await prompt(state.messages, this.startIndex);
+            promptText =
+              resolvedPrompt == null
+                ? undefined
+                : serializeToolContentBounded(
+                  resolvedPrompt,
+                  await getMaxRoutingPromptChars()
+                );
           } else if (prompt != null) {
             if (prompt.includes('{results}')) {
               const resultsMessages = state.messages.slice(this.startIndex);

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1594,12 +1594,13 @@ export class MultiAgentGraph extends StandardGraph {
                   ? undefined
                   : destinationContext.getTokenBudgetBreakdown()
                     .availableForMessages;
-              const maxRoutingPromptChars =
-                availableMessageTokens == null
-                  ? HARD_MAX_TOOL_RESULT_CHARS
-                  : availableMessageTokens <= 0
+              let maxRoutingPromptChars = HARD_MAX_TOOL_RESULT_CHARS;
+              if (availableMessageTokens != null) {
+                maxRoutingPromptChars =
+                  availableMessageTokens <= 0
                     ? 0
                     : calculateMaxToolResultChars(availableMessageTokens);
+              }
               const resultsString = serializeToolContentBounded(
                 getBufferString(resultsMessages),
                 maxRoutingPromptChars

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -30,7 +30,10 @@ import {
 } from '@/messages/provenance';
 import { serializeToolContentBounded } from '@/utils/toolContent';
 import { Constants, MULTI_AGENT_GRAPH_RUN_NAME } from '@/common';
-import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import {
+  calculateMaxToolResultChars,
+  HARD_MAX_TOOL_RESULT_CHARS,
+} from '@/utils/truncation';
 import { StandardGraph } from './Graph';
 
 /** Pattern to extract instructions from transfer ToolMessage content */
@@ -1582,7 +1585,13 @@ export class MultiAgentGraph extends StandardGraph {
           } else if (prompt != null) {
             if (prompt.includes('{results}')) {
               const resultsMessages = state.messages.slice(this.startIndex);
-              const resultsString = getBufferString(resultsMessages);
+              const destinationContext = this.agentContexts.get(destination);
+              const resultsString = serializeToolContentBounded(
+                getBufferString(resultsMessages),
+                calculateMaxToolResultChars(
+                  destinationContext?.maxContextTokens
+                )
+              );
               const promptTemplate = PromptTemplate.fromTemplate(prompt);
               const result = await promptTemplate.invoke({
                 results: resultsString,

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1579,28 +1579,33 @@ export class MultiAgentGraph extends StandardGraph {
         builder.addNode(wrapperNodeId, async (state: t.BaseGraphState) => {
           let promptText: string | undefined;
           let effectiveExcludeResults = excludeResults;
+          const getMaxRoutingPromptChars = async (): Promise<number> => {
+            const destinationContext = this.agentContexts.get(destination);
+            if (destinationContext?.tokenCalculationPromise != null) {
+              await destinationContext.tokenCalculationPromise;
+            }
+            const availableMessageTokens =
+              destinationContext?.maxContextTokens == null
+                ? undefined
+                : destinationContext.getTokenBudgetBreakdown()
+                  .availableForMessages;
+            if (availableMessageTokens == null) {
+              return HARD_MAX_TOOL_RESULT_CHARS;
+            }
+            return availableMessageTokens <= 0
+              ? 0
+              : calculateMaxToolResultChars(availableMessageTokens);
+          };
 
           if (typeof prompt === 'function') {
-            promptText = await prompt(state.messages, this.startIndex);
+            promptText = serializeToolContentBounded(
+              await prompt(state.messages, this.startIndex),
+              await getMaxRoutingPromptChars()
+            );
           } else if (prompt != null) {
             if (prompt.includes('{results}')) {
               const resultsMessages = state.messages.slice(this.startIndex);
-              const destinationContext = this.agentContexts.get(destination);
-              if (destinationContext?.tokenCalculationPromise != null) {
-                await destinationContext.tokenCalculationPromise;
-              }
-              const availableMessageTokens =
-                destinationContext?.maxContextTokens == null
-                  ? undefined
-                  : destinationContext.getTokenBudgetBreakdown()
-                    .availableForMessages;
-              let maxRoutingPromptChars = HARD_MAX_TOOL_RESULT_CHARS;
-              if (availableMessageTokens != null) {
-                maxRoutingPromptChars =
-                  availableMessageTokens <= 0
-                    ? 0
-                    : calculateMaxToolResultChars(availableMessageTokens);
-              }
+              const maxRoutingPromptChars = await getMaxRoutingPromptChars();
               const resultsString = serializeToolContentBounded(
                 getBufferString(resultsMessages),
                 maxRoutingPromptChars

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -973,6 +973,29 @@ export class MultiAgentGraph extends StandardGraph {
    * @param agentId - The agent ID to check for handoff reception
    * @returns Object with filtered messages, extracted instructions, source agent, and parallel siblings
    */
+  /**
+   * Character cap for text injected into an agent's context as a routing or
+   * handoff prompt, derived from that agent's remaining message budget. Fading
+   * only shrinks tool content, so a prompt above this cap could overflow the
+   * agent's window or force the routing instruction out of its context.
+   */
+  private async resolveMaxRoutingPromptChars(agentId: string): Promise<number> {
+    const agentContext = this.agentContexts.get(agentId);
+    if (agentContext?.tokenCalculationPromise != null) {
+      await agentContext.tokenCalculationPromise;
+    }
+    const availableMessageTokens =
+      agentContext?.maxContextTokens == null
+        ? undefined
+        : agentContext.getTokenBudgetBreakdown().availableForMessages;
+    if (availableMessageTokens == null) {
+      return HARD_MAX_TOOL_RESULT_CHARS;
+    }
+    return availableMessageTokens <= 0
+      ? 0
+      : calculateMaxToolResultChars(availableMessageTokens);
+  }
+
   private processHandoffReception(
     messages: BaseMessage[],
     agentId: string
@@ -1361,6 +1384,12 @@ export class MultiAgentGraph extends StandardGraph {
            */
           const hasInstructions = instructions !== null && instructions !== '';
           if (hasInstructions) {
+            /** Bounded like a direct-edge routing prompt: a HumanMessage is
+             * not tool content, so fading could never shrink it later. */
+            const boundedInstructions = serializeToolContentBounded(
+              instructions,
+              await this.resolveMaxRoutingPromptChars(agentId)
+            );
             const lastMsg =
               filteredMessages.length > 0
                 ? filteredMessages[filteredMessages.length - 1]
@@ -1374,12 +1403,12 @@ export class MultiAgentGraph extends StandardGraph {
                     `[Processed tool result and transferring to ${agentId}]`
                   )
                 ),
-                buildRoutingPrompt(instructions),
+                buildRoutingPrompt(boundedInstructions),
               ];
             } else {
               messagesForAgent = [
                 ...filteredMessages,
-                buildRoutingPrompt(instructions),
+                buildRoutingPrompt(boundedInstructions),
               ];
             }
           }
@@ -1579,23 +1608,8 @@ export class MultiAgentGraph extends StandardGraph {
         builder.addNode(wrapperNodeId, async (state: t.BaseGraphState) => {
           let promptText: string | undefined;
           let effectiveExcludeResults = excludeResults;
-          const getMaxRoutingPromptChars = async (): Promise<number> => {
-            const destinationContext = this.agentContexts.get(destination);
-            if (destinationContext?.tokenCalculationPromise != null) {
-              await destinationContext.tokenCalculationPromise;
-            }
-            const availableMessageTokens =
-              destinationContext?.maxContextTokens == null
-                ? undefined
-                : destinationContext.getTokenBudgetBreakdown()
-                  .availableForMessages;
-            if (availableMessageTokens == null) {
-              return HARD_MAX_TOOL_RESULT_CHARS;
-            }
-            return availableMessageTokens <= 0
-              ? 0
-              : calculateMaxToolResultChars(availableMessageTokens);
-          };
+          const getMaxRoutingPromptChars = (): Promise<number> =>
+            this.resolveMaxRoutingPromptChars(destination);
 
           if (typeof prompt === 'function') {
             const resolvedPrompt = await prompt(state.messages, this.startIndex);

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1586,9 +1586,20 @@ export class MultiAgentGraph extends StandardGraph {
             if (prompt.includes('{results}')) {
               const resultsMessages = state.messages.slice(this.startIndex);
               const destinationContext = this.agentContexts.get(destination);
-              const maxRoutingPromptChars = calculateMaxToolResultChars(
-                destinationContext?.maxContextTokens
-              );
+              if (destinationContext?.tokenCalculationPromise != null) {
+                await destinationContext.tokenCalculationPromise;
+              }
+              const availableMessageTokens =
+                destinationContext?.maxContextTokens == null
+                  ? undefined
+                  : destinationContext.getTokenBudgetBreakdown()
+                    .availableForMessages;
+              const maxRoutingPromptChars =
+                availableMessageTokens == null
+                  ? HARD_MAX_TOOL_RESULT_CHARS
+                  : availableMessageTokens <= 0
+                    ? 0
+                    : calculateMaxToolResultChars(availableMessageTokens);
               const resultsString = serializeToolContentBounded(
                 getBufferString(resultsMessages),
                 maxRoutingPromptChars

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -718,6 +718,77 @@ describe('LangGraph composition smoke tests', () => {
     }
   });
 
+  it('bounds handoff instructions to the destination budget', async () => {
+    const largeInstructions = `BEGIN\n${'large handoff instruction '.repeat(2000)}\nEND`;
+    class LargeHandoffChatModel extends FakeChatModel {
+      readonly invocations: BaseMessage[][] = [];
+      private invocationIndex = 0;
+
+      constructor() {
+        super({ responses: ['unused'] });
+      }
+
+      override async *_streamResponseChunks(
+        messages: BaseMessage[],
+        _options: this['ParsedCallOptions'],
+        runManager?: CallbackManagerForLLMRun
+      ): AsyncGenerator<ChatGenerationChunk> {
+        this.invocations.push(messages);
+        if (this.invocationIndex++ === 0) {
+          yield this._createResponseChunk('', [
+            {
+              id: 'transfer_large',
+              name: `${Constants.LC_TRANSFER_TO_}destination`,
+              args: JSON.stringify({ instructions: largeInstructions }),
+              index: 0,
+              type: 'tool_call_chunk',
+            },
+          ]);
+          void runManager?.handleLLMNewToken('');
+          return;
+        }
+        yield this._createResponseChunk('handoff complete');
+        void runManager?.handleLLMNewToken('handoff complete');
+      }
+    }
+    const model = new LargeHandoffChatModel();
+    const graph = new MultiAgentGraph({
+      runId: 'bounded-handoff-instructions',
+      tokenCounter: countMessageChars,
+      agents: [
+        makeAgent('source'),
+        {
+          ...makeAgent('destination'),
+          instructions: 'routing instruction '.repeat(120),
+          maxContextTokens: 1000,
+        },
+      ],
+      edges: [
+        {
+          from: 'source',
+          to: 'destination',
+          edgeType: 'handoff',
+          prompt: 'Provide transfer instructions.',
+        },
+      ],
+    });
+    graph.overrideModel = model;
+
+    await graph
+      .createWorkflow()
+      .invoke(
+        { messages: [new HumanMessage('start')] },
+        makeConfig('bounded-handoff-instructions')
+      );
+
+    const routingPrompt = model.invocations
+      .flat()
+      .find((message) => message.additional_kwargs.source === 'routing');
+    expect(routingPrompt?.content).toEqual(expect.stringContaining('truncated'));
+    expect(String(routingPrompt?.content).length).toBeLessThan(500);
+    expect(largeInstructions.length).toBeGreaterThan(40_000);
+  });
+
   it('compiles mixed handoff and direct routing from the same agent', () => {
     const graph = new MultiAgentGraph({
       runId: 'mixed-routing-smoke',

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -33,6 +33,13 @@ const makeStreamConfig = (threadId: string): t.WorkflowValuesStreamConfig => ({
   streamMode: 'values' as const,
 });
 
+const countMessageChars: t.TokenCounter = (message) =>
+  Math.ceil(
+    (typeof message.content === 'string'
+      ? message.content.length
+      : JSON.stringify(message.content).length) / 4
+  );
+
 const getAiContents = (messages: t.BaseGraphState['messages']): string[] =>
   messages
     .filter((message) => message.getType() === 'ai')
@@ -486,12 +493,7 @@ describe('LangGraph composition smoke tests', () => {
     const model = new CapturingChatModel([largeResult, 'done']);
     const graph = new MultiAgentGraph({
       runId: 'bounded-routing-results',
-      tokenCounter: (message) =>
-        Math.ceil(
-          (typeof message.content === 'string'
-            ? message.content.length
-            : JSON.stringify(message.content).length) / 4
-        ),
+      tokenCounter: countMessageChars,
       agents: [
         makeAgent('source'),
         {
@@ -517,6 +519,47 @@ describe('LangGraph composition smoke tests', () => {
       .invoke(
         { messages: [new HumanMessage('start')] },
         makeConfig('bounded-routing-results')
+      );
+
+    const routingPrompt = model.invocations[1].find(
+      (message) => message.additional_kwargs.source === 'routing'
+    );
+    expect(routingPrompt?.content).toEqual(expect.stringContaining('truncated'));
+    expect(String(routingPrompt?.content).length).toBeLessThan(500);
+    expect(largeResult).toContain('large routed result');
+  });
+
+  it('bounds routing text returned by prompt functions', async () => {
+    const largeResult = `BEGIN\n${'large routed result '.repeat(2000)}\nEND`;
+    const model = new CapturingChatModel([largeResult, 'done']);
+    const graph = new MultiAgentGraph({
+      runId: 'bounded-function-routing-results',
+      tokenCounter: countMessageChars,
+      agents: [
+        makeAgent('source'),
+        {
+          ...makeAgent('destination'),
+          instructions: 'routing instruction '.repeat(120),
+          maxContextTokens: 1000,
+        },
+      ],
+      edges: [
+        {
+          from: 'source',
+          to: 'destination',
+          edgeType: 'direct',
+          prompt: (messages) => getBufferString(messages),
+          excludeResults: true,
+        },
+      ],
+    });
+    graph.overrideModel = model;
+
+    await graph
+      .createWorkflow()
+      .invoke(
+        { messages: [new HumanMessage('start')] },
+        makeConfig('bounded-function-routing-results')
       );
 
     const routingPrompt = model.invocations[1].find(

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -570,6 +570,37 @@ describe('LangGraph composition smoke tests', () => {
     expect(largeResult).toContain('large routed result');
   });
 
+  it('preserves an undefined function prompt as no routing message', async () => {
+    const model = new CapturingChatModel(['source result', 'done']);
+    const graph = new MultiAgentGraph({
+      runId: 'undefined-function-routing-prompt',
+      agents: [makeAgent('source'), makeAgent('destination')],
+      edges: [
+        {
+          from: 'source',
+          to: 'destination',
+          edgeType: 'direct',
+          prompt: () => undefined,
+          excludeResults: true,
+        },
+      ],
+    });
+    graph.overrideModel = model;
+
+    await graph
+      .createWorkflow()
+      .invoke(
+        { messages: [new HumanMessage('start')] },
+        makeConfig('undefined-function-routing-prompt')
+      );
+
+    expect(
+      model.invocations[1].some(
+        (message) => message.additional_kwargs.source === 'routing'
+      )
+    ).toBe(false);
+  });
+
   it.each([
     ['without a prompt wrapper', undefined],
     ['with a prompt wrapper', 'Summarize these results:\n{results}'],

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -481,6 +481,42 @@ describe('LangGraph composition smoke tests', () => {
     expect(graph.getParallelGroupId('final')).toBeUndefined();
   });
 
+  it('bounds results before interpolating a routing prompt', async () => {
+    const largeResult = `BEGIN\n${'large routed result '.repeat(2000)}\nEND`;
+    const model = new CapturingChatModel([largeResult, 'done']);
+    const graph = new MultiAgentGraph({
+      runId: 'bounded-routing-results',
+      agents: [
+        makeAgent('source'),
+        { ...makeAgent('destination'), maxContextTokens: 1000 },
+      ],
+      edges: [
+        {
+          from: 'source',
+          to: 'destination',
+          edgeType: 'direct',
+          prompt: 'Review this result:\n{results}',
+          excludeResults: true,
+        },
+      ],
+    });
+    graph.overrideModel = model;
+
+    await graph
+      .createWorkflow()
+      .invoke(
+        { messages: [new HumanMessage('start')] },
+        makeConfig('bounded-routing-results')
+      );
+
+    const routingPrompt = model.invocations[1].find(
+      (message) => message.additional_kwargs.source === 'routing'
+    );
+    expect(routingPrompt?.content).toEqual(expect.stringContaining('truncated'));
+    expect(String(routingPrompt?.content).length).toBeLessThan(1300);
+    expect(largeResult).toContain('large routed result');
+  });
+
   it.each([
     ['without a prompt wrapper', undefined],
     ['with a prompt wrapper', 'Summarize these results:\n{results}'],

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -495,7 +495,7 @@ describe('LangGraph composition smoke tests', () => {
           from: 'source',
           to: 'destination',
           edgeType: 'direct',
-          prompt: 'Review this result:\n{results}',
+          prompt: `${'large static prefix '.repeat(1000)}\n{results}\n{results}`,
           excludeResults: true,
         },
       ],

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -488,7 +488,11 @@ describe('LangGraph composition smoke tests', () => {
       runId: 'bounded-routing-results',
       agents: [
         makeAgent('source'),
-        { ...makeAgent('destination'), maxContextTokens: 1000 },
+        {
+          ...makeAgent('destination'),
+          instructions: 'routing instruction '.repeat(120),
+          maxContextTokens: 1000,
+        },
       ],
       edges: [
         {
@@ -513,7 +517,7 @@ describe('LangGraph composition smoke tests', () => {
       (message) => message.additional_kwargs.source === 'routing'
     );
     expect(routingPrompt?.content).toEqual(expect.stringContaining('truncated'));
-    expect(String(routingPrompt?.content).length).toBeLessThan(1300);
+    expect(String(routingPrompt?.content).length).toBeLessThan(500);
     expect(largeResult).toContain('large routed result');
   });
 

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -486,6 +486,12 @@ describe('LangGraph composition smoke tests', () => {
     const model = new CapturingChatModel([largeResult, 'done']);
     const graph = new MultiAgentGraph({
       runId: 'bounded-routing-results',
+      tokenCounter: (message) =>
+        Math.ceil(
+          (typeof message.content === 'string'
+            ? message.content.length
+            : JSON.stringify(message.content).length) / 4
+        ),
       agents: [
         makeAgent('source'),
         {

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -48,11 +48,13 @@ import {
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
 import {
+  HARD_MAX_TOOL_RESULT_CHARS,
   calculateMaxToolCallInputChars,
+} from '@/utils/truncation';
+import {
   projectToolCallInputs,
   serializeToolCallInput,
 } from '@/messages/prune';
-import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from '@/messages/langchain';
 
 export type { OpenAICallOptions, OpenAIChatInput };

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -3,8 +3,7 @@ import {
   _convertMessagesToOpenAIParams,
   _convertMessagesToOpenAIResponsesParams,
 } from './index';
-import { calculateMaxToolCallInputChars } from '@/messages/prune';
-import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import { calculateMaxToolCallInputChars, HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 
 describe('_convertMessagesToOpenAIParams', () => {
   it('includes reasoning_content for assistant messages in tool-call context when requested', () => {

--- a/src/llm/preempt.ts
+++ b/src/llm/preempt.ts
@@ -5,7 +5,10 @@ import {
   DEFAULT_MAX_SEALS,
   DEFAULT_PREEMPT_RESTART_GRACE_MS,
 } from '@/common';
-import { isReasoningContentBlock } from '@/messages/core';
+import {
+  hasNonEmptyTextContent,
+  isReasoningContentBlock,
+} from '@/messages/core';
 
 /**
  * Normalizes a host-supplied seal budget.
@@ -33,22 +36,6 @@ export function resolveMaxSeals(maxSeals: number | undefined): number {
  * stripped or signed on several providers and cannot stand in for the visible
  * assistant turn a sealed sequence needs.
  */
-function hasNonEmptyTextContent(content: AIMessageChunk['content']): boolean {
-  if (typeof content === 'string') {
-    return content.trim() !== '';
-  }
-  for (const block of content) {
-    if (block.type !== ContentTypes.TEXT) {
-      continue;
-    }
-    const text = block[ContentTypes.TEXT];
-    if (typeof text === 'string' && text.trim() !== '') {
-      return true;
-    }
-  }
-  return false;
-}
-
 /**
  * True while a Gemini server-side tool call is still awaiting its response.
  *

--- a/src/messages/__tests__/observationMasking.test.ts
+++ b/src/messages/__tests__/observationMasking.test.ts
@@ -300,6 +300,28 @@ describe('maskConsumedToolResults', () => {
     expect(originalContentStore.get(2)).toContain('truncated');
   });
 
+  it('preserves the legacy aggregate masking budget', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('hello'),
+      aiToolCall('tc_old'),
+      toolMsg('A'.repeat(5_000), 'tool', 'tc_old'),
+      aiToolCall('tc_new'),
+      toolMsg('B'.repeat(5_000), 'tool', 'tc_new'),
+      aiWithText('done'),
+    ];
+
+    const count = maskConsumedToolResults({
+      messages,
+      indexTokenCountMap: {},
+      tokenCounter: charCounter,
+      availableRawBudget: 500,
+    });
+
+    expect(count).toBe(2);
+    expect((messages[2].content as string).length).toBeLessThanOrEqual(350);
+    expect((messages[4].content as string).length).toBeGreaterThan(1_000);
+  });
+
   it('handles empty messages array', () => {
     const map: Record<string, number | undefined> = {};
     const count = maskConsumedToolResults({

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1007,6 +1007,49 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     const again = pruneMessages({ messages, canonicalMessages });
     expect(again.fadingTier).toEqual(result.fadingTier);
   });
+
+  it('sizes parallel exchanges represented only by raw OpenAI tool calls', () => {
+    const ids = ['raw-1', 'raw-2', 'raw-3', 'raw-4'];
+    const rawToolCall = new AIMessage({
+      content: '',
+      tool_calls: [],
+    });
+    rawToolCall.additional_kwargs.tool_calls = ids.map((id) => ({
+      id,
+      type: 'function',
+      function: { name: 'fetch', arguments: '{}' },
+    }));
+    const canonicalMessages: BaseMessage[] = [
+      ...conversation(Array(20).fill(200)),
+      new HumanMessage('fetch everything at once'),
+      rawToolCall,
+      ...ids.map((id) => toolResult(id, 47_000)),
+    ];
+    const messages = [...canonicalMessages];
+    const pruneMessages = createPruneMessages({
+      provider: Providers.OPENAI,
+      maxTokens,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: true,
+      calibrationRatio: 1,
+    });
+
+    const result = pruneMessages({ messages, canonicalMessages });
+
+    expect(result.context.length).toBeGreaterThan(0);
+    expect(result.fadingTier.budgetTokens).toBe(20_000);
+    for (const id of ids) {
+      expect(
+        result.context.some(
+          (message) =>
+            message.getType() === 'tool' &&
+            (message as ToolMessage).tool_call_id === id
+        )
+      ).toBe(true);
+    }
+  });
 });
 
 describe('isInformativeFadingTier', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -23,6 +23,7 @@ import {
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { ContentTypes, Providers } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
+import { hasNonEmptyTextContent } from '@/messages/core';
 
 const tokenCounter: TokenCounter = (message) => {
   const content = message.content;
@@ -507,6 +508,20 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(serialize(messages[2])).toContain('truncated');
     expect(serialize(messages[2]).length).toBeLessThan(50_000);
     expect(serialize(canonicalMessages[2]).length).toBeGreaterThan(50_000);
+
+    canonicalMessages[2] = new ToolMessage({
+      content: `APPENDED:${'a'.repeat(50_000)}`,
+      tool_call_id: 'replace-canonical-result',
+    });
+    messages[2] = canonicalMessages[2];
+    const appended = new HumanMessage('next turn');
+    canonicalMessages.push(appended);
+    messages.push(appended);
+    pruneMessages({ messages, canonicalMessages });
+
+    expect(serialize(messages[2])).toContain('APPENDED:');
+    expect(serialize(messages[2])).toContain('truncated');
+    expect(serialize(messages[2]).length).toBeLessThan(50_000);
   });
 
   /** Mirrors a host that rebuilds full-content messages and a fresh pruner every run. */
@@ -1092,6 +1107,14 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
 });
 
 describe('isInformativeFadingTier', () => {
+  it('recognizes OpenAI Responses output text as substantive', () => {
+    expect(
+      hasNonEmptyTextContent([
+        { type: 'output_text', text: 'completed response' } as never,
+      ])
+    ).toBe(true);
+  });
+
   it('reports only tiers a host should persist', () => {
     expect(isInformativeFadingTier(undefined, 100_000)).toBe(false);
     expect(isInformativeFadingTier(createFadingTier(100_000), 100_000)).toBe(

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1,0 +1,234 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { TokenCounter } from '@/types/run';
+import {
+  calculateMaskedResultMaxChars,
+  maskConsumedToolResults,
+  preFlightTruncateToolResults,
+  resolveFadingBudgetTokens,
+  createPruneMessages,
+} from '@/messages/prune';
+import { calculateMaxToolResultChars } from '@/utils/truncation';
+
+const tokenCounter: TokenCounter = (message) => {
+  const content = message.content;
+  const text = typeof content === 'string' ? content : JSON.stringify(content);
+  return Math.ceil(text.length / 4);
+};
+
+function serialize(message: BaseMessage): string {
+  const content = message.content;
+  return typeof content === 'string' ? content : JSON.stringify(content);
+}
+
+function toolCall(id: string): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: [{ id, name: 'fetch', args: {}, type: 'tool_call' }],
+  });
+}
+
+function toolResult(id: string, chars: number): ToolMessage {
+  return new ToolMessage({
+    content: `${id}:${'x'.repeat(chars)}`,
+    tool_call_id: id,
+    name: 'fetch',
+  });
+}
+
+/** One user turn: question, tool call, tool result, answer. */
+function round(index: number, resultChars: number): BaseMessage[] {
+  const id = `tc-${index}`;
+  return [
+    new HumanMessage(`question ${index}`),
+    toolCall(id),
+    toolResult(id, resultChars),
+    new AIMessage(`answer ${index}`),
+  ];
+}
+
+function conversation(rounds: number[]): BaseMessage[] {
+  return rounds.flatMap((chars, index) => round(index, chars));
+}
+
+function countMap(
+  messages: BaseMessage[]
+): Record<string, number | undefined> {
+  const map: Record<string, number | undefined> = {};
+  for (let i = 0; i < messages.length; i++) {
+    map[i] = tokenCounter(messages[i]);
+  }
+  return map;
+}
+
+describe('resolveFadingBudgetTokens', () => {
+  it('scales the fixed context window by the discrete pressure band only', () => {
+    expect(resolveFadingBudgetTokens(100_000, 0.3)).toBe(100_000);
+    expect(resolveFadingBudgetTokens(100_000, 0.8)).toBe(100_000);
+    expect(resolveFadingBudgetTokens(100_000, 0.849)).toBe(100_000);
+    expect(resolveFadingBudgetTokens(100_000, 0.85)).toBe(50_000);
+    expect(resolveFadingBudgetTokens(100_000, 0.9)).toBe(20_000);
+    expect(resolveFadingBudgetTokens(100_000, 0.99)).toBe(5_000);
+    expect(resolveFadingBudgetTokens(2_000, 0.99)).toBe(1_024);
+  });
+});
+
+describe('calculateMaskedResultMaxChars', () => {
+  it('keeps a fixed fraction of the fresh-result cap with a floor', () => {
+    expect(calculateMaskedResultMaxChars(100_000)).toBe(
+      Math.floor(calculateMaxToolResultChars(100_000) * 0.1)
+    );
+    expect(calculateMaskedResultMaxChars(1_024)).toBe(300);
+  });
+});
+
+describe('preFlightTruncateToolResults stability', () => {
+  it('truncates a historical result to the same bytes however many results follow it', () => {
+    const snapshots = [0, 1, 4, 20].map((later) => {
+      const messages = conversation([6_000, 6_000, ...Array(later).fill(50)]);
+      const indexTokenCountMap = countMap(messages);
+      preFlightTruncateToolResults({
+        messages,
+        maxContextTokens: 1_000,
+        indexTokenCountMap,
+        tokenCounter,
+      });
+      return [serialize(messages[2]), serialize(messages[6])];
+    });
+
+    expect(snapshots[0][0]).toContain('truncated');
+    expect(snapshots[0][1]).toContain('truncated');
+    for (const snapshot of snapshots) {
+      expect(snapshot).toEqual(snapshots[0]);
+    }
+  });
+});
+
+describe('maskConsumedToolResults stability', () => {
+  it('masks a consumed result to the same bytes however many consumed results exist', () => {
+    const snapshots = [1, 3, 12].map((rounds) => {
+      const messages = conversation(Array(rounds).fill(6_000));
+      const indexTokenCountMap = countMap(messages);
+      const masked = maskConsumedToolResults({
+        messages,
+        indexTokenCountMap,
+        tokenCounter,
+        maxChars: 2_000,
+      });
+      expect(masked).toBe(rounds);
+      return serialize(messages[2]);
+    });
+
+    expect(snapshots[0].length).toBeLessThanOrEqual(2_000);
+    expect(snapshots[0]).toContain('truncated');
+    for (const snapshot of snapshots) {
+      expect(snapshot).toBe(snapshots[0]);
+    }
+  });
+
+  it('never masks below the placeholder floor', () => {
+    const messages = conversation([6_000]);
+    maskConsumedToolResults({
+      messages,
+      indexTokenCountMap: countMap(messages),
+      tokenCounter,
+      maxChars: 10,
+    });
+    expect(serialize(messages[2]).length).toBeLessThanOrEqual(300);
+    expect(serialize(messages[2]).length).toBeGreaterThan(10);
+  });
+});
+
+describe('pruner keeps historical tool results byte-stable across turns', () => {
+  const maxTokens = 40_000;
+
+  /** Mirrors a host that rebuilds full-content messages and a fresh pruner every run. */
+  function runTurn(
+    messages: BaseMessage[],
+    options: { summarizationEnabled: boolean; calibrationRatio: number }
+  ): { early: string; pressure: number } {
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: options.summarizationEnabled,
+      calibrationRatio: options.calibrationRatio,
+    });
+    const result = pruneMessages({ messages });
+    return { early: serialize(messages[2]), pressure: result.contextPressure ?? 0 };
+  }
+
+  it('fit-to-budget truncation (summarization on) ignores calibration drift and growth', () => {
+    const first = runTurn(conversation([60_000]), {
+      summarizationEnabled: true,
+      calibrationRatio: 1,
+    });
+    expect(first.early).toContain('truncated');
+    expect(first.early.length).toBeLessThanOrEqual(
+      calculateMaxToolResultChars(maxTokens)
+    );
+
+    const ratios = [1.03, 1.12, 1.25, 1.4];
+    ratios.forEach((calibrationRatio, index) => {
+      const later = runTurn(
+        conversation([60_000, ...Array(index + 1).fill(400)]),
+        { summarizationEnabled: true, calibrationRatio }
+      );
+      expect(later.pressure).toBeLessThan(0.8);
+      expect(later.early).toBe(first.early);
+    });
+  });
+
+  it('masking under pressure (summarization off) is stable within a band', () => {
+    const history = [60_000, 48_000, 16_000];
+    const first = runTurn(conversation(history), {
+      summarizationEnabled: false,
+      calibrationRatio: 1,
+    });
+    expect(first.pressure).toBeGreaterThanOrEqual(0.8);
+    expect(first.pressure).toBeLessThan(0.85);
+    expect(first.early).toContain('truncated');
+    expect(first.early.length).toBeLessThanOrEqual(
+      calculateMaskedResultMaxChars(maxTokens)
+    );
+
+    const ratios = [1.01, 1.02, 1.03];
+    ratios.forEach((calibrationRatio, index) => {
+      const later = runTurn(
+        conversation([...history, ...Array(index + 1).fill(200)]),
+        { summarizationEnabled: false, calibrationRatio }
+      );
+      expect(later.pressure).toBeGreaterThanOrEqual(0.8);
+      expect(later.pressure).toBeLessThan(0.85);
+      expect(later.early).toBe(first.early);
+    });
+  });
+
+  it('holds bytes stable within one run while provider usage recalibrates', () => {
+    const messages = conversation([60_000]);
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: true,
+    });
+    const first = pruneMessages({ messages });
+    const early = serialize(messages[2]);
+    expect(early).toContain('truncated');
+
+    let previousRatio = first.calibrationRatio ?? 1;
+    for (let turn = 1; turn <= 3; turn++) {
+      messages.push(...round(turn, 400));
+      const result = pruneMessages({
+        messages,
+        usageMetadata: { input_tokens: 13_500 + 500 * turn, output_tokens: 10 },
+        totalTokensFresh: true,
+      });
+      expect(result.calibrationRatio).not.toBe(previousRatio);
+      previousRatio = result.calibrationRatio ?? previousRatio;
+      expect(serialize(messages[2])).toBe(early);
+    }
+  });
+});

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -21,8 +21,8 @@ import {
   projectToolCallInputs,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
+import { ContentTypes, Providers } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
-import { Providers } from '@/common';
 
 const tokenCounter: TokenCounter = (message) => {
   const content = message.content;
@@ -287,6 +287,8 @@ describe('fading ladder', () => {
       resolveFadingCaps({ ...masked, budgetTokens: 400 }).consumedChars
     ).toBe(300);
     expect(resolveFadingCaps(masked, 1_000).resultChars).toBe(1_000);
+    expect(resolveFadingCaps(masked, 0).resultChars).toBe(0);
+    expect(resolveFadingCaps(masked, 0).consumedChars).toBe(0);
   });
 });
 
@@ -782,6 +784,69 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
 
     expect(serialize(messages[2])).not.toBe(firstProjection);
     expect(serialize(canonicalMessages[2])).toBe(originalResult);
+  });
+
+  it('preserves OpenAI thinking normalization while capping canonical tool inputs', () => {
+    const canonicalMessages: BaseMessage[] = [
+      new HumanMessage('fetch'),
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          reasoning_content: 'private reasoning',
+          provider_specific_fields: {
+            thinking_blocks: [
+              {
+                type: 'thinking',
+                thinking: 'private reasoning',
+                signature: 'signature',
+              },
+            ],
+          },
+        },
+        tool_calls: [
+          {
+            id: 'call-1',
+            name: 'fetch',
+            args: { query: 'q'.repeat(60_000) },
+            type: 'tool_call',
+          },
+        ],
+      }),
+    ];
+    const messages = [...canonicalMessages];
+    const pruneMessages = createPruneMessages({
+      provider: Providers.OPENAI,
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      thinkingEnabled: true,
+      fadingTier: {
+        v: 1,
+        budgetTokens: 10_000,
+        masked: false,
+        latched: true,
+      },
+    });
+
+    pruneMessages({ messages, canonicalMessages });
+
+    const projected = messages[1] as AIMessage;
+    expect(projected.content).toEqual([
+      expect.objectContaining({
+        type: ContentTypes.THINKING,
+        thinking: 'private reasoning',
+      }),
+    ]);
+    expect(projected.additional_kwargs.reasoning_content).toBeUndefined();
+    expect(JSON.stringify(projected.tool_calls?.[0].args)).toContain(
+      '_truncated'
+    );
+    expect(canonicalMessages[1].content).toBe('');
+    expect(
+      (canonicalMessages[1] as AIMessage).additional_kwargs.reasoning_content
+    ).toBe('private reasoning');
   });
 
   it('emergency truncation recovers on a clone without latching the tier', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -46,6 +46,58 @@ function toolCall(...ids: string[]): AIMessage {
   });
 }
 
+function toolCallWithInput(id: string, chars: number): AIMessage {
+  const query = 'q'.repeat(chars);
+  const serialized = JSON.stringify({ query });
+  return new AIMessage({
+    content: [
+      {
+        type: 'tool_use',
+        id,
+        name: 'fetch',
+        input: { query },
+      },
+    ],
+    tool_calls: [
+      {
+        id,
+        name: 'fetch',
+        args: { query },
+        type: 'tool_call',
+      },
+    ],
+    additional_kwargs: {
+      tool_calls: [
+        {
+          id,
+          type: 'function',
+          function: { name: 'fetch', arguments: serialized },
+        },
+      ],
+    },
+    response_metadata: {
+      output: [
+        {
+          type: 'function_call',
+          call_id: id,
+          name: 'fetch',
+          arguments: serialized,
+        },
+      ],
+    },
+  });
+}
+
+function serializeToolCallInputs(message: BaseMessage): string {
+  const aiMessage = message as AIMessage;
+  return JSON.stringify({
+    content: aiMessage.content,
+    toolCalls: aiMessage.tool_calls,
+    additionalKwargs: aiMessage.additional_kwargs,
+    responseMetadata: aiMessage.response_metadata,
+  });
+}
+
 function toolResult(id: string, chars: number): ToolMessage {
   return new ToolMessage({
     content: `${id}:${'x'.repeat(chars)}`,
@@ -472,6 +524,51 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     fresh({ messages: rebuilt });
 
     expect(serialize(rebuilt[2])).toBe(escalatedBytes);
+  });
+
+  it('derives deeper tool-call input caps from canonical arguments', () => {
+    const initial = [
+      new HumanMessage('fetch with a large query'),
+      toolCallWithInput('large-input', 60_000),
+      toolResult('large-input', 100),
+      new AIMessage('query complete'),
+    ];
+    const messages: BaseMessage[] = [...initial];
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+    });
+    pruneMessages({ messages });
+    const firstTierInputs = serializeToolCallInputs(messages[1]);
+
+    messages.push(...round(1, 60_000), ...round(2, 60_000));
+    const escalated = pruneMessages({ messages });
+    const escalatedInputs = serializeToolCallInputs(messages[1]);
+    expect(escalatedInputs).not.toBe(firstTierInputs);
+
+    const rebuilt: BaseMessage[] = [
+      new HumanMessage('fetch with a large query'),
+      toolCallWithInput('large-input', 60_000),
+      toolResult('large-input', 100),
+      new AIMessage('query complete'),
+      ...round(1, 60_000),
+      ...round(2, 60_000),
+    ];
+    const fresh = createPruneMessages({
+      maxTokens,
+      startIndex: rebuilt.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(rebuilt),
+      summarizationEnabled: false,
+      fadingTier: escalated.fadingTier,
+    });
+    const freshResult = fresh({ messages: rebuilt });
+
+    expect(freshResult.fadingTier).toEqual(escalated.fadingTier);
+    expect(serializeToolCallInputs(rebuilt[1])).toBe(escalatedInputs);
   });
 
   it('emergency truncation recovers on a clone without latching the tier', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -653,6 +653,31 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(projectAtWindow(100_000)).toBe(projectAtWindow(200_000));
   });
 
+  it('recounts provider-bound inputs after fixed-cap canonicalization', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('fetch an oversized input'),
+      toolCallWithInput('hard-cap-input', 300_000),
+    ];
+    const inputCounter: TokenCounter = (message) =>
+      Math.ceil(serializeToolCallInputs(message).length / 4);
+    const originalCount = inputCounter(messages[1]);
+    const pruneMessages = createPruneMessages({
+      maxTokens: 1_000_000,
+      startIndex: messages.length,
+      tokenCounter: inputCounter,
+      indexTokenCountMap: {
+        0: inputCounter(messages[0]),
+        1: originalCount,
+      },
+      summarizationEnabled: false,
+    });
+
+    const result = pruneMessages({ messages });
+
+    expect(result.indexTokenCountMap[1]).toBe(inputCounter(messages[1]));
+    expect(result.indexTokenCountMap[1]).toBeLessThan(originalCount);
+  });
+
   it('retains canonical result provenance through position pruning', () => {
     const contextPruningConfig = {
       enabled: true,
@@ -802,5 +827,32 @@ describe('per-agent fading tier persistence', () => {
     });
     snapshot.worker.budgetTokens = 1;
     expect(graph.getFadingTiers().worker).toEqual(workerTier);
+    const singular = graph.getFadingTier();
+    expect(singular).toEqual(defaultTier);
+    if (singular != null) {
+      singular.budgetTokens = 1;
+    }
+    expect(graph.getFadingTier()).toEqual(defaultTier);
+  });
+
+  it('does not restore a pre-compaction tier onto an initial summary', () => {
+    const staleTier: FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const graph = new StandardGraph({
+      agents: [
+        {
+          ...graphAgent('default'),
+          initialSummary: { text: 'Compacted history', tokenCount: 10 },
+        },
+      ],
+      fadingTier: staleTier,
+      fadingTiers: { default: staleTier },
+    });
+
+    expect(graph.agentContexts.get('default')?.fadingTier).toBeUndefined();
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -19,7 +19,6 @@ import {
   preFlightTruncateToolResults,
   createPruneMessages,
   projectToolCallInputs,
-  ORIGINAL_CONTENT_MAX_CHARS,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { StandardGraph } from '@/graphs/Graph';
@@ -720,33 +719,33 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(serialize(rebuilt[2])).toBe(escalatedBytes);
   });
 
-  it('retains bounded canonical results when overflow recreates the pruner', () => {
-    const messages = conversation([60_000]);
-    const canonicalToolContent = new Map<
-      number,
-      BaseMessage['content']
-    >();
+  it('recreates the provider projection from canonical graph messages after overflow', () => {
+    const canonicalMessages = conversation([60_000]);
+    const messages = [...canonicalMessages];
+    const originalResult = serialize(canonicalMessages[2]);
     const firstPruner = createPruneMessages({
       maxTokens,
       startIndex: 0,
       tokenCounter,
       indexTokenCountMap: countMap(messages),
       summarizationEnabled: false,
-      canonicalToolContent,
     });
-    const first = firstPruner({ messages });
-    expect(canonicalToolContent.get(2)).toBeDefined();
+    const first = firstPruner({ messages, canonicalMessages });
+    expect(serialize(canonicalMessages[2])).toBe(originalResult);
 
+    const correctedMessages = [...canonicalMessages];
     const correctedPruner = createPruneMessages({
       maxTokens: 20_000,
-      startIndex: messages.length,
+      startIndex: correctedMessages.length,
       tokenCounter,
-      indexTokenCountMap: countMap(messages),
+      indexTokenCountMap: countMap(correctedMessages),
       summarizationEnabled: false,
       fadingTier: first.fadingTier,
-      canonicalToolContent,
     });
-    const corrected = correctedPruner({ messages });
+    const corrected = correctedPruner({
+      messages: correctedMessages,
+      canonicalMessages,
+    });
 
     const rebuilt = conversation([60_000]);
     const freshPruner = createPruneMessages({
@@ -759,36 +758,30 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     });
     freshPruner({ messages: rebuilt });
 
-    expect(serialize(messages[2])).toBe(serialize(rebuilt[2]));
+    expect(serialize(correctedMessages[2])).toBe(serialize(rebuilt[2]));
+    expect(serialize(canonicalMessages[2])).toBe(originalResult);
   });
 
-  it('caps retained canonical result content across long histories', () => {
-    const messages = conversation(Array(8).fill(500_000));
-    const canonicalToolContent = new Map<
-      number,
-      BaseMessage['content']
-    >();
+  it('derives deeper tiers from canonical graph messages without mutating them', () => {
+    const canonicalMessages = conversation([60_000]);
+    const messages = [...canonicalMessages];
+    const originalResult = serialize(canonicalMessages[2]);
     const pruneMessages = createPruneMessages({
       maxTokens,
-      startIndex: messages.length,
+      startIndex: 0,
       tokenCounter,
       indexTokenCountMap: countMap(messages),
       summarizationEnabled: false,
-      canonicalToolContent,
     });
 
-    pruneMessages({ messages });
+    pruneMessages({ messages, canonicalMessages });
+    const firstProjection = serialize(messages[2]);
+    canonicalMessages.push(...round(1, 60_000), ...round(2, 60_000));
+    messages.push(...canonicalMessages.slice(messages.length));
+    pruneMessages({ messages, canonicalMessages });
 
-    const retainedChars = [...canonicalToolContent.values()].reduce(
-      (total, content) =>
-        total +
-        (typeof content === 'string'
-          ? content.length
-          : JSON.stringify(content).length),
-      0
-    );
-    expect(retainedChars).toBeLessThanOrEqual(ORIGINAL_CONTENT_MAX_CHARS);
-    expect(canonicalToolContent.size).toBeLessThan(8);
+    expect(serialize(messages[2])).not.toBe(firstProjection);
+    expect(serialize(canonicalMessages[2])).toBe(originalResult);
   });
 
   it('emergency truncation recovers on a clone without latching the tier', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -157,8 +157,8 @@ describe('fading ladder', () => {
     expect(fadingRungForBudget(100_000, 100_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 60_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 9_400)).toBe(3);
-    expect(fadingRungForBudget(100_000, 9_400, 1_000)).toBe(0);
-    expect(fadingRungForBudget(100_000, 9_400, 0)).toBe(0);
+    expect(fadingRungForBudget(100_000, 9_400, 1_000)).toBe(2);
+    expect(fadingRungForBudget(100_000, 9_400, 0)).toBe(2);
     expect(fadingRungForBudget(100_000, 0)).toBe(0);
     expect(
       calculateMaxToolResultChars(
@@ -281,7 +281,7 @@ describe('fading ladder', () => {
     expect(caps.consumedChars).toBe(caps.resultChars);
   });
 
-  it('does not deepen the tier when a configured result cap already fits', () => {
+  it('does not over-deepen when a configured result cap already fits', () => {
     const tier = resolveFadingTier(
       createFadingTier(100_000),
       100_000,
@@ -293,10 +293,15 @@ describe('fading ladder', () => {
       1_000
     );
 
-    expect(tier).toEqual(createFadingTier(100_000));
+    expect(tier).toEqual({
+      v: 1,
+      budgetTokens: 25_000,
+      masked: false,
+      latched: true,
+    });
     expect(resolveFadingCaps(tier, 1_000)).toMatchObject({
       resultChars: 1_000,
-      inputChars: 60_000,
+      inputChars: 15_000,
     });
   });
 

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -441,6 +441,35 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     instructionTokens?: number;
   };
 
+  it('uses a same-length caller replacement as the new canonical result', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('fetch'),
+      toolCall('replace-result'),
+      new ToolMessage({
+        content: `OLD:${'o'.repeat(100)}`,
+        tool_call_id: 'replace-result',
+      }),
+      new AIMessage('done'),
+    ];
+    const pruneMessages = createPruneMessages({
+      maxTokens: 10_000,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+    });
+
+    pruneMessages({ messages });
+    messages[2] = new ToolMessage({
+      content: `NEW:${'n'.repeat(50_000)}`,
+      tool_call_id: 'replace-result',
+    });
+    pruneMessages({ messages });
+
+    expect(serialize(messages[2])).toContain('NEW:');
+    expect(serialize(messages[2])).not.toContain('OLD:');
+  });
+
   /** Mirrors a host that rebuilds full-content messages and a fresh pruner every run. */
   function runTurn(
     messages: BaseMessage[],

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -31,10 +31,15 @@ function serialize(message: BaseMessage): string {
   return typeof content === 'string' ? content : JSON.stringify(content);
 }
 
-function toolCall(id: string): AIMessage {
+function toolCall(...ids: string[]): AIMessage {
   return new AIMessage({
     content: '',
-    tool_calls: [{ id, name: 'fetch', args: {}, type: 'tool_call' }],
+    tool_calls: ids.map((id) => ({
+      id,
+      name: 'fetch',
+      args: {},
+      type: 'tool_call' as const,
+    })),
   });
 }
 
@@ -99,77 +104,78 @@ describe('fading ladder', () => {
   });
 
   it('validates and seeds persisted tiers', () => {
-    expect(isFadingTier({ v: 1, window: 100, rung: 2, masked: true })).toBe(
-      true
-    );
-    expect(isFadingTier({ v: 2, window: 100, rung: 2, masked: true })).toBe(
-      false
-    );
-    expect(isFadingTier({ v: 1, window: 100, rung: 1.5, masked: true })).toBe(
-      false
-    );
+    expect(isFadingTier({ v: 1, budgetTokens: 100, masked: true })).toBe(true);
+    expect(isFadingTier({ v: 2, budgetTokens: 100, masked: true })).toBe(false);
+    expect(isFadingTier({ v: 1, budgetTokens: 0, masked: true })).toBe(false);
+    expect(isFadingTier({ v: 1, budgetTokens: 100, masked: 'yes' })).toBe(false);
     expect(isFadingTier(null)).toBe(false);
-    expect(
-      seedFadingTier(100_000, { v: 1, window: 100_000, rung: 3, masked: true })
-    ).toEqual({
+    expect(seedFadingTier(100_000, { v: 1, budgetTokens: 50_000, masked: true })).toEqual({
       v: 1,
-      window: 100_000,
-      rung: 3,
+      budgetTokens: 50_000,
       masked: true,
     });
-    expect(
-      seedFadingTier(100_000, { v: 1, window: 50_000, rung: 3, masked: true })
-    ).toEqual(createFadingTier(100_000));
-    expect(
-      seedFadingTier(100_000, {
-        v: 1,
-        window: 100_000,
-        rung: 99,
-        masked: false,
-      }).rung
-    ).toBe(maxFadingRung(100_000));
+    expect(seedFadingTier(100_000, { v: 1, budgetTokens: 150_000, masked: false })).toEqual({
+      v: 1,
+      budgetTokens: 100_000,
+      masked: false,
+    });
+    expect(seedFadingTier(100_000, { rung: 3 })).toEqual(createFadingTier(100_000));
   });
 
   it('only deepens and never oscillates across a band threshold', () => {
+    const window = 100_000;
     const base = { effectiveRawTokens: 100_000, summarizationEnabled: false };
-    let tier = createFadingTier(100_000);
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.5 });
-    expect(tier).toEqual(createFadingTier(100_000));
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.86 });
-    expect(tier).toEqual({ v: 1, window: 100_000, rung: 1, masked: true });
+    let tier = createFadingTier(window);
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.5 });
+    expect(tier).toEqual(createFadingTier(window));
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.86 });
+    expect(tier).toEqual({ v: 1, budgetTokens: 50_000, masked: true });
     const settled = tier;
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.84 });
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.84 });
     expect(tier).toBe(settled);
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.86 });
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.86 });
     expect(tier).toBe(settled);
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.91 });
-    expect(tier.rung).toBe(2);
-    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.3 });
-    expect(tier.rung).toBe(2);
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.91 });
+    expect(tier.budgetTokens).toBe(25_000);
+    tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.3 });
+    expect(tier.budgetTokens).toBe(25_000);
     expect(tier.masked).toBe(true);
   });
 
-  it('fits a single result within the effective budget with summarization on', () => {
-    const tier = resolveFadingTier(createFadingTier(32_000), {
+  it('survives a mid-run budget correction and the return to the normal window', () => {
+    const latched: FadingTier = { v: 1, budgetTokens: 100_000, masked: true };
+    const corrected = seedFadingTier(180_000, latched);
+    expect(corrected).toEqual(latched);
+    expect(
+      resolveFadingTier(corrected, 180_000, {
+        contextPressure: 0.4,
+        effectiveRawTokens: 170_000,
+        summarizationEnabled: true,
+      })
+    ).toBe(corrected);
+    expect(seedFadingTier(200_000, corrected)).toEqual(latched);
+    expect(resolveFadingCaps(seedFadingTier(200_000, corrected))).toEqual(
+      resolveFadingCaps(latched)
+    );
+  });
+
+  it('fits a single result within half the effective budget with summarization on', () => {
+    const tier = resolveFadingTier(createFadingTier(32_000), 32_000, {
       contextPressure: 0.3,
       effectiveRawTokens: 9_400,
       summarizationEnabled: true,
     });
     const caps = resolveFadingCaps(tier);
     expect(caps.resultChars / 4).toBeLessThanOrEqual(9_400 / 2);
-    expect(caps.resultChars).toBe(
-      calculateMaxToolResultChars(caps.budgetTokens)
-    );
+    expect(caps.resultChars).toBe(calculateMaxToolResultChars(caps.budgetTokens));
     expect(caps.consumedChars).toBe(caps.resultChars);
   });
 
   it('masks consumed results to a fraction of the fresh cap with a floor', () => {
-    const masked: FadingTier = { v: 1, window: 100_000, rung: 0, masked: true };
+    const masked: FadingTier = { v: 1, budgetTokens: 100_000, masked: true };
     const caps = resolveFadingCaps(masked);
     expect(caps.consumedChars).toBe(Math.floor(caps.resultChars * 0.1));
-    expect(
-      resolveFadingCaps({ ...masked, window: 400, rung: 0 }).consumedChars
-    ).toBe(300);
+    expect(resolveFadingCaps({ ...masked, budgetTokens: 400 }).consumedChars).toBe(300);
     expect(resolveFadingCaps(masked, 1_000).resultChars).toBe(1_000);
   });
 });
@@ -245,12 +251,7 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
   function runTurn(
     messages: BaseMessage[],
     options: TurnOptions
-  ): {
-    early: string;
-    pressure: number;
-    tier: FadingTier;
-    contextLength: number;
-  } {
+  ): { early: string; pressure: number; tier: FadingTier; contextLength: number } {
     const pruneMessages = createPruneMessages({
       maxTokens,
       startIndex: messages.length,
@@ -276,19 +277,14 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       calibrationRatio: 1,
     });
     expect(first.early).toContain('truncated');
-    expect(first.early.length).toBeLessThanOrEqual(
-      calculateMaxToolResultChars(maxTokens)
-    );
+    expect(first.early.length).toBeLessThanOrEqual(calculateMaxToolResultChars(maxTokens));
 
     const ratios = [1.03, 1.12, 1.25, 1.4];
     ratios.forEach((calibrationRatio, index) => {
-      const later = runTurn(
-        conversation([60_000, ...Array(index + 1).fill(400)]),
-        {
-          summarizationEnabled: true,
-          calibrationRatio,
-        }
-      );
+      const later = runTurn(conversation([60_000, ...Array(index + 1).fill(400)]), {
+        summarizationEnabled: true,
+        calibrationRatio,
+      });
       expect(later.pressure).toBeLessThan(0.8);
       expect(later.early).toBe(first.early);
     });
@@ -303,19 +299,14 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(first.pressure).toBeGreaterThanOrEqual(0.8);
     expect(first.tier.masked).toBe(true);
     expect(first.early).toContain('truncated');
-    expect(first.early.length).toBeLessThanOrEqual(
-      resolveFadingCaps(first.tier).consumedChars
-    );
+    expect(first.early.length).toBeLessThanOrEqual(resolveFadingCaps(first.tier).consumedChars);
 
     const ratios = [1.01, 1.02, 1.03];
     ratios.forEach((calibrationRatio, index) => {
-      const later = runTurn(
-        conversation([...history, ...Array(index + 1).fill(200)]),
-        {
-          summarizationEnabled: false,
-          calibrationRatio,
-        }
-      );
+      const later = runTurn(conversation([...history, ...Array(index + 1).fill(200)]), {
+        summarizationEnabled: false,
+        calibrationRatio,
+      });
       expect(later.tier).toEqual(first.tier);
       expect(later.early).toBe(first.early);
     });
@@ -360,9 +351,7 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(result.context.length).toBe(messages.length);
     expect(result.messagesToRefine).toEqual([]);
     expect(serialize(messages[2]).length).toBeLessThanOrEqual(
-      calculateMaxToolResultChars(
-        resolveFadingCaps(result.fadingTier).budgetTokens
-      )
+      resolveFadingCaps(result.fadingTier).resultChars
     );
   });
 
@@ -392,5 +381,41 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       expect(serialize(messages[2])).toBe(early);
       expect(result.fadingTier).toEqual(first.fadingTier);
     }
+  });
+
+  it('emergency truncation recovers on a clone without latching the tier', () => {
+    const ids = ['p1', 'p2', 'p3', 'p4'];
+    const messages: BaseMessage[] = [
+      ...conversation(Array(20).fill(200)),
+      new HumanMessage('fetch everything at once'),
+      toolCall(...ids),
+      ...ids.map((id) => toolResult(id, 47_000)),
+    ];
+    const originalLengths = ids.map((_, index) =>
+      serialize(messages[messages.length - ids.length + index]).length
+    );
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: true,
+      calibrationRatio: 1,
+    });
+
+    const result = pruneMessages({ messages });
+
+    expect(result.context.length).toBeGreaterThan(0);
+    expect(result.fadingTier.budgetTokens).toBe(maxTokens);
+    ids.forEach((_, index) => {
+      expect(serialize(messages[messages.length - ids.length + index]).length).toBe(
+        originalLengths[index]
+      );
+    });
+    const contextSet = new Set(result.context);
+    expect(result.messagesToRefine?.some((message) => contextSet.has(message))).toBe(false);
+
+    const again = pruneMessages({ messages });
+    expect(again.fadingTier).toEqual(result.fadingTier);
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -157,8 +157,9 @@ describe('fading ladder', () => {
     expect(fadingRungForBudget(100_000, 100_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 60_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 9_400)).toBe(3);
-    expect(fadingRungForBudget(100_000, 9_400, 1_000)).toBe(2);
-    expect(fadingRungForBudget(100_000, 9_400, 0)).toBe(2);
+    expect(fadingRungForBudget(100_000, 9_400, 1_000)).toBe(1);
+    expect(fadingRungForBudget(100_000, 9_400, 0)).toBe(1);
+    expect(fadingRungForBudget(100_000, 9_400, 1_000, 3)).toBe(3);
     expect(fadingRungForBudget(100_000, 0)).toBe(0);
     expect(
       calculateMaxToolResultChars(
@@ -267,14 +268,14 @@ describe('fading ladder', () => {
     expect(seedFadingTier(100_000, restored)).toEqual(restored);
   });
 
-  it('fits a single result within half the effective budget with summarization on', () => {
+  it('fits a complete tool exchange within the effective budget', () => {
     const tier = resolveFadingTier(createFadingTier(32_000), 32_000, {
       contextPressure: 0.3,
       effectiveRawTokens: 9_400,
       summarizationEnabled: true,
     });
     const caps = resolveFadingCaps(tier);
-    expect(caps.resultChars / 4).toBeLessThanOrEqual(9_400 / 2);
+    expect((caps.resultChars + caps.inputChars) / 4).toBeLessThanOrEqual(9_400);
     expect(caps.resultChars).toBe(
       calculateMaxToolResultChars(caps.budgetTokens)
     );
@@ -295,14 +296,36 @@ describe('fading ladder', () => {
 
     expect(tier).toEqual({
       v: 1,
-      budgetTokens: 25_000,
+      budgetTokens: 50_000,
       masked: false,
       latched: true,
     });
     expect(resolveFadingCaps(tier, 1_000)).toMatchObject({
       resultChars: 1_000,
-      inputChars: 15_000,
+      inputChars: 30_000,
     });
+  });
+
+  it('fits every input and result in the widest parallel exchange', () => {
+    const rawTokens = 9_400;
+    const width = 3;
+    const tier = resolveFadingTier(
+      createFadingTier(100_000),
+      100_000,
+      {
+        contextPressure: 0.3,
+        effectiveRawTokens: rawTokens,
+        summarizationEnabled: true,
+        toolExchangeWidth: width,
+      },
+      1_000
+    );
+    const caps = resolveFadingCaps(tier, 1_000);
+
+    expect(tier.budgetTokens).toBe(12_500);
+    expect(width * (caps.inputChars + caps.resultChars)).toBeLessThanOrEqual(
+      rawTokens * 4
+    );
   });
 
   it('masks consumed results to a fraction of the fresh cap with a floor', () => {
@@ -908,17 +931,20 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     ).toBe('private reasoning');
   });
 
-  it('emergency truncation recovers on a clone without latching the tier', () => {
+  it('latches a stable tier for a parallel exchange before emergency pruning', () => {
     const ids = ['p1', 'p2', 'p3', 'p4'];
-    const messages: BaseMessage[] = [
+    const canonicalMessages: BaseMessage[] = [
       ...conversation(Array(20).fill(200)),
       new HumanMessage('fetch everything at once'),
       toolCall(...ids),
       ...ids.map((id) => toolResult(id, 47_000)),
     ];
+    const messages = [...canonicalMessages];
     const originalLengths = ids.map(
       (_, index) =>
-        serialize(messages[messages.length - ids.length + index]).length
+        serialize(
+          canonicalMessages[canonicalMessages.length - ids.length + index]
+        ).length
     );
     const pruneMessages = createPruneMessages({
       maxTokens,
@@ -929,13 +955,19 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       calibrationRatio: 1,
     });
 
-    const result = pruneMessages({ messages });
+    const result = pruneMessages({ messages, canonicalMessages });
 
     expect(result.context.length).toBeGreaterThan(0);
-    expect(result.fadingTier.budgetTokens).toBe(maxTokens);
+    expect(result.fadingTier.budgetTokens).toBe(20_000);
+    const caps = resolveFadingCaps(result.fadingTier);
     ids.forEach((_, index) => {
       expect(
         serialize(messages[messages.length - ids.length + index]).length
+      ).toBeLessThanOrEqual(caps.resultChars);
+      expect(
+        serialize(
+          canonicalMessages[canonicalMessages.length - ids.length + index]
+        ).length
       ).toBe(originalLengths[index]);
     });
     const contextSet = new Set(result.context);
@@ -943,7 +975,7 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       result.messagesToRefine?.some((message) => contextSet.has(message))
     ).toBe(false);
 
-    const again = pruneMessages({ messages });
+    const again = pruneMessages({ messages, canonicalMessages });
     expect(again.fadingTier).toEqual(result.fadingTier);
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -314,6 +314,39 @@ describe('preFlightTruncateToolResults stability', () => {
   });
 });
 
+describe('projectToolCallInputs proxy safety', () => {
+  it('sanitizes a proxied nested tool call without invoking its traps', () => {
+    const nestedToolCall = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error('ownKeys trap must not run');
+        },
+        getOwnPropertyDescriptor: () => {
+          throw new Error('descriptor trap must not run');
+        },
+      }
+    );
+    const message = new AIMessage({
+      content: [
+        {
+          type: 'tool_call',
+          tool_call: nestedToolCall,
+        } as never,
+      ],
+    });
+
+    const [projected] = projectToolCallInputs([message], 1_000);
+    const block = projected.content[0] as unknown as {
+      tool_call: { args: unknown };
+    };
+
+    expect(block.tool_call).toEqual({
+      args: '[Property accessor omitted]',
+    });
+  });
+});
+
 describe('maskConsumedToolResults stability', () => {
   it('masks a consumed result to the same bytes however many consumed results exist', () => {
     const snapshots = [1, 3, 12].map((rounds) => {
@@ -965,8 +998,8 @@ describe('per-agent fading tier persistence', () => {
     expect(graph.getFadingTier()).toEqual(defaultTier);
   });
 
-  it('does not restore a pre-compaction tier onto an initial summary', () => {
-    const staleTier: FadingTier = {
+  it('restores a tier learned after a persistent initial summary', () => {
+    const postSummaryTier: FadingTier = {
       v: 1,
       budgetTokens: 25_000,
       masked: true,
@@ -979,11 +1012,13 @@ describe('per-agent fading tier persistence', () => {
           initialSummary: { text: 'Compacted history', tokenCount: 10 },
         },
       ],
-      fadingTier: staleTier,
-      fadingTiers: { default: staleTier },
+      fadingTier: postSummaryTier,
+      fadingTiers: { default: postSummaryTier },
     });
 
-    expect(graph.agentContexts.get('default')?.fadingTier).toBeUndefined();
+    expect(graph.agentContexts.get('default')?.fadingTier).toEqual(
+      postSummaryTier
+    );
   });
 
   it('round-trips prototype-sensitive agent IDs', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -470,6 +470,45 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(serialize(messages[2])).not.toContain('OLD:');
   });
 
+  it('reapplies a latched tier after explicit canonical prefix replacement', () => {
+    const canonicalMessages: BaseMessage[] = [
+      new HumanMessage('fetch'),
+      toolCall('replace-canonical-result'),
+      new ToolMessage({
+        content: `OLD:${'o'.repeat(50_000)}`,
+        tool_call_id: 'replace-canonical-result',
+      }),
+      new AIMessage('done'),
+    ];
+    const messages = [...canonicalMessages];
+    const pruneMessages = createPruneMessages({
+      maxTokens: 10_000,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      fadingTier: {
+        v: 1,
+        budgetTokens: 5000,
+        masked: true,
+        latched: true,
+      },
+    });
+
+    pruneMessages({ messages, canonicalMessages });
+    canonicalMessages[2] = new ToolMessage({
+      content: `NEW:${'n'.repeat(50_000)}`,
+      tool_call_id: 'replace-canonical-result',
+    });
+    messages[2] = canonicalMessages[2];
+    pruneMessages({ messages, canonicalMessages });
+
+    expect(serialize(messages[2])).toContain('NEW:');
+    expect(serialize(messages[2])).toContain('truncated');
+    expect(serialize(messages[2]).length).toBeLessThan(50_000);
+    expect(serialize(canonicalMessages[2]).length).toBeGreaterThan(50_000);
+  });
+
   /** Mirrors a host that rebuilds full-content messages and a fresh pruner every run. */
   function runTurn(
     messages: BaseMessage[],

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -3,8 +3,10 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { AgentInputs, FadingTier } from '@/types/graph';
 import type { TokenCounter } from '@/types/run';
 import {
+  FADING_MIN_BUDGET_TOKENS,
   fadingBudgetTokens,
   fadingRungForBudget,
+  fadingRungForExchangeChars,
   fadingRungForResultChars,
   isFadingTier,
   isInformativeFadingTier,
@@ -20,7 +22,10 @@ import {
   createPruneMessages,
   projectToolCallInputs,
 } from '@/messages/prune';
-import { calculateMaxToolResultChars } from '@/utils/truncation';
+import {
+  calculateMaxToolCallInputChars,
+  calculateMaxToolResultChars,
+} from '@/utils/truncation';
 import { ContentTypes, Providers } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
 import { hasNonEmptyTextContent } from '@/messages/core';
@@ -1211,6 +1216,21 @@ describe('per-agent fading tier persistence', () => {
     expect(graph.getFadingTier()).toEqual(defaultTier);
   });
 
+  it('ignores malformed restored tiers instead of reporting them back', () => {
+    const graph = new StandardGraph({
+      agents: [graphAgent('default'), graphAgent('worker')],
+      fadingTier: { v: 1, budgetTokens: Number.NaN, masked: true } as FadingTier,
+      fadingTiers: {
+        worker: { v: 1, budgetTokens: 'abc', masked: true } as unknown as FadingTier,
+      },
+    });
+
+    expect(graph.agentContexts.get('default')?.fadingTier).toBeUndefined();
+    expect(graph.agentContexts.get('worker')?.fadingTier).toBeUndefined();
+    expect(graph.getFadingTier()).toBeUndefined();
+    expect(graph.getFadingTiers()).toEqual({});
+  });
+
   it('restores a tier learned after a persistent initial summary', () => {
     const postSummaryTier: FadingTier = {
       v: 1,
@@ -1249,5 +1269,74 @@ describe('per-agent fading tier persistence', () => {
 
     expect(Object.hasOwn(graph.getFadingTiers(), '__proto__')).toBe(true);
     expect(graph.getFadingTiers()['__proto__']).toEqual(tier);
+  });
+});
+
+describe('seedFadingTier provenance', () => {
+  it('keeps a never-tightened seed fresh so a pruner rebuild cannot pin later runs', () => {
+    const fresh = createFadingTier(200_000);
+    const reseeded = seedFadingTier(200_000, fresh);
+    expect(reseeded).toEqual(fresh);
+    expect(reseeded.latched).toBeUndefined();
+    expect(isInformativeFadingTier(reseeded, 200_000)).toBe(false);
+  });
+
+  it('latches a seed that was tightened, masked, already latched, or clamped', () => {
+    expect(seedFadingTier(200_000, { v: 1, budgetTokens: 50_000, masked: false })).toEqual({
+      v: 1,
+      budgetTokens: 50_000,
+      masked: false,
+      latched: true,
+    });
+    expect(seedFadingTier(200_000, { v: 1, budgetTokens: 200_000, masked: true })).toEqual({
+      v: 1,
+      budgetTokens: 200_000,
+      masked: true,
+      latched: true,
+    });
+    expect(
+      seedFadingTier(200_000, { v: 1, budgetTokens: 200_000, masked: false, latched: true })
+    ).toEqual({ v: 1, budgetTokens: 200_000, masked: false, latched: true });
+    expect(seedFadingTier(8_000, { v: 1, budgetTokens: 200_000, masked: false })).toEqual({
+      v: 1,
+      budgetTokens: 8_000,
+      masked: false,
+      latched: true,
+    });
+  });
+
+  it('clamps a sub-floor budget up to the ladder floor so caps stay positive', () => {
+    const seeded = seedFadingTier(200_000, { v: 1, budgetTokens: 1, masked: false });
+    expect(seeded.budgetTokens).toBe(FADING_MIN_BUDGET_TOKENS);
+    expect(seeded.latched).toBe(true);
+    expect(resolveFadingCaps(seeded).resultChars).toBeGreaterThan(0);
+    expect(resolveFadingCaps(seeded).inputChars).toBeGreaterThan(0);
+  });
+});
+
+describe('fadingRungForExchangeChars', () => {
+  it('deepens until a result plus its input fit, even when the result cap is tiny', () => {
+    const window = 200_000;
+    const target = 8_000;
+    const exchangeChars = (rung: number, maxToolResultChars?: number): number => {
+      const budget = fadingBudgetTokens(window, rung);
+      const resultChars = calculateMaxToolResultChars(budget);
+      return (
+        (maxToolResultChars == null
+          ? resultChars
+          : Math.min(resultChars, maxToolResultChars)) +
+        calculateMaxToolCallInputChars(budget)
+      );
+    };
+    for (const cap of [undefined, 1_000, 8_000]) {
+      const rung = fadingRungForExchangeChars(window, target, cap);
+      expect(rung).toBeGreaterThan(0);
+      expect(exchangeChars(rung, cap)).toBeLessThanOrEqual(target);
+      expect(exchangeChars(rung - 1, cap)).toBeGreaterThan(target);
+    }
+    /** A result-only rung would stop at rung 0 for a tiny configured cap. */
+    expect(fadingRungForResultChars(window, target, 1_000)).toBe(0);
+    expect(fadingRungForExchangeChars(window, 10_000_000)).toBe(0);
+    expect(fadingRungForExchangeChars(window, 1)).toBe(maxFadingRung(window));
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -795,9 +795,12 @@ describe('per-agent fading tier persistence', () => {
     expect(graph.agentContexts.get('default')?.fadingTier).toEqual(defaultTier);
     expect(graph.agentContexts.get('worker')?.fadingTier).toEqual(workerTier);
     expect(graph.agentContexts.get('unseeded')?.fadingTier).toBeUndefined();
-    expect(graph.getFadingTiers()).toEqual({
+    const snapshot = graph.getFadingTiers();
+    expect(snapshot).toEqual({
       default: defaultTier,
       worker: workerTier,
     });
+    snapshot.worker.budgetTokens = 1;
+    expect(graph.getFadingTiers().worker).toEqual(workerTier);
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1,6 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { FadingTier } from '@/types/graph';
+import type { AgentInputs, FadingTier } from '@/types/graph';
 import type { TokenCounter } from '@/types/run';
 import {
   fadingBudgetTokens,
@@ -20,6 +20,8 @@ import {
   createPruneMessages,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
+import { StandardGraph } from '@/graphs/Graph';
+import { Providers } from '@/common';
 
 const tokenCounter: TokenCounter = (message) => {
   const content = message.content;
@@ -108,19 +110,29 @@ describe('fading ladder', () => {
     expect(isFadingTier({ v: 1, budgetTokens: 100, masked: true })).toBe(true);
     expect(isFadingTier({ v: 2, budgetTokens: 100, masked: true })).toBe(false);
     expect(isFadingTier({ v: 1, budgetTokens: 0, masked: true })).toBe(false);
-    expect(isFadingTier({ v: 1, budgetTokens: 100, masked: 'yes' })).toBe(false);
+    expect(isFadingTier({ v: 1, budgetTokens: 100, masked: 'yes' })).toBe(
+      false
+    );
     expect(isFadingTier(null)).toBe(false);
-    expect(seedFadingTier(100_000, { v: 1, budgetTokens: 50_000, masked: true })).toEqual({
+    expect(
+      seedFadingTier(100_000, { v: 1, budgetTokens: 50_000, masked: true })
+    ).toEqual({
       v: 1,
       budgetTokens: 50_000,
       masked: true,
+      latched: true,
     });
-    expect(seedFadingTier(100_000, { v: 1, budgetTokens: 150_000, masked: false })).toEqual({
+    expect(
+      seedFadingTier(100_000, { v: 1, budgetTokens: 150_000, masked: false })
+    ).toEqual({
       v: 1,
       budgetTokens: 100_000,
       masked: false,
+      latched: true,
     });
-    expect(seedFadingTier(100_000, { rung: 3 })).toEqual(createFadingTier(100_000));
+    expect(seedFadingTier(100_000, { rung: 3 })).toEqual(
+      createFadingTier(100_000)
+    );
   });
 
   it('only deepens and never oscillates across a band threshold', () => {
@@ -130,7 +142,12 @@ describe('fading ladder', () => {
     tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.5 });
     expect(tier).toEqual(createFadingTier(window));
     tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.86 });
-    expect(tier).toEqual({ v: 1, budgetTokens: 50_000, masked: true });
+    expect(tier).toEqual({
+      v: 1,
+      budgetTokens: 50_000,
+      masked: true,
+      latched: true,
+    });
     const settled = tier;
     tier = resolveFadingTier(tier, window, { ...base, contextPressure: 0.84 });
     expect(tier).toBe(settled);
@@ -144,7 +161,12 @@ describe('fading ladder', () => {
   });
 
   it('survives a mid-run budget correction and the return to the normal window', () => {
-    const latched: FadingTier = { v: 1, budgetTokens: 100_000, masked: true };
+    const latched: FadingTier = {
+      v: 1,
+      budgetTokens: 100_000,
+      masked: true,
+      latched: true,
+    };
     const corrected = seedFadingTier(180_000, latched);
     expect(corrected).toEqual(latched);
     expect(
@@ -160,6 +182,24 @@ describe('fading ladder', () => {
     );
   });
 
+  it('keeps a restored tier informative after clamping to a smaller window', () => {
+    const restored = seedFadingTier(30_000, {
+      v: 1,
+      budgetTokens: 50_000,
+      masked: false,
+      latched: true,
+    });
+
+    expect(restored).toEqual({
+      v: 1,
+      budgetTokens: 30_000,
+      masked: false,
+      latched: true,
+    });
+    expect(isInformativeFadingTier(restored, 30_000)).toBe(true);
+    expect(seedFadingTier(100_000, restored)).toEqual(restored);
+  });
+
   it('fits a single result within half the effective budget with summarization on', () => {
     const tier = resolveFadingTier(createFadingTier(32_000), 32_000, {
       contextPressure: 0.3,
@@ -168,7 +208,9 @@ describe('fading ladder', () => {
     });
     const caps = resolveFadingCaps(tier);
     expect(caps.resultChars / 4).toBeLessThanOrEqual(9_400 / 2);
-    expect(caps.resultChars).toBe(calculateMaxToolResultChars(caps.budgetTokens));
+    expect(caps.resultChars).toBe(
+      calculateMaxToolResultChars(caps.budgetTokens)
+    );
     expect(caps.consumedChars).toBe(caps.resultChars);
   });
 
@@ -176,7 +218,9 @@ describe('fading ladder', () => {
     const masked: FadingTier = { v: 1, budgetTokens: 100_000, masked: true };
     const caps = resolveFadingCaps(masked);
     expect(caps.consumedChars).toBe(Math.floor(caps.resultChars * 0.1));
-    expect(resolveFadingCaps({ ...masked, budgetTokens: 400 }).consumedChars).toBe(300);
+    expect(
+      resolveFadingCaps({ ...masked, budgetTokens: 400 }).consumedChars
+    ).toBe(300);
     expect(resolveFadingCaps(masked, 1_000).resultChars).toBe(1_000);
   });
 });
@@ -252,7 +296,12 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
   function runTurn(
     messages: BaseMessage[],
     options: TurnOptions
-  ): { early: string; pressure: number; tier: FadingTier; contextLength: number } {
+  ): {
+    early: string;
+    pressure: number;
+    tier: FadingTier;
+    contextLength: number;
+  } {
     const pruneMessages = createPruneMessages({
       maxTokens,
       startIndex: messages.length,
@@ -278,14 +327,19 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       calibrationRatio: 1,
     });
     expect(first.early).toContain('truncated');
-    expect(first.early.length).toBeLessThanOrEqual(calculateMaxToolResultChars(maxTokens));
+    expect(first.early.length).toBeLessThanOrEqual(
+      calculateMaxToolResultChars(maxTokens)
+    );
 
     const ratios = [1.03, 1.12, 1.25, 1.4];
     ratios.forEach((calibrationRatio, index) => {
-      const later = runTurn(conversation([60_000, ...Array(index + 1).fill(400)]), {
-        summarizationEnabled: true,
-        calibrationRatio,
-      });
+      const later = runTurn(
+        conversation([60_000, ...Array(index + 1).fill(400)]),
+        {
+          summarizationEnabled: true,
+          calibrationRatio,
+        }
+      );
       expect(later.pressure).toBeLessThan(0.8);
       expect(later.early).toBe(first.early);
     });
@@ -300,14 +354,19 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(first.pressure).toBeGreaterThanOrEqual(0.8);
     expect(first.tier.masked).toBe(true);
     expect(first.early).toContain('truncated');
-    expect(first.early.length).toBeLessThanOrEqual(resolveFadingCaps(first.tier).consumedChars);
+    expect(first.early.length).toBeLessThanOrEqual(
+      resolveFadingCaps(first.tier).consumedChars
+    );
 
     const ratios = [1.01, 1.02, 1.03];
     ratios.forEach((calibrationRatio, index) => {
-      const later = runTurn(conversation([...history, ...Array(index + 1).fill(200)]), {
-        summarizationEnabled: false,
-        calibrationRatio,
-      });
+      const later = runTurn(
+        conversation([...history, ...Array(index + 1).fill(200)]),
+        {
+          summarizationEnabled: false,
+          calibrationRatio,
+        }
+      );
       expect(later.tier).toEqual(first.tier);
       expect(later.early).toBe(first.early);
     });
@@ -384,6 +443,37 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     }
   });
 
+  it('derives a deeper tier from canonical content instead of the prior tier output', () => {
+    const messages = conversation([60_000]);
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+    });
+    pruneMessages({ messages });
+    const firstTierBytes = serialize(messages[2]);
+
+    messages.push(...round(1, 60_000), ...round(2, 60_000));
+    const escalated = pruneMessages({ messages });
+    const escalatedBytes = serialize(messages[2]);
+    expect(escalatedBytes).not.toBe(firstTierBytes);
+
+    const rebuilt = conversation([60_000, 60_000, 60_000]);
+    const fresh = createPruneMessages({
+      maxTokens,
+      startIndex: rebuilt.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(rebuilt),
+      summarizationEnabled: false,
+      fadingTier: escalated.fadingTier,
+    });
+    fresh({ messages: rebuilt });
+
+    expect(serialize(rebuilt[2])).toBe(escalatedBytes);
+  });
+
   it('emergency truncation recovers on a clone without latching the tier', () => {
     const ids = ['p1', 'p2', 'p3', 'p4'];
     const messages: BaseMessage[] = [
@@ -392,8 +482,9 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       toolCall(...ids),
       ...ids.map((id) => toolResult(id, 47_000)),
     ];
-    const originalLengths = ids.map((_, index) =>
-      serialize(messages[messages.length - ids.length + index]).length
+    const originalLengths = ids.map(
+      (_, index) =>
+        serialize(messages[messages.length - ids.length + index]).length
     );
     const pruneMessages = createPruneMessages({
       maxTokens,
@@ -409,12 +500,14 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(result.context.length).toBeGreaterThan(0);
     expect(result.fadingTier.budgetTokens).toBe(maxTokens);
     ids.forEach((_, index) => {
-      expect(serialize(messages[messages.length - ids.length + index]).length).toBe(
-        originalLengths[index]
-      );
+      expect(
+        serialize(messages[messages.length - ids.length + index]).length
+      ).toBe(originalLengths[index]);
     });
     const contextSet = new Set(result.context);
-    expect(result.messagesToRefine?.some((message) => contextSet.has(message))).toBe(false);
+    expect(
+      result.messagesToRefine?.some((message) => contextSet.has(message))
+    ).toBe(false);
 
     const again = pruneMessages({ messages });
     expect(again.fadingTier).toEqual(result.fadingTier);
@@ -424,9 +517,67 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
 describe('isInformativeFadingTier', () => {
   it('reports only tiers a host should persist', () => {
     expect(isInformativeFadingTier(undefined, 100_000)).toBe(false);
-    expect(isInformativeFadingTier(createFadingTier(100_000), 100_000)).toBe(false);
-    expect(isInformativeFadingTier({ v: 1, budgetTokens: 100_000, masked: true }, 100_000)).toBe(true);
-    expect(isInformativeFadingTier({ v: 1, budgetTokens: 50_000, masked: false }, 100_000)).toBe(true);
-    expect(isInformativeFadingTier({ v: 1, budgetTokens: 50_000, masked: false }, undefined)).toBe(false);
+    expect(isInformativeFadingTier(createFadingTier(100_000), 100_000)).toBe(
+      false
+    );
+    expect(
+      isInformativeFadingTier(
+        { v: 1, budgetTokens: 100_000, masked: true },
+        100_000
+      )
+    ).toBe(true);
+    expect(
+      isInformativeFadingTier(
+        { v: 1, budgetTokens: 50_000, masked: false },
+        100_000
+      )
+    ).toBe(true);
+    expect(
+      isInformativeFadingTier(
+        { v: 1, budgetTokens: 50_000, masked: false },
+        undefined
+      )
+    ).toBe(false);
+  });
+});
+
+describe('per-agent fading tier persistence', () => {
+  const graphAgent = (agentId: string): AgentInputs => ({
+    agentId,
+    provider: Providers.OPENAI,
+    instructions: agentId,
+    maxContextTokens: 100_000,
+  });
+
+  it('restores keyed tiers without applying the default tier to every agent', () => {
+    const defaultTier: FadingTier = {
+      v: 1,
+      budgetTokens: 50_000,
+      masked: false,
+      latched: true,
+    };
+    const workerTier: FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const graph = new StandardGraph({
+      agents: [
+        graphAgent('default'),
+        graphAgent('worker'),
+        graphAgent('unseeded'),
+      ],
+      fadingTier: defaultTier,
+      fadingTiers: { worker: workerTier },
+    });
+
+    expect(graph.agentContexts.get('default')?.fadingTier).toEqual(defaultTier);
+    expect(graph.agentContexts.get('worker')?.fadingTier).toEqual(workerTier);
+    expect(graph.agentContexts.get('unseeded')?.fadingTier).toBeUndefined();
+    expect(graph.getFadingTiers()).toEqual({
+      default: defaultTier,
+      worker: workerTier,
+    });
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1,11 +1,21 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { FadingTier } from '@/types/graph';
 import type { TokenCounter } from '@/types/run';
 import {
-  calculateMaskedResultMaxChars,
+  fadingBudgetTokens,
+  fadingRungForBudget,
+  fadingRungForResultChars,
+  isFadingTier,
+  maxFadingRung,
+  resolveFadingCaps,
+  resolveFadingTier,
+  seedFadingTier,
+  createFadingTier,
+} from '@/messages/fading';
+import {
   maskConsumedToolResults,
   preFlightTruncateToolResults,
-  resolveFadingBudgetTokens,
   createPruneMessages,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
@@ -51,9 +61,7 @@ function conversation(rounds: number[]): BaseMessage[] {
   return rounds.flatMap((chars, index) => round(index, chars));
 }
 
-function countMap(
-  messages: BaseMessage[]
-): Record<string, number | undefined> {
+function countMap(messages: BaseMessage[]): Record<string, number | undefined> {
   const map: Record<string, number | undefined> = {};
   for (let i = 0; i < messages.length; i++) {
     map[i] = tokenCounter(messages[i]);
@@ -61,24 +69,108 @@ function countMap(
   return map;
 }
 
-describe('resolveFadingBudgetTokens', () => {
-  it('scales the fixed context window by the discrete pressure band only', () => {
-    expect(resolveFadingBudgetTokens(100_000, 0.3)).toBe(100_000);
-    expect(resolveFadingBudgetTokens(100_000, 0.8)).toBe(100_000);
-    expect(resolveFadingBudgetTokens(100_000, 0.849)).toBe(100_000);
-    expect(resolveFadingBudgetTokens(100_000, 0.85)).toBe(50_000);
-    expect(resolveFadingBudgetTokens(100_000, 0.9)).toBe(20_000);
-    expect(resolveFadingBudgetTokens(100_000, 0.99)).toBe(5_000);
-    expect(resolveFadingBudgetTokens(2_000, 0.99)).toBe(1_024);
+describe('fading ladder', () => {
+  it('halves the budget per rung down to the floor', () => {
+    expect(fadingBudgetTokens(100_000, 0)).toBe(100_000);
+    expect(fadingBudgetTokens(100_000, 1)).toBe(50_000);
+    expect(fadingBudgetTokens(100_000, 3)).toBe(12_500);
+    expect(fadingBudgetTokens(100_000, 20)).toBe(170);
+    expect(fadingBudgetTokens(100, 5)).toBe(100);
+    expect(maxFadingRung(100_000)).toBe(10);
+    expect(maxFadingRung(100)).toBe(0);
   });
-});
 
-describe('calculateMaskedResultMaxChars', () => {
-  it('keeps a fixed fraction of the fresh-result cap with a floor', () => {
-    expect(calculateMaskedResultMaxChars(100_000)).toBe(
-      Math.floor(calculateMaxToolResultChars(100_000) * 0.1)
+  it('picks the shallowest rung that fits a budget or a result cap', () => {
+    expect(fadingRungForBudget(100_000, 100_000)).toBe(0);
+    expect(fadingRungForBudget(100_000, 60_000)).toBe(0);
+    expect(fadingRungForBudget(100_000, 9_400)).toBe(3);
+    expect(fadingRungForBudget(100_000, 0)).toBe(0);
+    expect(
+      calculateMaxToolResultChars(
+        fadingBudgetTokens(100_000, fadingRungForBudget(100_000, 9_400))
+      ) / 4
+    ).toBeLessThanOrEqual(9_400 / 2);
+    expect(fadingRungForResultChars(100_000, 200)).toBe(maxFadingRung(100_000));
+    expect(
+      calculateMaxToolResultChars(
+        fadingBudgetTokens(100_000, fadingRungForResultChars(100_000, 5_000))
+      )
+    ).toBeLessThanOrEqual(5_000);
+  });
+
+  it('validates and seeds persisted tiers', () => {
+    expect(isFadingTier({ v: 1, window: 100, rung: 2, masked: true })).toBe(
+      true
     );
-    expect(calculateMaskedResultMaxChars(1_024)).toBe(300);
+    expect(isFadingTier({ v: 2, window: 100, rung: 2, masked: true })).toBe(
+      false
+    );
+    expect(isFadingTier({ v: 1, window: 100, rung: 1.5, masked: true })).toBe(
+      false
+    );
+    expect(isFadingTier(null)).toBe(false);
+    expect(
+      seedFadingTier(100_000, { v: 1, window: 100_000, rung: 3, masked: true })
+    ).toEqual({
+      v: 1,
+      window: 100_000,
+      rung: 3,
+      masked: true,
+    });
+    expect(
+      seedFadingTier(100_000, { v: 1, window: 50_000, rung: 3, masked: true })
+    ).toEqual(createFadingTier(100_000));
+    expect(
+      seedFadingTier(100_000, {
+        v: 1,
+        window: 100_000,
+        rung: 99,
+        masked: false,
+      }).rung
+    ).toBe(maxFadingRung(100_000));
+  });
+
+  it('only deepens and never oscillates across a band threshold', () => {
+    const base = { effectiveRawTokens: 100_000, summarizationEnabled: false };
+    let tier = createFadingTier(100_000);
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.5 });
+    expect(tier).toEqual(createFadingTier(100_000));
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.86 });
+    expect(tier).toEqual({ v: 1, window: 100_000, rung: 1, masked: true });
+    const settled = tier;
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.84 });
+    expect(tier).toBe(settled);
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.86 });
+    expect(tier).toBe(settled);
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.91 });
+    expect(tier.rung).toBe(2);
+    tier = resolveFadingTier(tier, { ...base, contextPressure: 0.3 });
+    expect(tier.rung).toBe(2);
+    expect(tier.masked).toBe(true);
+  });
+
+  it('fits a single result within the effective budget with summarization on', () => {
+    const tier = resolveFadingTier(createFadingTier(32_000), {
+      contextPressure: 0.3,
+      effectiveRawTokens: 9_400,
+      summarizationEnabled: true,
+    });
+    const caps = resolveFadingCaps(tier);
+    expect(caps.resultChars / 4).toBeLessThanOrEqual(9_400 / 2);
+    expect(caps.resultChars).toBe(
+      calculateMaxToolResultChars(caps.budgetTokens)
+    );
+    expect(caps.consumedChars).toBe(caps.resultChars);
+  });
+
+  it('masks consumed results to a fraction of the fresh cap with a floor', () => {
+    const masked: FadingTier = { v: 1, window: 100_000, rung: 0, masked: true };
+    const caps = resolveFadingCaps(masked);
+    expect(caps.consumedChars).toBe(Math.floor(caps.resultChars * 0.1));
+    expect(
+      resolveFadingCaps({ ...masked, window: 400, rung: 0 }).consumedChars
+    ).toBe(300);
+    expect(resolveFadingCaps(masked, 1_000).resultChars).toBe(1_000);
   });
 });
 
@@ -142,11 +234,23 @@ describe('maskConsumedToolResults stability', () => {
 describe('pruner keeps historical tool results byte-stable across turns', () => {
   const maxTokens = 40_000;
 
+  type TurnOptions = {
+    summarizationEnabled: boolean;
+    calibrationRatio: number;
+    fadingTier?: FadingTier;
+    instructionTokens?: number;
+  };
+
   /** Mirrors a host that rebuilds full-content messages and a fresh pruner every run. */
   function runTurn(
     messages: BaseMessage[],
-    options: { summarizationEnabled: boolean; calibrationRatio: number }
-  ): { early: string; pressure: number } {
+    options: TurnOptions
+  ): {
+    early: string;
+    pressure: number;
+    tier: FadingTier;
+    contextLength: number;
+  } {
     const pruneMessages = createPruneMessages({
       maxTokens,
       startIndex: messages.length,
@@ -154,9 +258,16 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       indexTokenCountMap: countMap(messages),
       summarizationEnabled: options.summarizationEnabled,
       calibrationRatio: options.calibrationRatio,
+      fadingTier: options.fadingTier,
+      getInstructionTokens: () => options.instructionTokens ?? 0,
     });
     const result = pruneMessages({ messages });
-    return { early: serialize(messages[2]), pressure: result.contextPressure ?? 0 };
+    return {
+      early: serialize(messages[2]),
+      pressure: result.contextPressure ?? 0,
+      tier: result.fadingTier,
+      contextLength: result.context.length,
+    };
   }
 
   it('fit-to-budget truncation (summarization on) ignores calibration drift and growth', () => {
@@ -173,36 +284,86 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     ratios.forEach((calibrationRatio, index) => {
       const later = runTurn(
         conversation([60_000, ...Array(index + 1).fill(400)]),
-        { summarizationEnabled: true, calibrationRatio }
+        {
+          summarizationEnabled: true,
+          calibrationRatio,
+        }
       );
       expect(later.pressure).toBeLessThan(0.8);
       expect(later.early).toBe(first.early);
     });
   });
 
-  it('masking under pressure (summarization off) is stable within a band', () => {
+  it('masking under pressure (summarization off) is stable within a tier', () => {
     const history = [60_000, 48_000, 16_000];
     const first = runTurn(conversation(history), {
       summarizationEnabled: false,
       calibrationRatio: 1,
     });
     expect(first.pressure).toBeGreaterThanOrEqual(0.8);
-    expect(first.pressure).toBeLessThan(0.85);
+    expect(first.tier.masked).toBe(true);
     expect(first.early).toContain('truncated');
     expect(first.early.length).toBeLessThanOrEqual(
-      calculateMaskedResultMaxChars(maxTokens)
+      resolveFadingCaps(first.tier).consumedChars
     );
 
     const ratios = [1.01, 1.02, 1.03];
     ratios.forEach((calibrationRatio, index) => {
       const later = runTurn(
         conversation([...history, ...Array(index + 1).fill(200)]),
-        { summarizationEnabled: false, calibrationRatio }
+        {
+          summarizationEnabled: false,
+          calibrationRatio,
+        }
       );
-      expect(later.pressure).toBeGreaterThanOrEqual(0.8);
-      expect(later.pressure).toBeLessThan(0.85);
+      expect(later.tier).toEqual(first.tier);
       expect(later.early).toBe(first.early);
     });
+  });
+
+  it('a persisted tier reproduces the same bytes even when pressure falls below the threshold', () => {
+    const first = runTurn(conversation([60_000, 48_000, 16_000]), {
+      summarizationEnabled: false,
+      calibrationRatio: 1,
+    });
+    expect(first.tier.masked).toBe(true);
+
+    const seeded = runTurn(conversation([60_000, 48_000, 16_000]), {
+      summarizationEnabled: false,
+      calibrationRatio: 0.7,
+      fadingTier: first.tier,
+    });
+    expect(seeded.pressure).toBeLessThan(0.8);
+    expect(seeded.tier).toEqual(first.tier);
+    expect(seeded.early).toBe(first.early);
+
+    const unseeded = runTurn(conversation([60_000, 48_000, 16_000]), {
+      summarizationEnabled: false,
+      calibrationRatio: 0.7,
+    });
+    expect(unseeded.tier.masked).toBe(false);
+    expect(unseeded.early).not.toBe(first.early);
+  });
+
+  it('keeps a first context non-empty when instructions dominate a small window', () => {
+    const messages = conversation([38_400]);
+    const pruneMessages = createPruneMessages({
+      maxTokens: 32_000,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: true,
+      calibrationRatio: 1,
+      getInstructionTokens: () => 21_000,
+    });
+    const result = pruneMessages({ messages });
+    expect(result.context.length).toBe(messages.length);
+    expect(result.messagesToRefine).toEqual([]);
+    expect(serialize(messages[2]).length).toBeLessThanOrEqual(
+      calculateMaxToolResultChars(
+        resolveFadingCaps(result.fadingTier).budgetTokens
+      )
+    );
   });
 
   it('holds bytes stable within one run while provider usage recalibrates', () => {
@@ -229,6 +390,7 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       expect(result.calibrationRatio).not.toBe(previousRatio);
       previousRatio = result.calibrationRatio ?? previousRatio;
       expect(serialize(messages[2])).toBe(early);
+      expect(result.fadingTier).toEqual(first.fadingTier);
     }
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -7,6 +7,7 @@ import {
   fadingRungForBudget,
   fadingRungForResultChars,
   isFadingTier,
+  isInformativeFadingTier,
   maxFadingRung,
   resolveFadingCaps,
   resolveFadingTier,
@@ -417,5 +418,15 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
 
     const again = pruneMessages({ messages });
     expect(again.fadingTier).toEqual(result.fadingTier);
+  });
+});
+
+describe('isInformativeFadingTier', () => {
+  it('reports only tiers a host should persist', () => {
+    expect(isInformativeFadingTier(undefined, 100_000)).toBe(false);
+    expect(isInformativeFadingTier(createFadingTier(100_000), 100_000)).toBe(false);
+    expect(isInformativeFadingTier({ v: 1, budgetTokens: 100_000, masked: true }, 100_000)).toBe(true);
+    expect(isInformativeFadingTier({ v: 1, budgetTokens: 50_000, masked: false }, 100_000)).toBe(true);
+    expect(isInformativeFadingTier({ v: 1, budgetTokens: 50_000, masked: false }, undefined)).toBe(false);
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1115,6 +1115,27 @@ describe('isInformativeFadingTier', () => {
     ).toBe(true);
   });
 
+  it('ignores proxied and accessor-backed text blocks safely', () => {
+    const accessorBlock = Object.defineProperty({}, 'type', {
+      get() {
+        throw new Error('type getter must not run');
+      },
+    });
+    const proxiedBlock = new Proxy(
+      { type: 'text', text: 'hidden' },
+      {
+        get() {
+          throw new Error('proxy getter must not run');
+        },
+      }
+    );
+
+    expect(
+      hasNonEmptyTextContent([accessorBlock, proxiedBlock] as never)
+    ).toBe(false);
+    expect(hasNonEmptyTextContent(new Proxy([], {}) as never)).toBe(false);
+  });
+
   it('reports only tiers a host should persist', () => {
     expect(isInformativeFadingTier(undefined, 100_000)).toBe(false);
     expect(isInformativeFadingTier(createFadingTier(100_000), 100_000)).toBe(

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -19,6 +19,7 @@ import {
   preFlightTruncateToolResults,
   createPruneMessages,
   projectToolCallInputs,
+  ORIGINAL_CONTENT_MAX_CHARS,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { StandardGraph } from '@/graphs/Graph';
@@ -719,6 +720,77 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(serialize(rebuilt[2])).toBe(escalatedBytes);
   });
 
+  it('retains bounded canonical results when overflow recreates the pruner', () => {
+    const messages = conversation([60_000]);
+    const canonicalToolContent = new Map<
+      number,
+      BaseMessage['content']
+    >();
+    const firstPruner = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      canonicalToolContent,
+    });
+    const first = firstPruner({ messages });
+    expect(canonicalToolContent.get(2)).toBeDefined();
+
+    const correctedPruner = createPruneMessages({
+      maxTokens: 20_000,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      fadingTier: first.fadingTier,
+      canonicalToolContent,
+    });
+    const corrected = correctedPruner({ messages });
+
+    const rebuilt = conversation([60_000]);
+    const freshPruner = createPruneMessages({
+      maxTokens: 20_000,
+      startIndex: rebuilt.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(rebuilt),
+      summarizationEnabled: false,
+      fadingTier: corrected.fadingTier,
+    });
+    freshPruner({ messages: rebuilt });
+
+    expect(serialize(messages[2])).toBe(serialize(rebuilt[2]));
+  });
+
+  it('caps retained canonical result content across long histories', () => {
+    const messages = conversation(Array(8).fill(500_000));
+    const canonicalToolContent = new Map<
+      number,
+      BaseMessage['content']
+    >();
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: messages.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      canonicalToolContent,
+    });
+
+    pruneMessages({ messages });
+
+    const retainedChars = [...canonicalToolContent.values()].reduce(
+      (total, content) =>
+        total +
+        (typeof content === 'string'
+          ? content.length
+          : JSON.stringify(content).length),
+      0
+    );
+    expect(retainedChars).toBeLessThanOrEqual(ORIGINAL_CONTENT_MAX_CHARS);
+    expect(canonicalToolContent.size).toBeLessThan(8);
+  });
+
   it('emergency truncation recovers on a clone without latching the tier', () => {
     const ids = ['p1', 'p2', 'p3', 'p4'];
     const messages: BaseMessage[] = [
@@ -854,5 +926,22 @@ describe('per-agent fading tier persistence', () => {
     });
 
     expect(graph.agentContexts.get('default')?.fadingTier).toBeUndefined();
+  });
+
+  it('round-trips prototype-sensitive agent IDs', () => {
+    const tier: FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const fadingTiers = Object.fromEntries([['__proto__', tier]]);
+    const graph = new StandardGraph({
+      agents: [graphAgent('__proto__')],
+      fadingTiers,
+    });
+
+    expect(Object.hasOwn(graph.getFadingTiers(), '__proto__')).toBe(true);
+    expect(graph.getFadingTiers()['__proto__']).toEqual(tier);
   });
 });

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -571,6 +571,34 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
     expect(serializeToolCallInputs(rebuilt[1])).toBe(escalatedInputs);
   });
 
+  it('snapshots the true original for the summarizer when a capped result is masked later', () => {
+    const originalChars = serialize(conversation([60_000])[2]).length;
+    const messages = conversation([60_000]);
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: true,
+      calibrationRatio: 1,
+      getInstructionTokens: () => 0,
+    });
+    const first = pruneMessages({ messages });
+    expect(first.fadingTier.masked).toBe(false);
+    expect(serialize(messages[2]).length).toBeLessThan(originalChars);
+
+    messages.push(...round(1, 40_000), ...round(2, 40_000));
+    const second = pruneMessages({ messages });
+    expect(second.fadingTier.masked).toBe(true);
+    expect(serialize(messages[2]).length).toBeLessThanOrEqual(
+      resolveFadingCaps(second.fadingTier).consumedChars
+    );
+    expect(serialize(messages[2])).toContain(
+      `truncated: ${originalChars} chars`
+    );
+    expect(second.newOriginalToolContent?.get(2)?.length).toBe(originalChars);
+  });
+
   it('emergency truncation recovers on a clone without latching the tier', () => {
     const ids = ['p1', 'p2', 'p3', 'p4'];
     const messages: BaseMessage[] = [

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -18,6 +18,7 @@ import {
   maskConsumedToolResults,
   preFlightTruncateToolResults,
   createPruneMessages,
+  projectToolCallInputs,
 } from '@/messages/prune';
 import { calculateMaxToolResultChars } from '@/utils/truncation';
 import { StandardGraph } from '@/graphs/Graph';
@@ -84,6 +85,18 @@ function toolCallWithInput(id: string, chars: number): AIMessage {
           arguments: serialized,
         },
       ],
+    },
+  });
+}
+
+function legacyToolCallWithInput(chars: number): AIMessage {
+  return new AIMessage({
+    content: '',
+    additional_kwargs: {
+      function_call: {
+        name: 'fetch',
+        arguments: 'q'.repeat(chars),
+      },
     },
   });
 }
@@ -597,6 +610,88 @@ describe('pruner keeps historical tool results byte-stable across turns', () => 
       `truncated: ${originalChars} chars`
     );
     expect(second.newOriginalToolContent?.get(2)?.length).toBe(originalChars);
+  });
+
+  it('composes nearby tool-call input caps without retaining the source message', () => {
+    const source = toolCallWithInput('composable-input', 60_000);
+    const [firstProjection] = projectToolCallInputs([source], 30_000);
+    const [composedProjection] = projectToolCallInputs(
+      [firstProjection],
+      29_990
+    );
+    const [directProjection] = projectToolCallInputs([source], 29_990);
+
+    expect(serializeToolCallInputs(composedProjection)).toBe(
+      serializeToolCallInputs(directProjection)
+    );
+  });
+
+  it('restores legacy function calls identically across model windows', () => {
+    const tier: FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: false,
+      latched: true,
+    };
+    const projectAtWindow = (windowTokens: number): string => {
+      const messages: BaseMessage[] = [
+        new HumanMessage('fetch with legacy arguments'),
+        legacyToolCallWithInput(180_000),
+      ];
+      const pruneMessages = createPruneMessages({
+        maxTokens: windowTokens,
+        startIndex: messages.length,
+        tokenCounter,
+        indexTokenCountMap: countMap(messages),
+        summarizationEnabled: false,
+        fadingTier: tier,
+      });
+      pruneMessages({ messages });
+      return serializeToolCallInputs(messages[1]);
+    };
+
+    expect(projectAtWindow(100_000)).toBe(projectAtWindow(200_000));
+  });
+
+  it('retains canonical result provenance through position pruning', () => {
+    const contextPruningConfig = {
+      enabled: true,
+      keepLastAssistants: 1,
+      softTrimRatio: 0,
+      minPrunableToolChars: 1,
+      softTrim: { maxChars: 4_000, headChars: 1_500, tailChars: 1_500 },
+      hardClear: { enabled: false },
+    };
+    const messages = conversation([60_000]);
+    const pruneMessages = createPruneMessages({
+      maxTokens,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap: countMap(messages),
+      summarizationEnabled: false,
+      contextPruningConfig,
+    });
+    pruneMessages({ messages });
+    const positionPruned = serialize(messages[2]);
+
+    messages.push(...round(1, 60_000), ...round(2, 60_000));
+    const escalated = pruneMessages({ messages });
+    const escalatedBytes = serialize(messages[2]);
+    expect(escalatedBytes).not.toBe(positionPruned);
+
+    const rebuilt = conversation([60_000, 60_000, 60_000]);
+    const fresh = createPruneMessages({
+      maxTokens,
+      startIndex: rebuilt.length,
+      tokenCounter,
+      indexTokenCountMap: countMap(rebuilt),
+      summarizationEnabled: false,
+      contextPruningConfig,
+      fadingTier: escalated.fadingTier,
+    });
+    fresh({ messages: rebuilt });
+
+    expect(serialize(rebuilt[2])).toBe(escalatedBytes);
   });
 
   it('emergency truncation recovers on a clone without latching the tier', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -157,6 +157,8 @@ describe('fading ladder', () => {
     expect(fadingRungForBudget(100_000, 100_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 60_000)).toBe(0);
     expect(fadingRungForBudget(100_000, 9_400)).toBe(3);
+    expect(fadingRungForBudget(100_000, 9_400, 1_000)).toBe(0);
+    expect(fadingRungForBudget(100_000, 9_400, 0)).toBe(0);
     expect(fadingRungForBudget(100_000, 0)).toBe(0);
     expect(
       calculateMaxToolResultChars(
@@ -277,6 +279,25 @@ describe('fading ladder', () => {
       calculateMaxToolResultChars(caps.budgetTokens)
     );
     expect(caps.consumedChars).toBe(caps.resultChars);
+  });
+
+  it('does not deepen the tier when a configured result cap already fits', () => {
+    const tier = resolveFadingTier(
+      createFadingTier(100_000),
+      100_000,
+      {
+        contextPressure: 0.3,
+        effectiveRawTokens: 9_400,
+        summarizationEnabled: true,
+      },
+      1_000
+    );
+
+    expect(tier).toEqual(createFadingTier(100_000));
+    expect(resolveFadingCaps(tier, 1_000)).toMatchObject({
+      resultChars: 1_000,
+      inputChars: 60_000,
+    });
   });
 
   it('masks consumed results to a fraction of the fresh cap with a floor', () => {

--- a/src/messages/__tests__/truncationStability.test.ts
+++ b/src/messages/__tests__/truncationStability.test.ts
@@ -1340,3 +1340,43 @@ describe('fadingRungForExchangeChars', () => {
     expect(fadingRungForExchangeChars(window, 1)).toBe(maxFadingRung(window));
   });
 });
+
+describe('hasNonEmptyTextContent hostile iteration', () => {
+  it('never invokes iterators or accessors while scanning content blocks', () => {
+    const hostileIterator: unknown[] = [{ type: 'text', text: 'hidden' }];
+    Object.defineProperty(hostileIterator, Symbol.iterator, {
+      get() {
+        throw new Error('iterator invoked');
+      },
+    });
+    expect(
+      hasNonEmptyTextContent(hostileIterator as BaseMessage['content'])
+    ).toBe(true);
+
+    const accessorElement: unknown[] = [];
+    Object.defineProperty(accessorElement, 0, {
+      get() {
+        throw new Error('accessor invoked');
+      },
+      enumerable: true,
+    });
+    accessorElement.length = 2;
+    accessorElement[1] = { type: 'text', text: 'visible' };
+    expect(
+      hasNonEmptyTextContent(accessorElement as BaseMessage['content'])
+    ).toBe(true);
+
+    const accessorOnly: unknown[] = [];
+    Object.defineProperty(accessorOnly, 0, {
+      get() {
+        throw new Error('accessor invoked');
+      },
+    });
+    expect(hasNonEmptyTextContent(accessorOnly as BaseMessage['content'])).toBe(
+      false
+    );
+    expect(
+      hasNonEmptyTextContent({ type: 'text', text: 'x' } as unknown as BaseMessage['content'])
+    ).toBe(false);
+  });
+});

--- a/src/messages/contextPruning.test.ts
+++ b/src/messages/contextPruning.test.ts
@@ -181,4 +181,53 @@ describe('applyContextPruning', () => {
     expect(messages[2]).toBe(computerOutput);
     expect(messages[2].content).toBe(screenshot);
   });
+
+  it('keeps canonical-size eligibility after fading rebuilds a result', () => {
+    const canonicalMessages: BaseMessage[] = [
+      new HumanMessage('old question'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'tc-old',
+            name: 'fetch',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'x'.repeat(100_000),
+        tool_call_id: 'tc-old',
+      }),
+      new AIMessage('old answer'),
+      new HumanMessage('new question'),
+      new AIMessage('new answer'),
+    ];
+    const messages = [...canonicalMessages];
+    messages[2] = new ToolMessage({
+      content: 'x'.repeat(25_000),
+      tool_call_id: 'tc-old',
+    });
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+
+    const result = applyContextPruning({
+      messages,
+      canonicalMessages,
+      indexTokenCountMap,
+      tokenCounter: charCounter,
+      config: {
+        enabled: true,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        hardClearRatio: 0,
+        minPrunableToolChars: 50_000,
+        softTrim: { maxChars: 10_000, headChars: 4_000, tailChars: 2_000 },
+        hardClear: { enabled: true, placeholder: '[cleared]' },
+      },
+    });
+
+    expect(result.hardCleared).toBe(1);
+    expect(messages[2].content).toBe('[cleared]');
+  });
 });

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -64,6 +64,8 @@ export function applyContextPruning(params: {
   tokenCounter: TokenCounter;
   config?: ContextPruningConfig;
   resolvedSettings?: ContextPruningSettings;
+  /** Carries caller-owned provenance across immutable message replacement. */
+  onMessageCloned?: (source: BaseMessage, clone: BaseMessage) => void;
 }): ContextPruningResult {
   const {
     messages,
@@ -156,6 +158,7 @@ export function applyContextPruning(params: {
           message as ToolMessage,
           compacted.content
         );
+        params.onMessageCloned?.(message, cloned);
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);
         softTrimmed++;
@@ -169,6 +172,7 @@ export function applyContextPruning(params: {
         message as ToolMessage,
         settings.hardClear.placeholder
       );
+      params.onMessageCloned?.(message, cloned);
       messages[i] = cloned;
       indexTokenCountMap[i] = tokenCounter(cloned);
       hardCleared++;
@@ -187,6 +191,7 @@ export function applyContextPruning(params: {
             settings.softTrim
           )
         );
+        params.onMessageCloned?.(message, cloned);
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);
         softTrimmed++;

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -64,8 +64,6 @@ export function applyContextPruning(params: {
   tokenCounter: TokenCounter;
   config?: ContextPruningConfig;
   resolvedSettings?: ContextPruningSettings;
-  /** Carries caller-owned provenance across immutable message replacement. */
-  onMessageCloned?: (source: BaseMessage, clone: BaseMessage) => void;
 }): ContextPruningResult {
   const {
     messages,
@@ -158,7 +156,6 @@ export function applyContextPruning(params: {
           message as ToolMessage,
           compacted.content
         );
-        params.onMessageCloned?.(message, cloned);
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);
         softTrimmed++;
@@ -172,7 +169,6 @@ export function applyContextPruning(params: {
         message as ToolMessage,
         settings.hardClear.placeholder
       );
-      params.onMessageCloned?.(message, cloned);
       messages[i] = cloned;
       indexTokenCountMap[i] = tokenCounter(cloned);
       hardCleared++;
@@ -191,7 +187,6 @@ export function applyContextPruning(params: {
             settings.softTrim
           )
         );
-        params.onMessageCloned?.(message, cloned);
         messages[i] = cloned;
         indexTokenCountMap[i] = tokenCounter(cloned);
         softTrimmed++;

--- a/src/messages/contextPruning.ts
+++ b/src/messages/contextPruning.ts
@@ -60,6 +60,8 @@ export interface ContextPruningResult {
  */
 export function applyContextPruning(params: {
   messages: BaseMessage[];
+  /** Full graph history used only to decide whether a projected result is eligible. */
+  canonicalMessages?: BaseMessage[];
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
   config?: ContextPruningConfig;
@@ -138,7 +140,11 @@ export function applyContextPruning(params: {
     }
     const content = message.content;
     const contentLength = getToolContentCharLength(content);
-    if (contentLength < settings.minPrunableToolChars) {
+    const eligibilityContent = params.canonicalMessages?.[i]?.content ?? content;
+    if (
+      getToolContentCharLength(eligibilityContent) <
+      settings.minPrunableToolChars
+    ) {
       continue;
     }
 

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -2794,16 +2794,31 @@ export function findLastIndex<T>(
   return -1;
 }
 
+/** Reads an own data property without invoking accessors; `undefined` otherwise. */
+function readOwnDataProperty(target: object, key: PropertyKey): unknown {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+    return descriptor != null && 'value' in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Whether message content carries non-whitespace text in any text block. */
 export function hasNonEmptyTextContent(content: BaseMessage['content']): boolean {
   if (typeof content === 'string') {
     return content.trim() !== '';
   }
-  if (isProxy(content)) {
+  if (!Array.isArray(content) || isProxy(content)) {
     return false;
   }
-  for (const block of content) {
-    if (typeof block !== 'object' || isProxy(block)) {
+  /** Index reads through own data descriptors: `for...of` would invoke a
+   * hostile `Symbol.iterator` or an accessor-backed element before any guard. */
+  const length = readOwnDataProperty(content, 'length');
+  const blockCount = typeof length === 'number' ? length : 0;
+  for (let i = 0; i < blockCount; i++) {
+    const block = readOwnDataProperty(content, i);
+    if (typeof block !== 'object' || block == null || isProxy(block)) {
       continue;
     }
     try {

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -2793,3 +2793,20 @@ export function findLastIndex<T>(
   }
   return -1;
 }
+
+/** Whether message content carries non-whitespace text in any text block. */
+export function hasNonEmptyTextContent(content: BaseMessage['content']): boolean {
+  if (typeof content === 'string') {
+    return content.trim() !== '';
+  }
+  for (const block of content) {
+    if (block.type !== ContentTypes.TEXT) {
+      continue;
+    }
+    const text = block[ContentTypes.TEXT];
+    if (typeof text === 'string' && text.trim() !== '') {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -2800,7 +2800,7 @@ export function hasNonEmptyTextContent(content: BaseMessage['content']): boolean
     return content.trim() !== '';
   }
   for (const block of content) {
-    if (block.type !== ContentTypes.TEXT) {
+    if (block.type !== ContentTypes.TEXT && block.type !== 'output_text') {
       continue;
     }
     const text = block[ContentTypes.TEXT];

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -2799,13 +2799,33 @@ export function hasNonEmptyTextContent(content: BaseMessage['content']): boolean
   if (typeof content === 'string') {
     return content.trim() !== '';
   }
+  if (isProxy(content)) {
+    return false;
+  }
   for (const block of content) {
-    if (block.type !== ContentTypes.TEXT && block.type !== 'output_text') {
+    if (typeof block !== 'object' || isProxy(block)) {
       continue;
     }
-    const text = block[ContentTypes.TEXT];
-    if (typeof text === 'string' && text.trim() !== '') {
-      return true;
+    try {
+      const type = Object.getOwnPropertyDescriptor(block, 'type');
+      if (
+        type == null ||
+        !('value' in type) ||
+        (type.value !== ContentTypes.TEXT && type.value !== 'output_text')
+      ) {
+        continue;
+      }
+      const text = Object.getOwnPropertyDescriptor(block, ContentTypes.TEXT);
+      if (
+        text != null &&
+        'value' in text &&
+        typeof text.value === 'string' &&
+        text.value.trim() !== ''
+      ) {
+        return true;
+      }
+    } catch {
+      continue;
     }
   }
   return false;

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -9,7 +9,7 @@ export const FADING_TIER_VERSION = 1;
 /** Context pressure at which observation masking activates. */
 export const PRESSURE_THRESHOLD_MASKING = 0.8;
 
-/** Smallest token budget a rung can shrink to; keeps the emergency floor near 200 chars. */
+/** Smallest token budget the ladder can shrink to; keeps the emergency floor near 200 chars. */
 export const FADING_MIN_BUDGET_TOKENS = 170;
 
 /** Floor for masked (consumed) tool results. */
@@ -37,7 +37,7 @@ export type FadingSignals = {
   /** (pruningBudget − instruction tokens) ÷ calibrationRatio, in raw token space. */
   effectiveRawTokens: number;
   summarizationEnabled: boolean;
-  /** Recovery paths force at least this rung. */
+  /** Recovery paths force at least this rung on the current window's ladder. */
   minRung?: number;
 };
 
@@ -55,25 +55,23 @@ function floorBudgetTokens(window: number): number {
   return Math.min(FADING_MIN_BUDGET_TOKENS, window);
 }
 
+/** Tier for a conversation that has never faded: the whole window, nothing masked. */
 export function createFadingTier(window: number): FadingTier {
-  return { v: FADING_TIER_VERSION, window, rung: 0, masked: false };
+  return { v: FADING_TIER_VERSION, budgetTokens: window, masked: false };
 }
 
 export function isFadingTier(value: unknown): value is FadingTier {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
-  const { v, window, rung, masked } = value as Partial<
+  const { v, budgetTokens, masked } = value as Partial<
     Record<keyof FadingTier, unknown>
   >;
   return (
     v === FADING_TIER_VERSION &&
-    typeof window === 'number' &&
-    Number.isFinite(window) &&
-    window > 0 &&
-    typeof rung === 'number' &&
-    Number.isInteger(rung) &&
-    rung >= 0 &&
+    typeof budgetTokens === 'number' &&
+    Number.isFinite(budgetTokens) &&
+    budgetTokens > 0 &&
     typeof masked === 'boolean'
   );
 }
@@ -93,18 +91,18 @@ export function fadingBudgetTokens(window: number, rung: number): number {
 }
 
 /**
- * Restores a tier persisted by the host. Anything invalid, or derived for a
- * different context window (model switch), starts fresh: the prefix cache is
- * invalid in that case anyway.
+ * Restores a tier persisted by the host. The budget is absolute, so a tier
+ * survives a mid-run budget correction and the return to the normal window
+ * on the next run; it is only clamped to the current window. Anything
+ * invalid starts fresh.
  */
 export function seedFadingTier(window: number, seed?: unknown): FadingTier {
-  if (!isFadingTier(seed) || seed.window !== window) {
+  if (!isFadingTier(seed)) {
     return createFadingTier(window);
   }
   return {
     v: FADING_TIER_VERSION,
-    window,
-    rung: Math.min(seed.rung, maxFadingRung(window)),
+    budgetTokens: Math.min(seed.budgetTokens, window),
     masked: seed.masked,
   };
 }
@@ -142,12 +140,12 @@ export function fadingRungForBudget(window: number, rawTokens: number): number {
   );
 }
 
-/** Character caps for a tier; a pure function of `(window, rung, masked)`. */
+/** Character caps for a tier; a pure function of `(budgetTokens, masked)`. */
 export function resolveFadingCaps(
   tier: FadingTier,
   maxToolResultChars?: number
 ): FadingCaps {
-  const budgetTokens = fadingBudgetTokens(tier.window, tier.rung);
+  const { budgetTokens } = tier;
   const windowResultChars = calculateMaxToolResultChars(budgetTokens);
   const resultChars =
     maxToolResultChars != null && maxToolResultChars > 0
@@ -171,21 +169,24 @@ export function resolveFadingCaps(
 }
 
 /**
- * Advances a tier from this call's signals. The rung only ever deepens and
- * masking only ever activates, which is the hysteresis: drift in calibration,
- * instruction overhead or message count can escalate once at a boundary but
- * never oscillate. Returns the same object when nothing changes.
+ * Advances a tier from this call's signals on the current window's ladder.
+ * The budget only ever shrinks and masking only ever activates, which is the
+ * hysteresis: drift in calibration, instruction overhead or message count
+ * can escalate once at a rung boundary but never oscillate. Returns the same
+ * object when nothing changes.
  *
- * - The fit rung guarantees a single tool result (30 % of the rung budget)
- *   fits the effective budget, so summarization never sees an empty context.
+ * - The fit rung guarantees a single tool result fits half the effective
+ *   budget, so summarization never sees an empty context.
  * - Pressure bands add rungs on top of the fit rung when summarization is
  *   off, mirroring the staged budget factors of progressive context fading.
+ * - A window larger than the latched budget (model switch) does not loosen
+ *   the tier; only compaction, which rewrites the prefix anyway, resets it.
  */
 export function resolveFadingTier(
   tier: FadingTier,
+  window: number,
   signals: FadingSignals
 ): FadingTier {
-  const { window } = tier;
   const fitRung = fadingRungForBudget(window, signals.effectiveRawTokens);
   const bandRung = signals.summarizationEnabled
     ? 0
@@ -194,12 +195,16 @@ export function resolveFadingTier(
     )?.[1] ?? 0);
   const rung = Math.min(
     maxFadingRung(window),
-    Math.max(tier.rung, fitRung + bandRung, signals.minRung ?? 0)
+    Math.max(fitRung + bandRung, signals.minRung ?? 0)
+  );
+  const budgetTokens = Math.min(
+    tier.budgetTokens,
+    fadingBudgetTokens(window, rung)
   );
   const masked =
     tier.masked || signals.contextPressure >= PRESSURE_THRESHOLD_MASKING;
-  if (rung === tier.rung && masked === tier.masked) {
+  if (budgetTokens === tier.budgetTokens && masked === tier.masked) {
     return tier;
   }
-  return { v: FADING_TIER_VERSION, window, rung, masked };
+  return { v: FADING_TIER_VERSION, budgetTokens, masked };
 }

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -18,9 +18,6 @@ export const MASKED_RESULT_MIN_CHARS = 300;
 /** Fraction of a fresh result's cap that a masked (consumed) result keeps. */
 const MASKED_RESULT_CAP_RATIO = 0.1;
 
-/** Largest share of the effective budget a single fresh tool result may occupy. */
-const FIT_SHARE = 0.5;
-
 /**
  * Pressure bands expressed as extra rungs on top of the fit rung, so the
  * budget factors land at ×0.5 (85 %), ×0.25 (90 %) and ×0.0625 (99 %).
@@ -37,6 +34,8 @@ export type FadingSignals = {
   /** (pruningBudget − instruction tokens) ÷ calibrationRatio, in raw token space. */
   effectiveRawTokens: number;
   summarizationEnabled: boolean;
+  /** Largest number of parallel calls observed in one assistant exchange. */
+  toolExchangeWidth?: number;
   /** Recovery paths force at least this rung on the current window's ladder. */
   minRung?: number;
 };
@@ -132,39 +131,37 @@ export function fadingRungForResultChars(
 }
 
 /**
- * Shallowest rung at which both halves of a historical tool exchange fit:
- * the fresh result and its tool-call input must each stay within `FIT_SHARE`
- * of `rawTokens`, the effective budget in raw token space. Together they fit
- * the whole effective budget, preventing orphan repair from dropping a result
- * merely because its matching input used the room left by a configured result
- * cap.
+ * Shallowest rung at which the configured number of parallel tool-call inputs
+ * and fresh results fit together within `rawTokens`, the effective budget in
+ * raw token space. This prevents orphan repair from dropping results merely
+ * because their shared assistant message used the room left by a configured
+ * result cap.
  */
 export function fadingRungForBudget(
   window: number,
   rawTokens: number,
-  maxToolResultChars?: number
+  maxToolResultChars?: number,
+  toolExchangeWidth = 1
 ): number {
   if (!(rawTokens > 0)) {
     return 0;
   }
-  const targetChars = Math.floor(rawTokens * FIT_SHARE) * 4;
-  const resultRung = fadingRungForResultChars(
-    window,
-    targetChars,
-    maxToolResultChars
-  );
+  const targetChars = Math.floor(rawTokens) * 4;
+  const width = Math.max(1, Math.floor(toolExchangeWidth));
   const deepest = maxFadingRung(window);
-  let inputRung = deepest;
   for (let rung = 0; rung < deepest; rung++) {
-    if (
-      calculateMaxToolCallInputChars(fadingBudgetTokens(window, rung)) <=
-      targetChars
-    ) {
-      inputRung = rung;
-      break;
+    const budgetTokens = fadingBudgetTokens(window, rung);
+    const windowResultChars = calculateMaxToolResultChars(budgetTokens);
+    const resultChars =
+      maxToolResultChars == null
+        ? windowResultChars
+        : Math.min(windowResultChars, maxToolResultChars);
+    const inputChars = calculateMaxToolCallInputChars(budgetTokens);
+    if (width * (resultChars + inputChars) <= targetChars) {
+      return rung;
     }
   }
-  return Math.max(resultRung, inputRung);
+  return deepest;
 }
 
 /** Character caps for a tier; a pure function of `(budgetTokens, masked)`. */
@@ -202,8 +199,8 @@ export function resolveFadingCaps(
  * can escalate once at a rung boundary but never oscillate. Returns the same
  * object when nothing changes.
  *
- * - The fit rung guarantees a tool result and its matching call input each fit
- *   half the effective budget, so their pair cannot empty the context.
+ * - The fit rung guarantees the widest observed parallel tool exchange fits
+ *   the effective budget as a complete input/result batch.
  * - Pressure bands add rungs on top of the fit rung when summarization is
  *   off, mirroring the staged budget factors of progressive context fading.
  * - A window larger than the latched budget (model switch) does not loosen
@@ -218,7 +215,8 @@ export function resolveFadingTier(
   const fitRung = fadingRungForBudget(
     window,
     signals.effectiveRawTokens,
-    maxToolResultChars
+    maxToolResultChars,
+    signals.toolExchangeWidth
   );
   const bandRung = signals.summarizationEnabled
     ? 0

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -208,3 +208,18 @@ export function resolveFadingTier(
   }
   return { v: FADING_TIER_VERSION, budgetTokens, masked };
 }
+
+/**
+ * Whether a tier carries information a host should persist: masking has
+ * activated or the budget sits below the pruner's window. A fresh tier only
+ * seeds what the next run derives on its own.
+ */
+export function isInformativeFadingTier(
+  tier: FadingTier | undefined,
+  window: number | undefined
+): tier is FadingTier {
+  if (tier == null) {
+    return false;
+  }
+  return tier.masked || (window != null && window > 0 && tier.budgetTokens < window);
+}

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -64,7 +64,7 @@ export function isFadingTier(value: unknown): value is FadingTier {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
-  const { v, budgetTokens, masked } = value as Partial<
+  const { v, budgetTokens, masked, latched } = value as Partial<
     Record<keyof FadingTier, unknown>
   >;
   return (
@@ -72,7 +72,8 @@ export function isFadingTier(value: unknown): value is FadingTier {
     typeof budgetTokens === 'number' &&
     Number.isFinite(budgetTokens) &&
     budgetTokens > 0 &&
-    typeof masked === 'boolean'
+    typeof masked === 'boolean' &&
+    (latched === undefined || latched === true)
   );
 }
 
@@ -104,6 +105,7 @@ export function seedFadingTier(window: number, seed?: unknown): FadingTier {
     v: FADING_TIER_VERSION,
     budgetTokens: Math.min(seed.budgetTokens, window),
     masked: seed.masked,
+    latched: true,
   };
 }
 
@@ -206,7 +208,7 @@ export function resolveFadingTier(
   if (budgetTokens === tier.budgetTokens && masked === tier.masked) {
     return tier;
   }
-  return { v: FADING_TIER_VERSION, budgetTokens, masked };
+  return { v: FADING_TIER_VERSION, budgetTokens, masked, latched: true };
 }
 
 /**
@@ -221,5 +223,9 @@ export function isInformativeFadingTier(
   if (tier == null) {
     return false;
   }
-  return tier.masked || (window != null && window > 0 && tier.budgetTokens < window);
+  return (
+    tier.latched === true ||
+    tier.masked ||
+    (window != null && window > 0 && tier.budgetTokens < window)
+  );
 }

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -1,0 +1,205 @@
+import type { FadingTier } from '@/types/graph';
+import {
+  calculateMaxToolCallInputChars,
+  calculateMaxToolResultChars,
+} from '@/utils/truncation';
+
+export const FADING_TIER_VERSION = 1;
+
+/** Context pressure at which observation masking activates. */
+export const PRESSURE_THRESHOLD_MASKING = 0.8;
+
+/** Smallest token budget a rung can shrink to; keeps the emergency floor near 200 chars. */
+export const FADING_MIN_BUDGET_TOKENS = 170;
+
+/** Floor for masked (consumed) tool results. */
+export const MASKED_RESULT_MIN_CHARS = 300;
+
+/** Fraction of a fresh result's cap that a masked (consumed) result keeps. */
+const MASKED_RESULT_CAP_RATIO = 0.1;
+
+/** Largest share of the effective budget a single fresh tool result may occupy. */
+const FIT_SHARE = 0.5;
+
+/**
+ * Pressure bands expressed as extra rungs on top of the fit rung, so the
+ * budget factors land at ×0.5 (85 %), ×0.25 (90 %) and ×0.0625 (99 %).
+ */
+const PRESSURE_BAND_RUNGS: readonly (readonly [number, number])[] = [
+  [0.99, 4],
+  [0.9, 2],
+  [0.85, 1],
+];
+
+export type FadingSignals = {
+  /** calibratedTotal / pruningBudget, measured before any truncation. */
+  contextPressure: number;
+  /** (pruningBudget − instruction tokens) ÷ calibrationRatio, in raw token space. */
+  effectiveRawTokens: number;
+  summarizationEnabled: boolean;
+  /** Recovery paths force at least this rung. */
+  minRung?: number;
+};
+
+export type FadingCaps = {
+  budgetTokens: number;
+  /** Cap for tool results the model has not answered yet. */
+  resultChars: number;
+  /** Cap for consumed tool results; equals `resultChars` until masking activates. */
+  consumedChars: number;
+  /** Cap for historical tool-call inputs. */
+  inputChars: number;
+};
+
+function floorBudgetTokens(window: number): number {
+  return Math.min(FADING_MIN_BUDGET_TOKENS, window);
+}
+
+export function createFadingTier(window: number): FadingTier {
+  return { v: FADING_TIER_VERSION, window, rung: 0, masked: false };
+}
+
+export function isFadingTier(value: unknown): value is FadingTier {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const { v, window, rung, masked } = value as Partial<
+    Record<keyof FadingTier, unknown>
+  >;
+  return (
+    v === FADING_TIER_VERSION &&
+    typeof window === 'number' &&
+    Number.isFinite(window) &&
+    window > 0 &&
+    typeof rung === 'number' &&
+    Number.isInteger(rung) &&
+    rung >= 0 &&
+    typeof masked === 'boolean'
+  );
+}
+
+/** Deepest rung for a window: the point where the budget reaches its floor. */
+export function maxFadingRung(window: number): number {
+  const floor = floorBudgetTokens(window);
+  if (!(floor > 0)) {
+    return 0;
+  }
+  return Math.max(0, Math.ceil(Math.log2(window / floor)));
+}
+
+/** Token budget at a rung: the window halved per rung, never below the floor. */
+export function fadingBudgetTokens(window: number, rung: number): number {
+  return Math.max(floorBudgetTokens(window), Math.floor(window / 2 ** rung));
+}
+
+/**
+ * Restores a tier persisted by the host. Anything invalid, or derived for a
+ * different context window (model switch), starts fresh: the prefix cache is
+ * invalid in that case anyway.
+ */
+export function seedFadingTier(window: number, seed?: unknown): FadingTier {
+  if (!isFadingTier(seed) || seed.window !== window) {
+    return createFadingTier(window);
+  }
+  return {
+    v: FADING_TIER_VERSION,
+    window,
+    rung: Math.min(seed.rung, maxFadingRung(window)),
+    masked: seed.masked,
+  };
+}
+
+/** Shallowest rung whose fresh-result cap is at most `targetChars`. */
+export function fadingRungForResultChars(
+  window: number,
+  targetChars: number
+): number {
+  const deepest = maxFadingRung(window);
+  for (let rung = 0; rung < deepest; rung++) {
+    if (
+      calculateMaxToolResultChars(fadingBudgetTokens(window, rung)) <=
+      targetChars
+    ) {
+      return rung;
+    }
+  }
+  return deepest;
+}
+
+/**
+ * Shallowest rung at which a single fresh tool result fits within
+ * `FIT_SHARE` of `rawTokens`, the effective budget in raw token space.
+ * This is the fit guarantee: summarization never sees an empty context
+ * because one result alone overflowed the budget.
+ */
+export function fadingRungForBudget(window: number, rawTokens: number): number {
+  if (!(rawTokens > 0)) {
+    return 0;
+  }
+  return fadingRungForResultChars(
+    window,
+    Math.floor(rawTokens * FIT_SHARE) * 4
+  );
+}
+
+/** Character caps for a tier; a pure function of `(window, rung, masked)`. */
+export function resolveFadingCaps(
+  tier: FadingTier,
+  maxToolResultChars?: number
+): FadingCaps {
+  const budgetTokens = fadingBudgetTokens(tier.window, tier.rung);
+  const windowResultChars = calculateMaxToolResultChars(budgetTokens);
+  const resultChars =
+    maxToolResultChars != null && maxToolResultChars > 0
+      ? Math.min(windowResultChars, maxToolResultChars)
+      : windowResultChars;
+  const consumedChars = tier.masked
+    ? Math.min(
+      resultChars,
+      Math.max(
+        MASKED_RESULT_MIN_CHARS,
+        Math.floor(resultChars * MASKED_RESULT_CAP_RATIO)
+      )
+    )
+    : resultChars;
+  return {
+    budgetTokens,
+    resultChars,
+    consumedChars,
+    inputChars: calculateMaxToolCallInputChars(budgetTokens),
+  };
+}
+
+/**
+ * Advances a tier from this call's signals. The rung only ever deepens and
+ * masking only ever activates, which is the hysteresis: drift in calibration,
+ * instruction overhead or message count can escalate once at a boundary but
+ * never oscillate. Returns the same object when nothing changes.
+ *
+ * - The fit rung guarantees a single tool result (30 % of the rung budget)
+ *   fits the effective budget, so summarization never sees an empty context.
+ * - Pressure bands add rungs on top of the fit rung when summarization is
+ *   off, mirroring the staged budget factors of progressive context fading.
+ */
+export function resolveFadingTier(
+  tier: FadingTier,
+  signals: FadingSignals
+): FadingTier {
+  const { window } = tier;
+  const fitRung = fadingRungForBudget(window, signals.effectiveRawTokens);
+  const bandRung = signals.summarizationEnabled
+    ? 0
+    : (PRESSURE_BAND_RUNGS.find(
+      ([threshold]) => signals.contextPressure >= threshold
+    )?.[1] ?? 0);
+  const rung = Math.min(
+    maxFadingRung(window),
+    Math.max(tier.rung, fitRung + bandRung, signals.minRung ?? 0)
+  );
+  const masked =
+    tier.masked || signals.contextPressure >= PRESSURE_THRESHOLD_MASKING;
+  if (rung === tier.rung && masked === tier.masked) {
+    return tier;
+  }
+  return { v: FADING_TIER_VERSION, window, rung, masked };
+}

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -112,14 +112,19 @@ export function seedFadingTier(window: number, seed?: unknown): FadingTier {
 /** Shallowest rung whose fresh-result cap is at most `targetChars`. */
 export function fadingRungForResultChars(
   window: number,
-  targetChars: number
+  targetChars: number,
+  maxToolResultChars?: number
 ): number {
   const deepest = maxFadingRung(window);
   for (let rung = 0; rung < deepest; rung++) {
-    if (
-      calculateMaxToolResultChars(fadingBudgetTokens(window, rung)) <=
-      targetChars
-    ) {
+    const windowResultChars = calculateMaxToolResultChars(
+      fadingBudgetTokens(window, rung)
+    );
+    const effectiveResultChars =
+      maxToolResultChars == null
+        ? windowResultChars
+        : Math.min(windowResultChars, maxToolResultChars);
+    if (effectiveResultChars <= targetChars) {
       return rung;
     }
   }
@@ -132,13 +137,18 @@ export function fadingRungForResultChars(
  * This is the fit guarantee: summarization never sees an empty context
  * because one result alone overflowed the budget.
  */
-export function fadingRungForBudget(window: number, rawTokens: number): number {
+export function fadingRungForBudget(
+  window: number,
+  rawTokens: number,
+  maxToolResultChars?: number
+): number {
   if (!(rawTokens > 0)) {
     return 0;
   }
   return fadingRungForResultChars(
     window,
-    Math.floor(rawTokens * FIT_SHARE) * 4
+    Math.floor(rawTokens * FIT_SHARE) * 4,
+    maxToolResultChars
   );
 }
 
@@ -187,9 +197,14 @@ export function resolveFadingCaps(
 export function resolveFadingTier(
   tier: FadingTier,
   window: number,
-  signals: FadingSignals
+  signals: FadingSignals,
+  maxToolResultChars?: number
 ): FadingTier {
-  const fitRung = fadingRungForBudget(window, signals.effectiveRawTokens);
+  const fitRung = fadingRungForBudget(
+    window,
+    signals.effectiveRawTokens,
+    maxToolResultChars
+  );
   const bandRung = signals.summarizationEnabled
     ? 0
     : (PRESSURE_BAND_RUNGS.find(

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -132,10 +132,12 @@ export function fadingRungForResultChars(
 }
 
 /**
- * Shallowest rung at which a single fresh tool result fits within
- * `FIT_SHARE` of `rawTokens`, the effective budget in raw token space.
- * This is the fit guarantee: summarization never sees an empty context
- * because one result alone overflowed the budget.
+ * Shallowest rung at which both halves of a historical tool exchange fit:
+ * the fresh result and its tool-call input must each stay within `FIT_SHARE`
+ * of `rawTokens`, the effective budget in raw token space. Together they fit
+ * the whole effective budget, preventing orphan repair from dropping a result
+ * merely because its matching input used the room left by a configured result
+ * cap.
  */
 export function fadingRungForBudget(
   window: number,
@@ -145,11 +147,24 @@ export function fadingRungForBudget(
   if (!(rawTokens > 0)) {
     return 0;
   }
-  return fadingRungForResultChars(
+  const targetChars = Math.floor(rawTokens * FIT_SHARE) * 4;
+  const resultRung = fadingRungForResultChars(
     window,
-    Math.floor(rawTokens * FIT_SHARE) * 4,
+    targetChars,
     maxToolResultChars
   );
+  const deepest = maxFadingRung(window);
+  let inputRung = deepest;
+  for (let rung = 0; rung < deepest; rung++) {
+    if (
+      calculateMaxToolCallInputChars(fadingBudgetTokens(window, rung)) <=
+      targetChars
+    ) {
+      inputRung = rung;
+      break;
+    }
+  }
+  return Math.max(resultRung, inputRung);
 }
 
 /** Character caps for a tier; a pure function of `(budgetTokens, masked)`. */
@@ -187,8 +202,8 @@ export function resolveFadingCaps(
  * can escalate once at a rung boundary but never oscillate. Returns the same
  * object when nothing changes.
  *
- * - The fit rung guarantees a single tool result fits half the effective
- *   budget, so summarization never sees an empty context.
+ * - The fit rung guarantees a tool result and its matching call input each fit
+ *   half the effective budget, so their pair cannot empty the context.
  * - Pressure bands add rungs on top of the fit rung when summarization is
  *   off, mirroring the staged budget factors of progressive context fading.
  * - A window larger than the latched budget (model switch) does not loosen

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -100,9 +100,26 @@ export function seedFadingTier(window: number, seed?: unknown): FadingTier {
   if (!isFadingTier(seed)) {
     return createFadingTier(window);
   }
+  /** The ladder never produces a budget below its floor, so a persisted one
+   * is corrupt; clamping it up keeps every cap positive. */
+  const budgetTokens = Math.max(
+    floorBudgetTokens(window),
+    Math.min(seed.budgetTokens, window)
+  );
+  /** Only a tier that was tightened, masked, or clamped carries information.
+   * A fresh tier re-seeded through a pruner rebuild must stay fresh, or it
+   * would be reported and pin later runs to this window. */
+  const informative =
+    seed.latched === true ||
+    seed.masked ||
+    budgetTokens !== seed.budgetTokens ||
+    budgetTokens < window;
+  if (!informative) {
+    return createFadingTier(window);
+  }
   return {
     v: FADING_TIER_VERSION,
-    budgetTokens: Math.min(seed.budgetTokens, window),
+    budgetTokens,
     masked: seed.masked,
     latched: true,
   };
@@ -158,6 +175,31 @@ export function fadingRungForBudget(
         : Math.min(windowResultChars, maxToolResultChars);
     const inputChars = calculateMaxToolCallInputChars(budgetTokens);
     if (width * (resultChars + inputChars) <= targetChars) {
+      return rung;
+    }
+  }
+  return deepest;
+}
+
+/**
+ * Shallowest rung at which one complete tool exchange (a fresh result plus its
+ * call input) fits within `targetChars`. The emergency pass uses it so a small
+ * configured result cap cannot satisfy the target while inputs stay uncapped.
+ */
+export function fadingRungForExchangeChars(
+  window: number,
+  targetChars: number,
+  maxToolResultChars?: number
+): number {
+  const deepest = maxFadingRung(window);
+  for (let rung = 0; rung < deepest; rung++) {
+    const budgetTokens = fadingBudgetTokens(window, rung);
+    const windowResultChars = calculateMaxToolResultChars(budgetTokens);
+    const resultChars =
+      maxToolResultChars == null
+        ? windowResultChars
+        : Math.min(windowResultChars, maxToolResultChars);
+    if (resultChars + calculateMaxToolCallInputChars(budgetTokens) <= targetChars) {
       return rung;
     }
   }

--- a/src/messages/fading.ts
+++ b/src/messages/fading.ts
@@ -150,7 +150,7 @@ export function resolveFadingCaps(
   const { budgetTokens } = tier;
   const windowResultChars = calculateMaxToolResultChars(budgetTokens);
   const resultChars =
-    maxToolResultChars != null && maxToolResultChars > 0
+    maxToolResultChars != null
       ? Math.min(windowResultChars, maxToolResultChars)
       : windowResultChars;
   const consumedChars = tier.masked

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -17,3 +17,4 @@ export * from './recency';
 export * from './assistantPhase';
 export * from './provenance';
 export * from './projectionInvariant';
+export * from './fading';

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -31,7 +31,7 @@ import {
 } from '@/utils/toolContent';
 import {
   MASKED_RESULT_MIN_CHARS,
-  fadingRungForResultChars,
+  fadingRungForExchangeChars,
   isFadingTier,
   resolveFadingCaps,
   resolveFadingTier,
@@ -3199,7 +3199,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         factoryParams.maxTokens,
         {
           ...fadingSignals,
-          minRung: fadingRungForResultChars(
+          minRung: fadingRungForExchangeChars(
             factoryParams.maxTokens,
             emergencyMaxChars,
             factoryParams.maxToolResultChars

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -269,6 +269,32 @@ function getToolCallIds(message: BaseMessage): Set<string> {
   return ids;
 }
 
+function getMaxToolExchangeWidth(messages: BaseMessage[]): number {
+  let width = 1;
+  for (const message of messages) {
+    const messageRole = (message as BaseMessage & { role?: unknown }).role;
+    if (message.getType() !== 'ai' && messageRole !== 'assistant') {
+      continue;
+    }
+    const aiMessage = message as AIMessage;
+    const contentCallCount = Array.isArray(aiMessage.content)
+      ? aiMessage.content.filter(
+        (part) =>
+          typeof part === 'object' &&
+          ((part as { type?: unknown }).type === 'tool_use' ||
+            (part as { type?: unknown }).type === 'tool_call')
+      ).length
+      : 0;
+    width = Math.max(
+      width,
+      getToolCallIds(message).size,
+      aiMessage.tool_calls?.length ?? 0,
+      contentCallCount
+    );
+  }
+  return width;
+}
+
 type ResponsesToolOutputSource = {
   source: 'response_metadata' | 'tool_outputs';
   items: unknown[];
@@ -2903,6 +2929,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           ? Math.floor(effectiveMaxTokens / calibrationRatio)
           : effectiveMaxTokens,
       summarizationEnabled: factoryParams.summarizationEnabled === true,
+      toolExchangeWidth: getMaxToolExchangeWidth(canonicalMessages),
     };
     const faded = fade(fadingSignals);
     const observationsMasked = restoredFading.masked + faded.masked;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -41,7 +41,10 @@ import { resolveContextPruningSettings } from './contextPruningSettings';
 import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
 import { ContentTypes, Providers, Constants } from '@/common';
 import { getProviderFamily } from '@/llm/providerRegistry';
-import { dropIncompleteToolStreamContent } from './core';
+import {
+  dropIncompleteToolStreamContent,
+  hasNonEmptyTextContent,
+} from './core';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
 
@@ -1167,23 +1170,6 @@ export type FadingApplyResult = {
   consumedBoundary: number;
 };
 
-function hasTextContent(message: BaseMessage): boolean {
-  const { content } = message;
-  if (typeof content === 'string') {
-    return content.trim().length > 0;
-  }
-  return (
-    Array.isArray(content) &&
-    content.some(
-      (block) =>
-        typeof block === 'object' &&
-        (block as Record<string, unknown>).type === 'text' &&
-        typeof (block as Record<string, unknown>).text === 'string' &&
-        ((block as Record<string, unknown>).text as string).trim().length > 0
-    )
-  );
-}
-
 /**
  * Index of the newest AI message with substantive text. Every ToolMessage
  * before it has been answered by the model ("consumed"); results after it are
@@ -1192,7 +1178,7 @@ function hasTextContent(message: BaseMessage): boolean {
 function findConsumedBoundary(messages: BaseMessage[]): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
-    if (message.getType() === 'ai' && hasTextContent(message)) {
+    if (message.getType() === 'ai' && hasNonEmptyTextContent(message.content)) {
       return i;
     }
   }
@@ -2653,7 +2639,11 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
 
     /** Advances the tier from the signals and applies its caps; escalation rescans everything. */
     const fade = (signals: FadingSignals): FadingApplyResult => {
-      const nextTier = resolveFadingTier(fadingTier, signals);
+      const nextTier = resolveFadingTier(
+        fadingTier,
+        factoryParams.maxTokens,
+        signals
+      );
       if (nextTier !== fadingTier) {
         fadingTier = nextTier;
         fadedThrough = 0;
@@ -2834,10 +2824,12 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
 
     // ---------------------------------------------------------------
     // Emergency truncation: if pruning produced an empty context but
-    // messages exist, deepen the fading tier until a per-message share of
-    // the effective budget (~4 chars/token, floor 200 chars) fits, apply
-    // it to the live messages and retry.  The tier latches, so the next
-    // call reproduces the same bytes instead of re-deriving them.
+    // messages exist, derive a deeper, temporary tier from a per-message
+    // share of the effective budget (~4 chars/token, floor 200 chars),
+    // apply it to a clone and retry.  The latched tier is left alone: this
+    // share depends on the message count, so latching it would pin every
+    // future result to one transient event.  The clone keeps graph state
+    // intact for later turns where more budget may be available.
     // ---------------------------------------------------------------
     if (
       context.length === 0 &&
@@ -2848,9 +2840,20 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         effectiveMaxTokens / Math.max(1, params.messages.length)
       );
       const emergencyMaxChars = Math.max(200, perMessageTokenBudget * 4);
-      const minRung = fadingRungForResultChars(
+      const emergencyTier = resolveFadingTier(
+        fadingTier,
         factoryParams.maxTokens,
-        emergencyMaxChars
+        {
+          ...fadingSignals,
+          minRung: fadingRungForResultChars(
+            factoryParams.maxTokens,
+            emergencyMaxChars
+          ),
+        }
+      );
+      const emergencyCaps = resolveFadingCaps(
+        emergencyTier,
+        factoryParams.maxToolResultChars
       );
 
       factoryParams.log?.(
@@ -2860,55 +2863,78 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           messageCount: params.messages.length,
           effectiveMax: effectiveMaxTokens,
           emergencyMaxChars,
-          rung: minRung,
+          budgetTokens: emergencyCaps.budgetTokens,
         }
       );
 
-      const emergency = fade({ ...fadingSignals, minRung });
-
-      factoryParams.log?.('info', 'Emergency truncation complete');
-      factoryParams.log?.('debug', 'Emergency truncation details', {
-        truncatedCount:
-          emergency.truncated + emergency.inputs + emergency.masked,
-        rung: fadingTier.rung,
-      });
-
-      const retryResult = getMessagesWithinTokenLimit({
-        maxContextTokens: pruningBudget,
-        messages: params.messages,
-        indexTokenCountMap,
-        startType: params.startType,
-        thinkingEnabled: factoryParams.thinkingEnabled,
-        tokenCounter: factoryParams.tokenCounter,
-        instructionTokens: currentInstructionTokens,
-        reasoningType: usesBedrockThinking
-          ? ContentTypes.REASONING_CONTENT
-          : ContentTypes.THINKING,
-        thinkingStartIndex:
-          factoryParams.thinkingEnabled === true
-            ? runThinkingStartIndex
-            : undefined,
-      });
-
-      const repaired = repairOrphanedToolMessages({
-        context: retryResult.context,
-        allMessages: params.messages,
-        tokenCounter: factoryParams.tokenCounter,
-        indexTokenCountMap,
-      });
-
-      context = repaired.context;
-      reclaimedTokens = repaired.reclaimedTokens;
-      appendItems(messagesToRefine, retryResult.messagesToRefine);
-      if (repaired.droppedMessages.length > 0) {
-        appendItems(messagesToRefine, repaired.droppedMessages);
+      const emergencyMessages = [...params.messages];
+      const preEmergencyTokenCounts: Record<string, number | undefined> = {};
+      for (let i = 0; i < params.messages.length; i++) {
+        preEmergencyTokenCounts[i] = indexTokenCountMap[i];
       }
 
-      factoryParams.log?.('debug', 'Emergency truncation retry result', {
-        contextLength: context.length,
-        messagesToRefineCount: messagesToRefine.length,
-        remainingTokens: retryResult.remainingContextTokens,
-      });
+      try {
+        const emergency = applyFadingCaps({
+          messages: emergencyMessages,
+          indexTokenCountMap,
+          tokenCounter: factoryParams.tokenCounter,
+          caps: emergencyCaps,
+          masked: emergencyTier.masked,
+        });
+
+        factoryParams.log?.('info', 'Emergency truncation complete');
+        factoryParams.log?.('debug', 'Emergency truncation details', {
+          truncatedCount:
+            emergency.truncated + emergency.inputs + emergency.masked,
+          budgetTokens: emergencyCaps.budgetTokens,
+        });
+
+        const retryResult = getMessagesWithinTokenLimit({
+          maxContextTokens: pruningBudget,
+          messages: emergencyMessages,
+          indexTokenCountMap,
+          startType: params.startType,
+          thinkingEnabled: factoryParams.thinkingEnabled,
+          tokenCounter: factoryParams.tokenCounter,
+          instructionTokens: currentInstructionTokens,
+          reasoningType: usesBedrockThinking
+            ? ContentTypes.REASONING_CONTENT
+            : ContentTypes.THINKING,
+          thinkingStartIndex:
+            factoryParams.thinkingEnabled === true
+              ? runThinkingStartIndex
+              : undefined,
+        });
+
+        const repaired = repairOrphanedToolMessages({
+          context: retryResult.context,
+          allMessages: emergencyMessages,
+          tokenCounter: factoryParams.tokenCounter,
+          indexTokenCountMap,
+        });
+
+        context = repaired.context;
+        reclaimedTokens = repaired.reclaimedTokens;
+        /** The retry supersedes the failed pass: messages now in context
+         *  must not also be handed to the summarizer. */
+        messagesToRefine.length = 0;
+        appendItems(messagesToRefine, retryResult.messagesToRefine);
+        if (repaired.droppedMessages.length > 0) {
+          appendItems(messagesToRefine, repaired.droppedMessages);
+        }
+
+        factoryParams.log?.('debug', 'Emergency truncation retry result', {
+          contextLength: context.length,
+          messagesToRefineCount: messagesToRefine.length,
+          remainingTokens: retryResult.remainingContextTokens,
+        });
+      } finally {
+        // Restore the closure's indexTokenCountMap to pre-emergency values so the
+        // next turn counts old messages at their original (un-truncated) size.
+        for (const [key, value] of Object.entries(preEmergencyTokenCounts)) {
+          indexTokenCountMap[key] = value;
+        }
+      }
     }
 
     /** Scale raw-space remaining back to calibrated/provider units so it is

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2238,8 +2238,37 @@ function applyToolCallInputCaps(params: {
     if (projected[i] === messages[i]) {
       continue;
     }
-    messages[i] = projected[i];
-    indexTokenCountMap[i] = tokenCounter(projected[i]);
+    const current = messages[i] as AIMessage;
+    const canonical = sourceMessages[i] as AIMessage;
+    const capped = projected[i] as AIMessage;
+    const changes: Record<string, unknown> = {};
+    if (capped.content !== canonical.content) {
+      changes.content = capped.content;
+    }
+    if (capped.tool_calls !== canonical.tool_calls) {
+      changes.tool_calls = capped.tool_calls;
+    }
+    const additionalKwargsChanges: Record<string, unknown> = {};
+    for (const key of ['tool_calls', 'function_call']) {
+      if (capped.additional_kwargs[key] !== canonical.additional_kwargs[key]) {
+        additionalKwargsChanges[key] = capped.additional_kwargs[key];
+      }
+    }
+    if (Object.keys(additionalKwargsChanges).length > 0) {
+      changes.additional_kwargs = cloneWithProjectedProperties(
+        current.additional_kwargs,
+        additionalKwargsChanges
+      );
+    }
+    if (capped.response_metadata.output !== canonical.response_metadata.output) {
+      changes.response_metadata = cloneWithProjectedProperties(
+        current.response_metadata,
+        { output: capped.response_metadata.output }
+      );
+    }
+    const merged = cloneWithProjectedProperties(current, changes);
+    messages[i] = merged;
+    indexTokenCountMap[i] = tokenCounter(merged);
     truncatedCount++;
   }
   return truncatedCount;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2865,7 +2865,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       const nextTier = resolveFadingTier(
         fadingTier,
         factoryParams.maxTokens,
-        signals
+        signals,
+        factoryParams.maxToolResultChars
       );
       if (nextTier !== fadingTier) {
         fadingTier = nextTier;
@@ -3071,9 +3072,11 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           ...fadingSignals,
           minRung: fadingRungForResultChars(
             factoryParams.maxTokens,
-            emergencyMaxChars
+            emergencyMaxChars,
+            factoryParams.maxToolResultChars
           ),
-        }
+        },
+        factoryParams.maxToolResultChars
       );
       const emergencyCaps = resolveFadingCaps(
         emergencyTier,

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2932,6 +2932,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           tokenCounter: factoryParams.tokenCounter,
           caps: emergencyCaps,
           masked: emergencyTier.masked,
+          canonicalContentStore: canonicalToolContent,
+          canonicalMessageStore: canonicalToolCallMessages,
         });
 
         factoryParams.log?.('info', 'Emergency truncation complete');

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -33,6 +33,7 @@ import {
 import {
   MASKED_RESULT_MIN_CHARS,
   fadingRungForResultChars,
+  isFadingTier,
   resolveFadingCaps,
   resolveFadingTier,
   seedFadingTier,
@@ -1156,6 +1157,8 @@ type FadingApplyParams = {
   originalContentStore?: Map<number, string>;
   /** Canonical pre-fading content keyed by live message for tier escalation. */
   canonicalContentStore?: WeakMap<BaseMessage, BaseMessage['content']>;
+  /** Canonical pre-fading AI messages for tool-call input escalation. */
+  canonicalMessageStore?: WeakMap<BaseMessage, BaseMessage>;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 };
@@ -1256,6 +1259,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       indexTokenCountMap,
       tokenCounter,
       fromIndex,
+      canonicalMessageStore: params.canonicalMessageStore,
     })
     : 0;
 
@@ -2106,19 +2110,28 @@ function applyToolCallInputCaps(params: {
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
   fromIndex?: number;
+  canonicalMessageStore?: WeakMap<BaseMessage, BaseMessage>;
 }): number {
   const { messages, maxInputChars, indexTokenCountMap, tokenCounter } = params;
   const fromIndex = params.fromIndex ?? 0;
-  const projected = projectToolCallInputs(messages, maxInputChars, fromIndex);
-  if (projected === messages) {
+  let sources = messages;
+  if (params.canonicalMessageStore != null) {
+    sources = [...messages];
+    for (let i = fromIndex; i < messages.length; i++) {
+      sources[i] = params.canonicalMessageStore.get(messages[i]) ?? messages[i];
+    }
+  }
+  const projected = projectToolCallInputs(sources, maxInputChars, fromIndex);
+  if (projected === sources) {
     return 0;
   }
 
   let truncatedCount = 0;
   for (let i = fromIndex; i < messages.length; i++) {
-    if (projected[i] === messages[i]) {
+    if (projected[i] === sources[i]) {
       continue;
     }
+    params.canonicalMessageStore?.set(projected[i], sources[i]);
     messages[i] = projected[i];
     indexTokenCountMap[i] = tokenCounter(projected[i]);
     truncatedCount++;
@@ -2198,11 +2211,14 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     BaseMessage,
     BaseMessage['content']
   >();
+  /** Pre-fading AI messages retained so deeper input caps share one source. */
+  const canonicalToolCallMessages = new WeakMap<BaseMessage, BaseMessage>();
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
     factoryParams.fadingTier
   );
+  let restoredTierPending = isFadingTier(factoryParams.fadingTier);
   /** Fresh results and inputs below this index already carry the tier's caps. */
   let fadedThrough = 0;
   /** Consumed results below this index already carry the tier's masked cap. */
@@ -2548,16 +2564,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
 
     let calibratedTotalTokens = Math.round(totalTokens * calibrationRatio);
 
-    factoryParams.log?.('debug', 'Budget', {
-      maxTokens: factoryParams.maxTokens,
-      pruningBudget,
-      effectiveMax: effectiveMaxTokens,
-      instructionTokens: currentInstructionTokens,
-      messageCount: params.messages.length,
-      calibratedTotalTokens,
-      calibrationRatio: Math.round(calibrationRatio * 100) / 100,
-    });
-
     // When instructions alone consume the entire budget, no message can
     // fit regardless of truncation.  Short-circuit: yield all messages for
     // summarization and return an empty context so the Graph can route to
@@ -2605,11 +2611,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // every call and provider prompt-cache prefixes survive from turn to turn;
     // only escalation rewrites them.
     // ---------------------------------------------------------------------------
-    totalTokens = sumTokenCounts(indexTokenCountMap, params.messages.length);
-    calibratedTotalTokens = Math.round(totalTokens * calibrationRatio);
-    const contextPressure =
-      pruningBudget > 0 ? calibratedTotalTokens / pruningBudget : 0;
-
     // -----------------------------------------------------------------------
     // Observation masking (80%+ pressure, both paths):
     // Replace consumed ToolMessage content with tight head+tail placeholders.
@@ -2642,6 +2643,50 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       }
     };
 
+    let restoredFading: FadingApplyResult = {
+      truncated: 0,
+      inputs: 0,
+      masked: 0,
+      consumedBoundary: 0,
+    };
+    if (restoredTierPending) {
+      restoredFading = applyFadingCaps({
+        messages: params.messages,
+        indexTokenCountMap,
+        tokenCounter: factoryParams.tokenCounter,
+        caps: resolveFadingCaps(fadingTier, factoryParams.maxToolResultChars),
+        masked: fadingTier.masked,
+        originalContentStore:
+          factoryParams.summarizationEnabled === true
+            ? originalToolContent
+            : undefined,
+        canonicalContentStore: canonicalToolContent,
+        canonicalMessageStore: canonicalToolCallMessages,
+        onContentStored:
+          factoryParams.summarizationEnabled === true
+            ? storeOriginalToolContent
+            : undefined,
+      });
+      fadedThrough = params.messages.length;
+      maskedThrough = restoredFading.consumedBoundary;
+      restoredTierPending = false;
+    }
+
+    totalTokens = sumTokenCounts(indexTokenCountMap, params.messages.length);
+    calibratedTotalTokens = Math.round(totalTokens * calibrationRatio);
+    const contextPressure =
+      pruningBudget > 0 ? calibratedTotalTokens / pruningBudget : 0;
+
+    factoryParams.log?.('debug', 'Budget', {
+      maxTokens: factoryParams.maxTokens,
+      pruningBudget,
+      effectiveMax: effectiveMaxTokens,
+      instructionTokens: currentInstructionTokens,
+      messageCount: params.messages.length,
+      calibratedTotalTokens,
+      calibrationRatio: Math.round(calibrationRatio * 100) / 100,
+    });
+
     /** Advances the tier from the signals and applies its caps; escalation rescans everything. */
     const fade = (signals: FadingSignals): FadingApplyResult => {
       const nextTier = resolveFadingTier(
@@ -2667,6 +2712,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             ? originalToolContent
             : undefined,
         canonicalContentStore: canonicalToolContent,
+        canonicalMessageStore: canonicalToolCallMessages,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2686,9 +2732,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       summarizationEnabled: factoryParams.summarizationEnabled === true,
     };
     const faded = fade(fadingSignals);
-    const observationsMasked = faded.masked;
-    const preFlightResultCount = faded.truncated;
-    const preFlightInputCount = faded.inputs;
+    const observationsMasked = restoredFading.masked + faded.masked;
+    const preFlightResultCount = restoredFading.truncated + faded.truncated;
+    const preFlightInputCount = restoredFading.inputs + faded.inputs;
     if (observationsMasked > 0) {
       cumulativeRawSent = 0;
       cumulativeProviderReported = 0;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -47,6 +47,7 @@ import { ContentTypes, Providers, Constants } from '@/common';
 import { getProviderFamily } from '@/llm/providerRegistry';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
+import { cloneMessage } from './cache';
 
 function sumTokenCounts(
   tokenMap: Record<string, number | undefined>,
@@ -178,8 +179,6 @@ export type PruneMessagesFactoryParams = {
    * current context window without losing their latched provenance.
    */
   fadingTier?: FadingTier | null;
-  /** Bounded canonical tool-result content retained across pruner recreation. */
-  canonicalToolContent?: Map<number, BaseMessage['content']>;
   /** Optional diagnostic log callback wired by the graph for observability. */
   log?: (
     level: 'debug' | 'info' | 'warn' | 'error',
@@ -188,6 +187,12 @@ export type PruneMessagesFactoryParams = {
   ) => void;
 };
 export type PruneMessagesParams = {
+  /**
+   * Immutable graph history corresponding index-for-index with `messages`.
+   * When supplied, provider projections always derive from this source rather
+   * than from an earlier, already-truncated projection.
+   */
+  canonicalMessages?: BaseMessage[];
   messages: BaseMessage[];
   usageMetadata?: Partial<UsageMetadata>;
   startType?: ReturnType<BaseMessage['getType']>;
@@ -1144,6 +1149,7 @@ export function checkValidNumber(value: unknown): value is number {
 }
 
 type FadingApplyParams = {
+  canonicalMessages?: BaseMessage[];
   messages: BaseMessage[];
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
@@ -1156,13 +1162,6 @@ type FadingApplyParams = {
   maskedFromIndex?: number;
   /** Original (pre-masking) content keyed by message index, captured for the summarizer. */
   originalContentStore?: Map<number, string>;
-  /** Canonical pre-fading content keyed by stable message index. */
-  canonicalContentStore?: Map<number, BaseMessage['content']>;
-  /** Called after storing newly captured canonical content. */
-  onCanonicalContentStored?: (
-    index: number,
-    content: BaseMessage['content']
-  ) => void;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 };
@@ -1225,7 +1224,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       continue;
     }
     const canonicalContent =
-      params.canonicalContentStore?.get(i) ?? message.content;
+      params.canonicalMessages?.[i]?.content ?? message.content;
     const compacted = compactToolContent(canonicalContent, maxChars);
     if (!compacted.changed) {
       continue;
@@ -1246,13 +1245,6 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       message as ToolMessage,
       compacted.content
     );
-    if (
-      params.canonicalContentStore != null &&
-      !params.canonicalContentStore.has(i)
-    ) {
-      params.canonicalContentStore.set(i, canonicalContent);
-      params.onCanonicalContentStored?.(i, canonicalContent);
-    }
     messages[i] = cloned;
     indexTokenCountMap[i] = tokenCounter(cloned);
     if (consumed) {
@@ -1265,6 +1257,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
   const inputs = Number.isFinite(caps.inputChars)
     ? applyToolCallInputCaps({
       messages,
+      canonicalMessages: params.canonicalMessages,
       maxInputChars: caps.inputChars,
       indexTokenCountMap,
       tokenCounter,
@@ -2218,6 +2211,7 @@ export function projectToolMessagesForProvider(
 }
 
 function applyToolCallInputCaps(params: {
+  canonicalMessages?: BaseMessage[];
   messages: BaseMessage[];
   maxInputChars: number;
   indexTokenCountMap: Record<string, number | undefined>;
@@ -2226,13 +2220,21 @@ function applyToolCallInputCaps(params: {
 }): number {
   const { messages, maxInputChars, indexTokenCountMap, tokenCounter } = params;
   const fromIndex = params.fromIndex ?? 0;
-  const projected = projectToolCallInputs(messages, maxInputChars, fromIndex);
-  if (projected === messages) {
+  const sourceMessages = params.canonicalMessages ?? messages;
+  const projected = projectToolCallInputs(
+    sourceMessages,
+    maxInputChars,
+    fromIndex
+  );
+  if (projected === sourceMessages) {
     return 0;
   }
 
   let truncatedCount = 0;
   for (let i = fromIndex; i < messages.length; i++) {
+    if (projected[i] === sourceMessages[i]) {
+      continue;
+    }
     if (projected[i] === messages[i]) {
       continue;
     }
@@ -2311,42 +2313,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
    *  pruner is recreated after summarization. */
   const originalToolContent = new Map<number, string>();
   let originalToolContentSize = 0;
-  /** Pre-fading content retained so every deeper tier derives from one source. */
-  const canonicalToolContent =
-    factoryParams.canonicalToolContent ??
-    new Map<number, BaseMessage['content']>();
-  const getCanonicalContentChars = (
-    content: BaseMessage['content']
-  ): number =>
-    serializeToolContentBounded(content, ORIGINAL_CONTENT_MAX_CHARS).length;
-  let canonicalToolContentChars = 0;
-  for (const content of canonicalToolContent.values()) {
-    canonicalToolContentChars += getCanonicalContentChars(content);
-  }
-  const enforceCanonicalContentCap = (): void => {
-    while (
-      canonicalToolContentChars > ORIGINAL_CONTENT_MAX_CHARS &&
-      canonicalToolContent.size > 0
-    ) {
-      const oldest = canonicalToolContent.keys().next();
-      if (oldest.done === true) {
-        break;
-      }
-      const removed = canonicalToolContent.get(oldest.value);
-      if (removed != null) {
-        canonicalToolContentChars -= getCanonicalContentChars(removed);
-      }
-      canonicalToolContent.delete(oldest.value);
-    }
-  };
-  enforceCanonicalContentCap();
-  const onCanonicalContentStored = (
-    _index: number,
-    content: BaseMessage['content']
-  ): void => {
-    canonicalToolContentChars += getCanonicalContentChars(content);
-    enforceCanonicalContentCap();
-  };
+  /** Canonical source retained only for this pruner/run when callers do not
+   * provide graph-owned history explicitly. Slots are references (with a
+   * shallow content-array clone where needed), not a second serialized copy. */
+  const capturedCanonicalMessages: BaseMessage[] = [];
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
@@ -2379,6 +2349,23 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     /** Calibrated instruction overhead actually applied this call */
     effectiveInstructionTokens?: number;
   } {
+    if (params.canonicalMessages == null) {
+      for (
+        let i = capturedCanonicalMessages.length;
+        i < params.messages.length;
+        i++
+      ) {
+        const message = params.messages[i];
+        capturedCanonicalMessages[i] = Array.isArray(message.content)
+          ? cloneMessage(message, [...message.content])
+          : message;
+      }
+      if (capturedCanonicalMessages.length > params.messages.length) {
+        capturedCanonicalMessages.length = params.messages.length;
+      }
+    }
+    const canonicalMessages =
+      params.canonicalMessages ?? capturedCanonicalMessages;
     let newOriginalToolContent: Map<number, string> | undefined;
     if (params.messages.length === 0) {
       /** Post-compaction calls still invoke the model — report the same
@@ -2811,6 +2798,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     if (restoredTierPending) {
       restoredFading = applyFadingCaps({
         messages: params.messages,
+        canonicalMessages,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         caps: resolveFadingCaps(fadingTier, factoryParams.maxToolResultChars),
@@ -2819,8 +2807,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           factoryParams.summarizationEnabled === true
             ? originalToolContent
             : undefined,
-        canonicalContentStore: canonicalToolContent,
-        onCanonicalContentStored,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2860,6 +2846,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       }
       const result = applyFadingCaps({
         messages: params.messages,
+        canonicalMessages,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         caps: resolveFadingCaps(fadingTier, factoryParams.maxToolResultChars),
@@ -2870,8 +2857,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           factoryParams.summarizationEnabled === true
             ? originalToolContent
             : undefined,
-        canonicalContentStore: canonicalToolContent,
-        onCanonicalContentStored,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -3087,12 +3072,11 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       try {
         const emergency = applyFadingCaps({
           messages: emergencyMessages,
+          canonicalMessages,
           indexTokenCountMap,
           tokenCounter: factoryParams.tokenCounter,
           caps: emergencyCaps,
           masked: emergencyTier.masked,
-          canonicalContentStore: canonicalToolContent,
-          onCanonicalContentStored,
         });
 
         factoryParams.log?.('info', 'Emergency truncation complete');

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2456,7 +2456,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     };
     for (let i = 0; i < params.messages.length; i++) {
       let message = params.messages[i];
-      const cachedCount = indexTokenCountMap[i];
+      let cachedCount = indexTokenCountMap[i];
       const messageType = message.getType();
       const messageRole = (message as BaseMessage & { role?: unknown }).role;
       const isAssistant = messageType === 'ai' || messageRole === 'assistant';
@@ -2468,6 +2468,13 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         if (canonicalized !== message) {
           message = canonicalized;
           params.messages[i] = message;
+          const canonicalizedCount = factoryParams.tokenCounter(message);
+          indexTokenCountMap[i] = canonicalizedCount;
+          totalTokens += canonicalizedCount - (cachedCount ?? 0);
+          cachedCount = canonicalizedCount;
+          if (i >= lastTurnStartIndex) {
+            newOutputs.add(i);
+          }
         }
         canonicalizedToolCallMessages.add(message);
       }
@@ -2488,6 +2495,13 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         if (projected !== message) {
           message = projected;
           params.messages[i] = message;
+          const projectedCount = factoryParams.tokenCounter(message);
+          indexTokenCountMap[i] = projectedCount;
+          totalTokens += projectedCount - (cachedCount ?? 0);
+          cachedCount = projectedCount;
+          if (i >= lastTurnStartIndex) {
+            newOutputs.add(i);
+          }
         }
         reconciledLegacyAiMessages.add(message);
         if (cachedCount !== undefined || i < lastTurnStartIndex) {

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -16,13 +16,6 @@ import type { FadingCaps, FadingSignals } from './fading';
 import type { TokenCounter } from '@/types/run';
 import type { ProviderName } from '@/types';
 import {
-  cloneToolMessageWithContent,
-  compactToolContent,
-  isComputerCallOutputMessage,
-  serializeStructuredValueBounded,
-  serializeToolContentBounded,
-} from '@/utils/toolContent';
-import {
   HARD_MAX_TOOL_CALL_INPUT_CHARS,
   HARD_MAX_TOOL_RESULT_CHARS,
   MIN_JSON_VALUE_CHARS,
@@ -31,24 +24,29 @@ import {
   truncateToolResultContent,
 } from '@/utils/truncation';
 import {
+  cloneToolMessageWithContent,
+  compactToolContent,
+  isComputerCallOutputMessage,
+  serializeStructuredValueBounded,
+  serializeToolContentBounded,
+} from '@/utils/toolContent';
+import {
   MASKED_RESULT_MIN_CHARS,
   fadingRungForResultChars,
   resolveFadingCaps,
   resolveFadingTier,
   seedFadingTier,
 } from './fading';
-import { resolveContextPruningSettings } from './contextPruningSettings';
-import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
-import { ContentTypes, Providers, Constants } from '@/common';
-import { getProviderFamily } from '@/llm/providerRegistry';
 import {
   dropIncompleteToolStreamContent,
   hasNonEmptyTextContent,
 } from './core';
+import { resolveContextPruningSettings } from './contextPruningSettings';
+import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
+import { ContentTypes, Providers, Constants } from '@/common';
+import { getProviderFamily } from '@/llm/providerRegistry';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
-
-export { calculateMaxToolCallInputChars } from '@/utils/truncation';
 
 function sumTokenCounts(
   tokenMap: Record<string, number | undefined>,
@@ -176,7 +174,8 @@ export type PruneMessagesFactoryParams = {
   /**
    * Context-fading tier persisted from a previous run's contextMeta. Seeds the
    * latched cap ladder so historical tool results keep the same truncated
-   * bytes across runs. Invalid values or a different context window start fresh.
+   * bytes across runs. Invalid values start fresh; valid values clamp to the
+   * current context window without losing their latched provenance.
    */
   fadingTier?: FadingTier | null;
   /** Optional diagnostic log callback wired by the graph for observability. */
@@ -1155,6 +1154,8 @@ type FadingApplyParams = {
   maskedFromIndex?: number;
   /** Original (pre-masking) content keyed by message index, captured for the summarizer. */
   originalContentStore?: Map<number, string>;
+  /** Canonical pre-fading content keyed by live message for tier escalation. */
+  canonicalContentStore?: WeakMap<BaseMessage, BaseMessage['content']>;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 };
@@ -1205,10 +1206,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
 
   for (let i = start; i < messages.length; i++) {
     const message = messages[i];
-    if (
-      message.getType() !== 'tool' ||
-      isComputerCallOutputMessage(message)
-    ) {
+    if (message.getType() !== 'tool' || isComputerCallOutputMessage(message)) {
       continue;
     }
     const consumed = masked && i < consumedBoundary;
@@ -1219,8 +1217,9 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
     if (!Number.isFinite(maxChars)) {
       continue;
     }
-    const content = message.content;
-    const compacted = compactToolContent(content, maxChars);
+    const canonicalContent =
+      params.canonicalContentStore?.get(message) ?? message.content;
+    const compacted = compactToolContent(canonicalContent, maxChars);
     if (!compacted.changed) {
       continue;
     }
@@ -1230,7 +1229,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       !params.originalContentStore.has(i)
     ) {
       const original = serializeToolContentBounded(
-        content,
+        canonicalContent,
         ORIGINAL_CONTENT_MAX_CHARS
       );
       params.originalContentStore.set(i, original);
@@ -1240,6 +1239,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       message as ToolMessage,
       compacted.content
     );
+    params.canonicalContentStore?.set(cloned, canonicalContent);
     messages[i] = cloned;
     indexTokenCountMap[i] = tokenCounter(cloned);
     if (consumed) {
@@ -2193,6 +2193,11 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
    *  pruner is recreated after summarization. */
   const originalToolContent = new Map<number, string>();
   let originalToolContentSize = 0;
+  /** Pre-fading content retained so every deeper tier derives from one source. */
+  const canonicalToolContent = new WeakMap<
+    BaseMessage,
+    BaseMessage['content']
+  >();
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
@@ -2661,6 +2666,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           factoryParams.summarizationEnabled === true
             ? originalToolContent
             : undefined,
+        canonicalContentStore: canonicalToolContent,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -222,24 +222,32 @@ function getToolCallIds(message: BaseMessage): Set<string> {
 
   const ids = new Set<string>();
   const aiMessage = message as AIMessage;
-  for (const toolCall of aiMessage.tool_calls ?? []) {
-    if (typeof toolCall.id === 'string' && toolCall.id.length > 0) {
-      ids.add(toolCall.id);
+  const toolCalls = aiMessage.tool_calls;
+  if (Array.isArray(toolCalls) && !isProxy(toolCalls)) {
+    for (const toolCall of toolCalls) {
+      if (typeof toolCall !== 'object') {
+        continue;
+      }
+      const id = getStringProperty(toolCall, 'id');
+      if (id != null && id.length > 0) {
+        ids.add(id);
+      }
     }
   }
 
-  if (Array.isArray(aiMessage.content)) {
+  if (Array.isArray(aiMessage.content) && !isProxy(aiMessage.content)) {
     for (const part of aiMessage.content) {
       if (typeof part !== 'object') {
         continue;
       }
-      const record = part as { type?: unknown; id?: unknown };
+      const type = getStringProperty(part, 'type');
+      const id = getStringProperty(part, 'id');
       if (
-        (record.type === 'tool_use' || record.type === 'tool_call') &&
-        typeof record.id === 'string' &&
-        record.id.length > 0
+        (type === 'tool_use' || type === 'tool_call') &&
+        id != null &&
+        id.length > 0
       ) {
-        ids.add(record.id);
+        ids.add(id);
       }
     }
   }
@@ -250,49 +258,21 @@ function getToolCallIds(message: BaseMessage): Set<string> {
       if (item == null || typeof item !== 'object') {
         continue;
       }
-      const record = item as {
-        type?: unknown;
-        call_id?: unknown;
-      };
+      const type = getStringProperty(item, 'type');
+      const callId = getStringProperty(item, 'call_id');
       if (
-        (record.type === 'function_call' ||
-          record.type === 'custom_tool_call' ||
-          record.type === 'computer_call') &&
-        typeof record.call_id === 'string' &&
-        record.call_id !== ''
+        (type === 'function_call' ||
+          type === 'custom_tool_call' ||
+          type === 'computer_call') &&
+        callId != null &&
+        callId !== ''
       ) {
-        ids.add(record.call_id);
+        ids.add(callId);
       }
     }
   }
 
   return ids;
-}
-
-function getMaxToolExchangeWidth(messages: BaseMessage[]): number {
-  let width = 1;
-  for (const message of messages) {
-    const messageRole = (message as BaseMessage & { role?: unknown }).role;
-    if (message.getType() !== 'ai' && messageRole !== 'assistant') {
-      continue;
-    }
-    const aiMessage = message as AIMessage;
-    const contentCallCount = Array.isArray(aiMessage.content)
-      ? aiMessage.content.filter(
-        (part) =>
-          typeof part === 'object' &&
-          ((part as { type?: unknown }).type === 'tool_use' ||
-            (part as { type?: unknown }).type === 'tool_call')
-      ).length
-      : 0;
-    width = Math.max(
-      width,
-      getToolCallIds(message).size,
-      aiMessage.tool_calls?.length ?? 0,
-      contentCallCount
-    );
-  }
-  return width;
 }
 
 type ResponsesToolOutputSource = {
@@ -2377,6 +2357,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     factoryParams.fadingTier
   );
   let restoredTierPending = isFadingTier(factoryParams.fadingTier);
+  /** Widest exchange seen so far; updated only from the appended suffix. */
+  let maxToolExchangeWidth = 1;
+  let toolExchangeWidthThrough = 0;
   /** Fresh results and inputs below this index already carry the tier's caps. */
   let fadedThrough = 0;
   /** Consumed results below this index already carry the tier's masked cap. */
@@ -2420,6 +2403,21 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     }
     const canonicalMessages =
       params.canonicalMessages ?? capturedCanonicalMessages;
+    if (canonicalMessages.length < toolExchangeWidthThrough) {
+      maxToolExchangeWidth = 1;
+      toolExchangeWidthThrough = 0;
+    }
+    for (
+      let i = toolExchangeWidthThrough;
+      i < canonicalMessages.length;
+      i++
+    ) {
+      maxToolExchangeWidth = Math.max(
+        maxToolExchangeWidth,
+        getToolCallIds(canonicalMessages[i]).size
+      );
+    }
+    toolExchangeWidthThrough = canonicalMessages.length;
     let newOriginalToolContent: Map<number, string> | undefined;
     if (params.messages.length === 0) {
       /** Post-compaction calls still invoke the model — report the same
@@ -2929,7 +2927,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           ? Math.floor(effectiveMaxTokens / calibrationRatio)
           : effectiveMaxTokens,
       summarizationEnabled: factoryParams.summarizationEnabled === true,
-      toolExchangeWidth: getMaxToolExchangeWidth(canonicalMessages),
+      toolExchangeWidth: maxToolExchangeWidth,
     };
     const faded = fade(fadingSignals);
     const observationsMasked = restoredFading.masked + faded.masked;
@@ -2946,6 +2944,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     ) {
       applyContextPruning({
         messages: params.messages,
+        canonicalMessages,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         resolvedSettings: contextPruningSettings,

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -21,7 +21,6 @@ import {
   MIN_JSON_VALUE_CHARS,
   calculateMaxToolCallInputChars,
   calculateMaxToolResultChars,
-  truncateToolResultContent,
 } from '@/utils/truncation';
 import {
   cloneToolMessageWithContent,
@@ -1157,8 +1156,6 @@ type FadingApplyParams = {
   originalContentStore?: Map<number, string>;
   /** Canonical pre-fading content keyed by live message for tier escalation. */
   canonicalContentStore?: WeakMap<BaseMessage, BaseMessage['content']>;
-  /** Canonical pre-fading AI messages for tool-call input escalation. */
-  canonicalMessageStore?: WeakMap<BaseMessage, BaseMessage>;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 };
@@ -1259,7 +1256,6 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       indexTokenCountMap,
       tokenCounter,
       fromIndex,
-      canonicalMessageStore: params.canonicalMessageStore,
     })
     : 0;
 
@@ -1465,14 +1461,19 @@ function cloneAIMessageWithProjectedStreamContent(
   ) as AIMessage | AIMessageChunk;
 }
 
+const TOOL_INPUT_TRUNCATION_MARKER = '… [truncated]\n';
+
 function createBoundedTruncationValue(
   preview: string,
   originalChars: number,
   maxChars: number
 ): unknown {
   const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  const canonicalPrefix = preview.startsWith(TOOL_INPUT_TRUNCATION_MARKER)
+    ? preview.slice(TOOL_INPUT_TRUNCATION_MARKER.length)
+    : preview;
   const emptyEnvelope = {
-    _truncated: '',
+    _truncated: TOOL_INPUT_TRUNCATION_MARKER,
     _originalChars: originalChars,
   };
   if (JSON.stringify(emptyEnvelope).length > normalizedMaxChars) {
@@ -1491,11 +1492,12 @@ function createBoundedTruncationValue(
   }
 
   let low = 0;
-  let high = Math.min(preview.length, normalizedMaxChars);
+  let high = Math.min(canonicalPrefix.length, normalizedMaxChars);
   while (low < high) {
     const next = Math.ceil((low + high) / 2);
     const candidate = {
-      _truncated: preview.slice(0, next),
+      _truncated:
+        TOOL_INPUT_TRUNCATION_MARKER + canonicalPrefix.slice(0, next),
       _originalChars: originalChars,
     };
     if (JSON.stringify(candidate).length <= normalizedMaxChars) {
@@ -1504,15 +1506,47 @@ function createBoundedTruncationValue(
       high = next - 1;
     }
   }
-  const truncationMarker = '… [truncated]';
-  const boundedPreview =
-    low < preview.length && low >= truncationMarker.length
-      ? preview.slice(0, low - truncationMarker.length) + truncationMarker
-      : preview.slice(0, low);
   return {
-    _truncated: boundedPreview,
+    // Keep the marker separate from a pure canonical prefix so another,
+    // slightly smaller cap can be derived without nesting the envelope.
+    _truncated:
+      TOOL_INPUT_TRUNCATION_MARKER + canonicalPrefix.slice(0, low),
     _originalChars: originalChars,
   };
+}
+
+function readBoundedTruncationValue(
+  input: unknown
+): { preview: string; originalChars: number } | undefined {
+  if (input == null || typeof input !== 'object' || isProxy(input)) {
+    return undefined;
+  }
+  try {
+    const prototype = Object.getPrototypeOf(input);
+    const keys = Object.keys(input);
+    if (
+      (prototype !== Object.prototype && prototype !== null) ||
+      keys.length !== 2 ||
+      !keys.includes('_truncated') ||
+      !keys.includes('_originalChars')
+    ) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  const preview = readPropertyWithoutAccessors(input, '_truncated');
+  const originalChars = readPropertyWithoutAccessors(input, '_originalChars');
+  return preview.own &&
+    !preview.accessor &&
+    typeof preview.value === 'string' &&
+    originalChars.own &&
+    !originalChars.accessor &&
+    typeof originalChars.value === 'number' &&
+    Number.isFinite(originalChars.value) &&
+    originalChars.value >= 0
+    ? { preview: preview.value, originalChars: originalChars.value }
+    : undefined;
 }
 
 function projectToolInputWithinLimit(
@@ -1520,11 +1554,33 @@ function projectToolInputWithinLimit(
   maxChars: number
 ): ToolInputProjection {
   const normalizedMaxChars = normalizeToolInputLimit(maxChars);
-  const serialized = serializeStructuredValueBounded(input, normalizedMaxChars);
+  const priorTruncation = readBoundedTruncationValue(input);
+  if (priorTruncation != null) {
+    const serializedLength = serializeStructuredValueBounded(
+      input,
+      normalizedMaxChars
+    );
+    if (!serializedLength.truncated) {
+      return { value: input, changed: false };
+    }
+    return {
+      value: createBoundedTruncationValue(
+        priorTruncation.preview,
+        priorTruncation.originalChars,
+        normalizedMaxChars
+      ),
+      changed: true,
+    };
+  }
+  const serialized = serializeStructuredValueBounded(
+    input,
+    normalizedMaxChars,
+    normalizedMaxChars
+  );
   if (serialized.truncated) {
     return {
       value: createBoundedTruncationValue(
-        serialized.content,
+        serialized.prefix,
         serialized.originalChars,
         normalizedMaxChars
       ),
@@ -1561,13 +1617,14 @@ export function serializeToolCallInput(
   const projected = projectToolInputWithinLimit(input, normalizedMaxChars);
   const serialized = serializeStructuredValueBounded(
     projected.value,
+    normalizedMaxChars,
     normalizedMaxChars
   );
   if (!serialized.truncated) {
     return serialized.content === 'undefined' ? 'null' : serialized.content;
   }
   const fallback = createBoundedTruncationValue(
-    serialized.content,
+    serialized.prefix,
     serialized.originalChars,
     normalizedMaxChars
   );
@@ -1651,8 +1708,54 @@ function projectSerializedArguments(
   if (typeof value === 'string' && value.length <= normalizedMaxChars) {
     return { value, changed: false };
   }
+  if (
+    typeof value === 'string' &&
+    value.includes('"_truncated"') &&
+    value.includes('"_originalChars"')
+  ) {
+    try {
+      const priorTruncation = readBoundedTruncationValue(JSON.parse(value));
+      if (priorTruncation != null) {
+        return {
+          value: JSON.stringify(
+            createBoundedTruncationValue(
+              priorTruncation.preview,
+              priorTruncation.originalChars,
+              normalizedMaxChars
+            )
+          ),
+          changed: true,
+        };
+      }
+    } catch {
+      // Fall through to the accessor-safe serializer for malformed JSON.
+    }
+  }
   return {
     value: serializeToolCallInput(value, normalizedMaxChars),
+    changed: true,
+  };
+}
+
+const TRUNCATED_STRING_INPUT_PATTERN = /\n… \[truncated: (\d+) chars\]$/u;
+
+function projectStringInputWithinLimit(
+  value: string,
+  maxChars: number
+): { value: string; changed: boolean } {
+  const normalizedMaxChars = normalizeToolInputLimit(maxChars);
+  if (value.length <= normalizedMaxChars) {
+    return { value, changed: false };
+  }
+  const match = TRUNCATED_STRING_INPUT_PATTERN.exec(value);
+  const originalChars = match == null ? value.length : Number(match[1]);
+  const prefix = match == null ? value : value.slice(0, match.index);
+  const marker = `\n… [truncated: ${originalChars} chars]`;
+  return {
+    value:
+      marker.length >= normalizedMaxChars
+        ? prefix.slice(0, normalizedMaxChars)
+        : prefix.slice(0, normalizedMaxChars - marker.length) + marker,
     changed: true,
   };
 }
@@ -1873,10 +1976,7 @@ function projectResponsesOutput(
       } else if (type === 'custom_tool_call') {
         const value =
           typeof source === 'string'
-            ? truncateToolResultContent(
-              source,
-              normalizeToolInputLimit(maxChars)
-            )
+            ? projectStringInputWithinLimit(source, maxChars).value
             : serializeToolCallInput(source, maxChars);
         projectedInput = {
           value,
@@ -2110,28 +2210,19 @@ function applyToolCallInputCaps(params: {
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
   fromIndex?: number;
-  canonicalMessageStore?: WeakMap<BaseMessage, BaseMessage>;
 }): number {
   const { messages, maxInputChars, indexTokenCountMap, tokenCounter } = params;
   const fromIndex = params.fromIndex ?? 0;
-  let sources = messages;
-  if (params.canonicalMessageStore != null) {
-    sources = [...messages];
-    for (let i = fromIndex; i < messages.length; i++) {
-      sources[i] = params.canonicalMessageStore.get(messages[i]) ?? messages[i];
-    }
-  }
-  const projected = projectToolCallInputs(sources, maxInputChars, fromIndex);
-  if (projected === sources) {
+  const projected = projectToolCallInputs(messages, maxInputChars, fromIndex);
+  if (projected === messages) {
     return 0;
   }
 
   let truncatedCount = 0;
   for (let i = fromIndex; i < messages.length; i++) {
-    if (projected[i] === sources[i]) {
+    if (projected[i] === messages[i]) {
       continue;
     }
-    params.canonicalMessageStore?.set(projected[i], sources[i]);
     messages[i] = projected[i];
     indexTokenCountMap[i] = tokenCounter(projected[i]);
     truncatedCount++;
@@ -2195,6 +2286,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
    *  Self-seeds from provider observations within the run. */
   let bestInstructionOverhead: number | undefined;
   const reconciledLegacyAiMessages = new WeakSet<BaseMessage>();
+  const canonicalizedToolCallMessages = new WeakSet<BaseMessage>();
   let bestVarianceAbs = Infinity;
   /** Local estimate at the time bestInstructionOverhead was observed.
    *  Used to invalidate the cached overhead when instructions change
@@ -2211,8 +2303,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     BaseMessage,
     BaseMessage['content']
   >();
-  /** Pre-fading AI messages retained so deeper input caps share one source. */
-  const canonicalToolCallMessages = new WeakMap<BaseMessage, BaseMessage>();
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
@@ -2370,6 +2460,17 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       const messageType = message.getType();
       const messageRole = (message as BaseMessage & { role?: unknown }).role;
       const isAssistant = messageType === 'ai' || messageRole === 'assistant';
+      if (isAssistant && !canonicalizedToolCallMessages.has(message)) {
+        const [canonicalized] = projectToolCallInputs(
+          [message],
+          HARD_MAX_TOOL_CALL_INPUT_CHARS
+        );
+        if (canonicalized !== message) {
+          message = canonicalized;
+          params.messages[i] = message;
+        }
+        canonicalizedToolCallMessages.add(message);
+      }
       const legacyFunctionCall = isAssistant
         ? readPropertyWithoutAccessors(
           message.additional_kwargs,
@@ -2661,7 +2762,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             ? originalToolContent
             : undefined,
         canonicalContentStore: canonicalToolContent,
-        canonicalMessageStore: canonicalToolCallMessages,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2712,7 +2812,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             ? originalToolContent
             : undefined,
         canonicalContentStore: canonicalToolContent,
-        canonicalMessageStore: canonicalToolCallMessages,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2749,6 +2848,12 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         resolvedSettings: contextPruningSettings,
+        onMessageCloned: (source, clone) => {
+          const canonicalContent = canonicalToolContent.get(source);
+          if (canonicalContent !== undefined) {
+            canonicalToolContent.set(clone, canonicalContent);
+          }
+        },
       });
     }
 
@@ -2933,7 +3038,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           caps: emergencyCaps,
           masked: emergencyTier.masked,
           canonicalContentStore: canonicalToolContent,
-          canonicalMessageStore: canonicalToolCallMessages,
         });
 
         factoryParams.log?.('info', 'Emergency truncation complete');

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -193,6 +193,12 @@ export type PruneMessagesParams = {
    * than from an earlier, already-truncated projection.
    */
   canonicalMessages?: BaseMessage[];
+  /**
+   * The caller guarantees that an existing canonical prefix cannot have been
+   * rewritten since the previous call. Graph reducers provide this guarantee
+   * by invalidating and recreating the pruner on replacements/removals.
+   */
+  canonicalPrefixStable?: boolean;
   messages: BaseMessage[];
   usageMetadata?: Partial<UsageMetadata>;
   startType?: ReturnType<BaseMessage['getType']>;
@@ -2426,13 +2432,13 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           (source, index) => canonicalMessages[index] !== source
         )
       : canonicalMessages.length < priorWidthLength ||
-        (canonicalMessages.length === priorWidthLength
-          ? toolExchangeWidthSources.some(
-            (source, index) => canonicalMessages[index] !== source
-          )
-          : priorWidthLength > 0 &&
+        (params.canonicalPrefixStable === true
+          ? priorWidthLength > 0 &&
             canonicalMessages[priorWidthLength - 1] !==
-              toolExchangeWidthSources[priorWidthLength - 1]);
+              toolExchangeWidthSources[priorWidthLength - 1]
+          : toolExchangeWidthSources.some(
+            (source, index) => canonicalMessages[index] !== source
+          ));
     if (widthPrefixChanged) {
       maxToolExchangeWidth = 1;
       toolExchangeWidthThrough = 0;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2416,6 +2416,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     if (widthPrefixChanged) {
       maxToolExchangeWidth = 1;
       toolExchangeWidthThrough = 0;
+      toolExchangeWidthSources = [];
     }
     for (
       let i = toolExchangeWidthThrough;
@@ -2426,9 +2427,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         maxToolExchangeWidth,
         getToolCallIds(canonicalMessages[i]).size
       );
+      toolExchangeWidthSources[i] = canonicalMessages[i];
     }
     toolExchangeWidthThrough = canonicalMessages.length;
-    toolExchangeWidthSources = [...canonicalMessages];
     let newOriginalToolContent: Map<number, string> | undefined;
     if (params.messages.length === 0) {
       /** Post-compaction calls still invoke the model — report the same

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -11,22 +11,32 @@ import type {
   MessageContentComplex,
   ReasoningContentText,
 } from '@/types/stream';
-import type { ContextPruningConfig } from '@/types/graph';
+import type { ContextPruningConfig, FadingTier } from '@/types/graph';
+import type { FadingCaps, FadingSignals } from './fading';
 import type { TokenCounter } from '@/types/run';
 import type { ProviderName } from '@/types';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
-  getToolContentCharLength,
   isComputerCallOutputMessage,
   serializeStructuredValueBounded,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
+  HARD_MAX_TOOL_CALL_INPUT_CHARS,
   HARD_MAX_TOOL_RESULT_CHARS,
+  MIN_JSON_VALUE_CHARS,
+  calculateMaxToolCallInputChars,
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
+import {
+  MASKED_RESULT_MIN_CHARS,
+  fadingRungForResultChars,
+  resolveFadingCaps,
+  resolveFadingTier,
+  seedFadingTier,
+} from './fading';
 import { resolveContextPruningSettings } from './contextPruningSettings';
 import { hasUnsafeStructuredSerialization } from '@/utils/tokens';
 import { ContentTypes, Providers, Constants } from '@/common';
@@ -34,6 +44,8 @@ import { getProviderFamily } from '@/llm/providerRegistry';
 import { dropIncompleteToolStreamContent } from './core';
 import { applyContextPruning } from './contextPruning';
 import { toLangChainContent } from './langchain';
+
+export { calculateMaxToolCallInputChars } from '@/utils/truncation';
 
 function sumTokenCounts(
   tokenMap: Record<string, number | undefined>,
@@ -73,59 +85,6 @@ export const DEFAULT_RESERVE_RATIO = 0.05;
 
 /** Provider framing reserved for the assistant reply label. */
 export const REPLY_PRIMER_TOKENS = 3;
-
-/** Context pressure at which observation masking and context fading activate. */
-const PRESSURE_THRESHOLD_MASKING = 0.8;
-
-/** Pressure band thresholds paired with budget factors for progressive context fading. */
-const PRESSURE_BANDS: [number, number][] = [
-  [0.99, 0.05],
-  [0.9, 0.2],
-  [0.85, 0.5],
-  [0.8, 1.0],
-];
-
-/** Maximum character length for masked (consumed) tool results. */
-const MASKED_RESULT_MAX_CHARS = 300;
-
-/** Fraction of a fresh tool result's cap that a masked (consumed) result keeps. */
-const MASKED_RESULT_CAP_RATIO = 0.1;
-
-/**
- * Token budget that context fading derives its caps from: the fixed context
- * window scaled by the discrete pressure band.
- *
- * Deliberately independent of the calibration ratio, the instruction overhead
- * and the number of tool results in the conversation. Those move from call to
- * call, and a cap that follows them re-truncates historical tool results to a
- * slightly different length on every request — which invalidates prefix-based
- * provider prompt caches for the rest of the conversation once pressure
- * crosses the fading threshold. Within a band, a given tool result maps to the
- * same bytes on every call.
- */
-export function resolveFadingBudgetTokens(
-  maxTokens: number,
-  contextPressure: number
-): number {
-  const budgetFactor =
-    contextPressure >= PRESSURE_THRESHOLD_MASKING
-      ? (PRESSURE_BANDS.find(([threshold]) => contextPressure >= threshold)?.[1] ??
-        1.0)
-      : 1.0;
-  return Math.max(1024, Math.floor(maxTokens * budgetFactor));
-}
-
-/** Character cap for masked (consumed) tool results at the given fading budget. */
-export function calculateMaskedResultMaxChars(
-  fadingBudgetTokens: number
-): number {
-  return Math.max(
-    MASKED_RESULT_MAX_CHARS,
-    Math.floor(
-      calculateMaxToolResultChars(fadingBudgetTokens) * MASKED_RESULT_CAP_RATIO
-    )
-  );
-}
 
 /** Hard cap for the originalToolContent store (~2 MB estimated from char length). */
 export const ORIGINAL_CONTENT_MAX_CHARS = 2_000_000;
@@ -211,6 +170,12 @@ export type PruneMessagesFactoryParams = {
    * of waiting for the first provider response.  Ignored when <= 0.
    */
   calibrationRatio?: number;
+  /**
+   * Context-fading tier persisted from a previous run's contextMeta. Seeds the
+   * latched cap ladder so historical tool results keep the same truncated
+   * bytes across runs. Invalid values or a different context window start fresh.
+   */
+  fadingTier?: FadingTier | null;
   /** Optional diagnostic log callback wired by the graph for observability. */
   log?: (
     level: 'debug' | 'info' | 'warn' | 'error',
@@ -1174,18 +1139,147 @@ export function checkValidNumber(value: unknown): value is number {
   return typeof value === 'number' && !isNaN(value) && value > 0;
 }
 
+type FadingApplyParams = {
+  messages: BaseMessage[];
+  indexTokenCountMap: Record<string, number | undefined>;
+  tokenCounter: TokenCounter;
+  caps: Pick<FadingCaps, 'resultChars' | 'consumedChars' | 'inputChars'>;
+  /** Whether consumed results shrink to `caps.consumedChars`. */
+  masked: boolean;
+  /** First index to visit for fresh results and tool-call inputs. */
+  fromIndex?: number;
+  /** First consumed index to visit for masking. */
+  maskedFromIndex?: number;
+  /** Original (pre-masking) content keyed by message index, captured for the summarizer. */
+  originalContentStore?: Map<number, string>;
+  /** Called after storing a newly captured entry. */
+  onContentStored?: (index: number, content: string) => void;
+};
+
+export type FadingApplyResult = {
+  /** Fresh tool results rewritten. */
+  truncated: number;
+  /** Tool-call inputs rewritten. */
+  inputs: number;
+  /** Consumed tool results rewritten. */
+  masked: number;
+  /** Index of the newest AI message with text; tool results before it are consumed. */
+  consumedBoundary: number;
+};
+
+function hasTextContent(message: BaseMessage): boolean {
+  const { content } = message;
+  if (typeof content === 'string') {
+    return content.trim().length > 0;
+  }
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (block) =>
+        typeof block === 'object' &&
+        (block as Record<string, unknown>).type === 'text' &&
+        typeof (block as Record<string, unknown>).text === 'string' &&
+        ((block as Record<string, unknown>).text as string).trim().length > 0
+    )
+  );
+}
+
+/**
+ * Index of the newest AI message with substantive text. Every ToolMessage
+ * before it has been answered by the model ("consumed"); results after it are
+ * still fresh. Scans backward, so the cost is bounded by the last turn.
+ */
+function findConsumedBoundary(messages: BaseMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.getType() === 'ai' && hasTextContent(message)) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Applies a fading tier's caps in one forward pass. Consumed results (before
+ * the boundary) shrink to `consumedChars`, fresh results to `resultChars` and
+ * historical tool-call inputs to `inputChars`. Messages already within their
+ * cap keep object identity and token count, so at an unchanged tier the pass
+ * only touches what arrived since the watermarks. Truncation is a pure
+ * function of (content, cap), which is what keeps the bytes of a historical
+ * result identical from call to call.
+ */
+export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
+  const { messages, indexTokenCountMap, tokenCounter, caps, masked } = params;
+  const fromIndex = params.fromIndex ?? 0;
+  const maskedFromIndex = params.maskedFromIndex ?? 0;
+  const consumedBoundary = masked ? findConsumedBoundary(messages) : 0;
+  const start = masked ? Math.min(fromIndex, maskedFromIndex) : fromIndex;
+  let truncated = 0;
+  let maskedCount = 0;
+
+  for (let i = start; i < messages.length; i++) {
+    const message = messages[i];
+    if (
+      message.getType() !== 'tool' ||
+      isComputerCallOutputMessage(message)
+    ) {
+      continue;
+    }
+    const consumed = masked && i < consumedBoundary;
+    if (consumed ? i < maskedFromIndex : i < fromIndex) {
+      continue;
+    }
+    const maxChars = consumed ? caps.consumedChars : caps.resultChars;
+    if (!Number.isFinite(maxChars)) {
+      continue;
+    }
+    const content = message.content;
+    const compacted = compactToolContent(content, maxChars);
+    if (!compacted.changed) {
+      continue;
+    }
+    if (
+      consumed &&
+      params.originalContentStore &&
+      !params.originalContentStore.has(i)
+    ) {
+      const original = serializeToolContentBounded(
+        content,
+        ORIGINAL_CONTENT_MAX_CHARS
+      );
+      params.originalContentStore.set(i, original);
+      params.onContentStored?.(i, original);
+    }
+    const cloned = cloneToolMessageWithContent(
+      message as ToolMessage,
+      compacted.content
+    );
+    messages[i] = cloned;
+    indexTokenCountMap[i] = tokenCounter(cloned);
+    if (consumed) {
+      maskedCount++;
+    } else {
+      truncated++;
+    }
+  }
+
+  const inputs = Number.isFinite(caps.inputChars)
+    ? applyToolCallInputCaps({
+      messages,
+      maxInputChars: caps.inputChars,
+      indexTokenCountMap,
+      tokenCounter,
+      fromIndex,
+    })
+    : 0;
+
+  return { truncated, inputs, masked: maskedCount, consumedBoundary };
+}
+
 /**
  * Observation masking: replaces consumed ToolMessage content with tight
- * head+tail truncations that serve as informative placeholders.
- *
- * A ToolMessage is "consumed" when a subsequent AI message exists that is NOT
- * purely tool calls — meaning the model has already read and acted on the
- * result. Unconsumed results (the latest tool outputs the model hasn't
- * responded to yet) are left intact so the model can still use them.
- *
- * AI messages are never masked — they contain the model's own reasoning and
- * conclusions, which is what prevents the model from repeating work after
- * its tool results are masked.
+ * head+tail truncations that serve as informative placeholders. Fresh results
+ * and tool-call inputs are left alone.
  *
  * @returns The number of tool messages that were masked.
  */
@@ -1194,10 +1288,7 @@ export function maskConsumedToolResults(params: {
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
   /** Character cap applied to every consumed result (never below
-   *  MASKED_RESULT_MAX_CHARS, which is also the default). The cap must stay
-   *  stable across calls for a given pressure band: one that depends on the
-   *  number of consumed results or on calibration re-truncates historical
-   *  results on every call and shifts provider prompt-cache prefixes. */
+   *  MASKED_RESULT_MIN_CHARS, which is also the default). */
   maxChars?: number;
   /** When provided, original (pre-masking) content is stored here keyed by
    *  message index — only for entries that actually get truncated. */
@@ -1205,100 +1296,28 @@ export function maskConsumedToolResults(params: {
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 }): number {
-  const { messages, indexTokenCountMap, tokenCounter } = params;
-  let maskedCount = 0;
-
-  // Pass 1 (backward): identify consumed tool message indices.
-  // A ToolMessage is "consumed" once we've seen a subsequent AI message with
-  // substantive text content (not just tool calls).
-  // Processed oldest first so originals are stored in eviction order.
-  let seenNonToolCallAI = false;
-  const consumedIndices: number[] = [];
-
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    const type = msg.getType();
-
-    if (type === 'ai') {
-      const hasText =
-        typeof msg.content === 'string'
-          ? msg.content.trim().length > 0
-          : Array.isArray(msg.content) &&
-            msg.content.some(
-              (b) =>
-                typeof b === 'object' &&
-                (b as Record<string, unknown>).type === 'text' &&
-                typeof (b as Record<string, unknown>).text === 'string' &&
-                ((b as Record<string, unknown>).text as string).trim().length >
-                  0
-            );
-      if (hasText) {
-        seenNonToolCallAI = true;
-      }
-    } else if (type === 'tool' && seenNonToolCallAI) {
-      consumedIndices.push(i);
-    }
-  }
-
-  if (consumedIndices.length === 0) {
-    return 0;
-  }
-
-  consumedIndices.reverse();
-
-  const maxChars = Math.max(
-    MASKED_RESULT_MAX_CHARS,
-    Math.floor(params.maxChars ?? MASKED_RESULT_MAX_CHARS)
-  );
-
-  for (const i of consumedIndices) {
-    const message = messages[i];
-    if (isComputerCallOutputMessage(message)) {
-      continue;
-    }
-    const content = message.content;
-
-    const compacted = compactToolContent(content, maxChars);
-    if (!compacted.changed) {
-      continue;
-    }
-
-    if (params.originalContentStore && !params.originalContentStore.has(i)) {
-      const original = serializeToolContentBounded(
-        content,
-        ORIGINAL_CONTENT_MAX_CHARS
-      );
-      params.originalContentStore.set(i, original);
-      if (params.onContentStored) {
-        params.onContentStored(i, original);
-      }
-    }
-
-    const cloned = cloneToolMessageWithContent(
-      message as ToolMessage,
-      compacted.content
-    );
-    messages[i] = cloned;
-    indexTokenCountMap[i] = tokenCounter(cloned);
-    maskedCount++;
-  }
-
-  return maskedCount;
+  return applyFadingCaps({
+    messages: params.messages,
+    indexTokenCountMap: params.indexTokenCountMap,
+    tokenCounter: params.tokenCounter,
+    caps: {
+      resultChars: Number.POSITIVE_INFINITY,
+      consumedChars: Math.max(
+        MASKED_RESULT_MIN_CHARS,
+        Math.floor(params.maxChars ?? MASKED_RESULT_MIN_CHARS)
+      ),
+      inputChars: Number.POSITIVE_INFINITY,
+    },
+    masked: true,
+    originalContentStore: params.originalContentStore,
+    onContentStored: params.onContentStored,
+  }).masked;
 }
 
 /**
  * Pre-flight truncation: truncates oversized ToolMessage content before the
- * main backward-iteration pruning runs. Unlike the ingestion guard (which caps
- * at tool-execution time), pre-flight truncation applies per-turn based on the
- * budget the caller derives from the current pressure band.
- *
- * Every tool result gets the same cap. A per-result cap that depended on the
- * result's position among all tool results would change for every historical
- * result each time a new tool call is appended, re-truncating already-sent
- * messages and invalidating prefix-based provider prompt caches on every turn.
- *
- * After truncation, recounts tokens via tokenCounter and updates indexTokenCountMap
- * so subsequent pruning works with accurate counts.
+ * main backward-iteration pruning runs, applying one cap derived from
+ * `maxContextTokens` to every tool result.
  *
  * @returns The number of tool messages that were truncated.
  */
@@ -1308,34 +1327,17 @@ export function preFlightTruncateToolResults(params: {
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
 }): number {
-  const { messages, maxContextTokens, indexTokenCountMap, tokenCounter } =
-    params;
-  const maxChars = calculateMaxToolResultChars(maxContextTokens);
-  let truncatedCount = 0;
-
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i];
-    if (
-      message.getType() !== 'tool' ||
-      isComputerCallOutputMessage(message)
-    ) {
-      continue;
-    }
-
-    const compacted = compactToolContent(message.content, maxChars);
-    if (!compacted.changed) {
-      continue;
-    }
-    const cloned = cloneToolMessageWithContent(
-      message as ToolMessage,
-      compacted.content
-    );
-    messages[i] = cloned;
-    indexTokenCountMap[i] = tokenCounter(cloned);
-    truncatedCount++;
-  }
-
-  return truncatedCount;
+  return applyFadingCaps({
+    messages: params.messages,
+    indexTokenCountMap: params.indexTokenCountMap,
+    tokenCounter: params.tokenCounter,
+    caps: {
+      resultChars: calculateMaxToolResultChars(params.maxContextTokens),
+      consumedChars: Number.POSITIVE_INFINITY,
+      inputChars: Number.POSITIVE_INFINITY,
+    },
+    masked: false,
+  }).truncated;
 }
 
 /**
@@ -1351,8 +1353,6 @@ export function preFlightTruncateToolResults(params: {
  *
  * @returns The number of AI messages that had tool_use inputs truncated.
  */
-const HARD_MAX_TOOL_CALL_INPUT_CHARS = 200_000;
-const MIN_JSON_VALUE_CHARS = 4;
 const ACCESSOR_INPUT_PLACEHOLDER = '[Property accessor omitted]';
 
 type ToolInputProjection = {
@@ -1917,35 +1917,15 @@ function projectResponsesOutput(
   };
 }
 
-/** Per-input cap: 15% of context at ~4 chars/token, never above 200K chars. */
-export function calculateMaxToolCallInputChars(
-  maxContextTokens?: number
-): number {
-  if (maxContextTokens == null || maxContextTokens <= 0) {
-    return HARD_MAX_TOOL_CALL_INPUT_CHARS;
-  }
-  return Math.max(
-    MIN_JSON_VALUE_CHARS,
-    Math.min(
-      Math.floor(maxContextTokens * 0.15) * 4,
-      HARD_MAX_TOOL_CALL_INPUT_CHARS
-    )
-  );
-}
-
-/**
- * Projects historical tool-call inputs into a provider-safe bounded form.
- * Returns the original array when no message changes and otherwise clones only
- * the array and AI messages whose inline input or `tool_calls` args changed.
- */
 function projectToolCallInputsInternal(
   messages: BaseMessage[],
   maxInputChars: number,
-  dropIncompleteStreamContent: boolean
+  dropIncompleteStreamContent: boolean,
+  fromIndex = 0
 ): BaseMessage[] {
   const normalizedMaxInputChars = normalizeToolInputLimit(maxInputChars);
   let projectedMessages: BaseMessage[] | undefined;
-  for (let i = 0; i < messages.length; i++) {
+  for (let i = fromIndex; i < messages.length; i++) {
     const message = messages[i];
     const messageRole = (message as BaseMessage & { role?: unknown }).role;
     if (message.getType() !== 'ai' && messageRole !== 'assistant') {
@@ -2112,9 +2092,15 @@ function projectToolCallInputsInternal(
 /** Projects all historical tool-call input representations to bounded values. */
 export function projectToolCallInputs(
   messages: BaseMessage[],
-  maxInputChars: number
+  maxInputChars: number,
+  fromIndex = 0
 ): BaseMessage[] {
-  return projectToolCallInputsInternal(messages, maxInputChars, false);
+  return projectToolCallInputsInternal(
+    messages,
+    maxInputChars,
+    false,
+    fromIndex
+  );
 }
 
 /**
@@ -2128,22 +2114,22 @@ export function projectToolMessagesForProvider(
   return projectToolCallInputsInternal(messages, maxInputChars, true);
 }
 
-export function preFlightTruncateToolCallInputs(params: {
+function applyToolCallInputCaps(params: {
   messages: BaseMessage[];
-  maxContextTokens: number;
+  maxInputChars: number;
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
+  fromIndex?: number;
 }): number {
-  const { messages, maxContextTokens, indexTokenCountMap, tokenCounter } =
-    params;
-  const maxInputChars = calculateMaxToolCallInputChars(maxContextTokens);
-  const projected = projectToolCallInputs(messages, maxInputChars);
+  const { messages, maxInputChars, indexTokenCountMap, tokenCounter } = params;
+  const fromIndex = params.fromIndex ?? 0;
+  const projected = projectToolCallInputs(messages, maxInputChars, fromIndex);
   if (projected === messages) {
     return 0;
   }
 
   let truncatedCount = 0;
-  for (let i = 0; i < messages.length; i++) {
+  for (let i = fromIndex; i < messages.length; i++) {
     if (projected[i] === messages[i]) {
       continue;
     }
@@ -2152,6 +2138,20 @@ export function preFlightTruncateToolCallInputs(params: {
     truncatedCount++;
   }
   return truncatedCount;
+}
+
+export function preFlightTruncateToolCallInputs(params: {
+  messages: BaseMessage[];
+  maxContextTokens: number;
+  indexTokenCountMap: Record<string, number | undefined>;
+  tokenCounter: TokenCounter;
+}): number {
+  return applyToolCallInputCaps({
+    messages: params.messages,
+    maxInputChars: calculateMaxToolCallInputChars(params.maxContextTokens),
+    indexTokenCountMap: params.indexTokenCountMap,
+    tokenCounter: params.tokenCounter,
+  });
 }
 
 type ThinkingBlocks = {
@@ -2207,6 +2207,15 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
    *  pruner is recreated after summarization. */
   const originalToolContent = new Map<number, string>();
   let originalToolContentSize = 0;
+  /** Latched fading tier; caps derive from it alone so bytes stay stable. */
+  let fadingTier = seedFadingTier(
+    factoryParams.maxTokens,
+    factoryParams.fadingTier
+  );
+  /** Fresh results and inputs below this index already carry the tier's caps. */
+  let fadedThrough = 0;
+  /** Consumed results below this index already carry the tier's masked cap. */
+  let maskedThrough = 0;
   const contextPruningSettings = resolveContextPruningSettings(
     factoryParams.contextPruningConfig
   );
@@ -2221,6 +2230,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     originalToolContent?: Map<number, string>;
     newOriginalToolContent?: Map<number, string>;
     calibrationRatio?: number;
+    /** Latched fading tier after this call; hosts persist it beside calibrationRatio. */
+    fadingTier: FadingTier;
     resolvedInstructionOverhead?: number;
     /** Usable budget this call: maxTokens minus output reserve */
     contextBudget?: number;
@@ -2253,6 +2264,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           emptyBudget - emptyInstructionTokens - emptyReplyPrimerTokens
         ),
         calibrationRatio,
+        fadingTier,
         resolvedInstructionOverhead: bestInstructionOverhead,
         contextBudget: emptyBudget,
         effectiveInstructionTokens: emptyInstructionTokens,
@@ -2585,6 +2597,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         contextPressure:
           pruningBudget > 0 ? calibratedTotalTokens / pruningBudget : 0,
         calibrationRatio,
+        fadingTier,
         resolvedInstructionOverhead: bestInstructionOverhead,
         contextBudget: pruningBudget,
         effectiveInstructionTokens: currentInstructionTokens,
@@ -2593,26 +2606,18 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
 
     // ---------------------------------------------------------------------------
     // Progressive context fading — inspired by Claude Code's staged compaction.
-    // Below 80%: no modifications, tool results retain full size.
-    // Above 80%: graduated truncation with increasing aggression per pressure band.
-    // Consumed results (already answered by the model) fade first via masking.
-    //
-    //   80%: gentle — budget factor 1.0
-    //   85%: moderate — budget factor 0.50
-    //   90%: aggressive — budget factor 0.20
-    //   99%: emergency — budget factor 0.05, effectively placeholders
-    //
-    // Every cap is a function of the fixed context window and the band only
-    // (see resolveFadingBudgetTokens): within a band, a historical tool result
-    // maps to the same bytes on every call, so provider prompt-cache prefixes
-    // survive from turn to turn instead of being rewritten each request.
+    // Every cap comes from the latched fading tier (see ./fading.ts): the fit
+    // rung keeps a single tool result within the effective budget, pressure
+    // bands deepen the rung when summarization is off, and masking (80%+)
+    // shrinks consumed results the model has already answered. The tier only
+    // ever deepens, so a historical tool result maps to the same bytes on
+    // every call and provider prompt-cache prefixes survive from turn to turn;
+    // only escalation rewrites them.
     // ---------------------------------------------------------------------------
     totalTokens = sumTokenCounts(indexTokenCountMap, params.messages.length);
     calibratedTotalTokens = Math.round(totalTokens * calibrationRatio);
     const contextPressure =
       pruningBudget > 0 ? calibratedTotalTokens / pruningBudget : 0;
-    let preFlightResultCount = 0;
-    let preFlightInputCount = 0;
 
     // -----------------------------------------------------------------------
     // Observation masking (80%+ pressure, both paths):
@@ -2624,71 +2629,75 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // When summarization is enabled, snapshot messages first so the
     // summarizer can see the full originals when compaction fires.
     // -----------------------------------------------------------------------
-    let observationsMasked = 0;
-    const fadingBudgetTokens = resolveFadingBudgetTokens(
-      factoryParams.maxTokens,
-      contextPressure
-    );
+    const storeOriginalToolContent = (index: number, content: string): void => {
+      originalToolContentSize += content.length;
+      if (newOriginalToolContent == null) {
+        newOriginalToolContent = new Map();
+      }
+      newOriginalToolContent.set(index, content);
+      while (
+        originalToolContentSize > ORIGINAL_CONTENT_MAX_CHARS &&
+        originalToolContent.size > 0
+      ) {
+        const oldest = originalToolContent.keys().next();
+        if (oldest.done === true) {
+          break;
+        }
+        const removed = originalToolContent.get(oldest.value);
+        if (removed != null) {
+          originalToolContentSize -= removed.length;
+        }
+        originalToolContent.delete(oldest.value);
+      }
+    };
 
-    if (contextPressure >= PRESSURE_THRESHOLD_MASKING) {
-      observationsMasked = maskConsumedToolResults({
+    /** Advances the tier from the signals and applies its caps; escalation rescans everything. */
+    const fade = (signals: FadingSignals): FadingApplyResult => {
+      const nextTier = resolveFadingTier(fadingTier, signals);
+      if (nextTier !== fadingTier) {
+        fadingTier = nextTier;
+        fadedThrough = 0;
+        maskedThrough = 0;
+      }
+      const result = applyFadingCaps({
         messages: params.messages,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
-        maxChars: calculateMaskedResultMaxChars(fadingBudgetTokens),
+        caps: resolveFadingCaps(fadingTier, factoryParams.maxToolResultChars),
+        masked: fadingTier.masked,
+        fromIndex: fadedThrough,
+        maskedFromIndex: maskedThrough,
         originalContentStore:
           factoryParams.summarizationEnabled === true
             ? originalToolContent
             : undefined,
         onContentStored:
           factoryParams.summarizationEnabled === true
-            ? (index: number, content: string): void => {
-              originalToolContentSize += content.length;
-              if (newOriginalToolContent == null) {
-                newOriginalToolContent = new Map();
-              }
-              newOriginalToolContent.set(index, content);
-              while (
-                originalToolContentSize > ORIGINAL_CONTENT_MAX_CHARS &&
-                  originalToolContent.size > 0
-              ) {
-                const oldest = originalToolContent.keys().next();
-                if (oldest.done === true) {
-                  break;
-                }
-                const removed = originalToolContent.get(oldest.value);
-                if (removed != null) {
-                  originalToolContentSize -= removed.length;
-                }
-                originalToolContent.delete(oldest.value);
-              }
-            }
+            ? storeOriginalToolContent
             : undefined,
       });
-      if (observationsMasked > 0) {
-        cumulativeRawSent = 0;
-        cumulativeProviderReported = 0;
-      }
+      fadedThrough = params.messages.length;
+      maskedThrough = result.consumedBoundary;
+      return result;
+    };
+
+    const fadingSignals: FadingSignals = {
+      contextPressure,
+      effectiveRawTokens:
+        calibrationRatio > 0
+          ? Math.floor(effectiveMaxTokens / calibrationRatio)
+          : effectiveMaxTokens,
+      summarizationEnabled: factoryParams.summarizationEnabled === true,
+    };
+    const faded = fade(fadingSignals);
+    const observationsMasked = faded.masked;
+    const preFlightResultCount = faded.truncated;
+    const preFlightInputCount = faded.inputs;
+    if (observationsMasked > 0) {
+      cumulativeRawSent = 0;
+      cumulativeProviderReported = 0;
     }
 
-    if (
-      contextPressure >= PRESSURE_THRESHOLD_MASKING &&
-      factoryParams.summarizationEnabled !== true
-    ) {
-      preFlightResultCount = preFlightTruncateToolResults({
-        messages: params.messages,
-        maxContextTokens: fadingBudgetTokens,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
-      });
-
-      preFlightInputCount = preFlightTruncateToolCallInputs({
-        messages: params.messages,
-        maxContextTokens: fadingBudgetTokens,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
-      });
-    }
     if (
       factoryParams.contextPruningConfig?.enabled === true &&
       factoryParams.summarizationEnabled !== true
@@ -2698,38 +2707,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         resolvedSettings: contextPruningSettings,
-      });
-    }
-
-    // Fit-to-budget: when summarization is enabled and individual messages
-    // exceed the context window, truncate them so every message can fit in
-    // a single context slot.  Without this, oversized tool results (e.g.
-    // take_snapshot at 9K chars) cause empty context → emergency truncation
-    // → immediate re-summarization after just one tool call.
-    //
-    // This is NOT the pressure-scaled fading above — it only targets messages
-    // that individually exceed the window-derived cap, the same cap the
-    // ingestion guard applies at tool-execution time. It is deliberately not
-    // derived from the calibrated effective budget: that value moves with
-    // every provider response, and a cap that follows it re-truncates
-    // historical results to a different length on each call, invalidating
-    // provider prompt caches for the rest of the conversation.
-    if (
-      factoryParams.summarizationEnabled === true &&
-      factoryParams.maxTokens > 0
-    ) {
-      preFlightResultCount = preFlightTruncateToolResults({
-        messages: params.messages,
-        maxContextTokens: factoryParams.maxTokens,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
-      });
-
-      preFlightInputCount = preFlightTruncateToolCallInputs({
-        messages: params.messages,
-        maxContextTokens: factoryParams.maxTokens,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
       });
     }
 
@@ -2781,6 +2758,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           originalToolContent.size > 0 ? originalToolContent : undefined,
         newOriginalToolContent,
         calibrationRatio,
+        fadingTier,
         resolvedInstructionOverhead: bestInstructionOverhead,
         contextBudget: pruningBudget,
         effectiveInstructionTokens: currentInstructionTokens,
@@ -2855,52 +2833,49 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     }
 
     // ---------------------------------------------------------------
-    // Fallback fading: when summarization skipped fading earlier and
-    // pruning still produced an empty context, apply lossy pressure-band
-    // fading and retry.  This is a last resort before emergency truncation
-    // — the summarizer already saw the full messages, so fading the
-    // surviving context for the LLM is acceptable.
+    // Emergency truncation: if pruning produced an empty context but
+    // messages exist, deepen the fading tier until a per-message share of
+    // the effective budget (~4 chars/token, floor 200 chars) fits, apply
+    // it to the live messages and retry.  The tier latches, so the next
+    // call reproduces the same bytes instead of re-deriving them.
     // ---------------------------------------------------------------
     if (
       context.length === 0 &&
       params.messages.length > 0 &&
-      effectiveMaxTokens > 0 &&
-      factoryParams.summarizationEnabled === true
+      effectiveMaxTokens > 0
     ) {
-      const fadingBudget = Math.max(1024, effectiveMaxTokens);
+      const perMessageTokenBudget = Math.floor(
+        effectiveMaxTokens / Math.max(1, params.messages.length)
+      );
+      const emergencyMaxChars = Math.max(200, perMessageTokenBudget * 4);
+      const minRung = fadingRungForResultChars(
+        factoryParams.maxTokens,
+        emergencyMaxChars
+      );
 
       factoryParams.log?.(
-        'debug',
-        'Fallback fading — empty context with summarization',
+        'warn',
+        'Empty context, entering emergency truncation',
         {
           messageCount: params.messages.length,
-          effectiveMaxTokens,
-          fadingBudget,
+          effectiveMax: effectiveMaxTokens,
+          emergencyMaxChars,
+          rung: minRung,
         }
       );
 
-      const fadedMessages = [...params.messages];
-      const preFadingTokenCounts: Record<string, number | undefined> = {};
-      for (let i = 0; i < params.messages.length; i++) {
-        preFadingTokenCounts[i] = indexTokenCountMap[i];
-      }
+      const emergency = fade({ ...fadingSignals, minRung });
 
-      preFlightTruncateToolResults({
-        messages: fadedMessages,
-        maxContextTokens: fadingBudget,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
-      });
-      preFlightTruncateToolCallInputs({
-        messages: fadedMessages,
-        maxContextTokens: fadingBudget,
-        indexTokenCountMap,
-        tokenCounter: factoryParams.tokenCounter,
+      factoryParams.log?.('info', 'Emergency truncation complete');
+      factoryParams.log?.('debug', 'Emergency truncation details', {
+        truncatedCount:
+          emergency.truncated + emergency.inputs + emergency.masked,
+        rung: fadingTier.rung,
       });
 
-      const fadingRetry = getMessagesWithinTokenLimit({
+      const retryResult = getMessagesWithinTokenLimit({
         maxContextTokens: pruningBudget,
-        messages: fadedMessages,
+        messages: params.messages,
         indexTokenCountMap,
         startType: params.startType,
         thinkingEnabled: factoryParams.thinkingEnabled,
@@ -2915,170 +2890,25 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             : undefined,
       });
 
-      const fadingRepaired = repairOrphanedToolMessages({
-        context: fadingRetry.context,
-        allMessages: fadedMessages,
+      const repaired = repairOrphanedToolMessages({
+        context: retryResult.context,
+        allMessages: params.messages,
         tokenCounter: factoryParams.tokenCounter,
         indexTokenCountMap,
       });
 
-      if (fadingRepaired.context.length > 0) {
-        context = fadingRepaired.context;
-        reclaimedTokens = fadingRepaired.reclaimedTokens;
-        appendItems(messagesToRefine, fadingRetry.messagesToRefine);
-        if (fadingRepaired.droppedMessages.length > 0) {
-          appendItems(messagesToRefine, fadingRepaired.droppedMessages);
-        }
-
-        factoryParams.log?.('debug', 'Fallback fading recovered context', {
-          contextLength: context.length,
-          messagesToRefineCount: messagesToRefine.length,
-          remainingTokens: fadingRetry.remainingContextTokens,
-        });
-
-        for (const [key, value] of Object.entries(preFadingTokenCounts)) {
-          indexTokenCountMap[key] = value;
-        }
-      } else {
-        for (const [key, value] of Object.entries(preFadingTokenCounts)) {
-          indexTokenCountMap[key] = value;
-        }
-      }
-    }
-
-    // ---------------------------------------------------------------
-    // Emergency truncation: if pruning produced an empty context but
-    // messages exist, aggressively truncate all tool_call inputs and
-    // tool results, then retry.  Budget is proportional to the
-    // effective token limit (~4 chars/token, spread across messages)
-    // with a floor of 200 chars so content is never completely blank.
-    // Uses head+tail so the model sees both what was called and the
-    // final outcome (e.g., return value at the end of a script eval).
-    // ---------------------------------------------------------------
-    if (
-      context.length === 0 &&
-      params.messages.length > 0 &&
-      effectiveMaxTokens > 0
-    ) {
-      const perMessageTokenBudget = Math.floor(
-        effectiveMaxTokens / Math.max(1, params.messages.length)
-      );
-      const emergencyMaxChars = Math.max(200, perMessageTokenBudget * 4);
-
-      factoryParams.log?.(
-        'warn',
-        'Empty context, entering emergency truncation',
-        {
-          messageCount: params.messages.length,
-          effectiveMax: effectiveMaxTokens,
-          emergencyMaxChars,
-        }
-      );
-
-      // Clone the messages array so emergency truncation doesn't permanently
-      // mutate graph state.  The originals remain intact for future turns
-      // where more budget may be available.  Also snapshot indexTokenCountMap
-      // entries so the closure doesn't retain stale (too-small) counts for
-      // the original un-truncated messages on the next turn.
-      const emergencyMessages = [...params.messages];
-      const preEmergencyTokenCounts: Record<string, number | undefined> = {};
-      for (let i = 0; i < params.messages.length; i++) {
-        preEmergencyTokenCounts[i] = indexTokenCountMap[i];
+      context = repaired.context;
+      reclaimedTokens = repaired.reclaimedTokens;
+      appendItems(messagesToRefine, retryResult.messagesToRefine);
+      if (repaired.droppedMessages.length > 0) {
+        appendItems(messagesToRefine, repaired.droppedMessages);
       }
 
-      try {
-        let emergencyTruncatedCount = 0;
-        for (let i = 0; i < emergencyMessages.length; i++) {
-          const message = emergencyMessages[i];
-          if (
-            message.getType() === 'tool' &&
-            !isComputerCallOutputMessage(message)
-          ) {
-            const content = message.content;
-            if (getToolContentCharLength(content) > emergencyMaxChars) {
-              const compacted = compactToolContent(content, emergencyMaxChars);
-              if (!compacted.changed) {
-                continue;
-              }
-              const cloned = cloneToolMessageWithContent(
-                message as ToolMessage,
-                compacted.content
-              );
-              emergencyMessages[i] = cloned;
-              indexTokenCountMap[i] = factoryParams.tokenCounter(cloned);
-              emergencyTruncatedCount++;
-            }
-          }
-        }
-
-        const projectedToolInputs = projectToolCallInputs(
-          emergencyMessages,
-          emergencyMaxChars
-        );
-        if (projectedToolInputs !== emergencyMessages) {
-          for (let i = 0; i < emergencyMessages.length; i++) {
-            if (projectedToolInputs[i] === emergencyMessages[i]) {
-              continue;
-            }
-            emergencyMessages[i] = projectedToolInputs[i];
-            indexTokenCountMap[i] = factoryParams.tokenCounter(
-              projectedToolInputs[i]
-            );
-            emergencyTruncatedCount++;
-          }
-        }
-
-        factoryParams.log?.('info', 'Emergency truncation complete');
-        factoryParams.log?.('debug', 'Emergency truncation details', {
-          truncatedCount: emergencyTruncatedCount,
-          emergencyMaxChars,
-        });
-
-        const retryResult = getMessagesWithinTokenLimit({
-          maxContextTokens: pruningBudget,
-          messages: emergencyMessages,
-          indexTokenCountMap,
-          startType: params.startType,
-          thinkingEnabled: factoryParams.thinkingEnabled,
-          tokenCounter: factoryParams.tokenCounter,
-          instructionTokens: currentInstructionTokens,
-          reasoningType: usesBedrockThinking
-            ? ContentTypes.REASONING_CONTENT
-            : ContentTypes.THINKING,
-          thinkingStartIndex:
-            factoryParams.thinkingEnabled === true
-              ? runThinkingStartIndex
-              : undefined,
-        });
-
-        const repaired = repairOrphanedToolMessages({
-          context: retryResult.context,
-          allMessages: emergencyMessages,
-          tokenCounter: factoryParams.tokenCounter,
-          indexTokenCountMap,
-        });
-
-        context = repaired.context;
-        reclaimedTokens = repaired.reclaimedTokens;
-        appendItems(messagesToRefine, retryResult.messagesToRefine);
-        if (repaired.droppedMessages.length > 0) {
-          appendItems(messagesToRefine, repaired.droppedMessages);
-        }
-
-        factoryParams.log?.('debug', 'Emergency truncation retry result', {
-          contextLength: context.length,
-          messagesToRefineCount: messagesToRefine.length,
-          remainingTokens: retryResult.remainingContextTokens,
-        });
-      } finally {
-        // Restore the closure's indexTokenCountMap to pre-emergency values so the
-        // next turn counts old messages at their original (un-truncated) size.
-        // The emergency-truncated counts were only needed for this turn's
-        // getMessagesWithinTokenLimit retry.
-        for (const [key, value] of Object.entries(preEmergencyTokenCounts)) {
-          indexTokenCountMap[key] = value;
-        }
-      }
+      factoryParams.log?.('debug', 'Emergency truncation retry result', {
+        contextLength: context.length,
+        messagesToRefineCount: messagesToRefine.length,
+        remainingTokens: retryResult.remainingContextTokens,
+      });
     }
 
     /** Scale raw-space remaining back to calibrated/provider units so it is
@@ -3116,6 +2946,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         originalToolContent.size > 0 ? originalToolContent : undefined,
       newOriginalToolContent,
       calibrationRatio,
+      fadingTier,
       resolvedInstructionOverhead: bestInstructionOverhead,
       contextBudget: pruningBudget,
       effectiveInstructionTokens: currentInstructionTokens,

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2437,6 +2437,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       maxToolExchangeWidth = 1;
       toolExchangeWidthThrough = 0;
       toolExchangeWidthSources = [];
+      fadedThrough = 0;
+      maskedThrough = 0;
+      originalToolContent.clear();
+      originalToolContentSize = 0;
     }
     for (
       let i = toolExchangeWidthThrough;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1690,10 +1690,9 @@ function projectInlineToolInput(
       nestedChanges
     );
     if (Object.keys(nestedChanges).length > 0) {
-      changes.tool_call = cloneWithProjectedProperties(
-        nestedProperty.value,
-        nestedChanges
-      );
+      changes.tool_call = isProxy(nestedProperty.value)
+        ? { args: ACCESSOR_INPUT_PLACEHOLDER }
+        : cloneWithProjectedProperties(nestedProperty.value, nestedChanges);
     } else if (!nestedProperty.own) {
       changes.tool_call = nestedProperty.value;
     }

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1314,12 +1314,68 @@ export function maskConsumedToolResults(params: {
   /** Character cap applied to every consumed result (never below
    *  MASKED_RESULT_MIN_CHARS, which is also the default). */
   maxChars?: number;
+  /** @deprecated Aggregate raw-token budget distributed by recency. Prefer
+   *  `maxChars` for byte-stable masking across otherwise identical calls. */
+  availableRawBudget?: number;
   /** When provided, original (pre-masking) content is stored here keyed by
    *  message index — only for entries that actually get truncated. */
   originalContentStore?: Map<number, string>;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 }): number {
+  if (
+    params.maxChars == null &&
+    params.availableRawBudget != null &&
+    params.availableRawBudget > 0
+  ) {
+    const consumedBoundary = findConsumedBoundary(params.messages);
+    const consumedIndices: number[] = [];
+    for (let i = 0; i < consumedBoundary; i++) {
+      if (params.messages[i].getType() === 'tool') {
+        consumedIndices.push(i);
+      }
+    }
+    const count = consumedIndices.length;
+    const totalBudgetChars = params.availableRawBudget * 4;
+    let masked = 0;
+    for (let c = 0; c < count; c++) {
+      const i = consumedIndices[c];
+      const message = params.messages[i];
+      if (isComputerCallOutputMessage(message)) {
+        continue;
+      }
+      const position = count > 1 ? c / (count - 1) : 1;
+      const weight = 0.2 + 0.8 * position;
+      const totalWeight = count > 1 ? 0.6 * count : 1;
+      const maxChars = Math.max(
+        MASKED_RESULT_MIN_CHARS,
+        Math.floor((weight / totalWeight) * totalBudgetChars)
+      );
+      const compacted = compactToolContent(message.content, maxChars);
+      if (!compacted.changed) {
+        continue;
+      }
+      if (
+        params.originalContentStore != null &&
+        !params.originalContentStore.has(i)
+      ) {
+        const original = serializeToolContentBounded(
+          message.content,
+          ORIGINAL_CONTENT_MAX_CHARS
+        );
+        params.originalContentStore.set(i, original);
+        params.onContentStored?.(i, original);
+      }
+      const cloned = cloneToolMessageWithContent(
+        message as ToolMessage,
+        compacted.content
+      );
+      params.messages[i] = cloned;
+      params.indexTokenCountMap[i] = params.tokenCounter(cloned);
+      masked++;
+    }
+    return masked;
+  }
   return applyFadingCaps({
     messages: params.messages,
     indexTokenCountMap: params.indexTokenCountMap,

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2347,10 +2347,9 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
    *  pruner is recreated after summarization. */
   const originalToolContent = new Map<number, string>();
   let originalToolContentSize = 0;
-  /** Canonical source retained only for this pruner/run when callers do not
-   * provide graph-owned history explicitly. Slots are references (with a
-   * shallow content-array clone where needed), not a second serialized copy. */
-  const capturedCanonicalMessages: BaseMessage[] = [];
+  /** Recovers canonical sources for direct callers that reuse this mutating
+   * projection without passing graph-owned history explicitly. */
+  const canonicalByProjection = new WeakMap<BaseMessage, BaseMessage>();
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
@@ -2360,6 +2359,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
   /** Widest exchange seen so far; updated only from the appended suffix. */
   let maxToolExchangeWidth = 1;
   let toolExchangeWidthThrough = 0;
+  let toolExchangeWidthSources: BaseMessage[] = [];
   /** Fresh results and inputs below this index already carry the tier's caps. */
   let fadedThrough = 0;
   /** Consumed results below this index already carry the tier's masked cap. */
@@ -2386,24 +2386,34 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     /** Calibrated instruction overhead actually applied this call */
     effectiveInstructionTokens?: number;
   } {
-    if (params.canonicalMessages == null) {
-      for (
-        let i = capturedCanonicalMessages.length;
-        i < params.messages.length;
-        i++
-      ) {
-        const message = params.messages[i];
-        capturedCanonicalMessages[i] = Array.isArray(message.content)
+    const suppliedCanonicalMessages = params.canonicalMessages;
+    const derivesCanonicalHistory = suppliedCanonicalMessages == null;
+    const canonicalMessages =
+      suppliedCanonicalMessages ??
+      params.messages.map((message) => {
+        const recovered = canonicalByProjection.get(message);
+        if (recovered != null) {
+          return recovered;
+        }
+        return Array.isArray(message.content)
           ? cloneMessage(message, [...message.content])
           : message;
-      }
-      if (capturedCanonicalMessages.length > params.messages.length) {
-        capturedCanonicalMessages.length = params.messages.length;
-      }
-    }
-    const canonicalMessages =
-      params.canonicalMessages ?? capturedCanonicalMessages;
-    if (canonicalMessages.length < toolExchangeWidthThrough) {
+      });
+    const priorWidthLength = toolExchangeWidthSources.length;
+    const widthPrefixChanged = derivesCanonicalHistory
+      ? canonicalMessages.length < priorWidthLength ||
+        toolExchangeWidthSources.some(
+          (source, index) => canonicalMessages[index] !== source
+        )
+      : canonicalMessages.length < priorWidthLength ||
+        (canonicalMessages.length === priorWidthLength
+          ? toolExchangeWidthSources.some(
+            (source, index) => canonicalMessages[index] !== source
+          )
+          : priorWidthLength > 0 &&
+            canonicalMessages[priorWidthLength - 1] !==
+              toolExchangeWidthSources[priorWidthLength - 1]);
+    if (widthPrefixChanged) {
       maxToolExchangeWidth = 1;
       toolExchangeWidthThrough = 0;
     }
@@ -2418,6 +2428,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       );
     }
     toolExchangeWidthThrough = canonicalMessages.length;
+    toolExchangeWidthSources = [...canonicalMessages];
     let newOriginalToolContent: Map<number, string> | undefined;
     if (params.messages.length === 0) {
       /** Post-compaction calls still invoke the model — report the same
@@ -2949,6 +2960,11 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         tokenCounter: factoryParams.tokenCounter,
         resolvedSettings: contextPruningSettings,
       });
+    }
+    if (derivesCanonicalHistory) {
+      for (let i = 0; i < params.messages.length; i++) {
+        canonicalByProjection.set(params.messages[i], canonicalMessages[i]);
+      }
     }
 
     const preTruncationTotalTokens = totalTokens;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -88,6 +88,45 @@ const PRESSURE_BANDS: [number, number][] = [
 /** Maximum character length for masked (consumed) tool results. */
 const MASKED_RESULT_MAX_CHARS = 300;
 
+/** Fraction of a fresh tool result's cap that a masked (consumed) result keeps. */
+const MASKED_RESULT_CAP_RATIO = 0.1;
+
+/**
+ * Token budget that context fading derives its caps from: the fixed context
+ * window scaled by the discrete pressure band.
+ *
+ * Deliberately independent of the calibration ratio, the instruction overhead
+ * and the number of tool results in the conversation. Those move from call to
+ * call, and a cap that follows them re-truncates historical tool results to a
+ * slightly different length on every request — which invalidates prefix-based
+ * provider prompt caches for the rest of the conversation once pressure
+ * crosses the fading threshold. Within a band, a given tool result maps to the
+ * same bytes on every call.
+ */
+export function resolveFadingBudgetTokens(
+  maxTokens: number,
+  contextPressure: number
+): number {
+  const budgetFactor =
+    contextPressure >= PRESSURE_THRESHOLD_MASKING
+      ? (PRESSURE_BANDS.find(([threshold]) => contextPressure >= threshold)?.[1] ??
+        1.0)
+      : 1.0;
+  return Math.max(1024, Math.floor(maxTokens * budgetFactor));
+}
+
+/** Character cap for masked (consumed) tool results at the given fading budget. */
+export function calculateMaskedResultMaxChars(
+  fadingBudgetTokens: number
+): number {
+  return Math.max(
+    MASKED_RESULT_MAX_CHARS,
+    Math.floor(
+      calculateMaxToolResultChars(fadingBudgetTokens) * MASKED_RESULT_CAP_RATIO
+    )
+  );
+}
+
 /** Hard cap for the originalToolContent store (~2 MB estimated from char length). */
 export const ORIGINAL_CONTENT_MAX_CHARS = 2_000_000;
 
@@ -1154,11 +1193,12 @@ export function maskConsumedToolResults(params: {
   messages: BaseMessage[];
   indexTokenCountMap: Record<string, number | undefined>;
   tokenCounter: TokenCounter;
-  /** Raw-space token budget available for all consumed tool results combined.
-   *  When provided, the budget is distributed across consumed results weighted
-   *  by recency (newest get the most, oldest get MASKED_RESULT_MAX_CHARS min).
-   *  When omitted, falls back to a flat MASKED_RESULT_MAX_CHARS per result. */
-  availableRawBudget?: number;
+  /** Character cap applied to every consumed result (never below
+   *  MASKED_RESULT_MAX_CHARS, which is also the default). The cap must stay
+   *  stable across calls for a given pressure band: one that depends on the
+   *  number of consumed results or on calibration re-truncates historical
+   *  results on every call and shifts provider prompt-cache prefixes. */
+  maxChars?: number;
   /** When provided, original (pre-masking) content is stored here keyed by
    *  message index — only for entries that actually get truncated. */
   originalContentStore?: Map<number, string>;
@@ -1171,7 +1211,7 @@ export function maskConsumedToolResults(params: {
   // Pass 1 (backward): identify consumed tool message indices.
   // A ToolMessage is "consumed" once we've seen a subsequent AI message with
   // substantive text content (not just tool calls).
-  // Collected in forward order (oldest first) for recency weighting.
+  // Processed oldest first so originals are stored in eviction order.
   let seenNonToolCallAI = false;
   const consumedIndices: number[] = [];
 
@@ -1206,31 +1246,17 @@ export function maskConsumedToolResults(params: {
 
   consumedIndices.reverse();
 
-  const totalBudgetChars =
-    params.availableRawBudget != null && params.availableRawBudget > 0
-      ? params.availableRawBudget * 4
-      : 0;
+  const maxChars = Math.max(
+    MASKED_RESULT_MAX_CHARS,
+    Math.floor(params.maxChars ?? MASKED_RESULT_MAX_CHARS)
+  );
 
-  const count = consumedIndices.length;
-
-  for (let c = 0; c < count; c++) {
-    const i = consumedIndices[c];
+  for (const i of consumedIndices) {
     const message = messages[i];
     if (isComputerCallOutputMessage(message)) {
       continue;
     }
     const content = message.content;
-
-    let maxChars: number;
-    if (totalBudgetChars > 0) {
-      const position = count > 1 ? c / (count - 1) : 1;
-      const weight = 0.2 + 0.8 * position;
-      const totalWeight = count > 1 ? 0.6 * count : 1;
-      const share = (weight / totalWeight) * totalBudgetChars;
-      maxChars = Math.max(MASKED_RESULT_MAX_CHARS, Math.floor(share));
-    } else {
-      maxChars = MASKED_RESULT_MAX_CHARS;
-    }
 
     const compacted = compactToolContent(content, maxChars);
     if (!compacted.changed) {
@@ -1264,7 +1290,12 @@ export function maskConsumedToolResults(params: {
  * Pre-flight truncation: truncates oversized ToolMessage content before the
  * main backward-iteration pruning runs. Unlike the ingestion guard (which caps
  * at tool-execution time), pre-flight truncation applies per-turn based on the
- * current context window budget (which may have shrunk due to growing conversation).
+ * budget the caller derives from the current pressure band.
+ *
+ * Every tool result gets the same cap. A per-result cap that depended on the
+ * result's position among all tool results would change for every historical
+ * result each time a new tool call is appended, re-truncating already-sent
+ * messages and invalidating prefix-based provider prompt caches on every turn.
  *
  * After truncation, recounts tokens via tokenCounter and updates indexTokenCountMap
  * so subsequent pruning works with accurate counts.
@@ -1279,29 +1310,19 @@ export function preFlightTruncateToolResults(params: {
 }): number {
   const { messages, maxContextTokens, indexTokenCountMap, tokenCounter } =
     params;
-  const baseMaxChars = calculateMaxToolResultChars(maxContextTokens);
+  const maxChars = calculateMaxToolResultChars(maxContextTokens);
   let truncatedCount = 0;
 
-  const toolIndices: number[] = [];
   for (let i = 0; i < messages.length; i++) {
-    if (
-      messages[i].getType() === 'tool' &&
-      !isComputerCallOutputMessage(messages[i])
-    ) {
-      toolIndices.push(i);
-    }
-  }
-
-  for (let t = 0; t < toolIndices.length; t++) {
-    const i = toolIndices[t];
     const message = messages[i];
-    const content = message.content;
+    if (
+      message.getType() !== 'tool' ||
+      isComputerCallOutputMessage(message)
+    ) {
+      continue;
+    }
 
-    const position = toolIndices.length > 1 ? t / (toolIndices.length - 1) : 1;
-    const recencyFactor = 0.2 + 0.8 * position;
-    const maxChars = Math.max(200, Math.floor(baseMaxChars * recencyFactor));
-
-    const compacted = compactToolContent(content, maxChars);
+    const compacted = compactToolContent(message.content, maxChars);
     if (!compacted.changed) {
       continue;
     }
@@ -2574,15 +2595,17 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // Progressive context fading — inspired by Claude Code's staged compaction.
     // Below 80%: no modifications, tool results retain full size.
     // Above 80%: graduated truncation with increasing aggression per pressure band.
-    // Recency weighting ensures older results fade first, newer results last.
+    // Consumed results (already answered by the model) fade first via masking.
     //
-    // At the gentlest level, truncation preserves most content (head+tail).
-    // At the most aggressive level, the result is effectively a one-line placeholder.
+    //   80%: gentle — budget factor 1.0
+    //   85%: moderate — budget factor 0.50
+    //   90%: aggressive — budget factor 0.20
+    //   99%: emergency — budget factor 0.05, effectively placeholders
     //
-    //   80%: gentle — budget factor 1.0, oldest get light truncation
-    //   85%: moderate — budget factor 0.50, older results shrink significantly
-    //   90%: aggressive — budget factor 0.20, most results heavily truncated
-    //   99%: emergency — budget factor 0.05, effectively placeholders for old results
+    // Every cap is a function of the fixed context window and the band only
+    // (see resolveFadingBudgetTokens): within a band, a historical tool result
+    // maps to the same bytes on every call, so provider prompt-cache prefixes
+    // survive from turn to turn instead of being rewritten each request.
     // ---------------------------------------------------------------------------
     totalTokens = sumTokenCounts(indexTokenCountMap, params.messages.length);
     calibratedTotalTokens = Math.round(totalTokens * calibrationRatio);
@@ -2602,29 +2625,17 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     // summarizer can see the full originals when compaction fires.
     // -----------------------------------------------------------------------
     let observationsMasked = 0;
+    const fadingBudgetTokens = resolveFadingBudgetTokens(
+      factoryParams.maxTokens,
+      contextPressure
+    );
 
     if (contextPressure >= PRESSURE_THRESHOLD_MASKING) {
-      const rawMessageBudget =
-        calibrationRatio > 0
-          ? Math.floor(effectiveMaxTokens / calibrationRatio)
-          : effectiveMaxTokens;
-      // When summarization is enabled, use half the reserve ratio as extra
-      // masking headroom — the LLM keeps more context while the summarizer
-      // gets full content from originalToolContent regardless. The remaining
-      // half of the reserve covers estimation errors.
-      const reserveHeadroom =
-        factoryParams.summarizationEnabled === true
-          ? Math.floor(
-            rawMessageBudget *
-                (factoryParams.reserveRatio ?? DEFAULT_RESERVE_RATIO) *
-                0.5
-          )
-          : 0;
       observationsMasked = maskConsumedToolResults({
         messages: params.messages,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
-        availableRawBudget: rawMessageBudget + reserveHeadroom,
+        maxChars: calculateMaskedResultMaxChars(fadingBudgetTokens),
         originalContentStore:
           factoryParams.summarizationEnabled === true
             ? originalToolContent
@@ -2664,26 +2675,16 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       contextPressure >= PRESSURE_THRESHOLD_MASKING &&
       factoryParams.summarizationEnabled !== true
     ) {
-      const budgetFactor =
-        PRESSURE_BANDS.find(
-          ([threshold]) => contextPressure >= threshold
-        )?.[1] ?? 1.0;
-
-      const baseBudget = Math.max(
-        1024,
-        Math.floor(effectiveMaxTokens * budgetFactor)
-      );
-
       preFlightResultCount = preFlightTruncateToolResults({
         messages: params.messages,
-        maxContextTokens: baseBudget,
+        maxContextTokens: fadingBudgetTokens,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
       });
 
       preFlightInputCount = preFlightTruncateToolCallInputs({
         messages: params.messages,
-        maxContextTokens: baseBudget,
+        maxContextTokens: fadingBudgetTokens,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
       });
@@ -2701,35 +2702,32 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     }
 
     // Fit-to-budget: when summarization is enabled and individual messages
-    // exceed the effective budget, truncate them so every message can fit in
+    // exceed the context window, truncate them so every message can fit in
     // a single context slot.  Without this, oversized tool results (e.g.
     // take_snapshot at 9K chars) cause empty context → emergency truncation
     // → immediate re-summarization after just one tool call.
     //
-    // This is NOT the lossy position-based fading above — it only targets
-    // messages that individually exceed the budget, using the full effective
-    // budget as the cap (not a pressure-scaled fraction).
-    // Fit-to-budget caps are in raw space (divide by ratio) so that after
-    // calibration the truncated results actually fit within the budget.
-    const rawSpaceEffectiveMax =
-      calibrationRatio > 0
-        ? Math.round(effectiveMaxTokens / calibrationRatio)
-        : effectiveMaxTokens;
-
+    // This is NOT the pressure-scaled fading above — it only targets messages
+    // that individually exceed the window-derived cap, the same cap the
+    // ingestion guard applies at tool-execution time. It is deliberately not
+    // derived from the calibrated effective budget: that value moves with
+    // every provider response, and a cap that follows it re-truncates
+    // historical results to a different length on each call, invalidating
+    // provider prompt caches for the rest of the conversation.
     if (
       factoryParams.summarizationEnabled === true &&
-      rawSpaceEffectiveMax > 0
+      factoryParams.maxTokens > 0
     ) {
       preFlightResultCount = preFlightTruncateToolResults({
         messages: params.messages,
-        maxContextTokens: rawSpaceEffectiveMax,
+        maxContextTokens: factoryParams.maxTokens,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
       });
 
       preFlightInputCount = preFlightTruncateToolCallInputs({
         messages: params.messages,
-        maxContextTokens: rawSpaceEffectiveMax,
+        maxContextTokens: factoryParams.maxTokens,
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
       });

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -235,6 +235,26 @@ function getToolCallIds(message: BaseMessage): Set<string> {
     }
   }
 
+  const rawToolCalls = readPropertyWithoutAccessors(
+    aiMessage.additional_kwargs,
+    'tool_calls'
+  );
+  if (
+    !rawToolCalls.accessor &&
+    Array.isArray(rawToolCalls.value) &&
+    !isProxy(rawToolCalls.value)
+  ) {
+    for (const toolCall of rawToolCalls.value) {
+      if (toolCall == null || typeof toolCall !== 'object') {
+        continue;
+      }
+      const id = getStringProperty(toolCall, 'id');
+      if (id != null && id.length > 0) {
+        ids.add(id);
+      }
+    }
+  }
+
   if (Array.isArray(aiMessage.content) && !isProxy(aiMessage.content)) {
     for (const part of aiMessage.content) {
       if (typeof part !== 'object') {

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -178,6 +178,8 @@ export type PruneMessagesFactoryParams = {
    * current context window without losing their latched provenance.
    */
   fadingTier?: FadingTier | null;
+  /** Bounded canonical tool-result content retained across pruner recreation. */
+  canonicalToolContent?: Map<number, BaseMessage['content']>;
   /** Optional diagnostic log callback wired by the graph for observability. */
   log?: (
     level: 'debug' | 'info' | 'warn' | 'error',
@@ -1154,8 +1156,13 @@ type FadingApplyParams = {
   maskedFromIndex?: number;
   /** Original (pre-masking) content keyed by message index, captured for the summarizer. */
   originalContentStore?: Map<number, string>;
-  /** Canonical pre-fading content keyed by live message for tier escalation. */
-  canonicalContentStore?: WeakMap<BaseMessage, BaseMessage['content']>;
+  /** Canonical pre-fading content keyed by stable message index. */
+  canonicalContentStore?: Map<number, BaseMessage['content']>;
+  /** Called after storing newly captured canonical content. */
+  onCanonicalContentStored?: (
+    index: number,
+    content: BaseMessage['content']
+  ) => void;
   /** Called after storing a newly captured entry. */
   onContentStored?: (index: number, content: string) => void;
 };
@@ -1218,7 +1225,7 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       continue;
     }
     const canonicalContent =
-      params.canonicalContentStore?.get(message) ?? message.content;
+      params.canonicalContentStore?.get(i) ?? message.content;
     const compacted = compactToolContent(canonicalContent, maxChars);
     if (!compacted.changed) {
       continue;
@@ -1239,7 +1246,13 @@ export function applyFadingCaps(params: FadingApplyParams): FadingApplyResult {
       message as ToolMessage,
       compacted.content
     );
-    params.canonicalContentStore?.set(cloned, canonicalContent);
+    if (
+      params.canonicalContentStore != null &&
+      !params.canonicalContentStore.has(i)
+    ) {
+      params.canonicalContentStore.set(i, canonicalContent);
+      params.onCanonicalContentStored?.(i, canonicalContent);
+    }
     messages[i] = cloned;
     indexTokenCountMap[i] = tokenCounter(cloned);
     if (consumed) {
@@ -2299,10 +2312,41 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
   const originalToolContent = new Map<number, string>();
   let originalToolContentSize = 0;
   /** Pre-fading content retained so every deeper tier derives from one source. */
-  const canonicalToolContent = new WeakMap<
-    BaseMessage,
-    BaseMessage['content']
-  >();
+  const canonicalToolContent =
+    factoryParams.canonicalToolContent ??
+    new Map<number, BaseMessage['content']>();
+  const getCanonicalContentChars = (
+    content: BaseMessage['content']
+  ): number =>
+    serializeToolContentBounded(content, ORIGINAL_CONTENT_MAX_CHARS).length;
+  let canonicalToolContentChars = 0;
+  for (const content of canonicalToolContent.values()) {
+    canonicalToolContentChars += getCanonicalContentChars(content);
+  }
+  const enforceCanonicalContentCap = (): void => {
+    while (
+      canonicalToolContentChars > ORIGINAL_CONTENT_MAX_CHARS &&
+      canonicalToolContent.size > 0
+    ) {
+      const oldest = canonicalToolContent.keys().next();
+      if (oldest.done === true) {
+        break;
+      }
+      const removed = canonicalToolContent.get(oldest.value);
+      if (removed != null) {
+        canonicalToolContentChars -= getCanonicalContentChars(removed);
+      }
+      canonicalToolContent.delete(oldest.value);
+    }
+  };
+  enforceCanonicalContentCap();
+  const onCanonicalContentStored = (
+    _index: number,
+    content: BaseMessage['content']
+  ): void => {
+    canonicalToolContentChars += getCanonicalContentChars(content);
+    enforceCanonicalContentCap();
+  };
   /** Latched fading tier; caps derive from it alone so bytes stay stable. */
   let fadingTier = seedFadingTier(
     factoryParams.maxTokens,
@@ -2776,6 +2820,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             ? originalToolContent
             : undefined,
         canonicalContentStore: canonicalToolContent,
+        onCanonicalContentStored,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2826,6 +2871,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
             ? originalToolContent
             : undefined,
         canonicalContentStore: canonicalToolContent,
+        onCanonicalContentStored,
         onContentStored:
           factoryParams.summarizationEnabled === true
             ? storeOriginalToolContent
@@ -2862,12 +2908,6 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         indexTokenCountMap,
         tokenCounter: factoryParams.tokenCounter,
         resolvedSettings: contextPruningSettings,
-        onMessageCloned: (source, clone) => {
-          const canonicalContent = canonicalToolContent.get(source);
-          if (canonicalContent !== undefined) {
-            canonicalToolContent.set(clone, canonicalContent);
-          }
-        },
       });
     }
 
@@ -3052,6 +3092,7 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           caps: emergencyCaps,
           masked: emergencyTier.masked,
           canonicalContentStore: canonicalToolContent,
+          onCanonicalContentStored,
         });
 
         factoryParams.log?.('info', 'Emergency truncation complete');

--- a/src/run.ts
+++ b/src/run.ts
@@ -473,6 +473,7 @@ export class Run<_T extends t.BaseGraphState> {
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   fadingTier?: t.FadingTier;
+  fadingTiers: t.FadingTiers = {};
   graphRunnable?: t.CompiledStateWorkflow;
   Graph: StandardGraph | MultiAgentGraph | undefined;
   returnContent: boolean = false;
@@ -519,6 +520,9 @@ export class Run<_T extends t.BaseGraphState> {
     }
     if (config.fadingTier != null) {
       this.fadingTier = config.fadingTier;
+    }
+    if (config.fadingTiers != null) {
+      this.fadingTiers = { ...config.fadingTiers };
     }
 
     const handlerRegistry = new HandlerRegistry();
@@ -637,6 +641,7 @@ export class Run<_T extends t.BaseGraphState> {
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
         fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
@@ -678,6 +683,7 @@ export class Run<_T extends t.BaseGraphState> {
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
         fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
@@ -944,13 +950,17 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   /**
-   * Returns the latched context-fading tier. Hosts should persist it beside the
-   * calibration ratio and pass it back as `RunConfig.fadingTier` on the next run
-   * for the same conversation so historical tool results keep the same
-   * truncated bytes, which is what keeps provider prompt-cache prefixes valid.
+   * Returns the default agent's latched context-fading tier. Single-agent hosts
+   * may persist it beside the calibration ratio; multi-agent hosts should use
+   * `getFadingTiers()` so independent agent tiers are retained.
    */
   getFadingTier(): t.FadingTier | undefined {
     return this.fadingTier;
+  }
+
+  /** Returns a defensive snapshot of latched tiers keyed by agent ID. */
+  getFadingTiers(): t.FadingTiers {
+    return { ...this.fadingTiers };
   }
 
   getResolvedInstructionOverhead(): number | undefined {
@@ -1778,6 +1788,7 @@ export class Run<_T extends t.BaseGraphState> {
 
       this.calibrationRatio = this.Graph.getCalibrationRatio();
       this.fadingTier = this.Graph.getFadingTier();
+      this.fadingTiers = this.Graph.getFadingTiers();
 
       /**
        * Skip `clearHeavyState()` when the run paused on a clean HITL

--- a/src/run.ts
+++ b/src/run.ts
@@ -960,7 +960,12 @@ export class Run<_T extends t.BaseGraphState> {
 
   /** Returns a defensive snapshot of latched tiers keyed by agent ID. */
   getFadingTiers(): t.FadingTiers {
-    return { ...this.fadingTiers };
+    return Object.fromEntries(
+      Object.entries(this.fadingTiers).map(([agentId, tier]) => [
+        agentId,
+        { ...tier },
+      ])
+    );
   }
 
   getResolvedInstructionOverhead(): number | undefined {

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,6 +22,7 @@ import type {
 } from '@langchain/core/messages';
 import type { StringPromptValue } from '@langchain/core/prompt_values';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import { isFadingTier } from '@/messages/fading';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import type { StandardGraph } from '@/graphs/Graph';
@@ -520,15 +521,14 @@ export class Run<_T extends t.BaseGraphState> {
     if (config.calibrationRatio != null && config.calibrationRatio > 0) {
       this.calibrationRatio = config.calibrationRatio;
     }
-    if (config.fadingTier != null) {
+    if (isFadingTier(config.fadingTier)) {
       this.fadingTier = { ...config.fadingTier };
     }
     if (config.fadingTiers != null) {
       this.fadingTiers = Object.fromEntries(
-        Object.entries(config.fadingTiers).map(([agentId, tier]) => [
-          agentId,
-          { ...tier },
-        ])
+        Object.entries(config.fadingTiers).flatMap(([agentId, tier]) =>
+          isFadingTier(tier) ? [[agentId, { ...tier }] as const] : []
+        )
       );
     }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -472,6 +472,7 @@ export class Run<_T extends t.BaseGraphState> {
   private subagentTasks?: t.SubagentTaskConfig;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
+  fadingTier?: t.FadingTier;
   graphRunnable?: t.CompiledStateWorkflow;
   Graph: StandardGraph | MultiAgentGraph | undefined;
   returnContent: boolean = false;
@@ -515,6 +516,9 @@ export class Run<_T extends t.BaseGraphState> {
     this.indexTokenCountMap = config.indexTokenCountMap;
     if (config.calibrationRatio != null && config.calibrationRatio > 0) {
       this.calibrationRatio = config.calibrationRatio;
+    }
+    if (config.fadingTier != null) {
+      this.fadingTier = config.fadingTier;
     }
 
     const handlerRegistry = new HandlerRegistry();
@@ -632,6 +636,7 @@ export class Run<_T extends t.BaseGraphState> {
         tokenCounter: this.tokenCounter,
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
+        fadingTier: this.fadingTier,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
@@ -672,6 +677,7 @@ export class Run<_T extends t.BaseGraphState> {
         tokenCounter: this.tokenCounter,
         indexTokenCountMap: this.indexTokenCountMap,
         calibrationRatio: this.calibrationRatio,
+        fadingTier: this.fadingTier,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
         preemption: this.preemption,
@@ -935,6 +941,16 @@ export class Run<_T extends t.BaseGraphState> {
    */
   getCalibrationRatio(): number {
     return this.calibrationRatio;
+  }
+
+  /**
+   * Returns the latched context-fading tier. Hosts should persist it beside the
+   * calibration ratio and pass it back as `RunConfig.fadingTier` on the next run
+   * for the same conversation so historical tool results keep the same
+   * truncated bytes, which is what keeps provider prompt-cache prefixes valid.
+   */
+  getFadingTier(): t.FadingTier | undefined {
+    return this.fadingTier;
   }
 
   getResolvedInstructionOverhead(): number | undefined {
@@ -1761,6 +1777,7 @@ export class Run<_T extends t.BaseGraphState> {
         : undefined;
 
       this.calibrationRatio = this.Graph.getCalibrationRatio();
+      this.fadingTier = this.Graph.getFadingTier();
 
       /**
        * Skip `clearHeavyState()` when the run paused on a clean HITL

--- a/src/run.ts
+++ b/src/run.ts
@@ -519,10 +519,15 @@ export class Run<_T extends t.BaseGraphState> {
       this.calibrationRatio = config.calibrationRatio;
     }
     if (config.fadingTier != null) {
-      this.fadingTier = config.fadingTier;
+      this.fadingTier = { ...config.fadingTier };
     }
     if (config.fadingTiers != null) {
-      this.fadingTiers = { ...config.fadingTiers };
+      this.fadingTiers = Object.fromEntries(
+        Object.entries(config.fadingTiers).map(([agentId, tier]) => [
+          agentId,
+          { ...tier },
+        ])
+      );
     }
 
     const handlerRegistry = new HandlerRegistry();
@@ -955,7 +960,7 @@ export class Run<_T extends t.BaseGraphState> {
    * `getFadingTiers()` so independent agent tiers are retained.
    */
   getFadingTier(): t.FadingTier | undefined {
-    return this.fadingTier;
+    return this.fadingTier == null ? undefined : { ...this.fadingTier };
   }
 
   /** Returns a defensive snapshot of latched tiers keyed by agent ID. */

--- a/src/run.ts
+++ b/src/run.ts
@@ -474,6 +474,8 @@ export class Run<_T extends t.BaseGraphState> {
   calibrationRatio: number = 1;
   fadingTier?: t.FadingTier;
   fadingTiers: t.FadingTiers = {};
+  private fadingTierReset: boolean = false;
+  private fadingTierResetAgentIds: string[] = [];
   graphRunnable?: t.CompiledStateWorkflow;
   Graph: StandardGraph | MultiAgentGraph | undefined;
   returnContent: boolean = false;
@@ -971,6 +973,16 @@ export class Run<_T extends t.BaseGraphState> {
         { ...tier },
       ])
     );
+  }
+
+  /** Agent IDs whose canonical history was compacted during this run. */
+  getFadingTierResetAgentIds(): string[] {
+    return [...this.fadingTierResetAgentIds];
+  }
+
+  /** Whether the default agent compacted canonical history during this run. */
+  didResetFadingTier(): boolean {
+    return this.fadingTierReset;
   }
 
   getResolvedInstructionOverhead(): number | undefined {
@@ -1799,6 +1811,8 @@ export class Run<_T extends t.BaseGraphState> {
       this.calibrationRatio = this.Graph.getCalibrationRatio();
       this.fadingTier = this.Graph.getFadingTier();
       this.fadingTiers = this.Graph.getFadingTiers();
+      this.fadingTierReset = this.Graph.didResetFadingTier();
+      this.fadingTierResetAgentIds = this.Graph.getFadingTierResetAgentIds();
 
       /**
        * Skip `clearHeavyState()` when the run paused on a clean HITL

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -852,6 +852,10 @@ export class AgentSession {
   private calibrationRatio: number | undefined;
   private fadingTier: t.FadingTier | undefined;
   private fadingTiers: t.FadingTiers | undefined;
+  private alternateThreadFadingState = new Map<
+    string,
+    { fadingTier?: t.FadingTier; fadingTiers?: t.FadingTiers }
+  >();
   private checkpointing: SessionCheckpointingState;
   cwd: string;
   threadId: string;
@@ -917,6 +921,37 @@ export class AgentSession {
 
   getCheckpointer(): BaseCheckpointSaver | undefined {
     return this.checkpointing.checkpointer;
+  }
+
+  private getFadingState(threadId: string): {
+    fadingTier?: t.FadingTier;
+    fadingTiers?: t.FadingTiers;
+  } {
+    return threadId === this.threadId
+      ? { fadingTier: this.fadingTier, fadingTiers: this.fadingTiers }
+      : (this.alternateThreadFadingState.get(threadId) ?? {});
+  }
+
+  private setFadingState(
+    threadId: string,
+    fadingTier: t.FadingTier | undefined,
+    fadingTiers: t.FadingTiers
+  ): void {
+    if (threadId === this.threadId) {
+      this.fadingTier = fadingTier;
+      this.fadingTiers = fadingTiers;
+      return;
+    }
+    this.alternateThreadFadingState.set(threadId, {
+      fadingTier,
+      fadingTiers,
+    });
+  }
+
+  private clearFadingState(): void {
+    this.fadingTier = undefined;
+    this.fadingTiers = undefined;
+    this.alternateThreadFadingState.clear();
   }
 
   async getLatestCheckpoint(
@@ -1094,6 +1129,7 @@ export class AgentSession {
     const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
+    const fadingState = this.getFadingState(threadId);
     let run: Run<t.IState> | undefined;
     try {
       const runConfig: t.RunConfig = {
@@ -1108,8 +1144,8 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
-        fadingTier: this.fadingTier,
-        fadingTiers: this.fadingTiers,
+        fadingTier: fadingState.fadingTier,
+        fadingTiers: fadingState.fadingTiers,
         customHandlers: {
           ...(this.runConfig.customHandlers ?? {}),
           ...handlerResult.handlers,
@@ -1132,8 +1168,11 @@ export class AgentSession {
         }
       }
       this.calibrationRatio = run.getCalibrationRatio();
-      this.fadingTier = run.getFadingTier();
-      this.fadingTiers = run.getFadingTiers();
+      this.setFadingState(
+        threadId,
+        run.getFadingTier(),
+        run.getFadingTiers()
+      );
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {
@@ -1245,11 +1284,13 @@ export class AgentSession {
       this.store = await JsonlSessionStore.open(sessions[0].path);
       this.cwd = this.store.header.cwd;
       this.threadId = this.store.header.id;
+      this.clearFadingState();
       return this;
     }
     this.store = await JsonlSessionStore.open(pathOrId);
     this.cwd = this.store.header.cwd;
     this.threadId = this.store.header.id;
+    this.clearFadingState();
     return this;
   }
 
@@ -1259,7 +1300,11 @@ export class AgentSession {
     }
     const store = await this.store.clone(options);
     return new AgentSession({
-      runConfig: this.runConfig,
+      runConfig: {
+        ...this.runConfig,
+        fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
+      },
       cwd: store.header.cwd,
       threadId: store.header.id,
       checkpointing: this.checkpointing,
@@ -1276,7 +1321,11 @@ export class AgentSession {
     }
     const store = await this.store.fork(entryId, options);
     return new AgentSession({
-      runConfig: this.runConfig,
+      runConfig: {
+        ...this.runConfig,
+        fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
+      },
       cwd: store.header.cwd,
       threadId: store.header.id,
       checkpointing: this.checkpointing,
@@ -1321,6 +1370,7 @@ export class AgentSession {
       return;
     }
     await store.setLeaf(leafId);
+    this.clearFadingState();
     await this.resetCheckpointThreads('branch');
   }
 
@@ -1442,8 +1492,7 @@ export class AgentSession {
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
     });
-    this.fadingTier = undefined;
-    this.fadingTiers = undefined;
+    this.clearFadingState();
     return summary;
   }
 
@@ -1471,6 +1520,7 @@ export class AgentSession {
     const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
+    const fadingState = this.getFadingState(threadId);
     let run: Run<t.IState> | undefined;
     try {
       run = await Run.create<t.IState>({
@@ -1485,8 +1535,8 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
-        fadingTier: this.fadingTier,
-        fadingTiers: this.fadingTiers,
+        fadingTier: fadingState.fadingTier,
+        fadingTiers: fadingState.fadingTiers,
         customHandlers: {
           ...(this.runConfig.customHandlers ?? {}),
           ...handlerResult.handlers,
@@ -1500,8 +1550,11 @@ export class AgentSession {
         }
       }
       this.calibrationRatio = run.getCalibrationRatio();
-      this.fadingTier = run.getFadingTier();
-      this.fadingTiers = run.getFadingTiers();
+      this.setFadingState(
+        threadId,
+        run.getFadingTier(),
+        run.getFadingTiers()
+      );
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -905,6 +905,8 @@ export class AgentSession {
   private calibrationRatio: number | undefined;
   private fadingTier: t.FadingTier | undefined;
   private fadingTiers: t.FadingTiers | undefined;
+  private fadingRunSequence = 0;
+  private fadingResetSequences = new Map<string, Map<string, number>>();
   private alternateThreadFadingState = new Map<
     string,
     { fadingTier?: t.FadingTier; fadingTiers?: t.FadingTiers }
@@ -1014,6 +1016,10 @@ export class AgentSession {
       fadingTier: mergeFadingTier(current?.fadingTier, fadingTier),
       fadingTiers: mergeFadingTiers(current?.fadingTiers, fadingTiers),
     });
+    this.trimAlternateFadingStates();
+  }
+
+  private trimAlternateFadingStates(): void {
     while (
       this.alternateThreadFadingState.size >
       MAX_ALTERNATE_THREAD_FADING_STATES
@@ -1023,6 +1029,7 @@ export class AgentSession {
         break;
       }
       this.alternateThreadFadingState.delete(oldestThreadId.value);
+      this.fadingResetSequences.delete(oldestThreadId.value);
     }
   }
 
@@ -1030,6 +1037,7 @@ export class AgentSession {
     this.fadingTier = undefined;
     this.fadingTiers = undefined;
     this.alternateThreadFadingState.clear();
+    this.fadingResetSequences.clear();
   }
 
   private restoreFadingStateFromStore(clearWhenMissing = false): void {
@@ -1091,15 +1099,73 @@ export class AgentSession {
   private async captureRunContextState(
     threadId: string,
     checkpointNs: string,
-    run: Run<t.IState>
+    run: Run<t.IState>,
+    runSequence: number
   ): Promise<void> {
     this.calibrationRatio = run.getCalibrationRatio();
-    this.setFadingState(
-      threadId,
-      checkpointNs,
-      run.getFadingTier(),
-      run.getFadingTiers()
+    const current = this.getFadingState(threadId, checkpointNs);
+    const incomingTier = run.getFadingTier();
+    const incomingTiers = run.getFadingTiers();
+    const scopeKey = fadingScopeKey(threadId, checkpointNs);
+    let resetSequences = this.fadingResetSequences.get(scopeKey);
+    if (resetSequences == null) {
+      resetSequences = new Map();
+      this.fadingResetSequences.set(scopeKey, resetSequences);
+    }
+    const mergeCapturedTier = (
+      agentId: string,
+      existing: t.FadingTier | undefined,
+      incoming: t.FadingTier | undefined,
+      reset: boolean
+    ): t.FadingTier | undefined => {
+      const latestReset = resetSequences.get(agentId) ?? 0;
+      if (reset) {
+        if (runSequence < latestReset) {
+          return existing;
+        }
+        resetSequences.set(agentId, runSequence);
+        return incoming == null ? undefined : { ...incoming };
+      }
+      if (runSequence < latestReset) {
+        return existing;
+      }
+      return mergeFadingTier(existing, incoming);
+    };
+    const resetAgentIds = new Set(run.getFadingTierResetAgentIds());
+    const nextTiers: t.FadingTiers = {};
+    const allAgentIds = new Set([
+      ...Object.keys(current.fadingTiers ?? {}),
+      ...Object.keys(incomingTiers),
+      ...resetAgentIds,
+    ]);
+    for (const agentId of allAgentIds) {
+      const tier = mergeCapturedTier(
+        agentId,
+        current.fadingTiers?.[agentId],
+        incomingTiers[agentId],
+        resetAgentIds.has(agentId)
+      );
+      if (tier != null) {
+        nextTiers[agentId] = tier;
+      }
+    }
+    const nextTier = mergeCapturedTier(
+      '$default',
+      current.fadingTier,
+      incomingTier,
+      run.didResetFadingTier()
     );
+    if (threadId === this.threadId && checkpointNs === '') {
+      this.fadingTier = nextTier;
+      this.fadingTiers = nextTiers;
+    } else {
+      this.alternateThreadFadingState.delete(scopeKey);
+      this.alternateThreadFadingState.set(scopeKey, {
+        fadingTier: nextTier,
+        fadingTiers: nextTiers,
+      });
+      this.trimAlternateFadingStates();
+    }
     await this.persistFadingState(threadId, checkpointNs);
   }
 
@@ -1241,6 +1307,7 @@ export class AgentSession {
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
+    const fadingRunSequence = ++this.fadingRunSequence;
     const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     if (isSessionThread) {
@@ -1322,7 +1389,8 @@ export class AgentSession {
       await this.captureRunContextState(
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
-        run
+        run,
+        fadingRunSequence
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1374,7 +1442,12 @@ export class AgentSession {
       };
     } catch (error) {
       if (run != null && !runContextCaptured) {
-        await this.captureRunContextState(threadId, checkpointNs, run);
+        await this.captureRunContextState(
+          threadId,
+          checkpointNs,
+          run,
+          fadingRunSequence
+        );
       }
       emitTerminalEvent({
         type: 'run.failed',
@@ -1475,12 +1548,14 @@ export class AgentSession {
     if (!this.store) {
       throw new Error('Cannot fork an ephemeral session');
     }
+    const retainsActiveLeaf =
+      options.position === 'at' && this.store.getLeafEntry()?.id === entryId;
     const store = await this.store.fork(entryId, options);
     const session = new AgentSession({
       runConfig: {
         ...this.runConfig,
-        fadingTier: this.fadingTier,
-        fadingTiers: this.fadingTiers,
+        fadingTier: retainsActiveLeaf ? this.fadingTier : undefined,
+        fadingTiers: retainsActiveLeaf ? this.fadingTiers : undefined,
       },
       cwd: store.header.cwd,
       threadId: store.header.id,
@@ -1669,6 +1744,7 @@ export class AgentSession {
       getStoredCheckpointForConfig(this.store, threadId, baseCallerConfig)?.data
     );
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
+    const fadingRunSequence = ++this.fadingRunSequence;
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1715,7 +1791,8 @@ export class AgentSession {
       await this.captureRunContextState(
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
-        run
+        run,
+        fadingRunSequence
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1764,7 +1841,12 @@ export class AgentSession {
       };
     } catch (error) {
       if (run != null && !runContextCaptured) {
-        await this.captureRunContextState(threadId, checkpointNs, run);
+        await this.captureRunContextState(
+          threadId,
+          checkpointNs,
+          run,
+          fadingRunSequence
+        );
       }
       await this.store?.appendRunEvent('run.failed', error, {
         runId,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -905,8 +905,7 @@ export class AgentSession {
   private calibrationRatio: number | undefined;
   private fadingTier: t.FadingTier | undefined;
   private fadingTiers: t.FadingTiers | undefined;
-  private fadingRunSequence = 0;
-  private fadingResetSequences = new Map<string, Map<string, number>>();
+  private fadingGenerations = new Map<string, number>();
   private alternateThreadFadingState = new Map<
     string,
     { fadingTier?: t.FadingTier; fadingTiers?: t.FadingTiers }
@@ -1029,7 +1028,7 @@ export class AgentSession {
         break;
       }
       this.alternateThreadFadingState.delete(oldestThreadId.value);
-      this.fadingResetSequences.delete(oldestThreadId.value);
+      this.fadingGenerations.delete(oldestThreadId.value);
     }
   }
 
@@ -1037,7 +1036,7 @@ export class AgentSession {
     this.fadingTier = undefined;
     this.fadingTiers = undefined;
     this.alternateThreadFadingState.clear();
-    this.fadingResetSequences.clear();
+    this.fadingGenerations.clear();
   }
 
   private restoreFadingStateFromStore(clearWhenMissing = false): void {
@@ -1100,38 +1099,32 @@ export class AgentSession {
     threadId: string,
     checkpointNs: string,
     run: Run<t.IState>,
-    runSequence: number
+    runGeneration: number
   ): Promise<void> {
     this.calibrationRatio = run.getCalibrationRatio();
     const current = this.getFadingState(threadId, checkpointNs);
     const incomingTier = run.getFadingTier();
     const incomingTiers = run.getFadingTiers();
     const scopeKey = fadingScopeKey(threadId, checkpointNs);
-    let resetSequences = this.fadingResetSequences.get(scopeKey);
-    if (resetSequences == null) {
-      resetSequences = new Map();
-      this.fadingResetSequences.set(scopeKey, resetSequences);
+    const currentGeneration = this.fadingGenerations.get(scopeKey) ?? 0;
+    if (runGeneration < currentGeneration) {
+      return;
     }
     const mergeCapturedTier = (
-      agentId: string,
       existing: t.FadingTier | undefined,
       incoming: t.FadingTier | undefined,
       reset: boolean
     ): t.FadingTier | undefined => {
-      const latestReset = resetSequences.get(agentId) ?? 0;
       if (reset) {
-        if (runSequence < latestReset) {
-          return existing;
-        }
-        resetSequences.set(agentId, runSequence);
         return incoming == null ? undefined : { ...incoming };
-      }
-      if (runSequence < latestReset) {
-        return existing;
       }
       return mergeFadingTier(existing, incoming);
     };
+    const didResetTier = run.didResetFadingTier();
     const resetAgentIds = new Set(run.getFadingTierResetAgentIds());
+    if (didResetTier || resetAgentIds.size > 0) {
+      this.fadingGenerations.set(scopeKey, currentGeneration + 1);
+    }
     const nextTiers: t.FadingTiers = Object.create(null) as t.FadingTiers;
     const allAgentIds = new Set([
       ...Object.keys(current.fadingTiers ?? {}),
@@ -1140,7 +1133,6 @@ export class AgentSession {
     ]);
     for (const agentId of allAgentIds) {
       const tier = mergeCapturedTier(
-        agentId,
         current.fadingTiers?.[agentId],
         incomingTiers[agentId],
         resetAgentIds.has(agentId)
@@ -1150,10 +1142,9 @@ export class AgentSession {
       }
     }
     const nextTier = mergeCapturedTier(
-      '$default',
       current.fadingTier,
       incomingTier,
-      run.didResetFadingTier()
+      didResetTier
     );
     if (threadId === this.threadId && checkpointNs === '') {
       this.fadingTier = nextTier;
@@ -1307,7 +1298,8 @@ export class AgentSession {
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
-    const fadingRunSequence = ++this.fadingRunSequence;
+    const fadingGeneration =
+      this.fadingGenerations.get(fadingScopeKey(threadId, checkpointNs)) ?? 0;
     const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     if (isSessionThread) {
@@ -1390,7 +1382,7 @@ export class AgentSession {
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
         run,
-        fadingRunSequence
+        fadingGeneration
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1446,7 +1438,7 @@ export class AgentSession {
           threadId,
           checkpointNs,
           run,
-          fadingRunSequence
+          fadingGeneration
         );
       }
       emitTerminalEvent({
@@ -1744,7 +1736,8 @@ export class AgentSession {
       getStoredCheckpointForConfig(this.store, threadId, baseCallerConfig)?.data
     );
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
-    const fadingRunSequence = ++this.fadingRunSequence;
+    const fadingGeneration =
+      this.fadingGenerations.get(fadingScopeKey(threadId, checkpointNs)) ?? 0;
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1792,7 +1785,7 @@ export class AgentSession {
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
         run,
-        fadingRunSequence
+        fadingGeneration
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1845,7 +1838,7 @@ export class AgentSession {
           threadId,
           checkpointNs,
           run,
-          fadingRunSequence
+          fadingGeneration
         );
       }
       await this.store?.appendRunEvent('run.failed', error, {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -369,6 +369,10 @@ function createCallerConfig(
   };
 }
 
+function fadingScopeKey(threadId: string, checkpointNs = ''): string {
+  return JSON.stringify([threadId, checkpointNs]);
+}
+
 function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
   const threadId = getConfigString(config, 'thread_id');
   if (threadId == null) {
@@ -928,35 +932,38 @@ export class AgentSession {
     return this.checkpointing.checkpointer;
   }
 
-  private getFadingState(threadId: string): {
+  private getFadingState(threadId: string, checkpointNs = ''): {
     fadingTier?: t.FadingTier;
     fadingTiers?: t.FadingTiers;
   } {
-    if (threadId === this.threadId) {
+    if (threadId === this.threadId && checkpointNs === '') {
       return { fadingTier: this.fadingTier, fadingTiers: this.fadingTiers };
     }
-    const state = this.alternateThreadFadingState.get(threadId);
+    const scopeKey = fadingScopeKey(threadId, checkpointNs);
+    const state = this.alternateThreadFadingState.get(scopeKey);
     if (state == null) {
       return {};
     }
     /** Refresh insertion order so the bounded map acts as an LRU. */
-    this.alternateThreadFadingState.delete(threadId);
-    this.alternateThreadFadingState.set(threadId, state);
+    this.alternateThreadFadingState.delete(scopeKey);
+    this.alternateThreadFadingState.set(scopeKey, state);
     return state;
   }
 
   private setFadingState(
     threadId: string,
+    checkpointNs: string,
     fadingTier: t.FadingTier | undefined,
     fadingTiers: t.FadingTiers
   ): void {
-    if (threadId === this.threadId) {
+    if (threadId === this.threadId && checkpointNs === '') {
       this.fadingTier = fadingTier;
       this.fadingTiers = fadingTiers;
       return;
     }
-    this.alternateThreadFadingState.delete(threadId);
-    this.alternateThreadFadingState.set(threadId, {
+    const scopeKey = fadingScopeKey(threadId, checkpointNs);
+    this.alternateThreadFadingState.delete(scopeKey);
+    this.alternateThreadFadingState.set(scopeKey, {
       fadingTier,
       fadingTiers,
     });
@@ -996,6 +1003,7 @@ export class AgentSession {
       const state = states[i];
       this.setFadingState(
         state.threadId,
+        state.checkpointNs ?? '',
         state.fadingTier == null ? undefined : { ...state.fadingTier },
         state.fadingTiers == null
           ? {}
@@ -1009,10 +1017,14 @@ export class AgentSession {
     }
   }
 
-  private async persistFadingState(threadId: string): Promise<void> {
-    const state = this.getFadingState(threadId);
+  private async persistFadingState(
+    threadId: string,
+    checkpointNs = ''
+  ): Promise<void> {
+    const state = this.getFadingState(threadId, checkpointNs);
     await this.store?.appendFadingState({
       threadId,
+      ...(checkpointNs === '' ? {} : { checkpointNs }),
       ...(state.fadingTier == null
         ? {}
         : { fadingTier: { ...state.fadingTier } }),
@@ -1031,15 +1043,17 @@ export class AgentSession {
 
   private async captureRunContextState(
     threadId: string,
+    checkpointNs: string,
     run: Run<t.IState>
   ): Promise<void> {
     this.calibrationRatio = run.getCalibrationRatio();
     this.setFadingState(
       threadId,
+      checkpointNs,
       run.getFadingTier(),
       run.getFadingTiers()
     );
-    await this.persistFadingState(threadId);
+    await this.persistFadingState(threadId, checkpointNs);
   }
 
   async getLatestCheckpoint(
@@ -1179,6 +1193,7 @@ export class AgentSession {
     const normalizedInput = normalizeInput(input);
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
+    const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
     const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     if (isSessionThread) {
@@ -1217,7 +1232,7 @@ export class AgentSession {
     const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
-    const fadingState = this.getFadingState(threadId);
+    const fadingState = this.getFadingState(threadId, checkpointNs);
     let run: Run<t.IState> | undefined;
     let runContextCaptured = false;
     try {
@@ -1256,7 +1271,7 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      await this.captureRunContextState(threadId, run);
+      await this.captureRunContextState(threadId, checkpointNs, run);
       runContextCaptured = true;
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
@@ -1308,7 +1323,7 @@ export class AgentSession {
       };
     } catch (error) {
       if (run != null && !runContextCaptured) {
-        await this.captureRunContextState(threadId, run);
+        await this.captureRunContextState(threadId, checkpointNs, run);
       }
       emitTerminalEvent({
         type: 'run.failed',
@@ -1602,6 +1617,7 @@ export class AgentSession {
       baseCallerConfig,
       getStoredCheckpointForConfig(this.store, threadId, baseCallerConfig)?.data
     );
+    const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1614,7 +1630,7 @@ export class AgentSession {
     const sessionState = deriveMessages(
       isSessionThread ? (this.store?.getPath() ?? []) : []
     );
-    const fadingState = this.getFadingState(threadId);
+    const fadingState = this.getFadingState(threadId, checkpointNs);
     let run: Run<t.IState> | undefined;
     let runContextCaptured = false;
     try {
@@ -1644,7 +1660,7 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      await this.captureRunContextState(threadId, run);
+      await this.captureRunContextState(threadId, checkpointNs, run);
       runContextCaptured = true;
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
@@ -1693,7 +1709,7 @@ export class AgentSession {
       };
     } catch (error) {
       if (run != null && !runContextCaptured) {
-        await this.captureRunContextState(threadId, run);
+        await this.captureRunContextState(threadId, checkpointNs, run);
       }
       await this.store?.appendRunEvent('run.failed', error, {
         runId,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1271,9 +1271,13 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      await this.captureRunContextState(threadId, checkpointNs, run);
-      runContextCaptured = true;
       const interrupt = run.getInterrupt();
+      await this.captureRunContextState(
+        threadId,
+        interrupt?.checkpointNs ?? checkpointNs,
+        run
+      );
+      runContextCaptured = true;
       const haltedReason = run.getHaltReason();
       if (interrupt) {
         emitTerminalEvent({ type: 'run.interrupted' });
@@ -1660,9 +1664,13 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      await this.captureRunContextState(threadId, checkpointNs, run);
-      runContextCaptured = true;
       const interrupt = run.getInterrupt();
+      await this.captureRunContextState(
+        threadId,
+        interrupt?.checkpointNs ?? checkpointNs,
+        run
+      );
+      runContextCaptured = true;
       const haltedReason = run.getHaltReason();
       if (interrupt) {
         await this.store?.appendRunEvent('run.interrupted', interrupt, {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -21,6 +21,7 @@ import type {
   SessionEntry,
   SessionForkOptions,
 } from './types';
+import { isFadingTier } from '@/messages/fading';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
 import { createSummarizeNode } from '@/summarization/node';
@@ -373,10 +374,14 @@ function fadingScopeKey(threadId: string, checkpointNs = ''): string {
   return JSON.stringify([threadId, checkpointNs]);
 }
 
+/** Merges two tiers monotonically. A malformed side (a corrupt store line or
+ * host input) is ignored rather than poisoning the budget with `NaN`. */
 function mergeFadingTier(
-  current: t.FadingTier | undefined,
-  incoming: t.FadingTier | undefined
+  currentTier: t.FadingTier | undefined,
+  incomingTier: t.FadingTier | undefined
 ): t.FadingTier | undefined {
+  const current = isFadingTier(currentTier) ? currentTier : undefined;
+  const incoming = isFadingTier(incomingTier) ? incomingTier : undefined;
   if (current == null) {
     return incoming == null ? undefined : { ...incoming };
   }
@@ -413,10 +418,24 @@ function mergeFadingTiers(
   ]);
   return Object.fromEntries(
     [...agentIds].flatMap((agentId) => {
-      const tier = mergeFadingTier(current?.[agentId], incoming?.[agentId]);
+      const tier = mergeFadingTier(
+        ownFadingTier(current, agentId),
+        ownFadingTier(incoming, agentId)
+      );
       return tier == null ? [] : [[agentId, tier]];
     })
   );
+}
+
+/** Reads an agent's tier as an own property, so an ID such as `constructor`
+ * never resolves through the prototype chain. */
+function ownFadingTier(
+  tiers: t.FadingTiers | undefined,
+  agentId: string
+): t.FadingTier | undefined {
+  return tiers != null && Object.prototype.hasOwnProperty.call(tiers, agentId)
+    ? tiers[agentId]
+    : undefined;
 }
 
 function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
@@ -1058,14 +1077,13 @@ export class AgentSession {
       this.setFadingState(
         state.threadId,
         state.checkpointNs ?? '',
-        state.fadingTier == null ? undefined : { ...state.fadingTier },
+        isFadingTier(state.fadingTier) ? { ...state.fadingTier } : undefined,
         state.fadingTiers == null
           ? {}
           : Object.fromEntries(
-            Object.entries(state.fadingTiers).map(([agentId, tier]) => [
-              agentId,
-              { ...tier },
-            ])
+            Object.entries(state.fadingTiers).flatMap(([agentId, tier]) =>
+              isFadingTier(tier) ? [[agentId, { ...tier }] as const] : []
+            )
           )
       );
     }

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1029,6 +1029,19 @@ export class AgentSession {
     });
   }
 
+  private async captureRunContextState(
+    threadId: string,
+    run: Run<t.IState>
+  ): Promise<void> {
+    this.calibrationRatio = run.getCalibrationRatio();
+    this.setFadingState(
+      threadId,
+      run.getFadingTier(),
+      run.getFadingTiers()
+    );
+    await this.persistFadingState(threadId);
+  }
+
   async getLatestCheckpoint(
     options: AgentSessionCheckpointLookupOptions = {}
   ): Promise<AgentSessionCheckpointReference | undefined> {
@@ -1206,6 +1219,7 @@ export class AgentSession {
     );
     const fadingState = this.getFadingState(threadId);
     let run: Run<t.IState> | undefined;
+    let runContextCaptured = false;
     try {
       const runConfig: t.RunConfig = {
         ...this.runConfig,
@@ -1242,13 +1256,8 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      this.calibrationRatio = run.getCalibrationRatio();
-      this.setFadingState(
-        threadId,
-        run.getFadingTier(),
-        run.getFadingTiers()
-      );
-      await this.persistFadingState(threadId);
+      await this.captureRunContextState(threadId, run);
+      runContextCaptured = true;
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {
@@ -1298,6 +1307,9 @@ export class AgentSession {
         threadId,
       };
     } catch (error) {
+      if (run != null && !runContextCaptured) {
+        await this.captureRunContextState(threadId, run);
+      }
       emitTerminalEvent({
         type: 'run.failed',
         data: error instanceof Error ? error.message : String(error),
@@ -1604,6 +1616,7 @@ export class AgentSession {
     );
     const fadingState = this.getFadingState(threadId);
     let run: Run<t.IState> | undefined;
+    let runContextCaptured = false;
     try {
       run = await Run.create<t.IState>({
         ...this.runConfig,
@@ -1631,13 +1644,8 @@ export class AgentSession {
           await this.store?.appendMessage(message);
         }
       }
-      this.calibrationRatio = run.getCalibrationRatio();
-      this.setFadingState(
-        threadId,
-        run.getFadingTier(),
-        run.getFadingTiers()
-      );
-      await this.persistFadingState(threadId);
+      await this.captureRunContextState(threadId, run);
+      runContextCaptured = true;
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {
@@ -1684,6 +1692,9 @@ export class AgentSession {
         threadId,
       };
     } catch (error) {
+      if (run != null && !runContextCaptured) {
+        await this.captureRunContextState(threadId, run);
+      }
       await this.store?.appendRunEvent('run.failed', error, {
         runId,
         threadId,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -979,7 +979,11 @@ export class AgentSession {
   }
 
   private restoreFadingStateFromStore(clearWhenMissing = false): void {
-    const states = this.store?.getFadingStates() ?? [];
+    const states =
+      this.store?.getFadingStates(
+        this.threadId,
+        MAX_ALTERNATE_THREAD_FADING_STATES
+      ) ?? [];
     if (states.length === 0) {
       if (clearWhenMissing || this.store?.hasFadingState() === true) {
         this.clearFadingState();

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1132,7 +1132,7 @@ export class AgentSession {
       return mergeFadingTier(existing, incoming);
     };
     const resetAgentIds = new Set(run.getFadingTierResetAgentIds());
-    const nextTiers: t.FadingTiers = {};
+    const nextTiers: t.FadingTiers = Object.create(null) as t.FadingTiers;
     const allAgentIds = new Set([
       ...Object.keys(current.fadingTiers ?? {}),
       ...Object.keys(incomingTiers),

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -902,7 +902,7 @@ export class AgentSession {
       sessionId: explicitSessionId,
       ephemeral: normalized.ephemeral,
     });
-    return new AgentSession({
+    const session = new AgentSession({
       runConfig: normalized.runConfig,
       cwd: normalized.cwd,
       threadId: store?.header.id ?? explicitSessionId ?? createSessionId(),
@@ -912,6 +912,8 @@ export class AgentSession {
       ),
       store,
     });
+    session.restoreFadingStateFromStore();
+    return session;
   }
 
   get sessionPath(): string | undefined {
@@ -974,6 +976,53 @@ export class AgentSession {
     this.fadingTier = undefined;
     this.fadingTiers = undefined;
     this.alternateThreadFadingState.clear();
+  }
+
+  private restoreFadingStateFromStore(clearWhenMissing = false): void {
+    const states = this.store?.getFadingStates() ?? [];
+    if (states.length === 0) {
+      if (clearWhenMissing || this.store?.hasFadingState() === true) {
+        this.clearFadingState();
+      }
+      return;
+    }
+    this.clearFadingState();
+    /** Store returns newest first; replay oldest first to retain LRU order. */
+    for (let i = states.length - 1; i >= 0; i--) {
+      const state = states[i];
+      this.setFadingState(
+        state.threadId,
+        state.fadingTier == null ? undefined : { ...state.fadingTier },
+        state.fadingTiers == null
+          ? {}
+          : Object.fromEntries(
+            Object.entries(state.fadingTiers).map(([agentId, tier]) => [
+              agentId,
+              { ...tier },
+            ])
+          )
+      );
+    }
+  }
+
+  private async persistFadingState(threadId: string): Promise<void> {
+    const state = this.getFadingState(threadId);
+    await this.store?.appendFadingState({
+      threadId,
+      ...(state.fadingTier == null
+        ? {}
+        : { fadingTier: { ...state.fadingTier } }),
+      ...(state.fadingTiers == null
+        ? {}
+        : {
+          fadingTiers: Object.fromEntries(
+            Object.entries(state.fadingTiers).map(([agentId, tier]) => [
+              agentId,
+              { ...tier },
+            ])
+          ),
+        }),
+    });
   }
 
   async getLatestCheckpoint(
@@ -1195,6 +1244,7 @@ export class AgentSession {
         run.getFadingTier(),
         run.getFadingTiers()
       );
+      await this.persistFadingState(threadId);
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {
@@ -1306,13 +1356,13 @@ export class AgentSession {
       this.store = await JsonlSessionStore.open(sessions[0].path);
       this.cwd = this.store.header.cwd;
       this.threadId = this.store.header.id;
-      this.clearFadingState();
+      this.restoreFadingStateFromStore(true);
       return this;
     }
     this.store = await JsonlSessionStore.open(pathOrId);
     this.cwd = this.store.header.cwd;
     this.threadId = this.store.header.id;
-    this.clearFadingState();
+    this.restoreFadingStateFromStore(true);
     return this;
   }
 
@@ -1321,7 +1371,7 @@ export class AgentSession {
       throw new Error('Cannot clone an ephemeral session');
     }
     const store = await this.store.clone(options);
-    return new AgentSession({
+    const session = new AgentSession({
       runConfig: {
         ...this.runConfig,
         fadingTier: this.fadingTier,
@@ -1332,6 +1382,8 @@ export class AgentSession {
       checkpointing: this.checkpointing,
       store,
     });
+    await session.persistFadingState(session.threadId);
+    return session;
   }
 
   async fork(
@@ -1342,7 +1394,7 @@ export class AgentSession {
       throw new Error('Cannot fork an ephemeral session');
     }
     const store = await this.store.fork(entryId, options);
-    return new AgentSession({
+    const session = new AgentSession({
       runConfig: {
         ...this.runConfig,
         fadingTier: this.fadingTier,
@@ -1353,6 +1405,8 @@ export class AgentSession {
       checkpointing: this.checkpointing,
       store,
     });
+    await session.persistFadingState(session.threadId);
+    return session;
   }
 
   async branch(
@@ -1393,6 +1447,7 @@ export class AgentSession {
     }
     await store.setLeaf(leafId);
     this.clearFadingState();
+    await store.appendFadingState(null);
     await this.resetCheckpointThreads('branch');
   }
 
@@ -1515,6 +1570,7 @@ export class AgentSession {
       summarizedEntryIds: summarized.map((entry) => entry.id),
     });
     this.clearFadingState();
+    await store.appendFadingState(null);
     return summary;
   }
 
@@ -1577,6 +1633,7 @@ export class AgentSession {
         run.getFadingTier(),
         run.getFadingTiers()
       );
+      await this.persistFadingState(threadId);
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -23,13 +23,13 @@ import type {
 } from './types';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
-import { deriveMessages } from './deriveMessages';
 import { createSummarizeNode } from '@/summarization/node';
 import { resolveStreamLimits } from '@/llm/streamLimits';
 import { JsonlSessionStore } from './JsonlSessionStore';
 import { AgentContext } from '@/agents/AgentContext';
 import { ContentTypes, GraphEvents } from '@/common';
 import { createRunId, createSessionId } from './ids';
+import { deriveMessages } from './deriveMessages';
 import { createRunHandlers } from './handlers';
 import { Run } from '@/run';
 
@@ -850,6 +850,8 @@ export class AgentSession {
   private runConfig: t.RunConfig;
   private store: JsonlSessionStore | undefined;
   private calibrationRatio: number | undefined;
+  private fadingTier: t.FadingTier | undefined;
+  private fadingTiers: t.FadingTiers | undefined;
   private checkpointing: SessionCheckpointingState;
   cwd: string;
   threadId: string;
@@ -866,6 +868,18 @@ export class AgentSession {
     this.threadId = params.threadId;
     this.store = params.store;
     this.checkpointing = params.checkpointing;
+    this.fadingTier =
+      params.runConfig.fadingTier == null
+        ? undefined
+        : { ...params.runConfig.fadingTier };
+    this.fadingTiers =
+      params.runConfig.fadingTiers == null
+        ? undefined
+        : Object.fromEntries(
+          Object.entries(params.runConfig.fadingTiers).map(
+            ([agentId, tier]) => [agentId, { ...tier }]
+          )
+        );
   }
 
   static async create(config: AgentSessionConfig): Promise<AgentSession> {
@@ -1094,6 +1108,8 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
+        fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
         customHandlers: {
           ...(this.runConfig.customHandlers ?? {}),
           ...handlerResult.handlers,
@@ -1116,6 +1132,8 @@ export class AgentSession {
         }
       }
       this.calibrationRatio = run.getCalibrationRatio();
+      this.fadingTier = run.getFadingTier();
+      this.fadingTiers = run.getFadingTiers();
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {
@@ -1424,6 +1442,8 @@ export class AgentSession {
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
     });
+    this.fadingTier = undefined;
+    this.fadingTiers = undefined;
     return summary;
   }
 
@@ -1465,6 +1485,8 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
+        fadingTier: this.fadingTier,
+        fadingTiers: this.fadingTiers,
         customHandlers: {
           ...(this.runConfig.customHandlers ?? {}),
           ...handlerResult.handlers,
@@ -1478,6 +1500,8 @@ export class AgentSession {
         }
       }
       this.calibrationRatio = run.getCalibrationRatio();
+      this.fadingTier = run.getFadingTier();
+      this.fadingTiers = run.getFadingTiers();
       const interrupt = run.getInterrupt();
       const haltedReason = run.getHaltReason();
       if (interrupt) {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -373,6 +373,52 @@ function fadingScopeKey(threadId: string, checkpointNs = ''): string {
   return JSON.stringify([threadId, checkpointNs]);
 }
 
+function mergeFadingTier(
+  current: t.FadingTier | undefined,
+  incoming: t.FadingTier | undefined
+): t.FadingTier | undefined {
+  if (current == null) {
+    return incoming == null ? undefined : { ...incoming };
+  }
+  if (incoming == null) {
+    return { ...current };
+  }
+  const budgetTokens = Math.min(
+    current.budgetTokens,
+    incoming.budgetTokens
+  );
+  const masked = current.masked || incoming.masked;
+  const latched =
+    current.latched === true ||
+    incoming.latched === true ||
+    budgetTokens !== current.budgetTokens ||
+    budgetTokens !== incoming.budgetTokens ||
+    masked !== current.masked ||
+    masked !== incoming.masked;
+  return {
+    v: 1,
+    budgetTokens,
+    masked,
+    ...(latched ? { latched: true } : {}),
+  };
+}
+
+function mergeFadingTiers(
+  current: t.FadingTiers | undefined,
+  incoming: t.FadingTiers | undefined
+): t.FadingTiers {
+  const agentIds = new Set([
+    ...Object.keys(current ?? {}),
+    ...Object.keys(incoming ?? {}),
+  ]);
+  return Object.fromEntries(
+    [...agentIds].flatMap((agentId) => {
+      const tier = mergeFadingTier(current?.[agentId], incoming?.[agentId]);
+      return tier == null ? [] : [[agentId, tier]];
+    })
+  );
+}
+
 function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
   const threadId = getConfigString(config, 'thread_id');
   if (threadId == null) {
@@ -957,15 +1003,16 @@ export class AgentSession {
     fadingTiers: t.FadingTiers
   ): void {
     if (threadId === this.threadId && checkpointNs === '') {
-      this.fadingTier = fadingTier;
-      this.fadingTiers = fadingTiers;
+      this.fadingTier = mergeFadingTier(this.fadingTier, fadingTier);
+      this.fadingTiers = mergeFadingTiers(this.fadingTiers, fadingTiers);
       return;
     }
     const scopeKey = fadingScopeKey(threadId, checkpointNs);
+    const current = this.alternateThreadFadingState.get(scopeKey);
     this.alternateThreadFadingState.delete(scopeKey);
     this.alternateThreadFadingState.set(scopeKey, {
-      fadingTier,
-      fadingTiers,
+      fadingTier: mergeFadingTier(current?.fadingTier, fadingTier),
+      fadingTiers: mergeFadingTiers(current?.fadingTiers, fadingTiers),
     });
     while (
       this.alternateThreadFadingState.size >

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -33,6 +33,9 @@ import { deriveMessages } from './deriveMessages';
 import { createRunHandlers } from './handlers';
 import { Run } from '@/run';
 
+/** Compact per-thread fading metadata retained for recently used checkpoints. */
+const MAX_ALTERNATE_THREAD_FADING_STATES = 64;
+
 function isBaseMessage(value: unknown): value is BaseMessage {
   return (
     value instanceof BaseMessage ||
@@ -927,9 +930,17 @@ export class AgentSession {
     fadingTier?: t.FadingTier;
     fadingTiers?: t.FadingTiers;
   } {
-    return threadId === this.threadId
-      ? { fadingTier: this.fadingTier, fadingTiers: this.fadingTiers }
-      : (this.alternateThreadFadingState.get(threadId) ?? {});
+    if (threadId === this.threadId) {
+      return { fadingTier: this.fadingTier, fadingTiers: this.fadingTiers };
+    }
+    const state = this.alternateThreadFadingState.get(threadId);
+    if (state == null) {
+      return {};
+    }
+    /** Refresh insertion order so the bounded map acts as an LRU. */
+    this.alternateThreadFadingState.delete(threadId);
+    this.alternateThreadFadingState.set(threadId, state);
+    return state;
   }
 
   private setFadingState(
@@ -942,10 +953,21 @@ export class AgentSession {
       this.fadingTiers = fadingTiers;
       return;
     }
+    this.alternateThreadFadingState.delete(threadId);
     this.alternateThreadFadingState.set(threadId, {
       fadingTier,
       fadingTiers,
     });
+    while (
+      this.alternateThreadFadingState.size >
+      MAX_ALTERNATE_THREAD_FADING_STATES
+    ) {
+      const oldestThreadId = this.alternateThreadFadingState.keys().next();
+      if (oldestThreadId.done === true) {
+        break;
+      }
+      this.alternateThreadFadingState.delete(oldestThreadId.value);
+    }
   }
 
   private clearFadingState(): void {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -370,6 +370,22 @@ function createCallerConfig(
   };
 }
 
+/** Generation key for one tier within a scope; `''` names the default tier. */
+function fadingGenerationKey(scopeKey: string, agentKey: string): string {
+  return JSON.stringify([scopeKey, agentKey]);
+}
+
+function fadingGenerationScope(generationKey: string): string {
+  const parsed: unknown = JSON.parse(generationKey);
+  return Array.isArray(parsed) && typeof parsed[0] === 'string' ? parsed[0] : '';
+}
+
+/** What a run saw when it started, so its capture can tell stale from current. */
+type FadingCaptureSnapshot = {
+  epoch: number;
+  generations: Map<string, number>;
+};
+
 function fadingScopeKey(threadId: string, checkpointNs = ''): string {
   return JSON.stringify([threadId, checkpointNs]);
 }
@@ -924,7 +940,10 @@ export class AgentSession {
   private calibrationRatio: number | undefined;
   private fadingTier: t.FadingTier | undefined;
   private fadingTiers: t.FadingTiers | undefined;
+  /** Reset generations keyed per scope and per tier (`''` for the default). */
   private fadingGenerations = new Map<string, number>();
+  /** Advances on every explicit history rewrite (branch, compact, restore). */
+  private fadingRewriteEpoch = 0;
   private alternateThreadFadingState = new Map<
     string,
     { fadingTier?: t.FadingTier; fadingTiers?: t.FadingTiers }
@@ -1047,7 +1066,11 @@ export class AgentSession {
         break;
       }
       this.alternateThreadFadingState.delete(oldestThreadId.value);
-      this.fadingGenerations.delete(oldestThreadId.value);
+      for (const key of [...this.fadingGenerations.keys()]) {
+        if (fadingGenerationScope(key) === oldestThreadId.value) {
+          this.fadingGenerations.delete(key);
+        }
+      }
     }
   }
 
@@ -1056,6 +1079,16 @@ export class AgentSession {
     this.fadingTiers = undefined;
     this.alternateThreadFadingState.clear();
     this.fadingGenerations.clear();
+    /** A run that started before the rewrite would otherwise re-persist tiers
+     * learned on a history that no longer exists once it completes. */
+    this.fadingRewriteEpoch += 1;
+  }
+
+  private snapshotFadingGenerations(): FadingCaptureSnapshot {
+    return {
+      epoch: this.fadingRewriteEpoch,
+      generations: new Map(this.fadingGenerations),
+    };
   }
 
   private restoreFadingStateFromStore(clearWhenMissing = false): void {
@@ -1117,17 +1150,30 @@ export class AgentSession {
     threadId: string,
     checkpointNs: string,
     run: Run<t.IState>,
-    runGeneration: number
+    snapshot: FadingCaptureSnapshot
   ): Promise<void> {
     this.calibrationRatio = run.getCalibrationRatio();
+    if (snapshot.epoch < this.fadingRewriteEpoch) {
+      return;
+    }
     const current = this.getFadingState(threadId, checkpointNs);
     const incomingTier = run.getFadingTier();
     const incomingTiers = run.getFadingTiers();
     const scopeKey = fadingScopeKey(threadId, checkpointNs);
-    const currentGeneration = this.fadingGenerations.get(scopeKey) ?? 0;
-    if (runGeneration < currentGeneration) {
-      return;
-    }
+    /** A tier whose generation moved after this run started was reset by a
+     * concurrent run; this run's view of it is obsolete, while its other
+     * agents' tiers remain valid escalations. */
+    const isStale = (agentKey: string): boolean => {
+      const key = fadingGenerationKey(scopeKey, agentKey);
+      return (
+        (snapshot.generations.get(key) ?? 0) <
+        (this.fadingGenerations.get(key) ?? 0)
+      );
+    };
+    const advanceGeneration = (agentKey: string): void => {
+      const key = fadingGenerationKey(scopeKey, agentKey);
+      this.fadingGenerations.set(key, (this.fadingGenerations.get(key) ?? 0) + 1);
+    };
     const mergeCapturedTier = (
       existing: t.FadingTier | undefined,
       incoming: t.FadingTier | undefined,
@@ -1138,11 +1184,7 @@ export class AgentSession {
       }
       return mergeFadingTier(existing, incoming);
     };
-    const didResetTier = run.didResetFadingTier();
     const resetAgentIds = new Set(run.getFadingTierResetAgentIds());
-    if (didResetTier || resetAgentIds.size > 0) {
-      this.fadingGenerations.set(scopeKey, currentGeneration + 1);
-    }
     const nextTiers: t.FadingTiers = Object.create(null) as t.FadingTiers;
     const allAgentIds = new Set([
       ...Object.keys(current.fadingTiers ?? {}),
@@ -1150,20 +1192,34 @@ export class AgentSession {
       ...resetAgentIds,
     ]);
     for (const agentId of allAgentIds) {
+      const existing = ownFadingTier(current.fadingTiers, agentId);
+      if (isStale(agentId)) {
+        if (existing != null) {
+          nextTiers[agentId] = existing;
+        }
+        continue;
+      }
+      const reset = resetAgentIds.has(agentId);
+      if (reset) {
+        advanceGeneration(agentId);
+      }
       const tier = mergeCapturedTier(
-        current.fadingTiers?.[agentId],
-        incomingTiers[agentId],
-        resetAgentIds.has(agentId)
+        existing,
+        ownFadingTier(incomingTiers, agentId),
+        reset
       );
       if (tier != null) {
         nextTiers[agentId] = tier;
       }
     }
-    const nextTier = mergeCapturedTier(
-      current.fadingTier,
-      incomingTier,
-      didResetTier
-    );
+    let nextTier = current.fadingTier;
+    if (!isStale('')) {
+      const didResetTier = run.didResetFadingTier();
+      if (didResetTier) {
+        advanceGeneration('');
+      }
+      nextTier = mergeCapturedTier(current.fadingTier, incomingTier, didResetTier);
+    }
     if (threadId === this.threadId && checkpointNs === '') {
       this.fadingTier = nextTier;
       this.fadingTiers = nextTiers;
@@ -1316,8 +1372,7 @@ export class AgentSession {
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
-    const fadingGeneration =
-      this.fadingGenerations.get(fadingScopeKey(threadId, checkpointNs)) ?? 0;
+    const fadingSnapshot = this.snapshotFadingGenerations();
     const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     if (isSessionThread) {
@@ -1400,7 +1455,7 @@ export class AgentSession {
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
         run,
-        fadingGeneration
+        fadingSnapshot
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1456,7 +1511,7 @@ export class AgentSession {
           threadId,
           checkpointNs,
           run,
-          fadingGeneration
+          fadingSnapshot
         );
       }
       emitTerminalEvent({
@@ -1754,8 +1809,7 @@ export class AgentSession {
       getStoredCheckpointForConfig(this.store, threadId, baseCallerConfig)?.data
     );
     const checkpointNs = getConfigString(callerConfig, 'checkpoint_ns') ?? '';
-    const fadingGeneration =
-      this.fadingGenerations.get(fadingScopeKey(threadId, checkpointNs)) ?? 0;
+    const fadingSnapshot = this.snapshotFadingGenerations();
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1803,7 +1857,7 @@ export class AgentSession {
         threadId,
         interrupt?.checkpointNs ?? checkpointNs,
         run,
-        fadingGeneration
+        fadingSnapshot
       );
       runContextCaptured = true;
       const haltedReason = run.getHaltReason();
@@ -1856,7 +1910,7 @@ export class AgentSession {
           threadId,
           checkpointNs,
           run,
-          fadingGeneration
+          fadingSnapshot
         );
       }
       await this.store?.appendRunEvent('run.failed', error, {

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -26,6 +26,7 @@ import type {
   SessionRunEventEntry,
   SessionSummaryEntry,
   SessionStateEntry,
+  SessionFadingState,
   SessionTreeNode,
 } from './types';
 import {
@@ -371,6 +372,46 @@ export class JsonlSessionStore {
       type: 'session_state',
       parentId: leafId,
       data: { leafId },
+    });
+  }
+
+  getFadingStates(): SessionFadingState[] {
+    const states = new Map<string, SessionFadingState>();
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      const entry = this.entries[i];
+      if (
+        entry.type !== 'session_state' ||
+        !Object.prototype.hasOwnProperty.call(entry.data, 'fadingState')
+      ) {
+        continue;
+      }
+      if (entry.data.fadingState == null) {
+        break;
+      }
+      const state = entry.data.fadingState;
+      if (!states.has(state.threadId)) {
+        states.set(state.threadId, state);
+      }
+    }
+    return [...states.values()];
+  }
+
+  hasFadingState(): boolean {
+    return this.entries.some(
+      (entry) =>
+        entry.type === 'session_state' &&
+        Object.prototype.hasOwnProperty.call(entry.data, 'fadingState')
+    );
+  }
+
+  async appendFadingState(
+    fadingState: SessionStateEntry['data']['fadingState']
+  ): Promise<SessionStateEntry> {
+    const leafId = this.getLeafEntry()?.id ?? null;
+    return this.appendEntry<SessionStateEntry>({
+      type: 'session_state',
+      parentId: leafId,
+      data: { leafId, fadingState },
     });
   }
 

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -397,14 +397,21 @@ export class JsonlSessionStore {
         break;
       }
       const state = entry.data.fadingState;
-      if (states.has(state.threadId)) {
+      const scopeKey = JSON.stringify([
+        state.threadId,
+        state.checkpointNs ?? '',
+      ]);
+      if (states.has(scopeKey)) {
         continue;
       }
-      if (state.threadId === mainThreadId) {
-        states.set(state.threadId, state);
+      if (
+        state.threadId === mainThreadId &&
+        (state.checkpointNs ?? '') === ''
+      ) {
+        states.set(scopeKey, state);
         mainFound = true;
       } else if (alternateCount < alternateLimit) {
-        states.set(state.threadId, state);
+        states.set(scopeKey, state);
         alternateCount += 1;
       }
       if (mainFound && alternateCount >= alternateLimit) {

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -375,8 +375,16 @@ export class JsonlSessionStore {
     });
   }
 
-  getFadingStates(): SessionFadingState[] {
+  getFadingStates(
+    mainThreadId?: string,
+    maxAlternateStates = Number.POSITIVE_INFINITY
+  ): SessionFadingState[] {
     const states = new Map<string, SessionFadingState>();
+    const alternateLimit = Number.isFinite(maxAlternateStates)
+      ? Math.max(0, Math.floor(maxAlternateStates))
+      : Number.POSITIVE_INFINITY;
+    let alternateCount = 0;
+    let mainFound = mainThreadId == null;
     for (let i = this.entries.length - 1; i >= 0; i--) {
       const entry = this.entries[i];
       if (
@@ -389,8 +397,18 @@ export class JsonlSessionStore {
         break;
       }
       const state = entry.data.fadingState;
-      if (!states.has(state.threadId)) {
+      if (states.has(state.threadId)) {
+        continue;
+      }
+      if (state.threadId === mainThreadId) {
         states.set(state.threadId, state);
+        mainFound = true;
+      } else if (alternateCount < alternateLimit) {
+        states.set(state.threadId, state);
+        alternateCount += 1;
+      }
+      if (mainFound && alternateCount >= alternateLimit) {
+        break;
       }
     }
     return [...states.values()];

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -83,6 +83,16 @@ function parseLine(line: string): SessionHeader | SessionEntry | undefined {
   }
 }
 
+/** A `session_state` line may carry `data: null`; only an object can hold fading state. */
+function hasFadingStateField(entry: SessionStateEntry): boolean {
+  const data: unknown = entry.data;
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    Object.prototype.hasOwnProperty.call(data, 'fadingState')
+  );
+}
+
 function createHeader(options: CreateSessionFileOptions): SessionHeader {
   return {
     type: 'session',
@@ -387,10 +397,7 @@ export class JsonlSessionStore {
     let mainFound = mainThreadId == null;
     for (let i = this.entries.length - 1; i >= 0; i--) {
       const entry = this.entries[i];
-      if (
-        entry.type !== 'session_state' ||
-        !Object.prototype.hasOwnProperty.call(entry.data, 'fadingState')
-      ) {
+      if (entry.type !== 'session_state' || !hasFadingStateField(entry)) {
         continue;
       }
       if (entry.data.fadingState == null) {
@@ -423,9 +430,7 @@ export class JsonlSessionStore {
 
   hasFadingState(): boolean {
     return this.entries.some(
-      (entry) =>
-        entry.type === 'session_state' &&
-        Object.prototype.hasOwnProperty.call(entry.data, 'fadingState')
+      (entry) => entry.type === 'session_state' && hasFadingStateField(entry)
     );
   }
 

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -2105,6 +2105,133 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[2].fadingTiers).toEqual({});
   });
 
+  it('discards a capture from a run that started before an explicit history rewrite', async () => {
+    const mockRun = createMockRun('continued');
+    const preRewriteTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    let markStaleStarted!: () => void;
+    let releaseStale!: () => void;
+    const staleStarted = new Promise<void>((resolve) => {
+      markStaleStarted = resolve;
+    });
+    const staleResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseStale = () => resolve([{ type: 'text', text: 'stale' }]);
+    });
+    mockRun.processStream
+      .mockResolvedValueOnce([{ type: 'text', text: 'seed' }])
+      .mockImplementationOnce(async () => {
+        markStaleStarted();
+        return staleResult;
+      })
+      .mockResolvedValue([{ type: 'text', text: 'after' }]);
+    mockRun.getFadingTier
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(preRewriteTier)
+      .mockReturnValue(undefined);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({ default: preRewriteTier })
+      .mockReturnValue({});
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('seed run');
+    const firstEntryId = session.getSessionStore()?.getPath()[0]?.id;
+    expect(firstEntryId).toBeDefined();
+    const staleRun = session.run('stale run');
+    await staleStarted;
+    await session.branch(firstEntryId as string);
+    releaseStale();
+    await staleRun;
+    await session.run('after rewrite');
+
+    expect(capturedConfigs[2].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTiers ?? {}).toEqual({});
+  });
+
+  it('keeps a concurrent escalation from another agent when one agent resets', async () => {
+    const mockRun = createMockRun('continued');
+    const escalatedTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    let markResetStarted!: () => void;
+    let markEscalationStarted!: () => void;
+    let releaseReset!: () => void;
+    let releaseEscalation!: () => void;
+    const resetStarted = new Promise<void>((resolve) => {
+      markResetStarted = resolve;
+    });
+    const escalationStarted = new Promise<void>((resolve) => {
+      markEscalationStarted = resolve;
+    });
+    const resetResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseReset = () => resolve([{ type: 'text', text: 'reset' }]);
+    });
+    const escalationResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseEscalation = () => resolve([{ type: 'text', text: 'escalated' }]);
+    });
+    mockRun.processStream
+      .mockImplementationOnce(async () => {
+        markResetStarted();
+        return resetResult;
+      })
+      .mockImplementationOnce(async () => {
+        markEscalationStarted();
+        return escalationResult;
+      })
+      .mockResolvedValue([{ type: 'text', text: 'after' }]);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({ worker: escalatedTier })
+      .mockReturnValue({});
+    mockRun.getFadingTierResetAgentIds
+      .mockReturnValueOnce(['planner'])
+      .mockReturnValue([]);
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    const resetRun = session.run('planner compacts');
+    await resetStarted;
+    const escalationRun = session.run('worker escalates');
+    await escalationStarted;
+    releaseReset();
+    await resetRun;
+    releaseEscalation();
+    await escalationRun;
+    await session.run('after overlap');
+
+    expect(capturedConfigs[2].fadingTiers).toEqual({ worker: escalatedTier });
+  });
+
   it('bounds fading metadata retained for alternate checkpoint threads', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -25,6 +25,10 @@ type MockRun = {
   >;
   getFadingTier: jest.MockedFunction<Run<t.IState>['getFadingTier']>;
   getFadingTiers: jest.MockedFunction<Run<t.IState>['getFadingTiers']>;
+  didResetFadingTier: jest.MockedFunction<Run<t.IState>['didResetFadingTier']>;
+  getFadingTierResetAgentIds: jest.MockedFunction<
+    Run<t.IState>['getFadingTierResetAgentIds']
+  >;
   getInterrupt: jest.MockedFunction<Run<t.IState>['getInterrupt']>;
   getHaltReason: jest.MockedFunction<Run<t.IState>['getHaltReason']>;
   getChildCheckpointThreadIds: jest.MockedFunction<
@@ -50,6 +54,8 @@ function createMockRun(outputText = 'ok'): MockRun {
     getCalibrationRatio: jest.fn(() => 1),
     getFadingTier: jest.fn(() => undefined),
     getFadingTiers: jest.fn(() => ({})),
+    didResetFadingTier: jest.fn(() => false),
+    getFadingTierResetAgentIds: jest.fn(() => []),
     getInterrupt: jest.fn(() => undefined),
     getHaltReason: jest.fn(() => undefined),
     getChildCheckpointThreadIds: jest.fn(() => []),
@@ -1532,6 +1538,88 @@ describe('JsonlSessionStore', () => {
 
     expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
     expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
+  it('only carries live fading tiers into a fork that retains the active leaf', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('advance tier');
+    const leafId = session.getSessionStore()?.getLeafEntry()?.id ?? '';
+    const rewound = await session.fork(leafId, { cwd: dir });
+    await rewound.run('continue rewound fork');
+    const full = await session.fork(leafId, { cwd: dir, position: 'at' });
+    await full.run('continue full fork');
+
+    expect(capturedConfigs[1].fadingTier).toBeUndefined();
+    expect(capturedConfigs[1].fadingTiers).toBeUndefined();
+    expect(capturedConfigs[2].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[2].fadingTiers).toEqual({ default: fadingTier });
+  });
+
+  it('allows graph compaction to clear a persisted fading tier', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier
+      .mockReturnValueOnce(fadingTier)
+      .mockReturnValue(undefined);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({ default: fadingTier })
+      .mockReturnValue({});
+    mockRun.didResetFadingTier
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    mockRun.getFadingTierResetAgentIds
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce(['default'])
+      .mockReturnValue([]);
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('advance tier');
+    await session.run('compact history');
+    await session.run('after compaction');
+
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[2].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTiers).toEqual({});
   });
 
   it('restores fading tiers when reopening a persisted session', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -23,6 +23,8 @@ type MockRun = {
   getCalibrationRatio: jest.MockedFunction<
     Run<t.IState>['getCalibrationRatio']
   >;
+  getFadingTier: jest.MockedFunction<Run<t.IState>['getFadingTier']>;
+  getFadingTiers: jest.MockedFunction<Run<t.IState>['getFadingTiers']>;
   getInterrupt: jest.MockedFunction<Run<t.IState>['getInterrupt']>;
   getHaltReason: jest.MockedFunction<Run<t.IState>['getHaltReason']>;
   getChildCheckpointThreadIds: jest.MockedFunction<
@@ -46,6 +48,8 @@ function createMockRun(outputText = 'ok'): MockRun {
       .mockResolvedValue([{ type: 'text', text: outputText }]),
     getRunMessages: jest.fn(() => [new AIMessage(outputText)]),
     getCalibrationRatio: jest.fn(() => 1),
+    getFadingTier: jest.fn(() => undefined),
+    getFadingTiers: jest.fn(() => ({})),
     getInterrupt: jest.fn(() => undefined),
     getHaltReason: jest.fn(() => undefined),
     getChildCheckpointThreadIds: jest.fn(() => []),
@@ -1349,9 +1353,52 @@ describe('JsonlSessionStore', () => {
     expect(compaction?.data.retainedEntryIds).toEqual([]);
   });
 
+  it('clears persisted fading tiers after session compaction', async () => {
+    mockSummarizer('summary of prior work');
+    const mockRun = createMockRun('continued');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      fadingTier,
+      fadingTiers: { default: fadingTier },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    await store?.appendMessage(new HumanMessage('old'));
+    await store?.appendMessage(new AIMessage('old answer'));
+
+    await session.compact({ retainRecentTurns: 0 });
+    await session.run('continue after compaction');
+
+    expect(capturedConfigs[0].fadingTier).toBeUndefined();
+    expect(capturedConfigs[0].fadingTiers).toBeUndefined();
+  });
+
   it('carries calibration ratio forward after resumeInterrupt', async () => {
     const mockRun = createMockRun('resumed');
     mockRun.getCalibrationRatio.mockReturnValue(2);
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
     const capturedConfigs = mockRunCreate(mockRun);
     const session = await createAgentSession({
       cwd: dir,
@@ -1370,6 +1417,8 @@ describe('JsonlSessionStore', () => {
     await session.run('after resume');
 
     expect(capturedConfigs[1].calibrationRatio).toBe(2);
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
   });
 
   it('summarizes an abandoned branch before switching in place', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1256,8 +1256,16 @@ describe('JsonlSessionStore', () => {
 
   it('records run.failed when resumeInterrupt throws', async () => {
     const mockRun = createMockRun('unused');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
     mockRun.resume.mockRejectedValue(new Error('resume failed'));
-    mockRunCreate(mockRun);
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
     const session = await createAgentSession({
       cwd: dir,
       runId: 'template-run',
@@ -1284,6 +1292,43 @@ describe('JsonlSessionStore', () => {
       .filter((entry) => entry.type === 'run_event')
       .map((entry) => entry.data.event);
     expect(events).toEqual(['run.started', 'run.failed']);
+    await session.run('after failed resume');
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
+  it('persists fading tiers when processStream throws', async () => {
+    const mockRun = createMockRun('unused');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    mockRun.processStream.mockRejectedValueOnce(new Error('run failed'));
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await expect(session.run('fail after fading')).rejects.toThrow(
+      'run failed'
+    );
+    await session.run('continue');
+
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1421,6 +1421,84 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
   });
 
+  it('carries live fading tiers into cloned sessions', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('advance tier');
+    const cloned = await session.clone({ cwd: dir });
+    await cloned.run('continue clone');
+
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
+  it('keeps fading tiers isolated by checkpoint thread', async () => {
+    const mockRun = createMockRun('continued');
+    const mainTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const alternateTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier
+      .mockReturnValueOnce(mainTier)
+      .mockReturnValueOnce(alternateTier)
+      .mockReturnValue(mainTier);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({ default: mainTier })
+      .mockReturnValueOnce({ default: alternateTier })
+      .mockReturnValue({ default: mainTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('main');
+    await session.run('alternate', { threadId: 'alternate-thread' });
+    await session.run('main again');
+    await session.run('alternate again', { threadId: 'alternate-thread' });
+
+    expect(capturedConfigs[1].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTier).toEqual(mainTier);
+    expect(capturedConfigs[3].fadingTier).toEqual(alternateTier);
+  });
+
   it('summarizes an abandoned branch before switching in place', async () => {
     mockSummarizer('summary of abandoned branch');
     const session = await createAgentSession({

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1624,6 +1624,69 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[3].fadingTier).toEqual(alternateTier);
   });
 
+  it('keeps fading tiers isolated by checkpoint namespace', async () => {
+    const mockRun = createMockRun('continued');
+    const namespaceATier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const namespaceBTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier
+      .mockReturnValueOnce(namespaceATier)
+      .mockReturnValueOnce(namespaceBTier)
+      .mockReturnValue(namespaceATier);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({ default: namespaceATier })
+      .mockReturnValueOnce({ default: namespaceBTier })
+      .mockReturnValue({ default: namespaceATier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const namespaceOptions = (checkpointNs: string) => ({
+      config: { configurable: { checkpoint_ns: checkpointNs } },
+    });
+
+    await session.run('namespace A', namespaceOptions('namespace-a'));
+    await session.run('namespace B', namespaceOptions('namespace-b'));
+    const reopened = await createAgentSession({
+      cwd: dir,
+      sessionPath: session.sessionPath,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await reopened.run('namespace A again', namespaceOptions('namespace-a'));
+    await reopened.run('namespace B again', namespaceOptions('namespace-b'));
+
+    expect(capturedConfigs[0].fadingTier).toBeUndefined();
+    expect(capturedConfigs[1].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTier).toEqual(namespaceATier);
+    expect(capturedConfigs[3].fadingTier).toEqual(namespaceBTier);
+  });
+
   it('bounds fading metadata retained for alternate checkpoint threads', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1921,6 +1921,82 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[2].fadingTiers).toEqual({ default: deepTier });
   });
 
+  it('rejects a stale capture that started before a concurrent compaction', async () => {
+    const mockRun = createMockRun('continued');
+    const staleTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    let markResetStarted!: () => void;
+    let markStaleStarted!: () => void;
+    let releaseReset!: () => void;
+    let releaseStale!: () => void;
+    const resetStarted = new Promise<void>((resolve) => {
+      markResetStarted = resolve;
+    });
+    const staleStarted = new Promise<void>((resolve) => {
+      markStaleStarted = resolve;
+    });
+    const resetResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseReset = () => resolve([{ type: 'text', text: 'reset' }]);
+    });
+    const staleResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseStale = () => resolve([{ type: 'text', text: 'stale' }]);
+    });
+    mockRun.processStream
+      .mockImplementationOnce(async () => {
+        markResetStarted();
+        return resetResult;
+      })
+      .mockImplementationOnce(async () => {
+        markStaleStarted();
+        return staleResult;
+      })
+      .mockResolvedValue([{ type: 'text', text: 'after' }]);
+    mockRun.getFadingTier
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(staleTier)
+      .mockReturnValue(undefined);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({})
+      .mockReturnValueOnce({ default: staleTier })
+      .mockReturnValue({});
+    mockRun.didResetFadingTier
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    mockRun.getFadingTierResetAgentIds
+      .mockReturnValueOnce(['default'])
+      .mockReturnValue([]);
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    const resetRun = session.run('reset run');
+    await resetStarted;
+    const staleRun = session.run('stale run');
+    await staleStarted;
+    releaseReset();
+    await resetRun;
+    releaseStale();
+    await staleRun;
+    await session.run('after overlap');
+
+    expect(capturedConfigs[2].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTiers).toEqual({});
+  });
+
   it('bounds fading metadata retained for alternate checkpoint threads', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1622,6 +1622,40 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[2].fadingTiers).toEqual({});
   });
 
+  it('preserves prototype-named agent tiers across runs', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTiers.mockReturnValue(
+      Object.fromEntries([['__proto__', fadingTier]])
+    );
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('capture prototype tier');
+    await session.run('reuse prototype tier');
+
+    expect(
+      Object.hasOwn(capturedConfigs[1].fadingTiers ?? {}, '__proto__')
+    ).toBe(true);
+    expect(capturedConfigs[1].fadingTiers?.['__proto__']).toEqual(fadingTier);
+  });
+
   it('restores fading tiers when reopening a persisted session', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1687,6 +1687,56 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[3].fadingTier).toEqual(namespaceBTier);
   });
 
+  it('persists an interrupted tier under the interrupt checkpoint namespace', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('interrupted');
+    const nestedTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(nestedTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: nestedTier });
+    mockRun.getInterrupt.mockReturnValueOnce({
+      interruptId: 'nested-interrupt',
+      threadId: 'nested-thread',
+      checkpointId: 'nested-checkpoint',
+      checkpointNs: 'nested-namespace',
+      payload: {
+        type: 'tool_approval',
+        action_requests: [],
+        review_configs: [],
+      },
+    });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'nested-checkpoint',
+      checkpointNs: 'nested-namespace',
+    });
+
+    await session.run('pause in nested namespace');
+    await session.resumeInterrupt([{ type: 'approve' }]);
+
+    expect(capturedConfigs[1].fadingTier).toEqual(nestedTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: nestedTier });
+  });
+
   it('bounds fading metadata retained for alternate checkpoint threads', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1499,6 +1499,40 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[3].fadingTier).toEqual(alternateTier);
   });
 
+  it('bounds fading metadata retained for alternate checkpoint threads', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    for (let i = 0; i < 65; i++) {
+      await session.run(`alternate ${i}`, { threadId: `thread-${i}` });
+    }
+    await session.run('oldest again', { threadId: 'thread-0' });
+    await session.run('newest again', { threadId: 'thread-64' });
+
+    expect(capturedConfigs[65].fadingTier).toBeUndefined();
+    expect(capturedConfigs[66].fadingTier).toEqual(fadingTier);
+  });
+
   it('summarizes an abandoned branch before switching in place', async () => {
     mockSummarizer('summary of abandoned branch');
     const session = await createAgentSession({

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1603,14 +1603,33 @@ describe('JsonlSessionStore', () => {
       },
     });
 
+    await session.run('main');
     for (let i = 0; i < 65; i++) {
       await session.run(`alternate ${i}`, { threadId: `thread-${i}` });
     }
-    await session.run('oldest again', { threadId: 'thread-0' });
-    await session.run('newest again', { threadId: 'thread-64' });
+    expect(
+      session
+        .getSessionStore()
+        ?.getFadingStates(session.threadId, 64)
+    ).toHaveLength(65);
+    const reopened = await createAgentSession({
+      cwd: dir,
+      sessionPath: session.sessionPath,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await reopened.run('oldest again', { threadId: 'thread-0' });
+    await reopened.run('newest again', { threadId: 'thread-64' });
 
-    expect(capturedConfigs[65].fadingTier).toBeUndefined();
-    expect(capturedConfigs[66].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[66].fadingTier).toBeUndefined();
+    expect(capturedConfigs[67].fadingTier).toEqual(fadingTier);
   });
 
   it('summarizes an abandoned branch before switching in place', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1388,6 +1388,42 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[0].fadingTiers).toBeUndefined();
   });
 
+  it('carries a tier learned after compaction into the next summarized run', async () => {
+    mockSummarizer('summary of prior work');
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('old'));
+    await session.getSessionStore()?.appendMessage(new AIMessage('old answer'));
+
+    await session.compact({ retainRecentTurns: 0 });
+    await session.run('first post-compaction turn');
+    await session.run('second post-compaction turn');
+
+    expect(capturedConfigs[0].fadingTier).toBeUndefined();
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
   it('carries calibration ratio forward after resumeInterrupt', async () => {
     const mockRun = createMockRun('resumed');
     mockRun.getCalibrationRatio.mockReturnValue(2);

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1453,6 +1453,50 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
   });
 
+  it('restores fading tiers when reopening a persisted session', async () => {
+    const mockRun = createMockRun('continued');
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('advance tier');
+    const reopened = await createAgentSession({
+      cwd: dir,
+      sessionPath: session.sessionPath,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await reopened.run('continue reopened session');
+
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
   it('keeps fading tiers isolated by checkpoint thread', async () => {
     const mockRun = createMockRun('continued');
     const mainTier: t.FadingTier = {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { MemorySaver } from '@langchain/langgraph';
-import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { appendFile, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import {
   AIMessage,
   HumanMessage,
@@ -141,6 +141,32 @@ describe('JsonlSessionStore', () => {
   afterEach(async () => {
     jest.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it('opens a file whose session_state line carries null data', async () => {
+    const path = join(dir, 'null-state.jsonl');
+    const store = await JsonlSessionStore.create({
+      path,
+      cwd: dir,
+      sessionId: 'session-null-state',
+    });
+    await store.appendMessage(new HumanMessage('hello'));
+    await appendFile(
+      path,
+      `${JSON.stringify({
+        type: 'session_state',
+        id: 'state-null',
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        data: null,
+      })}\n`,
+      'utf8'
+    );
+
+    const reopened = await JsonlSessionStore.open(path);
+
+    expect(reopened.hasFadingState()).toBe(false);
+    expect(reopened.getFadingStates('session-null-state')).toEqual([]);
   });
 
   it('stores messages as an append-only tree and restores the active path', async () => {
@@ -1258,6 +1284,88 @@ describe('JsonlSessionStore', () => {
       .find((checkpoint) => checkpoint.data.source === 'reset');
     expect(tuple).toBeUndefined();
     expect(reset?.data.reason).toBe('branch');
+  });
+
+  it('ignores a malformed persisted tier instead of poisoning later merges', async () => {
+    const sessionPath = join(dir, 'corrupt-tier.jsonl');
+    const store = await JsonlSessionStore.create({
+      path: sessionPath,
+      cwd: dir,
+      sessionId: 'corrupt-tier-session',
+    });
+    await store.appendFadingState({
+      threadId: store.header.id,
+      fadingTier: { v: 1, budgetTokens: 'abc', masked: true } as unknown as t.FadingTier,
+      fadingTiers: {
+        default: { v: 1, budgetTokens: Number.NaN, masked: true } as t.FadingTier,
+      },
+    });
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const mockRun = createMockRun('ok');
+    mockRun.getFadingTier.mockReturnValue(fadingTier);
+    mockRun.getFadingTiers.mockReturnValue({ default: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      sessionPath,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('first');
+    await session.run('second');
+
+    expect(capturedConfigs[0].fadingTier).toBeUndefined();
+    expect(capturedConfigs[0].fadingTiers ?? {}).toEqual({});
+    expect(capturedConfigs[1].fadingTier).toEqual(fadingTier);
+    expect(capturedConfigs[1].fadingTiers).toEqual({ default: fadingTier });
+  });
+
+  it('persists a tier for an agent whose ID is an object prototype key', async () => {
+    const fadingTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    const mockRun = createMockRun('ok');
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({ worker: fadingTier })
+      .mockReturnValueOnce({ constructor: fadingTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('first');
+    await session.run('second');
+    await session.run('third');
+
+    const tiers = capturedConfigs[2].fadingTiers ?? {};
+    expect(Object.hasOwn(tiers, 'constructor')).toBe(true);
+    expect(tiers.constructor).toEqual(fadingTier);
+    expect(tiers.worker).toEqual(fadingTier);
   });
 
   it('records run.failed when resumeInterrupt throws', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1737,6 +1737,68 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[1].fadingTiers).toEqual({ default: nestedTier });
   });
 
+  it('merges overlapping run tiers monotonically', async () => {
+    const mockRun = createMockRun('continued');
+    const deepTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 12_500,
+      masked: true,
+      latched: true,
+    };
+    const staleTier: t.FadingTier = {
+      v: 1,
+      budgetTokens: 50_000,
+      masked: false,
+    };
+    let markSlowStarted!: () => void;
+    let releaseSlow!: () => void;
+    const slowStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const slowResult = new Promise<t.MessageContentComplex[]>((resolve) => {
+      releaseSlow = () => resolve([{ type: 'text', text: 'slow' }]);
+    });
+    mockRun.processStream
+      .mockImplementationOnce(async () => {
+        markSlowStarted();
+        return slowResult;
+      })
+      .mockResolvedValue([{ type: 'text', text: 'fast' }]);
+    mockRun.getFadingTier
+      .mockReturnValueOnce(deepTier)
+      .mockReturnValueOnce(staleTier)
+      .mockReturnValue(deepTier);
+    mockRun.getFadingTiers
+      .mockReturnValueOnce({ default: deepTier })
+      .mockReturnValueOnce({ default: staleTier })
+      .mockReturnValue({ default: deepTier });
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    const slowRun = session.run('slow run');
+    await slowStarted;
+    await session.run('fast run');
+    releaseSlow();
+    await slowRun;
+    await session.run('after overlap');
+
+    expect(capturedConfigs[0].fadingTier).toBeUndefined();
+    expect(capturedConfigs[1].fadingTier).toBeUndefined();
+    expect(capturedConfigs[2].fadingTier).toEqual(deepTier);
+    expect(capturedConfigs[2].fadingTiers).toEqual({ default: deepTier });
+  });
+
   it('bounds fading metadata retained for alternate checkpoint threads', async () => {
     const mockRun = createMockRun('continued');
     const fadingTier: t.FadingTier = {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -118,6 +118,8 @@ export type SessionRunEventEntry = SessionEntryBase<
 
 export interface SessionFadingState {
   threadId: string;
+  /** LangGraph checkpoint namespace within `threadId`; empty when omitted. */
+  checkpointNs?: string;
   fadingTier?: t.FadingTier;
   fadingTiers?: t.FadingTiers;
 }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -116,10 +116,18 @@ export type SessionRunEventEntry = SessionEntryBase<
   }
 >;
 
+export interface SessionFadingState {
+  threadId: string;
+  fadingTier?: t.FadingTier;
+  fadingTiers?: t.FadingTiers;
+}
+
 export type SessionStateEntry = SessionEntryBase<
   'session_state',
   {
     leafId: string | null;
+    /** Latest compact fading state for one checkpoint thread; null clears all. */
+    fadingState?: SessionFadingState | null;
   }
 >;
 

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -21,12 +21,12 @@ import {
   sanitizeOrphanToolBlocks,
   enforceOriginalContentCap,
   ORIGINAL_CONTENT_MAX_CHARS,
-  calculateMaxToolCallInputChars,
   createPruneMessages,
   projectToolCallInputs,
   projectToolMessagesForProvider,
   serializeToolCallInput,
 } from '@/messages/prune';
+import { calculateMaxToolCallInputChars } from '@/utils/truncation';
 import { projectToolStreamContentForProvider } from '@/messages/core';
 import { getLLMConfig } from '@/utils/llmConfig';
 import { ensureThinkingBlockInMessages } from '@/messages/format';

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -384,6 +384,92 @@ const hasAnthropic = hasEnv('ANTHROPIC_API_KEY');
     expect(alignedCacheRead).toBeGreaterThan(0);
   }, 180_000);
 
+  test('fresh runs reuse a persisted fading tier without mutating canonical tool history', async () => {
+    const tokenCounter = await createTokenCounter();
+    const largeToolResult = `BEGIN-LIVE-PAYLOAD\n${'stable provider payload '.repeat(
+      3000
+    )}\nEND-LIVE-PAYLOAD`;
+    const buildHistory = (): BaseMessage[] => [
+      new HumanMessage('Inspect the synthetic provider payload.'),
+      new AIMessage({
+        content: 'I inspected the payload.',
+        tool_calls: [
+          {
+            id: 'live_fading_tool_call',
+            name: 'inspect_payload',
+            args: { source: 'live-regression' },
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: largeToolResult,
+        tool_call_id: 'live_fading_tool_call',
+        name: 'inspect_payload',
+      }),
+      new AIMessage('The inspection completed successfully.'),
+      new HumanMessage('Reply with exactly OK.'),
+    ];
+    const executeRun = async (
+      history: BaseMessage[],
+      fadingTier?: t.FadingTier,
+      calibrationRatio?: number
+    ): Promise<Run<t.IState>> => {
+      const run = await Run.create<t.IState>({
+        runId: `anthropic-live-fading-${Date.now()}-${Math.random()}`,
+        graphConfig: {
+          type: 'standard',
+          llmConfig: {
+            ...getLLMConfig(Providers.ANTHROPIC),
+            model: 'claude-haiku-4-5',
+            streaming: false,
+            maxTokens: 32,
+            temperature: 0,
+          },
+          tools: [],
+          instructions: 'Reply with exactly OK and do not call tools.',
+          maxContextTokens: 4000,
+          summarizationEnabled: false,
+        },
+        returnContent: true,
+        tokenCounter,
+        indexTokenCountMap: buildIndexTokenCountMap(history, tokenCounter),
+        fadingTier,
+        fadingTiers:
+          fadingTier == null ? undefined : { default: fadingTier },
+        calibrationRatio,
+      });
+      await run.processStream(
+        { messages: history },
+        {
+          configurable: { thread_id: run.id },
+          recursionLimit: 10,
+          streamMode: 'values',
+          version: 'v2',
+        } as any
+      );
+      expect(run.getRunMessages()?.length ?? 0).toBeGreaterThan(0);
+      return run;
+    };
+
+    const firstHistory = buildHistory();
+    const firstRun = await executeRun(firstHistory);
+    const firstTier = firstRun.getFadingTier();
+
+    expect(firstHistory[2].content).toBe(largeToolResult);
+    expect(firstTier?.latched).toBe(true);
+    expect(firstTier?.masked).toBe(true);
+
+    const secondHistory = buildHistory();
+    const secondRun = await executeRun(
+      secondHistory,
+      firstTier,
+      firstRun.getCalibrationRatio()
+    );
+
+    expect(secondHistory[2].content).toBe(largeToolResult);
+    expect(secondRun.getFadingTier()).toEqual(firstTier);
+  }, 180_000);
+
   test('heavy multi-turn with tool calls triggers and survives summarization', async () => {
     const spies = createSpies();
     let collectedUsage: UsageMetadata[] = [];

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2457,6 +2457,12 @@ export class SubagentExecutor {
       streamLimits: this.streamLimits,
       subagentScope: true,
       subagentExecutionContext: childExecutionContext,
+      ...(resumeExecution?.graphState.fadingTier == null
+        ? {}
+        : { fadingTier: resumeExecution.graphState.fadingTier }),
+      ...(resumeExecution?.graphState.fadingTiers == null
+        ? {}
+        : { fadingTiers: resumeExecution.graphState.fadingTiers }),
       /**
        * Forwarded so the child graph's own `SubagentExecutor` (created in
        * its `createAgentNode` when `allowNested` keeps subagentConfigs)

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -2,7 +2,13 @@ import type { ToolCall, ToolMessage } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolOutputReferenceState } from '@/tools/toolOutputReferences';
 import type { ToolApprovalReplaySnapshot } from '@/hooks';
-import type { RunStepResumeState, ToolSessionContext } from '@/types';
+import type {
+  FadingTier,
+  FadingTiers,
+  RunStepResumeState,
+  ToolSessionContext,
+} from '@/types';
+import { isFadingTier } from '@/messages/fading';
 import {
   attachRunStepResumeState,
   getRunStepResumeState,
@@ -65,6 +71,8 @@ export interface SubagentGraphResumeState {
   eagerToolSuppressions: string[];
   runStepState?: RunStepResumeState;
   toolOutputReferences?: ToolOutputReferenceState;
+  fadingTier?: FadingTier;
+  fadingTiers?: FadingTiers;
 }
 
 /** Private checkpoint payload linking a parent pause to an exact child state. */
@@ -301,7 +309,12 @@ function isGraphResumeState(value: unknown): value is SubagentGraphResumeState {
     (state.runStepState != null &&
       !isRunStepResumeState(state.runStepState)) ||
     (state.toolOutputReferences != null &&
-      !isToolOutputReferenceState(state.toolOutputReferences))
+      !isToolOutputReferenceState(state.toolOutputReferences)) ||
+    (state.fadingTier != null && !isFadingTier(state.fadingTier)) ||
+    (state.fadingTiers != null &&
+      (typeof state.fadingTiers !== 'object' ||
+        Array.isArray(state.fadingTiers) ||
+        !Object.values(state.fadingTiers).every(isFadingTier)))
   ) {
     return false;
   }

--- a/src/tools/subagent/__tests__/SubagentExecutor.lazy.test.ts
+++ b/src/tools/subagent/__tests__/SubagentExecutor.lazy.test.ts
@@ -2047,10 +2047,23 @@ describe('SubagentExecutor lazy selected-subagent resolution', () => {
     const parentToolCallId = 'call_legacy_eager';
     const resumeExecution = makeResumeExecution(parentToolCallId, configId);
     delete resumeExecution.subagentType;
+    resumeExecution.graphState.fadingTier = {
+      v: 1,
+      budgetTokens: 25_000,
+      masked: true,
+      latched: true,
+    };
+    resumeExecution.graphState.fadingTiers = {
+      'eager-child': resumeExecution.graphState.fadingTier,
+    };
+    let observedInput: StandardGraphInput | undefined;
     const executor = createExecutor([eagerConfig], {
       checkpointer: new MemorySaver(),
       humanInTheLoop: { enabled: true },
-      createChildGraph: makeRecoveredGraph,
+      createChildGraph: (input) => {
+        observedInput = input;
+        return makeRecoveredGraph();
+      },
     });
     const forkTarget = executor as unknown as {
       forkCheckpointSnapshot: () => Promise<void>;
@@ -2073,6 +2086,12 @@ describe('SubagentExecutor lazy selected-subagent resolution', () => {
     });
 
     expect(result.content).toBe('persisted result');
+    expect(observedInput?.fadingTier).toEqual(
+      resumeExecution.graphState.fadingTier
+    );
+    expect(observedInput?.fadingTiers).toEqual(
+      resumeExecution.graphState.fadingTiers
+    );
   });
 
   it('preserves nested lazy descriptors and decrements the child depth', async () => {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -132,6 +132,22 @@ export interface ContextUsageEvent {
   calibrationRatio?: number;
 }
 
+/**
+ * Latched context-fading tier. Caps for historical tool results derive from
+ * `(window, rung, masked)` only, so carrying the tier across runs keeps their
+ * truncated bytes stable for prefix-based provider prompt caches. Hosts
+ * persist it beside `calibrationRatio` and pass it back via `RunConfig.fadingTier`.
+ */
+export interface FadingTier {
+  v: 1;
+  /** Context window the tier was derived for; a mismatch starts fresh. */
+  window: number;
+  /** Ladder position: the window is halved per rung. Never decreases. */
+  rung: number;
+  /** Whether observation masking has activated. Never deactivates. */
+  masked: boolean;
+}
+
 export interface EventHandler {
   handle(
     event: string,
@@ -346,6 +362,8 @@ export type StandardGraphInput = {
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;
   calibrationRatio?: number;
+  /** Persisted fading tier from a previous run; see `FadingTier`. */
+  fadingTier?: FadingTier | null;
   /**
    * Receives a {@link SubagentUsageEvent} for every model call that reports
    * usage metadata inside a subagent child run spawned from this graph

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -136,7 +136,8 @@ export interface ContextUsageEvent {
  * Latched context-fading tier. Caps for historical tool results derive from
  * `(budgetTokens, masked)` only, so carrying the tier across runs keeps their
  * truncated bytes stable for prefix-based provider prompt caches. Hosts
- * persist it beside `calibrationRatio` and pass it back via `RunConfig.fadingTier`.
+ * persist it beside `calibrationRatio` and pass it back via
+ * `RunConfig.fadingTiers[agentId]`.
  */
 export interface FadingTier {
   v: 1;
@@ -145,7 +146,12 @@ export interface FadingTier {
   budgetTokens: number;
   /** Whether observation masking has activated. Never deactivates. */
   masked: boolean;
+  /** Whether this tier was reduced, masked, or restored from host state. */
+  latched?: true;
 }
+
+/** Latched fading tiers keyed by agent ID. */
+export type FadingTiers = Record<string, FadingTier>;
 
 export interface EventHandler {
   handle(
@@ -361,8 +367,10 @@ export type StandardGraphInput = {
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;
   calibrationRatio?: number;
-  /** Persisted fading tier from a previous run; see `FadingTier`. */
+  /** Persisted default-agent tier retained for single-agent compatibility. */
   fadingTier?: FadingTier | null;
+  /** Persisted fading tiers keyed by agent ID. */
+  fadingTiers?: FadingTiers | null;
   /**
    * Receives a {@link SubagentUsageEvent} for every model call that reports
    * usage metadata inside a subagent child run spawned from this graph

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -134,16 +134,15 @@ export interface ContextUsageEvent {
 
 /**
  * Latched context-fading tier. Caps for historical tool results derive from
- * `(window, rung, masked)` only, so carrying the tier across runs keeps their
+ * `(budgetTokens, masked)` only, so carrying the tier across runs keeps their
  * truncated bytes stable for prefix-based provider prompt caches. Hosts
  * persist it beside `calibrationRatio` and pass it back via `RunConfig.fadingTier`.
  */
 export interface FadingTier {
   v: 1;
-  /** Context window the tier was derived for; a mismatch starts fresh. */
-  window: number;
-  /** Ladder position: the window is halved per rung. Never decreases. */
-  rung: number;
+  /** Token budget the caps derive from, in raw token space. Never grows;
+   *  clamped to the current context window when seeded. */
+  budgetTokens: number;
   /** Whether observation masking has activated. Never deactivates. */
   masked: boolean;
 }

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -338,6 +338,12 @@ export type RunConfig = {
    * conversation. Without this, the EMA resets to 1 on every new Run instance.
    */
   calibrationRatio?: number;
+  /**
+   * Context-fading tier from a previous run's contextMeta. Hosts should persist
+   * the value returned by `Run.getFadingTier()` and pass it back here so
+   * historical tool results keep the same truncated bytes across runs.
+   */
+  fadingTier?: g.FadingTier | null;
   /** Skip post-stream cleanup (clearHeavyState) — useful for tests that inspect graph state after processStream */
   skipCleanup?: boolean;
   /**

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -339,11 +339,15 @@ export type RunConfig = {
    */
   calibrationRatio?: number;
   /**
-   * Context-fading tier from a previous run's contextMeta. Hosts should persist
-   * the value returned by `Run.getFadingTier()` and pass it back here so
-   * historical tool results keep the same truncated bytes across runs.
+   * Default-agent fading tier retained for single-agent compatibility. New
+   * multi-agent integrations should use `fadingTiers`.
    */
   fadingTier?: g.FadingTier | null;
+  /**
+   * Context-fading tiers keyed by agent ID. Multi-agent hosts should persist
+   * the value returned by `Run.getFadingTiers()` and pass it back here.
+   */
+  fadingTiers?: g.FadingTiers | null;
   /** Skip post-stream cleanup (clearHeavyState) — useful for tests that inspect graph state after processStream */
   skipCleanup?: boolean;
   /**

--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -152,3 +152,28 @@ export function truncateToolResultContent(
 
   return content.slice(0, headEnd) + indicator + content.slice(tailStart);
 }
+
+/** Absolute hard cap on a single tool-call input (characters). */
+export const HARD_MAX_TOOL_CALL_INPUT_CHARS = 200_000;
+
+/** Smallest JSON value a truncated tool-call input can shrink to. */
+export const MIN_JSON_VALUE_CHARS = 4;
+
+/**
+ * Computes the max tool-call input size for a context window: 15 % of the
+ * window in estimated characters (~4 chars/token), capped at 200K.
+ */
+export function calculateMaxToolCallInputChars(
+  maxContextTokens?: number
+): number {
+  if (maxContextTokens == null || maxContextTokens <= 0) {
+    return HARD_MAX_TOOL_CALL_INPUT_CHARS;
+  }
+  return Math.max(
+    MIN_JSON_VALUE_CHARS,
+    Math.min(
+      Math.floor(maxContextTokens * 0.15) * 4,
+      HARD_MAX_TOOL_CALL_INPUT_CHARS
+    )
+  );
+}


### PR DESCRIPTION
## Summary

I made context fading produce the same bytes for a historical tool result on every call, so Anthropic's prefix-based prompt cache survives from turn to turn instead of being rewritten on every request.

Pre-flight truncation and observation masking recomputed every historical tool result's character cap on every call from quantities that move from turn to turn:

- the number of tool results, through `0.2 + 0.8 * t / (n - 1)` recency weighting in `preFlightTruncateToolResults` and per-count budget shares in `maskConsumedToolResults`, so appending one tool call re-truncated every earlier result
- the calibration ratio, through `effectiveMaxTokens / calibrationRatio`, which updates after every provider response
- the instruction overhead folded into `effectiveMaxTokens`

With summarization enabled (the default), the fit-to-budget pass ran on every call regardless of pressure, so the drift started with the first oversized result. Because `messages/cache.ts` places a single tail breakpoint for Anthropic, one byte changed early in the conversation invalidated the entire cached prefix. The reporting user measured ~18.7M cache-write tokens against ~35.8M cache-read tokens in one day on a single conversation.

A flat, window-derived cap alone is not enough. A result under the ingestion cap but over the *effective* budget still has to be pre-truncated (a 32k window with 21k of instructions would otherwise produce an empty first context and send everything to the summarizer after one tool call), the fallback and emergency paths must not reintroduce drifting caps, and band thresholds need hysteresis. The fix is a latched cap ladder:

- Added `messages/fading.ts`, a pure policy module. A tier is `{ v, budgetTokens, masked, latched? }`. Budgets sit on a ladder that halves the context window per rung; `resolveFadingTier` deepens to the shallowest rung at which the widest observed parallel tool exchange (call inputs plus fresh results) fits within the effective budget (the fit guarantee), adds pressure-band rungs when summarization is off (×0.5 at 85 %, ×0.25 at 90 %, ×0.0625 at 99 %), and latches masking at 80 %. The budget only ever shrinks and masking only ever activates, which is the hysteresis: drift can escalate once at a boundary but never oscillate.
- Derived every cap from `(budgetTokens, masked)` alone (`resolveFadingCaps`). Within a tier, a historical tool result maps to identical bytes on every call; only escalation rewrites the prefix. The budget is absolute rather than a `(window, rung)` pair, so a mid-run budget correction and the next run's return to the normal window keep the same bytes; it is only clamped to the current window.
- Kept graph history canonical and moved fading into a provider-facing projection built per Run, re-derived from the original bytes. Each capped tool result and each input-capped AI message maps back to its canonical content, so a deeper tier or masking truncates the original bytes (the marker embeds the original length) and matches what a fresh run seeded with the resulting tier derives from the host's stored content. A restored tier's caps are applied before pressure is measured, the emergency pass reads the same stores, and the summarizer snapshot captures the same originals.
- Applied caps in one forward pass (`applyFadingCaps`) with watermarks for fresh and consumed results, so an unchanged tier only visits messages that arrived since the last call. `maskConsumedToolResults` and `preFlightTruncateToolResults` became thin wrappers over it.
- Dropped fallback fading, which the fit rung subsumes. Emergency truncation stays transient: it derives a temporary deeper tier at which one complete tool exchange (result plus call input) fits within a per-message share of the effective budget, applies it to a clone and retries, without latching that count-dependent share. After a recovery, `messagesToRefine` is reset to the retry outcome so messages in the recovered context are not also summarized.
- Threaded the tier through `createPruneMessages`, `AgentContext`, `StandardGraph` and `Run`, mirroring `calibrationRatio`. Tiers are keyed by agent ID: `RunConfig.fadingTiers` seeds each agent from its own entry and `Run.getFadingTiers()` returns them, while the single `RunConfig.fadingTier` / `Run.getFadingTier()` keeps working for single-agent hosts and seeds only the default agent. A tier is latched once it has been reduced, masked or clamped, and a restored tier keeps that provenance, so a tier clamped to a smaller model window stays reported and survives the hop back to the larger window. A fresh tier is never latched or persisted, even when a pruner rebuild re-seeds it at an unchanged window, so later runs are not pinned to it. An invalid seed starts fresh, and restored tiers are validated at every boundary (`Run`, `StandardGraph`, `AgentSession`).
- Persisted fading state across `AgentSession` runs and `JsonlSessionStore` files, scoped per thread and checkpoint namespace, merged monotonically across overlapping runs, with reset generations tracked per scope and per tier (the default tier and each agent) and a rewrite epoch that invalidates runs started before `branch()`, `compact()` or a restore. Compaction emits an explicit per-agent reset signal (`Run.didResetFadingTier()`, `Run.getFadingTierResetAgentIds()`) for hosts that merge tiers.
- Bounded every prompt injected into an agent's context against that agent's remaining message budget: direct-edge `{results}` templates, function-valued prompts, and handoff instructions all pass through the same destination-derived cap, since fading only shrinks tool content and could never shrink a human message later.
- Let `projectAgentContextUsage` accept the persisted `fadingTier`, so host-side page-load and branch-switch projections truncate history to the bytes the restored run sends.
- Shared `hasNonEmptyTextContent` from `messages/core` between the consumed-boundary scan and the preempt gate, reading blocks by index through own data descriptors so hostile iterators or accessors cannot abort pruning, and moved `calculateMaxToolCallInputChars` beside `calculateMaxToolResultChars` in `utils/truncation.ts`.
- Updated `docs/summarization-behavior.md` for the tier shape, the exchange-wide fit rung, the band rungs, per-agent persistence and reset reporting, canonical history behind the per-Run projection, validated restores, the removed fallback stage and the transient emergency path.

Fixes danny-avila/LibreChat#15499

## Testing

`src/messages/__tests__/truncationStability.test.ts` covers:

- the ladder (halving, floor, deepest rung), the fit-rung, exchange-rung and result-cap lookups, tier validation and seeding (version, clamping to the window, the floor clamp, `latched` provenance, a fresh seed staying fresh, invalid input), and which tiers count as informative, including a restored tier clamped to a smaller window
- band hysteresis: pressure 0.5 → 0.86 → 0.84 → 0.86 → 0.91 → 0.3 escalates exactly twice and never relaxes
- a latched tier surviving a mid-run budget correction to a smaller window and the return to the normal window with identical caps
- the fit guarantee: a 32k window with 21k of instructions and a result at the ingestion cap yields a full, non-empty first context with nothing sent to the summarizer
- `preFlightTruncateToolResults` and `maskConsumedToolResults` producing identical bytes regardless of how many results follow or how many are consumed
- `createPruneMessages` across runs (fresh pruner, full-content messages, seeded `calibrationRatio` as LibreChat does): identical bytes under calibration drift and growth with summarization on, and within a masked tier with summarization off; a seeded tier reproducing the bytes even when pressure has fallen below the threshold, where an unseeded run would not
- `createPruneMessages` within a run: identical bytes and an unchanged tier while `usageMetadata` recalibrates the ratio each call
- escalation from canonical originals: after a mid-run escalation, a historical tool result and a historical tool-call input carry exactly the bytes a fresh run seeded with the resulting tier produces from full content; the summarizer snapshot of a result capped fresh and masked later is the true original
- per-agent restore: keyed tiers land on their agents, the default tier is not applied to every agent, and malformed restored tiers are ignored instead of reported back
- emergency truncation recovering a context from four parallel oversized results on a clone, leaving the live messages and the latched tier untouched and `messagesToRefine` disjoint from the context
- hostile content: a throwing `Symbol.iterator` getter or accessor-backed element never aborts the substantive-text scan

`src/session/__tests__/JsonlSessionStore.test.ts` covers persistence and restore of fading state per scope, monotonic merges across overlapping runs, rejection of captures that predate a compaction or an explicit history rewrite, per-agent reset isolation, prototype-named agent IDs, and malformed persisted tiers. `src/graphs/__tests__/composition.smoke.test.ts` covers the destination-bounded routing prompts, function prompts and handoff instructions. `src/agents/__tests__/projection.test.ts` covers a persisted tier applied to a projected branch.

Also green: the prune, observation-masking, summarization, token-accounting, tools, preempt, context-overflow and graph suites, `npx tsc --noEmit`, and eslint on every changed file. Automated review ran repeatedly against the branch and every finding was addressed or explicitly deferred as non-blocking hardening. A final class-based sweep over the whole diff, re-verified against the head, confirmed the core guarantee end to end: a fresh Run seeded with the previous Run's tier reproduced the provider bytes slot for slot under growth, calibration and instruction drift, summarization on and off, a real overflow window correction and return, per-agent tiers, emergency truncation, a session restore round trip and the host projection.

## Deferred hardening (non-blocking)

- Bound the per-prune `newOriginalToolContent` delta alongside the primary map, and skip re-cloning hard-cleared tool messages whose projection already holds the placeholder.
- Give runs with an explicit `checkpoint_id` their own tier scope instead of the live head's, carry override-thread tier state through `clone()`, and fall back to the store for an LRU-evicted alternate scope.
- Read `canonical.additional_kwargs` through the accessor-safe reader in the input-cap merge, and subtract instruction overhead from the routing bound when a graph has no `tokenCounter`.

## Follow-up

- danny-avila/LibreChat#15505 persists `Run.getFadingTier()` and `Run.getFadingTiers()` in `contextMeta` beside `calibrationRatio`, carries them across HITL pause/resume, Stop and disconnect, and passes them back through `RunConfig.fadingTier` / `fadingTiers`. The latest release, 3.7.15, was cut from `main` before this PR, so LibreChat activates the seed with a dependency bump to the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNbgMeR2aZDyhsqAy4L8gF