### PR TITLE
🧳 fix: Repack Attachments for Provider Handoffs

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -104,6 +104,7 @@ export class AgentContext {
   ): AgentContext {
     const {
       agentId,
+      endpoint,
       codeSessionKey,
       name,
       provider,
@@ -135,6 +136,7 @@ export class AgentContext {
 
     const agentContext = new AgentContext({
       agentId,
+      endpoint,
       codeSessionKey,
       name: name ?? agentId,
       provider,
@@ -219,6 +221,8 @@ export class AgentContext {
 
   /** Agent identifier */
   agentId: string;
+  /** Logical endpoint selected by the host before provider resolution. */
+  endpoint: string;
   /** Partition for this agent's transient code session and file refs. */
   codeSessionKey?: string;
   /** Human-readable name for this agent (used in handoff context). Falls back to agentId if not provided. */
@@ -454,6 +458,7 @@ export class AgentContext {
 
   constructor({
     agentId,
+    endpoint,
     codeSessionKey,
     name,
     provider,
@@ -481,6 +486,7 @@ export class AgentContext {
     maxToolResultChars,
   }: {
     agentId: string;
+    endpoint?: string;
     codeSessionKey?: string;
     name?: string;
     provider: t.ProviderName;
@@ -508,6 +514,7 @@ export class AgentContext {
     maxToolResultChars?: number;
   }) {
     this.agentId = agentId;
+    this.endpoint = endpoint ?? provider;
     this.codeSessionKey = codeSessionKey;
     this.name = name;
     this.provider = provider;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3992,6 +3992,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
         activeAgentId: agentId,
         activeAgentName: agentContext.name,
+        endpoint: agentContext.endpoint,
+        model: preparedRequest.modelId,
+        provider: agentContext.provider,
+        resolvedProvider: agentContext.provider,
       });
       let langfuseHandler: CallbackEntry | undefined;
       let invokeConfig = {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -151,6 +151,7 @@ import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
 import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
+import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
@@ -163,7 +164,6 @@ import { initializeLangfuseTracing } from '@/instrumentation';
 import { shouldTriggerSummarization } from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
-import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createSummarizeNode } from '@/summarization/node';
 import { getTruncationStopReason } from '@/llm/truncation';
 import { messagesStateReducer } from '@/messages/reducer';
@@ -3993,9 +3993,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         activeAgentId: agentId,
         activeAgentName: agentContext.name,
         endpoint: agentContext.endpoint,
-        model: preparedRequest.modelId,
-        provider: agentContext.provider,
-        resolvedProvider: agentContext.provider,
       });
       let langfuseHandler: CallbackEntry | undefined;
       let invokeConfig = {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -840,6 +840,10 @@ export function createLangfuseTraceMetadata({
   rootAgentName,
   activeAgentId,
   activeAgentName,
+  endpoint,
+  model,
+  provider,
+  resolvedProvider,
 }: {
   messageId?: unknown;
   parentMessageId?: unknown;
@@ -849,6 +853,10 @@ export function createLangfuseTraceMetadata({
   rootAgentName?: unknown;
   activeAgentId?: unknown;
   activeAgentName?: unknown;
+  endpoint?: unknown;
+  model?: unknown;
+  provider?: unknown;
+  resolvedProvider?: unknown;
 }): LangfuseTraceMetadata {
   return createTraceMetadata({
     messageId,
@@ -859,6 +867,10 @@ export function createLangfuseTraceMetadata({
     rootAgentName,
     activeAgentId,
     activeAgentName,
+    endpoint,
+    model,
+    provider,
+    resolvedProvider,
   });
 }
 

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -19,8 +19,8 @@ import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/messag
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { convertMessageContentToParts } from '@/llm/google/utils/common';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
-import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { StreamLimitExceededError } from '@/llm/streamLimits';
 import { toLangChainContent } from '@/messages/langchain';
 import { Constants, Providers } from '@/common';
 import { ToolNode } from '@/tools/ToolNode';
@@ -32,6 +32,7 @@ import { ChatOpenAI } from '@/llm/openai';
  * extending the real `BaseChatModel` would pull in too much surface.
  */
 type StubModel = {
+  model?: string;
   _useResponsesApi?: (options?: unknown) => boolean;
   defaultOptions?: unknown;
   last?: unknown;
@@ -1019,6 +1020,7 @@ describe('invocation attribution metadata', () => {
   it('stamps INVOKED_PROVIDER on the config passed to the model', async () => {
     const capturedConfigs: unknown[] = [];
     const model: StubModel = {
+      model: 'claude-opus-4-8',
       invoke: jest.fn(
         async (_m: BaseMessage[], config?: unknown): Promise<AIMessage> => {
           capturedConfigs.push(config);
@@ -1034,7 +1036,15 @@ describe('invocation attribution metadata', () => {
         /** A ChatOpenAI-derived provider — `ls_provider` would lie here. */
         provider: Providers.DEEPSEEK,
       },
-      { configurable: { run_id: 'run-attr' }, metadata: { existing: true } }
+      {
+        configurable: { run_id: 'run-attr' },
+        metadata: {
+          existing: true,
+          endpoint: 'DWAINE',
+          rootAgentId: 'sales-copilot',
+          activeAgentId: 'dwaine',
+        },
+      }
     );
 
     const config = capturedConfigs[0] as {
@@ -1043,6 +1053,14 @@ describe('invocation attribution metadata', () => {
     expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
       Providers.DEEPSEEK
     );
+    expect(config.metadata).toMatchObject({
+      endpoint: 'DWAINE',
+      model: 'claude-opus-4-8',
+      provider: Providers.DEEPSEEK,
+      resolvedProvider: Providers.DEEPSEEK,
+      rootAgentId: 'sales-copilot',
+      activeAgentId: 'dwaine',
+    });
     /** Pre-existing metadata is preserved, not replaced. */
     expect(config.metadata?.existing).toBe(true);
   });

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -1105,6 +1105,9 @@ describe('invocation attribution metadata', () => {
     expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
       Providers.ANTHROPIC
     );
+    expect(config.metadata?.model).toBe('claude-fallback-1');
+    expect(config.metadata?.provider).toBe(Providers.ANTHROPIC);
+    expect(config.metadata?.resolvedProvider).toBe(Providers.ANTHROPIC);
 
     jest.dontMock('@/llm/init');
     jest.resetModules();

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -692,11 +692,27 @@ export async function attemptInvoke(
   config?: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
   const provider = resolveAttemptProvider(params);
-  const stampedConfig: RunnableConfig = {
+  const providerStampedConfig: RunnableConfig = {
     ...config,
     metadata: {
       ...(config?.metadata ?? {}),
       [Constants.INVOKED_PROVIDER]: provider,
+      provider,
+      resolvedProvider: provider,
+    },
+  };
+  const request = resolveAttemptRequest(params, providerStampedConfig);
+  const stampedConfig: RunnableConfig = {
+    ...providerStampedConfig,
+    metadata: {
+      ...providerStampedConfig.metadata,
+      [Constants.INVOKED_PROVIDER]: provider,
+      ...(request.modelId == null
+        ? {}
+        : {
+          [Constants.INVOKED_MODEL]: request.modelId,
+          model: request.modelId,
+        }),
       /**
        * One `attemptInvoke` call is one model attempt; primary, fallback,
        * and retry attempts within a node otherwise share the same langgraph
@@ -727,7 +743,7 @@ export async function attemptInvoke(
   try {
     return await attemptInvokeBody(
       {
-        request: resolveAttemptRequest(params, stampedConfig),
+        request,
         context: params.context,
         onChunk: params.onChunk,
         preemptAgentId: params.preemptAgentId,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -702,16 +702,21 @@ export async function attemptInvoke(
     },
   };
   const request = resolveAttemptRequest(params, providerStampedConfig);
+  const configuredModel = providerStampedConfig.metadata?.[
+    Constants.INVOKED_MODEL
+  ];
+  const modelId =
+    request.modelId ??
+    (typeof configuredModel === 'string' ? configuredModel : undefined);
   const stampedConfig: RunnableConfig = {
     ...providerStampedConfig,
     metadata: {
       ...providerStampedConfig.metadata,
-      [Constants.INVOKED_PROVIDER]: provider,
-      ...(request.modelId == null
+      ...(modelId == null
         ? {}
         : {
-          [Constants.INVOKED_MODEL]: request.modelId,
-          model: request.modelId,
+          [Constants.INVOKED_MODEL]: modelId,
+          model: modelId,
         }),
       /**
        * One `attemptInvoke` call is one model attempt; primary, fallback,

--- a/src/llm/prepareProviderRequest.test.ts
+++ b/src/llm/prepareProviderRequest.test.ts
@@ -11,6 +11,7 @@ import {
   prepareProviderRequest,
 } from '@/llm/prepareProviderRequest';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
 import { attemptInvoke } from '@/llm/invoke';
 import { Providers } from '@/common';
 
@@ -40,6 +41,184 @@ function createCapturingModel(): CapturingModel {
 }
 
 describe('prepareProviderRequest', () => {
+  it.each([
+    ['CSV', 'csv'],
+    ['XLSX', 'xlsx'],
+  ])(
+    'removes a persisted Bedrock %s block for OpenAI while retaining extracted file context',
+    (_label, format) => {
+      const { model } = createCapturingModel();
+      const document = {
+        type: 'document',
+        document: {
+          name: `sales.${format}`,
+          format,
+          source: {
+            bytes: { type: 'Buffer', data: [99, 111, 108, 49, 10] },
+          },
+        },
+      };
+      const source = new HumanMessage({
+        content: [
+          { type: 'text', text: 'Attached document(s):\ncol1\nvalue' },
+          document,
+        ],
+      });
+
+      const request = prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: [source],
+        provider: Providers.OPENAI,
+      });
+
+      expect(request.messages[0]).not.toBe(source);
+      expect(request.messages[0].content).toEqual([
+        { type: 'text', text: 'Attached document(s):\ncol1\nvalue' },
+      ]);
+      expect(_convertMessagesToOpenAIParams(request.messages)).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Attached document(s):\ncol1\nvalue' },
+          ],
+        },
+      ]);
+      expect(source.content).toEqual([
+        { type: 'text', text: 'Attached document(s):\ncol1\nvalue' },
+        document,
+      ]);
+    }
+  );
+
+  it('reprojects a persisted Bedrock PDF and preserves image content for OpenAI', () => {
+    const { model } = createCapturingModel();
+    const pdf = {
+      type: 'document',
+      document: {
+        name: 'report.pdf',
+        format: 'pdf',
+        source: { bytes: { type: 'Buffer', data: [37, 80, 68, 70] } },
+      },
+    };
+    const image = {
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,AA==' },
+    };
+    const source = new HumanMessage({ content: [pdf, image] });
+
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages: [source],
+      provider: Providers.OPENAI,
+    });
+
+    expect(request.messages[0].content).toEqual([
+      {
+        type: 'file',
+        source_type: 'base64',
+        mime_type: 'application/pdf',
+        data: 'JVBERg==',
+        metadata: { name: 'report.pdf' },
+      },
+      image,
+    ]);
+    expect(_convertMessagesToOpenAIParams(request.messages)).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            file: {
+              file_data: 'data:application/pdf;base64,JVBERg==',
+              filename: 'report.pdf',
+            },
+          },
+          image,
+        ],
+      },
+    ]);
+    expect(source.content).toEqual([pdf, image]);
+  });
+
+  it('filters a canonical spreadsheet descriptor at the same final projection seam', () => {
+    const { model } = createCapturingModel();
+    const source = new HumanMessage({
+      content: [
+        { type: 'text', text: 'Attached document(s):\nRevenue: 42' },
+        {
+          type: 'file',
+          source_type: 'base64',
+          mime_type:
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          data: 'UEs=',
+          metadata: { name: 'sales.xlsx' },
+        },
+      ],
+    });
+
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages: [source],
+      provider: Providers.OPENAI,
+    });
+
+    expect(request.messages[0].content).toEqual([
+      { type: 'text', text: 'Attached document(s):\nRevenue: 42' },
+    ]);
+    expect(source.content).toHaveLength(2);
+  });
+
+  it('does not scan or re-encode Bedrock-native documents for a Bedrock target', () => {
+    const { model } = createCapturingModel();
+    const document = {
+      type: 'document',
+      document: {
+        name: 'sales.csv',
+        format: 'csv',
+        source: { bytes: new Uint8Array([99, 111, 108, 49]) },
+      },
+    };
+    const source = new HumanMessage({ content: [document] });
+
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages: [source],
+      provider: Providers.BEDROCK,
+    });
+
+    expect(request.messages[0]).toBe(source);
+    expect(request.messages[0].content[0]).toBe(document);
+  });
+
+  it('keeps an attachment-only turn valid when its binary block is unsupported', () => {
+    const { model } = createCapturingModel();
+    const source = new HumanMessage({
+      content: [
+        {
+          type: 'document',
+          document: {
+            name: 'sales.xlsx',
+            format: 'xlsx',
+            source: { bytes: { type: 'Buffer', data: [80, 75] } },
+          },
+        },
+      ],
+    });
+
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages: [source],
+      provider: Providers.OPENAI,
+    });
+
+    expect(request.messages[0].content).toEqual([
+      {
+        type: 'text',
+        text: '[Attachment omitted because its binary format is unsupported by this provider.]',
+      },
+    ]);
+  });
+
   it('measures and sends the exact prepared message array without re-projection', async () => {
     const { model, invocations } = createCapturingModel();
     const source = [

--- a/src/llm/prepareProviderRequest.test.ts
+++ b/src/llm/prepareProviderRequest.test.ts
@@ -168,6 +168,44 @@ describe('prepareProviderRequest', () => {
     expect(source.content).toHaveLength(2);
   });
 
+  it('retains canonical Anthropic PDF and image files with parameterized MIME types', () => {
+    const { model } = createCapturingModel();
+    const supportedFiles = [
+      {
+        type: 'file',
+        source_type: 'base64',
+        mime_type: 'application/pdf; charset=binary',
+        data: 'JVBERg==',
+      },
+      {
+        type: 'file',
+        source_type: 'base64',
+        mime_type: 'image/png; name=chart.png',
+        data: 'iVBORw==',
+      },
+    ];
+    const source = new HumanMessage({
+      content: [
+        ...supportedFiles,
+        {
+          type: 'file',
+          source_type: 'base64',
+          mime_type: 'application/vnd.ms-excel',
+          data: '0M8R4A==',
+        },
+      ],
+    });
+
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      messages: [source],
+      provider: Providers.ANTHROPIC,
+    });
+
+    expect(request.messages[0].content).toEqual(supportedFiles);
+    expect(source.content).toHaveLength(3);
+  });
+
   it('does not scan or re-encode Bedrock-native documents for a Bedrock target', () => {
     const { model } = createCapturingModel();
     const document = {
@@ -194,6 +232,7 @@ describe('prepareProviderRequest', () => {
     const { model } = createCapturingModel();
     const source = new HumanMessage({
       content: [
+        { type: 'text', text: '' },
         {
           type: 'document',
           document: {

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -1,5 +1,10 @@
+import { Buffer } from 'node:buffer';
+import type {
+  BaseMessage,
+  Data,
+  MessageContentComplex,
+} from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type * as t from '@/types';
 import {
@@ -20,14 +25,60 @@ import {
 import {
   stripAnthropicCacheControl,
   stripBedrockCacheControl,
+  cloneMessage,
 } from '@/messages/cache';
+import {
+  isAnthropicLike,
+  isGoogleLike,
+  isOpenAILike,
+} from '@/utils/llm';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
-import { isAnthropicLike, isOpenAILike } from '@/utils/llm';
 import { getProviderFamily } from '@/llm/providerRegistry';
 import { Providers } from '@/common';
 
 const preparedProviderRequestBrand = Symbol('PreparedProviderRequest');
+const OMITTED_ATTACHMENT_TEXT =
+  '[Attachment omitted because its binary format is unsupported by this provider.]';
+
+const BEDROCK_DOCUMENT_MIME_TYPES: Readonly<Partial<Record<string, string>>> = {
+  csv: 'text/csv',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  html: 'text/html',
+  md: 'text/markdown',
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+interface SerializedBuffer {
+  type: 'Buffer';
+  data: number[];
+}
+
+interface BedrockDocumentBlock {
+  type: 'document';
+  document: {
+    name: string;
+    format: string;
+    source: {
+      bytes: Uint8Array | SerializedBuffer;
+    };
+  };
+}
+
+type StandardBase64FileBlock = Data.StandardFileBlock & {
+  source_type: 'base64';
+  mime_type: string;
+  data: string;
+};
+
+type ProviderContentBlock =
+  | MessageContentComplex
+  | BedrockDocumentBlock
+  | StandardBase64FileBlock;
 
 export type ProviderMessageProjectionMode =
   | 'chat-messages'
@@ -159,16 +210,186 @@ interface ProjectMessagesForProviderParams {
   callOptions?: unknown;
 }
 
+function isSerializedBuffer(value: object): value is SerializedBuffer {
+  return (
+    'type' in value &&
+    value.type === 'Buffer' &&
+    'data' in value &&
+    Array.isArray(value.data)
+  );
+}
+
+function isBedrockDocumentBlock(
+  block: ProviderContentBlock
+): block is BedrockDocumentBlock {
+  if (block.type !== 'document' || !('document' in block)) {
+    return false;
+  }
+  const document = block.document;
+  if (typeof document !== 'object' || document == null) {
+    return false;
+  }
+  if (
+    !('name' in document) ||
+    typeof document.name !== 'string' ||
+    !('format' in document) ||
+    typeof document.format !== 'string' ||
+    !('source' in document) ||
+    typeof document.source !== 'object' ||
+    document.source == null ||
+    !('bytes' in document.source)
+  ) {
+    return false;
+  }
+  const bytes = document.source.bytes;
+  return (
+    bytes instanceof Uint8Array ||
+    (typeof bytes === 'object' && bytes != null && isSerializedBuffer(bytes))
+  );
+}
+
+function toStandardFileBlock(
+  block: BedrockDocumentBlock
+): StandardBase64FileBlock | undefined {
+  const mimeType = BEDROCK_DOCUMENT_MIME_TYPES[block.document.format];
+  if (mimeType == null) {
+    return undefined;
+  }
+  const source = block.document.source.bytes;
+  const bytes = source instanceof Uint8Array ? source : source.data;
+  return {
+    type: 'file',
+    source_type: 'base64',
+    mime_type: mimeType,
+    data: Buffer.from(bytes).toString('base64'),
+    metadata: { name: block.document.name },
+  };
+}
+
+function isStandardFileBlock(
+  block: ProviderContentBlock
+): block is StandardBase64FileBlock {
+  return (
+    block.type === 'file' &&
+    'source_type' in block &&
+    block.source_type === 'base64' &&
+    'mime_type' in block &&
+    typeof block.mime_type === 'string' &&
+    'data' in block &&
+    typeof block.data === 'string'
+  );
+}
+
+function shouldRetainStandardFile(
+  provider: t.ProviderName,
+  mimeType: string
+): boolean {
+  if (
+    provider === Providers.ANTHROPIC ||
+    getProviderFamily(provider) === 'anthropic' ||
+    isOpenAILike(provider)
+  ) {
+    return mimeType === 'application/pdf';
+  }
+  return true;
+}
+
+function canProjectBedrockDocument(
+  provider: t.ProviderName,
+  mimeType: string
+): boolean {
+  if (isGoogleLike(provider)) {
+    return true;
+  }
+  if (
+    provider === Providers.ANTHROPIC ||
+    getProviderFamily(provider) === 'anthropic' ||
+    isOpenAILike(provider)
+  ) {
+    return mimeType === 'application/pdf';
+  }
+  return false;
+}
+
+/** Reprojects persisted provider-native attachments without changing history. */
+function projectAttachmentsForProvider(
+  messages: BaseMessage[],
+  provider: t.ProviderName
+): BaseMessage[] {
+  if (
+    provider === Providers.BEDROCK ||
+    getProviderFamily(provider) === 'bedrock'
+  ) {
+    return messages;
+  }
+  let projected: BaseMessage[] | undefined;
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const message = messages[messageIndex];
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    const sourceContent = message.content as ProviderContentBlock[];
+    let content: ProviderContentBlock[] | undefined;
+    let removedCount = 0;
+    for (let blockIndex = 0; blockIndex < sourceContent.length; blockIndex++) {
+      const block = sourceContent[blockIndex];
+      if (isStandardFileBlock(block)) {
+        if (shouldRetainStandardFile(provider, block.mime_type)) {
+          content?.push(block);
+          continue;
+        }
+        content ??= sourceContent.slice(0, blockIndex);
+        removedCount++;
+        continue;
+      }
+      if (!isBedrockDocumentBlock(block)) {
+        content?.push(block);
+        continue;
+      }
+      content ??= sourceContent.slice(0, blockIndex);
+      const mimeType = BEDROCK_DOCUMENT_MIME_TYPES[block.document.format];
+      if (
+        mimeType == null ||
+        !canProjectBedrockDocument(provider, mimeType)
+      ) {
+        removedCount++;
+        continue;
+      }
+      const standardFile = toStandardFileBlock(block);
+      if (standardFile == null) {
+        removedCount++;
+        continue;
+      }
+      content.push(standardFile);
+    }
+    if (content == null) {
+      continue;
+    }
+    if (content.length === 0 && removedCount > 0) {
+      content.push({ type: 'text', text: OMITTED_ATTACHMENT_TEXT });
+    }
+    projected ??= [...messages];
+    projected[messageIndex] = cloneMessage(
+      message,
+      content as MessageContentComplex[]
+    );
+  }
+  return projected ?? messages;
+}
+
 function projectMessagesForProviderMode(
   { messages, provider, maxToolResultChars }: ProjectMessagesForProviderParams,
   projectionMode: ProviderMessageProjectionMode
 ): BaseMessage[] {
   const providerFamily = getProviderFamily(provider);
   const nativeOpenAIResponses = projectionMode === 'openai-responses';
-  const providerInputMessages = projectToolStreamContentForProvider(
-    messages,
-    nativeOpenAIResponses ? 'native' : 'fallback',
-    maxToolResultChars
+  const providerInputMessages = projectAttachmentsForProvider(
+    projectToolStreamContentForProvider(
+      messages,
+      nativeOpenAIResponses ? 'native' : 'fallback',
+      maxToolResultChars
+    ),
+    provider
   );
   if (nativeOpenAIResponses) {
     return projectOpenAIResponsesToolMessageContent(

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -284,12 +284,21 @@ function shouldRetainStandardFile(
   provider: t.ProviderName,
   mimeType: string
 ): boolean {
+  const normalizedMimeType = mimeType.split(';', 1)[0].trim().toLowerCase();
   if (
     provider === Providers.ANTHROPIC ||
-    getProviderFamily(provider) === 'anthropic' ||
-    isOpenAILike(provider)
+    getProviderFamily(provider) === 'anthropic'
   ) {
-    return mimeType === 'application/pdf';
+    return (
+      normalizedMimeType === 'application/pdf' ||
+      normalizedMimeType === 'image/jpeg' ||
+      normalizedMimeType === 'image/png' ||
+      normalizedMimeType === 'image/gif' ||
+      normalizedMimeType === 'image/webp'
+    );
+  }
+  if (isOpenAILike(provider)) {
+    return normalizedMimeType === 'application/pdf';
   }
   return true;
 }
@@ -311,6 +320,29 @@ function canProjectBedrockDocument(
   return false;
 }
 
+function isBlankTextBlock(block: ProviderContentBlock): boolean {
+  return (
+    block.type === 'text' &&
+    'text' in block &&
+    typeof block.text === 'string' &&
+    block.text.trim() === ''
+  );
+}
+
+function copyUsableContentPrefix(
+  sourceContent: ProviderContentBlock[],
+  end: number
+): ProviderContentBlock[] {
+  const content: ProviderContentBlock[] = [];
+  for (let index = 0; index < end; index++) {
+    const block = sourceContent[index];
+    if (!isBlankTextBlock(block)) {
+      content.push(block);
+    }
+  }
+  return content;
+}
+
 /** Reprojects persisted provider-native attachments without changing history. */
 function projectAttachmentsForProvider(
   messages: BaseMessage[],
@@ -330,7 +362,6 @@ function projectAttachmentsForProvider(
     }
     const sourceContent = message.content as ProviderContentBlock[];
     let content: ProviderContentBlock[] | undefined;
-    let removedCount = 0;
     for (let blockIndex = 0; blockIndex < sourceContent.length; blockIndex++) {
       const block = sourceContent[blockIndex];
       if (isStandardFileBlock(block)) {
@@ -338,26 +369,25 @@ function projectAttachmentsForProvider(
           content?.push(block);
           continue;
         }
-        content ??= sourceContent.slice(0, blockIndex);
-        removedCount++;
+        content ??= copyUsableContentPrefix(sourceContent, blockIndex);
         continue;
       }
       if (!isBedrockDocumentBlock(block)) {
-        content?.push(block);
+        if (content != null && !isBlankTextBlock(block)) {
+          content.push(block);
+        }
         continue;
       }
-      content ??= sourceContent.slice(0, blockIndex);
+      content ??= copyUsableContentPrefix(sourceContent, blockIndex);
       const mimeType = BEDROCK_DOCUMENT_MIME_TYPES[block.document.format];
       if (
         mimeType == null ||
         !canProjectBedrockDocument(provider, mimeType)
       ) {
-        removedCount++;
         continue;
       }
       const standardFile = toStandardFileBlock(block);
       if (standardFile == null) {
-        removedCount++;
         continue;
       }
       content.push(standardFile);
@@ -365,7 +395,7 @@ function projectAttachmentsForProvider(
     if (content == null) {
       continue;
     }
-    if (content.length === 0 && removedCount > 0) {
+    if (content.length === 0) {
       content.push({ type: 'text', text: OMITTED_ATTACHMENT_TEXT });
     }
     projected ??= [...messages];

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -853,6 +853,8 @@ export interface LangfuseConfig {
 
 interface AgentInputFields {
   agentId: string;
+  /** Logical endpoint selected by the host before provider resolution. */
+  endpoint?: string;
   /**
    * Partition key for transient code-session ids and file refs. Agents with
    * the same key share those refs; different execution profiles/scopes must


### PR DESCRIPTION
## Summary

I normalized attachment content at the final provider projection boundary so multi-agent handoffs cannot leak provider-native document blocks into incompatible requests.

- Reproject persisted Bedrock PDF documents into canonical file descriptors for providers that support them.
- Remove unsupported CSV and XLSX binary blocks while preserving LibreChat-extracted file context.
- Preserve image blocks and avoid mutating persisted conversation messages.
- Add a Bedrock identity fast path and copy-on-write, single-pass projection for scalable message handling.
- Record root agent, active agent, endpoint, model, provider, and resolved provider metadata on model generations.
- Cover legacy persisted documents, canonical descriptors, PDF/image handoffs, Bedrock passthrough, retry-safe immutability, and attribution metadata.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/llm/prepareProviderRequest.test.ts src/llm/invoke.test.ts src/langfuse-metadata.test.ts src/specs/agent-handoffs.test.ts --runInBand`
- `npx jest langfuse deterministic-trace-id --runInBand`
- `npx tsc --noEmit`
- `npx eslint` on all touched TypeScript files
- `npm run build`
- `npm run bench:provider-projection`
- `node scripts/sort-imports.ts --check` on touched import-bearing files
- `git diff --check`

### Test Configuration

- Node.js: repository-configured local runtime
- Package manager: npm
- Base branch: `main` at `f0e6bd98`
- Production evidence: eight failing Langfuse traces from August 28–30 were inspected read-only to confirm the rejected Bedrock `document` block and misleading agent attribution.

## Checklist

- [x] My code adheres to this project’s style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas where the behavior is non-obvious
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes