### PR TITLE
🫗 fix: Never Send Bedrock a Blank User Text Block

### DIFF
--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -1349,7 +1349,9 @@ describe('convertToConverseMessages', () => {
       ]);
 
       const content = result.converseMessages[0].content!;
-      expect(content).toHaveLength(1);
+      expect(content).toHaveLength(2);
+      // Converse requires a text block alongside document blocks; it is appended last.
+      expect(content[1]).toEqual({ text: '_' });
       const documentBlock = expectDocumentBlock(content[0]);
       expect(documentBlock.document.format).toBe('pdf');
       expect(documentBlock.document.name).toBeDefined();
@@ -1397,7 +1399,9 @@ describe('convertToConverseMessages', () => {
       ]);
 
       const content = result.converseMessages[0].content!;
-      expect(content).toHaveLength(2);
+      expect(content).toHaveLength(3);
+      // Converse requires a text block alongside document blocks; it is appended last.
+      expect(content[2]).toEqual({ text: '_' });
       const firstDocument = expectDocumentBlock(content[0]);
       const secondDocument = expectDocumentBlock(content[1]);
       expect(firstDocument.document.name).toBeDefined();

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -704,6 +704,26 @@ describe('convertToConverseMessages — blank user content', () => {
     });
   });
 
+  it('does not inject the placeholder into a merged user group', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('hello'),
+      new HumanMessage(''),
+    ]);
+    expect(converseMessages).toEqual([
+      { role: 'user', content: [{ text: 'hello' }] },
+    ]);
+  });
+
+  it('applies the placeholder when an entire user group is empty', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage(''),
+      new HumanMessage('   '),
+    ]);
+    expect(converseMessages).toEqual([
+      { role: 'user', content: [{ text: '_' }] },
+    ]);
+  });
+
   it('keeps non-blank user text unchanged', () => {
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('hello'),

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -688,6 +688,22 @@ describe('convertToConverseMessages — blank user content', () => {
     expect(content.some((block) => 'text' in block)).toBe(false);
   });
 
+  it('folds whitespace-only text into the preceding block instead of dropping it', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: 'text', text: 'hello' },
+          { type: 'text', text: ' ' },
+          { type: 'text', text: 'world' },
+        ],
+      }),
+    ]);
+    expect(converseMessages[0]).toEqual({
+      role: 'user',
+      content: [{ text: 'hello ' }, { text: 'world' }],
+    });
+  });
+
   it('keeps non-blank user text unchanged', () => {
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('hello'),

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -724,6 +724,26 @@ describe('convertToConverseMessages — blank user content', () => {
     ]);
   });
 
+  it('adds a text block to a promptless document upload, which Converse requires', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: 'text', text: '' },
+          {
+            type: 'file',
+            source_type: 'base64',
+            mime_type: 'application/pdf',
+            data: 'JVBERi0xLjQK',
+          },
+        ],
+      }),
+    ]);
+    const content = converseMessages[0].content ?? [];
+    expect(content).toHaveLength(2);
+    expect(content[0]).toHaveProperty('document');
+    expect(content[1]).toEqual({ text: '_' });
+  });
+
   it('keeps non-blank user text unchanged', () => {
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('hello'),

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -648,3 +648,53 @@ describe('convertToConverseMessages — user-role run merging', () => {
     ]);
   });
 });
+
+describe('convertToConverseMessages — blank user content', () => {
+  it('replaces an empty-string user message with the placeholder instead of a blank text block', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage(''),
+    ]);
+    expect(converseMessages[0]).toEqual({
+      role: 'user',
+      content: [{ text: '_' }],
+    });
+  });
+
+  it('replaces whitespace-only user text with the placeholder', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('   '),
+    ]);
+    expect(converseMessages[0]).toEqual({
+      role: 'user',
+      content: [{ text: '_' }],
+    });
+  });
+
+  it('drops a blank text block from an image-only user message and keeps the image', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: 'text', text: '' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+          },
+        ],
+      }),
+    ]);
+    const content = converseMessages[0].content ?? [];
+    expect(content).toHaveLength(1);
+    expect(content[0]).toHaveProperty('image');
+    expect(content.some((block) => 'text' in block)).toBe(false);
+  });
+
+  it('keeps non-blank user text unchanged', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('hello'),
+    ]);
+    expect(converseMessages[0]).toEqual({
+      role: 'user',
+      content: [{ text: 'hello' }],
+    });
+  });
+});

