### PR TITLE
🧪 test: Cover Provider Migration Recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "script5": "tsx -r dotenv/config ./src/scripts/cli5.ts --name 'Jo' --location 'New York, NY'",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:live:handoffs": "RUN_HANDOFF_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/agent-handoffs.live.test.ts --runInBand",
+    "test:live:cross-provider-attachments": "RUN_CROSS_PROVIDER_ATTACHMENT_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/cross-provider-attachments.live.test.ts --runInBand",
     "test:live:ask-user-questions": "RUN_ASK_USER_QUESTIONS_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/ask-user-questions.live.test.ts --runInBand",
     "test:memory": "NODE_OPTIONS='--expose-gc' npx jest src/specs/title.memory-leak.test.ts",
     "test:all": "npm test -- --testPathIgnorePatterns=title.memory-leak.test.ts && npm run test:memory",

--- a/src/llm/prepareProviderRequest.test.ts
+++ b/src/llm/prepareProviderRequest.test.ts
@@ -45,7 +45,7 @@ describe('prepareProviderRequest', () => {
     ['CSV', 'csv'],
     ['XLSX', 'xlsx'],
   ])(
-    'removes a persisted Bedrock %s block for OpenAI while retaining extracted file context',
+    'recovers an existing Bedrock %s chat after its agent moves to an OpenAI-compatible endpoint',
     (_label, format) => {
       const { model } = createCapturingModel();
       const document = {
@@ -65,12 +65,19 @@ describe('prepareProviderRequest', () => {
         ],
       });
 
+      const bedrockRequest = prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: [source],
+        provider: Providers.BEDROCK,
+      });
       const request = prepareProviderRequest({
         model: model as t.ChatModel,
         messages: [source],
         provider: Providers.OPENAI,
       });
 
