### PR TITLE
feat: support custom Cohere reranker API URL

### DIFF
--- a/src/tools/search/cohere-reranker.test.ts
+++ b/src/tools/search/cohere-reranker.test.ts
@@ -1,7 +1,15 @@
 import axios from 'axios';
 
-import { CohereReranker } from './rerankers';
+import { createReranker, CohereReranker } from './rerankers';
 import { createDefaultLogger } from './utils';
+
+const getApiUrl = (reranker: CohereReranker): string => {
+  const descriptor = Object.getOwnPropertyDescriptor(reranker, 'apiUrl');
+  if (typeof descriptor?.value === 'string') {
+    return descriptor.value;
+  }
+  throw new Error('Expected CohereReranker apiUrl to be initialized.');
+};
 
 describe('CohereReranker', () => {
   const mockLogger = createDefaultLogger();
@@ -10,7 +18,10 @@ describe('CohereReranker', () => {
     jest.restoreAllMocks();
   });
 
-  const spyOnLogger = (): { warn: jest.SpyInstance; error: jest.SpyInstance } => {
+  const spyOnLogger = (): {
+    warn: jest.SpyInstance;
+    error: jest.SpyInstance;
+  } => {
     jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
     return {
       warn: jest.spyOn(mockLogger, 'warn').mockImplementation(() => mockLogger),
@@ -101,5 +112,101 @@ describe('CohereReranker', () => {
     expect(spies.warn).toHaveBeenCalledWith(
       expect.stringContaining('fallbacks=1 reasons={no_api_key:1}')
     );
+  });
+
+  describe('constructor', () => {
+    it('should use the default API URL when no apiUrl is provided', () => {
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        logger: mockLogger,
+      });
+
+      expect(getApiUrl(reranker)).toBe('https://api.cohere.com/v2/rerank');
+    });
+
+    it('should use a custom API URL when provided', () => {
+      const customUrl = 'https://litellm.internal/v2/rerank';
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        apiUrl: customUrl,
+        logger: mockLogger,
+      });
+
+      expect(getApiUrl(reranker)).toBe(customUrl);
+    });
+
+    it('should use environment variable COHERE_API_URL when available', () => {
+      const originalEnv = process.env.COHERE_API_URL;
+      process.env.COHERE_API_URL = 'https://env-cohere-endpoint.com/v2/rerank';
+
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        logger: mockLogger,
+      });
+
+      expect(getApiUrl(reranker)).toBe(
+        'https://env-cohere-endpoint.com/v2/rerank'
+      );
+
+      if (typeof originalEnv === 'string') {
+        process.env.COHERE_API_URL = originalEnv;
+      } else {
+        delete process.env.COHERE_API_URL;
+      }
+    });
+  });
+
+  describe('rerank method', () => {
+    it('should post to the configured API URL', async () => {
+      const customUrl = 'https://litellm.internal/v2/rerank';
+      const reranker = new CohereReranker({
+        apiKey: 'test-key',
+        apiUrl: customUrl,
+        logger: mockLogger,
+      });
+      const spies = spyOnLogger();
+      const postSpy = jest.spyOn(axios, 'post').mockResolvedValueOnce({
+        data: { results: [{ index: 0, relevance_score: 0.9 }] },
+      });
+
+      await reranker.rerank('query', ['a'], 1);
+
+      expect(postSpy).toHaveBeenCalledWith(
+        customUrl,
+        expect.any(Object),
+        expect.anything()
+      );
+      expect(spies.error).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('createReranker', () => {
+  it('should create CohereReranker with cohereApiUrl when provided', () => {
+    const customUrl = 'https://litellm.internal/v2/rerank';
+    const reranker = createReranker({
+      rerankerType: 'cohere',
+      cohereApiKey: 'test-key',
+      cohereApiUrl: customUrl,
+    });
+
+    expect(reranker).toBeInstanceOf(CohereReranker);
+    if (!(reranker instanceof CohereReranker)) {
+      throw new Error('Expected createReranker to return a CohereReranker.');
+    }
+    expect(getApiUrl(reranker)).toBe(customUrl);
+  });
+
+  it('should create CohereReranker with default URL when cohereApiUrl is not provided', () => {
+    const reranker = createReranker({
+      rerankerType: 'cohere',
+      cohereApiKey: 'test-key',
+    });
+
+    expect(reranker).toBeInstanceOf(CohereReranker);
+    if (!(reranker instanceof CohereReranker)) {
+      throw new Error('Expected createReranker to return a CohereReranker.');
+    }
+    expect(getApiUrl(reranker)).toBe('https://api.cohere.com/v2/rerank');
   });
 });

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -4,6 +4,7 @@ import { createDefaultLogger, formatErrorForLog } from './utils';
 import { createSearchMetrics } from './metrics';
 
 const DEFAULT_JINA_API_URL = 'https://api.jina.ai/v1/rerank';
+const DEFAULT_COHERE_API_URL = 'https://api.cohere.com/v2/rerank';
 
 /** Every other network call in the search pipeline is bounded (scrapers,
  * search providers); rerank requests must be too, or a hung rerank API
@@ -14,6 +15,11 @@ const getDefaultJinaApiUrl = (): string =>
   process.env.JINA_API_URL != null && process.env.JINA_API_URL !== ''
     ? process.env.JINA_API_URL
     : DEFAULT_JINA_API_URL;
+
+const getDefaultCohereApiUrl = (): string =>
+  process.env.COHERE_API_URL != null && process.env.COHERE_API_URL !== ''
+    ? process.env.COHERE_API_URL
+    : DEFAULT_COHERE_API_URL;
 
 export abstract class BaseReranker {
   protected apiKey: string | undefined;
@@ -219,23 +225,27 @@ export class JinaReranker extends BaseReranker {
 
 export class CohereReranker extends BaseReranker {
   readonly provider = 'cohere';
+  private apiUrl: string;
   private timeout: number;
   private httpAgent?: t.HttpAgent;
   private httpsAgent?: t.HttpsAgent;
 
   constructor({
     apiKey = process.env.COHERE_API_KEY,
+    apiUrl = getDefaultCohereApiUrl(),
     timeout = DEFAULT_RERANKER_TIMEOUT,
     logger,
     httpAgent,
     httpsAgent,
   }: {
     apiKey?: string;
+    apiUrl?: string;
     timeout?: number;
     logger?: t.Logger;
   } & t.HttpAgentConfig) {
     super(logger);
     this.apiKey = apiKey;
+    this.apiUrl = apiUrl;
     this.timeout = timeout;
     this.httpAgent = httpAgent;
     this.httpsAgent = httpsAgent;
@@ -263,7 +273,7 @@ export class CohereReranker extends BaseReranker {
       };
 
       const response = await axios.post<t.CohereRerankerResponse | undefined>(
-        'https://api.cohere.com/v2/rerank',
+        this.apiUrl,
         requestData,
         {
           headers: {
@@ -560,6 +570,7 @@ export const createReranker = (
     jinaApiKey?: string;
     jinaApiUrl?: string;
     cohereApiKey?: string;
+    cohereApiUrl?: string;
     ragApiUrl?: string;
     ragApiTokenSupplier?: t.RagApiTokenSupplier;
     ragApiProfile?: string;
@@ -572,6 +583,7 @@ export const createReranker = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    cohereApiUrl,
     ragApiUrl,
     ragApiTokenSupplier,
     ragApiProfile,
@@ -597,6 +609,7 @@ export const createReranker = (
   case 'cohere':
     return new CohereReranker({
       apiKey: cohereApiKey,
+      apiUrl: cohereApiUrl,
       timeout: rerankerTimeout,
       logger: defaultLogger,
       httpAgent,

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -20,8 +20,8 @@ import { createFirecrawlScraper } from './firecrawl';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
-import { formatResultsForLLM } from './format';
 import { createSearchMetrics } from './metrics';
+import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
 import { createReranker } from './rerankers';
 import { Constants } from '@/common';
@@ -514,6 +514,7 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    cohereApiUrl,
     ragApiUrl,
     ragApiTokenSupplier,
     ragApiProfile,
@@ -637,6 +638,7 @@ export const createSearchTool = (
     jinaApiKey,
     jinaApiUrl,
     cohereApiKey,
+    cohereApiUrl,
     ragApiUrl,
     ragApiTokenSupplier,
     ragApiProfile,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -519,6 +519,7 @@ export interface SearchToolConfig
   jinaApiKey?: string;
   jinaApiUrl?: string;
   cohereApiKey?: string;
+  cohereApiUrl?: string;
   /** Base URL of the public `rag_api` service (`RAG_API_URL` env fallback).
    * Requests post to `${ragApiUrl}/v1/rerank`. */
   ragApiUrl?: string;


### PR DESCRIPTION
## Summary
- `CohereReranker` now accepts an `apiUrl` option, mirroring `JinaReranker`'s existing `apiUrl`/`JINA_API_URL` pattern.
- Defaults to the `COHERE_API_URL` env var, falling back to `https://api.cohere.com/v2/rerank` when unset.
- `createReranker` accepts and forwards a new `cohereApiUrl` field.

This lets callers point the Cohere reranker at a Cohere-compatible endpoint (e.g. a self-hosted LiteLLM proxy) instead of Cohere's own API, the same way `jinaApiUrl` already does for Jina.

Companion PR on the LibreChat side wiring this through the web search config: https://github.com/danny-avila/LibreChat/pull/15518

## Test plan
- [x] Added constructor/env-var/`createReranker` tests mirroring the existing `JinaReranker` suite
- [x] `npx jest cohere-reranker jina-reranker rag-api-reranker` — 53/53 passing
- [x] `npx tsc --noEmit` and `npx eslint src/` clean

## A note on why this is a re-submission

This is at least the fourth independent submission of this exact feature on this repo. All add the same `apiUrl`/`COHERE_API_URL` option to `CohereReranker`. A one-file, backward-compatible, test-covered change going unreviewed for over a year — independently, from three different contributors — isn't a great signal about how community PRs get handled here.

**Related PRs:**
- #11 — @davidjrh, opened Aug 2025. Still open, unanswered.
- #47 — mine, opened Jan 2026. Closed in favor of this version.
- #149 — @npeham, opened May 2026. Still open, unanswered.

The companion LibreChat-side PR (#9544, now closed in favor of #15518) has real users confirming the underlying need and the fix working in production. Happy to coordinate with @davidjrh and @npeham so effort isn't split four ways.