--- a/src/llm/bedrock/utils/message_inputs.test.ts
+++ b/src/llm/bedrock/utils/message_inputs.test.ts
@@ -744,6 +744,60 @@ describe('convertToConverseMessages — blank user content', () => {
     expect(content[1]).toEqual({ text: '_' });
   });
 
+  it('keeps whitespace that precedes the first text fragment', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          { type: 'text', text: ' ' },
+          { type: 'text', text: 'hello' },
+        ],
+      }),
+    ]);
+    expect(converseMessages[0]).toEqual({
+      role: 'user',
+      content: [{ text: ' hello' }],
+    });
+  });
+
+  it('keeps whitespace between media and the text that follows it', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+          },
+          { type: 'text', text: ' ' },
+          { type: 'text', text: 'hello' },
+        ],
+      }),
+    ]);
+    const content = converseMessages[0].content ?? [];
+    expect(content).toHaveLength(2);
+    expect(content[0]).toHaveProperty('image');
+    expect(content[1]).toEqual({ text: ' hello' });
+  });
+
+  it('adds the document text block to a merged group only when no member had text', () => {
+    const { converseMessages } = convertToConverseMessages([
+      new HumanMessage('read this'),
+      new HumanMessage({
+        content: [
+          {
+            type: 'file',
+            source_type: 'base64',
+            mime_type: 'application/pdf',
+            data: 'JVBERi0xLjQK',
+          },
+        ],
+      }),
+    ]);
+    const content = converseMessages[0].content ?? [];
+    expect(content).toHaveLength(2);
+    expect(content[0]).toEqual({ text: 'read this' });
+    expect(content[1]).toHaveProperty('document');
+  });
+
   it('keeps non-blank user text unchanged', () => {
     const { converseMessages } = convertToConverseMessages([
       new HumanMessage('hello'),

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -971,14 +971,36 @@ function convertHumanMessageToConverseMessage(
   };
 
   if (typeof msg.content === 'string') {
-    userMessage.content = [{ text: msg.content }];
+    userMessage.content = isBlankText(msg.content)
+      ? []
+      : [{ text: msg.content }];
   } else if (Array.isArray(msg.content)) {
-    userMessage.content = msg.content.map((block) =>
-      convertLangChainContentBlockToConverseContentBlock({ block })
-    );
+    userMessage.content = msg.content
+      .map((block) =>
+        convertLangChainContentBlockToConverseContentBlock({ block })
+      )
+      .filter((block) => !isBlankTextBlock(block));
+  }
+
+  // Bedrock rejects a blank text block and an empty user message alike
+  // (`The text field in the ContentBlock object at messages.N.content.0 is blank`),
+  // and the rejection fences the whole conversation on every retry. A promptless send
+  // — attachment, no typed text — reaches here as exactly that shape. Mirror the
+  // assistant path: drop the blank, and fall back to the placeholder if nothing remains.
+  if (userMessage.content == null || userMessage.content.length === 0) {
+    userMessage.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
   }
 
   return userMessage;
+}
+
+function isBlankText(text: string): boolean {
+  return text.trim() === '';
+}
+
+function isBlankTextBlock(block: BedrockContentBlock): boolean {
+  const text = (block as { text?: unknown }).text;
+  return typeof text === 'string' && isBlankText(text);
 }
 
 /**

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -974,13 +974,7 @@ function convertHumanMessageToConverseMessage(
     // whitespace-only text into the preceding text block so prose spacing survives;
     // every other block converts inline.
     for (const block of msg.content) {
-      if (typeof block === 'string') {
-        appendSerializableBedrockTextBlock(contentBlocks, block);
-        continue;
-      }
       if (
-        typeof block === 'object' &&
-        block != null &&
         block.type === 'text' &&
         typeof (block as { text?: unknown }).text === 'string'
       ) {

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -965,42 +965,47 @@ function convertFromV1ToChatBedrockConverseMessage(
 function convertHumanMessageToConverseMessage(
   msg: BaseMessage
 ): BedrockMessage {
-  const userMessage: BedrockMessage = {
-    role: 'user',
-    content: [],
-  };
+  const contentBlocks: BedrockContentBlock[] = [];
 
   if (typeof msg.content === 'string') {
-    userMessage.content = isBlankText(msg.content)
-      ? []
-      : [{ text: msg.content }];
+    appendSerializableBedrockTextBlock(contentBlocks, msg.content);
   } else if (Array.isArray(msg.content)) {
-    userMessage.content = msg.content
-      .map((block) =>
+    // One pass. Text goes through the serializer, which drops a blank block and folds
+    // whitespace-only text into the preceding text block so prose spacing survives;
+    // every other block converts inline.
+    for (const block of msg.content) {
+      if (typeof block === 'string') {
+        appendSerializableBedrockTextBlock(contentBlocks, block);
+        continue;
+      }
+      if (
+        typeof block === 'object' &&
+        block != null &&
+        block.type === 'text' &&
+        typeof (block as { text?: unknown }).text === 'string'
+      ) {
+        appendSerializableBedrockTextBlock(
+          contentBlocks,
+          (block as { text: string }).text
+        );
+        continue;
+      }
+      contentBlocks.push(
         convertLangChainContentBlockToConverseContentBlock({ block })
-      )
-      .filter((block) => !isBlankTextBlock(block));
+      );
+    }
   }
 
   // Bedrock rejects a blank text block and an empty user message alike
   // (`The text field in the ContentBlock object at messages.N.content.0 is blank`),
   // and the rejection fences the whole conversation on every retry. A promptless send
   // — attachment, no typed text — reaches here as exactly that shape. Mirror the
-  // assistant path: drop the blank, and fall back to the placeholder if nothing remains.
-  if (userMessage.content == null || userMessage.content.length === 0) {
-    userMessage.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
+  // assistant path: fall back to the placeholder if nothing serializable remains.
+  if (contentBlocks.length === 0) {
+    contentBlocks.push({ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER });
   }
 
-  return userMessage;
-}
-
-function isBlankText(text: string): boolean {
-  return text.trim() === '';
-}
-
-function isBlankTextBlock(block: BedrockContentBlock): boolean {
-  const text = (block as { text?: unknown }).text;
-  return typeof text === 'string' && isBlankText(text);
+  return { role: 'user', content: contentBlocks };
 }
 
 /**

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -999,11 +999,28 @@ function convertHumanMessageToConverseMessage(
  * placeholder would inject a synthetic `_` into an otherwise valid message.
  */
 function finalizeUserMessage(message: BedrockMessage): void {
-  if (
-    message.role === 'user' &&
-    (message.content == null || message.content.length === 0)
-  ) {
+  if (message.role !== 'user') {
+    return;
+  }
+  const content = message.content ?? [];
+  if (content.length === 0) {
     message.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
+    return;
+  }
+  // Converse also requires a text block in any message that carries a document block. A
+  // promptless document upload arrives as blank text plus the document; the blank is
+  // dropped during conversion, so supply the placeholder if no text survived.
+  let hasText = false;
+  let hasDocument = false;
+  for (const block of content) {
+    if ('text' in block) {
+      hasText = true;
+    } else if ('document' in block) {
+      hasDocument = true;
+    }
+  }
+  if (hasDocument && !hasText) {
+    message.content = [...content, { text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
   }
 }
 

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -970,9 +970,6 @@ function convertHumanMessageToConverseMessage(
   if (typeof msg.content === 'string') {
     appendSerializableBedrockTextBlock(contentBlocks, msg.content);
   } else if (Array.isArray(msg.content)) {
-    // One pass. Text goes through the serializer, which drops a blank block and folds
-    // whitespace-only text into the preceding text block so prose spacing survives;
-    // every other block converts inline.
     for (const block of msg.content) {
       if (
         block.type === 'text' &&
@@ -990,16 +987,24 @@ function convertHumanMessageToConverseMessage(
     }
   }
 
-  // Bedrock rejects a blank text block and an empty user message alike
-  // (`The text field in the ContentBlock object at messages.N.content.0 is blank`),
-  // and the rejection fences the whole conversation on every retry. A promptless send
-  // — attachment, no typed text — reaches here as exactly that shape. Mirror the
-  // assistant path: fall back to the placeholder if nothing serializable remains.
-  if (contentBlocks.length === 0) {
-    contentBlocks.push({ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER });
-  }
-
   return { role: 'user', content: contentBlocks };
+}
+
+/**
+ * Bedrock rejects an empty user message just as it rejects a blank text block
+ * (`The text field in the ContentBlock object at messages.N.content.0 is blank`), and the
+ * rejection fences the whole conversation on every retry. A promptless send — attachment, no
+ * typed text — serializes to exactly that. Applied only once a user group is complete: an
+ * empty human turn adjacent to a tool result merges into it below, and a per-message
+ * placeholder would inject a synthetic `_` into an otherwise valid message.
+ */
+function finalizeUserMessage(message: BedrockMessage): void {
+  if (
+    message.role === 'user' &&
+    (message.content == null || message.content.length === 0)
+  ) {
+    message.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
+  }
 }
 
 /**
@@ -1132,12 +1137,18 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
       if (lastMessage.role === 'user' && curr.role === 'user') {
         lastMessage.content = lastMessage.content?.concat(curr.content ?? []);
       } else {
+        finalizeUserMessage(lastMessage);
         acc.push(curr);
       }
       return acc;
     },
     []
   );
+  if (combinedConverseMessages.length > 0) {
+    finalizeUserMessage(
+      combinedConverseMessages[combinedConverseMessages.length - 1]
+    );
+  }
 
   return { converseMessages: combinedConverseMessages, converseSystem };
 }

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -58,6 +58,15 @@ const FOREIGN_SERVER_TOOL_TYPES = ['toolCall', 'toolResponse'];
  * also has no tool calls, fall back to this placeholder text.
  */
 const BEDROCK_EMPTY_TEXT_PLACEHOLDER = '_';
+/**
+ * Whether a converted user message carries top-level text and document blocks, recorded
+ * during its single conversion pass and OR-ed through merging so finalization never
+ * rescans content.
+ */
+const userGroupShape = new WeakMap<
+  BedrockMessage,
+  { hasText: boolean; hasDocument: boolean }
+>();
 
 /**
  * Convert a LangChain reasoning block to a Bedrock reasoning block.
@@ -966,28 +975,46 @@ function convertHumanMessageToConverseMessage(
   msg: BaseMessage
 ): BedrockMessage {
   const contentBlocks: BedrockContentBlock[] = [];
+  let hasText = false;
+  let hasDocument = false;
+  // Whitespace with nothing before it to fold into is held until the next text fragment,
+  // so `[' ', 'hello']` and `[image, ' ', 'hello']` keep their leading space instead of
+  // losing it; whitespace left over at the end has nothing to attach to and is dropped.
+  let pendingWhitespace = '';
+  const appendText = (text: string): void => {
+    const candidate = pendingWhitespace + text;
+    if (appendSerializableBedrockTextBlock(contentBlocks, candidate)) {
+      hasText = true;
+      pendingWhitespace = '';
+      return;
+    }
+    pendingWhitespace = candidate;
+  };
 
   if (typeof msg.content === 'string') {
-    appendSerializableBedrockTextBlock(contentBlocks, msg.content);
+    appendText(msg.content);
   } else if (Array.isArray(msg.content)) {
     for (const block of msg.content) {
       if (
         block.type === 'text' &&
         typeof (block as { text?: unknown }).text === 'string'
       ) {
-        appendSerializableBedrockTextBlock(
-          contentBlocks,
-          (block as { text: string }).text
-        );
+        appendText((block as { text: string }).text);
         continue;
       }
-      contentBlocks.push(
-        convertLangChainContentBlockToConverseContentBlock({ block })
-      );
+      const converted = convertLangChainContentBlockToConverseContentBlock({
+        block,
+      });
+      if ('document' in converted) {
+        hasDocument = true;
+      }
+      contentBlocks.push(converted);
     }
   }
 
-  return { role: 'user', content: contentBlocks };
+  const message: BedrockMessage = { role: 'user', content: contentBlocks };
+  userGroupShape.set(message, { hasText, hasDocument });
+  return message;
 }
 
 /**
@@ -1002,25 +1029,16 @@ function finalizeUserMessage(message: BedrockMessage): void {
   if (message.role !== 'user') {
     return;
   }
-  const content = message.content ?? [];
-  if (content.length === 0) {
+  if (message.content == null || message.content.length === 0) {
     message.content = [{ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
     return;
   }
   // Converse also requires a text block in any message that carries a document block. A
   // promptless document upload arrives as blank text plus the document; the blank is
   // dropped during conversion, so supply the placeholder if no text survived.
-  let hasText = false;
-  let hasDocument = false;
-  for (const block of content) {
-    if ('text' in block) {
-      hasText = true;
-    } else if ('document' in block) {
-      hasDocument = true;
-    }
-  }
-  if (hasDocument && !hasText) {
-    message.content = [...content, { text: BEDROCK_EMPTY_TEXT_PLACEHOLDER }];
+  const shape = userGroupShape.get(message);
+  if (shape != null && shape.hasDocument && !shape.hasText) {
+    message.content.push({ text: BEDROCK_EMPTY_TEXT_PLACEHOLDER });
   }
 }
 
@@ -1153,6 +1171,17 @@ export function convertToConverseMessages(messages: BaseMessage[]): {
       const lastMessage = acc[acc.length - 1];
       if (lastMessage.role === 'user' && curr.role === 'user') {
         lastMessage.content = lastMessage.content?.concat(curr.content ?? []);
+        const lastShape = userGroupShape.get(lastMessage);
+        const nextShape = userGroupShape.get(curr);
+        if (lastShape != null || nextShape != null) {
+          userGroupShape.set(lastMessage, {
+            hasText:
+              (lastShape?.hasText ?? false) || (nextShape?.hasText ?? false),
+            hasDocument:
+              (lastShape?.hasDocument ?? false) ||
+              (nextShape?.hasDocument ?? false),
+          });
+        }
       } else {
         finalizeUserMessage(lastMessage);
         acc.push(curr);


### PR DESCRIPTION
## Problem

A user message whose text is empty is sent to Bedrock as a blank text block, and Bedrock
rejects the entire request:

```
ValidationException: The text field in the ContentBlock object at
messages.446.content.0 is blank. Add text to the text field, and try again.
```

Because every retry replays the same message, the conversation is wedged permanently. Seen
twice on a live instance in one day, both times from the same user action: attaching a
screenshot and sending without typing anything. The second occurrence happened with
LibreChat's own formatter guard (danny-avila/LibreChat#15530) already deployed — this sits
below that layer, so the guard could not reach it.

## Cause

`convertHumanMessageToConverseMessage` maps content without any emptiness check:

```ts
if (typeof msg.content === 'string') {
  userMessage.content = [{ text: msg.content }];          // '' -> [{ text: '' }]
} else if (Array.isArray(msg.content)) {
  userMessage.content = msg.content.map(...)               // { type:'text', text:'' } passes through 1:1
}
```

The **assistant** converter already handles both shapes — it guards `msg.content !== ''`
and, when filtering leaves no blocks, emits `BEDROCK_EMPTY_TEXT_PLACEHOLDER` with the comment
"Bedrock rejects an assistant message with no content blocks." The human path simply never
got the same treatment.

## Fix

Mirror the assistant path exactly:

- a blank string (`''` or whitespace-only) produces no text block
- blank text blocks are dropped from content arrays — an image-only send keeps its image
- if nothing remains, fall back to the existing `BEDROCK_EMPTY_TEXT_PLACEHOLDER`, since
  Bedrock rejects an empty user message just as it rejects a blank block

No new convention: the placeholder and the null guard are the ones the assistant converter
already uses.

## Tests

Four cases added to `message_inputs.test.ts`: empty string → placeholder, whitespace-only →
placeholder, image-only with a blank text block → image kept and no text block, and non-blank
text unchanged as a control. Verified against the original converter: the three guarding
cases fail and the control passes.

`npm run build` (tsdown + tsc) passes; `message_inputs.test.ts` + `llm.spec.ts` → **85 passed**;
ESLint clean.