+      expect(bedrockRequest.messages[0]).toBe(source);
+      expect(bedrockRequest.messages[0].content[1]).toBe(document);
       expect(request.messages[0]).not.toBe(source);
       expect(request.messages[0].content).toEqual([
         { type: 'text', text: 'Attached document(s):\ncol1\nvalue' },

--- a/src/specs/cross-provider-attachments.live.test.ts
+++ b/src/specs/cross-provider-attachments.live.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Live recovery verification for chats created before an agent moved from
+ * Bedrock to an OpenAI-compatible endpoint.
+ *
+ * Run with:
+ * CROSS_PROVIDER_ATTACHMENT_BASE_URL=... \
+ * CROSS_PROVIDER_ATTACHMENT_API_KEY=... \
+ * CROSS_PROVIDER_ATTACHMENT_MODEL=... \
+ * npm run test:live:cross-provider-attachments
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig({ path: process.env.DOTENV_CONFIG_PATH ?? '.env' });
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { ContentBlock } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+const apiKey = process.env.CROSS_PROVIDER_ATTACHMENT_API_KEY;
+const configuredBaseURL = process.env.CROSS_PROVIDER_ATTACHMENT_BASE_URL;
+const model = process.env.CROSS_PROVIDER_ATTACHMENT_MODEL;
+const shouldRunLive =
+  process.env.RUN_CROSS_PROVIDER_ATTACHMENT_LIVE_TESTS === '1' &&
+  apiKey != null &&
+  apiKey !== '' &&
+  configuredBaseURL != null &&
+  configuredBaseURL !== '' &&
+  model != null &&
+  model !== '';
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+const expectedAnswer = '42';
+
+interface PersistedBedrockDocument extends ContentBlock {
+  type: 'document';
+  document: {
+    name: string;
+    format: 'csv' | 'xlsx';
+    source: {
+      bytes: { type: 'Buffer'; data: number[] };
+    };
+  };
+}
+
+function requireLiveValue(
+  value: string | undefined,
+  name: string
+): string {
+  if (value == null || value === '') {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function normalizeBaseURL(value: string): string {
+  return value
+    .replace(/\/chat\/completions\/?$/, '')
+    .replace(/\/$/, '');
+}
+
+function createPersistedDocument(
+  name: string,
+  format: PersistedBedrockDocument['document']['format']
+): PersistedBedrockDocument {
+  return {
+    type: 'document',
+    document: {
+      name,
+      format,
+      source: {
+        bytes: { type: 'Buffer', data: [80, 75, 3, 4] },
+      },
+    },
+  };
+}
+
+function contentPartsToText(
+  content: t.MessageContentComplex[] | undefined
+): string {
+  const text: string[] = [];
+  for (const block of content ?? []) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      text.push(block.text);
+    }
+  }
+  return text.join('');
+}
+
+describeIfLive('cross-provider attachment recovery live API', () => {
+  jest.setTimeout(120_000);
+
+  it('reads extracted CSV/XLSX context without sending persisted Bedrock documents', async () => {
+    const requestBodies: string[] = [];
+    const nativeFetch = globalThis.fetch.bind(globalThis);
+    const capturingFetch: typeof fetch = async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBodies.push(init.body);
+      }
+      return nativeFetch(input, init);
+    };
+    const resolvedApiKey = requireLiveValue(
+      apiKey,
+      'CROSS_PROVIDER_ATTACHMENT_API_KEY'
+    );
+    const resolvedModel = requireLiveValue(
+      model,
+      'CROSS_PROVIDER_ATTACHMENT_MODEL'
+    );
+    const baseURL = normalizeBaseURL(
+      requireLiveValue(
+        configuredBaseURL,
+        'CROSS_PROVIDER_ATTACHMENT_BASE_URL'
+      )
+    );
+    const nonce = `cross-provider-attachment-${Date.now()}`;
+    const run = await Run.create({
+      runId: nonce,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENAI,
+          model: resolvedModel,
+          modelName: resolvedModel,
+          apiKey: resolvedApiKey,
+          temperature: 0,
+          maxTokens: 32,
+          streaming: false,
+          streamUsage: false,
+          configuration: { baseURL, fetch: capturingFetch },
+        },
+        instructions:
+          'Answer only with the requested numeric total. Do not add punctuation or explanation.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+    const historicalMessage = new HumanMessage({
+      content: [
+        {
+          type: 'text',
+          text: [
+            'Attached document(s):',
+            'sales.csv extracted rows: north revenue = 17',
+            'forecast.xlsx extracted rows: north forecast = 25',
+            `Recovery probe: ${nonce}`,
+            'Return the sum of north revenue and north forecast.',
+          ].join('\n'),
+        },
+        createPersistedDocument('sales.csv', 'csv'),
+        createPersistedDocument('forecast.xlsx', 'xlsx'),
+      ],
+    });
+
+    const finalContent = await run.processStream(
+      { messages: [historicalMessage] },
+      {
+        configurable: { thread_id: `${nonce}-thread` },
+        version: 'v2',
+      }
+    );
+
+    const requestBody = requestBodies.at(-1);
+    expect(requestBody).toBeDefined();
+    expect(requestBody).not.toContain('"type":"document"');
+    expect(requestBody).toContain('sales.csv extracted rows');
+    expect(requestBody).toContain('forecast.xlsx extracted rows');
+    expect(historicalMessage.content).toHaveLength(3);
+
+    const finalText = contentPartsToText(finalContent).trim();
+    expect(finalText).toBe(expectedAnswer);
+  });
+});


### PR DESCRIPTION
I made the existing-conversation recovery scenario explicit after Sales Copilot moved from Bedrock to a ClickHouse OpenAI-compatible endpoint, and added a one-call live SDK harness for validating the real gateway.

- Exercise the same serialized CSV/XLSX message first through the original Bedrock projection and then through the active OpenAI projection.
- Verify the Bedrock-native `document` block remains available to Bedrock but is removed from the OpenAI wire payload.
- Verify extracted file context remains usable and canonical conversation history is not mutated.
- Add an opt-in `Run.create` live harness that sends CSV and XLSX fixtures together in one bounded chat-completions request.
- Capture the actual outgoing request body and assert that extracted rows are present while legacy Bedrock blocks are absent.
- Accept either a base URL or a full `/chat/completions` URL without duplicating the route.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/llm/prepareProviderRequest.test.ts src/specs/cross-provider-attachments.live.test.ts --runInBand` — 12 focused tests passed; credential-gated live test skipped as expected.
- Ran the live harness against a local OpenAI-compatible HTTP server — 1 live test passed.
- `npx eslint src/llm/prepareProviderRequest.test.ts src/specs/cross-provider-attachments.live.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

### **Test Configuration**:

- Node.js: repository-configured local runtime
- Test framework: Jest with ts-jest
- Live command: `CROSS_PROVIDER_ATTACHMENT_BASE_URL=... CROSS_PROVIDER_ATTACHMENT_API_KEY=... CROSS_PROVIDER_ATTACHMENT_MODEL=... npm run test:live:cross-provider-attachments`
- Optional env file: `DOTENV_CONFIG_PATH=/path/to/env`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes